### PR TITLE
docs: fix broken architecture diagram link in openhands/README.md

### DIFF
--- a/openhands/README.md
+++ b/openhands/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the core components of OpenHands.
 
-For an overview of the system architecture, see the [architecture documentation](https://docs.all-hands.dev/usage/architecture/backend) (v0 backend architecture).
+For an overview of the system architecture, see the [architecture documentation](https://docs.openhands.dev/usage/architecture/backend) (v0 backend architecture).
 
 ## Classes
 


### PR DESCRIPTION
## Summary of PR

Replace broken image reference (`../docs/static/img/system_architecture_overview.png`) with a link to the official architecture documentation. The original image was removed during the docs migration to a separate repository (PR #11261).

## Change Type

- [x] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #11370

## Release Notes

- [ ] Include this change in the Release Notes.