### PR TITLE
feat(runtime/local): Enable PyInstaller multi-arch packaging for CLI via internal server subcommand

### DIFF
--- a/openhands/cli/entry.py
+++ b/openhands/cli/entry.py
@@ -30,7 +30,7 @@ def main():
 
     # Special case: no subcommand provided, simulate "openhands cli"
     if len(sys.argv) == 1 or (
-        len(sys.argv) > 1 and sys.argv[1] not in ['cli', 'serve']
+        len(sys.argv) > 1 and sys.argv[1] not in ['cli', 'serve', 'run-action-server']
     ):
         # Inject 'cli' as default command
         sys.argv.insert(1, 'cli')
@@ -45,6 +45,16 @@ def main():
         launch_gui_server(mount_cwd=args.mount_cwd, gpu=args.gpu)
     elif args.command == 'cli' or args.command is None:
         run_cli_command(args)
+    elif args.command == 'run-action-server':
+        # Internal entry point: run the action execution server in the current process
+        from multiprocessing import freeze_support
+
+        from openhands.runtime.action_execution_server import (
+            run_action_execution_server_with_args,
+        )
+
+        freeze_support()
+        run_action_execution_server_with_args(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/openhands/core/config/arg_utils.py
+++ b/openhands/core/config/arg_utils.py
@@ -204,6 +204,36 @@ def get_cli_parser() -> argparse.ArgumentParser:
         default=None,
     )
 
+    # Internal subcommand used to launch the local action execution server from a frozen binary
+    internal_server_parser = subparsers.add_parser(
+        'run-action-server', help=argparse.SUPPRESS
+    )
+    internal_server_parser.add_argument('port', type=int, help='Port to listen on')
+    internal_server_parser.add_argument(
+        '--working-dir', type=str, help='Working directory'
+    )
+    internal_server_parser.add_argument(
+        '--plugins', type=str, help='Plugins to initialize', nargs='+'
+    )
+    internal_server_parser.add_argument(
+        '--username', type=str, help='User to run as', default='openhands'
+    )
+    internal_server_parser.add_argument(
+        '--user-id', type=int, help='User ID to run as', default=1000
+    )
+    internal_server_parser.add_argument(
+        '--enable-browser',
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help='Enable the browser environment',
+    )
+    internal_server_parser.add_argument(
+        '--browsergym-eval-env',
+        type=str,
+        help='BrowserGym environment used for browser evaluation',
+        default=None,
+    )
+
     return parser
 
 

--- a/openhands/runtime/impl/local/local_runtime.py
+++ b/openhands/runtime/impl/local/local_runtime.py
@@ -40,7 +40,9 @@ from openhands.runtime.plugins import PluginRequirement
 from openhands.runtime.plugins.vscode import VSCodeRequirement
 from openhands.runtime.runtime_status import RuntimeStatus
 from openhands.runtime.utils import find_available_tcp_port
-from openhands.runtime.utils.command import get_action_execution_server_startup_command
+from openhands.runtime.utils.command import (
+    get_action_execution_server_startup_command,
+)
 from openhands.utils.async_utils import call_sync_from_async
 from openhands.utils.tenacity_stop import stop_if_should_exit
 


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you must provide an end-user friendly description for your change below

End-user friendly description of the problem this fixes or functionality this introduces.

This PR lays the groundwork for distributing the OpenHands CLI as a single binary across platforms using PyInstaller. It preserves existing unfrozen (pip/Docker/K8s) workflows while enabling a safe path for LocalRuntime to operate in frozen executables, so users can run the CLI without a Python environment.

---
Summarize what the PR does, explaining any non-trivial design decisions.

Core goals:
- Allow LocalRuntime to work under PyInstaller without relying on `-m` module spawning
- Keep the existing behavior for unfrozen installs intact
- Ensure multiprocessing works in frozen mode (Windows/macOS spawn) with `freeze_support()`
- Ensure child processes do not outlive the parent

Key changes:
1) Programmatic server runner
   - Add `run_action_execution_server_with_args(args: argparse.Namespace)` to `openhands/runtime/action_execution_server.py`.
   - This shares the same setup logic as `__main__`, so the unfrozen `python -m` path remains intact.
   - Fix `ActionExecutor.close()` by consolidating cleanup (memory monitor, bash session, browser) into the method and removing stray lines.

2) Hidden CLI subcommand for frozen executables
   - Add a hidden `run-action-server` subcommand (parity with existing server args).
   - Update CLI entry (`openhands/cli/entry.py`) to:
     - Allow `run-action-server` to bypass default `cli` injection
     - Call `multiprocessing.freeze_support()` and then invoke the programmatic runner

3) Command builder auto-switch
   - Update `get_action_execution_server_startup_command()` to detect frozen state and switch from `python -m openhands.runtime.action_execution_server ...` to `[sys.executable, 'run-action-server', ...]`.
   - This ensures LocalRuntime can start the server from the same frozen binary.

4) LocalRuntime integration
   - LocalRuntime uses the command builder so unfrozen vs frozen logic is centralized.

No change to default Docker/K8s behavior: In unfrozen environments, we continue to use `-m` spawning.

Follow-ups (tracked):
- LR-005: Lazy imports/guards for heavy optional deps (browsergym/visualbrowsing) to reduce binary size/risk.
- LR-006: PyInstaller spec/hooks and CI matrix to build across OS/arch; include datas/hiddenimports; ensure version discovery in frozen env.
- LR-007: Tests for frozen vs non-frozen command construction, LocalRuntime startup (smoke `/alive` with browser disabled).

---
Link of any specific issues this addresses:

- Internal tracking tasks: LR-001 to LR-007


@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ce766077fb6c4ad5ab8dd5f9e728fc48)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:11f9ba2-nikolaik   --name openhands-app-11f9ba2   docker.all-hands.dev/all-hands-ai/openhands:11f9ba2
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@feat/pyinstaller-multiarch-cli openhands
```