### PR TITLE
fix(frontend): Prevent Enter key from submitting during IME composition

### DIFF
--- a/frontend/src/components/features/conversation-panel/conversation-card/conversation-card-title.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-card/conversation-card-title.tsx
@@ -30,6 +30,10 @@ export function ConversationCardTitle({
           onSave(trimmed);
         }}
         onKeyUp={(event: React.KeyboardEvent<HTMLInputElement>) => {
+          // Ignore Enter key during IME composition (e.g., Chinese, Japanese, Korean input)
+          if (event.nativeEvent.isComposing) {
+            return;
+          }
           if (event.key === "Enter") {
             event.currentTarget.blur();
           }

--- a/frontend/src/components/features/conversation/conversation-name.tsx
+++ b/frontend/src/components/features/conversation/conversation-name.tsx
@@ -91,6 +91,10 @@ export function ConversationName() {
   };
 
   const handleKeyUp = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    // Ignore Enter key during IME composition (e.g., Chinese, Japanese, Korean input)
+    if (event.nativeEvent.isComposing) {
+      return;
+    }
     if (event.key === "Enter") {
       event.currentTarget.blur();
     }

--- a/frontend/src/hooks/chat/use-chat-input-events.ts
+++ b/frontend/src/hooks/chat/use-chat-input-events.ts
@@ -68,6 +68,12 @@ export const useChatInputEvents = (
         return;
       }
 
+      // Ignore Enter key during IME composition (e.g., Chinese, Japanese, Korean input)
+      // When using IME, Enter is used to confirm the composition, not to submit
+      if (e.nativeEvent.isComposing) {
+        return;
+      }
+
       if (checkIsContentEmpty()) {
         e.preventDefault();
         increaseHeightForEmptyContent();


### PR DESCRIPTION
## Summary of PR

This PR fixes a regression where pressing Enter during IME (Input Method Editor) composition for Chinese, Japanese, or Korean input would incorrectly submit the chat message or save the conversation title, instead of confirming the IME composition.

The original fix was implemented in PR #6025 (commit e6499a68f) in `chat-input.tsx`, but was lost during a refactoring that split the chat input into multiple components.

### Changes Made

1. **`frontend/src/hooks/chat/use-chat-input-events.ts`**: Added `isComposing` check to the main chat input's `handleKeyDown` function
2. **`frontend/src/components/features/conversation-panel/conversation-card/conversation-card-title.tsx`**: Added `isComposing` check to conversation card title editing
3. **`frontend/src/components/features/conversation/conversation-name.tsx`**: Added `isComposing` check to conversation name editing
4. **`frontend/__tests__/components/interactive-chat-box.test.tsx`**: Added test to verify IME composition behavior

### How it works

When using an IME, the `isComposing` property of the keyboard event's `nativeEvent` is `true` during active composition. By checking this property before processing the Enter key, we can distinguish between:
- Enter to confirm IME composition (should NOT submit)
- Enter to submit the message (should submit)

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Fixes the Chinese/Japanese/Korean IME input issue where Enter key submits instead of confirming composition.

## Release Notes

- [x] Include this change in the Release Notes.

Fixed an issue where pressing Enter while using Chinese, Japanese, or Korean input methods would incorrectly submit the message instead of confirming the IME composition.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fdbbccba84e14222b960ddf170e53136)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:9008eac-nikolaik   --name openhands-app-9008eac   docker.openhands.dev/openhands/openhands:9008eac
```