### PR TITLE
ALL-4531 Fix for issue where reconnect triggers jumping and scrolling

### DIFF
--- a/frontend/src/contexts/conversation-websocket-context.tsx
+++ b/frontend/src/contexts/conversation-websocket-context.tsx
@@ -602,6 +602,7 @@ export function ConversationWebSocketProvider({
         }
       },
       onClose: (event: CloseEvent) => {
+        queryParams.resend_all = false;
         setMainConnectionState("CLOSED");
         // Only show error message if we've previously connected successfully
         // This prevents showing errors during initial connection attempts (e.g., when auto-starting a conversation)


### PR DESCRIPTION
## Summary of PR

Websocket reconnections were done with `resend_all=true` resulting in duplicate events being displayed and weird scrolling behavior. We no longer reload all events when reconnecting.

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [X] I have read and reviewed the code and I understand what the code is doing.
- [X] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

## Testing

* Tested Navigating to Conversation
* Tested Navigating between conversations
* Tested refresh page
* Tested websocket disconnect. (Reconnected)
* Tested websocket disconnect and navigate to different conversation.

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.
