### PR TITLE
feat: Add sk-oh- prefix to OpenHands Cloud API keys

### DIFF
--- a/enterprise/storage/api_key_store.py
+++ b/enterprise/storage/api_key_store.py
@@ -17,10 +17,13 @@ from openhands.core.logger import openhands_logger as logger
 class ApiKeyStore:
     session_maker: sessionmaker
 
+    API_KEY_PREFIX = 'sk-oh-'
+
     def generate_api_key(self, length: int = 32) -> str:
-        """Generate a random API key."""
+        """Generate a random API key with the sk-oh- prefix."""
         alphabet = string.ascii_letters + string.digits
-        return ''.join(secrets.choice(alphabet) for _ in range(length))
+        random_part = ''.join(secrets.choice(alphabet) for _ in range(length))
+        return f'{self.API_KEY_PREFIX}{random_part}'
 
     def create_api_key(
         self, user_id: str, name: str | None = None, expires_at: datetime | None = None

--- a/enterprise/tests/unit/test_api_key_store.py
+++ b/enterprise/tests/unit/test_api_key_store.py
@@ -25,10 +25,12 @@ def api_key_store(mock_session_maker):
 
 
 def test_generate_api_key(api_key_store):
-    """Test that generate_api_key returns a string of the expected length."""
+    """Test that generate_api_key returns a string with sk-oh- prefix and expected length."""
     key = api_key_store.generate_api_key(length=32)
     assert isinstance(key, str)
-    assert len(key) == 32
+    assert key.startswith('sk-oh-')
+    # Total length should be prefix (6 chars) + random part (32 chars) = 38 chars
+    assert len(key) == len('sk-oh-') + 32
 
 
 def test_create_api_key(api_key_store, mock_session):


### PR DESCRIPTION
## Description
API keys generated by OpenHands Cloud now start with `sk-oh-` prefix for better identification and consistency with common API key patterns (similar to OpenAI's `sk-` prefix).

**Before:** `lZQ16HChNjeeVKaj373VrrNqa2vkXE3O`
**After:** `sk-oh-lZQ16HChNjeeVKaj373VrrNqa2vkXE3O`

## Changes
- Modified `generate_api_key()` in `enterprise/storage/api_key_store.py` to prepend `sk-oh-` prefix to generated keys
- Added `API_KEY_PREFIX` class constant for maintainability
- Updated tests to verify the new prefix behavior

## Testing
- Linting passes
- Manual tests verify:
  - Generated keys start with `sk-oh-`
  - Total key length is prefix (6 chars) + random part (32 chars) = 38 chars
  - Validation still works correctly (uses exact key match from database)

## Notes
- Existing API keys in the database will continue to work since validation uses exact key matching
- Only newly generated keys will have the prefix

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/17df2bf3fa8740dca61c6796c2644fa5)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:8b1ec9d-nikolaik   --name openhands-app-8b1ec9d   docker.openhands.dev/openhands/openhands:8b1ec9d
```