### PR TITLE
fix(frontend): Not able to scroll the chat input after pasting long content or clicking on a suggested action.

### DIFF
--- a/frontend/src/components/features/chat/chat-input.tsx
+++ b/frontend/src/components/features/chat/chat-input.tsx
@@ -29,7 +29,7 @@ export function ChatInput({
   disabled,
   showButton = true,
   value,
-  maxRows = 16,
+  maxRows = 8,
   onSubmit,
   onStop,
   onChange,


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

**Description:**  
Not able to scroll the chat input after pasting long content or clicking on a suggested action.

---

### ✅ Expected Behavior
- The chat input should be scrollable.

---

### ❌ Current Behavior
- Not able to scroll the chat input after pasting long content or clicking on a suggested action.
---

### 🔁 Steps to Reproduce
1. Navigate to the **Conversation** page.
2. Click on a suggested action or paste a long content to the chat input

---

### 📹 Additional Context
A video demonstrating the issue can be found here:  

https://github.com/user-attachments/assets/06f14e92-d90f-4162-a25a-b94a3423e2d4

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR reduces the maximum number of rows in the chat input to address the related display issue.

You can refer to the video below to see the result of this change:

https://github.com/user-attachments/assets/b57c180e-f832-4a95-a6d4-725ab13aec24

---
**Link of any specific issues this addresses:**

Resolves All-Hands-AI/OpenHands-Cloud#74 
