### PR TITLE
feat(recaptcha): add user_id and email to assessment log

### DIFF
--- a/enterprise/server/auth/recaptcha_service.py
+++ b/enterprise/server/auth/recaptcha_service.py
@@ -64,6 +64,7 @@ class RecaptchaService:
         user_ip: str,
         user_agent: str,
         email: str | None = None,
+        user_id: str | None = None,
     ) -> AssessmentResult:
         """Create a reCAPTCHA Enterprise assessment.
 
@@ -73,6 +74,7 @@ class RecaptchaService:
             user_ip: The user's IP address.
             user_agent: The user's browser user agent.
             email: Optional email for Account Defender hashing.
+            user_id: Optional Keycloak user ID for logging correlation.
 
         Returns:
             AssessmentResult with score, validity, and allowed status.
@@ -143,6 +145,8 @@ class RecaptchaService:
                 'has_suspicious_labels': has_suspicious_labels,
                 'allowed': allowed,
                 'user_ip': user_ip,
+                'user_id': user_id,
+                'email': email,
             },
         )
 

--- a/enterprise/server/routes/auth.py
+++ b/enterprise/server/routes/auth.py
@@ -219,6 +219,7 @@ async def keycloak_callback(
                 user_ip=user_ip,
                 user_agent=user_agent,
                 email=email,
+                user_id=user_id,
             )
 
             if not result.allowed:

--- a/enterprise/tests/unit/test_recaptcha_service.py
+++ b/enterprise/tests/unit/test_recaptcha_service.py
@@ -290,6 +290,64 @@ class TestRecaptchaServiceCreateAssessment:
             assert call_kwargs[1]['extra']['action_valid'] is True
             assert call_kwargs[1]['extra']['user_ip'] == '192.168.1.1'
 
+    def test_should_log_user_id_and_email_when_provided(
+        self, recaptcha_service, mock_gcp_client
+    ):
+        """Test that user_id and email are included in log when provided."""
+        # Arrange
+        mock_response = MagicMock()
+        mock_response.name = 'projects/test-project/assessments/xyz123'
+        mock_response.token_properties.valid = True
+        mock_response.token_properties.action = 'LOGIN'
+        mock_response.risk_analysis.score = 0.9
+        mock_response.risk_analysis.reasons = []
+        mock_gcp_client.create_assessment.return_value = mock_response
+
+        with patch('server.auth.recaptcha_service.logger') as mock_logger:
+            # Act
+            recaptcha_service.create_assessment(
+                token='test-token',
+                action='LOGIN',
+                user_ip='192.168.1.1',
+                user_agent='Mozilla/5.0',
+                email='test@example.com',
+                user_id='keycloak-user-123',
+            )
+
+            # Assert
+            mock_logger.info.assert_called_once()
+            call_kwargs = mock_logger.info.call_args
+            assert call_kwargs[1]['extra']['user_id'] == 'keycloak-user-123'
+            assert call_kwargs[1]['extra']['email'] == 'test@example.com'
+
+    def test_should_log_none_for_user_id_and_email_when_not_provided(
+        self, recaptcha_service, mock_gcp_client
+    ):
+        """Test that user_id and email are logged as None when not provided."""
+        # Arrange
+        mock_response = MagicMock()
+        mock_response.name = 'projects/test-project/assessments/abc456'
+        mock_response.token_properties.valid = True
+        mock_response.token_properties.action = 'LOGIN'
+        mock_response.risk_analysis.score = 0.9
+        mock_response.risk_analysis.reasons = []
+        mock_gcp_client.create_assessment.return_value = mock_response
+
+        with patch('server.auth.recaptcha_service.logger') as mock_logger:
+            # Act
+            recaptcha_service.create_assessment(
+                token='test-token',
+                action='LOGIN',
+                user_ip='192.168.1.1',
+                user_agent='Mozilla/5.0',
+            )
+
+            # Assert
+            mock_logger.info.assert_called_once()
+            call_kwargs = mock_logger.info.call_args
+            assert call_kwargs[1]['extra']['user_id'] is None
+            assert call_kwargs[1]['extra']['email'] is None
+
     def test_should_raise_exception_when_gcp_client_fails(
         self, recaptcha_service, mock_gcp_client
     ):


### PR DESCRIPTION
## Summary

Adds `user_id` (Keycloak user ID) and `email` to the `recaptcha_assessment` log to enable correlation between assessments and users.

## Problem

Previously, `user_id` was only logged in the `recaptcha_blocked_at_callback` log (when a user was blocked). This made it **impossible to trace assessments for allowed logins** back to specific users.

| Log Message | Had `user_id`? | Had `email`? |
|-------------|----------------|--------------|
| `recaptcha_assessment` | ❌ No | ❌ No |
| `recaptcha_blocked_at_callback` | ✅ Yes | ❌ No |

## Solution

Now you can query logs to find all assessments for a specific user:

```
jsonPayload.message="recaptcha_assessment"
jsonPayload.user_id="abc123"
```

Or find all assessments for a specific email:

```
jsonPayload.message="recaptcha_assessment"
jsonPayload.email="user@example.com"
```

## Log Output (After)

```json
{
  "message": "recaptcha_assessment",
  "assessment_name": "projects/xxx/assessments/yyy",
  "score": 0.9,
  "valid": true,
  "action_valid": true,
  "reasons": [],
  "account_defender_labels": [],
  "has_suspicious_labels": false,
  "allowed": true,
  "user_ip": "203.0.113.45",
  "user_id": "keycloak-user-123",    // NEW
  "email": "user@example.com"         // NEW
}
```

## Changes

- Add `user_id` parameter to `RecaptchaService.create_assessment()`
- Include `user_id` and `email` in the `recaptcha_assessment` log extra fields
- Pass `user_id` from auth callback to `create_assessment()`
- Add tests for `user_id` and `email` logging

## Use Case

This enables tracking down abusive users by their reCAPTCHA scores:

1. Find a known abusive user_id
2. Query: `jsonPayload.user_id="abusive-user-id"`
3. See all their assessment scores and whether they were allowed/blocked

@saurya can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:0eb239f-nikolaik   --name openhands-app-0eb239f   docker.openhands.dev/openhands/openhands:0eb239f
```