### PR TITLE
fix: remove accidentally committed Docker image tags from config.sh

### DIFF
--- a/containers/runtime/config.sh
+++ b/containers/runtime/config.sh
@@ -5,6 +5,3 @@ DOCKER_IMAGE=runtime
 # These variables will be appended by the runtime_build.py script
 # DOCKER_IMAGE_TAG=
 # DOCKER_IMAGE_SOURCE_TAG=
-
-DOCKER_IMAGE_TAG=oh_v0.59.0_image_nikolaik_s_python-nodejs_tag_python3.12-nodejs22
-DOCKER_IMAGE_SOURCE_TAG=oh_v0.59.0_cwpsf0pego28lacp_p73ruf86qxiulkou


### PR DESCRIPTION
Remove hardcoded DOCKER_IMAGE_TAG and DOCKER_IMAGE_SOURCE_TAG values that were accidentally included in PR #11296. These variables should only be appended dynamically by the runtime_build.py script during the build process, not hardcoded in the repository.

## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:8c7a852-nikolaik   --name openhands-app-8c7a852   docker.all-hands.dev/all-hands-ai/openhands:8c7a852
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@fix/remove-hardcoded-docker-tags-from-config#subdirectory=openhands-cli openhands
```