### PR TITLE
fix(cli): filter out LiteLLM coroutine not awaited warning at shutdown

### DIFF
--- a/openhands/cli/suppress_warnings.py
+++ b/openhands/cli/suppress_warnings.py
@@ -42,6 +42,13 @@ def suppress_cli_warnings():
         category=UserWarning,
     )
 
+    # Suppress LiteLLM close_litellm_async_clients was never awaited warning
+    warnings.filterwarnings(
+        'ignore',
+        message="coroutine 'close_litellm_async_clients' was never awaited",
+        category=RuntimeWarning,
+    )
+
 
 # Apply warning suppressions when module is imported
 suppress_cli_warnings()


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Hides warning about unawaited close_litellm_async_clients() at CLI shutdown

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Adds filter for ```RuntimeWarning: coroutine 'close_litellm_async_clients' was never awaited
    loop.close()``` to `suppress_warnings.py`

---
**Link of any specific issues this addresses:**
