### PR TITLE
fix: Cap Databricks max_tokens at 25000 and prevent condenser crash

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -214,6 +214,21 @@ class LLM(RetryMixin, DebugMixin):
         if self.config.completion_kwargs is not None:
             kwargs.update(self.config.completion_kwargs)
 
+        # Databricks has a 25000 max_tokens limit - cap it AFTER completion_kwargs
+        if self.config.model.startswith('databricks/'):
+            # Get the effective max tokens value
+            effective_max = kwargs.get('max_tokens') or kwargs.get(
+                'max_completion_tokens'
+            )
+            if effective_max and effective_max > 25000:
+                logger.warning(
+                    f'Databricks model {self.config.model}: Capping max_tokens from {effective_max} to 25000 (API limit)'
+                )
+            # Databricks uses max_tokens parameter (not max_completion_tokens)
+            # Cap at 25000 or use the effective max if it's already lower
+            kwargs['max_tokens'] = min(effective_max or 25000, 25000)
+            kwargs.pop('max_completion_tokens', None)
+
         self._completion = partial(
             litellm_completion,
             model=self.config.model,

--- a/openhands/memory/condenser/impl/amortized_forgetting_condenser.py
+++ b/openhands/memory/condenser/impl/amortized_forgetting_condenser.py
@@ -47,6 +47,12 @@ class AmortizedForgettingCondenser(RollingCondenser):
         event_ids_to_keep = {event.id for event in head + tail}
         event_ids_to_forget = {event.id for event in view} - event_ids_to_keep
 
+        # If there are no events to forget, return a condensation with empty forgotten list
+        # This should normally be prevented by should_condense(), but we handle it defensively
+        if not event_ids_to_forget:
+            event = CondensationAction(forgotten_event_ids=[])
+            return Condensation(action=event)
+
         event = CondensationAction(
             forgotten_events_start_id=min(event_ids_to_forget),
             forgotten_events_end_id=max(event_ids_to_forget),
@@ -54,8 +60,23 @@ class AmortizedForgettingCondenser(RollingCondenser):
 
         return Condensation(action=event)
 
+    def _can_condense(self, view: View) -> bool:
+        """Check if condensation would actually forget any events."""
+        target_size = self.max_size // 2
+        head = view[: self.keep_first]
+        events_from_tail = target_size - len(head)
+
+        # If the view is smaller than or equal to target_size, all events would be kept
+        return len(view) > len(head) + events_from_tail
+
     def should_condense(self, view: View) -> bool:
-        return len(view) > self.max_size or view.unhandled_condensation_request
+        # Only condense if we exceed max_size AND there are events we can actually forget
+        if len(view) > self.max_size:
+            return self._can_condense(view)
+        # If there's an unhandled condensation request, only condense if possible
+        if view.unhandled_condensation_request:
+            return self._can_condense(view)
+        return False
 
     @classmethod
     def from_config(

--- a/tests/unit/memory/condenser/test_condenser.py
+++ b/tests/unit/memory/condenser/test_condenser.py
@@ -510,6 +510,33 @@ def test_amortized_forgetting_condenser_keeps_first_and_last_events():
         assert view[:keep_first] == events[: min(keep_first, i + 1)]
 
 
+def test_amortized_forgetting_condenser_handles_small_view_with_condensation_request():
+    """Test that AmortizedForgettingCondenser doesn't crash when there are too few events to condense.
+
+    This test verifies the fix for the bug where the condenser would try to call min()/max()
+    on an empty set of event_ids_to_forget when the view is smaller than the target size.
+    """
+    max_size = 100
+    condenser = AmortizedForgettingCondenser(max_size=max_size, keep_first=0)
+
+    # Create a small number of events (less than target_size which is max_size // 2)
+    events = [create_test_event(f'Event {i}', id=i) for i in range(10)]
+
+    state = State()
+    state.history = events
+
+    # Create a view with unhandled_condensation_request to trigger condensation attempt
+    view = View(events=events, unhandled_condensation_request=True)
+
+    # Before the fix, this would raise ValueError: min() arg is an empty sequence
+    # After the fix, should_condense should return False and the view should be returned as-is
+    result = condenser.condense(view)
+
+    # The result should be the same view since there are not enough events to condense
+    assert isinstance(result, View)
+    assert result == view
+
+
 def test_llm_attention_condenser_from_config(mock_llm_registry):
     """Test that LLMAttentionCondenser objects can be made from config."""
     config = LLMAttentionCondenserConfig(


### PR DESCRIPTION
## Summary
This PR provides a minimal fix for two issues:

### 1. Databricks max_tokens limit
The Databricks API has a hard limit of 25000 for `max_tokens`, but OpenHands was sending higher values, causing API errors.

### 2. AmortizedForgettingCondenser crash
The condenser would crash with `ValueError: min() arg is an empty sequence` when trying to condense a view with too few events.

## Changes

### Databricks Fix (1 location)
- **`openhands/llm/llm.py`**: Cap `max_tokens` at 25000 after `completion_kwargs` are processed
  - Ensures Databricks uses `max_tokens` (not `max_completion_tokens`)
  - Single location fix instead of multiple places
  - Applied right before the completion function is created
  - Covers all code paths (V0, V1, any future versions)

### Condenser Fix
- **`openhands/memory/condenser/impl/amortized_forgetting_condenser.py`**: 
  - Add check in `should_condense()` to return False if no events can be forgotten
  - Add defensive check in `get_condensation()` to handle empty `event_ids_to_forget`
- **`tests/unit/memory/condenser/test_condenser.py`**: Add test for the fix

## Why This is Minimal

The previous version of this PR attempted to fix the Databricks issue in **5 different places**. This version fixes it in **1 location** - right where kwargs are passed to litellm, ensuring:
- All code paths are covered (V0, V1, any future versions)
- The fix happens after completion_kwargs, preventing overrides
- No redundant checks in multiple places

## Testing

✅ Unit test for condenser fix passes  
✅ Pre-commit hooks pass  
✅ Only 3 files changed, 64 lines added, 1 line removed

## Files Changed
- `openhands/llm/llm.py` - Databricks max_tokens cap (15 lines added)
- `openhands/memory/condenser/impl/amortized_forgetting_condenser.py` - Condenser fix (23 lines added)
- `tests/unit/memory/condenser/test_condenser.py` - Test for condenser fix (27 lines added)

**Total: 3 files, 64 lines added, 1 line removed**
