### PR TITLE
Include closing issue comments in PR resolver context

### DIFF
--- a/openhands/resolver/interfaces/forgejo.py
+++ b/openhands/resolver/interfaces/forgejo.py
@@ -417,6 +417,39 @@ class ForgejoPRHandler(ForgejoIssueHandler):
             thread_comments,
         )
 
+    def _enrich_closing_issues_with_comments(
+        self,
+        closing_issues: list[str],
+        closing_issue_numbers: list[int],
+    ) -> list[str]:
+        """Enrich closing issue bodies with their thread comments.
+
+        For each closing issue, fetches its comments and appends them to the
+        issue body so the agent has full context from the issue discussion.
+        """
+        enriched = []
+        for i, issue_body in enumerate(closing_issues):
+            if i < len(closing_issue_numbers):
+                issue_number = closing_issue_numbers[i]
+                try:
+                    comments = self.get_issue_comments(issue_number)
+                    if comments:
+                        comments_str = '\n---\n'.join(comments)
+                        enriched.append(
+                            f'{issue_body}\n\n--- Issue Comments ---\n{comments_str}'
+                        )
+                    else:
+                        enriched.append(issue_body)
+                except Exception:
+                    logger.warning(
+                        f'Failed to fetch comments for closing issue #{issue_number}',
+                        exc_info=True,
+                    )
+                    enriched.append(issue_body)
+            else:
+                enriched.append(issue_body)
+        return enriched
+
     def get_converted_issues(
         self, issue_numbers: list[int] | None = None, comment_id: int | None = None
     ) -> list[Issue]:
@@ -451,6 +484,11 @@ class ForgejoPRHandler(ForgejoIssueHandler):
             ) = self.download_pr_metadata(pr_number, comment_id)
             head_branch = (pr.get('head') or {}).get('ref')
             thread_comments = self.get_pr_comments(pr_number, comment_id)
+
+            # Enrich closing issues with their thread comments
+            closing_issues = self._enrich_closing_issues_with_comments(
+                closing_issues, closing_issue_numbers
+            )
 
             closing_issues = self.get_context_from_external_issues_references(
                 closing_issues,

--- a/openhands/resolver/interfaces/github.py
+++ b/openhands/resolver/interfaces/github.py
@@ -576,6 +576,39 @@ class GithubPRHandler(GithubIssueHandler):
 
         return closing_issues
 
+    def _enrich_closing_issues_with_comments(
+        self,
+        closing_issues: list[str],
+        closing_issue_numbers: list[int],
+    ) -> list[str]:
+        """Enrich closing issue bodies with their thread comments.
+
+        For each closing issue, fetches its comments and appends them to the
+        issue body so the agent has full context from the issue discussion.
+        """
+        enriched = []
+        for i, issue_body in enumerate(closing_issues):
+            if i < len(closing_issue_numbers):
+                issue_number = closing_issue_numbers[i]
+                try:
+                    comments = self.get_issue_comments(issue_number)
+                    if comments:
+                        comments_str = '\n---\n'.join(comments)
+                        enriched.append(
+                            f'{issue_body}\n\n--- Issue Comments ---\n{comments_str}'
+                        )
+                    else:
+                        enriched.append(issue_body)
+                except Exception:
+                    logger.warning(
+                        f'Failed to fetch comments for closing issue #{issue_number}',
+                        exc_info=True,
+                    )
+                    enriched.append(issue_body)
+            else:
+                enriched.append(issue_body)
+        return enriched
+
     def get_converted_issues(
         self, issue_numbers: list[int] | None = None, comment_id: int | None = None
     ) -> list[Issue]:
@@ -603,6 +636,11 @@ class GithubPRHandler(GithubIssueHandler):
                 thread_ids,
             ) = self.download_pr_metadata(issue['number'], comment_id=comment_id)
             head_branch = issue['head']['ref']
+
+            # Enrich closing issues with their thread comments
+            closing_issues = self._enrich_closing_issues_with_comments(
+                closing_issues, closing_issues_numbers
+            )
 
             # Get PR thread comments
             thread_comments = self.get_pr_comments(

--- a/openhands/resolver/interfaces/gitlab.py
+++ b/openhands/resolver/interfaces/gitlab.py
@@ -549,6 +549,39 @@ class GitlabPRHandler(GitlabIssueHandler):
 
         return closing_issues
 
+    def _enrich_closing_issues_with_comments(
+        self,
+        closing_issues: list[str],
+        closing_issue_numbers: list[int],
+    ) -> list[str]:
+        """Enrich closing issue bodies with their thread comments.
+
+        For each closing issue, fetches its comments and appends them to the
+        issue body so the agent has full context from the issue discussion.
+        """
+        enriched = []
+        for i, issue_body in enumerate(closing_issues):
+            if i < len(closing_issue_numbers):
+                issue_number = closing_issue_numbers[i]
+                try:
+                    comments = self.get_issue_comments(issue_number)
+                    if comments:
+                        comments_str = '\n---\n'.join(comments)
+                        enriched.append(
+                            f'{issue_body}\n\n--- Issue Comments ---\n{comments_str}'
+                        )
+                    else:
+                        enriched.append(issue_body)
+                except Exception:
+                    logger.warning(
+                        f'Failed to fetch comments for closing issue #{issue_number}',
+                        exc_info=True,
+                    )
+                    enriched.append(issue_body)
+            else:
+                enriched.append(issue_body)
+        return enriched
+
     def get_converted_issues(
         self, issue_numbers: list[int] | None = None, comment_id: int | None = None
     ) -> list[Issue]:
@@ -578,6 +611,11 @@ class GitlabPRHandler(GitlabIssueHandler):
                 thread_ids,
             ) = self.download_pr_metadata(issue['iid'], comment_id=comment_id)
             head_branch = issue['source_branch']
+
+            # Enrich closing issues with their thread comments
+            closing_issues = self._enrich_closing_issues_with_comments(
+                closing_issues, closing_issues_numbers
+            )
 
             # Get PR thread comments
             thread_comments = self.get_pr_comments(issue['iid'], comment_id=comment_id)

--- a/tests/unit/resolver/github/test_issue_handler.py
+++ b/tests/unit/resolver/github/test_issue_handler.py
@@ -643,3 +643,147 @@ def test_pr_handler_get_converted_issues_with_duplicate_issue_refs():
                 'External context #1.',
                 'External context #2.',
             ]
+
+
+def test_pr_handler_closing_issues_include_comments():
+    """Test that closing issue comments are included in PR resolver context."""
+    with patch('httpx.get') as mock_get:
+        # Mock the response for PRs
+        mock_prs_response = MagicMock()
+        mock_prs_response.json.return_value = [
+            {
+                'number': 1,
+                'title': 'Test PR',
+                'body': 'Test Body',
+                'head': {'ref': 'test-branch'},
+            }
+        ]
+
+        # Mock GraphQL response with a closing issue
+        mock_graphql_response = MagicMock()
+        mock_graphql_response.json.return_value = {
+            'data': {
+                'repository': {
+                    'pullRequest': {
+                        'closingIssuesReferences': {
+                            'edges': [
+                                {
+                                    'node': {
+                                        'body': 'Add caching to the API',
+                                        'number': 42,
+                                    }
+                                }
+                            ]
+                        },
+                        'reviews': {'nodes': []},
+                        'reviewThreads': {'edges': []},
+                    }
+                }
+            }
+        }
+
+        # Mock empty response
+        mock_empty_response = MagicMock()
+        mock_empty_response.json.return_value = []
+
+        # Mock comments for the closing issue #42
+        mock_issue_comments_response = MagicMock()
+        mock_issue_comments_response.json.return_value = [
+            {'body': 'We should use Redis for this'},
+            {'body': 'Agreed, and add TTL support'},
+        ]
+
+        # Mock the response for PR comments
+        mock_pr_comments_response = MagicMock()
+        mock_pr_comments_response.json.return_value = [
+            {'body': 'This needs TTL handling'},
+        ]
+
+        mock_get.side_effect = [
+            mock_prs_response,  # download_issues: PRs list
+            mock_empty_response,  # download_issues: empty page
+            mock_issue_comments_response,  # _enrich: comments for closing issue #42
+            mock_empty_response,  # _enrich: comments pagination
+            mock_pr_comments_response,  # get_pr_comments: PR comments
+            mock_empty_response,  # get_pr_comments: pagination
+        ]
+
+        with patch('httpx.post') as mock_post:
+            mock_post.return_value = mock_graphql_response
+
+            llm_config = LLMConfig(model='test', api_key='test')
+            handler = ServiceContextPR(
+                GithubPRHandler('test-owner', 'test-repo', 'test-token'), llm_config
+            )
+
+            prs = handler.get_converted_issues(issue_numbers=[1])
+
+            assert len(prs) == 1
+            # Verify closing issues include both body and comments
+            assert len(prs[0].closing_issues) == 1
+            assert 'Add caching to the API' in prs[0].closing_issues[0]
+            assert '--- Issue Comments ---' in prs[0].closing_issues[0]
+            assert 'We should use Redis for this' in prs[0].closing_issues[0]
+            assert 'Agreed, and add TTL support' in prs[0].closing_issues[0]
+
+            # Verify PR thread comments are still set
+            assert prs[0].thread_comments == ['This needs TTL handling']
+
+
+def test_pr_handler_closing_issues_no_comments():
+    """Test that closing issues without comments just include the body."""
+    with patch('httpx.get') as mock_get:
+        mock_prs_response = MagicMock()
+        mock_prs_response.json.return_value = [
+            {
+                'number': 1,
+                'title': 'Test PR',
+                'body': 'Test Body',
+                'head': {'ref': 'test-branch'},
+            }
+        ]
+
+        mock_graphql_response = MagicMock()
+        mock_graphql_response.json.return_value = {
+            'data': {
+                'repository': {
+                    'pullRequest': {
+                        'closingIssuesReferences': {
+                            'edges': [
+                                {
+                                    'node': {
+                                        'body': 'Simple issue body',
+                                        'number': 10,
+                                    }
+                                }
+                            ]
+                        },
+                        'reviews': {'nodes': []},
+                        'reviewThreads': {'edges': []},
+                    }
+                }
+            }
+        }
+
+        mock_empty_response = MagicMock()
+        mock_empty_response.json.return_value = []
+
+        mock_get.side_effect = [
+            mock_prs_response,  # download_issues: PRs list
+            mock_empty_response,  # download_issues: empty page
+            mock_empty_response,  # _enrich: no comments for closing issue #10
+            mock_empty_response,  # get_pr_comments: no PR comments
+        ]
+
+        with patch('httpx.post') as mock_post:
+            mock_post.return_value = mock_graphql_response
+
+            llm_config = LLMConfig(model='test', api_key='test')
+            handler = ServiceContextPR(
+                GithubPRHandler('test-owner', 'test-repo', 'test-token'), llm_config
+            )
+
+            prs = handler.get_converted_issues(issue_numbers=[1])
+
+            assert len(prs) == 1
+            assert prs[0].closing_issues == ['Simple issue body']


### PR DESCRIPTION
## Summary
- When the resolver runs in PR mode, closing/linked issues now include their thread comments in addition to the issue body
- Adds `_enrich_closing_issues_with_comments()` method to GitHub, GitLab, and Forgejo PR handlers
- Comments are fetched using the existing `get_issue_comments()` method and appended to the issue body with a `--- Issue Comments ---` separator
- Gracefully handles failures (logs warning, preserves the issue body without comments)

## Context
Previously, `download_pr_metadata` only fetched the `body` from closing issues. When a PR was opened from an issue where important requirements were discussed in comments (e.g., TTL handling, architectural decisions), the agent lost that context during PR feedback rounds.

## Test plan
- [x] All 185 existing resolver tests pass
- [x] 2 new tests: `test_pr_handler_closing_issues_include_comments` and `test_pr_handler_closing_issues_no_comments`
- [x] mypy type checking passes
- [x] ruff linting passes

Fixes #12886