### PR TITLE
Fix: Allow Ctrl+C to cancel settings configuration prompts

### DIFF
--- a/openhands-cli/openhands_cli/user_actions/settings_action.py
+++ b/openhands-cli/openhands_cli/user_actions/settings_action.py
@@ -27,7 +27,7 @@ def settings_type_confirmation() -> SettingsType:
         'Go back',
     ]
 
-    index = cli_confirm(question, choices)
+    index = cli_confirm(question, choices, escapable=True)
 
     if choices[index] == 'Go back':
         raise KeyboardInterrupt
@@ -141,7 +141,7 @@ def save_settings_confirmation() -> bool:
     discard = 'No, discard'
     options = ['Yes, save', discard]
 
-    index = cli_confirm(question, options)
+    index = cli_confirm(question, options, escapable=True)
     if options[index] == discard:
         raise KeyboardInterrupt
 


### PR DESCRIPTION
Fixes issue where users could not interrupt settings configuration flow with Ctrl+C.

Added escapable=True to settings_type_confirmation() and save_settings_confirmation().

All 13 settings-related tests pass.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:a0cac39-nikolaik   --name openhands-app-a0cac39   docker.all-hands.dev/all-hands-ai/openhands:a0cac39
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@xw/ctrl-c openhands
```