### PR TITLE
fix(stream) Optimize Subscription Resource Cleanup in Stream to Ensure Complete Resource Management

### DIFF
--- a/openhands/events/stream.py
+++ b/openhands/events/stream.py
@@ -101,7 +101,7 @@ class EventStream(EventStore):
             subscriber_id in self._thread_loops
             and callback_id in self._thread_loops[subscriber_id]
         ):
-            loop = self._thread_loops[subscriber_id][callback_id]
+            loop = self._thread_loops[subscriber_id].pop(callback_id)
             current_task = asyncio.current_task(loop)
             pending = [
                 task for task in asyncio.all_tasks(loop) if task is not current_task
@@ -115,17 +115,21 @@ class EventStream(EventStore):
                 logger.warning(
                     f'Error closing loop for {subscriber_id}/{callback_id}: {e}'
                 )
-            del self._thread_loops[subscriber_id][callback_id]
+            if not self._thread_loops[subscriber_id]:
+                del self._thread_loops[subscriber_id]
 
         if (
             subscriber_id in self._thread_pools
             and callback_id in self._thread_pools[subscriber_id]
         ):
-            pool = self._thread_pools[subscriber_id][callback_id]
+            pool = self._thread_pools[subscriber_id].pop(callback_id)
             pool.shutdown()
-            del self._thread_pools[subscriber_id][callback_id]
+            if not self._thread_pools[subscriber_id]:
+                del self._thread_pools[subscriber_id]
 
         del self._subscribers[subscriber_id][callback_id]
+        if not self._subscribers[subscriber_id]:
+            del self._subscribers[subscriber_id]
 
     def subscribe(
         self,


### PR DESCRIPTION
**Background**
Right now, when we clean up subscription resources, we only delete specific resources. We don't think about the case where the whole resource container becomes empty (that is, empty dictionaries). This causes problems with resource management.
**Optimization**
After deleting specific resources, we automatically clean up empty parent containers. This stops empty dictionaries from being left in memory and makes resource management more complete.