### PR TITLE
fix(a11y): add aria-label to sidebar for screen reader accessibility

### DIFF
--- a/frontend/src/components/features/sidebar/sidebar.tsx
+++ b/frontend/src/components/features/sidebar/sidebar.tsx
@@ -64,6 +64,7 @@ export function Sidebar() {
   return (
     <>
       <aside
+        aria-label="Main navigation sidebar"
         className={cn(
           "h-[54px] p-3 md:p-0 md:h-[40px] md:h-auto flex flex-row md:flex-col gap-1 bg-base md:w-[75px] md:min-w-[75px] sm:pt-0 sm:px-2 md:pt-[14px] md:px-0",
           pathname === "/" && "md:pt-6.5 md:pb-3",


### PR DESCRIPTION
## Description

Adds an `aria-label` attribute to the `<aside>` element in the Sidebar component to satisfy WCAG accessibility guidelines.

## Problem

Elements with the 'complementary' role (implicit for `<aside>`) must have an accessible name to help users of assistive technologies find and navigate the content.

The IBM Equal Access Accessibility Checker flagged this as a violation of [IBM 2.4.1 Bypass Blocks](https://www.ibm.com/able/requirements/requirements/#2_4_1).

## Solution

Added `aria-label="Main navigation sidebar"` to the `<aside>` element to provide a descriptive label for screen reader users.

## Changes

- Added `aria-label` attribute to the Sidebar component's `<aside>` element

## Testing

After this change, the accessibility checker should no longer flag the sidebar as missing an accessible label.

## Related Issue

Fixes #12727