### PR TITLE
Add Kimi-K2.5 model support to frontend

### DIFF
--- a/frontend/src/utils/verified-models.ts
+++ b/frontend/src/utils/verified-models.ts
@@ -20,6 +20,7 @@ export const VERIFIED_MODELS = [
   "deepseek-chat",
   "devstral-medium-2512",
   "kimi-k2-0711-preview",
+  "kimi-k2.5",
   "qwen3-coder-480b",
   "glm-4.7",
 ];
@@ -65,6 +66,7 @@ export const VERIFIED_OPENHANDS_MODELS = [
   "gemini-3-flash-preview",
   "devstral-medium-2512",
   "kimi-k2-0711-preview",
+  "kimi-k2.5",
   "qwen3-coder-480b",
   "glm-4.7",
 ];

--- a/openhands/llm/model_features.py
+++ b/openhands/llm/model_features.py
@@ -93,6 +93,7 @@ FUNCTION_CALLING_PATTERNS: list[str] = [
     # Others
     'kimi-k2-0711-preview',
     'kimi-k2-instruct',
+    'kimi-k2.5',
     'qwen3-coder*',
     'qwen3-coder-480b-a35b-instruct',
     'deepseek-chat',
@@ -119,6 +120,8 @@ REASONING_EFFORT_PATTERNS: list[str] = [
     'claude-sonnet-4-5*',
     'claude-sonnet-4-6*',
     'claude-haiku-4-5*',
+    # Kimi series - verified via litellm config
+    'kimi-k2.5',
     # GLM series - verified via litellm config
     'glm-4*',
 ]
@@ -134,6 +137,8 @@ PROMPT_CACHE_PATTERNS: list[str] = [
     'claude-3-opus-20240229',
     'claude-sonnet-4*',
     'claude-opus-4*',
+    # Kimi series - verified via litellm config
+    'kimi-k2.5',
     # GLM series - verified via litellm config
     'glm-4*',
 ]

--- a/openhands/utils/llm.py
+++ b/openhands/utils/llm.py
@@ -26,6 +26,7 @@ OPENHANDS_MODELS = [
     'openhands/deepseek-chat',
     'openhands/devstral-medium-2512',
     'openhands/kimi-k2-0711-preview',
+    'openhands/kimi-k2.5',
     'openhands/qwen3-coder-480b',
     'openhands/glm-4.7',
 ]


### PR DESCRIPTION
## Description
Adds Kimi-K2.5 model to OpenHands with full capability definitions verified via LiteLLM configuration.

Closes #13226

## Changes Made

### Backend Changes
- ✅ Added `'openhands/kimi-k2.5'` to OPENHANDS_MODELS in `openhands/utils/llm.py`

### Frontend Changes
- ✅ Added `'kimi-k2.5'` to VERIFIED_MODELS array in `frontend/src/utils/verified-models.ts`
- ✅ Added `'kimi-k2.5'` to VERIFIED_OPENHANDS_MODELS array

### Model Capabilities
- ✅ Added `'kimi-k2.5'` to FUNCTION_CALLING_PATTERNS in `openhands/llm/model_features.py`
- ✅ Added `'kimi-k2.5'` to REASONING_EFFORT_PATTERNS
- ✅ Added `'kimi-k2.5'` to PROMPT_CACHE_PATTERNS
- ✅ Stop words support (default behavior)

## Evidence of Capabilities

### Official LiteLLM Configuration
Source: https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json

**Kimi-K2.5 variants with verified capabilities (multiple providers):**

Multiple providers confirm:
- `moonshot/kimi-k2.5` (moonshot provider)
- `together_ai/moonshotai/Kimi-K2.5` (together_ai provider)
- `bedrock/moonshotai.kimi-k2.5` (bedrock provider - multiple regions)
- `bedrock/ap-northeast-1/moonshotai.kimi-k2.5`
- `bedrock/ap-south-1/moonshotai.kimi-k2.5`
- `bedrock/ap-southeast-3/moonshotai.kimi-k2.5`
- `azure_ai/kimi-k2.5` (azure_ai provider)

All show extensive capabilities:
- `supports_function_calling: true`
- `supports_tool_choice: true`
- `supports_reasoning: true` (bedrock, together_ai providers)
- `supports_vision: true`
- `supports_video_input: true`
- `cache_read_input_token_cost`: present (prompt caching support)

**Max tokens**: 262,144 input tokens / 262,144 output tokens

## Testing

### Files Modified
- `openhands/utils/llm.py` - Backend model list
- `frontend/src/utils/verified-models.ts` - Frontend verification arrays
- `openhands/llm/model_features.py` - Model capability patterns

### Expected Behavior
- Kimi-K2.5 should appear in the frontend model selector dropdown
- Model should support function calling
- Model should support reasoning effort
- Model should support prompt caching
- Model should support vision and video input
- Stop words should work (default behavior)

## Notes
- Kimi-K2.5 is available across multiple providers (moonshot, together_ai, bedrock, azure_ai)
- Advanced capabilities include vision support and video input support
- Part of the Kimi-K2 model family alongside kimi-k2-0711-preview

## Additional Information
- Official docs: https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart
- Together AI page: https://www.together.ai/models/kimi-k2-5

## Related
- Similar to PR #13202 (GLM-4.7 support), PR #13213 (GLM-5 support), PR #13222 (Qwen3-Coder-Next support), and PR #13224 (Claude-Sonnet-4-6 support)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:817c430-nikolaik   --name openhands-app-817c430   docker.openhands.dev/openhands/openhands:817c430
```