### PR TITLE
Fix flaky test_condenser_metrics_included by creating new action objects

### DIFF
--- a/tests/unit/controller/test_agent_controller.py
+++ b/tests/unit/controller/test_agent_controller.py
@@ -1582,16 +1582,15 @@ async def test_condenser_metrics_included(mock_agent_with_stats, test_event_stre
     # Attach the condenser to the mock_agent
     mock_agent.condenser = condenser
 
-    # Create a real CondensationAction
-    action = CondensationAction(
-        forgotten_events_start_id=1,
-        forgotten_events_end_id=5,
-        summary='Test summary',
-        summary_offset=1,
-    )
-    action._source = EventSource.AGENT  # Required for event_stream.add_event
-
     def agent_step_fn(state):
+        # Create a new CondensationAction each time to avoid ID reuse
+        action = CondensationAction(
+            forgotten_events_start_id=1,
+            forgotten_events_end_id=5,
+            summary='Test summary',
+            summary_offset=1,
+        )
+        action._source = EventSource.AGENT  # Required for event_stream.add_event
         return action
 
     mock_agent.step = agent_step_fn


### PR DESCRIPTION
## Summary of PR

Update flakey `test_condenser_metrics_included` to have agent_step_fn return a fresh CondensationAction on every call, hoping to avoid a race condition with duplicate IDs.

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [X] I have read and reviewed the code and I understand what the code is doing.
- [X] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.
