### PR TITLE
fix(openrouter): Force string serialization for openrouter/anthropic/claude-sonnet-4 model

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -850,6 +850,8 @@ class LLM(RetryMixin, DebugMixin):
                 message.force_string_serializer = True
             if 'kimi-k2-instruct' in self.config.model and 'groq' in self.config.model:
                 message.force_string_serializer = True
+            if 'openrouter/anthropic/claude-sonnet-4' in self.config.model:
+                message.force_string_serializer = True
 
         # let pydantic handle the serialization
         return [message.model_dump() for message in messages]


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

---

- **The Issue**:
  API requests were failing with the validation error: `messages.1.content.0.text.text: Input should be a valid string`.

