### PR TITLE
feat: support blocking specific email domains

### DIFF
--- a/enterprise/server/auth/constants.py
+++ b/enterprise/server/auth/constants.py
@@ -38,3 +38,8 @@ ROLE_CHECK_ENABLED = os.getenv('ROLE_CHECK_ENABLED', 'false').lower() in (
     'y',
     'on',
 )
+BLOCKED_EMAIL_DOMAINS = [
+    domain.strip().lower()
+    for domain in os.getenv('BLOCKED_EMAIL_DOMAINS', '').split(',')
+    if domain.strip()
+]

--- a/enterprise/server/auth/domain_blocker.py
+++ b/enterprise/server/auth/domain_blocker.py
@@ -1,0 +1,56 @@
+from server.auth.constants import BLOCKED_EMAIL_DOMAINS
+
+from openhands.core.logger import openhands_logger as logger
+
+
+class DomainBlocker:
+    def __init__(self) -> None:
+        logger.debug('Initializing DomainBlocker')
+        self.blocked_domains: list[str] = BLOCKED_EMAIL_DOMAINS
+        if self.blocked_domains:
+            logger.info(
+                f'Successfully loaded {len(self.blocked_domains)} blocked email domains: {self.blocked_domains}'
+            )
+
+    def is_active(self) -> bool:
+        """Check if domain blocking is enabled"""
+        return bool(self.blocked_domains)
+
+    def _extract_domain(self, email: str) -> str | None:
+        """Extract and normalize email domain from email address"""
+        if not email:
+            return None
+        try:
+            # Extract domain part after @
+            if '@' not in email:
+                return None
+            domain = email.split('@')[1].strip().lower()
+            return domain if domain else None
+        except Exception:
+            logger.debug(f'Error extracting domain from email: {email}', exc_info=True)
+            return None
+
+    def is_domain_blocked(self, email: str) -> bool:
+        """Check if email domain is blocked"""
+        if not self.is_active():
+            return False
+
+        if not email:
+            logger.debug('No email provided for domain check')
+            return False
+
+        domain = self._extract_domain(email)
+        if not domain:
+            logger.debug(f'Could not extract domain from email: {email}')
+            return False
+
+        is_blocked = domain in self.blocked_domains
+        if is_blocked:
+            logger.warning(f'Email domain {domain} is blocked for email: {email}')
+        else:
+            logger.debug(f'Email domain {domain} is not blocked')
+
+        return is_blocked
+
+
+domain_blocker = DomainBlocker()

--- a/enterprise/tests/unit/test_domain_blocker.py
+++ b/enterprise/tests/unit/test_domain_blocker.py
@@ -1,0 +1,181 @@
+"""Unit tests for DomainBlocker class."""
+
+import pytest
+from server.auth.domain_blocker import DomainBlocker
+
+
+@pytest.fixture
+def domain_blocker():
+    """Create a DomainBlocker instance for testing."""
+    return DomainBlocker()
+
+
+@pytest.mark.parametrize(
+    'blocked_domains,expected',
+    [
+        (['colsch.us', 'other-domain.com'], True),
+        (['example.com'], True),
+        ([], False),
+    ],
+)
+def test_is_active(domain_blocker, blocked_domains, expected):
+    """Test that is_active returns correct value based on blocked domains configuration."""
+    # Arrange
+    domain_blocker.blocked_domains = blocked_domains
+
+    # Act
+    result = domain_blocker.is_active()
+
+    # Assert
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    'email,expected_domain',
+    [
+        ('user@example.com', 'example.com'),
+        ('test@colsch.us', 'colsch.us'),
+        ('user.name@other-domain.com', 'other-domain.com'),
+        ('USER@EXAMPLE.COM', 'example.com'),  # Case insensitive
+        ('user@EXAMPLE.COM', 'example.com'),
+        ('  user@example.com  ', 'example.com'),  # Whitespace handling
+    ],
+)
+def test_extract_domain_valid_emails(domain_blocker, email, expected_domain):
+    """Test that _extract_domain correctly extracts and normalizes domains from valid emails."""
+    # Act
+    result = domain_blocker._extract_domain(email)
+
+    # Assert
+    assert result == expected_domain
+
+
+@pytest.mark.parametrize(
+    'email,expected',
+    [
+        (None, None),
+        ('', None),
+        ('invalid-email', None),
+        ('user@', None),  # Empty domain after @
+        ('no-at-sign', None),
+    ],
+)
+def test_extract_domain_invalid_emails(domain_blocker, email, expected):
+    """Test that _extract_domain returns None for invalid email formats."""
+    # Act
+    result = domain_blocker._extract_domain(email)
+
+    # Assert
+    assert result == expected
+
+
+def test_is_domain_blocked_when_inactive(domain_blocker):
+    """Test that is_domain_blocked returns False when blocking is not active."""
+    # Arrange
+    domain_blocker.blocked_domains = []
+
+    # Act
+    result = domain_blocker.is_domain_blocked('user@colsch.us')
+
+    # Assert
+    assert result is False
+
+
+def test_is_domain_blocked_with_none_email(domain_blocker):
+    """Test that is_domain_blocked returns False when email is None."""
+    # Arrange
+    domain_blocker.blocked_domains = ['colsch.us']
+
+    # Act
+    result = domain_blocker.is_domain_blocked(None)
+
+    # Assert
+    assert result is False
+
+
+def test_is_domain_blocked_with_empty_email(domain_blocker):
+    """Test that is_domain_blocked returns False when email is empty."""
+    # Arrange
+    domain_blocker.blocked_domains = ['colsch.us']
+
+    # Act
+    result = domain_blocker.is_domain_blocked('')
+
+    # Assert
+    assert result is False
+
+
+def test_is_domain_blocked_with_invalid_email(domain_blocker):
+    """Test that is_domain_blocked returns False when email format is invalid."""
+    # Arrange
+    domain_blocker.blocked_domains = ['colsch.us']
+
+    # Act
+    result = domain_blocker.is_domain_blocked('invalid-email')
+
+    # Assert
+    assert result is False
+
+
+def test_is_domain_blocked_domain_not_blocked(domain_blocker):
+    """Test that is_domain_blocked returns False when domain is not in blocked list."""
+    # Arrange
+    domain_blocker.blocked_domains = ['colsch.us', 'other-domain.com']
+
+    # Act
+    result = domain_blocker.is_domain_blocked('user@example.com')
+
+    # Assert
+    assert result is False
+
+
+def test_is_domain_blocked_domain_blocked(domain_blocker):
+    """Test that is_domain_blocked returns True when domain is in blocked list."""
+    # Arrange
+    domain_blocker.blocked_domains = ['colsch.us', 'other-domain.com']
+
+    # Act
+    result = domain_blocker.is_domain_blocked('user@colsch.us')
+
+    # Assert
+    assert result is True
+
+
+def test_is_domain_blocked_case_insensitive(domain_blocker):
+    """Test that is_domain_blocked performs case-insensitive domain matching."""
+    # Arrange
+    domain_blocker.blocked_domains = ['colsch.us']
+
+    # Act
+    result = domain_blocker.is_domain_blocked('user@COLSCH.US')
+
+    # Assert
+    assert result is True
+
+
+def test_is_domain_blocked_multiple_blocked_domains(domain_blocker):
+    """Test that is_domain_blocked correctly checks against multiple blocked domains."""
+    # Arrange
+    domain_blocker.blocked_domains = ['colsch.us', 'other-domain.com', 'blocked.org']
+
+    # Act
+    result1 = domain_blocker.is_domain_blocked('user@other-domain.com')
+    result2 = domain_blocker.is_domain_blocked('user@blocked.org')
+    result3 = domain_blocker.is_domain_blocked('user@allowed.com')
+
+    # Assert
+    assert result1 is True
+    assert result2 is True
+    assert result3 is False
+
+
+def test_is_domain_blocked_with_whitespace(domain_blocker):
+    """Test that is_domain_blocked handles emails with whitespace correctly."""
+    # Arrange
+    domain_blocker.blocked_domains = ['colsch.us']
+
+    # Act
+    result = domain_blocker.is_domain_blocked('  user@colsch.us  ')
+
+    # Assert
+    assert result is True


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

In our SaaS platform, there may be a need to block specific email domains to prevent account creation using those domains. Any accounts associated with the specified domains should therefore not be created.

The solution must be configurable, preferably through an environment variable.

**Acceptance Criteria:**
- Email domains specified in the environment variable are blocked.
- Accounts associated with the blocked email domains are not created in the SaaS platform.

We can refer to the videos below for the output of the pull request.

**Case 1:** No email domains are blocked.

https://github.com/user-attachments/assets/2a834322-5db3-4f29-9ad0-6f150ba3c515

**Case 2:** Specific email domains are blocked.

https://github.com/user-attachments/assets/5a3799bf-11fd-43f5-8695-c82787352fa7

**Case 3:** A user has already signed in; however, their email domain is subsequently blocked. As a result, the user is signed out and can no longer access SaaS services.

https://github.com/user-attachments/assets/986a9f0b-c0ac-40b8-8bb0-ed9b2e98c69b

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:335a7c0-nikolaik   --name openhands-app-335a7c0   docker.openhands.dev/openhands/openhands:335a7c0
```