### PR TITLE
feat: Add Bitbucket Resolver templates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,7 +71,7 @@ jobs:
         run: pip install pre-commit==4.2.0
       - name: Run pre-commit hooks
         working-directory: ./enterprise
-        run: pre-commit run --all-files --config ./dev_config/python/.pre-commit-config.yaml
+        run: pre-commit run --all-files --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml
 
   # Check version consistency across documentation
   check-version-consistency:

--- a/openhands/integrations/templates/resolver/bitbucket/issue_conversation_instructions.j2
+++ b/openhands/integrations/templates/resolver/bitbucket/issue_conversation_instructions.j2
@@ -1,0 +1,39 @@
+{% if issue_number %}
+You are requested to fix issue #{{ issue_number }}: "{{ issue_title }}" in a repository on Bitbucket.
+A comment on the issue has been addressed to you.
+{% else %}
+Your task is to fix the issue: "{{ issue_title }}".
+{% endif %}
+
+# Issue Body
+{{ issue_body }}
+
+{% if previous_comments %}
+# Previous Comments
+For reference, here are the previous comments on the issue:
+
+{% for comment in previous_comments %}
+- @{{ comment.author }} said:
+{{ comment.body }}
+{% if not loop.last %}\n\n{% endif %}
+{% endfor %}
+{% endif %}
+
+# Guidelines
+
+1. Review the task carefully.
+2. For all changes to actual application code (e.g. in Python or Javascript), add an appropriate test to the testing directory to make sure that the issue has been fixed
+3. Run the tests, and if they pass you are done!
+4. You do NOT need to write new tests if there are only changes to documentation or configuration files.
+
+# Final Checklist
+Re-read the issue title, body, and comments and make sure that you have successfully implemented all requirements.
+
+Use the Bitbucket token and Bitbucket APIs to:
+
+1. Create a new branch using `openhands/` as a prefix (e.g `openhands/update-readme`)
+2. Commit your changes with a clear commit message
+3. Push the branch to Bitbucket
+4. Create a pull request that:
+   - Mentions that it "fixes" or "resolves" the issue number
+   - Has a clear description of the changes made

--- a/openhands/integrations/templates/resolver/bitbucket/issue_prompt.j2
+++ b/openhands/integrations/templates/resolver/bitbucket/issue_prompt.j2
@@ -1,0 +1,5 @@
+{% if issue_comment %}
+{{ issue_comment }}
+{% else %}
+Please fix issue number #{{ issue_number }}.
+{% endif %}

--- a/openhands/integrations/templates/resolver/bitbucket/pr_update_conversation_instructions.j2
+++ b/openhands/integrations/templates/resolver/bitbucket/pr_update_conversation_instructions.j2
@@ -1,0 +1,38 @@
+You are checked out to branch {{ branch_name }}, which has an open PR #{{ pr_number }}: "{{ pr_title }}" on Bitbucket.
+A comment on the PR has been addressed to you.
+
+# PR Description
+{{ pr_body }}
+
+{% if comments %}
+# Previous Comments
+You may find these other comments relevant:
+{% for comment in comments %}
+- @{{ comment.author }} said at {{ comment.created_at }}:
+{{ comment.body }}
+{% if not loop.last %}\n\n{% endif %}
+{% endfor %}
+{% endif %}
+
+{% if file_location %}
+# Comment location
+The comment is in the file `{{ file_location }}` on line #{{ line_number }}
+{% endif %}.
+
+# Steps to Handle the Comment
+
+## Understand the PR Context
+Use the Bitbucket token and Bitbucket API to:
+    1. Retrieve the diff against the main branch to understand the changes
+    2. Fetch the PR body and any linked issues for context
+
+## Process the Comment
+If it's a question:
+    1. Answer the question asked
+    2. DO NOT leave any comments on the PR
+
+If it requests a code update:
+    1. Modify the code accordingly in the current branch
+    2. Commit your changes with a clear commit message
+    3. Push the changes to Bitbucket to update the PR
+    4. DO NOT leave any comments on the PR

--- a/openhands/integrations/templates/resolver/bitbucket/pr_update_prompt.j2
+++ b/openhands/integrations/templates/resolver/bitbucket/pr_update_prompt.j2
@@ -1,0 +1,1 @@
+{{ pr_comment }}

--- a/openhands/storage/data_models/conversation_metadata.py
+++ b/openhands/storage/data_models/conversation_metadata.py
@@ -15,6 +15,7 @@ class ConversationTrigger(Enum):
     JIRA = 'jira'
     JIRA_DC = 'jira_dc'
     LINEAR = 'linear'
+    BITBUCKET = 'bitbucket'
 
 
 @dataclass


### PR DESCRIPTION
- Add BITBUCKET to ConversationTrigger enum
- Add Bitbucket resolver templates (matching GitHub pattern)

This adds the foundation for Bitbucket integration without any functional changes. Templates and enum will be used by upcoming Bitbucket webhook integration.

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:cd7a970-nikolaik   --name openhands-app-cd7a970   docker.all-hands.dev/all-hands-ai/openhands:cd7a970
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@alona/all-2685-enhancement-use-openhands-on-bitbucket-cloud-repos-0 openhands
```