### PR TITLE
Remove dead test code for non-existent update_common_room_signal function

### DIFF
--- a/enterprise/sync/test_common_room_sync.py
+++ b/enterprise/sync/test_common_room_sync.py
@@ -7,17 +7,13 @@ without making any API calls to Common Room or database connections.
 """
 
 import os
-
-# Import the module to test
 import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from sync.common_room_sync import (
-    CommonRoomAPIError,
     retry_with_backoff,
-    update_common_room_signal,
 )
 
 
@@ -49,78 +45,6 @@ class TestCommonRoomSync(unittest.TestCase):
             mock_func.assert_called_with('arg1', 'arg2', kwarg1='kwarg1')
             # Check that the function returned the expected result
             self.assertEqual(result, 'success')
-
-    @patch('sync.common_room_sync.requests.post')
-    @patch('sync.common_room_sync.COMMON_ROOM_API_KEY', 'test_api_key')
-    @patch(
-        'sync.common_room_sync.COMMON_ROOM_DESTINATION_SOURCE_ID',
-        'test_source_id',
-    )
-    def test_update_common_room_signal(self, mock_post):
-        """Test the update_common_room_signal function."""
-        # Mock successful API responses
-        mock_user_response = MagicMock()
-        mock_user_response.status_code = 200
-        mock_user_response.json.return_value = {'id': 'user123'}
-
-        mock_activity_response = MagicMock()
-        mock_activity_response.status_code = 200
-        mock_activity_response.json.return_value = {'id': 'activity123'}
-
-        mock_post.side_effect = [mock_user_response, mock_activity_response]
-
-        # Call the function
-        result = update_common_room_signal(
-            user_id='user123',
-            email='user@example.com',
-            github_username='user123',
-            conversation_count=5,
-        )
-
-        # Check that the function made the expected API calls
-        self.assertEqual(mock_post.call_count, 2)
-
-        # Check the first call (user creation)
-        args1, kwargs1 = mock_post.call_args_list[0]
-        self.assertIn('/source/test_source_id/user', args1[0])
-        self.assertEqual(kwargs1['headers']['Authorization'], 'Bearer test_api_key')
-        self.assertEqual(kwargs1['json']['id'], 'user123')
-        self.assertEqual(kwargs1['json']['email'], 'user@example.com')
-
-        # Check the second call (activity creation)
-        args2, kwargs2 = mock_post.call_args_list[1]
-        self.assertIn('/source/test_source_id/activity', args2[0])
-        self.assertEqual(kwargs2['headers']['Authorization'], 'Bearer test_api_key')
-        self.assertEqual(kwargs2['json']['user']['id'], 'user123')
-        self.assertEqual(
-            kwargs2['json']['content']['value'], 'User has created 5 conversations'
-        )
-
-        # Check the return value
-        self.assertEqual(result, {'id': 'activity123'})
-
-    @patch('sync.common_room_sync.requests.post')
-    @patch('sync.common_room_sync.COMMON_ROOM_API_KEY', 'test_api_key')
-    @patch(
-        'sync.common_room_sync.COMMON_ROOM_DESTINATION_SOURCE_ID',
-        'test_source_id',
-    )
-    def test_update_common_room_signal_error(self, mock_post):
-        """Test error handling in update_common_room_signal function."""
-        # Mock failed API response
-        mock_response = MagicMock()
-        mock_response.status_code = 400
-        mock_response.text = 'Bad Request'
-        mock_post.return_value = mock_response
-
-        # Call the function and check that it raises the expected exception
-        with self.assertRaises(CommonRoomAPIError):
-            update_common_room_signal(
-                user_id='user123',
-                email='user@example.com',
-                github_username='user123',
-                conversation_count=5,
-            )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary of PR

This PR removes dead test code in `enterprise/sync/test_common_room_sync.py` that was testing a function (`update_common_room_signal`) that doesn't exist in the source module and never did based on git history.

### Changes

**Removed:**
- Import of `update_common_room_signal` and `CommonRoomAPIError` 
- `test_update_common_room_signal` test method
- `test_update_common_room_signal_error` test method

**Kept:**
- `test_retry_with_backoff` test - this tests a function that actually exists

### Context

This was discovered while running stricter mypy type checking (see #13138). The error was:
```
enterprise/sync/test_common_room_sync.py:17: error: Module "sync.common_room_sync" has no attribute "update_common_room_signal"  [attr-defined]
```

Looking at `common_room_sync.py`, the function `update_common_room_signal` doesn't exist. The module has:
- `register_user_in_common_room()`
- `register_conversation_activity()`
- `retry_with_backoff()`
- etc.

But no `update_common_room_signal`. Git history confirms this function was never implemented.

## Demo Screenshots/Videos

N/A - Dead code removal.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Partially addresses #13138 (fixes mypy error in enterprise/sync/)

## Release Notes

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:0cde97b-nikolaik   --name openhands-app-0cde97b   docker.openhands.dev/openhands/openhands:0cde97b
```