### PR TITLE
feat: initial BB Forge app Webhook Integration 

### DIFF
--- a/enterprise/integrations/bitbucket/bitbucket_manager.py
+++ b/enterprise/integrations/bitbucket/bitbucket_manager.py
@@ -1,0 +1,198 @@
+"""BitbucketManager handles incoming webhook events from Bitbucket."""
+
+import hashlib
+import os
+from typing import Optional
+
+import aiohttp
+from integrations.models import Message, SourceType
+from integrations.types import UserData
+from server.auth.token_manager import TokenManager
+
+from openhands.core.logger import openhands_logger as logger
+from openhands.integrations.provider import ProviderType
+
+
+class BitbucketManager:
+    """Manages Bitbucket webhook events and PR comment processing."""
+
+    def __init__(self, token_manager: Optional[TokenManager] = None):
+        self.token_manager = token_manager or TokenManager()
+        logger.info('BitbucketManager initialized')
+
+    def _extract_user_info(self, event_data: dict) -> Optional[UserData]:
+        actor = event_data.get('actor', {})
+        if not actor:
+            return None
+
+        account_id = actor.get('accountId', '')
+        username = actor.get('username', '')
+
+        if not account_id:
+            return None
+
+        user_id_int = int(hashlib.sha256(account_id.encode()).hexdigest()[:8], 16)
+
+        return UserData(
+            user_id=user_id_int,
+            username=username or account_id,
+            keycloak_user_id=None,
+            bitbucket_id=account_id,
+        )
+
+    async def receive_message(self, message: Message):
+        if message.source != SourceType.BITBUCKET:
+            logger.error(f'Received non-Bitbucket message: {message.source}')
+            return
+
+        payload = message.message
+        if not isinstance(payload, dict):
+            logger.warning(f'Received unexpected message format: {type(payload)}')
+            return
+
+        event_data = payload.get('event', {})
+
+        user_info = self._extract_user_info(event_data)
+
+        workspace_slug = event_data.get('workspace', {}).get('slug')
+        repo_slug = event_data.get('repository', {}).get('slug')
+        pr_data = event_data.get('pullrequest', {})
+        pr_id = pr_data.get('id')
+        comment_text = event_data.get('comment', {}).get('content', {}).get('raw', '')
+
+        logger.info(
+            f'BitbucketManager received PR comment:\n'
+            f'  Workspace: {workspace_slug}\n'
+            f'  Repository: {repo_slug}\n'
+            f'  PR: #{pr_id}\n'
+            f'  User: {user_info.username if user_info else "Unknown"} (ID: {user_info.user_id if user_info else "Unknown"})\n'
+            f'  Comment: {comment_text[:100]}...'
+        )
+
+        if '@openhands' not in comment_text.lower():
+            logger.debug('Comment does not mention @openhands, ignoring')
+            return
+
+        user_found = False
+        if user_info:
+            bitbucket_account_id = user_info.bitbucket_id
+            keycloak_user_id = await self.token_manager.get_user_id_from_idp_user_id(
+                bitbucket_account_id, ProviderType.BITBUCKET
+            )
+            user_found = keycloak_user_id is not None
+            if user_found:
+                user_info.keycloak_user_id = keycloak_user_id
+
+        acknowledgment_message = (
+            "🤖 **OpenHands** received your request!\n\n"
+            "📋 **Details received:**\n\n"
+            f"- Workspace: `{workspace_slug}`\n\n"
+            f"- Repository: `{repo_slug}`\n\n"
+            f"- PR: #{pr_id}\n\n"
+            f"- User: {user_info.username if user_info else 'Unknown'}\n\n"
+            f"- User found in Keycloak: {'✅ Yes' if user_found else '❌ No'}"
+        )
+
+        if workspace_slug and repo_slug and pr_id:
+            await self.send_response_to_pr(
+                workspace_slug, repo_slug, pr_id, acknowledgment_message
+            )
+
+        if user_found:
+            await self._check_user_authorization(
+                user_info, workspace_slug, repo_slug, pr_id
+            )
+        else:
+            if user_info:
+                logger.warning(f'User {user_info.bitbucket_id} not found in Keycloak')
+            else:
+                logger.warning('No user info extracted from webhook')
+
+    async def _check_user_authorization(
+        self,
+        user_info: UserData,
+        workspace_slug: str,
+        repo_slug: str,
+        pr_id: Optional[int],
+    ):
+        bitbucket_account_id = user_info.bitbucket_id
+
+        user_token = await self.token_manager.get_idp_token_from_idp_user_id(
+            bitbucket_account_id, ProviderType.BITBUCKET
+        )
+
+        if user_token:
+            logger.info(f'Found Bitbucket token for user {bitbucket_account_id}')
+
+            has_write_access = await self._check_write_access(
+                user_token, workspace_slug, repo_slug, user_info
+            )
+
+            if has_write_access:
+                logger.info(
+                    f'User {bitbucket_account_id} has write access to {workspace_slug}/{repo_slug}'
+                )
+                # TODO: Trigger OpenHands agent with PR context
+            else:
+                logger.warning(
+                    f'User {bitbucket_account_id} does not have write access to {workspace_slug}/{repo_slug}'
+                )
+        else:
+            logger.warning(
+                f'No Bitbucket token found for user {bitbucket_account_id}. '
+                f'User needs to re-authenticate with Bitbucket.'
+            )
+
+    async def _check_write_access(
+        self, user_token: str, workspace_slug: str, repo_slug: str, user_info: UserData
+    ) -> bool:
+        # TODO: Implement actual permission check using Bitbucket API
+        # API endpoint: GET /repositories/{workspace}/{repo_slug}/permissions-config/users/{selected_user_id}
+        # This should be implemented after Keycloak Bitbucket IDP support is merged
+
+        logger.info(
+            f'Checking write access for user {user_info.bitbucket_id} '
+            f'to repository {workspace_slug}/{repo_slug}'
+        )
+
+        return True
+
+    async def send_response_to_pr(
+        self, workspace_slug: str, repo_slug: str, pr_id: int, message: str
+    ) -> bool:
+        forge_webhook_url = os.getenv('FORGE_APP_WEBHOOK_URL', '')
+
+        if not forge_webhook_url:
+            logger.warning('FORGE_APP_WEBHOOK_URL not configured, cannot send response')
+            return False
+
+        payload = {
+            'workspace': workspace_slug,
+            'repo': repo_slug,
+            'prId': pr_id,
+            'message': message,
+        }
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    forge_webhook_url,
+                    json=payload,
+                    headers={'Content-Type': 'application/json'},
+                ) as response:
+                    if response.status == 200:
+                        logger.info(
+                            f'Successfully sent response to PR #{pr_id} in {workspace_slug}/{repo_slug}'
+                        )
+                        return True
+                    else:
+                        error_text = await response.text()
+                        logger.error(
+                            f'Failed to send response to Forge app. Status: {response.status}, '
+                            f'Error: {error_text}'
+                        )
+                        return False
+
+        except Exception as e:
+            logger.error(f'Error sending response to Forge app: {str(e)}')
+            return False

--- a/enterprise/integrations/models.py
+++ b/enterprise/integrations/models.py
@@ -8,6 +8,7 @@ from openhands.core.schema import AgentState
 class SourceType(str, Enum):
     GITHUB = 'github'
     GITLAB = 'gitlab'
+    BITBUCKET = 'bitbucket'
     OPENHANDS = 'openhands'
     SLACK = 'slack'
     JIRA = 'jira'

--- a/enterprise/integrations/types.py
+++ b/enterprise/integrations/types.py
@@ -20,6 +20,7 @@ class UserData(BaseModel):
     user_id: int
     username: str
     keycloak_user_id: str | None
+    bitbucket_id: str | None = None  # Bitbucket's string account ID
 
 
 @dataclass

--- a/enterprise/saas_server.py
+++ b/enterprise/saas_server.py
@@ -29,6 +29,9 @@ from server.routes.email import api_router as email_router  # noqa: E402
 from server.routes.event_webhook import event_webhook_router  # noqa: E402
 from server.routes.feedback import router as feedback_router  # noqa: E402
 from server.routes.github_proxy import add_github_proxy_routes  # noqa: E402
+from server.routes.integration.bitbucket import (  # noqa: E402
+    bitbucket_integration_router,
+)
 from server.routes.integration.jira import jira_integration_router  # noqa: E402
 from server.routes.integration.jira_dc import jira_dc_integration_router  # noqa: E402
 from server.routes.integration.linear import linear_integration_router  # noqa: E402
@@ -78,6 +81,8 @@ if GITLAB_APP_CLIENT_ID:
     from server.routes.integration.gitlab import gitlab_integration_router  # noqa: E402
 
     base_app.include_router(gitlab_integration_router)
+
+base_app.include_router(bitbucket_integration_router)
 
 base_app.include_router(api_keys_router)  # Add routes for API key management
 add_github_proxy_routes(base_app)

--- a/enterprise/server/auth/token_manager.py
+++ b/enterprise/server/auth/token_manager.py
@@ -499,7 +499,8 @@ class TokenManager:
         self, idp_user_id: str, idp: ProviderType
     ) -> str | None:
         keycloak_admin = get_keycloak_admin(self.external)
-        users = await keycloak_admin.a_get_users({'q': f'{idp.value}_id:{idp_user_id}'})
+        query = f'{idp.value}_id:{idp_user_id}'
+        users = await keycloak_admin.a_get_users({'q': query})
         if not users:
             logger.info(f'{idp.value} user with IDP ID {idp_user_id} not found.')
             return None

--- a/enterprise/server/routes/integration/bitbucket.py
+++ b/enterprise/server/routes/integration/bitbucket.py
@@ -1,0 +1,93 @@
+import os
+
+from fastapi import APIRouter, Header, HTTPException, Request
+from fastapi.responses import JSONResponse
+from integrations.bitbucket.bitbucket_manager import BitbucketManager
+from integrations.models import Message, SourceType
+from server.auth.token_manager import TokenManager
+
+from openhands.core.logger import openhands_logger as logger
+
+BITBUCKET_WEBHOOKS_ENABLED = os.environ.get('BITBUCKET_WEBHOOKS_ENABLED', '1') in (
+    '1',
+    'true',
+)
+
+BITBUCKET_WEBHOOK_SECRET = os.environ.get('BITBUCKET_WEBHOOK_SECRET', '')
+
+bitbucket_integration_router = APIRouter(prefix='/integration')
+token_manager = TokenManager()
+bitbucket_manager = BitbucketManager(token_manager)
+
+
+def verify_forge_signature(payload: bytes, signature: str):
+    """Verify the webhook signature from Forge app."""
+    if not signature:
+        raise HTTPException(status_code=403, detail='X-Forge-Secret header is missing!')
+
+    # TODO: Upgrade to HMAC-based verification for production
+    if signature != BITBUCKET_WEBHOOK_SECRET:
+        raise HTTPException(status_code=403, detail='Invalid webhook secret!')
+
+
+@bitbucket_integration_router.post('/bitbucket/events')
+async def bitbucket_events(
+    request: Request,
+    x_forge_secret: str = Header(None),
+):
+    """Handle webhook events from Bitbucket via Forge app."""
+
+    if not BITBUCKET_WEBHOOKS_ENABLED:
+        logger.info(
+            'Bitbucket webhooks are disabled by BITBUCKET_WEBHOOKS_ENABLED environment variable'
+        )
+        return JSONResponse(
+            status_code=200,
+            content={'message': 'Bitbucket webhooks are currently disabled.'},
+        )
+
+    try:
+        payload = await request.body()
+
+        if not BITBUCKET_WEBHOOK_SECRET:
+            logger.error(
+                'BITBUCKET_WEBHOOK_SECRET not configured - rejecting request for security'
+            )
+            raise HTTPException(
+                status_code=500, detail='Webhook secret not configured on server'
+            )
+
+        verify_forge_signature(payload, x_forge_secret)
+
+        payload_data = await request.json()
+
+        event_data = payload_data.get('event', {})
+        context_data = payload_data.get('context', {})
+
+        workspace_slug = event_data.get('workspace', {}).get('slug')
+        repo_slug = event_data.get('repository', {}).get('slug')
+        pr_id = event_data.get('pullrequest', {}).get('id')
+
+        message_payload = {
+            'event': event_data,
+            'context': context_data,
+        }
+        message = Message(source=SourceType.BITBUCKET, message=message_payload)
+
+        await bitbucket_manager.receive_message(message)
+
+        return JSONResponse(
+            status_code=200,
+            content={
+                'message': 'Bitbucket event received and logged successfully.',
+                'workspace': workspace_slug,
+                'repository': repo_slug,
+                'pr_id': pr_id,
+            },
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f'Error processing Bitbucket event: {e}')
+        return JSONResponse(status_code=400, content={'error': 'Invalid payload.'})

--- a/enterprise/tests/unit/test_bitbucket_manager.py
+++ b/enterprise/tests/unit/test_bitbucket_manager.py
@@ -1,0 +1,231 @@
+"""
+Tests for the Bitbucket manager.
+"""
+
+import hashlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from integrations.bitbucket.bitbucket_manager import BitbucketManager
+from integrations.models import Message, SourceType
+from server.auth.token_manager import ProviderType
+
+
+@pytest.fixture
+def bitbucket_manager():
+    """Create a BitbucketManager instance for testing."""
+    with patch('integrations.bitbucket.bitbucket_manager.TokenManager'):
+        manager = BitbucketManager()
+        manager.token_manager = AsyncMock()
+        return manager
+
+
+@pytest.mark.asyncio
+async def test_extract_user_info(bitbucket_manager):
+    """Test extracting user information from Bitbucket webhook event."""
+    event_data = {
+        'actor': {
+            'accountId': '5b857d7bb8e3cb58958607cc',
+            'username': 'testuser',
+            'uuid': '{82ebd5fb-c165-4e68-b5ab-ddab6c8467d1}',
+        }
+    }
+
+    user_info = bitbucket_manager._extract_user_info(event_data)
+
+    assert user_info is not None
+    assert user_info.bitbucket_id == '5b857d7bb8e3cb58958607cc'
+    assert user_info.username == 'testuser'
+    assert user_info.keycloak_user_id is None
+    # Verify the integer user_id is stable (hash-based)
+    expected_hash = int(
+        hashlib.sha256('5b857d7bb8e3cb58958607cc'.encode()).hexdigest()[:8], 16
+    )
+    assert user_info.user_id == expected_hash
+
+
+@pytest.mark.asyncio
+async def test_extract_user_info_no_username(bitbucket_manager):
+    """Test extracting user info when username is missing."""
+    event_data = {
+        'actor': {
+            'accountId': '5b857d7bb8e3cb58958607cc',
+            'uuid': '{82ebd5fb-c165-4e68-b5ab-ddab6c8467d1}',
+        }
+    }
+
+    user_info = bitbucket_manager._extract_user_info(event_data)
+
+    assert user_info is not None
+    assert user_info.bitbucket_id == '5b857d7bb8e3cb58958607cc'
+    assert user_info.username == '5b857d7bb8e3cb58958607cc'  # Falls back to account_id
+
+
+@pytest.mark.asyncio
+async def test_extract_user_info_missing_actor(bitbucket_manager):
+    """Test extracting user info when actor is missing."""
+    event_data: dict = {}
+
+    user_info = bitbucket_manager._extract_user_info(event_data)
+
+    assert user_info is None
+
+
+@pytest.mark.asyncio
+async def test_receive_message_pr_comment_with_mention(bitbucket_manager):
+    """Test processing a PR comment with @openhands mention."""
+    # Mock the token manager responses
+    bitbucket_manager.token_manager.get_user_id_from_idp_user_id.return_value = (
+        'keycloak-user-123'
+    )
+    bitbucket_manager.token_manager.get_idp_token_from_idp_user_id.return_value = (
+        'test-token'
+    )
+
+    # Create a PR comment event with mention
+    event_data = {
+        'actor': {
+            'accountId': '5b857d7bb8e3cb58958607cc',
+            'username': 'testuser',
+        },
+        'comment': {'content': {'raw': '@openhands help me fix this bug'}},
+        'workspace': {'slug': 'test-workspace'},
+        'repository': {'slug': 'test-repo'},
+        'pullrequest': {'id': 1},
+    }
+
+    message = Message(
+        source=SourceType.BITBUCKET, message={'event': event_data, 'context': {}}
+    )
+
+    with patch.object(bitbucket_manager, '_check_write_access', return_value=True):
+        await bitbucket_manager.receive_message(message)
+
+    # Verify user lookup was attempted
+    bitbucket_manager.token_manager.get_user_id_from_idp_user_id.assert_called_once_with(
+        '5b857d7bb8e3cb58958607cc', ProviderType.BITBUCKET
+    )
+
+    # Verify token retrieval was attempted
+    bitbucket_manager.token_manager.get_idp_token_from_idp_user_id.assert_called_once_with(
+        '5b857d7bb8e3cb58958607cc', ProviderType.BITBUCKET
+    )
+
+
+@pytest.mark.asyncio
+async def test_receive_message_no_mention(bitbucket_manager):
+    """Test that comments without @openhands mention are ignored."""
+    event_data = {
+        'actor': {
+            'accountId': '5b857d7bb8e3cb58958607cc',
+            'username': 'testuser',
+        },
+        'comment': {'content': {'raw': 'This is just a regular comment'}},
+        'workspace': {'slug': 'test-workspace'},
+        'repository': {'slug': 'test-repo'},
+    }
+
+    message = Message(
+        source=SourceType.BITBUCKET, message={'event': event_data, 'context': {}}
+    )
+
+    await bitbucket_manager.receive_message(message)
+
+    # Verify no user lookup was attempted
+    bitbucket_manager.token_manager.get_user_id_from_idp_user_id.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_receive_message_user_not_found(bitbucket_manager):
+    """Test handling when user is not found in Keycloak."""
+    # Mock the token manager to return None (user not found)
+    bitbucket_manager.token_manager.get_user_id_from_idp_user_id.return_value = None
+
+    event_data = {
+        'actor': {
+            'accountId': '5b857d7bb8e3cb58958607cc',
+            'username': 'testuser',
+        },
+        'comment': {'content': {'raw': '@openhands help me'}},
+        'workspace': {'slug': 'test-workspace'},
+        'repository': {'slug': 'test-repo'},
+    }
+
+    message = Message(
+        source=SourceType.BITBUCKET, message={'event': event_data, 'context': {}}
+    )
+
+    await bitbucket_manager.receive_message(message)
+
+    # Verify user lookup was attempted
+    bitbucket_manager.token_manager.get_user_id_from_idp_user_id.assert_called_once()
+
+    # Verify token retrieval was NOT attempted (user not found)
+    bitbucket_manager.token_manager.get_idp_token_from_idp_user_id.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_receive_message_wrong_source(bitbucket_manager):
+    """Test that non-Bitbucket messages are rejected."""
+    message = Message(source=SourceType.GITHUB, message={'event': {}, 'context': {}})
+
+    await bitbucket_manager.receive_message(message)
+
+    # Verify no processing occurred
+    bitbucket_manager.token_manager.get_user_id_from_idp_user_id.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_response_to_pr(bitbucket_manager):
+    """Test sending response back to Bitbucket PR."""
+    import os
+
+    # Set the webhook URL environment variable
+    with patch.dict(
+        os.environ, {'FORGE_APP_WEBHOOK_URL': 'https://forge.example.com/webhook'}
+    ):
+        with patch(
+            'integrations.bitbucket.bitbucket_manager.aiohttp.ClientSession'
+        ) as mock_session_class:
+            # Mock the response
+            mock_response = AsyncMock()
+            mock_response.status = 200
+
+            # Mock the ClientSession and its async context manager behavior
+            mock_session = MagicMock()
+            mock_session_class.return_value.__aenter__.return_value = mock_session
+
+            # Mock session.post() to return an async context manager
+            mock_session.post.return_value.__aenter__.return_value = mock_response
+
+            # Send a response
+            result = await bitbucket_manager.send_response_to_pr(
+                'test-workspace', 'test-repo', 123, 'Test message'
+            )
+
+            assert result is True
+
+            # Verify the request was made with correct data
+            mock_session.post.assert_called_once()
+            call_args = mock_session.post.call_args
+            assert call_args[0][0] == 'https://forge.example.com/webhook'
+            assert call_args[1]['json'] == {
+                'workspace': 'test-workspace',
+                'repo': 'test-repo',
+                'prId': 123,
+                'message': 'Test message',
+            }
+
+
+@pytest.mark.asyncio
+async def test_send_response_no_webhook_url(bitbucket_manager):
+    """Test that sending response fails gracefully when webhook URL is not configured."""
+    import os
+
+    # Ensure FORGE_APP_WEBHOOK_URL is not set
+    with patch.dict(os.environ, {}, clear=True):
+        result = await bitbucket_manager.send_response_to_pr(
+            'test-workspace', 'test-repo', 123, 'Test message'
+        )
+
+        assert result is False


### PR DESCRIPTION
  Summary

  This PR adds support for Bitbucket Cloud webhooks to enable OpenHands to respond to pull request comments and issue conversations on Bitbucket repositories, similar to the existing GitHub integration. This PR is 

  Changes

  Core Integration Features:
  - New BitbucketManager class to handle incoming webhook events and manage user authentication
  - Webhook endpoint (/api/webhooks/bitbucket) to receive and process PR comment events

  Supporting Changes:
  - Added Bitbucket platform to SourceType enum
  - Extended conversation metadata to support Bitbucket platform
  - Updated token manager to handle Bitbucket user authentication

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:2feeda4-nikolaik   --name openhands-app-2feeda4   docker.all-hands.dev/all-hands-ai/openhands:2feeda4
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@alona/all-2685-enhancement-use-openhands-on-bitbucket-cloud-repos-1 openhands
```