### PR TITLE
chore(logging): Reduce microagents directory logging noise from WARNING to DEBUG

### DIFF
--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -580,7 +580,7 @@ fi
 
         if not files:
             self.log(
-                'warning',
+                'debug',
                 f'No files found in {source_description} microagents directory: {microagents_dir}',
             )
             return loaded_microagents


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Reduces unnecessary warning messages in logs when repository microagents directories don't exist. This is a common and expected scenario that was previously generating warning-level log noise. The information is still logged at DEBUG level for troubleshooting purposes.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR changes the logging level for the "No files found in repository microagents directory" message from WARNING to DEBUG in `openhands/runtime/base.py`. 

**Rationale:**
- Many repositories don't have a `.openhands/microagents/` directory, which is perfectly normal
- This was generating WARNING-level log messages that added noise without providing actionable information
- The message is still logged at DEBUG level for developers who need to troubleshoot microagent loading issues

**Technical details:**
- Modified `_load_microagents_from_directory()` method in `openhands/runtime/base.py`
- Changed logging level from `'warning'` to `'debug'` on line 583
- All existing tests continue to pass
- No functional behavior changes, only logging level adjustment

---
**Link of any specific issues this addresses:**

This addresses the logging noise mentioned in the setup output where users see:
```
WARNING - No files found in repository microagents directory: /workspace/.openhands/microagents
We should drop this logging to "DEBUG" in openhands repo
```

---

To run this PR locally, use the following command:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d7f65ea-nikolaik   --name openhands-app-d7f65ea   docker.all-hands.dev/all-hands-ai/openhands:d7f65ea
```