### PR TITLE
fix(frontend): highlight preceding stars on hover in LikertScale

### DIFF
--- a/frontend/src/components/features/feedback/likert-scale.tsx
+++ b/frontend/src/components/features/feedback/likert-scale.tsx
@@ -188,7 +188,7 @@ export function LikertScale({
 
     return selectedRating && selectedRating >= rating
       ? "text-yellow-400"
-      : "text-gray-300 hover:text-yellow-200";
+      : "text-gray-300";
   };
 
   return (
@@ -206,7 +206,12 @@ export function LikertScale({
               key={rating}
               onClick={() => handleRatingClick(rating)}
               disabled={isSubmitted}
-              className={cn("text-xl transition-all", getButtonClass(rating))}
+              className={cn(
+                "oh-star text-xl transition-all",
+                getButtonClass(rating),
+                !isSubmitted &&
+                  "hover:text-yellow-400 [&:has(~.oh-star:hover)]:text-yellow-400",
+              )}
               aria-label={`Rate ${rating} stars`}
             >
               <FaStar />


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

- Highlights hovered star and all preceding stars for clearer intent.
- Adds oh-star marker class and uses Tailwind :has(~.oh-star:hover) to color earlier siblings.
- Removes per-button hover color from getButtonClass to avoid conflicts.
- Preserves selected/submitted logic; no backend/API changes.
- Pure CSS solution; minimal code churn.

---

What changed

- frontend/src/components/features/feedback/likert-scale.tsx
    - Add oh-star class on each button.
    - Button classes: hover:text-yellow-400 [&:has(~.oh-star:hover)]:text-yellow-400 when not submitted.
    - getButtonClass no longer sets a hover: color; relies on the relational selector.

Impact

- UX: clearer preview of the rating to be chosen.
- Accessibility: aria-label unchanged; keyboard interaction unaffected.
- Performance: negligible; CSS-only.

How I validated

- Manually tested hover on stars 1–5 to confirm cascading highlight.
- Verified no regression in reason selection flow (for ratings ≤3).
- Confirmed hover disabled after submission.


---
**Link of any specific issues this addresses:**

https://github.com/All-Hands-AI/OpenHands/issues/9584