### PR TITLE
fix(frontend): implement a pointer cursor on applicable UI elements when hovered over on the settings page

### DIFF
--- a/frontend/src/components/features/settings/api-keys-manager.tsx
+++ b/frontend/src/components/features/settings/api-keys-manager.tsx
@@ -97,7 +97,7 @@ function LlmApiKeyManager({
               {llmApiKey.key && (
                 <button
                   type="button"
-                  className="text-white hover:text-gray-300 mr-2"
+                  className="text-white hover:text-gray-300 mr-2 cursor-pointer"
                   aria-label={showLlmApiKey ? "Hide API key" : "Show API key"}
                   title={showLlmApiKey ? "Hide API key" : "Show API key"}
                   onClick={() => setShowLlmApiKey(!showLlmApiKey)}
@@ -111,7 +111,7 @@ function LlmApiKeyManager({
               )}
               <button
                 type="button"
-                className="text-white hover:text-gray-300 mr-2"
+                className="text-white hover:text-gray-300 mr-2 cursor-pointer"
                 aria-label="Copy API key"
                 title="Copy API key"
                 onClick={() => {

--- a/frontend/src/components/features/settings/settings-navigation.tsx
+++ b/frontend/src/components/features/settings/settings-navigation.tsx
@@ -59,7 +59,7 @@ export function SettingsNavigation({
           <button
             type="button"
             onClick={onCloseMobileMenu}
-            className="md:hidden p-0.5 hover:bg-[#454545] rounded-md transition-colors"
+            className="md:hidden p-0.5 hover:bg-[#454545] rounded-md transition-colors cursor-pointer"
             aria-label="Close navigation menu"
           >
             <CloseIcon width={32} height={32} />


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

When navigating to the Settings page and hovering over certain UI elements—such as the Close Settings Drawer button, the Copy button, and the Eye icon—the cursor does not change to a pointer.

These interactive elements should display the cursor-pointer style on hover to indicate clickability and improve user experience.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The PR implements a pointer cursor on applicable UI elements when hovered over on the settings page

---
**Link of any specific issues this addresses:**

Resolves #11292

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:87dd6da-nikolaik   --name openhands-app-87dd6da   docker.all-hands.dev/all-hands-ai/openhands:87dd6da
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3904#subdirectory=openhands-cli openhands
```