### PR TITLE
fix(frontend): there is insufficient padding below the code block.

### DIFF
--- a/frontend/src/components/features/markdown/paragraph.tsx
+++ b/frontend/src/components/features/markdown/paragraph.tsx
@@ -7,5 +7,5 @@ export function paragraph({
 }: React.ClassAttributes<HTMLParagraphElement> &
   React.HTMLAttributes<HTMLParagraphElement> &
   ExtraProps) {
-  return <p className="pb-[10px] last:pb-0">{children}</p>;
+  return <p className="py-2.5 first:pt-0 last:pb-0">{children}</p>;
 }


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

<img width="480" height="421" alt="Image" src="https://github.com/user-attachments/assets/3ddadbac-8ba0-4a05-be1a-63bf835981e6" />

According to the image above, there appears to be insufficient padding beneath the code block.

The PR updates the code to fix the issue. We can refer to the image below for the output of the PR.

<img width="1439" height="746" alt="11614" src="https://github.com/user-attachments/assets/edf578e3-2c63-476c-b01e-8a98bbe0a132" />

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #11614

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:0e2dfe2-nikolaik   --name openhands-app-0e2dfe2   docker.openhands.dev/openhands/openhands:0e2dfe2
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@hieptl/11614#subdirectory=openhands-cli openhands
```