### PR TITLE
Add saas-rel* branch pattern to ghcr-build workflow

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       - main
-      - "saas-rel*"
+      - "saas-rel-*"
     tags:
       - "*"
   pull_request:


### PR DESCRIPTION
The reason we are adding this is so that we don't have to create a PR to get the docker images. It will run on the branch.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:e6d8935-nikolaik   --name openhands-app-e6d8935   docker.openhands.dev/openhands/openhands:e6d8935
```