### PR TITLE
fix(frontend): frontend connects to WebSocket too early

### DIFF
--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -123,7 +123,10 @@ export const useWebSocket = <T = string>(
     shouldReconnectRef.current = true;
     attemptCountRef.current = 0;
 
-    connectWebSocket();
+    // Only attempt connection if we have a valid URL
+    if (url && url.trim() !== "") {
+      connectWebSocket();
+    }
 
     return () => {
       // Disable reconnection on unmount to prevent reconnection attempts


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

Frontend connects to WebSocket too early. We can refer to the image below for more information.

<img width="1148" height="276" alt="image" src="https://github.com/user-attachments/assets/b5b9f874-e7dd-44b7-a25c-e4bfbf1fd5b0" />

**Acceptance criteria:**
- Frontend should connect to WebSocket when the connection is ready.

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:b26b22a-nikolaik   --name openhands-app-b26b22a   docker.all-hands.dev/all-hands-ai/openhands:b26b22a
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@hieptl/app-94#subdirectory=openhands-cli openhands
```