### PR TITLE
fix(frontend): terminal output not appearing in v1

### DIFF
--- a/frontend/__tests__/stores/use-event-store.test.ts
+++ b/frontend/__tests__/stores/use-event-store.test.ts
@@ -55,7 +55,7 @@ const mockObservationEvent: ObservationEvent = {
   tool_call_id: "call_123",
   observation: {
     kind: "ExecuteBashObservation",
-    output: "hello\n",
+    content: [{ type: "text", text: "hello\n" }],
     command: "echo hello",
     exit_code: 0,
     error: false,

--- a/frontend/__tests__/utils/handle-event-for-ui.test.ts
+++ b/frontend/__tests__/utils/handle-event-for-ui.test.ts
@@ -17,7 +17,7 @@ describe("handleEventForUI", () => {
     tool_call_id: "call_123",
     observation: {
       kind: "ExecuteBashObservation",
-      output: "hello\n",
+      content: [{ type: "text", text: "hello\n" }],
       command: "echo hello",
       exit_code: 0,
       error: false,

--- a/frontend/src/components/v1/chat/event-content-helpers/get-observation-content.ts
+++ b/frontend/src/components/v1/chat/event-content-helpers/get-observation-content.ts
@@ -47,17 +47,19 @@ const getExecuteBashObservationContent = (
 ): string => {
   const { observation } = event;
 
-  let { output } = observation;
+  // Extract text content from the observation
+  const textContent = observation.content
+    .filter((c) => c.type === "text")
+    .map((c) => c.text)
+    .join("\n");
 
-  if (!output) {
-    output = "";
+  let content = textContent || "";
+
+  if (content.length > MAX_CONTENT_LENGTH) {
+    content = `${content.slice(0, MAX_CONTENT_LENGTH)}...`;
   }
 
-  if (output.length > MAX_CONTENT_LENGTH) {
-    output = `${output.slice(0, MAX_CONTENT_LENGTH)}...`;
-  }
-
-  return `Output:\n\`\`\`sh\n${output.trim() || i18n.t("OBSERVATION$COMMAND_NO_OUTPUT")}\n\`\`\``;
+  return `Output:\n\`\`\`sh\n${content.trim() || i18n.t("OBSERVATION$COMMAND_NO_OUTPUT")}\n\`\`\``;
 };
 
 // Tool Observations

--- a/frontend/src/contexts/conversation-websocket-context.tsx
+++ b/frontend/src/contexts/conversation-websocket-context.tsx
@@ -178,7 +178,12 @@ export function ConversationWebSocketProvider({
 
           // Handle ExecuteBashObservation events - add output to terminal
           if (isExecuteBashObservationEvent(event)) {
-            appendOutput(event.observation.output);
+            // Extract text content from the observation content array
+            const textContent = event.observation.content
+              .filter((c) => c.type === "text")
+              .map((c) => c.text)
+              .join("\n");
+            appendOutput(textContent);
           }
         }
       } catch (error) {

--- a/frontend/src/mocks/mock-ws-helpers.ts
+++ b/frontend/src/mocks/mock-ws-helpers.ts
@@ -165,7 +165,7 @@ export const createMockExecuteBashActionEvent = (
  * Creates a mock ExecuteBashObservation event for testing terminal output handling
  */
 export const createMockExecuteBashObservationEvent = (
-  output: string = "total 24\ndrwxr-xr-x  5 user  staff  160 Jan 10 12:00 .",
+  content: string = "total 24\ndrwxr-xr-x  5 user  staff  160 Jan 10 12:00 .",
   command: string = "ls -la",
 ) => ({
   id: "bash-obs-123",
@@ -175,7 +175,7 @@ export const createMockExecuteBashObservationEvent = (
   tool_call_id: "bash-call-456",
   observation: {
     kind: "ExecuteBashObservation",
-    output,
+    content: [{ type: "text", text: content }],
     command,
     exit_code: 0,
     error: false,

--- a/frontend/src/types/v1/core/base/observation.ts
+++ b/frontend/src/types/v1/core/base/observation.ts
@@ -56,9 +56,9 @@ export interface BrowserObservation
 export interface ExecuteBashObservation
   extends ObservationBase<"ExecuteBashObservation"> {
   /**
-   * The raw output from the tool.
+   * Content returned from the tool as a list of TextContent/ImageContent objects.
    */
-  output: string;
+  content: Array<TextContent | ImageContent>;
   /**
    * The bash command that was executed. Can be empty string if the observation is from a previous command that hit soft timeout and is not yet finished.
    */


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

The PR fixes the issue - terminal output not appearing in v1.

We can refer to the image below for the output of the PR.

<img width="1425" height="748" alt="app-158" src="https://github.com/user-attachments/assets/1d44b429-23c8-4789-92aa-cf9f90c3725f" />

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:90c4a7a-nikolaik   --name openhands-app-90c4a7a   docker.openhands.dev/openhands/openhands:90c4a7a
```

CLI with uvx:
```
uvx --python 3.12 --from git+https://github.com/OpenHands/OpenHands@hieptl/app-158#subdirectory=openhands-cli openhands
```