### PR TITLE
Fix SANDBOX_VOLUMES not being passed to runtime containers

### DIFF
--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -137,6 +137,7 @@ def config_from_env() -> AppServerConfig:
     )
     from openhands.app_server.sandbox.docker_sandbox_service import (
         DockerSandboxServiceInjector,
+        VolumeMount,
     )
     from openhands.app_server.sandbox.docker_sandbox_spec_service import (
         DockerSandboxSpecServiceInjector,
@@ -175,7 +176,27 @@ def config_from_env() -> AppServerConfig:
         elif os.getenv('RUNTIME') in ('local', 'process'):
             config.sandbox = ProcessSandboxServiceInjector()
         else:
-            config.sandbox = DockerSandboxServiceInjector()
+            # Parse SANDBOX_VOLUMES environment variable to create mounts
+            mounts = []
+            sandbox_volumes = os.environ.get('SANDBOX_VOLUMES')
+            if sandbox_volumes:
+                # Support multiple volumes separated by commas
+                volume_specs = sandbox_volumes.split(',')
+                for spec in volume_specs:
+                    parts = spec.strip().split(':')
+                    if len(parts) >= 2:
+                        host_path = parts[0]
+                        container_path = parts[1]
+                        mode = parts[2] if len(parts) > 2 else 'rw'
+                        mounts.append(
+                            VolumeMount(
+                                host_path=host_path,
+                                container_path=container_path,
+                                mode=mode,
+                            )
+                        )
+
+            config.sandbox = DockerSandboxServiceInjector(mounts=mounts)
 
     if config.sandbox_spec is None:
         if os.getenv('RUNTIME') == 'remote':


### PR DESCRIPTION
## Problem

When `SANDBOX_VOLUMES` environment variable is set in the app server configuration, the volume mounts are not being passed to runtime containers (agent-server containers). This causes runtime containers to have isolated workspaces instead of accessing the volumes specified in `SANDBOX_VOLUMES`.

## Root Cause

In `openhands/app_server/config.py`, the `DockerSandboxServiceInjector` was being created without any `mounts` parameter:

```python
config.sandbox = DockerSandboxServiceInjector()
```

The `DockerSandboxServiceInjector` class has a `mounts` field that defaults to an empty list, but the configuration code wasn't reading `SANDBOX_VOLUMES` or passing any mounts.

## Solution

This PR adds logic to:
1. Parse the `SANDBOX_VOLUMES` environment variable (supports comma-separated volumes)
2. Create `VolumeMount` objects with `host_path`, `container_path`, and `mode`
3. Pass the mounts list to `DockerSandboxServiceInjector`

## Changes

- Added `VolumeMount` import from `docker_sandbox_service`
- Added volume parsing logic that handles the format: `/host/path:/container/path:mode`
- Supports multiple volumes separated by commas
- Passes parsed mounts to `DockerSandboxServiceInjector`

## Testing

Tested with `SANDBOX_VOLUMES=/host/workspace:/workspace:rw`:
- Runtime containers now correctly receive the volume mount
- Agent can access all files from the host volume
- File explorer shows complete directory structure

## Example Configuration

```bash
docker run -e SANDBOX_VOLUMES="/home/user/workspace:/workspace:rw" ...
```

Fixes issue where runtime containers couldn't access host volumes configured via `SANDBOX_VOLUMES`.