### PR TITLE
feat: add proxy methods to SaasNestedConversationManager for deprecated V0 endpoints

### DIFF
--- a/enterprise/server/saas_nested_conversation_manager.py
+++ b/enterprise/server/saas_nested_conversation_manager.py
@@ -95,6 +95,15 @@ _POLLING_INTERVAL = 10
 # Timeout for http operations
 _HTTP_TIMEOUT = 15
 
+# Timeout for nested server proxy operations
+_NESTED_PROXY_TIMEOUT = 30
+
+# Maximum number of retries for nested server proxy operations
+_NESTED_PROXY_MAX_RETRIES = 3
+
+# Base delay between retries in seconds (exponential backoff)
+_NESTED_PROXY_RETRY_BASE_DELAY = 1.0
+
 
 class EventRetrieval(Enum):
     """Determine mode for getting events out of the nested runtime back into the main app."""
@@ -605,18 +614,8 @@ class SaasNestedConversationManager(ConversationManager):
         raise ValueError('unsupported_operation')
 
     async def send_event_to_conversation(self, sid: str, data: dict):
-        runtime = await self._get_runtime(sid)
-        if runtime is None:
-            raise ValueError(f'no_such_conversation:{sid}')
-        nested_url = self._get_nested_url_for_runtime(runtime['runtime_id'], sid)
-        async with httpx.AsyncClient(
-            verify=httpx_verify_option(),
-            headers={
-                'X-Session-API-Key': runtime['session_api_key'],
-            },
-        ) as client:
-            response = await client.post(f'{nested_url}/events', json=data)
-            response.raise_for_status()
+        """Send an event to a conversation by proxying to the nested server."""
+        await self._proxy_post_to_nested_server(sid, '/events', data)
 
     async def disconnect_from_session(self, connection_id: str):
         # Not supported - clients should connect directly to the nested server!
@@ -978,6 +977,255 @@ class SaasNestedConversationManager(ConversationManager):
             timeout=_HTTP_TIMEOUT,
         ) as client:
             yield client
+
+    @contextlib.asynccontextmanager
+    async def _nested_httpx_client(self, session_api_key: str):
+        """Create an httpx client configured for nested server requests."""
+        async with httpx.AsyncClient(
+            verify=httpx_verify_option(),
+            headers={'X-Session-API-Key': session_api_key},
+            timeout=_NESTED_PROXY_TIMEOUT,
+        ) as client:
+            yield client
+
+    async def _proxy_get_to_nested_server(
+        self,
+        sid: str,
+        endpoint: str,
+    ) -> dict[str, Any]:
+        """Proxy a GET request to the nested server with retries and error handling.
+
+        Args:
+            sid: The session/conversation ID
+            endpoint: The endpoint path to call (e.g., '/vscode-url', '/web-hosts')
+
+        Returns:
+            The JSON response from the nested server
+
+        Raises:
+            ValueError: If the runtime is not found or the request fails after retries
+        """
+        runtime = await self._get_runtime(sid)
+        if runtime is None:
+            raise ValueError(f'no_such_conversation:{sid}')
+
+        session_api_key = runtime.get('session_api_key')
+        if not session_api_key:
+            raise ValueError(f'no_session_api_key:{sid}')
+
+        nested_url = self._get_nested_url_for_runtime(runtime['runtime_id'], sid)
+        url = f'{nested_url}{endpoint}'
+
+        last_error: Exception | None = None
+
+        for attempt in range(_NESTED_PROXY_MAX_RETRIES):
+            try:
+                async with self._nested_httpx_client(session_api_key) as client:
+                    response = await client.get(url)
+                    response.raise_for_status()
+                    return response.json()
+            except httpx.TimeoutException as e:
+                last_error = e
+                logger.warning(
+                    'nested_proxy_timeout',
+                    extra={
+                        'sid': sid,
+                        'endpoint': endpoint,
+                        'attempt': attempt + 1,
+                        'error': str(e),
+                    },
+                )
+            except httpx.HTTPStatusError as e:
+                # Don't retry on client errors (4xx)
+                if 400 <= e.response.status_code < 500:
+                    logger.warning(
+                        'nested_proxy_client_error',
+                        extra={
+                            'sid': sid,
+                            'endpoint': endpoint,
+                            'status_code': e.response.status_code,
+                            'error': str(e),
+                        },
+                    )
+                    raise ValueError(
+                        f'nested_server_error:{sid}:{e.response.status_code}'
+                    )
+                last_error = e
+                logger.warning(
+                    'nested_proxy_server_error',
+                    extra={
+                        'sid': sid,
+                        'endpoint': endpoint,
+                        'attempt': attempt + 1,
+                        'status_code': e.response.status_code,
+                        'error': str(e),
+                    },
+                )
+            except httpx.RequestError as e:
+                last_error = e
+                logger.warning(
+                    'nested_proxy_request_error',
+                    extra={
+                        'sid': sid,
+                        'endpoint': endpoint,
+                        'attempt': attempt + 1,
+                        'error': str(e),
+                    },
+                )
+
+            # Exponential backoff before retry
+            if attempt < _NESTED_PROXY_MAX_RETRIES - 1:
+                delay = _NESTED_PROXY_RETRY_BASE_DELAY * (2**attempt)
+                await asyncio.sleep(delay)
+
+        # All retries exhausted
+        logger.error(
+            'nested_proxy_failed',
+            extra={
+                'sid': sid,
+                'endpoint': endpoint,
+                'max_retries': _NESTED_PROXY_MAX_RETRIES,
+                'error': str(last_error),
+            },
+        )
+        raise ValueError(f'nested_proxy_failed:{sid}:{endpoint}')
+
+    async def _proxy_post_to_nested_server(
+        self,
+        sid: str,
+        endpoint: str,
+        data: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Proxy a POST request to the nested server with retries and error handling.
+
+        Args:
+            sid: The session/conversation ID
+            endpoint: The endpoint path to call (e.g., '/events')
+            data: The JSON data to send in the request body
+
+        Returns:
+            The JSON response from the nested server
+
+        Raises:
+            ValueError: If the runtime is not found or the request fails after retries
+        """
+        runtime = await self._get_runtime(sid)
+        if runtime is None:
+            raise ValueError(f'no_such_conversation:{sid}')
+
+        session_api_key = runtime.get('session_api_key')
+        if not session_api_key:
+            raise ValueError(f'no_session_api_key:{sid}')
+
+        nested_url = self._get_nested_url_for_runtime(runtime['runtime_id'], sid)
+        url = f'{nested_url}{endpoint}'
+
+        last_error: Exception | None = None
+
+        for attempt in range(_NESTED_PROXY_MAX_RETRIES):
+            try:
+                async with self._nested_httpx_client(session_api_key) as client:
+                    response = await client.post(url, json=data)
+                    response.raise_for_status()
+                    return response.json()
+            except httpx.TimeoutException as e:
+                last_error = e
+                logger.warning(
+                    'nested_proxy_timeout',
+                    extra={
+                        'sid': sid,
+                        'endpoint': endpoint,
+                        'attempt': attempt + 1,
+                        'error': str(e),
+                    },
+                )
+            except httpx.HTTPStatusError as e:
+                # Don't retry on client errors (4xx)
+                if 400 <= e.response.status_code < 500:
+                    logger.warning(
+                        'nested_proxy_client_error',
+                        extra={
+                            'sid': sid,
+                            'endpoint': endpoint,
+                            'status_code': e.response.status_code,
+                            'error': str(e),
+                        },
+                    )
+                    raise ValueError(
+                        f'nested_server_error:{sid}:{e.response.status_code}'
+                    )
+                last_error = e
+                logger.warning(
+                    'nested_proxy_server_error',
+                    extra={
+                        'sid': sid,
+                        'endpoint': endpoint,
+                        'attempt': attempt + 1,
+                        'status_code': e.response.status_code,
+                        'error': str(e),
+                    },
+                )
+            except httpx.RequestError as e:
+                last_error = e
+                logger.warning(
+                    'nested_proxy_request_error',
+                    extra={
+                        'sid': sid,
+                        'endpoint': endpoint,
+                        'attempt': attempt + 1,
+                        'error': str(e),
+                    },
+                )
+
+            # Exponential backoff before retry
+            if attempt < _NESTED_PROXY_MAX_RETRIES - 1:
+                delay = _NESTED_PROXY_RETRY_BASE_DELAY * (2**attempt)
+                await asyncio.sleep(delay)
+
+        # All retries exhausted
+        logger.error(
+            'nested_proxy_failed',
+            extra={
+                'sid': sid,
+                'endpoint': endpoint,
+                'max_retries': _NESTED_PROXY_MAX_RETRIES,
+                'error': str(last_error),
+            },
+        )
+        raise ValueError(f'nested_proxy_failed:{sid}:{endpoint}')
+
+    async def get_vscode_url(self, sid: str) -> dict[str, str | None]:
+        """Get the VSCode URL for a conversation by proxying to the nested server.
+
+        Args:
+            sid: The session/conversation ID
+
+        Returns:
+            Dictionary with 'vscode_url' key
+        """
+        return await self._proxy_get_to_nested_server(sid, '/vscode-url')
+
+    async def get_web_hosts(self, sid: str) -> dict[str, list[str]]:
+        """Get the web hosts for a conversation by proxying to the nested server.
+
+        Args:
+            sid: The session/conversation ID
+
+        Returns:
+            Dictionary with 'hosts' key containing list of host URLs
+        """
+        return await self._proxy_get_to_nested_server(sid, '/web-hosts')
+
+    async def get_microagents(self, sid: str) -> dict[str, Any]:
+        """Get the microagents for a conversation by proxying to the nested server.
+
+        Args:
+            sid: The session/conversation ID
+
+        Returns:
+            Dictionary with 'microagents' key containing list of microagent info
+        """
+        return await self._proxy_get_to_nested_server(sid, '/microagents')
 
     async def _get_runtimes(self) -> list[dict]:
         async with self._httpx_client() as client:

--- a/enterprise/tests/unit/test_saas_nested_conversation_manager_proxy.py
+++ b/enterprise/tests/unit/test_saas_nested_conversation_manager_proxy.py
@@ -1,0 +1,562 @@
+"""
+Tests for SaasNestedConversationManager proxy methods.
+
+This module tests the proxy functionality that forwards requests
+to the nested server with retries and error handling.
+
+Test Coverage:
+- _proxy_get_to_nested_server method with retries
+- _proxy_post_to_nested_server method with retries
+- get_vscode_url proxy method
+- get_web_hosts proxy method
+- get_microagents proxy method
+- send_event_to_conversation with new retry logic
+- Error handling and retry behavior
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+
+from enterprise.server.saas_nested_conversation_manager import (
+    SaasNestedConversationManager,
+    _NESTED_PROXY_MAX_RETRIES,
+    _NESTED_PROXY_RETRY_BASE_DELAY,
+)
+
+
+class TestNestedServerProxy:
+    """Test suite for nested server proxy methods."""
+
+    @pytest.fixture
+    def conversation_manager(self):
+        """Create a minimal SaasNestedConversationManager instance for testing."""
+        mock_sio = Mock()
+        mock_config = Mock()
+        mock_config.max_concurrent_conversations = 5
+        mock_config.sandbox = Mock()
+        mock_config.sandbox.api_key = 'test_api_key'
+        mock_server_config = Mock()
+        mock_file_store = Mock()
+
+        manager = SaasNestedConversationManager(
+            sio=mock_sio,
+            config=mock_config,
+            server_config=mock_server_config,
+            file_store=mock_file_store,
+            event_retrieval=Mock(),
+        )
+        return manager
+
+    @pytest.fixture
+    def mock_runtime(self):
+        """Create a mock runtime response."""
+        return {
+            'runtime_id': 'test_runtime_123',
+            'session_id': 'test_session_456',
+            'session_api_key': 'test_session_api_key_789',
+            'status': 'running',
+        }
+
+    @pytest.mark.asyncio
+    async def test_proxy_get_raises_error_when_runtime_not_found(
+        self, conversation_manager
+    ):
+        """Test that proxy raises error when runtime is not found."""
+        sid = 'nonexistent_session'
+
+        with patch.object(
+            conversation_manager, '_get_runtime', new_callable=AsyncMock
+        ) as mock_get_runtime:
+            mock_get_runtime.return_value = None
+
+            with pytest.raises(ValueError, match='no_such_conversation'):
+                await conversation_manager._proxy_get_to_nested_server(
+                    sid, '/vscode-url'
+                )
+
+    @pytest.mark.asyncio
+    async def test_proxy_get_raises_error_when_no_session_api_key(
+        self, conversation_manager
+    ):
+        """Test that proxy raises error when session_api_key is missing."""
+        sid = 'test_session'
+        runtime_without_key = {
+            'runtime_id': 'test_runtime',
+            'session_id': sid,
+            'status': 'running',
+        }
+
+        with patch.object(
+            conversation_manager, '_get_runtime', new_callable=AsyncMock
+        ) as mock_get_runtime:
+            mock_get_runtime.return_value = runtime_without_key
+
+            with pytest.raises(ValueError, match='no_session_api_key'):
+                await conversation_manager._proxy_get_to_nested_server(
+                    sid, '/vscode-url'
+                )
+
+    @pytest.mark.asyncio
+    async def test_proxy_get_success(self, conversation_manager, mock_runtime):
+        """Test successful proxy GET request."""
+        sid = 'test_session_456'
+        expected_response = {'vscode_url': 'https://vscode.example.com'}
+
+        with patch.object(
+            conversation_manager, '_get_runtime', new_callable=AsyncMock
+        ) as mock_get_runtime:
+            mock_get_runtime.return_value = mock_runtime
+
+            with patch.object(
+                conversation_manager,
+                '_get_nested_url_for_runtime',
+                return_value='https://nested.example.com/api/conversations/test_session_456',
+            ):
+                with patch('httpx.AsyncClient') as mock_client_class:
+                    mock_response = Mock()
+                    mock_response.json.return_value = expected_response
+                    mock_response.raise_for_status = Mock()
+
+                    mock_client = AsyncMock()
+                    mock_client.get.return_value = mock_response
+                    mock_client.__aenter__.return_value = mock_client
+                    mock_client.__aexit__.return_value = None
+                    mock_client_class.return_value = mock_client
+
+                    result = await conversation_manager._proxy_get_to_nested_server(
+                        sid, '/vscode-url'
+                    )
+
+                    assert result == expected_response
+                    mock_client.get.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_proxy_get_retries_on_timeout(self, conversation_manager, mock_runtime):
+        """Test that proxy retries on timeout errors."""
+        sid = 'test_session_456'
+        expected_response = {'vscode_url': 'https://vscode.example.com'}
+
+        with patch.object(
+            conversation_manager, '_get_runtime', new_callable=AsyncMock
+        ) as mock_get_runtime:
+            mock_get_runtime.return_value = mock_runtime
+
+            with patch.object(
+                conversation_manager,
+                '_get_nested_url_for_runtime',
+                return_value='https://nested.example.com/api/conversations/test_session_456',
+            ):
+                with patch('httpx.AsyncClient') as mock_client_class:
+                    # First two calls timeout, third succeeds
+                    mock_response = Mock()
+                    mock_response.json.return_value = expected_response
+                    mock_response.raise_for_status = Mock()
+
+                    mock_client = AsyncMock()
+                    mock_client.get.side_effect = [
+                        httpx.TimeoutException('timeout'),
+                        httpx.TimeoutException('timeout'),
+                        mock_response,
+                    ]
+                    mock_client.__aenter__.return_value = mock_client
+                    mock_client.__aexit__.return_value = None
+                    mock_client_class.return_value = mock_client
+
+                    with patch('asyncio.sleep', new_callable=AsyncMock):
+                        result = await conversation_manager._proxy_get_to_nested_server(
+                            sid, '/vscode-url'
+                        )
+
+                    assert result == expected_response
+                    assert mock_client.get.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_proxy_get_fails_after_max_retries(
+        self, conversation_manager, mock_runtime
+    ):
+        """Test that proxy fails after exhausting retries."""
+        sid = 'test_session_456'
+
+        with patch.object(
+            conversation_manager, '_get_runtime', new_callable=AsyncMock
+        ) as mock_get_runtime:
+            mock_get_runtime.return_value = mock_runtime
+
+            with patch.object(
+                conversation_manager,
+                '_get_nested_url_for_runtime',
+                return_value='https://nested.example.com/api/conversations/test_session_456',
+            ):
+                with patch('httpx.AsyncClient') as mock_client_class:
+                    mock_client = AsyncMock()
+                    mock_client.get.side_effect = httpx.TimeoutException('timeout')
+                    mock_client.__aenter__.return_value = mock_client
+                    mock_client.__aexit__.return_value = None
+                    mock_client_class.return_value = mock_client
+
+                    with patch('asyncio.sleep', new_callable=AsyncMock):
+                        with pytest.raises(ValueError, match='nested_proxy_failed'):
+                            await conversation_manager._proxy_get_to_nested_server(
+                                sid, '/vscode-url'
+                            )
+
+                    assert mock_client.get.call_count == _NESTED_PROXY_MAX_RETRIES
+
+    @pytest.mark.asyncio
+    async def test_proxy_get_no_retry_on_client_error(
+        self, conversation_manager, mock_runtime
+    ):
+        """Test that proxy does not retry on 4xx client errors."""
+        sid = 'test_session_456'
+
+        with patch.object(
+            conversation_manager, '_get_runtime', new_callable=AsyncMock
+        ) as mock_get_runtime:
+            mock_get_runtime.return_value = mock_runtime
+
+            with patch.object(
+                conversation_manager,
+                '_get_nested_url_for_runtime',
+                return_value='https://nested.example.com/api/conversations/test_session_456',
+            ):
+                with patch('httpx.AsyncClient') as mock_client_class:
+                    mock_response = Mock()
+                    mock_response.status_code = 404
+
+                    mock_client = AsyncMock()
+                    mock_client.get.side_effect = httpx.HTTPStatusError(
+                        'Not Found', request=Mock(), response=mock_response
+                    )
+                    mock_client.__aenter__.return_value = mock_client
+                    mock_client.__aexit__.return_value = None
+                    mock_client_class.return_value = mock_client
+
+                    with pytest.raises(ValueError, match='nested_server_error'):
+                        await conversation_manager._proxy_get_to_nested_server(
+                            sid, '/vscode-url'
+                        )
+
+                    # Should only be called once (no retry on 4xx)
+                    assert mock_client.get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_proxy_get_retries_on_server_error(
+        self, conversation_manager, mock_runtime
+    ):
+        """Test that proxy retries on 5xx server errors."""
+        sid = 'test_session_456'
+        expected_response = {'vscode_url': 'https://vscode.example.com'}
+
+        with patch.object(
+            conversation_manager, '_get_runtime', new_callable=AsyncMock
+        ) as mock_get_runtime:
+            mock_get_runtime.return_value = mock_runtime
+
+            with patch.object(
+                conversation_manager,
+                '_get_nested_url_for_runtime',
+                return_value='https://nested.example.com/api/conversations/test_session_456',
+            ):
+                with patch('httpx.AsyncClient') as mock_client_class:
+                    # First call gets 500, second succeeds
+                    mock_error_response = Mock()
+                    mock_error_response.status_code = 500
+
+                    mock_success_response = Mock()
+                    mock_success_response.json.return_value = expected_response
+                    mock_success_response.raise_for_status = Mock()
+
+                    mock_client = AsyncMock()
+                    mock_client.get.side_effect = [
+                        httpx.HTTPStatusError(
+                            'Server Error', request=Mock(), response=mock_error_response
+                        ),
+                        mock_success_response,
+                    ]
+                    mock_client.__aenter__.return_value = mock_client
+                    mock_client.__aexit__.return_value = None
+                    mock_client_class.return_value = mock_client
+
+                    with patch('asyncio.sleep', new_callable=AsyncMock):
+                        result = await conversation_manager._proxy_get_to_nested_server(
+                            sid, '/vscode-url'
+                        )
+
+                    assert result == expected_response
+                    assert mock_client.get.call_count == 2
+
+
+class TestGetVscodeUrl:
+    """Test suite for get_vscode_url method."""
+
+    @pytest.fixture
+    def conversation_manager(self):
+        """Create a minimal SaasNestedConversationManager instance for testing."""
+        mock_sio = Mock()
+        mock_config = Mock()
+        mock_config.max_concurrent_conversations = 5
+        mock_server_config = Mock()
+        mock_file_store = Mock()
+
+        manager = SaasNestedConversationManager(
+            sio=mock_sio,
+            config=mock_config,
+            server_config=mock_server_config,
+            file_store=mock_file_store,
+            event_retrieval=Mock(),
+        )
+        return manager
+
+    @pytest.mark.asyncio
+    async def test_get_vscode_url_calls_proxy(self, conversation_manager):
+        """Test that get_vscode_url calls the proxy method correctly."""
+        sid = 'test_session'
+        expected_result = {'vscode_url': 'https://vscode.example.com'}
+
+        with patch.object(
+            conversation_manager,
+            '_proxy_get_to_nested_server',
+            new_callable=AsyncMock,
+        ) as mock_proxy:
+            mock_proxy.return_value = expected_result
+
+            result = await conversation_manager.get_vscode_url(sid)
+
+            mock_proxy.assert_called_once_with(sid, '/vscode-url')
+            assert result == expected_result
+
+
+class TestGetWebHosts:
+    """Test suite for get_web_hosts method."""
+
+    @pytest.fixture
+    def conversation_manager(self):
+        """Create a minimal SaasNestedConversationManager instance for testing."""
+        mock_sio = Mock()
+        mock_config = Mock()
+        mock_config.max_concurrent_conversations = 5
+        mock_server_config = Mock()
+        mock_file_store = Mock()
+
+        manager = SaasNestedConversationManager(
+            sio=mock_sio,
+            config=mock_config,
+            server_config=mock_server_config,
+            file_store=mock_file_store,
+            event_retrieval=Mock(),
+        )
+        return manager
+
+    @pytest.mark.asyncio
+    async def test_get_web_hosts_calls_proxy(self, conversation_manager):
+        """Test that get_web_hosts calls the proxy method correctly."""
+        sid = 'test_session'
+        expected_result = {'hosts': ['https://host1.example.com', 'https://host2.example.com']}
+
+        with patch.object(
+            conversation_manager,
+            '_proxy_get_to_nested_server',
+            new_callable=AsyncMock,
+        ) as mock_proxy:
+            mock_proxy.return_value = expected_result
+
+            result = await conversation_manager.get_web_hosts(sid)
+
+            mock_proxy.assert_called_once_with(sid, '/web-hosts')
+            assert result == expected_result
+
+
+class TestGetMicroagents:
+    """Test suite for get_microagents method."""
+
+    @pytest.fixture
+    def conversation_manager(self):
+        """Create a minimal SaasNestedConversationManager instance for testing."""
+        mock_sio = Mock()
+        mock_config = Mock()
+        mock_config.max_concurrent_conversations = 5
+        mock_server_config = Mock()
+        mock_file_store = Mock()
+
+        manager = SaasNestedConversationManager(
+            sio=mock_sio,
+            config=mock_config,
+            server_config=mock_server_config,
+            file_store=mock_file_store,
+            event_retrieval=Mock(),
+        )
+        return manager
+
+    @pytest.mark.asyncio
+    async def test_get_microagents_calls_proxy(self, conversation_manager):
+        """Test that get_microagents calls the proxy method correctly."""
+        sid = 'test_session'
+        expected_result = {
+            'microagents': [
+                {'name': 'agent1', 'type': 'repo', 'content': 'test content'}
+            ]
+        }
+
+        with patch.object(
+            conversation_manager,
+            '_proxy_get_to_nested_server',
+            new_callable=AsyncMock,
+        ) as mock_proxy:
+            mock_proxy.return_value = expected_result
+
+            result = await conversation_manager.get_microagents(sid)
+
+            mock_proxy.assert_called_once_with(sid, '/microagents')
+            assert result == expected_result
+
+
+class TestSendEventToConversation:
+    """Test suite for send_event_to_conversation with retry logic."""
+
+    @pytest.fixture
+    def conversation_manager(self):
+        """Create a minimal SaasNestedConversationManager instance for testing."""
+        mock_sio = Mock()
+        mock_config = Mock()
+        mock_config.max_concurrent_conversations = 5
+        mock_server_config = Mock()
+        mock_file_store = Mock()
+
+        manager = SaasNestedConversationManager(
+            sio=mock_sio,
+            config=mock_config,
+            server_config=mock_server_config,
+            file_store=mock_file_store,
+            event_retrieval=Mock(),
+        )
+        return manager
+
+    @pytest.mark.asyncio
+    async def test_send_event_calls_proxy(self, conversation_manager):
+        """Test that send_event_to_conversation calls the proxy method correctly."""
+        sid = 'test_session'
+        event_data = {'type': 'message', 'content': 'Hello'}
+
+        with patch.object(
+            conversation_manager,
+            '_proxy_post_to_nested_server',
+            new_callable=AsyncMock,
+        ) as mock_proxy:
+            mock_proxy.return_value = {'success': True}
+
+            await conversation_manager.send_event_to_conversation(sid, event_data)
+
+            mock_proxy.assert_called_once_with(sid, '/events', event_data)
+
+
+class TestProxyPostToNestedServer:
+    """Test suite for _proxy_post_to_nested_server method."""
+
+    @pytest.fixture
+    def conversation_manager(self):
+        """Create a minimal SaasNestedConversationManager instance for testing."""
+        mock_sio = Mock()
+        mock_config = Mock()
+        mock_config.max_concurrent_conversations = 5
+        mock_config.sandbox = Mock()
+        mock_config.sandbox.api_key = 'test_api_key'
+        mock_server_config = Mock()
+        mock_file_store = Mock()
+
+        manager = SaasNestedConversationManager(
+            sio=mock_sio,
+            config=mock_config,
+            server_config=mock_server_config,
+            file_store=mock_file_store,
+            event_retrieval=Mock(),
+        )
+        return manager
+
+    @pytest.fixture
+    def mock_runtime(self):
+        """Create a mock runtime response."""
+        return {
+            'runtime_id': 'test_runtime_123',
+            'session_id': 'test_session_456',
+            'session_api_key': 'test_session_api_key_789',
+            'status': 'running',
+        }
+
+    @pytest.mark.asyncio
+    async def test_proxy_post_success(self, conversation_manager, mock_runtime):
+        """Test successful proxy POST request."""
+        sid = 'test_session_456'
+        post_data = {'type': 'message', 'content': 'Hello'}
+        expected_response = {'success': True}
+
+        with patch.object(
+            conversation_manager, '_get_runtime', new_callable=AsyncMock
+        ) as mock_get_runtime:
+            mock_get_runtime.return_value = mock_runtime
+
+            with patch.object(
+                conversation_manager,
+                '_get_nested_url_for_runtime',
+                return_value='https://nested.example.com/api/conversations/test_session_456',
+            ):
+                with patch('httpx.AsyncClient') as mock_client_class:
+                    mock_response = Mock()
+                    mock_response.json.return_value = expected_response
+                    mock_response.raise_for_status = Mock()
+
+                    mock_client = AsyncMock()
+                    mock_client.post.return_value = mock_response
+                    mock_client.__aenter__.return_value = mock_client
+                    mock_client.__aexit__.return_value = None
+                    mock_client_class.return_value = mock_client
+
+                    result = await conversation_manager._proxy_post_to_nested_server(
+                        sid, '/events', post_data
+                    )
+
+                    assert result == expected_response
+                    mock_client.post.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_proxy_post_retries_on_timeout(
+        self, conversation_manager, mock_runtime
+    ):
+        """Test that proxy POST retries on timeout errors."""
+        sid = 'test_session_456'
+        post_data = {'type': 'message', 'content': 'Hello'}
+        expected_response = {'success': True}
+
+        with patch.object(
+            conversation_manager, '_get_runtime', new_callable=AsyncMock
+        ) as mock_get_runtime:
+            mock_get_runtime.return_value = mock_runtime
+
+            with patch.object(
+                conversation_manager,
+                '_get_nested_url_for_runtime',
+                return_value='https://nested.example.com/api/conversations/test_session_456',
+            ):
+                with patch('httpx.AsyncClient') as mock_client_class:
+                    mock_response = Mock()
+                    mock_response.json.return_value = expected_response
+                    mock_response.raise_for_status = Mock()
+
+                    mock_client = AsyncMock()
+                    mock_client.post.side_effect = [
+                        httpx.TimeoutException('timeout'),
+                        mock_response,
+                    ]
+                    mock_client.__aenter__.return_value = mock_client
+                    mock_client.__aexit__.return_value = None
+                    mock_client_class.return_value = mock_client
+
+                    with patch('asyncio.sleep', new_callable=AsyncMock):
+                        result = await conversation_manager._proxy_post_to_nested_server(
+                            sid, '/events', post_data
+                        )
+
+                    assert result == expected_response
+                    assert mock_client.post.call_count == 2


### PR DESCRIPTION
## Summary of PR

Implement async httpx client methods in `SaasNestedConversationManager` to proxy requests to the nested server with reasonable error handling, retries, and timeouts. This allows deprecated V0 API endpoints (`/vscode-url`, `/web-hosts`, `/microagents`) to work with the SaaS nested conversation manager by forwarding requests to the nested server running inside remote containers.

### Changes:
- Add `_nested_httpx_client` context manager for nested server requests
- Add `_proxy_get_to_nested_server` with exponential backoff retry logic (1s, 2s, 4s delays)
- Add `_proxy_post_to_nested_server` with exponential backoff retry logic
- Add `get_vscode_url`, `get_web_hosts`, `get_microagents` proxy methods
- Update `send_event_to_conversation` to use the new retry logic
- Add configuration constants for proxy timeout (30s), max retries (3), and retry delay
- Add comprehensive unit tests for all proxy methods

### Key Features:
- **Retries on transient failures**: Timeouts and 5xx server errors are retried with exponential backoff
- **No retry on client errors**: 4xx errors fail immediately without retry
- **Comprehensive logging**: Warning logs for each retry attempt, error logs when all retries are exhausted
- **Configurable**: Constants can be adjusted for timeout, max retries, and retry delay

## Demo Screenshots/Videos

N/A - Backend functionality

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

N/A

## Release Notes

- [ ] Include this change in the Release Notes.


@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:5ea4492-nikolaik   --name openhands-app-5ea4492   docker.openhands.dev/openhands/openhands:5ea4492
```