### PR TITLE
fix: preserve HTTP protocol for self-hosted Gitea/Forgejo instances

### DIFF
--- a/openhands/integrations/forgejo/service/base.py
+++ b/openhands/integrations/forgejo/service/base.py
@@ -57,7 +57,9 @@ class ForgejoMixinBase(BaseGitService, HTTPClient):
         self.base_url = self.BASE_URL  # Backwards compatibility for existing usage
         parsed = urlparse(self.BASE_URL)
         self.base_domain = parsed.netloc or self.DEFAULT_DOMAIN
-        self.web_base_url = f'https://{self.base_domain}'.rstrip('/')
+        # Preserve the protocol from BASE_URL (http or https)
+        protocol = parsed.scheme or 'https'
+        self.web_base_url = f'{protocol}://{self.base_domain}'.rstrip('/')
 
     @property
     def provider(self) -> str:


### PR DESCRIPTION
## Summary of PR

This PR fixes the issue where self-hosted Gitea/Forgejo instances running on HTTP fail with a 500 Internal Server Error due to the sandbox forcing HTTPS for git clone operations.

The root cause was that `get_authenticated_git_url()` in `provider.py` strips the protocol from the host and always reconstructs URLs with `https://`, regardless of the user's configuration. This causes a GnuTLS handshake failure when the target server only supports HTTP.

**Changes:**
- Detect the protocol from the host before normalizing the domain
- Use the detected protocol (`http` or `https`) when constructing git clone URLs for all providers (GitLab, Bitbucket, GitHub, Forgejo)
- Fix `web_base_url` in Forgejo service to preserve the protocol from `BASE_URL`

## Demo Screenshots/Videos

N/A - Backend fix, no UI changes.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #12358

## Release Notes

- [x] Include this change in the Release Notes.

Self-hosted Gitea/Forgejo instances running on HTTP now work correctly. Previously, the sandbox would force HTTPS for git clone operations, causing connection failures.

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=94194147