### PR TITLE
Enable JavaScript source maps and make them available in GitHub workflows

### DIFF
--- a/.github/workflows/fe-unit-tests.yml
+++ b/.github/workflows/fe-unit-tests.yml
@@ -42,3 +42,10 @@ jobs:
       - name: Run tests and collect coverage
         working-directory: ./frontend
         run: npm run test:coverage
+      - name: Upload source maps as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-source-maps-${{ github.sha }}
+          path: frontend/build/**/*.map
+          retention-days: 30
+          if-no-files-found: warn

--- a/.github/workflows/frontend-source-maps.yml
+++ b/.github/workflows/frontend-source-maps.yml
@@ -1,0 +1,76 @@
+# Workflow that builds frontend and uploads source maps as artifacts
+name: Build Frontend Source Maps
+
+# Run on main branch pushes, releases, and manual triggers
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-source-maps.yml"
+  release:
+    types: [published]
+  workflow_dispatch:
+
+# If triggered by a PR, it will be in the same group. However, each commit on main will be in its own unique group
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.head_ref && github.ref) || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build-source-maps:
+    name: Build Frontend and Upload Source Maps
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    strategy:
+      matrix:
+        node-version: [22]
+      fail-fast: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Set up Node.js
+        uses: useblacksmith/setup-node@v5
+        with:
+          node-version: ${{ matrix.node-version }}
+      
+      - name: Install dependencies
+        working-directory: ./frontend
+        run: npm ci
+      
+      - name: Build frontend with source maps
+        working-directory: ./frontend
+        run: npm run build
+      
+      - name: Upload source maps as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-source-maps-${{ github.sha }}
+          path: frontend/build/**/*.map
+          retention-days: 90
+          if-no-files-found: error
+      
+      - name: Upload complete build artifacts (for debugging)
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-build-${{ github.sha }}
+          path: |
+            frontend/build/**/*
+            !frontend/build/**/*.map
+          retention-days: 30
+          if-no-files-found: error
+      
+      - name: Create source maps summary
+        run: |
+          echo "## Source Maps Generated 🗺️" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Source maps have been generated and uploaded as artifacts." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Statistics:" >> $GITHUB_STEP_SUMMARY
+          echo "- **Total source map files:** $(find frontend/build -name "*.map" | wc -l)" >> $GITHUB_STEP_SUMMARY
+          echo "- **Total size:** $(du -sh frontend/build/**/*.map 2>/dev/null | tail -1 | cut -f1 || echo 'N/A')" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit SHA:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Download:" >> $GITHUB_STEP_SUMMARY
+          echo "Source maps are available as workflow artifacts and can be downloaded from the Actions tab." >> $GITHUB_STEP_SUMMARY

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -31,6 +31,9 @@ export default defineConfig(({ mode }) => {
       svgr(),
       tailwindcss(),
     ],
+    build: {
+      sourcemap: true,
+    },
     optimizeDeps: {
       include: [
         // Pre-bundle ALL dependencies to prevent runtime optimization and page reloads


### PR DESCRIPTION
## Summary

This PR enables JavaScript source maps for the React frontend application and makes them available as downloadable artifacts from GitHub workflows.

## Changes Made

### 1. Enable Source Maps in Vite Configuration
- Modified `frontend/vite.config.ts` to add `build.sourcemap: true`
- This generates `.map` files alongside the built JavaScript files
- Source maps allow mapping minified production code back to original source code for debugging

### 2. Upload Source Maps in Existing Workflow
- Modified `.github/workflows/fe-unit-tests.yml` to upload source maps as artifacts
- Source maps are now available after the frontend unit tests workflow runs
- Artifacts are retained for 30 days with warning if no files found

### 3. Create Dedicated Source Maps Workflow
- Added new `.github/workflows/frontend-source-maps.yml` workflow
- Runs on main branch pushes, releases, and manual triggers
- Uploads both source maps and complete build artifacts
- Provides detailed summary of generated source maps
- Artifacts retained for 90 days (source maps) and 30 days (builds)

## Benefits

1. **Debugging Production Issues**: Developers can download source maps to debug minified production code
2. **Error Tracking**: Source maps enable better error reporting and stack traces in production
3. **Development Workflow**: Source maps are automatically generated and available for every build
4. **Accessibility**: Source maps are easily downloadable from GitHub Actions artifacts

## Testing

- ✅ Source maps are successfully generated during build (88 `.map` files created)
- ✅ JavaScript files include proper `sourceMappingURL` comments
- ✅ Build process completes successfully with source maps enabled
- ✅ Pre-commit hooks pass (frontend linting, TypeScript compilation, etc.)

## Workflow Triggers

The new `frontend-source-maps.yml` workflow will run:
- On pushes to `main` branch that modify frontend files
- On published releases
- On manual workflow dispatch

## Artifact Details

- **Source Maps**: Available as `frontend-source-maps-{commit-sha}` artifacts
- **Complete Build**: Available as `frontend-build-{commit-sha}` artifacts (excluding source maps)
- **Retention**: 90 days for source maps, 30 days for builds
- **Download**: Available from the Actions tab of any workflow run

## Related Issues

Addresses the need for JavaScript source maps to enable debugging of production builds and improve error tracking capabilities.

@chuckbutkus can click here to [continue refining the PR](https://app.all-hands.dev/conversations/516bdba9cfde441eadc1ad677d74c098)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:4095770-nikolaik   --name openhands-app-4095770   docker.all-hands.dev/all-hands-ai/openhands:4095770
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@enable-frontend-source-maps openhands
```