### PR TITLE
feat: add Avian as LLM provider

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -227,6 +227,13 @@ model = "gpt-4o"
 #for_routing = true
 #max_input_tokens = 128000
 
+# Example Avian LLM configuration (OpenAI-compatible API)
+# Get your API key at https://avian.io
+#[llm.avian]
+#model = "avian/deepseek/deepseek-v3.2"
+#api_key = ""
+#base_url = "https://api.avian.io/v1"
+
 
 #################################### Agent ###################################
 # Configuration for agents (group name starts with 'agent')

--- a/frontend/__tests__/utils/map-provider.test.ts
+++ b/frontend/__tests__/utils/map-provider.test.ts
@@ -25,4 +25,5 @@ test("mapProvider", () => {
   expect(mapProvider("voyage")).toBe("Voyage AI");
   expect(mapProvider("openrouter")).toBe("OpenRouter");
   expect(mapProvider("clarifai")).toBe("Clarifai");
+  expect(mapProvider("avian")).toBe("Avian");
 });

--- a/frontend/src/utils/map-provider.ts
+++ b/frontend/src/utils/map-provider.ts
@@ -26,6 +26,7 @@ export const MAP_PROVIDER = {
   openhands: "OpenHands",
   lemonade: "Lemonade",
   clarifai: "Clarifai",
+  avian: "Avian",
 };
 
 export const mapProvider = (provider: string) =>

--- a/frontend/src/utils/verified-models.ts
+++ b/frontend/src/utils/verified-models.ts
@@ -6,6 +6,7 @@ export const VERIFIED_PROVIDERS = [
   "mistral",
   "lemonade",
   "clarifai",
+  "avian",
 ];
 export const VERIFIED_MODELS = [
   "claude-opus-4-5-20251101",

--- a/openhands/utils/llm.py
+++ b/openhands/utils/llm.py
@@ -43,6 +43,14 @@ CLARIFAI_MODELS = [
     'clarifai/moonshotai.kimi.Kimi-K2-Instruct',
 ]
 
+# Avian provider models (OpenAI-compatible API at https://api.avian.io/v1)
+AVIAN_MODELS = [
+    'avian/deepseek/deepseek-v3.2',
+    'avian/moonshotai/kimi-k2.5',
+    'avian/z-ai/glm-5',
+    'avian/minimax/minimax-m2.5',
+]
+
 
 def is_openhands_model(model: str | None) -> bool:
     """Check if the model uses the OpenHands provider.
@@ -151,6 +159,6 @@ def get_supported_llm_models(
 
     # Use database-backed models if provided (SaaS), otherwise use hardcoded list
     openhands_models = verified_models if verified_models else OPENHANDS_MODELS
-    model_list = openhands_models + CLARIFAI_MODELS + model_list
+    model_list = openhands_models + CLARIFAI_MODELS + AVIAN_MODELS + model_list
 
     return sorted(set(model_list))


### PR DESCRIPTION
## Summary
- Add [Avian](https://avian.io) as an LLM provider for OpenHands
- Avian provides an OpenAI-compatible API (`https://api.avian.io/v1`) with Bearer token authentication via `AVIAN_API_KEY`
- Available models: DeepSeek V3.2 (164K context), Kimi K2.5 (131K context), GLM-5 (131K context), MiniMax M2.5 (1M context)
- Follows the same integration pattern as Clarifai (#11324) and Lemonade (#11181)

## Changes
- **`openhands/utils/llm.py`**: Add `AVIAN_MODELS` list and include in `get_supported_llm_models()`
- **`frontend/src/utils/map-provider.ts`**: Add `avian: "Avian"` provider display name
- **`frontend/src/utils/verified-models.ts`**: Add `"avian"` to `VERIFIED_PROVIDERS`
- **`frontend/__tests__/utils/map-provider.test.ts`**: Add test for Avian provider mapping
- **`config.template.toml`**: Add example Avian LLM configuration section

## Usage
```toml
[llm]
model = "avian/deepseek/deepseek-v3.2"
api_key = "<your-avian-api-key>"
base_url = "https://api.avian.io/v1"
```

## Test plan
- [ ] Verify `avian/` prefixed models appear in the model selector dropdown
- [ ] Verify Avian provider shows correct display name ("Avian") in the UI
- [ ] Verify `map-provider.test.ts` passes with new Avian assertion
- [ ] Verify chat completions work with Avian API key and base URL configured

cc @amanape @neubig @xingyaoww