### PR TITLE
fix: redirect to login page on 401 session expiration

### DIFF
--- a/enterprise/integrations/utils.py
+++ b/enterprise/integrations/utils.py
@@ -61,8 +61,8 @@ def get_session_expired_message(username: str | None = None) -> str:
         A formatted session expired message
     """
     if username:
-        return f'@{username} your session has expired. Please log out and log in again at [OpenHands Cloud]({HOST_URL}) to refresh your session, then try again.'
-    return f'Your session has expired. Please log out and log in again at [OpenHands Cloud]({HOST_URL}) to refresh your session, then try again.'
+        return f'@{username} your session has expired. Please login again at [OpenHands Cloud]({HOST_URL}) and try again.'
+    return f'Your session has expired. Please login again at [OpenHands Cloud]({HOST_URL}) and try again.'
 
 
 # Toggle for solvability report feature

--- a/enterprise/tests/unit/integrations/test_utils.py
+++ b/enterprise/tests/unit/integrations/test_utils.py
@@ -180,10 +180,9 @@ class TestGetSessionExpiredMessage:
         assert 'session has expired' in result
 
     def test_message_with_username_contains_login_instruction(self):
-        """Test that the message contains log out and login instruction."""
+        """Test that the message contains login instruction."""
         result = get_session_expired_message('testuser')
-        assert 'log out' in result
-        assert 'log in again' in result
+        assert 'login again' in result
 
     def test_message_with_username_contains_host_url(self):
         """Test that the message contains the OpenHands Cloud URL."""
@@ -206,10 +205,9 @@ class TestGetSessionExpiredMessage:
         assert 'session has expired' in result
 
     def test_message_without_username_contains_login_instruction(self):
-        """Test that the message without username contains log out and login instruction."""
+        """Test that the message without username contains login instruction."""
         result = get_session_expired_message()
-        assert 'log out' in result
-        assert 'log in again' in result
+        assert 'login again' in result
 
     def test_message_without_username_contains_host_url(self):
         """Test that the message without username contains the OpenHands Cloud URL."""


### PR DESCRIPTION
## Problem
Users seeing a "session expired" message were not being automatically logged out and redirected to the login page. They had to manually log out and log in again.

This was reported in https://github.com/OpenHands/docs/pull/281#discussion_r2744958933

## Changes

### 1. Add 401 error handling in axios interceptor
When a 401 error is received from the backend, the interceptor now clears the stored login method from localStorage. This triggers the root-layout to redirect the user to the login page instead of showing the ReauthModal (which would attempt auto-login but potentially fail).

### 2. Add Azure DevOps support to useAutoLogin hook
The `useAutoLogin` hook was missing support for the `AZURE_DEVOPS` login method, meaning users who logged in with Azure DevOps would not be properly redirected for auto-login.

## Testing
- Frontend lint passes ✅
- Frontend tests pass (136 passed) ✅

## Files Changed
- `frontend/src/api/open-hands-axios.ts` - Add 401 error handling
- `frontend/src/hooks/use-auto-login.ts` - Add Azure DevOps support

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:93baf7b-nikolaik   --name openhands-app-93baf7b   docker.openhands.dev/openhands/openhands:93baf7b
```