### PR TITLE
fix(frontend): suppress expected console warnings in tests

### DIFF
--- a/frontend/__tests__/components/features/maintenance/maintenance-banner.test.tsx
+++ b/frontend/__tests__/components/features/maintenance/maintenance-banner.test.tsx
@@ -48,9 +48,12 @@ describe("MaintenanceBanner", () => {
     expect(button).toBeInTheDocument();
   });
 
-  // maintenance-banner
-
   it("handles invalid date gracefully", () => {
+    // Suppress expected console.warn for invalid date parsing
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+
     const invalidTime = "invalid-date";
 
     render(
@@ -62,6 +65,9 @@ describe("MaintenanceBanner", () => {
     // Check if the banner is rendered
     const banner = screen.queryByTestId("maintenance-banner");
     expect(banner).not.toBeInTheDocument();
+
+    // Restore console.warn
+    consoleWarnSpy.mockRestore();
   });
 
   it("click on dismiss button removes banner", () => {

--- a/frontend/__tests__/conversation-websocket-handler.test.tsx
+++ b/frontend/__tests__/conversation-websocket-handler.test.tsx
@@ -6,6 +6,7 @@ import {
   beforeEach,
   afterAll,
   afterEach,
+  vi,
 } from "vitest";
 import { screen, waitFor, render, cleanup } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -141,6 +142,11 @@ describe("Conversation WebSocket Handler", () => {
     });
 
     it("should handle malformed/invalid event data gracefully", async () => {
+      // Suppress expected console.warn for invalid JSON parsing
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
       // Set up MSW to send various invalid events when connection is established
       mswServer.use(
         wsLink.addEventListener("connection", ({ client, server }) => {
@@ -203,6 +209,9 @@ describe("Conversation WebSocket Handler", () => {
         "valid-event-123",
       );
       expect(screen.getByTestId("ui-events-count")).toHaveTextContent("1");
+
+      // Restore console.warn
+      consoleWarnSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `console.warn` mock in WebSocket malformed data test
- Add `console.warn` mock in maintenance banner invalid date test

These warnings are expected behavior for error handling tests.

## Test plan
- [x] All 648 tests pass
- [x] lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)