### PR TITLE
Add PR Review by OpenHands workflow

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -7,7 +7,7 @@ on:
     #   1. A new PR is opened (non-draft), OR
     #   2. A draft PR is marked as ready for review, OR
     #   3. A maintainer adds the 'review-this' label, OR
-    #   4. A maintainer requests openhands-agent as a reviewer
+    #   4. A maintainer requests openhands-agent or all-hands-bot as a reviewer
     # Only users with write access can add labels or request reviews, ensuring security.
     # The PR code is explicitly checked out for review, but secrets are only accessible
     # because the workflow runs in the base repository context
@@ -25,13 +25,14 @@ jobs:
         #   1. A new non-draft PR is opened by a trusted contributor, OR
         #   2. A draft PR is converted to ready for review by a trusted contributor, OR
         #   3. 'review-this' label is added, OR
-        #   4. openhands-agent is requested as a reviewer
+        #   4. openhands-agent or all-hands-bot is requested as a reviewer
         # Note: FIRST_TIME_CONTRIBUTOR PRs require manual trigger via label/reviewer request
         if: |
             (github.event.action == 'opened' && github.event.pull_request.draft == false && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR') ||
             (github.event.action == 'ready_for_review' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR') ||
             github.event.label.name == 'review-this' ||
-            github.event.requested_reviewer.login == 'openhands-agent'
+            github.event.requested_reviewer.login == 'openhands-agent' ||
+            github.event.requested_reviewer.login == 'all-hands-bot'
         concurrency:
             group: pr-review-${{ github.event.pull_request.number }}
             cancel-in-progress: true
@@ -107,6 +108,7 @@ jobs:
               env:
                   LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
                   GITHUB_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  LMNR_PROJECT_API_KEY: ${{ secrets.LMNR_SKILLS_API_KEY }}
               run: |
                   # Change to the PR repository directory so agent can analyze the code
                   cd pr-repo


### PR DESCRIPTION
## Summary

This PR adds the `pr-review-by-openhands.yml` GitHub Actions workflow from the [OpenHands/software-agent-sdk](https://github.com/OpenHands/software-agent-sdk) repository.

## What this workflow does

The workflow provides automated PR reviews using OpenHands agents. It triggers when:

1. A new non-draft PR is opened (by non-first-time contributors)
2. A draft PR is marked as ready for review (by non-first-time contributors)
3. A maintainer adds the `review-this` label
4. A maintainer requests `openhands-agent` or `all-hands-bot` as a reviewer

## Security considerations

- Uses `pull_request_target` to safely handle fork PRs while accessing secrets
- Only trusted contributors (non-first-time) get automatic reviews
- First-time contributors require manual trigger via label or reviewer request
- PR code is checked out without persisting credentials to prevent untrusted code from accessing tokens

## Required secrets

The workflow expects the following repository secrets:
- `LLM_API_KEY` - API key for the LLM service
- `ALLHANDS_BOT_GITHUB_PAT` - GitHub PAT for posting review comments
- `LMNR_SKILLS_API_KEY` (optional) - For observability/logging

## Source

This workflow is adapted from:
https://github.com/OpenHands/software-agent-sdk/blob/main/.github/workflows/pr-review-by-openhands.yml

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:f728054-nikolaik   --name openhands-app-f728054   docker.openhands.dev/openhands/openhands:f728054
```