### PR TITLE
Sort conversations by created_at (newest first)

### DIFF
--- a/openhands/storage/conversation/file_conversation_store.py
+++ b/openhands/storage/conversation/file_conversation_store.py
@@ -114,22 +114,16 @@ class FileConversationStore(ConversationStore):
         return FileConversationStore(file_store)
 
 
-def _sort_key(conversation: ConversationMetadata) -> tuple:
+def _sort_key(conversation: ConversationMetadata) -> str:
     """
-    Sort conversations with the following priority:
-    1. Active conversations first
-    2. Within active and inactive groups, sort by created_at (newest first)
+    Sort conversations by created_at (newest first).
     
-    Returns a tuple of (is_active, created_at) for sorting.
-    - is_active: 1 if conversation has activity, 0 otherwise (for reverse sorting)
-    - created_at: ISO format string for chronological sorting
+    Since we can't reliably determine which conversations are "active" (RUNNING or STARTING)
+    from the metadata alone, we sort by created_at to ensure consistent behavior.
+    
+    Returns the created_at timestamp as an ISO format string for chronological sorting.
     """
-    # Check if conversation is active (has last_updated_at)
-    is_active = 1 if conversation.last_updated_at else 0
-    
-    # Use created_at for secondary sorting
     created_at = conversation.created_at
-    created_at_str = created_at.isoformat() if created_at else ''
-    
-    # Return tuple for sorting (active conversations first, then by created_at)
-    return (is_active, created_at_str)
+    if created_at:
+        return created_at.isoformat()  # YYYY-MM-DDTHH:MM:SS for sorting
+    return ''


### PR DESCRIPTION
This PR reverts the sorting of conversations to use `created_at` instead of `last_updated_at`.

After investigating the code, I found that:
1. The existence of `last_updated_at` is not an indicator of an active conversation
2. The conversation status (RUNNING, STARTING, STOPPED) is not stored in the metadata
3. The UI determines "active" conversations based on whether they're currently selected

Given these constraints, sorting by `created_at` (newest first) is the most reliable approach, as it ensures consistent behavior and matches the original implementation.

This PR replaces PR #9832.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/999dcbb7a9de41bd9a727297ffd22824)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:6e66c35-nikolaik   --name openhands-app-6e66c35   docker.all-hands.dev/all-hands-ai/openhands:6e66c35
```