### PR TITLE
Optimize Docker layer ordering to reduce data transfer on updates

### DIFF
--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -184,7 +184,7 @@ COPY ./code/pyproject.toml ./code/poetry.lock /openhands/code/
 # ================================================================
 # Copy dependency files and install dependencies (changes less frequently than source code)
 # ================================================================
-{% if not build_from_scratch %}
+{% if build_from_versioned %}
 RUN if [ -d /openhands/code ]; then rm -rf /openhands/code; fi && \
     mkdir -p /openhands/code/openhands && \
     touch /openhands/code/openhands/__init__.py
@@ -197,6 +197,15 @@ COPY ./code/pyproject.toml ./code/poetry.lock /openhands/code/
 # ================================================================
 # Copy Project source files (changes most frequently, should be last)
 # ================================================================
+{% if not build_from_scratch and not build_from_versioned %}
+{# This is the LOCK build case - only copy source files, no dependency installation #}
+RUN if [ -d /openhands/code ]; then rm -rf /openhands/code; fi && \
+    mkdir -p /openhands/code/openhands && \
+    touch /openhands/code/openhands/__init__.py
+
+COPY ./code/pyproject.toml ./code/poetry.lock /openhands/code/
+{% endif %}
+
 RUN if [ -d /openhands/code/openhands ]; then rm -rf /openhands/code/openhands; fi
 
 COPY ./code/openhands /openhands/code/openhands


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**
- Move VSCode server setup before source code copy to improve caching
- Separate dependency files copy from source code copy in versioned builds
- Ensure frequently changing layers (source code) come last
- This reduces data transfer when pulling new Docker images during development


---
**Link of any specific issues this addresses:**
Fixes #7664