### PR TITLE
fixed the readme to use the new cli launcher command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ See the [uv installation guide](https://docs.astral.sh/uv/getting-started/instal
 **Launch OpenHands**:
 ```bash
 # Launch the GUI server
-uvx --python 3.12 --from openhands-ai openhands serve
+uvx --python 3.12 openhands
 
 # Or launch the CLI
-uvx --python 3.12 --from openhands-ai openhands
+uvx --python 3.12 openhands
 ```
 
 You'll find OpenHands running at [http://localhost:3000](http://localhost:3000) (for GUI mode)!


### PR DESCRIPTION
## Summary of PR
Updated the README.md to use the simplified new CLI launcher command. The command has been changed from the verbose multi-flag format (`uvx --python 3.12 --from openhands-ai openhands` and `uvx --python 3.12 --from openhands-ai openhands serve`) to the simplified format (`uvx --python 3.12 openhands`). This makes the launcher command more user-friendly and easier to remember.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (documentation update)

## Checklist
- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes
Fixes #11572 

## Release Notes
- [x] Include this change in the Release Notes.

Updated CLI launcher commands in the README to use the new simplified format for easier user experience.