### PR TITLE
fix: skip conversation link when conversation_id is None

### DIFF
--- a/openhands/server/routes/mcp.py
+++ b/openhands/server/routes/mcp.py
@@ -32,10 +32,13 @@ CONVERSATION_URL = HOST + '/conversations/{}'
 
 
 async def get_conversation_link(
-    service: GitService, conversation_id: str, body: str
+    service: GitService, conversation_id: str | None, body: str
 ) -> str:
     """Appends a followup link, in the PR body, to the OpenHands conversation that opened the PR"""
     if server_config.app_mode != AppMode.SAAS:
+        return body
+
+    if not conversation_id:
         return body
 
     user = await service.get_user()

--- a/tests/unit/server/routes/test_mcp_routes.py
+++ b/tests/unit/server/routes/test_mcp_routes.py
@@ -94,6 +94,38 @@ async def test_get_conversation_link_saas_mode():
 
 
 @pytest.mark.asyncio
+async def test_get_conversation_link_none_conversation_id():
+    """Test get_conversation_link returns body unchanged when conversation_id is None."""
+    mock_service = AsyncMock(spec=GitService)
+
+    with patch('openhands.server.routes.mcp.server_config') as mock_config:
+        mock_config.app_mode = AppMode.SAAS
+
+        result = await get_conversation_link(
+            service=mock_service, conversation_id=None, body='Original body'
+        )
+
+        assert result == 'Original body'
+        mock_service.get_user.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_conversation_link_empty_conversation_id():
+    """Test get_conversation_link returns body unchanged when conversation_id is empty string."""
+    mock_service = AsyncMock(spec=GitService)
+
+    with patch('openhands.server.routes.mcp.server_config') as mock_config:
+        mock_config.app_mode = AppMode.SAAS
+
+        result = await get_conversation_link(
+            service=mock_service, conversation_id='', body='Original body'
+        )
+
+        assert result == 'Original body'
+        mock_service.get_user.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_get_conversation_link_empty_body():
     """Test get_conversation_link with an empty body."""
     # Mock GitService and user


### PR DESCRIPTION
## Summary
- Adds a `None`/empty check in `get_conversation_link()` to prevent broken `/conversations/None` URLs in PR descriptions created via MCP tools
- Updates the type hint for `conversation_id` from `str` to `str | None` to reflect that it can be `None`
- Adds unit tests for both `None` and empty string cases

Fixes #12832

## Test plan
- [x] `test_get_conversation_link_none_conversation_id` — verifies `None` conversation_id returns body unchanged
- [x] `test_get_conversation_link_empty_conversation_id` — verifies empty string returns body unchanged
- [x] Existing tests still pass (`pytest tests/unit/server/routes/test_mcp_routes.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)