### PR TITLE
Add debug logging for sandbox startup health checks

### DIFF
--- a/openhands/app_server/sandbox/docker_sandbox_service.py
+++ b/openhands/app_server/sandbox/docker_sandbox_service.py
@@ -230,7 +230,7 @@ class DockerSandboxService(SandboxService):
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
-                # If the server is
+                # If the server has exceeded the startup grace period, it's an error
                 if sandbox_info.created_at < utc_now() - timedelta(
                     seconds=self.startup_grace_seconds
                 ):
@@ -239,6 +239,10 @@ class DockerSandboxService(SandboxService):
                     )
                     sandbox_info.status = SandboxStatus.ERROR
                 else:
+                    _logger.debug(
+                        f'Sandbox server not yet available (still starting): '
+                        f'{app_server_url} : {exc}'
+                    )
                     sandbox_info.status = SandboxStatus.STARTING
                 sandbox_info.exposed_urls = None
                 sandbox_info.session_api_key = None


### PR DESCRIPTION
## Summary of PR

This PR adds debug-level logging to help diagnose sandbox startup issues, particularly when users encounter errors like "Sandbox failed to start within 120s".

**Changes:**

1. **`sandbox_service.py`**: Added debug logging to `_check_agent_server_alive()` when the health check fails, including the sandbox ID, URL being checked, and exception details.

2. **`docker_sandbox_service.py`**: Added debug logging in `_container_to_checked_sandbox_info()` when the sandbox server is not yet available during the startup grace period. Also fixed an incomplete comment.

**Why debug level?**
- Health checks fail repeatedly during normal server startup (this is expected behavior)
- We don't want to spam logs with errors during the expected startup period
- Users can enable DEBUG logging when troubleshooting startup issues to see the actual connection errors

This was suggested in [Slack discussion](https://github.com/OpenHands/OpenHands/blob/aa0b2d0b74c49c5ae3bc6d84bd15352c018f82d4/openhands/app_server/sandbox/docker_sandbox_service.py#L300) to help users debug issues related to sandbox startup failures.

## Demo Screenshots/Videos

N/A - This is a logging-only change with no visible UI changes.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

N/A - Addresses a debugging/troubleshooting improvement suggestion.

## Release Notes

- [ ] Include this change in the Release Notes.

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:87d35bf-nikolaik   --name openhands-app-87d35bf   docker.openhands.dev/openhands/openhands:87d35bf
```