### PR TITLE
fix(frontend): the width of the branch dropdown appears inconsistent on medium-sized screens.

### DIFF
--- a/frontend/src/components/features/home/repo-selection-form.tsx
+++ b/frontend/src/components/features/home/repo-selection-form.tsx
@@ -131,7 +131,7 @@ export function RepositorySelectionForm({
         onBranchSelect={handleBranchSelection}
         defaultBranch={defaultBranch}
         placeholder="Select branch..."
-        className="max-w-[500px]"
+        className="max-w-full"
         disabled={!selectedRepository || isLoadingSettings}
       />
     );


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

<img width="719" height="384" alt="Image" src="https://github.com/user-attachments/assets/00b31d7e-e2ca-4cfc-8e86-6513fd01f11d" />

Description: As shown in the image above, the branch dropdown’s width is not properly optimized for medium-width screens, resulting in a visually unbalanced layout.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/1579b4fb-e2b6-4441-bddf-43d7ce985a5d

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #11619 

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:86f5293-nikolaik   --name openhands-app-86f5293   docker.openhands.dev/openhands/openhands:86f5293
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@hieptl/11619#subdirectory=openhands-cli openhands
```