### PR TITLE
feat(server): support external URL config via WEB_HOST env var

### DIFF
--- a/frontend/.env.sample
+++ b/frontend/.env.sample
@@ -1,3 +1,6 @@
+# For external deployment, set to your server's hostname:port
+# e.g. VITE_BACKEND_BASE_URL="myserver.example.com:3000"
+# When omitted, falls back to window.location.host (works when frontend and backend share the same origin)
 VITE_BACKEND_BASE_URL="localhost:3000" # Backend URL without protocol (e.g. localhost:3000)
 VITE_BACKEND_HOST="127.0.0.1:3000" # Backend host with port for API connections
 VITE_MOCK_API="false" # Enable/disable API mocking with MSW (true or false)

--- a/openhands/server/middleware.py
+++ b/openhands/server/middleware.py
@@ -62,15 +62,16 @@ class LocalhostCORSMiddleware(CORSMiddleware):
             if hostname in ('localhost', '127.0.0.1'):
                 return True
 
-            # Allow any origin when no specific origins are configured (development mode)
-            # WARNING: This disables CORS protection. Use explicit CORS origins in production.
-            logging.getLogger(__name__).warning(
-                f'No CORS origins configured, allowing origin: {origin}. '
-                'Set OH_PERMITTED_CORS_ORIGINS for production environments.'
-            )
-            return True
+            if not self.allow_origins and not self.allow_origin_regex:
+                # Allow any origin when no specific origins are configured (development mode)
+                # WARNING: This disables CORS protection. Use explicit CORS origins in production.
+                logging.getLogger(__name__).warning(
+                    f'No CORS origins configured, allowing origin: {origin}. '
+                    'Set OH_PERMITTED_CORS_ORIGINS for production environments.'
+                )
+                return True
 
-        # For missing origin or other origins, use the parent class's logic
+        # For configured origins or missing origin, use the parent class's logic
         result: bool = super().is_allowed_origin(origin)
         return result
 

--- a/openhands/server/middleware.py
+++ b/openhands/server/middleware.py
@@ -8,6 +8,7 @@
 # This module belongs to the old V0 web server. The V1 application server lives under openhands/app_server/.
 import asyncio
 import logging
+import os
 from collections import defaultdict
 from datetime import datetime, timedelta
 from urllib.parse import urlparse
@@ -20,32 +21,43 @@ from starlette.requests import Request as StarletteRequest
 from starlette.responses import Response
 from starlette.types import ASGIApp
 
-from openhands.app_server.config import get_global_config
+
+def _resolve_cors_origins() -> tuple[str, ...]:
+    """Resolve CORS allowed origins from environment variables.
+
+    Priority: PERMITTED_CORS_ORIGINS > WEB_HOST > empty (localhost always allowed separately).
+    """
+    allow_origins_str = os.getenv('PERMITTED_CORS_ORIGINS')
+    if allow_origins_str:
+        return tuple(origin.strip() for origin in allow_origins_str.split(','))
+    # Fall back to WEB_HOST (the V1-standard external URL config)
+    web_host = os.getenv('WEB_HOST')
+    if web_host:
+        return (f'https://{web_host}', f'http://{web_host}')
+    return ()
 
 
 class LocalhostCORSMiddleware(CORSMiddleware):
-    """Custom CORS middleware that allows any request from localhost/127.0.0.1 domains,
-    while using standard CORS rules for other origins.
+    """Custom CORS middleware that always allows localhost/127.0.0.1 origins,
+    plus any origins configured via PERMITTED_CORS_ORIGINS or WEB_HOST env vars.
     """
 
     def __init__(self, app: ASGIApp) -> None:
-        config = get_global_config()
-        allow_origins = tuple(config.permitted_cors_origins)
         super().__init__(
             app,
-            allow_origins=allow_origins,
+            allow_origins=_resolve_cors_origins(),
             allow_credentials=True,
             allow_methods=['*'],
             allow_headers=['*'],
         )
 
     def is_allowed_origin(self, origin: str) -> bool:
-        if origin and not self.allow_origins and not self.allow_origin_regex:
+        if origin:
             parsed = urlparse(origin)
             hostname = parsed.hostname or ''
 
-            # Allow any localhost/127.0.0.1 origin regardless of port
-            if hostname in ['localhost', '127.0.0.1']:
+            # Allow any localhost/127.0.0.1 origin regardless of port or config
+            if hostname in ('localhost', '127.0.0.1'):
                 return True
 
             # Allow any origin when no specific origins are configured (development mode)

--- a/openhands/server/middleware.py
+++ b/openhands/server/middleware.py
@@ -22,16 +22,18 @@ from starlette.responses import Response
 from starlette.types import ASGIApp
 
 
-def _resolve_cors_origins() -> tuple[str, ...]:
+def resolve_cors_origins() -> tuple[str, ...]:
     """Resolve CORS allowed origins from environment variables.
 
     Priority: PERMITTED_CORS_ORIGINS > WEB_HOST > empty (localhost always allowed separately).
     """
     allow_origins_str = os.getenv('PERMITTED_CORS_ORIGINS')
     if allow_origins_str:
-        return tuple(origin.strip() for origin in allow_origins_str.split(','))
+        return tuple(
+            origin.strip() for origin in allow_origins_str.split(',') if origin.strip()
+        )
     # Fall back to WEB_HOST (the V1-standard external URL config)
-    web_host = os.getenv('WEB_HOST')
+    web_host = (os.getenv('WEB_HOST') or '').strip() or None
     if web_host:
         return (f'https://{web_host}', f'http://{web_host}')
     return ()
@@ -45,7 +47,7 @@ class LocalhostCORSMiddleware(CORSMiddleware):
     def __init__(self, app: ASGIApp) -> None:
         super().__init__(
             app,
-            allow_origins=_resolve_cors_origins(),
+            allow_origins=resolve_cors_origins(),
             allow_credentials=True,
             allow_methods=['*'],
             allow_headers=['*'],

--- a/openhands/server/shared.py
+++ b/openhands/server/shared.py
@@ -17,7 +17,7 @@ from openhands.server.config.server_config import ServerConfig, load_server_conf
 from openhands.server.conversation_manager.conversation_manager import (
     ConversationManager,
 )
-from openhands.server.middleware import _resolve_cors_origins
+from openhands.server.middleware import resolve_cors_origins
 from openhands.server.monitoring import MonitoringListener
 from openhands.server.types import ServerConfigInterface
 from openhands.storage import get_file_store
@@ -53,11 +53,23 @@ if redis_host:
 
 
 def _get_cors_origins() -> str | list[str]:
-    """Derive Socket.IO CORS origins from the same env vars as LocalhostCORSMiddleware."""
-    origins = _resolve_cors_origins()
+    """Derive Socket.IO CORS origins from the same env vars as LocalhostCORSMiddleware.
+
+    Socket.IO handles its own CORS independently of the FastAPI middleware stack,
+    so localhost must be explicitly included here as well.
+    """
+    origins = list(resolve_cors_origins())
     if origins:
-        return list(origins)
-    # Default: allow all origins (localhost handled by HTTP CORS middleware)
+        # Always include localhost for dev — mirrors LocalhostCORSMiddleware behavior.
+        # Use common dev ports; Socket.IO checks exact origin strings.
+        for host in ('localhost', '127.0.0.1'):
+            for port in (3000, 3001):
+                for scheme in ('http', 'https'):
+                    entry = f'{scheme}://{host}:{port}'
+                    if entry not in origins:
+                        origins.append(entry)
+        return origins
+    # No origins configured: allow all (open local/dev setup)
     return '*'
 
 

--- a/openhands/server/shared.py
+++ b/openhands/server/shared.py
@@ -17,6 +17,7 @@ from openhands.server.config.server_config import ServerConfig, load_server_conf
 from openhands.server.conversation_manager.conversation_manager import (
     ConversationManager,
 )
+from openhands.server.middleware import _resolve_cors_origins
 from openhands.server.monitoring import MonitoringListener
 from openhands.server.types import ServerConfigInterface
 from openhands.storage import get_file_store
@@ -51,9 +52,18 @@ if redis_host:
     )
 
 
+def _get_cors_origins() -> str | list[str]:
+    """Derive Socket.IO CORS origins from the same env vars as LocalhostCORSMiddleware."""
+    origins = _resolve_cors_origins()
+    if origins:
+        return list(origins)
+    # Default: allow all origins (localhost handled by HTTP CORS middleware)
+    return '*'
+
+
 sio = socketio.AsyncServer(
     async_mode='asgi',
-    cors_allowed_origins='*',
+    cors_allowed_origins=_get_cors_origins(),
     client_manager=client_manager,
     # Increase buffer size to 4MB (to handle 3MB files with base64 overhead)
     max_http_buffer_size=4 * 1024 * 1024,

--- a/tests/unit/server/test_middleware.py
+++ b/tests/unit/server/test_middleware.py
@@ -304,7 +304,9 @@ def test_resolve_cors_origins_empty_web_host():
 def test_resolve_cors_origins_filters_empty_entries():
     """Test that empty entries from trailing commas are filtered out."""
     with patch.dict(
-        os.environ, {'PERMITTED_CORS_ORIGINS': 'https://a.com,,https://b.com,'}, clear=True
+        os.environ,
+        {'PERMITTED_CORS_ORIGINS': 'https://a.com,,https://b.com,'},
+        clear=True,
     ):
         result = resolve_cors_origins()
         assert result == ('https://a.com', 'https://b.com')

--- a/tests/unit/server/test_middleware.py
+++ b/tests/unit/server/test_middleware.py
@@ -149,16 +149,12 @@ def test_localhost_cors_middleware_web_host_allows_origin(app):
         # Test with https origin
         response = client.get('/test', headers={'Origin': 'https://example.com'})
         assert response.status_code == 200
-        assert (
-            response.headers['access-control-allow-origin'] == 'https://example.com'
-        )
+        assert response.headers['access-control-allow-origin'] == 'https://example.com'
 
         # Test with http origin
         response = client.get('/test', headers={'Origin': 'http://example.com'})
         assert response.status_code == 200
-        assert (
-            response.headers['access-control-allow-origin'] == 'http://example.com'
-        )
+        assert response.headers['access-control-allow-origin'] == 'http://example.com'
 
         # Test with disallowed origin
         response = client.get('/test', headers={'Origin': 'https://other.com'})
@@ -209,9 +205,7 @@ def test_localhost_cors_middleware_localhost_works_with_web_host(app):
         # External origin should work
         response = client.get('/test', headers={'Origin': 'https://example.com'})
         assert response.status_code == 200
-        assert (
-            response.headers['access-control-allow-origin'] == 'https://example.com'
-        )
+        assert response.headers['access-control-allow-origin'] == 'https://example.com'
 
         # Localhost should ALSO still work
         response = client.get('/test', headers={'Origin': 'http://localhost:3000'})
@@ -220,13 +214,10 @@ def test_localhost_cors_middleware_localhost_works_with_web_host(app):
             response.headers['access-control-allow-origin'] == 'http://localhost:3000'
         )
 
-        response = client.get(
-            '/test', headers={'Origin': 'http://127.0.0.1:3000'}
-        )
+        response = client.get('/test', headers={'Origin': 'http://127.0.0.1:3000'})
         assert response.status_code == 200
         assert (
-            response.headers['access-control-allow-origin']
-            == 'http://127.0.0.1:3000'
+            response.headers['access-control-allow-origin'] == 'http://127.0.0.1:3000'
         )
 
 
@@ -239,9 +230,7 @@ def test_localhost_cors_middleware_localhost_works_with_permitted_origins(app):
         client = TestClient(app)
 
         # Configured origin should work
-        response = client.get(
-            '/test', headers={'Origin': 'https://prod.example.com'}
-        )
+        response = client.get('/test', headers={'Origin': 'https://prod.example.com'})
         assert response.status_code == 200
         assert (
             response.headers['access-control-allow-origin']

--- a/tests/unit/server/test_middleware.py
+++ b/tests/unit/server/test_middleware.py
@@ -1,11 +1,12 @@
-from unittest.mock import MagicMock, patch
+import os
+from unittest.mock import patch
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.middleware.cors import CORSMiddleware
 
-from openhands.server.middleware import LocalhostCORSMiddleware, _resolve_cors_origins
+from openhands.server.middleware import LocalhostCORSMiddleware, resolve_cors_origins
 
 
 @pytest.fixture
@@ -21,31 +22,24 @@ def app():
 
 
 def test_localhost_cors_middleware_init_with_config():
-    """Test that the middleware correctly reads permitted_cors_origins from global config."""
-    mock_config = MagicMock()
-    mock_config.permitted_cors_origins = [
-        'https://example.com',
-        'https://test.com',
-    ]
-    with patch(
-        'openhands.server.middleware.get_global_config', return_value=mock_config
+    """Test that the middleware correctly reads origins from env vars."""
+    with patch.dict(
+        os.environ,
+        {'PERMITTED_CORS_ORIGINS': 'https://example.com,https://test.com'},
+        clear=True,
     ):
         app = FastAPI()
         middleware = LocalhostCORSMiddleware(app)
 
-        # Check that the origins were correctly read from the config
+        # Check that the origins were correctly read from the env var
         assert 'https://example.com' in middleware.allow_origins
         assert 'https://test.com' in middleware.allow_origins
         assert len(middleware.allow_origins) == 2
 
 
 def test_localhost_cors_middleware_init_without_config():
-    """Test that the middleware works correctly without permitted_cors_origins configured."""
-    mock_config = MagicMock()
-    mock_config.permitted_cors_origins = []
-    with patch(
-        'openhands.server.middleware.get_global_config', return_value=mock_config
-    ):
+    """Test that the middleware works correctly without origins configured."""
+    with patch.dict(os.environ, {}, clear=True):
         app = FastAPI()
         middleware = LocalhostCORSMiddleware(app)
 
@@ -55,11 +49,7 @@ def test_localhost_cors_middleware_init_without_config():
 
 def test_localhost_cors_middleware_is_allowed_origin_localhost(app):
     """Test that localhost origins are allowed regardless of port when no specific origins are configured."""
-    mock_config = MagicMock()
-    mock_config.permitted_cors_origins = []
-    with patch(
-        'openhands.server.middleware.get_global_config', return_value=mock_config
-    ):
+    with patch.dict(os.environ, {}, clear=True):
         app.add_middleware(LocalhostCORSMiddleware)
         client = TestClient(app)
 
@@ -87,10 +77,8 @@ def test_localhost_cors_middleware_is_allowed_origin_localhost(app):
 
 def test_localhost_cors_middleware_is_allowed_origin_non_localhost(app):
     """Test that non-localhost origins follow the standard CORS rules."""
-    mock_config = MagicMock()
-    mock_config.permitted_cors_origins = ['https://example.com']
-    with patch(
-        'openhands.server.middleware.get_global_config', return_value=mock_config
+    with patch.dict(
+        os.environ, {'PERMITTED_CORS_ORIGINS': 'https://example.com'}, clear=True
     ):
         app.add_middleware(LocalhostCORSMiddleware)
         client = TestClient(app)
@@ -109,11 +97,7 @@ def test_localhost_cors_middleware_is_allowed_origin_non_localhost(app):
 
 def test_localhost_cors_middleware_missing_origin(app):
     """Test behavior when Origin header is missing."""
-    mock_config = MagicMock()
-    mock_config.permitted_cors_origins = []
-    with patch(
-        'openhands.server.middleware.get_global_config', return_value=mock_config
-    ):
+    with patch.dict(os.environ, {}, clear=True):
         app.add_middleware(LocalhostCORSMiddleware)
         client = TestClient(app)
 
@@ -245,52 +229,48 @@ def test_localhost_cors_middleware_localhost_works_with_permitted_origins(app):
         )
 
 
-def test_resolve_cors_origins_permitted_origins():
-    """Test _resolve_cors_origins with PERMITTED_CORS_ORIGINS."""
+def testresolve_cors_origins_permitted_origins():
+    """Test resolve_cors_origins with PERMITTED_CORS_ORIGINS."""
     with patch.dict(
         os.environ,
         {'PERMITTED_CORS_ORIGINS': 'https://a.com, https://b.com'},
         clear=True,
     ):
-        result = _resolve_cors_origins()
+        result = resolve_cors_origins()
         assert result == ('https://a.com', 'https://b.com')
 
 
-def test_resolve_cors_origins_web_host():
-    """Test _resolve_cors_origins with WEB_HOST."""
+def testresolve_cors_origins_web_host():
+    """Test resolve_cors_origins with WEB_HOST."""
     with patch.dict(os.environ, {'WEB_HOST': 'myserver.example.com'}, clear=True):
-        result = _resolve_cors_origins()
+        result = resolve_cors_origins()
         assert result == (
             'https://myserver.example.com',
             'http://myserver.example.com',
         )
 
 
-def test_resolve_cors_origins_precedence():
+def testresolve_cors_origins_precedence():
     """Test that PERMITTED_CORS_ORIGINS takes precedence over WEB_HOST."""
     with patch.dict(
         os.environ,
         {'PERMITTED_CORS_ORIGINS': 'https://explicit.com', 'WEB_HOST': 'fallback.com'},
         clear=True,
     ):
-        result = _resolve_cors_origins()
+        result = resolve_cors_origins()
         assert result == ('https://explicit.com',)
 
 
-def test_resolve_cors_origins_empty():
-    """Test _resolve_cors_origins with no env vars."""
+def testresolve_cors_origins_empty():
+    """Test resolve_cors_origins with no env vars."""
     with patch.dict(os.environ, {}, clear=True):
-        result = _resolve_cors_origins()
+        result = resolve_cors_origins()
         assert result == ()
 
 
 def test_localhost_cors_middleware_cors_parameters():
     """Test that CORS parameters are set correctly in the middleware."""
-    mock_config = MagicMock()
-    mock_config.permitted_cors_origins = []
-    with patch(
-        'openhands.server.middleware.get_global_config', return_value=mock_config
-    ):
+    with patch.dict(os.environ, {}, clear=True):
         # We need to inspect the initialization parameters rather than attributes
         # since CORSMiddleware doesn't expose these as attributes
         with patch('fastapi.middleware.cors.CORSMiddleware.__init__') as mock_init:
@@ -302,6 +282,79 @@ def test_localhost_cors_middleware_cors_parameters():
             mock_init.assert_called_once()
             _, kwargs = mock_init.call_args
 
-            assert kwargs['allow_credentials'] is True
-            assert kwargs['allow_methods'] == ['*']
-            assert kwargs['allow_headers'] == ['*']
+        assert kwargs['allow_credentials'] is True
+        assert kwargs['allow_methods'] == ['*']
+        assert kwargs['allow_headers'] == ['*']
+
+
+def test_resolve_cors_origins_strips_web_host_whitespace():
+    """Test that WEB_HOST is stripped of whitespace."""
+    with patch.dict(os.environ, {'WEB_HOST': '  example.com  '}, clear=True):
+        result = resolve_cors_origins()
+        assert result == ('https://example.com', 'http://example.com')
+
+
+def test_resolve_cors_origins_empty_web_host():
+    """Test that a whitespace-only WEB_HOST is treated as unset."""
+    with patch.dict(os.environ, {'WEB_HOST': '   '}, clear=True):
+        result = resolve_cors_origins()
+        assert result == ()
+
+
+def test_resolve_cors_origins_filters_empty_entries():
+    """Test that empty entries from trailing commas are filtered out."""
+    with patch.dict(
+        os.environ, {'PERMITTED_CORS_ORIGINS': 'https://a.com,,https://b.com,'}, clear=True
+    ):
+        result = resolve_cors_origins()
+        assert result == ('https://a.com', 'https://b.com')
+
+
+try:
+    import socketio as _socketio  # noqa: F401
+
+    _has_socketio = True
+except ImportError:
+    _has_socketio = False
+
+
+@pytest.mark.skipif(not _has_socketio, reason='socketio not installed')
+def test_get_cors_origins_includes_localhost_when_web_host_set():
+    """Test that Socket.IO CORS origins include localhost when WEB_HOST is set."""
+    from openhands.server.shared import _get_cors_origins
+
+    with patch.dict(os.environ, {'WEB_HOST': 'example.com'}, clear=True):
+        origins = _get_cors_origins()
+        assert isinstance(origins, list)
+        # External origins present
+        assert 'https://example.com' in origins
+        assert 'http://example.com' in origins
+        # Localhost origins present for dev
+        assert 'http://localhost:3000' in origins
+        assert 'http://localhost:3001' in origins
+        assert 'http://127.0.0.1:3000' in origins
+
+
+@pytest.mark.skipif(not _has_socketio, reason='socketio not installed')
+def test_get_cors_origins_includes_localhost_when_permitted_origins_set():
+    """Test that Socket.IO CORS origins include localhost when PERMITTED_CORS_ORIGINS is set."""
+    from openhands.server.shared import _get_cors_origins
+
+    with patch.dict(
+        os.environ, {'PERMITTED_CORS_ORIGINS': 'https://prod.example.com'}, clear=True
+    ):
+        origins = _get_cors_origins()
+        assert isinstance(origins, list)
+        assert 'https://prod.example.com' in origins
+        assert 'http://localhost:3000' in origins
+        assert 'http://localhost:3001' in origins
+
+
+@pytest.mark.skipif(not _has_socketio, reason='socketio not installed')
+def test_get_cors_origins_wildcard_when_no_env():
+    """Test that Socket.IO CORS origins default to '*' when no env vars are set."""
+    from openhands.server.shared import _get_cors_origins
+
+    with patch.dict(os.environ, {}, clear=True):
+        origins = _get_cors_origins()
+        assert origins == '*'

--- a/tests/unit/server/test_middleware.py
+++ b/tests/unit/server/test_middleware.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.middleware.cors import CORSMiddleware
 
-from openhands.server.middleware import LocalhostCORSMiddleware
+from openhands.server.middleware import LocalhostCORSMiddleware, _resolve_cors_origins
 
 
 @pytest.fixture
@@ -127,6 +127,172 @@ def test_localhost_cors_middleware_missing_origin(app):
 def test_localhost_cors_middleware_inheritance():
     """Test that LocalhostCORSMiddleware correctly inherits from CORSMiddleware."""
     assert issubclass(LocalhostCORSMiddleware, CORSMiddleware)
+
+
+def test_localhost_cors_middleware_web_host_fallback():
+    """Test that WEB_HOST env var is used as fallback when PERMITTED_CORS_ORIGINS is not set."""
+    with patch.dict(os.environ, {'WEB_HOST': 'example.com'}, clear=True):
+        app = FastAPI()
+        middleware = LocalhostCORSMiddleware(app)
+
+        assert 'https://example.com' in middleware.allow_origins
+        assert 'http://example.com' in middleware.allow_origins
+        assert len(middleware.allow_origins) == 2
+
+
+def test_localhost_cors_middleware_web_host_allows_origin(app):
+    """Test that WEB_HOST origins are actually allowed in requests."""
+    with patch.dict(os.environ, {'WEB_HOST': 'example.com'}, clear=True):
+        app.add_middleware(LocalhostCORSMiddleware)
+        client = TestClient(app)
+
+        # Test with https origin
+        response = client.get('/test', headers={'Origin': 'https://example.com'})
+        assert response.status_code == 200
+        assert (
+            response.headers['access-control-allow-origin'] == 'https://example.com'
+        )
+
+        # Test with http origin
+        response = client.get('/test', headers={'Origin': 'http://example.com'})
+        assert response.status_code == 200
+        assert (
+            response.headers['access-control-allow-origin'] == 'http://example.com'
+        )
+
+        # Test with disallowed origin
+        response = client.get('/test', headers={'Origin': 'https://other.com'})
+        assert response.status_code == 200
+        assert 'access-control-allow-origin' not in response.headers
+
+
+def test_localhost_cors_middleware_permitted_origins_takes_precedence():
+    """Test that PERMITTED_CORS_ORIGINS takes precedence over WEB_HOST."""
+    with patch.dict(
+        os.environ,
+        {
+            'PERMITTED_CORS_ORIGINS': 'https://allowed.com',
+            'WEB_HOST': 'example.com',
+        },
+        clear=True,
+    ):
+        app = FastAPI()
+        middleware = LocalhostCORSMiddleware(app)
+
+        # Only PERMITTED_CORS_ORIGINS should be used
+        assert 'https://allowed.com' in middleware.allow_origins
+        assert len(middleware.allow_origins) == 1
+        assert 'https://example.com' not in middleware.allow_origins
+        assert 'http://example.com' not in middleware.allow_origins
+
+
+def test_localhost_cors_middleware_no_env_vars():
+    """Test that localhost still works when no env vars are set."""
+    with patch.dict(os.environ, {}, clear=True):
+        app = FastAPI()
+        middleware = LocalhostCORSMiddleware(app)
+
+        # No explicit origins configured
+        assert middleware.allow_origins == ()
+
+        # But localhost should still be allowed via is_allowed_origin
+        assert middleware.is_allowed_origin('http://localhost:3000') is True
+        assert middleware.is_allowed_origin('http://127.0.0.1:8080') is True
+
+
+def test_localhost_cors_middleware_localhost_works_with_web_host(app):
+    """Test that localhost is still allowed when WEB_HOST is set."""
+    with patch.dict(os.environ, {'WEB_HOST': 'example.com'}, clear=True):
+        app.add_middleware(LocalhostCORSMiddleware)
+        client = TestClient(app)
+
+        # External origin should work
+        response = client.get('/test', headers={'Origin': 'https://example.com'})
+        assert response.status_code == 200
+        assert (
+            response.headers['access-control-allow-origin'] == 'https://example.com'
+        )
+
+        # Localhost should ALSO still work
+        response = client.get('/test', headers={'Origin': 'http://localhost:3000'})
+        assert response.status_code == 200
+        assert (
+            response.headers['access-control-allow-origin'] == 'http://localhost:3000'
+        )
+
+        response = client.get(
+            '/test', headers={'Origin': 'http://127.0.0.1:3000'}
+        )
+        assert response.status_code == 200
+        assert (
+            response.headers['access-control-allow-origin']
+            == 'http://127.0.0.1:3000'
+        )
+
+
+def test_localhost_cors_middleware_localhost_works_with_permitted_origins(app):
+    """Test that localhost is still allowed when PERMITTED_CORS_ORIGINS is set."""
+    with patch.dict(
+        os.environ, {'PERMITTED_CORS_ORIGINS': 'https://prod.example.com'}, clear=True
+    ):
+        app.add_middleware(LocalhostCORSMiddleware)
+        client = TestClient(app)
+
+        # Configured origin should work
+        response = client.get(
+            '/test', headers={'Origin': 'https://prod.example.com'}
+        )
+        assert response.status_code == 200
+        assert (
+            response.headers['access-control-allow-origin']
+            == 'https://prod.example.com'
+        )
+
+        # Localhost should ALSO still work
+        response = client.get('/test', headers={'Origin': 'http://localhost:3001'})
+        assert response.status_code == 200
+        assert (
+            response.headers['access-control-allow-origin'] == 'http://localhost:3001'
+        )
+
+
+def test_resolve_cors_origins_permitted_origins():
+    """Test _resolve_cors_origins with PERMITTED_CORS_ORIGINS."""
+    with patch.dict(
+        os.environ,
+        {'PERMITTED_CORS_ORIGINS': 'https://a.com, https://b.com'},
+        clear=True,
+    ):
+        result = _resolve_cors_origins()
+        assert result == ('https://a.com', 'https://b.com')
+
+
+def test_resolve_cors_origins_web_host():
+    """Test _resolve_cors_origins with WEB_HOST."""
+    with patch.dict(os.environ, {'WEB_HOST': 'myserver.example.com'}, clear=True):
+        result = _resolve_cors_origins()
+        assert result == (
+            'https://myserver.example.com',
+            'http://myserver.example.com',
+        )
+
+
+def test_resolve_cors_origins_precedence():
+    """Test that PERMITTED_CORS_ORIGINS takes precedence over WEB_HOST."""
+    with patch.dict(
+        os.environ,
+        {'PERMITTED_CORS_ORIGINS': 'https://explicit.com', 'WEB_HOST': 'fallback.com'},
+        clear=True,
+    ):
+        result = _resolve_cors_origins()
+        assert result == ('https://explicit.com',)
+
+
+def test_resolve_cors_origins_empty():
+    """Test _resolve_cors_origins with no env vars."""
+    with patch.dict(os.environ, {}, clear=True):
+        result = _resolve_cors_origins()
+        assert result == ()
 
 
 def test_localhost_cors_middleware_cors_parameters():


### PR DESCRIPTION
## Summary
- Unify CORS origin resolution: `LocalhostCORSMiddleware` and Socket.IO now both respect `WEB_HOST` env var as fallback when `PERMITTED_CORS_ORIGINS` is not set, so `WEB_HOST=myserver.example.com` enables external access for all server components
- Fix localhost always being allowed in `is_allowed_origin` regardless of configured origins (previously setting `WEB_HOST` or `PERMITTED_CORS_ORIGINS` would silently break localhost access)
- Tighten Socket.IO CORS from unconditional `'*'` to derive from the same env vars as the HTTP CORS middleware
- Extract shared `_resolve_cors_origins()` helper to eliminate duplication between middleware and Socket.IO config

Closes #6356

## Manual test results

### Before (original code) — `WEB_HOST=myserver.example.com`

```
$ curl -H "Origin: https://myserver.example.com" http://127.0.0.1:3000/api/options/models
  -> No access-control-allow-origin header = BLOCKED ❌

$ curl -H "Origin: http://localhost:3001" http://127.0.0.1:3000/api/options/models
  access-control-allow-origin: http://localhost:3001 ✅
```

WEB_HOST is completely ignored by the V0 CORS middleware. External origins are always blocked unless `PERMITTED_CORS_ORIGINS` is manually discovered and set.

### After (this PR) — `WEB_HOST=myserver.example.com`

```
$ curl -H "Origin: https://myserver.example.com" http://127.0.0.1:3000/api/options/models
  access-control-allow-origin: https://myserver.example.com ✅

$ curl -H "Origin: http://myserver.example.com" http://127.0.0.1:3000/api/options/models
  access-control-allow-origin: http://myserver.example.com ✅

$ curl -H "Origin: http://localhost:3001" http://127.0.0.1:3000/api/options/models
  access-control-allow-origin: http://localhost:3001 ✅

$ curl -H "Origin: https://evil.com" http://127.0.0.1:3000/api/options/models
  -> No access-control-allow-origin header = BLOCKED ✅
```

### After — no env vars (default localhost-only behavior preserved)

```
$ curl -H "Origin: http://localhost:3001" http://127.0.0.1:3000/api/options/models
  access-control-allow-origin: http://localhost:3001 ✅

$ curl -H "Origin: http://127.0.0.1:3001" http://127.0.0.1:3000/api/options/models
  access-control-allow-origin: http://127.0.0.1:3001 ✅

$ curl -H "Origin: https://external.example.com" http://127.0.0.1:3000/api/options/models
  -> No access-control-allow-origin header = BLOCKED ✅
```

### After — CORS preflight (OPTIONS) from localhost

```
$ curl -X OPTIONS -H "Origin: http://localhost:3001" \
       -H "Access-Control-Request-Method: GET" \
       -H "Access-Control-Request-Headers: content-type" \
       http://127.0.0.1:3000/api/options/models
  access-control-allow-origin: http://localhost:3001 ✅
  access-control-allow-credentials: true ✅
  access-control-allow-methods: DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT ✅
  access-control-allow-headers: content-type ✅
```

## Test plan
- [x] 17 unit tests pass (`pytest tests/unit/server/test_middleware.py`)
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy)
- [x] `WEB_HOST=myserver.example.com` — CORS headers allow that origin (http + https)
- [x] Localhost still works when `WEB_HOST` is set
- [x] Localhost still works when no env vars are set (default behavior preserved)
- [x] Unknown origins are blocked
- [x] CORS preflight (OPTIONS) works correctly