### PR TITLE
Fix for frontend stall

### DIFF
--- a/frontend/src/utils/parse-terminal-output.ts
+++ b/frontend/src/utils/parse-terminal-output.ts
@@ -15,13 +15,13 @@ const START = "[Python Interpreter: ";
  * console.log(parsed.symbol); // openhands@659478cb008c:/workspace $
  */
 export const parseTerminalOutput = (raw: string) => {
-  let start = raw.indexOf(START);
+  const start = raw.indexOf(START);
   if (start < 0) {
     return raw;
   }
-  start += START.length;
-  const end = raw.indexOf("]", start);
-  if (end <= start) {
+  const offset = start + START.length;
+  const end = raw.indexOf("]", offset);
+  if (end <= offset) {
     return raw;
   }
   return raw.substring(0, start).trim();


### PR DESCRIPTION
## Summary of PR

Replace a concise but inefficient regex with precise, explicit, efficient code.

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [X] I have read and reviewed the code and I understand what the code is doing.
- [X] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Fixes issue where frontend locks up when faced with certain inputs. For example - when an observation output is ~1/2 a Mb:
<img width="1286" height="375" alt="image" src="https://github.com/user-attachments/assets/7c50d78a-f3e1-42a3-aa9d-a949f5dae893" />

The browser tab often locks up an in unrecoverable state.


Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:e76a385-nikolaik   --name openhands-app-e76a385   docker.openhands.dev/openhands/openhands:e76a385
```