### PR TITLE
Remove error icon from ExpandableMessage component

### DIFF
--- a/frontend/__tests__/components/chat/expandable-message.test.tsx
+++ b/frontend/__tests__/components/chat/expandable-message.test.tsx
@@ -61,7 +61,7 @@ describe("ExpandableMessage", () => {
     expect(icon).toHaveClass("fill-success");
   });
 
-  it("should render with error icon for failed action messages", () => {
+  it("should render with no icon for failed action messages", () => {
     renderWithProviders(
       <ExpandableMessage
         id="OBSERVATION_MESSAGE$RUN"
@@ -75,8 +75,7 @@ describe("ExpandableMessage", () => {
       "div.flex.gap-2.items-center.justify-start",
     );
     expect(container).toHaveClass("border-neutral-300");
-    const icon = screen.getByTestId("status-icon");
-    expect(icon).toHaveClass("fill-danger");
+    expect(screen.queryByTestId("status-icon")).not.toBeInTheDocument();
   });
 
   it("should render with neutral border and no icon for action messages without success prop", () => {

--- a/frontend/src/components/features/chat/expandable-message.tsx
+++ b/frontend/src/components/features/chat/expandable-message.tsx
@@ -6,7 +6,6 @@ import { I18nKey } from "#/i18n/declaration";
 import ArrowDown from "#/icons/angle-down-solid.svg?react";
 import ArrowUp from "#/icons/angle-up-solid.svg?react";
 import CheckCircle from "#/icons/check-circle-solid.svg?react";
-import XCircle from "#/icons/x-circle-solid.svg?react";
 import { OpenHandsAction } from "#/types/core/actions";
 import { OpenHandsObservation } from "#/types/core/observations";
 import { cn } from "#/utils/utils";
@@ -169,19 +168,12 @@ export function ExpandableMessage({
               )}
             </button>
           </span>
-          {type === "action" && success !== undefined && (
+          {type === "action" && success && (
             <span className="flex-shrink-0">
-              {success ? (
-                <CheckCircle
-                  data-testid="status-icon"
-                  className={cn(statusIconClasses, "fill-success")}
-                />
-              ) : (
-                <XCircle
-                  data-testid="status-icon"
-                  className={cn(statusIconClasses, "fill-danger")}
-                />
-              )}
+              <CheckCircle
+                data-testid="status-icon"
+                className={cn(statusIconClasses, "fill-success")}
+              />
             </span>
           )}
         </div>


### PR DESCRIPTION
Red X icons on failed actions are too visually prominent and cause unnecessary user concern even when the agent is iterating normally or the error is harmless. This is a follow-up to the same change made in SuccessIndicator.

- Remove XCircle import and error icon rendering
- Update test to expect no icon for failed actions

## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:0431703-nikolaik   --name openhands-app-0431703   docker.openhands.dev/openhands/openhands:0431703
```