### PR TITLE
Add detailed logging to remote runtime resume process

### DIFF
--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -100,7 +100,6 @@ class RemoteRuntime(ActionExecutionClient):
         self.available_hosts: dict[str, int] = {}
 
     def log(self, level: str, message: str, exc_info: bool | None = None) -> None:
-        message = f'[runtime session_id={self.sid} runtime_id={self.runtime_id or "unknown"}] {message}'
         getattr(logger, level)(
             message,
             stacklevel=2,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Improved logging for remote runtime resume operations to help diagnose issues when paused runtimes fail to resume properly.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR adds detailed logging to the remote runtime resume process to help diagnose issues when we fail to call `/resume` on a paused runtime. The changes include:

1. Added info logs to track the code path through `_start_or_attach_to_runtime`
2. Added detailed logging in `_check_existing_runtime` to track runtime status and resume attempts
3. Added comprehensive try/except blocks with logging in `_resume_runtime` to capture any failures during the resume process
4. Added detailed logging in the 503 response handler where we attempt to resume paused runtimes
5. Removed redundant prefix from log messages since this information is already included in the log extras

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:cff7207-nikolaik   --name openhands-app-cff7207   docker.all-hands.dev/all-hands-ai/openhands:cff7207
```