### PR TITLE
Replace USE_V1_CONVERSATION_API feature flag with settings-based v1_enabled flag

### DIFF
--- a/frontend/src/hooks/mutation/use-create-conversation.ts
+++ b/frontend/src/hooks/mutation/use-create-conversation.ts
@@ -4,8 +4,8 @@ import V1ConversationService from "#/api/conversation-service/v1-conversation-se
 import { SuggestedTask } from "#/utils/types";
 import { Provider } from "#/types/settings";
 import { CreateMicroagent, Conversation } from "#/api/open-hands.types";
-import { USE_V1_CONVERSATION_API } from "#/utils/feature-flags";
 import { useTracking } from "#/hooks/use-tracking";
+import { useSettings } from "#/hooks/query/use-settings";
 
 interface CreateConversationVariables {
   query?: string;
@@ -34,6 +34,7 @@ interface CreateConversationResponse extends Partial<Conversation> {
 export const useCreateConversation = () => {
   const queryClient = useQueryClient();
   const { trackConversationCreated } = useTracking();
+  const { data: settings } = useSettings();
 
   return useMutation({
     mutationKey: ["create-conversation"],
@@ -50,7 +51,7 @@ export const useCreateConversation = () => {
         agentType,
       } = variables;
 
-      const useV1 = USE_V1_CONVERSATION_API() && !createMicroagent;
+      const useV1 = (settings?.V1_ENABLED ?? false) && !createMicroagent;
 
       if (useV1) {
         // Use V1 API - creates a conversation start task

--- a/frontend/src/hooks/mutation/use-save-settings.ts
+++ b/frontend/src/hooks/mutation/use-save-settings.ts
@@ -35,6 +35,7 @@ const saveSettingsMutationFn = async (settings: Partial<PostSettings>) => {
       settings.GIT_USER_NAME?.trim() || DEFAULT_SETTINGS.GIT_USER_NAME,
     git_user_email:
       settings.GIT_USER_EMAIL?.trim() || DEFAULT_SETTINGS.GIT_USER_EMAIL,
+    v1_enabled: settings.v1_enabled ?? DEFAULT_SETTINGS.V1_ENABLED,
   };
 
   await SettingsService.saveSettings(apiSettings);

--- a/frontend/src/hooks/query/use-settings.ts
+++ b/frontend/src/hooks/query/use-settings.ts
@@ -35,6 +35,7 @@ const getSettingsQueryFn = async (): Promise<Settings> => {
     GIT_USER_NAME: apiSettings.git_user_name || DEFAULT_SETTINGS.GIT_USER_NAME,
     GIT_USER_EMAIL:
       apiSettings.git_user_email || DEFAULT_SETTINGS.GIT_USER_EMAIL,
+    V1_ENABLED: apiSettings.v1_enabled,
     IS_NEW_USER: false,
   };
 };

--- a/frontend/src/hooks/query/use-start-tasks.ts
+++ b/frontend/src/hooks/query/use-start-tasks.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import V1ConversationService from "#/api/conversation-service/v1-conversation-service.api";
-import { USE_V1_CONVERSATION_API } from "#/utils/feature-flags";
+import { useSettings } from "./use-settings";
 
 /**
  * Hook to fetch in-progress V1 conversation start tasks
@@ -13,13 +13,16 @@ import { USE_V1_CONVERSATION_API } from "#/utils/feature-flags";
  * @param limit Maximum number of tasks to return (max 100)
  * @returns Query result with array of in-progress start tasks
  */
-export const useStartTasks = (limit = 10) =>
-  useQuery({
+export const useStartTasks = (limit = 10) => {
+  const { data: settings } = useSettings();
+
+  return useQuery({
     queryKey: ["start-tasks", "search", limit],
     queryFn: () => V1ConversationService.searchStartTasks(limit),
-    enabled: USE_V1_CONVERSATION_API(),
+    enabled: settings?.V1_ENABLED ?? false,
     select: (tasks) =>
       tasks.filter(
         (task) => task.status !== "READY" && task.status !== "ERROR",
       ),
   });
+};

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -35,6 +35,7 @@ export const MOCK_DEFAULT_USER_SETTINGS: ApiSettings | PostApiSettings = {
   enable_solvability_analysis: DEFAULT_SETTINGS.ENABLE_SOLVABILITY_ANALYSIS,
   user_consents_to_analytics: DEFAULT_SETTINGS.USER_CONSENTS_TO_ANALYTICS,
   max_budget_per_task: DEFAULT_SETTINGS.MAX_BUDGET_PER_TASK,
+  v1_enabled: DEFAULT_SETTINGS.V1_ENABLED,
 };
 
 const MOCK_USER_PREFERENCES: {

--- a/frontend/src/services/settings.ts
+++ b/frontend/src/services/settings.ts
@@ -31,6 +31,7 @@ export const DEFAULT_SETTINGS: Settings = {
   },
   GIT_USER_NAME: "openhands",
   GIT_USER_EMAIL: "openhands@all-hands.dev",
+  V1_ENABLED: false,
 };
 
 /**

--- a/frontend/src/settings-service/settings.types.ts
+++ b/frontend/src/settings-service/settings.types.ts
@@ -35,6 +35,7 @@ export type ApiSettings = {
   email_verified?: boolean;
   git_user_name?: string;
   git_user_email?: string;
+  v1_enabled: boolean;
 };
 
 export type PostApiSettings = ApiSettings & {

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -63,6 +63,7 @@ export type Settings = {
   EMAIL_VERIFIED?: boolean;
   GIT_USER_NAME?: string;
   GIT_USER_EMAIL?: string;
+  V1_ENABLED: boolean;
 };
 
 export type PostSettings = Settings & {
@@ -70,4 +71,5 @@ export type PostSettings = Settings & {
   llm_api_key?: string | null;
   search_api_key?: string;
   mcp_config?: MCPConfig;
+  v1_enabled: boolean;
 };

--- a/frontend/src/utils/feature-flags.ts
+++ b/frontend/src/utils/feature-flags.ts
@@ -17,6 +17,4 @@ export const HIDE_LLM_SETTINGS = () => loadFeatureFlag("HIDE_LLM_SETTINGS");
 export const VSCODE_IN_NEW_TAB = () => loadFeatureFlag("VSCODE_IN_NEW_TAB");
 export const ENABLE_TRAJECTORY_REPLAY = () =>
   loadFeatureFlag("TRAJECTORY_REPLAY");
-export const USE_V1_CONVERSATION_API = () =>
-  loadFeatureFlag("USE_V1_CONVERSATION_API");
 export const USE_PLANNING_AGENT = () => loadFeatureFlag("USE_PLANNING_AGENT");


### PR DESCRIPTION
## Summary

This PR replaces the localStorage-based `USE_V1_CONVERSATION_API` feature flag with a proper settings-based `v1_enabled` flag that is stored in the user's settings and managed through the backend.


@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/720423fc96f5477587fb451ff86476ef)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:ee451d1-nikolaik   --name openhands-app-ee451d1   docker.openhands.dev/openhands/openhands:ee451d1
```