### PR TITLE
fix(frontend): unable to create a new conversation through the Microagent Management page when the feature flag is enabled.

### DIFF
--- a/frontend/src/hooks/mutation/use-create-conversation.ts
+++ b/frontend/src/hooks/mutation/use-create-conversation.ts
@@ -45,7 +45,7 @@ export const useCreateConversation = () => {
         createMicroagent,
       } = variables;
 
-      const useV1 = USE_V1_CONVERSATION_API();
+      const useV1 = USE_V1_CONVERSATION_API() && !createMicroagent;
 
       if (useV1) {
         // Use V1 API - creates a conversation start task


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

We are currently using the useCreateConversationAndSubscribeMultiple hook to create new conversations through the Microagent Management page. However, this hook only supports V0. When the feature flag is enabled, the functionality does not work as expected.

**Acceptance criteria:**
- We should disable V1 for the microagent management page.

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/openhands/runtime:9b6d36f-nikolaik   --name openhands-app-9b6d36f   docker.all-hands.dev/openhands/openhands:9b6d36f
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@hieptl/app-98#subdirectory=openhands-cli openhands
```