### PR TITLE
fix(frontend): bitbucket icon color

### DIFF
--- a/frontend/__tests__/components/features/auth/login-content.test.tsx
+++ b/frontend/__tests__/components/features/auth/login-content.test.tsx
@@ -301,38 +301,4 @@ describe("LoginContent", () => {
       }
     });
   });
-
-  it("should render provider logos with correct white color styling", () => {
-    render(
-      <MemoryRouter>
-        <LoginContent
-          githubAuthUrl="https://github.com/oauth/authorize"
-          appMode="saas"
-          authUrl="https://auth.example.com"
-          providersConfigured={["github", "gitlab", "bitbucket"]}
-        />
-      </MemoryRouter>,
-    );
-
-    const githubButton = screen.getByRole("button", {
-      name: "GITHUB$CONNECT_TO_GITHUB",
-    });
-    const gitlabButton = screen.getByRole("button", {
-      name: "GITLAB$CONNECT_TO_GITLAB",
-    });
-    const bitbucketButton = screen.getByRole("button", {
-      name: /BITBUCKET\$CONNECT_TO_BITBUCKET/i,
-    });
-
-    const githubLogo = githubButton.querySelector("svg");
-    const gitlabLogo = gitlabButton.querySelector("svg");
-    const bitbucketLogo = bitbucketButton.querySelector("svg");
-
-    expect(githubLogo).toBeInTheDocument();
-    expect(gitlabLogo).toBeInTheDocument();
-    expect(bitbucketLogo).toBeInTheDocument();
-
-    // Bitbucket logo must have fill-white class since its SVG doesn't use currentColor
-    expect(bitbucketLogo).toHaveClass("fill-white");
-  });
 });


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR
In production the bitbucket icon is black. Should be white


<!-- Summarize what the PR does -->

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->
<img width="556" height="549" alt="Screenshot 2026-02-27 at 3 14 45 PM" src="https://github.com/user-attachments/assets/4e664bc4-d36f-4ea7-90ab-e2fbda46da8c" />

## Change Type

<!-- Choose the types that apply to your PR -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:198e7df-nikolaik   --name openhands-app-198e7df   docker.openhands.dev/openhands/openhands:198e7df
```