### PR TITLE
Fix mypy type errors in Jira integration

### DIFF
--- a/enterprise/integrations/jira_dc/jira_dc_view.py
+++ b/enterprise/integrations/jira_dc/jira_dc_view.py
@@ -155,6 +155,9 @@ class JiraDcExistingConversationView(JiraDcViewInterface):
                 self.conversation_id, conversation_init_data, user_id
             )
 
+            if agent_loop_info.event_store is None:
+                raise StartingConvoException('Event store not available')
+
             final_agent_observation = get_final_agent_observation(
                 agent_loop_info.event_store
             )

--- a/enterprise/server/routes/integration/jira.py
+++ b/enterprise/server/routes/integration/jira.py
@@ -601,6 +601,12 @@ async def get_current_workspace_link(request: Request):
         user_auth = cast(SaasUserAuth, await get_user_auth(request))
         user_id = await user_auth.get_user_id()
 
+        if not user_id:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail='User ID not found',
+            )
+
         user = await jira_manager.integration_store.get_user_by_active_workspace(
             user_id
         )
@@ -653,6 +659,12 @@ async def unlink_workspace(request: Request):
     try:
         user_auth = cast(SaasUserAuth, await get_user_auth(request))
         user_id = await user_auth.get_user_id()
+
+        if not user_id:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail='User ID not found',
+            )
 
         user = await jira_manager.integration_store.get_user_by_active_workspace(
             user_id

--- a/enterprise/server/routes/integration/jira_dc.py
+++ b/enterprise/server/routes/integration/jira_dc.py
@@ -281,6 +281,12 @@ async def create_jira_dc_workspace(
         user_id = await user_auth.get_user_id()
         user_email = await user_auth.get_user_email()
 
+        if not user_id:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail='User ID not found',
+            )
+
         if JIRA_DC_ENABLE_OAUTH:
             # OAuth flow enabled - create session and redirect to OAuth
             state = str(uuid.uuid4())
@@ -403,6 +409,12 @@ async def create_workspace_link(request: Request, link_data: JiraDcLinkCreate):
         user_auth = cast(SaasUserAuth, await get_user_auth(request))
         user_id = await user_auth.get_user_id()
         user_email = await user_auth.get_user_email()
+
+        if not user_id:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail='User ID not found',
+            )
 
         target_workspace = link_data.workspace_name
 
@@ -593,6 +605,12 @@ async def get_current_workspace_link(request: Request):
         user_auth = cast(SaasUserAuth, await get_user_auth(request))
         user_id = await user_auth.get_user_id()
 
+        if not user_id:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail='User ID not found',
+            )
+
         user = await jira_dc_manager.integration_store.get_user_by_active_workspace(
             user_id
         )
@@ -644,6 +662,12 @@ async def unlink_workspace(request: Request):
     try:
         user_auth = cast(SaasUserAuth, await get_user_auth(request))
         user_id = await user_auth.get_user_id()
+
+        if not user_id:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail='User ID not found',
+            )
 
         user = await jira_dc_manager.integration_store.get_user_by_active_workspace(
             user_id


### PR DESCRIPTION
## Summary of PR

Fix mypy `arg-type` errors in the Jira and Jira DC integration code by adding proper None guards before using values that could be None.

### Changes:

**1. `enterprise/integrations/jira_dc/jira_dc_view.py`**
- Added None guard for `agent_loop_info.event_store` before calling `get_final_agent_observation()`
- Raises `StartingConvoException` if event_store is None

**2. `enterprise/server/routes/integration/jira_dc.py`**
- `create_jira_dc_workspace()` - Added `user_id` None guard
- `create_workspace_link()` - Added `user_id` None guard
- `get_current_workspace_link()` - Added `user_id` None guard
- `unlink_workspace()` - Added `user_id` None guard

**3. `enterprise/server/routes/integration/jira.py`**
- `get_current_workspace_link()` - Added `user_id` None guard
- `unlink_workspace()` - Added `user_id` None guard

All user_id guards raise `HTTPException` with status 401 (UNAUTHORIZED) if user_id is None.

## Demo Screenshots/Videos

N/A - Type checking fixes only, no functional changes.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Related to #13138

## Release Notes

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:35ac86e-nikolaik   --name openhands-app-35ac86e   docker.openhands.dev/openhands/openhands:35ac86e
```