### PR TITLE
feat(frontend): add titles to action panel tabs

### DIFF
--- a/frontend/src/components/features/conversation/conversation-tabs/conversation-tab-content.tsx
+++ b/frontend/src/components/features/conversation/conversation-tabs/conversation-tab-content.tsx
@@ -1,9 +1,12 @@
-import { lazy } from "react";
+import { lazy, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { cn } from "#/utils/utils";
 import { RootState } from "#/store";
 import { ConversationLoading } from "../conversation-loading";
 import Terminal from "../../terminal/terminal";
+import { ConversationTabTitle } from "./conversation-tab-title";
+import { I18nKey } from "#/i18n/declaration";
 
 // Lazy load all tab components
 const EditorTab = lazy(() => import("#/routes/changes-tab"));
@@ -20,6 +23,8 @@ export function ConversationTabContent() {
     (state: RootState) => state.conversation,
   );
 
+  const { t } = useTranslation();
+
   // Determine which tab is active based on the current path
   const isEditorActive = selectedTab === "editor";
   const isBrowserActive = selectedTab === "browser";
@@ -27,6 +32,35 @@ export function ConversationTabContent() {
   const isServedActive = selectedTab === "served";
   const isVSCodeActive = selectedTab === "vscode";
   const isTerminalActive = selectedTab === "terminal";
+
+  const conversationTabTitle = useMemo(() => {
+    if (isEditorActive) {
+      return t(I18nKey.COMMON$CHANGES);
+    }
+    if (isBrowserActive) {
+      return t(I18nKey.COMMON$BROWSER);
+    }
+    if (isJupyterActive) {
+      return t(I18nKey.COMMON$JUPYTER);
+    }
+    if (isServedActive) {
+      return t(I18nKey.COMMON$APP);
+    }
+    if (isVSCodeActive) {
+      return t(I18nKey.COMMON$CODE);
+    }
+    if (isTerminalActive) {
+      return t(I18nKey.COMMON$TERMINAL);
+    }
+    return "";
+  }, [
+    isEditorActive,
+    isBrowserActive,
+    isJupyterActive,
+    isServedActive,
+    isVSCodeActive,
+    isTerminalActive,
+  ]);
 
   if (shouldShownAgentLoading) {
     return <ConversationLoading />;
@@ -39,6 +73,8 @@ export function ConversationTabContent() {
         "h-full w-full",
       )}
     >
+      <ConversationTabTitle title={conversationTabTitle} />
+
       <div className="overflow-hidden flex-grow rounded-b-xl">
         <div className="h-full w-full">
           <div className="h-full w-full relative">

--- a/frontend/src/components/features/conversation/conversation-tabs/conversation-tab-title.tsx
+++ b/frontend/src/components/features/conversation/conversation-tabs/conversation-tab-title.tsx
@@ -1,0 +1,11 @@
+type ConversationTabTitleProps = {
+  title: string;
+};
+
+export function ConversationTabTitle({ title }: ConversationTabTitleProps) {
+  return (
+    <div className="flex flex-row items-center justify-between border-b border-[#474A54] py-2 px-3">
+      <span className="text-xs font-medium text-white">{title}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/features/terminal/terminal.tsx
+++ b/frontend/src/components/features/terminal/terminal.tsx
@@ -5,7 +5,6 @@ import { useTerminal } from "#/hooks/use-terminal";
 import "@xterm/xterm/css/xterm.css";
 import { RUNTIME_INACTIVE_STATES } from "#/types/agent-state";
 import { cn } from "#/utils/utils";
-import { I18nKey } from "#/i18n/declaration";
 
 function Terminal() {
   const { commands } = useSelector((state: RootState) => state.cmd);
@@ -21,12 +20,6 @@ function Terminal() {
 
   return (
     <div className="h-full flex flex-col rounded-xl">
-      <div className="flex flex-row items-center justify-between border-b border-[#474A54] py-2 px-3">
-        <span className="text-xs font-medium text-white">
-          {t(I18nKey.COMMON$TERMINAL)}
-        </span>
-      </div>
-
       {isRuntimeInactive && (
         <div className="w-full flex items-center text-center justify-center text-2xl text-tertiary-light pt-16">
           {t("DIFF_VIEWER$WAITING_FOR_RUNTIME")}

--- a/frontend/src/routes/vscode-tab.tsx
+++ b/frontend/src/routes/vscode-tab.tsx
@@ -91,7 +91,7 @@ function VSCodeTab() {
         ref={iframeRef}
         title={t(I18nKey.VSCODE$TITLE)}
         src={data.url}
-        className="w-full h-full border-0 rounded-xl"
+        className="w-full h-full border-0"
         allow="clipboard-read; clipboard-write"
       />
     </div>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Every tab should have a title for clarity. Without titles, it’s difficult to understand what’s happening. The terminal tab already includes a title, but the others do not, which creates inconsistency in the UI.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR adds titles to action panel tabs

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/dbf86d92-a490-4210-9f34-eb87edf932c3

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:783d9dc-nikolaik   --name openhands-app-783d9dc   docker.all-hands.dev/all-hands-ai/openhands:783d9dc
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3496 openhands
```