### PR TITLE
fix: handle containers with tagless images in DockerSandboxService

### DIFF
--- a/openhands/app_server/sandbox/docker_sandbox_service.py
+++ b/openhands/app_server/sandbox/docker_sandbox_service.py
@@ -197,6 +197,12 @@ class DockerSandboxService(SandboxService):
                                     )
                                 )
 
+        if not container.image.tags:
+            _logger.debug(
+                f'Skipping container {container.name!r}: image has no tags (image id: {container.image.id})'
+            )
+            return None
+
         return SandboxInfo(
             id=container.name,
             created_by_user_id=None,

--- a/tests/unit/app_server/test_docker_sandbox_service.py
+++ b/tests/unit/app_server/test_docker_sandbox_service.py
@@ -245,6 +245,61 @@ class TestDockerSandboxService:
         assert len(result.items) == 0
         assert result.next_page_id is None
 
+    async def test_search_sandboxes_skips_containers_with_no_image_tags(
+        self, service, mock_running_container
+    ):
+        """Test that containers with tagless images are skipped without crashing.
+
+        Regression test: when a container's image has been rebuilt with the same tag,
+        the old container's image loses its tags, causing container.image.tags to be
+        an empty list. Previously this caused an IndexError.
+        """
+        # Setup a container with no image tags (e.g. image was retagged/rebuilt)
+        tagless_container = MagicMock()
+        tagless_container.name = 'oh-test-tagless'
+        tagless_container.status = 'paused'
+        tagless_container.image.tags = []
+        tagless_container.image.id = 'sha256:abc123def456'
+        tagless_container.attrs = {
+            'Created': '2024-01-15T10:30:00.000000000Z',
+            'Config': {'Env': []},
+            'NetworkSettings': {'Ports': {}},
+        }
+
+        service.docker_client.containers.list.return_value = [
+            mock_running_container,
+            tagless_container,
+        ]
+        service.httpx_client.get.return_value.raise_for_status.return_value = None
+
+        # Execute - should not raise IndexError
+        result = await service.search_sandboxes()
+
+        # Verify - only the properly tagged container is returned
+        assert isinstance(result, SandboxPage)
+        assert len(result.items) == 1
+        assert result.items[0].id == 'oh-test-abc123'
+
+    async def test_get_sandbox_returns_none_for_tagless_image(self, service):
+        """Test that get_sandbox returns None for containers with tagless images."""
+        tagless_container = MagicMock()
+        tagless_container.name = 'oh-test-tagless'
+        tagless_container.status = 'paused'
+        tagless_container.image.tags = []
+        tagless_container.image.id = 'sha256:abc123def456'
+        tagless_container.attrs = {
+            'Created': '2024-01-15T10:30:00.000000000Z',
+            'Config': {'Env': []},
+            'NetworkSettings': {'Ports': {}},
+        }
+        service.docker_client.containers.get.return_value = tagless_container
+
+        # Execute - should not raise IndexError
+        result = await service.get_sandbox('oh-test-tagless')
+
+        # Verify - returns None for tagless container
+        assert result is None
+
     async def test_search_sandboxes_filters_by_prefix(self, service):
         """Test that search filters containers by name prefix."""
         # Setup


### PR DESCRIPTION

<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

<!-- Summarize what the PR does -->
Fix to allow new conversations and view existing conversations when tagless container images are seen in docker sandboxes.

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

## Change Type

<!-- Choose the types that apply to your PR -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [X] I have read and reviewed the code and I understand what the code is doing.
- [X] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

When a Docker image is rebuilt with the same tag, existing containers that used the old image have their image's tags list become empty. Previously, _container_to_sandbox_info() would crash with an IndexError when accessing container.image.tags[0] on such containers.

```
"/app/openhands/app_server/sandbox/docker_sandbox_service.py", line 203, in _container_to_sandbox_info
    sandbox_spec_id=container.image.tags[0],
                    ~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```
Fix by returning None when image has no tags, so search_sandboxes() and get_sandbox() gracefully skip these containers instead of crashing.

Adds regression tests for both search_sandboxes and get_sandbox paths.

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.
