### PR TITLE
Fix MCP tool timeout causing agent to stall indefinitely

### DIFF
--- a/openhands/mcp/utils.py
+++ b/openhands/mcp/utils.py
@@ -5,14 +5,14 @@ if TYPE_CHECKING:
     from openhands.controller.agent import Agent
 
 
+from mcp import McpError
+
 from openhands.core.config.mcp_config import (
     MCPConfig,
     MCPSHTTPServerConfig,
     MCPSSEServerConfig,
 )
 from openhands.core.logger import openhands_logger as logger
-from mcp import McpError
-
 from openhands.events.action.mcp import MCPAction
 from openhands.events.observation.mcp import MCPObservation
 from openhands.events.observation.observation import Observation
@@ -192,11 +192,7 @@ async def call_tool_mcp(mcp_clients: list[MCPClient], action: MCPAction) -> Obse
     except McpError as e:
         # Handle MCP errors by returning an error observation instead of raising
         logger.error(f'MCP error when calling tool {action.name}: {e}')
-        error_content = json.dumps({
-            'isError': True,
-            'error': str(e),
-            'content': []
-        })
+        error_content = json.dumps({'isError': True, 'error': str(e), 'content': []})
         return MCPObservation(
             content=error_content,
             name=action.name,

--- a/tests/unit/test_mcp_tool_timeout_stall.py
+++ b/tests/unit/test_mcp_tool_timeout_stall.py
@@ -10,10 +10,10 @@ from mcp import McpError
 from openhands.controller.agent import Agent
 from openhands.controller.agent_controller import AgentController, AgentState
 from openhands.events.action.mcp import MCPAction
-from openhands.events.event import EventSource
-from openhands.events.stream import EventStream
-from openhands.events.observation.mcp import MCPObservation
 from openhands.events.action.message import SystemMessageAction
+from openhands.events.event import EventSource
+from openhands.events.observation.mcp import MCPObservation
+from openhands.events.stream import EventStream
 from openhands.mcp.client import MCPClient
 from openhands.mcp.tool import MCPClientTool
 from openhands.mcp.utils import call_tool_mcp
@@ -21,14 +21,14 @@ from openhands.mcp.utils import call_tool_mcp
 
 class MockConfig:
     """Mock config for testing."""
-    
+
     def __init__(self):
         self.max_message_chars = 10000
 
 
 class MockLLM:
     """Mock LLM for testing."""
-    
+
     def __init__(self):
         self.metrics = None
         self.config = MockConfig()
@@ -49,7 +49,7 @@ class MockAgent(Agent):
 
     def get_system_message(self):
         """Mock get_system_message method."""
-        return SystemMessageAction(content="System message")
+        return SystemMessageAction(content='System message')
 
 
 @pytest.mark.asyncio
@@ -118,26 +118,26 @@ async def test_mcp_tool_timeout_error_handling():
     # Before the fix, this would raise an exception and not return an observation
     # Now with the fix, it should return an error observation
     result = await call_tool_mcp([mock_client], mcp_action)
-    
+
     # Verify that the function returns an error observation
     assert isinstance(result, MCPObservation)
     content = json.loads(result.content)
     assert content['isError'] is True
     assert 'timed out' in content['error'].lower()
-    
+
     # The agent controller would now be able to continue processing
     # because it received an error observation instead of an exception
-    
+
     # Verify that the agent is still in the RUNNING state
     assert controller.get_agent_state() == AgentState.RUNNING
-    
+
     # Verify that the agent can continue processing
     agent.next_action = MCPAction(
         name='another_tool',
         arguments={'param': 'value'},
         thought='Another action after timeout',
     )
-    
+
     # The agent controller would be able to step because it received an observation
     # This demonstrates that the fix is working
 


### PR DESCRIPTION
This PR fixes an issue where MCP tool timeouts cause the agent to stall indefinitely.
The problem occurs when an MCP tool call times out, raising a McpError exception
that is not caught, preventing the agent from continuing its work.

## Problem
When an MCP tool call times out, it raises a McpError exception that is not caught in the call_tool_mcp function. This causes the agent to stall indefinitely because:
1. The exception propagates up and prevents the agent from receiving an observation
2. The agent controller remains in a state where it's waiting for the observation
3. No further processing can occur

## Solution
The fix:
1. Adds try/except block in call_tool_mcp to catch McpError exceptions
2. Returns an error observation instead of propagating the exception
3. This allows the agent to continue processing after a timeout

## Tests
Added tests:
- test_mcp_tool_timeout_error_handling: Verifies that MCP errors are properly handled
- test_mcp_tool_timeout_agent_continuation: Verifies the agent can continue after a timeout

Fixes #9777

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a3d25fcdcbca4e23a4a9f18d934bdd3f)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:220af0f-nikolaik   --name openhands-app-220af0f   docker.all-hands.dev/all-hands-ai/openhands:220af0f
```