### PR TITLE
fix: Prevent old instructions from being re-executed after conversation condensation

### DIFF
--- a/openhands/memory/view.py
+++ b/openhands/memory/view.py
@@ -18,6 +18,8 @@ class View(BaseModel):
 
     events: list[Event]
     unhandled_condensation_request: bool = False
+    # Set of event IDs that have been forgotten/condensed
+    forgotten_event_ids: set[int] = set()
 
     def __len__(self) -> int:
         return len(self.events)
@@ -90,4 +92,5 @@ class View(BaseModel):
         return View(
             events=kept_events,
             unhandled_condensation_request=unhandled_condensation_request,
+            forgotten_event_ids=forgotten_event_ids,
         )

--- a/tests/unit/agenthub/test_agents.py
+++ b/tests/unit/agenthub/test_agents.py
@@ -393,7 +393,7 @@ def test_mismatched_tool_call_events_and_auto_add_system_message(
     # 2. The action message
     # 3. The observation message
     mock_state.history = [initial_user_message, action, observation]
-    messages = agent._get_messages(mock_state.history, initial_user_message)
+    messages = agent._get_messages(mock_state.history, initial_user_message, set())
     assert len(messages) == 4  # System + initial user + action + observation
     assert messages[0].role == 'system'  # First message should be the system message
     assert (
@@ -404,7 +404,7 @@ def test_mismatched_tool_call_events_and_auto_add_system_message(
 
     # The same should hold if the events are presented out-of-order
     mock_state.history = [initial_user_message, observation, action]
-    messages = agent._get_messages(mock_state.history, initial_user_message)
+    messages = agent._get_messages(mock_state.history, initial_user_message, set())
     assert len(messages) == 4
     assert messages[0].role == 'system'  # First message should be the system message
     assert (
@@ -414,7 +414,7 @@ def test_mismatched_tool_call_events_and_auto_add_system_message(
     # If only one of the two events is present, then we should just get the system message
     # plus any valid message from the event
     mock_state.history = [initial_user_message, action]
-    messages = agent._get_messages(mock_state.history, initial_user_message)
+    messages = agent._get_messages(mock_state.history, initial_user_message, set())
     assert (
         len(messages) == 2
     )  # System + initial user message, action is waiting for its observation
@@ -422,7 +422,7 @@ def test_mismatched_tool_call_events_and_auto_add_system_message(
     assert messages[1].role == 'user'
 
     mock_state.history = [initial_user_message, observation]
-    messages = agent._get_messages(mock_state.history, initial_user_message)
+    messages = agent._get_messages(mock_state.history, initial_user_message, set())
     assert (
         len(messages) == 2
     )  # System + initial user message, observation has no matching action

--- a/tests/unit/agenthub/test_prompt_caching.py
+++ b/tests/unit/agenthub/test_prompt_caching.py
@@ -80,7 +80,7 @@ def test_get_messages(codeact_agent: CodeActAgent):
     history.append(message_action_5)
 
     codeact_agent.reset()
-    messages = codeact_agent._get_messages(history, message_action_1)
+    messages = codeact_agent._get_messages(history, message_action_1, set())
 
     assert (
         len(messages) == 6
@@ -122,7 +122,7 @@ def test_get_messages_prompt_caching(codeact_agent: CodeActAgent):
         history.append(message_action_agent)
 
     codeact_agent.reset()
-    messages = codeact_agent._get_messages(history, initial_user_message)
+    messages = codeact_agent._get_messages(history, initial_user_message, set())
 
     # Check that only the last two user messages have cache_prompt=True
     cached_user_messages = [


### PR DESCRIPTION
## Summary

This PR fixes issue #11910 where old user instructions were being re-executed after conversation condensation.

### The Bug

In long-running conversations, when the conversation history was condensed/summarized:
- The initial user message containing old instructions was always extracted from the **full** history (which is never modified by condensation)
- This message was then re-inserted into the condensed history
- The LLM saw both the condensation summary AND the original verbatim instruction
- This caused the LLM to sometimes re-execute already-completed tasks

### The Fix

The fix tracks which event IDs have been "forgotten" (condensed) and prevents the initial user message from being re-inserted if its ID is in the forgotten set.

**Key changes:**
- `View` class now tracks `forgotten_event_ids`
- `_ensure_initial_user_message()` checks if the initial user action has been condensed before re-inserting
- If condensed, the message is NOT re-inserted - the condensation summary already contains the context

### Files Changed

- `openhands/memory/view.py` - Added `forgotten_event_ids` field to View
- `openhands/agenthub/codeact_agent/codeact_agent.py` - Pass forgotten IDs through the chain
- `openhands/memory/conversation_memory.py` - Check if initial message is condensed before re-inserting
- `tests/unit/memory/test_conversation_memory.py` - Added tests for the fix + updated existing tests

## Test plan

- [x] Added unit test `test_ensure_initial_user_message_not_reinserted_when_condensed` - verifies condensed messages are not re-inserted
- [x] Added unit test `test_ensure_initial_user_message_reinserted_when_not_condensed` - ensures backward compatibility
- [x] Added integration test `test_process_events_does_not_reinsert_condensed_initial_message` - tests the full flow
- [x] Updated existing tests to pass `forgotten_event_ids` parameter
- [ ] Manual testing with long-running conversations and condensation enabled

Closes #11910