### PR TITLE
Fix mypy type errors in enterprise/server/auth and clustered_conversation_manager

### DIFF
--- a/enterprise/server/auth/saas_user_auth.py
+++ b/enterprise/server/auth/saas_user_auth.py
@@ -119,13 +119,12 @@ class SaasUserAuth(UserAuth):
             self._settings = settings
         return settings
 
-    async def get_secrets_store(self):
+    async def get_secrets_store(self) -> SaasSecretsStore:
         logger.debug('saas_user_auth_get_secrets_store')
         secrets_store = self.secrets_store
         if secrets_store:
             return secrets_store
-        user_id = await self.get_user_id()
-        secrets_store = SaasSecretsStore(user_id, get_config())
+        secrets_store = SaasSecretsStore(self.user_id, get_config())
         self.secrets_store = secrets_store
         return secrets_store
 
@@ -211,8 +210,7 @@ class SaasUserAuth(UserAuth):
         settings_store = self.settings_store
         if settings_store:
             return settings_store
-        user_id = await self.get_user_id()
-        settings_store = SaasSettingsStore(user_id, get_config())
+        settings_store = SaasSettingsStore(self.user_id, get_config())
         self.settings_store = settings_store
         return settings_store
 

--- a/enterprise/server/clustered_conversation_manager.py
+++ b/enterprise/server/clustered_conversation_manager.py
@@ -749,6 +749,9 @@ class ClusteredConversationManager(StandaloneConversationManager):
         config = load_openhands_config()
         settings_store = await SaasSettingsStore.get_instance(config, user_id)
         settings = await settings_store.load()
+        if not settings:
+            logger.error(f'Failed to load settings for user {user_id}')
+            return
         await self.maybe_start_agent_loop(conversation_id, settings, user_id)
 
     async def _start_agent_loop(


### PR DESCRIPTION
## Summary of PR

This PR fixes mypy type errors in `enterprise/server/auth/saas_user_auth.py` and `enterprise/server/clustered_conversation_manager.py` that were exposed by improved mypy configuration (see #13138).

### Changes

#### `enterprise/server/auth/saas_user_auth.py`

**`get_secrets_store()`**:
- Use `self.user_id` directly instead of `await self.get_user_id()`
- `self.user_id` is typed as `str` (not `str | None`), so no null check needed
- Added return type annotation `-> SaasSecretsStore`

**`get_user_settings_store()`**:
- Same fix: use `self.user_id` directly instead of `await self.get_user_id()`

#### `enterprise/server/clustered_conversation_manager.py`

**`_handle_reconnection()`**:
- Added `None` check for `settings` before calling `maybe_start_agent_loop()`
- `settings_store.load()` returns `Settings | None`, but `maybe_start_agent_loop()` expects `Settings`
- Logs an error and returns early if settings can't be loaded

## Demo Screenshots/Videos

N/A - Type annotation fixes.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Partially addresses #13138 (fixes type errors in enterprise/server/)

## Release Notes

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:05881b1-nikolaik   --name openhands-app-05881b1   docker.openhands.dev/openhands/openhands:05881b1
```