### PR TITLE
Fix PostHog alias parameter order to properly merge backend and frontend events

### DIFF
--- a/openhands/server/routes/git.py
+++ b/openhands/server/routes/git.py
@@ -118,7 +118,8 @@ async def get_user(
         try:
             user: User = await client.get_user()
 
-            # Alias git provider login with Keycloak user ID in PostHog (SaaS mode only)
+            # Alias Keycloak user ID with git provider login in PostHog (SaaS mode only)
+            # This merges backend events (keycloak_id) into frontend user profile (git_login)
             if user_id and user.login and server_config.app_mode == AppMode.SAAS:
                 alias_user_identities(
                     keycloak_user_id=user_id,

--- a/tests/unit/utils/test_posthog_tracker.py
+++ b/tests/unit/utils/test_posthog_tracker.py
@@ -312,7 +312,8 @@ def test_alias_user_identities(mock_posthog):
     """Test aliasing user identities.
 
     Verifies that posthog.alias(previous_id, distinct_id) is called correctly
-    where git_login is the previous_id and keycloak_user_id is the distinct_id.
+    where keycloak_user_id is the previous_id (no restrictions) and
+    git_login is the distinct_id (already identified).
     """
     import openhands.utils.posthog_tracker as tracker
 
@@ -324,8 +325,8 @@ def test_alias_user_identities(mock_posthog):
         git_login='git-user',
     )
 
-    # Verify: posthog.alias(previous_id='git-user', distinct_id='keycloak-123')
-    mock_posthog.alias.assert_called_once_with('git-user', 'keycloak-123')
+    # Verify: posthog.alias(previous_id='keycloak-123', distinct_id='git-user')
+    mock_posthog.alias.assert_called_once_with('keycloak-123', 'git-user')
 
 
 def test_alias_user_identities_handles_errors(mock_posthog):


### PR DESCRIPTION


## Summary of PR

We were tracking the same user via separate IDs. This PR aliases the backend keycloak ID to the distinct git login to merge the two for better tracking across environments.

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:c830616-nikolaik   --name openhands-app-c830616   docker.openhands.dev/openhands/openhands:c830616
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@chore/fix-aliasing#subdirectory=openhands-cli openhands
```