### PR TITLE
Fixes for git diff viewer

### DIFF
--- a/openhands/runtime/utils/git_diff.py
+++ b/openhands/runtime/utils/git_diff.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+MAX_FILE_SIZE_FOR_GIT_DIFF = 1024 * 1024  # 1 Mb
+
 
 def get_closest_git_repo(path: Path) -> Path | None:
     while True:
@@ -75,9 +77,11 @@ def get_valid_ref(repo_dir: str) -> str | None:
 
 def get_git_diff(relative_file_path: str) -> dict[str, str]:
     path = Path(os.getcwd(), relative_file_path).resolve()
+    if os.path.getsize(path) > MAX_FILE_SIZE_FOR_GIT_DIFF:
+        raise ValueError('file_to_large')
     closest_git_repo = get_closest_git_repo(path)
     if not closest_git_repo:
-        raise ValueError('no_repo')
+        raise ValueError('no_repository')
     current_rev = get_valid_ref(str(closest_git_repo))
     try:
         original = run(

--- a/openhands/runtime/utils/git_handler.py
+++ b/openhands/runtime/utils/git_handler.py
@@ -115,7 +115,7 @@ class GitHandler:
 
         result = self.execute(self.git_diff_cmd.format(file_path=file_path), self.cwd)
         if result.exit_code == 0:
-            diff = json.loads(result.content)
+            diff = json.loads(result.content, strict=False)
             return diff
 
         if self.git_diff_cmd != GIT_DIFF_CMD:


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
* Max file size is 1Mb (Because telling it to open a 500Mb file could do nasty things to the server.)
* Files can now contain `"` without confusing the json parser

---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**
**Select the OpenHands repository...**
<img width="621" height="473" alt="image" src="https://github.com/user-attachments/assets/a5b34680-c70b-42ef-8e43-a61eb7bef2a2" />

**Edit and Save the DockerRuntime file**
<img width="771" height="569" alt="image" src="https://github.com/user-attachments/assets/776f02d6-a15f-4d0e-bac9-dda8199ad857" />

**Try to Open it in the Changes Panel**
<img width="1402" height="483" alt="image" src="https://github.com/user-attachments/assets/e716791e-1154-4fae-8b6d-85d6b563cfc3" />

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:68eb26c-nikolaik   --name openhands-app-68eb26c   docker.all-hands.dev/all-hands-ai/openhands:68eb26c
```