### PR TITLE
Add GitLab provider check to schedule_gitlab_repo_sync

### DIFF
--- a/enterprise/server/auth/gitlab_sync.py
+++ b/enterprise/server/auth/gitlab_sync.py
@@ -1,9 +1,34 @@
 import asyncio
 
 from pydantic import SecretStr
+from sqlalchemy import select
 
 from openhands.core.logger import openhands_logger as logger
+from openhands.integrations.service_types import ProviderType
 from openhands.server.types import AppMode
+
+
+async def _user_has_gitlab_provider(user_id: str) -> bool:
+    """Check if the user has authenticated with GitLab.
+
+    Args:
+        user_id: The Keycloak user ID
+
+    Returns:
+        True if the user has a GitLab provider token, False otherwise
+    """
+    # Lazy import to avoid circular dependency issues at module load time
+    from storage.auth_tokens import AuthTokens
+    from storage.database import a_session_maker
+
+    async with a_session_maker() as session:
+        result = await session.execute(
+            select(AuthTokens).where(
+                AuthTokens.keycloak_user_id == user_id,
+                AuthTokens.identity_provider == ProviderType.GITLAB.value,
+            )
+        )
+        return result.scalars().first() is not None
 
 
 def schedule_gitlab_repo_sync(
@@ -14,10 +39,20 @@ def schedule_gitlab_repo_sync(
     Because the outer call is already a background task, we instruct the service
     to store repository data synchronously (store_in_background=False) to avoid
     nested background tasks while still keeping the overall operation async.
+
+    The sync is only performed if the user has authenticated with GitLab.
     """
 
     async def _run():
         try:
+            # Check if the user has a GitLab provider token before syncing
+            if not await _user_has_gitlab_provider(user_id):
+                logger.debug(
+                    'gitlab_repo_sync_skipped: user has no GitLab provider',
+                    extra={'user_id': user_id},
+                )
+                return
+
             # Lazy import to avoid circular dependency:
             # middleware -> gitlab_sync -> integrations.gitlab.gitlab_service
             # -> openhands.integrations.gitlab.gitlab_service -> get_impl


### PR DESCRIPTION
Check if user has authenticated with GitLab before scheduling the background repository sync. This prevents unnecessary sync attempts for users who haven't connected their GitLab account.

- Add _user_has_gitlab_provider() helper function that queries AuthTokens
- Use ProviderType.GITLAB enum from service_types.py for provider check
- Skip sync with debug log if user has no GitLab provider token

<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Change Type

<!-- Choose the types that apply to your PR -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:a281eec-nikolaik   --name openhands-app-a281eec   docker.openhands.dev/openhands/openhands:a281eec
```