### PR TITLE
Fix PR review workflow condition to isolate trigger types

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -30,26 +30,27 @@ jobs:
         #   3. openhands-agent or all-hands-bot is requested as a reviewer on a PR from a
         #      collaborator/member/owner, OR
         #   4. A maintainer adds the 'review-this' label (manual trigger for external authors)
+        # Condition structure: Each trigger type is isolated to avoid accessing undefined
+        # event properties (e.g., github.event.label when action != 'labeled').
+        # - Non-label triggers require author_association check
+        # - Label trigger ('review-this') is open to anyone (for external contributors)
         if: |
             (
               (
                 (
-                  (
-                    github.event.action == 'opened' &&
-                    github.event.pull_request.draft == false
-                  ) ||
-                  (github.event.action == 'ready_for_review') ||
-                  (
-                    github.event.action == 'review_requested' &&
-                    (
-                      github.event.requested_reviewer.login == 'openhands-agent' ||
-                      github.event.requested_reviewer.login == 'all-hands-bot'
-                    )
-                  )
+                  (github.event.action == 'opened' && github.event.pull_request.draft == false) ||
+                  (github.event.action == 'ready_for_review')
                 ) && contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.pull_request.author_association)
-              ) || (
-                github.event.action == 'labeled' && github.event.label.name == 'review-this'
-              )
+              ) ||
+              (
+                github.event.action == 'review_requested' &&
+                contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.pull_request.author_association) &&
+                (
+                  github.event.requested_reviewer.login == 'openhands-agent' ||
+                  github.event.requested_reviewer.login == 'all-hands-bot'
+                )
+              ) ||
+              (github.event.action == 'labeled' && github.event.label.name == 'review-this')
             )
         concurrency:
             group: pr-review-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Fixes the PR review workflow condition to properly isolate each trigger type, avoiding potential issues with accessing undefined event properties.

## Problem

The current condition structure accesses `github.event.requested_reviewer.login` inside the main OR block. When the action is `ready_for_review` or `opened`, this property is undefined. GitHub Actions expressions may not properly short-circuit when accessing properties on undefined objects, potentially causing the condition to fail.

Current success rate: ~33% (10/30 recent runs succeeded, 20 skipped)

## Solution

Restructure the condition to isolate each trigger type:

1. **opened/ready_for_review** - grouped together with author_association check (no event-specific properties accessed)
2. **review_requested** - isolated with `action == 'review_requested'` check BEFORE accessing `requested_reviewer.login`
3. **labeled** - already isolated (no change needed)

**Before:**
```yaml
(
  (
    (opened || ready_for_review || (review_requested && reviewer.login == X))  # ← reviewer undefined for non-review events
  ) && author_association
) || (labeled && label.name)
```

**After:**
```yaml
(
  ((opened || ready_for_review) && author_association) ||
  (review_requested && author_association && reviewer.login == X) ||  # ← isolated
  (labeled && label.name)
)
```

## Related

- OpenHands/software-agent-sdk#2157 - Same fix for software-agent-sdk (was at 6% success rate)

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:324af4d-nikolaik   --name openhands-app-324af4d   docker.openhands.dev/openhands/openhands:324af4d
```