### PR TITLE
feat(microagent): add dependency_repos frontmatter field for multiple repos

### DIFF
--- a/openhands/agenthub/codeact_agent/prompts/additional_info.j2
+++ b/openhands/agenthub/codeact_agent/prompts/additional_info.j2
@@ -9,6 +9,15 @@ IMPORTANT: You should work within the current branch "{{ repository_info.branch_
 {% endif %}
 </REPOSITORY_INFO>
 {% endif %}
+{% if dependency_repos %}
+<DEPENDENCY_REPOSITORIES>
+The following dependency repositories have been cloned to the workspace:
+{% for name, directory in dependency_repos.items() -%}
+* {{ name }}: cloned to {{ directory }}
+{% endfor %}
+These repositories are available for reference or use as needed.
+</DEPENDENCY_REPOSITORIES>
+{% endif %}
 {% if repository_instructions -%}
 <REPOSITORY_INSTRUCTIONS>
 {{ repository_instructions }}

--- a/openhands/agenthub/readonly_agent/prompts/additional_info.j2
+++ b/openhands/agenthub/readonly_agent/prompts/additional_info.j2
@@ -9,6 +9,15 @@ IMPORTANT: You should work within the current branch "{{ repository_info.branch_
 {% endif %}
 </REPOSITORY_INFO>
 {% endif %}
+{% if dependency_repos %}
+<DEPENDENCY_REPOSITORIES>
+The following dependency repositories have been cloned to the workspace:
+{% for name, directory in dependency_repos.items() -%}
+* {{ name }}: cloned to {{ directory }}
+{% endfor %}
+These repositories are available for reference or use as needed.
+</DEPENDENCY_REPOSITORIES>
+{% endif %}
 {% if repository_instructions -%}
 <REPOSITORY_INSTRUCTIONS>
 {{ repository_instructions }}

--- a/openhands/core/setup.py
+++ b/openhands/core/setup.py
@@ -219,10 +219,15 @@ def create_memory(
         memory.set_runtime_info(runtime, {}, working_dir)
 
         # loads microagents from repo/.openhands/microagents
-        microagents: list[BaseMicroagent] = runtime.get_microagents_from_selected_repo(
+        # also clones any dependency repos specified in microagent frontmatter
+        microagents, cloned_dependency_repos = runtime.get_microagents_from_selected_repo(
             selected_repository
         )
         memory.load_user_workspace_microagents(microagents)
+
+        # Store info about cloned dependency repos for the agent
+        if cloned_dependency_repos:
+            memory.set_dependency_repos_info(cloned_dependency_repos)
 
         if selected_repository and repo_directory:
             memory.set_repository_info(selected_repository, repo_directory)

--- a/openhands/events/observation/agent.py
+++ b/openhands/events/observation/agent.py
@@ -77,6 +77,17 @@ class RecallObservation(Observation):
     custom_secrets_descriptions: dict[str, str] = field(default_factory=dict)
     conversation_instructions: str = ''
     working_dir: str = ''
+    dependency_repos: dict[str, str] = field(default_factory=dict)
+    """
+    A dictionary mapping dependency repo names to their cloned directory paths.
+    These repos are specified in microagent frontmatter and cloned at startup.
+
+    Example:
+    {
+        "frontend": "OpenHands",
+        "backend": "software-agent-sdk"
+    }
+    """
 
     # knowledge
     microagent_knowledge: list[MicroagentKnowledge] = field(default_factory=list)

--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -589,6 +589,7 @@ class ConversationMemory:
                 )
                 has_repo_instructions = bool(repo_instructions.strip())
                 has_conversation_instructions = conversation_instructions is not None
+                has_dependency_repos = bool(obs.dependency_repos)
 
                 # Filter and process microagent knowledge
                 filtered_agents = []
@@ -611,6 +612,7 @@ class ConversationMemory:
                     or has_runtime_info
                     or has_repo_instructions
                     or has_conversation_instructions
+                    or has_dependency_repos
                 ):
                     formatted_workspace_text = (
                         self.prompt_manager.build_workspace_context(
@@ -618,6 +620,7 @@ class ConversationMemory:
                             runtime_info=runtime_info,
                             conversation_instructions=conversation_instructions,
                             repo_instructions=repo_instructions,
+                            dependency_repos=obs.dependency_repos,
                         )
                     )
                     message_content.append(TextContent(text=formatted_workspace_text))

--- a/openhands/memory/memory.py
+++ b/openhands/memory/memory.py
@@ -76,6 +76,7 @@ class Memory:
         self.repository_info: RepositoryInfo | None = None
         self.runtime_info: RuntimeInfo | None = None
         self.conversation_instructions: ConversationInstructions | None = None
+        self.dependency_repos_info: dict[str, str] = {}  # name -> directory mapping
 
         # Load global microagents (Knowledge + Repo)
         # from typically OpenHands/skills (i.e., the PUBLIC microagents)
@@ -170,6 +171,7 @@ class Memory:
             or repo_instructions
             or microagent_knowledge
             or self.conversation_instructions
+            or self.dependency_repos_info
         ):
             obs = RecallObservation(
                 recall_type=RecallType.WORKSPACE_CONTEXT,
@@ -218,6 +220,7 @@ class Memory:
                     else ''
                 ),
                 working_dir=self.runtime_info.working_dir if self.runtime_info else '',
+                dependency_repos=self.dependency_repos_info,
             )
             return obs
         return None
@@ -345,6 +348,14 @@ class Memory:
             )
         else:
             self.repository_info = None
+
+    def set_dependency_repos_info(self, dependency_repos: dict[str, str]) -> None:
+        """Store dependency repos info so we can reference it in an observation.
+
+        Args:
+            dependency_repos: Dictionary mapping repo names to their cloned directory paths.
+        """
+        self.dependency_repos_info = dependency_repos
 
     def set_runtime_info(
         self,

--- a/openhands/microagent/__init__.py
+++ b/openhands/microagent/__init__.py
@@ -2,15 +2,18 @@ from .microagent import (
     BaseMicroagent,
     KnowledgeMicroagent,
     RepoMicroagent,
+    collect_dependency_repos,
     load_microagents_from_dir,
 )
-from .types import MicroagentMetadata, MicroagentType
+from .types import DependencyRepo, MicroagentMetadata, MicroagentType
 
 __all__ = [
     'BaseMicroagent',
+    'DependencyRepo',
     'KnowledgeMicroagent',
     'RepoMicroagent',
     'MicroagentMetadata',
     'MicroagentType',
+    'collect_dependency_repos',
     'load_microagents_from_dir',
 ]

--- a/openhands/microagent/microagent.py
+++ b/openhands/microagent/microagent.py
@@ -11,7 +11,12 @@ from openhands.core.exceptions import (
     MicroagentValidationError,
 )
 from openhands.core.logger import openhands_logger as logger
-from openhands.microagent.types import InputMetadata, MicroagentMetadata, MicroagentType
+from openhands.microagent.types import (
+    DependencyRepo,
+    InputMetadata,
+    MicroagentMetadata,
+    MicroagentType,
+)
 
 
 class BaseMicroagent(BaseModel):
@@ -28,6 +33,11 @@ class BaseMicroagent(BaseModel):
         'agents.md': 'agents',
         'agent.md': 'agents',
     }
+
+    @property
+    def dependency_repos(self) -> list[DependencyRepo]:
+        """Get the dependency repos for this microagent."""
+        return self.metadata.dependency_repos
 
     @classmethod
     def _handle_third_party(
@@ -339,3 +349,32 @@ def load_microagents_from_dir(
         f'{[*repo_agents.keys(), *knowledge_agents.keys()]}'
     )
     return repo_agents, knowledge_agents
+
+
+def collect_dependency_repos(
+    microagents: list[BaseMicroagent],
+) -> list[DependencyRepo]:
+    """Collect all unique dependency repos from a list of microagents.
+
+    Args:
+        microagents: List of microagents to collect dependency repos from.
+
+    Returns:
+        List of unique DependencyRepo objects (deduplicated by repo identifier).
+    """
+    seen_repos: set[str] = set()
+    dependency_repos: list[DependencyRepo] = []
+
+    for agent in microagents:
+        for dep_repo in agent.dependency_repos:
+            if dep_repo.repo not in seen_repos:
+                seen_repos.add(dep_repo.repo)
+                dependency_repos.append(dep_repo)
+
+    if dependency_repos:
+        logger.debug(
+            f'Collected {len(dependency_repos)} dependency repos from microagents: '
+            f'{[dep.repo for dep in dependency_repos]}'
+        )
+
+    return dependency_repos

--- a/openhands/microagent/types.py
+++ b/openhands/microagent/types.py
@@ -23,6 +23,13 @@ class InputMetadata(BaseModel):
     description: str
 
 
+class DependencyRepo(BaseModel):
+    """Metadata for a dependency repository."""
+
+    name: str  # A friendly name/alias for the repo (e.g., "frontend", "backend")
+    repo: str  # The repository identifier (e.g., "OpenHands/OpenHands")
+
+
 class MicroagentMetadata(BaseModel):
     """Metadata for all microagents."""
 
@@ -32,6 +39,7 @@ class MicroagentMetadata(BaseModel):
     agent: str = Field(default='CodeActAgent')
     triggers: list[str] = []  # optional, only exists for knowledge microagents
     inputs: list[InputMetadata] = []  # optional, only exists for task microagents
+    dependency_repos: list[DependencyRepo] = []  # optional, repos to clone at startup
     mcp_tools: MCPConfig | None = (
         None  # optional, for microagents that provide additional MCP tools
     )

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -58,6 +58,8 @@ from openhands.integrations.service_types import AuthenticationError
 from openhands.llm.llm_registry import LLMRegistry
 from openhands.microagent import (
     BaseMicroagent,
+    DependencyRepo,
+    collect_dependency_repos,
     load_microagents_from_dir,
 )
 from openhands.runtime.plugins import (
@@ -501,6 +503,70 @@ class Runtime(FileEditRuntimeMixin):
 
         return dir_name
 
+    async def clone_dependency_repos(
+        self,
+        dependency_repos: list[DependencyRepo],
+    ) -> dict[str, str]:
+        """Clone dependency repositories specified in microagent frontmatter.
+
+        Args:
+            dependency_repos: List of DependencyRepo objects to clone.
+
+        Returns:
+            Dictionary mapping repo names to their cloned directory paths.
+        """
+        cloned_repos: dict[str, str] = {}
+
+        if not dependency_repos:
+            return cloned_repos
+
+        self.log('info', f'Cloning {len(dependency_repos)} dependency repos...')
+
+        for dep_repo in dependency_repos:
+            try:
+                remote_repo_url = await self.provider_handler.get_authenticated_git_url(
+                    dep_repo.repo
+                )
+
+                if not remote_repo_url:
+                    self.log(
+                        'warning',
+                        f'Could not get authenticated URL for dependency repo: {dep_repo.repo}',
+                    )
+                    continue
+
+                dir_name = dep_repo.repo.split('/')[-1]
+                repo_path = self.workspace_root / dir_name
+                quoted_repo_path = shlex.quote(str(repo_path))
+                quoted_remote_repo_url = shlex.quote(remote_repo_url)
+
+                # Clone the dependency repository
+                clone_command = f'git clone {quoted_remote_repo_url} {quoted_repo_path}'
+                clone_action = CmdRunAction(command=clone_command)
+                obs = await call_sync_from_async(self.run_action, clone_action)
+
+                if isinstance(obs, CmdOutputObservation) and obs.exit_code == 0:
+                    cloned_repos[dep_repo.name] = dir_name
+                    self.log(
+                        'info',
+                        f'Cloned dependency repo "{dep_repo.name}": {dep_repo.repo} -> {dir_name}',
+                    )
+                else:
+                    error_content = (
+                        obs.content if isinstance(obs, CmdOutputObservation) else 'unknown error'
+                    )
+                    self.log(
+                        'warning',
+                        f'Failed to clone dependency repo {dep_repo.repo}: {error_content}',
+                    )
+            except Exception as e:
+                self.log(
+                    'warning',
+                    f'Error cloning dependency repo {dep_repo.repo}: {str(e)}',
+                )
+
+        return cloned_repos
+
     def maybe_run_setup_script(self):
         """Run .openhands/setup.sh if it exists in the workspace or repository."""
         setup_script = '.openhands/setup.sh'
@@ -901,7 +967,7 @@ fi
 
     def get_microagents_from_selected_repo(
         self, selected_repository: str | None
-    ) -> list[BaseMicroagent]:
+    ) -> tuple[list[BaseMicroagent], dict[str, str]]:
         """Load microagents from the selected repository.
         If selected_repository is None, load microagents from the current workspace.
         This is the main entry point for loading microagents.
@@ -913,6 +979,10 @@ fi
         For GitLab repositories, it will use openhands-config instead of .openhands
         since GitLab doesn't support repository names starting with non-alphanumeric
         characters.
+
+        Returns:
+            Tuple of (loaded_microagents, cloned_dependency_repos) where
+            cloned_dependency_repos is a dict mapping repo names to directory paths.
         """
         loaded_microagents: list[BaseMicroagent] = []
         microagents_dir = self.workspace_root / '.openhands' / 'microagents'
@@ -964,7 +1034,21 @@ fi
         )
         loaded_microagents.extend(repo_microagents)
 
-        return loaded_microagents
+        # Collect and clone dependency repos from all loaded microagents
+        dependency_repos = collect_dependency_repos(loaded_microagents)
+        cloned_repos: dict[str, str] = {}
+        if dependency_repos:
+            try:
+                cloned_repos = asyncio.get_event_loop().run_until_complete(
+                    self.clone_dependency_repos(dependency_repos)
+                )
+            except Exception as e:
+                self.log(
+                    'warning',
+                    f'Error cloning dependency repos: {str(e)}',
+                )
+
+        return loaded_microagents, cloned_repos
 
     def run_action(self, action: Action) -> Observation:
         """Run an action and return the resulting observation.

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -476,11 +476,16 @@ class AgentSession:
             memory.set_conversation_instructions(conversation_instructions)
 
             # loads microagents from repo/.openhands/microagents
-            microagents: list[BaseMicroagent] = await call_sync_from_async(
+            # also clones any dependency repos specified in microagent frontmatter
+            microagents, cloned_dependency_repos = await call_sync_from_async(
                 self.runtime.get_microagents_from_selected_repo,
                 selected_repository or None,
             )
             memory.load_user_workspace_microagents(microagents)
+
+            # Store info about cloned dependency repos for the agent
+            if cloned_dependency_repos:
+                memory.set_dependency_repos_info(cloned_dependency_repos)
 
             if selected_repository and repo_directory:
                 memory.set_repository_info(

--- a/openhands/utils/prompt.py
+++ b/openhands/utils/prompt.py
@@ -110,6 +110,7 @@ class PromptManager:
         runtime_info: RuntimeInfo | None,
         conversation_instructions: ConversationInstructions | None,
         repo_instructions: str = '',
+        dependency_repos: dict[str, str] | None = None,
     ) -> str:
         """Renders the additional info template with the stored repository/runtime info."""
         return self.additional_info_template.render(
@@ -117,6 +118,7 @@ class PromptManager:
             repository_instructions=repo_instructions,
             runtime_info=runtime_info,
             conversation_instructions=conversation_instructions,
+            dependency_repos=dependency_repos or {},
         ).strip()
 
     def build_microagent_info(

--- a/tests/unit/microagent/test_microagent_utils.py
+++ b/tests/unit/microagent/test_microagent_utils.py
@@ -545,3 +545,108 @@ def test_load_both_cursorrules_and_agents_md(temp_dir_with_both_cursorrules_and_
     agents_agent = repo_agents['agents']
     assert isinstance(agents_agent, RepoMicroagent)
     assert 'Install deps: `poetry install`' in agents_agent.content
+
+
+def test_dependency_repos_parsing():
+    """Test parsing of dependency_repos from frontmatter."""
+    from openhands.microagent import DependencyRepo, collect_dependency_repos
+
+    # Create a microagent with dependency_repos
+    agent_content = """---
+name: test-agent
+version: 1.0.0
+dependency_repos:
+  - name: frontend
+    repo: OpenHands/OpenHands
+  - name: backend
+    repo: OpenHands/software-agent-sdk
+---
+
+# Test Agent
+
+This agent has dependency repos.
+"""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        (root / 'test.md').write_text(agent_content)
+
+        agent = BaseMicroagent.load(root / 'test.md', root)
+
+        # Check that dependency_repos are parsed correctly
+        assert len(agent.dependency_repos) == 2
+        assert agent.dependency_repos[0].name == 'frontend'
+        assert agent.dependency_repos[0].repo == 'OpenHands/OpenHands'
+        assert agent.dependency_repos[1].name == 'backend'
+        assert agent.dependency_repos[1].repo == 'OpenHands/software-agent-sdk'
+
+
+def test_collect_dependency_repos():
+    """Test collecting dependency repos from multiple microagents."""
+    from openhands.microagent import DependencyRepo, collect_dependency_repos
+
+    # Create microagents with dependency_repos
+    agent1_content = """---
+name: agent1
+version: 1.0.0
+dependency_repos:
+  - name: frontend
+    repo: OpenHands/OpenHands
+---
+
+# Agent 1
+"""
+    agent2_content = """---
+name: agent2
+version: 1.0.0
+dependency_repos:
+  - name: backend
+    repo: OpenHands/software-agent-sdk
+  - name: frontend
+    repo: OpenHands/OpenHands
+---
+
+# Agent 2
+"""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        (root / 'agent1.md').write_text(agent1_content)
+        (root / 'agent2.md').write_text(agent2_content)
+
+        agent1 = BaseMicroagent.load(root / 'agent1.md', root)
+        agent2 = BaseMicroagent.load(root / 'agent2.md', root)
+
+        # Collect dependency repos (should deduplicate)
+        dependency_repos = collect_dependency_repos([agent1, agent2])
+
+        # Should have 2 unique repos (frontend appears twice but should be deduplicated)
+        assert len(dependency_repos) == 2
+        repo_names = {dep.repo for dep in dependency_repos}
+        assert 'OpenHands/OpenHands' in repo_names
+        assert 'OpenHands/software-agent-sdk' in repo_names
+
+
+def test_microagent_without_dependency_repos():
+    """Test that microagents without dependency_repos work correctly."""
+    from openhands.microagent import collect_dependency_repos
+
+    agent_content = """---
+name: simple-agent
+version: 1.0.0
+---
+
+# Simple Agent
+
+No dependency repos here.
+"""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        (root / 'simple.md').write_text(agent_content)
+
+        agent = BaseMicroagent.load(root / 'simple.md', root)
+
+        # Check that dependency_repos is empty
+        assert len(agent.dependency_repos) == 0
+
+        # Collect should return empty list
+        dependency_repos = collect_dependency_repos([agent])
+        assert len(dependency_repos) == 0

--- a/tests/unit/runtime/test_runtime_gitlab_microagents.py
+++ b/tests/unit/runtime/test_runtime_gitlab_microagents.py
@@ -316,12 +316,13 @@ def test_get_microagents_from_selected_repo_gitlab_uses_openhands(temp_workspace
     with patch.object(runtime, '_is_gitlab_repository', return_value=True):
         # Mock org-level microagents (empty)
         with patch.object(runtime, 'get_microagents_from_org_or_user', return_value=[]):
-            result = runtime.get_microagents_from_selected_repo('gitlab.com/owner/repo')
+            result, cloned_repos = runtime.get_microagents_from_selected_repo('gitlab.com/owner/repo')
 
             # Should find microagents from .openhands directory
             # The exact assertion depends on the mock implementation
             # At minimum, it should not raise an exception
             assert isinstance(result, list)
+            assert isinstance(cloned_repos, dict)
 
 
 def test_get_microagents_from_selected_repo_github_only_openhands(temp_workspace):
@@ -340,7 +341,8 @@ def test_get_microagents_from_selected_repo_github_only_openhands(temp_workspace
     with patch.object(runtime, '_is_gitlab_repository', return_value=False):
         # Mock org-level microagents (empty)
         with patch.object(runtime, 'get_microagents_from_org_or_user', return_value=[]):
-            result = runtime.get_microagents_from_selected_repo('github.com/owner/repo')
+            result, cloned_repos = runtime.get_microagents_from_selected_repo('github.com/owner/repo')
 
             # Should only check .openhands directory, not openhands-config
             assert isinstance(result, list)
+            assert isinstance(cloned_repos, dict)


### PR DESCRIPTION
## Summary of PR

Add support for specifying dependency repositories in microagent frontmatter. These repos are automatically cloned at startup and made available to the agent.

### Frontmatter format:
```yaml
---
name: my-agent
dependency_repos:
  - name: frontend
    repo: OpenHands/OpenHands
  - name: backend
    repo: OpenHands/software-agent-sdk
---
```

### Changes:
- Add `DependencyRepo` model to microagent types
- Add `dependency_repos` field to `MicroagentMetadata`
- Add `clone_dependency_repos` method to Runtime
- Update `get_microagents_from_selected_repo` to return cloned repos info
- Add `dependency_repos` to `RecallObservation` for agent context
- Update prompt templates to inform agent about cloned dependency repos
- Add tests for dependency_repos parsing and collection

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #11938

## Release Notes

- [x] Include this change in the Release Notes.