### PR TITLE
Add 4px margin to notification bar on home screen

### DIFF
--- a/frontend/src/components/features/home/guide-message.tsx
+++ b/frontend/src/components/features/home/guide-message.tsx
@@ -5,7 +5,7 @@ export function GuideMessage() {
 
   return (
     <div className="w-full flex items-center justify-center">
-      <div className="w-fit flex items-center justify-center gap-1 px-[15px] rounded-[12px] bg-[#454545] leading-5 text-white text-[15px] font-normal h-[38px]">
+      <div className="w-fit flex items-center justify-center gap-1 px-[15px] rounded-[12px] bg-[#454545] leading-5 text-white text-[15px] font-normal h-[38px] m-1">
         <div>
           <span className="">{t("HOME$GUIDE_MESSAGE_TITLE")} </span>
           <a


### PR DESCRIPTION


- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
- Added m-1 class to GuideMessage component for consistent 4px margin
- Improves visual appearance with rounded corners
- Provides better spacing around the notification banner

---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ad649ca-nikolaik   --name openhands-app-ad649ca   docker.all-hands.dev/all-hands-ai/openhands:ad649ca
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@banner-margin openhands
```