### PR TITLE
fix: exclude unused pypdf2 transitive dependency (CVE-2023-36464) (#1…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,3 +316,8 @@ lint.pydocstyle.convention = "google"
 concurrency = [ "gevent" ]
 relative_files = true
 omit = [ "enterprise/tests/*", "**/test_*" ]
+
+[tool.uv]
+# Exclude pypdf2 — unused transitive dependency from archived openhands-aci (CVE-2023-36464).
+# openhands-aci already ships pypdf (the modern replacement) which is what the code actually uses.
+override-dependencies = [ "pypdf2 ; python_version < '0'" ]


### PR DESCRIPTION
## Summary
- Add `[tool.uv]` override to exclude `pypdf2` from the dependency tree
- `pypdf2` is an unused transitive dependency pulled in by the archived `openhands-aci` package (v0.3.2)
- It contains CVE-2023-36464 with no fix available (project is deprecated)
- The codebase uses `pypdf` (the modern replacement), which is already a direct dependency
- Zero imports of `pypdf2`/`PyPDF2` exist anywhere in the codebase

## Context
The `openhands-aci` package declares both `pypdf` and `pypdf2` as dependencies, but only `pypdf` is actually used. Since the `openhands-aci` repository is archived and can't be updated, this override prevents the vulnerable `pypdf2` from being installed via `uv`.

## Test plan
- [x] Verified zero `pypdf2`/`PyPDF2` imports in codebase
- [x] `pypdf` (modern replacement) remains as direct dependency
- [ ] `uv lock` should no longer include `pypdf2`

Fixes #13080

