### PR TITLE
Fix getGitPath to handle nested GitLab group paths

### DIFF
--- a/frontend/__tests__/utils/get-git-path.test.ts
+++ b/frontend/__tests__/utils/get-git-path.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { getGitPath } from "#/utils/get-git-path";
+
+describe("getGitPath", () => {
+  it("should return /workspace/project when no repository is selected", () => {
+    expect(getGitPath(null)).toBe("/workspace/project");
+    expect(getGitPath(undefined)).toBe("/workspace/project");
+  });
+
+  it("should handle standard owner/repo format (GitHub)", () => {
+    expect(getGitPath("OpenHands/OpenHands")).toBe("/workspace/project/OpenHands");
+    expect(getGitPath("facebook/react")).toBe("/workspace/project/react");
+  });
+
+  it("should handle nested group paths (GitLab)", () => {
+    expect(getGitPath("modernhealth/frontend-guild/pan")).toBe("/workspace/project/pan");
+    expect(getGitPath("group/subgroup/repo")).toBe("/workspace/project/repo");
+    expect(getGitPath("a/b/c/d/repo")).toBe("/workspace/project/repo");
+  });
+
+  it("should handle single segment paths", () => {
+    expect(getGitPath("repo")).toBe("/workspace/project/repo");
+  });
+
+  it("should handle empty string", () => {
+    expect(getGitPath("")).toBe("/workspace/project");
+  });
+});

--- a/frontend/src/utils/get-git-path.ts
+++ b/frontend/src/utils/get-git-path.ts
@@ -3,7 +3,7 @@
  * If a repository is selected, returns /workspace/project/{repo-name}
  * Otherwise, returns /workspace/project
  *
- * @param selectedRepository The selected repository (e.g., "OpenHands/OpenHands" or "owner/repo")
+ * @param selectedRepository The selected repository (e.g., "OpenHands/OpenHands", "owner/repo", or "group/subgroup/repo")
  * @returns The git path to use
  */
 export function getGitPath(
@@ -13,10 +13,10 @@ export function getGitPath(
     return "/workspace/project";
   }
 
-  // Extract the repository name from "owner/repo" format
-  // The folder name is the second part after "/"
+  // Extract the repository name from the path
+  // The folder name is always the last part (handles both "owner/repo" and "group/subgroup/repo" formats)
   const parts = selectedRepository.split("/");
-  const repoName = parts.length > 1 ? parts[1] : parts[0];
+  const repoName = parts[parts.length - 1];
 
   return `/workspace/project/${repoName}`;
 }


### PR DESCRIPTION
## Summary

Fixes the Changes tab 500 error when viewing repositories with nested GitLab group paths (e.g., `group/subgroup/repo`).

## Problem

The `getGitPath` function was incorrectly extracting the repository name from nested paths. For a repository like `modernhealth/frontend-guild/pan`, it took the second segment (`frontend-guild`) instead of the last segment (`pan`), resulting in the path `/workspace/project/frontend-guild` which doesn't exist.

## Solution

Changed the function to always use the last segment of the path, which is the actual repository name regardless of how many nested groups exist:

```typescript
// Before (broken for nested paths)
const repoName = parts.length > 1 ? parts[1] : parts[0];

// After (works for all path formats)
const repoName = parts[parts.length - 1];
```

## Testing

Added unit tests covering:
- Standard `owner/repo` format (GitHub)
- Nested group paths (GitLab)
- Single segment paths
- Null/undefined/empty inputs

Fixes #13005

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:90974d7-nikolaik   --name openhands-app-90974d7   docker.openhands.dev/openhands/openhands:90974d7
```