### PR TITLE
refactor(frontend): remove max_budget_per_task input element for v1

### DIFF
--- a/frontend/src/routes/app-settings.tsx
+++ b/frontend/src/routes/app-settings.tsx
@@ -239,18 +239,20 @@ function AppSettingsScreen() {
             </SettingsSwitch>
           )}
 
-          <SettingsInput
-            testId="max-budget-per-task-input"
-            name="max-budget-per-task-input"
-            type="number"
-            label={t(I18nKey.SETTINGS$MAX_BUDGET_PER_CONVERSATION)}
-            defaultValue={settings.MAX_BUDGET_PER_TASK?.toString() || ""}
-            onChange={checkIfMaxBudgetPerTaskHasChanged}
-            placeholder={t(I18nKey.SETTINGS$MAXIMUM_BUDGET_USD)}
-            min={1}
-            step={1}
-            className="w-full max-w-[680px]" // Match the width of the language field
-          />
+          {!settings?.V1_ENABLED && (
+            <SettingsInput
+              testId="max-budget-per-task-input"
+              name="max-budget-per-task-input"
+              type="number"
+              label={t(I18nKey.SETTINGS$MAX_BUDGET_PER_CONVERSATION)}
+              defaultValue={settings.MAX_BUDGET_PER_TASK?.toString() || ""}
+              onChange={checkIfMaxBudgetPerTaskHasChanged}
+              placeholder={t(I18nKey.SETTINGS$MAXIMUM_BUDGET_USD)}
+              min={1}
+              step={1}
+              className="w-full max-w-[680px]" // Match the width of the language field
+            />
+          )}
 
           <div className="border-t border-t-tertiary pt-6 mt-2">
             <h3 className="text-lg font-medium mb-2">


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

This feature is not supported in V1. Therefore, the input element should be removed from the settings page.

When V1 is enabled, the input element should not be displayed.

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #11920 

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:d555b5e-nikolaik   --name openhands-app-d555b5e   docker.openhands.dev/openhands/openhands:d555b5e
```