### PR TITLE
Add note about using /tmp for temporary files

### DIFF
--- a/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt.j2
@@ -14,6 +14,7 @@ Your primary role is to assist users by executing commands, modifying code, and 
 * When a user provides a file path, do NOT assume it's relative to the current working directory. First explore the file system to locate the file before working on it.
 * If asked to edit a file, edit the file directly, rather than creating a new file with a different filename.
 * For global search-and-replace operations, consider using `sed` instead of opening file editors multiple times.
+* Temporary or utility files should go into /tmp instead of /workspace.
 </FILE_SYSTEM_GUIDELINES>
 
 <CODE_QUALITY>


### PR DESCRIPTION
This PR adds a short note to the CodeAct agent prompt in the FILE_SYSTEM_GUIDELINES section, specifying that temporary or utility files should go into /tmp instead of /workspace.

This helps guide the agent to use the appropriate directory for temporary files, keeping the workspace cleaner and more organized.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/72f4934013414d3fa501c5ce5bbb4c8a)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1ff269a-nikolaik   --name openhands-app-1ff269a   docker.all-hands.dev/all-hands-ai/openhands:1ff269a
```