### PR TITLE
fix: Raise error for directory paths in file handling

### DIFF
--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -489,6 +489,10 @@ class ActionExecutor:
         working_dir = self.bash_session.cwd
         filepath = self._resolve_path(action.path, working_dir)
         try:
+            if os.path.isdir(filepath):
+                # for windows, we need to raise an error
+                raise IsADirectoryError(f"'{filepath}' is a directory, not a file.")
+
             if filepath.lower().endswith(('.png', '.jpg', '.jpeg', '.bmp', '.gif')):
                 with open(filepath, 'rb') as file:
                     image_data = file.read()


### PR DESCRIPTION
Fixes:

```shell
  File "C:\Users\smart\Desktop\GD\Kevin\openhands\runtime\action_execution_server.py", line 526, in read
    with open(filepath, 'r', encoding='utf-8') as file:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: 'C:\\Users\\smart\\Desktop\\GD\\Kevin\\workspace'
```