### PR TITLE
fix(frontend): AppConversationStartTask timezone display in ui

### DIFF
--- a/frontend/src/components/features/conversation-panel/conversation-card/conversation-card-footer.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card/conversation-card-footer.tsx
@@ -39,7 +39,7 @@ export function ConversationCardFooter({
       {(createdAt ?? lastUpdatedAt) && (
         <p className="text-xs text-[#A3A3A3] flex-1 text-right">
           <time>
-            {`${formatTimeDelta(new Date(lastUpdatedAt ?? createdAt))} ${t(I18nKey.CONVERSATION$AGO)}`}
+            {`${formatTimeDelta(lastUpdatedAt ?? createdAt)} ${t(I18nKey.CONVERSATION$AGO)}`}
           </time>
         </p>
       )}

--- a/frontend/src/components/features/conversation-panel/start-task-card/start-task-card-footer.tsx
+++ b/frontend/src/components/features/conversation-panel/start-task-card/start-task-card-footer.tsx
@@ -31,7 +31,7 @@ export function StartTaskCardFooter({
         {createdAt && (
           <p className="text-xs text-[#A3A3A3] flex-1 text-right">
             <time>
-              {`${formatTimeDelta(new Date(createdAt))} ${t(I18nKey.CONVERSATION$AGO)}`}
+              {`${formatTimeDelta(createdAt)} ${t(I18nKey.CONVERSATION$AGO)}`}
             </time>
           </p>
         )}

--- a/frontend/src/components/features/home/recent-conversations/recent-conversation.tsx
+++ b/frontend/src/components/features/home/recent-conversations/recent-conversation.tsx
@@ -67,12 +67,14 @@ export function RecentConversation({ conversation }: RecentConversationProps) {
               </div>
             ) : null}
           </div>
-          <span>
-            {formatTimeDelta(
-              new Date(conversation.created_at || conversation.last_updated_at),
-            )}{" "}
-            {t(I18nKey.CONVERSATION$AGO)}
-          </span>
+          {(conversation.created_at || conversation.last_updated_at) && (
+            <span>
+              {formatTimeDelta(
+                conversation.created_at || conversation.last_updated_at,
+              )}{" "}
+              {t(I18nKey.CONVERSATION$AGO)}
+            </span>
+          )}
         </div>
       </button>
     </Link>

--- a/frontend/src/utils/format-time-delta.ts
+++ b/frontend/src/utils/format-time-delta.ts
@@ -1,16 +1,45 @@
 /**
+ * Parses a date string as UTC if it doesn't have a timezone indicator.
+ * This fixes the issue where ISO strings without timezone info are interpreted as local time.
+ * @param dateString ISO 8601 date string
+ * @returns Date object parsed as UTC
+ *
+ * @example
+ * parseDateAsUTC("2025-12-01T11:53:37.273886"); // Parsed as UTC
+ * parseDateAsUTC("2025-12-01T11:53:37.273886Z"); // Already has timezone, parsed correctly
+ * parseDateAsUTC("2025-12-01T11:53:37+00:00"); // Already has timezone, parsed correctly
+ */
+const parseDateAsUTC = (dateString: string): Date => {
+  // Check if the string already has a timezone indicator
+  // Look for 'Z' (UTC), '+' (positive offset), or '-' after the time part (negative offset)
+  const hasTimezone =
+    dateString.includes("Z") || dateString.match(/[+-]\d{2}:\d{2}$/) !== null;
+
+  if (hasTimezone) {
+    // Already has timezone info, parse normally
+    return new Date(dateString);
+  }
+
+  // No timezone indicator - append 'Z' to force UTC parsing
+  return new Date(`${dateString}Z`);
+};
+
+/**
  * Formats a date into a compact string representing the time delta between the given date and the current date.
- * @param date The date to format
+ * @param date The date to format (Date object or ISO 8601 string)
  * @returns A compact string representing the time delta between the given date and the current date
  *
  * @example
  * // now is 2024-01-01T00:00:00Z
  * formatTimeDelta(new Date("2023-12-31T23:59:59Z")); // "1s"
- * formatTimeDelta(new Date("2022-01-01T00:00:00Z")); // "2y"
+ * formatTimeDelta("2023-12-31T23:59:59Z"); // "1s"
+ * formatTimeDelta("2025-12-01T11:53:37.273886"); // Parsed as UTC automatically
  */
-export const formatTimeDelta = (date: Date) => {
+export const formatTimeDelta = (date: Date | string) => {
+  // Parse string dates as UTC if needed, or use Date object directly
+  const dateObj = typeof date === "string" ? parseDateAsUTC(date) : date;
   const now = new Date();
-  const delta = now.getTime() - date.getTime();
+  const delta = now.getTime() - dateObj.getTime();
 
   const seconds = Math.floor(delta / 1000);
   const minutes = Math.floor(seconds / 60);


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

<img width="864" height="188" alt="image" src="https://github.com/user-attachments/assets/5d1272bb-6d21-4571-b995-f523f112506b" />

According to the image above, It looks like the timezone is not being displayed correctly.

We can refer to the image below for the output of the PR.

<img width="798" height="748" alt="app-181" src="https://github.com/user-attachments/assets/a9864dc3-5fbf-485d-b896-da5d6c70305c" />



## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:48eeb93-nikolaik   --name openhands-app-48eeb93   docker.openhands.dev/openhands/openhands:48eeb93
```