### PR TITLE
chore - log size of large events

### DIFF
--- a/openhands/events/stream.py
+++ b/openhands/events/stream.py
@@ -190,7 +190,7 @@ class EventStream(EventStore):
             filename = self._get_filename_for_id(event.id, self.user_id)
             if len(event_json) > 1_000_000:  # Roughly 1MB in bytes, ignoring encoding
                 logger.warning(
-                    f'Saving event JSON over 1MB: {len(event_json)} bytes, filename: {filename}',
+                    f'Saving event JSON over 1MB: {len(event_json):,} bytes, filename: {filename}',
                     extra={
                         'user_id': self.user_id,
                         'session_id': self.sid,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

We've had instances of very large (> 10mb) events with browser data which have caused trouble in hosted environments. We're investigating reducing that data, this PR adds a warning log on events over 1mb so we can troubleshoot better in the future.

This example shows the nature of the data:
```
jq ".extras.axtree_object.nodes | length"event.json
102488

 jq ".extras.extra_element_properties | length" event.json
51859
```
---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:cac3be9-nikolaik   --name openhands-app-cac3be9   docker.all-hands.dev/all-hands-ai/openhands:cac3be9
```