### PR TITLE
Hotfix(CLI VI): unable to launch via default entrypoint

### DIFF
--- a/openhands-cli/pyproject.toml
+++ b/openhands-cli/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
   "typer>=0.17.4",
 ]
 
-# TODO: remove once agent-sdk packages are pinned to released versions
 scripts = { openhands = "openhands_cli.simple_main:main" }
 
 [dependency-groups]


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fix CLI entrypoint not working via package managers `uvx --python 3.12 openhands` 

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

Users have reported that they are unable to launch the CLI via `uvx --python 3.12 openhands`. The error message thrown is 

```
Package `openhands` does not provide any executables.
```

On further inspection, it seems that uv was installing `0.0.0` version of openhands. When I attempted to pin openhands version to the latest release `uvx --python 3.12 openhands@1.0.1` we see the error log 

```
  × No solution found when resolving tool dependencies:
  ╰─▶ Because openhands-sdk was not found in the package registry and openhands==1.0.1 depends on openhands-sdk, we can conclude that openhands==1.0.1 cannot be used.
      And because you require openhands==1.0.1, we can conclude that your requirements are unsatisfiable.
```


This occurs because the `agent-sdk` dependencies have not been published as PyPI packages, and PyPI is unable to resolve them. This is why uv will attempt to install every released version of openhands until one of them works, starting with `1.0.1`, then `1.0.0` and finally `0.0.0` (which doesn't contain the entrypoint)


Running the following command works as expected though

```
uvx --python 3.12 \          
  --with "openhands-sdk @ git+https://github.com/All-Hands-AI/agent-sdk.git@50b094a9#subdirectory=openhands/sdk" \
  --with "openhands-tools @ git+https://github.com/All-Hands-AI/agent-sdk.git@50b094a9#subdirectory=openhands/tools" \
  openhands --help       
  ```
  
  
Thus this PR for now patches this problem by including the git URLs in the dependencies. Once the agent-sdk has released PyPI packages we should pin it to their released versions 


---
**Link of any specific issues this addresses:**

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:5ef7033-nikolaik   --name openhands-app-5ef7033   docker.all-hands.dev/all-hands-ai/openhands:5ef7033
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@fix-cli-entrypoint#subdirectory=openhands-cli openhands
```