### PR TITLE
fix(cli): escape action content before passing to HTML

### DIFF
--- a/openhands-cli/openhands_cli/user_actions/agent_action.py
+++ b/openhands-cli/openhands_cli/user_actions/agent_action.py
@@ -1,3 +1,4 @@
+import html
 from prompt_toolkit import HTML, print_formatted_text
 
 from openhands.sdk.security.confirmation_policy import (
@@ -37,7 +38,7 @@ def ask_user_confirmation(
             or '[unknown action]'
         )
         print_formatted_text(
-            HTML(f'<grey>  {i}. {tool_name}: {action_content}...</grey>')
+            HTML(f'<grey>  {i}. {tool_name}: {html.escape(action_content)}...</grey>')
         )
 
     question = 'Choose an option:'


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR escapes the action content to converts problematic characters (&, <, >, ") into safe HTML entities. Without it I got a crash with the CLI in the image below.

<img width="1050" height="902" alt="image" src="https://github.com/user-attachments/assets/8d58cd24-c727-484e-ad38-0f35c4f7972c" />


---
**Link of any specific issues this addresses:**
