### PR TITLE
Run .openhands/agent_finish.sh when agent finishes

### DIFF
--- a/tests/unit/controller/test_agent_finish_hook.py
+++ b/tests/unit/controller/test_agent_finish_hook.py
@@ -1,0 +1,45 @@
+"""Unit tests for the repository agent_finish.sh hook."""
+
+from unittest.mock import MagicMock, patch
+
+from openhands.controller.agent_controller import AgentController
+from openhands.events.action import CmdRunAction
+from openhands.events.event import EventSource
+
+
+def test_enqueue_agent_finish_hook_adds_cmd_run_action():
+    controller = MagicMock(spec=AgentController)
+    controller.is_delegate = False
+    controller.event_stream = MagicMock()
+
+    with patch.object(
+        AgentController,
+        '_enqueue_agent_finish_hook',
+        AgentController._enqueue_agent_finish_hook,
+    ):
+        AgentController._enqueue_agent_finish_hook(controller)
+
+    controller.event_stream.add_event.assert_called_once()
+    action, source = controller.event_stream.add_event.call_args.args
+
+    assert isinstance(action, CmdRunAction)
+    assert source == EventSource.ENVIRONMENT
+    assert '.openhands/agent_finish.sh' in action.command
+    assert action.hidden is True
+    assert action.blocking is True
+    assert action.timeout == 600
+
+
+def test_enqueue_agent_finish_hook_skips_for_delegate_controller():
+    controller = MagicMock(spec=AgentController)
+    controller.is_delegate = True
+    controller.event_stream = MagicMock()
+
+    with patch.object(
+        AgentController,
+        '_enqueue_agent_finish_hook',
+        AgentController._enqueue_agent_finish_hook,
+    ):
+        AgentController._enqueue_agent_finish_hook(controller)
+
+    controller.event_stream.add_event.assert_not_called()


### PR DESCRIPTION
Adds a repository hook script `.openhands/agent_finish.sh` that is executed in the sandbox whenever the top-level agent finishes a task (AgentFinishAction -> FINISHED).

- Injects a hidden ENVIRONMENT CmdRunAction on FINISHED
- Best-effort repo root detection via `git rev-parse --show-toplevel`
- 10 minute timeout

Also adds unit tests for the hook enqueue behavior.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:1701c18-nikolaik   --name openhands-app-1701c18   docker.openhands.dev/openhands/openhands:1701c18
```