### PR TITLE
CLI: rename deprecated args

### DIFF
--- a/openhands-cli/openhands_cli/tui/settings/settings_screen.py
+++ b/openhands-cli/openhands_cli/tui/settings/settings_screen.py
@@ -174,7 +174,7 @@ class SettingsScreen:
             model=model,
             api_key=api_key,
             base_url=base_url,
-            service_id='agent',
+            usage_id='agent',
             metadata=get_llm_metadata(model_name=model, llm_type='agent'),
         )
 

--- a/openhands-cli/tests/settings/test_settings_workflow.py
+++ b/openhands-cli/tests/settings/test_settings_workflow.py
@@ -18,7 +18,7 @@ def read_json(path: Path) -> dict:
 
 
 def make_screen_with_conversation(model='openai/gpt-4o-mini', api_key='sk-xyz'):
-    llm = LLM(model=model, api_key=SecretStr(api_key), service_id='test-service')
+    llm = LLM(model=model, api_key=SecretStr(api_key), usage_id='test-service')
     # Conversation(agent) signature may vary across versions; adapt if needed:
     from openhands.sdk.agent import Agent
 
@@ -31,7 +31,7 @@ def seed_file(path: Path, model: str = 'openai/gpt-4o-mini', api_key: str = 'sk-
     store = AgentStore()
     store.file_store = LocalFileStore(root=str(path))
     agent = get_default_cli_agent(
-        llm=LLM(model=model, api_key=SecretStr(api_key), service_id='test-service')
+        llm=LLM(model=model, api_key=SecretStr(api_key), usage_id='test-service')
     )
     store.save(agent)
 

--- a/openhands-cli/tests/test_conversation_runner.py
+++ b/openhands-cli/tests/test_conversation_runner.py
@@ -50,7 +50,7 @@ class FakeAgent(AgentBase):
 
 @pytest.fixture()
 def agent() -> FakeAgent:
-    llm = LLM(**default_config(), service_id='test-service')
+    llm = LLM(**default_config(), usage_id='test-service')
     return FakeAgent(llm=llm, tools=[])
 
 

--- a/openhands-cli/tests/test_directory_separation.py
+++ b/openhands-cli/tests/test_directory_separation.py
@@ -37,7 +37,7 @@ class TestToolFix:
         """Test that entire tools list is replaced with default tools when loading agent."""
         # Create a mock agent with different tools and working directories
         mock_agent = Agent(
-            llm=LLM(model='test/model', api_key='test-key', service_id='test-service'),
+            llm=LLM(model='test/model', api_key='test-key', usage_id='test-service'),
             tools=[
                 Tool(name='BashTool'),
                 Tool(name='FileEditorTool'),

--- a/openhands-cli/tests/test_mcp_config_validation.py
+++ b/openhands-cli/tests/test_mcp_config_validation.py
@@ -26,7 +26,7 @@ def _create_agent(mcp_config=None) -> Agent:
     if mcp_config is None:
         mcp_config = {}
     return Agent(
-        llm=LLM(model='test-model', api_key='test-key', service_id='test-service'),
+        llm=LLM(model='test-model', api_key='test-key', usage_id='test-service'),
         tools=[],
         mcp_config=mcp_config,
     )


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [X] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [X] I have read and reviewed the code and I understand what the code is doing.
- [X] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:c000fe3-nikolaik   --name openhands-app-c000fe3   docker.openhands.dev/openhands/openhands:c000fe3
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@cli-swap-deprecated-field#subdirectory=openhands-cli openhands
```