### PR TITLE
refactor(frontend): expand repository pill to full available width

### DIFF
--- a/frontend/src/components/features/chat/git-control-bar-branch-button.tsx
+++ b/frontend/src/components/features/chat/git-control-bar-branch-button.tsx
@@ -31,27 +31,21 @@ export function GitControlBarBranchButton({
       target="_blank"
       rel="noopener noreferrer"
       className={cn(
-        "group flex flex-row items-center justify-between gap-2 pl-2.5 pr-2.5 py-1 rounded-[100px] w-fit max-w-none flex-shrink-0 max-w-[108px] truncate relative",
+        "group flex flex-row items-center justify-between gap-2 pl-2.5 pr-2.5 py-1 rounded-[100px] w-fit flex-shrink-0 max-w-[200px] truncate relative",
         hasBranch
           ? "border border-[#525252] bg-transparent hover:border-[#454545] cursor-pointer"
           : "border border-[rgba(71,74,84,0.50)] bg-transparent cursor-not-allowed min-w-[108px]",
       )}
     >
-      <div className="flex flex-row gap-2 items-center justify-start">
-        <div className="w-3 h-3 flex items-center justify-center">
-          <BranchIcon width={12} height={12} color="white" />
-        </div>
-        <div
-          className={cn(
-            "font-normal text-white text-sm leading-5 truncate",
-            hasBranch && "max-w-[70px]",
-          )}
-          title={buttonText}
-        >
-          {buttonText}
-        </div>
+      <div className="w-3 h-3 flex items-center justify-center flex-shrink-0">
+        <BranchIcon width={12} height={12} color="white" />
       </div>
-
+      <div
+        className="font-normal text-white text-sm leading-5 truncate"
+        title={buttonText}
+      >
+        {buttonText}
+      </div>
       {hasBranch && <GitExternalLinkIcon />}
     </a>
   );

--- a/frontend/src/components/features/chat/git-control-bar-repo-button.tsx
+++ b/frontend/src/components/features/chat/git-control-bar-repo-button.tsx
@@ -33,32 +33,27 @@ export function GitControlBarRepoButton({
       target="_blank"
       rel="noopener noreferrer"
       className={cn(
-        "group flex flex-row items-center justify-between gap-2 pl-2.5 pr-2.5 py-1 rounded-[100px] w-fit flex-shrink-0 max-w-[170px] truncate relative",
+        "group flex flex-row items-center justify-between gap-2 pl-2.5 pr-2.5 py-1 rounded-[100px] flex-1 truncate relative",
         hasRepository
           ? "border border-[#525252] bg-transparent hover:border-[#454545] cursor-pointer"
           : "border border-[rgba(71,74,84,0.50)] bg-transparent cursor-not-allowed min-w-[170px]",
       )}
     >
-      <div className="flex flex-row gap-2 items-center justify-start">
-        <div className="w-3 h-3 flex items-center justify-center">
-          {hasRepository ? (
-            <GitProviderIcon
-              gitProvider={gitProvider as Provider}
-              className="w-3 h-3 inline-flex"
-            />
-          ) : (
-            <RepoForkedIcon width={12} height={12} color="white" />
-          )}
-        </div>
-        <div
-          className={cn(
-            "font-normal text-white text-sm leading-5 truncate",
-            hasRepository && "max-w-[100px]",
-          )}
-          title={buttonText}
-        >
-          {buttonText}
-        </div>
+      <div className="w-3 h-3 flex items-center justify-center flex-shrink-0">
+        {hasRepository ? (
+          <GitProviderIcon
+            gitProvider={gitProvider as Provider}
+            className="w-3 h-3 inline-flex"
+          />
+        ) : (
+          <RepoForkedIcon width={12} height={12} color="white" />
+        )}
+      </div>
+      <div
+        className="font-normal text-white text-sm leading-5 truncate flex-1 min-w-0"
+        title={buttonText}
+      >
+        {buttonText}
       </div>
       {hasRepository && <GitExternalLinkIcon />}
     </a>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

<img width="1592" height="268" alt="all-3514-issue" src="https://github.com/user-attachments/assets/31960f86-4681-4059-adae-0bdecee62e17" />

**Description:**

The repository pill on the conversation page does not provide sufficient space to display its contents. To enhance usability, the pill should be expanded to occupy the full available width.

**Acceptance Criteria:**
- The repository pill expands to utilize the full available width on the conversation page.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR expands repository pill to full available width.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/00ec9338-8263-4e03-9ad7-768283c9b463

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:4692658-nikolaik   --name openhands-app-4692658   docker.all-hands.dev/all-hands-ai/openhands:4692658
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3514-1 openhands
```