### PR TITLE
Feat: view agent browser session recordings

### DIFF
--- a/openhands/app_server/sandbox/sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/sandbox_spec_service.py
@@ -13,7 +13,7 @@ from openhands.sdk.utils.models import DiscriminatedUnionMixin
 
 # The version of the agent server to use for deployments.
 # Typically this will be the same as the values from the pyproject.toml
-AGENT_SERVER_IMAGE = 'ghcr.io/openhands/agent-server:be475c0-python'
+AGENT_SERVER_IMAGE = 'ghcr.io/openhands/agent-server:38a5c59-python'
 
 
 class SandboxSpecService(ABC):

--- a/poetry.lock
+++ b/poetry.lock
@@ -6361,8 +6361,8 @@ wsproto = ">=1.2.0"
 [package.source]
 type = "git"
 url = "https://github.com/OpenHands/software-agent-sdk.git"
-reference = "be475c0ddb0579ca46e79d9088c37ea304a0f1fa"
-resolved_reference = "be475c0ddb0579ca46e79d9088c37ea304a0f1fa"
+reference = "38a5c59d61abb377f50d6527b6a63b6f0fc70f06"
+resolved_reference = "38a5c59d61abb377f50d6527b6a63b6f0fc70f06"
 subdirectory = "openhands-agent-server"
 
 [[package]]
@@ -6394,8 +6394,8 @@ boto3 = ["boto3 (>=1.35.0)"]
 [package.source]
 type = "git"
 url = "https://github.com/OpenHands/software-agent-sdk.git"
-reference = "be475c0ddb0579ca46e79d9088c37ea304a0f1fa"
-resolved_reference = "be475c0ddb0579ca46e79d9088c37ea304a0f1fa"
+reference = "38a5c59d61abb377f50d6527b6a63b6f0fc70f06"
+resolved_reference = "38a5c59d61abb377f50d6527b6a63b6f0fc70f06"
 subdirectory = "openhands-sdk"
 
 [[package]]
@@ -6422,8 +6422,8 @@ tom-swe = ">=1.0.3"
 [package.source]
 type = "git"
 url = "https://github.com/OpenHands/software-agent-sdk.git"
-reference = "be475c0ddb0579ca46e79d9088c37ea304a0f1fa"
-resolved_reference = "be475c0ddb0579ca46e79d9088c37ea304a0f1fa"
+reference = "38a5c59d61abb377f50d6527b6a63b6f0fc70f06"
+resolved_reference = "38a5c59d61abb377f50d6527b6a63b6f0fc70f06"
 subdirectory = "openhands-tools"
 
 [[package]]
@@ -14945,4 +14945,4 @@ third-party-runtimes = ["daytona", "e2b-code-interpreter", "modal", "runloop-api
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12,<3.14"
-content-hash = "b6c35a284a4fb7f05790ac5315a3eeb361cd24f15582ef743fe64748f2806d21"
+content-hash = "ef8a592904de4e2bbc0d4177b84f49f4b5eb26ac017be27e10739187fa81eab0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,9 @@ dependencies = [
   "numpy",
   "openai==2.8",
   "openhands-aci==0.3.2",
-  "openhands-agent-server @ git+https://github.com/OpenHands/software-agent-sdk.git@be475c0ddb0579ca46e79d9088c37ea304a0f1fa#subdirectory=openhands-agent-server",
-  "openhands-sdk @ git+https://github.com/OpenHands/software-agent-sdk.git@be475c0ddb0579ca46e79d9088c37ea304a0f1fa#subdirectory=openhands-sdk",
-  "openhands-tools @ git+https://github.com/OpenHands/software-agent-sdk.git@be475c0ddb0579ca46e79d9088c37ea304a0f1fa#subdirectory=openhands-tools",
+  "openhands-agent-server @ git+https://github.com/OpenHands/software-agent-sdk.git@38a5c59d61abb377f50d6527b6a63b6f0fc70f06#subdirectory=openhands-agent-server",
+  "openhands-sdk @ git+https://github.com/OpenHands/software-agent-sdk.git@38a5c59d61abb377f50d6527b6a63b6f0fc70f06#subdirectory=openhands-sdk",
+  "openhands-tools @ git+https://github.com/OpenHands/software-agent-sdk.git@38a5c59d61abb377f50d6527b6a63b6f0fc70f06#subdirectory=openhands-tools",
   "opentelemetry-api>=1.33.1",
   "opentelemetry-exporter-otlp-proto-grpc>=1.33.1",
   "pathspec>=0.12.1",
@@ -246,9 +246,9 @@ e2b-code-interpreter = { version = "^2.0.0", optional = true }
 pybase62 = "^1.0.0"
 
 # V1 dependencies
-openhands-sdk = { git = "https://github.com/OpenHands/software-agent-sdk.git", rev = "be475c0ddb0579ca46e79d9088c37ea304a0f1fa", subdirectory = "openhands-sdk" }
-openhands-agent-server = { git = "https://github.com/OpenHands/software-agent-sdk.git", rev = "be475c0ddb0579ca46e79d9088c37ea304a0f1fa", subdirectory = "openhands-agent-server" }
-openhands-tools = { git = "https://github.com/OpenHands/software-agent-sdk.git", rev = "be475c0ddb0579ca46e79d9088c37ea304a0f1fa", subdirectory = "openhands-tools" }
+openhands-sdk = { git = "https://github.com/OpenHands/software-agent-sdk.git", rev = "38a5c59d61abb377f50d6527b6a63b6f0fc70f06", subdirectory = "openhands-sdk" }
+openhands-agent-server = { git = "https://github.com/OpenHands/software-agent-sdk.git", rev = "38a5c59d61abb377f50d6527b6a63b6f0fc70f06", subdirectory = "openhands-agent-server" }
+openhands-tools = { git = "https://github.com/OpenHands/software-agent-sdk.git", rev = "38a5c59d61abb377f50d6527b6a63b6f0fc70f06", subdirectory = "openhands-tools" }
 python-jose = { version = ">=3.3", extras = [ "cryptography" ] }
 sqlalchemy = { extras = [ "asyncio" ], version = "^2.0.40" }
 pg8000 = "^1.31.5"


### PR DESCRIPTION
## Summary of PR

Update openhands-sdk, openhands-agent-server, and openhands-tools packages to point to commit `53dfacede2d6073f9c0fd272048d5586127b3b75` from the openhands-agent-sdk repository, enabling view agent browser session recordings functionality.

Also updates the agent server image tag to `f331726-python`.

### Changes:
- Updated `pyproject.toml` to reference the new commit hash for:
  - `openhands-sdk`
  - `openhands-agent-server`
  - `openhands-tools`
- Updated `AGENT_SERVER_IMAGE` tag in `openhands/app_server/sandbox/sandbox_spec_service.py` to `f331726-python`

## Demo Screenshots/Videos

N/A - dependency update

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

N/A

## Release Notes

- [x] Include this change in the Release Notes.

Users can now view agent browser session recordings.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:2f49c92-nikolaik   --name openhands-app-2f49c92   docker.openhands.dev/openhands/openhands:2f49c92
```