### PR TITLE
Workaround: Add image content as user message after tool message

### DIFF
--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -654,11 +654,17 @@ class ConversationMemory:
             # add Image Content as user message after the tool message
             # https://community.openai.com/t/allowing-images-in-non-user-messages/804176/13
             if message.contains_image:
-                return [Message(
-                    role='user',
-                    content=[content for content in message.content if isinstance(content, ImageContent)],
-                    vision_enabled=vision_is_active,
-                )]
+                return [
+                    Message(
+                        role='user',
+                        content=[
+                            content
+                            for content in message.content
+                            if isinstance(content, ImageContent)
+                        ],
+                        vision_enabled=vision_is_active,
+                    )
+                ]
 
             # No need to return the observation message
             # because it will be added by get_action_message when all the corresponding


### PR DESCRIPTION
Currently images are not allowed in tool Messages

Workaround: 
https://community.openai.com/t/allowing-images-in-non-user-messages/804176/13

<img width="2543" height="1318" alt="image" src="https://github.com/user-attachments/assets/f3020586-9a56-4f2f-afc6-e5ae0c5058da" />
