### PR TITLE
Add tool name filtering for mcp_clients

### DIFF
--- a/openhands/mcp/utils.py
+++ b/openhands/mcp/utils.py
@@ -66,6 +66,7 @@ async def create_mcp_clients(
     shttp_servers: list[MCPSHTTPServerConfig],
     conversation_id: str | None = None,
     stdio_servers: list[MCPStdioServerConfig] | None = None,
+    tool_name: str | None = None
 ) -> list[MCPClient]:
     import sys
 
@@ -114,6 +115,8 @@ async def create_mcp_clients(
                     f'Successfully connected to MCP stdio server {server_name} - '
                     f'provides {len(tool_names)} tools: {tool_names}'
                 )
+                if tool_name is not None and tool_name in tool_names:
+                    return [client]
 
                 mcp_clients.append(client)
             except Exception as e:
@@ -143,6 +146,8 @@ async def create_mcp_clients(
                 f'Successfully connected to MCP STTP server {server.url} - '
                 f'provides {len(tool_names)} tools: {tool_names}'
             )
+            if tool_name is not None and tool_name in tool_names:
+                return [client]
 
             # Only add the client to the list after a successful connection
             mcp_clients.append(client)

--- a/openhands/runtime/impl/action_execution/action_execution_client.py
+++ b/openhands/runtime/impl/action_execution/action_execution_client.py
@@ -476,7 +476,7 @@ class ActionExecutionClient(Runtime):
 
         # Create clients for this specific operation
         mcp_clients = await create_mcp_clients(
-            updated_mcp_config.sse_servers, updated_mcp_config.shttp_servers, self.sid
+            updated_mcp_config.sse_servers, updated_mcp_config.shttp_servers, self.sid, action.name
         )
 
         # Call the tool and return the result


### PR DESCRIPTION
**Context**: Currently, when executing MCP tool calls, the system first establishes connections with all configured MCP Servers (including SSE, SHTTP, and Stdio types) and retrieves the full toolset before performing tool matching. This full-connection approach incurs unnecessary resource consumption, especially when only a specific tool needs to be called.

**Optimization**: Added a `tool_name` filtering mechanism. During the process of iterating through servers to establish client connections, the tool list provided by the current client is checked in real-time. Once the target `tool_name` is matched, subsequent connection operations are terminated immediately and the corresponding client is returned, reducing invalid server connections and resource usage.