### PR TITLE
Extend expiration time for CLI device links

### DIFF
--- a/enterprise/server/routes/oauth_device.py
+++ b/enterprise/server/routes/oauth_device.py
@@ -21,7 +21,7 @@ DEVICE_CODE_EXPIRES_IN = 600  # 10 minutes
 DEVICE_TOKEN_POLL_INTERVAL = 5  # seconds
 
 API_KEY_NAME = 'Device Link Access Key'
-KEY_EXPIRATION_TIME = timedelta(days=1)  # Key expires in 24 hours
+KEY_EXPIRATION_TIME = timedelta(days=7)  # Key expires in a week
 
 # ---------------------------------------------------------------------------
 # Models


### PR DESCRIPTION
<!-- Ideally you should open a PR when it is ready for review. Draft PRs will not be reviewed -->

This is a quality of life improvement. It extends the CLI <> Cloud device link from 24 hours to 1 week instead.


## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

## Change Type

<!-- Choose the types that apply to your PR -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [X] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:b97a983-nikolaik   --name openhands-app-b97a983   docker.openhands.dev/openhands/openhands:b97a983
```