### PR TITLE
Fix Docker build error 'groupadd: GID 1000 already exists'

### DIFF
--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -69,9 +69,17 @@ RUN (if getent passwd 1000 | grep -q pn; then userdel pn; fi) && \
     (if getent group 1000 | grep -q pn; then groupdel pn; fi) && \
     (if getent group 1000 | grep -q ubuntu; then groupdel ubuntu; fi)
 
-# Create openhands group and user
-RUN groupadd -g 1000 openhands && \
-    useradd -u 1000 -g 1000 -m -s /bin/bash openhands && \
+# Create openhands group and user (with fallback IDs if 1000 is taken)
+RUN (if getent group 1000 >/dev/null 2>&1; then \
+        groupadd openhands; \
+    else \
+        groupadd -g 1000 openhands; \
+    fi) && \
+    (if getent passwd 1000 >/dev/null 2>&1; then \
+        useradd -g openhands -m -s /bin/bash openhands; \
+    else \
+        useradd -u 1000 -g openhands -m -s /bin/bash openhands; \
+    fi) && \
     usermod -aG sudo openhands && \
     echo 'openhands ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
     # Set empty password for openhands user to allow passwordless su


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

- Problem: Some base images have existing users/groups with UID/GID 1000, causing the openhands user creation to fail.
- Solution:
  - Keep existing cleanup logic for known problematic users (`pn`, `ubuntu`)
  - Add fallback to use system-assigned IDs when 1000 is already taken
  - Maintains preferred UID/GID 1000 when available, gracefully adapts when not

---
**Link of any specific issues this addresses:**
