### PR TITLE
Make ExperimentManager methods async

### DIFF
--- a/enterprise/experiments/experiment_manager.py
+++ b/enterprise/experiments/experiment_manager.py
@@ -17,7 +17,7 @@ from openhands.server.session.conversation_init_data import ConversationInitData
 
 class SaaSExperimentManager(ExperimentManager):
     @staticmethod
-    def run_agent_variant_tests__v1(
+    async def run_agent_variant_tests__v1(
         user_id: str | None, conversation_id: UUID, agent: Agent
     ) -> Agent:
         if not ENABLE_EXPERIMENT_MANAGER:
@@ -37,7 +37,7 @@ class SaaSExperimentManager(ExperimentManager):
         return agent
 
     @staticmethod
-    def run_conversation_variant_test(
+    async def run_conversation_variant_test(
         user_id, conversation_id, conversation_settings
     ) -> ConversationInitData:
         """
@@ -60,7 +60,7 @@ class SaaSExperimentManager(ExperimentManager):
         return conversation_settings
 
     @staticmethod
-    def run_config_variant_test(
+    async def run_config_variant_test(
         user_id: str | None, conversation_id: str, config: OpenHandsConfig
     ) -> OpenHandsConfig:
         """
@@ -90,7 +90,7 @@ class SaaSExperimentManager(ExperimentManager):
 
         # Pass the entire OpenHands config to the system prompt experiment
         # Let the experiment handler directly modify the config as needed
-        modified_config = handle_system_prompt_experiment(
+        modified_config = await handle_system_prompt_experiment(
             user_id, conversation_id, config
         )
 

--- a/enterprise/experiments/experiment_versions/_001_litellm_default_model_experiment.py
+++ b/enterprise/experiments/experiment_versions/_001_litellm_default_model_experiment.py
@@ -15,7 +15,7 @@ from server.constants import (
 from openhands.core.logger import openhands_logger as logger
 
 
-def handle_litellm_default_model_experiment(
+async def handle_litellm_default_model_experiment(
     user_id, conversation_id, conversation_settings
 ):
     """

--- a/enterprise/experiments/experiment_versions/_002_system_prompt_experiment.py
+++ b/enterprise/experiments/experiment_versions/_002_system_prompt_experiment.py
@@ -16,7 +16,7 @@ from openhands.core.config.openhands_config import OpenHandsConfig
 from openhands.core.logger import openhands_logger as logger
 
 
-def _get_system_prompt_variant(user_id, conversation_id):
+async def _get_system_prompt_variant(user_id, conversation_id):
     """
     Get the system prompt variant for the experiment.
 
@@ -58,7 +58,7 @@ def _get_system_prompt_variant(user_id, conversation_id):
     # Store the experiment assignment in the database
     try:
         experiment_store = ExperimentAssignmentStore()
-        experiment_store.update_experiment_variant(
+        await experiment_store.update_experiment_variant(
             conversation_id=conversation_id,
             experiment_name='system_prompt_experiment',
             variant=enabled_variant,
@@ -116,7 +116,7 @@ def _get_system_prompt_variant(user_id, conversation_id):
     return enabled_variant
 
 
-def handle_system_prompt_experiment(
+async def handle_system_prompt_experiment(
     user_id, conversation_id, config: OpenHandsConfig
 ) -> OpenHandsConfig:
     """
@@ -130,7 +130,7 @@ def handle_system_prompt_experiment(
     Returns:
         Modified OpenHands configuration
     """
-    enabled_variant = _get_system_prompt_variant(user_id, conversation_id)
+    enabled_variant = await _get_system_prompt_variant(user_id, conversation_id)
 
     # If variant is None, experiment is not enabled or there was an error
     if enabled_variant is None:

--- a/enterprise/experiments/experiment_versions/_003_llm_claude4_vs_gpt5_experiment.py
+++ b/enterprise/experiments/experiment_versions/_003_llm_claude4_vs_gpt5_experiment.py
@@ -17,7 +17,7 @@ from openhands.core.logger import openhands_logger as logger
 from openhands.server.session.conversation_init_data import ConversationInitData
 
 
-def _get_model_variant(user_id: str | None, conversation_id: str) -> str | None:
+async def _get_model_variant(user_id: str | None, conversation_id: str) -> str | None:
     if not EXPERIMENT_CLAUDE4_VS_GPT5:
         logger.info(
             'experiment_manager:ab_testing:skipped',
@@ -47,7 +47,7 @@ def _get_model_variant(user_id: str | None, conversation_id: str) -> str | None:
     # Store the experiment assignment in the database
     try:
         experiment_store = ExperimentAssignmentStore()
-        experiment_store.update_experiment_variant(
+        await experiment_store.update_experiment_variant(
             conversation_id=conversation_id,
             experiment_name='claude4_vs_gpt5_experiment',
             variant=enabled_variant,
@@ -105,7 +105,7 @@ def _get_model_variant(user_id: str | None, conversation_id: str) -> str | None:
     return enabled_variant
 
 
-def handle_claude4_vs_gpt5_experiment(
+async def handle_claude4_vs_gpt5_experiment(
     user_id: str | None,
     conversation_id: str,
     conversation_settings: ConversationInitData,
@@ -122,7 +122,7 @@ def handle_claude4_vs_gpt5_experiment(
         Modified conversation settings
     """
 
-    enabled_variant = _get_model_variant(user_id, conversation_id)
+    enabled_variant = await _get_model_variant(user_id, conversation_id)
 
     if not enabled_variant:
         return conversation_settings

--- a/enterprise/experiments/experiment_versions/_004_condenser_max_step_experiment.py
+++ b/enterprise/experiments/experiment_versions/_004_condenser_max_step_experiment.py
@@ -20,7 +20,7 @@ from openhands.sdk.context.condenser import (
 from openhands.server.session.conversation_init_data import ConversationInitData
 
 
-def _get_condenser_max_step_variant(user_id, conversation_id):
+async def _get_condenser_max_step_variant(user_id, conversation_id):
     """
     Get the condenser max step variant for the experiment.
 
@@ -62,7 +62,7 @@ def _get_condenser_max_step_variant(user_id, conversation_id):
     # Store the experiment assignment in the database
     try:
         experiment_store = ExperimentAssignmentStore()
-        experiment_store.update_experiment_variant(
+        await experiment_store.update_experiment_variant(
             conversation_id=conversation_id,
             experiment_name='condenser_max_step_experiment',
             variant=enabled_variant,
@@ -120,7 +120,7 @@ def _get_condenser_max_step_variant(user_id, conversation_id):
     return enabled_variant
 
 
-def handle_condenser_max_step_experiment(
+async def handle_condenser_max_step_experiment(
     user_id: str | None,
     conversation_id: str,
     conversation_settings: ConversationInitData,
@@ -138,7 +138,7 @@ def handle_condenser_max_step_experiment(
     Returns the (potentially) modified conversation_settings.
     """
 
-    enabled_variant = _get_condenser_max_step_variant(user_id, conversation_id)
+    enabled_variant = await _get_condenser_max_step_variant(user_id, conversation_id)
 
     if enabled_variant is None:
         return conversation_settings
@@ -198,12 +198,12 @@ def handle_condenser_max_step_experiment(
     return conversation_settings
 
 
-def handle_condenser_max_step_experiment__v1(
+async def handle_condenser_max_step_experiment__v1(
     user_id: str | None,
     conversation_id: UUID,
     agent: Agent,
 ) -> Agent:
-    enabled_variant = _get_condenser_max_step_variant(user_id, str(conversation_id))
+    enabled_variant = await _get_condenser_max_step_variant(user_id, str(conversation_id))
 
     if enabled_variant is None:
         return agent

--- a/enterprise/server/saas_nested_conversation_manager.py
+++ b/enterprise/server/saas_nested_conversation_manager.py
@@ -407,7 +407,7 @@ class SaasNestedConversationManager(ConversationManager):
             ExperimentManagerImpl,
         )
 
-        config: OpenHandsConfig = ExperimentManagerImpl.run_config_variant_test(
+        config: OpenHandsConfig = await ExperimentManagerImpl.run_config_variant_test(
             user_id, sid, self.config
         )
 

--- a/enterprise/storage/experiment_assignment_store.py
+++ b/enterprise/storage/experiment_assignment_store.py
@@ -5,7 +5,7 @@ This store handles creating and updating experiment assignments for conversation
 """
 
 from sqlalchemy.dialects.postgresql import insert
-from storage.database import session_maker
+from storage.database import a_session_maker
 from storage.experiment_assignment import ExperimentAssignment
 
 from openhands.core.logger import openhands_logger as logger
@@ -14,7 +14,7 @@ from openhands.core.logger import openhands_logger as logger
 class ExperimentAssignmentStore:
     """Store for managing experiment assignments."""
 
-    def update_experiment_variant(
+    async def update_experiment_variant(
         self,
         conversation_id: str,
         experiment_name: str,
@@ -28,7 +28,7 @@ class ExperimentAssignmentStore:
             experiment_name: The name of the experiment
             variant: The variant assigned
         """
-        with session_maker() as session:
+        async with a_session_maker() as session:
             # Use PostgreSQL's INSERT ... ON CONFLICT DO NOTHING to handle unique constraint
             stmt = insert(ExperimentAssignment).values(
                 conversation_id=conversation_id,
@@ -39,8 +39,8 @@ class ExperimentAssignmentStore:
                 constraint='uq_experiment_assignments_conversation_experiment'
             )
 
-            session.execute(stmt)
-            session.commit()
+            await session.execute(stmt)
+            await session.commit()
 
             logger.info(
                 'experiment_assignment_store:upserted_variant',

--- a/enterprise/tests/unit/experiments/test_saas_experiment_manager.py
+++ b/enterprise/tests/unit/experiments/test_saas_experiment_manager.py
@@ -1,8 +1,9 @@
 # tests/test_condenser_max_step_experiment_v1.py
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
+import pytest
 from experiments.experiment_manager import SaaSExperimentManager
 
 # SUT imports (update the module path if needed)
@@ -25,21 +26,26 @@ def make_agent() -> Agent:
     return Agent(llm=llm)
 
 
-def _patch_variant(monkeypatch, return_value):
-    """Patch the internal variant getter to return a specific value."""
+def _patch_variant_async(monkeypatch, return_value):
+    """Patch the internal variant getter to return a specific value (async)."""
+
+    async def mock_get_variant(user_id, conv_id):
+        return return_value
+
     monkeypatch.setattr(
         'experiments.experiment_versions._004_condenser_max_step_experiment._get_condenser_max_step_variant',
-        lambda user_id, conv_id: return_value,
+        mock_get_variant,
         raising=True,
     )
 
 
-def test_control_variant_sets_condenser_with_max_size_120(monkeypatch):
-    _patch_variant(monkeypatch, 'control')
+@pytest.mark.asyncio
+async def test_control_variant_sets_condenser_with_max_size_120(monkeypatch):
+    _patch_variant_async(monkeypatch, 'control')
     agent = make_agent()
     conv_id = uuid4()
 
-    result = handle_condenser_max_step_experiment__v1('user-1', conv_id, agent)
+    result = await handle_condenser_max_step_experiment__v1('user-1', conv_id, agent)
 
     # Should be a new Agent instance with a condenser installed
     assert result is not agent
@@ -55,12 +61,13 @@ def test_control_variant_sets_condenser_with_max_size_120(monkeypatch):
     assert result.condenser.keep_first == 4
 
 
-def test_treatment_variant_sets_condenser_with_max_size_80(monkeypatch):
-    _patch_variant(monkeypatch, 'treatment')
+@pytest.mark.asyncio
+async def test_treatment_variant_sets_condenser_with_max_size_80(monkeypatch):
+    _patch_variant_async(monkeypatch, 'treatment')
     agent = make_agent()
     conv_id = uuid4()
 
-    result = handle_condenser_max_step_experiment__v1('user-2', conv_id, agent)
+    result = await handle_condenser_max_step_experiment__v1('user-2', conv_id, agent)
 
     assert result is not agent
     assert isinstance(result.condenser, LLMSummarizingCondenser)
@@ -69,36 +76,39 @@ def test_treatment_variant_sets_condenser_with_max_size_80(monkeypatch):
     assert result.condenser.keep_first == 4
 
 
-def test_none_variant_returns_original_agent_without_changes(monkeypatch):
-    _patch_variant(monkeypatch, None)
+@pytest.mark.asyncio
+async def test_none_variant_returns_original_agent_without_changes(monkeypatch):
+    _patch_variant_async(monkeypatch, None)
     agent = make_agent()
     conv_id = uuid4()
 
-    result = handle_condenser_max_step_experiment__v1('user-3', conv_id, agent)
+    result = await handle_condenser_max_step_experiment__v1('user-3', conv_id, agent)
 
     # No changes—same instance and no condenser attribute added
     assert result is agent
     assert getattr(result, 'condenser', None) is None
 
 
-def test_unknown_variant_returns_original_agent_without_changes(monkeypatch):
-    _patch_variant(monkeypatch, 'weird-variant')
+@pytest.mark.asyncio
+async def test_unknown_variant_returns_original_agent_without_changes(monkeypatch):
+    _patch_variant_async(monkeypatch, 'weird-variant')
     agent = make_agent()
     conv_id = uuid4()
 
-    result = handle_condenser_max_step_experiment__v1('user-4', conv_id, agent)
+    result = await handle_condenser_max_step_experiment__v1('user-4', conv_id, agent)
 
     assert result is agent
     assert getattr(result, 'condenser', None) is None
 
 
+@pytest.mark.asyncio
 @patch('experiments.experiment_manager.ENABLE_EXPERIMENT_MANAGER', False)
-def test_run_agent_variant_tests_v1_noop_when_manager_disabled():
+async def test_run_agent_variant_tests_v1_noop_when_manager_disabled():
     """If ENABLE_EXPERIMENT_MANAGER is False, the method returns the exact same agent and does not call the handler."""
     agent = make_agent()
     conv_id = uuid4()
 
-    result = SaaSExperimentManager.run_agent_variant_tests__v1(
+    result = await SaaSExperimentManager.run_agent_variant_tests__v1(
         user_id='user-123',
         conversation_id=conv_id,
         agent=agent,
@@ -108,16 +118,19 @@ def test_run_agent_variant_tests_v1_noop_when_manager_disabled():
     assert result is agent
 
 
+@pytest.mark.asyncio
 @patch('experiments.experiment_manager.ENABLE_EXPERIMENT_MANAGER', True)
 @patch('experiments.experiment_manager.EXPERIMENT_SYSTEM_PROMPT_EXPERIMENT', True)
-def test_run_agent_variant_tests_v1_calls_handler_and_sets_system_prompt(monkeypatch):
+async def test_run_agent_variant_tests_v1_calls_handler_and_sets_system_prompt(
+    monkeypatch,
+):
     """When enabled, it should call the condenser experiment handler and set the long-horizon system prompt."""
     agent = make_agent()
     conv_id = uuid4()
 
-    _patch_variant(monkeypatch, 'treatment')
+    _patch_variant_async(monkeypatch, 'treatment')
 
-    result: Agent = SaaSExperimentManager.run_agent_variant_tests__v1(
+    result: Agent = await SaaSExperimentManager.run_agent_variant_tests__v1(
         user_id='user-abc',
         conversation_id=conv_id,
         agent=agent,
@@ -128,9 +141,10 @@ def test_run_agent_variant_tests_v1_calls_handler_and_sets_system_prompt(monkeyp
     assert result.system_prompt_filename == 'system_prompt_long_horizon.j2'
 
 
+@pytest.mark.asyncio
 @patch('experiments.experiment_manager.ENABLE_EXPERIMENT_MANAGER', True)
 @patch('experiments.experiment_manager.EXPERIMENT_SYSTEM_PROMPT_EXPERIMENT', True)
-def test_run_agent_variant_tests_v1_preserves_planning_agent_system_prompt():
+async def test_run_agent_variant_tests_v1_preserves_planning_agent_system_prompt():
     """Planning agents should retain their specialized system prompt and not be overwritten by the experiment."""
     # Arrange
     planning_agent = make_agent().model_copy(
@@ -139,7 +153,7 @@ def test_run_agent_variant_tests_v1_preserves_planning_agent_system_prompt():
     conv_id = uuid4()
 
     # Act
-    result: Agent = SaaSExperimentManager.run_agent_variant_tests__v1(
+    result: Agent = await SaaSExperimentManager.run_agent_variant_tests__v1(
         user_id='user-planning',
         conversation_id=conv_id,
         agent=planning_agent,

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1162,7 +1162,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         conversation_id = conversation_id or uuid4()
 
         # Apply experiment variants
-        agent = ExperimentManagerImpl.run_agent_variant_tests__v1(
+        agent = await ExperimentManagerImpl.run_agent_variant_tests__v1(
             user.id, conversation_id, agent
         )
 

--- a/openhands/experiments/experiment_manager.py
+++ b/openhands/experiments/experiment_manager.py
@@ -32,13 +32,13 @@ def load_experiment_config(conversation_id: str) -> ExperimentConfig | None:
 
 class ExperimentManager:
     @staticmethod
-    def run_agent_variant_tests__v1(
+    async def run_agent_variant_tests__v1(
         user_id: str | None, conversation_id: UUID, agent: Agent
     ) -> Agent:
         return agent
 
     @staticmethod
-    def run_conversation_variant_test(
+    async def run_conversation_variant_test(
         user_id: str | None,
         conversation_id: str,
         conversation_settings: ConversationInitData,
@@ -46,7 +46,7 @@ class ExperimentManager:
         return conversation_settings
 
     @staticmethod
-    def run_config_variant_test(
+    async def run_config_variant_test(
         user_id: str | None, conversation_id: str, config: OpenHandsConfig
     ) -> OpenHandsConfig:
         exp_config = load_experiment_config(conversation_id)

--- a/openhands/server/conversation_manager/docker_nested_conversation_manager.py
+++ b/openhands/server/conversation_manager/docker_nested_conversation_manager.py
@@ -551,7 +551,7 @@ class DockerNestedConversationManager(ConversationManager):
         # This session is created here only because it is the easiest way to get a runtime, which
         # is the easiest way to create the needed docker container
 
-        config: OpenHandsConfig = ExperimentManagerImpl.run_config_variant_test(
+        config: OpenHandsConfig = await ExperimentManagerImpl.run_config_variant_test(
             user_id, sid, self.config
         )
 

--- a/openhands/server/conversation_manager/standalone_conversation_manager.py
+++ b/openhands/server/conversation_manager/standalone_conversation_manager.py
@@ -26,6 +26,7 @@ from openhands.core.schema.observation import ObservationType
 from openhands.events.action import FileReadAction, MessageAction
 from openhands.events.observation.commands import CmdOutputObservation
 from openhands.events.stream import EventStreamSubscriber, session_exists
+from openhands.experiments.experiment_manager import ExperimentManagerImpl
 from openhands.llm.llm_registry import LLMRegistry
 from openhands.runtime import get_runtime_cls
 from openhands.server.config.server_config import ServerConfig
@@ -347,8 +348,11 @@ class StandaloneConversationManager(ConversationManager):
                 )
                 await self.close_session(oldest_conversation_id)
 
+        config = await ExperimentManagerImpl.run_config_variant_test(
+            user_id, sid, self.config
+        )
         llm_registry, conversation_stats, config = (
-            create_registry_and_conversation_stats(self.config, sid, user_id, settings)
+            create_registry_and_conversation_stats(config, sid, user_id, settings)
         )
         session = Session(
             sid=sid,

--- a/openhands/server/services/conversation_service.py
+++ b/openhands/server/services/conversation_service.py
@@ -142,7 +142,7 @@ async def start_conversation(
 
     conversation_init_data = ConversationInitData(**session_init_args)
 
-    conversation_init_data = ExperimentManagerImpl.run_conversation_variant_test(
+    conversation_init_data = await ExperimentManagerImpl.run_conversation_variant_test(
         user_id, conversation_id, conversation_init_data
     )
 
@@ -283,6 +283,6 @@ async def setup_init_conversation_settings(
 
     conversation_init_data = ConversationInitData(**session_init_args)
     # We should recreate the same experiment conditions when restarting a conversation
-    return ExperimentManagerImpl.run_conversation_variant_test(
+    return await ExperimentManagerImpl.run_conversation_variant_test(
         user_id, conversation_id, conversation_init_data
     )

--- a/openhands/server/session/session.py
+++ b/openhands/server/session/session.py
@@ -108,13 +108,6 @@ class WebSession:
             EventStreamSubscriber.SERVER, self.on_event, self.sid
         )
         self.config = config
-
-        # Lazy import to avoid circular dependency
-        from openhands.experiments.experiment_manager import ExperimentManagerImpl
-
-        self.config = ExperimentManagerImpl.run_config_variant_test(
-            user_id, sid, self.config
-        )
         self.loop = asyncio.get_event_loop()
         self.user_id = user_id
 

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -1050,7 +1050,7 @@ class TestLiveStatusAppConversationService:
         mock_updated_agent = Mock(spec=Agent)
         mock_updated_agent.llm = mock_llm
         mock_updated_agent.condenser = None  # No condenser
-        mock_experiment_manager.run_agent_variant_tests__v1.return_value = (
+        mock_experiment_manager.run_agent_variant_tests__v1 = AsyncMock(return_value=
             mock_updated_agent
         )
 
@@ -1117,7 +1117,7 @@ class TestLiveStatusAppConversationService:
         mock_updated_agent = Mock(spec=Agent)
         mock_updated_agent.llm = mock_llm
         mock_updated_agent.condenser = None  # No condenser
-        mock_experiment_manager.run_agent_variant_tests__v1.return_value = (
+        mock_experiment_manager.run_agent_variant_tests__v1 = AsyncMock(return_value=
             mock_updated_agent
         )
 
@@ -1163,7 +1163,7 @@ class TestLiveStatusAppConversationService:
         mock_updated_agent = Mock(spec=Agent)
         mock_updated_agent.llm = mock_llm
         mock_updated_agent.condenser = None  # No condenser
-        mock_experiment_manager.run_agent_variant_tests__v1.return_value = (
+        mock_experiment_manager.run_agent_variant_tests__v1 = AsyncMock(return_value=
             mock_updated_agent
         )
 
@@ -2286,7 +2286,7 @@ class TestPluginHandling:
         mock_updated_agent = Mock(spec=Agent)
         mock_updated_agent.llm = mock_llm
         mock_updated_agent.condenser = None
-        mock_experiment_manager.run_agent_variant_tests__v1.return_value = (
+        mock_experiment_manager.run_agent_variant_tests__v1 = AsyncMock(return_value=
             mock_updated_agent
         )
 
@@ -2346,7 +2346,7 @@ class TestPluginHandling:
         mock_updated_agent = Mock(spec=Agent)
         mock_updated_agent.llm = mock_llm
         mock_updated_agent.condenser = None
-        mock_experiment_manager.run_agent_variant_tests__v1.return_value = (
+        mock_experiment_manager.run_agent_variant_tests__v1 = AsyncMock(return_value=
             mock_updated_agent
         )
 
@@ -2393,7 +2393,7 @@ class TestPluginHandling:
         mock_updated_agent = Mock(spec=Agent)
         mock_updated_agent.llm = mock_llm
         mock_updated_agent.condenser = None
-        mock_experiment_manager.run_agent_variant_tests__v1.return_value = (
+        mock_experiment_manager.run_agent_variant_tests__v1 = AsyncMock(return_value=
             mock_updated_agent
         )
 
@@ -2448,7 +2448,7 @@ class TestPluginHandling:
         mock_updated_agent = Mock(spec=Agent)
         mock_updated_agent.llm = mock_llm
         mock_updated_agent.condenser = None
-        mock_experiment_manager.run_agent_variant_tests__v1.return_value = (
+        mock_experiment_manager.run_agent_variant_tests__v1 = AsyncMock(return_value=
             mock_updated_agent
         )
 
@@ -2508,7 +2508,7 @@ class TestPluginHandling:
         mock_updated_agent = Mock(spec=Agent)
         mock_updated_agent.llm = mock_llm
         mock_updated_agent.condenser = None
-        mock_experiment_manager.run_agent_variant_tests__v1.return_value = (
+        mock_experiment_manager.run_agent_variant_tests__v1 = AsyncMock(return_value=
             mock_updated_agent
         )
 

--- a/tests/unit/experiments/test_experiment_manager.py
+++ b/tests/unit/experiments/test_experiment_manager.py
@@ -1,7 +1,7 @@
 """Unit tests for ExperimentManager class, focusing on the v1 agent method."""
 
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 from uuid import UUID, uuid4
 
 import pytest
@@ -34,35 +34,38 @@ class TestExperimentManager:
         self.mock_agent.system_prompt_filename = 'default_system_prompt.j2'
         self.mock_agent.model_copy = Mock(return_value=self.mock_agent)
 
-    def test_run_agent_variant_tests__v1_returns_agent_unchanged(self):
+    @pytest.mark.asyncio
+    async def test_run_agent_variant_tests__v1_returns_agent_unchanged(self):
         """Test that the base ExperimentManager returns the agent unchanged."""
-        result = ExperimentManager.run_agent_variant_tests__v1(
+        result = await ExperimentManager.run_agent_variant_tests__v1(
             self.user_id, self.conversation_id, self.mock_agent
         )
 
         assert result is self.mock_agent
         assert result == self.mock_agent
 
-    def test_run_agent_variant_tests__v1_with_none_user_id(self):
+    @pytest.mark.asyncio
+    async def test_run_agent_variant_tests__v1_with_none_user_id(self):
         """Test that the method works with None user_id."""
         # Act
-        result = ExperimentManager.run_agent_variant_tests__v1(
+        result = await ExperimentManager.run_agent_variant_tests__v1(
             None, self.conversation_id, self.mock_agent
         )
 
         # Assert
         assert result is self.mock_agent
 
-    def test_run_agent_variant_tests__v1_with_different_conversation_ids(self):
+    @pytest.mark.asyncio
+    async def test_run_agent_variant_tests__v1_with_different_conversation_ids(self):
         """Test that the method works with different conversation IDs."""
         conversation_id_1 = uuid4()
         conversation_id_2 = uuid4()
 
         # Act
-        result_1 = ExperimentManager.run_agent_variant_tests__v1(
+        result_1 = await ExperimentManager.run_agent_variant_tests__v1(
             self.user_id, conversation_id_1, self.mock_agent
         )
-        result_2 = ExperimentManager.run_agent_variant_tests__v1(
+        result_2 = await ExperimentManager.run_agent_variant_tests__v1(
             self.user_id, conversation_id_2, self.mock_agent
         )
 
@@ -90,14 +93,15 @@ class TestExperimentManagerIntegration:
         self.mock_agent.system_prompt_filename = 'default_system_prompt.j2'
         self.mock_agent.model_copy = Mock(return_value=self.mock_agent)
 
+    @pytest.mark.asyncio
     @patch('openhands.experiments.experiment_manager.ExperimentManagerImpl')
-    def test_start_app_conversation_calls_experiment_manager_v1(
+    async def test_start_app_conversation_calls_experiment_manager_v1(
         self, mock_experiment_manager_impl
     ):
         """Test that start_app_conversation calls the experiment manager v1 method with correct parameters."""
-        # Arrange
-        mock_experiment_manager_impl.run_agent_variant_tests__v1.return_value = (
-            self.mock_agent
+        # Arrange - use AsyncMock for async method
+        mock_experiment_manager_impl.run_agent_variant_tests__v1 = AsyncMock(
+            return_value=self.mock_agent
         )
 
         # Create a mock service instance
@@ -110,8 +114,8 @@ class TestExperimentManagerIntegration:
 
             conversation_id = uuid4()
 
-            # This simulates the call that happens in the actual service
-            result_agent = mock_experiment_manager_impl.run_agent_variant_tests__v1(
+            # This simulates the call that happens in the actual service (now async)
+            result_agent = await mock_experiment_manager_impl.run_agent_variant_tests__v1(
                 self.user_id, conversation_id, self.mock_agent
             )
 
@@ -235,9 +239,9 @@ class TestExperimentManagerIntegration:
                 'openhands.app_server.app_conversation.live_status_app_conversation_service.ExperimentManagerImpl'
             ) as mock_experiment_manager,
         ):
-            # Configure the experiment manager mock to return the same agent
-            mock_experiment_manager.run_agent_variant_tests__v1.return_value = (
-                mock_agent
+            # Configure the experiment manager mock to return the same agent (async)
+            mock_experiment_manager.run_agent_variant_tests__v1 = AsyncMock(
+                return_value=mock_agent
             )
 
             # --- Act: build the start request


### PR DESCRIPTION
## Summary of PR

This PR makes the ExperimentManager methods async to support async database operations. The key changes include:

### Core Changes
- **Base ExperimentManager** (`openhands/experiments/experiment_manager.py`): Made all 3 methods async:
  - `run_agent_variant_tests__v1`
  - `run_conversation_variant_test`  
  - `run_config_variant_test`

- **SaaSExperimentManager** (`enterprise/experiments/experiment_manager.py`): Updated all 3 methods to be async

- **ExperimentAssignmentStore** (`enterprise/storage/experiment_assignment_store.py`): 
  - Changed `update_experiment_variant` to async
  - Replaced `session_maker` with `a_session_maker` for async database operations
  - Updated to use `await session.execute()` and `await session.commit()`

### Experiment Version Handlers
Made all 4 experiment handlers async in `enterprise/experiments/experiment_versions/`:
- `_001_litellm_default_model_experiment.py`
- `_002_system_prompt_experiment.py`
- `_003_llm_claude4_vs_gpt5_experiment.py`
- `_004_condenser_max_step_experiment.py`

### Call Sites Updated
- `live_status_app_conversation_service.py`: Added `await` to `run_agent_variant_tests__v1`
- `session.py`: Removed redundant `run_config_variant_test` call from `__init__` (callers handle this)
- `docker_nested_conversation_manager.py`: Added `await` to `run_config_variant_test`
- `standalone_conversation_manager.py`: Added import and `await` call for `run_config_variant_test`
- `conversation_service.py`: Added `await` to both `run_conversation_variant_test` calls
- `saas_nested_conversation_manager.py`: Added `await` to `run_config_variant_test`

### Tests Updated
- Updated test methods to be async with `@pytest.mark.asyncio`
- Changed mock setups to use `AsyncMock` for async method mocking

## Demo Screenshots/Videos

N/A - Backend refactoring only

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

N/A

## Release Notes

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:387519e-nikolaik   --name openhands-app-387519e   docker.openhands.dev/openhands/openhands:387519e
```