### PR TITLE
fix(frontend): make secrets table responsive when descriptions are long

### DIFF
--- a/frontend/src/components/features/settings/secrets-settings/secret-list-item.tsx
+++ b/frontend/src/components/features/settings/secrets-settings/secret-list-item.tsx
@@ -30,40 +30,39 @@ export function SecretListItem({
   onDelete,
 }: SecretListItemProps) {
   return (
-    <tr
-      data-testid="secret-item"
-      className="flex w-full items-center border-t border-tertiary"
-    >
-      <td className="p-3 w-1/4 text-sm text-content-2 truncate" title={title}>
+    <tr data-testid="secret-item" className="border-t border-tertiary">
+      <td className="p-3 text-sm text-content-2 truncate" title={title}>
         {title}
       </td>
 
       <td
-        className="p-3 w-1/2 truncate overflow-hidden whitespace-nowrap text-sm text-content-2 opacity-80 italic"
+        className="p-3 truncate overflow-hidden whitespace-nowrap text-sm text-content-2 opacity-80 italic"
         title={description || ""}
       >
         {description || ""}
       </td>
 
-      <td className="p-3 w-1/4 flex items-center justify-end gap-4">
-        <button
-          data-testid="edit-secret-button"
-          type="button"
-          onClick={onEdit}
-          aria-label={`Edit ${title}`}
-          className="cursor-pointer"
-        >
-          <FaPencil size={16} />
-        </button>
-        <button
-          data-testid="delete-secret-button"
-          type="button"
-          onClick={onDelete}
-          aria-label={`Delete ${title}`}
-          className="cursor-pointer"
-        >
-          <FaTrash size={16} />
-        </button>
+      <td className="p-3">
+        <div className="flex items-center justify-end gap-4">
+          <button
+            data-testid="edit-secret-button"
+            type="button"
+            onClick={onEdit}
+            aria-label={`Edit ${title}`}
+            className="cursor-pointer"
+          >
+            <FaPencil size={16} />
+          </button>
+          <button
+            data-testid="delete-secret-button"
+            type="button"
+            onClick={onDelete}
+            aria-label={`Delete ${title}`}
+            className="cursor-pointer"
+          >
+            <FaTrash size={16} />
+          </button>
+        </div>
       </td>
     </tr>
   );

--- a/frontend/src/routes/secrets-settings.tsx
+++ b/frontend/src/routes/secrets-settings.tsx
@@ -85,9 +85,9 @@ function SecretsSettingsScreen() {
 
       {view === "list" && (
         <div className="border border-tertiary rounded-md overflow-hidden">
-          <table className="w-full">
+          <table className="w-full min-w-full table-fixed">
             <thead className="bg-base-tertiary">
-              <tr className="flex w-full items-center">
+              <tr>
                 <th className="w-1/4 text-left p-3 text-sm font-medium">
                   {t(I18nKey.SETTINGS$NAME)}
                 </th>


### PR DESCRIPTION
<!-- Ideally you should open a PR when it is ready for review. Draft PRs will not be reviewed -->

## Demo Video

https://github.com/user-attachments/assets/7fc58916-0930-4b06-890d-02a4611afc25

## Summary of PR

<!-- Summarize what the PR does -->

https://github.com/user-attachments/assets/c3b83e7a-9722-4e33-8730-5842adf2c91f

As shown in the video above, the Secrets table does not display properly when the description content is too long.

**Acceptance Criteria:**
- Update the table styling to ensure the Secrets table is fully responsive across different screen sizes.

## Change Type

<!-- Choose the types that apply to your PR -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #12362

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:9617bc9-nikolaik   --name openhands-app-9617bc9   docker.openhands.dev/openhands/openhands:9617bc9
```