### PR TITLE
Fix resume runtime after a pause

### DIFF
--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -91,7 +91,6 @@ class RemoteRuntime(Runtime):
         self.runtime_url: str | None = None
 
     async def connect(self):
-        print('CONNECT')
         try:
             await call_sync_from_async(self._start_or_attach_to_runtime)
         except RuntimeNotReadyError:
@@ -100,7 +99,6 @@ class RemoteRuntime(Runtime):
         await call_sync_from_async(self.setup_initial_env)
 
     def _start_or_attach_to_runtime(self):
-        print('START OR ATTACH')
         existing_runtime = self._check_existing_runtime()
         if existing_runtime:
             self.log('debug', f'Using existing runtime with ID: {self.runtime_id}')
@@ -249,7 +247,6 @@ class RemoteRuntime(Runtime):
         )
 
     def _resume_runtime(self):
-        print('RESUME RUNTIME')
         self._send_request(
             'POST',
             f'{self.config.sandbox.remote_runtime_api_url}/resume',
@@ -311,8 +308,6 @@ class RemoteRuntime(Runtime):
                     f'Runtime /alive failed to respond with 200: {e}'
                 )
             return
-        elif pod_status == 'Paused':
-            print('paused')
         elif (
             pod_status == 'Not Found'
             or pod_status == 'Pending'
@@ -417,6 +412,7 @@ class RemoteRuntime(Runtime):
                 if not is_retry:
                     self.log('warning', 'Runtime appears to be paused. Resuming...')
                     self._resume_runtime()
+                    self._wait_until_alive()
                     return self._send_request(method, url, True, **kwargs)
                 else:
                     raise e


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below
no changelog

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

If you hang out in your session too long, the backend will pause your runtime. If you then send a new message to the agent, you get a 503 error.

This tries to resume the runtime whenever we get a 503

This might not be the best design--probably better to put the agent back into `INITIALIZING` state so that the user can see it warming up. But this works a little better for now


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e577e02-nikolaik   --name openhands-app-e577e02   docker.all-hands.dev/all-hands-ai/openhands:e577e02
```