### PR TITLE
fix(frontend): resolve the issue with the ellipsis button functionality on the conversation card within the conversation panel

### DIFF
--- a/frontend/src/components/features/conversation-panel/conversation-card/conversation-card-actions.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card/conversation-card-actions.tsx
@@ -37,7 +37,7 @@ export function ConversationCardActions({
           event.stopPropagation();
           onContextMenuToggle(!contextMenuOpen);
         }}
-        className="cursor-pointer w-6 h-6 flex flex-row items-center justify-end"
+        className="cursor-pointer w-6 h-6 flex flex-row items-center justify-center translate-x-2.5"
       >
         <EllipsisIcon />
       </button>


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

<img width="491" height="234" alt="Image" src="https://github.com/user-attachments/assets/18fdcb26-a650-4f41-9a67-9ec6ecefa99b" />

According to the image above, could the ellipsis button be centered within its container?

It is somewhat confusing that clicking or hovering directly on the button, or slightly to its left, functions as expected, whereas interacting on its right side does not. The focus outline illustrates this behavior. Typically, users expect such buttons to include equal clickable padding on both sides.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The ellipsis button should be centered within its container.

We can refer to the image below for the output of the PR.

<img width="1440" height="742" alt="ellipsis-button-solution" src="https://github.com/user-attachments/assets/8a8709cc-e803-4820-9c0b-d830c18f6744" />

---
**Link of any specific issues this addresses:**

Resolves #11290

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:be2745d-nikolaik   --name openhands-app-be2745d   docker.all-hands.dev/all-hands-ai/openhands:be2745d
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-3902#subdirectory=openhands-cli openhands
```