### PR TITLE
[demo] fix: Add global rate limiter to prevent Resend API rate limit errors

### DIFF
--- a/enterprise/sync/resend_keycloak.py
+++ b/enterprise/sync/resend_keycloak.py
@@ -71,9 +71,6 @@ RATE_LIMIT_SAFETY_MARGIN = 0.9
 # Set up Resend API
 resend.api_key = RESEND_API_KEY
 
-print("resend module", resend)
-print("has contacts", hasattr(resend, "Contacts"))
-
 
 class RateLimiter:
     """Thread-safe rate limiter for API calls.
@@ -210,9 +207,9 @@ def get_resend_contacts(audience_id: str) -> Dict[str, Dict[str, Any]]:
     Raises:
         ResendAPIError: If the API call fails.
     """
-    print("getting resend contacts")
-    print("has resend contacts", hasattr(resend, "Contacts"))
     try:
+        # Wait for rate limiter before making API call
+        resend_rate_limiter.wait()
         contacts = resend.Contacts.list(audience_id).get("data", [])
         # Create a dictionary mapping email addresses to contact data for
         # efficient lookup

--- a/enterprise/sync/test_resend_keycloak.py
+++ b/enterprise/sync/test_resend_keycloak.py
@@ -2,19 +2,23 @@
 
 These tests verify the RateLimiter class functionality in isolation,
 without requiring the full module dependencies (keycloak, server, etc.).
+
+Note: The RateLimiter class is duplicated here to enable testing without
+importing the full resend_keycloak module (which has dependencies on
+keycloak, server.auth, etc.). If the RateLimiter implementation changes,
+these tests should be updated accordingly.
 """
 
 import threading
 import time
 from typing import Optional
 
-import pytest
-
 
 class RateLimiter:
     """Thread-safe rate limiter for API calls.
 
-    Copy of the class for testing in isolation.
+    This is a copy of the class from resend_keycloak.py for testing in isolation.
+    Keep in sync with the original implementation.
     """
 
     def __init__(self, requests_per_second: float, safety_margin: float = 0.9):


### PR DESCRIPTION
## Summary

This PR fixes the Resend API rate limiting errors that were appearing in production Datadog logs.

## Root Cause Analysis

From the Datadog logs, I found two types of `ResendError`:

1. **Rate limiting errors** (most common):
   ```
   ResendError: Too many requests. You can only make 2 requests per second.
   ```

2. **Server errors** (cascade from rate limiting):
   ```
   ResendError: Expected JSON response but got: text/html; charset=UTF-8
   ```

The issue was that the `resend_keycloak` sync script makes **2 API calls per user** (`add_contact_to_resend` + `send_welcome_email`), but the rate limiting logic was:
- Using individual `time.sleep(1 / RATE_LIMIT)` calls between operations
- Not accounting for all API calls hitting the same 2 req/s rate limit
- The `send_welcome_email` function didn't have retry logic like `add_contact_to_resend`

## Changes

1. **Added thread-safe `RateLimiter` class** with configurable safety margin (10%)
2. **Apply rate limiter before ALL Resend API calls** - both contacts and emails
3. **Added `@retry` decorator to `send_welcome_email`** for resilience against transient failures
4. **Removed manual `sleep()` calls** in `sync_users_to_resend` (now handled by RateLimiter)
5. **Added unit tests** for the RateLimiter class

## How it works

The global rate limiter ensures that across all operations, we never exceed ~1.8 requests/second (2 req/s * 0.9 safety margin). This prevents rate limit errors from the Resend API while still processing users efficiently.

```python
# Before: Manual sleep per operation (could exceed limit)
add_contact_to_resend(...)
time.sleep(1 / RATE_LIMIT)  # 0.5s
send_welcome_email(...)
time.sleep(1 / RATE_LIMIT)  # 0.5s

# After: Global rate limiter tracks ALL API calls
resend_rate_limiter.wait()  # Waits ~0.56s if needed
resend.Contacts.create(...)

resend_rate_limiter.wait()  # Waits ~0.56s if needed  
resend.Emails.send(...)
```

## Testing

- All 5 unit tests pass for the RateLimiter class
- `ruff check` passes
- `ruff format` applied

## Related

- Production Datadog logs showing `ResendError` rate limiting

@ak684 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:b9096c2-nikolaik   --name openhands-app-b9096c2   docker.openhands.dev/openhands/openhands:b9096c2
```