### PR TITLE
feat(backend): implement get_remote_runtime_config support for V1 conversations

### DIFF
--- a/frontend/src/api/conversation-service/conversation-service.api.ts
+++ b/frontend/src/api/conversation-service/conversation-service.api.ts
@@ -187,7 +187,7 @@ class ConversationService {
   static async getRuntimeId(
     conversationId: string,
   ): Promise<{ runtime_id: string }> {
-    const url = `${this.getConversationUrl(conversationId)}/config`;
+    const url = `/api/conversations/${conversationId}/config`;
     const { data } = await openHands.get<{ runtime_id: string }>(url, {
       headers: this.getConversationHeaders(),
     });


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

**Problem**

Legacy conversations retrieve configuration data from the agent server endpoint (/api/conversations/{conversationId}/config). This approach is outdated and not compatible with V1 conversations.

**Proposed Solution**

Identify and utilize the appropriate API endpoint for V1 conversations to retrieve configuration data, replacing the legacy endpoint currently in use.

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:427b14e-nikolaik   --name openhands-app-427b14e   docker.all-hands.dev/all-hands-ai/openhands:427b14e
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/all-88#subdirectory=openhands-cli openhands
```