### PR TITLE
fix(frontend): the content of the BrowserObservation event is not being rendered correctly

### DIFF
--- a/frontend/src/components/v1/chat/event-content-helpers/get-action-content.ts
+++ b/frontend/src/components/v1/chat/event-content-helpers/get-action-content.ts
@@ -132,27 +132,61 @@ type BrowserAction =
 
 const getBrowserActionContent = (action: BrowserAction): string => {
   switch (action.kind) {
-    case "BrowserNavigateAction":
-      if ("url" in action) {
-        return `Browsing ${action.url}`;
+    case "BrowserNavigateAction": {
+      let content = `Browsing ${action.url}`;
+      if (action.new_tab) {
+        content += `\n**New Tab:** Yes`;
       }
-      break;
-    case "BrowserClickAction":
-    case "BrowserTypeAction":
-    case "BrowserGetStateAction":
-    case "BrowserGetContentAction":
-    case "BrowserScrollAction":
-    case "BrowserGoBackAction":
-    case "BrowserListTabsAction":
-    case "BrowserSwitchTabAction":
-    case "BrowserCloseTabAction":
-      // These browser actions typically don't need detailed content display
+      return content;
+    }
+    case "BrowserClickAction": {
+      let content = `**Element Index:** ${action.index}`;
+      if (action.new_tab) {
+        content += `\n**New Tab:** Yes`;
+      }
+      return content;
+    }
+    case "BrowserTypeAction": {
+      const textPreview =
+        action.text.length > 50
+          ? `${action.text.slice(0, 50)}...`
+          : action.text;
+      return `**Element Index:** ${action.index}\n**Text:** ${textPreview}`;
+    }
+    case "BrowserGetStateAction": {
+      if (action.include_screenshot) {
+        return `**Include Screenshot:** Yes`;
+      }
       return getNoContentActionContent();
+    }
+    case "BrowserGetContentAction": {
+      const parts: string[] = [];
+      if (action.extract_links) {
+        parts.push(`**Extract Links:** Yes`);
+      }
+      if (action.start_from_char > 0) {
+        parts.push(`**Start From Character:** ${action.start_from_char}`);
+      }
+      return parts.length > 0 ? parts.join("\n") : getNoContentActionContent();
+    }
+    case "BrowserScrollAction": {
+      return `**Direction:** ${action.direction}`;
+    }
+    case "BrowserGoBackAction": {
+      return getNoContentActionContent();
+    }
+    case "BrowserListTabsAction": {
+      return getNoContentActionContent();
+    }
+    case "BrowserSwitchTabAction": {
+      return `**Tab ID:** ${action.tab_id}`;
+    }
+    case "BrowserCloseTabAction": {
+      return `**Tab ID:** ${action.tab_id}`;
+    }
     default:
       return getNoContentActionContent();
   }
-
-  return getNoContentActionContent();
 };
 
 export const getActionContent = (event: ActionEvent): string => {

--- a/frontend/src/components/v1/chat/event-content-helpers/get-event-content.tsx
+++ b/frontend/src/components/v1/chat/event-content-helpers/get-event-content.tsx
@@ -85,11 +85,20 @@ const getActionEventTitle = (event: OpenHandsEvent): React.ReactNode => {
       actionKey = "ACTION_MESSAGE$TASK_TRACKING";
       break;
     case "BrowserNavigateAction":
+    case "BrowserClickAction":
+    case "BrowserTypeAction":
+    case "BrowserGetStateAction":
+    case "BrowserGetContentAction":
+    case "BrowserScrollAction":
+    case "BrowserGoBackAction":
+    case "BrowserListTabsAction":
+    case "BrowserSwitchTabAction":
+    case "BrowserCloseTabAction":
       actionKey = "ACTION_MESSAGE$BROWSE";
       break;
     default:
       // For unknown actions, use the type name
-      return actionType.replace("Action", "").toUpperCase();
+      return String(actionType).replace("Action", "").toUpperCase();
   }
 
   if (actionKey) {

--- a/frontend/src/components/v1/chat/event-content-helpers/get-observation-content.ts
+++ b/frontend/src/components/v1/chat/event-content-helpers/get-observation-content.ts
@@ -80,13 +80,22 @@ const getBrowserObservationContent = (
 ): string => {
   const { observation } = event;
 
+  // Extract text content from the observation
+  const textContent =
+    "content" in observation && Array.isArray(observation.content)
+      ? observation.content
+          .filter((c) => c.type === "text")
+          .map((c) => c.text)
+          .join("\n")
+      : "";
+
   let contentDetails = "";
 
-  if ("error" in observation && observation.error) {
-    contentDetails += `**Error:**\n${observation.error}\n\n`;
+  if ("is_error" in observation && observation.is_error) {
+    contentDetails += `**Error:**\n${textContent}`;
+  } else {
+    contentDetails += `**Output:**\n${textContent}`;
   }
-
-  contentDetails += `**Output:**\n${observation.output}`;
 
   if (contentDetails.length > MAX_CONTENT_LENGTH) {
     contentDetails = `${contentDetails.slice(0, MAX_CONTENT_LENGTH)}...(truncated)`;


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

https://github.com/user-attachments/assets/802aef0f-b74e-4f5f-b3ed-86ed73c13daf

Based on the referenced video, the BrowserObservation event content fails to display as expected.

**Acceptance Criteria:**
- The BrowserObservation event content must be rendered accurately.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/99bc489c-b7aa-4312-bc56-599b6923573e

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:5e58ec8-nikolaik   --name openhands-app-5e58ec8   docker.openhands.dev/openhands/openhands:5e58ec8
```