### PR TITLE
refactor(frontend): remove background of scrollbar in dropdown

### DIFF
--- a/frontend/src/components/common/react-select-styles.ts
+++ b/frontend/src/components/common/react-select-styles.ts
@@ -269,6 +269,7 @@ export const repoBranchDropdownStyles: StylesConfig<SelectOption, false> = {
       padding: "0.5rem",
       display: "flex",
       alignItems: "center",
+      overflowWrap: "anywhere",
       "&:hover": {
         cursor: "pointer",
         backgroundColor: "#5C5D62",


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

<img width="343" height="384" alt="all-3169-issue" src="https://github.com/user-attachments/assets/11e1c285-199a-4257-a620-2f38bb31429d" />

According to the image above, we need to remove the scrollbar background in the dropdown.

**Acceptance Criteria:**
- The background of the scrollbar in this dropdown should be removed.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR removes background of scrollbar in dropdown

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/45479a7d-698e-45bb-87c6-b139f7e68343

---
**Link of any specific issues this addresses:**
