### PR TITLE
fix(frontend): display error content when FileEditorAction encounters an error

### DIFF
--- a/frontend/src/components/v1/chat/event-content-helpers/get-observation-content.ts
+++ b/frontend/src/components/v1/chat/event-content-helpers/get-observation-content.ts
@@ -19,6 +19,10 @@ const getFileEditorObservationContent = (
 ): string => {
   const { observation } = event;
 
+  if (observation.error) {
+    return `**Error:**\n${observation.error}`;
+  }
+
   const successMessage = getObservationResult(event) === "success";
 
   // For view commands or successful edits with content changes, format as code block


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

**Description:**

In the current implementation for V1 conversations, error content is not displayed when a FileEditorAction results in an error. This prevents users from understanding the cause of the issue.

**Acceptance Criteria:**
- The system must display the error content whenever a FileEditorAction encounters an error.

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/openhands/runtime:4143777-nikolaik   --name openhands-app-4143777   docker.all-hands.dev/openhands/openhands:4143777
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@hieptl/app-117#subdirectory=openhands-cli openhands
```