### PR TITLE
Fix Typos in Comment and Docs

### DIFF
--- a/docs/usage/runtimes/e2b.mdx
+++ b/docs/usage/runtimes/e2b.mdx
@@ -22,7 +22,7 @@ SDK to spawn and control these sandboxes.
 
 You can use the E2B CLI to create a custom sandbox with a Dockerfile. Read the full guide
 [here](https://e2b.dev/docs/guide/custom-sandbox). The premade OpenHands sandbox for E2B is set up in the `containers`
-directory. and it's called `openhands`.
+directory, and it's called `openhands`.
 
 ## Debugging
 

--- a/tests/unit/memory/condenser/test_condenser.py
+++ b/tests/unit/memory/condenser/test_condenser.py
@@ -489,7 +489,7 @@ def test_amortized_forgetting_condenser_keeps_first_and_last_events():
 
     events = [create_test_event(f'Event {i}', id=i) for i in range(max_size * 10)]
 
-    # To ensure the most recent event is always recorded, track it in a non-local variable udpated
+    # To ensure the most recent event is always recorded, track it in a non-local variable updated
     # with a closure we'll pass to the view generator as a callback.
     most_recent_event: Event | None = None
 
@@ -773,7 +773,7 @@ def test_structured_summary_condenser_keeps_first_and_summary_events(
             i, max_size
         )
 
-        # Ensure that the prefix is appropiately maintained
+        # Ensure that the prefix is appropriately maintained
         assert view[:keep_first] == events[: min(keep_first, i + 1)]
 
         # If we've condensed, ensure that the summary event is present


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `udpated` → `updated`
  - `appropiately` → `appropriately`
  - `.` → `,`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.