### PR TITLE
fix(frontend): inconsistent most recent repository list after page refresh

### DIFF
--- a/frontend/src/components/features/home/git-repo-dropdown/git-repo-dropdown.tsx
+++ b/frontend/src/components/features/home/git-repo-dropdown/git-repo-dropdown.tsx
@@ -117,9 +117,8 @@ export function GitRepoDropdown({
   const prioritizeRecentRepositories = useCallback(
     (repoList: GitRepository[]) => {
       const recentRepoIds = new Set(recentRepositories.map((repo) => repo.id));
-      const recentRepos = repoList.filter((repo) => recentRepoIds.has(repo.id));
       const otherRepos = repoList.filter((repo) => !recentRepoIds.has(repo.id));
-      return [...recentRepos, ...otherRepos];
+      return [...recentRepositories, ...otherRepos];
     },
     [recentRepositories],
   );


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

**Reproduction Steps:**
1. Select any repository (e.g., repoA) and open it.
2. Return to the home screen and observe that repoA appears under “Most Recent”.
3. Scroll to the bottom of the list to trigger a “fetch next page” request, then select a repository from the newly loaded results (e.g., repoB).
4. Navigate back to the home screen — both repoA and repoB should appear under “Most Recent” (this works because the cached pages are still displayed).
5. Refresh the page.
6. Notice that repoA remains visible (as it was from the first page), but repoB is missing or replaced by an unrelated repository.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR fixes the issue - Inconsistent “Most Recent” Repository List After Page Refresh.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/a774477c-4abf-443a-bcd1-549c07fb419b

---
**Link of any specific issues this addresses:**

Resolves #11282

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f4ebc33-nikolaik   --name openhands-app-f4ebc33   docker.all-hands.dev/all-hands-ai/openhands:f4ebc33
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3896#subdirectory=openhands-cli openhands
```