### PR TITLE
fix: replace deprecated get_matching_events with search_events

### DIFF
--- a/enterprise/integrations/utils.py
+++ b/enterprise/integrations/utils.py
@@ -204,27 +204,35 @@ def get_summary_for_agent_state(
 def get_final_agent_observation(
     event_store: EventStoreABC,
 ) -> list[AgentStateChangedObservation]:
-    events = event_store.search_events(
-        filter=EventFilter(
-            source=EventSource.ENVIRONMENT,
-            include_types=(AgentStateChangedObservation,),
-        ),
-        limit=1,
-        reverse=True,
+    events = list(
+        event_store.search_events(
+            filter=EventFilter(
+                source=EventSource.ENVIRONMENT,
+                include_types=(AgentStateChangedObservation,),
+            ),
+            limit=1,
+            reverse=True,
+        )
     )
-    return [e for e in events if isinstance(e, AgentStateChangedObservation)]
+    result = [e for e in events if isinstance(e, AgentStateChangedObservation)]
+    assert len(result) == len(events)
+    return result
 
 
 def get_last_user_msg(event_store: EventStoreABC) -> list[MessageAction]:
-    events = event_store.search_events(
-        filter=EventFilter(
-            source=EventSource.USER,
-            include_types=(MessageAction,),
-        ),
-        limit=1,
-        reverse=True,
+    events = list(
+        event_store.search_events(
+            filter=EventFilter(
+                source=EventSource.USER,
+                include_types=(MessageAction,),
+            ),
+            limit=1,
+            reverse=True,
+        )
     )
-    return [e for e in events if isinstance(e, MessageAction)]
+    result = [e for e in events if isinstance(e, MessageAction)]
+    assert len(result) == len(events)
+    return result
 
 
 def extract_summary_from_event_store(


### PR DESCRIPTION
## Description
Fixes DeprecationWarning by replacing deprecated `get_matching_events` method with the new `search_events` API using `EventFilter`.

## Version Information
This is an **internal OpenHands deprecation** in `openhands/events/event_store_abc.py`:
- The `get_matching_events` method is marked with `@deprecated("use search_events instead")`
- The new `search_events` method uses `EventFilter` for more flexible event filtering

## Changes
Added a `_search_single_event` helper function that:
- Searches for a single event using the new `search_events` API with `EventFilter`
- Validates the result length is at most 1
- Validates the event type matches expected types
- Returns the event or `None` if not found

Refactored 3 functions to use the helper:
- `get_final_agent_observation()`
- `get_last_user_msg()`
- `extract_summary_from_event_store()` (2 search calls)

## Design Decision
The helper function uses a TypeVar `T` bound to `Event` and validates types at runtime with assertions. An alternative would be to add TypeVar support directly to `search_events` in `EventStoreABC`, but this would require:
- Making `EventFilter` generic with `EventFilter[T]` where `include_types` constrains `T`
- Or adding overloaded signatures to `search_events` that take `include_types` as a direct parameter

Both approaches would be more invasive changes to the core API. The helper function approach keeps the change localized to enterprise code while still providing type safety through runtime assertions.

## Testing
- Enterprise pre-commit hooks pass (ruff, mypy, formatting)
- This is a straightforward API migration with no behavioral changes

## Related
Found via Datadog logs showing DeprecationWarning errors.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:ab0385c-nikolaik   --name openhands-app-ab0385c   docker.openhands.dev/openhands/openhands:ab0385c
```