### PR TITLE
fix: hide Notes from task list when notes are empty

### DIFF
--- a/frontend/__tests__/components/features/chat/task-tracking-observation-content.test.tsx
+++ b/frontend/__tests__/components/features/chat/task-tracking-observation-content.test.tsx
@@ -97,6 +97,15 @@ describe("TaskTrackingObservationContent", () => {
     ).toBeInTheDocument();
   });
 
+  it("does not display Notes when notes are empty", () => {
+    render(<TaskTrackingObservationContent event={mockEvent} />);
+
+    // task-2 has no notes, so "Notes:" should not appear for it
+    // We have 2 tasks with notes, so there should be exactly 2 "Notes:" elements
+    const notesElements = screen.getAllByText(/^Notes:/);
+    expect(notesElements).toHaveLength(2);
+  });
+
   it("does not render task list when command is not 'plan'", () => {
     const eventWithoutPlan = {
       ...mockEvent,

--- a/frontend/src/components/features/chat/task-tracking/task-item.tsx
+++ b/frontend/src/components/features/chat/task-tracking/task-item.tsx
@@ -52,9 +52,11 @@ export function TaskItem({ task }: TaskItemProps) {
         <Typography.Text className="text-[10px] text-[#A3A3A3] font-normal">
           {t(I18nKey.TASK_TRACKING_OBSERVATION$TASK_ID)}: {task.id}
         </Typography.Text>
-        <Typography.Text className="text-[10px] text-[#A3A3A3]">
-          {t(I18nKey.TASK_TRACKING_OBSERVATION$TASK_NOTES)}: {task.notes}
-        </Typography.Text>
+        {task.notes && (
+          <Typography.Text className="text-[10px] text-[#A3A3A3]">
+            {t(I18nKey.TASK_TRACKING_OBSERVATION$TASK_NOTES)}: {task.notes}
+          </Typography.Text>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/v1/chat/task-tracking/task-item.tsx
+++ b/frontend/src/components/v1/chat/task-tracking/task-item.tsx
@@ -45,9 +45,11 @@ export function TaskItem({ task }: TaskItemProps) {
         >
           {task.title}
         </Typography.Text>
-        <Typography.Text className="text-[10px] text-[#A3A3A3]">
-          {t(I18nKey.TASK_TRACKING_OBSERVATION$TASK_NOTES)}: {task.notes}
-        </Typography.Text>
+        {task.notes && (
+          <Typography.Text className="text-[10px] text-[#A3A3A3]">
+            {t(I18nKey.TASK_TRACKING_OBSERVATION$TASK_NOTES)}: {task.notes}
+          </Typography.Text>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary of PR

Hide "Notes:" label from task list items in the conversation feed when notes are empty.

## Demo Screenshots/Videos

<img width="551" height="538" alt="Screenshot 2026-01-29 030852" src="https://github.com/user-attachments/assets/c07ed0a3-aeea-4017-8841-7b36143cc9ba" />

Tasks without notes no longer show the "Notes:" label, reducing visual clutter.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #12661

## Release Notes

- [ ] Include this change in the Release Notes.
