### PR TITLE
Fix circular import in gitlab_sync.py

### DIFF
--- a/enterprise/server/auth/gitlab_sync.py
+++ b/enterprise/server/auth/gitlab_sync.py
@@ -1,6 +1,5 @@
 import asyncio
 
-from integrations.gitlab.gitlab_service import SaaSGitLabService
 from pydantic import SecretStr
 
 from openhands.core.logger import openhands_logger as logger
@@ -19,6 +18,12 @@ def schedule_gitlab_repo_sync(
 
     async def _run():
         try:
+            # Lazy import to avoid circular dependency:
+            # middleware -> gitlab_sync -> integrations.gitlab.gitlab_service
+            # -> openhands.integrations.gitlab.gitlab_service -> get_impl
+            # -> integrations.gitlab.gitlab_service (circular)
+            from integrations.gitlab.gitlab_service import SaaSGitLabService
+
             service = SaaSGitLabService(
                 external_auth_id=user_id, external_auth_token=keycloak_access_token
             )


### PR DESCRIPTION
## Summary of PR

This PR fixes a circular import that was breaking the app load during server startup. The error was:

```
AttributeError: partially initialized module 'integrations.gitlab.gitlab_service' from '/app/integrations/gitlab/gitlab_service.py' has no attribute 'SaaSGitLabService' (most likely due to a circular import)
```

The fix moves the import of `SaaSGitLabService` inside the async `_run()` function in `gitlab_sync.py` to break the circular dependency chain.

### The circular import chain was:
1. `saas_server.py` → `server.middleware`
2. `server/middleware.py` → `server.auth.gitlab_sync`
3. `server/auth/gitlab_sync.py` → `integrations.gitlab.gitlab_service.SaaSGitLabService`
4. `integrations/gitlab/gitlab_service.py` → `openhands.integrations.gitlab.gitlab_service.GitLabService`
5. `openhands/integrations/gitlab/gitlab_service.py` → `get_impl()` tries to import `SaaSGitLabService` from `integrations.gitlab.gitlab_service` (via env var)
6. But `integrations.gitlab.gitlab_service` is only partially initialized → **AttributeError**

### The fix:
By deferring the import to runtime (when the function is called rather than at module load time), all modules are fully initialized before the import occurs.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves the circular import error that prevents the app from loading.

## Release Notes

- [ ] Include this change in the Release Notes.

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:3f2ac05-nikolaik   --name openhands-app-3f2ac05   docker.openhands.dev/openhands/openhands:3f2ac05
```