### PR TITLE
Fix dark background in chat status row hiding message content

### DIFF
--- a/frontend/src/components/features/chat/chat-interface.tsx
+++ b/frontend/src/components/features/chat/chat-interface.tsx
@@ -295,7 +295,7 @@ export function ChatInterface() {
           )}
         </div>
 
-        <div className="flex flex-col gap-[6px]">
+        <div className="bg-[#25272D] flex flex-col gap-[6px]">
           <div className="flex justify-between relative">
             <div className="flex items-end gap-1">
               <ConfirmationModeEnabled />


### PR DESCRIPTION
Fixes #12552. Adds background color matching the chat input to the status row container, preventing the dark bar effect that was hiding message content prematurely.