### PR TITLE
fix: resolve chat input not resizing when expected

### DIFF
--- a/frontend/__tests__/hooks/use-auto-resize.test.ts
+++ b/frontend/__tests__/hooks/use-auto-resize.test.ts
@@ -1,0 +1,119 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { useAutoResize } from "#/hooks/use-auto-resize";
+import { RefObject } from "react";
+
+class MockHTMLElement {
+  style: CSSStyleDeclaration;
+  offsetHeight = 20;
+  clientHeight = 20;
+  scrollHeight = 20;
+
+  constructor() {
+    const styleObj: any = {};
+
+    styleObj.setProperty = (property: string, value: string) => {
+      styleObj[property] = value;
+    };
+
+    this.style = styleObj as CSSStyleDeclaration;
+  }
+
+  // Simulate setting height and measuring scrollHeight
+  setScrollHeight(height: number) {
+    this.scrollHeight = height;
+  }
+
+  setOffsetHeight(height: number) {
+    this.offsetHeight = height;
+  }
+}
+
+describe("useAutoResize", () => {
+  let mockElement: MockHTMLElement;
+  let elementRef: RefObject<HTMLElement>;
+
+  beforeEach(() => {
+    mockElement = new MockHTMLElement();
+    elementRef = { current: mockElement as unknown as HTMLElement };
+  });
+
+  it("should shrink input height after content is deleted (bug reproduction)", () => {
+    const { result } = renderHook(() =>
+      useAutoResize(elementRef, {
+        minHeight: 20,
+        maxHeight: 400,
+      }),
+    );
+
+    // Step 1: Simulate large content that expands input to max height
+    mockElement.setScrollHeight(500); // Content larger than maxHeight
+    mockElement.setOffsetHeight(400); // Input expanded to maxHeight
+    mockElement.style.height = "400px";
+
+    act(() => {
+      result.current.smartResize();
+    });
+
+    // Verify input is at max height
+    expect(mockElement.style.height).toBe("400px");
+
+    // Step 2: Simulate deleting all content (content becomes very small)
+    mockElement.setScrollHeight(20); // Very small content
+    // offsetHeight stays 400px (this is the bug - it should shrink)
+    mockElement.setOffsetHeight(400);
+
+    act(() => {
+      result.current.smartResize();
+    });
+
+    // BUG: This test will FAIL because the input stays at 400px
+    // EXPECTED: Input should shrink back to minHeight (20px) or close to content size
+    expect(parseInt(mockElement.style.height)).toBeLessThan(100);
+  });
+
+  it("should preserve manually resized height when content is small", () => {
+    const { result } = renderHook(() =>
+      useAutoResize(elementRef, {
+        minHeight: 20,
+        maxHeight: 400,
+      }),
+    );
+
+    // Simulate manually resized input (not at maxHeight)
+    mockElement.setScrollHeight(30); // Small content
+    mockElement.setOffsetHeight(150); // Manually resized to 150px
+    mockElement.style.height = "150px";
+
+    act(() => {
+      result.current.smartResize();
+    });
+
+    // Should preserve manual height since it's not at maxHeight
+    expect(mockElement.style.height).toBe("150px");
+  });
+
+  it("should grow input height when content increases", () => {
+    const { result } = renderHook(() =>
+      useAutoResize(elementRef, {
+        minHeight: 20,
+        maxHeight: 400,
+      }),
+    );
+
+    // Start with small content and height
+    mockElement.setScrollHeight(20);
+    mockElement.setOffsetHeight(20);
+    mockElement.style.height = "20px";
+
+    // Content grows
+    mockElement.setScrollHeight(100);
+
+    act(() => {
+      result.current.smartResize();
+    });
+
+    // Should grow to accommodate content
+    expect(parseInt(mockElement.style.height)).toBeGreaterThanOrEqual(100);
+  });
+});


### PR DESCRIPTION

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**
If you were to paste large text into the chat input, then remove it, the height does not reset

---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**
Resolves #11025

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:073d122-nikolaik   --name openhands-app-073d122   docker.all-hands.dev/all-hands-ai/openhands:073d122
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@fix/use-auto-resize-test-typescript-error openhands
```