### PR TITLE
Remove Bitbucket login button from SAAS auth modal

### DIFF
--- a/frontend/src/components/features/waitlist/auth-modal.tsx
+++ b/frontend/src/components/features/waitlist/auth-modal.tsx
@@ -7,7 +7,6 @@ import { ModalBody } from "#/components/shared/modals/modal-body";
 import { BrandButton } from "../settings/brand-button";
 import GitHubLogo from "#/assets/branding/github-logo.svg?react";
 import GitLabLogo from "#/assets/branding/gitlab-logo.svg?react";
-import BitbucketLogo from "#/assets/branding/bitbucket-logo.svg?react";
 import { useAuthUrl } from "#/hooks/use-auth-url";
 import { GetConfigResponse } from "#/api/open-hands.types";
 
@@ -24,11 +23,6 @@ export function AuthModal({ githubAuthUrl, appMode }: AuthModalProps) {
     identityProvider: "gitlab",
   });
 
-  const bitbucketAuthUrl = useAuthUrl({
-    appMode: appMode || null,
-    identityProvider: "bitbucket",
-  });
-
   const handleGitHubAuth = () => {
     if (githubAuthUrl) {
       // Always start the OIDC flow, let the backend handle TOS check
@@ -40,13 +34,6 @@ export function AuthModal({ githubAuthUrl, appMode }: AuthModalProps) {
     if (gitlabAuthUrl) {
       // Always start the OIDC flow, let the backend handle TOS check
       window.location.href = gitlabAuthUrl;
-    }
-  };
-
-  const handleBitbucketAuth = () => {
-    if (bitbucketAuthUrl) {
-      // Always start the OIDC flow, let the backend handle TOS check
-      window.location.href = bitbucketAuthUrl;
     }
   };
 
@@ -79,16 +66,6 @@ export function AuthModal({ githubAuthUrl, appMode }: AuthModalProps) {
             startContent={<GitLabLogo width={20} height={20} />}
           >
             {t(I18nKey.GITLAB$CONNECT_TO_GITLAB)}
-          </BrandButton>
-
-          <BrandButton
-            type="button"
-            variant="primary"
-            onClick={handleBitbucketAuth}
-            className="w-full"
-            startContent={<BitbucketLogo width={20} height={20} />}
-          >
-            {t(I18nKey.BITBUCKET$CONNECT_TO_BITBUCKET)}
           </BrandButton>
         </div>
       </ModalBody>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

We're removing the login button for bitbucket from cloud openhands because we'd like to make a release and haven't finished all the requirements for this integration.


---
**Link of any specific issues this addresses:**


@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/13ad092c8b0040bf8d3693505c6f4d9b)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:4c0ff81-nikolaik   --name openhands-app-4c0ff81   docker.all-hands.dev/all-hands-ai/openhands:4c0ff81
```