### PR TITLE
feat: add prominent circle around pause button

### DIFF
--- a/frontend/src/components/shared/buttons/action-button.tsx
+++ b/frontend/src/components/shared/buttons/action-button.tsx
@@ -20,10 +20,10 @@ export function ActionButton({
       <button
         onClick={() => handleAction(action)}
         disabled={isDisabled}
-        className="relative overflow-visible cursor-default hover:cursor-pointer group disabled:cursor-not-allowed transition-colors duration-300 ease-in-out border border-transparent hover:border-red-400/40 rounded-full p-1"
+        className="relative overflow-visible cursor-default hover:cursor-pointer group disabled:cursor-not-allowed transition-all duration-300 ease-in-out border-2 border-gray-300/50 hover:border-red-400/60 rounded-full p-3 bg-white/5 hover:bg-red-400/10 shadow-lg hover:shadow-xl"
         type="button"
       >
-        <span className="relative group-hover:filter group-hover:drop-shadow-[0_0_5px_rgba(255,64,0,0.4)]">
+        <span className="relative group-hover:filter group-hover:drop-shadow-[0_0_8px_rgba(255,64,0,0.6)] transition-all duration-300">
           {children}
         </span>
       </button>


### PR DESCRIPTION
## Summary

This PR enhances the visual prominence of the pause button by adding a more visible circular border and improved styling to make it stand out better in the UI.

## Changes Made

- **Enhanced ActionButton component styling**:
  - Added visible border (`border-2 border-gray-300/50`) that becomes more prominent on hover (`hover:border-red-400/60`)
  - Added subtle background color (`bg-white/5`) with hover effect (`hover:bg-red-400/10`)
  - Increased padding from `p-1` to `p-3` for better visual presence
  - Added shadow effects (`shadow-lg hover:shadow-xl`) for depth
  - Enhanced drop-shadow effect on hover for better visual feedback
  - Improved transition animations for smoother interactions

## Visual Impact

The pause button now has:
- A clearly visible circular border that makes it more prominent
- Better hover states with color transitions
- Enhanced shadow effects for depth perception
- Larger clickable area due to increased padding
- Smoother animations for better user experience

## Testing

The changes affect the `ActionButton` component which is used by the pause/resume button in the agent control bar. The styling changes are purely visual and don't affect functionality.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] UI/UX improvement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Screenshots

The pause button now appears with a prominent circular border and enhanced visual effects, making it more noticeable and easier to interact with.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/63ae2bc51e1e41758dc5540fd67b0005)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:03c5be7-nikolaik   --name openhands-app-03c5be7   docker.all-hands.dev/all-hands-ai/openhands:03c5be7
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@enhance-pause-button-circle-v2 openhands
```