### PR TITLE
feat(frontend): display command in observation block in ui

### DIFF
--- a/frontend/src/components/v1/chat/event-content-helpers/get-observation-content.ts
+++ b/frontend/src/components/v1/chat/event-content-helpers/get-observation-content.ts
@@ -71,7 +71,18 @@ const getTerminalObservationContent = (
     content = `${content.slice(0, MAX_CONTENT_LENGTH)}...`;
   }
 
-  return `Output:\n\`\`\`sh\n${content.trim() || i18n.t("OBSERVATION$COMMAND_NO_OUTPUT")}\n\`\`\``;
+  // Build the output string
+  let output = "";
+
+  // Display the command if available
+  if (observation.command) {
+    output += `Command: \`${observation.command}\`\n\n`;
+  }
+
+  // Display the output
+  output += `Output:\n\`\`\`sh\n${content.trim() || i18n.t("OBSERVATION$COMMAND_NO_OUTPUT")}\n\`\`\``;
+
+  return output;
 };
 
 // Tool Observations


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

Currently, when observations are displayed in the UI as collapsible blocks, the command that generated the observation is not shown. This makes it difficult for users to understand what action led to a particular observation.

<img width="1588" height="1196" alt="Image" src="https://github.com/user-attachments/assets/ac22a7be-b48e-4279-9bee-e8962edd6a02" />

## Example

When a command like `ls -la` is executed and generates an observation, the observation block should show:
- The command that was run (`ls -la`)
- The output/result of that command

## Context

This enhancement would improve the user experience by providing better context about what actions the agent is taking.

We can refer to the video below for the output of the PR.

https://github.com/user-attachments/assets/1000636b-a0bc-41e5-aaf8-ecf485821713

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #11853 

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:ccfa18a-nikolaik   --name openhands-app-ccfa18a   docker.openhands.dev/openhands/openhands:ccfa18a
```