### PR TITLE
fix: add default uuid4 to event_callback_result primary key

### DIFF
--- a/openhands/app_server/event_callback/sql_event_callback_service.py
+++ b/openhands/app_server/event_callback/sql_event_callback_service.py
@@ -7,7 +7,7 @@ import asyncio
 import logging
 from dataclasses import dataclass
 from typing import AsyncGenerator
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from fastapi import Request
 from sqlalchemy import UUID as SQLUUID
@@ -59,7 +59,7 @@ class StoredEventCallback(Base):  # type: ignore
 
 class StoredEventCallbackResult(Base):  # type: ignore
     __tablename__ = 'event_callback_result'
-    id = Column(SQLUUID, primary_key=True)
+    id = Column(SQLUUID, primary_key=True, default=uuid4)
     status = Column(Enum(EventCallbackResultStatus), nullable=True)
     event_callback_id = Column(SQLUUID, index=True)
     event_id = Column(String, index=True)


### PR DESCRIPTION
## Summary of PR

This fix resolves the SQLAlchemy warning about the `event_callback_result.id` column being marked as a primary key without a default generator.

## Changes Made

- Added `default=uuid4` to the `id` column definition in `StoredEventCallbackResult` SQLAlchemy model
- Added `uuid4` to the imports

## Root Cause

The warning occurred because when an exception happens in a callback processor, the code creates a `StoredEventCallbackResult` without passing an `id` value. Since the column was defined as part of the primary key with no default, SQLAlchemy couldn't determine what value to use.

The successful path worked because it used `result.model_dump()` which includes the `id` from the Pydantic model's `default_factory=uuid4`.

## Change Type

- [x] Bug fix

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:977a895-nikolaik   --name openhands-app-977a895   docker.openhands.dev/openhands/openhands:977a895
```