### PR TITLE
chore(frontend): Close conversation card context menu when clicking elsewhere

### DIFF
--- a/frontend/src/components/features/conversation-panel/conversation-card-context-menu.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card-context-menu.tsx
@@ -1,0 +1,27 @@
+import { useClickOutsideElement } from "#/hooks/use-click-outside-element";
+import { ContextMenu } from "../context-menu/context-menu";
+import { ContextMenuListItem } from "../context-menu/context-menu-list-item";
+
+interface ConversationCardContextMenuProps {
+  onClose: () => void;
+  onDelete: (event: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+export function ConversationCardContextMenu({
+  onClose,
+  onDelete,
+}: ConversationCardContextMenuProps) {
+  const ref = useClickOutsideElement<HTMLUListElement>(onClose);
+
+  return (
+    <ContextMenu
+      ref={ref}
+      testId="context-menu"
+      className="left-full float-right"
+    >
+      <ContextMenuListItem testId="delete-button" onClick={onDelete}>
+        Delete
+      </ContextMenuListItem>
+    </ContextMenu>
+  );
+}

--- a/frontend/src/components/features/conversation-panel/conversation-card.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card.tsx
@@ -5,11 +5,10 @@ import {
   ProjectStatus,
   ConversationStateIndicator,
 } from "./conversation-state-indicator";
-import { ContextMenu } from "../context-menu/context-menu";
-import { ContextMenuListItem } from "../context-menu/context-menu-list-item";
 import { EllipsisButton } from "./ellipsis-button";
+import { ConversationCardContextMenu } from "./conversation-card-context-menu";
 
-interface ProjectCardProps {
+interface ConversationCardProps {
   onClick: () => void;
   onDelete: () => void;
   onChangeTitle: (title: string) => void;
@@ -27,7 +26,7 @@ export function ConversationCard({
   selectedRepository,
   lastUpdatedAt,
   status = "STOPPED",
-}: ProjectCardProps) {
+}: ConversationCardProps) {
   const [contextMenuVisible, setContextMenuVisible] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement>(null);
 
@@ -86,11 +85,10 @@ export function ConversationCard({
         </div>
       </div>
       {contextMenuVisible && (
-        <ContextMenu testId="context-menu" className="left-full float-right">
-          <ContextMenuListItem testId="delete-button" onClick={handleDelete}>
-            Delete
-          </ContextMenuListItem>
-        </ContextMenu>
+        <ConversationCardContextMenu
+          onClose={() => setContextMenuVisible(false)}
+          onDelete={handleDelete}
+        />
       )}
       {selectedRepository && (
         <ConversationRepoLink


### PR DESCRIPTION
**End-user friendly description of the problem this fixes or functionality that this introduces**
User can open context menu for each card

- [ ] Include this change in the Release Notes. If checked, you must provide an **end-user friendly** description for your change below

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
Hide context menu when clicking elsewhere


---
**Link of any specific issues this addresses**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:c66b2c2-nikolaik   --name openhands-app-c66b2c2   docker.all-hands.dev/all-hands-ai/openhands:c66b2c2
```