### PR TITLE
fix(frontend): fileeditorobservationevent rendering issue

### DIFF
--- a/frontend/src/components/v1/chat/event-content-helpers/get-observation-content.ts
+++ b/frontend/src/components/v1/chat/event-content-helpers/get-observation-content.ts
@@ -24,6 +24,15 @@ const getFileEditorObservationContent = (
     return `**Error:**\n${observation.error}`;
   }
 
+  // Extract text content from the observation if it exists
+  const textContent =
+    "content" in observation && Array.isArray(observation.content)
+      ? observation.content
+          .filter((c) => c.type === "text")
+          .map((c) => c.text)
+          .join("\n")
+      : null;
+
   const successMessage = getObservationResult(event) === "success";
 
   // For view commands or successful edits with content changes, format as code block
@@ -35,11 +44,13 @@ const getFileEditorObservationContent = (
       observation.new_content) ||
     observation.command === "view"
   ) {
-    return `\`\`\`\n${observation.output}\n\`\`\``;
+    // Prefer content over output for view commands, fallback to output if content is not available
+    const displayContent = textContent || observation.output;
+    return `\`\`\`\n${displayContent}\n\`\`\``;
   }
 
-  // For other commands, return the output as-is
-  return observation.output;
+  // For other commands, prefer content if available, otherwise use output
+  return textContent || observation.output;
 };
 
 // Command Observations


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

Context:

Recent changes in our SDK may have affected the rendering of the FileEditorObservationEvent. Before this change, the front-end rendered `undefined` on the UI.

**Acceptance Criteria:**
- The event should be displayed correctly in the UI.

We can refer to the image below for the output of the PR.

<img width="1436" height="749" alt="app-174" src="https://github.com/user-attachments/assets/61ae2a66-797a-4dc5-a9bd-69731b6d2dec" />

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:24619a2-nikolaik   --name openhands-app-24619a2   docker.openhands.dev/openhands/openhands:24619a2
```