### PR TITLE
refactor(frontend): hide run button (conversation UX improvements)

### DIFF
--- a/frontend/src/components/features/chat/chat-actions.tsx
+++ b/frontend/src/components/features/chat/chat-actions.tsx
@@ -1,23 +1,11 @@
-import { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useTranslation } from "react-i18next";
 import BlockDrawerLeftIcon from "#/icons/block-drawer-left.svg?react";
-import PlayIcon from "#/icons/play-solid.svg?react";
-import {
-  setIsRightPanelShown,
-  setSubmittedMessage,
-} from "#/state/conversation-slice";
+import { setIsRightPanelShown } from "#/state/conversation-slice";
 import { RootState } from "#/store";
 import { cn } from "#/utils/utils";
 import { ChatActionTooltip } from "./chat-action-tooltip";
-import { I18nKey } from "#/i18n/declaration";
-import { RUN_SERVER_SUGGESTION } from "#/utils/suggestions/repo-suggestions";
-import { useActiveHost } from "#/hooks/query/use-active-host";
-import { useConversationTabs } from "../conversation/conversation-tabs/use-conversation-tabs";
 
 export function ChatActions() {
-  // eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-unused-vars
-  const [_, { onTabChange }] = useConversationTabs();
   const isRightPanelShown = useSelector(
     (state: RootState) => state.conversation.isRightPanelShown,
   );
@@ -27,16 +15,6 @@ export function ChatActions() {
   );
 
   const dispatch = useDispatch();
-  const { t } = useTranslation();
-
-  const { activeHost } = useActiveHost();
-  const onStartServerClick = useCallback(() => {
-    if (activeHost) {
-      onTabChange("served");
-    } else {
-      dispatch(setSubmittedMessage(RUN_SERVER_SUGGESTION));
-    }
-  }, [activeHost]);
 
   return (
     <div className="flex items-center justify-end gap-x-4">
@@ -65,21 +43,6 @@ export function ChatActions() {
           />
         </button>
       </ChatActionTooltip>
-      <button
-        type="button"
-        onClick={onStartServerClick}
-        data-testid="run-button"
-        className={cn(
-          "bg-white hover:bg-[#717171] py-0.75 pl-2 pr-3.5 rounded-full cursor-pointer",
-          `flex flex-row items-center`,
-          "text-black",
-        )}
-      >
-        <PlayIcon className="w-4.5 h-4.5 text-inherit" />
-        <span className="text-inherit text-sm font-medium">
-          {t(activeHost ? I18nKey.COMMON$VIEW : I18nKey.COMMON$RUN)}
-        </span>
-      </button>
     </div>
   );
 }


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

We would like to temporarily remove the Run button from the user interface.

Since the button may be reinstated in the future, this change should only hide the button in the UI rather than removing the associated logic.

**Acceptance Criteria:**

- The Run button must not be visible in the user interface.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR hides run button (conversation UX improvements).

We can refer to the image below for the output of the PR.

<img width="1440" height="738" alt="all-3310" src="https://github.com/user-attachments/assets/6e601395-6688-48d3-9e2e-b6f8430861b7" />

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d5b62bf-nikolaik   --name openhands-app-d5b62bf   docker.all-hands.dev/all-hands-ai/openhands:d5b62bf
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3310 openhands
```