### PR TITLE
fix(frontend): render terminal input commands and skip empty outputs

### DIFF
--- a/frontend/src/hooks/use-terminal.ts
+++ b/frontend/src/hooks/use-terminal.ts
@@ -26,9 +26,11 @@ const renderCommand = (
     return;
   }
 
-  terminal.writeln(
-    parseTerminalOutput(content.replaceAll("\n", "\r\n").trim()),
-  );
+  const trimmedContent = content.replaceAll("\n", "\r\n").trim();
+  // Only write if there's actual content to avoid empty newlines
+  if (trimmedContent) {
+    terminal.writeln(parseTerminalOutput(trimmedContent));
+  }
 };
 
 // Create a persistent reference that survives component unmounts
@@ -153,7 +155,7 @@ export const useTerminal = () => {
         lastCommandType = commands[i].type;
         // Pass true for isUserInput to skip rendering user input commands
         // that have already been displayed as the user typed
-        renderCommand(commands[i], terminal.current, true);
+        renderCommand(commands[i], terminal.current, false);
       }
       lastCommandIndex.current = commands.length;
       if (lastCommandType === "output") {


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/openhands/runtime:d6357c5-nikolaik   --name openhands-app-d6357c5   docker.all-hands.dev/openhands/openhands:d6357c5
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@APP-111/terminal-inputs#subdirectory=openhands-cli openhands
```