### PR TITLE
refactor(frontend): update chat input spacing (conversation ux improvements)

### DIFF
--- a/frontend/src/components/features/chat/custom-chat-input.tsx
+++ b/frontend/src/components/features/chat/custom-chat-input.tsx
@@ -299,7 +299,7 @@ export function CustomChatInput({
       {/* Chat Input Component */}
       <div
         ref={chatContainerRef}
-        className="bg-[#25272D] box-border content-stretch flex flex-col items-start justify-center p-[16px] relative rounded-[15px] w-full"
+        className="bg-[#25272D] box-border content-stretch flex flex-col items-start justify-center p-4 pt-3 relative rounded-[15px] w-full"
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

The chat input currently has extra padding at the top, causing misalignment with the design.

**Acceptance Criteria:**
- Remove the extra top padding so that the chat input aligns correctly with the design.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR updates chat input spacing (conversation ux improvements)

We can refer to the image below for the output of the PR.

<img width="1440" height="743" alt="all-3286" src="https://github.com/user-attachments/assets/d36cc6b7-9cc0-4106-9744-8763456f0dc8" />

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d1fbc62-nikolaik   --name openhands-app-d1fbc62   docker.all-hands.dev/all-hands-ai/openhands:d1fbc62
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3286 openhands
```