### PR TITLE
fix(ci): update PAT_TOKEN to ALLHANDS_BOT_GITHUB_PAT for enterprise preview

### DIFF
--- a/.github/workflows/enterprise-preview.yml
+++ b/.github/workflows/enterprise-preview.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Trigger remote job
         run: |
           curl --fail-with-body -sS -X POST \
-            -H "Authorization: Bearer ${{ secrets.PAT_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}" \
             -H "Accept: application/vnd.github+json" \
             -d "{\"ref\": \"main\", \"inputs\": {\"openhandsPrNumber\": \"${{ github.event.pull_request.number }}\", \"deployEnvironment\": \"feature\", \"enterpriseImageTag\": \"pr-${{ github.event.pull_request.number }}\" }}" \
             https://api.github.com/repos/OpenHands/deploy/actions/workflows/deploy.yaml/dispatches

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -247,7 +247,7 @@ jobs:
       - name: Trigger remote job
         run: |
           curl --fail-with-body -sS -X POST \
-            -H "Authorization: Bearer ${{ secrets.PAT_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}" \
             -H "Accept: application/vnd.github+json" \
             -d "{\"ref\": \"main\", \"inputs\": {\"openhandsPrNumber\": \"${{ github.event.pull_request.number }}\", \"deployEnvironment\": \"feature\", \"enterpriseImageTag\": \"pr-${{ github.event.pull_request.number }}\" }}" \
             https://api.github.com/repos/OpenHands/deploy/actions/workflows/deploy.yaml/dispatches


### PR DESCRIPTION
## Summary of PR

Fixes the "Bad credentials" error in the enterprise preview deploy job by updating the token secret name from `PAT_TOKEN` to `ALLHANDS_BOT_GITHUB_PAT`.

**Root cause:** The enterprise preview workflow was failing at the "Trigger remote job" step with a "Bad credentials" error when trying to dispatch a workflow on the `OpenHands/deploy` repository. This indicates the `PAT_TOKEN` secret is either expired, revoked, or not properly configured.

**Fix:** Updated the secret reference from `secrets.PAT_TOKEN` to `secrets.ALLHANDS_BOT_GITHUB_PAT` in both:
- `.github/workflows/enterprise-preview.yml`
- `.github/workflows/ghcr-build.yml`

**Note:** The `openhands-resolver.yml` workflow also uses `PAT_TOKEN` but with a fallback to `github.token`, so it was left unchanged as it serves a different purpose.

## Change Type

- [x] Bug fix

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves the failing deploy job: https://github.com/OpenHands/OpenHands/actions/runs/20600843486/job/59165834604?pr=12200

## Release Notes

- [ ] Include this change in the Release Notes.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c2388b565436496f8ffc05737a843cae)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:0e7dc78-nikolaik   --name openhands-app-0e7dc78   docker.openhands.dev/openhands/openhands:0e7dc78
```