### PR TITLE
Ensure .bashrc exists

### DIFF
--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -280,7 +280,7 @@ class Runtime(FileEditRuntimeMixin):
                 # Note: json.dumps gives us nice escaping for free
                 cmd += f'export {key}={json.dumps(value)}; '
                 # Add to .bashrc if not already present
-                bashrc_cmd += f'grep -q "^export {key}=" ~/.bashrc || echo "export {key}={json.dumps(value)}" >> ~/.bashrc; '
+                bashrc_cmd += f'touch ~/.bashrc; grep -q "^export {key}=" ~/.bashrc || echo "export {key}={json.dumps(value)}" >> ~/.bashrc; '
 
             if not cmd:
                 return


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR proposes a possible fix for a weird error starting runtime this morning: when adding env vars, during initialization. I'm not sure it's the correct fix (it actually did work later...), but it's harmless: only making sure ~/.bashrc exists. 

(maybe something messed with execution timing...?)

`12:08:07 - openhands:ERROR: session.py:266 - Error creating agent_session: Failed to add env vars [dict_keys(['GITHUB_TOKEN', 'GEMINI_API_KEY', 'OPENHANDS_API_KEY'])] to environment: `

---
**Link of any specific issues this addresses:**

Logs
<Summary>Logs
<Details>
12:08:06 - openhands:DEBUG: agent_session.py:338 - Initializing runtime `docker` now...
12:08:06 - openhands:INFO: docker_runtime.py:203 - [runtime 5bb9a8d6bea14881aca019e40bf46532] Runtime is ready.
12:08:06 - openhands:DEBUG: base.py:199 - Adding env vars: dict_keys(['GITHUB_TOKEN', 'GEMINI_API_KEY', 'OPENHANDS_API_KEY', 'github_token'])
12:08:06 - openhands:DEBUG: base.py:243 - Added env vars to IPython
12:08:06 - openhands:DEBUG: base.py:289 - Adding env vars to bash
12:08:06 - openhands:ERROR: agent_session.py:222 - Agent session start failed in 2.913944959640503s
Traceback (most recent call last):
  File "/Users/enyst/repos/odie/openhands/server/session/agent_session.py", line 137, in start
    runtime_connected = await self._create_runtime(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/enyst/repos/odie/openhands/server/session/agent_session.py", line 387, in _create_runtime
    await self.runtime.connect()
  File "/Users/enyst/repos/odie/openhands/runtime/impl/docker/docker_runtime.py", line 206, in connect
    await call_sync_from_async(self.setup_initial_env)
  File "/Users/enyst/repos/odie/openhands/utils/async_utils.py", line 17, in call_sync_from_async
    result = await coro
             ^^^^^^^^^^
  File "/Users/enyst/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/enyst/repos/odie/openhands/utils/async_utils.py", line 16, in <lambda>
    coro = loop.run_in_executor(None, lambda: fn(*args, **kwargs))
                                              ^^^^^^^^^^^^^^^^^^^
  File "/Users/enyst/repos/odie/openhands/runtime/base.py", line 200, in setup_initial_env
    self.add_env_vars(self.initial_env_vars)
  File "/Users/enyst/repos/odie/openhands/runtime/base.py", line 293, in add_env_vars
    raise RuntimeError(
RuntimeError: Failed to add env vars [dict_keys(['GITHUB_TOKEN', 'GEMINI_API_KEY', 'OPENHANDS_API_KEY'])] to environment: 
  File "/Users/enyst/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/runpy.py", line 198, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/enyst/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/runpy.py", line 88, in _run_code
    exec(code, run_globals)
  File "/Users/enyst/.vscode/extensions/ms-python.debugpy-2025.10.0-darwin-arm64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 71, in <module>
    cli.main()
  File "/Users/enyst/.vscode/extensions/ms-python.debugpy-2025.10.0-darwin-arm64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 501, in main
    run()
  File "/Users/enyst/.vscode/extensions/ms-python.debugpy-2025.10.0-darwin-arm64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 384, in run_module
    run_module_as_main(options.target, alter_argv=True)
  File "/Users/enyst/.vscode/extensions/ms-python.debugpy-2025.10.0-darwin-arm64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 228, in _run_module_as_main
    return _run_code(code, main_globals, None, "__main__", mod_spec)
  File "/Users/enyst/.vscode/extensions/ms-python.debugpy-2025.10.0-darwin-arm64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 118, in _run_code
    exec(code, run_globals)
  File "/Users/enyst/repos/odie/.venv/lib/python3.12/site-packages/uvicorn/__main__.py", line 4, in <module>
    uvicorn.main()
  File "/Users/enyst/repos/odie/.venv/lib/python3.12/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
  File "/Users/enyst/repos/odie/.venv/lib/python3.12/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/Users/enyst/repos/odie/.venv/lib/python3.12/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/enyst/repos/odie/.venv/lib/python3.12/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/Users/enyst/repos/odie/.venv/lib/python3.12/site-packages/uvicorn/main.py", line 413, in main
    run(
  File "/Users/enyst/repos/odie/.venv/lib/python3.12/site-packages/uvicorn/main.py", line 580, in run
    server.run()
  File "/Users/enyst/repos/odie/.venv/lib/python3.12/site-packages/uvicorn/server.py", line 67, in run
    return asyncio.run(self.serve(sockets=sockets))
  File "/Users/enyst/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
  File "/Users/enyst/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
  File "/Users/enyst/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/asyncio/base_events.py", line 674, in run_until_complete
    self.run_forever()
  File "/Users/enyst/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/asyncio/base_events.py", line 641, in run_forever
    self._run_once()
  File "/Users/enyst/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/asyncio/base_events.py", line 1986, in _run_once
    handle._run()
  File "/Users/enyst/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
  File "/Users/enyst/repos/odie/openhands/server/session/session.py", line 232, in initialize_agent
    await self.agent_session.start(
  File "/Users/enyst/repos/odie/openhands/server/session/agent_session.py", line 222, in start
    self.logger.error(
  File "/Users/enyst/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/logging/__init__.py", line 1941, in error
    self.log(ERROR, msg, *args, **kwargs)
  File "/Users/enyst/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/logging/__init__.py", line 1962, in log
    self.logger.log(level, msg, *args, **kwargs)
  File "/Users/enyst/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/logging/__init__.py", line 1609, in log
    self._log(level, msg, args, **kwargs)
  File "/Users/enyst/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/lib/python3.12/logging/__init__.py", line 1684, in _log
    self.handle(record)

... TRIMMED...

12:08:23 - openhands:INFO: docker_runtime.py:203 - [runtime dde9854f508c48e88eb5a725f992a16a] Runtime is ready.
12:08:23 - openhands:DEBUG: base.py:199 - Adding env vars: dict_keys(['GITHUB_TOKEN', 'GEMINI_API_KEY', 'OPENHANDS_API_KEY', 'github_token'])
12:08:23 - openhands:DEBUG: base.py:243 - Added env vars to IPython
12:08:23 - openhands:DEBUG: base.py:289 - Adding env vars to bash
12:08:24 - openhands:DEBUG: base.py:299 - Adding env var to .bashrc: dict_keys(['GITHUB_TOKEN', 'GEMINI_API_KEY', 'OPENHANDS_API_KEY'])
12:08:25 - openhands:INFO: base.py:986 - Successfully configured git: name=openhands, email=openhands@all-hands.dev
12:08:25 - openhands:DEBUG: docker_runtime.py:208 - [runtime dde9854f508c48e88eb5a725f992a16a] Container initialized with plugins: ['agent_skills', 'jupyter', 'vscode']. VSCode URL: None
12:08:25 - openhands:INFO: base.py:397 - In workspace mount mode, not initializing a new git repository.
12:08:25 - openhands:DEBUG: agent_session.py:402 - Runtime initialized with plugins: ['agent_skills', 'jupyter', 'vscode']
</Details>
</Summary>

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:7697c3e-nikolaik   --name openhands-app-7697c3e   docker.all-hands.dev/all-hands-ai/openhands:7697c3e
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@runtime-bashrc openhands
```