### PR TITLE
V1: avoid forwarding api_key for Bedrock models

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -73,6 +73,7 @@ from openhands.app_server.user.user_models import UserInfo
 from openhands.app_server.utils.docker_utils import (
     replace_localhost_hostname_for_docker,
 )
+from openhands.app_server.utils.litellm_provider import coerce_llm_api_key_for_model
 from openhands.app_server.utils.llm_metadata import (
     get_llm_metadata,
     should_set_litellm_extra_body,
@@ -688,10 +689,16 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         if model and model.startswith('openhands/'):
             base_url = user.llm_base_url or self.openhands_provider_base_url
 
+        api_key = coerce_llm_api_key_for_model(
+            api_key=user.llm_api_key,
+            model=model,
+            api_base=base_url,
+        )
+
         return LLM(
             model=model,
             base_url=base_url,
-            api_key=user.llm_api_key,
+            api_key=api_key,
             usage_id='agent',
         )
 

--- a/openhands/app_server/utils/litellm_provider.py
+++ b/openhands/app_server/utils/litellm_provider.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import warnings
+from typing import Any, cast
+
+from pydantic import SecretStr
+
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    import litellm
+
+
+def infer_litellm_provider(*, model: str, api_base: str | None) -> str | None:
+    """Infer the LiteLLM provider for a given model.
+
+    This delegates to LiteLLM's provider inference logic.
+    """
+    try:
+        get_llm_provider = cast(Any, litellm).get_llm_provider
+        _model, provider, _dynamic_key, _api_base = get_llm_provider(
+            model=model,
+            custom_llm_provider=None,
+            api_base=api_base,
+            api_key=None,
+        )
+    except Exception:
+        return None
+
+    return provider
+
+
+def coerce_llm_api_key_for_model(
+    *,
+    api_key: SecretStr | None,
+    model: str | None,
+    api_base: str | None,
+) -> SecretStr | None:
+    """Return an api_key value appropriate for the given model/provider.
+
+    For Bedrock models, LiteLLM treats api_key as an AWS bearer token. When using
+    IAM/SigV4 auth, this should be omitted.
+    """
+    if api_key is None or model is None:
+        return api_key
+
+    if infer_litellm_provider(model=model, api_base=api_base) == "bedrock":
+        return None
+
+    return api_key

--- a/tests/unit/test_litellm_provider_inference.py
+++ b/tests/unit/test_litellm_provider_inference.py
@@ -1,0 +1,28 @@
+from pydantic import SecretStr
+
+from openhands.app_server.utils.litellm_provider import (
+    coerce_llm_api_key_for_model,
+    infer_litellm_provider,
+)
+
+
+def test_infer_litellm_provider_bedrock_regional_model_id() -> None:
+    provider = infer_litellm_provider(
+        model="us.anthropic.claude-3-sonnet-20240229-v1:0",
+        api_base=None,
+    )
+    assert provider == "bedrock"
+
+
+def test_infer_litellm_provider_openai() -> None:
+    provider = infer_litellm_provider(model="gpt-4o-mini", api_base=None)
+    assert provider == "openai"
+
+
+def test_coerce_llm_api_key_for_bedrock_model() -> None:
+    forwarded_api_key = coerce_llm_api_key_for_model(
+        api_key=SecretStr("sk-not-a-bedrock-token"),
+        model="us.anthropic.claude-3-sonnet-20240229-v1:0",
+        api_base=None,
+    )
+    assert forwarded_api_key is None


### PR DESCRIPTION
### Problem
In the V1 app-server path (`openhands/app_server/...`), we build an SDK `LLM` by passing through `user.llm_api_key`.

LiteLLM treats the `api_key` parameter for Bedrock models as an AWS bearer token. If the user has a generic key saved (e.g. OpenAI/Anthropic) and selects a Bedrock model (including regional IDs like `us.anthropic...`), Bedrock can reject requests with:

`Invalid API Key format: Must start with pre-defined prefix`

### Fix
- Add a small helper that delegates provider inference to `litellm.get_llm_provider()`.
- When the inferred provider is `bedrock`, omit `api_key` when constructing the SDK `LLM`.

### Tests
- Added unit tests for provider inference and api_key coercion.

Co-authored-by: openhands <openhands@all-hands.dev>

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:f049e23-nikolaik   --name openhands-app-f049e23   docker.openhands.dev/openhands/openhands:f049e23
```