### PR TITLE
Fix 'Unknown event' displayed before file operations complete

### DIFF
--- a/frontend/src/components/v1/chat/event-content-helpers/get-event-content.tsx
+++ b/frontend/src/components/v1/chat/event-content-helpers/get-event-content.tsx
@@ -16,6 +16,18 @@ const trimText = (text: string, maxLength: number): string => {
   return text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
 };
 
+// Helper function to detect partial ActionEvents that are still loading
+const isPartialActionEvent = (event: OpenHandsEvent): boolean => {
+  return (
+    event.source === "agent" &&
+    "action" in event &&
+    (event.action === null ||
+      (typeof event.action === "object" &&
+        event.action !== null &&
+        "kind" in event.action))
+  );
+};
+
 // Helper function to create title from translation key
 const createTitleFromKey = (
   key: string,
@@ -39,10 +51,69 @@ const createTitleFromKey = (
 
 // Action Event Processing
 const getActionEventTitle = (event: OpenHandsEvent): React.ReactNode => {
-  // Early return if not an action event
-  if (!isActionEvent(event)) {
-    return "";
+  // Handle complete ActionEvents
+  if (isActionEvent(event)) {
+    return getCompleteActionEventTitle(event);
   }
+
+  // Handle partial ActionEvents that are still loading
+  if (isPartialActionEvent(event)) {
+    return getPartialActionEventTitle(event);
+  }
+
+  // Not an action event at all
+  return "";
+};
+
+// Handle partial ActionEvents that are still loading/streaming
+const getPartialActionEventTitle = (event: OpenHandsEvent): React.ReactNode => {
+  // For partial events, try to extract what information we can
+  if (
+    event.action &&
+    typeof event.action === "object" &&
+    "kind" in event.action
+  ) {
+    // We have action kind but the event might be missing other required fields
+    const actionType = event.action.kind;
+
+    switch (actionType) {
+      case "FileEditorAction":
+      case "StrReplaceEditorAction":
+        // Try to extract path information if available
+        if ("path" in event.action && event.action.path) {
+          if ("command" in event.action && event.action.command === "view") {
+            return createTitleFromKey("ACTION_MESSAGE$READ", {
+              path: event.action.path,
+            });
+          } else {
+            return createTitleFromKey("ACTION_MESSAGE$EDIT", {
+              path: event.action.path,
+            });
+          }
+        }
+        break;
+      case "ExecuteBashAction":
+      case "TerminalAction":
+        // Try to extract command if available
+        if ("command" in event.action && event.action.command) {
+          return createTitleFromKey("ACTION_MESSAGE$RUN", {
+            command: trimText(String(event.action.command), 80),
+          });
+        }
+        break;
+      default:
+        // For other action types, show a generic loading message
+        return i18n.t("HOME$LOADING");
+    }
+  }
+
+  // Fallback for very partial events
+  return i18n.t("HOME$LOADING");
+};
+
+// Handle complete ActionEvents with all required fields
+const getCompleteActionEventTitle = (event: OpenHandsEvent): React.ReactNode => {
+  // At this point we know isActionEvent(event) is true
 
   const actionType = event.action.kind;
   let actionKey = "";


### PR DESCRIPTION
**Fixes #12865**

## Problem
Users were seeing "Unknown event" displayed in the UI when the agent was about to read files or perform other actions. This occurred when ActionEvents arrived via WebSocket streaming with incomplete data (e.g., `action: null` or missing `tool_name`/`tool_call_id` fields), causing them to fail the strict `isActionEvent()` type guard.

## Root Cause
The `getActionEventTitle()` function returned an empty string when `isActionEvent()` failed, which eventually defaulted to "Unknown event" in the UI. This happened during the brief window when events were being streamed but not yet fully populated.

## Solution
- **Added `isPartialActionEvent()` helper** to detect streaming/partial ActionEvents
- **Split event handling** into separate functions for complete vs partial events
- **Extract available information** from partial events (file paths, commands) when possible  
- **Show "Loading..."** for partial events instead of "Unknown event"
- **Maintains backward compatibility** with existing complete events

## Technical Details
The fix handles ActionEvents that arrive with:
- `action: null` (completely missing action data)
- Partial action objects with `kind` but missing other required fields
- Missing `tool_name` or `tool_call_id` properties

For partial events, the code now:
1. Extracts whatever information is available (e.g., file path for FileEditorAction)
2. Uses appropriate action messages when possible ("Reading {path}" vs "Loading...")  
3. Falls back to generic "Loading..." when no specific information is available

## Testing
- Verified the function compiles and follows existing patterns
- Used existing translation keys (HOME$LOADING) for consistency
- Preserves all existing behavior for complete events

This provides a much better user experience during file operations and other streaming actions.