### PR TITLE
feat(frontend): display text label when items are selected across all canvas views

### DIFF
--- a/frontend/src/components/features/conversation/conversation-tabs/conversation-tab-nav.tsx
+++ b/frontend/src/components/features/conversation/conversation-tabs/conversation-tab-nav.tsx
@@ -5,12 +5,16 @@ type ConversationTabNavProps = {
   icon: ComponentType<{ className: string }>;
   onClick(): void;
   isActive?: boolean;
+  label?: string;
+  className?: string;
 };
 
 export function ConversationTabNav({
   icon: Icon,
   onClick,
   isActive,
+  label,
+  className,
 }: ConversationTabNavProps) {
   return (
     <button
@@ -19,18 +23,21 @@ export function ConversationTabNav({
         onClick();
       }}
       className={cn(
-        "p-1 rounded-md cursor-pointer",
+        "flex items-center gap-2 rounded-md cursor-pointer",
+        "pl-1.5 pr-2 py-1",
         "text-[#9299AA] bg-[#0D0F11]",
         isActive && "bg-[#25272D] text-white",
         isActive
           ? "hover:text-white hover:bg-tertiary"
           : "hover:text-white hover:bg-[#0D0F11]",
-        isActive
-          ? "focus-within:text-white focus-within:bg-tertiary"
-          : "focus-within:text-[#9299AA] focus-within:bg-[#0D0F11]",
+        isActive ? "focus-within:text-white" : "focus-within:text-[#9299AA]",
+        className,
       )}
     >
-      <Icon className={cn("w-5 h-5 text-inherit")} />
+      <Icon className={cn("w-5 h-5 text-inherit flex-shrink-0")} />
+      {isActive && label && (
+        <span className="text-sm font-medium whitespace-nowrap">{label}</span>
+      )}
     </button>
   );
 }

--- a/frontend/src/components/features/conversation/conversation-tabs/conversation-tabs.tsx
+++ b/frontend/src/components/features/conversation/conversation-tabs/conversation-tabs.tsx
@@ -92,6 +92,7 @@ export function ConversationTabs() {
       onClick: () => onTabSelected("editor"),
       tooltipContent: t(I18nKey.COMMON$CHANGES),
       tooltipAriaLabel: t(I18nKey.COMMON$CHANGES),
+      label: t(I18nKey.COMMON$CHANGES),
     },
     {
       isActive: isTabActive("vscode"),
@@ -99,6 +100,7 @@ export function ConversationTabs() {
       onClick: () => onTabSelected("vscode"),
       tooltipContent: <VSCodeTooltipContent />,
       tooltipAriaLabel: t(I18nKey.COMMON$CODE),
+      label: t(I18nKey.COMMON$CODE),
     },
     {
       isActive: isTabActive("terminal"),
@@ -106,6 +108,8 @@ export function ConversationTabs() {
       onClick: () => onTabSelected("terminal"),
       tooltipContent: t(I18nKey.COMMON$TERMINAL),
       tooltipAriaLabel: t(I18nKey.COMMON$TERMINAL),
+      label: t(I18nKey.COMMON$TERMINAL),
+      className: "pl-2",
     },
     {
       isActive: isTabActive("served"),
@@ -113,6 +117,7 @@ export function ConversationTabs() {
       onClick: () => onTabSelected("served"),
       tooltipContent: t(I18nKey.COMMON$APP),
       tooltipAriaLabel: t(I18nKey.COMMON$APP),
+      label: t(I18nKey.COMMON$APP),
     },
     {
       isActive: isTabActive("browser"),
@@ -120,6 +125,7 @@ export function ConversationTabs() {
       onClick: () => onTabSelected("browser"),
       tooltipContent: t(I18nKey.COMMON$BROWSER),
       tooltipAriaLabel: t(I18nKey.COMMON$BROWSER),
+      label: t(I18nKey.COMMON$BROWSER),
     },
   ];
 
@@ -132,7 +138,15 @@ export function ConversationTabs() {
     >
       {tabs.map(
         (
-          { icon, onClick, isActive, tooltipContent, tooltipAriaLabel },
+          {
+            icon,
+            onClick,
+            isActive,
+            tooltipContent,
+            tooltipAriaLabel,
+            label,
+            className,
+          },
           index,
         ) => (
           <ChatActionTooltip
@@ -144,6 +158,8 @@ export function ConversationTabs() {
               icon={icon}
               onClick={onClick}
               isActive={isActive}
+              label={label}
+              className={className}
             />
           </ChatActionTooltip>
         ),


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

<img width="814" height="374" alt="image" src="https://github.com/user-attachments/assets/501f5a8e-a9a1-468e-8c76-85f9b337158a" />

As outlined in the design, a text label should be displayed whenever items are selected across all canvas views.

**Acceptance Criteria:**
- When users click on a conversation tab, a text label must be displayed.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/3c07d98a-ca8b-4a52-bb4c-71add98daabc

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:22ffb2f-nikolaik   --name openhands-app-22ffb2f   docker.openhands.dev/openhands/openhands:22ffb2f
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@hieptl/all-4158#subdirectory=openhands-cli openhands
```