### PR TITLE
Fix excessive error logging for missing org-level microagents

### DIFF
--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -449,7 +449,10 @@ class ProviderHandler:
         return f'{provider.value}_token'.lower()
 
     async def verify_repo_provider(
-        self, repository: str, specified_provider: ProviderType | None = None
+        self,
+        repository: str,
+        specified_provider: ProviderType | None = None,
+        is_optional: bool = False,
     ) -> Repository:
         errors = []
 
@@ -468,19 +471,22 @@ class ProviderHandler:
                 errors.append(f'{provider.value}: {str(e)}')
 
         # Log detailed error based on whether we had tokens or not
+        # For optional repositories (like org-level microagents), use debug level
+        log_fn = logger.debug if is_optional else logger.error
+
         if not self.provider_tokens:
-            logger.error(
+            log_fn(
                 f'Failed to access repository {repository}: No provider tokens available. '
                 f'provider_tokens dict is empty.'
             )
         elif errors:
-            logger.error(
+            log_fn(
                 f'Failed to access repository {repository} with all available providers. '
                 f'Tried providers: {list(self.provider_tokens.keys())}. '
                 f'Errors: {"; ".join(errors)}'
             )
         else:
-            logger.error(
+            log_fn(
                 f'Failed to access repository {repository}: Unknown error (no providers tried, no errors recorded)'
             )
         raise AuthenticationError(f'Unable to access repo {repository}')
@@ -626,17 +632,22 @@ class ProviderHandler:
             f'Microagent file {file_path} not found in {repository}'
         )
 
-    async def get_authenticated_git_url(self, repo_name: str) -> str:
+    async def get_authenticated_git_url(
+        self, repo_name: str, is_optional: bool = False
+    ) -> str:
         """Get an authenticated git URL for a repository.
 
         Args:
             repo_name: Repository name (owner/repo)
+            is_optional: If True, logs at debug level instead of error level when repo not found
 
         Returns:
             Authenticated git URL if credentials are available, otherwise regular HTTPS URL
         """
         try:
-            repository = await self.verify_repo_provider(repo_name)
+            repository = await self.verify_repo_provider(
+                repo_name, is_optional=is_optional
+            )
         except AuthenticationError:
             raise Exception('Git provider authentication issue when getting remote URL')
 

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -747,6 +747,7 @@ fi
                     self.provider_handler.get_authenticated_git_url,
                     GENERAL_TIMEOUT,
                     org_openhands_repo,
+                    is_optional=True,
                 )
             except AuthenticationError as e:
                 self.log(


### PR DESCRIPTION
## Summary of PR

This PR fixes issue #11424 by reducing excessive error logging when checking for missing org-level microagent repositories (`.openhands` or `openhands-config`).

**Changes made:**
- Added an `is_optional` parameter to `verify_repo_provider()` and `get_authenticated_git_url()` methods in `ProviderHandler`
- When `is_optional=True`, the method logs at DEBUG level instead of ERROR level
- Updated `Runtime.initialize` to pass `is_optional=True` when checking for org-level microagent repos
- Error-level logging is still used for required repositories (default behavior)

This ensures that missing org-level configuration repositories don't flood error logs, as these repositories are expected to be optional and may not exist for many organizations.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #11424

## Release Notes

- [x] Include this change in the Release Notes.

**Fixed excessive error logging when org-level microagent directories are missing** - The system now logs at debug level instead of error level when checking for optional organization-level `.openhands` or `openhands-config` repositories that don't exist.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7cda1f711b204026996715a2db50bc8a)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:e0bad5b-nikolaik   --name openhands-app-e0bad5b   docker.all-hands.dev/all-hands-ai/openhands:e0bad5b
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@openhands/fix-org-microagent-logging#subdirectory=openhands-cli openhands
```