### PR TITLE
Fix org repo deletion to run in runtime

### DIFF
--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -720,7 +720,8 @@ fi
                 )
 
                 # Clean up the org repo directory
-                shutil.rmtree(org_repo_dir)
+                action = CmdRunAction(f'rm -rf {org_repo_dir}')
+                self.run_action(action)
             else:
                 self.log(
                     'info',


### PR DESCRIPTION
- [x] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fix error in deleting org-level microagents download directory.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Previously, `sh.rmtree` was being run on the host machine to delete the downloaded org microagents when these microagents actually existed in the runtime, resulting in the following error, and the org microagents directory not being properly deleted.

```
^[[92m22:08:41 - openhands:INFO^[[0m: base.py:762 - [runtime 35f83904f9af4cd6a5697cd1006fc474] Successfully cloned org-level microagents from neubig/.openhands
^[[92m22:08:41 - openhands:DEBUG^[[0m: log_streamer.py:46 - [runtime 35f83904f9af4cd6a5697cd1006fc474] [inside container] INFO:     192.168.65.1:22962 - "POST /list_files HTTP/1.1" 200 OK
^[[92m22:08:41 - openhands:ERROR^[[0m: base.py:782 - [runtime 35f83904f9af4cd6a5697cd1006fc474] Error loading org-level microagents: [Errno 2] No such file or directory: '/workspace/org_openhands_neubig'
Traceback (most recent call last):
  File "/Users/gneubig/work/OpenHands/openhands/runtime/base.py", line 774, in get_microagents_from_org_or_user
    shutil.rmtree(org_repo_dir)
  File "/Users/gneubig/miniconda3/lib/python3.12/shutil.py", line 775, in rmtree
    onexc(os.lstat, path, err)
  File "/Users/gneubig/miniconda3/lib/python3.12/shutil.py", line 773, in rmtree
    orig_st = os.lstat(path, dir_fd=dir_fd)
```

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f0f7b49-nikolaik   --name openhands-app-f0f7b49   docker.all-hands.dev/all-hands-ai/openhands:f0f7b49
```