### PR TITLE
Clear conversation state when switching between V1 conversations

### DIFF
--- a/frontend/src/routes/conversation.tsx
+++ b/frontend/src/routes/conversation.tsx
@@ -30,12 +30,14 @@ import { WebSocketProviderWrapper } from "#/contexts/websocket-provider-wrapper"
 import { useErrorMessageStore } from "#/stores/error-message-store";
 import { useUnifiedResumeConversationSandbox } from "#/hooks/mutation/use-unified-start-conversation";
 import { I18nKey } from "#/i18n/declaration";
+import { useEventStore } from "#/stores/use-event-store";
 
 function AppContent() {
   useConversationConfig();
 
   const { t } = useTranslation();
   const { conversationId } = useConversationId();
+  const clearEvents = useEventStore((state) => state.clearEvents);
 
   // Handle both task IDs (task-{uuid}) and regular conversation IDs
   const { isTask, taskStatus, taskDetail } = useTaskPolling();
@@ -72,6 +74,7 @@ function AppContent() {
     resetConversationState();
     setCurrentAgentState(AgentState.LOADING);
     removeErrorMessage();
+    clearEvents();
 
     // Reset tracking ONLY if we're navigating to a DIFFERENT conversation
     // Don't reset on StrictMode remounts (conversationId is the same)
@@ -85,6 +88,7 @@ function AppContent() {
     resetConversationState,
     setCurrentAgentState,
     removeErrorMessage,
+    clearEvents,
   ]);
 
   // 2. Task Error Display Effect


### PR DESCRIPTION
## Summary of PR

Conversation state was not properly clearing when switching between V1 conversations. This PR calls `clearEvents` when navigating to a different conversation

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.


## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:1c1a8a0-nikolaik   --name openhands-app-1c1a8a0   docker.all-hands.dev/all-hands-ai/openhands:1c1a8a0
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@APP-85/clear-v1-state-clean#subdirectory=openhands-cli openhands
```