### PR TITLE
Remove loud red x icon on agent commands

### DIFF
--- a/frontend/src/components/features/chat/success-indicator.tsx
+++ b/frontend/src/components/features/chat/success-indicator.tsx
@@ -1,6 +1,5 @@
 import { FaClock } from "react-icons/fa";
 import CheckCircle from "#/icons/check-circle-solid.svg?react";
-import XCircle from "#/icons/x-circle-solid.svg?react";
 import { ObservationResultStatus } from "./event-content-helpers/get-observation-result";
 
 interface SuccessIndicatorProps {
@@ -14,13 +13,6 @@ export function SuccessIndicator({ status }: SuccessIndicatorProps) {
         <CheckCircle
           data-testid="status-icon"
           className="h-4 w-4 ml-2 inline fill-success"
-        />
-      )}
-
-      {status === "error" && (
-        <XCircle
-          data-testid="status-icon"
-          className="h-4 w-4 ml-2 inline fill-danger"
         />
       )}
 


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

This might be controversial PR (hopefully not). I've been on call with customers and every once and awhile they complain that our agent is 'not as good' as other agents and they point to this red x as an example of the agent making mistakes. In reality in many of these cases, our agent figures out the task, and this red x represents a command the agent ran that perhaps didn't work but wasnt necessarily a mistake, it was just the agent iterating on the task. As such, I think this red x icon for agent "errors" is simply too loud. Other ai agent offerings do not show agent commands that error with red x icons and I don't think we should either.

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:6f61277-nikolaik   --name openhands-app-6f61277   docker.openhands.dev/openhands/openhands:6f61277
```