### PR TITLE
Enhance pause/play button visibility with gray circle background

### DIFF
--- a/frontend/src/assets/pause.tsx
+++ b/frontend/src/assets/pause.tsx
@@ -2,20 +2,24 @@ import React from "react";
 
 function PauseIcon() {
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-      className="w-5 h-5"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M15.75 5.25v13.5m-7.5-13.5v13.5"
-      />
-    </svg>
+    <div className="relative flex items-center justify-center w-6 h-6">
+      {/* Gray circle background */}
+      <div className="absolute w-6 h-6 bg-gray-200 rounded-full" />
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className="w-5 h-5 relative z-10"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M15.75 5.25v13.5m-7.5-13.5v13.5"
+        />
+      </svg>
+    </div>
   );
 }
 

--- a/frontend/src/assets/play.tsx
+++ b/frontend/src/assets/play.tsx
@@ -2,20 +2,24 @@ import React from "react";
 
 function PlayIcon() {
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-      className="w-5 h-5"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 0 1 0 1.972l-11.54 6.347a1.125 1.125 0 0 1-1.667-.986V5.653Z"
-      />
-    </svg>
+    <div className="relative flex items-center justify-center w-6 h-6">
+      {/* Gray circle background */}
+      <div className="absolute w-6 h-6 bg-gray-200 rounded-full" />
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className="w-5 h-5 relative z-10"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 0 1 0 1.972l-11.54 6.347a1.125 1.125 0 0 1-1.667-.986V5.653Z"
+        />
+      </svg>
+    </div>
   );
 }
 


### PR DESCRIPTION
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This PR enhances the visibility of the pause and play buttons in the agent control bar by adding a gray circle background. The improved visual prominence makes it easier for users to locate and interact with these important controls during agent operation.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR adds a gray circle background to both the pause and play buttons in the agent control interface to make them more visually prominent. The implementation:

1. Wraps both the pause and play SVG icons in a container div with relative positioning
2. Adds a gray circle background using an absolute-positioned div with rounded corners
3. Ensures proper sizing and centering of both the background and the icon
4. Maintains the existing hover effects and interactive behavior

The gray background color (#E5E7EB) was chosen to provide sufficient contrast without being too visually distracting.

---
**Link of any specific issues this addresses:**

N/A

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1802eb6-nikolaik   --name openhands-app-1802eb6   docker.all-hands.dev/all-hands-ai/openhands:1802eb6
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@enhance/pause-button-visibility openhands
```