### PR TITLE
server: enforce Pro-only for actual LLM settings changes; add robust tests mirroring frontend full-payload behavior

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+# Ensure the repository source tree is imported before any pre-installed site packages
+# This avoids picking up a preinstalled OpenHands copy under /openhands/code during tests
+import sys
+from pathlib import Path
+
+# tests/ -> repo root
+REPO_ROOT = str(Path(__file__).resolve().parent.parent)
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)


### PR DESCRIPTION



- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

- Precise LLM change detection to avoid blocking language-only saves
- SaaS: call subscription validation only when LLM fields truly change
- Tests updated to patch correct target and add regression for full-payload save

---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:4946d7d-nikolaik   --name openhands-app-4946d7d   docker.all-hands.dev/all-hands-ai/openhands:4946d7d
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@fix/llm-settings-validation-tdd openhands
```