### PR TITLE
fix: filter null secrets from conversation JSON before validation

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -69,6 +69,9 @@ from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.services.jwt_service import JwtService
 from openhands.app_server.user.user_context import UserContext
 from openhands.app_server.user.user_models import UserInfo
+from openhands.app_server.utils.conversation_validation import (
+    filter_null_secrets_from_conversation_data,
+)
 from openhands.app_server.utils.docker_utils import (
     replace_localhost_hostname_for_docker,
 )
@@ -277,7 +280,10 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             )
 
             response.raise_for_status()
-            info = ConversationInfo.model_validate(response.json())
+            raw = response.json()
+            info = ConversationInfo.model_validate(
+                filter_null_secrets_from_conversation_data(raw)
+            )
 
             # Store info...
             user_id = await self.user_context.get_user_id()

--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -46,6 +46,9 @@ from openhands.app_server.sandbox.sandbox_spec_service import SandboxSpecService
 from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.user.specifiy_user_context import ADMIN, USER_CONTEXT_ATTR
 from openhands.app_server.user.user_context import UserContext
+from openhands.app_server.utils.conversation_validation import (
+    filter_null_secrets_from_conversation_data,
+)
 from openhands.app_server.utils.sql_utils import Base, UtcDateTime
 from openhands.sdk.utils.paging import page_iterator
 
@@ -709,7 +712,10 @@ async def refresh_conversation(
         )
         response.raise_for_status()
 
-        updated_conversation_info = ConversationInfo.model_validate(response.json())
+        raw = response.json()
+        updated_conversation_info = ConversationInfo.model_validate(
+            filter_null_secrets_from_conversation_data(raw)
+        )
 
         app_conversation_info.updated_at = updated_conversation_info.updated_at
 

--- a/openhands/app_server/utils/conversation_validation.py
+++ b/openhands/app_server/utils/conversation_validation.py
@@ -1,0 +1,21 @@
+"""Utilities for validating conversation data from the agent server."""
+
+
+def filter_null_secrets_from_conversation_data(data: dict) -> dict:
+    """Remove secrets with null values so Pydantic validation does not fail.
+
+    After secrets are masked (e.g. missing OH_SECRET_KEY or runtime recreation),
+    the agent server may return conversation state where secrets have value: null.
+    Filter those out before validating with ConversationInfo.
+    """
+    secrets = data.get('secrets')
+    if not secrets or not isinstance(secrets, dict):
+        return data
+    filtered = {
+        k: v
+        for k, v in secrets.items()
+        if v is not None and not (isinstance(v, dict) and v.get('value') is None)
+    }
+    result = dict(data)
+    result['secrets'] = filtered
+    return result


### PR DESCRIPTION
### summary of PR

- conversation JSON from the agent server can include masked secrets with value: null, which triggers a pydantic ValidationError.

- This PR adds a helper that removes secrets with null values before validating with ConversationInfo.
- The helper is used when refreshing a conversation (remote sandbox) and when starting a conversation (live status service).
- conversation list and load flows no longer fail when secrets are masked.

### Change Type

- [x] Bug fix

fix: #12714