### PR TITLE
fix(slack): add V1 privacy check for Slack callback responses

### DIFF
--- a/enterprise/integrations/slack/slack_v1_callback_processor.py
+++ b/enterprise/integrations/slack/slack_v1_callback_processor.py
@@ -28,7 +28,21 @@ _logger = logging.getLogger(__name__)
 
 
 class SlackV1CallbackProcessor(EventCallbackProcessor):
-    """Callback processor for Slack V1 integrations."""
+    """Callback processor for Slack V1 integrations.
+
+    This processor tracks the content of the last message sent from Slack to ensure
+    responses are only sent back to Slack when the user's last message originated
+    from Slack. This prevents privacy issues where a user who continues a conversation
+    via the Web UI would have their messages echoed back to Slack.
+
+    The `slack_view_data` dict should contain:
+    - channel_id: Slack channel ID
+    - team_id: Slack team ID
+    - message_ts: Message timestamp
+    - thread_ts: Thread timestamp (optional)
+    - slack_user_id: Slack user ID
+    - last_slack_message_content: Content of the last message sent from Slack (for privacy)
+    """
 
     slack_view_data: dict[str, str | None] = Field(default_factory=dict)
 
@@ -51,6 +65,19 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
         _logger.info('[Slack V1] Callback agent state was %s', event)
 
         try:
+            # Privacy check: Only respond to Slack if the last message originated from Slack
+            if not await self._should_respond_to_slack(conversation_id):
+                _logger.info(
+                    '[Slack V1] Skipping Slack response - last message did not originate from Slack'
+                )
+                return EventCallbackResult(
+                    status=EventCallbackResultStatus.SUCCESS,
+                    event_callback_id=callback.id,
+                    event_id=event.id,
+                    conversation_id=conversation_id,
+                    detail='Skipped: last message not from Slack',
+                )
+
             summary = await self._request_summary(conversation_id)
             await self._post_summary_to_slack(summary)
 
@@ -83,6 +110,139 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
                 conversation_id=conversation_id,
                 detail=str(e),
             )
+
+    async def _should_respond_to_slack(self, conversation_id: UUID) -> bool:
+        """Check if we should respond to Slack based on the last message source.
+
+        Returns True if:
+        - We don't have tracking info (backward compatibility)
+        - The last user message matches what was sent from Slack
+        - The last user message is a summary instruction (callback's own message)
+
+        Returns False if:
+        - The last user message content doesn't match the tracked Slack message
+          (indicating the user sent a message via Web UI)
+        """
+        last_slack_content = self.slack_view_data.get('last_slack_message_content')
+
+        # If we don't have tracking info, allow the response (backward compatibility)
+        if last_slack_content is None:
+            return True
+
+        try:
+            last_user_message = await self._get_last_user_message(conversation_id)
+            if last_user_message is None:
+                return True
+
+            # Allow if the message matches what was sent from Slack
+            if last_user_message == last_slack_content:
+                return True
+
+            # Allow if it's a summary instruction (our own request)
+            summary_instruction = get_summary_instruction()
+            if last_user_message == summary_instruction:
+                return True
+
+            # Message doesn't match - user likely sent message from Web UI
+            _logger.info(
+                '[Slack V1] Privacy check failed: last message does not match Slack message',
+                extra={
+                    'conversation_id': str(conversation_id),
+                    'last_user_message_preview': last_user_message[:100]
+                    if last_user_message
+                    else None,
+                    'last_slack_content_preview': last_slack_content[:100]
+                    if last_slack_content
+                    else None,
+                },
+            )
+            return False
+
+        except Exception as e:
+            _logger.warning(
+                '[Slack V1] Error checking last message source, allowing response: %s', e
+            )
+            # On error, allow the response to not break existing functionality
+            return True
+
+    async def _get_last_user_message(self, conversation_id: UUID) -> str | None:
+        """Fetch the last user message content from the conversation.
+
+        Returns the content of the most recent user message, or None if not found.
+        """
+        from openhands.app_server.config import (
+            get_app_conversation_info_service,
+            get_httpx_client,
+            get_sandbox_service,
+        )
+        from openhands.app_server.event_callback.util import (
+            ensure_conversation_found,
+            ensure_running_sandbox,
+            get_agent_server_url_from_sandbox,
+        )
+        from openhands.app_server.services.injector import InjectorState
+        from openhands.app_server.user.specifiy_user_context import (
+            ADMIN,
+            USER_CONTEXT_ATTR,
+        )
+
+        state = InjectorState()
+        setattr(state, USER_CONTEXT_ATTR, ADMIN)
+
+        async with (
+            get_app_conversation_info_service(state) as app_conversation_info_service,
+            get_sandbox_service(state) as sandbox_service,
+            get_httpx_client(state) as httpx_client,
+        ):
+            app_conversation_info = ensure_conversation_found(
+                await app_conversation_info_service.get_app_conversation_info(
+                    conversation_id
+                ),
+                conversation_id,
+            )
+
+            sandbox = ensure_running_sandbox(
+                await sandbox_service.get_sandbox(app_conversation_info.sandbox_id),
+                app_conversation_info.sandbox_id,
+            )
+
+            if sandbox.session_api_key is None:
+                return None
+
+            agent_server_url = get_agent_server_url_from_sandbox(sandbox)
+
+            # Fetch the last user message from the agent server
+            url = f'{agent_server_url.rstrip("/")}/api/conversations/{conversation_id}/events'
+            headers = {'X-Session-API-Key': sandbox.session_api_key}
+
+            try:
+                response = await httpx_client.get(
+                    url,
+                    headers=headers,
+                    params={'limit': 50, 'reverse': True},  # Get most recent events
+                    timeout=10.0,
+                )
+                response.raise_for_status()
+                events = response.json().get('events', [])
+
+                # Find the most recent user message
+                for event in events:
+                    if (
+                        event.get('role') == 'user'
+                        and event.get('content')
+                        and isinstance(event['content'], list)
+                    ):
+                        for content_item in event['content']:
+                            if content_item.get('type') == 'text':
+                                return content_item.get('text')
+
+                return None
+
+            except Exception as e:
+                _logger.warning(
+                    '[Slack V1] Failed to fetch last user message: %s', e
+                )
+                return None
 
     # -------------------------------------------------------------------------
     # Slack helpers

--- a/enterprise/integrations/slack/slack_view.py
+++ b/enterprise/integrations/slack/slack_view.py
@@ -205,8 +205,16 @@ class SlackNewConversationView(SlackViewInterface):
             )
             await slack_conversation_store.create_slack_conversation(slack_conversation)
 
-    def _create_slack_v1_callback_processor(self) -> SlackV1CallbackProcessor:
-        """Create a SlackV1CallbackProcessor for V1 conversation handling."""
+    def _create_slack_v1_callback_processor(
+        self, message_content: str
+    ) -> SlackV1CallbackProcessor:
+        """Create a SlackV1CallbackProcessor for V1 conversation handling.
+
+        Args:
+            message_content: The content of the message being sent from Slack,
+                            used for privacy tracking (to know if responses should
+                            be sent back to Slack).
+        """
         return SlackV1CallbackProcessor(
             slack_view_data={
                 'channel_id': self.channel_id,
@@ -214,6 +222,7 @@ class SlackNewConversationView(SlackViewInterface):
                 'thread_ts': self.thread_ts,
                 'team_id': self.team_id,
                 'slack_user_id': self.slack_user_id,
+                'last_slack_message_content': message_content,
             }
         )
 
@@ -280,8 +289,11 @@ class SlackNewConversationView(SlackViewInterface):
             role='user', content=[TextContent(text=user_instructions)]
         )
 
-        # Create the Slack V1 callback processor
-        slack_callback_processor = self._create_slack_v1_callback_processor()
+        # Create the Slack V1 callback processor with the initial message content
+        # for privacy tracking (so we only respond to Slack when message came from Slack)
+        slack_callback_processor = self._create_slack_v1_callback_processor(
+            user_instructions
+        )
 
         # Determine git provider from repository
         git_provider = None
@@ -410,9 +422,14 @@ class SlackUpdateExistingConversationView(SlackNewConversationView):
     async def send_message_to_v1_conversation(self, jinja: Environment):
         """Send a message to a v1 conversation using the agent server API."""
         # Import services within the method to avoid circular imports
+        from integrations.slack.slack_v1_callback_processor import (
+            SlackV1CallbackProcessor,
+        )
+
         from openhands.agent_server.models import SendMessageRequest
         from openhands.app_server.config import (
             get_app_conversation_info_service,
+            get_event_callback_service,
             get_httpx_client,
             get_sandbox_service,
         )
@@ -429,6 +446,27 @@ class SlackUpdateExistingConversationView(SlackNewConversationView):
         # Create injector state for dependency injection
         state = InjectorState()
         setattr(state, USER_CONTEXT_ATTR, ADMIN)
+
+        # Get the message content before sending
+        user_msg, _ = self._get_instructions(jinja)
+
+        # Update the Slack V1 callback processor with the new message content
+        # (for privacy: so we only respond to Slack when message came from Slack)
+        async with get_event_callback_service(state) as event_callback_service:
+            callbacks = await event_callback_service.search_event_callbacks(
+                conversation_id__eq=UUID(self.conversation_id)
+            )
+            for callback in callbacks.items:
+                if isinstance(callback.processor, SlackV1CallbackProcessor):
+                    callback.processor.slack_view_data[
+                        'last_slack_message_content'
+                    ] = user_msg
+                    await event_callback_service.save_event_callback(callback)
+                    logger.info(
+                        '[Slack V1] Updated callback with new message content for conversation %s',
+                        self.conversation_id,
+                    )
+                    break
 
         async with (
             get_app_conversation_info_service(state) as app_conversation_info_service,
@@ -468,15 +506,12 @@ class SlackUpdateExistingConversationView(SlackNewConversationView):
             # 3. Get the agent server URL
             agent_server_url = get_agent_server_url_from_sandbox(running_sandbox)
 
-            # 4. Prepare the message content
-            user_msg, _ = self._get_instructions(jinja)
-
-            # 5. Create the message request
+            # 4. Create the message request
             send_message_request = SendMessageRequest(
                 role='user', content=[TextContent(text=user_msg)], run=True
             )
 
-            # 6. Send the message to the agent server
+            # 5. Send the message to the agent server
             url = f'{agent_server_url.rstrip("/")}/api/conversations/{UUID(self.conversation_id)}/events'
 
             headers = {'X-Session-API-Key': running_sandbox.session_api_key}

--- a/enterprise/tests/unit/integrations/slack/test_slack_v1_callback_processor.py
+++ b/enterprise/tests/unit/integrations/slack/test_slack_v1_callback_processor.py
@@ -429,3 +429,181 @@ class TestSlackV1CallbackProcessor:
         assert result is not None
         assert result.status == EventCallbackResultStatus.ERROR
         assert expected_error_fragment in result.detail
+
+    # -------------------------------------------------------------------------
+    # Privacy feature tests
+    # -------------------------------------------------------------------------
+
+    @patch('storage.slack_team_store.SlackTeamStore.get_instance')
+    @patch.object(SlackV1CallbackProcessor, '_request_summary')
+    @patch.object(SlackV1CallbackProcessor, '_get_last_user_message')
+    async def test_skips_response_when_message_not_from_slack(
+        self,
+        mock_get_last_user_message,
+        mock_request_summary,
+        mock_slack_team_store,
+        finish_event,
+        event_callback,
+    ):
+        """Test that callback skips sending to Slack when last message didn't come from Slack.
+
+        This is a privacy feature: if user continues conversation via Web UI,
+        responses should NOT be sent back to Slack.
+        """
+        # Create processor with message tracking enabled
+        processor = SlackV1CallbackProcessor(
+            slack_view_data={
+                'channel_id': 'C1234567890',
+                'message_ts': '1234567890.123456',
+                'team_id': 'T1234567890',
+                'last_slack_message_content': 'Message sent from Slack',
+            }
+        )
+
+        # Mock last user message being different (from Web UI)
+        mock_get_last_user_message.return_value = 'Message sent from Web UI'
+
+        # Execute
+        result = await processor(uuid4(), event_callback, finish_event)
+
+        # Verify callback was skipped
+        assert result is not None
+        assert result.status == EventCallbackResultStatus.SUCCESS
+        assert 'Skipped: last message not from Slack' in result.detail
+
+        # Verify summary was NOT requested
+        mock_request_summary.assert_not_called()
+
+    @patch('storage.slack_team_store.SlackTeamStore.get_instance')
+    @patch('integrations.slack.slack_v1_callback_processor.WebClient')
+    @patch.object(SlackV1CallbackProcessor, '_request_summary')
+    @patch.object(SlackV1CallbackProcessor, '_get_last_user_message')
+    async def test_sends_response_when_message_from_slack(
+        self,
+        mock_get_last_user_message,
+        mock_request_summary,
+        mock_web_client,
+        mock_slack_team_store,
+        finish_event,
+        event_callback,
+    ):
+        """Test that callback sends to Slack when last message came from Slack."""
+        slack_message = 'Message sent from Slack'
+
+        # Create processor with message tracking enabled
+        processor = SlackV1CallbackProcessor(
+            slack_view_data={
+                'channel_id': 'C1234567890',
+                'message_ts': '1234567890.123456',
+                'team_id': 'T1234567890',
+                'last_slack_message_content': slack_message,
+            }
+        )
+
+        # Mock SlackTeamStore
+        mock_store = MagicMock()
+        mock_store.get_team_bot_token.return_value = 'xoxb-test-token'
+        mock_slack_team_store.return_value = mock_store
+
+        # Mock last user message matching Slack message
+        mock_get_last_user_message.return_value = slack_message
+
+        # Mock successful summary
+        mock_request_summary.return_value = 'Summary from agent'
+
+        # Mock Slack WebClient
+        mock_slack_client = MagicMock()
+        mock_slack_client.chat_postMessage.return_value = {'ok': True}
+        mock_web_client.return_value = mock_slack_client
+
+        # Execute
+        result = await processor(uuid4(), event_callback, finish_event)
+
+        # Verify callback succeeded and sent to Slack
+        assert result is not None
+        assert result.status == EventCallbackResultStatus.SUCCESS
+        assert result.detail == 'Summary from agent'
+
+        # Verify summary was requested and sent to Slack
+        mock_request_summary.assert_called_once()
+        mock_slack_client.chat_postMessage.assert_called_once()
+
+    @patch('storage.slack_team_store.SlackTeamStore.get_instance')
+    @patch('integrations.slack.slack_v1_callback_processor.WebClient')
+    @patch.object(SlackV1CallbackProcessor, '_request_summary')
+    @patch.object(SlackV1CallbackProcessor, '_get_last_user_message')
+    async def test_backward_compatibility_when_no_tracking(
+        self,
+        mock_get_last_user_message,
+        mock_request_summary,
+        mock_web_client,
+        mock_slack_team_store,
+        finish_event,
+        event_callback,
+    ):
+        """Test backward compatibility: when last_slack_message_content is not set,
+        responses should still be sent to Slack (old behavior).
+        """
+        # Create processor WITHOUT message tracking (backward compatibility)
+        processor = SlackV1CallbackProcessor(
+            slack_view_data={
+                'channel_id': 'C1234567890',
+                'message_ts': '1234567890.123456',
+                'team_id': 'T1234567890',
+                # No 'last_slack_message_content' key
+            }
+        )
+
+        # Mock SlackTeamStore
+        mock_store = MagicMock()
+        mock_store.get_team_bot_token.return_value = 'xoxb-test-token'
+        mock_slack_team_store.return_value = mock_store
+
+        # Mock successful summary
+        mock_request_summary.return_value = 'Summary from agent'
+
+        # Mock Slack WebClient
+        mock_slack_client = MagicMock()
+        mock_slack_client.chat_postMessage.return_value = {'ok': True}
+        mock_web_client.return_value = mock_slack_client
+
+        # Execute
+        result = await processor(uuid4(), event_callback, finish_event)
+
+        # Verify callback succeeded without checking message source
+        assert result is not None
+        assert result.status == EventCallbackResultStatus.SUCCESS
+        assert result.detail == 'Summary from agent'
+
+        # Verify _get_last_user_message was NOT called (because tracking is disabled)
+        mock_get_last_user_message.assert_not_called()
+
+        # Verify summary was requested and sent to Slack
+        mock_request_summary.assert_called_once()
+        mock_slack_client.chat_postMessage.assert_called_once()
+
+    def test_last_slack_message_content_serialization(self):
+        """Test that last_slack_message_content is properly stored in slack_view_data."""
+        message_content = 'Test message from Slack'
+        processor = SlackV1CallbackProcessor(
+            slack_view_data={
+                'channel_id': 'C1234567890',
+                'message_ts': '1234567890.123456',
+                'team_id': 'T1234567890',
+                'last_slack_message_content': message_content,
+            }
+        )
+
+        # Verify the content is stored
+        assert (
+            processor.slack_view_data.get('last_slack_message_content')
+            == message_content
+        )
+
+        # Verify serialization/deserialization
+        json_data = processor.model_dump_json()
+        restored = SlackV1CallbackProcessor.model_validate_json(json_data)
+        assert (
+            restored.slack_view_data.get('last_slack_message_content')
+            == message_content
+        )


### PR DESCRIPTION
## Description

This PR implements the V1 privacy fix for the Slack integration. When a user starts a conversation via Slack and later continues via the Web UI, the agent's responses should NOT be posted back to Slack. This is a privacy concern - users who move to a different interface may want more privacy.

**Note:** This is the V1 (current, non-legacy) implementation. There is a separate PR OpenHands/OpenHands#12864 for the V0 (legacy) implementation.

## Changes

### `SlackV1CallbackProcessor`

1. **Added `_should_respond_to_slack(conversation_id)` method**:
   - Checks if `last_slack_message_content` is stored in `slack_view_data`
   - Fetches the last user message from the conversation via the agent server API
   - Returns `True` if messages match (from Slack) or if tracking is disabled (backward compatibility)
   - Returns `False` if messages don't match (user sent message via Web UI)

2. **Added `_get_last_user_message(conversation_id)` method**:
   - Connects to the agent server using existing patterns
   - Fetches recent events and finds the most recent user message
   - Returns the message content or `None` if not found

3. **Modified `__call__` method**:
   - Added privacy check before sending summary to Slack
   - If check fails, returns success with detail indicating skip reason
   - If check passes, continues with normal flow

### `slack_view.py`

1. **Updated `_create_slack_v1_callback_processor`**:
   - Now accepts `message_content` parameter
   - Stores `last_slack_message_content` in `slack_view_data`

2. **Updated `_create_v1_conversation`**:
   - Passes initial user instructions to the callback processor

3. **Updated `send_message_to_v1_conversation`**:
   - Before sending follow-up messages, updates the existing callback's `slack_view_data['last_slack_message_content']`
   - Uses `EventCallbackService` to find and update the callback

## Flow

1. When a new V1 Slack conversation is created, the processor stores the initial message content in `slack_view_data['last_slack_message_content']`
2. When a follow-up message is sent from Slack, the view updates the callback with the new message content
3. When the callback fires:
   - If `last_slack_message_content` is set AND the current last user message doesn't match AND it's not a summary instruction → Skip sending to Slack
   - Otherwise → Continue normal processing (send summary to Slack)

## Backward Compatibility

- If `last_slack_message_content` is not set in `slack_view_data`, the privacy check is skipped
- Existing callbacks in the database will continue to work as before
- New callbacks will have privacy tracking enabled

## Tests Added

- `test_skips_response_when_message_not_from_slack`: Verifies callback skips when message came from Web UI
- `test_sends_response_when_message_from_slack`: Verifies callback processes when message came from Slack
- `test_backward_compatibility_when_no_tracking`: Verifies old callbacks still work
- `test_last_slack_message_content_serialization`: Verifies data is properly stored/restored

## Related

Fixes OpenHands/enterprise#20

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:cfe973e-nikolaik   --name openhands-app-cfe973e   docker.openhands.dev/openhands/openhands:cfe973e
```