### PR TITLE
fix(frontend): Consider start task job error status for loading indicators

### DIFF
--- a/frontend/__tests__/utils/status.test.ts
+++ b/frontend/__tests__/utils/status.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getStatusCode, getIndicatorColor, IndicatorColor } from "../status";
+import { getStatusCode, getIndicatorColor, IndicatorColor } from "#/utils/status";
 import { AgentState } from "#/types/agent-state";
 import { I18nKey } from "#/i18n/declaration";
 
@@ -86,6 +86,36 @@ describe("getStatusCode", () => {
 
     // Should return runtime status since no agent state
     expect(result).toBe("STATUS$STARTING_RUNTIME");
+  });
+
+  it("should prioritize task ERROR status over websocket CONNECTING state", () => {
+    // Test case: Task has errored but websocket is still trying to connect
+    const result = getStatusCode(
+      { id: "", message: "", type: "info", status_update: true }, // statusMessage
+      "CONNECTING", // webSocketStatus (stuck connecting)
+      null, // conversationStatus
+      null, // runtimeStatus
+      AgentState.LOADING, // agentState
+      "ERROR", // taskStatus (ERROR)
+    );
+
+    // Should return error message, not "Connecting..."
+    expect(result).toBe(I18nKey.AGENT_STATUS$ERROR_OCCURRED);
+  });
+
+  it("should show Connecting when task is working and websocket is connecting", () => {
+    // Test case: Task is in progress and websocket is connecting normally
+    const result = getStatusCode(
+      { id: "", message: "", type: "info", status_update: true }, // statusMessage
+      "CONNECTING", // webSocketStatus
+      null, // conversationStatus
+      null, // runtimeStatus
+      AgentState.LOADING, // agentState
+      "WORKING", // taskStatus (in progress)
+    );
+
+    // Should show connecting message since task hasn't errored
+    expect(result).toBe(I18nKey.CHAT_INTERFACE$CONNECTING);
   });
 });
 

--- a/frontend/src/components/features/controls/agent-status.tsx
+++ b/frontend/src/components/features/controls/agent-status.tsx
@@ -44,6 +44,7 @@ export function AgentStatus({
     conversation?.status || null,
     conversation?.runtime_status || null,
     curAgentState,
+    taskStatus,
   );
 
   const isTaskLoading =


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:0ac663f-nikolaik   --name openhands-app-0ac663f   docker.openhands.dev/openhands/openhands:0ac663f
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@APP-138/no-loadinh-when-error#subdirectory=openhands-cli openhands
```