### PR TITLE
[Fix]: Check if existing store is None

### DIFF
--- a/openhands/server/routes/secrets.py
+++ b/openhands/server/routes/secrets.py
@@ -65,7 +65,7 @@ def process_token_validation_result(
 
 async def check_provider_tokens(
     incoming_provider_tokens: POSTProviderModel,
-    existing_provider_tokens: PROVIDER_TOKEN_TYPE) -> str:
+    existing_provider_tokens: PROVIDER_TOKEN_TYPE | None) -> str:
 
     msg = ''
     if incoming_provider_tokens.provider_tokens:
@@ -75,7 +75,7 @@ async def check_provider_tokens(
                 confirmed_token_type = await validate_provider_token(token_value.token, token_value.host) # FE always sends latest host
                 msg = process_token_validation_result(confirmed_token_type, token_type)
 
-            existing_token = existing_provider_tokens.get(token_type, None)
+            existing_token = existing_provider_tokens.get(token_type, None) if existing_provider_tokens else None
             if existing_token and (existing_token.host != token_value.host) and existing_token.token:
                 confirmed_token_type = await validate_provider_token(existing_token.token, token_value.host) # Host has changed, check it against existing token
                 if not confirmed_token_type or confirmed_token_type != token_type:
@@ -88,7 +88,7 @@ async def check_provider_tokens(
 async def store_provider_tokens(
     provider_info: POSTProviderModel,
     secrets_store: SecretsStore = Depends(get_secrets_store),
-    provider_tokens: PROVIDER_TOKEN_TYPE = Depends(get_provider_tokens)
+    provider_tokens: PROVIDER_TOKEN_TYPE | None = Depends(get_provider_tokens)
 ) -> JSONResponse:
 
     provider_err_msg = await check_provider_tokens(provider_info, provider_tokens)


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

- Fixes issue where first time user's cant set their git tokens

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

For users that have never stored provider tokens, they are unable to set their provider tokens. 

This occurs because we have a check in place against their existing tokens. For first time users, the existing tokens object is None and we were checking for this condition before. This PR explicitly checks whether its None before trying to check the token values from the existing tokens object


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7ca694b-nikolaik   --name openhands-app-7ca694b   docker.all-hands.dev/all-hands-ai/openhands:7ca694b
```