### PR TITLE
fix: Add CORS instructions to work_hosts skill for App tab

### DIFF
--- a/openhands/app_server/app_conversation/skill_loader.py
+++ b/openhands/app_server/app_conversation/skill_loader.py
@@ -30,6 +30,50 @@ GLOBAL_SKILLS_DIR = os.path.join(
 WORK_HOSTS_SKILL = """The user has access to the following hosts for accessing a web application,
 each of which has a corresponding port:"""
 
+WORK_HOSTS_SKILL_FOOTER = """
+**IMPORTANT: Enable CORS on your web server**
+
+When starting a web server, you MUST enable CORS (Cross-Origin Resource Sharing) so the App tab can detect and display your application. Without CORS headers, the App tab will show an empty state even if the server is running.
+
+Examples for common frameworks:
+
+**Express.js:**
+```javascript
+const cors = require('cors');
+app.use(cors());
+```
+
+**Flask (Python):**
+```python
+from flask import Flask
+from flask_cors import CORS
+app = Flask(__name__)
+CORS(app)
+```
+
+**FastAPI (Python):**
+```python
+from fastapi.middleware.cors import CORSMiddleware
+app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+```
+
+**Vite (dev server):**
+```javascript
+// vite.config.js
+export default { server: { cors: true } }
+```
+
+**Simple Python HTTP server** (use this instead of `python -m http.server`):
+```python
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+class CORSHandler(SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header('Access-Control-Allow-Origin', '*')
+        super().end_headers()
+HTTPServer(('', PORT), CORSHandler).serve_forever()
+```
+"""
+
 
 def _find_and_load_global_skill_files(skill_dir: Path) -> list[Skill]:
     """Find and load all .md files from the global skills directory.
@@ -73,6 +117,7 @@ def load_sandbox_skills(sandbox: SandboxInfo) -> list[Skill]:
     content_list = [WORK_HOSTS_SKILL]
     for url in urls:
         content_list.append(f'* {url.url} (port {url.port})')
+    content_list.append(WORK_HOSTS_SKILL_FOOTER)
     content = '\n'.join(content_list)
     return [Skill(name='work_hosts', content=content, trigger=None)]
 


### PR DESCRIPTION
## Summary

This PR adds CORS (Cross-Origin Resource Sharing) enablement instructions to the `work_hosts` skill that agents receive in V1 conversations.

## Problem

The App tab polls worker URLs via axios to detect if a server is running:

```typescript
// use-unified-active-host.ts
try {
  await axios.get(host);  // Blocked by CORS if server doesn't send headers
  return host;
} catch (e) {
  return "";  // Returns empty → App tab shows "empty state"
}
```

When web servers don't send CORS headers, the browser blocks these cross-origin requests, causing the App tab to show an empty state even when the server is accessible directly via its URL.

## Solution

Added clear CORS instructions to the `work_hosts` skill with examples for common frameworks:
- **Express.js** - `app.use(cors())`
- **Flask** - `CORS(app)`
- **FastAPI** - `CORSMiddleware`
- **Vite** - dev server config
- **Python http.server** - custom handler with CORS headers

## Testing

Verified manually that the issue is CORS-related:
```
Access to fetch at 'https://work-1-xxx.staging-runtime.all-hands.dev/' from origin 
'https://ohpr-12424-44.staging.all-hands.dev' has been blocked by CORS policy: 
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

The sandbox API correctly returns the worker URLs with `status: "RUNNING"`, confirming the backend is working correctly and this is purely a frontend CORS detection issue.

## Related

- Related to testing PR #12424 (add WORKER_1/WORKER_2 env vars)
- Fixes App tab not appearing for V1 conversations when agents create web servers without CORS configuration

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:e147d75-nikolaik   --name openhands-app-e147d75   docker.openhands.dev/openhands/openhands:e147d75
```