### PR TITLE
feat(frontend): improve pause button visibility with gray circular background

### DIFF
--- a/frontend/src/assets/pause.tsx
+++ b/frontend/src/assets/pause.tsx
@@ -10,6 +10,7 @@ function PauseIcon() {
       stroke="currentColor"
       className="w-5 h-5"
     >
+      <circle cx="12" cy="12" r="10" fill="#e5e7eb" />
       <path
         strokeLinecap="round"
         strokeLinejoin="round"


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Makes the Pause button easier to see and click by adding a subtle gray circular background behind the pause icon. This improves contrast and discoverability without altering existing behavior.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

- Adds a light gray circular background to the Pause icon to improve visibility
  - File: `frontend/src/assets/pause.tsx`
  - Implementation: insert an SVG `<circle cx="12" cy="12" r="10" fill="#e5e7eb" />` behind the existing pause bars
- Verified UI build and linting pass (`npm run lint:fix && npm run build`)
- Pre-commit hooks (frontend + backend) pass locally
- No changes to state management, APIs, or routing; purely a visual refinement

Design considerations:
- Chose Tailwind's gray-200 hex (#e5e7eb) for a subtle neutral that fits existing palette
- Kept icon size and surrounding `ActionButton` styles unchanged to avoid layout shifts

---
**Link of any specific issues this addresses:**



@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ac689c6a3ff047b986085e77a1fd22d2)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:cedd940-nikolaik   --name openhands-app-cedd940   docker.all-hands.dev/all-hands-ai/openhands:cedd940
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@feat/pause-button-visibility openhands
```