### PR TITLE
feat(V1 sandbox): add use_host_network support for DockerSandboxService

### DIFF
--- a/openhands/app_server/sandbox/docker_sandbox_service.py
+++ b/openhands/app_server/sandbox/docker_sandbox_service.py
@@ -352,7 +352,6 @@ class DockerSandboxService(SandboxService):
         )
 
         # Determine network mode and prepare port mappings
-        network_mode: str | None = 'host' if self.use_host_network else None
         port_mappings: dict[int, int] | None = None
 
         if self.use_host_network:
@@ -389,26 +388,34 @@ class DockerSandboxService(SandboxService):
         }
 
         try:
+            # Build container run arguments
+            # Note: ports and network_mode='host' are mutually exclusive in Docker
+            run_kwargs: dict = {
+                'image': sandbox_spec.id,
+                'command': sandbox_spec.command,
+                'remove': False,
+                'name': container_name,
+                'environment': env_vars,
+                'volumes': volumes,
+                'working_dir': sandbox_spec.working_dir,
+                'labels': labels,
+                'detach': True,
+                'init': True,
+            }
+
+            # Add network_mode for host networking, or ports for bridge networking
+            # These are mutually exclusive - Docker throws error if both are specified
+            if self.use_host_network:
+                run_kwargs['network_mode'] = 'host'
+            else:
+                run_kwargs['ports'] = port_mappings
+
+            # Add extra_hosts if configured
+            if self.extra_hosts:
+                run_kwargs['extra_hosts'] = self.extra_hosts
+
             # Create and start the container
-            container = self.docker_client.containers.run(  # type: ignore[call-overload]
-                image=sandbox_spec.id,
-                command=sandbox_spec.command,  # Use default command from image
-                remove=False,
-                name=container_name,
-                environment=env_vars,
-                ports=port_mappings,
-                network_mode=network_mode,
-                volumes=volumes,
-                working_dir=sandbox_spec.working_dir,
-                labels=labels,
-                detach=True,
-                # Use Docker's tini init process to ensure proper signal handling and reaping of
-                # zombie child processes.
-                init=True,
-                # Allow agent-server containers to resolve host.docker.internal
-                # and other custom hostnames for LAN deployments
-                extra_hosts=self.extra_hosts if self.extra_hosts else None,
-            )
+            container = self.docker_client.containers.run(**run_kwargs)  # type: ignore[call-overload]
 
             sandbox_info = await self._container_to_sandbox_info(container)
             assert sandbox_info is not None

--- a/tests/unit/app_server/test_docker_sandbox_service.py
+++ b/tests/unit/app_server/test_docker_sandbox_service.py
@@ -610,10 +610,10 @@ class TestDockerSandboxService:
             # Execute
             await service_without_extra_hosts.start_sandbox()
 
-        # Verify extra_hosts is None when empty dict is provided
+        # Verify extra_hosts is not passed when empty dict is provided
         mock_docker_client.containers.run.assert_called_once()
         call_args = mock_docker_client.containers.run.call_args
-        assert call_args[1]['extra_hosts'] is None
+        assert 'extra_hosts' not in call_args[1]
 
     async def test_resume_sandbox_from_paused(self, service):
         """Test resuming a paused sandbox."""
@@ -1202,7 +1202,7 @@ class TestDockerSandboxServiceHostNetwork:
         # Should use host network mode
         assert call_args[1]['network_mode'] == 'host'
         # Should NOT have port mappings in host network mode
-        assert call_args[1]['ports'] is None
+        assert 'ports' not in call_args[1]
         # Environment variables should have container ports (not dynamic host ports)
         assert call_args[1]['environment'][AGENT_SERVER] == '8000'
         assert call_args[1]['environment'][VSCODE] == '8001'
@@ -1286,8 +1286,8 @@ class TestDockerSandboxServiceHostNetwork:
         mock_docker_client.containers.run.assert_called_once()
         call_args = mock_docker_client.containers.run.call_args
 
-        # Should NOT use host network mode
-        assert call_args[1]['network_mode'] is None
+        # Should NOT use host network mode (network_mode not in kwargs)
+        assert 'network_mode' not in call_args[1]
         # Should have port mappings
         assert call_args[1]['ports'] == {8000: 12345, 8001: 12346}
         # Environment variables should have dynamic host ports


### PR DESCRIPTION
## Summary

Implements Option 1 from issue #12403 - enabling host network mode for V1 `DockerSandboxService`. This allows containers to share the host network stack, making container ports directly accessible without dynamic port mapping.

### Problem

When deploying OpenHands behind a reverse proxy (nginx/CloudFront), accessing user-launched applications (e.g., Flask apps on port 5000) via `/runtime/{port}/` URLs results in 502 Bad Gateway errors. This is because V1's `DockerSandboxService` uses bridge network mode with dynamic port mappings, which is incompatible with proxy patterns like `localhost:{container_port}`.

### Solution

Add support for `use_host_network` configuration in V1 `DockerSandboxService`:

- Add `use_host_network` field to `DockerSandboxService` and `DockerSandboxServiceInjector`
- When enabled, containers use `network_mode='host'` instead of bridge
- In host network mode, no port mapping is needed; container ports are directly accessible on the host
- Update `_container_to_sandbox_info` to detect and handle host network containers by checking `HostConfig.NetworkMode`

### Key Changes

1. **DockerSandboxService**:
   - Added `use_host_network: bool = False` field
   - Modified `start_sandbox()` to conditionally use host network mode
   - Modified `_container_to_sandbox_info()` to detect host network containers and generate URLs using container ports directly

2. **DockerSandboxServiceInjector**:
   - Added `use_host_network` configuration field with documentation

3. **Tests**:
   - Added comprehensive tests for both host and bridge network modes
   - Tests cover sandbox startup, container info conversion, and injector configuration

### Usage

Users can enable host network mode by configuring:

```python
DockerSandboxServiceInjector(use_host_network=True)
```

Or via environment variable (implementation of env var reading is outside the scope of this PR, but the field is ready to be used):

```bash
export SANDBOX_USE_HOST_NETWORK=true
```

**Note**: On macOS, host network mode requires Docker Desktop 4.29.0 or later.

## Test plan

- [x] All existing tests pass (489 tests in `tests/unit/app_server/`)
- [x] New tests added for host network mode functionality
- [x] Code passes ruff linting checks
- [ ] Manual testing with reverse proxy setup (to be done by reviewer or deployer)

Closes #12403