### PR TITLE
AISWE-539: Change default model to Claude Sonnet 4.5

### DIFF
--- a/openhands/core/config/llm_config.py
+++ b/openhands/core/config/llm_config.py
@@ -57,7 +57,7 @@ class LLMConfig(BaseModel):
         completion_kwargs: Custom kwargs to pass to litellm.completion.
     """
 
-    model: str = Field(default='claude-opus-4-5-20251101')
+    model: str = Field(default='claude-sonnet-4-5-20250929')
     api_key: SecretStr | None = Field(default=None)
     base_url: str | None = Field(default=None)
     api_version: str | None = Field(default=None)


### PR DESCRIPTION
## Summary
This PR changes the default LLM model from `claude-opus-4-5-20251101` to `claude-sonnet-4-5-20250929` in the OpenHands configuration.

## Changes
- Modified `openhands/core/config/llm_config.py` to update the default model in the `LLMConfig` class

## Impact
This change only affects the default model selection when no explicit model is configured by the user. All existing override mechanisms remain functional:
- Environment variables
- Config files (TOML)
- API parameters

## Related Issue
Jira Ticket: [AISWE-539](https://telnyx.atlassian.net/browse/AISWE-539)

## Testing
No new tests are required as this is a simple default value change. The change maintains backward compatibility and doesn't alter any functionality.
