### PR TITLE
feat(frontend): show full command on hover for truncated text

### DIFF
--- a/frontend/src/components/features/chat/mono-component.tsx
+++ b/frontend/src/components/features/chat/mono-component.tsx
@@ -1,6 +1,8 @@
 import { ReactNode } from "react";
 import EventLogger from "#/utils/event-logger";
 
+const MAX_DISPLAY_LENGTH = 80;
+
 const decodeHtmlEntities = (text: string): string => {
   const textarea = document.createElement("textarea");
   textarea.innerHTML = text;
@@ -10,25 +12,43 @@ const decodeHtmlEntities = (text: string): string => {
 function MonoComponent(props: { children?: ReactNode }) {
   const { children } = props;
 
-  const decodeString = (str: string): string => {
+  const processString = (str: string): ReactNode => {
     try {
-      return decodeHtmlEntities(str);
+      const decoded = decodeHtmlEntities(str);
+      const isTruncated = decoded.length > MAX_DISPLAY_LENGTH;
+      const displayText = isTruncated
+        ? `${decoded.substring(0, MAX_DISPLAY_LENGTH)}...`
+        : decoded;
+
+      if (isTruncated) {
+        return (
+          <span className="font-mono cursor-help" title={decoded}>
+            {displayText}
+          </span>
+        );
+      }
+
+      return <span className="font-mono">{displayText}</span>;
     } catch (e) {
       EventLogger.error(String(e));
-      return str;
+      return <span className="font-mono">{str}</span>;
     }
   };
 
   if (Array.isArray(children)) {
-    const processedChildren = children.map((child) =>
-      typeof child === "string" ? decodeString(child) : child,
+    const processedChildren = children.map((child, index) =>
+      typeof child === "string" ? (
+        <span key={index}>{processString(child)}</span>
+      ) : (
+        child
+      ),
     );
 
     return <strong className="font-mono">{processedChildren}</strong>;
   }
 
   if (typeof children === "string") {
-    return <strong className="font-mono">{decodeString(children)}</strong>;
+    return <strong>{processString(children)}</strong>;
   }
 
   return <strong className="font-mono">{children}</strong>;

--- a/frontend/src/components/v1/chat/event-content-helpers/get-event-content.tsx
+++ b/frontend/src/components/v1/chat/event-content-helpers/get-event-content.tsx
@@ -11,10 +11,6 @@ import { TaskTrackerObservation } from "#/types/v1/core/base/observation";
 import { SkillReadyEvent, isSkillReadyEvent } from "./create-skill-ready-event";
 import i18n from "#/i18n";
 
-const trimText = (text: string, maxLength: number): string => {
-  if (!text) return "";
-  return text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
-};
 
 // Helper function to create title from translation key
 const createTitleFromKey = (
@@ -53,7 +49,7 @@ const getActionEventTitle = (event: OpenHandsEvent): React.ReactNode => {
     case "TerminalAction":
       actionKey = "ACTION_MESSAGE$RUN";
       actionValues = {
-        command: trimText(event.action.command, 80),
+        command: event.action.command || "",
       };
       break;
     case "FileEditorAction":
@@ -124,9 +120,7 @@ const getObservationEventTitle = (event: OpenHandsEvent): React.ReactNode => {
     case "TerminalObservation":
       observationKey = "OBSERVATION_MESSAGE$RUN";
       observationValues = {
-        command: event.observation.command
-          ? trimText(event.observation.command, 80)
-          : "",
+        command: event.observation.command || "",
       };
       break;
     case "FileEditorObservation":


### PR DESCRIPTION
## Summary
- Update `MonoComponent` to handle text truncation with native tooltip
- Long commands (>80 chars) are now truncated with `...` but show full text on hover
- Added `cursor-help` style to indicate the text is hoverable
- Removed redundant `trimText` function from `get-event-content.tsx`

## Before
Long commands were truncated with no way to see the full text.

## After
Hovering over truncated commands shows the full command in a native browser tooltip.

## Test plan
- [x] All 648 frontend tests pass
- [x] Verify truncated commands show tooltip on hover

Fixes #11889