### PR TITLE
fix: enable terminal scrollback to view command history

### DIFF
--- a/frontend/src/hooks/use-terminal.ts
+++ b/frontend/src/hooks/use-terminal.ts
@@ -44,7 +44,7 @@ export const useTerminal = () => {
     new Terminal({
       fontFamily: "Menlo, Monaco, 'Courier New', monospace",
       fontSize: 14,
-      scrollback: 1000,
+      scrollback: 10000,
       scrollSensitivity: 1,
       fastScrollModifier: "alt",
       fastScrollSensitivity: 5,
@@ -62,6 +62,7 @@ export const useTerminal = () => {
         terminal.current.open(ref.current);
         // Hide cursor for read-only terminal using ANSI escape sequence
         terminal.current.write("\x1b[?25l");
+        fitAddon.current?.fit();
       }
     }
   };


### PR DESCRIPTION
fix: #11852 

## Summary of PR

Fixes terminal scrolling to allow users to view command history and previous output. Increased scrollback buffer from 1,000 to 10,000 lines and added initial fit call on terminal mount.

## Change Type

- [x] Bug fix