### PR TITLE
fix for status messages not showing up

### DIFF
--- a/frontend/src/components/features/controls/agent-status-bar.tsx
+++ b/frontend/src/components/features/controls/agent-status-bar.tsx
@@ -47,7 +47,7 @@ export function AgentStatusBar() {
       });
       return;
     }
-    if (curAgentState === AgentState.LOADING && message.trim()) {
+    if (message.trim()) {
       setStatusMessage(message);
     } else {
       setStatusMessage(AGENT_STATUS_MAP[curAgentState].message);


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below
CHANGELOG: fix for status messages when reloading old sessions


When restoring an old session, the agent often starts out in STOPPED (the last state it was in)

IMO there's no reason to gate this on LOADING, and it lets us send other status messages when the agent is running.

**End-user friendly description of the problem this fixes or functionality that this introduces.**


---
**Give a summary of what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses.**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:4592d30-nikolaik   --name openhands-app-4592d30   docker.all-hands.dev/all-hands-ai/openhands:4592d30
```