### PR TITLE
fix(frontend): UI does not display triggered microagent knowledge well.

### DIFF
--- a/frontend/src/components/features/chat/event-content-helpers/get-observation-content.ts
+++ b/frontend/src/components/features/chat/event-content-helpers/get-observation-content.ts
@@ -83,7 +83,7 @@ const getRecallObservationContent = (event: RecallObservation): string => {
   ) {
     content += `\n\n**Triggered Microagent Knowledge:**`;
     for (const knowledge of event.extras.microagent_knowledge) {
-      content += `\n\n- **${knowledge.name}** (triggered by keyword: ${knowledge.trigger})\n\n\`\`\`\n${knowledge.content}\n\`\`\``;
+      content += `\n\n- **${knowledge.name}** (triggered by keyword: ${knowledge.trigger})\n\n${knowledge.content}`;
     }
   }
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

In "Microagent ready" action at the beginning of each conversation, we visualize the microagent knowledge by showing it as a code block. However, the content of a microagent could also contain its OWN code block, causing the visualization to break.

<img width="1280" height="2142" alt="issue" src="https://github.com/user-attachments/assets/773b87e8-08c7-4236-8578-2dea8120a6f2" />

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR removes the backticks to ensure the markdown content renders correctly.

Refer to the video below for a demonstration of the PR’s output.

https://github.com/user-attachments/assets/8a0d568b-d589-49d9-a80a-90dfbbab99ff

---
**Link of any specific issues this addresses:**

Resolves #10271 