### PR TITLE
doc: correct Slack channel to #dev-ui-ux

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ We're always looking to improve the look and feel of the application. If you've 
 for something that's bugging you, feel free to open up a PR that changes the [`./frontend`](./frontend) directory.
 
 If you're looking to make a bigger change, add a new UI element, or significantly alter the style
-of the application, please open an issue first, or better, join the #eng-ui-ux channel in our Slack
+of the application, please open an issue first, or better, join the #dev-ui-ux channel in our Slack
 to gather consensus from our design team first.
 
 #### Improving the agent


### PR DESCRIPTION
## Summary of PR

This PR fixes an incorrect Slack channel reference in `CONTRIBUTING.md`. The documentation currently points contributors to `#eng-ui-ux`, but the correct and active Slack channel for UI/UX discussions is `#dev-ui-ux`. This change helps new contributors join the right channel and avoids confusion during onboarding.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #(issue)

## Release Notes

- [x] Include this change in the Release Notes.
