### PR TITLE
feat(cli): add user-skills flag (default on); wire to AgentContext

### DIFF
--- a/openhands-cli/openhands_cli/agent_chat.py
+++ b/openhands-cli/openhands_cli/agent_chat.py
@@ -60,7 +60,7 @@ def _print_exit_hint(conversation_id: str) -> None:
 
 
 
-def run_cli_entry(resume_conversation_id: str | None = None) -> None:
+def run_cli_entry(resume_conversation_id: str | None = None, user_skills: bool = True) -> None:
     """Run the agent chat session using the agent SDK.
 
 
@@ -83,7 +83,7 @@ def run_cli_entry(resume_conversation_id: str | None = None) -> None:
             return
 
     try:
-        initialized_agent = verify_agent_exists_or_setup_agent()
+        initialized_agent = verify_agent_exists_or_setup_agent(load_user_skills=user_skills)
     except MissingAgentSpec:
         print_formatted_text(HTML('\n<yellow>Setup is required to use OpenHands CLI.</yellow>'))
         print_formatted_text(HTML('\n<yellow>Goodbye! 👋</yellow>'))
@@ -197,7 +197,7 @@ def run_cli_entry(resume_conversation_id: str | None = None) -> None:
                 message = None
 
             if not runner or not conversation:
-                conversation = setup_conversation(conversation_id)
+                conversation = setup_conversation(conversation_id, load_user_skills=user_skills)
                 runner = ConversationRunner(conversation)
             runner.process_message(message)
 

--- a/openhands-cli/openhands_cli/argparsers/main_parser.py
+++ b/openhands-cli/openhands_cli/argparsers/main_parser.py
@@ -30,6 +30,20 @@ Examples:
         type=str,
         help='Conversation ID to resume'
     )
+    # Control loading of user skills from ~/.openhands
+    parser.add_argument(
+        '--user-skills',
+        dest='user_skills',
+        action='store_true',
+        help='Enable loading user skills from ~/.openhands (default)'
+    )
+    parser.add_argument(
+        '--no-user-skills',
+        dest='user_skills',
+        action='store_false',
+        help='Disable loading user skills from ~/.openhands'
+    )
+    parser.set_defaults(user_skills=True)
     
     # Only serve as subcommand
     subparsers = parser.add_subparsers(

--- a/openhands-cli/openhands_cli/setup.py
+++ b/openhands-cli/openhands_cli/setup.py
@@ -27,9 +27,11 @@ class MissingAgentSpec(Exception):
 
 def load_agent_specs(
     conversation_id: str | None = None,
+    *,
+    load_user_skills: bool = True,
 ) -> Agent:
     agent_store = AgentStore()
-    agent = agent_store.load(session_id=conversation_id)
+    agent = agent_store.load(session_id=conversation_id, load_user_skills=load_user_skills)
     if not agent:
         raise MissingAgentSpec(
             'Agent specification not found. Please configure your agent settings.'
@@ -37,13 +39,13 @@ def load_agent_specs(
     return agent
 
 
-def verify_agent_exists_or_setup_agent() -> Agent:
+def verify_agent_exists_or_setup_agent(*, load_user_skills: bool = True) -> Agent:
     """Verify agent specs exists by attempting to load it.
 
     """
     settings_screen = SettingsScreen()
     try:
-        agent = load_agent_specs()
+        agent = load_agent_specs(load_user_skills=load_user_skills)
         return agent
     except MissingAgentSpec:
         # For first-time users, show the full settings flow with choice between basic/advanced
@@ -51,12 +53,14 @@ def verify_agent_exists_or_setup_agent() -> Agent:
 
 
     # Try once again after settings setup attempt
-    return load_agent_specs()
+    return load_agent_specs(load_user_skills=load_user_skills)
 
 
 def setup_conversation(
     conversation_id: uuid,
-    include_security_analyzer: bool = True
+    include_security_analyzer: bool = True,
+    *,
+    load_user_skills: bool = True,
 ) -> BaseConversation:
     """
     Setup the conversation with agent.
@@ -72,7 +76,7 @@ def setup_conversation(
         HTML(f'<white>Initializing agent...</white>')
     )
 
-    agent = load_agent_specs(str(conversation_id))
+    agent = load_agent_specs(str(conversation_id), load_user_skills=load_user_skills)
 
     if not include_security_analyzer:
         # Remove security analyzer from agent spec

--- a/openhands-cli/openhands_cli/simple_main.py
+++ b/openhands-cli/openhands_cli/simple_main.py
@@ -42,7 +42,7 @@ def main() -> None:
             from openhands_cli.agent_chat import run_cli_entry
 
             # Start agent chat
-            run_cli_entry(resume_conversation_id=args.resume)
+            run_cli_entry(resume_conversation_id=args.resume, user_skills=args.user_skills)
     except KeyboardInterrupt:
         print_formatted_text(HTML('\n<yellow>Goodbye! 👋</yellow>'))
     except EOFError:


### PR DESCRIPTION
- Implements `--user-skills` and `--no-user-skills` in CLI (default enabled).
- Wires flag through `simple_main.py` → `agent_chat.py` → `setup.py` → `AgentStore.load` to `AgentContext`.
- Backward-compatible: falls back if `AgentContext` does not accept `load_user_skills`.
- Acceptance criteria:
   - CLI loads user skills from `~/.openhands/skills` and `~/.openhands/microagents` by default.
   - Disable via `--no-user-skills`.
   - SDK precedence rules respected (explicit > user; skills/ > microagents/).