### PR TITLE
fix: update agent-server image tag to existing build

### DIFF
--- a/openhands/app_server/sandbox/sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/sandbox_spec_service.py
@@ -13,7 +13,7 @@ from openhands.sdk.utils.models import DiscriminatedUnionMixin
 
 # The version of the agent server to use for deployments.
 # Typically this will be the same as the values from the pyproject.toml
-AGENT_SERVER_IMAGE = 'ghcr.io/openhands/agent-server:2c1e72a-python'
+AGENT_SERVER_IMAGE = 'ghcr.io/openhands/agent-server:50d8f1b-python'
 
 
 class SandboxSpecService(ABC):


### PR DESCRIPTION
## Description

Fixes the broken "Changes" tab in the local GUI caused by PR #13120.

### Root Cause

The image tag `ghcr.io/openhands/agent-server:2c1e72a-python` specified in PR #13120 **does not exist** in the container registry because:

1. Commit `2c1e72a` was a **merge commit** 
2. The Agent Server workflow only built images for the `pull_request` event (targeting commit `3e81846`), not for the `push` event on the merge commit
3. The Container Registry confirms the `2c1e72a-python` tag is missing

### Fix

Updated `AGENT_SERVER_IMAGE` to `50d8f1b-python`, which is a recent successful push build from 2026-03-04T13:58:07Z that includes the query parameter support from [SDK PR #2249](https://github.com/OpenHands/openhands-sdk/pull/2249).

## Testing

- [x] Pre-commit checks pass
- [ ] Manual verification: Local GUI Changes tab should work with the new image tag

## Linked Issues

Related to #13120 - this fixes the regression introduced by that PR.

---

**Summary:** Simple one-line fix to update the agent-server image tag from a non-existent tag to an existing one.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:af8687e-nikolaik   --name openhands-app-af8687e   docker.openhands.dev/openhands/openhands:af8687e
```