### PR TITLE
Improve token refresh error logging

### DIFF
--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -188,7 +188,10 @@ class ProviderHandler:
             return SecretStr(data.token)
 
         except Exception as e:
-            logger.warning(f'Failed to fetch latest token for provider {provider}: {e}')
+            logger.error(
+                f'Failed to fetch latest token for provider {provider}: {e}',
+                exc_info=True,
+            )
 
         return None
 

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -340,9 +340,15 @@ class Runtime(FileEditRuntimeMixin):
             sid=self.sid,
         )
 
-        logger.info(f'Fetching latest provider tokens for runtime: {self.sid}')
+        logger.info(
+            f'Fetching latest provider tokens for runtime: {self.sid}, '
+            f'providers: {providers_called}'
+        )
         env_vars = await provider_handler.get_env_vars(
             providers=providers_called, expose_secrets=False, get_latest=True
+        )
+        logger.info(
+            f'Successfully fetched {len(env_vars)} token(s) for runtime: {self.sid}'
         )
 
         if len(env_vars) == 0:
@@ -355,8 +361,9 @@ class Runtime(FileEditRuntimeMixin):
                 )
             self.add_env_vars(provider_handler.expose_env_vars(env_vars))
         except Exception as e:
-            logger.warning(
-                f'Failed export latest github token to runtime: {self.sid}, {e}'
+            logger.error(
+                f'Failed to export latest github token to runtime: {self.sid}, {e}',
+                exc_info=True,
             )
 
     async def _handle_action(self, event: Action) -> None:


### PR DESCRIPTION
- Change warning to error with exc_info in provider.py line 191
- Change warning to error with exc_info in base.py line 358-360
- Add detailed logging for token refresh operations
- Log providers being refreshed and number of tokens fetched

This helps diagnose token refresh issues when sessions fail to resume

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:881ca0b-nikolaik   --name openhands-app-881ca0b   docker.all-hands.dev/all-hands-ai/openhands:881ca0b
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@alona/all-3654-improve-logging-for-token-refresh-error-on-resume-failures openhands
```