### PR TITLE
fix(frontend): resolve overlap between conversation panel and account context menu

### DIFF
--- a/frontend/src/components/features/conversation-panel/conversation-panel-wrapper.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-panel-wrapper.tsx
@@ -20,7 +20,7 @@ export function ConversationPanelWrapper({
   return ReactDOM.createPortal(
     <div
       className={cn(
-        "absolute h-full w-full left-0 top-0 z-[9999] bg-black/80 rounded-xl",
+        "absolute h-full w-full left-0 top-0 z-[100] bg-black/80 rounded-xl",
         pathname === "/" && "bottom-0 top-0 md:top-3 md:bottom-3 h-auto",
       )}
     >


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

As demonstrated in the video below, the conversation panel overlaps the account context menu.

https://github.com/user-attachments/assets/9240fce0-a320-4375-b97b-c21a3f384f39

We can refer to the video below for the output of the pull request.

https://github.com/user-attachments/assets/4b1ca692-0b6c-4d36-998d-dc82affa03e1

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #12078

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:36fc1f4-nikolaik   --name openhands-app-36fc1f4   docker.openhands.dev/openhands/openhands:36fc1f4
```