### PR TITLE
Update modal runtime for modal>=1.0

### DIFF
--- a/third_party/runtime/impl/modal/modal_runtime.py
+++ b/third_party/runtime/impl/modal/modal_runtime.py
@@ -150,7 +150,7 @@ class ModalRuntime(ActionExecutionClient):
             raise Exception("Sandbox not initialized")
         tunnel = self.sandbox.tunnels()[self.container_port]
         self.api_url = tunnel.url
-       self.log("info", "Waiting 20 secs for the container to be ready... (avoiding RemoteProtocolError)")
+        self.log("info", "Waiting 20 secs for the container to be ready... (avoiding RemoteProtocolError)")
         sleep(20)
         self.log("debug", f"Container started. Server url: {self.api_url}")
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
Updates the modal runtime to work with modal>1.0

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
Updates the modal runtime to work with modal>1.0, where the use of modal.Mount is deprecated (see https://modal.com/docs/guide/modal-1-0-migration#deprecating-mount-as-part-of-the-public-api)
Additionally, the sandboxed require a bit of time to not hit the retry timeouts, which is why I added 20s of sleep. I have confirmed with some SWE-Bench Verified images that not including the sleep let's the OpenHands agent fail the swebench tasks.

---
**Link of any specific issues this addresses:**
