### PR TITLE
Fix mypy type errors in enterprise/integrations/github/github_manager.py

### DIFF
--- a/enterprise/integrations/github/github_manager.py
+++ b/enterprise/integrations/github/github_manager.py
@@ -301,12 +301,17 @@ class GithubManager(Manager[GithubViewType]):
                     comment_id=github_view.comment_id, body=message
                 )
 
-        else:
-            # GithubPRComment, GithubIssueComment, or GithubIssue
+        elif isinstance(
+            github_view, (GithubPRComment, GithubIssueComment, GithubIssue)
+        ):
             with Github(auth=Auth.Token(installation_token)) as github_client:
                 repo = github_client.get_repo(github_view.full_repo_name)
                 issue = repo.get_issue(number=github_view.issue_number)
                 issue.create_comment(message)
+
+        else:
+            logger.warning('Unsupported location')
+            return
 
     async def start_job(self, github_view: GithubViewType) -> None:
         """Kick off a job with openhands agent.


### PR DESCRIPTION
## Summary of PR

This PR fixes mypy type errors in `enterprise/integrations/github/github_manager.py` that were exposed by improved mypy configuration (see #13138).

### Changes

#### `_get_installation_access_token`
- Changed parameter type from `str` to `int` to match what PyGithub's `get_access_token` expects
- Removed the `type: ignore[arg-type]` comment and outdated docstring about accepting str

#### `send_message`
- **Changed parameter type** from `ResolverViewInterface` to `GithubViewType` - this gives mypy the knowledge that `installation_id` is `int` (not `int | str`)
- **Added missing `await`** on `load_org_token()` - this was a bug where a coroutine was being passed to `Auth.Token()` instead of the actual token string

#### Removed dead code
- The `elif` branch with explicit `isinstance` checks for `GithubPRComment | GithubIssueComment | GithubIssue` plus a final `else` with a warning was redundant
- Since `GithubViewType` only has 4 variants and `GithubInlinePRComment` is handled in the `if`, the remaining 3 are exhaustively covered
- Simplified to `if/else` with a comment documenting the covered types

## Demo Screenshots/Videos

N/A - Type annotation fixes and bug fix.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Partially addresses #13138 (fixes type errors in enterprise/integrations/github/github_manager.py)

## Release Notes

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:da01d0c-nikolaik   --name openhands-app-da01d0c   docker.openhands.dev/openhands/openhands:da01d0c
```