### PR TITLE
fix: remove import from completed migration

### DIFF
--- a/enterprise/migrations/versions/060_create_user_version_upgrade_tasks.py
+++ b/enterprise/migrations/versions/060_create_user_version_upgrade_tasks.py
@@ -28,8 +28,9 @@ def upgrade():
 
     This replaces the functionality of the removed admin maintenance endpoint.
     """
-    # Import here to avoid circular imports
-    from server.constants import CURRENT_USER_SETTINGS_VERSION
+    # Hardcoded value to prevent migration failures when constant is removed from codebase
+    # This migration has already run in production, so we use the value that was current at the time
+    CURRENT_USER_SETTINGS_VERSION = 4
 
     # Create a connection and bind it to a session
     connection = op.get_bind()


### PR DESCRIPTION
## Summary of PR

This PR fixes migration 060 by replacing the import of `CURRENT_USER_SETTINGS_VERSION` from `server.constants` with a hardcoded value (4). This prevents migration failures when the constant is eventually removed from the codebase.

The migration has already run in production, so using a hardcoded value ensures it will continue to work in new deployments even after the constant is removed. This is a common pattern for completed migrations to avoid dependencies on code that may change or be removed.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/58937b8fd31b4f669cc430af1a275e2b)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:363c9f8-nikolaik   --name openhands-app-363c9f8   docker.all-hands.dev/all-hands-ai/openhands:363c9f8
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@fix/hardcode-user-version-in-migration-060#subdirectory=openhands-cli openhands
```