### PR TITLE
Fix Slack V1 callback reporting on every prompt in conversation

### DIFF
--- a/enterprise/integrations/slack/slack_v1_callback_processor.py
+++ b/enterprise/integrations/slack/slack_v1_callback_processor.py
@@ -11,6 +11,7 @@ from openhands.agent_server.models import AskAgentRequest, AskAgentResponse
 from openhands.app_server.event_callback.event_callback_models import (
     EventCallback,
     EventCallbackProcessor,
+    EventCallbackStatus,
 )
 from openhands.app_server.event_callback.event_callback_result_models import (
     EventCallbackResult,
@@ -53,6 +54,11 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
         try:
             summary = await self._request_summary(conversation_id)
             await self._post_summary_to_slack(summary)
+
+            # Mark callback as completed to prevent further processing
+            # The outer execute_callbacks method will persist this change
+            callback.status = EventCallbackStatus.COMPLETED
+            _logger.info('[Slack V1] Marked callback %s as completed', callback.id)
 
             return EventCallbackResult(
                 status=EventCallbackResultStatus.SUCCESS,


### PR DESCRIPTION
## Summary
Fixes the issue where every prompt entered in a Slack-initiated conversation reports back to the Slack thread, which is not the desired behavior.

## Problem
The `SlackV1CallbackProcessor` was not marking the callback as completed after successfully sending the summary to Slack. This meant the callback remained in `ACTIVE` status and would be invoked on every subsequent agent state change (specifically when `execution_status` becomes `finished`), triggering additional messages to the Slack thread.

## Solution
Mark the callback status as `COMPLETED` after successfully sending the summary to Slack. The status change is persisted by the outer `execute_callbacks` method in the SQL event callback service, which saves all callbacks after execution.

This follows the same pattern used by `SetTitleCallbackProcessor` which sets the callback status to `DISABLED` after completing its task.

## Changes
- Added `EventCallbackStatus` import to `slack_v1_callback_processor.py`
- Set `callback.status = EventCallbackStatus.COMPLETED` after sending the summary to Slack
- Added logging for when the callback is marked as completed
- Updated tests to verify the callback status is set to `COMPLETED` after successful processing

## Testing
- Updated `test_callback_marked_completed_after_success` (previously `test_double_callback_processing`) to verify the callback status is set to `COMPLETED`
- Updated `test_successful_end_to_end_flow` to verify the callback status is set to `COMPLETED`

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:04e7afb-nikolaik   --name openhands-app-04e7afb   docker.openhands.dev/openhands/openhands:04e7afb
```