### PR TITLE
Fix: Remove temperature parameter for codex-mini-latest model

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -122,6 +122,10 @@ class LLM(RetryMixin, DebugMixin):
             # openai doesn't expose top_p, but litellm does
             kwargs['top_p'] = self.config.top_p
 
+        if 'codex-mini-latest' in self.config.model.lower():
+            kwargs.pop('temperature', None)
+            kwargs.pop('top_p', None)
+
         # Handle OpenHands provider - rewrite to litellm_proxy
         if self.config.model.startswith('openhands/'):
             model_name = self.config.model.removeprefix('openhands/')


### PR DESCRIPTION
## Summary of PR

This PR fixes a BadRequestError that occurs when using the `codex-mini-latest` model with OpenHands. The `codex-mini-latest` model doesn't support the `temperature` parameter, but OpenHands was always including it in API requests, causing the error: "Unsupported parameter: 'temperature' is not supported with this model."

The fix adds a model-specific check to remove the `temperature` and `top_p` parameters when using `codex-mini-latest`, similar to how other model-specific parameter restrictions are handled in the codebase.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves OpenHands/software-agent-sdk#1075

## Release Notes

- [x] Include this change in the Release Notes.

**Release Notes Description:**
Fixed compatibility issue with `codex-mini-latest` model that was causing "Unsupported parameter: temperature" errors. The model now works correctly without throwing parameter-related errors.