### PR TITLE
fix: Add global rate limiter to prevent Resend API rate limit errors

### DIFF
--- a/enterprise/sync/resend_keycloak.py
+++ b/enterprise/sync/resend_keycloak.py
@@ -87,32 +87,32 @@ class RateLimiter:
 resend_rate_limiter = RateLimiter(requests_per_second=2.0, safety_margin=0.1)
 
 # Get Keycloak configuration from environment variables
-KEYCLOAK_SERVER_URL = os.environ.get("KEYCLOAK_SERVER_URL", "")
-KEYCLOAK_REALM_NAME = os.environ.get("KEYCLOAK_REALM_NAME", "")
-KEYCLOAK_PROVIDER_NAME = os.environ.get("KEYCLOAK_PROVIDER_NAME", "")
-KEYCLOAK_CLIENT_ID = os.environ.get("KEYCLOAK_CLIENT_ID", "")
-KEYCLOAK_CLIENT_SECRET = os.environ.get("KEYCLOAK_CLIENT_SECRET", "")
-KEYCLOAK_ADMIN_PASSWORD = os.environ.get("KEYCLOAK_ADMIN_PASSWORD", "")
+KEYCLOAK_SERVER_URL = os.environ.get('KEYCLOAK_SERVER_URL', '')
+KEYCLOAK_REALM_NAME = os.environ.get('KEYCLOAK_REALM_NAME', '')
+KEYCLOAK_PROVIDER_NAME = os.environ.get('KEYCLOAK_PROVIDER_NAME', '')
+KEYCLOAK_CLIENT_ID = os.environ.get('KEYCLOAK_CLIENT_ID', '')
+KEYCLOAK_CLIENT_SECRET = os.environ.get('KEYCLOAK_CLIENT_SECRET', '')
+KEYCLOAK_ADMIN_PASSWORD = os.environ.get('KEYCLOAK_ADMIN_PASSWORD', '')
 
 # Logger is imported from openhands.core.logger
 
 # Get configuration from environment variables
-RESEND_API_KEY = os.environ.get("RESEND_API_KEY")
-RESEND_AUDIENCE_ID = os.environ.get("RESEND_AUDIENCE_ID", "")
+RESEND_API_KEY = os.environ.get('RESEND_API_KEY')
+RESEND_AUDIENCE_ID = os.environ.get('RESEND_AUDIENCE_ID', '')
 
 # Sync configuration
-BATCH_SIZE = int(os.environ.get("BATCH_SIZE", "100"))
-MAX_RETRIES = int(os.environ.get("MAX_RETRIES", "3"))
-INITIAL_BACKOFF_SECONDS = float(os.environ.get("INITIAL_BACKOFF_SECONDS", "1"))
-MAX_BACKOFF_SECONDS = float(os.environ.get("MAX_BACKOFF_SECONDS", "60"))
-BACKOFF_FACTOR = float(os.environ.get("BACKOFF_FACTOR", "2"))
-RATE_LIMIT = float(os.environ.get("RATE_LIMIT", "2"))  # Requests per second
+BATCH_SIZE = int(os.environ.get('BATCH_SIZE', '100'))
+MAX_RETRIES = int(os.environ.get('MAX_RETRIES', '3'))
+INITIAL_BACKOFF_SECONDS = float(os.environ.get('INITIAL_BACKOFF_SECONDS', '1'))
+MAX_BACKOFF_SECONDS = float(os.environ.get('MAX_BACKOFF_SECONDS', '60'))
+BACKOFF_FACTOR = float(os.environ.get('BACKOFF_FACTOR', '2'))
+RATE_LIMIT = float(os.environ.get('RATE_LIMIT', '2'))  # Requests per second
 
 # Set up Resend API
 resend.api_key = RESEND_API_KEY
 
-print("resend module", resend)
-print("has contacts", hasattr(resend, "Contacts"))
+print('resend module', resend)
+print('has contacts', hasattr(resend, 'Contacts'))
 
 
 class ResendSyncError(Exception):
@@ -152,34 +152,34 @@ def get_keycloak_users(offset: int = 0, limit: int = 100) -> List[Dict[str, Any]
         # Get users with pagination
         # The Keycloak API uses 'first' for offset and 'max' for limit
         params: Dict[str, Any] = {
-            "first": offset,
-            "max": limit,
-            "briefRepresentation": False,  # Get full user details
+            'first': offset,
+            'max': limit,
+            'briefRepresentation': False,  # Get full user details
         }
 
         users_data = keycloak_admin.get_users(params)
-        logger.info(f"Fetched {len(users_data)} users from Keycloak")
+        logger.info(f'Fetched {len(users_data)} users from Keycloak')
 
         # Transform the response to match our expected format
         users = []
         for user in users_data:
-            if user.get("email"):  # Ensure user has an email
+            if user.get('email'):  # Ensure user has an email
                 users.append(
                     {
-                        "id": user.get("id"),
-                        "email": user.get("email"),
-                        "first_name": user.get("firstName"),
-                        "last_name": user.get("lastName"),
-                        "username": user.get("username"),
+                        'id': user.get('id'),
+                        'email': user.get('email'),
+                        'first_name': user.get('firstName'),
+                        'last_name': user.get('lastName'),
+                        'username': user.get('username'),
                     }
                 )
 
         return users
     except KeycloakError:
-        logger.exception("Failed to get users from Keycloak")
+        logger.exception('Failed to get users from Keycloak')
         raise
     except Exception:
-        logger.exception("Unexpected error getting users from Keycloak")
+        logger.exception('Unexpected error getting users from Keycloak')
         raise
 
 
@@ -197,10 +197,10 @@ def get_total_keycloak_users() -> int:
         count = keycloak_admin.users_count()
         return count
     except KeycloakError:
-        logger.exception("Failed to get total users from Keycloak")
+        logger.exception('Failed to get total users from Keycloak')
         raise
     except Exception:
-        logger.exception("Unexpected error getting total users from Keycloak")
+        logger.exception('Unexpected error getting total users from Keycloak')
         raise
 
 
@@ -216,15 +216,15 @@ def get_resend_contacts(audience_id: str) -> Dict[str, Dict[str, Any]]:
     Raises:
         ResendAPIError: If the API call fails.
     """
-    print("getting resend contacts")
-    print("has resend contacts", hasattr(resend, "Contacts"))
+    print('getting resend contacts')
+    print('has resend contacts', hasattr(resend, 'Contacts'))
     try:
-        contacts = resend.Contacts.list(audience_id).get("data", [])
+        contacts = resend.Contacts.list(audience_id).get('data', [])
         # Create a dictionary mapping email addresses to contact data for
         # efficient lookup
-        return {contact["email"].lower(): contact for contact in contacts}
+        return {contact['email'].lower(): contact for contact in contacts}
     except Exception:
-        logger.exception("Failed to get contacts from Resend")
+        logger.exception('Failed to get contacts from Resend')
         raise
 
 
@@ -258,19 +258,19 @@ def add_contact_to_resend(
         ResendAPIError: If the API call fails after retries.
     """
     try:
-        params = {"audience_id": audience_id, "email": email}
+        params = {'audience_id': audience_id, 'email': email}
 
         if first_name:
-            params["first_name"] = first_name
+            params['first_name'] = first_name
 
         if last_name:
-            params["last_name"] = last_name
+            params['last_name'] = last_name
 
         # Wait for rate limiter BEFORE making the API call
         resend_rate_limiter.wait()
         return resend.Contacts.create(params)
     except Exception:
-        logger.exception(f"Failed to add contact {email} to Resend")
+        logger.exception(f'Failed to add contact {email} to Resend')
         raise
 
 
@@ -303,23 +303,23 @@ def send_welcome_email(
     """
     try:
         # Prepare the recipient name
-        recipient_name = ""
+        recipient_name = ''
         if first_name:
             recipient_name = first_name
             if last_name:
-                recipient_name += f" {last_name}"
+                recipient_name += f' {last_name}'
 
         # Personalize greeting based on available information
-        greeting = f"Hi {recipient_name}," if recipient_name else "Hi there,"
+        greeting = f'Hi {recipient_name},' if recipient_name else 'Hi there,'
 
         # Prepare email parameters
         params = {
-            "from": os.environ.get(
-                "RESEND_FROM_EMAIL", "All Hands Team <contact@all-hands.dev>"
+            'from': os.environ.get(
+                'RESEND_FROM_EMAIL', 'All Hands Team <contact@all-hands.dev>'
             ),
-            "to": [email],
-            "subject": "Welcome to OpenHands Cloud",
-            "html": f"""
+            'to': [email],
+            'subject': 'Welcome to OpenHands Cloud',
+            'html': f"""
             <div>
                 <p>{greeting}</p>
                 <p>Thanks for joining OpenHands Cloud — we're excited to help you start building with the world's leading open source AI coding agent!</p>
@@ -340,10 +340,10 @@ def send_welcome_email(
         resend_rate_limiter.wait()
         # Send the email
         response = resend.Emails.send(params)
-        logger.info(f"Welcome email sent to {email}")
+        logger.info(f'Welcome email sent to {email}')
         return response
     except Exception:
-        logger.exception(f"Failed to send welcome email to {email}")
+        logger.exception(f'Failed to send welcome email to {email}')
         raise
 
 
@@ -351,105 +351,105 @@ def sync_users_to_resend():
     """Sync users from Keycloak to Resend."""
     # Check required environment variables
     required_vars = {
-        "RESEND_API_KEY": RESEND_API_KEY,
-        "RESEND_AUDIENCE_ID": RESEND_AUDIENCE_ID,
-        "KEYCLOAK_SERVER_URL": KEYCLOAK_SERVER_URL,
-        "KEYCLOAK_REALM_NAME": KEYCLOAK_REALM_NAME,
-        "KEYCLOAK_ADMIN_PASSWORD": KEYCLOAK_ADMIN_PASSWORD,
+        'RESEND_API_KEY': RESEND_API_KEY,
+        'RESEND_AUDIENCE_ID': RESEND_AUDIENCE_ID,
+        'KEYCLOAK_SERVER_URL': KEYCLOAK_SERVER_URL,
+        'KEYCLOAK_REALM_NAME': KEYCLOAK_REALM_NAME,
+        'KEYCLOAK_ADMIN_PASSWORD': KEYCLOAK_ADMIN_PASSWORD,
     }
 
     missing_vars = [var for var, value in required_vars.items() if not value]
 
     if missing_vars:
         for var in missing_vars:
-            logger.error(f"{var} environment variable is not set")
+            logger.error(f'{var} environment variable is not set')
         sys.exit(1)
 
     # Log configuration (without sensitive info)
-    logger.info(f"Using Keycloak server: {KEYCLOAK_SERVER_URL}")
-    logger.info(f"Using Keycloak realm: {KEYCLOAK_REALM_NAME}")
+    logger.info(f'Using Keycloak server: {KEYCLOAK_SERVER_URL}')
+    logger.info(f'Using Keycloak realm: {KEYCLOAK_REALM_NAME}')
 
     logger.info(
-        f"Starting sync of Keycloak users to Resend audience {RESEND_AUDIENCE_ID}"
+        f'Starting sync of Keycloak users to Resend audience {RESEND_AUDIENCE_ID}'
     )
 
     try:
         # Get the total number of users
         total_users = get_total_keycloak_users()
         logger.info(
-            f"Found {total_users} users in Keycloak realm {KEYCLOAK_REALM_NAME}"
+            f'Found {total_users} users in Keycloak realm {KEYCLOAK_REALM_NAME}'
         )
 
         # Get contacts from Resend
         resend_contacts = get_resend_contacts(RESEND_AUDIENCE_ID)
         logger.info(
-            f"Found {len(resend_contacts)} contacts in Resend audience "
-            f"{RESEND_AUDIENCE_ID}"
+            f'Found {len(resend_contacts)} contacts in Resend audience '
+            f'{RESEND_AUDIENCE_ID}'
         )
 
         # Stats
         stats = {
-            "total_users": total_users,
-            "existing_contacts": len(resend_contacts),
-            "added_contacts": 0,
-            "errors": 0,
+            'total_users': total_users,
+            'existing_contacts': len(resend_contacts),
+            'added_contacts': 0,
+            'errors': 0,
         }
 
         # Process users in batches
         offset = 0
         while offset < total_users:
             users = get_keycloak_users(offset, BATCH_SIZE)
-            logger.info(f"Processing batch of {len(users)} users (offset {offset})")
+            logger.info(f'Processing batch of {len(users)} users (offset {offset})')
 
             for user in users:
-                email = user.get("email")
+                email = user.get('email')
                 if not email:
                     continue
 
                 email = email.lower()
                 if email in resend_contacts:
-                    logger.debug(f"User {email} already exists in Resend, skipping")
+                    logger.debug(f'User {email} already exists in Resend, skipping')
                     continue
 
                 try:
-                    first_name = user.get("first_name")
-                    last_name = user.get("last_name")
+                    first_name = user.get('first_name')
+                    last_name = user.get('last_name')
 
                     # Add the contact to the Resend audience
                     # Rate limiting is handled inside add_contact_to_resend
                     add_contact_to_resend(
                         RESEND_AUDIENCE_ID, email, first_name, last_name
                     )
-                    logger.info(f"Added user {email} to Resend")
-                    stats["added_contacts"] += 1
+                    logger.info(f'Added user {email} to Resend')
+                    stats['added_contacts'] += 1
 
                     # Send a welcome email to the newly added contact
                     # Rate limiting is handled inside send_welcome_email
                     try:
                         send_welcome_email(email, first_name, last_name)
-                        logger.info(f"Sent welcome email to {email}")
+                        logger.info(f'Sent welcome email to {email}')
                     except Exception:
                         logger.exception(
-                            f"Failed to send welcome email to {email}, but contact was added to audience"
+                            f'Failed to send welcome email to {email}, but contact was added to audience'
                         )
                         # Continue with the sync process even if sending the welcome email fails
                 except Exception:
-                    logger.exception(f"Error adding user {email} to Resend")
-                    stats["errors"] += 1
+                    logger.exception(f'Error adding user {email} to Resend')
+                    stats['errors'] += 1
 
             offset += BATCH_SIZE
 
-        logger.info(f"Sync completed: {stats}")
+        logger.info(f'Sync completed: {stats}')
     except KeycloakClientError:
-        logger.exception("Keycloak client error")
+        logger.exception('Keycloak client error')
         sys.exit(1)
     except ResendAPIError:
-        logger.exception("Resend API error")
+        logger.exception('Resend API error')
         sys.exit(1)
     except Exception:
-        logger.exception("Sync failed with unexpected error")
+        logger.exception('Sync failed with unexpected error')
         sys.exit(1)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     sync_users_to_resend()

--- a/enterprise/sync/test_rate_limiter.py
+++ b/enterprise/sync/test_rate_limiter.py
@@ -96,5 +96,5 @@ class TestRateLimiter(unittest.TestCase):
         self.assertLess(elapsed, 0.01)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

This PR fixes the Resend API rate limiting errors that were appearing in production Datadog logs.

## Root Cause Analysis

From the Datadog logs, I found `ResendError` rate limiting errors:

```
ResendError: Too many requests. You can only make 2 requests per second.
```

The error trace showed:
- File: `/app/sync/resend_keycloak.py`, line 286 in `send_welcome_email`
- File: `/app/sync/resend_keycloak.py`, line 226 in `add_contact_to_resend`
- Service: `deploy` (enterprise-server)

The issues were:

1. **Missing retry logic on `send_welcome_email`**: The `add_contact_to_resend` function had `@retry` decorator, but `send_welcome_email` did not. When rate limit errors occurred during email sending, they failed immediately without retry.

2. **Rate limiting applied after API calls instead of before**: The code used `time.sleep(1 / RATE_LIMIT)` after each API call, which does not prevent rate limit violations when timing drifts occur or retries happen.

3. **No global coordination of API calls**: Each function managed its own timing independently, leading to scenarios where combined calls exceeded the rate limit.

## Changes

1. **Added thread-safe `RateLimiter` class** with configurable safety margin (default 10%)
2. **Apply rate limiter before ALL Resend API calls** - both `Contacts.create` and `Emails.send`
3. **Added `@retry` decorator to `send_welcome_email`** for resilience against transient failures
4. **Removed manual `sleep()` calls** in `sync_users_to_resend` (now handled by RateLimiter)
5. **Added unit tests** for the RateLimiter class

## How it works

The global rate limiter ensures that across all operations, we never exceed ~1.8 requests/second (2 req/s * 0.9 safety margin). This prevents rate limit errors from the Resend API while still processing users efficiently.

```python
# Before: Manual sleep per operation (could exceed limit during retries)
add_contact_to_resend(...)  # Has @retry, could make multiple calls
time.sleep(1 / RATE_LIMIT)  # 0.5s
send_welcome_email(...)      # No @retry, immediate failure on rate limit
time.sleep(1 / RATE_LIMIT)  # 0.5s

# After: Global rate limiter tracks ALL API calls
resend_rate_limiter.wait()  # Waits ~0.55s if needed (before API call)
resend.Contacts.create(...)

resend_rate_limiter.wait()  # Waits ~0.55s if needed (before API call)
resend.Emails.send(...)
```

## Testing

- Added 5 unit tests for the RateLimiter class covering:
  - First call has no wait
  - Subsequent calls respect rate limit
  - Safety margin increases wait time
  - Thread safety
  - No wait after sufficient time has passed
- `ruff check` passes
- `ruff format` check passes

## Related

- Production Datadog logs showing `ResendError` rate limiting

@ak684 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:879e989-nikolaik   --name openhands-app-879e989   docker.openhands.dev/openhands/openhands:879e989
```