### PR TITLE
fix: prevent self-mention loops by sanitizing @OpenHands in assistant

### DIFF
--- a/enterprise/integrations/github/github_manager.py
+++ b/enterprise/integrations/github/github_manager.py
@@ -21,6 +21,7 @@ from integrations.utils import (
     CONVERSATION_URL,
     HOST_URL,
     OPENHANDS_RESOLVER_TEMPLATES_DIR,
+    sanitize_openhands_mentions
 )
 from jinja2 import Environment, FileSystemLoader
 from pydantic import SecretStr
@@ -33,7 +34,6 @@ from openhands.integrations.provider import ProviderToken, ProviderType
 from openhands.server.types import LLMAuthenticationError, MissingSettingsError
 from openhands.storage.data_models.secrets import Secrets
 from openhands.utils.async_utils import call_sync_from_async
-
 
 class GithubManager(Manager):
     def __init__(
@@ -191,6 +191,8 @@ class GithubManager(Manager):
             return
 
         outgoing_message = message.message
+
+        outgoing_message = sanitize_openhands_mentions(outgoing_message)
 
         if isinstance(github_view, GithubInlinePRComment):
             with Github(installation_token) as github_client:

--- a/enterprise/integrations/utils.py
+++ b/enterprise/integrations/utils.py
@@ -555,3 +555,21 @@ def markdown_to_jira_markup(markdown_text: str) -> str:
         # Log the error but don't raise it - return original text as fallback
         print(f'Error converting markdown to Jira markup: {str(e)}')
         return markdown_text or ''
+
+def sanitize_openhands_mentions(text: str) -> str:
+    """Sanitize @OpenHands mentions by inserting zero-width joiner after @.
+
+    This prevents GitHub from making @OpenHands a clickable mention,
+    avoiding self-mention loops and unwanted notifications.
+
+    Args:
+        text: The text to sanitize
+
+    Returns:
+        Text with @OpenHands mentions sanitized (e.g., @OpenHands -> @\u200dOpenHands)
+    """
+    # Pattern to match @OpenHands, @openhands, @OpenHandsAI, etc.
+    # Matches @ followed by OpenHands (case-insensitive) and captures it
+    pattern = r'@([Oo]pen[Hh]ands)'
+    # Replace @OpenHands with @\u200dOpenHands (zero-width joiner after @)
+    return re.sub(pattern, r'@\u200d\1', text)


### PR DESCRIPTION
## Summary of PR

This PR prevents self-mention loops by sanitizing @OpenHands (and variants) in assistant message outputs. When the assistant mentions @OpenHands, it could trigger platform notifications or create clickable mentions that lead to unintended behavior. This fix neutralizes such mentions by inserting a zero-width joiner after the @ symbol, making them non-clickable while preserving readability.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #11548 

## Release Notes

- [x] Include this change in the Release Notes.

**For users:** Assistant responses now automatically sanitize @OpenHands mentions to prevent accidental platform notifications and clickable mentions, improving overall system reliability and user experience.