### PR TITLE
refactor(frontend): move auth APIs to a dedicated service handler

### DIFF
--- a/frontend/__tests__/routes/git-settings.test.tsx
+++ b/frontend/__tests__/routes/git-settings.test.tsx
@@ -7,6 +7,7 @@ import i18next from "i18next";
 import { I18nextProvider } from "react-i18next";
 import GitSettingsScreen from "#/routes/git-settings";
 import OpenHands from "#/api/open-hands";
+import AuthService from "#/api/auth-service/auth-service.api";
 import { MOCK_DEFAULT_USER_SETTINGS } from "#/mocks/handlers";
 import { GetConfigResponse } from "#/api/open-hands.types";
 import * as ToastHandlers from "#/utils/custom-toast-handlers";
@@ -392,7 +393,7 @@ describe("Form submission", () => {
 
   it("should call logout when pressing the disconnect tokens button", async () => {
     const getConfigSpy = vi.spyOn(OpenHands, "getConfig");
-    const logoutSpy = vi.spyOn(OpenHands, "logout");
+    const logoutSpy = vi.spyOn(AuthService, "logout");
     const getSettingsSpy = vi.spyOn(OpenHands, "getSettings");
 
     getConfigSpy.mockResolvedValue(VALID_OSS_CONFIG);

--- a/frontend/src/api/auth-service/auth-service.api.ts
+++ b/frontend/src/api/auth-service/auth-service.api.ts
@@ -1,0 +1,52 @@
+import { openHands } from "../open-hands-axios";
+import { AuthenticateResponse, GitHubAccessTokenResponse } from "./auth.types";
+import { GetConfigResponse } from "../open-hands.types";
+
+/**
+ * Authentication service for handling all authentication-related API calls
+ */
+class AuthService {
+  /**
+   * Authenticate with GitHub token
+   * @param appMode The application mode (saas or oss)
+   * @returns Response with authentication status and user info if successful
+   */
+  static async authenticate(
+    appMode: GetConfigResponse["APP_MODE"],
+  ): Promise<boolean> {
+    if (appMode === "oss") return true;
+
+    // Just make the request, if it succeeds (no exception thrown), return true
+    await openHands.post<AuthenticateResponse>("/api/authenticate");
+    return true;
+  }
+
+  /**
+   * Get GitHub access token from Keycloak callback
+   * @param code Code provided by GitHub
+   * @returns GitHub access token
+   */
+  static async getGitHubAccessToken(
+    code: string,
+  ): Promise<GitHubAccessTokenResponse> {
+    const { data } = await openHands.post<GitHubAccessTokenResponse>(
+      "/api/keycloak/callback",
+      {
+        code,
+      },
+    );
+    return data;
+  }
+
+  /**
+   * Logout user from the application
+   * @param appMode The application mode (saas or oss)
+   */
+  static async logout(appMode: GetConfigResponse["APP_MODE"]): Promise<void> {
+    const endpoint =
+      appMode === "saas" ? "/api/logout" : "/api/unset-provider-tokens";
+    await openHands.post(endpoint);
+  }
+}
+
+export default AuthService;

--- a/frontend/src/api/auth-service/auth.types.ts
+++ b/frontend/src/api/auth-service/auth.types.ts
@@ -1,0 +1,8 @@
+export interface AuthenticateResponse {
+  message?: string;
+  error?: string;
+}
+
+export interface GitHubAccessTokenResponse {
+  access_token: string;
+}

--- a/frontend/src/api/open-hands.ts
+++ b/frontend/src/api/open-hands.ts
@@ -2,10 +2,8 @@ import { AxiosHeaders } from "axios";
 import {
   Feedback,
   FeedbackResponse,
-  GitHubAccessTokenResponse,
   GetConfigResponse,
   GetVSCodeUrlResponse,
-  AuthenticateResponse,
   Conversation,
   ResultSet,
   GetTrajectoryResponse,
@@ -211,20 +209,6 @@ class OpenHands {
   }
 
   /**
-   * Authenticate with GitHub token
-   * @returns Response with authentication status and user info if successful
-   */
-  static async authenticate(
-    appMode: GetConfigResponse["APP_MODE"],
-  ): Promise<boolean> {
-    if (appMode === "oss") return true;
-
-    // Just make the request, if it succeeds (no exception thrown), return true
-    await openHands.post<AuthenticateResponse>("/api/authenticate");
-    return true;
-  }
-
-  /**
    * Get the blob of the workspace zip
    * @returns Blob of the workspace zip
    */
@@ -247,22 +231,6 @@ class OpenHands {
       headers: this.getConversationHeaders(),
     });
     return Object.keys(response.data.hosts);
-  }
-
-  /**
-   * @param code Code provided by GitHub
-   * @returns GitHub access token
-   */
-  static async getGitHubAccessToken(
-    code: string,
-  ): Promise<GitHubAccessTokenResponse> {
-    const { data } = await openHands.post<GitHubAccessTokenResponse>(
-      "/api/keycloak/callback",
-      {
-        code,
-      },
-    );
-    return data;
   }
 
   /**
@@ -485,12 +453,6 @@ class OpenHands {
       headers: this.getConversationHeaders(),
     });
     return data;
-  }
-
-  static async logout(appMode: GetConfigResponse["APP_MODE"]): Promise<void> {
-    const endpoint =
-      appMode === "saas" ? "/api/logout" : "/api/unset-provider-tokens";
-    await openHands.post(endpoint);
   }
 
   static async getGitChanges(conversationId: string): Promise<GitChange[]> {

--- a/frontend/src/api/open-hands.types.ts
+++ b/frontend/src/api/open-hands.types.ts
@@ -26,10 +26,6 @@ export interface FeedbackResponse {
   body: FeedbackBodyResponse;
 }
 
-export interface GitHubAccessTokenResponse {
-  access_token: string;
-}
-
 export interface AuthenticationResponse {
   message: string;
   login?: string; // Only present when allow list is enabled
@@ -42,6 +38,16 @@ export interface Feedback {
   polarity: "positive" | "negative";
   permissions: "public" | "private";
   trajectory: unknown[];
+}
+
+export interface GetVSCodeUrlResponse {
+  vscode_url: string | null;
+  error?: string;
+}
+
+export interface GetTrajectoryResponse {
+  trajectory: unknown[] | null;
+  error?: string;
 }
 
 export interface GetConfigResponse {
@@ -61,21 +67,6 @@ export interface GetConfigResponse {
   MAINTENANCE?: {
     startTime: string;
   };
-}
-
-export interface GetVSCodeUrlResponse {
-  vscode_url: string | null;
-  error?: string;
-}
-
-export interface GetTrajectoryResponse {
-  trajectory: unknown[] | null;
-  error?: string;
-}
-
-export interface AuthenticateResponse {
-  message?: string;
-  error?: string;
 }
 
 export interface RepositorySelection {

--- a/frontend/src/hooks/mutation/use-logout.ts
+++ b/frontend/src/hooks/mutation/use-logout.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import posthog from "posthog-js";
-import OpenHands from "#/api/open-hands";
+import AuthService from "#/api/auth-service/auth-service.api";
 import { useConfig } from "../query/use-config";
 import { clearLoginData } from "#/utils/local-storage";
 
@@ -9,7 +9,7 @@ export const useLogout = () => {
   const { data: config } = useConfig();
 
   return useMutation({
-    mutationFn: () => OpenHands.logout(config?.APP_MODE ?? "oss"),
+    mutationFn: () => AuthService.logout(config?.APP_MODE ?? "oss"),
     onSuccess: async () => {
       queryClient.removeQueries({ queryKey: ["tasks"] });
       queryClient.removeQueries({ queryKey: ["settings"] });

--- a/frontend/src/hooks/query/use-is-authed.ts
+++ b/frontend/src/hooks/query/use-is-authed.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import axios, { AxiosError } from "axios";
-import OpenHands from "#/api/open-hands";
+import AuthService from "#/api/auth-service/auth-service.api";
 import { useConfig } from "./use-config";
 import { useIsOnTosPage } from "#/hooks/use-is-on-tos-page";
 
@@ -15,7 +15,7 @@ export const useIsAuthed = () => {
     queryFn: async () => {
       try {
         // If in OSS mode or authentication succeeds, return true
-        await OpenHands.authenticate(appMode!);
+        await AuthService.authenticate(appMode!);
         return true;
       } catch (error) {
         // If it's a 401 error, return false (not authenticated)

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,8 +1,8 @@
 import { delay, http, HttpResponse } from "msw";
 import {
-  GetConfigResponse,
   Conversation,
   ResultSet,
+  GetConfigResponse,
 } from "#/api/open-hands.types";
 import { DEFAULT_SETTINGS } from "#/services/settings";
 import { STRIPE_BILLING_HANDLERS } from "./billing-handlers";


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

**Acceptance Criteria:**
- Create a new folder named auth-service.
- Inside this folder, add two new files:
  - auth-service.api.ts
  - auth.types.ts
- Relocate all API endpoints that begin with /api/authenticate and /api/keycloak into the auth-service.api.ts file.
- Relocate all corresponding type definitions into the auth.types.ts file.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR updates the code to align with the acceptance criteria outlined above.

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d665796-nikolaik   --name openhands-app-d665796   docker.all-hands.dev/all-hands-ai/openhands:d665796
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3486-1 openhands
```