### PR TITLE
chore: update posthog-js from 1.290.0 to 1.298.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,7 +39,7 @@
         "jose": "^6.1.0",
         "lucide-react": "^0.544.0",
         "monaco-editor": "^0.53.0",
-        "posthog-js": "^1.290.0",
+        "posthog-js": "^1.298.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-highlight": "^0.15.0",
@@ -3910,9 +3910,9 @@
       "license": "MIT"
     },
     "node_modules/@posthog/core": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.5.2.tgz",
-      "integrity": "sha512-iedUP3EnOPPxTA2VaIrsrd29lSZnUV+ZrMnvY56timRVeZAXoYCkmjfIs3KBAsF8OUT5h1GXLSkoQdrV0r31OQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-Tbh8UACwbb7jFdDC7wwXHtfNzO+4wKh3VbyMHmp2UBe6w1jliJixexTJNfkqdGZm+ht3M10mcKvGGPnoZ2zLBg==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6"
@@ -14711,12 +14711,12 @@
       "license": "MIT"
     },
     "node_modules/posthog-js": {
-      "version": "1.290.0",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.290.0.tgz",
-      "integrity": "sha512-zavBwZkf+3JeiSDVE7ZDXBfzva/iOljicdhdJH+cZoqp0LsxjKxjnNhGOd3KpAhw0wqdwjhd7Lp1aJuI7DXyaw==",
+      "version": "1.298.1",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.298.1.tgz",
+      "integrity": "sha512-MynFhC2HO6sg5moUfpkd0s6RzAqcqFX75kjIi4Xrj2Gl0/YQWYvFUgvv8FCpWPKPs2mdvNWYhs+oqJg0BVVHPw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@posthog/core": "1.5.2",
+        "@posthog/core": "1.6.0",
         "core-js": "^3.38.1",
         "fflate": "^0.4.8",
         "preact": "^10.19.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "jose": "^6.1.0",
     "lucide-react": "^0.544.0",
     "monaco-editor": "^0.53.0",
-    "posthog-js": "^1.290.0",
+    "posthog-js": "^1.298.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-highlight": "^0.15.0",


### PR DESCRIPTION
## Summary of PR

Updated posthog-js dependency from ^1.290.0 to ^1.298.1. There is a vulnerability affecting 1.297.3 but that didn't affect us, this updates to the latest.

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [X] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [X] I have read and reviewed the code and I understand what the code is doing.
- [X] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:43aff96-nikolaik   --name openhands-app-43aff96   docker.openhands.dev/openhands/openhands:43aff96
```