### PR TITLE
Add V1 conversation support for GitLab resolver

### DIFF
--- a/enterprise/integrations/gitlab/gitlab_manager.py
+++ b/enterprise/integrations/gitlab/gitlab_manager.py
@@ -17,6 +17,7 @@ from integrations.utils import (
     OPENHANDS_RESOLVER_TEMPLATES_DIR,
     get_session_expired_message,
 )
+from integrations.v1_utils import get_saas_user_auth
 from jinja2 import Environment, FileSystemLoader
 from pydantic import SecretStr
 from server.auth.token_manager import TokenManager
@@ -182,6 +183,8 @@ class GitlabManager(Manager):
         )
 
         try:
+            msg_info = None
+
             try:
                 user_info = gitlab_view.user_info
 
@@ -214,8 +217,14 @@ class GitlabManager(Manager):
                     )
                 )
 
+                saas_user_auth = await get_saas_user_auth(
+                    gitlab_view.user_info.keycloak_user_id, self.token_manager
+                )
+
                 await gitlab_view.create_new_conversation(
-                    self.jinja_env, secret_store.provider_tokens
+                    self.jinja_env,
+                    secret_store.provider_tokens,
+                    saas_user_auth,
                 )
 
                 conversation_id = gitlab_view.conversation_id
@@ -224,18 +233,19 @@ class GitlabManager(Manager):
                     f'[GitLab] Created conversation {conversation_id} for user {user_info.username}'
                 )
 
-                # Create a GitlabCallbackProcessor for this conversation
-                processor = GitlabCallbackProcessor(
-                    gitlab_view=gitlab_view,
-                    send_summary_instruction=True,
-                )
+                if not gitlab_view.v1_enabled:
+                    # Create a GitlabCallbackProcessor for this conversation (V0 only)
+                    processor = GitlabCallbackProcessor(
+                        gitlab_view=gitlab_view,
+                        send_summary_instruction=True,
+                    )
 
-                # Register the callback processor
-                register_callback_processor(conversation_id, processor)
+                    # Register the callback processor
+                    register_callback_processor(conversation_id, processor)
 
-                logger.info(
-                    f'[GitLab] Created callback processor for conversation {conversation_id}'
-                )
+                    logger.info(
+                        f'[GitLab] Registered callback processor for conversation {conversation_id}'
+                    )
 
                 conversation_link = CONVERSATION_URL.format(conversation_id)
                 msg_info = f"I'm on it! {user_info.username} can [track my progress at all-hands.dev]({conversation_link})"

--- a/enterprise/integrations/gitlab/gitlab_v1_callback_processor.py
+++ b/enterprise/integrations/gitlab/gitlab_v1_callback_processor.py
@@ -1,0 +1,298 @@
+import logging
+from typing import Any
+from uuid import UUID
+
+import httpx
+from integrations.utils import CONVERSATION_URL, get_summary_instruction
+from pydantic import Field
+
+from openhands.agent_server.models import AskAgentRequest, AskAgentResponse
+from openhands.app_server.event_callback.event_callback_models import (
+    EventCallback,
+    EventCallbackProcessor,
+)
+from openhands.app_server.event_callback.event_callback_result_models import (
+    EventCallbackResult,
+    EventCallbackResultStatus,
+)
+from openhands.app_server.event_callback.util import (
+    ensure_conversation_found,
+    ensure_running_sandbox,
+    get_agent_server_url_from_sandbox,
+)
+from openhands.integrations.gitlab.gitlab_service import GitLabServiceImpl
+from openhands.sdk import Event
+from openhands.sdk.event import ConversationStateUpdateEvent
+
+_logger = logging.getLogger(__name__)
+
+
+class GitlabV1CallbackProcessor(EventCallbackProcessor):
+    """Callback processor for GitLab V1 integrations."""
+
+    gitlab_view_data: dict[str, Any] = Field(default_factory=dict)
+    should_request_summary: bool = Field(default=True)
+    inline_mr_comment: bool = Field(default=False)
+
+    async def __call__(
+        self,
+        conversation_id: UUID,
+        callback: EventCallback,
+        event: Event,
+    ) -> EventCallbackResult | None:
+        """Process events for GitLab V1 integration."""
+
+        # Only handle ConversationStateUpdateEvent
+        if not isinstance(event, ConversationStateUpdateEvent):
+            return None
+
+        # Only act when execution has finished
+        if not (event.key == 'execution_status' and event.value == 'finished'):
+            return None
+
+        _logger.info('[GitLab V1] Callback agent state was %s', event)
+        _logger.info(
+            '[GitLab V1] Should request summary: %s', self.should_request_summary
+        )
+
+        if not self.should_request_summary:
+            return None
+
+        self.should_request_summary = False
+
+        try:
+            _logger.info(f'[GitLab V1] Requesting summary {conversation_id}')
+            summary = await self._request_summary(conversation_id)
+            _logger.info(
+                f'[GitLab V1] Posting summary {conversation_id}',
+                extra={'summary': summary},
+            )
+            await self._post_summary_to_gitlab(summary)
+
+            return EventCallbackResult(
+                status=EventCallbackResultStatus.SUCCESS,
+                event_callback_id=callback.id,
+                event_id=event.id,
+                conversation_id=conversation_id,
+                detail=summary,
+            )
+        except Exception as e:
+            _logger.exception('[GitLab V1] Error processing callback: %s', e)
+
+            # Only try to post error to GitLab if we have basic requirements
+            try:
+                # Check if we have user keycloak ID before posting
+                if self.gitlab_view_data.get('user_keycloak_id'):
+                    await self._post_summary_to_gitlab(
+                        f'OpenHands encountered an error: **{str(e)}**.\n\n'
+                        f'[See the conversation]({CONVERSATION_URL.format(conversation_id)})'
+                        'for more information.'
+                    )
+            except Exception as post_error:
+                _logger.warning(
+                    '[GitLab V1] Failed to post error message to GitLab: %s', post_error
+                )
+
+            return EventCallbackResult(
+                status=EventCallbackResultStatus.ERROR,
+                event_callback_id=callback.id,
+                event_id=event.id,
+                conversation_id=conversation_id,
+                detail=str(e),
+            )
+
+    # -------------------------------------------------------------------------
+    # GitLab helpers
+    # -------------------------------------------------------------------------
+
+    def _get_gitlab_service(self) -> GitLabServiceImpl:
+        """Get a GitLab service instance for the user."""
+        user_keycloak_id = self.gitlab_view_data.get('user_keycloak_id')
+
+        if not user_keycloak_id:
+            raise ValueError(
+                f'Missing user keycloak ID for GitLab payload: {self.gitlab_view_data}'
+            )
+
+        return GitLabServiceImpl(external_auth_id=user_keycloak_id)
+
+    async def _post_summary_to_gitlab(self, summary: str) -> None:
+        """Post a summary comment to the configured GitLab issue or MR."""
+        gitlab_service = self._get_gitlab_service()
+
+        project_id = self.gitlab_view_data.get('project_id')
+        issue_number = self.gitlab_view_data.get('issue_number')
+        discussion_id = self.gitlab_view_data.get('discussion_id')
+
+        if not project_id or not issue_number:
+            raise RuntimeError('Missing GitLab project_id or issue_number')
+
+        # Determine if this is an MR or issue based on discussion_id presence
+        # For MR comments, we reply to the discussion
+        # For issues, we create a new comment
+        if discussion_id:
+            # This is a comment on an MR or issue with a discussion
+            # Try to reply to the MR first, fall back to issue
+            try:
+                await gitlab_service.reply_to_mr(
+                    str(project_id),
+                    issue_number,
+                    discussion_id,
+                    summary,
+                )
+            except Exception:
+                # Fall back to issue reply
+                await gitlab_service.reply_to_issue(
+                    str(project_id),
+                    issue_number,
+                    discussion_id,
+                    summary,
+                )
+        else:
+            # This is a labeled issue without a discussion
+            await gitlab_service.reply_to_issue(
+                str(project_id),
+                issue_number,
+                None,
+                summary,
+            )
+
+    # -------------------------------------------------------------------------
+    # Agent / sandbox helpers
+    # -------------------------------------------------------------------------
+
+    async def _ask_question(
+        self,
+        httpx_client: httpx.AsyncClient,
+        agent_server_url: str,
+        conversation_id: UUID,
+        session_api_key: str,
+        message_content: str,
+    ) -> str:
+        """Send a message to the agent server via the V1 API and return response text."""
+        send_message_request = AskAgentRequest(question=message_content)
+
+        url = (
+            f'{agent_server_url.rstrip("/")}'
+            f'/api/conversations/{conversation_id}/ask_agent'
+        )
+        headers = {'X-Session-API-Key': session_api_key}
+        payload = send_message_request.model_dump()
+
+        try:
+            response = await httpx_client.post(
+                url,
+                json=payload,
+                headers=headers,
+                timeout=30.0,
+            )
+            response.raise_for_status()
+
+            agent_response = AskAgentResponse.model_validate(response.json())
+            return agent_response.response
+
+        except httpx.HTTPStatusError as e:
+            error_detail = f'HTTP {e.response.status_code} error'
+            try:
+                error_body = e.response.text
+                if error_body:
+                    error_detail += f': {error_body}'
+            except Exception:  # noqa: BLE001
+                pass
+
+            _logger.error(
+                '[GitLab V1] HTTP error sending message to %s: %s. '
+                'Request payload: %s. Response headers: %s',
+                url,
+                error_detail,
+                payload,
+                dict(e.response.headers),
+                exc_info=True,
+            )
+            raise Exception(f'Failed to send message to agent server: {error_detail}')
+
+        except httpx.TimeoutException:
+            error_detail = f'Request timeout after 30 seconds to {url}'
+            _logger.error(
+                '[GitLab V1] %s. Request payload: %s',
+                error_detail,
+                payload,
+                exc_info=True,
+            )
+            raise Exception(error_detail)
+
+        except httpx.RequestError as e:
+            error_detail = f'Request error to {url}: {str(e)}'
+            _logger.error(
+                '[GitLab V1] %s. Request payload: %s',
+                error_detail,
+                payload,
+                exc_info=True,
+            )
+            raise Exception(error_detail)
+
+    # -------------------------------------------------------------------------
+    # Summary orchestration
+    # -------------------------------------------------------------------------
+
+    async def _request_summary(self, conversation_id: UUID) -> str:
+        """
+        Ask the agent to produce a summary of its work and return the agent response.
+
+        NOTE: This method now returns a string (the agent server's response text)
+        and raises exceptions on errors. The wrapping into EventCallbackResult
+        is handled by __call__.
+        """
+        # Import services within the method to avoid circular imports
+        from openhands.app_server.config import (
+            get_app_conversation_info_service,
+            get_httpx_client,
+            get_sandbox_service,
+        )
+        from openhands.app_server.services.injector import InjectorState
+        from openhands.app_server.user.specifiy_user_context import (
+            ADMIN,
+            USER_CONTEXT_ATTR,
+        )
+
+        # Create injector state for dependency injection
+        state = InjectorState()
+        setattr(state, USER_CONTEXT_ATTR, ADMIN)
+
+        async with (
+            get_app_conversation_info_service(state) as app_conversation_info_service,
+            get_sandbox_service(state) as sandbox_service,
+            get_httpx_client(state) as httpx_client,
+        ):
+            # 1. Conversation lookup
+            app_conversation_info = ensure_conversation_found(
+                await app_conversation_info_service.get_app_conversation_info(
+                    conversation_id
+                ),
+                conversation_id,
+            )
+
+            # 2. Sandbox lookup + validation
+            sandbox = ensure_running_sandbox(
+                await sandbox_service.get_sandbox(app_conversation_info.sandbox_id),
+                app_conversation_info.sandbox_id,
+            )
+
+            assert (
+                sandbox.session_api_key is not None
+            ), f'No session API key for sandbox: {sandbox.id}'
+
+            # 3. URL + instruction
+            agent_server_url = get_agent_server_url_from_sandbox(sandbox)
+
+            # Prepare message based on agent state
+            message_content = get_summary_instruction()
+
+            # Ask the agent and return the response text
+            return await self._ask_question(
+                httpx_client=httpx_client,
+                agent_server_url=agent_server_url,
+                conversation_id=conversation_id,
+                session_api_key=sandbox.session_api_key,
+                message_content=message_content,
+            )

--- a/enterprise/integrations/utils.py
+++ b/enterprise/integrations/utils.py
@@ -78,6 +78,11 @@ ENABLE_V1_GITHUB_RESOLVER = (
     os.getenv('ENABLE_V1_GITHUB_RESOLVER', 'false').lower() == 'true'
 )
 
+# Toggle for V1 GitLab resolver feature
+ENABLE_V1_GITLAB_RESOLVER = (
+    os.getenv('ENABLE_V1_GITLAB_RESOLVER', 'false').lower() == 'true'
+)
+
 
 OPENHANDS_RESOLVER_TEMPLATES_DIR = (
     os.getenv('OPENHANDS_RESOLVER_TEMPLATES_DIR')


### PR DESCRIPTION
## Summary of PR

This PR implements V1 conversation support for the GitLab resolver, following the same pattern as the existing GitHub resolver V1 implementation.

The V1 conversation system uses the new `AppConversationStartRequest` API with callback processors passed directly to the conversation start request, rather than registering them separately via `register_callback_processor()`.

### Key Changes:

1. **`enterprise/integrations/utils.py`**: Added `ENABLE_V1_GITLAB_RESOLVER` environment variable toggle

2. **`enterprise/integrations/gitlab/gitlab_view.py`**:
   - Added `get_user_v1_enabled_setting()` function to check if V1 is enabled for a user
   - Added `v1_enabled` field to `GitlabIssue` dataclass
   - Added `initialize_new_conversation()` method that checks V1 setting and creates appropriate metadata
   - Updated `create_new_conversation()` to route to V0 or V1 based on the setting
   - Added `_create_v0_conversation()` and `_create_v1_conversation()` methods
   - Added `_create_gitlab_v1_callback_processor()` method
   - Added `v1_enabled=False` to all factory return statements

3. **`enterprise/integrations/gitlab/gitlab_v1_callback_processor.py`** (new file):
   - Created `GitlabV1CallbackProcessor` class extending `EventCallbackProcessor`
   - Handles `ConversationStateUpdateEvent` events
   - Requests summary from agent when execution finishes
   - Posts summary to GitLab via the GitLab service

4. **`enterprise/integrations/gitlab/gitlab_manager.py`**:
   - Updated `start_job()` to call `initialize_new_conversation()` first
   - Added `get_saas_user_auth()` call for V1 support
   - Updated `create_new_conversation()` call with new parameters
   - Only registers V0 callback processor when `v1_enabled` is False

## Change Type

- [x] New feature

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Release Notes

- [ ] Include this change in the Release Notes.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/586f4ba0e01347ecb8b4d0a8049707cc)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:6156f81-nikolaik   --name openhands-app-6156f81   docker.openhands.dev/openhands/openhands:6156f81
```