### PR TITLE
Fix: Parse SANDBOX_VOLUMES env var for agent-server volume mounts

### DIFF
--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -186,6 +186,33 @@ def config_from_env() -> AppServerConfig:
                 docker_sandbox_kwargs['container_url_pattern'] = os.environ[
                     'SANDBOX_CONTAINER_URL_PATTERN'
                 ]
+            # Parse SANDBOX_VOLUMES and convert to VolumeMount objects
+            # This is set by the CLI's --mount-cwd flag
+            sandbox_volumes = os.getenv('SANDBOX_VOLUMES')
+            if sandbox_volumes:
+                from openhands.app_server.sandbox.docker_sandbox_service import (
+                    VolumeMount,
+                )
+
+                mounts = []
+                for mount_spec in sandbox_volumes.split(','):
+                    mount_spec = mount_spec.strip()
+                    if not mount_spec:
+                        continue
+                    parts = mount_spec.split(':')
+                    if len(parts) >= 2:
+                        host_path = parts[0]
+                        container_path = parts[1]
+                        mode = parts[2] if len(parts) > 2 else 'rw'
+                        mounts.append(
+                            VolumeMount(
+                                host_path=host_path,
+                                container_path=container_path,
+                                mode=mode,
+                            )
+                        )
+                if mounts:
+                    docker_sandbox_kwargs['mounts'] = mounts
             config.sandbox = DockerSandboxServiceInjector(**docker_sandbox_kwargs)
 
     if config.sandbox_spec is None:


### PR DESCRIPTION
## Summary

Fixes #12326

The `--mount-cwd` flag in the CLI sets the `SANDBOX_VOLUMES` environment variable, but the new agent-server architecture was not reading this variable when creating Docker containers. This caused the mounted directory to not appear in the agent-server container.

## Changes

This PR adds parsing of the `SANDBOX_VOLUMES` environment variable in `openhands/app_server/config.py`. The variable is parsed and converted to `VolumeMount` objects that are passed to `DockerSandboxServiceInjector`.

### Before
When using `openhands serve --mount-cwd`:
- CLI correctly sets `-e SANDBOX_VOLUMES=/your/cwd:/workspace:rw`
- App server ignores this variable
- Agent-server container has no volume mounts for user's directory

### After
When using `openhands serve --mount-cwd`:
- CLI sets `-e SANDBOX_VOLUMES=/your/cwd:/workspace:rw`
- App server parses this variable and creates `VolumeMount` objects
- Agent-server container correctly mounts user's directory at `/workspace`

## Testing

The fix handles:
- Single volume mounts: `/path:/workspace:rw`
- Multiple volume mounts: `/path1:/container1:rw,/path2:/container2:ro`
- Default mode (rw) when not specified: `/path:/workspace`
- Empty/whitespace entries in the comma-separated list

## Checklist

- [x] Code follows project style guidelines (passed pre-commit hooks)
- [x] Changes are minimal and focused on the bug fix
- [x] No breaking changes to existing functionality

@saurya can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ef0d55e51eae46fca2aa7c96046e7a09)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:9b099e4-nikolaik   --name openhands-app-9b099e4   docker.openhands.dev/openhands/openhands:9b099e4
```