### PR TITLE
Revert "Fix dark background in chat status row hiding message content"

### DIFF
--- a/frontend/src/components/features/chat/chat-interface.tsx
+++ b/frontend/src/components/features/chat/chat-interface.tsx
@@ -295,7 +295,7 @@ export function ChatInterface() {
           )}
         </div>
 
-        <div className="bg-[#25272D] flex flex-col gap-[6px]">
+        <div className="flex flex-col gap-[6px]">
           <div className="flex justify-between relative">
             <div className="flex items-end gap-1">
               <ConfirmationModeEnabled />


### PR DESCRIPTION
Reverts OpenHands/OpenHands#13236

Incorrectly merged, made UI worse

<img width="2842" height="1480" alt="image" src="https://github.com/user-attachments/assets/40c5c5ec-b816-4456-81d4-221c06f2ada8" />

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:18c02ad-nikolaik   --name openhands-app-18c02ad   docker.openhands.dev/openhands/openhands:18c02ad
```