### PR TITLE
chore: update skills path comments

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_router.py
+++ b/openhands/app_server/app_conversation/app_conversation_router.py
@@ -469,8 +469,8 @@ async def get_conversation_skills(
     Skills are loaded from multiple sources:
     - Sandbox skills (exposed URLs)
     - Global skills (OpenHands/skills/)
-    - User skills (~/.agents/skills/)
-    - Organization skills (org/.agents repository)
+    - User skills (~/.openhands/skills/)
+    - Organization skills (org/.openhands repository)
     - Repository skills (repo .agents/skills/, .openhands/microagents/, and legacy .openhands/skills/)
 
     Returns:

--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -69,9 +69,9 @@ class AppConversationServiceBase(AppConversationService, ABC):
         This method calls the agent-server's /api/skills endpoint to load and
         merge skills from all sources. The agent-server handles:
         - Public skills (from OpenHands/skills GitHub repo)
-        - User skills (from ~/.agents/skills/)
-        - Organization skills (from {org}/.agents repo)
-        - Project/repo skills (from repo .agents/skills/, and legacy .openhands/microagents/, and .openhands/skills/)
+        - User skills (from ~/.openhands/skills/)
+        - Organization skills (from {org}/.openhands repo)
+        - Project/repo skills (from repo .agents/skills/, .openhands/microagents/, and legacy .openhands/skills/)
         - Sandbox skills (from exposed URLs)
 
         Args:


### PR DESCRIPTION
Update skills path comments to reference .agents/skills while noting microagents and legacy .openhands/skills support.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/44c67ab32c1b47b6a88e668e2aded0a5)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:d85223b-nikolaik   --name openhands-app-d85223b   docker.openhands.dev/openhands/openhands:d85223b
```