### PR TITLE
refactor: use consolidated pr-review action

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -9,7 +9,9 @@ on:
     #   3. openhands-agent or all-hands-bot is requested as a reviewer on a PR from a
     #      collaborator/member/owner, OR
     #   4. A maintainer adds the 'review-this' label (manual trigger for external authors)
-    # Note: PR authors from forks can request reviewers; we gate via author_association.
+    # Note: PR authors (including from forks) can request reviewers, but this workflow
+    # will only auto-run when the PR author is collaborator/member/owner.
+    # For external authors, a maintainer can trigger it by applying the 'review-this' label.
     # The PR code is explicitly checked out for review, but secrets are only accessible
     # because the workflow runs in the base repository context
     pull_request_target:
@@ -31,19 +33,24 @@ jobs:
         if: |
             (
               (
-                github.event.action == 'opened' &&
-                github.event.pull_request.draft == false
-              ) ||
-              (github.event.action == 'ready_for_review') ||
-              (
-                github.event.action == 'review_requested' &&
                 (
-                  github.event.requested_reviewer.login == 'openhands-agent' ||
-                  github.event.requested_reviewer.login == 'all-hands-bot'
-                )
+                  (
+                    github.event.action == 'opened' &&
+                    github.event.pull_request.draft == false
+                  ) ||
+                  (github.event.action == 'ready_for_review') ||
+                  (
+                    github.event.action == 'review_requested' &&
+                    (
+                      github.event.requested_reviewer.login == 'openhands-agent' ||
+                      github.event.requested_reviewer.login == 'all-hands-bot'
+                    )
+                  )
+                ) && contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.pull_request.author_association)
+              ) || (
+                github.event.action == 'labeled' && github.event.label.name == 'review-this'
               )
-            ) && contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.pull_request.author_association) ||
-            github.event.label.name == 'review-this'
+            )
         concurrency:
             group: pr-review-${{ github.event.pull_request.number }}
             cancel-in-progress: true


### PR DESCRIPTION
## Summary
This PR refactors the **PR Review by OpenHands** GitHub Actions workflow to use the consolidated `pr-review` action from `OpenHands/software-agent-sdk` instead of duplicating the review steps inline.

This is primarily a **simplicity/maintainability refactor** (single shared implementation, fewer moving parts, easier future updates), and also a **security hardening**:
- The workflow uses `pull_request_target` (base-repo context + secrets). Keeping the workflow logic minimal and delegating behavior to a single vetted action reduces the chance of accidentally introducing unsafe checkout/execution patterns in YAML.
- The workflow is gated so it runs automatically only for **collaborator/member/owner** PR authors, with an explicit maintainer-controlled escape hatch via the `review-this` label for external contributors.

Changes included:
- Replace hardcoded PR review workflow steps with the consolidated SDK action
- Update the runner to match other workflows
- Require maintainer/collaborator gating for execution

## Testing
- Not run (workflow change only)

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f3ef7167cfa949929eeadb6a8060864e)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:c25e908-nikolaik   --name openhands-app-c25e908   docker.openhands.dev/openhands/openhands:c25e908
```