### PR TITLE
Upgrade fastmcp from 2.5.2 to 2.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ prompt-toolkit = "^3.0.50"
 poetry = "^2.1.2"
 anyio = "4.9.0"
 pythonnet = "*"
-fastmcp = "^2.5.2"
+fastmcp = "^2.11.0"
 python-frontmatter = "^1.1.0"
 shellingham = "^1.5.4"
 # TODO: Should these go into the runtime group?


### PR DESCRIPTION
This PR upgrades the fastmcp dependency from version 2.5.2 to the latest version 2.11.0.

## Changes
- Updated fastmcp version in pyproject.toml from ^2.5.2 to ^2.11.0

## Testing
- Pre-commit hooks have passed successfully
- CI tests will verify compatibility with the new version