### PR TITLE
Increase action timeout buffer from 5 to 100 seconds for debugging

### DIFF
--- a/openhands/runtime/impl/action_execution/action_execution_client.py
+++ b/openhands/runtime/impl/action_execution/action_execution_client.py
@@ -324,8 +324,8 @@ class ActionExecutionClient(Runtime):
                     'POST',
                     f'{self.action_execution_server_url}/execute_action',
                     json=execution_action_body,
-                    # wait a few more seconds to get the timeout error from client side
-                    timeout=action.timeout + 5,
+                    # wait additional seconds to get the timeout error from server side
+                    timeout=action.timeout + 100,
                 )
                 assert response.is_closed
                 output = response.json()


### PR DESCRIPTION
## Summary of PR

This PR increases the HTTP client timeout buffer from **5 seconds** to **100 seconds** when executing actions through the action execution client. This change is intended for **debugging purposes** to better observe timeout behavior on the server side.

### Background

In `ActionExecutionClient.send_action_for_execution()`, the HTTP client adds a buffer to the action timeout to ensure the server times out first and returns a proper error message. Currently, this buffer is 5 seconds (`action.timeout + 5`).

### Changes

- Changed timeout buffer from `action.timeout + 5` to `action.timeout + 100` in line 328 of `action_execution_client.py`
- Updated comment to reflect the purpose more clearly

### Rationale

With a 100-second buffer, developers can:
- Better observe and debug server-side timeout behavior without HTTP client timeouts interfering
- Get more reliable timeout error messages from the server
- Have more time to investigate issues during development and debugging

**Note:** This is a debugging change and may need to be reverted or adjusted once the debugging is complete.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (debugging enhancement)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

N/A - This is a debugging enhancement, not a bug fix.

## Release Notes

- [ ] Include this change in the Release Notes.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e38ccf2074cc443f87d740d2778ee5d7)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:bd5ed70-nikolaik   --name openhands-app-bd5ed70   docker.openhands.dev/openhands/openhands:bd5ed70
```