### PR TITLE
Fix AttributeError in GoogleCloudSharedEventService: use self.bucket instead of erroneous import

### DIFF
--- a/enterprise/server/sharing/google_cloud_shared_event_service.py
+++ b/enterprise/server/sharing/google_cloud_shared_event_service.py
@@ -20,7 +20,6 @@ from fastapi import Request
 from google.cloud import storage
 from google.cloud.storage.bucket import Bucket
 from google.cloud.storage.client import Client
-from more_itertools import bucket
 from pydantic import Field
 from server.sharing.shared_conversation_info_service import (
     SharedConversationInfoService,
@@ -62,7 +61,7 @@ class GoogleCloudSharedEventService(SharedEventService):
             return None
 
         return GoogleCloudEventService(
-            bucket=bucket,
+            bucket=self.bucket,
             prefix=Path('users'),
             user_id=shared_conversation_info.created_by_user_id,
             app_conversation_info_service=None,


### PR DESCRIPTION
## Summary of PR

Fixes a bug in `GoogleCloudSharedEventService.get_event_service()` that was causing a 500 error with:
```
AttributeError: type object 'bucket' has no attribute 'list_blobs'
```

The issue was caused by an erroneous import `from more_itertools import bucket` that was auto-added by IDE when `bucket=bucket` was written instead of `bucket=self.bucket`. The `more_itertools.bucket` is a class for grouping iterables, not a GCS bucket instance.

**Changes:**
- Remove incorrect `from more_itertools import bucket` import
- Change `bucket=bucket` to `bucket=self.bucket` in `get_event_service` method

## Change Type

- [x] Bug fix

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Release Notes

- [x] Include this change in the Release Notes.

Fixed a 500 error in shared event service caused by incorrect bucket reference.

@tofarr can click here to [continue refining the PR](https://staging.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:d608139-nikolaik   --name openhands-app-d608139   docker.openhands.dev/openhands/openhands:d608139
```