### PR TITLE
Fix: don't double count v1 conversation metadata 

### DIFF
--- a/enterprise/integrations/github/github_view.py
+++ b/enterprise/integrations/github/github_view.py
@@ -191,16 +191,15 @@ class GithubIssue(ResolverViewInterface):
                 conversation_id=uuid4().hex, selected_repository=self.full_repo_name
             )
 
-        else:
-            conversation_metadata: ConversationMetadata = await initialize_conversation(  # type: ignore[assignment]
-                user_id=self.user_info.keycloak_user_id,
-                conversation_id=None,
-                selected_repository=self.full_repo_name,
-                selected_branch=None,
-                conversation_trigger=ConversationTrigger.RESOLVER,
-                git_provider=ProviderType.GITHUB,
-            )
-            self.conversation_id = conversation_metadata.conversation_id
+        conversation_metadata: ConversationMetadata = await initialize_conversation(  # type: ignore[assignment]
+            user_id=self.user_info.keycloak_user_id,
+            conversation_id=None,
+            selected_repository=self.full_repo_name,
+            selected_branch=None,
+            conversation_trigger=ConversationTrigger.RESOLVER,
+            git_provider=ProviderType.GITHUB,
+        )
+        self.conversation_id = conversation_metadata.conversation_id
         return conversation_metadata
 
     async def create_new_conversation(


### PR DESCRIPTION
## Summary of PR

Previously we were saving V1 conversations to `conversation_metadata` table. However, V1 conversations use a separate table. Kicking off a resolver job would display two conversations in the pane listing even though only one was kicked off. 

This PR ensures that we only call `initialize_new_conversation` for V0 conversations. In the V1 case we return a dummy metadata.

<img width="720" height="268" alt="image" src="https://github.com/user-attachments/assets/db101366-c4ad-420e-9dcd-670e6ef80e1c" />
 


## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:cd71dbf-nikolaik   --name openhands-app-cd71dbf   docker.openhands.dev/openhands/openhands:cd71dbf
```