### PR TITLE
fix(frontend): displaying observation result statuses

### DIFF
--- a/frontend/src/components/v1/chat/event-content-helpers/get-observation-result.ts
+++ b/frontend/src/components/v1/chat/event-content-helpers/get-observation-result.ts
@@ -11,9 +11,10 @@ export const getObservationResult = (
   switch (observationType) {
     case "ExecuteBashObservation": {
       const exitCode = observation.exit_code;
+      const { metadata } = observation;
 
-      if (exitCode === -1) return "timeout"; // Command timed out
-      if (exitCode === 0) return "success"; // Command executed successfully
+      if (exitCode === -1 || metadata.exit_code === -1) return "timeout"; // Command timed out
+      if (exitCode === 0 || metadata.exit_code === 0) return "success"; // Command executed successfully
       return "error"; // Command failed
     }
     case "FileEditorObservation":


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

<img width="1440" height="797" alt="app-116-issue" src="https://github.com/user-attachments/assets/5e5a7833-4550-4468-bfcb-8a053a4fd85e" />

**Description:**

Currently, when creating a V1 conversation and sending a message such as “Write a Python program for adding two numbers,” the observation events do not display success indicators for successful events in the chat interface. This needs to be fixed.

**Acceptance Criteria:**
- The indicator should accurately reflect the correct status of each event.

We can refer to the image below for the output of the PR.

<img width="1440" height="797" alt="app-116-output" src="https://github.com/user-attachments/assets/99c90480-7a46-4034-874a-fc65b7a1be04" />

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/openhands/runtime:55f46db-nikolaik   --name openhands-app-55f46db   docker.all-hands.dev/openhands/openhands:55f46db
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@hieptl/app-116#subdirectory=openhands-cli openhands
```