### PR TITLE
Add --vi-mode CLI argument to enable existing vi_mode functionality

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -354,6 +354,14 @@ classpath = "my_package.my_module.MyCustomAgent"
 # [sandbox]
 # volumes = "/my/host/dir:/workspace:rw,/path2:/workspace/path2:ro"
 
+#################################### CLI ########################################
+# Configuration for CLI mode
+##############################################################################
+[cli]
+
+# Enable vi-style key bindings in CLI mode (default: false, uses emacs-style)
+#vi_mode = false
+
 #################################### Security ###################################
 # Configuration for security features
 ##############################################################################

--- a/docs/CLI_EDITOR_MODES.md
+++ b/docs/CLI_EDITOR_MODES.md
@@ -1,0 +1,63 @@
+# CLI Editor Modes
+
+OpenHands CLI supports two editor modes for command-line input:
+
+## Editor Modes
+
+### Emacs Mode (Default)
+By default, OpenHands CLI uses **emacs-style key bindings** for command input. This provides familiar shortcuts for users accustomed to emacs or bash default behavior.
+
+### Vi Mode
+OpenHands also supports **vi-style key bindings** for users who prefer vim-like navigation and editing.
+
+## Activation
+
+### Command Line
+To enable vi mode, use the `--vi-mode` flag:
+
+```bash
+# Enable vi-style key bindings
+poetry run openhands cli --vi-mode
+
+# Or with a task
+poetry run openhands cli --vi-mode --task "Create a Python script"
+```
+
+### Configuration File
+You can also enable vi mode in your `config.toml` file:
+
+```toml
+[cli]
+vi_mode = true
+```
+
+## Key Bindings
+
+### Emacs Mode (Default)
+- Standard bash/emacs key bindings
+- `Ctrl+A` - Beginning of line
+- `Ctrl+E` - End of line
+- `Ctrl+K` - Kill to end of line
+- And other standard emacs shortcuts
+
+### Vi Mode
+- Vi-style navigation and editing
+- `Esc` - Enter command mode
+- `i` - Enter insert mode
+- `h/j/k/l` - Navigation in command mode
+- And other standard vi shortcuts
+
+## Examples
+
+```bash
+# Use default emacs mode
+poetry run openhands cli
+
+# Use vi mode
+poetry run openhands cli --vi-mode
+
+# Use vi mode with specific task
+poetry run openhands cli --vi-mode --task "Debug this Python code"
+```
+
+The editor mode only affects the command-line input interface and does not change OpenHands' core functionality.

--- a/openhands/core/config/arg_utils.py
+++ b/openhands/core/config/arg_utils.py
@@ -62,6 +62,12 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         '-v', '--version', action='store_true', help='Show version information'
     )
+    parser.add_argument(
+        '--vi-mode',
+        action='store_true',
+        default=False,
+        help='Enable vi-style key bindings in CLI mode (default: emacs-style)'
+    )
 
 
 def add_evaluation_arguments(parser: argparse.ArgumentParser) -> None:

--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -316,6 +316,12 @@ def load_from_toml(cfg: OpenHandsConfig, toml_file: str = 'config.toml') -> None
                 f'Cannot parse [extended] config from toml, values have not been applied.\nError: {e}'
             )
 
+    # Process CLI section if present
+    if 'cli' in toml_config:
+        cli_config = toml_config['cli']
+        if 'vi_mode' in cli_config:
+            cfg.cli.vi_mode = cli_config['vi_mode']
+
     # Check for unknown sections
     known_sections = {
         'core',
@@ -327,6 +333,7 @@ def load_from_toml(cfg: OpenHandsConfig, toml_file: str = 'config.toml') -> None
         'condenser',
         'mcp',
         'kubernetes',
+        'cli',
     }
     for key in toml_config:
         if key.lower() not in known_sections:
@@ -790,5 +797,9 @@ def setup_config_from_args(args: argparse.Namespace) -> OpenHandsConfig:
     # Read selected repository in config for use by CLI and main.py
     if hasattr(args, 'selected_repo') and args.selected_repo is not None:
         config.sandbox.selected_repo = args.selected_repo
+
+    # Set vi_mode if provided
+    if hasattr(args, 'vi_mode') and args.vi_mode:
+        config.cli.vi_mode = True
 
     return config

--- a/tests/unit/test_vi_mode_cli.py
+++ b/tests/unit/test_vi_mode_cli.py
@@ -1,0 +1,72 @@
+"""Test vi_mode CLI argument functionality."""
+
+import argparse
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from openhands.core.config.arg_utils import get_cli_parser
+from openhands.core.config.utils import setup_config_from_args
+
+
+def test_vi_mode_cli_argument():
+    """Test that --vi-mode CLI argument sets vi_mode to True."""
+    parser = get_cli_parser()
+    args = parser.parse_args(['cli', '--vi-mode'])
+    
+    assert args.vi_mode is True
+    
+    config = setup_config_from_args(args)
+    assert config.cli.vi_mode is True
+
+
+def test_vi_mode_default():
+    """Test that vi_mode defaults to False."""
+    parser = get_cli_parser()
+    args = parser.parse_args(['cli'])
+    
+    assert args.vi_mode is False
+    
+    config = setup_config_from_args(args)
+    assert config.cli.vi_mode is False
+
+
+def test_vi_mode_config_file():
+    """Test that vi_mode can be set via config file."""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.toml', delete=False) as f:
+        f.write('[cli]\nvi_mode = true\n')
+        config_file = f.name
+    
+    try:
+        parser = get_cli_parser()
+        args = parser.parse_args(['cli', '--config-file', config_file])
+        
+        # CLI arg should be False (not set)
+        assert args.vi_mode is False
+        
+        # But config should load vi_mode from file
+        config = setup_config_from_args(args)
+        assert config.cli.vi_mode is True
+    finally:
+        Path(config_file).unlink()
+
+
+def test_vi_mode_cli_overrides_config():
+    """Test that CLI argument overrides config file setting."""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.toml', delete=False) as f:
+        f.write('[cli]\nvi_mode = false\n')
+        config_file = f.name
+    
+    try:
+        parser = get_cli_parser()
+        args = parser.parse_args(['cli', '--config-file', config_file, '--vi-mode'])
+        
+        # CLI arg should be True
+        assert args.vi_mode is True
+        
+        # Config should use CLI override
+        config = setup_config_from_args(args)
+        assert config.cli.vi_mode is True
+    finally:
+        Path(config_file).unlink()


### PR DESCRIPTION
## Summary

This PR adds a simple  CLI argument to enable the existing but dormant vi_mode functionality in OpenHands CLI.

## Background

The OpenHands CLI already had a  field in  and the TUI code already supported vi-style key bindings when enabled, but there was no way to activate this feature. This PR provides the missing activation mechanism.

## Changes

- **Add  CLI argument** in  with help text explaining the feature
- **Add CLI argument processing** in  to set  when the flag is used
- **Add config file support** for the  section with  option
- **Add comprehensive documentation** in  explaining both vi and emacs modes
- **Update config template** with  section example
- **Add full test coverage** for CLI argument and config file functionality

## Testing

- ✅ CLI argument  correctly sets 
- ✅ Config file  section with  works correctly  
- ✅ CLI argument overrides config file setting
- ✅ Default behavior remains emacs mode ()
- ✅ Integration with existing TUI code verified
- ✅ All unit tests pass

## Usage

### CLI Argument
```bash
openhands cli --vi-mode
```

### Config File
```toml
[cli]
vi_mode = true
```

## Documentation

The PR includes comprehensive documentation in  explaining:
- How to enable vi mode via CLI argument or config file
- Key differences between vi and emacs modes
- Default behavior (emacs mode)

This is a minimal, focused solution that enables existing functionality without adding complexity.