### PR TITLE
Fix double slash in git API path causing 400 errors

### DIFF
--- a/frontend/src/api/git-service/v1-git-service.api.ts
+++ b/frontend/src/api/git-service/v1-git-service.api.ts
@@ -43,7 +43,10 @@ class V1GitService {
     sessionApiKey: string | null | undefined,
     path: string,
   ): Promise<GitChange[]> {
-    const encodedPath = encodeURIComponent(path);
+    // Remove leading slash to avoid double slash in API path
+    // Backend expects: /api/git/changes/workspace/project (not //workspace/project)
+    const cleanPath = path.startsWith("/") ? path.slice(1) : path;
+    const encodedPath = encodeURIComponent(cleanPath);
     const url = this.buildRuntimeUrl(
       conversationUrl,
       `/api/git/changes/${encodedPath}`,
@@ -81,7 +84,10 @@ class V1GitService {
     sessionApiKey: string | null | undefined,
     path: string,
   ): Promise<GitChangeDiff> {
-    const encodedPath = encodeURIComponent(path);
+    // Remove leading slash to avoid double slash in API path
+    // Backend expects: /api/git/diff/workspace/project/file.py (not //workspace/project/file.py)
+    const cleanPath = path.startsWith("/") ? path.slice(1) : path;
+    const encodedPath = encodeURIComponent(cleanPath);
     const url = this.buildRuntimeUrl(
       conversationUrl,
       `/api/git/diff/${encodedPath}`,


### PR DESCRIPTION
## Description

Fixes a bug where git change tracking API calls fail with 400 Bad Request errors due to double slashes in the URL path.

### Problem
When accessing OpenHands from a remote browser, the V1 git API endpoints receive paths with double slashes:
- **Incorrect:** `/api/git/changes//workspace/project` (causes 400 error)
- **Correct:** `/api/git/changes/workspace/project`

This happens because:
1. Workspace paths start with `/` (e.g., `/workspace/project`)
2. Frontend code concatenates: `/api/git/changes/${encodedPath}`
3. Result: `/api/git/changes/%2Fworkspace%2Fproject` → decodes to `//workspace/project` ❌

### Solution
Strip the leading slash from workspace paths before encoding them for URL construction.

```typescript
// Before: encodedPath = encodeURIComponent("/workspace/project")
// After:  cleanPath = "workspace/project", then encode
const cleanPath = path.startsWith("/") ? path.slice(1) : path;
const encodedPath = encodeURIComponent(cleanPath);
```

### Changes
- Modified `V1GitService.getGitChanges()` to remove leading slash before encoding
- Modified `V1GitService.getGitChangeDiff()` to remove leading slash before encoding
- Added clear comments explaining the fix

### Testing
- [ ] Fix needs E2E testing with remote deployment
- [ ] Should eliminate repeated 400 errors in browser console
- [ ] Git change tracking should work correctly in remote access scenarios

### Related Issues
- Discovered while testing remote deployment fixes
- Related to CORS issues fixed in #12660

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/OpenHands/OpenHands/blob/main/CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A - bug fix)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Co-authored-by: openhands <openhands@all-hands.dev>