### PR TITLE
Save CLI settings directly under ~/.openhands

### DIFF
--- a/openhands/core/config/openhands_config.py
+++ b/openhands/core/config/openhands_config.py
@@ -64,7 +64,7 @@ class OpenHandsConfig(BaseModel):
     extended: ExtendedConfig = Field(default_factory=lambda: ExtendedConfig({}))
     runtime: str = Field(default='docker')
     file_store: str = Field(default='local')
-    file_store_path: str = Field(default='~/.openhands/file_store')
+    file_store_path: str = Field(default='~/.openhands')
     file_store_web_hook_url: str | None = Field(default=None)
     file_store_web_hook_headers: dict | None = Field(default=None)
     save_trajectory_path: str | None = Field(default=None)


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR proposes to adjust the default settings save path, to be directly under `~/.openhands`. It seems quite counterintuitive to be hidden under `file_store/`, even though this is a file store. The user will want the sessions somehow visible too, rather than know that OH has defined them under a file store. Idk, seems reasonable to me?

Cc: @mamoodi 

Note: this won't yet make the web UI settings in the same place, they're in ~/.openhands-state by default. We could address that by migrating them at a later point, and change the _default_ there too.

---
**Link of any specific issues this addresses:**
