### PR TITLE
Change error logging to info for missing config files

### DIFF
--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -149,7 +149,7 @@ def load_from_toml(cfg: OpenHandsConfig, toml_file: str = 'config.toml') -> None
         with open(toml_file, 'r', encoding='utf-8') as toml_contents:
             toml_config = toml.load(toml_contents)
     except FileNotFoundError as e:
-        logger.openhands_logger.error(
+        logger.openhands_logger.info(
             f'{toml_file} not found: {e}. Toml values have not been applied.'
         )
         return
@@ -505,7 +505,7 @@ def get_agent_config_arg(
         with open(toml_file, 'r', encoding='utf-8') as toml_contents:
             toml_config = toml.load(toml_contents)
     except FileNotFoundError as e:
-        logger.openhands_logger.error(f'Config file not found: {e}')
+        logger.openhands_logger.info(f'Config file not found: {e}')
         return None
     except toml.TomlDecodeError as e:
         logger.openhands_logger.error(
@@ -569,7 +569,7 @@ def get_llm_config_arg(
         with open(toml_file, 'r', encoding='utf-8') as toml_contents:
             toml_config = toml.load(toml_contents)
     except FileNotFoundError as e:
-        logger.openhands_logger.error(f'Config file not found: {e}')
+        logger.openhands_logger.info(f'Config file not found: {e}')
         return None
     except toml.TomlDecodeError as e:
         logger.openhands_logger.error(
@@ -605,7 +605,7 @@ def get_llms_for_routing_config(toml_file: str = 'config.toml') -> dict[str, LLM
         with open(toml_file, 'r', encoding='utf-8') as toml_contents:
             toml_config = toml.load(toml_contents)
     except FileNotFoundError as e:
-        logger.openhands_logger.error(
+        logger.openhands_logger.info(
             f'Config file not found: {e}. Toml values have not been applied.'
         )
         return llms_for_routing
@@ -670,7 +670,7 @@ def get_condenser_config_arg(
         with open(toml_file, 'r', encoding='utf-8') as toml_contents:
             toml_config = toml.load(toml_contents)
     except FileNotFoundError as e:
-        logger.openhands_logger.error(f'Config file not found: {toml_file}. Error: {e}')
+        logger.openhands_logger.info(f'Config file not found: {toml_file}. Error: {e}')
         return None
     except toml.TomlDecodeError as e:
         logger.openhands_logger.error(
@@ -756,7 +756,7 @@ def get_model_routing_config_arg(toml_file: str = 'config.toml') -> ModelRouting
         with open(toml_file, 'r', encoding='utf-8') as toml_contents:
             toml_config = toml.load(toml_contents)
     except FileNotFoundError as e:
-        logger.openhands_logger.error(f'Config file not found: {toml_file}. Error: {e}')
+        logger.openhands_logger.info(f'Config file not found: {toml_file}. Error: {e}')
         return default_cfg
     except toml.TomlDecodeError as e:
         logger.openhands_logger.error(


### PR DESCRIPTION
## Summary of PR

It is not necessarily the case that config.toml must always be present, so this changes logging of missing config.toml files from "error" to "info"

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Release Notes

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:8bb306d-nikolaik   --name openhands-app-8bb306d   docker.openhands.dev/openhands/openhands:8bb306d
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@neubig/set-missing-config-files-to-info#subdirectory=openhands-cli openhands
```