### PR TITLE
fix(tests): increase hard timeout in test_bash_server to avoid timeout on Windows

### DIFF
--- a/tests/runtime/test_bash.py
+++ b/tests/runtime/test_bash.py
@@ -94,7 +94,7 @@ def test_bash_server(temp_dir, runtime_cls, run_as_openhands):
         # Verify the server is actually stopped by trying to start another one
         # on the same port (regardless of OS)
         action = CmdRunAction(command='ls')
-        action.set_hard_timeout(1)
+        action.set_hard_timeout(3)
         obs = runtime.run_action(action)
         logger.info(obs, extra={'msg_type': 'OBSERVATION'})
         assert isinstance(obs, CmdOutputObservation)


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Increased the hard timeout in test_bash_server from 1s to 3s to avoid timeout error on Windows.

Error message from failed test workflow run:
```
FAILED tests/runtime/test_bash.py::test_bash_server[LocalRuntime-True] - assert -1 == 0
 +  where -1 = CmdOutputObservation(content='', command='ls', observation=<ObservationType.RUN: 'run'>, metadata=CmdOutputMetadata(exit_code=-1, pid=-1, username=None, hostname=None, working_dir='C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pytest-of-runneradmin\\pytest-0\\rt_190331', py_interpreter_path=None, prefix='', suffix="\n[The command timed out after 1.0 seconds. You may wait longer to see additional output by sending empty command '', send other commands to interact with the current process, send keys to interrupt/kill the command, or use the timeout parameter in execute_bash for future commands.]"), hidden=False).exit_code
```

Edit: Here's an [example of a failed run](https://github.com/All-Hands-AI/OpenHands/actions/runs/16547305515/job/46797076534).

---
**Link of any specific issues this addresses:**
