### PR TITLE
Add Qwen3-Coder-Next model support to frontend

### DIFF
--- a/frontend/src/utils/verified-models.ts
+++ b/frontend/src/utils/verified-models.ts
@@ -20,6 +20,7 @@ export const VERIFIED_MODELS = [
   "devstral-medium-2512",
   "kimi-k2-0711-preview",
   "qwen3-coder-480b",
+  "qwen3-coder-next",
   "glm-4.7",
 ];
 
@@ -64,6 +65,7 @@ export const VERIFIED_OPENHANDS_MODELS = [
   "devstral-medium-2512",
   "kimi-k2-0711-preview",
   "qwen3-coder-480b",
+  "qwen3-coder-next",
   "glm-4.7",
 ];
 

--- a/openhands/utils/llm.py
+++ b/openhands/utils/llm.py
@@ -26,6 +26,7 @@ OPENHANDS_MODELS = [
     'openhands/devstral-medium-2512',
     'openhands/kimi-k2-0711-preview',
     'openhands/qwen3-coder-480b',
+    'openhands/qwen3-coder-next',
     'openhands/glm-4.7',
 ]
 


### PR DESCRIPTION
## Description
Adds Qwen3-Coder-Next model to OpenHands, leveraging existing capability patterns.

Closes #13221

## Changes Made

### Backend Changes
- ✅ Added `'openhands/qwen3-coder-next'` to OPENHANDS_MODELS in `openhands/utils/llm.py`

### Frontend Changes
- ✅ Added `'qwen3-coder-next'` to VERIFIED_MODELS array in `frontend/src/utils/verified-models.ts`
- ✅ Added `'qwen3-coder-next'` to VERIFIED_OPENHANDS_MODELS array

### Model Capabilities
- ✅ Function calling support already provided by existing `'qwen3-coder*'` pattern in FUNCTION_CALLING_PATTERNS
- ✅ Stop words support (default behavior)
- ❌ Reasoning effort not supported
- ❌ Prompt caching not supported

## Evidence of Capabilities

### Official LiteLLM Configuration
Source: https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json

**Qwen3-Coder-Next variants with verified capabilities (Bedrock providers):**

Multiple regional endpoints confirm:
- `qwen.qwen3-coder-next` (bedrock_converse)
- `bedrock/ap-northeast-1/qwen.qwen3-coder-next`
- `bedrock/us-east-1/qwen.qwen3-coder-next`
- `bedrock/eu-west-1/qwen.qwen3-coder-next`
- `bedrock/ap-south-1/qwen.qwen3-coder-next`
- `bedrock/ap-southeast-3/qwen.qwen3-coder-next`
- `bedrock/sa-east-1/qwen.qwen3-coder-next`
- ...and more regions

All show:
- `supports_function_calling: true`
- `supports_tool_choice: true`
- `supports_system_messages: true`

## Testing

### Files Modified
- `openhands/utils/llm.py` - Backend model list
- `frontend/src/utils/verified-models.ts` - Frontend verification arrays

### Expected Behavior
- Qwen3-Coder-Next should appear in the frontend model selector dropdown
- Model should support function calling (via existing qwen3-coder* pattern)
- Stop words should work (default behavior)

## Notes
- **No changes to `openhands/llm/model_features.py`** - Function calling support is already provided by the existing `'qwen3-coder*'` wildcard pattern in FUNCTION_CALLING_PATTERNS
- This is more efficient than adding specific patterns since it automatically covers all qwen3-coder variants

## Related
- Similar to PR #13202 (GLM-4.7 support) and PR #13213 (GLM-5 support)
- Part of Qwen3-Coder model family alongside qwen3-coder-480b

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:1370c6a-nikolaik   --name openhands-app-1370c6a   docker.openhands.dev/openhands/openhands:1370c6a
```