### PR TITLE
fix(backend): resolve timezone mismatch in accept_tos causing database error

### DIFF
--- a/enterprise/server/routes/auth.py
+++ b/enterprise/server/routes/auth.py
@@ -610,7 +610,7 @@ async def accept_tos(request: Request):
     redirect_url = body.get('redirect_url', str(request.base_url))
 
     # Update user settings with TOS acceptance
-    accepted_tos: datetime = datetime.now(timezone.utc)
+    accepted_tos: datetime = datetime.now(timezone.utc).replace(tzinfo=None)
     async with a_session_maker() as session:
         result = await session.execute(
             select(User).where(User.id == uuid.UUID(user_id))

--- a/enterprise/tests/unit/test_auth_routes.py
+++ b/enterprise/tests/unit/test_auth_routes.py
@@ -11,6 +11,7 @@ from server.auth.auth_error import AuthError
 from server.auth.saas_user_auth import SaasUserAuth
 from server.routes.auth import (
     _extract_recaptcha_state,
+    accept_tos,
     authenticate,
     keycloak_callback,
     keycloak_offline_callback,
@@ -1996,3 +1997,50 @@ async def test_keycloak_callback_calls_backfill_user_email_for_existing_user(
         mock_user_store.backfill_user_email.assert_called_once_with(
             'test_user_id', user_info
         )
+
+
+@pytest.mark.asyncio
+async def test_accept_tos_stores_timezone_naive_datetime(mock_request):
+    """Test that accept_tos stores a timezone-naive datetime for database compatibility."""
+    # Arrange
+    test_user_id = '12345678-1234-5678-1234-567812345678'
+
+    mock_user = MagicMock()
+    mock_user.id = test_user_id
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = mock_user
+
+    mock_session = AsyncMock()
+    mock_session.execute.return_value = mock_result
+    mock_session.commit = AsyncMock()
+
+    mock_session_context = AsyncMock()
+    mock_session_context.__aenter__.return_value = mock_session
+    mock_session_context.__aexit__.return_value = None
+
+    mock_user_auth = MagicMock(spec=SaasUserAuth)
+    mock_user_auth.get_access_token = AsyncMock(
+        return_value=SecretStr('test_access_token')
+    )
+    mock_user_auth.refresh_token = SecretStr('test_refresh_token')
+    mock_user_auth.get_user_id = AsyncMock(return_value=test_user_id)
+
+    mock_request.json = AsyncMock(return_value={'redirect_url': 'http://example.com'})
+
+    with (
+        patch(
+            'server.routes.auth.get_user_auth', AsyncMock(return_value=mock_user_auth)
+        ),
+        patch('server.routes.auth.a_session_maker', return_value=mock_session_context),
+        patch('server.routes.auth.set_response_cookie'),
+    ):
+        # Act
+        result = await accept_tos(mock_request)
+
+        # Assert
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == status.HTTP_200_OK
+        # The datetime assigned to user.accepted_tos must be timezone-naive
+        # (compatible with TIMESTAMP WITHOUT TIME ZONE database column)
+        assert mock_user.accepted_tos.tzinfo is None


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

<!-- Summarize what the PR does -->

The accept_tos endpoint was passing a timezone-aware datetime to the database, while the accepted_tos column is defined as TIMESTAMP WITHOUT TIME ZONE. This mismatch caused asyncpg to raise a “can’t subtract offset-naive and offset-aware datetimes” error.

To resolve this, the timezone information is stripped from the datetime before storing it, ensuring compatibility with the database column definition. This issue was preventing users from creating new accounts, so addressing it restores the account creation flow.

**Acceptance criteria:**
- The issue should now be resolved.
- Users should be able to create new accounts successfully.

---

* Fix the 500 Internal Server Error that occurred when accepting the Terms of Service.
* The `accepted_tos` database column is defined as `TIMESTAMP WITHOUT TIME ZONE`, while the code was passing a timezone-aware datetime (`datetime.now(timezone.utc)`), which caused `asyncpg` to fail due to a timezone mismatch.
* Strip the timezone information using `.replace(tzinfo=None)` to ensure compatibility with the column type.

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

https://github.com/user-attachments/assets/bbf210bd-b496-42c6-9a26-051ccc80ee65

## Change Type

<!-- Choose the types that apply to your PR -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:c3cc005-nikolaik   --name openhands-app-c3cc005   docker.openhands.dev/openhands/openhands:c3cc005
```