### PR TITLE
fix(frontend): correct handling of OBSERVATION_MESSAGE messages for task events

### DIFF
--- a/frontend/src/components/v1/chat/event-content-helpers/get-event-content.tsx
+++ b/frontend/src/components/v1/chat/event-content-helpers/get-event-content.tsx
@@ -134,9 +134,16 @@ const getObservationEventTitle = (event: OpenHandsEvent): React.ReactNode => {
     case "BrowserObservation":
       observationKey = "OBSERVATION_MESSAGE$BROWSE";
       break;
-    case "TaskTrackerObservation":
-      observationKey = "OBSERVATION_MESSAGE$TASK_TRACKING";
+    case "TaskTrackerObservation": {
+      const { command } = event.observation;
+      if (command === "plan") {
+        observationKey = "OBSERVATION_MESSAGE$TASK_TRACKING_PLAN";
+      } else {
+        // command === "view"
+        observationKey = "OBSERVATION_MESSAGE$TASK_TRACKING_VIEW";
+      }
       break;
+    }
     default:
       // For unknown observations, use the type name
       return observationType.replace("Observation", "").toUpperCase();


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

The PR updates the code for correct handling of OBSERVATION_MESSAGE messages for task events.

We can refer to the image below for the output of the PR.

<img width="1439" height="746" alt="app-127" src="https://github.com/user-attachments/assets/7cc02ed9-b05c-4673-9bee-930ac9ab656c" />

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:37ff152-nikolaik   --name openhands-app-37ff152   docker.openhands.dev/openhands/openhands:37ff152
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@hieptl/app-127#subdirectory=openhands-cli openhands
```