### PR TITLE
fix(backend): update current_org_id when removing a member from an organization

### DIFF
--- a/enterprise/server/services/org_member_service.py
+++ b/enterprise/server/services/org_member_service.py
@@ -168,6 +168,12 @@ class OrgMemberService:
             if not success:
                 return False, 'removal_failed'
 
+            # Update user's current_org_id if it points to the org they were removed from
+            user = UserStore.get_user_by_id(str(target_user_id))
+            if user and user.current_org_id == org_id:
+                # Set current_org_id to personal workspace (org.id == user.id)
+                UserStore.update_current_org(str(target_user_id), target_user_id)
+
             return True, None
 
         return await call_sync_from_async(_remove_member)

--- a/enterprise/tests/unit/server/services/test_org_member_service.py
+++ b/enterprise/tests/unit/server/services/test_org_member_service.py
@@ -549,6 +549,9 @@ class TestOrgMemberServiceRemoveOrgMember:
             patch(
                 'server.services.org_member_service.OrgMemberStore.remove_user_from_org'
             ) as mock_remove,
+            patch(
+                'server.services.org_member_service.UserStore.get_user_by_id'
+            ) as mock_get_user,
         ):
             mock_get_member.side_effect = [
                 requester_membership_owner,
@@ -556,6 +559,7 @@ class TestOrgMemberServiceRemoveOrgMember:
             ]
             mock_get_role.side_effect = [owner_role, member_role]
             mock_remove.return_value = True
+            mock_get_user.return_value = None
 
             # Act
             success, error = await OrgMemberService.remove_org_member(
@@ -590,6 +594,9 @@ class TestOrgMemberServiceRemoveOrgMember:
             patch(
                 'server.services.org_member_service.OrgMemberStore.remove_user_from_org'
             ) as mock_remove,
+            patch(
+                'server.services.org_member_service.UserStore.get_user_by_id'
+            ) as mock_get_user,
         ):
             mock_get_member.side_effect = [
                 requester_membership_owner,
@@ -597,6 +604,7 @@ class TestOrgMemberServiceRemoveOrgMember:
             ]
             mock_get_role.side_effect = [owner_role, admin_role]
             mock_remove.return_value = True
+            mock_get_user.return_value = None
 
             # Act
             success, error = await OrgMemberService.remove_org_member(
@@ -630,6 +638,9 @@ class TestOrgMemberServiceRemoveOrgMember:
             patch(
                 'server.services.org_member_service.OrgMemberStore.remove_user_from_org'
             ) as mock_remove,
+            patch(
+                'server.services.org_member_service.UserStore.get_user_by_id'
+            ) as mock_get_user,
         ):
             mock_get_member.side_effect = [
                 requester_membership_admin,
@@ -637,6 +648,7 @@ class TestOrgMemberServiceRemoveOrgMember:
             ]
             mock_get_role.side_effect = [admin_role, member_role]
             mock_remove.return_value = True
+            mock_get_user.return_value = None
 
             # Act
             success, error = await OrgMemberService.remove_org_member(
@@ -927,6 +939,9 @@ class TestOrgMemberServiceRemoveOrgMember:
             patch(
                 'server.services.org_member_service.OrgMemberStore.remove_user_from_org'
             ) as mock_remove,
+            patch(
+                'server.services.org_member_service.UserStore.get_user_by_id'
+            ) as mock_get_user,
         ):
             mock_get_member.side_effect = [
                 requester_membership_owner,
@@ -940,6 +955,7 @@ class TestOrgMemberServiceRemoveOrgMember:
                 another_owner,
             ]
             mock_remove.return_value = True
+            mock_get_user.return_value = None
 
             # Act
             success, error = await OrgMemberService.remove_org_member(
@@ -989,6 +1005,159 @@ class TestOrgMemberServiceRemoveOrgMember:
             # Assert
             assert success is False
             assert error == 'removal_failed'
+
+    @pytest.mark.asyncio
+    async def test_remove_member_updates_current_org_id_when_matching(
+        self,
+        org_id,
+        current_user_id,
+        target_user_id,
+        requester_membership_owner,
+        target_membership_user,
+        owner_role,
+        member_role,
+    ):
+        """Test that current_org_id is updated to personal workspace when it matches removed org."""
+        # Arrange
+        mock_user = MagicMock(spec=User)
+        mock_user.current_org_id = (
+            org_id  # User's current org matches the org being removed
+        )
+
+        with (
+            patch(
+                'server.services.org_member_service.OrgMemberStore.get_org_member'
+            ) as mock_get_member,
+            patch(
+                'server.services.org_member_service.RoleStore.get_role_by_id'
+            ) as mock_get_role,
+            patch(
+                'server.services.org_member_service.OrgMemberStore.remove_user_from_org'
+            ) as mock_remove,
+            patch(
+                'server.services.org_member_service.UserStore.get_user_by_id'
+            ) as mock_get_user,
+            patch(
+                'server.services.org_member_service.UserStore.update_current_org'
+            ) as mock_update_org,
+        ):
+            mock_get_member.side_effect = [
+                requester_membership_owner,
+                target_membership_user,
+            ]
+            mock_get_role.side_effect = [owner_role, member_role]
+            mock_remove.return_value = True
+            mock_get_user.return_value = mock_user
+
+            # Act
+            success, error = await OrgMemberService.remove_org_member(
+                org_id, target_user_id, current_user_id
+            )
+
+            # Assert
+            assert success is True
+            assert error is None
+            mock_update_org.assert_called_once_with(str(target_user_id), target_user_id)
+
+    @pytest.mark.asyncio
+    async def test_remove_member_does_not_update_current_org_id_when_not_matching(
+        self,
+        org_id,
+        current_user_id,
+        target_user_id,
+        requester_membership_owner,
+        target_membership_user,
+        owner_role,
+        member_role,
+    ):
+        """Test that current_org_id is NOT updated when it differs from removed org."""
+        # Arrange
+        different_org_id = uuid.uuid4()
+        mock_user = MagicMock(spec=User)
+        mock_user.current_org_id = different_org_id  # User's current org is different
+
+        with (
+            patch(
+                'server.services.org_member_service.OrgMemberStore.get_org_member'
+            ) as mock_get_member,
+            patch(
+                'server.services.org_member_service.RoleStore.get_role_by_id'
+            ) as mock_get_role,
+            patch(
+                'server.services.org_member_service.OrgMemberStore.remove_user_from_org'
+            ) as mock_remove,
+            patch(
+                'server.services.org_member_service.UserStore.get_user_by_id'
+            ) as mock_get_user,
+            patch(
+                'server.services.org_member_service.UserStore.update_current_org'
+            ) as mock_update_org,
+        ):
+            mock_get_member.side_effect = [
+                requester_membership_owner,
+                target_membership_user,
+            ]
+            mock_get_role.side_effect = [owner_role, member_role]
+            mock_remove.return_value = True
+            mock_get_user.return_value = mock_user
+
+            # Act
+            success, error = await OrgMemberService.remove_org_member(
+                org_id, target_user_id, current_user_id
+            )
+
+            # Assert
+            assert success is True
+            assert error is None
+            mock_update_org.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_remove_member_succeeds_when_user_not_found_after_removal(
+        self,
+        org_id,
+        current_user_id,
+        target_user_id,
+        requester_membership_owner,
+        target_membership_user,
+        owner_role,
+        member_role,
+    ):
+        """Test that removal succeeds even if user lookup returns None after removal."""
+        # Arrange
+        with (
+            patch(
+                'server.services.org_member_service.OrgMemberStore.get_org_member'
+            ) as mock_get_member,
+            patch(
+                'server.services.org_member_service.RoleStore.get_role_by_id'
+            ) as mock_get_role,
+            patch(
+                'server.services.org_member_service.OrgMemberStore.remove_user_from_org'
+            ) as mock_remove,
+            patch(
+                'server.services.org_member_service.UserStore.get_user_by_id'
+            ) as mock_get_user,
+            patch(
+                'server.services.org_member_service.UserStore.update_current_org'
+            ) as mock_update_org,
+        ):
+            mock_get_member.side_effect = [
+                requester_membership_owner,
+                target_membership_user,
+            ]
+            mock_get_role.side_effect = [owner_role, member_role]
+            mock_remove.return_value = True
+            mock_get_user.return_value = None  # User not found
+
+            # Act
+            success, error = await OrgMemberService.remove_org_member(
+                org_id, target_user_id, current_user_id
+            )
+
+            # Assert
+            assert success is True
+            assert error is None
+            mock_update_org.assert_not_called()
 
 
 class TestOrgMemberServiceCanRemoveMember:


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

<!-- Summarize what the PR does -->

This update addresses an issue where a removed member’s current_org_id continued to reference the organization they were removed from. After the member is removed, if their current_org_id matches the removed organization, it is now updated to their personal workspace.

**Acceptance Criteria:**
- The issue where a removed member’s current_org_id remained associated with the removed organization is resolved.
- After a member is removed, if their current_org_id matches the removed organization, it is updated to the user’s personal workspace.

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

https://github.com/user-attachments/assets/5b259d1e-7d7d-41f6-9ed5-9788c33d85da

## Change Type

<!-- Choose the types that apply to your PR -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:b833458-nikolaik   --name openhands-app-b833458   docker.openhands.dev/openhands/openhands:b833458
```