### PR TITLE
fix(frontend): display repository information after creating a V1 conversation

### DIFF
--- a/frontend/src/components/features/chat/git-control-bar.tsx
+++ b/frontend/src/components/features/chat/git-control-bar.tsx
@@ -5,6 +5,7 @@ import { GitControlBarPullButton } from "./git-control-bar-pull-button";
 import { GitControlBarPushButton } from "./git-control-bar-push-button";
 import { GitControlBarPrButton } from "./git-control-bar-pr-button";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
+import { useTaskPolling } from "#/hooks/query/use-task-polling";
 import { Provider } from "#/types/settings";
 import { I18nKey } from "#/i18n/declaration";
 import { GitControlBarTooltipWrapper } from "./git-control-bar-tooltip-wrapper";
@@ -17,10 +18,16 @@ export function GitControlBar({ onSuggestionsClick }: GitControlBarProps) {
   const { t } = useTranslation();
 
   const { data: conversation } = useActiveConversation();
+  const { repositoryInfo } = useTaskPolling();
 
-  const selectedRepository = conversation?.selected_repository;
-  const gitProvider = conversation?.git_provider as Provider;
-  const selectedBranch = conversation?.selected_branch;
+  // Priority: conversation data > task data
+  // This ensures we show repository info immediately from task, then transition to conversation data
+  const selectedRepository =
+    conversation?.selected_repository || repositoryInfo?.selectedRepository;
+  const gitProvider = (conversation?.git_provider ||
+    repositoryInfo?.gitProvider) as Provider;
+  const selectedBranch =
+    conversation?.selected_branch || repositoryInfo?.selectedBranch;
 
   const hasRepository = !!selectedRepository;
 

--- a/frontend/src/hooks/query/use-task-polling.ts
+++ b/frontend/src/hooks/query/use-task-polling.ts
@@ -68,5 +68,11 @@ export const useTaskPolling = () => {
     taskDetail: taskQuery.data?.detail,
     taskError: taskQuery.error,
     isLoadingTask: taskQuery.isLoading,
+    // Repository information from task request
+    repositoryInfo: {
+      selectedRepository: taskQuery.data?.request?.selected_repository,
+      selectedBranch: taskQuery.data?.request?.selected_branch,
+      gitProvider: taskQuery.data?.request?.git_provider,
+    },
   };
 };


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

**Problem**

When a user initiates a V1 conversation with a selected repository, the interface initially displays the repository’s zero-state. This behavior may cause confusion, as it appears that no repository was selected. The repository data is only updated and displayed correctly after the conversation has been initiated.

This issue likely occurs because the system first navigates to a temporary “start task” route, during which the necessary repository data is not yet available for display.

**Proposed Solution**

The “start task” that is continuously polled until the conversation begins already contains repository-related information. This data should be utilized when initializing V1 conversations, replacing the current approach to ensure that the correct repository information is displayed from the start.

We can refer to the video below for the output of the PR.


https://github.com/user-attachments/assets/63b4e860-c622-4292-9d71-2c4dfd8ebe1f


## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:9e8df5a-nikolaik   --name openhands-app-9e8df5a   docker.all-hands.dev/all-hands-ai/openhands:9e8df5a
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/app-80#subdirectory=openhands-cli openhands
```