### PR TITLE
refactor(frontend): align conversation metrics title to the left in the modal

### DIFF
--- a/frontend/src/components/features/conversation/metrics-modal/metrics-modal.tsx
+++ b/frontend/src/components/features/conversation/metrics-modal/metrics-modal.tsx
@@ -21,7 +21,7 @@ export function MetricsModal({ isOpen, onOpenChange }: MetricsModalProps) {
 
   return (
     <ModalBackdrop onClose={() => onOpenChange(false)}>
-      <ModalBody className="items-center border border-tertiary">
+      <ModalBody className="items-start border border-tertiary">
         <BaseModalTitle title={t(I18nKey.CONVERSATION$METRICS_INFO)} />
         <div className="space-y-4 w-full">
           {(metrics?.cost !== null || metrics?.usage !== null) && (


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

Currently, the “Conversation Metrics” title is center-aligned, which is inconsistent with other modals in the product.

We should update the styling to align the “Conversation Metrics” title to the left within the modal.

We can refer to the images below for the output of the pull request.

<img width="1439" height="743" alt="image1" src="https://github.com/user-attachments/assets/aa1a07c5-5daf-49de-83d1-2ca9d0907df3" />

<img width="1439" height="743" alt="image2" src="https://github.com/user-attachments/assets/6bf588a0-7430-4da2-a139-2f16ae40ec54" />

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #12309

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:822cada-nikolaik   --name openhands-app-822cada   docker.openhands.dev/openhands/openhands:822cada
```