### PR TITLE
Fix linear-related mypy type errors and make Manager.start_job async

### DIFF
--- a/enterprise/integrations/github/github_manager.py
+++ b/enterprise/integrations/github/github_manager.py
@@ -319,7 +319,7 @@ class GithubManager(Manager[GithubViewType]):
             logger.warning('Unsupported location')
             return
 
-    async def start_job(self, github_view: GithubViewType):
+    async def start_job(self, github_view: GithubViewType) -> None:
         """Kick off a job with openhands agent.
 
         1. Get user credential

--- a/enterprise/integrations/gitlab/gitlab_manager.py
+++ b/enterprise/integrations/gitlab/gitlab_manager.py
@@ -170,7 +170,7 @@ class GitlabManager(Manager[GitlabViewType]):
                 f'[GitLab] Unsupported view type: {type(gitlab_view).__name__}'
             )
 
-    async def start_job(self, gitlab_view: GitlabViewType):
+    async def start_job(self, gitlab_view: GitlabViewType) -> None:
         """
         Start a job for the GitLab view.
 

--- a/enterprise/integrations/jira/jira_manager.py
+++ b/enterprise/integrations/jira/jira_manager.py
@@ -257,7 +257,7 @@ class JiraManager(Manager[JiraViewInterface]):
 
         return jira_user, saas_user_auth
 
-    async def start_job(self, view: JiraViewInterface):
+    async def start_job(self, view: JiraViewInterface) -> None:
         """Start a Jira job/conversation."""
         # Import here to prevent circular import
         from server.conversation_callback_processor.jira_callback_processor import (

--- a/enterprise/integrations/jira_dc/jira_dc_manager.py
+++ b/enterprise/integrations/jira_dc/jira_dc_manager.py
@@ -353,7 +353,7 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
             logger.error(f'[Jira DC] Error in is_job_requested: {str(e)}')
             return False
 
-    async def start_job(self, jira_dc_view: JiraDcViewInterface):
+    async def start_job(self, jira_dc_view: JiraDcViewInterface) -> None:
         """Start a Jira DC job/conversation."""
         # Import here to prevent circular import
         from server.conversation_callback_processor.jira_dc_callback_processor import (

--- a/enterprise/integrations/linear/linear_manager.py
+++ b/enterprise/integrations/linear/linear_manager.py
@@ -343,7 +343,7 @@ class LinearManager(Manager[LinearViewInterface]):
             logger.error(f'[Linear] Error in is_job_requested: {str(e)}')
             return False
 
-    async def start_job(self, linear_view: LinearViewInterface):
+    async def start_job(self, linear_view: LinearViewInterface) -> None:
         """Start a Linear job/conversation."""
         # Import here to prevent circular import
         from server.conversation_callback_processor.linear_callback_processor import (

--- a/enterprise/integrations/linear/linear_view.py
+++ b/enterprise/integrations/linear/linear_view.py
@@ -152,6 +152,9 @@ class LinearExistingConversationView(LinearViewInterface):
                 self.conversation_id, conversation_init_data, user_id
             )
 
+            if agent_loop_info.event_store is None:
+                raise StartingConvoException('Event store not available')
+
             final_agent_observation = get_final_agent_observation(
                 agent_loop_info.event_store
             )

--- a/enterprise/integrations/manager.py
+++ b/enterprise/integrations/manager.py
@@ -25,7 +25,7 @@ class Manager(ABC, Generic[ViewT]):
         raise NotImplementedError
 
     @abstractmethod
-    def start_job(self, view: ViewT) -> None:
+    async def start_job(self, view: ViewT) -> None:
         """Kick off a job with openhands agent.
 
         Args:

--- a/enterprise/integrations/slack/slack_manager.py
+++ b/enterprise/integrations/slack/slack_manager.py
@@ -303,7 +303,7 @@ class SlackManager(Manager[SlackViewInterface]):
 
         return True
 
-    async def start_job(self, slack_view: SlackViewInterface):
+    async def start_job(self, slack_view: SlackViewInterface) -> None:
         # Importing here prevents circular import
         from server.conversation_callback_processor.slack_callback_processor import (
             SlackCallbackProcessor,

--- a/enterprise/server/routes/integration/linear.py
+++ b/enterprise/server/routes/integration/linear.py
@@ -523,6 +523,11 @@ async def get_current_workspace_link(request: Request):
     try:
         user_auth = cast(SaasUserAuth, await get_user_auth(request))
         user_id = await user_auth.get_user_id()
+        if not user_id:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail='User not authenticated',
+            )
 
         user = await linear_manager.integration_store.get_user_by_active_workspace(
             user_id
@@ -576,6 +581,11 @@ async def unlink_workspace(request: Request):
     try:
         user_auth = cast(SaasUserAuth, await get_user_auth(request))
         user_id = await user_auth.get_user_id()
+        if not user_id:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail='User not authenticated',
+            )
 
         user = await linear_manager.integration_store.get_user_by_active_workspace(
             user_id


### PR DESCRIPTION
## Summary of PR

This PR fixes linear-related mypy type errors that were exposed by improved mypy configuration (see #13138). It also makes the `Manager.start_job` base class method async to properly match all subclass implementations.

### Changes:

1. **`enterprise/integrations/linear/linear_view.py`**
   - Added None check for `event_store` before calling `get_final_agent_observation()` since `AgentLoopInfo.event_store` can be `EventStoreABC | None`

2. **`enterprise/server/routes/integration/linear.py`**
   - Added None checks for `user_id` (which is `str | None`) in `get_current_workspace_link()` and `unlink_workspace()` endpoints
   - Returns 401 Unauthorized if user_id is None

3. **`enterprise/integrations/manager.py`**
   - Changed `start_job` from sync to async: `async def start_job(self, view: ViewT) -> None`
   - This fixes the type incompatibility where all subclasses were async but the base class was sync

4. **All manager subclasses** (github, gitlab, slack, jira, jira_dc, linear)
   - Added explicit `-> None` return type annotations for consistency

## Demo Screenshots/Videos

N/A - Type annotation fixes only.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Partially addresses #13138 (fixes the linear-related type errors)

## Release Notes

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:50cb13c-nikolaik   --name openhands-app-50cb13c   docker.openhands.dev/openhands/openhands:50cb13c
```