### PR TITLE
feat(frontend): add gpt-5.2 and gpt-5.2-codex models, remove gpt-5 models

### DIFF
--- a/frontend/__tests__/utils/extract-model-and-provider.test.ts
+++ b/frontend/__tests__/utils/extract-model-and-provider.test.ts
@@ -59,6 +59,18 @@ describe("extractModelAndProvider", () => {
       separator: "/",
     });
 
+    expect(extractModelAndProvider("gpt-5.2")).toEqual({
+      provider: "openai",
+      model: "gpt-5.2",
+      separator: "/",
+    });
+
+    expect(extractModelAndProvider("gpt-5.2-codex")).toEqual({
+      provider: "openai",
+      model: "gpt-5.2-codex",
+      separator: "/",
+    });
+
     expect(extractModelAndProvider("claude-3-5-sonnet-20240620")).toEqual({
       provider: "anthropic",
       model: "claude-3-5-sonnet-20240620",

--- a/frontend/src/utils/verified-models.ts
+++ b/frontend/src/utils/verified-models.ts
@@ -28,15 +28,15 @@ export const VERIFIED_MODELS = [
   "devstral-medium-2507",
   "kimi-k2-0711-preview",
   "qwen3-coder-480b",
-  "gpt-5-2025-08-07",
-  "gpt-5-mini-2025-08-07",
+  "gpt-5.2",
+  "gpt-5.2-codex",
 ];
 
 // LiteLLM does not return OpenAI models with the provider, so we list them here to set them ourselves for consistency
 // (e.g., they return `gpt-4o` instead of `openai/gpt-4o`)
 export const VERIFIED_OPENAI_MODELS = [
-  "gpt-5-2025-08-07",
-  "gpt-5-mini-2025-08-07",
+  "gpt-5.2",
+  "gpt-5.2-codex",
   "gpt-4o",
   "gpt-4o-mini",
   "gpt-4.1",
@@ -77,8 +77,8 @@ export const VERIFIED_OPENHANDS_MODELS = [
   "claude-sonnet-4-20250514",
   "claude-sonnet-4-5-20250929",
   "claude-haiku-4-5-20251001",
-  "gpt-5-2025-08-07",
-  "gpt-5-mini-2025-08-07",
+  "gpt-5.2",
+  "gpt-5.2-codex",
   "claude-opus-4-20250514",
   "claude-opus-4-1-20250805",
   "claude-opus-4-5-20251101",


### PR DESCRIPTION
## Summary of PR

Add support for the latest OpenAI models `gpt-5.2` and `gpt-5.2-codex` in the OpenHands frontend. Remove the older `gpt-5-2025-08-07` and `gpt-5-mini-2025-08-07` models.

Changes:
- Update `VERIFIED_MODELS` to include `gpt-5.2` and `gpt-5.2-codex`
- Update `VERIFIED_OPENAI_MODELS` to include `gpt-5.2` and `gpt-5.2-codex`
- Update `VERIFIED_OPENHANDS_MODELS` to include `gpt-5.2` and `gpt-5.2-codex`
- Add tests for the new models in `extract-model-and-provider.test.ts`

## Demo Screenshots/Videos

N/A - This is a configuration change to add new models to the frontend dropdown.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Fixes #12638

## Release Notes

- [x] Include this change in the Release Notes.

Added support for OpenAI's latest models `gpt-5.2` and `gpt-5.2-codex` in the frontend model selector. Removed the older `gpt-5` models.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1978dca5a12e47b089b446512c2a5387)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:6e2473b-nikolaik   --name openhands-app-6e2473b   docker.openhands.dev/openhands/openhands:6e2473b
```