### PR TITLE
refactor(frontend): adjust right padding (changes tab)

### DIFF
--- a/frontend/src/routes/changes-tab.tsx
+++ b/frontend/src/routes/changes-tab.tsx
@@ -67,7 +67,7 @@ function GitChanges() {
   ]);
 
   return (
-    <main className="h-full overflow-y-scroll px-4 py-3 gap-3 flex flex-col items-center custom-scrollbar-always">
+    <main className="h-full overflow-y-scroll px-4 py-3 pr-1.5 gap-3 flex flex-col items-center custom-scrollbar-always">
       {!isSuccess || !gitChanges.length ? (
         <div className="relative flex h-full w-full items-center">
           <div className="absolute inset-x-0 top-1/2 -translate-y-1/2">


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

<img width="1440" height="739" alt="all-3357-issue" src="https://github.com/user-attachments/assets/55ea22df-59a5-4a0f-958b-4585a9ae3863" />

The right padding in the Changes tab should be reduced to align with the updated design specifications provided in the reference image.

**Acceptance Criteria:**
- The right padding in the Changes tab is reduced in accordance with the reference design.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR adjusts right padding (changes tab)

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d4d159d-nikolaik   --name openhands-app-d4d159d   docker.all-hands.dev/all-hands-ai/openhands:d4d159d
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3357 openhands
```