### PR TITLE
feat(frontend): add a grip to resize the new chat input

### DIFF
--- a/frontend/src/components/features/chat/custom-chat-input.tsx
+++ b/frontend/src/components/features/chat/custom-chat-input.tsx
@@ -12,6 +12,7 @@ import { DragOver } from "./drag-over";
 import { UploadedFiles } from "./uploaded-files";
 import { Tools } from "../controls/tools";
 import {
+  clearAllFiles,
   setShouldHideSuggestions,
   setSubmittedMessage,
 } from "#/state/conversation-slice";
@@ -117,7 +118,7 @@ export function CustomChatInput({
   // Use the auto-resize hook with height change callback
   const { smartResize, handleGripMouseDown } = useAutoResize(chatInputRef, {
     minHeight: 20,
-    maxHeight: 450,
+    maxHeight: 400,
     onHeightChange: handleHeightChange,
     onGripDragStart: handleDragStart,
     onGripDragEnd: handleDragEnd,
@@ -129,6 +130,7 @@ export function CustomChatInput({
   useEffect(
     () => () => {
       dispatch(setShouldHideSuggestions(false));
+      dispatch(clearAllFiles());
     },
     [dispatch],
   );
@@ -394,7 +396,7 @@ export function CustomChatInput({
                   <div
                     ref={chatInputRef}
                     className={cn(
-                      "chat-input bg-transparent text-white text-[16px] font-normal leading-[20px] outline-none resize-none custom-scrollbar min-h-[20px] max-h-[450px] [text-overflow:inherit] [text-wrap-mode:inherit] [white-space-collapse:inherit] block whitespace-pre-wrap",
+                      "chat-input bg-transparent text-white text-[16px] font-normal leading-[20px] outline-none resize-none custom-scrollbar min-h-[20px] max-h-[400px] [text-overflow:inherit] [text-wrap-mode:inherit] [white-space-collapse:inherit] block whitespace-pre-wrap",
                       disabled && "cursor-not-allowed",
                     )}
                     contentEditable={!disabled}

--- a/frontend/src/hooks/use-auto-resize.ts
+++ b/frontend/src/hooks/use-auto-resize.ts
@@ -24,8 +24,8 @@ export const useAutoResize = (
   const {
     minHeight = 20,
     maxHeight = 120,
-    value,
     enableManualResize = false,
+    value,
     onGripDragStart,
     onGripDragEnd,
     onHeightChange,
@@ -182,14 +182,14 @@ export const useAutoResize = (
     const element = elementRef.current;
     if (element && value !== undefined) {
       element.textContent = value.text;
-      autoResize();
+      smartResize();
     }
-  }, [value, autoResize]);
+  }, [value, smartResize]);
 
   // Initialize auto-resize on mount
   useEffect(() => {
-    autoResize();
-  }, [autoResize]);
+    smartResize();
+  }, [smartResize]);
 
   return { autoResize, smartResize, handleGripMouseDown };
 };


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

**Acceptance Criteria:**
- Add a grip to the new chat input according to the design.
- Users should be able to resize the input up and down.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR adds a grip to resize the new chat input.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/3e707cab-9530-4e95-8c4f-fe87b3778f70

---
**Link of any specific issues this addresses:**
