### PR TITLE
fix: pass unpinnedTabs state from parent to context menu to fix tab h…

### DIFF
--- a/frontend/src/components/features/conversation/conversation-tabs/conversation-tabs-context-menu.tsx
+++ b/frontend/src/components/features/conversation/conversation-tabs/conversation-tabs-context-menu.tsx
@@ -2,8 +2,6 @@ import { useTranslation } from "react-i18next";
 import { ContextMenu } from "#/ui/context-menu";
 import { ContextMenuListItem } from "../../context-menu/context-menu-list-item";
 import { useClickOutsideElement } from "#/hooks/use-click-outside-element";
-import { useConversationId } from "#/hooks/use-conversation-id";
-import { useConversationLocalStorageState } from "#/utils/conversation-local-storage";
 import { I18nKey } from "#/i18n/declaration";
 import TerminalIcon from "#/icons/terminal.svg?react";
 import GlobeIcon from "#/icons/globe.svg?react";
@@ -18,17 +16,18 @@ import LessonPlanIcon from "#/icons/lesson-plan.svg?react";
 interface ConversationTabsContextMenuProps {
   isOpen: boolean;
   onClose: () => void;
+  unpinnedTabs: string[];
+  setUnpinnedTabs: (tabs: string[]) => void;
 }
 
 export function ConversationTabsContextMenu({
   isOpen,
   onClose,
+  unpinnedTabs,
+  setUnpinnedTabs,
 }: ConversationTabsContextMenuProps) {
   const ref = useClickOutsideElement<HTMLUListElement>(onClose);
   const { t } = useTranslation();
-  const { conversationId } = useConversationId();
-  const { state, setUnpinnedTabs } =
-    useConversationLocalStorageState(conversationId);
 
   const shouldUsePlanningAgent = USE_PLANNING_AGENT();
 
@@ -51,10 +50,10 @@ export function ConversationTabsContextMenu({
   if (!isOpen) return null;
 
   const handleTabClick = (tab: string) => {
-    if (state.unpinnedTabs.includes(tab)) {
-      setUnpinnedTabs(state.unpinnedTabs.filter((item) => item !== tab));
+    if (unpinnedTabs.includes(tab)) {
+      setUnpinnedTabs(unpinnedTabs.filter((item) => item !== tab));
     } else {
-      setUnpinnedTabs([...state.unpinnedTabs, tab]);
+      setUnpinnedTabs([...unpinnedTabs, tab]);
     }
   };
 
@@ -66,7 +65,7 @@ export function ConversationTabsContextMenu({
       className="mt-2 w-fit z-[9999]"
     >
       {tabConfig.map(({ tab, icon: Icon, i18nKey }) => {
-        const pinned = !state.unpinnedTabs.includes(tab);
+        const pinned = !unpinnedTabs.includes(tab);
         return (
           <ContextMenuListItem
             key={tab}

--- a/frontend/src/components/features/conversation/conversation-tabs/conversation-tabs.tsx
+++ b/frontend/src/components/features/conversation/conversation-tabs/conversation-tabs.tsx
@@ -25,7 +25,7 @@ export function ConversationTabs() {
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-  const { state: persistedState } =
+  const { state: persistedState, setUnpinnedTabs } =
     useConversationLocalStorageState(conversationId);
 
   const shouldUsePlanningAgent = USE_PLANNING_AGENT();
@@ -183,6 +183,8 @@ export function ConversationTabs() {
         <ConversationTabsContextMenu
           isOpen={isMenuOpen}
           onClose={() => setIsMenuOpen(false)}
+          unpinnedTabs={persistedState.unpinnedTabs}
+          setUnpinnedTabs={setUnpinnedTabs}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary of PR

Fixes a bug where unpinning tabs via the context menu didn't hide them from the tab bar.

**Root cause:** `ConversationTabs` and `ConversationTabsContextMenu` each called `useConversationLocalStorageState` independently, creating two separate `useState` instances. When the context menu updated its state, the parent component was never notified, so the tab bar didn't re-render.

**Fix:** Lifted `unpinnedTabs` and `setUnpinnedTabs` from the context menu to the parent `ConversationTabs` component and passed them as props. Both components now share a single state instance.

## Demo Screenshots/Videos

https://github.com/user-attachments/assets/a9543042-8bd6-45b4-9f65-f87901c69ffa

## Change Type

- [x] Bug fix

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #12884

## Release Notes

- [ ] Include this change in the Release Notes.
