### PR TITLE
fix(frontend): Remove azure devops integration button from cloud settings

### DIFF
--- a/frontend/src/routes/git-settings.tsx
+++ b/frontend/src/routes/git-settings.tsx
@@ -9,7 +9,6 @@ import { GitLabTokenInput } from "#/components/features/settings/git-settings/gi
 import { BitbucketTokenInput } from "#/components/features/settings/git-settings/bitbucket-token-input";
 import { AzureDevOpsTokenInput } from "#/components/features/settings/git-settings/azure-devops-token-input";
 import { ConfigureGitHubRepositoriesAnchor } from "#/components/features/settings/git-settings/configure-github-repositories-anchor";
-import { ConfigureAzureDevOpsAnchor } from "#/components/features/settings/git-settings/configure-azure-devops-anchor";
 import { InstallSlackAppAnchor } from "#/components/features/settings/git-settings/install-slack-app-anchor";
 import { I18nKey } from "#/i18n/declaration";
 import {
@@ -148,18 +147,6 @@ function GitSettingsScreen() {
                   {t(I18nKey.SETTINGS$GITHUB)}
                 </h3>
                 <ConfigureGitHubRepositoriesAnchor slug={config.APP_SLUG!} />
-              </div>
-              <div className="w-1/2 border-b border-gray-200" />
-            </>
-          )}
-
-          {shouldRenderExternalConfigureButtons && !isLoading && (
-            <>
-              <div className="pb-1 mt-6 flex flex-col">
-                <h3 className="text-xl font-medium text-white">
-                  {t(I18nKey.SETTINGS$AZURE_DEVOPS)}
-                </h3>
-                <ConfigureAzureDevOpsAnchor />
               </div>
               <div className="w-1/2 border-b border-gray-200" />
             </>


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

<img width="1167" height="417" alt="image" src="https://github.com/user-attachments/assets/6c5ae7a4-5a80-41b3-835f-c562cc6c1a01" />

As indicated in the image above, the ‘Connect Azure DevOps Account’ button should be removed from the SaaS interface.

We can refer to the image below for the output of the PR.

<img width="720" height="400" alt="image" src="https://github.com/user-attachments/assets/b683f9b4-8722-4112-88e6-f0c90d38e49d" />

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:b9fc0aa-nikolaik   --name openhands-app-b9fc0aa   docker.openhands.dev/openhands/openhands:b9fc0aa
```