### PR TITLE
feat: add WarpGrep codebase search tool for CodeAct agent

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -275,6 +275,10 @@ enable_history_truncation = true
 # Whether the condensation request tool is enabled
 enable_condensation_request = false
 
+# Whether the WarpGrep codebase search tool is enabled
+# Requires WARPGREP_API_KEY or MORPH_API_KEY environment variable
+enable_warpgrep = false
+
 [agent.RepoExplorerAgent]
 # Example: use a cheaper model for RepoExplorerAgent to reduce cost, especially
 # useful when an agent doesn't demand high quality but uses a lot of tokens

--- a/openhands/agenthub/codeact_agent/codeact_agent.py
+++ b/openhands/agenthub/codeact_agent/codeact_agent.py
@@ -35,6 +35,7 @@ from openhands.agenthub.codeact_agent.tools.task_tracker import (
     create_task_tracker_tool,
 )
 from openhands.agenthub.codeact_agent.tools.think import ThinkTool
+from openhands.agenthub.codeact_agent.tools.warpgrep import WarpGrepTool
 from openhands.controller.agent import Agent
 from openhands.controller.state.state import State
 from openhands.core.config import AgentConfig
@@ -149,6 +150,8 @@ class CodeActAgent(Agent):
         if self.config.enable_plan_mode:
             # In plan mode, we use the task_tracker tool for task management
             tools.append(create_task_tracker_tool(use_short_tool_desc))
+        if self.config.enable_warpgrep:
+            tools.append(WarpGrepTool)
         if self.config.enable_llm_editor:
             tools.append(LLMBasedFileEditTool)
         elif self.config.enable_editor:

--- a/openhands/agenthub/codeact_agent/function_calling.py
+++ b/openhands/agenthub/codeact_agent/function_calling.py
@@ -23,6 +23,7 @@ from openhands.agenthub.codeact_agent.tools import (
     IPythonTool,
     LLMBasedFileEditTool,
     ThinkTool,
+    WarpGrepTool,
     create_cmd_run_tool,
     create_str_replace_editor_tool,
 )
@@ -48,9 +49,12 @@ from openhands.events.action import (
 )
 from openhands.events.action.agent import CondensationRequestAction
 from openhands.events.action.mcp import MCPAction
+from openhands.events.action.warpgrep import WarpGrepAction
 from openhands.events.event import FileEditSource, FileReadSource
 from openhands.events.tool import ToolCallMetadata
 from openhands.llm.tool_names import TASK_TRACKER_TOOL_NAME
+
+WARPGREP_TOOL_NAME = WarpGrepTool['function']['name']
 
 
 def combine_thought(action: Action, thought: str) -> Action:
@@ -301,6 +305,16 @@ def response_to_actions(
                     command=arguments['command'],
                     task_list=normalized_task_list,
                 )
+
+            # ================================================
+            # WarpGrepAction (WarpGrep codebase search)
+            # ================================================
+            elif tool_call.function.name == WARPGREP_TOOL_NAME:
+                if 'query' not in arguments:
+                    raise FunctionCallValidationError(
+                        f'Missing required argument "query" in tool call {tool_call.function.name}'
+                    )
+                action = WarpGrepAction(query=arguments['query'])
 
             # ================================================
             # MCPAction (MCP)

--- a/openhands/agenthub/codeact_agent/tools/__init__.py
+++ b/openhands/agenthub/codeact_agent/tools/__init__.py
@@ -6,6 +6,7 @@ from .ipython import IPythonTool
 from .llm_based_edit import LLMBasedFileEditTool
 from .str_replace_editor import create_str_replace_editor_tool
 from .think import ThinkTool
+from .warpgrep import WarpGrepTool
 
 __all__ = [
     'BrowserTool',
@@ -16,4 +17,5 @@ __all__ = [
     'LLMBasedFileEditTool',
     'create_str_replace_editor_tool',
     'ThinkTool',
+    'WarpGrepTool',
 ]

--- a/openhands/agenthub/codeact_agent/tools/warpgrep.py
+++ b/openhands/agenthub/codeact_agent/tools/warpgrep.py
@@ -1,0 +1,27 @@
+from litellm import ChatCompletionToolParam, ChatCompletionToolParamFunctionChunk
+
+WARPGREP_TOOL_NAME = 'warpgrep_codebase_search'
+
+_WARPGREP_DESCRIPTION = """Search the codebase using WarpGrep, an AI-powered code search subagent.
+
+WarpGrep runs in an isolated context window. Instead of doing sequential grep/read calls (which pollutes your context with dead ends), WarpGrep does 8 parallel tool calls per turn across 4 turns, returning only the relevant code sections.
+
+Use this for semantic searches like 'find the authentication middleware', 'where is rate limiting configured', or 'how are database connections managed'. For exact pattern matching, use bash with grep/rg instead."""
+
+WarpGrepTool = ChatCompletionToolParam(
+    type='function',
+    function=ChatCompletionToolParamFunctionChunk(
+        name=WARPGREP_TOOL_NAME,
+        description=_WARPGREP_DESCRIPTION,
+        parameters={
+            'type': 'object',
+            'properties': {
+                'query': {
+                    'type': 'string',
+                    'description': 'A natural language description of what code to find.',
+                },
+            },
+            'required': ['query'],
+        },
+    ),
+)

--- a/openhands/core/config/agent_config.py
+++ b/openhands/core/config/agent_config.py
@@ -50,6 +50,8 @@ class AgentConfig(BaseModel):
     """Whether to enable prompt extensions"""
     enable_mcp: bool = Field(default=True)
     """Whether to enable MCP tools"""
+    enable_warpgrep: bool = Field(default=False)
+    """Whether to enable WarpGrep codebase search tool"""
     disabled_microagents: list[str] = Field(default_factory=list)
     """A list of microagents to disable (by name, without .py extension, e.g. ["github", "lint"]). Default is None."""
     enable_history_truncation: bool = Field(default=True)

--- a/openhands/core/schema/action.py
+++ b/openhands/core/schema/action.py
@@ -107,3 +107,6 @@ class ActionType(str, Enum):
 
     LOOP_RECOVERY = 'loop_recovery'
     """Recover dead loop."""
+
+    WARPGREP_SEARCH = 'warpgrep_search'
+    """Searches the codebase using WarpGrep, an AI-powered code search subagent."""

--- a/openhands/core/schema/observation.py
+++ b/openhands/core/schema/observation.py
@@ -68,3 +68,6 @@ class ObservationType(str, Enum):
 
     LOOP_DETECTION = 'loop_detection'
     """Results of a dead-loop detection"""
+
+    WARPGREP_SEARCH = 'warpgrep_search'
+    """Results of a WarpGrep codebase search"""

--- a/openhands/events/action/__init__.py
+++ b/openhands/events/action/__init__.py
@@ -23,6 +23,7 @@ from openhands.events.action.files import (
 )
 from openhands.events.action.mcp import MCPAction
 from openhands.events.action.message import MessageAction, SystemMessageAction
+from openhands.events.action.warpgrep import WarpGrepAction
 
 __all__ = [
     'Action',
@@ -47,4 +48,5 @@ __all__ = [
     'TaskTrackingAction',
     'ActionSecurityRisk',
     'LoopRecoveryAction',
+    'WarpGrepAction',
 ]

--- a/openhands/events/action/warpgrep.py
+++ b/openhands/events/action/warpgrep.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+from typing import ClassVar
+
+from openhands.core.schema import ActionType
+from openhands.events.action.action import Action, ActionSecurityRisk
+
+
+@dataclass
+class WarpGrepAction(Action):
+    query: str
+    thought: str = ''
+    action: str = ActionType.WARPGREP_SEARCH
+    runnable: ClassVar[bool] = True
+    security_risk: ActionSecurityRisk | None = ActionSecurityRisk.LOW
+
+    @property
+    def message(self) -> str:
+        return f'Searching the codebase with WarpGrep:\n```\n{self.query}\n```'
+
+    def __str__(self) -> str:
+        ret = '**WarpGrepAction**\n'
+        if self.thought:
+            ret += f'THOUGHT: {self.thought}\n'
+        ret += f'QUERY: {self.query}'
+        return ret

--- a/openhands/events/observation/__init__.py
+++ b/openhands/events/observation/__init__.py
@@ -27,6 +27,7 @@ from openhands.events.observation.observation import Observation
 from openhands.events.observation.reject import UserRejectObservation
 from openhands.events.observation.success import SuccessObservation
 from openhands.events.observation.task_tracking import TaskTrackingObservation
+from openhands.events.observation.warpgrep import WarpGrepObservation
 from openhands.events.recall_type import RecallType
 
 __all__ = [
@@ -52,4 +53,5 @@ __all__ = [
     'MCPObservation',
     'FileDownloadObservation',
     'TaskTrackingObservation',
+    'WarpGrepObservation',
 ]

--- a/openhands/events/observation/warpgrep.py
+++ b/openhands/events/observation/warpgrep.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass, field
+
+from openhands.core.schema import ObservationType
+from openhands.events.observation.observation import Observation
+
+
+@dataclass
+class WarpGrepObservation(Observation):
+    """Result of a WarpGrep codebase search operation."""
+
+    observation: str = ObservationType.WARPGREP_SEARCH
+    query: str = ''
+    results: list[dict] = field(default_factory=list)
+
+    @property
+    def message(self) -> str:
+        return self.content

--- a/openhands/events/serialization/action.py
+++ b/openhands/events/serialization/action.py
@@ -27,6 +27,7 @@ from openhands.events.action.files import (
 )
 from openhands.events.action.mcp import MCPAction
 from openhands.events.action.message import MessageAction, SystemMessageAction
+from openhands.events.action.warpgrep import WarpGrepAction
 
 actions = (
     NullAction,
@@ -50,6 +51,7 @@ actions = (
     MCPAction,
     TaskTrackingAction,
     LoopRecoveryAction,
+    WarpGrepAction,
 )
 
 ACTION_TYPE_TO_CLASS = {action_class.action: action_class for action_class in actions}  # type: ignore[attr-defined]

--- a/openhands/events/serialization/observation.py
+++ b/openhands/events/serialization/observation.py
@@ -31,6 +31,7 @@ from openhands.events.observation.observation import Observation
 from openhands.events.observation.reject import UserRejectObservation
 from openhands.events.observation.success import SuccessObservation
 from openhands.events.observation.task_tracking import TaskTrackingObservation
+from openhands.events.observation.warpgrep import WarpGrepObservation
 from openhands.events.recall_type import RecallType
 
 observations = (
@@ -53,6 +54,7 @@ observations = (
     FileDownloadObservation,
     TaskTrackingObservation,
     LoopDetectionObservation,
+    WarpGrepObservation,
 )
 
 OBSERVATION_TYPE_TO_CLASS = {

--- a/openhands/memory/conversation_memory.py
+++ b/openhands/memory/conversation_memory.py
@@ -22,6 +22,7 @@ from openhands.events.action import (
 )
 from openhands.events.action.mcp import MCPAction
 from openhands.events.action.message import SystemMessageAction
+from openhands.events.action.warpgrep import WarpGrepAction
 from openhands.events.event import Event
 from openhands.events.observation import (
     AgentCondensationObservation,
@@ -43,6 +44,7 @@ from openhands.events.observation.agent import (
 )
 from openhands.events.observation.error import ErrorObservation
 from openhands.events.observation.mcp import MCPObservation
+from openhands.events.observation.warpgrep import WarpGrepObservation
 from openhands.events.observation.observation import Observation
 from openhands.events.recall_type import RecallType
 from openhands.events.serialization.event import truncate_content
@@ -241,6 +243,7 @@ class ConversationMemory:
                 BrowseURLAction,
                 MCPAction,
                 TaskTrackingAction,
+                WarpGrepAction,
             ),
         ) or (isinstance(action, CmdRunAction) and action.source == 'agent'):
             tool_metadata = action.tool_call_metadata
@@ -408,7 +411,9 @@ class ConversationMemory:
                 text = truncate_content(obs.to_agent_observation(), max_message_chars)
             message = Message(role='user', content=[TextContent(text=text)])
         elif isinstance(obs, MCPObservation):
-            # logger.warning(f'MCPObservation: {obs}')
+            text = truncate_content(obs.content, max_message_chars)
+            message = Message(role='user', content=[TextContent(text=text)])
+        elif isinstance(obs, WarpGrepObservation):
             text = truncate_content(obs.content, max_message_chars)
             message = Message(role='user', content=[TextContent(text=text)])
         elif isinstance(obs, IPythonRunCellObservation):

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -45,6 +45,7 @@ from openhands.events.action import (
     TaskTrackingAction,
 )
 from openhands.events.action.mcp import MCPAction
+from openhands.events.action.warpgrep import WarpGrepAction
 from openhands.events.event import Event
 from openhands.events.observation import (
     AgentThinkObservation,
@@ -1209,6 +1210,10 @@ fi
 
     @abstractmethod
     async def call_tool_mcp(self, action: MCPAction) -> Observation:
+        pass
+
+    @abstractmethod
+    def warpgrep_search(self, action: WarpGrepAction) -> Observation:
         pass
 
     # ====================================================================

--- a/openhands/runtime/impl/action_execution/action_execution_client.py
+++ b/openhands/runtime/impl/action_execution/action_execution_client.py
@@ -40,8 +40,10 @@ from openhands.events.action import (
 from openhands.events.action.action import Action
 from openhands.events.action.files import FileEditSource
 from openhands.events.action.mcp import MCPAction
+from openhands.events.action.warpgrep import WarpGrepAction
 from openhands.events.observation import (
     AgentThinkObservation,
+    CmdOutputObservation,
     ErrorObservation,
     NullObservation,
     Observation,
@@ -490,6 +492,50 @@ class ActionExecutionClient(Runtime):
         # No need for try/finally since disconnect() is now just resetting state
         result = await call_tool_mcp_handler(mcp_clients, action)
         return result
+
+    def warpgrep_search(self, action: WarpGrepAction) -> Observation:
+        from openhands.events.observation.warpgrep import WarpGrepObservation
+
+        api_key = os.environ.get('WARPGREP_API_KEY') or os.environ.get(
+            'MORPH_API_KEY', ''
+        )
+        if not api_key:
+            return ErrorObservation(
+                'WarpGrep API key not configured. Set WARPGREP_API_KEY or MORPH_API_KEY environment variable.'
+            )
+
+        def run_in_sandbox(cmd: str) -> str:
+            obs = self.run(CmdRunAction(command=cmd))
+            if isinstance(obs, CmdOutputObservation):
+                return obs.content
+            return ''
+
+        from openhands.runtime.utils.warpgrep_client import WarpGrepClient
+
+        client = WarpGrepClient(
+            api_key=api_key,
+            run_in_sandbox_fn=run_in_sandbox,
+            workspace_root='/workspace',
+        )
+        results = client.search(action.query)
+
+        # Format results as readable content
+        content_parts = []
+        for r in results:
+            if r.get('file'):
+                content_parts.append(
+                    f"=== {r['file']} (lines {r['start']}-{r['end']}) ===\n{r['content']}"
+                )
+            else:
+                content_parts.append(r.get('content', ''))
+
+        content = '\n\n'.join(content_parts) if content_parts else 'No results found.'
+
+        return WarpGrepObservation(
+            content=content,
+            query=action.query,
+            results=results,
+        )
 
     def close(self) -> None:
         # Make sure we don't close the session multiple times

--- a/openhands/runtime/impl/cli/cli_runtime.py
+++ b/openhands/runtime/impl/cli/cli_runtime.py
@@ -43,6 +43,7 @@ from openhands.events.action import (
     IPythonRunCellAction,
 )
 from openhands.events.action.mcp import MCPAction
+from openhands.events.action.warpgrep import WarpGrepAction
 from openhands.events.event import FileEditSource, FileReadSource
 from openhands.events.observation import (
     CmdOutputObservation,
@@ -755,6 +756,49 @@ class CLIRuntime(Runtime):
             error_msg = f'Error executing MCP tool {action.name}: {str(e)}'
             self.log('error', error_msg)
             return ErrorObservation(error_msg)
+
+    def warpgrep_search(self, action: WarpGrepAction) -> Observation:
+        """Execute a WarpGrep codebase search in CLI runtime."""
+        api_key = os.environ.get('WARPGREP_API_KEY') or os.environ.get(
+            'MORPH_API_KEY', ''
+        )
+        if not api_key:
+            return ErrorObservation(
+                'WarpGrep API key not configured. Set WARPGREP_API_KEY or MORPH_API_KEY environment variable.'
+            )
+
+        def run_in_sandbox(cmd: str) -> str:
+            obs = self.run(CmdRunAction(command=cmd))
+            if isinstance(obs, CmdOutputObservation):
+                return obs.content
+            return ''
+
+        from openhands.events.observation.warpgrep import WarpGrepObservation
+        from openhands.runtime.utils.warpgrep_client import WarpGrepClient
+
+        client = WarpGrepClient(
+            api_key=api_key,
+            run_in_sandbox_fn=run_in_sandbox,
+            workspace_root=str(self.workspace_root),
+        )
+        results = client.search(action.query)
+
+        content_parts = []
+        for r in results:
+            if r.get('file'):
+                content_parts.append(
+                    f"=== {r['file']} (lines {r['start']}-{r['end']}) ===\n{r['content']}"
+                )
+            else:
+                content_parts.append(r.get('content', ''))
+
+        content = '\n\n'.join(content_parts) if content_parts else 'No results found.'
+
+        return WarpGrepObservation(
+            content=content,
+            query=action.query,
+            results=results,
+        )
 
     @property
     def workspace_root(self) -> Path:

--- a/openhands/runtime/utils/warpgrep_client.py
+++ b/openhands/runtime/utils/warpgrep_client.py
@@ -1,0 +1,178 @@
+"""WarpGrep client that implements the multi-turn WarpGrep protocol.
+
+The client makes API calls from the host process and executes local tool calls
+(ripgrep, read, list_dir) inside the sandbox via callbacks. The API key stays
+on the host and is never exposed inside the sandbox.
+"""
+
+import re
+from typing import Callable
+
+import httpx
+
+from openhands.core.logger import openhands_logger as logger
+
+
+class WarpGrepClient:
+    API_URL = 'https://api.morphllm.com/v1/chat/completions'
+    MODEL = 'morph-warp-grep-v2'
+    MAX_TURNS = 4
+    MAX_GREP_LINES = 200
+    MAX_READ_LINES = 800
+    MAX_LIST_LINES = 200
+
+    def __init__(
+        self,
+        api_key: str,
+        run_in_sandbox_fn: Callable[[str], str],
+        workspace_root: str = '/workspace',
+    ):
+        self.api_key = api_key
+        self.run_in_sandbox = run_in_sandbox_fn
+        self.workspace_root = workspace_root
+
+    def search(self, query: str) -> list[dict]:
+        """Execute a multi-turn WarpGrep search and return results."""
+        repo_tree = self._get_repo_tree()
+        messages = [
+            {
+                'role': 'user',
+                'content': f'<repo_structure>{repo_tree}</repo_structure>\n<search_string>{query}</search_string>',
+            }
+        ]
+
+        for turn in range(self.MAX_TURNS):
+            response_text = self._call_api(messages)
+            if not response_text:
+                break
+
+            tool_calls = self._parse_tool_calls(response_text)
+            if not tool_calls:
+                # Model finished - parse final results
+                return self._parse_finish(response_text)
+
+            messages.append({'role': 'assistant', 'content': response_text})
+
+            tool_results = []
+            for tc in tool_calls:
+                result = self._execute_tool_call(tc)
+                tool_results.append(result)
+
+            results_content = '\n'.join(
+                f'<tool_response>{r}</tool_response>' for r in tool_results
+            )
+            results_content += f'\n[Turn {turn + 1}/{self.MAX_TURNS}]'
+            messages.append({'role': 'user', 'content': results_content})
+
+        # If we exhausted turns, try to parse whatever we have
+        return self._parse_finish(response_text if 'response_text' in dir() else '')
+
+    def _get_repo_tree(self) -> str:
+        """Generate a file tree of the workspace."""
+        cmd = f'find {self.workspace_root} -type f -not -path "*/.git/*" -not -path "*/node_modules/*" -not -path "*/__pycache__/*" -not -path "*/.venv/*" | head -500'
+        return self.run_in_sandbox(cmd)
+
+    def _call_api(self, messages: list[dict]) -> str:
+        """Make a completion request to the WarpGrep API."""
+        try:
+            with httpx.Client(timeout=60.0) as client:
+                response = client.post(
+                    self.API_URL,
+                    headers={
+                        'Authorization': f'Bearer {self.api_key}',
+                        'Content-Type': 'application/json',
+                    },
+                    json={
+                        'model': self.MODEL,
+                        'messages': messages,
+                        'temperature': 0.0,
+                        'max_tokens': 2048,
+                    },
+                )
+                response.raise_for_status()
+                data = response.json()
+                return data['choices'][0]['message']['content']
+        except Exception as e:
+            logger.error(f'WarpGrep API error: {e}')
+            return ''
+
+    def _parse_tool_calls(self, text: str) -> list[dict]:
+        """Parse XML tool calls from model response."""
+        calls = []
+        pattern = r'<tool_call>\s*<function=(\w+)>(.*?)</function>\s*</tool_call>'
+        for match in re.finditer(pattern, text, re.DOTALL):
+            func_name = match.group(1)
+            params_text = match.group(2)
+            params = {}
+            param_pattern = r'<parameter=(\w+)>(.*?)</parameter>'
+            for pm in re.finditer(param_pattern, params_text, re.DOTALL):
+                params[pm.group(1)] = pm.group(2).strip()
+            calls.append({'function': func_name, 'params': params})
+        return calls
+
+    def _execute_tool_call(self, tool_call: dict) -> str:
+        """Execute a tool call in the sandbox and return the result."""
+        func = tool_call['function']
+        params = tool_call['params']
+
+        if func == 'ripgrep':
+            pattern = params.get('pattern', '')
+            path = params.get('path', self.workspace_root)
+            if not path.startswith('/'):
+                path = f'{self.workspace_root}/{path}'
+            # Escape single quotes in pattern for shell safety
+            safe_pattern = pattern.replace("'", "'\\''")
+            cmd = f"rg --line-number --no-heading --color never -C 1 '{safe_pattern}' {path} | head -{self.MAX_GREP_LINES}"
+            return self.run_in_sandbox(cmd)
+
+        elif func == 'read':
+            path = params.get('path', '')
+            if not path.startswith('/'):
+                path = f'{self.workspace_root}/{path}'
+            start = params.get('start', '1')
+            end = params.get('end', str(self.MAX_READ_LINES))
+            cmd = f"sed -n '{start},{end}p' {path} | cat -n"
+            return self.run_in_sandbox(cmd)
+
+        elif func == 'list_directory':
+            path = params.get('path', self.workspace_root)
+            if not path.startswith('/'):
+                path = f'{self.workspace_root}/{path}'
+            cmd = f'find {path} -maxdepth 2 -type f | head -{self.MAX_LIST_LINES}'
+            return self.run_in_sandbox(cmd)
+
+        else:
+            return f'Unknown tool: {func}'
+
+    def _parse_finish(self, text: str) -> list[dict]:
+        """Parse the final results from the model's finish response."""
+        results = []
+        # Look for file spans in the finish response
+        # Pattern: file path followed by line ranges
+        span_pattern = r'<file_span>\s*<path>(.*?)</path>\s*<start>(\d+)</start>\s*<end>(\d+)</end>\s*</file_span>'
+        for match in re.finditer(span_pattern, text, re.DOTALL):
+            path = match.group(1).strip()
+            start = int(match.group(2))
+            end = int(match.group(3))
+            # Read the span from the sandbox
+            if not path.startswith('/'):
+                path = f'{self.workspace_root}/{path}'
+            cmd = f"sed -n '{start},{end}p' {path} | cat -n"
+            content = self.run_in_sandbox(cmd)
+            results.append(
+                {
+                    'file': path,
+                    'start': start,
+                    'end': end,
+                    'content': content,
+                }
+            )
+
+        # If no structured results, return the raw text as a single result
+        if not results and text:
+            # Strip think tags
+            clean = re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL).strip()
+            if clean:
+                results.append({'file': '', 'start': 0, 'end': 0, 'content': clean})
+
+        return results

--- a/openhands/runtime/utils/warpgrep_client.py
+++ b/openhands/runtime/utils/warpgrep_client.py
@@ -40,32 +40,54 @@ class WarpGrepClient:
                 'content': f'<repo_structure>{repo_tree}</repo_structure>\n<search_string>{query}</search_string>',
             }
         ]
+        context_chars = len(messages[0]['content'])
+        last_response = ''
 
         for turn in range(self.MAX_TURNS):
             response_text = self._call_api(messages)
             if not response_text:
                 break
+            last_response = response_text
 
             tool_calls = self._parse_tool_calls(response_text)
+
+            # Check for finish tool call
+            for tc in tool_calls:
+                if tc['function'] == 'finish':
+                    files_param = tc['params'].get('files', '')
+                    return self._process_finish(files_param)
+
             if not tool_calls:
-                # Model finished - parse final results
-                return self._parse_finish(response_text)
+                return []
 
             messages.append({'role': 'assistant', 'content': response_text})
 
             tool_results = []
             for tc in tool_calls:
                 result = self._execute_tool_call(tc)
-                tool_results.append(result)
+                tool_results.append(f'<tool_response>\n{result}\n</tool_response>')
 
-            results_content = '\n'.join(
-                f'<tool_response>{r}</tool_response>' for r in tool_results
+            tool_response_text = '\n\n'.join(tool_results)
+            context_chars += len(response_text) + len(tool_response_text)
+            remaining = self.MAX_TURNS - turn - 1
+            budget_pct = min(100, int(context_chars / 160000 * 100))
+
+            if remaining == 0:
+                turn_msg = (
+                    f'You have used {turn + 1} turns, you only have 1 turn remaining. '
+                    'You have run out of turns to explore the code base and MUST call the finish tool now'
+                )
+            else:
+                turn_msg = f'You have used {turn + 1} turn{"s" if turn + 1 > 1 else ""} and have {remaining} remaining.'
+
+            user_content = (
+                f'{tool_response_text}\n\n'
+                f'{turn_msg}\n'
+                f'<context_budget>{budget_pct}% ({context_chars}/160000 chars)</context_budget>'
             )
-            results_content += f'\n[Turn {turn + 1}/{self.MAX_TURNS}]'
-            messages.append({'role': 'user', 'content': results_content})
+            messages.append({'role': 'user', 'content': user_content})
 
-        # If we exhausted turns, try to parse whatever we have
-        return self._parse_finish(response_text if 'response_text' in dir() else '')
+        return []
 
     def _get_repo_tree(self) -> str:
         """Generate a file tree of the workspace."""
@@ -122,57 +144,105 @@ class WarpGrepClient:
                 path = f'{self.workspace_root}/{path}'
             # Escape single quotes in pattern for shell safety
             safe_pattern = pattern.replace("'", "'\\''")
-            cmd = f"rg --line-number --no-heading --color never -C 1 '{safe_pattern}' {path} | head -{self.MAX_GREP_LINES}"
+            glob_param = params.get('glob', '')
+            glob_flag = f" --glob '{glob_param}'" if glob_param else ''
+            cmd = f"rg --line-number --no-heading --color never -C 1{glob_flag} '{safe_pattern}' '{path}' | head -{self.MAX_GREP_LINES}"
             return self.run_in_sandbox(cmd)
 
         elif func == 'read':
             path = params.get('path', '')
             if not path.startswith('/'):
                 path = f'{self.workspace_root}/{path}'
-            start = params.get('start', '1')
-            end = params.get('end', str(self.MAX_READ_LINES))
-            cmd = f"sed -n '{start},{end}p' {path} | cat -n"
+            lines_param = params.get('lines', '')
+            if lines_param:
+                # Parse line ranges like "1-50" or "1-20,45-80"
+                ranges = []
+                for part in lines_param.split(','):
+                    part = part.strip()
+                    if '-' in part:
+                        s, e = part.split('-', 1)
+                        ranges.append(f'{s.strip()},{e.strip()}p')
+                    else:
+                        ranges.append(f'{part}p')
+                sed_expr = ';'.join(ranges)
+                cmd = f"sed -n '{sed_expr}' '{path}' | cat -n"
+            else:
+                cmd = f"head -{self.MAX_READ_LINES} '{path}' | cat -n"
             return self.run_in_sandbox(cmd)
 
         elif func == 'list_directory':
             path = params.get('path', self.workspace_root)
             if not path.startswith('/'):
                 path = f'{self.workspace_root}/{path}'
-            cmd = f'find {path} -maxdepth 2 -type f | head -{self.MAX_LIST_LINES}'
+            cmd = f"find '{path}' -maxdepth 2 -type f | head -{self.MAX_LIST_LINES}"
             return self.run_in_sandbox(cmd)
 
         else:
             return f'Unknown tool: {func}'
 
-    def _parse_finish(self, text: str) -> list[dict]:
-        """Parse the final results from the model's finish response."""
-        results = []
-        # Look for file spans in the finish response
-        # Pattern: file path followed by line ranges
-        span_pattern = r'<file_span>\s*<path>(.*?)</path>\s*<start>(\d+)</start>\s*<end>(\d+)</end>\s*</file_span>'
-        for match in re.finditer(span_pattern, text, re.DOTALL):
-            path = match.group(1).strip()
-            start = int(match.group(2))
-            end = int(match.group(3))
-            # Read the span from the sandbox
-            if not path.startswith('/'):
-                path = f'{self.workspace_root}/{path}'
-            cmd = f"sed -n '{start},{end}p' {path} | cat -n"
-            content = self.run_in_sandbox(cmd)
-            results.append(
-                {
-                    'file': path,
-                    'start': start,
-                    'end': end,
-                    'content': content,
-                }
-            )
+    def _process_finish(self, files_param: str) -> list[dict]:
+        """Process the finish tool call's files parameter.
 
-        # If no structured results, return the raw text as a single result
-        if not results and text:
-            # Strip think tags
-            clean = re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL).strip()
-            if clean:
-                results.append({'file': '', 'start': 0, 'end': 0, 'content': clean})
+        Format is newline-delimited file specs:
+          path/to/file.py:1-15,45-80
+          path/to/other.py:*
+          path/to/another.py
+        """
+        results = []
+        if not files_param.strip():
+            return results
+
+        for line in files_param.strip().split('\n'):
+            line = line.strip()
+            if not line:
+                continue
+
+            if ':' in line:
+                path, ranges_str = line.rsplit(':', 1)
+                path = path.strip()
+            else:
+                path = line
+                ranges_str = '*'
+
+            if not path.startswith('/'):
+                full_path = f'{self.workspace_root}/{path}'
+            else:
+                full_path = path
+
+            if ranges_str.strip() == '*':
+                cmd = f"cat -n '{full_path}'"
+                content = self.run_in_sandbox(cmd)
+                results.append({
+                    'file': path,
+                    'start': 1,
+                    'end': 0,
+                    'content': content,
+                })
+            else:
+                for part in ranges_str.split(','):
+                    part = part.strip()
+                    if not part:
+                        continue
+                    if '-' in part:
+                        try:
+                            start_s, end_s = part.split('-', 1)
+                            start = int(start_s.strip())
+                            end = int(end_s.strip())
+                        except ValueError:
+                            continue
+                    else:
+                        try:
+                            start = end = int(part.strip())
+                        except ValueError:
+                            continue
+
+                    cmd = f"sed -n '{start},{end}p' '{full_path}' | cat -n"
+                    content = self.run_in_sandbox(cmd)
+                    results.append({
+                        'file': path,
+                        'start': start,
+                        'end': end,
+                        'content': content,
+                    })
 
         return results


### PR DESCRIPTION
## Summary

Adds `warpgrep_codebase_search` as a new tool for the CodeAct agent, powered by [WarpGrep](https://morphllm.com/products/warpgrep). WarpGrep is an RL-trained search subagent that runs in an isolated context window, performing up to 8 parallel tool calls per turn across 4 turns, returning only the relevant code sections.

Instead of the agent running sequential grep/find commands via bash (polluting its context with dead ends), it delegates semantic search to WarpGrep and receives clean, precise file spans.

### Architecture

- **API calls happen on the host** (API key never enters the sandbox)
- **Tool execution (ripgrep, file reads, dir listings) runs inside the sandbox** via the runtime's existing `run()` method
- **Opt-in via config**: `enable_warpgrep = true` in `config.toml` under `[agent]`

### Changes (19 files, +387 lines)

**New files:**
- `openhands/events/action/warpgrep.py` - WarpGrepAction dataclass
- `openhands/events/observation/warpgrep.py` - WarpGrepObservation dataclass
- `openhands/agenthub/codeact_agent/tools/warpgrep.py` - Tool definition
- `openhands/runtime/utils/warpgrep_client.py` - Multi-turn WarpGrep protocol client

**Modified files:**
- Schema enums, serialization, init files - Register new action/observation types
- `agent_config.py` - `enable_warpgrep` flag (default: false)
- `codeact_agent.py` - Conditional tool registration
- `function_calling.py` - Tool call to WarpGrepAction routing
- `runtime/base.py` - Abstract `warpgrep_search()` method
- `action_execution_client.py` - Sandbox-backed implementation
- `cli_runtime.py` - Local subprocess implementation
- `conversation_memory.py` - Message conversion support
- `config.template.toml` - Documentation

### Configuration

```toml
[agent]
enable_warpgrep = true
```

Set `WARPGREP_API_KEY` or `MORPH_API_KEY` environment variable. Get a free key at [morphllm.com](https://morphllm.com).

## Test plan

- [x] Syntax checks pass
- [ ] Unit tests for WarpGrepClient protocol
- [ ] Integration test with sandbox execution
- [ ] Manual test with CodeAct agent on a real repo