### PR TITLE
Enable JSON logging for enterprise cloud deployments

### DIFF
--- a/enterprise/Dockerfile
+++ b/enterprise/Dockerfile
@@ -2,6 +2,9 @@ ARG OPENHANDS_VERSION=latest
 ARG BASE="ghcr.io/openhands/openhands"
 FROM ${BASE}:${OPENHANDS_VERSION}
 
+# Enable JSON logging for cloud deployments
+ENV LOG_JSON=1
+
 # Datadog labels
 LABEL com.datadoghq.tags.service="deploy"
 LABEL com.datadoghq.tags.env="${DD_ENV}"


### PR DESCRIPTION
## Problem

We've been seeing unstructured log messages in our cloud deployments, particularly from third-party libraries like LiteLLM:

```
LiteLLM completion() model= prod/claude-sonnet-4-5-20250929; provider = litellm_proxy
```

This is happening because the `LOG_JSON` environment variable is not set in the enterprise Dockerfile, causing logs to be emitted in plain text format instead of structured JSON.

## Solution

This PR adds `ENV LOG_JSON=1` to the enterprise Dockerfile to ensure that all logs (including those from third-party libraries) are properly formatted as JSON for cloud logging systems.

## Changes

- Set `LOG_JSON=1` environment variable in `enterprise/Dockerfile`
- Added comment explaining the purpose of this setting

## Benefits

- ✅ All logs will be properly structured as JSON
- ✅ Better parsing, filtering, and analysis in cloud environments (Google Cloud Logging, Datadog, etc.)
- ✅ Consistent logging format across all components
- ✅ Easier to query and alert on specific log patterns

## Testing

The enterprise logger code (`enterprise/server/logger.py`) already expects `LOG_JSON=1` and properly configures JSON logging when this variable is set. This change ensures the variable is set at the container level.

Co-authored-by: openhands <openhands@all-hands.dev>

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:c590153-nikolaik   --name openhands-app-c590153   docker.openhands.dev/openhands/openhands:c590153
```