### PR TITLE
fix: avoid broken conversation links when conversation_id missing

### DIFF
--- a/openhands/server/routes/mcp.py
+++ b/openhands/server/routes/mcp.py
@@ -32,10 +32,15 @@ CONVERSATION_URL = HOST + '/conversations/{}'
 
 
 async def get_conversation_link(
-    service: GitService, conversation_id: str, body: str
+    service: GitService, conversation_id: str | None, body: str
 ) -> str:
-    """Appends a followup link, in the PR body, to the OpenHands conversation that opened the PR"""
+    """Appends a followup link, in the PR body, to the OpenHands conversation that opened the PR."""
     if server_config.app_mode != AppMode.SAAS:
+        return body
+
+    # Some callers may be outside a conversation context (missing/empty header).
+    # Avoid generating broken links like .../conversations/None.
+    if not conversation_id or conversation_id == 'None':
         return body
 
     user = await service.get_user()

--- a/tests/unit/server/routes/test_mcp_routes.py
+++ b/tests/unit/server/routes/test_mcp_routes.py
@@ -94,6 +94,23 @@ async def test_get_conversation_link_saas_mode():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize('conversation_id', [None, '', 'None'])
+async def test_get_conversation_link_missing_conversation_id(conversation_id):
+    """Do not append a broken conversation link if conversation_id is missing."""
+    mock_service = AsyncMock(spec=GitService)
+
+    with patch('openhands.server.routes.mcp.server_config') as mock_config:
+        mock_config.app_mode = AppMode.SAAS
+
+        result = await get_conversation_link(
+            service=mock_service, conversation_id=conversation_id, body='Original body'
+        )
+
+        assert result == 'Original body'
+        mock_service.get_user.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_get_conversation_link_empty_body():
     """Test get_conversation_link with an empty body."""
     # Mock GitService and user


### PR DESCRIPTION
Fixes #12832.

`get_conversation_link` now returns the PR body unchanged when `conversation_id` is missing/empty so we don't generate broken links like `.../conversations/None`.

Adds a unit test covering `conversation_id` values of `None`, empty string, and the literal string `"None"`.