### PR TITLE
Fix NoneType validation error in GitHub integration when user not registered

### DIFF
--- a/enterprise/integrations/github/github_manager.py
+++ b/enterprise/integrations/github/github_manager.py
@@ -22,6 +22,7 @@ from integrations.utils import (
     HOST_URL,
     OPENHANDS_RESOLVER_TEMPLATES_DIR,
     get_session_expired_message,
+    get_user_not_registered_message,
 )
 from integrations.v1_utils import get_saas_user_auth
 from jinja2 import Environment, FileSystemLoader
@@ -179,9 +180,39 @@ class GithubManager(Manager):
         if await self.is_job_requested(message):
             payload = message.message.get('payload', {})
             user_id = payload['sender']['id']
+            username = payload['sender']['login']
             keycloak_user_id = await self.token_manager.get_user_id_from_idp_user_id(
                 user_id, ProviderType.GITHUB
             )
+
+            # Check if user is registered with OpenHands Cloud
+            if keycloak_user_id is None:
+                logger.warning(
+                    f'[GitHub] User {username} (id={user_id}) is not registered with OpenHands Cloud'
+                )
+                # Get installation token to post a helpful message
+                installation_id = message.message.get('installation')
+                installation_token = self._get_installation_access_token(
+                    installation_id
+                )
+                repo_obj = payload.get('repository', {})
+                full_repo_name = self._get_full_repo_name(repo_obj)
+
+                # Determine where to post the message (issue or PR)
+                issue_number = None
+                if 'issue' in payload:
+                    issue_number = payload['issue']['number']
+                elif 'pull_request' in payload:
+                    issue_number = payload['pull_request']['number']
+
+                if issue_number:
+                    with Github(auth=Auth.Token(installation_token)) as github_client:
+                        repo = github_client.get_repo(full_repo_name)
+                        issue = repo.get_issue(number=issue_number)
+                        msg = get_user_not_registered_message(username)
+                        issue.create_comment(msg)
+                return
+
             github_view = await GithubFactory.create_github_view_from_payload(
                 message, keycloak_user_id
             )

--- a/enterprise/integrations/gitlab/gitlab_manager.py
+++ b/enterprise/integrations/gitlab/gitlab_manager.py
@@ -15,7 +15,9 @@ from integrations.utils import (
     CONVERSATION_URL,
     HOST_URL,
     OPENHANDS_RESOLVER_TEMPLATES_DIR,
+    UserNotRegisteredError,
     get_session_expired_message,
+    get_user_not_registered_message,
 )
 from jinja2 import Environment, FileSystemLoader
 from pydantic import SecretStr
@@ -44,6 +46,33 @@ class GitlabManager(Manager):
     def _confirm_incoming_source_type(self, message: Message):
         if message.source != SourceType.GITLAB:
             raise ValueError(f'Unexpected message source {message.source}')
+
+    async def _send_user_not_registered_message(
+        self, message: Message, username: str
+    ) -> None:
+        """Send a helpful message to an unregistered user.
+
+        Args:
+            message: The incoming message containing the payload
+            username: The username of the unregistered user
+
+        Note:
+            Currently this method only logs the message since we cannot send
+            GitLab messages without a registered user's token. In the future,
+            a bot/admin token could be used to actually post the comment.
+        """
+        payload = message.message['payload']
+        project_id = str(payload['object_attributes']['project_id'])
+
+        # Generate the message for logging purposes
+        msg = get_user_not_registered_message(username)
+
+        # Log that we would send this message
+        # Note: Actually sending requires admin/bot access which may not be available
+        logger.info(
+            f'[GitLab] Would send user not registered message to {username} '
+            f'for project {project_id}: {msg}'
+        )
 
     async def _user_has_write_access_to_repo(
         self, project_id: str, user_id: str
@@ -79,9 +108,18 @@ class GitlabManager(Manager):
     async def receive_message(self, message: Message):
         self._confirm_incoming_source_type(message)
         if await self.is_job_requested(message):
-            gitlab_view = await GitlabFactory.create_gitlab_view_from_payload(
-                message, self.token_manager
-            )
+            try:
+                gitlab_view = await GitlabFactory.create_gitlab_view_from_payload(
+                    message, self.token_manager
+                )
+            except UserNotRegisteredError as e:
+                logger.warning(
+                    f'[GitLab] User {e.username} (id={e.user_id}) is not registered with OpenHands Cloud'
+                )
+                # Send a helpful message to the user
+                await self._send_user_not_registered_message(message, e.username)
+                return
+
             logger.info(
                 f'[GitLab] Creating job for {gitlab_view.user_info.username} in {gitlab_view.full_repo_name}#{gitlab_view.issue_number}'
             )

--- a/enterprise/integrations/gitlab/gitlab_view.py
+++ b/enterprise/integrations/gitlab/gitlab_view.py
@@ -2,7 +2,12 @@ from dataclasses import dataclass
 
 from integrations.models import Message
 from integrations.types import ResolverViewInterface, UserData
-from integrations.utils import HOST, get_oh_labels, has_exact_mention
+from integrations.utils import (
+    HOST,
+    UserNotRegisteredError,
+    get_oh_labels,
+    has_exact_mention,
+)
 from jinja2 import Environment
 from server.auth.token_manager import TokenManager
 from server.config import get_config
@@ -317,6 +322,10 @@ class GitlabFactory:
         keycloak_user_id = await token_manager.get_user_id_from_idp_user_id(
             user_id, ProviderType.GITLAB
         )
+
+        # Check if user is registered with OpenHands Cloud
+        if keycloak_user_id is None:
+            raise UserNotRegisteredError(username=username, user_id=user_id)
 
         user_info = UserData(
             user_id=user_id, username=username, keycloak_user_id=keycloak_user_id

--- a/enterprise/integrations/utils.py
+++ b/enterprise/integrations/utils.py
@@ -64,6 +64,44 @@ def get_session_expired_message(username: str | None = None) -> str:
     return f'Your session has expired. Please login again at [OpenHands Cloud]({HOST_URL}) and try again.'
 
 
+def get_user_not_registered_message(username: str | None = None) -> str:
+    """Get a user-friendly message for users not registered with OpenHands Cloud.
+
+    Used by integrations to notify users when they attempt to interact with
+    OpenHands but haven't registered with OpenHands Cloud yet.
+
+    Args:
+        username: Optional username to mention in the message. If provided,
+                  the message will include @username prefix (used by Git providers
+                  like GitHub, GitLab).
+
+    Returns:
+        A formatted user not registered message
+    """
+    if username:
+        return f"@{username} it looks like you haven't registered with OpenHands Cloud yet. Please sign up at [OpenHands Cloud]({HOST_URL}) and connect your GitHub/GitLab account to get started!"
+    return f"It looks like you haven't registered with OpenHands Cloud yet. Please sign up at [OpenHands Cloud]({HOST_URL}) and connect your GitHub/GitLab account to get started!"
+
+
+class UserNotRegisteredError(Exception):
+    """Exception raised when a user is not registered with OpenHands Cloud.
+
+    This exception is used by integrations when processing webhooks from users
+    who haven't registered with OpenHands Cloud yet.
+
+    Attributes:
+        username: The username of the unregistered user
+        user_id: The provider-specific user ID
+    """
+
+    def __init__(self, username: str, user_id: int):
+        self.username = username
+        self.user_id = user_id
+        super().__init__(
+            f'User {username} (id={user_id}) is not registered with OpenHands Cloud'
+        )
+
+
 # Toggle for solvability report feature
 ENABLE_SOLVABILITY_ANALYSIS = (
     os.getenv('ENABLE_SOLVABILITY_ANALYSIS', 'false').lower() == 'true'

--- a/enterprise/tests/unit/integrations/test_user_not_registered.py
+++ b/enterprise/tests/unit/integrations/test_user_not_registered.py
@@ -1,0 +1,366 @@
+"""Tests for user not registered error handling in GitHub and GitLab integrations."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from integrations.github.github_manager import GithubManager
+from integrations.gitlab.gitlab_manager import GitlabManager
+from integrations.gitlab.gitlab_view import GitlabFactory
+from integrations.models import Message, SourceType
+from integrations.utils import (
+    HOST_URL,
+    UserNotRegisteredError,
+    get_user_not_registered_message,
+)
+
+
+class TestUserNotRegisteredError:
+    """Test cases for UserNotRegisteredError exception."""
+
+    def test_exception_with_username_and_user_id(self):
+        """Test that the exception stores username and user_id correctly."""
+        error = UserNotRegisteredError(username='testuser', user_id=12345)
+
+        assert error.username == 'testuser'
+        assert error.user_id == 12345
+        assert 'testuser' in str(error)
+        assert '12345' in str(error)
+        assert 'not registered' in str(error).lower()
+
+    def test_exception_is_subclass_of_exception(self):
+        """Test that UserNotRegisteredError is a proper exception."""
+        error = UserNotRegisteredError(username='user', user_id=1)
+        assert isinstance(error, Exception)
+
+
+class TestGetUserNotRegisteredMessage:
+    """Test cases for get_user_not_registered_message function."""
+
+    def test_message_with_username_contains_at_prefix(self):
+        """Test that the message contains the username with @ prefix."""
+        result = get_user_not_registered_message('testuser')
+        assert '@testuser' in result
+
+    def test_message_with_username_contains_not_registered_text(self):
+        """Test that the message contains registration text."""
+        result = get_user_not_registered_message('testuser')
+        assert "haven't registered" in result or 'not registered' in result.lower()
+
+    def test_message_with_username_contains_sign_up_instruction(self):
+        """Test that the message contains sign up instruction."""
+        result = get_user_not_registered_message('testuser')
+        assert 'sign up' in result.lower() or 'register' in result.lower()
+
+    def test_message_with_username_contains_host_url(self):
+        """Test that the message contains the OpenHands Cloud URL."""
+        result = get_user_not_registered_message('testuser')
+        assert HOST_URL in result
+        assert 'OpenHands Cloud' in result
+
+    def test_message_contains_account_connection_instruction(self):
+        """Test that the message instructs user to connect their account."""
+        result = get_user_not_registered_message('testuser')
+        assert 'connect' in result.lower() or 'github' in result.lower() or 'gitlab' in result.lower()
+
+    def test_different_usernames(self):
+        """Test that different usernames produce different messages."""
+        result1 = get_user_not_registered_message('user1')
+        result2 = get_user_not_registered_message('user2')
+        assert '@user1' in result1
+        assert '@user2' in result2
+        assert '@user1' not in result2
+        assert '@user2' not in result1
+
+    def test_message_without_username_contains_registration_text(self):
+        """Test that the message without username contains registration text."""
+        result = get_user_not_registered_message()
+        assert "haven't registered" in result or 'not registered' in result.lower()
+
+    def test_message_without_username_contains_host_url(self):
+        """Test that the message without username contains the OpenHands Cloud URL."""
+        result = get_user_not_registered_message()
+        assert HOST_URL in result
+        assert 'OpenHands Cloud' in result
+
+    def test_message_without_username_does_not_contain_at_prefix(self):
+        """Test that the message without username does not contain @ prefix."""
+        result = get_user_not_registered_message()
+        assert not result.startswith('@')
+
+    def test_message_with_none_username(self):
+        """Test that passing None explicitly works the same as no argument."""
+        result = get_user_not_registered_message(None)
+        assert not result.startswith('@')
+
+
+class TestGitHubManagerUserNotRegistered:
+    """Test cases for GitHub integration handling unregistered users."""
+
+    @staticmethod
+    def _create_github_message(action='created', has_issue=True, has_pr=False):
+        """Helper to create a mock GitHub message."""
+        payload = {
+            'action': action,
+            'sender': {'id': 12345, 'login': 'testuser'},
+            'repository': {
+                'owner': {'login': 'test-org'},
+                'name': 'test-repo',
+                'private': False,
+            },
+        }
+        if has_issue:
+            payload['issue'] = {'number': 42}
+            payload['comment'] = {'body': '@openhands help me', 'id': 123}
+        if has_pr:
+            payload['pull_request'] = {'number': 43}
+
+        return Message(
+            source=SourceType.GITHUB,
+            message={
+                'installation': 'inst_123',
+                'payload': payload,
+            },
+        )
+
+    @pytest.mark.asyncio
+    @patch('integrations.github.github_manager.Auth')
+    @patch('integrations.github.github_manager.GithubIntegration')
+    @patch('integrations.github.github_manager.Github')
+    async def test_receive_message_handles_unregistered_user(
+        self, mock_github_class, mock_github_integration, mock_auth
+    ):
+        """Test that receive_message handles unregistered users gracefully."""
+        # Setup manager with mocked dependencies
+        mock_token_manager = MagicMock()
+        mock_data_collector = MagicMock()
+        github_manager = GithubManager(
+            token_manager=mock_token_manager,
+            data_collector=mock_data_collector,
+        )
+
+        # Setup mocks
+        github_manager.is_job_requested = AsyncMock(return_value=True)
+        mock_token_manager.get_user_id_from_idp_user_id = AsyncMock(return_value=None)
+
+        # Mock _get_installation_access_token
+        github_manager._get_installation_access_token = MagicMock(
+            return_value='mock_installation_token'
+        )
+
+        # Create mock GitHub client
+        mock_repo = MagicMock()
+        mock_issue = MagicMock()
+        mock_repo.get_issue.return_value = mock_issue
+        mock_github_instance = MagicMock()
+        mock_github_instance.__enter__ = MagicMock(return_value=mock_github_instance)
+        mock_github_instance.__exit__ = MagicMock(return_value=None)
+        mock_github_instance.get_repo.return_value = mock_repo
+        mock_github_class.return_value = mock_github_instance
+
+        message = self._create_github_message()
+
+        # Mock data_collector.process_payload to be sync
+        mock_data_collector.process_payload = MagicMock()
+
+        # Execute
+        await github_manager.receive_message(message)
+
+        # Verify: Should post a helpful comment
+        mock_issue.create_comment.assert_called_once()
+        comment_text = mock_issue.create_comment.call_args[0][0]
+        assert '@testuser' in comment_text
+        assert 'OpenHands Cloud' in comment_text
+
+    @pytest.mark.asyncio
+    @patch('integrations.github.github_manager.Auth')
+    @patch('integrations.github.github_manager.GithubIntegration')
+    @patch('integrations.github.github_manager.GithubFactory')
+    async def test_receive_message_proceeds_for_registered_user(
+        self, mock_factory, mock_github_integration, mock_auth
+    ):
+        """Test that receive_message proceeds normally for registered users."""
+        # Setup manager with mocked dependencies
+        mock_token_manager = MagicMock()
+        mock_data_collector = MagicMock()
+        github_manager = GithubManager(
+            token_manager=mock_token_manager,
+            data_collector=mock_data_collector,
+        )
+
+        # Setup mocks
+        github_manager.is_job_requested = AsyncMock(return_value=True)
+        mock_token_manager.get_user_id_from_idp_user_id = AsyncMock(
+            return_value='keycloak-user-123'
+        )
+        mock_token_manager.store_org_token = AsyncMock()
+
+        # Mock internal methods
+        github_manager._get_installation_access_token = MagicMock(
+            return_value='mock_installation_token'
+        )
+        github_manager._add_reaction = MagicMock()
+        github_manager.start_job = AsyncMock()
+
+        mock_view = MagicMock()
+        mock_view.installation_id = 'inst_123'
+        mock_view.user_info.username = 'testuser'
+        mock_view.full_repo_name = 'test-org/test-repo'
+        mock_view.issue_number = 42
+        mock_factory.create_github_view_from_payload = AsyncMock(return_value=mock_view)
+
+        message = self._create_github_message()
+
+        # Mock data_collector.process_payload to be sync
+        mock_data_collector.process_payload = MagicMock()
+
+        # Execute
+        await github_manager.receive_message(message)
+
+        # Verify: Should call create_github_view_from_payload with keycloak_user_id
+        mock_factory.create_github_view_from_payload.assert_called_once()
+        call_args = mock_factory.create_github_view_from_payload.call_args
+        assert call_args[0][1] == 'keycloak-user-123'
+
+        # Verify: Should call start_job
+        github_manager.start_job.assert_called_once_with(mock_view)
+
+
+class TestGitLabViewUserNotRegistered:
+    """Test cases for GitLab integration handling unregistered users."""
+
+    def _create_gitlab_message(self, object_kind='issue', action='update'):
+        """Helper to create a mock GitLab message."""
+        payload = {
+            'object_kind': object_kind,
+            'event_type': 'note',
+            'user': {'id': 12345, 'username': 'testuser'},
+            'project': {
+                'path_with_namespace': 'test-org/test-repo',
+                'visibility_level': 20,
+                'id': 99,
+            },
+            'object_attributes': {
+                'project_id': 99,
+                'action': action,
+                'iid': 42,
+            },
+        }
+
+        if object_kind == 'issue':
+            payload['issue'] = {'iid': 42}
+            payload['labels'] = [{'title': 'openhands'}]
+
+        return Message(
+            source=SourceType.GITLAB,
+            message={
+                'installation_id': 'webhook_123',
+                'payload': payload,
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_gitlab_view_raises_for_unregistered_user(self):
+        """Test that create_gitlab_view_from_payload raises UserNotRegisteredError for unregistered users."""
+        # Setup
+        mock_token_manager = MagicMock()
+        mock_token_manager.get_user_id_from_idp_user_id = AsyncMock(return_value=None)
+
+        # Create a message that would trigger GitlabFactory
+        message = self._create_gitlab_message()
+
+        # Execute & Verify
+        with pytest.raises(UserNotRegisteredError) as exc_info:
+            await GitlabFactory.create_gitlab_view_from_payload(
+                message, mock_token_manager
+            )
+
+        error = exc_info.value
+        assert error.username == 'testuser'
+        assert error.user_id == 12345
+
+
+class TestGitLabManagerUserNotRegistered:
+    """Test cases for GitLab manager handling unregistered users."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_token_manager = MagicMock()
+        self.gitlab_manager = GitlabManager(token_manager=self.mock_token_manager)
+
+    def _create_gitlab_message(self):
+        """Helper to create a mock GitLab message."""
+        return Message(
+            source=SourceType.GITLAB,
+            message={
+                'installation_id': 'webhook_123',
+                'payload': {
+                    'object_kind': 'issue',
+                    'event_type': 'note',
+                    'user': {'id': 12345, 'username': 'testuser'},
+                    'project': {
+                        'path_with_namespace': 'test-org/test-repo',
+                        'visibility_level': 20,
+                        'id': 99,
+                    },
+                    'object_attributes': {
+                        'project_id': 99,
+                        'action': 'update',
+                        'iid': 42,
+                    },
+                    'issue': {'iid': 42},
+                    'labels': [{'title': 'openhands'}],
+                },
+            },
+        )
+
+    @pytest.mark.asyncio
+    @patch('integrations.gitlab.gitlab_manager.GitlabFactory')
+    @patch.object(GitlabManager, 'is_job_requested')
+    @patch.object(GitlabManager, '_send_user_not_registered_message')
+    async def test_receive_message_handles_unregistered_user(
+        self, mock_send_msg, mock_is_job_requested, mock_factory
+    ):
+        """Test that receive_message catches UserNotRegisteredError and sends helpful message."""
+        # Setup
+        mock_is_job_requested.return_value = True
+        mock_factory.create_gitlab_view_from_payload = AsyncMock(
+            side_effect=UserNotRegisteredError(username='testuser', user_id=12345)
+        )
+        mock_send_msg.return_value = None
+
+        message = self._create_gitlab_message()
+
+        # Execute
+        await self.gitlab_manager.receive_message(message)
+
+        # Verify: Should call _send_user_not_registered_message
+        mock_send_msg.assert_called_once()
+        call_args = mock_send_msg.call_args
+        assert call_args[0][1] == 'testuser'
+
+    @pytest.mark.asyncio
+    @patch('integrations.gitlab.gitlab_manager.GitlabFactory')
+    @patch.object(GitlabManager, 'is_job_requested')
+    @patch.object(GitlabManager, 'start_job')
+    async def test_receive_message_proceeds_for_registered_user(
+        self, mock_start_job, mock_is_job_requested, mock_factory
+    ):
+        """Test that receive_message proceeds normally for registered users."""
+        # Setup
+        mock_is_job_requested.return_value = True
+
+        mock_view = MagicMock()
+        mock_view.user_info.username = 'testuser'
+        mock_view.full_repo_name = 'test-org/test-repo'
+        mock_view.issue_number = 42
+        mock_factory.create_gitlab_view_from_payload = AsyncMock(return_value=mock_view)
+
+        mock_start_job.return_value = None
+
+        message = self._create_gitlab_message()
+
+        # Execute
+        await self.gitlab_manager.receive_message(message)
+
+        # Verify: Should call start_job
+        mock_start_job.assert_called_once_with(mock_view)


### PR DESCRIPTION
## Summary of PR

This PR fixes a production error that occurs when processing GitHub/GitLab webhooks from users who haven't registered with OpenHands Cloud. The `keycloak_user_id` lookup returns `None`, which was causing a Pydantic validation error when creating the `UserData` model.

**Error being fixed:**
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for UserData
keycloak_user_id
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

**Changes:**
- **`enterprise/integrations/utils.py`**: Added `get_user_not_registered_message()` helper function and `UserNotRegisteredError` exception class following existing patterns (similar to `get_session_expired_message`)
- **`enterprise/integrations/github/github_manager.py`**: Added null check for `keycloak_user_id` before creating `GithubView`. When user is not registered, posts a helpful comment on the GitHub issue/PR directing them to sign up at OpenHands Cloud
- **`enterprise/integrations/gitlab/gitlab_view.py`**: Added null check that raises `UserNotRegisteredError` when `keycloak_user_id` is None
- **`enterprise/integrations/gitlab/gitlab_manager.py`**: Catches `UserNotRegisteredError` and logs a helpful message (note: cannot actually post GitLab comment without a registered user's token)
- **`enterprise/tests/unit/integrations/test_user_not_registered.py`**: Added comprehensive unit tests (17 tests) for the new functionality

## Demo Screenshots/Videos

N/A - This is a backend fix for error handling.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #13168

## Release Notes

- [x] Include this change in the Release Notes.

Fixed a bug where GitHub/GitLab integrations would crash with a Pydantic validation error when processing webhooks from users who haven't registered with OpenHands Cloud. Now displays a helpful message directing unregistered users to sign up.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:76df4aa-nikolaik   --name openhands-app-76df4aa   docker.openhands.dev/openhands/openhands:76df4aa
```