### PR TITLE
fix: redact secret values from error messages in add_env_vars

### DIFF
--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -356,7 +356,7 @@ class Runtime(FileEditRuntimeMixin):
                 self._run_cmd_with_retry(
                     cmd, f'Failed to add env vars [{env_vars.keys()}] to environment'
                 )
-            except RuntimeError as e:
+            except RuntimeError:
                 # Re-raise with redacted error message to avoid leaking secret values
                 raise RuntimeError(
                     f'Failed to add env vars [{list(env_vars.keys())}] to environment. '
@@ -387,7 +387,7 @@ class Runtime(FileEditRuntimeMixin):
                 self._run_cmd_with_retry(
                     cmd, f'Failed to add env vars [{env_vars.keys()}] to environment'
                 )
-            except RuntimeError as e:
+            except RuntimeError:
                 # Re-raise with redacted error message to avoid leaking secret values
                 # The original error may contain the full export command with secrets
                 raise RuntimeError(
@@ -403,7 +403,7 @@ class Runtime(FileEditRuntimeMixin):
                 self._run_cmd_with_retry(
                     bashrc_cmd, f'Failed to add env vars [{env_vars.keys()}] to .bashrc'
                 )
-            except RuntimeError as e:
+            except RuntimeError:
                 # Re-raise with redacted error message to avoid leaking secret values
                 raise RuntimeError(
                     f'Failed to add env vars [{list(env_vars.keys())}] to .bashrc. '

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -14,6 +14,7 @@ import random
 import shlex
 import shutil
 import string
+import sys
 import tempfile
 import time
 from abc import abstractmethod
@@ -318,8 +319,61 @@ class Runtime(FileEditRuntimeMixin):
             return obs.content
         return str(obs)
 
+    def _run_env_cmd_redacted(
+        self,
+        cmd: str,
+        context: str,
+        var_names: list[str],
+        is_windows: bool = False,
+    ) -> CmdOutputObservation:
+        """Run a command that may contain secrets, redacting them from any errors.
+
+        This wrapper ensures that if the command fails, secret values are not
+        exposed in error messages. Only variable names are included in errors.
+
+        Args:
+            cmd: The command to execute (may contain secret values)
+            context: Description of what operation is being performed
+            var_names: List of environment variable names being set
+            is_windows: Whether this is a Windows environment (affects error message)
+
+        Returns:
+            CmdOutputObservation on success
+
+        Raises:
+            RuntimeError: With redacted message on failure (no secret values)
+        """
+        try:
+            return self._run_cmd_with_retry(
+                cmd, f'Failed to {context} for env vars {var_names}'
+            )
+        except RuntimeError as original_error:
+            # Log the original error at debug level for operators, but redact secret values
+            # We only log the variable names, not the command which contains secrets
+            logger.debug(
+                f'Environment variable command failed for vars {var_names}: '
+                f'exit_code and error details redacted to protect secrets'
+            )
+
+            # Build appropriate error message based on platform
+            if is_windows:
+                hint = 'Check that all variable names are valid PowerShell identifiers.'
+            else:
+                hint = (
+                    'Check that all variable names are valid bash identifiers '
+                    '(alphanumeric and underscores only, cannot start with a digit).'
+                )
+
+            raise RuntimeError(
+                f'Failed to {context} for env vars {var_names}. {hint}'
+            ) from None
+
     def add_env_vars(self, env_vars: dict[str, str]) -> None:
+        if not env_vars:
+            return
+
         env_vars = {key.upper(): value for key, value in env_vars.items()}
+        var_names = list(env_vars.keys())
 
         # Add env vars to the IPython shell (if Jupyter is used)
         if any(isinstance(plugin, JupyterRequirement) for plugin in self.plugins):
@@ -328,13 +382,18 @@ class Runtime(FileEditRuntimeMixin):
                 # Note: json.dumps gives us nice escaping for free
                 code += f'os.environ["{key}"] = {json.dumps(value)}\n'
             code += '\n'
-            self.run_ipython(IPythonRunCellAction(code))
-            # Note: we don't log the vars values, they're leaking info
-            logger.debug('Added env vars to IPython')
-
-        # Check if we're on Windows
-        import os
-        import sys
+            obs = self.run_ipython(IPythonRunCellAction(code))
+            # Check for errors in IPython output - the observation content may contain secrets
+            if isinstance(obs, ErrorObservation):
+                logger.debug(
+                    f'IPython env var setup failed for vars {var_names}: '
+                    'error details redacted to protect secrets'
+                )
+                raise RuntimeError(
+                    f'Failed to add env vars {var_names} to IPython environment. '
+                    'Check that all variable names are valid Python identifiers.'
+                )
+            logger.debug(f'Added env vars to IPython: {var_names}')
 
         is_windows = os.name == 'nt' or sys.platform == 'win32'
 
@@ -346,26 +405,16 @@ class Runtime(FileEditRuntimeMixin):
                 # Note: json.dumps gives us nice escaping for free
                 cmd += f'$env:{key} = {json.dumps(value)}; '
 
-            if not cmd:
-                return
-
             cmd = cmd.strip()
-            logger.debug('Adding env vars to PowerShell')  # don't log the values
+            logger.debug(f'Adding env vars to PowerShell: {var_names}')
 
-            try:
-                self._run_cmd_with_retry(
-                    cmd, f'Failed to add env vars [{env_vars.keys()}] to environment'
-                )
-            except RuntimeError:
-                # Re-raise with redacted error message to avoid leaking secret values
-                raise RuntimeError(
-                    f'Failed to add env vars [{list(env_vars.keys())}] to environment. '
-                    'Check that all variable names are valid identifiers.'
-                ) from None
+            self._run_env_cmd_redacted(
+                cmd, 'set environment variables', var_names, is_windows=True
+            )
 
             # We don't add to profile persistence on Windows as it's more complex
             # and varies between PowerShell versions
-            logger.debug(f'Added env vars to PowerShell session: {env_vars.keys()}')
+            logger.debug(f'Added env vars to PowerShell session: {var_names}')
 
         else:
             # Original bash implementation for Unix systems
@@ -377,39 +426,20 @@ class Runtime(FileEditRuntimeMixin):
                 # Add to .bashrc if not already present
                 bashrc_cmd += f'touch ~/.bashrc; grep -q "^export {key}=" ~/.bashrc || echo "export {key}={json.dumps(value)}" >> ~/.bashrc; '
 
-            if not cmd:
-                return
-
             cmd = cmd.strip()
-            logger.debug('Adding env vars to bash')  # don't log the values
+            logger.debug(f'Adding env vars to bash: {var_names}')
 
-            try:
-                self._run_cmd_with_retry(
-                    cmd, f'Failed to add env vars [{env_vars.keys()}] to environment'
-                )
-            except RuntimeError:
-                # Re-raise with redacted error message to avoid leaking secret values
-                # The original error may contain the full export command with secrets
-                raise RuntimeError(
-                    f'Failed to add env vars [{list(env_vars.keys())}] to environment. '
-                    'Check that all variable names are valid bash identifiers '
-                    '(alphanumeric and underscores only, cannot start with a digit).'
-                ) from None
+            self._run_env_cmd_redacted(
+                cmd, 'set environment variables', var_names, is_windows=False
+            )
 
             # Add to .bashrc for persistence
             bashrc_cmd = bashrc_cmd.strip()
-            logger.debug(f'Adding env var to .bashrc: {env_vars.keys()}')
-            try:
-                self._run_cmd_with_retry(
-                    bashrc_cmd, f'Failed to add env vars [{env_vars.keys()}] to .bashrc'
-                )
-            except RuntimeError:
-                # Re-raise with redacted error message to avoid leaking secret values
-                raise RuntimeError(
-                    f'Failed to add env vars [{list(env_vars.keys())}] to .bashrc. '
-                    'Check that all variable names are valid bash identifiers '
-                    '(alphanumeric and underscores only, cannot start with a digit).'
-                ) from None
+            logger.debug(f'Adding env vars to .bashrc: {var_names}')
+
+            self._run_env_cmd_redacted(
+                bashrc_cmd, 'persist environment variables to .bashrc', var_names, is_windows=False
+            )
 
     def on_event(self, event: Event) -> None:
         if isinstance(event, Action):

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -352,9 +352,16 @@ class Runtime(FileEditRuntimeMixin):
             cmd = cmd.strip()
             logger.debug('Adding env vars to PowerShell')  # don't log the values
 
-            self._run_cmd_with_retry(
-                cmd, f'Failed to add env vars [{env_vars.keys()}] to environment'
-            )
+            try:
+                self._run_cmd_with_retry(
+                    cmd, f'Failed to add env vars [{env_vars.keys()}] to environment'
+                )
+            except RuntimeError as e:
+                # Re-raise with redacted error message to avoid leaking secret values
+                raise RuntimeError(
+                    f'Failed to add env vars [{list(env_vars.keys())}] to environment. '
+                    'Check that all variable names are valid identifiers.'
+                ) from None
 
             # We don't add to profile persistence on Windows as it's more complex
             # and varies between PowerShell versions
@@ -376,16 +383,33 @@ class Runtime(FileEditRuntimeMixin):
             cmd = cmd.strip()
             logger.debug('Adding env vars to bash')  # don't log the values
 
-            self._run_cmd_with_retry(
-                cmd, f'Failed to add env vars [{env_vars.keys()}] to environment'
-            )
+            try:
+                self._run_cmd_with_retry(
+                    cmd, f'Failed to add env vars [{env_vars.keys()}] to environment'
+                )
+            except RuntimeError as e:
+                # Re-raise with redacted error message to avoid leaking secret values
+                # The original error may contain the full export command with secrets
+                raise RuntimeError(
+                    f'Failed to add env vars [{list(env_vars.keys())}] to environment. '
+                    'Check that all variable names are valid bash identifiers '
+                    '(alphanumeric and underscores only, cannot start with a digit).'
+                ) from None
 
             # Add to .bashrc for persistence
             bashrc_cmd = bashrc_cmd.strip()
             logger.debug(f'Adding env var to .bashrc: {env_vars.keys()}')
-            self._run_cmd_with_retry(
-                bashrc_cmd, f'Failed to add env vars [{env_vars.keys()}] to .bashrc'
-            )
+            try:
+                self._run_cmd_with_retry(
+                    bashrc_cmd, f'Failed to add env vars [{env_vars.keys()}] to .bashrc'
+                )
+            except RuntimeError as e:
+                # Re-raise with redacted error message to avoid leaking secret values
+                raise RuntimeError(
+                    f'Failed to add env vars [{list(env_vars.keys())}] to .bashrc. '
+                    'Check that all variable names are valid bash identifiers '
+                    '(alphanumeric and underscores only, cannot start with a digit).'
+                ) from None
 
     def on_event(self, event: Event) -> None:
         if isinstance(event, Action):

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -347,7 +347,7 @@ class Runtime(FileEditRuntimeMixin):
             return self._run_cmd_with_retry(
                 cmd, f'Failed to {context} for env vars {var_names}'
             )
-        except RuntimeError as original_error:
+        except RuntimeError:
             # Log the original error at debug level for operators, but redact secret values
             # We only log the variable names, not the command which contains secrets
             logger.debug(
@@ -438,7 +438,10 @@ class Runtime(FileEditRuntimeMixin):
             logger.debug(f'Adding env vars to .bashrc: {var_names}')
 
             self._run_env_cmd_redacted(
-                bashrc_cmd, 'persist environment variables to .bashrc', var_names, is_windows=False
+                bashrc_cmd,
+                'persist environment variables to .bashrc',
+                var_names,
+                is_windows=False,
             )
 
     def on_event(self, event: Event) -> None:

--- a/tests/unit/runtime/test_env_vars_security.py
+++ b/tests/unit/runtime/test_env_vars_security.py
@@ -1,0 +1,140 @@
+"""Tests for environment variable security in runtime.
+
+Tests that secret values are NOT exposed in error messages when
+add_env_vars fails (e.g., due to invalid variable names).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from openhands.events.observation import CmdOutputObservation
+
+
+class TestAddEnvVarsSecretRedaction:
+    """Tests that add_env_vars redacts secrets from error messages."""
+
+    @pytest.fixture
+    def mock_runtime(self):
+        """Create a mock runtime with the add_env_vars method."""
+        from openhands.runtime.base import Runtime
+
+        runtime = MagicMock(spec=Runtime)
+
+        # Bind the actual methods we need
+        runtime._run_cmd_with_retry = Runtime._run_cmd_with_retry.__get__(
+            runtime, Runtime
+        )
+        runtime._is_bash_session_timeout = Runtime._is_bash_session_timeout.__get__(
+            runtime, Runtime
+        )
+        runtime._calculate_retry_delay = Runtime._calculate_retry_delay.__get__(
+            runtime, Runtime
+        )
+        runtime._extract_error_content = Runtime._extract_error_content.__get__(
+            runtime, Runtime
+        )
+        runtime.add_env_vars = Runtime.add_env_vars.__get__(runtime, Runtime)
+
+        # Mock plugins to be empty (no Jupyter)
+        runtime.plugins = []
+
+        return runtime
+
+    def test_invalid_env_var_name_error_does_not_contain_secret_value(
+        self, mock_runtime
+    ):
+        """Test that invalid env var names raise error WITHOUT exposing secret values.
+
+        This tests the fix for the security issue where error messages like:
+        'bash: export: `MY_DUMMY-SECRET=secret_value': not a valid identifier'
+        were being logged, exposing the secret value.
+        """
+        # Simulate bash rejecting an invalid variable name (contains hyphen)
+        # The error output would normally contain the full export command with secret
+        error_output = (
+            "bash: export: `MY_INVALID-VAR=super_secret_password': "
+            'not a valid identifier'
+        )
+        error_obs = CmdOutputObservation(
+            content=error_output,
+            command='export MY_INVALID-VAR="super_secret_password"',
+            exit_code=1,
+        )
+        mock_runtime.run = MagicMock(return_value=error_obs)
+
+        # Call add_env_vars with an invalid variable name
+        with pytest.raises(RuntimeError) as exc_info:
+            mock_runtime.add_env_vars({'MY_INVALID-VAR': 'super_secret_password'})
+
+        error_message = str(exc_info.value)
+
+        # The error message should contain the variable NAME (key)
+        assert 'MY_INVALID-VAR' in error_message
+
+        # The error message should NOT contain the secret VALUE
+        assert 'super_secret_password' not in error_message
+
+        # The error message should NOT contain the raw bash error output
+        assert 'not a valid identifier' not in error_message
+
+        # The error message should provide helpful guidance
+        assert (
+            'valid bash identifier' in error_message.lower()
+            or 'valid identifier' in error_message.lower()
+        )
+
+    def test_multiple_env_vars_error_does_not_expose_any_secrets(self, mock_runtime):
+        """Test that when multiple env vars fail, no secrets are exposed."""
+        # Simulate bash error with multiple secrets in the command
+        error_output = (
+            'export API_KEY="secret123"; export MY-BAD-VAR="another_secret"\n'
+            "bash: export: `MY-BAD-VAR=another_secret': not a valid identifier"
+        )
+        error_obs = CmdOutputObservation(
+            content=error_output,
+            command='export API_KEY="secret123"; export MY-BAD-VAR="another_secret"',
+            exit_code=1,
+        )
+        mock_runtime.run = MagicMock(return_value=error_obs)
+
+        env_vars = {
+            'API_KEY': 'secret123',
+            'MY-BAD-VAR': 'another_secret',
+        }
+
+        with pytest.raises(RuntimeError) as exc_info:
+            mock_runtime.add_env_vars(env_vars)
+
+        error_message = str(exc_info.value)
+
+        # Should NOT contain any secret values
+        assert 'secret123' not in error_message
+        assert 'another_secret' not in error_message
+
+        # Should contain the variable names (keys)
+        assert 'API_KEY' in error_message
+        assert 'MY-BAD-VAR' in error_message
+
+    def test_bashrc_error_does_not_expose_secrets(self, mock_runtime):
+        """Test that .bashrc persistence errors also don't expose secrets."""
+        # First call succeeds (export command)
+        success_obs = CmdOutputObservation(content='', command='export', exit_code=0)
+        # Second call fails (.bashrc update)
+        error_obs = CmdOutputObservation(
+            content='bash: some error with SECRET_VALUE',
+            command='touch ~/.bashrc; grep...',
+            exit_code=1,
+        )
+        mock_runtime.run = MagicMock(side_effect=[success_obs, error_obs])
+
+        with pytest.raises(RuntimeError) as exc_info:
+            mock_runtime.add_env_vars({'VALID_VAR': 'SECRET_VALUE'})
+
+        error_message = str(exc_info.value)
+
+        # Should NOT contain the secret value
+        assert 'SECRET_VALUE' not in error_message
+
+        # Should mention .bashrc in the error
+        assert '.bashrc' in error_message

--- a/tests/unit/runtime/test_env_vars_security.py
+++ b/tests/unit/runtime/test_env_vars_security.py
@@ -2,70 +2,127 @@
 
 Tests that secret values are NOT exposed in error messages when
 add_env_vars fails (e.g., due to invalid variable names).
+
+These tests use a minimal test subclass of Runtime that overrides only the
+`run` and `run_ipython` methods to simulate command execution, while keeping
+the real implementation of `add_env_vars` and its helper methods. This ensures
+we test the actual code paths, not a Frankenstein mock.
 """
 
-from unittest.mock import MagicMock
+from typing import Callable
 
 import pytest
 
-from openhands.events.observation import CmdOutputObservation
+from openhands.events.action import CmdRunAction, IPythonRunCellAction
+from openhands.events.observation import (
+    CmdOutputObservation,
+    ErrorObservation,
+    IPythonRunCellObservation,
+    Observation,
+)
+from openhands.runtime.base import Runtime
+from openhands.runtime.plugins import JupyterRequirement
+
+
+class StubRuntime(Runtime):
+    """A minimal test subclass of Runtime for unit testing.
+
+    This stub overrides the external boundary methods (`run`, `run_ipython`)
+    to allow controlled simulation of command execution, while keeping the real
+    implementation of `add_env_vars`, `_run_cmd_with_retry`, `_run_env_cmd_redacted`,
+    and all other internal methods.
+
+    This approach ensures we test the actual code paths rather than rebinding
+    methods onto a mock object.
+    """
+
+    def __init__(
+        self,
+        run_handler: Callable[[CmdRunAction], Observation] | None = None,
+        ipython_handler: Callable[[IPythonRunCellAction], Observation] | None = None,
+        plugins: list | None = None,
+    ):
+        # Don't call super().__init__() as it requires complex setup.
+        # Instead, set only the attributes that add_env_vars needs.
+        self.plugins = plugins or []
+        self._run_handler = run_handler
+        self._ipython_handler = ipython_handler
+
+    def run(self, action: CmdRunAction) -> Observation:
+        """Execute a command action using the configured handler."""
+        if self._run_handler is None:
+            raise NotImplementedError('run_handler not configured')
+        return self._run_handler(action)
+
+    def run_ipython(self, action: IPythonRunCellAction) -> Observation:
+        """Execute an IPython action using the configured handler."""
+        if self._ipython_handler is None:
+            # Default: return success
+            return IPythonRunCellObservation(content='', code=action.code)
+        return self._ipython_handler(action)
+
+    # Implement abstract methods with stubs (not used in these tests)
+    async def connect(self) -> None:
+        pass
+
+    def browse(self, action) -> Observation:
+        raise NotImplementedError
+
+    def browse_interactive(self, action) -> Observation:
+        raise NotImplementedError
+
+    async def call_tool_mcp(self, action) -> Observation:
+        raise NotImplementedError
+
+    def copy_from(self, path: str):
+        raise NotImplementedError
+
+    def copy_to(self, host_src: str, sandbox_dest: str, recursive: bool = False):
+        raise NotImplementedError
+
+    def edit(self, action) -> Observation:
+        raise NotImplementedError
+
+    def get_mcp_config(self):
+        raise NotImplementedError
+
+    def list_files(self, path: str | None = None) -> list[str]:
+        raise NotImplementedError
+
+    def read(self, action) -> Observation:
+        raise NotImplementedError
+
+    def write(self, action) -> Observation:
+        raise NotImplementedError
 
 
 class TestAddEnvVarsSecretRedaction:
     """Tests that add_env_vars redacts secrets from error messages."""
 
-    @pytest.fixture
-    def mock_runtime(self):
-        """Create a mock runtime with the add_env_vars method."""
-        from openhands.runtime.base import Runtime
-
-        runtime = MagicMock(spec=Runtime)
-
-        # Bind the actual methods we need
-        runtime._run_cmd_with_retry = Runtime._run_cmd_with_retry.__get__(
-            runtime, Runtime
-        )
-        runtime._is_bash_session_timeout = Runtime._is_bash_session_timeout.__get__(
-            runtime, Runtime
-        )
-        runtime._calculate_retry_delay = Runtime._calculate_retry_delay.__get__(
-            runtime, Runtime
-        )
-        runtime._extract_error_content = Runtime._extract_error_content.__get__(
-            runtime, Runtime
-        )
-        runtime.add_env_vars = Runtime.add_env_vars.__get__(runtime, Runtime)
-
-        # Mock plugins to be empty (no Jupyter)
-        runtime.plugins = []
-
-        return runtime
-
-    def test_invalid_env_var_name_error_does_not_contain_secret_value(
-        self, mock_runtime
-    ):
+    def test_invalid_env_var_name_error_does_not_contain_secret_value(self):
         """Test that invalid env var names raise error WITHOUT exposing secret values.
 
         This tests the fix for the security issue where error messages like:
         'bash: export: `MY_DUMMY-SECRET=secret_value': not a valid identifier'
         were being logged, exposing the secret value.
         """
-        # Simulate bash rejecting an invalid variable name (contains hyphen)
-        # The error output would normally contain the full export command with secret
-        error_output = (
-            "bash: export: `MY_INVALID-VAR=super_secret_password': "
-            'not a valid identifier'
-        )
-        error_obs = CmdOutputObservation(
-            content=error_output,
-            command='export MY_INVALID-VAR="super_secret_password"',
-            exit_code=1,
-        )
-        mock_runtime.run = MagicMock(return_value=error_obs)
+        secret_value = 'super_secret_password_xyz123'
 
-        # Call add_env_vars with an invalid variable name
+        def run_handler(action: CmdRunAction) -> Observation:
+            # Simulate bash rejecting an invalid variable name (contains hyphen)
+            return CmdOutputObservation(
+                content=(
+                    f"bash: export: `MY_INVALID-VAR={secret_value}': "
+                    'not a valid identifier'
+                ),
+                command=action.command,
+                exit_code=1,
+            )
+
+        runtime = StubRuntime(run_handler=run_handler)
+
         with pytest.raises(RuntimeError) as exc_info:
-            mock_runtime.add_env_vars({'MY_INVALID-VAR': 'super_secret_password'})
+            runtime.add_env_vars({'MY_INVALID-VAR': secret_value})
 
         error_message = str(exc_info.value)
 
@@ -73,68 +130,177 @@ class TestAddEnvVarsSecretRedaction:
         assert 'MY_INVALID-VAR' in error_message
 
         # The error message should NOT contain the secret VALUE
-        assert 'super_secret_password' not in error_message
+        assert secret_value not in error_message
 
         # The error message should NOT contain the raw bash error output
         assert 'not a valid identifier' not in error_message
 
         # The error message should provide helpful guidance
-        assert (
-            'valid bash identifier' in error_message.lower()
-            or 'valid identifier' in error_message.lower()
-        )
+        assert 'valid bash identifier' in error_message.lower()
 
-    def test_multiple_env_vars_error_does_not_expose_any_secrets(self, mock_runtime):
+    def test_multiple_env_vars_error_does_not_expose_any_secrets(self):
         """Test that when multiple env vars fail, no secrets are exposed."""
-        # Simulate bash error with multiple secrets in the command
-        error_output = (
-            'export API_KEY="secret123"; export MY-BAD-VAR="another_secret"\n'
-            "bash: export: `MY-BAD-VAR=another_secret': not a valid identifier"
-        )
-        error_obs = CmdOutputObservation(
-            content=error_output,
-            command='export API_KEY="secret123"; export MY-BAD-VAR="another_secret"',
-            exit_code=1,
-        )
-        mock_runtime.run = MagicMock(return_value=error_obs)
-
-        env_vars = {
-            'API_KEY': 'secret123',
-            'MY-BAD-VAR': 'another_secret',
+        secrets = {
+            'API_KEY': 'secret_api_key_12345',
+            'MY-BAD-VAR': 'another_super_secret_value',
         }
 
+        def run_handler(action: CmdRunAction) -> Observation:
+            # Simulate bash error with secrets potentially in output
+            return CmdOutputObservation(
+                content=(
+                    f'export API_KEY="{secrets["API_KEY"]}"; '
+                    f'export MY-BAD-VAR="{secrets["MY-BAD-VAR"]}"\n'
+                    f"bash: export: `MY-BAD-VAR={secrets['MY-BAD-VAR']}': "
+                    'not a valid identifier'
+                ),
+                command=action.command,
+                exit_code=1,
+            )
+
+        runtime = StubRuntime(run_handler=run_handler)
+
         with pytest.raises(RuntimeError) as exc_info:
-            mock_runtime.add_env_vars(env_vars)
+            runtime.add_env_vars(secrets)
 
         error_message = str(exc_info.value)
 
         # Should NOT contain any secret values
-        assert 'secret123' not in error_message
-        assert 'another_secret' not in error_message
+        for secret in secrets.values():
+            assert secret not in error_message, f'Secret "{secret}" leaked in error message'
 
-        # Should contain the variable names (keys)
+        # Should contain the variable names (keys) - they get uppercased
         assert 'API_KEY' in error_message
         assert 'MY-BAD-VAR' in error_message
 
-    def test_bashrc_error_does_not_expose_secrets(self, mock_runtime):
+    def test_bashrc_error_does_not_expose_secrets(self):
         """Test that .bashrc persistence errors also don't expose secrets."""
-        # First call succeeds (export command)
-        success_obs = CmdOutputObservation(content='', command='export', exit_code=0)
-        # Second call fails (.bashrc update)
-        error_obs = CmdOutputObservation(
-            content='bash: some error with SECRET_VALUE',
-            command='touch ~/.bashrc; grep...',
-            exit_code=1,
-        )
-        mock_runtime.run = MagicMock(side_effect=[success_obs, error_obs])
+        secret_value = 'very_sensitive_token_abc789'
+        call_count = 0
+
+        def run_handler(action: CmdRunAction) -> Observation:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First call (export) succeeds
+                return CmdOutputObservation(
+                    content='', command=action.command, exit_code=0
+                )
+            else:
+                # Second call (.bashrc update) fails with secret in output
+                return CmdOutputObservation(
+                    content=f'bash: some error with {secret_value}',
+                    command=action.command,
+                    exit_code=1,
+                )
+
+        runtime = StubRuntime(run_handler=run_handler)
 
         with pytest.raises(RuntimeError) as exc_info:
-            mock_runtime.add_env_vars({'VALID_VAR': 'SECRET_VALUE'})
+            runtime.add_env_vars({'VALID_VAR': secret_value})
 
         error_message = str(exc_info.value)
 
         # Should NOT contain the secret value
-        assert 'SECRET_VALUE' not in error_message
+        assert secret_value not in error_message
 
         # Should mention .bashrc in the error
         assert '.bashrc' in error_message
+
+        # Should contain the variable name
+        assert 'VALID_VAR' in error_message
+
+    def test_ipython_error_does_not_expose_secrets(self):
+        """Test that IPython/Jupyter env var errors don't expose secrets."""
+        secret_value = 'jupyter_secret_token_456'
+
+        def ipython_handler(action: IPythonRunCellAction) -> Observation:
+            # Simulate an error that might contain the secret
+            return ErrorObservation(
+                content=f'NameError: invalid variable with {secret_value}'
+            )
+
+        # Enable Jupyter plugin
+        runtime = StubRuntime(
+            ipython_handler=ipython_handler,
+            plugins=[JupyterRequirement()],
+        )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            runtime.add_env_vars({'MY_VAR': secret_value})
+
+        error_message = str(exc_info.value)
+
+        # Should NOT contain the secret value
+        assert secret_value not in error_message
+
+        # Should mention IPython in the error
+        assert 'IPython' in error_message
+
+        # Should contain the variable name
+        assert 'MY_VAR' in error_message
+
+    def test_empty_env_vars_returns_early(self):
+        """Test that empty env_vars dict returns early without errors."""
+        call_count = 0
+
+        def run_handler(action: CmdRunAction) -> Observation:
+            nonlocal call_count
+            call_count += 1
+            return CmdOutputObservation(content='', command=action.command, exit_code=0)
+
+        runtime = StubRuntime(run_handler=run_handler)
+
+        # Should not raise and should not call run
+        runtime.add_env_vars({})
+
+        assert call_count == 0, 'run() should not be called for empty env_vars'
+
+    def test_non_runtime_error_propagates(self):
+        """Test that non-RuntimeError exceptions from run() propagate correctly."""
+
+        def run_handler(action: CmdRunAction) -> Observation:
+            raise ValueError('Unexpected internal error')
+
+        runtime = StubRuntime(run_handler=run_handler)
+
+        # ValueError should propagate, not be caught and converted
+        with pytest.raises(ValueError, match='Unexpected internal error'):
+            runtime.add_env_vars({'MY_VAR': 'some_value'})
+
+    def test_successful_env_vars_do_not_raise(self):
+        """Test that valid env vars are set successfully without errors."""
+
+        def run_handler(action: CmdRunAction) -> Observation:
+            return CmdOutputObservation(content='', command=action.command, exit_code=0)
+
+        runtime = StubRuntime(run_handler=run_handler)
+
+        # Should not raise
+        runtime.add_env_vars({
+            'VALID_VAR_1': 'value1',
+            'VALID_VAR_2': 'value2',
+        })
+
+    def test_var_names_are_uppercased_in_error(self):
+        """Test that variable names in errors are uppercased as they would be set."""
+        secret_value = 'secret_for_case_test'
+
+        def run_handler(action: CmdRunAction) -> Observation:
+            return CmdOutputObservation(
+                content='bash: export error',
+                command=action.command,
+                exit_code=1,
+            )
+
+        runtime = StubRuntime(run_handler=run_handler)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            runtime.add_env_vars({'lower_case_var': secret_value})
+
+        error_message = str(exc_info.value)
+
+        # Variable name should be uppercased in the error
+        assert 'LOWER_CASE_VAR' in error_message
+        # Secret should not be present
+        assert secret_value not in error_message

--- a/tests/unit/runtime/test_env_vars_security.py
+++ b/tests/unit/runtime/test_env_vars_security.py
@@ -167,7 +167,9 @@ class TestAddEnvVarsSecretRedaction:
 
         # Should NOT contain any secret values
         for secret in secrets.values():
-            assert secret not in error_message, f'Secret "{secret}" leaked in error message'
+            assert secret not in error_message, (
+                f'Secret "{secret}" leaked in error message'
+            )
 
         # Should contain the variable names (keys) - they get uppercased
         assert 'API_KEY' in error_message
@@ -277,10 +279,12 @@ class TestAddEnvVarsSecretRedaction:
         runtime = StubRuntime(run_handler=run_handler)
 
         # Should not raise
-        runtime.add_env_vars({
-            'VALID_VAR_1': 'value1',
-            'VALID_VAR_2': 'value2',
-        })
+        runtime.add_env_vars(
+            {
+                'VALID_VAR_1': 'value1',
+                'VALID_VAR_2': 'value2',
+            }
+        )
 
     def test_var_names_are_uppercased_in_error(self):
         """Test that variable names in errors are uppercased as they would be set."""


### PR DESCRIPTION
## Summary

Fixes a security issue where secret values were being exposed in error logs when `add_env_vars()` fails.

## Problem

When adding environment variables fails (e.g., due to invalid variable names like `MY_DUMMY-SECRET` with a hyphen), the error message contained the full bash command output which included all secret values in plaintext:

```
Error creating agent_session: Failed to add env vars [...] to environment: 
export GRB_LICENSEID="SECRET_VALUE"; export MY_DUMMY-SECRET="blahblah"
bash: export: `MY_DUMMY-SECRET=blahblah': not a valid identifier
```

This was being logged via `self.logger.exception(f'Error creating agent_session: {e}')` in `session.py`, exposing secrets in pod logs.

## Solution

Modified `add_env_vars()` in `openhands/runtime/base.py` to catch `RuntimeError` exceptions from `_run_cmd_with_retry()` and re-raise with a sanitized error message that only includes variable **names** (keys), not the secret **values**:

```python
try:
    self._run_cmd_with_retry(
        cmd, f'Failed to add env vars [{env_vars.keys()}] to environment'
    )
except RuntimeError as e:
    # Re-raise with redacted error message to avoid leaking secret values
    raise RuntimeError(
        f'Failed to add env vars [{list(env_vars.keys())}] to environment. '
        'Check that all variable names are valid bash identifiers '
        '(alphanumeric and underscores only, cannot start with a digit).'
    ) from None
```

## Result

Error messages now show only variable names with helpful guidance:
```
Failed to add env vars ['GRB_LICENSEID', 'MY_DUMMY-SECRET'] to environment. 
Check that all variable names are valid bash identifiers 
(alphanumeric and underscores only, cannot start with a digit).
```

## Changes

- `openhands/runtime/base.py`: Wrap `_run_cmd_with_retry()` calls in `add_env_vars()` with try-catch to sanitize error messages
  - Windows PowerShell section
  - Linux/Unix bash export section  
  - Linux/Unix .bashrc persistence section

## Tests

Added `tests/unit/runtime/test_env_vars_security.py` with 3 tests that verify:
- Invalid env var names raise `RuntimeError` without exposing secret values
- Multiple env vars errors don't expose any secrets
- `.bashrc` persistence errors don't expose secrets

Tests were verified to:
- **FAIL** without the fix (secrets exposed in error messages)
- **PASS** with the fix (secrets redacted)


@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:87176c6-nikolaik   --name openhands-app-87176c6   docker.openhands.dev/openhands/openhands:87176c6
```