### PR TITLE
feat(frontend): show server status menu when hovering over the status indicator

### DIFF
--- a/frontend/src/components/features/chat/components/chat-input-actions.tsx
+++ b/frontend/src/components/features/chat/components/chat-input-actions.tsx
@@ -1,11 +1,7 @@
-import { ConversationStatus } from "#/types/conversation-status";
-import { ServerStatus } from "#/components/features/controls/server-status";
 import { AgentStatus } from "#/components/features/controls/agent-status";
 import { Tools } from "../../controls/tools";
 import { useUnifiedPauseConversationSandbox } from "#/hooks/mutation/use-unified-stop-conversation";
 import { useConversationId } from "#/hooks/use-conversation-id";
-import { useUnifiedResumeConversationSandbox } from "#/hooks/mutation/use-unified-start-conversation";
-import { useUserProviders } from "#/hooks/use-user-providers";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useSendMessage } from "#/hooks/use-send-message";
 import { generateAgentStateChangeEvent } from "#/services/agent-state-service";
@@ -14,31 +10,22 @@ import { useV1PauseConversation } from "#/hooks/mutation/use-v1-pause-conversati
 import { useV1ResumeConversation } from "#/hooks/mutation/use-v1-resume-conversation";
 
 interface ChatInputActionsProps {
-  conversationStatus: ConversationStatus | null;
   disabled: boolean;
   handleResumeAgent: () => void;
 }
 
 export function ChatInputActions({
-  conversationStatus,
   disabled,
   handleResumeAgent,
 }: ChatInputActionsProps) {
   const { data: conversation } = useActiveConversation();
   const pauseConversationSandboxMutation = useUnifiedPauseConversationSandbox();
-  const resumeConversationSandboxMutation =
-    useUnifiedResumeConversationSandbox();
   const v1PauseConversationMutation = useV1PauseConversation();
   const v1ResumeConversationMutation = useV1ResumeConversation();
   const { conversationId } = useConversationId();
-  const { providers } = useUserProviders();
   const { send } = useSendMessage();
 
   const isV1Conversation = conversation?.conversation_version === "V1";
-
-  const handleStopClick = () => {
-    pauseConversationSandboxMutation.mutate({ conversationId });
-  };
 
   const handlePauseAgent = () => {
     if (isV1Conversation) {
@@ -62,10 +49,6 @@ export function ChatInputActions({
     handleResumeAgent();
   };
 
-  const handleStartClick = () => {
-    resumeConversationSandboxMutation.mutate({ conversationId, providers });
-  };
-
   const isPausing =
     pauseConversationSandboxMutation.isPending ||
     v1PauseConversationMutation.isPending;
@@ -74,12 +57,6 @@ export function ChatInputActions({
     <div className="w-full flex items-center justify-between">
       <div className="flex items-center gap-1">
         <Tools />
-        <ServerStatus
-          conversationStatus={conversationStatus}
-          isPausing={isPausing}
-          handleStop={handleStopClick}
-          handleResumeAgent={handleStartClick}
-        />
       </div>
       <AgentStatus
         className="ml-2 md:ml-3"

--- a/frontend/src/components/features/chat/components/chat-input-container.tsx
+++ b/frontend/src/components/features/chat/components/chat-input-container.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { ConversationStatus } from "#/types/conversation-status";
 import { DragOver } from "../drag-over";
 import { UploadedFiles } from "../uploaded-files";
 import { ChatInputRow } from "./chat-input-row";
@@ -11,7 +10,6 @@ interface ChatInputContainerProps {
   disabled: boolean;
   showButton: boolean;
   buttonClassName: string;
-  conversationStatus: ConversationStatus | null;
   chatInputRef: React.RefObject<HTMLDivElement | null>;
   handleFileIconClick: (isDisabled: boolean) => void;
   handleSubmit: () => void;
@@ -32,7 +30,6 @@ export function ChatInputContainer({
   disabled,
   showButton,
   buttonClassName,
-  conversationStatus,
   chatInputRef,
   handleFileIconClick,
   handleSubmit,
@@ -74,7 +71,6 @@ export function ChatInputContainer({
       />
 
       <ChatInputActions
-        conversationStatus={conversationStatus}
         disabled={disabled}
         handleResumeAgent={handleResumeAgent}
       />

--- a/frontend/src/components/features/chat/custom-chat-input.tsx
+++ b/frontend/src/components/features/chat/custom-chat-input.tsx
@@ -137,7 +137,6 @@ export function CustomChatInput({
           disabled={isDisabled}
           showButton={showButton}
           buttonClassName={buttonClassName}
-          conversationStatus={conversationStatus}
           chatInputRef={chatInputRef}
           handleFileIconClick={handleFileIconClick}
           handleSubmit={handleSubmit}

--- a/frontend/src/components/features/controls/server-status-context-menu-icon-text.tsx
+++ b/frontend/src/components/features/controls/server-status-context-menu-icon-text.tsx
@@ -13,7 +13,7 @@ export function ServerStatusContextMenuIconText({
 }: ServerStatusContextMenuIconTextProps) {
   return (
     <button
-      className="flex items-center gap-2 p-2 hover:bg-[#5C5D62] rounded text-sm text-white font-normal leading-5 cursor-pointer w-full"
+      className="flex items-center justify-between p-2 hover:bg-[#5C5D62] rounded text-sm text-white font-normal leading-5 cursor-pointer w-full"
       onClick={onClick}
       data-testid={testId}
       type="button"

--- a/frontend/src/components/features/controls/server-status-context-menu.tsx
+++ b/frontend/src/components/features/controls/server-status-context-menu.tsx
@@ -6,6 +6,9 @@ import { ConversationStatus } from "#/types/conversation-status";
 import StopCircleIcon from "#/icons/stop-circle.svg?react";
 import PlayCircleIcon from "#/icons/play-circle.svg?react";
 import { ServerStatusContextMenuIconText } from "./server-status-context-menu-icon-text";
+import { ServerStatus } from "./server-status";
+import { Divider } from "#/ui/divider";
+import { cn } from "#/utils/utils";
 
 interface ServerStatusContextMenuProps {
   onClose: () => void;
@@ -13,6 +16,8 @@ interface ServerStatusContextMenuProps {
   onStartServer?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   conversationStatus: ConversationStatus | null;
   position?: "top" | "bottom";
+  className?: string;
+  isPausing?: boolean;
 }
 
 export function ServerStatusContextMenu({
@@ -21,9 +26,14 @@ export function ServerStatusContextMenu({
   onStartServer,
   conversationStatus,
   position = "top",
+  className = "",
+  isPausing = false,
 }: ServerStatusContextMenuProps) {
   const { t } = useTranslation();
   const ref = useClickOutsideElement<HTMLUListElement>(onClose);
+
+  const shouldActionShown =
+    conversationStatus === "RUNNING" || conversationStatus === "STOPPED";
 
   return (
     <ContextMenu
@@ -32,24 +42,36 @@ export function ServerStatusContextMenu({
       position={position}
       alignment="left"
       size="default"
-      className="left-2 w-fit min-w-max"
+      className={cn("left-2 w-fit min-w-42", className)}
     >
-      {conversationStatus === "RUNNING" && onStopServer && (
-        <ServerStatusContextMenuIconText
-          icon={<StopCircleIcon width={18} height={18} />}
-          text={t(I18nKey.COMMON$STOP_RUNTIME)}
-          onClick={onStopServer}
-          testId="stop-server-button"
-        />
-      )}
+      <ServerStatus
+        conversationStatus={conversationStatus}
+        isPausing={isPausing}
+        className="py-1"
+      />
 
-      {conversationStatus === "STOPPED" && onStartServer && (
-        <ServerStatusContextMenuIconText
-          icon={<PlayCircleIcon width={18} height={18} />}
-          text={t(I18nKey.COMMON$START_RUNTIME)}
-          onClick={onStartServer}
-          testId="start-server-button"
-        />
+      {shouldActionShown && (
+        <>
+          <Divider />
+
+          {conversationStatus === "RUNNING" && onStopServer && (
+            <ServerStatusContextMenuIconText
+              icon={<StopCircleIcon width={18} height={18} />}
+              text={t(I18nKey.COMMON$STOP_RUNTIME)}
+              onClick={onStopServer}
+              testId="stop-server-button"
+            />
+          )}
+
+          {conversationStatus === "STOPPED" && onStartServer && (
+            <ServerStatusContextMenuIconText
+              icon={<PlayCircleIcon width={18} height={18} />}
+              text={t(I18nKey.COMMON$START_RUNTIME)}
+              onClick={onStartServer}
+              testId="start-server-button"
+            />
+          )}
+        </>
       )}
     </ContextMenu>
   );

--- a/frontend/src/components/features/controls/server-status.tsx
+++ b/frontend/src/components/features/controls/server-status.tsx
@@ -1,30 +1,23 @@
 import { useTranslation } from "react-i18next";
-import { useState } from "react";
 import DebugStackframeDot from "#/icons/debug-stackframe-dot.svg?react";
 import { I18nKey } from "#/i18n/declaration";
 import { ConversationStatus } from "#/types/conversation-status";
 import { AgentState } from "#/types/agent-state";
-import { ServerStatusContextMenu } from "./server-status-context-menu";
 import { useAgentState } from "#/hooks/use-agent-state";
 import { useTaskPolling } from "#/hooks/query/use-task-polling";
+import { getStatusColor } from "#/utils/utils";
 
 export interface ServerStatusProps {
   className?: string;
   conversationStatus: ConversationStatus | null;
   isPausing?: boolean;
-  handleStop: () => void;
-  handleResumeAgent: () => void;
 }
 
 export function ServerStatus({
   className = "",
   conversationStatus,
   isPausing = false,
-  handleStop,
-  handleResumeAgent,
 }: ServerStatusProps) {
-  const [showContextMenu, setShowContextMenu] = useState(false);
-
   const { curAgentState } = useAgentState();
   const { t } = useTranslation();
   const { isTask, taskStatus, taskDetail } = useTaskPolling();
@@ -34,34 +27,15 @@ export function ServerStatus({
 
   const isStopStatus = conversationStatus === "STOPPED";
 
-  // Get the appropriate color based on agent status
-  const getStatusColor = (): string => {
-    // Show pausing status
-    if (isPausing) {
-      return "#FFD600";
-    }
+  const statusColor = getStatusColor({
+    isPausing,
+    isTask,
+    taskStatus,
+    isStartingStatus,
+    isStopStatus,
+    curAgentState,
+  });
 
-    // Show task status if we're polling a task
-    if (isTask && taskStatus) {
-      if (taskStatus === "ERROR") {
-        return "#FF684E";
-      }
-      return "#FFD600";
-    }
-
-    if (isStartingStatus) {
-      return "#FFD600";
-    }
-    if (isStopStatus) {
-      return "#ffffff";
-    }
-    if (curAgentState === AgentState.ERROR) {
-      return "#FF684E";
-    }
-    return "#BCFF8C";
-  };
-
-  // Get the appropriate status text based on agent status
   const getStatusText = (): string => {
     // Show pausing status
     if (isPausing) {
@@ -100,49 +74,14 @@ export function ServerStatus({
     return t(I18nKey.COMMON$RUNNING);
   };
 
-  const handleClick = () => {
-    if (conversationStatus === "RUNNING" || conversationStatus === "STOPPED") {
-      setShowContextMenu(true);
-    }
-  };
-
-  const handleCloseContextMenu = () => {
-    setShowContextMenu(false);
-  };
-
-  const handleStopServer = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-    handleStop();
-    setShowContextMenu(false);
-  };
-
-  const handleStartServer = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-    handleResumeAgent();
-    setShowContextMenu(false);
-  };
-
-  const statusColor = getStatusColor();
   const statusText = getStatusText();
 
   return (
-    <div className={`relative ${className}`}>
-      <div className="flex items-center cursor-pointer" onClick={handleClick}>
+    <div className={className} data-testid="server-status">
+      <div className="flex items-center">
         <DebugStackframeDot className="w-6 h-6" color={statusColor} />
-        <span className="text-[11px] text-white font-normal leading-5">
-          {statusText}
-        </span>
+        <span className="text-[13px] text-white font-normal">{statusText}</span>
       </div>
-
-      {showContextMenu && (
-        <ServerStatusContextMenu
-          onClose={handleCloseContextMenu}
-          onStopServer={handleStopServer}
-          onStartServer={handleStartServer}
-          conversationStatus={conversationStatus}
-          position="top"
-        />
-      )}
     </div>
   );
 }

--- a/frontend/src/components/features/conversation/conversation-name-with-status.tsx
+++ b/frontend/src/components/features/conversation/conversation-name-with-status.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { useParams } from "react-router";
+import { useAgentState } from "#/hooks/use-agent-state";
+import { useTaskPolling } from "#/hooks/query/use-task-polling";
+import { useActiveConversation } from "#/hooks/query/use-active-conversation";
+import { useUnifiedPauseConversationSandbox } from "#/hooks/mutation/use-unified-stop-conversation";
+import { useUnifiedResumeConversationSandbox } from "#/hooks/mutation/use-unified-start-conversation";
+import { useUserProviders } from "#/hooks/use-user-providers";
+import { getStatusColor } from "#/utils/utils";
+import { AgentState } from "#/types/agent-state";
+import DebugStackframeDot from "#/icons/debug-stackframe-dot.svg?react";
+import { ServerStatusContextMenu } from "../controls/server-status-context-menu";
+import { ConversationName } from "./conversation-name";
+
+export function ConversationNameWithStatus() {
+  const { conversationId } = useParams<{ conversationId: string }>();
+  const { data: conversation } = useActiveConversation();
+  const { curAgentState } = useAgentState();
+  const { isTask, taskStatus } = useTaskPolling();
+  const { mutate: pauseConversationSandbox } =
+    useUnifiedPauseConversationSandbox();
+  const { mutate: resumeConversationSandbox } =
+    useUnifiedResumeConversationSandbox();
+  const { providers } = useUserProviders();
+
+  const isStartingStatus =
+    curAgentState === AgentState.LOADING || curAgentState === AgentState.INIT;
+  const isStopStatus = conversation?.status === "STOPPED";
+
+  const statusColor = getStatusColor({
+    isPausing: false,
+    isTask,
+    taskStatus,
+    isStartingStatus,
+    isStopStatus,
+    curAgentState,
+  });
+
+  const handleStopServer = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (conversationId) {
+      pauseConversationSandbox({ conversationId });
+    }
+  };
+
+  const handleStartServer = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (conversationId) {
+      resumeConversationSandbox({ conversationId, providers });
+    }
+  };
+
+  return (
+    <div className="flex items-center">
+      <div className="group relative">
+        <DebugStackframeDot
+          className="ml-[3.5px] w-6 h-6 cursor-pointer"
+          color={statusColor}
+        />
+        <ServerStatusContextMenu
+          onClose={() => {}}
+          onStopServer={
+            conversation?.status === "RUNNING" ? handleStopServer : undefined
+          }
+          onStartServer={
+            conversation?.status === "STOPPED" ? handleStartServer : undefined
+          }
+          conversationStatus={conversation?.status ?? null}
+          position="bottom"
+          className="opacity-0 invisible pointer-events-none group-hover:opacity-100 group-hover:visible group-hover:pointer-events-auto bottom-full left-0 mt-0 min-h-fit"
+          isPausing={false}
+        />
+      </div>
+      <ConversationName />
+    </div>
+  );
+}

--- a/frontend/src/components/features/conversation/conversation-name.tsx
+++ b/frontend/src/components/features/conversation/conversation-name.tsx
@@ -124,7 +124,7 @@ export function ConversationName() {
   return (
     <>
       <div
-        className="flex items-center gap-2 h-[22px] text-base font-normal text-left pl-0 lg:pl-3.5"
+        className="flex items-center gap-2 h-[22px] text-base font-normal text-left pl-0 lg:pl-1"
         data-testid="conversation-name"
       >
         {titleMode === "edit" ? (

--- a/frontend/src/routes/conversation.tsx
+++ b/frontend/src/routes/conversation.tsx
@@ -22,7 +22,7 @@ import { ConversationSubscriptionsProvider } from "#/context/conversation-subscr
 import { useUserProviders } from "#/hooks/use-user-providers";
 
 import { ConversationMain } from "#/components/features/conversation/conversation-main/conversation-main";
-import { ConversationName } from "#/components/features/conversation/conversation-name";
+import { ConversationNameWithStatus } from "#/components/features/conversation/conversation-name-with-status";
 
 import { ConversationTabs } from "#/components/features/conversation/conversation-tabs/conversation-tabs";
 import { WebSocketProviderWrapper } from "#/contexts/websocket-provider-wrapper";
@@ -160,7 +160,7 @@ function AppContent() {
           className="p-3 md:p-0 flex flex-col h-full gap-3"
         >
           <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4.5 pt-2 lg:pt-0">
-            <ConversationName />
+            <ConversationNameWithStatus />
             <ConversationTabs />
           </div>
 

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -6,6 +6,7 @@ import { ConversationStatus } from "#/types/conversation-status";
 import { GitRepository } from "#/types/git";
 import { sanitizeQuery } from "#/utils/sanitize-query";
 import { PRODUCT_URL } from "#/utils/constants";
+import { AgentState } from "#/types/agent-state";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -608,4 +609,67 @@ export const buildSessionHeaders = (
     headers["X-Session-API-Key"] = sessionApiKey;
   }
   return headers;
+};
+
+/**
+ * Get the appropriate color based on agent status
+ * @param options Configuration object for status color calculation
+ * @param options.isPausing Whether the agent is currently pausing
+ * @param options.isTask Whether we're polling a task
+ * @param options.taskStatus The task status string (e.g., "ERROR", "READY")
+ * @param options.isStartingStatus Whether the agent is in a starting state (LOADING or INIT)
+ * @param options.isStopStatus Whether the conversation status is STOPPED
+ * @param options.curAgentState The current agent state
+ * @returns The hex color code for the status
+ *
+ * @example
+ * getStatusColor({
+ *   isPausing: false,
+ *   isTask: false,
+ *   taskStatus: undefined,
+ *   isStartingStatus: false,
+ *   isStopStatus: false,
+ *   curAgentState: AgentState.RUNNING
+ * }) // Returns "#BCFF8C"
+ */
+export const getStatusColor = (options: {
+  isPausing: boolean;
+  isTask: boolean;
+  taskStatus?: string | null;
+  isStartingStatus: boolean;
+  isStopStatus: boolean;
+  curAgentState: AgentState;
+}): string => {
+  const {
+    isPausing,
+    isTask,
+    taskStatus,
+    isStartingStatus,
+    isStopStatus,
+    curAgentState,
+  } = options;
+
+  // Show pausing status
+  if (isPausing) {
+    return "#FFD600";
+  }
+
+  // Show task status if we're polling a task
+  if (isTask && taskStatus) {
+    if (taskStatus === "ERROR") {
+      return "#FF684E";
+    }
+    return "#FFD600";
+  }
+
+  if (isStartingStatus) {
+    return "#FFD600";
+  }
+  if (isStopStatus) {
+    return "#ffffff";
+  }
+  if (curAgentState === AgentState.ERROR) {
+    return "#FF684E";
+  }
+  return "#BCFF8C";
 };


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

<img width="1222" height="918" alt="image" src="https://github.com/user-attachments/assets/9903afac-fc18-4930-b918-85439d4747ae" />

**Description:**

Based on the image above, the runtime indicator needs to be repositioned to the top of the page.

**Acceptance Criteria:**
- The runtime indicator is moved to the top of the page.
- Hovering over the status indicator should display the context menu above.
- The runtime indicator in the chat input area is removed.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/ae995df9-cfc9-440e-bbff-ce08da1008f6

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:835f1dc-nikolaik   --name openhands-app-835f1dc   docker.openhands.dev/openhands/openhands:835f1dc
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@hieptl/all-4134#subdirectory=openhands-cli openhands
```