### PR TITLE
fix: update deprecated libtmux API calls

### DIFF
--- a/openhands/runtime/impl/local/local_runtime.py
+++ b/openhands/runtime/impl/local/local_runtime.py
@@ -108,10 +108,10 @@ def check_dependencies(code_repo_path: str, check_browser: bool) -> None:
             session = server.new_session(session_name='test-session')
         except Exception:
             raise ValueError('tmux is not properly installed or available on the path.')
-        pane = session.attached_pane
+        pane = session.active_pane
         pane.send_keys('echo "test"')
         pane_output = '\n'.join(pane.cmd('capture-pane', '-p').stdout)
-        session.kill_session()
+        session.kill()
         if 'test' not in pane_output:
             raise ValueError('libtmux is not properly installed. ' + ERROR_MESSAGE)
 


### PR DESCRIPTION
## Summary of PR

Fixed two outdated function calls in the local runtime that were causing the app to crash on startup.

The `libtmux` library updated their API and removed some old methods. This PR updates those method calls to use the new ones:
- `session.attached_pane` → `session.active_pane`
- `session.kill_session()` → `session.kill()`

Without this fix, running `make run` with `RUNTIME=local` throws an error and the app won't start.

## Demo Screenshots/Videos

N/A - This is a small code fix. The proof is that the app now starts without crashing.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves startup crash when using local runtime with newer versions of libtmux.

## Release Notes

- [x] Include this change in the Release Notes.

Fixed local runtime startup failure caused by deprecated libtmux API methods.