### PR TITLE
fix: ensure VSCode tab popout works for V1

### DIFF
--- a/frontend/src/components/features/conversation/conversation-tabs/vscode-tooltip-content.tsx
+++ b/frontend/src/components/features/conversation/conversation-tabs/vscode-tooltip-content.tsx
@@ -2,33 +2,27 @@ import { FaExternalLinkAlt } from "react-icons/fa";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
 import { RUNTIME_INACTIVE_STATES } from "#/types/agent-state";
-import { transformVSCodeUrl } from "#/utils/vscode-url-helper";
-import { useConversationId } from "#/hooks/use-conversation-id";
-import ConversationService from "#/api/conversation-service/conversation-service.api";
 import { useAgentState } from "#/hooks/use-agent-state";
+import { useUnifiedVSCodeUrl } from "#/hooks/query/use-unified-vscode-url";
 
 export function VSCodeTooltipContent() {
   const { curAgentState } = useAgentState();
-
   const { t } = useTranslation();
-  const { conversationId } = useConversationId();
+  const { data, refetch } = useUnifiedVSCodeUrl();
 
   const handleVSCodeClick = async (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
 
-    if (conversationId) {
-      try {
-        const data = await ConversationService.getVSCodeUrl(conversationId);
-        if (data.vscode_url) {
-          const transformedUrl = transformVSCodeUrl(data.vscode_url);
-          if (transformedUrl) {
-            window.open(transformedUrl, "_blank");
-          }
-        }
-      } catch (err) {
-        // Silently handle the error
-      }
+    let vscodeUrl = data?.url;
+
+    if (!vscodeUrl) {
+      const result = await refetch();
+      vscodeUrl = result.data?.url ?? null;
+    }
+
+    if (vscodeUrl) {
+      window.open(vscodeUrl, "_blank", "noopener,noreferrer");
     }
   };
 


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

<!-- Summarize what the PR does -->
Reuse useUnifiedVSCodeUrl that allows VSCode tab to work for both V0/V1 conversations with the VSCode popout tooltip.  Tooltip currently does nothing in V1 conversations.

Do need to flush browser cache to test fix.

## Change Type

<!-- Choose the types that apply to your PR -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [X] I have read and reviewed the code and I understand what the code is doing.
- [X] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

VSCode will open in new browser tab when clicking on tooltip in V1 conversations.
<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.
