### PR TITLE
fix(frontend): replace stale TaskTrackerObservation instead of stacking

### DIFF
--- a/frontend/__tests__/utils/handle-event-for-ui.test.ts
+++ b/frontend/__tests__/utils/handle-event-for-ui.test.ts
@@ -185,6 +185,67 @@ describe("handleEventForUI", () => {
     expect(result).not.toBe(initialUiEvents);
   });
 
+  it("should replace previous TaskTrackerObservation with new one", () => {
+    const mockTaskTracker1: ObservationEvent = {
+      id: "test-task-tracker-1",
+      timestamp: Date.now().toString(),
+      source: "environment",
+      tool_name: "task_tracker",
+      tool_call_id: "call_tt_1",
+      observation: {
+        kind: "TaskTrackerObservation",
+        content: "plan updated",
+        command: "plan",
+        task_list: [{ title: "Task 1", status: "in_progress", notes: "" }],
+      },
+      action_id: "test-tt-action-1",
+    };
+
+    const mockTaskTracker2: ObservationEvent = {
+      id: "test-task-tracker-2",
+      timestamp: Date.now().toString(),
+      source: "environment",
+      tool_name: "task_tracker",
+      tool_call_id: "call_tt_2",
+      observation: {
+        kind: "TaskTrackerObservation",
+        content: "plan updated",
+        command: "plan",
+        task_list: [{ title: "Task 1", status: "done", notes: "" }],
+      },
+      action_id: "test-tt-action-2",
+    };
+
+    // First task tracker gets added
+    const afterFirst = handleEventForUI(mockTaskTracker1, [mockMessageEvent]);
+    expect(afterFirst).toEqual([mockMessageEvent, mockTaskTracker1]);
+
+    // Second task tracker replaces the first
+    const afterSecond = handleEventForUI(mockTaskTracker2, afterFirst);
+    expect(afterSecond).toEqual([mockMessageEvent, mockTaskTracker2]);
+    expect(afterSecond).toHaveLength(2);
+  });
+
+  it("should add first TaskTrackerObservation normally", () => {
+    const mockTaskTracker: ObservationEvent = {
+      id: "test-task-tracker-1",
+      timestamp: Date.now().toString(),
+      source: "environment",
+      tool_name: "task_tracker",
+      tool_call_id: "call_tt_1",
+      observation: {
+        kind: "TaskTrackerObservation",
+        content: "plan updated",
+        command: "plan",
+        task_list: [{ title: "Task 1", status: "todo", notes: "" }],
+      },
+      action_id: "test-tt-action-1",
+    };
+
+    const result = handleEventForUI(mockTaskTracker, [mockMessageEvent]);
+    expect(result).toEqual([mockMessageEvent, mockTaskTracker]);
+  });
+
   it("should NOT add ThinkObservation even when ThinkAction is not found", () => {
     const mockThinkObservation: ObservationEvent = {
       id: "test-think-observation-1",

--- a/frontend/src/utils/handle-event-for-ui.ts
+++ b/frontend/src/utils/handle-event-for-ui.ts
@@ -26,6 +26,22 @@ export const handleEventForUI = (
       return newUiEvents;
     }
 
+    // TaskTrackerObservation: replace any previous task tracker observation
+    // so only the latest snapshot displays (prevents stacking/spinning)
+    if (event.observation.kind === "TaskTrackerObservation") {
+      const prevIndex = newUiEvents.findIndex(
+        (uiEvent) =>
+          isObservationEvent(uiEvent) &&
+          uiEvent.observation.kind === "TaskTrackerObservation",
+      );
+      if (prevIndex !== -1) {
+        newUiEvents[prevIndex] = event;
+        return newUiEvents;
+      }
+      newUiEvents.push(event);
+      return newUiEvents;
+    }
+
     // Find and replace the corresponding action from uiEvents
     const actionIndex = newUiEvents.findIndex(
       (uiEvent) => uiEvent.id === event.action_id,


### PR DESCRIPTION
## Summary
- When a new `TaskTrackerObservation` arrives, replace the previous one in `uiEvents` instead of appending it
- This prevents multiple task tracker panels from stacking up in the chat with stale spinning animations
- Added 2 unit tests covering the replacement and first-add behaviors

Fixes #12585

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` — 147 test files, 1036 tests pass
- [x] `npm run lint:fix` clean
- [x] Pre-commit hooks pass
- [x] New test: `should replace previous TaskTrackerObservation with new one`
- [x] New test: `should add first TaskTrackerObservation normally`

🤖 Generated with [Claude Code](https://claude.com/claude-code)