### PR TITLE
fix: Handle LiteLLM v1.80+ 404 response for new users

### DIFF
--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -287,15 +287,7 @@ class SaasSettingsStore(SettingsStore):
             ) as client:
                 # Get the previous max budget to prevent accidental loss.
                 #
-                # LiteLLM API behavior changed between versions:
-                # - v1.79.x and earlier: GET /user/info always succeeds, returning
-                #   empty user_info for non-existent users
-                # - v1.80.x and later: GET /user/info returns 404 for non-existent users
-                #
-                # We handle both cases to maintain compatibility during the transition:
-                # - 200 OK: User exists, extract their info
-                # - 404 Not Found: User doesn't exist yet (new user), use empty dict
-                # - Other errors: Raise as before (unexpected server issues)
+                # LiteLLM v1.80+ returns 404 for non-existent users (previously returned empty user_info)
                 response = await client.get(
                     f'{LITE_LLM_API_URL}/user/info?user_id={self.user_id}'
                 )

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -1,5 +1,6 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from pydantic import SecretStr
 from server.constants import (
@@ -336,20 +337,41 @@ async def test_update_settings_with_litellm_default_error(settings_store):
 
 
 @pytest.mark.asyncio
-async def test_update_settings_with_litellm_default_handles_404_for_new_user(
-    settings_store, session_maker
+@pytest.mark.parametrize(
+    'status_code,user_info_response,should_succeed',
+    [
+        # 200 OK with user info - existing user (v1.79.x and v1.80+ behavior)
+        (200, {'user_info': {'max_budget': 10, 'spend': 5}}, True),
+        # 200 OK with empty user info - new user (v1.79.x behavior)
+        (200, {'user_info': None}, True),
+        # 404 Not Found - new user (v1.80+ behavior)
+        (404, None, True),
+        # 500 Internal Server Error - should fail
+        (500, None, False),
+    ],
+)
+async def test_update_settings_with_litellm_default_handles_user_info_responses(
+    settings_store, session_maker, status_code, user_info_response, should_succeed
 ):
-    """Test that 404 response from LiteLLM user/info is handled gracefully.
+    """Test that various LiteLLM user/info responses are handled correctly.
 
     LiteLLM API behavior changed between versions:
     - v1.79.x and earlier: GET /user/info always succeeds with empty user_info
     - v1.80.x and later: GET /user/info returns 404 for non-existent users
-
-    This test verifies we handle the v1.80+ behavior correctly for new users.
     """
-    # Mock a 404 response for GET /user/info (new user doesn't exist in LiteLLM)
     mock_get_response = MagicMock()
-    mock_get_response.status_code = 404
+    mock_get_response.status_code = status_code
+    if user_info_response is not None:
+        mock_get_response.json = MagicMock(return_value=user_info_response)
+        mock_get_response.raise_for_status = MagicMock()
+    else:
+        mock_get_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                'Error', request=MagicMock(), response=mock_get_response
+            )
+            if status_code >= 500
+            else None
+        )
 
     # Mock successful responses for POST operations (delete and create)
     mock_post_response = MagicMock()
@@ -362,7 +384,7 @@ async def test_update_settings_with_litellm_default_handles_404_for_new_user(
         patch('storage.saas_settings_store.LITE_LLM_TEAM_ID', 'test_team'),
         patch(
             'server.auth.token_manager.TokenManager.get_user_info_from_user_id',
-            AsyncMock(return_value={'email': 'newuser@example.com'}),
+            AsyncMock(return_value={'email': 'testuser@example.com'}),
         ),
         patch('httpx.AsyncClient') as mock_client,
         patch('storage.saas_settings_store.session_maker', session_maker),
@@ -376,12 +398,16 @@ async def test_update_settings_with_litellm_default_handles_404_for_new_user(
         )
 
         settings = Settings()
-        settings = await settings_store.update_settings_with_litellm_default(settings)
-
-        # Verify the user was created successfully despite the 404
-        assert settings is not None
-        assert settings.llm_api_key is not None
-        assert settings.llm_api_key.get_secret_value() == 'new_user_api_key'
+        if should_succeed:
+            settings = await settings_store.update_settings_with_litellm_default(
+                settings
+            )
+            assert settings is not None
+            assert settings.llm_api_key is not None
+            assert settings.llm_api_key.get_secret_value() == 'new_user_api_key'
+        else:
+            with pytest.raises(httpx.HTTPStatusError):
+                await settings_store.update_settings_with_litellm_default(settings)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

This PR fixes a breaking change introduced by the LiteLLM proxy upgrade from v1.79.x to v1.80.x.

### Problem

The LiteLLM API behavior changed between versions:
- **v1.79.x and earlier**: `GET /user/info` always succeeds, returning empty `user_info` for non-existent users
- **v1.80.x and later**: `GET /user/info` returns **404** for non-existent users

This caused new user signup to fail because the code in `saas_settings_store.py` called `response.raise_for_status()` without handling the 404 case.

### Evidence from Datadog

- LiteLLM was upgraded from `v1.79.3` to `v1.80.8` at `2026-01-02T20:32:51Z`
- First `user_info` 404 errors appeared at `2026-01-02T20:42:24Z` (10 minutes later)
- No `user_info` 404 errors existed in the previous 30 days

### Solution

Handle both API behaviors to maintain compatibility:
- **200 OK**: User exists, extract their info (both versions)
- **404 Not Found**: User doesn't exist yet (new user), use empty dict (v1.80+ behavior)
- **Other errors**: Raise as before (unexpected server issues)

### Changes

1. **`enterprise/storage/saas_settings_store.py`**: Added 404 handling with detailed comments explaining the version differences
2. **`enterprise/tests/unit/test_saas_settings_store.py`**: Added test case for the 404 scenario

## Testing

- [x] Added unit test `test_update_settings_with_litellm_default_handles_404_for_new_user`
- [x] Test passes locally
- [x] Pre-commit hooks pass
- [x] HUMAN: This has been tested with a preview deployment, and I can confirm that it failed before and works after on staging.

## Related Issues

This fixes the login errors observed on staging deployments after the LiteLLM proxy upgrade.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/949d1cd676134f49ba667f0ebde23c59)

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:0afc83f-nikolaik   --name openhands-app-0afc83f   docker.openhands.dev/openhands/openhands:0afc83f
```