### PR TITLE
ci: remove flaky Windows Python tests workflow

### DIFF
--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -70,37 +70,7 @@ jobs:
             .coverage.${{ matrix.python_version }}
             .coverage.runtime.${{ matrix.python_version }}
           include-hidden-files: true
-  # Run specific Windows python tests
-  test-on-windows:
-    name: Python Tests on Windows
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: ["3.12"]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install pipx
-        run: pip install pipx
-      - name: Install poetry via pipx
-        run: pipx install poetry
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "poetry"
-      - name: Install Python dependencies using Poetry
-        run: poetry install --with dev,test,runtime
-      - name: Run Windows unit tests
-        run: poetry run pytest -svv tests/runtime//test_windows_bash.py
-        env:
-          PYTHONPATH: ".;$env:PYTHONPATH"
-          DEBUG: "1"
-      - name: Run Windows runtime tests with LocalRuntime
-        run: $env:TEST_RUNTIME="local"; poetry run pytest -svv tests/runtime/test_bash.py
-        env:
-          PYTHONPATH: ".;$env:PYTHONPATH"
-          TEST_RUNTIME: local
-          DEBUG: "1"
+
   test-enterprise:
     name: Enterprise Python Unit Tests
     runs-on: blacksmith-4vcpu-ubuntu-2404


### PR DESCRIPTION
Summary

Remove the Windows GitHub Actions job that was causing flaky CI. This job ran Windows-only runtime tests for LocalRuntime and direct Windows PowerShell session tests. LocalRuntime is considered legacy, and the flakiness was blocking unrelated changes.

Changes
- Drop the `test-on-windows` job from `.github/workflows/py-tests.yml`
- Searched for Windows-specific coupling in `tests/runtime/conftest.py` and found none, so no code changes needed there

Rationale
- The Windows job executed:
  - `tests/runtime/test_windows_bash.py` (direct tests of `WindowsPowershellSession` in `openhands/runtime/utils/windows_bash.py`)
  - `tests/runtime/test_bash.py` with `TEST_RUNTIME=local` (end-to-end via `LocalRuntime` -> `ActionExecutionServer` -> `WindowsPowershellSession`)
- These tests are flaky and currently block CI; Linux tests and enterprise/CLI tests still run and provide coverage of primary code paths.

Notes
- No source code changes, only CI workflow update.
- We can reintroduce Windows coverage later in a more stable way (e.g., nightly, optional, or a single smoke test).

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/92e43bb9d29f4d33ab7dc2ecf4d99c3b)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:97805da-nikolaik   --name openhands-app-97805da   docker.openhands.dev/openhands/openhands:97805da
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@ci/remove-windows-tests-workflow#subdirectory=openhands-cli openhands
```