### PR TITLE
feat(recaptcha): add assessment name to logging and AssessmentResult

### DIFF
--- a/enterprise/server/auth/recaptcha_service.py
+++ b/enterprise/server/auth/recaptcha_service.py
@@ -18,6 +18,7 @@ from openhands.core.logger import openhands_logger as logger
 class AssessmentResult:
     """Result of a reCAPTCHA Enterprise assessment."""
 
+    name: str
     score: float
     valid: bool
     action_valid: bool
@@ -100,6 +101,10 @@ class RecaptchaService:
 
         response = self.client.create_assessment(request)
 
+        # Capture assessment name for potential annotation later
+        # Format: projects/{project_id}/assessments/{assessment_id}
+        assessment_name = response.name
+
         token_properties = response.token_properties
         risk_analysis = response.risk_analysis
 
@@ -129,6 +134,7 @@ class RecaptchaService:
         logger.info(
             'recaptcha_assessment',
             extra={
+                'assessment_name': assessment_name,
                 'score': score,
                 'valid': valid,
                 'action_valid': action_valid,
@@ -141,6 +147,7 @@ class RecaptchaService:
         )
 
         return AssessmentResult(
+            name=assessment_name,
             score=score,
             valid=valid,
             action_valid=action_valid,

--- a/enterprise/tests/unit/test_recaptcha_service.py
+++ b/enterprise/tests/unit/test_recaptcha_service.py
@@ -94,6 +94,7 @@ class TestRecaptchaServiceCreateAssessment:
         """Test that assessment allows request when score is above threshold."""
         # Arrange
         mock_response = MagicMock()
+        mock_response.name = 'projects/test-project/assessments/abc123'
         mock_response.token_properties.valid = True
         mock_response.token_properties.action = 'LOGIN'
         mock_response.risk_analysis.score = 0.9
@@ -110,6 +111,7 @@ class TestRecaptchaServiceCreateAssessment:
 
         # Assert
         assert isinstance(result, AssessmentResult)
+        assert result.name == 'projects/test-project/assessments/abc123'
         assert result.allowed is True
         assert result.score == 0.9
         assert result.valid is True
@@ -122,6 +124,7 @@ class TestRecaptchaServiceCreateAssessment:
         """Test that assessment blocks request when score is below threshold."""
         # Arrange
         mock_response = MagicMock()
+        mock_response.name = 'projects/test-project/assessments/def456'
         mock_response.token_properties.valid = True
         mock_response.token_properties.action = 'LOGIN'
         mock_response.risk_analysis.score = 0.2
@@ -146,6 +149,7 @@ class TestRecaptchaServiceCreateAssessment:
         """Test that assessment blocks request when token is invalid."""
         # Arrange
         mock_response = MagicMock()
+        mock_response.name = 'projects/test-project/assessments/ghi789'
         mock_response.token_properties.valid = False
         mock_response.token_properties.action = 'LOGIN'
         mock_response.risk_analysis.score = 0.9
@@ -170,6 +174,7 @@ class TestRecaptchaServiceCreateAssessment:
         """Test that assessment blocks request when action doesn't match."""
         # Arrange
         mock_response = MagicMock()
+        mock_response.name = 'projects/test-project/assessments/jkl012'
         mock_response.token_properties.valid = True
         mock_response.token_properties.action = 'SIGNUP'
         mock_response.risk_analysis.score = 0.9
@@ -194,6 +199,7 @@ class TestRecaptchaServiceCreateAssessment:
         """Test that email is included in user_info when provided."""
         # Arrange
         mock_response = MagicMock()
+        mock_response.name = 'projects/test-project/assessments/mno345'
         mock_response.token_properties.valid = True
         mock_response.token_properties.action = 'LOGIN'
         mock_response.risk_analysis.score = 0.9
@@ -223,6 +229,7 @@ class TestRecaptchaServiceCreateAssessment:
         """Test that user_info is not included when email is None."""
         # Arrange
         mock_response = MagicMock()
+        mock_response.name = 'projects/test-project/assessments/pqr678'
         mock_response.token_properties.valid = True
         mock_response.token_properties.action = 'LOGIN'
         mock_response.risk_analysis.score = 0.9
@@ -248,10 +255,13 @@ class TestRecaptchaServiceCreateAssessment:
             # If user_info exists, verify account_id is empty (not set)
             assert not assessment.event.user_info.account_id
 
-    def test_should_log_assessment_details(self, recaptcha_service, mock_gcp_client):
-        """Test that assessment details are logged."""
+    def test_should_log_assessment_details_including_name(
+        self, recaptcha_service, mock_gcp_client
+    ):
+        """Test that assessment details including assessment name are logged."""
         # Arrange
         mock_response = MagicMock()
+        mock_response.name = 'projects/test-project/assessments/stu901'
         mock_response.token_properties.valid = True
         mock_response.token_properties.action = 'LOGIN'
         mock_response.risk_analysis.score = 0.9
@@ -271,6 +281,10 @@ class TestRecaptchaServiceCreateAssessment:
             mock_logger.info.assert_called_once()
             call_kwargs = mock_logger.info.call_args
             assert call_kwargs[0][0] == 'recaptcha_assessment'
+            assert (
+                call_kwargs[1]['extra']['assessment_name']
+                == 'projects/test-project/assessments/stu901'
+            )
             assert call_kwargs[1]['extra']['score'] == 0.9
             assert call_kwargs[1]['extra']['valid'] is True
             assert call_kwargs[1]['extra']['action_valid'] is True


### PR DESCRIPTION
## Summary

This PR adds the reCAPTCHA assessment name (ID) to both the `AssessmentResult` dataclass and the console/cloud logs. This enables later annotation of assessments via Google's reCAPTCHA Enterprise API to provide feedback on whether users turned out to be legitimate or fraudulent.

## Changes

- **Add `name` field to `AssessmentResult` dataclass** - Captures the full assessment resource name in format `projects/{project_id}/assessments/{assessment_id}`
- **Log `assessment_name` in recaptcha_assessment log entry** - The assessment name is now included in the structured log output, making it queryable in Google Cloud Logging
- **Update tests** - All tests now include mock assessment names and verify the name is properly logged

## Why This Is Needed

To [annotate reCAPTCHA assessments](https://cloud.google.com/recaptcha/docs/annotate-assessment) with Google, you need the assessment name/ID. By logging it, we can:

1. Query Cloud Logging to find assessments for specific users/IPs
2. Export logs to BigQuery for analysis
3. Use the assessment names to call `annotate_assessment()` to mark users as `LEGITIMATE` or `FRAUDULENT`

This feedback loop improves reCAPTCHA's accuracy for our site over time.

## Usage

After this change, log entries will include:
```json
{
  "message": "recaptcha_assessment",
  "assessment_name": "projects/my-project/assessments/abc123xyz456",
  "score": 0.9,
  "allowed": true,
  ...
}
```

The `assessment_name` can then be used to annotate the assessment later:
```python
recaptcha_service.client.annotate_assessment(
    AnnotateAssessmentRequest(
        name="projects/my-project/assessments/abc123xyz456",
        annotation=Annotation.LEGITIMATE
    )
)
```

## Testing

- Updated existing tests to include mock assessment names
- Added assertion to verify `assessment_name` is logged correctly

@saurya can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:026575e-nikolaik   --name openhands-app-026575e   docker.openhands.dev/openhands/openhands:026575e
```