### PR TITLE
fix: use timezone-naive datetime for accepted_tos to match TIMESTAMP …

### DIFF
--- a/enterprise/server/routes/auth.py
+++ b/enterprise/server/routes/auth.py
@@ -611,7 +611,8 @@ async def accept_tos(request: Request):
 
     # Update user settings with TOS acceptance
     # Use timezone-naive datetime for compatibility with TIMESTAMP WITHOUT TIME ZONE column
-    accepted_tos: datetime = datetime.now(timezone.utc).replace(tzinfo=None)
+    # TODO: Change accepted_tos column to TIMESTAMP WITH TIME ZONE and use datetime.now(timezone.utc)
+    accepted_tos: datetime = datetime.utcnow()  # Band-aid until schema is fixed
     async with a_session_maker() as session:
         result = await session.execute(
             select(User).where(User.id == uuid.UUID(user_id))


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

…WITHOUT TIME ZONE column

The accept_tos endpoint was passing a timezone-aware datetime (datetime.now(timezone.utc)) to a PostgreSQL TIMESTAMP WITHOUT TIME ZONE column, causing asyncpg to fail with: 'can't subtract offset-naive and offset-aware datetimes'

Fixed by stripping the timezone info with .replace(tzinfo=None) to match the database column type.

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

## Change Type

<!-- Choose the types that apply to your PR -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:944daf2-nikolaik   --name openhands-app-944daf2   docker.openhands.dev/openhands/openhands:944daf2
```