### PR TITLE
feat: add support for Kimi K2.5 model (#12709)

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -223,6 +223,7 @@ model = "gpt-4o"
 # Uncomment and configure to enable model routing with a secondary model
 #[llm.secondary_model]
 #model = "kimi-k2"
+#model = "kimi-k2.5"
 #api_key = ""
 #for_routing = true
 #max_input_tokens = 128000

--- a/frontend/src/utils/verified-models.ts
+++ b/frontend/src/utils/verified-models.ts
@@ -27,6 +27,7 @@ export const VERIFIED_MODELS = [
   "devstral-small-2507",
   "devstral-medium-2507",
   "kimi-k2-0711-preview",
+  "kimi-k2.5",
   "qwen3-coder-480b",
   "gpt-5.2",
   "gpt-5.2-codex",
@@ -89,6 +90,7 @@ export const VERIFIED_OPENHANDS_MODELS = [
   "devstral-medium-2507",
   "devstral-small-2505",
   "kimi-k2-0711-preview",
+  "kimi-k2.5",
   "qwen3-coder-480b",
 ];
 

--- a/openhands/llm/model_features.py
+++ b/openhands/llm/model_features.py
@@ -93,6 +93,7 @@ FUNCTION_CALLING_PATTERNS: list[str] = [
     # Others
     'kimi-k2-0711-preview',
     'kimi-k2-instruct',
+    'kimi-k2.5',
     'qwen3-coder*',
     'qwen3-coder-480b-a35b-instruct',
     'deepseek-chat',

--- a/openhands/llm/router/README.md
+++ b/openhands/llm/router/README.md
@@ -25,7 +25,7 @@ api_key = "your-api-key"
 
 # Secondary model for routing
 [llm.secondary_model]
-model = "kimi-k2"
+model = "kimi-k2"  # or "kimi-k2.5"
 api_key = "your-api-key"
 for_routing = true
 

--- a/openhands/utils/llm.py
+++ b/openhands/utils/llm.py
@@ -68,6 +68,7 @@ def get_supported_llm_models(config: OpenHandsConfig) -> list[str]:
         'openhands/devstral-small-2507',
         'openhands/devstral-medium-2507',
         'openhands/kimi-k2-0711-preview',
+        'openhands/kimi-k2.5',
         'openhands/qwen3-coder-480b',
     ]
     model_list = openhands_models + model_list

--- a/tests/unit/llm/test_model_features.py
+++ b/tests/unit/llm/test_model_features.py
@@ -192,6 +192,7 @@ def test_get_features(model, expect):
         # Others
         'kimi-k2-0711-preview',
         'kimi-k2-instruct',
+        'kimi-k2.5',
         'qwen3-coder',
         'qwen3-coder-480b-a35b-instruct',
     ],


### PR DESCRIPTION
Summary
This PR adds support for the Kimi K2.5 model, addressing the feature request in issue #12709. Kimi K2.5 is Moonshot AI's latest model, offering advanced capabilities for parallel agents and function calling. This integration allows users to select and use Kimi K2.5 directly within the OpenHands interface and via configuration.

Changes
- Backend Model Registration: Added openhands/kimi-k2.5 to openhands/utils/llm.py to support the OpenHands provider.
- Feature Configuration: Enabled function calling support for kimi-k2.5 in openhands/llm/model_features.py, matching the capabilities of previous Kimi K2 versions.
- Frontend Integration: Added kimi-k2.5 to VERIFIED_MODELS and VERIFIED_OPENHANDS_MODELS in frontend/src/utils/verified-models.ts to expose the model in the UI model selector.
- Testing: Added unit test cases for kimi-k2.5 in tests/unit/llm/test_model_features.py to verify correct feature detection.
- Documentation:
  - Updated config.template.toml with an example configuration for Kimi K2.5.
  - Added Kimi K2.5 as a secondary model example in the Model Routing README.md.

Changelog Message
Added support for the Kimi K2.5 model, including function calling support and visibility in the frontend model selector.

Related Issue
Fixes #12709