### PR TITLE
docs: improve and reflow CLI mode docs

### DIFF
--- a/docs/usage/how-to/cli-mode.mdx
+++ b/docs/usage/how-to/cli-mode.mdx
@@ -22,15 +22,15 @@ for scripting.
 
 **Note** - OpenHands requires Python version 3.12 or higher (Python 3.14 is not currently supported)
 
-1. Install OpenHands using pip:
+1. Install OpenHands using `pip`:
 ```bash
 pip install openhands-ai
 ```
 
-  Or if you prefer not to manage your own Python environment, you can use `uvx`:
+Or if you prefer not to manage your own Python environment, you can use `pipx`:
 
 ```bash
-uvx --python 3.12 --from openhands-ai openhands
+pipx install openhands-ai
 ```
 
 2. Launch an interactive OpenHands conversation from the command line:
@@ -39,9 +39,7 @@ openhands
 ```
 
 <Note>
-  If you have cloned the repository, you can also run the CLI directly using Poetry:
-
-  poetry run python -m openhands.cli.main
+  For alternative ways to run OpenHands, see <a href="#other-ways-to-run-the-cli">Other Ways to Run the CLI</a> below.
 </Note>
 
 3. Set your model, API key, and other preferences using the UI (or alternatively environment variables, below).
@@ -49,42 +47,6 @@ openhands
 This command opens an interactive prompt where you can type tasks or commands and get responses from OpenHands.
 The first time you run the CLI, it will take you through configuring the required LLM
 settings. These will be saved for future sessions.
-
-The conversation history will be saved in `~/.openhands/sessions`.
-
-### Running with Docker
-
-1. Set the following environment variables in your terminal:
-   - `SANDBOX_VOLUMES` to specify the directory you want OpenHands to access ([See using SANDBOX_VOLUMES for more info](../runtimes/docker#using-sandbox_volumes))
-   - `LLM_MODEL` - the LLM model to use (e.g. `export LLM_MODEL="anthropic/claude-sonnet-4-20250514"`)
-   - `LLM_API_KEY` - your API key (e.g. `export LLM_API_KEY="sk_test_12345"`)
-
-2. Run the following command:
-
-```bash
-docker run -it \
-    --pull=always \
-    -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0.48-nikolaik \
-    -e SANDBOX_USER_ID=$(id -u) \
-    -e SANDBOX_VOLUMES=$SANDBOX_VOLUMES \
-    -e LLM_API_KEY=$LLM_API_KEY \
-    -e LLM_MODEL=$LLM_MODEL \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    -v ~/.openhands:/.openhands \
-    --add-host host.docker.internal:host-gateway \
-    --name openhands-app-$(date +%Y%m%d%H%M%S) \
-    docker.all-hands.dev/all-hands-ai/openhands:0.48 \
-    python -m openhands.cli.main --override-cli-mode true
-```
-
-<Note>
-  If you used OpenHands before version 0.44, you may want to run `mv ~/.openhands-state ~/.openhands` to migrate your
-  conversation history to the new location.
-</Note>
-
-This launches the CLI in Docker, allowing you to interact with OpenHands.
-
-The `-e SANDBOX_USER_ID=$(id -u)` ensures files created by the agent in your workspace have the correct permissions.
 
 The conversation history will be saved in `~/.openhands/sessions`.
 
@@ -141,5 +103,65 @@ type `/resume` at the prompt.
 - For advanced LLM configuration, use the advanced options in `/settings`.
 - When confirmation mode is enabled, the CLI will prompt before sensitive operations. You can type `a` or `always` at the first confirmation prompt to automatically confirm subsequent actions for the current conversation.
 - If you want to start over, use `/new` to begin a fresh conversation without restarting the CLI.
+
+## Other Ways to Run the CLI
+
+You can also run OpenHands without managing a local Python environment, using either uvx, Docker, or Poetry.
+
+### Running with uvx
+
+```bash
+uvx --python 3.12 --from openhands-ai openhands
+```
+
+`uvx` doesn't install a global `openhands` command, so you’ll need to create a wrapper script in `~/.local/bin` to run it like a regular CLI tool.
+
+```bash
+mkdir -p ~/.local/bin && echo -e '#!/bin/bash\nexec uvx --from openhands-ai openhands "$@"' > ~/.local/bin/openhands && chmod +x ~/.local/bin/openhands
+```
+
+### Running with Docker
+
+1. Set the following environment variables in your terminal:
+   - `SANDBOX_VOLUMES` to specify the directory you want OpenHands to access ([See using SANDBOX_VOLUMES for more info](../runtimes/docker#using-sandbox_volumes))
+   - `LLM_MODEL` - the LLM model to use (e.g. `export LLM_MODEL="anthropic/claude-sonnet-4-20250514"`)
+   - `LLM_API_KEY` - your API key (e.g. `export LLM_API_KEY="sk_test_12345"`)
+
+2. Run the following command:
+
+```bash
+docker run -it \
+    --pull=always \
+    -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0.48-nikolaik \
+    -e SANDBOX_USER_ID=$(id -u) \
+    -e SANDBOX_VOLUMES=$SANDBOX_VOLUMES \
+    -e LLM_API_KEY=$LLM_API_KEY \
+    -e LLM_MODEL=$LLM_MODEL \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v ~/.openhands:/.openhands \
+    --add-host host.docker.internal:host-gateway \
+    --name openhands-app-$(date +%Y%m%d%H%M%S) \
+    docker.all-hands.dev/all-hands-ai/openhands:0.48 \
+    python -m openhands.cli.main --override-cli-mode true
+```
+
+<Note>
+  If you used OpenHands before version 0.44, you may want to run `mv ~/.openhands-state ~/.openhands` to migrate your
+  conversation history to the new location.
+</Note>
+
+This launches the CLI in Docker, allowing you to interact with OpenHands.
+
+The `-e SANDBOX_USER_ID=$(id -u)` ensures files created by the agent in your workspace have the correct permissions.
+
+The conversation history will be saved in `~/.openhands/sessions`.
+
+### Running with Poetry
+
+If you have cloned the repository, you can run the CLI directly using Poetry:
+
+```bash
+poetry run python -m openhands.cli.main
+```
 
 ---


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Simplifies CLI install instructions by switching to pipx, groups alternative instructions at the bottom, and adds a .local/bin wrapper example for uvx.

---

**Summarize what the PR does, explaining any non-trivial design decisions.**

1. Replaces uvx with pipx as a recommended install method.
2. Moves alternative install methods (docker, uvx, poetry) to the bottom, to reduce confusion.
3. Clarifies that uvx does not install a global command, and adds a one-liner example to create a ~/.local/bin/openhands wrapper for uvx.

---
**Link of any specific issues this addresses:**
