### PR TITLE
chore: remove pnpm settings from npmrc

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,2 +1,0 @@
-public-hoist-pattern[]=*@nextui-org/*
-enable-pre-post-scripts=true


### PR DESCRIPTION
### Summary of PR

- Remove pnpm-only entries from `frontend/.npmrc` to stop npm warnings about unknown config keys. No other files changed.

## Change Type

- [x] Bug fix

fix: #12024

Resolves # (issue)

## Release Notes

- [ ] Include this change in the Release Notes.