### PR TITLE
Clarify GitHub integration docs regarding @openhands mentions in pull requests

### DIFF
--- a/openhands/resolver/README.md
+++ b/openhands/resolver/README.md
@@ -55,8 +55,9 @@ Follow these steps to use this workflow in your own repository:
         4. Remove the 'fix-me' label once processed
 
    b. Using `@openhands-agent` mention:
-      - Create a new comment containing `@openhands-agent` in any issue
+      - Create a new comment containing `@openhands-agent` in any issue or pull request
       - The agent will only consider the comment where it's mentioned
+      - **Important**: For pull requests, this functionality only works if the pull request is both *to* and *from* a repository that you have added through the interface
       - The workflow will:
         1. Attempt to resolve the issue based on the specific comment
         2. Create a draft PR if successful, or push a branch if unsuccessful
@@ -162,6 +163,8 @@ python -m openhands.resolver.send_pull_request --issue-number PR_NUMBER --issue-
 ```
 
 This functionality is available both through the GitHub Actions workflow and when running the resolver locally.
+
+**Important Note**: When using the GitHub Actions workflow with `@openhands-agent` mentions in pull requests, this functionality only works if the pull request is both *to* and *from* a repository that you have added through the interface. This is because the agent needs appropriate permissions to access both repositories.
 
 ## Visualizing successful PRs
 


### PR DESCRIPTION
This PR clarifies the GitHub integration documentation to note that writing `@openhands-agent` on a pull request will only work if the pull request is both *to* and *from* a repository that you have added through the interface.

The changes include:
1. Adding a note in the `@openhands-agent` mention section to clarify this limitation
2. Adding a more detailed explanation in the "Responding to PR Comments" section

This addresses the issue where users might be confused when the `@openhands-agent` mention doesn't work on pull requests from forks or external repositories.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/02391367a2db46b7a0e8c86c3f6ab393)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:8a6c6f4-nikolaik   --name openhands-app-8a6c6f4   docker.all-hands.dev/all-hands-ai/openhands:8a6c6f4
```