### PR TITLE
Make auth modal buttons semi-bold

### DIFF
--- a/frontend/src/components/features/waitlist/auth-modal.tsx
+++ b/frontend/src/components/features/waitlist/auth-modal.tsx
@@ -117,7 +117,7 @@ export function AuthModal({
                   type="button"
                   variant="primary"
                   onClick={handleGitHubAuth}
-                  className="w-full"
+                  className="w-full font-semibold"
                   startContent={<GitHubLogo width={20} height={20} />}
                 >
                   {t(I18nKey.GITHUB$CONNECT_TO_GITHUB)}
@@ -129,7 +129,7 @@ export function AuthModal({
                   type="button"
                   variant="primary"
                   onClick={handleGitLabAuth}
-                  className="w-full"
+                  className="w-full font-semibold"
                   startContent={<GitLabLogo width={20} height={20} />}
                 >
                   {t(I18nKey.GITLAB$CONNECT_TO_GITLAB)}
@@ -141,7 +141,7 @@ export function AuthModal({
                   type="button"
                   variant="primary"
                   onClick={handleBitbucketAuth}
-                  className="w-full"
+                  className="w-full font-semibold"
                   startContent={<BitbucketLogo width={20} height={20} />}
                 >
                   {t(I18nKey.BITBUCKET$CONNECT_TO_BITBUCKET)}
@@ -153,7 +153,7 @@ export function AuthModal({
                   type="button"
                   variant="primary"
                   onClick={handleEnterpriseSsoAuth}
-                  className="w-full"
+                  className="w-full font-semibold"
                 >
                   {t(I18nKey.ENTERPRISE_SSO$CONNECT_TO_ENTERPRISE_SSO)}
                 </BrandButton>


### PR DESCRIPTION


- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**
- Add font-semibold class to all authentication buttons in auth modal
- Improves visual prominence and readability of sign-in buttons
- Affects GitHub, GitLab, Bitbucket, and Enterprise SSO buttons

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e59d051-nikolaik   --name openhands-app-e59d051   docker.all-hands.dev/all-hands-ai/openhands:e59d051
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@ALL-3424 openhands
```