### PR TITLE
fix(frontend): fetch full conversation data for WebSocket connection

### DIFF
--- a/frontend/src/hooks/use-create-conversation-and-subscribe-multiple.ts
+++ b/frontend/src/hooks/use-create-conversation-and-subscribe-multiple.ts
@@ -4,6 +4,7 @@ import { useUserProviders } from "./use-user-providers";
 import { useConversationSubscriptions } from "#/context/conversation-subscriptions-provider";
 import { Provider } from "#/types/settings";
 import { CreateMicroagent } from "#/api/open-hands.types";
+import OpenHands from "#/api/open-hands";
 
 /**
  * Custom hook to create a conversation and subscribe to it, supporting multiple subscriptions.
@@ -48,28 +49,71 @@ export const useCreateConversationAndSubscribeMultiple = () => {
           createMicroagent,
         },
         {
-          onSuccess: (data) => {
-            let baseUrl = "";
-            if (data?.url && !data.url.startsWith("/")) {
-              baseUrl = new URL(data.url).host;
-            } else {
-              baseUrl =
-                (import.meta.env.VITE_BACKEND_BASE_URL as string | undefined) ||
-                window?.location.host;
-            }
+          onSuccess: async (data) => {
+            try {
+              // NOTE: createConversation returns ConversationResponse (no url/session_api_key)
+              // but we need the full Conversation object for WebSocket connection.
+              // Wait for conversation to be fully loaded to get proper url and session_api_key
+              const conversation = await OpenHands.getConversation(
+                data.conversation_id,
+              );
+              if (!conversation) {
+                // eslint-disable-next-line no-console
+                console.error("Failed to load conversation after creation");
+                return;
+              }
 
-            // Subscribe to the conversation
-            subscribeToConversation({
-              conversationId: data.conversation_id,
-              sessionApiKey: data.session_api_key,
-              providersSet: providers,
-              baseUrl,
-              onEvent: onEventCallback,
-            });
+              let baseUrl = "";
+              if (conversation.url && !conversation.url.startsWith("/")) {
+                baseUrl = new URL(conversation.url).host;
+              } else {
+                baseUrl =
+                  (import.meta.env.VITE_BACKEND_BASE_URL as
+                    | string
+                    | undefined) || window?.location.host;
+              }
 
-            // Call the success callback if provided
-            if (onSuccessCallback) {
-              onSuccessCallback(data.conversation_id);
+              // Subscribe to the conversation using the loaded conversation data
+              subscribeToConversation({
+                conversationId: conversation.conversation_id,
+                sessionApiKey: conversation.session_api_key,
+                providersSet: providers,
+                baseUrl,
+                onEvent: onEventCallback,
+              });
+
+              // Call the success callback if provided
+              if (onSuccessCallback) {
+                onSuccessCallback(data.conversation_id);
+              }
+            } catch (error) {
+              // eslint-disable-next-line no-console
+              console.error(
+                "Error loading conversation for WebSocket connection:",
+                error,
+              );
+              // Fallback to original behavior if fetching conversation fails
+              let baseUrl = "";
+              if (data?.url && !data.url.startsWith("/")) {
+                baseUrl = new URL(data.url).host;
+              } else {
+                baseUrl =
+                  (import.meta.env.VITE_BACKEND_BASE_URL as
+                    | string
+                    | undefined) || window?.location.host;
+              }
+
+              subscribeToConversation({
+                conversationId: data.conversation_id,
+                sessionApiKey: data.session_api_key,
+                providersSet: providers,
+                baseUrl,
+                onEvent: onEventCallback,
+              });
+
+              if (onSuccessCallback) {
+                onSuccessCallback(data.conversation_id);
+              }
             }
           },
         },


### PR DESCRIPTION
The createConversation API returns ConversationResponse which lacks the url and session_api_key fields needed for WebSocket connection. This causes WebSocket connections to fail in SaaS environments where runtime pods have specific URLs like https://runtime-123.prod-runtime.all-hands.dev.

This fix:
- Fetches the full Conversation object after creation using getConversation()
- Uses the proper url and session_api_key from the loaded conversation
- Includes fallback to original behavior if fetching fails
- Resolves missing toast notifications due to failed WebSocket connections

Root cause: Backend POST /api/conversations returns ConversationResponse (no url/session_api_key) but WebSocket connection requires these fields from the full Conversation object.

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:3b88fd0-nikolaik   --name openhands-app-3b88fd0   docker.all-hands.dev/all-hands-ai/openhands:3b88fd0
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@fix/websocket-connection-missing-url-session-key openhands
```