### PR TITLE
fix(devcontainer): Install uv and in setup script

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -7,5 +7,15 @@ git config --global --add safe.directory "$(realpath .)"
 # Install `nc`
 sudo apt update && sudo apt install netcat -y
 
+# Install uv (which includes uvx)
+if ! command -v uv &> /dev/null; then
+    echo "Installing uv (which includes uvx)..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    # Add uv to PATH for current session
+    export PATH="$HOME/.cargo/bin:$PATH"
+    # Also add to PATH for future sessions
+    echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.bashrc
+fi
+
 # Do common setup tasks
 source .openhands/setup.sh


### PR DESCRIPTION
## Summary of PR
This PR fixes issue #11609. In the current devcontainer, running 'uvx' returns 'command not found' because 'uv' is not installed by default. This PR updates the setup script to always install 'uv' (which includes 'uvx'), so 'uvx' is available immediately after container startup. This resolves the bug and eliminates the need for manual installation.
## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)
## Checklist
- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.
## Fixes
Resolves #11609
## Release Notes
- [ ] Include this change in the Release Notes.