### PR TITLE
chore - Enforce python test coverage

### DIFF
--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -176,7 +176,6 @@ jobs:
 
   coverage-comment:
     name: Coverage Comment
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: [test-on-linux, test-enterprise, test-cli-python]
 
@@ -196,6 +195,7 @@ jobs:
         run: ln -sf openhands-cli/openhands_cli openhands_cli
 
       - name: Coverage comment
+        # In PR mode leaves a comment, otherwise records coverage in branch python-coverage-comment-action-data.
         id: coverage_comment
         uses: py-cov-action/python-coverage-comment-action@v3
         with:
@@ -203,5 +203,15 @@ jobs:
           MERGE_COVERAGE_FILES: true
 
       - name: Enforce coverage
-        if: ${{ steps.coverage_comment.outputs.new_percent_covered < steps.coverage_comment.outputs.reference_percent_covered }}
-        run: echo "Coverage decreased, which is not allowed. Please add some unit tests for the modified code." && exit 1
+        # Fail if on PR AND there are uncovered lines AND diff coverage is less than total coverage.
+        # To debug, try a step to log outputs like: `echo ${{ toJSON(steps.coverage_comment.outputs) }}`
+        # Once we track base branch, reference_percent_covered will be better to use than new_percent_covered.
+        if: ${{ github.event_name == 'pull_request' && fromJSON(steps.coverage_comment.outputs.diff_total_num_violations) > 0 && steps.coverage_comment.outputs.diff_total_percent_covered < steps.coverage_comment.outputs.new_percent_covered }}
+        run: |
+          echo "Coverage decreased, which is not allowed."
+          echo "Please add some unit tests for the modified code."
+          echo
+          echo "  diff_total_num_violations: ${{ steps.coverage_comment.outputs.diff_total_num_violations }}"
+          echo "  diff_total_percent_covered: ${{ steps.coverage_comment.outputs.diff_total_percent_covered}}"
+          echo "  new_percent_covered: ${{ steps.coverage_comment.outputs.new_percent_covered}}"
+          exit 1


### PR DESCRIPTION
## Summary of PR

We've recently discussed adding enforcement of test coverage, specifically to prevent these two scenarios:

* Lowering total test coverage of the repo
* Modifying untested code without adding tests

This PR adds a check with this logic: "Fail PR build when there are uncovered lines AND diff coverage is less than total coverage".

The calculation is done using outputs of the `python-coverage-comment` action ([docs](https://github.com/marketplace/actions/python-coverage-comment)):

**Limitations**

* Only checks Python test coverage, Typescript check can be added separately
* Won't catch if a test is deleted while no untested code is modified (probably not a practical concern)
* The fail message does not link to a testing style guide

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

ALL-4116

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/openhands/runtime:70fb1dd-nikolaik   --name openhands-app-70fb1dd   docker.all-hands.dev/openhands/openhands:70fb1dd
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@ray/enforce-coverage#subdirectory=openhands-cli openhands
```