### PR TITLE
Fix SANDBOX_VOLUMES format in headless mode documentation

### DIFF
--- a/docs/usage/how-to/headless-mode.mdx
+++ b/docs/usage/how-to/headless-mode.mdx
@@ -52,7 +52,7 @@ Set environment variables and run the Docker command:
 
 ```bash
 # Set required environment variables
-export SANDBOX_VOLUMES="/path/to/workspace"  # See SANDBOX_VOLUMES docs for details
+export SANDBOX_VOLUMES="/path/to/workspace:/workspace:rw"  # Format: host_path:container_path:mode
 export LLM_MODEL="anthropic/claude-sonnet-4-20250514"
 export LLM_API_KEY="your-api-key"
 export SANDBOX_SELECTED_REPO="owner/repo-name"  # Optional: requires GITHUB_TOKEN


### PR DESCRIPTION
## Summary

This PR fixes an incorrect `SANDBOX_VOLUMES` environment variable format in the headless mode documentation that was causing Docker runs to fail.

## Problem

The headless mode documentation showed:
```bash
export SANDBOX_VOLUMES="/path/to/workspace"
```

But the correct format requires `host_path:container_path:mode`, like:
```bash
export SANDBOX_VOLUMES="/path/to/workspace:/workspace:rw"
```

This caused Docker runs to fail with the error:
```
Invalid mount format in sandbox.volumes: /path/to/workspace. Expected format: 'host_path:container_path[:mode]'
```

## Solution

Updated the documentation in `docs/usage/how-to/headless-mode.mdx` to:
- Show the correct format with proper host:container:mode syntax
- Include a clearer comment explaining the required format
- Make it consistent with other documentation files that already show the correct format

## Testing

Verified that:
1. The corrected format works with Docker runs
2. Other documentation files already use the correct format
3. The server README.md shows the correct format as well

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related Issues

This fixes a documentation issue that would prevent users from successfully running OpenHands in headless mode with Docker using the documented command.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/905d902df07247069ea217525861bea8)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:46ec3c1-nikolaik   --name openhands-app-46ec3c1   docker.all-hands.dev/all-hands-ai/openhands:46ec3c1
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@fix-sandbox-volumes-docs openhands
```