### PR TITLE
fix: handle None return from version_info.get('Components') in docker builder

### DIFF
--- a/openhands/runtime/builder/docker.py
+++ b/openhands/runtime/builder/docker.py
@@ -19,8 +19,9 @@ class DockerRuntimeBuilder(RuntimeBuilder):
 
         version_info = self.docker_client.version()
         server_version = version_info.get('Version', '').replace('-', '.')
-        self.is_podman = (
-            version_info.get('Components')[0].get('Name').startswith('Podman')
+        components = version_info.get('Components', [])
+        self.is_podman = bool(components) and components[0].get('Name', '').startswith(
+            'Podman'
         )
         if (
             tuple(map(int, server_version.split('.')[:2])) < (18, 9)
@@ -79,8 +80,9 @@ class DockerRuntimeBuilder(RuntimeBuilder):
         self.docker_client = docker.from_env()
         version_info = self.docker_client.version()
         server_version = version_info.get('Version', '').split('+')[0].replace('-', '.')
-        self.is_podman = (
-            version_info.get('Components')[0].get('Name').startswith('Podman')
+        components = version_info.get('Components', [])
+        self.is_podman = bool(components) and components[0].get('Name', '').startswith(
+            'Podman'
         )
         if tuple(map(int, server_version.split('.'))) < (18, 9) and not self.is_podman:
             raise AgentRuntimeBuildError(


### PR DESCRIPTION
This is OH purely so would love if someone can take a look.


## Summary of PR

This PR fixes the failing `Lint / Lint python` workflow by addressing mypy type checking errors in `openhands/runtime/builder/docker.py`.

The issue was that `version_info.get('Components')` could return `None`, but the code was directly indexing it with `[0]` without checking if it exists first, causing mypy to report: `Value of type "Any | None" is not indexable`.

**Changes made:**
- Store `version_info.get('Components', [])` in a `components` variable with a default empty list
- Add `bool(components)` check before attempting to index
- Provide default empty string for the `Name` field using `.get('Name', '')`

This ensures type safety and prevents potential runtime errors if the Components field is missing from the Docker/Podman version info.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

This fixes the failing `Lint / Lint python` GitHub Actions workflow on the main branch.

## Release Notes

- [ ] Include this change in the Release Notes.

@mamoodi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1f36262ca8614b548ecbcc6e7473630d)