### PR TITLE
fix: validate base_url to reject API endpoint paths (#13079)

### DIFF
--- a/openhands/core/config/llm_config.py
+++ b/openhands/core/config/llm_config.py
@@ -10,7 +10,14 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr, ValidationError
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    ValidationError,
+    field_validator,
+)
 
 from openhands.core.logger import LOG_DIR
 from openhands.core.logger import openhands_logger as logger
@@ -110,6 +117,41 @@ class LLMConfig(BaseModel):
     )
 
     model_config = ConfigDict(extra='forbid')
+
+    @field_validator('base_url')
+    @classmethod
+    def validate_base_url_not_endpoint(cls, v: str | None) -> str | None:
+        """Reject base_url values that include API endpoint paths.
+
+        Users sometimes paste the full endpoint URL (e.g.
+        ``https://proxy.example.com/v1/chat/completions``) instead of just the
+        base (``https://proxy.example.com/v1``).  LiteLLM appends the endpoint
+        path automatically, so including it in base_url causes a cryptic 404.
+        """
+        if v is None:
+            return v
+
+        url = v.rstrip('/')
+
+        # Known API endpoint suffixes that LiteLLM appends automatically.
+        invalid_suffixes = [
+            '/chat/completions',
+            '/completions',
+            '/messages',
+            '/embeddings',
+        ]
+
+        url_lower = url.lower()
+        for suffix in invalid_suffixes:
+            if url_lower.endswith(suffix):
+                suggested_url = url[: len(url) - len(suffix)] or url
+                raise ValueError(
+                    f'base_url should not include the API endpoint path '
+                    f'"{suffix}". Use only the base URL, e.g., '
+                    f'"{suggested_url}".'
+                )
+
+        return v
 
     @classmethod
     def from_toml_section(cls, data: dict) -> dict[str, LLMConfig]:

--- a/openhands/storage/data_models/settings.py
+++ b/openhands/storage/data_models/settings.py
@@ -115,6 +115,12 @@ class Settings(BaseModel):
         data['secret_store'] = secret_store
         return data
 
+    @field_validator('llm_base_url')
+    @classmethod
+    def validate_llm_base_url_not_endpoint(cls, v: str | None) -> str | None:
+        """Delegate to LLMConfig's base_url validator."""
+        return LLMConfig.validate_base_url_not_endpoint(v)
+
     @field_validator('condenser_max_size')
     @classmethod
     def validate_condenser_max_size(cls, v: int | None) -> int | None:

--- a/tests/unit/core/config/test_llm_config.py
+++ b/tests/unit/core/config/test_llm_config.py
@@ -1,8 +1,10 @@
 import pathlib
 
 import pytest
+from pydantic import ValidationError
 
 from openhands.core.config import OpenHandsConfig
+from openhands.core.config.llm_config import LLMConfig
 from openhands.core.config.utils import load_from_toml
 
 
@@ -254,3 +256,79 @@ api_key = "test-api-key"
     non_azure_llm = default_config.get_llm_config('llm')
     assert non_azure_llm.model == 'anthropic/claude-3-sonnet'
     assert non_azure_llm.api_version is None
+
+
+# ---------------------------------------------------------------------------
+# base_url validation tests (issue #13079)
+# ---------------------------------------------------------------------------
+
+
+class TestBaseUrlValidation:
+    """Test that base_url rejects API endpoint paths."""
+
+    @pytest.mark.parametrize(
+        'bad_url, suffix',
+        [
+            ('https://proxy.example.com/v1/chat/completions', '/chat/completions'),
+            ('https://proxy.example.com/chat/completions', '/chat/completions'),
+            ('https://proxy.example.com/v1/completions', '/completions'),
+            ('https://proxy.example.com/v1/messages', '/messages'),
+            ('https://proxy.example.com/v1/embeddings', '/embeddings'),
+            # Trailing slash should still be caught
+            ('https://proxy.example.com/v1/chat/completions/', '/chat/completions'),
+            # Case-insensitive
+            ('https://proxy.example.com/V1/Chat/Completions', '/chat/completions'),
+        ],
+    )
+    def test_rejects_endpoint_paths(self, bad_url: str, suffix: str):
+        with pytest.raises(
+            ValidationError, match='should not include the API endpoint path'
+        ):
+            LLMConfig(model='test-model', base_url=bad_url)
+
+    @pytest.mark.parametrize(
+        'good_url',
+        [
+            'https://proxy.example.com/v1',
+            'https://proxy.example.com',
+            'https://api.openai.com/v1',
+            'https://api.anthropic.com',
+            'http://localhost:4000',
+            'http://localhost:11434',
+            None,
+        ],
+    )
+    def test_accepts_valid_base_urls(self, good_url: str | None):
+        config = LLMConfig(model='test-model', base_url=good_url)
+        assert config.base_url == good_url
+
+    def test_error_message_suggests_correct_url(self):
+        with pytest.raises(ValidationError) as exc_info:
+            LLMConfig(
+                model='test-model',
+                base_url='https://my-proxy.com/v1/chat/completions',
+            )
+        error_msg = str(exc_info.value)
+        assert 'https://my-proxy.com/v1' in error_msg
+
+    def test_toml_with_invalid_base_url(
+        self, default_config: OpenHandsConfig, tmp_path: pathlib.Path
+    ):
+        """Config loading with an invalid base_url should fall back to defaults."""
+        toml_content = """
+[core]
+workspace_base = "./workspace"
+
+[llm]
+model = "test-model"
+api_key = "test-key"
+base_url = "https://proxy.example.com/v1/chat/completions"
+        """
+        toml_file = tmp_path / 'bad_base_url.toml'
+        toml_file.write_text(toml_content)
+
+        load_from_toml(default_config, str(toml_file))
+
+        # The invalid config should be rejected, falling back to defaults
+        llm = default_config.get_llm_config('llm')
+        assert llm.base_url is None  # default


### PR DESCRIPTION
## Summary
- Add `field_validator` on `LLMConfig.base_url` that rejects URLs ending with known API endpoint paths (`/chat/completions`, `/completions`, `/messages`, `/embeddings`) with a clear error message suggesting the correct base URL
- Add matching validator on `Settings.llm_base_url` to catch invalid URLs from the web UI
- Add 16 parametrized tests covering invalid/valid URLs, case-insensitivity, trailing slashes, error message content, and TOML config fallback

## Context
Users can configure `base_url` with a complete API endpoint path (e.g., `https://api.openai.com/v1/chat/completions`) without receiving validation errors. LiteLLM automatically appends the endpoint path, so including it in `base_url` results in a doubled path and a cryptic `litellm.NotFoundError` 404 with no useful debugging info.

Now users get a clear validation error like:
