### PR TITLE
Fix: Previous menu remains open when opening another three-dot menu in the conversation list #9660

### DIFF
--- a/frontend/src/components/features/conversation-panel/conversation-card.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card.tsx
@@ -35,6 +35,8 @@ interface ConversationCardProps {
   conversationStatus?: ConversationStatus;
   variant?: "compact" | "default";
   conversationId?: string; // Optional conversation ID for VS Code URL
+  openContextMenuId: string | null;
+  setOpenContextMenuId: (id: string | null) => void;
 }
 
 const MAX_TIME_BETWEEN_CREATION_AND_UPDATE = 1000 * 60 * 30; // 30 minutes
@@ -55,6 +57,8 @@ export function ConversationCard({
   conversationStatus = "STOPPED",
   variant = "default",
   conversationId,
+  openContextMenuId,
+  setOpenContextMenuId
 }: ConversationCardProps) {
   const { t } = useTranslation();
   const { parsedEvents } = useWsClient();
@@ -175,6 +179,8 @@ export function ConversationCard({
     createdAt &&
     timeBetweenUpdateAndCreation > MAX_TIME_BETWEEN_CREATION_AND_UPDATE;
 
+const isContextMenuVisible = openContextMenuId === conversationId;
+
   return (
     <>
       <div
@@ -224,7 +230,7 @@ export function ConversationCard({
                   onClick={(event) => {
                     event.preventDefault();
                     event.stopPropagation();
-                    setContextMenuVisible((prev) => !prev);
+                    setOpenContextMenuId( isContextMenuVisible ? null : conversationId);
                   }}
                 />
               </div>


### PR DESCRIPTION
Passed these 2 addition props: 

 openContextMenuId: string | null;
  setOpenContextMenuId: (id: string | null) => void;

//used them like this :
  
  const isContextMenuVisible = openContextMenuId === conversationId;

  onClick={(event) => {
                    event.preventDefault();
                    event.stopPropagation();
                    setOpenContextMenuId( isContextMenuVisible ? null : conversationId); // Modified to this
                  }}