### PR TITLE
fix(frontend): fix cross-domain PostHog tracking param names and persist bootstrap IDs across OAuth redirects

### DIFF
--- a/frontend/__tests__/components/providers/posthog-wrapper.test.tsx
+++ b/frontend/__tests__/components/providers/posthog-wrapper.test.tsx
@@ -17,6 +17,8 @@ describe("PostHogWrapper", () => {
     vi.clearAllMocks();
     // Reset URL hash
     window.location.hash = "";
+    // Clear sessionStorage
+    sessionStorage.clear();
     // Mock the config fetch
     // @ts-expect-error - partial mock
     vi.spyOn(OptionService, "getConfig").mockResolvedValue({
@@ -24,9 +26,9 @@ describe("PostHogWrapper", () => {
     });
   });
 
-  it("should initialize PostHog with bootstrap IDs from URL hash", async () => {
-    // Set up URL hash with cross-domain tracking params
-    window.location.hash = "ph_distinct_id=user-123&ph_session_id=session-456";
+  it("should initialize PostHog with bootstrap IDs from URL hash (without ph_ prefix)", async () => {
+    // Webflow sends distinct_id and session_id without the ph_ prefix
+    window.location.hash = "distinct_id=user-123&session_id=session-456";
 
     render(
       <PostHogWrapper>
@@ -34,10 +36,8 @@ describe("PostHogWrapper", () => {
       </PostHogWrapper>,
     );
 
-    // Wait for async config fetch and PostHog initialization
     await screen.findByTestId("child");
 
-    // Verify PostHogProvider was called with bootstrap options
     expect(mockPostHogProvider).toHaveBeenCalledWith(
       expect.objectContaining({
         options: expect.objectContaining({
@@ -51,8 +51,7 @@ describe("PostHogWrapper", () => {
   });
 
   it("should clean up URL hash after extracting bootstrap IDs", async () => {
-    // Set up URL hash with cross-domain tracking params
-    window.location.hash = "ph_distinct_id=user-123&ph_session_id=session-456";
+    window.location.hash = "distinct_id=user-123&session_id=session-456";
 
     render(
       <PostHogWrapper>
@@ -60,10 +59,98 @@ describe("PostHogWrapper", () => {
       </PostHogWrapper>,
     );
 
-    // Wait for async config fetch and PostHog initialization
     await screen.findByTestId("child");
 
-    // Verify URL hash was cleaned up
     expect(window.location.hash).toBe("");
+  });
+
+  it("should persist bootstrap IDs to sessionStorage for OAuth survival", async () => {
+    window.location.hash = "distinct_id=user-123&session_id=session-456";
+
+    render(
+      <PostHogWrapper>
+        <div data-testid="child" />
+      </PostHogWrapper>,
+    );
+
+    await screen.findByTestId("child");
+
+    // After extracting from hash, IDs should NOT remain in sessionStorage
+    // because they were already consumed during this page load.
+    // But if a full-page redirect happened before PostHog init,
+    // sessionStorage would still have them for the next load.
+    // We verify the write happened by checking the provider received the IDs.
+    expect(mockPostHogProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          bootstrap: {
+            distinctID: "user-123",
+            sessionID: "session-456",
+          },
+        }),
+      }),
+    );
+  });
+
+  it("should read bootstrap IDs from sessionStorage when hash is absent (post-OAuth)", async () => {
+    // Simulate returning from OAuth: no hash, but sessionStorage has the IDs
+    sessionStorage.setItem(
+      "posthog_bootstrap",
+      JSON.stringify({ distinctID: "user-123", sessionID: "session-456" }),
+    );
+
+    render(
+      <PostHogWrapper>
+        <div data-testid="child" />
+      </PostHogWrapper>,
+    );
+
+    await screen.findByTestId("child");
+
+    expect(mockPostHogProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          bootstrap: {
+            distinctID: "user-123",
+            sessionID: "session-456",
+          },
+        }),
+      }),
+    );
+  });
+
+  it("should clean up sessionStorage after consuming bootstrap IDs", async () => {
+    sessionStorage.setItem(
+      "posthog_bootstrap",
+      JSON.stringify({ distinctID: "user-123", sessionID: "session-456" }),
+    );
+
+    render(
+      <PostHogWrapper>
+        <div data-testid="child" />
+      </PostHogWrapper>,
+    );
+
+    await screen.findByTestId("child");
+
+    expect(sessionStorage.getItem("posthog_bootstrap")).toBeNull();
+  });
+
+  it("should initialize without bootstrap when neither hash nor sessionStorage has IDs", async () => {
+    render(
+      <PostHogWrapper>
+        <div data-testid="child" />
+      </PostHogWrapper>,
+    );
+
+    await screen.findByTestId("child");
+
+    expect(mockPostHogProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          bootstrap: undefined,
+        }),
+      }),
+    );
   });
 });


### PR DESCRIPTION


<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

- Marketing website passes `session_id` without `ph_`
- For unauthenticated users, OAuth does a full-page redirect that destroys the URL hash. The fix stashes the IDs in `sessionStorage` before that happens, then retrieves them after OAuth returns.

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

## Change Type

<!-- Choose the types that apply to your PR -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:8ba3199-nikolaik   --name openhands-app-8ba3199   docker.openhands.dev/openhands/openhands:8ba3199
```