### PR TITLE
fix(CI): Pin @modelcontextprotocol/server-filesystem to version 2025.8.18

### DIFF
--- a/tests/runtime/test_mcp_action.py
+++ b/tests/runtime/test_mcp_action.py
@@ -44,7 +44,7 @@ def sse_mcp_docker_server():
 
     container_command_args = [
         '--stdio',
-        'npx -y @modelcontextprotocol/server-filesystem /',
+        'npx -y @modelcontextprotocol/server-filesystem@2025.8.18 /',
         '--port',
         str(container_internal_port),  # MCP server inside container listens on this
         '--baseUrl',
@@ -292,7 +292,7 @@ async def test_microagent_and_one_stdio_mcp_in_config(
             name='filesystem',
             command='npx',
             args=[
-                '@modelcontextprotocol/server-filesystem',
+                '@modelcontextprotocol/server-filesystem@2025.8.18',
                 '/',
             ],
         )


### PR DESCRIPTION

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**
- Fix failing MCP tests by pinning the filesystem server package to a stable version
- Update test_mcp_action.py to use @modelcontextprotocol/server-filesystem@2025.8.18 in SSE fixture
- Update documentation to reflect the pinned version
- Resolves test failures: test_filesystem_mcp_via_sse, test_both_stdio_and_sse_mcp, test_microagent_and_one_stdio_mcp_in_config

Runtime test will fail using the latest version of server-filesystem:

- Slack (https://openhands-ai.slack.com/archives/C078L0FUGUX/p1755805247753819)
- This was caused by https://www.npmjs.com/package/@modelcontextprotocol/server-filesystem upgrade

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0318680-nikolaik   --name openhands-app-0318680   docker.all-hands.dev/all-hands-ai/openhands:0318680
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@fix-ci openhands
```