### PR TITLE
feat(runtime): add Laminar tracing to plugins

### DIFF
--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -66,6 +66,7 @@ from openhands.runtime.file_viewer_server import start_file_viewer_server
 # Import our custom MCP Proxy Manager
 from openhands.runtime.mcp.proxy import MCPProxyManager
 from openhands.runtime.plugins import ALL_PLUGINS, JupyterPlugin, Plugin, VSCodePlugin
+from openhands.runtime.plugins.tracing_proxy import TracingPluginProxy
 from openhands.runtime.utils import find_available_tcp_port
 from openhands.runtime.utils.bash import BashSession
 from openhands.runtime.utils.files import insert_lines, read_lines
@@ -79,6 +80,27 @@ from openhands.utils.async_utils import call_sync_from_async, wait_all
 
 if sys.platform == 'win32':
     from openhands.runtime.utils.windows_bash import WindowsPowershellSession
+
+try:
+    from lmnr import Laminar
+
+    LAMINAR_AVAILABLE = True
+except ImportError:
+    LAMINAR_AVAILABLE = False
+
+
+def _maybe_init_laminar():
+    """Initialize Laminar observability if configured."""
+    if not LAMINAR_AVAILABLE:
+        return
+    if os.getenv('LMNR_PROJECT_API_KEY') or os.getenv(
+        'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT'
+    ):
+        try:
+            Laminar.initialize()
+            logger.info('Laminar observability initialized in runtime')
+        except Exception as e:
+            logger.warning(f'Failed to initialize Laminar: {e}')
 
 
 class ActionRequest(BaseModel):
@@ -684,12 +706,17 @@ if __name__ == '__main__':
     server_url, _ = start_file_viewer_server(port=_file_viewer_port)
     logger.info(f'File viewer server started at {server_url}')
 
+    _maybe_init_laminar()
+
     plugins_to_load: list[Plugin] = []
     if args.plugins:
         for plugin in args.plugins:
             if plugin not in ALL_PLUGINS:
                 raise ValueError(f'Plugin {plugin} not found')
-            plugins_to_load.append(ALL_PLUGINS[plugin]())  # type: ignore
+            plugin_instance = ALL_PLUGINS[plugin]()  # type: ignore
+            if LAMINAR_AVAILABLE and Laminar.is_initialized():
+                plugin_instance = TracingPluginProxy(plugin_instance)
+            plugins_to_load.append(plugin_instance)
 
     client: ActionExecutor | None = None
     mcp_proxy_manager: MCPProxyManager | None = None

--- a/openhands/runtime/plugins/tracing_proxy.py
+++ b/openhands/runtime/plugins/tracing_proxy.py
@@ -1,0 +1,79 @@
+"""Automatic tracing proxy for OpenHands runtime plugins."""
+
+from typing import Any
+
+from openhands.core.logger import openhands_logger as logger
+from openhands.events.action import Action
+from openhands.events.observation import Observation
+from openhands.runtime.plugins.requirement import Plugin
+
+try:
+    from lmnr import Laminar, observe as laminar_observe
+
+    LAMINAR_AVAILABLE = True
+except ImportError:
+    LAMINAR_AVAILABLE = False
+    logger.debug('Laminar not available, tracing disabled')
+
+
+class TracingPluginProxy(Plugin):
+    """Proxy that adds distributed tracing to any plugin.
+
+    Automatically wraps plugin.initialize() and plugin.run() with Laminar spans.
+    All other attributes are delegated to the wrapped plugin.
+    """
+
+    def __init__(self, wrapped_plugin: Plugin):
+        """Wrap a plugin with tracing.
+
+        Args:
+            wrapped_plugin: The plugin instance to wrap
+        """
+        self._plugin = wrapped_plugin
+        self.name = wrapped_plugin.name
+        logger.debug(f'Created tracing proxy for plugin: {self.name}')
+
+    async def initialize(self, *args, **kwargs) -> None:
+        """Initialize plugin with tracing."""
+        if not LAMINAR_AVAILABLE or not Laminar.is_initialized():
+            return await self._plugin.initialize(*args, **kwargs)
+
+        @laminar_observe(
+            name=f'plugin.{self.name}.initialize',
+            span_type='DEFAULT',
+            metadata={'plugin': self.name, 'component': 'runtime'},
+        )
+        async def _traced_init():
+            return await self._plugin.initialize(*args, **kwargs)
+
+        return await _traced_init()
+
+    async def run(self, action: Action) -> Observation:
+        """Run plugin with tracing."""
+        if not LAMINAR_AVAILABLE or not Laminar.is_initialized():
+            return await self._plugin.run(action)
+
+        @laminar_observe(
+            name=f'plugin.{self.name}.run',
+            span_type='TOOL',
+            metadata={
+                'plugin': self.name,
+                'action_type': action.__class__.__name__,
+                'component': 'runtime',
+            },
+        )
+        async def _traced_run():
+            return await self._plugin.run(action)
+
+        return await _traced_run()
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate all other attributes to the wrapped plugin."""
+        return getattr(self._plugin, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Set attributes on wrapped plugin (except internal proxy state)."""
+        if name in ('_plugin', 'name'):
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._plugin, name, value)


### PR DESCRIPTION
## Summary

Add automatic distributed tracing for all runtime plugins using a proxy pattern.

## Changes

- **New file**: `openhands/runtime/plugins/tracing_proxy.py` - Proxy that wraps plugins with tracing
- **Modified**: `openhands/runtime/action_execution_server.py` - Initialize Laminar and wrap plugins

## Benefits

- ✅ All plugins traced automatically (Jupyter, AgentSkills, VSCode)
- ✅ Zero changes to existing plugin code
- ✅ Future plugins get tracing for free
- ✅ Seamless integration with SDK tracing (same `LMNR_PROJECT_API_KEY`)

## How it works

1. When `LMNR_PROJECT_API_KEY` is set, Laminar is initialized
2. During plugin instantiation, each plugin is wrapped with `TracingPluginProxy`
3. Proxy automatically traces `plugin.initialize()` and `plugin.run()` calls
4. All traces include metadata: plugin name, action type, component

## Testing

```bash
export LMNR_PROJECT_API_KEY="your-key"
# Run OpenHands with plugins
# Check Laminar dashboard for plugin traces
```

## Example trace

```
Session
  └─ plugin.jupyter.initialize (1.2s)
  └─ plugin.jupyter.run (234ms)
      └─ Action: IPythonRunCellAction
```