### PR TITLE
Fix VSCode workspace dir

### DIFF
--- a/openhands/runtime/plugins/vscode/__init__.py
+++ b/openhands/runtime/plugins/vscode/__init__.py
@@ -104,7 +104,6 @@ class VSCodePlugin(Plugin):
 
         # Create the .vscode directory in the workspace if it doesn't exist
         workspace_dir = Path(os.getenv('WORKSPACE_BASE', '/workspace'))
-        # DO NOT USE /workspace as the base directory!!!
         vscode_dir = workspace_dir / '.vscode'
         vscode_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
The workspace directory is no longer hardcoded to /workspace as this may not be correct in a local runtime!

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
I think we need to have a discussion about deprecating the WORKSPACE_BASE and WORKSPACE_MOUNT_PATH_IN_SANDBOX values in the OpenHandsConfig

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0f98a5b-nikolaik   --name openhands-app-0f98a5b   docker.all-hands.dev/all-hands-ai/openhands:0f98a5b
```