### PR TITLE
fix(frontend): sub-conversation ids are missing when navigating from the conversation panel

### DIFF
--- a/frontend/src/hooks/query/use-paginated-conversations.ts
+++ b/frontend/src/hooks/query/use-paginated-conversations.ts
@@ -1,10 +1,9 @@
-import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import ConversationService from "#/api/conversation-service/conversation-service.api";
 import { useIsAuthed } from "./use-is-authed";
 
 export const usePaginatedConversations = (limit: number = 20) => {
   const { data: userIsAuthenticated } = useIsAuthed();
-  const queryClient = useQueryClient();
 
   return useInfiniteQuery({
     queryKey: ["user", "conversations", "paginated", limit],
@@ -13,14 +12,6 @@ export const usePaginatedConversations = (limit: number = 20) => {
         limit,
         pageParam,
       );
-
-      // Optimistically populate individual conversation caches
-      result.results.forEach((conversation) => {
-        queryClient.setQueryData(
-          ["user", "conversation", conversation.conversation_id],
-          conversation,
-        );
-      });
 
       return result;
     },


### PR DESCRIPTION
<!-- Ideally you should open a PR when it is ready for review. Draft PRs will not be reviewed -->

## Summary of PR

<!-- Summarize what the PR does -->

**Reproduction Steps:**

1. Create a new v1 conversation.
2. Switch to the Planning Agent. At this point, a sub-conversation should be created, and after refetching the parent conversation data, the sub_conversation_ids field is expected to include the newly created sub-conversation ID.
3. Navigate back to the home page.
4. From the home page, navigate again to the parent conversation.

At this stage, although the API request completes successfully, we observe that the sub_conversation_ids field appears empty on the front-end.

**Root Cause:**

This issue seems to be related to how React Query manages its cache and sets query data when navigation occurs from the conversation panel. The current behavior likely results in stale or incomplete data being used on the UI.

Please refer to the code snippet below for additional context and implementation details.

```
// Optimistically populate individual conversation caches
result.results.forEach((conversation) => {
  queryClient.setQueryData(
    ["user", "conversation", conversation.conversation_id],
    conversation, // <== Does not contain sub_conversation_ids field
  );
});
```

The code snippet mentioned above was introduced to address the issue raised in this pull request:

- https://github.com/OpenHands/OpenHands/pull/11510

However, I believe it would be beneficial for us to remove this snippet and reopen the issue in the attached pull request so that we can resolve it using a more appropriate solution.

One possible question to consider is why we are not returning the sub_conversation_ids field when fetching paginated conversations. While including it could also resolve the issue, this approach would introduce an N + 1 query problem, which we should try to avoid for performance and scalability reasons.

From my perspective, removing the current code snippet and addressing the root cause more directly would be the cleanest and most maintainable solution.

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

N/A.

## Change Type

<!-- Choose the types that apply to your PR -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:0f82db6-nikolaik   --name openhands-app-0f82db6   docker.openhands.dev/openhands/openhands:0f82db6
```