### PR TITLE
Prevent calling V1 "start tasks” API if feature flag is disabled + always set “start tasks” query cache to stale

### DIFF
--- a/frontend/src/hooks/query/use-start-tasks.ts
+++ b/frontend/src/hooks/query/use-start-tasks.ts
@@ -22,6 +22,4 @@ export const useStartTasks = (limit = 10) =>
       tasks.filter(
         (task) => task.status !== "READY" && task.status !== "ERROR",
       ),
-    staleTime: 1000 * 60 * 1, // 1 minute (short since these are in-progress)
-    gcTime: 1000 * 60 * 5, // 5 minutes
   });


### PR DESCRIPTION
## Summary of PR

- Prevent calling V1 "start tasks” API if feature flag is disabled
- Always set “start tasks” query cache to stale. This will allow the user to always get the latest data when opening the conversation panel

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:3824330-nikolaik   --name openhands-app-3824330   docker.all-hands.dev/all-hands-ai/openhands:3824330
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@APP-79/prevent-start-tasks-no-feature-flag#subdirectory=openhands-cli openhands
```