### PR TITLE
Fix: Use correct git provider in Push & Create PR button

### DIFF
--- a/frontend/src/components/features/chat/action-suggestions.tsx
+++ b/frontend/src/components/features/chat/action-suggestions.tsx
@@ -19,8 +19,11 @@ export function ActionSuggestions({
   const [hasPullRequest, setHasPullRequest] = React.useState(false);
 
   const providersAreSet = providers.length > 0;
-  const isGitLab = providers.includes("gitlab");
-  const isBitbucket = providers.includes("bitbucket");
+
+  // Use the git_provider from the conversation, not the user's authenticated providers
+  const currentGitProvider = conversation?.git_provider;
+  const isGitLab = currentGitProvider === "gitlab";
+  const isBitbucket = currentGitProvider === "bitbucket";
 
   const pr = isGitLab ? "merge request" : "pull request";
   const prShort = isGitLab ? "MR" : "PR";


### PR DESCRIPTION
## Summary

Fixes #9802

This PR fixes a bug where the "Push and Create PR" button incorrectly displayed "Bitbucket" for GitHub repositories when the user had authenticated with multiple git providers.

## Problem

The issue occurred because the `ActionSuggestions` component was using `useUserProviders()` to determine which provider name to display in the button text. This hook returns all providers that the user has authenticated with, not the provider of the current repository. When a user had tokens for both GitHub and Bitbucket, the component would incorrectly prioritize Bitbucket in the provider name logic.

## Solution

Changed the component to use `conversation.git_provider` from the active conversation data instead of the user's authenticated providers list. This ensures that the button text always reflects the actual git provider of the current repository.

### Changes Made

1. **ActionSuggestions Component**: Modified to use `conversation?.git_provider` instead of checking `providers.includes()` for provider detection
2. **Comprehensive Tests**: Added test cases to verify correct provider detection for:
   - GitHub repositories (should show "GitHub" even when user has Bitbucket tokens)
   - GitLab repositories (should show "GitLab" and use "merge request" terminology)
   - Bitbucket repositories (should show "Bitbucket")

## Testing

- ✅ All existing tests pass
- ✅ New tests verify the fix works correctly
- ✅ Frontend builds successfully
- ✅ Backend pre-commit hooks pass

## Before/After

**Before**: User with both GitHub and Bitbucket tokens working on a GitHub repo would see:
> "Please push the changes to **Bitbucket** and open a pull request..."

**After**: Same user working on a GitHub repo now correctly sees:
> "Please push the changes to **GitHub** and open a pull request..."

The fix ensures that the provider name in the suggestion text always matches the actual repository provider, regardless of what other providers the user has authenticated with.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/787373d6cddf44348533784901c9d8fc)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:2b23e25-nikolaik   --name openhands-app-2b23e25   docker.all-hands.dev/all-hands-ai/openhands:2b23e25
```