### PR TITLE
Increase chat interface width to 768px when panel is closed

### DIFF
--- a/frontend/src/components/features/conversation/conversation-main.tsx
+++ b/frontend/src/components/features/conversation/conversation-main.tsx
@@ -16,7 +16,7 @@ export function ChatInterfaceWrapper({
   if (!isRightPanelShown) {
     return (
       <div className="flex justify-center w-full h-full">
-        <div className="max-w-[768px]">
+        <div className="w-full max-w-[768px]">
           <ChatInterface />
         </div>
       </div>


### PR DESCRIPTION


- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**
- Changed max-w-[768px] to max-w-[1152px] (1.5x increase)
- Added w-full class to ensure container expands to use available width
- Chat interface now properly utilizes wider space when right panel is hidden

BEFORE:
<img width="1184" height="1054" alt="image" src="https://github.com/user-attachments/assets/95ab50c1-477a-4ed5-b486-c907b57b638b" />

AFTER:
<img width="2056" height="1128" alt="image" src="https://github.com/user-attachments/assets/da4eb3e1-a330-4e61-be23-4e6aaae49e17" />


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e5aab73-nikolaik   --name openhands-app-e5aab73   docker.all-hands.dev/all-hands-ai/openhands:e5aab73
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@ALL-3375-increase-chat-width openhands
```