### PR TITLE
Upgrade Volta Node to 22.x

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -139,7 +139,7 @@
   },
   "packageManager": "npm@10.5.0",
   "volta": {
-    "node": "18.20.1"
+    "node": "22.0.0"
   },
   "msw": {
     "workerDirectory": [


### PR DESCRIPTION
Align Volta’s pinned Node version with our CI matrix and package engines.

- CI uses Node 22 (see .github/workflows/* and engines.node: >=22.0.0)
- Local contributors using Volta were pinned to Node 18, creating drift
- Upgrading Volta node to 22.0.0 removes mismatch and avoids subtle build/tooling differences