### PR TITLE
fix: Prevent avatar context menu from closing on diagonal cursor movement

### DIFF
--- a/frontend/src/components/features/sidebar/user-actions.tsx
+++ b/frontend/src/components/features/sidebar/user-actions.tsx
@@ -56,7 +56,13 @@ export function UserActions({ onLogout, user, isLoading }: UserActionsProps) {
       {(shouldShowUserActions || isOSS) && (
         <div
           className={cn(
-            "opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto",
+            // Base styles: hidden by default with smooth transition
+            "opacity-0 pointer-events-none transition-all duration-200",
+            // Show on parent hover (avatar)
+            "group-hover:opacity-100 group-hover:pointer-events-auto",
+            // Keep visible when hovering directly on menu (fixes diagonal cursor movement)
+            "hover:opacity-100 hover:pointer-events-auto",
+            // Show when menu is explicitly toggled via click
             showMenu && "opacity-100 pointer-events-auto",
           )}
         >


### PR DESCRIPTION
## Summary

Fixes #11933 - Avatar context menu closes when moving cursor diagonally to menu (hover zone gap)

### Problem

When hovering over the avatar in the sidebar, a context menu appears to the right. To interact with menu items, users naturally move their cursor diagonally from the avatar toward the menu. However, this diagonal path exits the parent container's hover zone momentarily, causing the menu to disappear before users can reach it.

This is a classic "hover intent" UX problem.

### Solution

Applied the same pattern already used successfully in `tools-context-menu.tsx`:

1. **Added `transition-all duration-200`** - Smooth transitions prevent jarring state changes and give users a small window during cursor movement
2. **Added `hover:opacity-100 hover:pointer-events-auto`** - Direct hover on the menu container keeps it visible once the cursor reaches it

### How It Works

```tsx
className={cn(
  // Base styles: hidden by default with smooth transition
  "opacity-0 pointer-events-none transition-all duration-200",
  // Show on parent hover (avatar)
  "group-hover:opacity-100 group-hover:pointer-events-auto",
  // Keep visible when hovering directly on menu (fixes diagonal cursor movement)
  "hover:opacity-100 hover:pointer-events-auto",
  // Show when menu is explicitly toggled via click
  showMenu && "opacity-100 pointer-events-auto",
)}
```

- `group-hover` triggers the menu to appear when hovering the avatar
- Direct `hover` on the menu container keeps it visible once the cursor reaches it
- The 200ms transition creates a smoother experience

## Test plan

- [x] Hover over avatar - menu appears
- [x] Move cursor diagonally from avatar to menu - menu stays visible
- [x] Click avatar - menu toggles correctly
- [x] Click outside menu - menu closes
- [x] Existing functionality preserved

Fixes #11933