### PR TITLE
hotfix(frontend): add unified conversation config hook with V1 support

### DIFF
--- a/frontend/src/api/conversation-service/conversation-service.api.ts
+++ b/frontend/src/api/conversation-service/conversation-service.api.ts
@@ -187,7 +187,7 @@ class ConversationService {
   static async getRuntimeId(
     conversationId: string,
   ): Promise<{ runtime_id: string }> {
-    const url = `/api/conversations/${conversationId}/config`;
+    const url = `${this.getConversationUrl(conversationId)}/config`;
     const { data } = await openHands.get<{ runtime_id: string }>(url, {
       headers: this.getConversationHeaders(),
     });

--- a/frontend/src/api/conversation-service/v1-conversation-service.api.ts
+++ b/frontend/src/api/conversation-service/v1-conversation-service.api.ts
@@ -291,6 +291,19 @@ class V1ConversationService {
       },
     });
   }
+
+  /**
+   * Get the conversation config (runtime_id) for a V1 conversation
+   * @param conversationId The conversation ID
+   * @returns Object containing runtime_id
+   */
+  static async getConversationConfig(
+    conversationId: string,
+  ): Promise<{ runtime_id: string }> {
+    const url = `/api/conversations/${conversationId}/config`;
+    const { data } = await openHands.get<{ runtime_id: string }>(url);
+    return data;
+  }
 }
 
 export default V1ConversationService;

--- a/frontend/src/hooks/query/use-conversation-config.ts
+++ b/frontend/src/hooks/query/use-conversation-config.ts
@@ -2,14 +2,20 @@ import { useQuery } from "@tanstack/react-query";
 import React from "react";
 import { useConversationId } from "#/hooks/use-conversation-id";
 import ConversationService from "#/api/conversation-service/conversation-service.api";
+import V1ConversationService from "#/api/conversation-service/v1-conversation-service.api";
 import { useRuntimeIsReady } from "../use-runtime-is-ready";
+import { useActiveConversation } from "./use-active-conversation";
 
-export const useConversationConfig = () => {
+/**
+ * @deprecated This hook is for V0 conversations only. Use useUnifiedConversationConfig instead,
+ * or useV1ConversationConfig once we fully migrate to V1.
+ */
+export const useV0ConversationConfig = () => {
   const { conversationId } = useConversationId();
   const runtimeIsReady = useRuntimeIsReady();
 
   const query = useQuery({
-    queryKey: ["conversation_config", conversationId],
+    queryKey: ["v0_conversation_config", conversationId],
     queryFn: () => {
       if (!conversationId) throw new Error("No conversation ID");
       return ConversationService.getRuntimeId(conversationId);
@@ -34,3 +40,80 @@ export const useConversationConfig = () => {
 
   return query;
 };
+
+export const useV1ConversationConfig = () => {
+  const { conversationId } = useConversationId();
+  const runtimeIsReady = useRuntimeIsReady();
+
+  const query = useQuery({
+    queryKey: ["v1_conversation_config", conversationId],
+    queryFn: () => {
+      if (!conversationId) throw new Error("No conversation ID");
+      return V1ConversationService.getConversationConfig(conversationId);
+    },
+    enabled: runtimeIsReady && !!conversationId,
+    staleTime: 1000 * 60 * 5, // 5 minutes
+    gcTime: 1000 * 60 * 15, // 15 minutes
+  });
+
+  React.useEffect(() => {
+    if (query.data) {
+      const { runtime_id: runtimeId } = query.data;
+
+      // eslint-disable-next-line no-console
+      console.log(
+        "Runtime ID: %c%s",
+        "background: #444; color: #ffeb3b; font-weight: bold; padding: 2px 4px; border-radius: 4px;",
+        runtimeId,
+      );
+    }
+  }, [query.data]);
+
+  return query;
+};
+
+/**
+ * Unified hook that switches between V0 and V1 conversation config endpoints based on conversation version.
+ *
+ * @temporary This hook is temporary during the V0 to V1 migration period.
+ * Once we fully migrate to V1, all code should use useV1ConversationConfig directly.
+ */
+export const useUnifiedConversationConfig = () => {
+  const { conversationId } = useConversationId();
+  const { data: conversation } = useActiveConversation();
+  const runtimeIsReady = useRuntimeIsReady();
+  const isV1Conversation = conversation?.conversation_version === "V1";
+
+  const query = useQuery({
+    queryKey: ["conversation_config", conversationId, isV1Conversation],
+    queryFn: () => {
+      if (!conversationId) throw new Error("No conversation ID");
+
+      if (isV1Conversation) {
+        return V1ConversationService.getConversationConfig(conversationId);
+      }
+      return ConversationService.getRuntimeId(conversationId);
+    },
+    enabled: runtimeIsReady && !!conversationId && conversation !== undefined,
+    staleTime: 1000 * 60 * 5, // 5 minutes
+    gcTime: 1000 * 60 * 15, // 15 minutes
+  });
+
+  React.useEffect(() => {
+    if (query.data) {
+      const { runtime_id: runtimeId } = query.data;
+
+      // eslint-disable-next-line no-console
+      console.log(
+        "Runtime ID: %c%s",
+        "background: #444; color: #ffeb3b; font-weight: bold; padding: 2px 4px; border-radius: 4px;",
+        runtimeId,
+      );
+    }
+  }, [query.data]);
+
+  return query;
+};
+
+// Keep the old export name for backward compatibility (uses unified approach)
+export const useConversationConfig = useUnifiedConversationConfig;


### PR DESCRIPTION
## Summary of PR

Fixes an issue introduced in #11466

- Added `V1ConversationService.getConversationConfig()` endpoint that calls `/api/conversations/${conversationId}/config`
- Created `useV1ConversationConfig` hook for V1 conversations
- Renamed existing hook to `useV0ConversationConfig` and marked it as deprecated
- Created `useUnifiedConversationConfig` that automatically switches between V0/V1 based on conversation version (marked as temporary)
- Maintained backward compatibility by aliasing `useConversationConfig` to the unified hook

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/openhands/runtime:903b691-nikolaik   --name openhands-app-903b691   docker.all-hands.dev/openhands/openhands:903b691
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@hotfix/unified-config#subdirectory=openhands-cli openhands
```