### PR TITLE
Fix toast dismissal to target specific toast IDs instead of all toasts

### DIFF
--- a/frontend/src/hooks/mutation/use-unified-start-conversation.ts
+++ b/frontend/src/hooks/mutation/use-unified-start-conversation.ts
@@ -54,7 +54,7 @@ export const useUnifiedResumeConversationSandbox = () => {
         "conversations",
       ]);
 
-      return { previousConversations, toastId };
+      return { previousConversations };
     },
     onError: (_, __, context) => {
       if (context?.previousConversations) {


### PR DESCRIPTION
## Summary of PR

We currently call toast.dismiss()which dismisses ALL toasts when stopping a conversation. This is noticeable when stopping more than one conversation at the same time. This PR fixes this by dismissing toasts by ID

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9f3623e-nikolaik   --name openhands-app-9f3623e   docker.all-hands.dev/all-hands-ai/openhands:9f3623e
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@APP-78/dismiss-toast-id#subdirectory=openhands-cli openhands
```