### PR TITLE
refactor(backend): include current_org_id in organization list response

### DIFF
--- a/enterprise/server/routes/org_models.py
+++ b/enterprise/server/routes/org_models.py
@@ -214,6 +214,7 @@ class OrgPage(BaseModel):
 
     items: list[OrgResponse]
     next_page_id: str | None = None
+    current_org_id: str | None = None
 
 
 class OrgUpdate(BaseModel):

--- a/enterprise/server/routes/orgs.py
+++ b/enterprise/server/routes/orgs.py
@@ -32,6 +32,7 @@ from server.routes.org_models import (
 )
 from server.services.org_member_service import OrgMemberService
 from storage.org_service import OrgService
+from storage.user_store import UserStore
 
 from openhands.core.logger import openhands_logger as logger
 from openhands.server.user_auth import get_user_id
@@ -78,6 +79,12 @@ async def list_user_orgs(
     )
 
     try:
+        # Fetch user to get current_org_id
+        user = await UserStore.get_user_by_id_async(user_id)
+        current_org_id = (
+            str(user.current_org_id) if user and user.current_org_id else None
+        )
+
         # Fetch organizations from service layer
         orgs, next_page_id = OrgService.get_user_orgs_paginated(
             user_id=user_id,
@@ -99,7 +106,11 @@ async def list_user_orgs(
             },
         )
 
-        return OrgPage(items=org_responses, next_page_id=next_page_id)
+        return OrgPage(
+            items=org_responses,
+            next_page_id=next_page_id,
+            current_org_id=current_org_id,
+        )
 
     except Exception as e:
         logger.exception(


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

<!-- Summarize what the PR does -->

This enhancement will help preserve the user’s most recent organization selection when the front-end page is refreshed, ensuring a smoother and more consistent user experience.

**Acceptance Criteria:**
- The current_org_id field is returned as part of the organizations list response.

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

## Change Type

<!-- Choose the types that apply to your PR -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:67d0dff-nikolaik   --name openhands-app-67d0dff   docker.openhands.dev/openhands/openhands:67d0dff
```