### PR TITLE
refactor(frontend): top canvas icons missing when drawer is closed (conversation ux improvements)

### DIFF
--- a/frontend/src/components/features/conversation/conversation-tabs/use-conversation-tabs.tsx
+++ b/frontend/src/components/features/conversation/conversation-tabs/use-conversation-tabs.tsx
@@ -19,11 +19,11 @@ export type TerminalTab = "terminal";
 
 type ConversationTabsContext = [
   {
-    selectedTab: ConversationTab;
+    selectedTab: ConversationTab | null;
     terminalOpen: boolean;
   },
   {
-    onTabChange(value: ConversationTab): void;
+    onTabChange(value: ConversationTab | null): void;
     onTerminalChange: Dispatch<SetStateAction<boolean>>;
   },
 ];
@@ -32,7 +32,7 @@ export const ConversationTabContext = createContext<
 >(undefined);
 
 export function ConversationTabProvider({ children }: PropsWithChildren) {
-  const [selectedTab, onTabChange] = useState<ConversationTab>("editor");
+  const [selectedTab, onTabChange] = useState<ConversationTab | null>("editor");
   const [terminalOpen, onTerminalChange] = useState<boolean>(false);
 
   const state = useMemo<ConversationTabsContext>(

--- a/frontend/src/routes/conversation.tsx
+++ b/frontend/src/routes/conversation.tsx
@@ -1,13 +1,12 @@
 import { useDisclosure } from "@heroui/react";
 import React from "react";
 import { useNavigate } from "react-router";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 
 import { useConversationId } from "#/hooks/use-conversation-id";
 import { clearTerminal } from "#/state/command-slice";
 import { useEffectOnce } from "#/hooks/use-effect-once";
 import { clearJupyter } from "#/state/jupyter-slice";
-import { RootState } from "#/store";
 
 import { useBatchFeedback } from "#/hooks/query/use-batch-feedback";
 import { WsClientProvider } from "#/context/ws-client-provider";
@@ -39,10 +38,6 @@ function AppContent() {
   const { providers } = useUserProviders();
   const dispatch = useDispatch();
   const navigate = useNavigate();
-
-  const isRightPanelShown = useSelector(
-    (state: RootState) => state.conversation.isRightPanelShown,
-  );
 
   // Fetch batch feedback data when conversation is loaded
   useBatchFeedback();
@@ -88,12 +83,8 @@ function AppContent() {
             <div data-testid="app-route" className="flex flex-col h-full gap-3">
               <div className="flex items-center justify-between gap-4.5">
                 <ConversationName />
-                {isRightPanelShown && (
-                  <>
-                    <ConversationTabs />
-                    <div className="h-full w-0.25 bg-[#525252]" />
-                  </>
-                )}
+                <ConversationTabs />
+                <div className="h-full w-0.25 bg-[#525252]" />
                 <ChatActions />
               </div>
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

<img width="1600" height="935" alt="3170-issue" src="https://github.com/user-attachments/assets/8a93f138-cc72-49bc-ba06-4e6bb8406a80" />

According to the image above, the top canvas icons missing when the drawer is closed

**Acceptance Criteria:**
- The top canvas icons should be visible even when the drawer is closed.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR shows the top canvas icons should be visible even when the drawer is closed.

> VSCode is flashing when closing and drawing the drawer, we will address that issue in another ticket.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/f109a099-7800-452b-8553-e3a09318b6ce

---
**Link of any specific issues this addresses:**
