### PR TITLE
fix(backend): add SSL certificate verification bypass for self-hosted services

### DIFF
--- a/openhands/server/README.md
+++ b/openhands/server/README.md
@@ -43,6 +43,8 @@ websocat ws://127.0.0.1:3000/ws
 LLM_API_KEY=sk-... # Your Anthropic API Key
 LLM_MODEL=claude-3-5-sonnet-20241022 # Default model for the agent to use
 SANDBOX_VOLUMES=/path/to/your/workspace:/workspace:rw # Mount paths in format host_path:container_path:mode
+SSL_VERIFY=false # Disable SSL certificate verification for self-hosted services (default: true)
+INSECURE_SKIP_VERIFY=true # Alternative way to disable SSL verification (default: false)
 ```
 
 ## API Schema

--- a/openhands/utils/http_session.py
+++ b/openhands/utils/http_session.py
@@ -1,3 +1,4 @@
+import os
 import ssl
 from dataclasses import dataclass, field
 from threading import Lock
@@ -7,8 +8,26 @@ import httpx
 
 from openhands.core.logger import openhands_logger as logger
 
+
+def _get_verify_certificates_from_env() -> bool:
+    """Determine SSL certificate verification setting from environment variables.
+
+    Checks for SSL_VERIFY (explicit enable) or INSECURE_SKIP_VERIFY (explicit disable).
+    Returns True (verify certificates) by default for security.
+    """
+    ssl_verify = os.environ.get('SSL_VERIFY', '').lower()
+    if ssl_verify in ('false', '0', 'no'):
+        return False
+
+    insecure_skip = os.environ.get('INSECURE_SKIP_VERIFY', '').lower()
+    if insecure_skip in ('true', '1', 'yes'):
+        return False
+
+    return True
+
+
 _client_lock = Lock()
-_verify_certificates: bool = True
+_verify_certificates: bool = _get_verify_certificates_from_env()
 _client: httpx.Client | None = None
 
 

--- a/tests/unit/utils/test_http_session.py
+++ b/tests/unit/utils/test_http_session.py
@@ -1,0 +1,115 @@
+"""Tests for openhands.utils.http_session module."""
+
+import importlib
+import os
+import ssl
+from unittest import mock
+
+import pytest
+
+
+class TestGetVerifyCertificatesFromEnv:
+    """Tests for _get_verify_certificates_from_env function."""
+
+    def _reload_module(self):
+        """Reload the http_session module to pick up new environment variables."""
+        import openhands.utils.http_session as http_session_module
+
+        importlib.reload(http_session_module)
+        return http_session_module
+
+    def test_default_returns_true(self):
+        """By default, SSL verification should be enabled."""
+        with mock.patch.dict(os.environ, {}, clear=True):
+            # Remove any existing SSL-related env vars
+            env = {k: v for k, v in os.environ.items() if k not in ('SSL_VERIFY', 'INSECURE_SKIP_VERIFY')}
+            with mock.patch.dict(os.environ, env, clear=True):
+                module = self._reload_module()
+                assert module._verify_certificates is True
+
+    def test_ssl_verify_false_disables_verification(self):
+        """SSL_VERIFY=false should disable SSL verification."""
+        with mock.patch.dict(os.environ, {'SSL_VERIFY': 'false'}, clear=True):
+            module = self._reload_module()
+            assert module._verify_certificates is False
+
+    def test_ssl_verify_zero_disables_verification(self):
+        """SSL_VERIFY=0 should disable SSL verification."""
+        with mock.patch.dict(os.environ, {'SSL_VERIFY': '0'}, clear=True):
+            module = self._reload_module()
+            assert module._verify_certificates is False
+
+    def test_ssl_verify_no_disables_verification(self):
+        """SSL_VERIFY=no should disable SSL verification."""
+        with mock.patch.dict(os.environ, {'SSL_VERIFY': 'no'}, clear=True):
+            module = self._reload_module()
+            assert module._verify_certificates is False
+
+    def test_insecure_skip_verify_true_disables_verification(self):
+        """INSECURE_SKIP_VERIFY=true should disable SSL verification."""
+        with mock.patch.dict(os.environ, {'INSECURE_SKIP_VERIFY': 'true'}, clear=True):
+            module = self._reload_module()
+            assert module._verify_certificates is False
+
+    def test_insecure_skip_verify_one_disables_verification(self):
+        """INSECURE_SKIP_VERIFY=1 should disable SSL verification."""
+        with mock.patch.dict(os.environ, {'INSECURE_SKIP_VERIFY': '1'}, clear=True):
+            module = self._reload_module()
+            assert module._verify_certificates is False
+
+    def test_insecure_skip_verify_yes_disables_verification(self):
+        """INSECURE_SKIP_VERIFY=yes should disable SSL verification."""
+        with mock.patch.dict(os.environ, {'INSECURE_SKIP_VERIFY': 'yes'}, clear=True):
+            module = self._reload_module()
+            assert module._verify_certificates is False
+
+    def test_ssl_verify_true_enables_verification(self):
+        """SSL_VERIFY=true should keep SSL verification enabled."""
+        with mock.patch.dict(os.environ, {'SSL_VERIFY': 'true'}, clear=True):
+            module = self._reload_module()
+            assert module._verify_certificates is True
+
+    def test_ssl_verify_takes_precedence_over_insecure_skip(self):
+        """SSL_VERIFY=false should take precedence over INSECURE_SKIP_VERIFY=false."""
+        with mock.patch.dict(
+            os.environ,
+            {'SSL_VERIFY': 'false', 'INSECURE_SKIP_VERIFY': 'false'},
+            clear=True,
+        ):
+            module = self._reload_module()
+            assert module._verify_certificates is False
+
+    def test_case_insensitive(self):
+        """Environment variable values should be case-insensitive."""
+        with mock.patch.dict(os.environ, {'SSL_VERIFY': 'FALSE'}, clear=True):
+            module = self._reload_module()
+            assert module._verify_certificates is False
+
+        with mock.patch.dict(os.environ, {'INSECURE_SKIP_VERIFY': 'TRUE'}, clear=True):
+            module = self._reload_module()
+            assert module._verify_certificates is False
+
+
+class TestHttpxVerifyOption:
+    """Tests for httpx_verify_option function."""
+
+    def _reload_module(self):
+        """Reload the http_session module to pick up new environment variables."""
+        import openhands.utils.http_session as http_session_module
+
+        importlib.reload(http_session_module)
+        return http_session_module
+
+    def test_returns_ssl_context_when_verify_enabled(self):
+        """Should return SSLContext when verification is enabled."""
+        with mock.patch.dict(os.environ, {'SSL_VERIFY': 'true'}, clear=True):
+            module = self._reload_module()
+            result = module.httpx_verify_option()
+            assert isinstance(result, ssl.SSLContext)
+
+    def test_returns_false_when_verify_disabled(self):
+        """Should return False when verification is disabled."""
+        with mock.patch.dict(os.environ, {'SSL_VERIFY': 'false'}, clear=True):
+            module = self._reload_module()
+            result = module.httpx_verify_option()
+            assert result is False


### PR DESCRIPTION
## Summary of PR

Add environment variable support to disable SSL certificate verification for self-hosted GitLab and other services with self-signed certificates.

Users can now set either:
- `SSL_VERIFY=false` (explicit disable)
- `INSECURE_SKIP_VERIFY=true` (matches frontend pattern)

This resolves the `CERTIFICATE_VERIFY_FAILED` error when connecting to self-hosted GitLab instances with self-signed or internal CA certificates.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #11686

## Release Notes

- [ ] Include this change in the Release Notes.