### PR TITLE
fix(frontend): clicking think block in conversation pane breaks ui (v1 conversations)

### DIFF
--- a/frontend/src/components/v1/chat/event-content-helpers/get-event-content.tsx
+++ b/frontend/src/components/v1/chat/event-content-helpers/get-event-content.tsx
@@ -159,6 +159,9 @@ const getObservationEventTitle = (event: OpenHandsEvent): React.ReactNode => {
       }
       break;
     }
+    case "ThinkObservation":
+      observationKey = "OBSERVATION_MESSAGE$THINK";
+      break;
     default:
       // For unknown observations, use the type name
       return observationType.replace("Observation", "").toUpperCase();

--- a/frontend/src/components/v1/chat/event-content-helpers/get-observation-content.ts
+++ b/frontend/src/components/v1/chat/event-content-helpers/get-observation-content.ts
@@ -190,7 +190,13 @@ const getThinkObservationContent = (
   event: ObservationEvent<ThinkObservation>,
 ): string => {
   const { observation } = event;
-  return observation.content || "";
+
+  const textContent = observation.content
+    .filter((c) => c.type === "text")
+    .map((c) => c.text)
+    .join("\n");
+
+  return textContent || "";
 };
 
 const getFinishObservationContent = (

--- a/frontend/src/types/v1/core/base/observation.ts
+++ b/frontend/src/types/v1/core/base/observation.ts
@@ -36,7 +36,7 @@ export interface ThinkObservation extends ObservationBase<"ThinkObservation"> {
   /**
    * Confirmation message. DEFAULT: "Your thought has been logged."
    */
-  content: string;
+  content: Array<TextContent | ImageContent>;
 }
 
 export interface BrowserObservation extends ObservationBase<"BrowserObservation"> {


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

Currently, clicking the ‘Think’ block in the conversation pane causes the UI to break in v1 conversations.

https://github.com/user-attachments/assets/ee7a65ee-2b34-4f31-883a-cbe66d576933

We can refer to the video below for the output of the pull request.

https://github.com/user-attachments/assets/0ed5b5aa-8044-4c21-b6e9-71a4032c351a

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:4141548-nikolaik   --name openhands-app-4141548   docker.openhands.dev/openhands/openhands:4141548
```