### PR TITLE
fix(backend): organization members now see correct shared credit balance

### DIFF
--- a/enterprise/storage/lite_llm_manager.py
+++ b/enterprise/storage/lite_llm_manager.py
@@ -44,6 +44,34 @@ class LiteLlmManager:
     """Manage LiteLLM interactions."""
 
     @staticmethod
+    def get_budget_from_team_info(
+        user_team_info: dict | None, user_id: str, org_id: str
+    ) -> tuple[float, float]:
+        """Extract max_budget and spend from user team info.
+
+        For personal orgs (user_id == org_id), uses litellm_budget_table.max_budget.
+        For team orgs, uses max_budget_in_team (populated by get_user_team_info).
+
+        Args:
+            user_team_info: The response from get_user_team_info
+            user_id: The user's ID
+            org_id: The organization's ID
+
+        Returns:
+            Tuple of (max_budget, spend)
+        """
+        if not user_team_info:
+            return 0, 0
+        spend = user_team_info.get('spend', 0)
+        if user_id == org_id:
+            max_budget = (user_team_info.get('litellm_budget_table') or {}).get(
+                'max_budget', 0
+            )
+        else:
+            max_budget = user_team_info.get('max_budget_in_team') or 0
+        return max_budget, spend
+
+    @staticmethod
     async def create_entries(
         org_id: str,
         keycloak_user_id: str,
@@ -71,8 +99,34 @@ class LiteLlmManager:
                     'x-goog-api-key': LITE_LLM_API_KEY,
                 }
             ) as client:
-                # New users start with $0 budget - they must purchase credits
-                await LiteLlmManager._create_team(client, keycloak_user_id, org_id, 0)
+                # Check if team already exists and get its budget
+                # New users joining existing orgs should inherit the team's budget
+                team_budget = 0.0
+                try:
+                    existing_team = await LiteLlmManager._get_team(client, org_id)
+                    if existing_team:
+                        team_info = existing_team.get('team_info', {})
+                        team_budget = team_info.get('max_budget', 0.0) or 0.0
+                        logger.info(
+                            'LiteLlmManager:create_entries:existing_team_budget',
+                            extra={
+                                'org_id': org_id,
+                                'user_id': keycloak_user_id,
+                                'team_budget': team_budget,
+                            },
+                        )
+                except httpx.HTTPStatusError as e:
+                    # Team doesn't exist yet (404) - this is expected for first user
+                    if e.response.status_code != 404:
+                        raise
+                    logger.info(
+                        'LiteLlmManager:create_entries:no_existing_team',
+                        extra={'org_id': org_id, 'user_id': keycloak_user_id},
+                    )
+
+                await LiteLlmManager._create_team(
+                    client, keycloak_user_id, org_id, team_budget
+                )
 
                 if create_user:
                     await LiteLlmManager._create_user(
@@ -80,7 +134,7 @@ class LiteLlmManager:
                     )
 
                 await LiteLlmManager._add_user_to_team(
-                    client, keycloak_user_id, org_id, 0
+                    client, keycloak_user_id, org_id, team_budget
                 )
 
                 key = await LiteLlmManager._generate_key(
@@ -892,20 +946,30 @@ class LiteLlmManager:
         if LITE_LLM_API_KEY is None or LITE_LLM_API_URL is None:
             logger.warning('LiteLLM API configuration not found')
             return None
-        team_info = await LiteLlmManager._get_team(client, team_id)
-        if not team_info:
+        team_response = await LiteLlmManager._get_team(client, team_id)
+        if not team_response:
             return None
 
         # Filter team_memberships based on team_id and keycloak_user_id
         user_membership = next(
             (
                 membership
-                for membership in team_info.get('team_memberships', [])
+                for membership in team_response.get('team_memberships', [])
                 if membership.get('user_id') == keycloak_user_id
                 and membership.get('team_id') == team_id
             ),
             None,
         )
+
+        if not user_membership:
+            return None
+
+        # For team orgs (user_id != team_id), include team-level budget info
+        # The team's max_budget and spend are shared across all members
+        if keycloak_user_id != team_id:
+            team_info = team_response.get('team_info', {})
+            user_membership['max_budget_in_team'] = team_info.get('max_budget')
+            user_membership['spend'] = team_info.get('spend', 0)
 
         return user_membership
 

--- a/enterprise/storage/org_service.py
+++ b/enterprise/storage/org_service.py
@@ -656,10 +656,9 @@ class OrgService:
                 )
                 return None
 
-            max_budget = (user_team_info.get('litellm_budget_table') or {}).get(
-                'max_budget', 0
+            max_budget, spend = LiteLlmManager.get_budget_from_team_info(
+                user_team_info, user_id, str(org_id)
             )
-            spend = user_team_info.get('spend', 0)
             credits = max(max_budget - spend, 0)
 
             logger.debug(

--- a/enterprise/tests/unit/test_billing.py
+++ b/enterprise/tests/unit/test_billing.py
@@ -101,7 +101,7 @@ async def test_get_credits_success():
         json={
             'user_info': {
                 'spend': 25.50,
-                'litellm_budget_table': {'max_budget': 100.00},
+                'max_budget_in_team': 100.00,
             }
         },
         request=MagicMock(),
@@ -121,7 +121,7 @@ async def test_get_credits_success():
             'storage.lite_llm_manager.LiteLlmManager.get_user_team_info',
             return_value={
                 'spend': 25.50,
-                'litellm_budget_table': {'max_budget': 100.00},
+                'max_budget_in_team': 100.00,
             },
         ),
     ):
@@ -313,7 +313,7 @@ async def test_success_callback_success():
             'storage.lite_llm_manager.LiteLlmManager.get_user_team_info',
             return_value={
                 'spend': 25.50,
-                'litellm_budget_table': {'max_budget': 100.00},
+                'max_budget_in_team': 100.00,
             },
         ),
         patch(
@@ -430,7 +430,7 @@ async def test_success_callback_lite_llm_update_budget_error_rollback():
             'storage.lite_llm_manager.LiteLlmManager.get_user_team_info',
             return_value={
                 'spend': 0,
-                'litellm_budget_table': {'max_budget': 0},
+                'max_budget_in_team': 0,
             },
         ),
         patch(

--- a/enterprise/tests/unit/test_org_service.py
+++ b/enterprise/tests/unit/test_org_service.py
@@ -482,7 +482,7 @@ async def test_get_org_credits_success(mock_litellm_api):
     spend = 25.0
 
     mock_team_info = {
-        'litellm_budget_table': {'max_budget': max_budget},
+        'max_budget_in_team': max_budget,
         'spend': spend,
     }
 


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

<!-- Summarize what the PR does -->

**Summary**
- Fixed an issue where organization members could see inconsistent credit values.
- Ensured that new members joining an organization with existing credits correctly see the shared balance.
- Introduced a centralized helper to standardize budget extraction logic.

**Problem**
When User A (Owner) purchased $30 in credits, they saw the correct balance. However, User B (an Admin who joined later) saw a $0 balance, even though credits are shared at the organization level.

Please refer to the video below for additional context and details.

https://github.com/user-attachments/assets/7be6a75e-a39d-47d7-af50-5decfad1ff58

**Root Cause**
Previously, new members joining an organization would see **$0 credits** even when the organization had a positive balance. This happened due to the following issues:

1. `create_entries()` added users with a hardcoded `max_budget = 0` instead of inheriting the team’s existing budget.
2. The `get_credits` endpoint read the individual membership budget rather than the shared, team-level budget.

**Solution**
- Added `LiteLlmManager.get_budget_from_team_info()` to handle budget extraction for both:
  - Personal organizations (`user_id == org_id`)
  - Team organizations
- Modified `_get_user_team_info()` to include team-level `max_budget` and `spend` values for team organizations.
- Updated `create_entries()` to check for and inherit an existing team budget when adding new members.

**Changes**
- Added a `get_budget_from_team_info()` helper to `LiteLlmManager` to correctly extract budget information based on organization type (personal vs. team).
- Updated `_get_user_team_info()` to include team-level budget details for team organizations.
- Fixed `create_entries()` to inherit the existing team budget when adding new members.
- Updated `billing.py` and `org_service.py` to use the new helper method.

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

https://github.com/user-attachments/assets/149fa5a1-3cbc-4e5b-b64f-67613c94f467

https://github.com/user-attachments/assets/4a4e3df9-7796-4287-b636-7edde6cd2f58

## Change Type

<!-- Choose the types that apply to your PR -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:3858e8d-nikolaik   --name openhands-app-3858e8d   docker.openhands.dev/openhands/openhands:3858e8d
```