### PR TITLE
Revert "[Feat]: Add timestamp info to CmdOutputObservation"

### DIFF
--- a/openhands/events/observation/commands.py
+++ b/openhands/events/observation/commands.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel
 from openhands.core.logger import openhands_logger as logger
 from openhands.core.schema import ObservationType
 from openhands.events.observation.observation import Observation
-from datetime import datetime, timezone
 
 CMD_OUTPUT_PS1_BEGIN = '\n###PS1JSON###\n'
 CMD_OUTPUT_PS1_END = '\n###PS1END###'
@@ -162,9 +161,6 @@ class CmdOutputObservation(Observation):
             ret += f'\n[Python interpreter: {self.metadata.py_interpreter_path}]'
         if self.metadata.exit_code != -1:
             ret += f'\n[Command finished with exit code {self.metadata.exit_code}]'
-
-        utc_now = datetime.now(timezone.utc)
-        ret += f'\n[Timestamp (UTC): {utc_now.strftime('%a %b %d %H:%M:%S %Z %Y')}]' # Formatted time, e.g Mon Mar 25 22:01:53 UTC 2025
         return ret
 
 


### PR DESCRIPTION
Reverts All-Hands-AI/OpenHands#7514 because of this https://github.com/All-Hands-AI/OpenHands/pull/7514#issuecomment-2850423881

We should re-add it when we start the CmdOutputObservation

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:dd88e4e-nikolaik   --name openhands-app-dd88e4e   docker.all-hands.dev/all-hands-ai/openhands:dd88e4e
```