### PR TITLE
feat: Add current_datetime to AgentContext when creating agents

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 from abc import ABC
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, AsyncGenerator
 from uuid import UUID
@@ -149,8 +150,11 @@ class AppConversationServiceBase(AppConversationService, ABC):
                 }
             )
         else:
-            # Create new context
-            agent_context = AgentContext(skills=skills)
+            # Create new context with current datetime for time awareness
+            agent_context = AgentContext(
+                skills=skills,
+                current_datetime=datetime.now(),
+            )
             agent = agent.model_copy(update={'agent_context': agent_context})
 
         return agent

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -923,9 +923,11 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 mcp_config=mcp_config,
             )
 
-        # Add agent context
+        # Add agent context with current datetime for time awareness
         agent_context = AgentContext(
-            system_message_suffix=system_message_suffix, secrets=secrets
+            system_message_suffix=system_message_suffix,
+            secrets=secrets,
+            current_datetime=datetime.now(),
         )
         agent = agent.model_copy(update={'agent_context': agent_context})
 


### PR DESCRIPTION
## Summary

Include current time information in `AgentContext` to give agents awareness of the current date and time. This allows agents to provide time-appropriate responses and handle time-sensitive tasks.

## Dependencies

**Important**: This PR depends on the SDK changes in https://github.com/OpenHands/software-agent-sdk/pull/2012 which adds the `current_datetime` field to `AgentContext`. The SDK version will need to be bumped to >= 1.12.0 once that PR is merged.

## Changes

### `live_status_app_conversation_service.py`
- Add `current_datetime=datetime.now()` when creating `AgentContext` in `_create_agent_with_context`

### `app_conversation_service_base.py`
- Add `datetime` import
- Include `current_datetime=datetime.now()` in fallback `AgentContext` creation in `_create_agent_with_skills`

## How it works

When an agent is created, the current datetime is captured and included in the `AgentContext`. The SDK then renders this information in the system prompt as:

```xml
<CURRENT_DATETIME>
The current date and time is: 2024-03-15T14:30:00
</CURRENT_DATETIME>
```

This gives agents time awareness for tasks like:
- Scheduling-related questions
- Time-sensitive recommendations
- Date/time formatting in responses
- Understanding relative time references ("today", "this week", etc.)

## Testing

The datetime changes in the SDK include comprehensive tests. This PR focuses on integrating those changes into the OpenHands app server.


@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:e9e4ee0-nikolaik   --name openhands-app-e9e4ee0   docker.openhands.dev/openhands/openhands:e9e4ee0
```