### PR TITLE
refactor(backend): the delete_app_conversation_info function

### DIFF
--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -399,7 +399,6 @@ class SQLAppConversationInfoService(AppConversationInfoService):
 
         # Execute the secure delete query
         result = await self.db_session.execute(delete_query)
-        await self.db_session.commit()
 
         return result.rowcount > 0
 


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

[Link to the line in GitHub](https://github.com/OpenHands/OpenHands/blob/4ea3e4b1fd850ae07e7b972feb36fca6e789d7eb/openhands/app_server/app_conversation/sql_app_conversation_info_service.py#L402)

Transaction flow

1. Both services share the same session:

- SQLAppConversationInfoService uses db_session from get_db_session()
- SQLAppConversationStartTaskService uses session from get_db_session()
- Both resolve to the same AsyncSession via DbSessionInjector.inject() (request state reuse)

2. First operation commits immediately:

```
# In sql_app_conversation_info_service.py:378-404
async def delete_app_conversation_info(self, conversation_id: UUID) -> bool:
    # ... execute delete query ...
    result = await self.db_session.execute(delete_query)
    await self.db_session.commit()  # ← COMMIT HERE
    return result.rowcount > 0
```

3. Second operation does not commit:

```
# In sql_app_conversation_start_task_service.py:224-245
async def delete_app_conversation_start_tasks(self, conversation_id: UUID) -> bool:
    # ... execute delete query ...
    result = await self.session.execute(delete_query)
    return result.rowcount > 0  # ← NO COMMIT
```

If delete_app_conversation_start_tasks raises an exception:
1. The first commit is already persisted; it cannot be rolled back.
2. The DbSessionInjector context manager will rollback only the uncommitted changes from the second operation.
3. Result: partial deletion — the conversation info is deleted, but the start tasks may remain if the second operation failed.

**Acceptance criteria:**
- The following line should be removed from the delete_app_conversation_info function.

```
await self.db_session.commit()
```

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/b673537a-d2fb-483c-9c82-ab386f006349

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:793268f-nikolaik   --name openhands-app-793268f   docker.openhands.dev/openhands/openhands:793268f
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@hieptl/app-137#subdirectory=openhands-cli openhands
```