### PR TITLE
Fix get_version import error in namespace package setup

### DIFF
--- a/openhands/__init__.py
+++ b/openhands/__init__.py
@@ -4,6 +4,57 @@
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 
 # Import version information for backward compatibility
-from openhands.version import __version__, get_version
+# Handle the case where openhands.version might not exist in all namespace package paths
+try:
+    from openhands.version import __version__, get_version
+except ImportError:
+    # Fallback: define get_version function directly if version module is not available
+    import os
+    from pathlib import Path
+
+    __package_name__ = 'openhands_ai'
+
+    def get_version():
+        # Try getting the version from pyproject.toml
+        try:
+            root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            candidate_paths = [
+                Path(root_dir) / 'pyproject.toml',
+                Path(root_dir) / 'openhands' / 'pyproject.toml',
+            ]
+            for file_path in candidate_paths:
+                if file_path.is_file():
+                    with open(file_path, 'r') as f:
+                        for line in f:
+                            if line.strip().startswith('version ='):
+                                return (
+                                    line.split('=', 1)[1].strip().strip('"').strip("'")
+                                )
+        except FileNotFoundError:
+            pass
+
+        try:
+            from importlib.metadata import PackageNotFoundError, version
+
+            return version(__package_name__)
+        except (ImportError, PackageNotFoundError):
+            pass
+
+        try:
+            from pkg_resources import (  # type: ignore
+                DistributionNotFound,
+                get_distribution,
+            )
+
+            return get_distribution(__package_name__).version
+        except (ImportError, DistributionNotFound):
+            pass
+
+        return 'unknown'
+
+    try:
+        __version__ = get_version()
+    except Exception:
+        __version__ = 'unknown'
 
 __all__ = ['__version__', 'get_version']


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixes an import error that prevented installing OpenHands directly from git using `pip install git+https://github.com/All-Hands-AI/OpenHands.git@<commit>`. Users can now successfully install and run OpenHands from any git commit without encountering the "cannot import name 'get_version' from 'openhands'" error.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

The namespace package setup in `openhands/__init__.py` was causing import errors when installed via pip from git, due to conflicts with other openhands packages in the namespace path that don't have a `version.py` module.

This fix adds a try-except block around the import from `openhands.version`, with a fallback implementation that defines `get_version` directly in the `__init__.py` file when the version module is not available.

The fallback implementation uses the same logic as the original `version.py` to determine the package version from:
1. `pyproject.toml` file parsing
2. Package metadata via `pkg_resources` or `importlib.metadata`
3. Fallback to "unknown" if all methods fail

This approach maintains backward compatibility while making the package more robust in namespace package scenarios.

---
**Link of any specific issues this addresses:**

Fixes the import error reported in user context: `ImportError: cannot import name 'get_version' from 'openhands'`

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0d2ab46eaaa04a7cb691ff4bea6f6518)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f7642fe-nikolaik   --name openhands-app-f7642fe   docker.all-hands.dev/all-hands-ai/openhands:f7642fe
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@fix/get-version-import-error#subdirectory=openhands-cli openhands
```