### PR TITLE
fix(frontend): incorrect file drop placeholder display when chat input is expanded

### DIFF
--- a/frontend/src/tailwind.css
+++ b/frontend/src/tailwind.css
@@ -150,7 +150,7 @@
   position: absolute;
   width: 100%;
   z-index: 100;
-  transform: translateY(16%);
+  padding-top: 2rem;
 }
 
 .drag-over-ui-content {


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

The file drop placeholder UI is displayed incorrectly when the chat input field is expanded.

Please refer to the video below for more details.

https://github.com/user-attachments/assets/c5a9db4b-9aeb-4d5f-bbf6-790275825e13

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The file drop placeholder UI should be displayed correctly when the chat input field is expanded.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/3b9e55c2-264e-4c63-8e7e-f820d26cccd1

---
**Link of any specific issues this addresses:**

Resolves #11280

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:4e8fe55-nikolaik   --name openhands-app-4e8fe55   docker.all-hands.dev/all-hands-ai/openhands:4e8fe55
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3894#subdirectory=openhands-cli openhands
```