### PR TITLE
feat(backend): return is_personal field in OrgResponse

### DIFF
--- a/enterprise/server/routes/org_models.py
+++ b/enterprise/server/routes/org_models.py
@@ -91,14 +91,18 @@ class OrgResponse(BaseModel):
     enable_solvability_analysis: bool | None = None
     v1_enabled: bool | None = None
     credits: float | None = None
+    is_personal: bool = False
 
     @classmethod
-    def from_org(cls, org: Org, credits: float | None = None) -> 'OrgResponse':
+    def from_org(
+        cls, org: Org, credits: float | None = None, user_id: str | None = None
+    ) -> 'OrgResponse':
         """Create an OrgResponse from an Org entity.
 
         Args:
             org: The organization entity to convert
             credits: Optional credits value (defaults to None)
+            user_id: Optional user ID to determine if org is personal (defaults to None)
 
         Returns:
             OrgResponse: The response model instance
@@ -134,6 +138,7 @@ class OrgResponse(BaseModel):
             enable_solvability_analysis=org.enable_solvability_analysis,
             v1_enabled=org.v1_enabled,
             credits=credits,
+            is_personal=str(org.id) == user_id if user_id else False,
         )
 
 

--- a/enterprise/server/routes/orgs.py
+++ b/enterprise/server/routes/orgs.py
@@ -69,7 +69,9 @@ async def list_user_orgs(
         )
 
         # Convert Org entities to OrgResponse objects
-        org_responses = [OrgResponse.from_org(org, credits=None) for org in orgs]
+        org_responses = [
+            OrgResponse.from_org(org, credits=None, user_id=user_id) for org in orgs
+        ]
 
         logger.info(
             'Successfully retrieved organizations',
@@ -136,7 +138,7 @@ async def create_org(
         # Retrieve credits from LiteLLM
         credits = await OrgService.get_org_credits(user_id, org.id)
 
-        return OrgResponse.from_org(org, credits=credits)
+        return OrgResponse.from_org(org, credits=credits, user_id=user_id)
     except OrgNameExistsError as e:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -211,7 +213,7 @@ async def get_org(
         # Retrieve credits from LiteLLM
         credits = await OrgService.get_org_credits(user_id, org.id)
 
-        return OrgResponse.from_org(org, credits=credits)
+        return OrgResponse.from_org(org, credits=credits, user_id=user_id)
     except OrgNotFoundError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -368,7 +370,7 @@ async def update_org(
         # Retrieve credits from LiteLLM (following same pattern as create endpoint)
         credits = await OrgService.get_org_credits(user_id, updated_org.id)
 
-        return OrgResponse.from_org(updated_org, credits=credits)
+        return OrgResponse.from_org(updated_org, credits=credits, user_id=user_id)
 
     except ValueError as e:
         # Organization not found


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

<!-- Summarize what the PR does -->

The front end needs a reliable way to differentiate between a user’s personal workspace and other organizations. To support this, we should include an is_personal field in the OrgResponse, allowing the front end to clearly identify personal workspaces.

**Acceptance criteria:**
- Include the is_personal field in the OrgResponse when fetching a list of organizations.
- Include the is_personal field in the OrgResponse when fetching individual organization details.

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

https://github.com/user-attachments/assets/3243b0fd-23c9-4283-8aeb-8019a99234b3

## Change Type

<!-- Choose the types that apply to your PR -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:cff2a22-nikolaik   --name openhands-app-cff2a22   docker.openhands.dev/openhands/openhands:cff2a22
```