### PR TITLE
Add Claude-Sonnet-4-6 model support to frontend

### DIFF
--- a/frontend/src/utils/verified-models.ts
+++ b/frontend/src/utils/verified-models.ts
@@ -10,6 +10,7 @@ export const VERIFIED_PROVIDERS = [
 export const VERIFIED_MODELS = [
   "claude-opus-4-6",
   "claude-opus-4-5-20251101",
+  "claude-sonnet-4-6",
   "claude-sonnet-4-5-20250929",
   "gpt-5.2-codex",
   "gpt-5.2",
@@ -55,6 +56,7 @@ export const VERIFIED_MISTRAL_MODELS = ["devstral-medium-2512"];
 export const VERIFIED_OPENHANDS_MODELS = [
   "claude-opus-4-6",
   "claude-opus-4-5-20251101",
+  "claude-sonnet-4-6",
   "claude-sonnet-4-5-20250929",
   "gpt-5.2-codex",
   "gpt-5.2",

--- a/openhands/llm/model_features.py
+++ b/openhands/llm/model_features.py
@@ -117,6 +117,7 @@ REASONING_EFFORT_PATTERNS: list[str] = [
     # DeepSeek reasoning family
     'deepseek-r1-0528*',
     'claude-sonnet-4-5*',
+    'claude-sonnet-4-6*',
     'claude-haiku-4-5*',
     # GLM series - verified via litellm config
     'glm-4*',

--- a/openhands/utils/llm.py
+++ b/openhands/utils/llm.py
@@ -16,6 +16,7 @@ from openhands.llm import bedrock
 OPENHANDS_MODELS = [
     'openhands/claude-opus-4-6',
     'openhands/claude-opus-4-5-20251101',
+    'openhands/claude-sonnet-4-6',
     'openhands/claude-sonnet-4-5-20250929',
     'openhands/gpt-5.2-codex',
     'openhands/gpt-5.2',


### PR DESCRIPTION
## Description
Adds Claude-Sonnet-4-6 model to OpenHands with full capability definitions verified via LiteLLM configuration.

Closes #13223

## Changes Made

### Backend Changes
- ✅ Added `'openhands/claude-sonnet-4-6'` to OPENHANDS_MODELS in `openhands/utils/llm.py`

### Frontend Changes
- ✅ Added `'claude-sonnet-4-6'` to VERIFIED_MODELS array in `frontend/src/utils/verified-models.ts`
- ✅ Added `'claude-sonnet-4-6'` to VERIFIED_OPENHANDS_MODELS array

### Model Capabilities
- ✅ Function calling support already provided by existing `'claude-sonnet-4*'` pattern in FUNCTION_CALLING_PATTERNS
- ✅ Prompt caching support already provided by existing `'claude-sonnet-4*'` pattern in PROMPT_CACHE_PATTERNS
- ✅ Added `'claude-sonnet-4-6*'` to REASONING_EFFORT_PATTERNS in `openhands/llm/model_features.py`
- ✅ Stop words support (default behavior)

## Evidence of Capabilities

### Official LiteLLM Configuration
Source: https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json

**Claude-Sonnet-4-6 variants with verified capabilities (Bedrock providers):**

Multiple regional endpoints confirm:
- `anthropic.claude-sonnet-4-6` (bedrock_converse)
- `global.anthropic.claude-sonnet-4-6`
- `us.anthropic.claude-sonnet-4-6`
- `eu.anthropic.claude-sonnet-4-6`
- `apac.anthropic.claude-sonnet-4-6`

All show extensive capabilities:
- `supports_function_calling: true`
- `supports_prompt_caching: true`
- `supports_reasoning: true`
- `supports_tool_choice: true`
- `supports_vision: true`
- `supports_computer_use: true`
- `supports_pdf_input: true`
- `supports_response_schema: true`
- `supports_assistant_prefill: true`

## Testing

### Files Modified
- `openhands/utils/llm.py` - Backend model list
- `frontend/src/utils/verified-models.ts` - Frontend verification arrays
- `openhands/llm/model_features.py` - Reasoning effort capability

### Expected Behavior
- Claude-Sonnet-4-6 should appear in the frontend model selector dropdown
- Model should support function calling (via existing claude-sonnet-4* pattern)
- Model should support prompt caching (via existing claude-sonnet-4* pattern)
- Model should support reasoning effort (via new claude-sonnet-4-6* pattern)
- Stop words should work (default behavior)

## Notes
- **Efficient reuse of patterns**: Function calling and prompt caching support were already provided by existing `'claude-sonnet-4*'` wildcard patterns
- Only reasoning effort pattern needed to be added for complete coverage
- Claude-Sonnet-4-6 brings advanced capabilities like vision, computer use, and PDF input support

## Related
- Similar to PR #13202 (GLM-4.7 support), PR #13213 (GLM-5 support), and PR #13222 (Qwen3-Coder-Next support)
- Part of Claude-4 model family alongside claude-opus-4-6 and claude-sonnet-4-5

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:ca06a86-nikolaik   --name openhands-app-ca06a86   docker.openhands.dev/openhands/openhands:ca06a86
```