### PR TITLE
refactor(frontend): rename settings organization members route to settings org members for consistency

### DIFF
--- a/frontend/__tests__/components/features/user/user-context-menu.test.tsx
+++ b/frontend/__tests__/components/features/user/user-context-menu.test.tsx
@@ -74,8 +74,7 @@ describe("UserContextMenu", () => {
     // Verify that navigation items are rendered (except organization-members/org which are filtered out)
     SAAS_NAV_ITEMS.filter(
       (item) =>
-        item.to !== "/settings/organization-members" &&
-        item.to !== "/settings/org",
+        item.to !== "/settings/org-members" && item.to !== "/settings/org",
     ).forEach((item) => {
       expect(screen.getByText(item.text)).toBeInTheDocument();
     });
@@ -238,7 +237,7 @@ describe("UserContextMenu", () => {
     expect(integrationsLink).toHaveAttribute("href", "/settings/integrations");
   });
 
-  it("should navigate to /settings/organization-members when Manage Organization Members is clicked", async () => {
+  it("should navigate to /settings/org-members when Manage Organization Members is clicked", async () => {
     renderUserContextMenu({ type: "admin", onClose: vi.fn });
 
     const manageOrganizationMembersButton = screen.getByText(
@@ -247,7 +246,7 @@ describe("UserContextMenu", () => {
     await userEvent.click(manageOrganizationMembersButton);
 
     expect(navigateMock).toHaveBeenCalledExactlyOnceWith(
-      "/settings/organization-members",
+      "/settings/org-members",
     );
   });
 

--- a/frontend/__tests__/routes/manage-organization-members.test.tsx
+++ b/frontend/__tests__/routes/manage-organization-members.test.tsx
@@ -35,7 +35,7 @@ const RouteStub = createRoutesStub([
     children: [
       {
         Component: ManageOrganizationMembersWithPortalRoot,
-        path: "/settings/organization-members",
+        path: "/settings/org-members",
       },
       {
         Component: () => <div data-testid="user-settings" />,
@@ -79,7 +79,7 @@ describe("Manage Organization Members Route", () => {
   });
 
   const renderManageOrganizationMembers = () =>
-    render(<RouteStub initialEntries={["/settings/organization-members"]} />, {
+    render(<RouteStub initialEntries={["/settings/org-members"]} />, {
       wrapper: ({ children }) => (
         <QueryClientProvider client={queryClient}>
           {children}

--- a/frontend/src/components/features/settings/settings-navigation.tsx
+++ b/frontend/src/components/features/settings/settings-navigation.tsx
@@ -100,7 +100,7 @@ export function SettingsNavigation({
             .filter((navItem) => {
               // if user is not an admin or no org is selected, do not show organization members/org settings
               if (
-                (navItem.to === "/settings/organization-members" ||
+                (navItem.to === "/settings/org-members" ||
                   navItem.to === "/settings/org") &&
                 (isUser || !orgId)
               ) {

--- a/frontend/src/components/features/user/user-context-menu.tsx
+++ b/frontend/src/components/features/user/user-context-menu.tsx
@@ -65,8 +65,7 @@ export function UserContextMenu({ type, onClose }: UserContextMenuProps) {
   // Filter out organization members/org nav items since they're already handled separately in the menu
   let navItems = (isOss ? OSS_NAV_ITEMS : SAAS_NAV_ITEMS).filter(
     (item) =>
-      item.to !== "/settings/organization-members" &&
-      item.to !== "/settings/org",
+      item.to !== "/settings/org-members" && item.to !== "/settings/org",
   );
   // Hide LLM settings when the feature flag is enabled
   if (config?.FEATURE_FLAGS?.HIDE_LLM_SETTINGS) {
@@ -88,7 +87,7 @@ export function UserContextMenu({ type, onClose }: UserContextMenuProps) {
   };
 
   const handleManageOrganizationMembersClick = () => {
-    navigate("/settings/organization-members");
+    navigate("/settings/org-members");
     onClose();
   };
 

--- a/frontend/src/constants/settings-nav.tsx
+++ b/frontend/src/constants/settings-nav.tsx
@@ -55,7 +55,7 @@ export const SAAS_NAV_ITEMS: SettingsNavItem[] = [
     text: "SETTINGS$NAV_MCP",
   },
   {
-    to: "/settings/organization-members",
+    to: "/settings/org-members",
     text: "Organization Members",
     icon: <FiUsers size={22} />,
   },

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -18,7 +18,7 @@ export default [
       route("billing", "routes/billing.tsx"),
       route("secrets", "routes/secrets-settings.tsx"),
       route("api-keys", "routes/api-keys.tsx"),
-      route("organization-members", "routes/manage-organization-members.tsx"),
+      route("org-members", "routes/manage-organization-members.tsx"),
       route("org", "routes/manage-org.tsx"),
     ]),
     route("conversations/:conversationId", "routes/conversation.tsx"),


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

Since the Organization settings are located at /settings/org, we should apply the same structure for the Members section.

We can refer to the video below for the output of the pull request.

https://github.com/user-attachments/assets/3b09d511-b2d0-4a91-b7c3-0e9a74a829ad

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:88ccd17-nikolaik   --name openhands-app-88ccd17   docker.openhands.dev/openhands/openhands:88ccd17
```