### PR TITLE
Contribution to Ignoring SSL Errors

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
     trace: "on-first-retry",
     /* Ignore SSL errors for browser agent test */
     /* Solution inspired by StackOverflow post: https://stackoverflow.com/questions/67048422/ignore-ssl-errors-with-playwright-code-generation */
-    ignore HTTPSErrors: true,
+    ignoreHTTPSErrors: true,
   },
 
   /* Configure projects for major browsers */


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

This introduces functionality to ignore SSL errors when testing the browser agent.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR edits the config for playright test to make sure that when testing the playwright browser agent, SSL errors are ignored when using a self-signed certificate for an HTTPS proxy server.

---
**Link of any specific issues this addresses:**

https://github.com/All-Hands-AI/OpenHands/issues/10592