### PR TITLE
Add environment variable kill switch for V1 conversation creation

### DIFF
--- a/enterprise/integrations/github/github_view.py
+++ b/enterprise/integrations/github/github_view.py
@@ -13,7 +13,7 @@ from integrations.resolver_context import ResolverUserContext
 from integrations.types import ResolverViewInterface, UserData
 from integrations.utils import (
     ENABLE_PROACTIVE_CONVERSATION_STARTERS,
-    ENABLE_V1_CONVERSATIONS,
+    ENABLE_V1_GITHUB_RESOLVER,
     HOST,
     HOST_URL,
     get_oh_labels,
@@ -102,7 +102,7 @@ async def get_user_v1_enabled_setting(user_id: str) -> bool:
         the user's individual setting. Both must be true for the function to return true.
     """
     # Check the global environment variable first
-    if not ENABLE_V1_CONVERSATIONS:
+    if not ENABLE_V1_GITHUB_RESOLVER:
         return False
 
     config = get_config()

--- a/enterprise/integrations/utils.py
+++ b/enterprise/integrations/utils.py
@@ -51,9 +51,9 @@ ENABLE_SOLVABILITY_ANALYSIS = (
     os.getenv('ENABLE_SOLVABILITY_ANALYSIS', 'false').lower() == 'true'
 )
 
-# Toggle for V1 conversation creation feature
-ENABLE_V1_CONVERSATIONS = (
-    os.getenv('ENABLE_V1_CONVERSATIONS', 'false').lower() == 'true'
+# Toggle for V1 GitHub resolver feature
+ENABLE_V1_GITHUB_RESOLVER = (
+    os.getenv('ENABLE_V1_GITHUB_RESOLVER', 'false').lower() == 'true'
 )
 
 

--- a/enterprise/tests/unit/test_get_user_v1_enabled_setting.py
+++ b/enterprise/tests/unit/test_get_user_v1_enabled_setting.py
@@ -36,13 +36,21 @@ def mock_session_maker():
 
 
 @pytest.fixture
-def mock_dependencies(mock_settings_store, mock_config, mock_session_maker, mock_user_settings):
+def mock_dependencies(
+    mock_settings_store, mock_config, mock_session_maker, mock_user_settings
+):
     """Fixture that patches all the common dependencies."""
-    with patch('integrations.github.github_view.SaasSettingsStore', return_value=mock_settings_store) as mock_store_class, \
-         patch('integrations.github.github_view.get_config', return_value=mock_config) as mock_get_config, \
-         patch('integrations.github.github_view.session_maker', mock_session_maker), \
-         patch('integrations.github.github_view.call_sync_from_async', return_value=mock_user_settings) as mock_call_sync:
-        
+    with patch(
+        'integrations.github.github_view.SaasSettingsStore',
+        return_value=mock_settings_store,
+    ) as mock_store_class, patch(
+        'integrations.github.github_view.get_config', return_value=mock_config
+    ) as mock_get_config, patch(
+        'integrations.github.github_view.session_maker', mock_session_maker
+    ), patch(
+        'integrations.github.github_view.call_sync_from_async',
+        return_value=mock_user_settings,
+    ) as mock_call_sync:
         yield {
             'store_class': mock_store_class,
             'get_config': mock_get_config,
@@ -57,32 +65,46 @@ class TestGetUserV1EnabledSetting:
     """Test cases for get_user_v1_enabled_setting function."""
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("env_var_enabled,user_setting_enabled,expected_result", [
-        (False, True, False),   # Env var disabled, user enabled -> False
-        (True, False, False),   # Env var enabled, user disabled -> False  
-        (True, True, True),     # Both enabled -> True
-        (False, False, False),  # Both disabled -> False
-    ])
-    async def test_v1_enabled_combinations(self, mock_dependencies, env_var_enabled, user_setting_enabled, expected_result):
+    @pytest.mark.parametrize(
+        'env_var_enabled,user_setting_enabled,expected_result',
+        [
+            (False, True, False),  # Env var disabled, user enabled -> False
+            (True, False, False),  # Env var enabled, user disabled -> False
+            (True, True, True),  # Both enabled -> True
+            (False, False, False),  # Both disabled -> False
+        ],
+    )
+    async def test_v1_enabled_combinations(
+        self, mock_dependencies, env_var_enabled, user_setting_enabled, expected_result
+    ):
         """Test all combinations of environment variable and user setting values."""
         mock_dependencies['user_settings'].v1_enabled = user_setting_enabled
-        
-        with patch('integrations.github.github_view.ENABLE_V1_CONVERSATIONS', env_var_enabled):
+
+        with patch(
+            'integrations.github.github_view.ENABLE_V1_GITHUB_RESOLVER', env_var_enabled
+        ):
             result = await get_user_v1_enabled_setting('test_user_id')
             assert result is expected_result
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("env_var_value,env_var_bool,expected_result", [
-        ('false', False, False),  # Environment variable 'false' -> False
-        ('true', True, True),     # Environment variable 'true' -> True
-    ])
-    async def test_environment_variable_integration(self, mock_dependencies, env_var_value, env_var_bool, expected_result):
-        """Test that the function properly reads the ENABLE_V1_CONVERSATIONS environment variable."""
+    @pytest.mark.parametrize(
+        'env_var_value,env_var_bool,expected_result',
+        [
+            ('false', False, False),  # Environment variable 'false' -> False
+            ('true', True, True),  # Environment variable 'true' -> True
+        ],
+    )
+    async def test_environment_variable_integration(
+        self, mock_dependencies, env_var_value, env_var_bool, expected_result
+    ):
+        """Test that the function properly reads the ENABLE_V1_GITHUB_RESOLVER environment variable."""
         mock_dependencies['user_settings'].v1_enabled = True
 
-        with patch.dict(os.environ, {'ENABLE_V1_CONVERSATIONS': env_var_value}), \
-             patch('integrations.utils.os.getenv', return_value=env_var_value), \
-             patch('integrations.github.github_view.ENABLE_V1_CONVERSATIONS', env_var_bool):
+        with patch.dict(
+            os.environ, {'ENABLE_V1_GITHUB_RESOLVER': env_var_value}
+        ), patch('integrations.utils.os.getenv', return_value=env_var_value), patch(
+            'integrations.github.github_view.ENABLE_V1_GITHUB_RESOLVER', env_var_bool
+        ):
             result = await get_user_v1_enabled_setting('test_user_id')
             assert result is expected_result
 
@@ -90,21 +112,21 @@ class TestGetUserV1EnabledSetting:
     async def test_function_calls_correct_methods(self, mock_dependencies):
         """Test that the function calls the correct methods with correct parameters."""
         mock_dependencies['user_settings'].v1_enabled = True
-        
-        with patch('integrations.github.github_view.ENABLE_V1_CONVERSATIONS', True):
+
+        with patch('integrations.github.github_view.ENABLE_V1_GITHUB_RESOLVER', True):
             result = await get_user_v1_enabled_setting('test_user_123')
-            
+
             # Verify the result
             assert result is True
-            
+
             # Verify correct methods were called with correct parameters
             mock_dependencies['get_config'].assert_called_once()
             mock_dependencies['store_class'].assert_called_once_with(
                 user_id='test_user_123',
                 session_maker=mock_dependencies['session_maker'],
-                config=mock_dependencies['get_config'].return_value
+                config=mock_dependencies['get_config'].return_value,
             )
             mock_dependencies['call_sync'].assert_called_once_with(
                 mock_dependencies['settings_store'].get_user_settings_by_keycloak_id,
-                'test_user_123'
+                'test_user_123',
             )


### PR DESCRIPTION
## Summary of PR

This PR adds an environment variable kill switch (`ENABLE_V1_CONVERSATIONS`) for V1 conversation creation in the GitHub resolver. The feature provides administrators with the ability to globally disable V1 conversations while still respecting individual user preferences when enabled.

### Key Changes:
- **Environment Variable**: Added `ENABLE_V1_CONVERSATIONS` to `enterprise/integrations/utils.py` (defaults to `false`)
- **Dual-Gate Logic**: Updated `get_user_v1_enabled_setting()` to require both the environment variable AND user setting to be `true`
- **Performance Optimization**: Short-circuit logic avoids database calls when the environment variable is disabled
- **Comprehensive Tests**: Added parameterized unit tests covering all combinations of environment variable and user setting values

### Behavior:
- `ENABLE_V1_CONVERSATIONS=false` (default): V1 conversations disabled globally, regardless of user settings
- `ENABLE_V1_CONVERSATIONS=true`: V1 conversations enabled only when both environment variable and user's `v1_enabled` setting are `true`

## Change Type

- [x] New feature

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has reviewed and tested the changes. -->

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

This implements the requested kill switch functionality for V1 conversation creation.

## Release Notes

- [x] Include this change in the Release Notes.

Added environment variable kill switch (`ENABLE_V1_CONVERSATIONS`) for V1 conversation creation in GitHub resolver. Administrators can now globally disable V1 conversations by setting this environment variable to `false` (default), providing better control over feature rollout and the ability to quickly disable the feature if needed.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1717379df3ec4390ac3f9d3a4d7aae3b)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:7e28a7a-nikolaik   --name openhands-app-7e28a7a   docker.openhands.dev/openhands/openhands:7e28a7a
```