### PR TITLE
Fixed performance bug in remote sandbox service

### DIFF
--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -315,7 +315,9 @@ class RemoteSandboxService(SandboxService):
             for runtime in content['runtimes']:
                 if session_api_key == runtime['session_api_key']:
                     query = await self._secure_select()
-                    query = query.filter(StoredRemoteSandbox.id == runtime.get('session_id'))
+                    query = query.filter(
+                        StoredRemoteSandbox.id == runtime.get('session_id')
+                    )
                     result = await self.db_session.execute(query)
                     sandbox = result.first()
                     if sandbox is None:
@@ -346,7 +348,6 @@ class RemoteSandboxService(SandboxService):
     async def start_sandbox(self, sandbox_spec_id: str | None = None) -> SandboxInfo:
         """Start a new sandbox by creating a remote runtime."""
         try:
-
             # Enforce sandbox limits by cleaning up old sandboxes
             await self.pause_old_sandboxes(self.max_num_sandboxes - 1)
 


### PR DESCRIPTION
## Summary of PR

Nasty performance bug due to evolution. A week or two back, it was found that the url we use for webhook callbacks could not include the id of the conversation because this would mean it would have to be in the environment variables which would break warm runtimes. So it was removed and a method was devised to get the sandbox id based on nothing more than the session_api_key. Unfortunately, this introduced a nasty performance bug which is manifesting on production - Massive numbers of get requests are being fired at the runtime api.

This PR calls list which returns the currently running runtimes and uses this to get the session_id (Sandbox id) - rather than checking each of these in the runtime api one at a time.

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [X] I have read and reviewed the code and I understand what the code is doing.
- [X] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:72eda18-nikolaik   --name openhands-app-72eda18   docker.openhands.dev/openhands/openhands:72eda18
```