### PR TITLE
Fix feedback endpoint calls in OSS mode

### DIFF
--- a/frontend/__tests__/hooks/query/use-feedback-exists.test.tsx
+++ b/frontend/__tests__/hooks/query/use-feedback-exists.test.tsx
@@ -1,0 +1,140 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import OpenHands from "#/api/open-hands";
+import { useFeedbackExists } from "#/hooks/query/use-feedback-exists";
+
+// Mock the useConfig hook
+vi.mock("#/hooks/query/use-config", () => ({
+  useConfig: vi.fn(),
+}));
+
+// Mock the useConversationId hook
+vi.mock("#/hooks/use-conversation-id", () => ({
+  useConversationId: () => ({ conversationId: "test-conversation-id" }),
+}));
+
+describe("useFeedbackExists", () => {
+  let queryClient: QueryClient;
+  const mockCheckFeedbackExists = vi.spyOn(OpenHands, "checkFeedbackExists");
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    mockCheckFeedbackExists.mockClear();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  it("should not call API when APP_MODE is not saas", async () => {
+    const { useConfig } = await import("#/hooks/query/use-config");
+    vi.mocked(useConfig).mockReturnValue({
+      data: { APP_MODE: "oss" },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useConfig>);
+
+    const { result } = renderHook(() => useFeedbackExists(123), {
+      wrapper,
+    });
+
+    // Wait for any potential async operations
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Verify that the API was not called
+    expect(mockCheckFeedbackExists).not.toHaveBeenCalled();
+
+    // Verify that the query is disabled
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("should call API when APP_MODE is saas", async () => {
+    const { useConfig } = await import("#/hooks/query/use-config");
+    vi.mocked(useConfig).mockReturnValue({
+      data: { APP_MODE: "saas" },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useConfig>);
+
+    mockCheckFeedbackExists.mockResolvedValue({
+      exists: true,
+      rating: 5,
+      reason: "Great job!",
+    });
+
+    const { result } = renderHook(() => useFeedbackExists(123), {
+      wrapper,
+    });
+
+    // Wait for the query to complete
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Verify that the API was called
+    expect(mockCheckFeedbackExists).toHaveBeenCalledWith(
+      "test-conversation-id",
+      123,
+    );
+
+    // Verify that the data is returned
+    expect(result.current.data).toEqual({
+      exists: true,
+      rating: 5,
+      reason: "Great job!",
+    });
+  });
+
+  it("should not call API when eventId is not provided", async () => {
+    const { useConfig } = await import("#/hooks/query/use-config");
+    vi.mocked(useConfig).mockReturnValue({
+      data: { APP_MODE: "saas" },
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useConfig>);
+
+    const { result } = renderHook(() => useFeedbackExists(undefined), {
+      wrapper,
+    });
+
+    // Wait for any potential async operations
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Verify that the API was not called
+    expect(mockCheckFeedbackExists).not.toHaveBeenCalled();
+
+    // Verify that the query is disabled
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("should not call API when config is not loaded yet", async () => {
+    const { useConfig } = await import("#/hooks/query/use-config");
+    vi.mocked(useConfig).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as ReturnType<typeof useConfig>);
+
+    const { result } = renderHook(() => useFeedbackExists(123), {
+      wrapper,
+    });
+
+    // Wait for any potential async operations
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Verify that the API was not called
+    expect(mockCheckFeedbackExists).not.toHaveBeenCalled();
+
+    // Verify that the query is disabled
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/frontend/src/hooks/query/use-feedback-exists.ts
+++ b/frontend/src/hooks/query/use-feedback-exists.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import OpenHands from "#/api/open-hands";
 import { useConversationId } from "#/hooks/use-conversation-id";
+import { useConfig } from "#/hooks/query/use-config";
 
 export interface FeedbackData {
   exists: boolean;
@@ -10,6 +11,7 @@ export interface FeedbackData {
 
 export const useFeedbackExists = (eventId?: number) => {
   const { conversationId } = useConversationId();
+  const { data: config } = useConfig();
 
   return useQuery<FeedbackData>({
     queryKey: ["feedback", "exists", conversationId, eventId],
@@ -17,7 +19,7 @@ export const useFeedbackExists = (eventId?: number) => {
       if (!eventId) return { exists: false };
       return OpenHands.checkFeedbackExists(conversationId, eventId);
     },
-    enabled: !!eventId,
+    enabled: !!eventId && config?.APP_MODE === "saas",
     staleTime: 1000 * 60 * 5, // 5 minutes
     gcTime: 1000 * 60 * 15, // 15 minutes
   });


### PR DESCRIPTION
## Summary

This PR fixes issue #9437 where feedback endpoints were being called even when the frontend is not running in SAAS mode, causing 404 errors in local development.

## Problem

When running OpenHands locally using `make build && make run`, the frontend was making API calls to `/feedback/conversation/{conversationId}/{eventId}` endpoints that don't exist in OSS mode. This was happening because the `useFeedbackExists` hook was being called unconditionally, regardless of the APP_MODE setting.

The error messages were:
```
Error: No route matches URL "/feedback/conversation/21bac69c88dc47aebabdad33c6749519/4"
Error: No route matches URL "/feedback/conversation/21bac69c88dc47aebabdad33c6749519/7"
```

## Solution

- **Modified `useFeedbackExists` hook**: Added a check for `config?.APP_MODE === "saas"` in the `enabled` condition of the useQuery
- **Added comprehensive tests**: Created test cases to verify the hook behaves correctly in different scenarios:
  - Does not call API when APP_MODE is "oss"
  - Calls API when APP_MODE is "saas"
  - Does not call API when eventId is not provided
  - Does not call API when config is not loaded yet

## Technical Details

The fix ensures that the feedback-related API calls only happen when:
1. `eventId` is provided (existing condition)
2. `config?.APP_MODE === "saas"` (new condition)

This follows the same pattern already used in the UI rendering logic where feedback components are only shown in SAAS mode.

## Testing

- ✅ All existing tests pass
- ✅ New tests verify the fix works correctly
- ✅ Linting passes
- ✅ No breaking changes to existing functionality

## Related Issues

Fixes #9437

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/38804ce3f85b4760935cc7d437aae2b6)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:096263d-nikolaik   --name openhands-app-096263d   docker.all-hands.dev/all-hands-ai/openhands:096263d
```