### PR TITLE
Rename Development.md to DEVELOPMENT.md to match the rest of README files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ To understand the codebase, please refer to the README in each module:
 
 ## Setting up Your Development Environment
 
-We have a separate doc [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md) that tells you how to set up a development workflow.
+We have a separate doc [DEVELOPMENT.md](https://github.com/All-Hands-AI/OpenHands/blob/main/DEVELOPMENT.md) that tells you how to set up a development workflow.
 
 ## How Can I Contribute?
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -168,7 +168,7 @@ You do need [Docker](https://docs.docker.com/engine/install/) installed on your 
 Here's a guide to the important documentation files in the repository:
 
 - [/README.md](./README.md): Main project overview, features, and basic setup instructions
-- [/Development.md](./Development.md) (this file): Comprehensive guide for developers working on OpenHands
+- [/DEVELOPMENT.md](./DEVELOPMENT.md) (this file): Comprehensive guide for developers working on OpenHands
 - [/CONTRIBUTING.md](./CONTRIBUTING.md): Guidelines for contributing to the project, including code style and PR process
 - [/docs/DOC_STYLE_GUIDE.md](./docs/DOC_STYLE_GUIDE.md): Standards for writing and maintaining project documentation
 - [/openhands/README.md](./openhands/README.md): Details about the backend Python implementation

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@
   <a href="https://docs.google.com/spreadsheets/d/1wOUdFCMyY6Nt0AIqF705KN4JKOWgeI4wUGUP60krXXs/edit?gid=0#gid=0"><img src="https://img.shields.io/badge/Benchmark%20score-000?logoColor=FFE165&logo=huggingface&style=for-the-badge" alt="Evaluation Benchmark Score"></a>
 
   <!-- Keep these links. Translations will automatically update with the README. -->
-  <a href="https://www.readme-i18n.com/All-Hands-AI/OpenHands?lang=de">Deutsch</a> | 
-  <a href="https://www.readme-i18n.com/All-Hands-AI/OpenHands?lang=es">Español</a> | 
-  <a href="https://www.readme-i18n.com/All-Hands-AI/OpenHands?lang=fr">français</a> | 
-  <a href="https://www.readme-i18n.com/All-Hands-AI/OpenHands?lang=ja">日本語</a> | 
-  <a href="https://www.readme-i18n.com/All-Hands-AI/OpenHands?lang=ko">한국어</a> | 
-  <a href="https://www.readme-i18n.com/All-Hands-AI/OpenHands?lang=pt">Português</a> | 
-  <a href="https://www.readme-i18n.com/All-Hands-AI/OpenHands?lang=ru">Русский</a> | 
+  <a href="https://www.readme-i18n.com/All-Hands-AI/OpenHands?lang=de">Deutsch</a> |
+  <a href="https://www.readme-i18n.com/All-Hands-AI/OpenHands?lang=es">Español</a> |
+  <a href="https://www.readme-i18n.com/All-Hands-AI/OpenHands?lang=fr">français</a> |
+  <a href="https://www.readme-i18n.com/All-Hands-AI/OpenHands?lang=ja">日本語</a> |
+  <a href="https://www.readme-i18n.com/All-Hands-AI/OpenHands?lang=ko">한국어</a> |
+  <a href="https://www.readme-i18n.com/All-Hands-AI/OpenHands?lang=pt">Português</a> |
+  <a href="https://www.readme-i18n.com/All-Hands-AI/OpenHands?lang=ru">Русский</a> |
   <a href="https://www.readme-i18n.com/All-Hands-AI/OpenHands?lang=zh">中文</a>
-  
+
   <hr>
 </div>
 
@@ -98,7 +98,7 @@ or run it on tagged issues with [a github action](https://docs.all-hands.dev/usa
 
 Visit [Running OpenHands](https://docs.all-hands.dev/usage/installation) for more information and setup instructions.
 
-If you want to modify the OpenHands source code, check out [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md).
+If you want to modify the OpenHands source code, check out [DEVELOPMENT.md](https://github.com/All-Hands-AI/OpenHands/blob/main/DDEVELOPMENT.md).
 
 Having issues? The [Troubleshooting Guide](https://docs.all-hands.dev/usage/troubleshooting) can help.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -87,7 +87,7 @@ docker run -it --rm --pull=always \
 
 访问[运行OpenHands](https://docs.all-hands.dev/usage/installation)获取更多信息和设置说明。
 
-如果您想修改OpenHands源代码，请查看[Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md)。
+如果您想修改OpenHands源代码，请查看[DEVELOPMENT.md](https://github.com/All-Hands-AI/OpenHands/blob/main/DEVELOPMENT.md)。
 
 遇到问题？[故障排除指南](https://docs.all-hands.dev/usage/troubleshooting)可以提供帮助。
 

--- a/containers/dev/README.md
+++ b/containers/dev/README.md
@@ -23,7 +23,7 @@ Build and run in Docker ...
 root@93fc0005fcd2:/app#
 ```
 
-You may now proceed with the normal [build and run](../../Development.md) workflow as if you were on the host.
+You may now proceed with the normal [build and run](../../DEVELOPMENT.md) workflow as if you were on the host.
 
 ## Make changes
 

--- a/docs/usage/how-to/custom-sandbox-guide.mdx
+++ b/docs/usage/how-to/custom-sandbox-guide.mdx
@@ -59,7 +59,7 @@ docker run -it --rm --pull=always \
 
 ### Setup
 
-First, ensure you can run OpenHands by following the instructions in [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md).
+First, ensure you can run OpenHands by following the instructions in [DEVELOPMENT.md](https://github.com/All-Hands-AI/OpenHands/blob/main/DEVELOPMENT.md).
 
 ### Specify the Base Sandbox Image
 

--- a/docs/usage/how-to/development-overview.mdx
+++ b/docs/usage/how-to/development-overview.mdx
@@ -9,7 +9,7 @@ description: This guide provides an overview of the key documentation resources 
 - **Main Project Overview** (`/README.md`)
   The primary entry point for understanding OpenHands, including features and basic setup instructions.
 
-- **Development Guide** (`/Development.md`)
+- **Development Guide** (`/DEVELOPMENT.md`)
   Comprehensive guide for developers working on OpenHands, including setup, requirements, and development workflows.
 
 - **Contributing Guidelines** (`/CONTRIBUTING.md`)
@@ -56,7 +56,7 @@ If you're new to developing with OpenHands, we recommend following this sequence
 
 1. Start with the main `README.md` to understand the project's purpose and features
 2. Review the `CONTRIBUTING.md` guidelines if you plan to contribute
-3. Follow the setup instructions in `Development.md`
+3. Follow the setup instructions in `DEVELOPMENT.md`
 4. Dive into specific component documentation based on your area of interest:
    - Frontend developers should focus on `/frontend/README.md`
    - Backend developers should start with `/openhands/README.md`

--- a/docs/usage/how-to/evaluation-harness.mdx
+++ b/docs/usage/how-to/evaluation-harness.mdx
@@ -6,7 +6,7 @@ This guide provides an overview of how to integrate your own evaluation benchmar
 
 ## Setup Environment and LLM Configuration
 
-Please follow instructions [here](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md) to setup your local development environment.
+Please follow instructions [here](https://github.com/All-Hands-AI/OpenHands/blob/main/DEVELOPMENT.md) to setup your local development environment.
 OpenHands in development mode uses `config.toml` to keep track of most configurations.
 
 Here's an example configuration file you can use to define and use multiple LLMs:

--- a/docs/usage/how-to/headless-mode.mdx
+++ b/docs/usage/how-to/headless-mode.mdx
@@ -9,7 +9,7 @@ This is different from [the CLI](./cli-mode), which is interactive, and better f
 ## With Python
 
 To run OpenHands in headless mode with Python:
-1. Ensure you have followed the [Development setup instructions](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md).
+1. Ensure you have followed the [Development setup instructions](https://github.com/All-Hands-AI/OpenHands/blob/main/DEVELOPMENT.md).
 2. Run the following command:
 ```bash
 poetry run python -m openhands.core.main -t "write a bash script that prints hi"

--- a/docs/usage/llms/local-llms.mdx
+++ b/docs/usage/llms/local-llms.mdx
@@ -136,7 +136,7 @@ Run OpenHands using [the official docker run command](../installation#start-the-
 
 #### Using Development Mode
 
-Use the instructions in [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md) to build OpenHands.
+Use the instructions in [DEVELOPMENT.md](https://github.com/All-Hands-AI/OpenHands/blob/main/DEVELOPMENT.md) to build OpenHands.
 Ensure `config.toml` exists by running `make setup-config` which will create one for you. In the `config.toml`, enter the following:
 
 ```

--- a/docs/usage/runtimes/local.mdx
+++ b/docs/usage/runtimes/local.mdx
@@ -12,10 +12,10 @@ files on your machine. Only use this runtime in controlled environments or when 
 
 Before using the Local Runtime, ensure that:
 
-1. You can run OpenHands using the [Development workflow](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md).
+1. You can run OpenHands using the [Development workflow](https://github.com/All-Hands-AI/OpenHands/blob/main/DEVELOPMENT.md).
 2. For Linux and Mac, tmux is available on your system.
 3. For Windows, PowerShell is available on your system.
-    - Only [CLI mode](../how-to/cli-mode) and [headless mode](../how-to/headless-mode) are supported in Windows with Local Runtime. 
+    - Only [CLI mode](../how-to/cli-mode) and [headless mode](../how-to/headless-mode) are supported in Windows with Local Runtime.
 
 ## Configuration
 

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -6,7 +6,7 @@ This folder contains code and resources to run experiments and evaluations.
 
 ### Setup
 
-Before starting evaluation, follow the instructions [here](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md) to setup your local development environment and LLM.
+Before starting evaluation, follow the instructions [here](https://github.com/All-Hands-AI/OpenHands/blob/main/DEVELOPMENT.md) to setup your local development environment and LLM.
 
 Once you are done with setup, you can follow the benchmark-specific instructions in each subdirectory of the [evaluation directory](#supported-benchmarks).
 Generally these will involve running `run_infer.py` to perform inference with the agents.

--- a/evaluation/benchmarks/swe_bench/SWE-Gym.md
+++ b/evaluation/benchmarks/swe_bench/SWE-Gym.md
@@ -35,7 +35,7 @@ The process of running SWE-Gym is very similar to how you'd run SWE-Bench evalua
 
 
 1. First, clone OpenHands repo `git clone https://github.com/All-Hands-AI/OpenHands.git`
-2. Then setup the repo following [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md)
+2. Then setup the repo following [DEVELOPMENT.md](https://github.com/All-Hands-AI/OpenHands/blob/main/DEVELOPMENT.md)
 3. Then you can simply serve your own model as an OpenAI compatible endpoint, put those info in config.toml. You can do this by following instruction [here](../../README.md#setup).
 4. And then simply do the following to sample for 16x parallelism:
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -48,7 +48,7 @@ This will start the application in development mode. Open [http://localhost:3001
 
 **NOTE: The backend is _partially_ mocked using `msw`. Therefore, some features may not work as they would with the actual backend.**
 
-See the [Development.md](../Development.md) for extra tips on how to run in development mode.
+See the [DEVELOPMENT.md](../DEVELOPMENT.md) for extra tips on how to run in development mode.
 
 ### Running the Application with the Actual Backend (Production Mode)
 

--- a/openhands/runtime/impl/local/local_runtime.py
+++ b/openhands/runtime/impl/local/local_runtime.py
@@ -73,7 +73,7 @@ def get_user_info() -> tuple[int, str | None]:
 
 
 def check_dependencies(code_repo_path: str, poetry_venvs_path: str) -> None:
-    ERROR_MESSAGE = 'Please follow the instructions in https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md to install OpenHands.'
+    ERROR_MESSAGE = 'Please follow the instructions in https://github.com/All-Hands-AI/OpenHands/blob/main/DEVELOPMENT.md to install OpenHands.'
     if not os.path.exists(code_repo_path):
         raise ValueError(
             f'Code repo path {code_repo_path} does not exist. ' + ERROR_MESSAGE


### PR DESCRIPTION

Simple typo fix, `Development.md` vs `DEVELOPMENT.md` to match all of the other readme files, or was `Development.md` used on purpose?

cool project so far 🚀

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**
