### PR TITLE
fix: replace deprecated Pydantic .dict() with .model_dump()

### DIFF
--- a/openhands/server/routes/conversation.py
+++ b/openhands/server/routes/conversation.py
@@ -418,7 +418,7 @@ async def get_microagents(
 
         return JSONResponse(
             status_code=status.HTTP_200_OK,
-            content={'microagents': [m.dict() for m in microagents]},
+            content={'microagents': [m.model_dump() for m in microagents]},
         )
     except Exception as e:
         logger.error(f'Error getting microagents: {e}')


### PR DESCRIPTION
## Summary

Replace deprecated Pydantic V2 `.dict()` method with `.model_dump()` in `conversation.py` to fix `PydanticDeprecatedSince20` warnings appearing in production logs.

## Problem

Production Datadog logs show repeated deprecation warnings:

```
/openhands/code/openhands/server/routes/conversation.py:421: PydanticDeprecatedSince20: 
The `dict` method is deprecated; use `model_dump` instead. 
Deprecated in Pydantic V2.0 to be removed in V3.0.
```

## Solution

Replace `.dict()` with `.model_dump()` on line 421 of `conversation.py`:

```python
# Before
content={"microagents": [m.dict() for m in microagents]},

# After  
content={"microagents": [m.model_dump() for m in microagents]},
```

## Testing

This is a straightforward API rename with identical behavior. The `model_dump()` method is the Pydantic V2 equivalent of `dict()`.

## References

- [Pydantic V2 Migration Guide](https://errors.pydantic.dev/2.12/migration/)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:5beadac-nikolaik   --name openhands-app-5beadac   docker.openhands.dev/openhands/openhands:5beadac
```