### PR TITLE
refactor(frontend): revise the scrollbar styling on the settings page

### DIFF
--- a/frontend/src/components/features/settings/settings-layout.tsx
+++ b/frontend/src/components/features/settings/settings-layout.tsx
@@ -48,7 +48,9 @@ export function SettingsLayout({
         />
 
         {/* Main content */}
-        <main className="flex-1 overflow-auto">{children}</main>
+        <main className="flex-1 overflow-auto custom-scrollbar-always">
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -68,7 +68,7 @@ function SettingsScreen() {
       <SettingsLayout navigationItems={navItems} isSaas={isSaas}>
         <div className="flex flex-col gap-6 h-full">
           <Typography.H2>{t(currentSectionTitle)}</Typography.H2>
-          <div className="flex-1 overflow-auto">
+          <div className="flex-1 overflow-auto custom-scrollbar-always">
             <Outlet />
           </div>
         </div>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

<img width="1440" height="742" alt="Image" src="https://github.com/user-attachments/assets/9e3d14f3-99bf-486f-9f32-ed05a252a637" />

According to the image above, the scrollbar styling on the Settings page is inconsistent with the scrollbar styling used in other areas of the application.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The scrollbar styling on the Settings page should be consistent with the styling used throughout the rest of the application.

We can refer to the image below for the output of the PR.

<img width="1440" height="742" alt="scrollbar-settings-page-solution" src="https://github.com/user-attachments/assets/1264db6b-a20d-4082-8038-5abeaf409078" />

---
**Link of any specific issues this addresses:**

Resolves #11295

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:ab352c0-nikolaik   --name openhands-app-ab352c0   docker.all-hands.dev/all-hands-ai/openhands:ab352c0
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3907#subdirectory=openhands-cli openhands
```