### PR TITLE
fix: use http for localhost, IPs and docker internal in web URL

### DIFF
--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -1,5 +1,6 @@
 """Configuration for the OpenHands App Server."""
 
+import ipaddress
 import os
 from pathlib import Path
 from typing import AsyncContextManager
@@ -67,11 +68,30 @@ def get_default_persistence_dir() -> Path:
 def get_default_web_url() -> str | None:
     """Get legacy web host parameter.
 
-    If present, we assume we are running under https.
+    Use http for localhost, IPs and docker internal.
+    Otherwise default to https.
     """
     web_host = os.getenv('WEB_HOST')
     if not web_host:
         return None
+
+    if web_host.startswith('http://') or web_host.startswith('https://'):
+        return web_host
+
+    host_only = web_host.split(':')[0]
+
+    http_allowlist = ['localhost', '127.0.0.1', 'host.docker.internal']
+
+    is_ip = False
+    try:
+        ipaddress.ip_address(host_only)
+        is_ip = True
+    except ValueError:
+        is_ip = False
+
+    if host_only in http_allowlist or is_ip:
+        return f'http://{web_host}'
+
     return f'https://{web_host}'
 
 


### PR DESCRIPTION
## Summary of PR

- Add logic to detect localhost, IP addresses, and docker internal hosts
- Use http protocol for these hosts instead of https
- Maintain https for external domain names
- Support explicit http/https protocol prefixes in WEB_HOST

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

## Bug fix 

- [x ] Bug fix https://github.com/OpenHands/OpenHands/issues/12083#issuecomment-3678371944
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

If you visit this page with local server instead of localhost, it will report "Disconnectted"

