### PR TITLE
fix: restore agenthub import for agent registration

### DIFF
--- a/openhands/server/app.py
+++ b/openhands/server/app.py
@@ -22,7 +22,7 @@ from fastapi import (
 )
 from fastapi.responses import JSONResponse
 
-# import openhands.agenthub
+import openhands.agenthub  # noqa F401 (we import this to get the agents registered)
 from openhands.app_server import v1_router
 from openhands.app_server.config import get_app_lifespan_service
 from openhands.integrations.service_types import AuthenticationError


### PR DESCRIPTION
<!-- Ideally you should open a PR when it is ready for review. Draft PRs will not be reviewed -->

## Summary of PR

Restores accidentally commented out `import openhands.agenthub` in `openhands/server/app.py`. This import is required to register agents at startup. Without it, make run fails with `AgentNotRegisteredError: No agent class registered`.

Broken in #12243.

## Change Type

<!-- Choose the types that apply to your PR -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:f6d001b-nikolaik   --name openhands-app-f6d001b   docker.openhands.dev/openhands/openhands:f6d001b
```