### PR TITLE
Preload callback processor class to prevent Pydantic Deserialization Error

### DIFF
--- a/enterprise/saas_server.py
+++ b/enterprise/saas_server.py
@@ -78,9 +78,11 @@ base_app.include_router(shared_event_router)
 
 # Add GitHub integration router only if GITHUB_APP_CLIENT_ID is set
 if GITHUB_APP_CLIENT_ID:
-    from server.routes.integration.github import github_integration_router  # noqa: E402
     # Make sure that the callback processor is loaded here so we don't get an error when deserializing
-    from integrations.github.github_v1_callback_processor import GithubV1CallbackProcessor  # noqa: E402
+    from integrations.github.github_v1_callback_processor import (  # noqa: E402
+        GithubV1CallbackProcessor,
+    )
+    from server.routes.integration.github import github_integration_router  # noqa: E402
 
     # Bludgeon mypy into not deleting my import
     logger.debug(f'Loaded {GithubV1CallbackProcessor.__name__}')


### PR DESCRIPTION
## Summary of PR

If the callback processor is not preloaded, it may not be available when the code is deserialized from the db entry, and you get an error like:
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for AppConversationStartTask
request.processors.0
  Value error, Unknown kind 'GithubV1CallbackProcessor' for openhands.app_server.event_callback.event_callback_models.EventCallbackProcessor; Expected one of: ['SlackV1CallbackProcessor', 'LoggingCallbackProcessor', 'SetTitleCallbackProcessor'] [type=value_error, input_value={'github_view_data': {'is...line_pr_comment': False}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/value_error
```

## Demo Screenshots/Videos

Displaying summary callback working on staging:
<img width="770" height="641" alt="image" src="https://github.com/user-attachments/assets/15839d61-797b-416c-8ee2-eff81660507c" />

## Change Type

<!-- Choose the types that apply to your PR -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:7a0ecdd-nikolaik   --name openhands-app-7a0ecdd   docker.openhands.dev/openhands/openhands:7a0ecdd
```