### PR TITLE
Fix zero state not showing for V1 conversations

### DIFF
--- a/frontend/src/components/features/chat/chat-interface.tsx
+++ b/frontend/src/components/features/chat/chat-interface.tsx
@@ -40,7 +40,12 @@ import { useConfig } from "#/hooks/query/use-config";
 import { validateFiles } from "#/utils/file-validation";
 import { useConversationStore } from "#/state/conversation-store";
 import ConfirmationModeEnabled from "./confirmation-mode-enabled";
-import { isV0Event, isV1Event } from "#/types/v1/type-guards";
+import {
+  isV0Event,
+  isV1Event,
+  isSystemPromptEvent,
+  isConversationStateUpdateEvent,
+} from "#/types/v1/type-guards";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 
 function getEntryPoint(
@@ -111,7 +116,14 @@ export function ChatInterface() {
             event.source === "agent" &&
             event.action !== "system",
         ) ||
-      storeEvents.filter(isV1Event).some((event) => event.source === "agent"),
+      storeEvents
+        .filter(isV1Event)
+        .some(
+          (event) =>
+            event.source === "agent" &&
+            !isSystemPromptEvent(event) &&
+            !isConversationStateUpdateEvent(event),
+        ),
     [storeEvents],
   );
 

--- a/frontend/src/types/v1/type-guards.ts
+++ b/frontend/src/types/v1/type-guards.ts
@@ -13,6 +13,7 @@ import {
   ConversationStateUpdateEventAgentStatus,
   ConversationStateUpdateEventFullState,
 } from "./core/events/conversation-state-event";
+import { SystemPromptEvent } from "./core/events/system-event";
 import type { OpenHandsParsedEvent } from "../core/index";
 
 /**
@@ -107,6 +108,18 @@ export const isExecuteBashObservationEvent = (
 ): event is ObservationEvent<ExecuteBashObservation> =>
   isObservationEvent(event) &&
   event.observation.kind === "ExecuteBashObservation";
+
+/**
+ * Type guard function to check if an event is a system prompt event
+ */
+export const isSystemPromptEvent = (
+  event: OpenHandsEvent,
+): event is SystemPromptEvent =>
+  event.source === "agent" &&
+  "system_prompt" in event &&
+  "tools" in event &&
+  typeof event.system_prompt === "object" &&
+  Array.isArray(event.tools);
 
 /**
  * Type guard function to check if an event is a conversation state update event


### PR DESCRIPTION
## Summary of PR

After a V1 conversation has started, the chat suggestions / zero state of the chat interface is not present. That is because the agent now returns two initial messages on start, the conversation status update and system message. This PR takes the system message into account when checking whether to render the chat suggestions

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:f038f40-nikolaik   --name openhands-app-f038f40   docker.all-hands.dev/all-hands-ai/openhands:f038f40
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@APP-91/zero-state#subdirectory=openhands-cli openhands
```