### PR TITLE
fix: preserve llm_base_url when adding MCP server

### DIFF
--- a/openhands/server/routes/settings.py
+++ b/openhands/server/routes/settings.py
@@ -142,7 +142,7 @@ async def store_llm_settings(
         if settings.llm_model is None:
             settings.llm_model = existing_settings.llm_model
         # if llm_base_url is missing or empty, try to determine appropriate URL
-        if not settings.llm_base_url:
+        if settings.llm_base_url is None:
             if is_openhands_model(settings.llm_model):
                 # OpenHands models use the LiteLLM proxy
                 settings.llm_base_url = LITE_LLM_API_URL


### PR DESCRIPTION
## Summary

When adding an MCP server in the OpenHands WebUI, the `llm_base_url` setting was being unexpectedly reset to the default (`https://api.openai.com`). This happened because:

1. When adding an MCP server, the frontend only sends `{ mcp_config, v1_enabled }` to the backend
2. The backend code at `openhands/server/routes/settings.py:145` used `if not settings.llm_base_url:`
3. Since `llm_base_url` was not in the request, it was `None`, and `not None` = `True`
4. The backend then "helpfully" reset it to the default

## Fix

Changed line 145 from:
```python
if not settings.llm_base_url:
```
to:
```python
if settings.llm_base_url is None:
```

This follows the same pattern already used for `llm_api_key`, `llm_model`, and `search_api_key` in the same function (lines 140-143, 164-165), which correctly preserve existing values when the field is not provided.

## Testing

- [ ] Add an MCP server and verify `llm_base_url` is preserved
- [ ] Verify that clearing `llm_base_url` explicitly still works (sets to default)

Fixes #13242

---

**Note**: This is a draft PR as requested. Please review and let me know if any changes are needed.