### PR TITLE
fix: Add global rate limiter to prevent Resend API rate limit errors

### DIFF
--- a/enterprise/tests/unit/test_rate_limiter.py
+++ b/enterprise/tests/unit/test_rate_limiter.py
@@ -1,0 +1,75 @@
+"""Unit tests for the RateLimiter class."""
+
+import threading
+import time
+
+from sync.resend_keycloak import RateLimiter
+
+
+class TestRateLimiter:
+    """Test cases for RateLimiter."""
+
+    def test_first_call_no_wait(self):
+        """First call should not wait."""
+        limiter = RateLimiter(requests_per_second=2.0, safety_margin=0.0)
+        start = time.monotonic()
+        limiter.wait()
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.1
+
+    def test_respects_rate_limit(self):
+        """Consecutive calls should respect the rate limit."""
+        limiter = RateLimiter(requests_per_second=10.0, safety_margin=0.0)
+        start = time.monotonic()
+        for _ in range(3):
+            limiter.wait()
+        elapsed = time.monotonic() - start
+        # 3 calls at 10 req/s should take at least 0.2s (2 intervals of 0.1s)
+        assert elapsed >= 0.18
+
+    def test_safety_margin_reduces_rate(self):
+        """Safety margin should reduce the effective rate."""
+        # 2 req/s with 50% safety margin = 1 req/s effective
+        limiter = RateLimiter(requests_per_second=2.0, safety_margin=0.5)
+        start = time.monotonic()
+        for _ in range(2):
+            limiter.wait()
+        elapsed = time.monotonic() - start
+        # 2 calls at 1 req/s effective should take at least 1.0s
+        assert elapsed >= 0.95
+
+    def test_thread_safety(self):
+        """RateLimiter should be thread-safe."""
+        limiter = RateLimiter(requests_per_second=10.0, safety_margin=0.0)
+        call_count = 0
+        lock = threading.Lock()
+
+        def make_calls():
+            nonlocal call_count
+            for _ in range(5):
+                limiter.wait()
+                with lock:
+                    call_count += 1
+
+        threads = [threading.Thread(target=make_calls) for _ in range(3)]
+        start = time.monotonic()
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        elapsed = time.monotonic() - start
+
+        # 15 total calls at 10 req/s should take at least 1.4s (14 intervals)
+        assert call_count == 15
+        assert elapsed >= 1.3
+
+    def test_default_safety_margin(self):
+        """Default safety margin should be 10%."""
+        # 2 req/s with 10% safety margin = 1.8 req/s effective = ~0.556s interval
+        limiter = RateLimiter(requests_per_second=2.0)
+        start = time.monotonic()
+        for _ in range(3):
+            limiter.wait()
+        elapsed = time.monotonic() - start
+        # 3 calls with ~0.556s interval should take at least 1.1s (2 intervals)
+        assert elapsed >= 1.0


### PR DESCRIPTION
## Summary

This PR fixes the Resend API rate limiting errors that were appearing in production Datadog logs.

## Root Cause Analysis

From the Datadog logs, I found `ResendError` rate limiting errors:

```
ResendError: Too many requests. You can only make 2 requests per second.
```

The error trace showed:
- File: `/app/sync/resend_keycloak.py`, line 286 in `send_welcome_email`
- File: `/app/sync/resend_keycloak.py`, line 226 in `add_contact_to_resend`
- Service: `deploy` (enterprise-server)

The issues were:

1. **Missing retry logic on `send_welcome_email`**: The `add_contact_to_resend` function had `@retry` decorator, but `send_welcome_email` did not. When rate limit errors occurred during email sending, they failed immediately without retry.

2. **Rate limiting applied after API calls instead of before**: The code used `time.sleep(1 / RATE_LIMIT)` after each API call, which does not prevent rate limit violations when timing drifts occur or retries happen.

3. **No global coordination of API calls**: Each function managed its own timing independently, leading to scenarios where combined calls exceeded the rate limit.

## Changes

1. **Added thread-safe `RateLimiter` class** with configurable safety margin (default 10%)
2. **Apply rate limiter before ALL Resend API calls** - both `Contacts.create` and `Emails.send`
3. **Added `@retry` decorator to `send_welcome_email`** for resilience against transient failures
4. **Removed manual `sleep()` calls** in `sync_users_to_resend` (now handled by RateLimiter)
5. **Added unit tests** for the RateLimiter class

## How it works

The global rate limiter ensures that across all operations, we never exceed ~1.8 requests/second (2 req/s * 0.9 safety margin). This prevents rate limit errors from the Resend API while still processing users efficiently.

```python
# Before: Manual sleep per operation (could exceed limit)
add_contact_to_resend(...)
time.sleep(1 / RATE_LIMIT)  # 0.5s
send_welcome_email(...)
time.sleep(1 / RATE_LIMIT)  # 0.5s

# After: Global rate limiter tracks ALL API calls
resend_rate_limiter.wait()  # Waits ~0.56s if needed
resend.Contacts.create(...)

resend_rate_limiter.wait()  # Waits ~0.56s if needed  
resend.Emails.send(...)
```

## Testing

- All 5 unit tests pass for the RateLimiter class
- `ruff check` passes
- `ruff format` check passes

## Related

- Production Datadog logs showing `ResendError` rate limiting

@ak684 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:47b2209-nikolaik   --name openhands-app-47b2209   docker.openhands.dev/openhands/openhands:47b2209
```