### PR TITLE
hotfix(frontend): set terminal background color for `xterm.js` 6.0.0 compatibility

### DIFF
--- a/frontend/src/hooks/use-terminal.ts
+++ b/frontend/src/hooks/use-terminal.ts
@@ -89,10 +89,9 @@ export const useTerminal = () => {
       scrollback: 10000,
       scrollSensitivity: 1,
       fastScrollSensitivity: 5,
-      allowTransparency: true,
       disableStdin: true, // Make terminal read-only
       theme: {
-        background: "transparent",
+        background: "#25272D",
       },
     });
 


### PR DESCRIPTION

## Summary of PR

Problem: After upgrading to `xterm.js` 6.0.0, the terminal in the conversations panel displayed a black background instead of matching the container's background color.

<img width="568" height="216" alt="image" src="https://github.com/user-attachments/assets/3035671e-f27e-44e2-ba21-cbb675fc4483" />

Fix: Set an explicit background color (`#25272D`) in the terminal theme config to match the container, instead of relying on transparent which no longer works correctly.

<img width="577" height="232" alt="image" src="https://github.com/user-attachments/assets/a2e3618a-7bcb-489c-abe2-7e9a90c4de5a" />


## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:f1bf9ac-nikolaik   --name openhands-app-f1bf9ac   docker.openhands.dev/openhands/openhands:f1bf9ac
```