### PR TITLE
Disables Copilot icon by default

### DIFF
--- a/openhands/runtime/plugins/vscode/settings.json
+++ b/openhands/runtime/plugins/vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "workbench.colorTheme": "Default Dark Modern",
-    "workbench.startupEditor": "none"
+    "workbench.startupEditor": "none",
+    "chat.commandCenter.enabled": false
 }


### PR DESCRIPTION
## Summary of PR

This PR disables the copilot icon within the VSCode editor

## Change Type

- [ ] Bug fix
- [ X] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ X] I have read and reviewed the code and I understand what the code is doing.
- [ X] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #(issue)

## Release Notes

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:365947a-nikolaik   --name openhands-app-365947a   docker.openhands.dev/openhands/openhands:365947a
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@jp/vscode-settings#subdirectory=openhands-cli openhands
```