### PR TITLE
fix(frontend): update context menu styling for archived conversations

### DIFF
--- a/frontend/src/components/features/conversation-panel/conversation-card/conversation-card-actions.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card/conversation-card-actions.tsx
@@ -27,6 +27,8 @@ export function ConversationCardActions({
   conversationId,
   showOptions,
 }: ConversationCardActionsProps) {
+  const isConversationArchived = conversationStatus === "ARCHIVED";
+
   return (
     <div className="group">
       <button
@@ -37,7 +39,10 @@ export function ConversationCardActions({
           event.stopPropagation();
           onContextMenuToggle(!contextMenuOpen);
         }}
-        className="cursor-pointer w-6 h-6 flex flex-row items-center justify-center translate-x-2.5"
+        className={cn(
+          "cursor-pointer w-6 h-6 flex flex-row items-center justify-center translate-x-2.5",
+          isConversationArchived && "opacity-60",
+        )}
       >
         <EllipsisIcon />
       </button>

--- a/frontend/src/components/features/conversation-panel/conversation-card/conversation-card-footer.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card/conversation-card-footer.tsx
@@ -5,22 +5,32 @@ import { I18nKey } from "#/i18n/declaration";
 import { RepositorySelection } from "#/api/open-hands.types";
 import { ConversationRepoLink } from "./conversation-repo-link";
 import { NoRepository } from "./no-repository";
+import { ConversationStatus } from "#/types/conversation-status";
 
 interface ConversationCardFooterProps {
   selectedRepository: RepositorySelection | null;
   lastUpdatedAt: string; // ISO 8601
   createdAt?: string; // ISO 8601
+  conversationStatus?: ConversationStatus;
 }
 
 export function ConversationCardFooter({
   selectedRepository,
   lastUpdatedAt,
   createdAt,
+  conversationStatus,
 }: ConversationCardFooterProps) {
   const { t } = useTranslation();
 
+  const isConversationArchived = conversationStatus === "ARCHIVED";
+
   return (
-    <div className={cn("flex flex-row justify-between items-center mt-1")}>
+    <div
+      className={cn(
+        "flex flex-row justify-between items-center mt-1",
+        isConversationArchived && "opacity-60",
+      )}
+    >
       {selectedRepository?.selected_repository ? (
         <ConversationRepoLink selectedRepository={selectedRepository} />
       ) : (

--- a/frontend/src/components/features/conversation-panel/conversation-card/conversation-card-header.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card/conversation-card-header.tsx
@@ -19,6 +19,8 @@ export function ConversationCardHeader({
   conversationStatus,
   conversationVersion,
 }: ConversationCardHeaderProps) {
+  const isConversationArchived = conversationStatus === "ARCHIVED";
+
   return (
     <div className="flex items-center gap-2 flex-1 min-w-0 overflow-hidden mr-2">
       {/* Status Indicator */}
@@ -30,11 +32,15 @@ export function ConversationCardHeader({
         </div>
       )}
       {/* Version Badge */}
-      <ConversationVersionBadge version={conversationVersion} />
+      <ConversationVersionBadge
+        version={conversationVersion}
+        isConversationArchived={isConversationArchived}
+      />
       <ConversationCardTitle
         title={title}
         titleMode={titleMode}
         onSave={onTitleSave}
+        isConversationArchived={isConversationArchived}
       />
       {/* Status Badges */}
       {conversationStatus && (

--- a/frontend/src/components/features/conversation-panel/conversation-card/conversation-card-title.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card/conversation-card-title.tsx
@@ -1,15 +1,19 @@
+import { cn } from "#/utils/utils";
+
 export type ConversationCardTitleMode = "view" | "edit";
 
 export type ConversationCardTitleProps = {
   titleMode: ConversationCardTitleMode;
   title: string;
   onSave: (title: string) => void;
+  isConversationArchived?: boolean;
 };
 
 export function ConversationCardTitle({
   titleMode,
   title,
   onSave,
+  isConversationArchived,
 }: ConversationCardTitleProps) {
   if (titleMode === "edit") {
     return (
@@ -40,7 +44,10 @@ export function ConversationCardTitle({
   return (
     <p
       data-testid="conversation-card-title"
-      className="text-xs leading-6 font-semibold bg-transparent truncate overflow-hidden"
+      className={cn(
+        "text-xs leading-6 font-semibold bg-transparent truncate overflow-hidden",
+        isConversationArchived && "opacity-60",
+      )}
       title={title}
     >
       {title}

--- a/frontend/src/components/features/conversation-panel/conversation-card/conversation-card.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card/conversation-card.tsx
@@ -110,7 +110,6 @@ export function ConversationCard({
       className={cn(
         "relative h-auto w-full p-3.5 border-b border-neutral-600 cursor-pointer",
         "data-[context-menu-open=false]:hover:bg-[#454545]",
-        conversationStatus === "ARCHIVED" && "opacity-60",
       )}
     >
       <div className="flex items-center justify-between w-full">
@@ -141,6 +140,7 @@ export function ConversationCard({
         selectedRepository={selectedRepository}
         lastUpdatedAt={lastUpdatedAt}
         createdAt={createdAt}
+        conversationStatus={conversationStatus}
       />
     </div>
   );

--- a/frontend/src/components/features/conversation-panel/conversation-card/conversation-status-badges.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card/conversation-status-badges.tsx
@@ -15,7 +15,7 @@ export function ConversationStatusBadges({
 
   if (conversationStatus === "ARCHIVED") {
     return (
-      <span className="flex items-center gap-1 px-1.5 py-0.5 bg-[#868E96] text-white text-xs font-medium rounded-full">
+      <span className="flex items-center gap-1 px-1.5 py-0.5 bg-[#868E96] text-white text-xs font-medium rounded-full opacity-60">
         <FaArchive size={10} className="text-white" />
         <span>{t(I18nKey.COMMON$ARCHIVED)}</span>
       </span>

--- a/frontend/src/components/features/conversation-panel/conversation-card/conversation-version-badge.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card/conversation-version-badge.tsx
@@ -3,10 +3,12 @@ import { cn } from "#/utils/utils";
 
 interface ConversationVersionBadgeProps {
   version?: "V0" | "V1";
+  isConversationArchived?: boolean;
 }
 
 export function ConversationVersionBadge({
   version,
+  isConversationArchived,
 }: ConversationVersionBadgeProps) {
   if (!version) return null;
 
@@ -23,6 +25,7 @@ export function ConversationVersionBadge({
           version === "V1"
             ? "bg-green-500/20 text-green-500"
             : "bg-neutral-500/20 text-neutral-400",
+          isConversationArchived && "opacity-60",
         )}
       >
         {version}


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

<img width="784" height="404" alt="image" src="https://github.com/user-attachments/assets/a6838d56-07a0-4068-9296-5cce0481558b" />

The current context menu appearance is inconsistent when a conversation is archived, as shown in the image above.

**Task:**
- Adjust the opacity to ensure the context menu maintains a clear and consistent visual style for archived conversations.

**Acceptance Criteria:**
- Update the opacity of the context menu to achieve proper visibility and alignment with the design standards for archived conversations.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/3cda007e-c25d-461e-a9a2-ed9f99a42b4b

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:eb58e3d-nikolaik   --name openhands-app-eb58e3d   docker.all-hands.dev/all-hands-ai/openhands:eb58e3d
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-4055#subdirectory=openhands-cli openhands
```