### PR TITLE
chore(frontend): Remove `user_activated` PostHog capture event

### DIFF
--- a/frontend/src/hooks/query/use-settings.ts
+++ b/frontend/src/hooks/query/use-settings.ts
@@ -1,6 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import React from "react";
-import posthog from "posthog-js";
 import SettingsService from "#/settings-service/settings-service.api";
 import { DEFAULT_SETTINGS } from "#/services/settings";
 import { useIsOnTosPage } from "#/hooks/use-is-on-tos-page";
@@ -60,12 +58,6 @@ export const useSettings = () => {
       disableToast: true,
     },
   });
-
-  React.useEffect(() => {
-    if (query.isFetched && query.data?.LLM_API_KEY_SET) {
-      posthog.capture("user_activated");
-    }
-  }, [query.data?.LLM_API_KEY_SET, query.isFetched]);
 
   // We want to return the defaults if the settings aren't found so the user can still see the
   // options to make their initial save. We don't set the defaults in `initialData` above because


### PR DESCRIPTION
## Summary of PR

The `user_activated` capture event is not only outdated, but broken too. We’d capture a large amount of these at the same time for the same user.

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:fa45aa7-nikolaik   --name openhands-app-fa45aa7   docker.openhands.dev/openhands/openhands:fa45aa7
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@chore/remove-bad-capture#subdirectory=openhands-cli openhands
```