### PR TITLE
fix(frontend): resolve 403 error after organization deletion caused by stale cache race condition

### DIFF
--- a/frontend/src/hooks/mutation/use-delete-organization.ts
+++ b/frontend/src/hooks/mutation/use-delete-organization.ts
@@ -14,11 +14,22 @@ export const useDeleteOrganization = () => {
       return organizationService.deleteOrganization({ orgId: organizationId });
     },
     onSuccess: () => {
-      setOrganizationId(null);
-      queryClient.invalidateQueries({
+      // Remove stale cache BEFORE clearing the selected organization.
+      // This prevents useAutoSelectOrganization from using the old currentOrgId
+      // when it runs during the re-render triggered by setOrganizationId(null).
+      // Using removeQueries (not invalidateQueries) ensures stale data is gone immediately.
+      queryClient.removeQueries({
         queryKey: ["organizations"],
         exact: true,
       });
+      queryClient.removeQueries({
+        queryKey: ["organizations", organizationId],
+      });
+
+      // Now clear the selected organization - useAutoSelectOrganization will
+      // wait for fresh data since the cache is empty
+      setOrganizationId(null);
+
       navigate("/");
     },
   });


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

<!-- Summarize what the PR does -->

Fix race condition causing 403 error after organization deletion

When an organization is deleted, useAutoSelectOrganization was still running with a stale cached currentOrgId before the cache had been refreshed. As a result, the hook attempted to re-select the recently deleted organization, which triggered a 403 Forbidden error on GET /api/organizations/{deleted_org_id}.

This update addresses the issue by adjusting the order of operations and replacing invalidateQueries with removeQueries, ensuring that stale data is cleared before any state updates trigger re-renders.

Changes included:
- Fixed a race condition where useAutoSelectOrganization could use a stale currentOrgId after organization deletion
- Replaced invalidateQueries with removeQueries to immediately clear stale cache data
- Reordered operations to clear cache before triggering state update re-renders

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

https://github.com/user-attachments/assets/c43b56a5-d6e3-4c8d-9ed7-54434b3146c9

## Change Type

<!-- Choose the types that apply to your PR -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:cb1bd6d-nikolaik   --name openhands-app-cb1bd6d   docker.openhands.dev/openhands/openhands:cb1bd6d
```