### PR TITLE
Added feature flag for opening vscode in a new tab

### DIFF
--- a/frontend/src/routes/vscode-tab.tsx
+++ b/frontend/src/routes/vscode-tab.tsx
@@ -5,6 +5,7 @@ import { I18nKey } from "#/i18n/declaration";
 import { RootState } from "#/store";
 import { RUNTIME_INACTIVE_STATES } from "#/types/agent-state";
 import { useVSCodeUrl } from "#/hooks/query/use-vscode-url";
+import { VSCODE_IN_NEW_TAB } from "#/utils/feature-flags";
 
 function VSCodeTab() {
   const { t } = useTranslation();
@@ -22,7 +23,9 @@ function VSCodeTab() {
         const currentProtocol = window.location.protocol;
 
         // Check if the iframe URL has a different protocol than the current page
-        setIsCrossProtocol(iframeProtocol !== currentProtocol);
+        setIsCrossProtocol(
+          VSCODE_IN_NEW_TAB() || iframeProtocol !== currentProtocol,
+        );
       } catch (e) {
         // Silently handle URL parsing errors
         setIframeError(t("VSCODE$URL_PARSE_ERROR"));

--- a/frontend/src/utils/feature-flags.ts
+++ b/frontend/src/utils/feature-flags.ts
@@ -14,5 +14,6 @@ export function loadFeatureFlag(
 
 export const BILLING_SETTINGS = () => loadFeatureFlag("BILLING_SETTINGS");
 export const HIDE_LLM_SETTINGS = () => loadFeatureFlag("HIDE_LLM_SETTINGS");
+export const VSCODE_IN_NEW_TAB = () => loadFeatureFlag("VSCODE_IN_NEW_TAB");
 export const ENABLE_TRAJECTORY_REPLAY = () =>
   loadFeatureFlag("TRAJECTORY_REPLAY");


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Adds a feature flag that allows users to control whether VS Code should always open in a new tab rather than within an iframe. This provides a better user experience for users who encounter cross-protocol issues or prefer working with VS Code in a separate browser tab.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

When debugging, the VSCode plugin produces a lot of noise in the network tab, and sometimes a full window is preferable to an iframe.

This PR adds a new feature flag `VSCODE_IN_NEW_TAB` that, when enabled, forces VS Code to always open in a new browser tab instead of trying to embed it in an iframe. The implementation:

1. Adds a new feature flag constant in `feature-flags.ts`
2. Modifies the VS Code tab component to check this flag when determining whether to show the iframe or the "Open in new tab" button
3. When the flag is enabled, the VS Code interface will always show the "Open in new tab" button, regardless of protocol matching

This provides a simple way for users to control their preferred VS Code viewing experience without requiring code changes.

---
**Link of any specific issues this addresses:**

No specific issue linked, but addresses common user requests for better VS Code integration options.

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e04e13f-nikolaik   --name openhands-app-e04e13f   docker.all-hands.dev/all-hands-ai/openhands:e04e13f
```