### PR TITLE
refactor(frontend): update box shadow for context menus (conversation UX improvements)

### DIFF
--- a/frontend/src/components/features/conversation-panel/conversation-card/conversation-card-context-menu.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card/conversation-card-context-menu.tsx
@@ -46,7 +46,7 @@ export function ConversationCardContextMenu({
   const generateSection = useCallback(
     (items: React.ReactNode[], isLast?: boolean) => {
       const filteredItems = items.filter((i) => i != null);
-      const divider = <div className="border-b-1 border-[#A3A3A3]" />;
+      const divider = <div className="border-b-1 border-[#5C5D62]" />;
 
       if (filteredItems.length > 0) {
         return !isLast ? [...filteredItems, divider] : filteredItems;
@@ -62,8 +62,6 @@ export function ConversationCardContextMenu({
       testId="context-menu"
       position={position}
       alignment="right"
-      size="compact"
-      className="p-1"
     >
       {generateSection([
         onEdit && (

--- a/frontend/src/tailwind.css
+++ b/frontend/src/tailwind.css
@@ -244,3 +244,7 @@
     background: #c9b974;
   }
 }
+
+.context-menu-box-shadow {
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.10), 0 4px 6px -2px rgba(0, 0, 0, 0.05), 0 0 0 1px rgba(0, 0, 0, 0.05);
+}

--- a/frontend/src/ui/context-menu.tsx
+++ b/frontend/src/ui/context-menu.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "#/utils/utils";
 
 const contextMenuVariants = cva(
-  "absolute bg-tertiary rounded-[6px] text-white overflow-hidden z-50 shadow-[0_10px_15px_-3px_rgba(0,0,0,0.10),0_4px_6px_-2px_rgba(0,0,0,0.05),0_0_0_1px_rgba(0,0,0,0.05)]",
+  "absolute bg-tertiary rounded-[6px] text-white overflow-hidden z-50 context-menu-box-shadow",
   {
     variants: {
       size: {


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

The box shadow styling for context menus needs to be updated to match the intended design specifications.

**Acceptance Criteria:**
- The context menus use the updated box shadow styling.

```ts
box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.10), 0 4px 6px -2px rgba(0, 0, 0, 0.05), 0 0 0 1px rgba(0, 0, 0, 0.05);
```

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR updates box shadow for context menus.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/514a4a0d-75b7-4a69-adec-f1b3310d8b0f

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:86ede1a-nikolaik   --name openhands-app-86ede1a   docker.all-hands.dev/all-hands-ai/openhands:86ede1a
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3313 openhands
```