### PR TITLE
Enhance pause button visibility with gray circle background

### DIFF
--- a/frontend/src/assets/pause.tsx
+++ b/frontend/src/assets/pause.tsx
@@ -10,10 +10,16 @@ function PauseIcon() {
       stroke="currentColor"
       className="w-5 h-5"
     >
+      {/* Gray circle background */}
+      <circle cx="12" cy="12" r="10" fill="#4B5563" opacity="0.85" />
+      
+      {/* Pause icon lines */}
       <path
         strokeLinecap="round"
         strokeLinejoin="round"
         d="M15.75 5.25v13.5m-7.5-13.5v13.5"
+        stroke="white"
+        strokeWidth="2"
       />
     </svg>
   );


### PR DESCRIPTION
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This change makes the pause button more prominent and easier to see by adding a gray circle background behind the pause icon. The improved visibility helps users quickly identify and use the pause functionality during agent execution.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR enhances the visibility of the pause button by:
1. Adding a gray circle background (#4B5563) with 85% opacity behind the pause icon
2. Making the pause icon lines white for better contrast against the gray background
3. Increasing the stroke width of the pause lines from 1.5 to 2 for better visibility

These changes make the pause button more noticeable and easier to interact with, improving the overall user experience without changing the button's functionality.

---
**Link of any specific issues this addresses:**

N/A

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0499d3a5cbc94c4c9bf5506fa9dbbeac)

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:fa41b41-nikolaik   --name openhands-app-fa41b41   docker.all-hands.dev/all-hands-ai/openhands:fa41b41
```