### PR TITLE
fix(frontend): agent status shows “Disconnected” when starting a new conversation until sandbox initializes

### DIFF
--- a/frontend/src/hooks/use-unified-websocket-status.ts
+++ b/frontend/src/hooks/use-unified-websocket-status.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useWsClient, V0_WebSocketStatus } from "#/context/ws-client-provider";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useConversationWebSocket } from "#/contexts/conversation-websocket-context";
+import { useConversationId } from "#/hooks/use-conversation-id";
 
 /**
  * Unified hook that returns the current WebSocket status
@@ -9,11 +10,15 @@ import { useConversationWebSocket } from "#/contexts/conversation-websocket-cont
  * - For V1 conversations: Returns status from ConversationWebSocketProvider
  */
 export function useUnifiedWebSocketStatus(): V0_WebSocketStatus {
+  const { conversationId } = useConversationId();
   const { data: conversation } = useActiveConversation();
   const v0Status = useWsClient();
   const v1Context = useConversationWebSocket();
 
-  const isV1Conversation = conversation?.conversation_version === "V1";
+  // Check if this is a V1 conversation:
+  const isV1Conversation =
+    conversationId.startsWith("task-") ||
+    conversation?.conversation_version === "V1";
 
   const webSocketStatus = useMemo(() => {
     if (isV1Conversation) {
@@ -33,7 +38,13 @@ export function useUnifiedWebSocketStatus(): V0_WebSocketStatus {
       }
     }
     return v0Status.webSocketStatus;
-  }, [isV1Conversation, v1Context, v0Status.webSocketStatus]);
+  }, [
+    isV1Conversation,
+    v1Context,
+    v0Status.webSocketStatus,
+    conversationId,
+    conversation,
+  ]);
 
   return webSocketStatus;
 }


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

The agent status shows “Disconnected” when starting a new conversation until sandbox initializes

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/3a6a37f6-8132-4c15-8a79-a57edfb7b6b4

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:8b5d854-nikolaik   --name openhands-app-8b5d854   docker.openhands.dev/openhands/openhands:8b5d854
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@hieptl/app-124#subdirectory=openhands-cli openhands
```