### PR TITLE
fix(frontend): Changing languages on the settings page does not work for some languages.

### DIFF
--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -27,7 +27,7 @@ i18n
   .init({
     fallbackLng: "en",
     debug: import.meta.env.NODE_ENV === "development",
-    load: "languageOnly",
+    load: "currentOnly",
   });
 
 export default i18n;


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

**Description:**  
When changing the language from the **Settings** page (e.g., selecting Chinese), the selected language does not persist across the application. After navigating to a different page (such as **Home**), the UI reverts to the default language.

---

### ✅ Expected Behavior
- The selected language should be applied consistently across all pages.
- The language preference should persist even after navigation or page reloads.

---

### ❌ Current Behavior
- The selected language (e.g., Chinese) is applied only on the **Settings** page.
- After navigating to other pages, the language reverts and the selected language is not maintained.

---

### 🔁 Steps to Reproduce
1. Navigate to the **Settings** page.
2. Change the language to a different option (e.g., **Chinese**).
3. Navigate to another page (e.g., **Home**).
4. Observe that the language reverts to the default and the selection is not retained.

---

### 📹 Additional Context
A video demonstrating the issue can be found here:  

https://github.com/user-attachments/assets/1ea6d0ff-2cc5-4f09-be42-a122db6b0b5e

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR updates the i18next configuration to ensure the correct language variant is loaded and applied across the application.

```js
load: "languageOnly",
```

to 

```js
load: "currentOnly",
```

We can refer to this [documentation link](https://www.i18next.com/overview/configuration-options) for more information.

We can refer to the below video for the output of the PR:

https://github.com/user-attachments/assets/9ad3d814-1fc8-4e2c-8ef8-93772e915c31

---
**Link of any specific issues this addresses:**

Resolves #9514 
