### PR TITLE
feat: enhance pause button prominence with gray background

### DIFF
--- a/frontend/src/components/features/controls/agent-control-bar.tsx
+++ b/frontend/src/components/features/controls/agent-control-bar.tsx
@@ -39,6 +39,7 @@ export function AgentControlBar() {
             : AgentState.PAUSED
         }
         handleAction={handleAction}
+        variant={curAgentState === AgentState.RUNNING ? "prominent" : "default"}
       >
         {curAgentState === AgentState.PAUSED ? <PlayIcon /> : <PauseIcon />}
       </ActionButton>

--- a/frontend/src/components/shared/buttons/action-button.tsx
+++ b/frontend/src/components/shared/buttons/action-button.tsx
@@ -6,6 +6,7 @@ interface ActionButtonProps {
   content: string;
   action: AgentState;
   handleAction: (action: AgentState) => void;
+  variant?: "default" | "prominent";
 }
 
 export function ActionButton({
@@ -13,14 +14,24 @@ export function ActionButton({
   content,
   action,
   handleAction,
+  variant = "default",
   children,
 }: React.PropsWithChildren<ActionButtonProps>) {
+  const baseClasses =
+    "relative overflow-visible cursor-default hover:cursor-pointer group disabled:cursor-not-allowed transition-colors duration-300 ease-in-out border rounded-full p-1";
+
+  const variantClasses = {
+    default: "border-transparent hover:border-red-400/40",
+    prominent:
+      "border-transparent hover:border-red-400/40 bg-gray-600/50 hover:bg-gray-600/70",
+  };
+
   return (
     <Tooltip content={content} closeDelay={100}>
       <button
         onClick={() => handleAction(action)}
         disabled={isDisabled}
-        className="relative overflow-visible cursor-default hover:cursor-pointer group disabled:cursor-not-allowed transition-colors duration-300 ease-in-out border border-transparent hover:border-red-400/40 rounded-full p-1"
+        className={`${baseClasses} ${variantClasses[variant]}`}
         type="button"
       >
         <span className="relative group-hover:filter group-hover:drop-shadow-[0_0_5px_rgba(255,64,0,0.4)]">


### PR DESCRIPTION
## Summary

This PR enhances the pause button's visual prominence by adding a gray background, making it more noticeable to users when the agent is running.

## Changes Made

- **Added variant prop to ActionButton component**: Introduced `variant` prop with "default" and "prominent" options for flexible styling
- **Implemented gray background styling**: The "prominent" variant adds `bg-gray-600/50` with `hover:bg-gray-600/70` for better visibility
- **Updated AgentControlBar logic**: Now uses the "prominent" variant specifically when the agent is running (displaying the pause button)
- **Maintained existing UX**: All existing hover effects, transitions, and accessibility features are preserved

## Technical Details

### ActionButton Component Changes
- Added optional `variant` prop with type `"default" | "prominent"`
- Implemented variant-specific CSS classes using Tailwind
- Maintained backward compatibility with default variant

### AgentControlBar Component Changes  
- Updated to conditionally apply "prominent" variant when `curAgentState === AgentState.RUNNING`
- This ensures the pause button has a gray background only when it's actually displayed

## Visual Impact

The pause button now has:
- A subtle gray background (`bg-gray-600/50`) when the agent is running
- Enhanced hover state (`hover:bg-gray-600/70`) for better user feedback
- Improved visibility without being overly intrusive
- Consistent styling with the existing design system

## Testing

- ✅ Frontend linting and type checking passed
- ✅ Backend pre-commit hooks passed
- ✅ No breaking changes to existing functionality
- ✅ Maintains accessibility and responsive design

The changes are minimal, focused, and enhance the user experience by making the pause button more prominent when it's most needed.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/41a24b4e062c413eae614ba36aa55e02)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:22b6421-nikolaik   --name openhands-app-22b6421   docker.all-hands.dev/all-hands-ai/openhands:22b6421
```