### PR TITLE
Fix Pydantic UnsupportedFieldAttributeWarning in Settings model

### DIFF
--- a/openhands/storage/data_models/settings.py
+++ b/openhands/storage/data_models/settings.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Annotated
+
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -31,7 +33,9 @@ class Settings(BaseModel):
     user_version: int | None = None
     remote_runtime_resource_factor: int | None = None
     # Planned to be removed from settings
-    secrets_store: Secrets = Field(default_factory=Secrets)
+    secrets_store: Annotated[Secrets, Field(frozen=True)] = Field(
+        default_factory=Secrets
+    )
     enable_default_condenser: bool = True
     enable_sound_notifications: bool = False
     enable_proactive_conversation_starters: bool = True


### PR DESCRIPTION
## Problem

We were seeing the following error in our Datadog logs showing up as ERROR level:

```
The 'frozen' attribute with value True was provided to the `Field()` function, which has no effect in the context it was used. 'frozen' is field-specific metadata, and can only be attached to a model field using `Annotated` metadata or by assignment. This may have happened because an `Annotated` type alias using the `type` statement was used, or if the `Field()` function was attached to a single member of a union type.
```

**Location:** `openhands/storage/data_models/settings.py:34`

## Root Cause

The `secrets_store` field was defined with `frozen=True` parameter in the `Field()` function:

```python
secrets_store: Secrets = Field(default_factory=Secrets, frozen=True)
```

According to Pydantic's documentation, using `frozen=True` directly in `Field()` can trigger warnings in certain contexts. The proper Pydantic v2 approach is to use `Annotated` metadata for field-specific frozen constraints.

## Solution

Updated to use the proper Pydantic v2 pattern with `Annotated`:

```python
secrets_store: Annotated[Secrets, Field(frozen=True)] = Field(default_factory=Secrets)
```

This approach:
- Uses the officially recommended Pydantic v2 pattern for frozen fields
- Maintains field immutability (prevents `settings.secrets_store = ...` assignments)
- Avoids the UnsupportedFieldAttributeWarning
- Follows the same pattern used in PR #12518 for similar issues

## Why Not Just Remove `frozen=True`?

The initial fix attempted to simply remove `frozen=True`, but this broke the `test_settings_immutability` test which verifies that the `secrets_store` field cannot be reassigned. The immutability is intentional and required for security reasons - the `secrets_store` field should not be directly reassignable after initialization.

## Impact

- ✅ Eliminates the Pydantic warning in logs
- ✅ Reduces noise in error monitoring (Datadog)
- ✅ Maintains field immutability as intended
- ✅ Uses Pydantic v2 best practices
- ✅ No breaking changes

## Testing

- ✅ `test_settings_no_pydantic_frozen_field_warning` - Verifies no warnings are raised
- ✅ `test_settings_immutability` - Verifies field immutability is preserved
- ✅ All Settings and Secrets-related tests pass

@mamoodi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:4c445da-nikolaik   --name openhands-app-4c445da   docker.openhands.dev/openhands/openhands:4c445da
```