### PR TITLE
feat: display command in observation block

### DIFF
--- a/frontend/src/components/v1/chat/event-content-helpers/get-observation-content.ts
+++ b/frontend/src/components/v1/chat/event-content-helpers/get-observation-content.ts
@@ -71,12 +71,6 @@ const getTerminalObservationContent = (
     content = `${content.slice(0, MAX_CONTENT_LENGTH)}...`;
   }
 
-  const { command } = observation;
-
-  if (command) {
-    return `Command:\n\`\`\`sh\n${command}\n\`\`\`\n\nOutput:\n\`\`\`sh\n${content.trim() || i18n.t("OBSERVATION$COMMAND_NO_OUTPUT")}\n\`\`\``;
-  }
-
   return `Output:\n\`\`\`sh\n${content.trim() || i18n.t("OBSERVATION$COMMAND_NO_OUTPUT")}\n\`\`\``;
 };
 


### PR DESCRIPTION
## Summary of PR

fix: #11853

Displays the executed command alongside its output in observation blocks. Previously, only the output was shown when expanding an observation block. Now users can see both the command and output for better context on agent actions.

## Change Type

- [x] New feature