### PR TITLE
feat: daytona envs for state management

### DIFF
--- a/third_party/runtime/impl/daytona/daytona_runtime.py
+++ b/third_party/runtime/impl/daytona/daytona_runtime.py
@@ -117,12 +117,17 @@ class DaytonaRuntime(ActionExecutionClient):
         return env_vars
 
     def _create_sandbox(self) -> Sandbox:
+        # Check if auto-stop should be disabled - otherwise have it trigger after 60 minutes
+        disable_auto_stop = os.getenv('DAYTONA_DISABLE_AUTO_STOP', 'false').lower() == 'true'
+        auto_stop_interval = 0 if disable_auto_stop else 60
+
         sandbox_params = CreateSandboxFromSnapshotParams(
             language='python',
             snapshot=self.config.sandbox.runtime_container_image,
             public=True,
             env_vars=self._get_creation_env_vars(),
             labels={OPENHANDS_SID_LABEL: self.sid},
+            auto_stop_interval=auto_stop_interval,
         )
         return self.daytona.create(sandbox_params)
 
@@ -245,7 +250,14 @@ class DaytonaRuntime(ActionExecutionClient):
             return
 
         if self.sandbox:
-            self.sandbox.delete()
+            delete_on_close = os.getenv('DAYTONA_DELETE_ON_CLOSE', 'false').lower() == 'true'
+
+            if delete_on_close:
+                self.sandbox.delete()
+            else:
+                # Only stop if sandbox is currently started
+                if self._get_sandbox().state == 'started':
+                    self.sandbox.stop()
 
     @property
     def vscode_url(self) -> str | None:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Small improvements to Sandbox state management:
Adds environment variable `DAYTONA_DISABLE_AUTO_STOP` that makes Sandboxes stay in stated state indefinitely. If not defined, Sandboxes now autostop after 60 instead of 15 minutes. Also adds `DAYTONA_DELETE_ON_CLOSE` which will - if not set, now have the Sandboxes go to a stopped state instead of destroying them.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**
