### PR TITLE
fix(frontend): set v1_enable correctly when saving mcp settings

### DIFF
--- a/frontend/src/hooks/mutation/use-add-mcp-server.ts
+++ b/frontend/src/hooks/mutation/use-add-mcp-server.ts
@@ -57,6 +57,7 @@ export function useAddMcpServer() {
 
       const apiSettings = {
         mcp_config: newConfig,
+        v1_enabled: settings.V1_ENABLED,
       };
 
       await SettingsService.saveSettings(apiSettings);

--- a/frontend/src/hooks/mutation/use-delete-mcp-server.ts
+++ b/frontend/src/hooks/mutation/use-delete-mcp-server.ts
@@ -25,6 +25,7 @@ export function useDeleteMcpServer() {
 
       const apiSettings = {
         mcp_config: newConfig,
+        v1_enabled: settings.V1_ENABLED,
       };
 
       await SettingsService.saveSettings(apiSettings);

--- a/frontend/src/hooks/mutation/use-update-mcp-server.ts
+++ b/frontend/src/hooks/mutation/use-update-mcp-server.ts
@@ -59,6 +59,7 @@ export function useUpdateMcpServer() {
 
       const apiSettings = {
         mcp_config: newConfig,
+        v1_enabled: settings.V1_ENABLED,
       };
 
       await SettingsService.saveSettings(apiSettings);


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

**Description:**

If v1_enable is manually set to true in the database and a user subsequently opens the UI and saves the MCP settings, the v1_enable field is automatically changed to false, even when no update to this field was intended.

**Acceptance Criteria:**
- The v1_enable field must retain its existing value when saving MCP settings through the UI unless the user explicitly changes it.

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:2b89337-nikolaik   --name openhands-app-2b89337   docker.openhands.dev/openhands/openhands:2b89337
```