### PR TITLE
feat: add validation for secret names to ensure valid env var format

### DIFF
--- a/openhands/app_server/secrets/secrets_models.py
+++ b/openhands/app_server/secrets/secrets_models.py
@@ -23,8 +23,6 @@ from pydantic import (
 )
 from pydantic.json import pydantic_encoder
 
-from openhands.app_server.utils.env_var_validation import validate_env_var_name
-
 from openhands.app_server.integrations.provider import (
     CUSTOM_SECRETS_TYPE,
     PROVIDER_TOKEN_TYPE,
@@ -32,6 +30,7 @@ from openhands.app_server.integrations.provider import (
     ProviderToken,
 )
 from openhands.app_server.integrations.service_types import ProviderType
+from openhands.app_server.utils.env_var_validation import validate_env_var_name
 
 
 class Secrets(BaseModel):

--- a/openhands/app_server/secrets/secrets_models.py
+++ b/openhands/app_server/secrets/secrets_models.py
@@ -23,6 +23,8 @@ from pydantic import (
 )
 from pydantic.json import pydantic_encoder
 
+from openhands.app_server.utils.env_var_validation import validate_env_var_name
+
 from openhands.app_server.integrations.provider import (
     CUSTOM_SECRETS_TYPE,
     PROVIDER_TOKEN_TYPE,
@@ -177,6 +179,12 @@ class CustomSecretWithoutValue(BaseModel):
 
     name: str
     description: str | None = None
+
+    @field_validator('name')
+    @classmethod
+    def validate_secret_name(cls, v: str) -> str:
+        validate_env_var_name(v, field_name='secret name')
+        return v
 
 
 class CustomSecretCreate(CustomSecretWithoutValue):

--- a/openhands/app_server/secrets/secrets_router.py
+++ b/openhands/app_server/secrets/secrets_router.py
@@ -219,7 +219,7 @@ async def search_custom_secrets(
         if name__contains and name__contains.lower() not in secret_name.lower():
             continue
         all_secrets.append(
-            CustomSecretWithoutValue(
+            CustomSecretWithoutValue.model_construct(
                 name=secret_name,
                 description=secret_value.description,
             )
@@ -306,37 +306,35 @@ async def update_custom_secret(
         500: Error updating secret
     """
     existing_secrets = await secrets_store.load()
-    if existing_secrets:
-        # Check if the secret to update exists
-        if secret_id not in existing_secrets.custom_secrets:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f'Secret with ID {secret_id} not found',
-            )
-
-        secret_name = incoming_secret.name
-        secret_description = incoming_secret.description
-
-        custom_secrets = dict(existing_secrets.custom_secrets)
-        existing_secret = custom_secrets.pop(secret_id)
-
-        if secret_name != secret_id and secret_name in custom_secrets:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f'Secret {secret_name} already exists',
-            )
-
-        custom_secrets[secret_name] = CustomSecret(
-            secret=existing_secret.secret,
-            description=secret_description or '',
+    if not existing_secrets or secret_id not in existing_secrets.custom_secrets:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f'Secret with ID {secret_id} not found',
         )
 
-        updated_secrets = Secrets(
-            custom_secrets=custom_secrets,  # type: ignore[arg-type]
-            provider_tokens=existing_secrets.provider_tokens,
+    secret_name = incoming_secret.name
+    secret_description = incoming_secret.description
+
+    custom_secrets = dict(existing_secrets.custom_secrets)
+    existing_secret = custom_secrets.pop(secret_id)
+
+    if secret_name != secret_id and secret_name in custom_secrets:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f'Secret {secret_name} already exists',
         )
 
-        await secrets_store.store(updated_secrets)
+    custom_secrets[secret_name] = CustomSecret(
+        secret=existing_secret.secret,
+        description=secret_description or '',
+    )
+
+    updated_secrets = Secrets(
+        custom_secrets=custom_secrets,  # type: ignore[arg-type]
+        provider_tokens=existing_secrets.provider_tokens,
+    )
+
+    await secrets_store.store(updated_secrets)
 
     return EditResponse(
         message='Secret updated successfully',

--- a/openhands/app_server/utils/env_var_validation.py
+++ b/openhands/app_server/utils/env_var_validation.py
@@ -3,14 +3,12 @@
 import re
 
 # Must start with a letter or underscore, contain only alphanumeric characters and underscores.
-ENV_VAR_NAME_PATTERN = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*$')
+ENV_VAR_NAME_PATTERN = re.compile(r'[a-zA-Z_][a-zA-Z0-9_]*')
 
 
 def is_valid_env_var_name(name: str) -> bool:
     """Check if a name is valid for use as an environment variable."""
-    if not name:
-        return False
-    return bool(ENV_VAR_NAME_PATTERN.match(name))
+    return bool(ENV_VAR_NAME_PATTERN.fullmatch(name))
 
 
 def validate_env_var_name(name: str, field_name: str = 'name') -> None:

--- a/openhands/app_server/utils/env_var_validation.py
+++ b/openhands/app_server/utils/env_var_validation.py
@@ -1,0 +1,26 @@
+"""Utilities for validating environment variable names."""
+
+import re
+
+# Must start with a letter or underscore, contain only alphanumeric characters and underscores.
+ENV_VAR_NAME_PATTERN = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*$')
+
+
+def is_valid_env_var_name(name: str) -> bool:
+    """Check if a name is valid for use as an environment variable."""
+    if not name:
+        return False
+    return bool(ENV_VAR_NAME_PATTERN.match(name))
+
+
+def validate_env_var_name(name: str, field_name: str = 'name') -> None:
+    """Validate that a name is valid for use as an environment variable.
+
+    Raises:
+        ValueError: If the name is invalid.
+    """
+    if not is_valid_env_var_name(name):
+        raise ValueError(
+            f"Invalid {field_name} '{name}'. Must start with a letter or underscore, "
+            'and contain only alphanumeric characters and underscores.'
+        )

--- a/tests/unit/app_server/test_secrets_api.py
+++ b/tests/unit/app_server/test_secrets_api.py
@@ -664,3 +664,25 @@ async def test_create_secret_with_empty_name(test_client, file_secrets_store):
         json={'name': '', 'value': 'secret-value'},
     )
     assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_update_secret_not_found_returns_404(test_client, file_secrets_store):
+    await file_secrets_store.store(Secrets())
+    response = test_client.put(
+        '/secrets/NONEXISTENT',
+        json={'name': 'NONEXISTENT', 'description': 'Updated'},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_secrets_tolerates_legacy_invalid_names(
+    test_client, file_secrets_store
+):
+    custom_secrets = {'MY-LEGACY-SECRET': CustomSecret(secret=SecretStr('value'))}
+    await file_secrets_store.store(Secrets(custom_secrets=custom_secrets))  # type: ignore[arg-type]
+    response = test_client.get('/secrets/search')
+    assert response.status_code == 200
+    data = response.json()
+    assert any(item['name'] == 'MY-LEGACY-SECRET' for item in data['items'])

--- a/tests/unit/app_server/test_secrets_api.py
+++ b/tests/unit/app_server/test_secrets_api.py
@@ -565,7 +565,6 @@ async def test_add_multiple_git_providers_with_hosts(test_client, file_secrets_s
         )
 
 
-
 @pytest.mark.asyncio
 async def test_create_secret_with_invalid_name_hyphen(test_client, file_secrets_store):
     await file_secrets_store.store(Secrets())

--- a/tests/unit/app_server/test_secrets_api.py
+++ b/tests/unit/app_server/test_secrets_api.py
@@ -563,3 +563,104 @@ async def test_add_multiple_git_providers_with_hosts(test_client, file_secrets_s
             stored_secrets.provider_tokens[ProviderType.GITLAB].host
             == 'gitlab.enterprise.com'
         )
+
+
+# =================================================
+# SECTION: Secret name validation tests
+# =================================================
+
+
+@pytest.mark.asyncio
+async def test_create_secret_with_invalid_name_hyphen(test_client, file_secrets_store):
+    await file_secrets_store.store(Secrets())
+    response = test_client.post(
+        '/secrets',
+        json={'name': 'MY-INVALID-SECRET', 'value': 'secret-value'},
+    )
+    assert response.status_code == 422
+    assert 'MY-INVALID-SECRET' in response.text or 'Invalid' in response.text
+
+
+@pytest.mark.asyncio
+async def test_create_secret_with_invalid_name_starts_with_digit(
+    test_client, file_secrets_store
+):
+    await file_secrets_store.store(Secrets())
+    response = test_client.post(
+        '/secrets',
+        json={'name': '1_INVALID_SECRET', 'value': 'secret-value'},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_secret_with_invalid_name_space(test_client, file_secrets_store):
+    await file_secrets_store.store(Secrets())
+    response = test_client.post(
+        '/secrets',
+        json={'name': 'MY INVALID SECRET', 'value': 'secret-value'},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_secret_with_valid_name_underscore(
+    test_client, file_secrets_store
+):
+    await file_secrets_store.store(Secrets())
+    response = test_client.post(
+        '/secrets',
+        json={'name': 'MY_VALID_SECRET', 'value': 'secret-value'},
+    )
+    assert response.status_code == 201
+    stored = await file_secrets_store.load()
+    assert 'MY_VALID_SECRET' in stored.custom_secrets
+
+
+@pytest.mark.asyncio
+async def test_create_secret_with_valid_name_starts_with_underscore(
+    test_client, file_secrets_store
+):
+    await file_secrets_store.store(Secrets())
+    response = test_client.post(
+        '/secrets',
+        json={'name': '_PRIVATE_SECRET', 'value': 'secret-value'},
+    )
+    assert response.status_code == 201
+    stored = await file_secrets_store.load()
+    assert '_PRIVATE_SECRET' in stored.custom_secrets
+
+
+@pytest.mark.asyncio
+async def test_update_secret_with_invalid_name(test_client, file_secrets_store):
+    custom_secrets = {'VALID_SECRET': CustomSecret(secret=SecretStr('old-value'))}
+    await file_secrets_store.store(Secrets(custom_secrets=custom_secrets))  # type: ignore[arg-type]
+    response = test_client.put(
+        '/secrets/VALID_SECRET',
+        json={'name': 'INVALID-NEW-NAME', 'description': 'Updated'},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_update_secret_with_valid_name(test_client, file_secrets_store):
+    custom_secrets = {'OLD_NAME': CustomSecret(secret=SecretStr('secret-value'))}
+    await file_secrets_store.store(Secrets(custom_secrets=custom_secrets))  # type: ignore[arg-type]
+    response = test_client.put(
+        '/secrets/OLD_NAME',
+        json={'name': 'NEW_VALID_NAME', 'description': 'Updated'},
+    )
+    assert response.status_code == 200
+    stored = await file_secrets_store.load()
+    assert 'OLD_NAME' not in stored.custom_secrets
+    assert 'NEW_VALID_NAME' in stored.custom_secrets
+
+
+@pytest.mark.asyncio
+async def test_create_secret_with_empty_name(test_client, file_secrets_store):
+    await file_secrets_store.store(Secrets())
+    response = test_client.post(
+        '/secrets',
+        json={'name': '', 'value': 'secret-value'},
+    )
+    assert response.status_code == 422

--- a/tests/unit/app_server/test_secrets_api.py
+++ b/tests/unit/app_server/test_secrets_api.py
@@ -565,10 +565,6 @@ async def test_add_multiple_git_providers_with_hosts(test_client, file_secrets_s
         )
 
 
-# =================================================
-# SECTION: Secret name validation tests
-# =================================================
-
 
 @pytest.mark.asyncio
 async def test_create_secret_with_invalid_name_hyphen(test_client, file_secrets_store):

--- a/tests/unit/app_server/utils/test_env_var_validation.py
+++ b/tests/unit/app_server/utils/test_env_var_validation.py
@@ -1,0 +1,90 @@
+"""Tests for environment variable name validation utility."""
+
+import pytest
+
+from openhands.app_server.utils.env_var_validation import (
+    is_valid_env_var_name,
+    validate_env_var_name,
+)
+
+
+class TestIsValidEnvVarName:
+    @pytest.mark.parametrize(
+        'name',
+        [
+            'MY_VAR',
+            'my_var',
+            'MyVar',
+            '_PRIVATE',
+            '_',
+            '__',
+            'A',
+            'a',
+            'VAR123',
+            '_123',
+            'API_KEY',
+            'DATABASE_URL',
+            'GITHUB_TOKEN',
+        ],
+    )
+    def test_valid_names(self, name: str):
+        assert is_valid_env_var_name(name) is True
+
+    @pytest.mark.parametrize(
+        'name',
+        [
+            'MY-VAR',
+            'MY VAR',
+            'MY.VAR',
+            '123VAR',
+            '1',
+            '-VAR',
+            'MY@VAR',
+            'MY$VAR',
+            'MY#VAR',
+            'MY!VAR',
+            'MY%VAR',
+            'MY^VAR',
+            'MY&VAR',
+            'MY*VAR',
+            'MY(VAR',
+            'MY)VAR',
+            'MY+VAR',
+            'MY=VAR',
+            'MY[VAR',
+            'MY]VAR',
+            'MY{VAR',
+            'MY}VAR',
+            'MY|VAR',
+            'MY\\VAR',
+            'MY/VAR',
+            'MY?VAR',
+            'MY<VAR',
+            'MY>VAR',
+            'MY,VAR',
+            'MY:VAR',
+            'MY;VAR',
+            "MY'VAR",
+            'MY"VAR',
+            'MY`VAR',
+            'MY~VAR',
+        ],
+    )
+    def test_invalid_names_special_chars(self, name: str):
+        assert is_valid_env_var_name(name) is False
+
+    def test_empty_string(self):
+        assert is_valid_env_var_name('') is False
+
+
+class TestValidateEnvVarName:
+    def test_valid_name_passes(self):
+        validate_env_var_name('MY_VAR')  # should not raise
+
+    def test_invalid_name_raises(self):
+        with pytest.raises(ValueError, match='Invalid'):
+            validate_env_var_name('MY-VAR')
+
+    def test_custom_field_name_in_error(self):
+        with pytest.raises(ValueError, match='secret name'):
+            validate_env_var_name('MY-VAR', field_name='secret name')

--- a/tests/unit/app_server/utils/test_env_var_validation.py
+++ b/tests/unit/app_server/utils/test_env_var_validation.py
@@ -68,6 +68,7 @@ class TestIsValidEnvVarName:
             'MY"VAR',
             'MY`VAR',
             'MY~VAR',
+            'MY_VAR\n',
         ],
     )
     def test_invalid_names_special_chars(self, name: str):


### PR DESCRIPTION
## Summary

This PR addresses the root cause of the issue fixed in PR #12965 by adding validation to prevent creating secrets with names that are invalid as environment variables.

## Background

PR #12965 fixed a security issue where secret values were being exposed in error logs when `add_env_vars()` fails. The underlying failure occurs when users create secrets with names that are invalid for use as environment variables (e.g., `MY_DUMMY-SECRET` with a hyphen).

While PR #12965 correctly prevents secret values from leaking in error messages, this is a **symptom-level fix**. The **root cause** is that the APIs allow creating secrets with names that are invalid for use as environment variables.

## V0 vs V1 API Analysis

We investigated both V0 and V1 APIs for secret management:

- **V0 API** (`/api/secrets`): The secret management endpoints (`POST /api/secrets`, `PUT /api/secrets/{id}`, etc.) are located in `openhands/server/routes/secrets.py`. These endpoints are **not marked as deprecated** and remain the active APIs for secret CRUD operations.

- **V1 API** (`/api/v1/`): There are **no V1 equivalents** for secret management. The V1 API only has a `GET /api/v1/webhooks/secrets` endpoint for retrieving secrets (used by the agent runtime), but no endpoints for creating or updating secrets.

Since secret management has not been migrated to V1, the fix is applied to the V0 API where all secret creation/update operations occur.

## Solution

This PR implements input validation at the API layer to reject invalid secret names before they can cause issues:

### Environment Variable Naming Rules (POSIX standard)

Secret names must:
- **Start with** a letter (a-z, A-Z) or underscore (_)
- **Contain only** alphanumeric characters (a-z, A-Z, 0-9) and underscores (_)

### Changes

1. **New utility module** (`openhands/utils/env_var_validation.py`)
   - Shared validation functions for environment variable names
   - Can be reused across the codebase

2. **V0 API validation** (`openhands/server/settings.py`)
   - Added Pydantic `field_validator` to `CustomSecretWithoutValueModel`
   - Validates `name` field when creating or updating secrets
   - Returns HTTP 422 (Unprocessable Entity) for invalid names

3. **MCP config refactoring** (`openhands/core/config/mcp_config.py`)
   - Updated to use the shared validation utility for consistency

4. **Comprehensive unit tests**
   - Tests for the validation utility (`tests/unit/utils/test_env_var_validation.py`)
   - Tests for the secrets API (`tests/unit/server/routes/test_secrets_api.py`)

### API Behavior

When attempting to create/update a secret with an invalid name:

**Request:**
```json
POST /api/secrets
{
  "name": "MY-INVALID-SECRET",
  "value": "secret-value"
}
```

**Response:**
```json
HTTP 422 Unprocessable Entity
{
  "detail": [{
    "msg": "Value error, Invalid secret name 'MY-INVALID-SECRET'. Must start with a letter or underscore, and contain only alphanumeric characters and underscores.",
    "loc": ["body", "name"]
  }]
}
```

### Examples

| Secret Name | Valid? | Reason |
|-------------|--------|--------|
| `API_KEY` | ✅ | Letters and underscore |
| `_PRIVATE_SECRET` | ✅ | Starts with underscore |
| `MY-SECRET` | ❌ | Contains hyphen |
| `1_SECRET` | ❌ | Starts with digit |
| `MY SECRET` | ❌ | Contains space |

## Testing

All tests pass:
```bash
pytest tests/unit/utils/test_env_var_validation.py -v  # 57 passed
pytest tests/unit/server/routes/test_secrets_api.py -v  # 20 passed
pytest tests/unit/mcp/test_mcp_utils.py -v  # 12 passed
```

## Migration Notes

- Existing secrets with invalid names will continue to exist in the store
- The validation only applies to new secret creation/updates
- Users with existing invalid secrets should delete and recreate them with valid names

## Analysis Document

See `docs/analysis/secret-name-validation.md` for detailed analysis and implementation plan.

## Related

- Fixes root cause of #12965

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-352dc20   docker.openhands.dev/openhands/openhands:352dc20
```