### PR TITLE
Add distributed lock to prevent race condition in create_default_settings

### DIFF
--- a/enterprise/storage/distributed_lock.py
+++ b/enterprise/storage/distributed_lock.py
@@ -143,7 +143,9 @@ class DistributedLock:
         """
 
         try:
-            result = self.redis_client.eval(release_script, 1, self.key, self._lock_value)
+            result = self.redis_client.eval(
+                release_script, 1, self.key, self._lock_value
+            )
             self._acquired = False
             if result:
                 logger.debug(

--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -208,7 +208,10 @@ class SaasSettingsStore(SettingsStore):
         """
         with self.session_maker() as session:
             db_settings = self.get_user_settings_by_keycloak_id(self.user_id, session)
-            if db_settings and db_settings.user_version == CURRENT_USER_SETTINGS_VERSION:
+            if (
+                db_settings
+                and db_settings.user_version == CURRENT_USER_SETTINGS_VERSION
+            ):
                 logger.info(
                     'saas_settings_store:create_default_settings:loaded_after_wait',
                     extra={'user_id': self.user_id},

--- a/enterprise/tests/unit/test_distributed_lock.py
+++ b/enterprise/tests/unit/test_distributed_lock.py
@@ -1,6 +1,5 @@
 """Tests for distributed_lock module."""
 
-import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -1550,7 +1550,9 @@ async def test_create_default_settings_with_payment_required_no_payment(
 
 
 @pytest.mark.asyncio
-async def test_load_settings_after_lock_wait_with_old_version(session_maker, mock_config):
+async def test_load_settings_after_lock_wait_with_old_version(
+    session_maker, mock_config
+):
     """Test that _load_settings_after_lock_wait returns None for old version settings."""
     mock_redis = MagicMock()
     store = SaasSettingsStore('user-id', session_maker, mock_config, mock_redis)


### PR DESCRIPTION
## Summary of PR

This PR adds a Redis-based distributed lock to the `create_default_settings` method in `SaasSettingsStore` to prevent race conditions when multiple concurrent requests try to create settings for the same user. This addresses the issue where repeatedly calling create user with the same id causes a race condition in litellm.

### Changes

**New Files:**
- `enterprise/storage/distributed_lock.py` - A reusable `DistributedLock` class using Redis with:
  - Atomic lock acquisition using `SET NX EX` command
  - Atomic lock release using a Lua script to ensure only the owner can release
  - Configurable timeout, retry delay, and max wait time
  - Async context manager support
  - Graceful error handling (returns `False` on Redis errors instead of blocking)

- `enterprise/tests/unit/test_distributed_lock.py` - 16 comprehensive unit tests for `DistributedLock`

**Modified Files:**
- `enterprise/storage/saas_settings_store.py`:
  - Added optional `redis_client` field to `SaasSettingsStore` dataclass
  - Refactored `create_default_settings` to use distributed lock
  - Added `_load_settings_after_lock_wait()` helper method
  - Added `_create_default_settings_internal()` with original creation logic
  - Updated `get_instance()` to accept optional `redis_client` parameter

- `enterprise/tests/unit/test_saas_settings_store.py`:
  - Updated `settings_store` fixture to include mock Redis client
  - Added 8 new tests for the distributed lock functionality

### How It Works

When `create_default_settings` is called:
1. If no user_id or payment required but not available, returns `None` immediately (no lock needed)
2. Creates a distributed lock with key `lock:user_settings:{user_id}`
3. Attempts to acquire the lock (waits up to 15 seconds with 0.2s retry intervals)
4. If lock acquired: creates settings via LiteLLM integration and stores them
5. If lock not acquired: another process is creating settings, so load from database instead
6. Lock is always released in the `finally` block

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves race condition when repeatedly calling create user with the same id in litellm.

## Release Notes

- [ ] Include this change in the Release Notes.

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:010720f-nikolaik   --name openhands-app-010720f   docker.openhands.dev/openhands/openhands:010720f
```