### PR TITLE
fix: use appropriate log level for webhook installation results

### DIFF
--- a/enterprise/integrations/gitlab/webhook_installation.py
+++ b/enterprise/integrations/gitlab/webhook_installation.py
@@ -167,17 +167,15 @@ async def install_webhook_on_resource(
         scopes=SCOPES,
     )
 
-    logger.info(
-        'Creating new webhook',
-        extra={
-            'webhook_id': webhook_id,
-            'status': status,
-            'resource_id': resource_id,
-            'resource_type': resource_type,
-        },
-    )
+    log_extra = {
+        'webhook_id': webhook_id,
+        'status': status,
+        'resource_id': resource_id,
+        'resource_type': resource_type,
+    }
 
     if status == WebhookStatus.RATE_LIMITED:
+        logger.warning('Rate limited while creating webhook', extra=log_extra)
         raise BreakLoopException()
 
     if webhook_id:
@@ -191,9 +189,8 @@ async def install_webhook_on_resource(
                 'webhook_uuid': webhook_uuid,  # required to identify which webhook installation is sending payload
             },
         )
-
-        logger.info(
-            f'Installed webhook for {webhook.user_id} on {resource_type}:{resource_id}'
-        )
+        logger.info('Created new webhook', extra=log_extra)
+    else:
+        logger.error('Failed to create webhook', extra=log_extra)
 
     return webhook_id, status


### PR DESCRIPTION
## Summary

Fixes incorrect log level for GitLab webhook installation failures. Previously, all webhook installation attempts were logged as `INFO` regardless of outcome, causing failures to be misclassified in Datadog and other log monitoring systems.

## Problem

The `install_webhook_on_resource` function was unconditionally logging at INFO level:

```python
logger.info('Creating new webhook', extra={...})
```

When webhook creation failed (e.g., `status=INVALID`), the log still showed `severity: INFO`, but Datadog was displaying these as errors due to the numeric `status` field (e.g., `status: 3`) being misinterpreted.

This made it difficult to:
1. Properly filter/alert on actual webhook failures
2. Distinguish successful webhook creations from failures in dashboards

## Solution

Log at the appropriate level based on the actual outcome:

| Outcome | Log Level | Message |
|---------|-----------|---------|
| Success (`webhook_id` exists) | `INFO` | "Created new webhook" |
| Rate limited | `WARNING` | "Rate limited while creating webhook" |
| Failure (no `webhook_id`) | `ERROR` | "Failed to create webhook" |

## Testing

- [ ] Verified log output shows correct level for success case
- [ ] Verified log output shows correct level for failure case
- [ ] Verified log output shows correct level for rate-limited case

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:735f02f-nikolaik   --name openhands-app-735f02f   docker.openhands.dev/openhands/openhands:735f02f
```