### PR TITLE
fix: drop top_p for Claude Opus 4.x minor models

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -7,6 +7,7 @@
 # Tag: Legacy-V0
 # V1 replacement for this module lives in the Software Agent SDK.
 import copy
+import re
 import os
 import time
 import warnings
@@ -198,15 +199,15 @@ class LLM(RetryMixin, DebugMixin):
         if 'claude-opus-4-1' in self.config.model.lower():
             kwargs['thinking'] = {'type': 'disabled'}
 
-        # Anthropic constraint: Opus 4.1, Opus 4.5, and Sonnet 4 models cannot accept both temperature and top_p
+        # Anthropic constraint: some Claude 4 models reject both `temperature` and `top_p`.
         # Prefer temperature (drop top_p) if both are specified.
         _model_lower = self.config.model.lower()
-        # Apply to Opus 4.1, Opus 4.5, and Sonnet 4 models to avoid API errors
-        if (
-            ('claude-opus-4-1' in _model_lower)
-            or ('claude-opus-4-5' in _model_lower)
-            or ('claude-sonnet-4' in _model_lower)
-        ) and ('temperature' in kwargs and 'top_p' in kwargs):
+        is_claude4_opus_minor = bool(re.search(r'claude-opus-4-\d(?:-|$)', _model_lower))
+        is_claude4_sonnet = 'claude-sonnet-4' in _model_lower
+
+        if (is_claude4_opus_minor or is_claude4_sonnet) and (
+            'temperature' in kwargs and 'top_p' in kwargs
+        ):
             kwargs.pop('top_p', None)
 
         # Add completion_kwargs if present

--- a/tests/unit/llm/test_llm.py
+++ b/tests/unit/llm/test_llm.py
@@ -1275,6 +1275,25 @@ def test_opus_45_keeps_temperature_drops_top_p(mock_completion):
 
 
 @patch('openhands.llm.llm.litellm_completion')
+def test_opus_46_keeps_temperature_drops_top_p(mock_completion):
+    mock_completion.return_value = {
+        'choices': [{'message': {'content': 'ok'}}],
+    }
+    config = LLMConfig(
+        model='anthropic/claude-opus-4-6',
+        api_key='k',
+        temperature=0.7,
+        top_p=0.9,
+    )
+    llm = LLM(config, service_id='svc')
+    llm.completion(messages=[{'role': 'user', 'content': 'hi'}])
+    call_kwargs = mock_completion.call_args[1]
+    assert call_kwargs.get('temperature') == 0.7
+    # Anthropic rejects both temperature and top_p together on Opus 4.6; we keep temperature and drop top_p
+    assert 'top_p' not in call_kwargs
+
+
+@patch('openhands.llm.llm.litellm_completion')
 def test_sonnet_4_keeps_temperature_drops_top_p(mock_completion):
     mock_completion.return_value = {
         'choices': [{'message': {'content': 'ok'}}],


### PR DESCRIPTION
Fixes #12846.

Anthropic rejects sending both `temperature` and `top_p` for some Claude 4 models (including `anthropic/claude-opus-4-6`). This change drops `top_p` when both are set for:
- `claude-opus-4-<minor>` (e.g. 4-1/4-5/4-6)
- `claude-sonnet-4*`

Adds a unit test covering `anthropic/claude-opus-4-6`.