### PR TITLE
refactor(frontend): rename superadmin role to owner (org support)

### DIFF
--- a/frontend/__tests__/components/features/user/user-context-menu.test.tsx
+++ b/frontend/__tests__/components/features/user/user-context-menu.test.tsx
@@ -152,8 +152,8 @@ describe("UserContextMenu", () => {
     screen.getByText("ORG$MANAGE_ACCOUNT");
   });
 
-  it("should render additional context items when user is a super admin", () => {
-    renderUserContextMenu({ type: "superadmin", onClose: vi.fn });
+  it("should render additional context items when user is an owner", () => {
+    renderUserContextMenu({ type: "owner", onClose: vi.fn });
 
     screen.getByTestId("org-selector");
     screen.getByText("ORG$INVITE_ORGANIZATION_MEMBER");
@@ -226,7 +226,7 @@ describe("UserContextMenu", () => {
 
   it("should call the onClose handler after each action", async () => {
     const onCloseMock = vi.fn();
-    renderUserContextMenu({ type: "superadmin", onClose: onCloseMock });
+    renderUserContextMenu({ type: "owner", onClose: onCloseMock });
 
     const logoutButton = screen.getByText("ACCOUNT_SETTINGS$LOGOUT");
     await userEvent.click(logoutButton);

--- a/frontend/__tests__/routes/manage-org.test.tsx
+++ b/frontend/__tests__/routes/manage-org.test.tsx
@@ -107,7 +107,7 @@ describe("Manage Org Route", () => {
     renderManageOrg();
     await screen.findByTestId("manage-org-screen");
 
-    await selectOrganization({ orgIndex: 0 }); // user is superadmin in org 1
+    await selectOrganization({ orgIndex: 0 }); // user is owner in org 1
 
     expect(screen.queryByTestId("add-credits-form")).not.toBeInTheDocument();
     // Simulate adding credits
@@ -141,7 +141,7 @@ describe("Manage Org Route", () => {
     renderManageOrg();
     await screen.findByTestId("manage-org-screen");
 
-    await selectOrganization({ orgIndex: 0 }); // user is superadmin in org 1
+    await selectOrganization({ orgIndex: 0 }); // user is owner in org 1
 
     expect(screen.queryByTestId("add-credits-form")).not.toBeInTheDocument();
     // Simulate adding credits
@@ -230,7 +230,7 @@ describe("Manage Org Route", () => {
       });
     });
 
-    it("should NOT allow roles other than superadmins to change org name", async () => {
+    it("should NOT allow roles other than owners to change org name", async () => {
       renderManageOrg();
       await screen.findByTestId("manage-org-screen");
 
@@ -243,7 +243,7 @@ describe("Manage Org Route", () => {
       expect(changeOrgNameButton).not.toBeInTheDocument();
     });
 
-    it("should NOT allow roles other than superadmins to delete an organization", async () => {
+    it("should NOT allow roles other than owners to delete an organization", async () => {
       const getConfigSpy = vi.spyOn(OptionService, "getConfig");
       // @ts-expect-error - only return the properties we need for this test
       getConfigSpy.mockResolvedValue({

--- a/frontend/__tests__/routes/manage-organization-members.test.tsx
+++ b/frontend/__tests__/routes/manage-organization-members.test.tsx
@@ -183,21 +183,21 @@ describe("Manage Team Route", () => {
     expect(inviteButton).not.toBeInTheDocument();
   });
 
-  it("should not allow an admin to change the superadmin's role", async () => {
+  it("should not allow an admin to change the owner's role", async () => {
     renderManageOrganizationMembers();
     await screen.findByTestId("manage-organization-members-settings");
 
     await selectOrganization({ orgIndex: 2 }); // user is admin in org 3
 
     const memberListItems = await screen.findAllByTestId("member-item");
-    const superAdminMember = memberListItems[0]; // first member is "superadmin
-    const userCombobox = within(superAdminMember).getByText(/superadmin/i);
+    const ownerMember = memberListItems[0]; // first member is "owner
+    const userCombobox = within(ownerMember).getByText(/owner/i);
     expect(userCombobox).toBeInTheDocument();
     await userEvent.click(userCombobox);
 
-    // Verify that the dropdown does not open for superadmin
+    // Verify that the dropdown does not open for owner
     expect(
-      within(superAdminMember).queryByTestId("role-dropdown"),
+      within(ownerMember).queryByTestId("role-dropdown"),
     ).not.toBeInTheDocument();
   });
 
@@ -226,7 +226,7 @@ describe("Manage Team Route", () => {
     getMeSpy.mockResolvedValue({
       id: "1", // Same as Alice from org 1
       email: "alice@acme.org",
-      role: "superadmin",
+      role: "owner",
       status: "active",
     });
 
@@ -238,7 +238,7 @@ describe("Manage Team Route", () => {
     const memberListItems = await screen.findAllByTestId("member-item");
     const currentUserMember = memberListItems[0]; // First member is Alice (id: "1")
 
-    const roleText = within(currentUserMember).getByText(/superadmin/i);
+    const roleText = within(currentUserMember).getByText(/owner/i);
     await userEvent.click(roleText);
 
     // Verify that the dropdown does not open for the current user's own role

--- a/frontend/src/mocks/org-handlers.ts
+++ b/frontend/src/mocks/org-handlers.ts
@@ -34,7 +34,7 @@ export const ORGS_AND_MEMBERS: Record<string, OrganizationMember[]> = {
     {
       id: "1",
       email: "alice@acme.org",
-      role: "superadmin",
+      role: "owner",
       status: "active",
     },
     {
@@ -68,7 +68,7 @@ export const ORGS_AND_MEMBERS: Record<string, OrganizationMember[]> = {
     {
       id: "6",
       email: "robert@all-hands.dev",
-      role: "superadmin",
+      role: "owner",
       status: "active",
     },
     {
@@ -121,7 +121,7 @@ export const ORG_HANDLERS = [
     let role: OrganizationUserRole = "user";
     switch (orgId) {
       case "1":
-        role = "superadmin";
+        role = "owner";
         break;
       case "2":
         role = "user";

--- a/frontend/src/types/org.ts
+++ b/frontend/src/types/org.ts
@@ -1,4 +1,4 @@
-export type OrganizationUserRole = "user" | "admin" | "superadmin";
+export type OrganizationUserRole = "user" | "admin" | "owner";
 
 export interface Organization {
   id: string;

--- a/frontend/src/utils/org/permissions.ts
+++ b/frontend/src/utils/org/permissions.ts
@@ -17,12 +17,12 @@ type UserPermission =
   | DeleteOrganizationPermission
   | AddCreditsPermission;
 
-const superadminPerms: UserPermission[] = [
+const ownerPerms: UserPermission[] = [
   "invite_user_to_organization",
   "change_organization_name",
   "delete_organization",
   "add_credits",
-  "change_user_role:superadmin",
+  "change_user_role:owner",
   "change_user_role:admin",
   "change_user_role:user",
 ];
@@ -33,7 +33,7 @@ const adminPerms: UserPermission[] = [
 const userPerms: UserPermission[] = [];
 
 export const rolePermissions: Record<OrganizationUserRole, UserPermission[]> = {
-  superadmin: superadminPerms,
+  owner: ownerPerms,
   admin: adminPerms,
   user: userPerms,
 };


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

Within the organization’s frontend, there are currently three roles: Superadmin, Admin, and User. It is recommended that the ‘Superadmin’ role be renamed to ‘Owner’.

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:01e88c3-nikolaik   --name openhands-app-01e88c3   docker.openhands.dev/openhands/openhands:01e88c3
```