### PR TITLE
fix: suppress alembic INFO logs before import to prevent Datadog misclassification

### DIFF
--- a/enterprise/migrations/env.py
+++ b/enterprise/migrations/env.py
@@ -1,10 +1,15 @@
+import logging
 import os
 from logging.config import fileConfig
 
-from alembic import context
-from google.cloud.sql.connector import Connector
-from sqlalchemy import create_engine
-from storage.base import Base
+# Suppress alembic.runtime.plugins INFO logs during import to prevent non-JSON logs in production
+# These plugin setup messages would otherwise appear before logging is configured
+logging.getLogger('alembic.runtime.plugins').setLevel(logging.WARNING)
+
+from alembic import context  # noqa: E402
+from google.cloud.sql.connector import Connector  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from storage.base import Base  # noqa: E402
 
 target_metadata = Base.metadata
 

--- a/openhands/app_server/app_lifespan/alembic/env.py
+++ b/openhands/app_server/app_lifespan/alembic/env.py
@@ -1,8 +1,14 @@
+import logging
+import os
 import sys
 from logging.config import fileConfig
 from pathlib import Path
 
-from alembic import context
+# Suppress alembic.runtime.plugins INFO logs during import to prevent non-JSON logs in production
+# These plugin setup messages would otherwise appear before logging is configured
+logging.getLogger('alembic.runtime.plugins').setLevel(logging.WARNING)
+
+from alembic import context  # noqa: E402
 
 # Add the project root to the Python path so we can import OpenHands modules
 # From alembic/env.py, we need to go up 5 levels to reach the OpenHands project root
@@ -34,14 +40,10 @@ config = context.config
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
-    import os
-
     if os.path.exists(config.config_file_name):
         fileConfig(config.config_file_name)
     else:
         # Use basic logging configuration if config file doesn't exist
-        import logging
-
         logging.basicConfig(level=logging.INFO)
 
 # add your model's MetaData object here


### PR DESCRIPTION
## Summary

Fixes alembic logs appearing as errors in Datadog. The logs showing `INFO:alembic.runtime.plugins:setup` format were being misclassified as errors because they were not in JSON format.

## Root Cause

Alembic logs INFO messages about plugin setup during the `from alembic import context` import. When these messages are emitted before any logging configuration is set up, they use Python's default basicConfig format (e.g., `INFO:alembic.runtime.plugins:setup`). Datadog classifies non-JSON stderr output as "error" level regardless of actual log level.

## Solution

Suppress alembic INFO logs **BEFORE** importing alembic in both env.py files by setting the alembic logger level to WARNING. This prevents non-JSON formatted logs from appearing in production, avoiding Datadog misclassification.

The suppressed logs are only plugin setup messages that provide no operational value in production.

### Changes:
- Set `alembic` logger level to WARNING before the alembic import to suppress INFO-level plugin setup messages
- This prevents non-JSON formatted logs from appearing in production

### Files Modified:
- `openhands/app_server/app_lifespan/alembic/env.py`
- `enterprise/migrations/env.py`

## Testing

The fix ensures that when running in production, alembic's INFO-level plugin setup messages are suppressed, preventing Datadog from misclassifying them as errors.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:563d015-nikolaik   --name openhands-app-563d015   docker.openhands.dev/openhands/openhands:563d015
```