### PR TITLE
feat: add message queue support for V1 conversations

### DIFF
--- a/frontend/__tests__/conversation-websocket-handler.test.tsx
+++ b/frontend/__tests__/conversation-websocket-handler.test.tsx
@@ -709,9 +709,9 @@ describe("Conversation WebSocket Handler", () => {
       }
 
       // Set up MSW to delay connection (simulate slow connection)
-      let connectionDeferred: { resolve: () => void } | null = null;
+      const deferred: { resolve: () => void } = { resolve: () => {} };
       const connectionPromise = new Promise<void>((resolve) => {
-        connectionDeferred = { resolve };
+        deferred.resolve = resolve;
       });
 
       mswServer.use(
@@ -748,7 +748,7 @@ describe("Conversation WebSocket Handler", () => {
       );
 
       // Now establish the connection
-      connectionDeferred?.resolve();
+      deferred.resolve();
 
       // Wait for connection to be established
       await waitFor(() => {
@@ -800,9 +800,9 @@ describe("Conversation WebSocket Handler", () => {
       }
 
       // Set up MSW to delay connection establishment
-      let connectionDeferred: { resolve: () => void } | null = null;
+      const deferred: { resolve: () => void } = { resolve: () => {} };
       const connectionPromise = new Promise<void>((resolve) => {
-        connectionDeferred = { resolve };
+        deferred.resolve = resolve;
       });
 
       mswServer.use(
@@ -834,7 +834,7 @@ describe("Conversation WebSocket Handler", () => {
       });
 
       // Now establish the connection
-      connectionDeferred?.resolve();
+      deferred.resolve();
 
       // Wait for connection to be established
       // The test passes if no errors occur and connection is established

--- a/frontend/src/contexts/conversation-websocket-context.tsx
+++ b/frontend/src/contexts/conversation-websocket-context.tsx
@@ -129,6 +129,27 @@ export function ConversationWebSocketProvider({
     conversationId: string;
   } | null>(null);
 
+  // Queue for messages sent before WebSocket connection is established
+  const pendingMessagesRef = useRef<V1SendMessageRequest[]>([]);
+
+  // Helper function to flush pending messages when connection opens
+  const flushPendingMessages = useCallback(
+    (socket: WebSocket | null) => {
+      if (!socket || socket.readyState !== WebSocket.OPEN) return;
+      const messages = pendingMessagesRef.current;
+      pendingMessagesRef.current = [];
+      for (const message of messages) {
+        try {
+          socket.send(JSON.stringify(message));
+        } catch (error) {
+          const errorMessage =
+            error instanceof Error ? error.message : "Failed to send message";
+          setErrorMessage(errorMessage);
+        }
+      }
+    },
+    [setErrorMessage],
+  );
 
   // Helper function to update metrics from stats event
   const updateMetricsFromStats = useCallback(
@@ -677,13 +698,13 @@ export function ConversationWebSocketProvider({
     return {
       queryParams,
       reconnect: { enabled: true },
-      onOpen: async () => {
+      onOpen: async (event: Event) => {
         setMainConnectionState("OPEN");
         hasConnectedRefMain.current = true; // Mark that we've successfully connected
         removeErrorMessage(); // Clear any previous error messages on successful connection
 
         // Flush any pending messages now that connection is established
-        flushPendingMessages(mainSocket);
+        flushPendingMessages(event.target as WebSocket);
 
         // Fetch expected event count for history loading detection
         if (conversationId && conversationUrl) {
@@ -748,13 +769,13 @@ export function ConversationWebSocketProvider({
     return {
       queryParams,
       reconnect: { enabled: true },
-      onOpen: async () => {
+      onOpen: async (event: Event) => {
         setPlanningConnectionState("OPEN");
         hasConnectedRefPlanning.current = true; // Mark that we've successfully connected
         removeErrorMessage(); // Clear any previous error messages on successful connection
 
         // Flush any pending messages now that connection is established
-        flushPendingMessages(planningAgentSocket);
+        flushPendingMessages(event.target as WebSocket);
 
         // Fetch expected event count for history loading detection
         if (
@@ -818,7 +839,17 @@ export function ConversationWebSocketProvider({
     planningWebsocketOptions,
   );
 
+  // V1 send message function via WebSocket
+  const sendMessage = useCallback(
+    async (message: V1SendMessageRequest) => {
+      const currentMode = useConversationStore.getState().conversationMode;
+      const currentSocket =
+        currentMode === "plan" ? planningAgentSocket : mainSocket;
 
+      if (!currentSocket || currentSocket.readyState !== WebSocket.OPEN) {
+        // Queue the message to be sent when connection opens
+        pendingMessagesRef.current.push(message);
+        return;
       }
 
       try {


### PR DESCRIPTION
### Summary of PR

- adds message queuing for V1 conversations when WebSocket connection is not established, matching V0 behavior. Messages are automatically sent once connection opens.

## Change Type

- [x] New feature

## Fixes : #12279

Resolves V1 conversation message queuing issue during WebSocket connection.

**V1 conversations now queue messages sent before WebSocket connection is established.**