### PR TITLE
feat: add 'git' as trigger word for bitbucket microagent

### DIFF
--- a/microagents/bitbucket.md
+++ b/microagents/bitbucket.md
@@ -5,6 +5,7 @@ version: 1.0.0
 agent: CodeActAgent
 triggers:
 - bitbucket
+- git
 ---
 
 You have access to an environment variable, `BITBUCKET_TOKEN`, which allows you to interact with


### PR DESCRIPTION
Currently we already have 'git' as a trigger in the gitlab and github microagents. This helps the bitbucket microagent activate when users mention git operations, improving support for git push/pull issues with Bitbucket repositories.

## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:d1fa062-nikolaik   --name openhands-app-d1fa062   docker.all-hands.dev/all-hands-ai/openhands:d1fa062
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/All-Hands-AI/OpenHands@add-git-trigger-bitbucket#subdirectory=openhands-cli openhands
```