### PR TITLE
fix(sandbox): Change health_check_path from /health to /alive for DockerSandboxService

### DIFF
--- a/openhands/app_server/sandbox/docker_sandbox_service.py
+++ b/openhands/app_server/sandbox/docker_sandbox_service.py
@@ -558,7 +558,7 @@ class DockerSandboxServiceInjector(SandboxServiceInjector):
         ]
     )
     health_check_path: str | None = Field(
-        default='/health',
+        default='/alive',
         description=(
             'The url path in the sandbox agent server to check to '
             'determine whether the server is running'

--- a/tests/unit/app_server/test_docker_sandbox_service.py
+++ b/tests/unit/app_server/test_docker_sandbox_service.py
@@ -78,7 +78,7 @@ def service(mock_sandbox_spec_service, mock_httpx_client, mock_docker_client):
             ),
             ExposedPort(name=VSCODE, description='VSCode server', container_port=8001),
         ],
-        health_check_path='/health',
+        health_check_path='/alive',
         httpx_client=mock_httpx_client,
         max_num_sandboxes=3,
         docker_client=mock_docker_client,
@@ -523,7 +523,7 @@ class TestDockerSandboxService:
                     name=AGENT_SERVER, description='Agent server', container_port=8000
                 ),
             ],
-            health_check_path='/health',
+            health_check_path='/alive',
             httpx_client=mock_httpx_client,
             max_num_sandboxes=3,
             extra_hosts={
@@ -592,7 +592,7 @@ class TestDockerSandboxService:
                     name=AGENT_SERVER, description='Agent server', container_port=8000
                 ),
             ],
-            health_check_path='/health',
+            health_check_path='/alive',
             httpx_client=mock_httpx_client,
             max_num_sandboxes=3,
             extra_hosts={},
@@ -655,7 +655,7 @@ class TestDockerSandboxService:
                     name=AGENT_SERVER, description='Agent server', container_port=8000
                 ),
             ],
-            health_check_path='/health',
+            health_check_path='/alive',
             httpx_client=mock_httpx_client,
             max_num_sandboxes=3,
             web_url='http://192.168.1.100:3000',
@@ -716,7 +716,7 @@ class TestDockerSandboxService:
                     name=AGENT_SERVER, description='Agent server', container_port=8000
                 ),
             ],
-            health_check_path='/health',
+            health_check_path='/alive',
             httpx_client=mock_httpx_client,
             max_num_sandboxes=3,
             web_url=None,  # No web_url configured
@@ -1013,7 +1013,7 @@ class TestDockerSandboxService:
 
         # Verify health check was called with Docker-internal URL
         service.httpx_client.get.assert_called_once_with(
-            'http://host.docker.internal:12345/health'
+            'http://host.docker.internal:12345/alive'
         )
 
     @patch(
@@ -1040,7 +1040,7 @@ class TestDockerSandboxService:
 
         # Verify health check was called with original localhost URL
         service.httpx_client.get.assert_called_once_with(
-            'http://localhost:12345/health'
+            'http://localhost:12345/alive'
         )
 
     async def test_container_to_checked_sandbox_info_health_check_failure(
@@ -1288,7 +1288,7 @@ class TestDockerSandboxServiceHostNetwork:
                     name=VSCODE, description='VSCode server', container_port=8001
                 ),
             ],
-            health_check_path='/health',
+            health_check_path='/alive',
             httpx_client=mock_httpx_client,
             max_num_sandboxes=3,
             docker_client=mock_docker_client,
@@ -1468,7 +1468,7 @@ class TestDockerSandboxServiceHostNetwork:
                     name=AGENT_SERVER, description='Agent server', container_port=8000
                 ),
             ],
-            health_check_path='/health',
+            health_check_path='/alive',
             httpx_client=mock_httpx_client,
             max_num_sandboxes=3,  # > 1
             docker_client=mock_docker_client,
@@ -1529,7 +1529,7 @@ class TestDockerSandboxServiceHostNetwork:
                     name=AGENT_SERVER, description='Agent server', container_port=8000
                 ),
             ],
-            health_check_path='/health',
+            health_check_path='/alive',
             httpx_client=mock_httpx_client,
             max_num_sandboxes=1,  # = 1, no warning expected
             docker_client=mock_docker_client,


### PR DESCRIPTION
## Summary of PR

Fixes a critical bug where the Docker sandbox service was unable to start due to a mismatch between the configured health check endpoint and the actual endpoint provided by the agent server.

**Root Cause:**
- `DockerSandboxService` was configured with `health_check_path='/health'` (default)
- The agent server (`action_execution_server.py`) only provides the `/alive` endpoint, not `/health`
- Health checks to the non-existent `/health` endpoint failed with 404
- Failed health checks caused sandbox status to remain in `STARTING` state (within 15s grace period) or `ERROR` state (after 15s)
- `wait_for_sandbox_running()` timed out after 120 seconds because the sandbox never reached `RUNNING` state

**Solution:**
Changed the default `health_check_path` from `/health` to `/alive` in `DockerSandboxService` to match:
- The actual endpoint available in the agent server
- What `ProcessSandboxService` already correctly uses

## Demo Screenshots/Videos

N/A - Bug fix for sandbox startup

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves the issue reported where local GUI via Docker fails with:
```
SandboxError: 500: Sandbox failed to start within 120s: oh-agent-server-*
```

## Release Notes

- [x] Include this change in the Release Notes.

**Fixed:** Docker sandbox service now correctly uses `/alive` endpoint for health checks, resolving startup timeout issues when running OpenHands locally via Docker.

@mamoodi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:f593d44-nikolaik   --name openhands-app-f593d44   docker.openhands.dev/openhands/openhands:f593d44
```