### PR TITLE
UV Migration Step 1.2: Add PEP 735 [dependency-groups] section for UV compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,71 @@ classifiers = [
 dynamic = [ "version" ]
 
 urls.Homepage = "https://github.com/OpenHands/OpenHands"
+# PEP 735 dependency groups (for UV compatibility)
+# These coexist with [tool.poetry.group.*] during the migration period
 urls.Repository = "https://github.com/OpenHands/OpenHands"
+
+[dependency-groups]
+dev = [
+  "build",
+  "mypy==1.17",
+  "pre-commit==4.2",
+  "pytest>=8.4",
+  "pytest-asyncio>=1.3",
+  "ruff==0.12.5",
+  "types-setuptools",
+]
+test = [
+  "gevent>=24.2.1,<26",
+  "pandas",
+  "pytest",
+  "pytest-asyncio",
+  "pytest-cov",
+  "pytest-forked",
+  "pytest-playwright>=0.7",
+  "pytest-timeout>=2.4",
+  "pytest-xdist",
+  "reportlab",
+]
+runtime = [
+  "flake8",
+  "jupyterlab",
+  "notebook",
+]
+evaluation = [
+  "boto3-stubs[s3]>=1.37.19",
+  "browsergym==0.13.3",
+  "browsergym-miniwob==0.13.3",
+  "browsergym-visualwebarena==0.13.3",
+  "browsergym-webarena==0.13.3",
+  "commit0",
+  "datasets",
+  "evaluate",
+  "func-timeout",
+  "gdown",
+  "joblib",
+  "matplotlib",
+  "multi-swe-bench==0.1.2",
+  "pandas",
+  "pyarrow==21",
+  "retry",
+  "seaborn",
+  "streamlit",
+  "swebench",
+  "swegym",
+  "sympy",
+  "tabulate",
+  "visualswebench",
+  "whatthepatch",
+]
+testgeneval = [
+  "fuzzywuzzy>=0.18",
+  "python-levenshtein>=0.26.1,<0.28",
+  "rouge>=1.0.1",
+  "tree-sitter-python>=0.23.6",
+]
+
+# UV source configuration for git dependencies in evaluation group
 
 [tool.poetry]
 name = "openhands-ai"
@@ -241,3 +305,8 @@ lint.pydocstyle.convention = "google"
 concurrency = [ "gevent" ]
 relative_files = true
 omit = [ "enterprise/tests/*", "**/test_*" ]
+
+[tool.uv.sources]
+visualswebench = { git = "https://github.com/luolin101/Visual-SWE-bench.git" }
+swegym = { git = "https://github.com/SWE-Gym/SWE-Bench-Package.git" }
+swebench = { git = "https://github.com/ryanhoangt/SWE-bench.git", rev = "fix-modal-patch-eval" }


### PR DESCRIPTION
## Summary

This is Step 1.2 in migrating from Poetry to UV for Python dependency management. This PR adds a PEP 735 `[dependency-groups]` section to `pyproject.toml` while keeping all existing Poetry group configurations intact.

> **Note:** This change alone does not result in a testable UV configuration. UV support requires additional steps (adding `[project.dependencies]`, changing build-system to hatchling, and generating `uv.lock`). See the Migration Plan below for details.

**Note:** This PR is based on Step 1.1 branch and should be merged after #12414.

## Changes

- Add `[dependency-groups]` section with the following groups:
  - `dev`: Development tools (ruff, mypy, pre-commit, pytest, etc.)
  - `test`: Testing dependencies (pytest plugins, pandas, gevent, etc.)
  - `runtime`: Runtime dependencies (jupyterlab, notebook, flake8)
  - `evaluation`: Evaluation benchmark dependencies
  - `testgeneval`: Test generation evaluation dependencies
- Add `[tool.uv.sources]` section for git dependencies:
  - `visualswebench` from GitHub
  - `swegym` from GitHub
  - `swebench` from GitHub (with specific revision)
- Keep all existing `[tool.poetry.group.*]` sections intact for backward compatibility

## Dependency Groups Mapping

| Poetry Group | UV Dependency Group | Description |
|--------------|---------------------|-------------|
| `[tool.poetry.group.dev.dependencies]` | `[dependency-groups].dev` | Development tools |
| `[tool.poetry.group.test.dependencies]` | `[dependency-groups].test` | Testing dependencies |
| `[tool.poetry.group.runtime.dependencies]` | `[dependency-groups].runtime` | Runtime dependencies |
| `[tool.poetry.group.evaluation.dependencies]` | `[dependency-groups].evaluation` | Evaluation benchmarks |
| `[tool.poetry.group.testgeneval.dependencies]` | `[dependency-groups].testgeneval` | Test generation eval |

## Git Dependencies

The evaluation group contains git dependencies that require special handling in UV. These are configured via `[tool.uv.sources]`:

```toml
[tool.uv.sources]
visualswebench = { git = "https://github.com/luolin101/Visual-SWE-bench.git" }
swegym = { git = "https://github.com/SWE-Gym/SWE-Bench-Package.git" }
swebench = { git = "https://github.com/ryanhoangt/SWE-bench.git", rev = "fix-modal-patch-eval" }
```

## Why This Change?

UV uses PEP 735 dependency groups instead of Poetry's custom group format. This allows UV to understand and install the same dependency groups that Poetry uses, enabling a smooth migration path.

## Migration Plan

This is Step 1.2 of the Poetry to UV migration:
1. ✅ Step 1.1: Add PEP 621 `[project]` section (#12414)
2. ✅ **Step 1.2**: Add `[dependency-groups]` section (this PR)
3. Step 1.3: Add `[project.dependencies]` section
4. Step 1.4: Add `[project.optional-dependencies]` section
5. Step 1.5: Change build-system to hatchling
6. Step 1.6: Generate `uv.lock` file ← **UV becomes testable after this step**
7. ... (additional steps)

## Testing

- [x] `poetry check` passes (with expected warnings about coexisting sections)
- [x] Pre-commit hooks pass
- [x] No changes to existing Poetry functionality

---
Closes #12421 (partial)