### PR TITLE
fix(backend): set callback status to COMPLETED to prevent infinite loop

### DIFF
--- a/enterprise/integrations/github/github_v1_callback_processor.py
+++ b/enterprise/integrations/github/github_v1_callback_processor.py
@@ -12,6 +12,7 @@ from openhands.agent_server.models import AskAgentRequest, AskAgentResponse
 from openhands.app_server.event_callback.event_callback_models import (
     EventCallback,
     EventCallbackProcessor,
+    EventCallbackStatus,
 )
 from openhands.app_server.event_callback.event_callback_result_models import (
     EventCallbackResult,
@@ -69,6 +70,9 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
                 extra={'summary': summary},
             )
             await self._post_summary_to_github(summary)
+
+            # Mark callback as completed to prevent re-invocation
+            callback.status = EventCallbackStatus.COMPLETED
 
             return EventCallbackResult(
                 status=EventCallbackResultStatus.SUCCESS,


### PR DESCRIPTION
## Summary of PR

This PR fixes an infinite loop bug in `GithubV1CallbackProcessor` where the callback was being invoked repeatedly every time the agent reached a `finished` state.

**Root Cause:** The `GithubV1CallbackProcessor` was not setting `callback.status = EventCallbackStatus.COMPLETED` after successfully processing the callback. This caused the callback to remain in `ACTIVE` status, and since callbacks are filtered by `status == ACTIVE` in `sql_event_callback_service.py`, the callback would be invoked again on every subsequent `execution_status == 'finished'` event.

**Fix:** Added `callback.status = EventCallbackStatus.COMPLETED` after successfully posting the summary to GitHub, consistent with how other callback processors (e.g., `SetTitleCallbackProcessor`, enterprise `GithubCallbackProcessor`) handle callback completion.

## Demo Screenshots/Videos

N/A - Backend bug fix

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

This bug was introduced in PR #11773.

## Release Notes

- [x] Include this change in the Release Notes.

Fixed an infinite loop in the GitHub V1 resolver where the callback processor would be repeatedly invoked because it wasn't marking itself as completed after processing.

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:216006a-nikolaik   --name openhands-app-216006a   docker.openhands.dev/openhands/openhands:216006a
```