### PR TITLE
chore: Rename code-review.md to custom-codereview-guide.md

### DIFF
--- a/skills/custom-codereview-guide.md
+++ b/skills/custom-codereview-guide.md
@@ -1,4 +1,6 @@
 ---
+name: custom-codereview-guide
+description: Repo-specific code review guidelines for OpenHands/OpenHands. Provides additional review rules alongside the default code review skill.
 triggers:
 - /codereview
 ---


### PR DESCRIPTION
## Summary

Rename the repo-specific code review skill to use a unique name that won't conflict with the public `code-review` skill.

## Changes

- Renamed `skills/code-review.md` → `skills/custom-codereview-guide.md`
- Added `name: custom-codereview-guide` field to the frontmatter

## Why

With a skill named `code-review`, it would completely **override** the default public code-review skill from [OpenHands/extensions](https://github.com/OpenHands/extensions).

By using a unique name (`custom-codereview-guide`) with the same trigger (`/codereview`), **both** skills will now be activated:
1. The default public code review guidelines
2. The repo-specific guidelines

This gives reviewers the benefit of both general best practices AND repo-specific rules.

## Related

- Docs PR: https://github.com/OpenHands/docs/pull/348
- SDK PR: https://github.com/OpenHands/software-agent-sdk/pull/2121

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:9f1dc33-nikolaik   --name openhands-app-9f1dc33   docker.openhands.dev/openhands/openhands:9f1dc33
```