### PR TITLE
refactor(frontend): hide agent dropdown when v1 is enabled

### DIFF
--- a/frontend/src/routes/llm-settings.tsx
+++ b/frontend/src/routes/llm-settings.tsx
@@ -28,6 +28,7 @@ import { KeyStatusIcon } from "#/components/features/settings/key-status-icon";
 import { DEFAULT_SETTINGS } from "#/services/settings";
 import { getProviderId } from "#/utils/map-provider";
 import { DEFAULT_OPENHANDS_MODEL } from "#/utils/verified-models";
+import { USE_V1_CONVERSATION_API } from "#/utils/feature-flags";
 
 interface OpenHandsApiKeyHelpProps {
   testId: string;
@@ -117,6 +118,9 @@ function LlmSettingsScreen() {
     (view === "advanced" && currentModel?.startsWith("openhands/"));
   const isSaasMode = config?.APP_MODE === "saas";
   const shouldUseOpenHandsKey = isOpenHandsProvider && isSaasMode;
+
+  // Determine if we should hide the agent dropdown when V1 conversation API feature flag is enabled
+  const isV1Enabled = USE_V1_CONVERSATION_API();
 
   React.useEffect(() => {
     const determineWhetherToToggleAdvancedSettings = () => {
@@ -612,21 +616,23 @@ function LlmSettingsScreen() {
                     href="https://tavily.com/"
                   />
 
-                  <SettingsDropdownInput
-                    testId="agent-input"
-                    name="agent-input"
-                    label={t(I18nKey.SETTINGS$AGENT)}
-                    items={
-                      resources?.agents.map((agent) => ({
-                        key: agent,
-                        label: agent, // TODO: Add i18n support for agent names
-                      })) || []
-                    }
-                    defaultSelectedKey={settings.AGENT}
-                    isClearable={false}
-                    onInputChange={handleAgentIsDirty}
-                    wrapperClassName="w-full max-w-[680px]"
-                  />
+                  {!isV1Enabled && (
+                    <SettingsDropdownInput
+                      testId="agent-input"
+                      name="agent-input"
+                      label={t(I18nKey.SETTINGS$AGENT)}
+                      items={
+                        resources?.agents.map((agent) => ({
+                          key: agent,
+                          label: agent, // TODO: Add i18n support for agent names
+                        })) || []
+                      }
+                      defaultSelectedKey={settings.AGENT}
+                      isClearable={false}
+                      onInputChange={handleAgentIsDirty}
+                      wrapperClassName="w-full max-w-[680px]"
+                    />
+                  )}
                 </>
               )}
 


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

<img width="854" height="175" alt="Image" src="https://github.com/user-attachments/assets/56b624f0-4167-4d70-92de-4ece8daea5db" />

When V1 is enabled, the agent from the software-agent-sdk will be used. Consequently, the agent dropdown should be hidden when V1 is active.

We can refer to the image below for the output of the PR.

<img width="1440" height="748" alt="app-187" src="https://github.com/user-attachments/assets/2351a619-e2b5-4917-9ab3-c427158ec663" />

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #11859 

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:c959f28-nikolaik   --name openhands-app-c959f28   docker.openhands.dev/openhands/openhands:c959f28
```