### PR TITLE
Fix: Only redirect to last page after actual login, not on refresh or new tab

### DIFF
--- a/frontend/src/components/features/waitlist/auth-modal.tsx
+++ b/frontend/src/components/features/waitlist/auth-modal.tsx
@@ -9,7 +9,11 @@ import GitHubLogo from "#/assets/branding/github-logo.svg?react";
 import GitLabLogo from "#/assets/branding/gitlab-logo.svg?react";
 import { useAuthUrl } from "#/hooks/use-auth-url";
 import { GetConfigResponse } from "#/api/open-hands.types";
-import { LoginMethod, setLoginMethod } from "#/utils/local-storage";
+import {
+  LoginMethod,
+  setLoginMethod,
+  setJustLoggedIn,
+} from "#/utils/local-storage";
 
 interface AuthModalProps {
   githubAuthUrl: string | null;
@@ -29,6 +33,8 @@ export function AuthModal({ githubAuthUrl, appMode }: AuthModalProps) {
       // Store the login method in local storage (only in SAAS mode)
       if (appMode === "saas") {
         setLoginMethod(LoginMethod.GITHUB);
+        // Set the "just logged in" flag to true
+        setJustLoggedIn(true);
       }
       // Always start the OIDC flow, let the backend handle TOS check
       window.location.href = githubAuthUrl;
@@ -40,6 +46,8 @@ export function AuthModal({ githubAuthUrl, appMode }: AuthModalProps) {
       // Store the login method in local storage (only in SAAS mode)
       if (appMode === "saas") {
         setLoginMethod(LoginMethod.GITLAB);
+        // Set the "just logged in" flag to true
+        setJustLoggedIn(true);
       }
       // Always start the OIDC flow, let the backend handle TOS check
       window.location.href = gitlabAuthUrl;

--- a/frontend/src/hooks/use-auto-login.ts
+++ b/frontend/src/hooks/use-auto-login.ts
@@ -5,6 +5,8 @@ import { useIsAuthed } from "./query/use-is-authed";
 import {
   getLoginMethod,
   getLastPage,
+  getJustLoggedIn,
+  setJustLoggedIn,
   LoginMethod,
 } from "#/utils/local-storage";
 import { useAuthUrl } from "./use-auth-url";
@@ -59,6 +61,9 @@ export const useAutoLogin = () => {
 
     // If we have an auth URL, redirect to it
     if (authUrl) {
+      // Set the "just logged in" flag to true
+      setJustLoggedIn(true);
+
       // After successful login, the user will be redirected back and can navigate to the last page
       window.location.href = authUrl;
     }
@@ -95,11 +100,18 @@ export const useAutoLogin = () => {
     // Get the current pathname
     const currentPath = window.location.pathname;
 
+    // Check if the user just logged in
+
     // Only navigate to the last page if:
     // 1. Last page exists in local storage
     // 2. We're on the home page (/) - this prevents redirecting when a user
     //    explicitly navigates to a specific page or opens a link in a new tab
-    if (lastPage && currentPath === "/") {
+    // 3. The user just logged in (new condition)
+    if (lastPage && currentPath === "/" && getJustLoggedIn()) {
+      // Clear the "just logged in" flag
+      setJustLoggedIn(false);
+
+      // Navigate to the last page
       navigate(lastPage);
     }
   }, [config?.APP_MODE, isAuthed, isAuthLoading, navigate]);

--- a/frontend/src/utils/local-storage.ts
+++ b/frontend/src/utils/local-storage.ts
@@ -2,6 +2,7 @@
 export const LOCAL_STORAGE_KEYS = {
   LOGIN_METHOD: "openhands_login_method",
   LAST_PAGE: "openhands_last_page",
+  JUST_LOGGED_IN: "openhands_just_logged_in",
 };
 
 // Login methods
@@ -43,11 +44,12 @@ export const getLastPage = (): string | null =>
   localStorage.getItem(LOCAL_STORAGE_KEYS.LAST_PAGE);
 
 /**
- * Clear login method and last page from local storage
+ * Clear login method, last page, and just logged in flag from local storage
  */
 export const clearLoginData = (): void => {
   localStorage.removeItem(LOCAL_STORAGE_KEYS.LOGIN_METHOD);
   localStorage.removeItem(LOCAL_STORAGE_KEYS.LAST_PAGE);
+  localStorage.removeItem(LOCAL_STORAGE_KEYS.JUST_LOGGED_IN);
 };
 
 /**
@@ -57,3 +59,20 @@ export const clearLoginData = (): void => {
  */
 export const shouldExcludePath = (path: string): boolean =>
   path.startsWith("/settings");
+
+/**
+ * Set the "just logged in" flag in local storage
+ * @param value True if the user just logged in, false otherwise
+ */
+export const setJustLoggedIn = (value: boolean): void => {
+  localStorage.setItem(LOCAL_STORAGE_KEYS.JUST_LOGGED_IN, value.toString());
+};
+
+/**
+ * Get the "just logged in" flag from local storage
+ * @returns True if the user just logged in, false otherwise
+ */
+export const getJustLoggedIn = (): boolean => {
+  const value = localStorage.getItem(LOCAL_STORAGE_KEYS.JUST_LOGGED_IN);
+  return value === "true";
+};


### PR DESCRIPTION
- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [x] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**

Fixed an issue where users were being incorrectly redirected to their last visited page when refreshing the browser or opening a new tab, instead of only redirecting after an actual login. This improves the user experience by ensuring redirects only happen when appropriate.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**

This PR fixes the tab redirection logic to only redirect users to their last visited page after an actual login event, not when refreshing the page or opening a new tab. The changes ensure that:

1. Redirects only occur after successful authentication
2. Page refreshes and new tabs don't trigger unwanted redirects
3. Users have a more predictable navigation experience

The fix involves checking the authentication state more precisely to distinguish between actual login events and other page loads.

---
**Link of any specific issues this addresses:**

This addresses user experience issues with unexpected redirects during normal browsing.