### PR TITLE
build(devcontainer): add uvx installation

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -7,5 +7,8 @@ git config --global --add safe.directory "$(realpath .)"
 # Install `nc`
 sudo apt update && sudo apt install netcat -y
 
+# Install `uv` and `uvx`
+wget -qO- https://astral.sh/uv/install.sh | sh
+
 # Do common setup tasks
 source .openhands/setup.sh


### PR DESCRIPTION
  ## Summary of PR

  Pre-installs uvx in the devcontainer setup script so it's immediately
  available when following the README instructions. This removes the
  friction of manually installing uvx before being able to run `uvx --python
   python3.12 openhands`.

  ## Change Type

  - [x] Other (dependency update, docs, typo fixes, etc.)

  ## Checklist

  - [x] I have read and reviewed the code and I understand what the code is
  doing.
  - [x] I have tested the code to the best of my ability and ensured it
  works as expected.

  ## Fixes

  Resolves #9670

  ## Release Notes

  - [ ] Include this change in the Release Notes.