### PR TITLE
Fix VSCode tab corner overflow by adding rounded corners to iframe

### DIFF
--- a/frontend/src/routes/vscode-tab.tsx
+++ b/frontend/src/routes/vscode-tab.tsx
@@ -91,7 +91,7 @@ function VSCodeTab() {
         ref={iframeRef}
         title={t(I18nKey.VSCODE$TITLE)}
         src={data.url}
-        className="w-full h-full border-0"
+        className="w-full h-full border-0 rounded-xl"
         allow="clipboard-read; clipboard-write"
       />
     </div>


### PR DESCRIPTION


- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**
- Add rounded-xl class to VSCode iframe to match container styling
- Prevents iframe content from extending into rounded corner areas
- Ensures visual consistency with other tab content containers

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:31e042f-nikolaik   --name openhands-app-31e042f   docker.all-hands.dev/all-hands-ai/openhands:31e042f
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@ALL-3412-fix-vscode-tab-corner-overflow openhands
```