### PR TITLE
fix: remove invalid frozen parameter from Pydantic Field

### DIFF
--- a/openhands/storage/data_models/settings.py
+++ b/openhands/storage/data_models/settings.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Annotated
-
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -33,9 +31,7 @@ class Settings(BaseModel):
     user_version: int | None = None
     remote_runtime_resource_factor: int | None = None
     # Planned to be removed from settings
-    secrets_store: Annotated[Secrets, Field(frozen=True)] = Field(
-        default_factory=Secrets
-    )
+    secrets_store: Secrets = Field(default_factory=Secrets)
     enable_default_condenser: bool = True
     enable_sound_notifications: bool = False
     enable_proactive_conversation_starters: bool = True


### PR DESCRIPTION
## Summary
This PR fixes a Pydantic v2 warning by removing the invalid `frozen=True` parameter from the `secrets_store` field in the Settings model.

## Problem
The code was using `frozen=True` in a `Field()` function within an `Annotated` type, which is not supported in Pydantic v2 and causes the following warning:

```
UnsupportedFieldAttributeWarning: The 'frozen' attribute with value True was 
provided to the Field() function, which has no effect in the context it was used. 
'frozen' is field-specific metadata, and can only be attached to a model field 
using Annotated metadata or by assignment.
```

## Solution
- Removed the `frozen=True` parameter from the Field definition
- Simplified the field declaration to use `Field(default_factory=Secrets)` directly
- Removed the unused `Annotated` import

## Changes
- **File**: `openhands/storage/data_models/settings.py`
  - Changed `secrets_store: Annotated[Secrets, Field(frozen=True)] = Field(default_factory=Secrets)`
  - To: `secrets_store: Secrets = Field(default_factory=Secrets)`
  - Removed unused `from typing import Annotated` import

## Testing
- Existing unit test `test_settings_no_pydantic_frozen_field_warning` will validate this fix
- Python syntax validation passes
- The field behavior remains the same, only the warning is eliminated

## Related
- Addresses the Datadog error mentioned in infra issue about Pydantic warnings

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:4bc54fd-nikolaik   --name openhands-app-4bc54fd   docker.openhands.dev/openhands/openhands:4bc54fd
```