### PR TITLE
Add User-Agent header for LLM API calls

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -18,6 +18,7 @@ import httpx
 from openhands.core.config import LLMConfig
 from openhands.llm.metrics import Metrics
 from openhands.llm.model_features import get_features
+from openhands.version import __version__
 
 with warnings.catch_warnings():
     warnings.simplefilter('ignore')
@@ -212,6 +213,10 @@ class LLM(RetryMixin, DebugMixin):
         # Add completion_kwargs if present
         if self.config.completion_kwargs is not None:
             kwargs.update(self.config.completion_kwargs)
+
+        # Add User-Agent header for API calls
+        kwargs['extra_headers'] = kwargs.get('extra_headers', {})
+        kwargs['extra_headers'].setdefault('User-Agent', f'openhands/{__version__}')
 
         self._completion = partial(
             litellm_completion,

--- a/tests/unit/llm/test_llm.py
+++ b/tests/unit/llm/test_llm.py
@@ -1528,3 +1528,22 @@ def test_gemini_performance_optimization_end_to_end(mock_completion):
     # Verify temperature and top_p were removed for reasoning models
     assert 'temperature' not in call_kwargs
     assert 'top_p' not in call_kwargs
+
+
+@patch('openhands.llm.llm.litellm_completion')
+def test_user_agent_header_set(mock_litellm_completion, default_config):
+    """Test that the User-Agent header is set in extra_headers for LLM API calls."""
+    from openhands.version import __version__
+
+    mock_litellm_completion.return_value = {
+        'choices': [{'message': {'content': 'Test response'}}]
+    }
+
+    llm = LLM(config=default_config, service_id='test-service')
+    llm.completion(messages=[{'role': 'user', 'content': 'Hello!'}])
+
+    # Verify extra_headers contains the User-Agent header with openhands/ prefix
+    call_kwargs = mock_litellm_completion.call_args[1]
+    assert 'extra_headers' in call_kwargs
+    assert 'User-Agent' in call_kwargs['extra_headers']
+    assert call_kwargs['extra_headers']['User-Agent'] == f'openhands/{__version__}'


### PR DESCRIPTION
## Summary of PR

Passes User-Agent: openhands/{version} via extra_headers to LiteLLM so providers can identify traffic from OpenHands.

## Demo Screenshots/Videos

No demo secreenshot/video (human is writing this :P )

## Change Type

- [X] New feature

## Checklist

- [X] I have read and reviewed the code and I understand what the code is doing.
- [X] I have tested the code to the best of my ability and ensured it works as expected.
