### PR TITLE
feat(backend): add project filtering support

### DIFF
--- a/openhands/integrations/azure_devops/azure_devops_service.py
+++ b/openhands/integrations/azure_devops/azure_devops_service.py
@@ -61,6 +61,7 @@ class AzureDevOpsServiceImpl(
     token: SecretStr = SecretStr('')
     refresh = False
     organization: str = ''
+    project: str = ''
 
     def __init__(
         self,
@@ -92,6 +93,9 @@ class AzureDevOpsServiceImpl(
             parts = domain_path.split('/')
             if len(parts) >= 1:
                 self.organization = parts[0]
+
+            if len(parts) >= 2:
+                self.project = parts[1]  # dev.azure.com/org/project -> project
 
     async def get_installations(self) -> list[str]:
         """Get Azure DevOps organizations.

--- a/openhands/integrations/azure_devops/service/base.py
+++ b/openhands/integrations/azure_devops/service/base.py
@@ -15,6 +15,7 @@ class AzureDevOpsMixinBase(BaseGitService, HTTPClient):
     """Declares common attributes and method signatures used across Azure DevOps mixins."""
 
     organization: str
+    project: str = ''
 
     @property
     @abstractmethod

--- a/openhands/integrations/azure_devops/service/features.py
+++ b/openhands/integrations/azure_devops/service/features.py
@@ -42,9 +42,13 @@ class AzureDevOpsFeaturesMixin(AzureDevOpsMixinBase):
         # Azure DevOps requires querying each project separately for PRs and work items
         # Since we no longer specify a single project, we need to query all projects
         # Get all projects first
-        projects_url = f'{self.base_url}/_apis/projects?api-version=7.1'
-        projects_response, _ = await self._make_request(projects_url)
-        projects = projects_response.get('value', [])
+        projects = []
+        if self.project:
+            projects = [{'name': self.project}]
+        else:
+            projects_url = f'{self.base_url}/_apis/projects?api-version=7.1'
+            projects_response, _ = await self._make_request(projects_url)
+            projects = projects_response.get('value', [])
 
         # Get user info
         user = await self.get_user()
@@ -52,7 +56,7 @@ class AzureDevOpsFeaturesMixin(AzureDevOpsMixinBase):
 
         # Query each project for pull requests and work items
         for project in projects:
-            project_name = project.get('name')
+            project_name = str(project.get('name', ''))
 
             try:
                 # URL-encode project name to handle spaces and special characters

--- a/openhands/integrations/azure_devops/service/repos.py
+++ b/openhands/integrations/azure_devops/service/repos.py
@@ -47,16 +47,19 @@ class AzureDevOpsReposMixin(AzureDevOpsMixinBase):
         """Get repositories for the authenticated user."""
         MAX_REPOS = 1000
 
-        # Get all projects first
-        projects_url = f'{self.base_url}/_apis/projects?api-version=7.1'
-        projects_response, _ = await self._make_request(projects_url)
-        projects = projects_response.get('value', [])
-
+        projects = []
         all_repos = []
+        # Get all projects first
+        if self.project:
+            projects = [{'name': self.project}]
+        else:
+            projects_url = f'{self.base_url}/_apis/projects?api-version=7.1'
+            projects_response, _ = await self._make_request(projects_url)
+            projects = projects_response.get('value', [])
 
         # For each project, get its repositories
         for project in projects:
-            project_name = project.get('name')
+            project_name = str(project.get('name', ''))
             project_enc = self._encode_url_component(project_name)
             repos_url = (
                 f'{self.base_url}/{project_enc}/_apis/git/repositories?api-version=7.1'


### PR DESCRIPTION
- Add project field to AzureDevOpsServiceImpl and AzureDevOpsMixinBase
- Extract project from base_domain when provided in URL path
- Filter repositories and features by specific project when available
- Fall back to querying all projects when project is not specified
- Improve performance by avoiding unnecessary API calls when project is known

## Summary of PR

This PR adds project filtering support to the Azure DevOps integration. When a project is specified in the base_domain URL (e.g., `dev.azure.com/org/project`), the integration will now filter operations to that specific project instead of querying all projects. This improves performance by reducing unnecessary API calls and provides better scoping for users working with specific projects.

### Key Changes:
- Added `project` field to `AzureDevOpsServiceImpl` and `AzureDevOpsMixinBase` classes
- Enhanced URL parsing to extract project name from base_domain when provided
- Updated `get_repos()` and `get_features()` methods to filter by project when available
- Maintains backward compatibility by falling back to querying all projects when project is not specified

## Change Type

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.


## Release Notes

- [x] Include this change in the Release Notes.

**Release Notes Description:**
Added project filtering support for Azure DevOps integration. Users can now specify a project in the base_domain URL (e.g., `dev.azure.com/org/project`) to scope repository and feature queries to a specific project, improving performance and reducing API calls.

## Technical Details

### Files Modified:
- `openhands/integrations/azure_devops/azure_devops_service.py`: Added project field and extraction logic
- `openhands/integrations/azure_devops/service/base.py`: Added project field to base mixin
- `openhands/integrations/azure_devops/service/features.py`: Added project filtering to features query
- `openhands/integrations/azure_devops/service/repos.py`: Added project filtering to repositories query

### Implementation Notes:
- The project is extracted from the URL path when `base_domain` contains a project segment (format: `org/project`)
- When a project is specified, operations are scoped to that project only
- When no project is specified, the behavior remains unchanged (queries all projects)
- This change is backward compatible and does not affect existing integrations

