### PR TITLE
fix(frontend): preserve diff view when agent is stopped

### DIFF
--- a/frontend/__tests__/routes/changes-tab.test.tsx
+++ b/frontend/__tests__/routes/changes-tab.test.tsx
@@ -65,4 +65,71 @@ describe("Changes Tab", () => {
       screen.queryByText("DIFF_VIEWER$NO_CHANGES"),
     ).not.toBeInTheDocument();
   });
+
+  it("should show diffs when agent is stopped with cached changes", () => {
+    vi.mocked(useUnifiedGetGitChanges).mockReturnValue({
+      data: [{ path: "src/file.ts", status: "M" }],
+      isLoading: false,
+      isSuccess: false, // Query disabled when stopped
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    vi.mocked(useAgentState).mockReturnValue({
+      curAgentState: AgentState.STOPPED,
+    });
+
+    render(<GitChanges />, { wrapper });
+
+    // Should not show "waiting for runtime" message
+    expect(
+      screen.queryByText("DIFF_VIEWER$WAITING_FOR_RUNTIME"),
+    ).not.toBeInTheDocument();
+    // Should not show empty changes message
+    expect(
+      screen.queryByText("DIFF_VIEWER$NO_CHANGES"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show EmptyChangesMessage when agent is stopped with no changes", () => {
+    vi.mocked(useUnifiedGetGitChanges).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isSuccess: false, // Query disabled when stopped
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    vi.mocked(useAgentState).mockReturnValue({
+      curAgentState: AgentState.STOPPED,
+    });
+
+    render(<GitChanges />, { wrapper });
+
+    // Should show empty changes message, not "waiting for runtime"
+    expect(screen.getByText("DIFF_VIEWER$NO_CHANGES")).toBeInTheDocument();
+    expect(
+      screen.queryByText("DIFF_VIEWER$WAITING_FOR_RUNTIME"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should not show waiting for runtime when agent is stopped", () => {
+    vi.mocked(useUnifiedGetGitChanges).mockReturnValue({
+      data: [{ path: "src/file.ts", status: "M" }],
+      isLoading: false,
+      isSuccess: true,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    vi.mocked(useAgentState).mockReturnValue({
+      curAgentState: AgentState.STOPPED,
+    });
+
+    render(<GitChanges />, { wrapper });
+
+    expect(
+      screen.queryByText("DIFF_VIEWER$WAITING_FOR_RUNTIME"),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/routes/changes-tab.tsx
+++ b/frontend/src/routes/changes-tab.tsx
@@ -5,7 +5,7 @@ import { EmptyChangesMessage } from "#/components/features/diff-viewer/empty-cha
 import { retrieveAxiosErrorMessage } from "#/utils/retrieve-axios-error-message";
 import { useUnifiedGetGitChanges } from "#/hooks/query/use-unified-get-git-changes";
 import { I18nKey } from "#/i18n/declaration";
-import { RUNTIME_INACTIVE_STATES } from "#/types/agent-state";
+import { AgentState, RUNTIME_INACTIVE_STATES } from "#/types/agent-state";
 import { RandomTip } from "#/components/features/tips/random-tip";
 import { useAgentState } from "#/hooks/use-agent-state";
 
@@ -36,12 +36,17 @@ function GitChanges() {
 
   const { curAgentState } = useAgentState();
   const runtimeIsActive = !RUNTIME_INACTIVE_STATES.includes(curAgentState);
+  const agentIsStopped = curAgentState === AgentState.STOPPED;
 
   const isNotGitRepoError =
     error && GIT_REPO_ERROR_PATTERN.test(retrieveAxiosErrorMessage(error));
 
   React.useEffect(() => {
-    if (!runtimeIsActive) {
+    // When agent is stopped, preserve the current view (cached diffs or empty state)
+    // without showing "waiting for runtime" message
+    if (agentIsStopped) {
+      setStatusMessage(null);
+    } else if (!runtimeIsActive) {
       setStatusMessage([I18nKey.DIFF_VIEWER$WAITING_FOR_RUNTIME]);
     } else if (error) {
       const errorMessage = retrieveAxiosErrorMessage(error);
@@ -59,6 +64,7 @@ function GitChanges() {
       setStatusMessage(null);
     }
   }, [
+    agentIsStopped,
     runtimeIsActive,
     isNotGitRepoError,
     loadingGitChanges,
@@ -66,9 +72,14 @@ function GitChanges() {
     setStatusMessage,
   ]);
 
+  // Determine if we should show diffs: either successful query with changes,
+  // or agent is stopped with cached changes (preserve view when stopped)
+  const hasChangesToShow = gitChanges && gitChanges.length > 0;
+  const shouldShowDiffs = hasChangesToShow && (isSuccess || agentIsStopped);
+
   return (
     <main className="h-full overflow-y-scroll p-4 md:pr-1.5 gap-3 flex flex-col items-center custom-scrollbar-always">
-      {!isSuccess || !gitChanges.length ? (
+      {!shouldShowDiffs ? (
         <div className="relative flex h-full w-full items-center">
           <div className="absolute inset-x-0 top-1/2 -translate-y-1/2">
             {statusMessage && (
@@ -78,13 +89,13 @@ function GitChanges() {
                 ))}
               </StatusMessage>
             )}
-            {!statusMessage && isSuccess && gitChanges.length === 0 && (
-              <EmptyChangesMessage />
-            )}
+            {!statusMessage &&
+              (isSuccess || agentIsStopped) &&
+              !hasChangesToShow && <EmptyChangesMessage />}
           </div>
 
           <div className="absolute inset-x-0 bottom-0">
-            {!isError && gitChanges?.length === 0 && (
+            {!isError && !hasChangesToShow && (
               <div className="max-w-2xl mb-4 text-m bg-tertiary rounded-xl p-4 text-left mx-auto">
                 <RandomTip />
               </div>


### PR DESCRIPTION
## Summary of PR

When stopping the agent mid-conversation with changes in the diff view, the UI was incorrectly showing both the "waiting for runtime" message and the diffs simultaneously.

This fix:
- Adds explicit handling for the `STOPPED` agent state
- Preserves cached diffs when agent is stopped instead of showing status messages
- Shows `EmptyChangesMessage` when stopped with no changes
- Never shows "waiting for runtime" when agent is stopped

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #8061

## Release Notes

- [ ] Include this change in the Release Notes.