### PR TITLE
refactor(frontend): replace design library toggle

### DIFF
--- a/frontend/src/components/features/settings/settings-switch.tsx
+++ b/frontend/src/components/features/settings/settings-switch.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { Toggle } from "@openhands/ui";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
+import { StyledSwitchComponent } from "./styled-switch-component";
 
 interface SettingsSwitchProps {
   testId?: string;
@@ -30,21 +30,26 @@ export function SettingsSwitch({
   };
 
   return (
-    <Toggle
-      name={name}
-      testId={testId}
-      checked={controlledIsToggled ?? isToggled}
-      onChange={(e) => handleToggle(e.target.checked)}
-      label={
-        <div className="flex items-center gap-1">
-          <span className="text-sm">{children}</span>
-          {isBeta && (
-            <span className="text-[11px] leading-4 text-[#0D0F11] font-[500] tracking-tighter bg-primary px-1 rounded-full">
-              {t(I18nKey.BADGE$BETA)}
-            </span>
-          )}
-        </div>
-      }
-    />
+    <label className="flex items-center gap-2 w-fit cursor-pointer">
+      <input
+        hidden
+        data-testid={testId}
+        name={name}
+        type="checkbox"
+        onChange={(e) => handleToggle(e.target.checked)}
+        checked={controlledIsToggled ?? isToggled}
+      />
+
+      <StyledSwitchComponent isToggled={controlledIsToggled ?? isToggled} />
+
+      <div className="flex items-center gap-1">
+        <span className="text-sm">{children}</span>
+        {isBeta && (
+          <span className="text-[11px] leading-4 text-[#0D0F11] font-[500] tracking-tighter bg-primary px-1 rounded-full">
+            {t(I18nKey.BADGE$BETA)}
+          </span>
+        )}
+      </div>
+    </label>
   );
 }

--- a/frontend/src/components/features/settings/styled-switch-component.tsx
+++ b/frontend/src/components/features/settings/styled-switch-component.tsx
@@ -1,0 +1,27 @@
+import { cn } from "#/utils/utils";
+
+interface StyledSwitchComponentProps {
+  isToggled: boolean;
+}
+
+export function StyledSwitchComponent({
+  isToggled,
+}: StyledSwitchComponentProps) {
+  return (
+    <div
+      className={cn(
+        "w-12 h-6 rounded-xl flex items-center p-1.5 cursor-pointer",
+        isToggled && "justify-end bg-primary",
+        !isToggled &&
+          "justify-start bg-base-secondary border border-tertiary-light",
+      )}
+    >
+      <div
+        className={cn(
+          "w-3 h-3 rounded-xl",
+          isToggled ? "bg-base-secondary" : "bg-tertiary-light",
+        )}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

<img width="487" height="523" alt="all-3281-issue" src="https://github.com/user-attachments/assets/df94b35a-da05-4d07-9976-9b95ef994ed2" />

The UI is currently using the design library toggle, which causes inconsistencies in font styling. We need to remove it and use the existing toggle instead.

**Acceptance Criteria:**
- The current (non–design library) toggle is used in place of the design library toggle.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The current (non–design library) toggle is used in place of the design library toggle.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/c4376446-1f9e-4446-a545-1b99adad7374

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d00cd5f-nikolaik   --name openhands-app-d00cd5f   docker.all-hands.dev/all-hands-ai/openhands:d00cd5f
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3281 openhands
```