### PR TITLE
fix(backend): git settings not applying in v1 conversations

### DIFF
--- a/tests/unit/app_server/test_app_conversation_service_base.py
+++ b/tests/unit/app_server/test_app_conversation_service_base.py
@@ -5,9 +5,39 @@ and the recent bug fixes for git checkout operations.
 """
 
 import subprocess
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from openhands.app_server.app_conversation.app_conversation_service_base import (
+    AppConversationServiceBase,
+)
+
+
+class MockUserInfo:
+    """Mock class for UserInfo to simulate user settings."""
+
+    def __init__(
+        self, git_user_name: str | None = None, git_user_email: str | None = None
+    ):
+        self.git_user_name = git_user_name
+        self.git_user_email = git_user_email
+
+
+class MockCommandResult:
+    """Mock class for command execution result."""
+
+    def __init__(self, exit_code: int = 0, stderr: str = ''):
+        self.exit_code = exit_code
+        self.stderr = stderr
+
+
+class MockWorkspace:
+    """Mock class for AsyncRemoteWorkspace."""
+
+    def __init__(self, working_dir: str = '/workspace'):
+        self.working_dir = working_dir
+        self.execute_command = AsyncMock(return_value=MockCommandResult())
 
 
 class MockAppConversationServiceBase:
@@ -254,3 +284,197 @@ async def test_clone_or_init_git_repo_custom_timeout(service):
             text=True,
             timeout=600,  # Verify custom timeout is used
         )
+
+
+# =============================================================================
+# Tests for _configure_git_user_settings
+# =============================================================================
+
+
+def _create_service_with_mock_user_context(user_info: MockUserInfo) -> tuple:
+    """Create a mock service with the actual _configure_git_user_settings method.
+
+    Uses MagicMock for the service but binds the real method for testing.
+
+    Returns a tuple of (service, mock_user_context) for testing.
+    """
+    mock_user_context = MagicMock()
+    mock_user_context.get_user_info = AsyncMock(return_value=user_info)
+
+    # Create a simple mock service and set required attribute
+    service = MagicMock()
+    service.user_context = mock_user_context
+
+    # Bind the actual method from the real class to test real implementation
+    service._configure_git_user_settings = (
+        lambda workspace: AppConversationServiceBase._configure_git_user_settings(
+            service, workspace
+        )
+    )
+
+    return service, mock_user_context
+
+
+@pytest.fixture
+def mock_workspace():
+    """Create a mock workspace instance for testing."""
+    return MockWorkspace(working_dir='/workspace/project')
+
+
+@pytest.mark.asyncio
+async def test_configure_git_user_settings_both_name_and_email(mock_workspace):
+    """Test configuring both git user name and email."""
+    user_info = MockUserInfo(
+        git_user_name='Test User', git_user_email='test@example.com'
+    )
+    service, mock_user_context = _create_service_with_mock_user_context(user_info)
+
+    await service._configure_git_user_settings(mock_workspace)
+
+    # Verify get_user_info was called
+    mock_user_context.get_user_info.assert_called_once()
+
+    # Verify both git config commands were executed
+    assert mock_workspace.execute_command.call_count == 2
+
+    # Check git config user.name call
+    mock_workspace.execute_command.assert_any_call(
+        'git config --global user.name "Test User"', '/workspace/project'
+    )
+
+    # Check git config user.email call
+    mock_workspace.execute_command.assert_any_call(
+        'git config --global user.email "test@example.com"', '/workspace/project'
+    )
+
+
+@pytest.mark.asyncio
+async def test_configure_git_user_settings_only_name(mock_workspace):
+    """Test configuring only git user name."""
+    user_info = MockUserInfo(git_user_name='Test User', git_user_email=None)
+    service, _ = _create_service_with_mock_user_context(user_info)
+
+    await service._configure_git_user_settings(mock_workspace)
+
+    # Verify only user.name was configured
+    assert mock_workspace.execute_command.call_count == 1
+    mock_workspace.execute_command.assert_called_once_with(
+        'git config --global user.name "Test User"', '/workspace/project'
+    )
+
+
+@pytest.mark.asyncio
+async def test_configure_git_user_settings_only_email(mock_workspace):
+    """Test configuring only git user email."""
+    user_info = MockUserInfo(git_user_name=None, git_user_email='test@example.com')
+    service, _ = _create_service_with_mock_user_context(user_info)
+
+    await service._configure_git_user_settings(mock_workspace)
+
+    # Verify only user.email was configured
+    assert mock_workspace.execute_command.call_count == 1
+    mock_workspace.execute_command.assert_called_once_with(
+        'git config --global user.email "test@example.com"', '/workspace/project'
+    )
+
+
+@pytest.mark.asyncio
+async def test_configure_git_user_settings_neither_set(mock_workspace):
+    """Test when neither git user name nor email is set."""
+    user_info = MockUserInfo(git_user_name=None, git_user_email=None)
+    service, _ = _create_service_with_mock_user_context(user_info)
+
+    await service._configure_git_user_settings(mock_workspace)
+
+    # Verify no git config commands were executed
+    mock_workspace.execute_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_configure_git_user_settings_empty_strings(mock_workspace):
+    """Test when git user name and email are empty strings."""
+    user_info = MockUserInfo(git_user_name='', git_user_email='')
+    service, _ = _create_service_with_mock_user_context(user_info)
+
+    await service._configure_git_user_settings(mock_workspace)
+
+    # Empty strings are falsy, so no commands should be executed
+    mock_workspace.execute_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_configure_git_user_settings_get_user_info_fails(mock_workspace):
+    """Test handling of exception when get_user_info fails."""
+    user_info = MockUserInfo()
+    service, mock_user_context = _create_service_with_mock_user_context(user_info)
+    mock_user_context.get_user_info = AsyncMock(
+        side_effect=Exception('User info error')
+    )
+
+    # Should not raise exception, just log warning
+    await service._configure_git_user_settings(mock_workspace)
+
+    # Verify no git config commands were executed
+    mock_workspace.execute_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_configure_git_user_settings_name_command_fails(mock_workspace):
+    """Test handling when git config user.name command fails."""
+    user_info = MockUserInfo(
+        git_user_name='Test User', git_user_email='test@example.com'
+    )
+    service, _ = _create_service_with_mock_user_context(user_info)
+
+    # Make the first command fail (user.name), second succeed (user.email)
+    mock_workspace.execute_command = AsyncMock(
+        side_effect=[
+            MockCommandResult(exit_code=1, stderr='Permission denied'),
+            MockCommandResult(exit_code=0),
+        ]
+    )
+
+    # Should not raise exception
+    await service._configure_git_user_settings(mock_workspace)
+
+    # Verify both commands were still attempted
+    assert mock_workspace.execute_command.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_configure_git_user_settings_email_command_fails(mock_workspace):
+    """Test handling when git config user.email command fails."""
+    user_info = MockUserInfo(
+        git_user_name='Test User', git_user_email='test@example.com'
+    )
+    service, _ = _create_service_with_mock_user_context(user_info)
+
+    # Make the first command succeed (user.name), second fail (user.email)
+    mock_workspace.execute_command = AsyncMock(
+        side_effect=[
+            MockCommandResult(exit_code=0),
+            MockCommandResult(exit_code=1, stderr='Permission denied'),
+        ]
+    )
+
+    # Should not raise exception
+    await service._configure_git_user_settings(mock_workspace)
+
+    # Verify both commands were still attempted
+    assert mock_workspace.execute_command.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_configure_git_user_settings_special_characters_in_name(mock_workspace):
+    """Test git user name with special characters."""
+    user_info = MockUserInfo(
+        git_user_name="Test O'Brien", git_user_email='test@example.com'
+    )
+    service, _ = _create_service_with_mock_user_context(user_info)
+
+    await service._configure_git_user_settings(mock_workspace)
+
+    # Verify the name is passed with special characters
+    mock_workspace.execute_command.assert_any_call(
+        'git config --global user.name "Test O\'Brien"', '/workspace/project'
+    )


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

<img width="808" height="376" alt="Image" src="https://github.com/user-attachments/assets/d54a5cdc-4534-4325-898d-54b8298579d9" />

Git settings must be applied to V1 conversations. At present, these settings are not being applied.

**Acceptance Criteria:**
- Git settings are correctly applied to all V1 conversations.

We can refer to the image below for the output of the pull request.

<img width="1436" height="740" alt="all-4349" src="https://github.com/user-attachments/assets/ad0e01b8-6080-49d5-afc4-9bdc26c4d9a6" />

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #11865 

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:a703a62-nikolaik   --name openhands-app-a703a62   docker.openhands.dev/openhands/openhands:a703a62
```