### PR TITLE
feat: Add E2B and Kata Containers sandbox services for V1 architecture

### DIFF
--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -161,6 +161,9 @@ def config_from_env() -> AppServerConfig:
     from openhands.app_server.sandbox.e2b_sandbox_spec_service import (
         E2BSandboxSpecServiceInjector,
     )
+    from openhands.app_server.sandbox.kata_sandbox_service import (
+        KataSandboxServiceInjector,
+    )
     from openhands.app_server.sandbox.process_sandbox_service import (
         ProcessSandboxServiceInjector,
     )
@@ -219,6 +222,32 @@ def config_from_env() -> AppServerConfig:
             config.sandbox = E2BSandboxServiceInjector(**e2b_kwargs)
         elif os.getenv('RUNTIME') in ('local', 'process'):
             config.sandbox = ProcessSandboxServiceInjector()
+        elif os.getenv('RUNTIME') == 'kata':
+            # Kata Containers sandbox - runs agent-server inside lightweight VMs
+            kata_sandbox_kwargs: dict = {}
+            if os.getenv('KATA_RUNTIME_TYPE'):
+                kata_sandbox_kwargs['runtime_type'] = os.environ['KATA_RUNTIME_TYPE']
+            if os.getenv('KATA_CONTAINERD_NAMESPACE'):
+                kata_sandbox_kwargs['containerd_namespace'] = os.environ[
+                    'KATA_CONTAINERD_NAMESPACE'
+                ]
+            if os.getenv('KATA_CONTAINER_URL_PATTERN'):
+                kata_sandbox_kwargs['container_url_pattern'] = os.environ[
+                    'KATA_CONTAINER_URL_PATTERN'
+                ]
+            if os.getenv('KATA_MAX_NUM_SANDBOXES'):
+                kata_sandbox_kwargs['max_num_sandboxes'] = int(
+                    os.environ['KATA_MAX_NUM_SANDBOXES']
+                )
+            if os.getenv('KATA_STARTUP_TIMEOUT'):
+                kata_sandbox_kwargs['startup_timeout'] = int(
+                    os.environ['KATA_STARTUP_TIMEOUT']
+                )
+            if os.getenv('KATA_ENABLE_HOST_NETWORK'):
+                kata_sandbox_kwargs['enable_host_network'] = os.environ[
+                    'KATA_ENABLE_HOST_NETWORK'
+                ].lower() in ('true', '1', 'yes')
+            config.sandbox = KataSandboxServiceInjector(**kata_sandbox_kwargs)
         else:
             # Support legacy environment variables for Docker sandbox configuration
             docker_sandbox_kwargs: dict = {}

--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -155,6 +155,12 @@ def config_from_env() -> AppServerConfig:
     from openhands.app_server.sandbox.docker_sandbox_spec_service import (
         DockerSandboxSpecServiceInjector,
     )
+    from openhands.app_server.sandbox.e2b_sandbox_service import (
+        E2BSandboxServiceInjector,
+    )
+    from openhands.app_server.sandbox.e2b_sandbox_spec_service import (
+        E2BSandboxSpecServiceInjector,
+    )
     from openhands.app_server.sandbox.process_sandbox_service import (
         ProcessSandboxServiceInjector,
     )
@@ -192,6 +198,25 @@ def config_from_env() -> AppServerConfig:
                 api_key=os.environ['SANDBOX_API_KEY'],
                 api_url=os.environ['SANDBOX_REMOTE_RUNTIME_API_URL'],
             )
+        elif os.getenv('RUNTIME') == 'e2b':
+            # E2B sandbox service for self-hosted E2B micro VMs
+            e2b_api_url = os.environ.get('E2B_API_URL')
+            e2b_api_key = os.environ.get('E2B_API_KEY')
+            if not e2b_api_url or not e2b_api_key:
+                raise ValueError(
+                    'E2B runtime requires E2B_API_URL and E2B_API_KEY environment variables'
+                )
+            e2b_kwargs: dict = {
+                'api_url': e2b_api_url,
+                'api_key': e2b_api_key,
+            }
+            if os.getenv('E2B_MAX_SANDBOXES'):
+                e2b_kwargs['max_num_sandboxes'] = int(os.environ['E2B_MAX_SANDBOXES'])
+            if os.getenv('E2B_SANDBOX_TIMEOUT'):
+                e2b_kwargs['sandbox_timeout'] = int(os.environ['E2B_SANDBOX_TIMEOUT'])
+            if os.getenv('E2B_WEBHOOK_URL'):
+                e2b_kwargs['webhook_url'] = os.environ['E2B_WEBHOOK_URL']
+            config.sandbox = E2BSandboxServiceInjector(**e2b_kwargs)
         elif os.getenv('RUNTIME') in ('local', 'process'):
             config.sandbox = ProcessSandboxServiceInjector()
         else:
@@ -244,6 +269,17 @@ def config_from_env() -> AppServerConfig:
     if config.sandbox_spec is None:
         if os.getenv('RUNTIME') == 'remote':
             config.sandbox_spec = RemoteSandboxSpecServiceInjector()
+        elif os.getenv('RUNTIME') == 'e2b':
+            # E2B sandbox spec service for self-hosted E2B templates
+            e2b_api_url = os.environ.get('E2B_API_URL', '')
+            e2b_api_key = os.environ.get('E2B_API_KEY', '')
+            e2b_spec_kwargs: dict = {
+                'api_url': e2b_api_url,
+                'api_key': e2b_api_key,
+            }
+            if os.getenv('E2B_DEFAULT_TEMPLATE'):
+                e2b_spec_kwargs['default_template'] = os.environ['E2B_DEFAULT_TEMPLATE']
+            config.sandbox_spec = E2BSandboxSpecServiceInjector(**e2b_spec_kwargs)
         elif os.getenv('RUNTIME') in ('local', 'process'):
             config.sandbox_spec = ProcessSandboxSpecServiceInjector()
         else:

--- a/openhands/app_server/sandbox/README.md
+++ b/openhands/app_server/sandbox/README.md
@@ -10,6 +10,9 @@ Since agents can do things that may harm your system, they are typically run ins
 
 - **SandboxService**: Abstract service for sandbox lifecycle management
 - **DockerSandboxService**: Docker-based sandbox implementation
+- **KataSandboxService**: Kata Containers-based sandbox for enhanced VM isolation
+- **RemoteSandboxService**: Remote sandbox via runtime API
+- **ProcessSandboxService**: Local process-based sandbox for development
 - **SandboxSpecService**: Manages sandbox specifications and templates
 - **SandboxRouter**: FastAPI router for sandbox endpoints
 
@@ -17,5 +20,45 @@ Since agents can do things that may harm your system, they are typically run ins
 
 - Secure containerized execution environments
 - Sandbox lifecycle management (create, start, stop, destroy)
-- Multiple sandbox backend support (Docker, Remote, Local)
+- Multiple sandbox backend support (Docker, Kata, Remote, Process)
 - User-scoped sandbox access control
+
+## Sandbox Types
+
+### Docker Sandbox (Default)
+Standard Docker containers providing process-level isolation. Set `RUNTIME=docker` or leave unset.
+
+### Kata Sandbox
+Kata Containers provide VM-level isolation by running containers inside lightweight VMs. This is ideal for untrusted workloads requiring stronger security boundaries.
+
+**Usage:**
+```bash
+export RUNTIME=kata
+export KATA_RUNTIME_TYPE=io.containerd.kata.v2  # or kata-qemu, kata-clh, kata-fc
+export KATA_CONTAINERD_NAMESPACE=openhands
+```
+
+**Configuration options:**
+- `KATA_RUNTIME_TYPE`: Kata runtime to use (default: `io.containerd.kata.v2`)
+  - `io.containerd.kata.v2` - Default Kata runtime
+  - `io.containerd.kata-qemu.v2` - Kata with QEMU hypervisor
+  - `io.containerd.kata-clh.v2` - Kata with Cloud Hypervisor
+  - `io.containerd.kata-fc.v2` - Kata with Firecracker
+- `KATA_CONTAINERD_NAMESPACE`: Containerd namespace (default: `openhands`)
+- `KATA_CONTAINER_URL_PATTERN`: URL pattern for services (default: `http://{host}:{port}`)
+- `KATA_MAX_NUM_SANDBOXES`: Max concurrent sandboxes (default: 5)
+- `KATA_STARTUP_TIMEOUT`: Startup timeout in seconds (default: 120)
+- `KATA_ENABLE_HOST_NETWORK`: Enable host networking (default: false)
+
+**Requirements:**
+- containerd with Kata Containers runtime installed
+- nerdctl (or compatible containerd CLI)
+- Kata Containers 2.x or later
+
+### Remote Sandbox
+Uses a remote runtime API for sandbox management. Set `RUNTIME=remote` with:
+- `SANDBOX_API_KEY`: API key for authentication
+- `SANDBOX_REMOTE_RUNTIME_API_URL`: Remote runtime API URL
+
+### Process Sandbox
+Local process-based sandbox for development. Set `RUNTIME=process` or `RUNTIME=local`.

--- a/openhands/app_server/sandbox/e2b_sandbox_service.py
+++ b/openhands/app_server/sandbox/e2b_sandbox_service.py
@@ -1,0 +1,472 @@
+"""E2B Sandbox Service for OpenHands V1.
+
+This module provides sandbox management using E2B (https://e2b.dev) micro VMs.
+It's designed to work with self-hosted E2B infrastructure.
+
+Configuration:
+    - E2B_API_KEY: API key for E2B authentication
+    - E2B_API_URL: URL of the self-hosted E2B API (e.g., https://api.e2b.your-domain.com)
+"""
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import AsyncGenerator
+
+import base62
+import httpx
+from fastapi import Request
+from pydantic import Field
+
+from openhands.agent_server.utils import utc_now
+from openhands.app_server.errors import SandboxError
+from openhands.app_server.sandbox.sandbox_models import (
+    AGENT_SERVER,
+    VSCODE,
+    WORKER_1,
+    WORKER_2,
+    ExposedUrl,
+    SandboxInfo,
+    SandboxPage,
+    SandboxStatus,
+)
+from openhands.app_server.sandbox.sandbox_service import (
+    ALLOW_CORS_ORIGINS_VARIABLE,
+    SESSION_API_KEY_VARIABLE,
+    WEBHOOK_CALLBACK_VARIABLE,
+    SandboxService,
+    SandboxServiceInjector,
+)
+from openhands.app_server.sandbox.sandbox_spec_models import SandboxSpecInfo
+from openhands.app_server.sandbox.sandbox_spec_service import SandboxSpecService
+from openhands.app_server.services.injector import InjectorState
+
+_logger = logging.getLogger(__name__)
+
+# Default ports exposed by the agent server
+AGENT_SERVER_PORT = 8000
+VSCODE_PORT = 8001
+WORKER_1_PORT = 8011
+WORKER_2_PORT = 8012
+
+# E2B sandbox status mapping
+E2B_STATUS_MAPPING = {
+    'running': SandboxStatus.RUNNING,
+    'starting': SandboxStatus.STARTING,
+    'paused': SandboxStatus.PAUSED,
+    'stopped': SandboxStatus.PAUSED,
+    'error': SandboxStatus.ERROR,
+}
+
+
+@dataclass
+class E2BSandboxService(SandboxService):
+    """Sandbox service that uses E2B micro VMs.
+
+    This service communicates with a self-hosted E2B API to create and manage
+    sandboxes running the OpenHands agent server.
+    """
+
+    sandbox_spec_service: SandboxSpecService
+    api_url: str
+    api_key: str
+    web_url: str | None
+    webhook_url: str | None
+    max_num_sandboxes: int
+    sandbox_timeout: int
+    httpx_client: httpx.AsyncClient
+    _sandbox_cache: dict[str, SandboxInfo] = field(default_factory=dict)
+
+    async def _send_e2b_request(
+        self,
+        method: str,
+        path: str,
+        **kwargs,
+    ) -> httpx.Response:
+        """Send a request to the E2B API."""
+        url = f'{self.api_url.rstrip("/")}{path}'
+        headers = kwargs.pop('headers', {})
+        headers['X-API-Key'] = self.api_key
+        headers['Content-Type'] = 'application/json'
+
+        try:
+            response = await self.httpx_client.request(
+                method, url, headers=headers, **kwargs
+            )
+            return response
+        except httpx.TimeoutException:
+            _logger.error(f'E2B API request timed out: {method} {url}')
+            raise SandboxError(f'E2B API request timed out: {path}')
+        except httpx.HTTPError as e:
+            _logger.error(f'E2B API request failed: {method} {url} - {e}')
+            raise SandboxError(f'E2B API request failed: {e}')
+
+    def _e2b_status_to_sandbox_status(self, e2b_status: str) -> SandboxStatus:
+        """Convert E2B sandbox status to SandboxStatus."""
+        return E2B_STATUS_MAPPING.get(e2b_status.lower(), SandboxStatus.ERROR)
+
+    def _build_exposed_urls(
+        self,
+        sandbox_id: str,
+        sandbox_host: str,
+        session_api_key: str,
+        working_dir: str = '/workspace',
+    ) -> list[ExposedUrl]:
+        """Build the list of exposed URLs for a sandbox."""
+        exposed_urls = []
+
+        # Agent server URL
+        agent_server_url = f'https://{AGENT_SERVER_PORT}-{sandbox_id}.{sandbox_host}'
+        exposed_urls.append(
+            ExposedUrl(name=AGENT_SERVER, url=agent_server_url, port=AGENT_SERVER_PORT)
+        )
+
+        # VSCode URL
+        vscode_url = f'https://{VSCODE_PORT}-{sandbox_id}.{sandbox_host}'
+        vscode_url += f'/?tkn={session_api_key}&folder={working_dir}'
+        exposed_urls.append(ExposedUrl(name=VSCODE, url=vscode_url, port=VSCODE_PORT))
+
+        # Worker URLs
+        worker_1_url = f'https://{WORKER_1_PORT}-{sandbox_id}.{sandbox_host}'
+        exposed_urls.append(
+            ExposedUrl(name=WORKER_1, url=worker_1_url, port=WORKER_1_PORT)
+        )
+
+        worker_2_url = f'https://{WORKER_2_PORT}-{sandbox_id}.{sandbox_host}'
+        exposed_urls.append(
+            ExposedUrl(name=WORKER_2, url=worker_2_url, port=WORKER_2_PORT)
+        )
+
+        return exposed_urls
+
+    def _e2b_sandbox_to_info(
+        self,
+        e2b_sandbox: dict,
+        session_api_key: str | None = None,
+    ) -> SandboxInfo:
+        """Convert E2B sandbox response to SandboxInfo."""
+        sandbox_id = e2b_sandbox.get('sandboxId') or e2b_sandbox.get('sandbox_id', '')
+        status = self._e2b_status_to_sandbox_status(
+            e2b_sandbox.get('status', 'unknown')
+        )
+
+        # Get created_at timestamp
+        created_at_str = e2b_sandbox.get('createdAt') or e2b_sandbox.get('created_at')
+        if created_at_str:
+            try:
+                created_at = datetime.fromisoformat(
+                    created_at_str.replace('Z', '+00:00')
+                )
+            except (ValueError, AttributeError):
+                created_at = utc_now()
+        else:
+            created_at = utc_now()
+
+        # Build exposed URLs if sandbox is running
+        exposed_urls = None
+        if status == SandboxStatus.RUNNING and session_api_key:
+            sandbox_host = e2b_sandbox.get('clientId') or self._get_sandbox_host()
+            working_dir = e2b_sandbox.get('cwd', '/workspace')
+            exposed_urls = self._build_exposed_urls(
+                sandbox_id, sandbox_host, session_api_key, working_dir
+            )
+
+        return SandboxInfo(
+            id=sandbox_id,
+            created_by_user_id=e2b_sandbox.get('userId'),
+            sandbox_spec_id=e2b_sandbox.get('templateId', 'openhands'),
+            status=status,
+            session_api_key=session_api_key
+            if status == SandboxStatus.RUNNING
+            else None,
+            exposed_urls=exposed_urls,
+            created_at=created_at,
+        )
+
+    def _get_sandbox_host(self) -> str:
+        """Extract the sandbox host from the API URL."""
+        # E2B sandboxes are typically accessible at {port}-{sandbox_id}.{host}
+        # Extract host from API URL (e.g., api.e2b.example.com -> e2b.example.com)
+        from urllib.parse import urlparse
+
+        parsed = urlparse(self.api_url)
+        host = parsed.netloc
+        if host.startswith('api.'):
+            host = host[4:]
+        return host
+
+    async def search_sandboxes(
+        self,
+        page_id: str | None = None,
+        limit: int = 100,
+    ) -> SandboxPage:
+        """Search for sandboxes."""
+        params: dict[str, str | int] = {'limit': limit}
+        if page_id:
+            params['cursor'] = page_id
+
+        response = await self._send_e2b_request('GET', '/sandboxes', params=params)
+
+        if response.status_code == 200:
+            data = response.json()
+            sandboxes = data.get('sandboxes', data) if isinstance(data, dict) else data
+
+            items = []
+            for e2b_sandbox in sandboxes:
+                sandbox_id = e2b_sandbox.get('sandboxId') or e2b_sandbox.get(
+                    'sandbox_id', ''
+                )
+                # Try to get session_api_key from cache
+                cached = self._sandbox_cache.get(sandbox_id)
+                session_api_key = cached.session_api_key if cached else None
+                items.append(self._e2b_sandbox_to_info(e2b_sandbox, session_api_key))
+
+            next_page_id = data.get('nextCursor') if isinstance(data, dict) else None
+            return SandboxPage(items=items, next_page_id=next_page_id)
+
+        _logger.warning(f'Failed to search E2B sandboxes: {response.status_code}')
+        return SandboxPage(items=[])
+
+    async def get_sandbox(self, sandbox_id: str) -> SandboxInfo | None:
+        """Get a single sandbox."""
+        response = await self._send_e2b_request('GET', f'/sandboxes/{sandbox_id}')
+
+        if response.status_code == 200:
+            e2b_sandbox = response.json()
+            # Try to get session_api_key from cache
+            cached = self._sandbox_cache.get(sandbox_id)
+            session_api_key = cached.session_api_key if cached else None
+            sandbox_info = self._e2b_sandbox_to_info(e2b_sandbox, session_api_key)
+
+            # Update cache
+            if session_api_key:
+                self._sandbox_cache[sandbox_id] = sandbox_info
+
+            return sandbox_info
+
+        if response.status_code == 404:
+            # Remove from cache if not found
+            self._sandbox_cache.pop(sandbox_id, None)
+            return None
+
+        _logger.warning(
+            f'Failed to get E2B sandbox {sandbox_id}: {response.status_code}'
+        )
+        return None
+
+    async def get_sandbox_by_session_api_key(
+        self, session_api_key: str
+    ) -> SandboxInfo | None:
+        """Get a sandbox by its session API key."""
+        # Search through cached sandboxes first
+        for sandbox_id, sandbox_info in self._sandbox_cache.items():
+            if sandbox_info.session_api_key == session_api_key:
+                # Verify it still exists
+                current = await self.get_sandbox(sandbox_id)
+                if current and current.status == SandboxStatus.RUNNING:
+                    return current
+
+        # Fall back to searching all sandboxes
+        async for sandbox in self._iter_all_sandboxes():
+            if sandbox.session_api_key == session_api_key:
+                return sandbox
+
+        return None
+
+    async def _iter_all_sandboxes(self):
+        """Iterate through all sandboxes."""
+        page_id = None
+        while True:
+            page = await self.search_sandboxes(page_id=page_id)
+            for sandbox in page.items:
+                yield sandbox
+            if not page.next_page_id:
+                break
+            page_id = page.next_page_id
+
+    async def start_sandbox(
+        self, sandbox_spec_id: str | None = None, sandbox_id: str | None = None
+    ) -> SandboxInfo:
+        """Start a new E2B sandbox."""
+        # Enforce sandbox limits
+        await self.pause_old_sandboxes(self.max_num_sandboxes - 1)
+
+        # Get sandbox spec (template)
+        sandbox_spec: SandboxSpecInfo
+        if sandbox_spec_id is None:
+            sandbox_spec = await self.sandbox_spec_service.get_default_sandbox_spec()
+            sandbox_spec_id = sandbox_spec.id
+        else:
+            sandbox_spec_maybe = await self.sandbox_spec_service.get_sandbox_spec(
+                sandbox_spec_id
+            )
+            if sandbox_spec_maybe is None:
+                raise SandboxError(f'Sandbox spec not found: {sandbox_spec_id}')
+            sandbox_spec = sandbox_spec_maybe
+
+        # Generate session API key
+        session_api_key = base62.encodebytes(os.urandom(32))
+
+        # Prepare environment variables
+        env_vars = sandbox_spec.initial_env.copy()
+        env_vars[SESSION_API_KEY_VARIABLE] = session_api_key
+
+        # Set webhook callback URL
+        if self.webhook_url:
+            env_vars[WEBHOOK_CALLBACK_VARIABLE] = f'{self.webhook_url}/api/v1/webhooks'
+
+        # Set CORS origins for remote browser access
+        if self.web_url:
+            env_vars[ALLOW_CORS_ORIGINS_VARIABLE] = self.web_url
+
+        # Prepare request payload
+        payload = {
+            'templateId': sandbox_spec_id,
+            'timeout': self.sandbox_timeout,
+            'envVars': env_vars,
+        }
+
+        # Include custom sandbox ID if provided
+        if sandbox_id:
+            payload['sandboxId'] = sandbox_id
+
+        response = await self._send_e2b_request('POST', '/sandboxes', json=payload)
+
+        if response.status_code in (200, 201):
+            e2b_sandbox = response.json()
+            sandbox_info = self._e2b_sandbox_to_info(e2b_sandbox, session_api_key)
+
+            # Cache the sandbox info with session_api_key
+            self._sandbox_cache[sandbox_info.id] = sandbox_info
+
+            _logger.info(f'Started E2B sandbox: {sandbox_info.id}')
+            return sandbox_info
+
+        error_msg = f'Failed to start E2B sandbox: {response.status_code}'
+        try:
+            error_detail = response.json()
+            error_msg += f' - {error_detail}'
+        except Exception:
+            pass
+
+        _logger.error(error_msg)
+        raise SandboxError(error_msg)
+
+    async def resume_sandbox(self, sandbox_id: str) -> bool:
+        """Resume a paused sandbox."""
+        # Enforce sandbox limits
+        await self.pause_old_sandboxes(self.max_num_sandboxes - 1)
+
+        response = await self._send_e2b_request(
+            'POST', f'/sandboxes/{sandbox_id}/resume'
+        )
+
+        if response.status_code in (200, 204):
+            _logger.info(f'Resumed E2B sandbox: {sandbox_id}')
+            return True
+
+        if response.status_code == 404:
+            return False
+
+        _logger.warning(
+            f'Failed to resume E2B sandbox {sandbox_id}: {response.status_code}'
+        )
+        return False
+
+    async def pause_sandbox(self, sandbox_id: str) -> bool:
+        """Pause a running sandbox."""
+        response = await self._send_e2b_request(
+            'POST', f'/sandboxes/{sandbox_id}/pause'
+        )
+
+        if response.status_code in (200, 204):
+            _logger.info(f'Paused E2B sandbox: {sandbox_id}')
+            return True
+
+        if response.status_code == 404:
+            return False
+
+        _logger.warning(
+            f'Failed to pause E2B sandbox {sandbox_id}: {response.status_code}'
+        )
+        return False
+
+    async def delete_sandbox(self, sandbox_id: str) -> bool:
+        """Delete a sandbox."""
+        response = await self._send_e2b_request('DELETE', f'/sandboxes/{sandbox_id}')
+
+        if response.status_code in (200, 204):
+            # Remove from cache
+            self._sandbox_cache.pop(sandbox_id, None)
+            _logger.info(f'Deleted E2B sandbox: {sandbox_id}')
+            return True
+
+        if response.status_code == 404:
+            self._sandbox_cache.pop(sandbox_id, None)
+            return False
+
+        _logger.warning(
+            f'Failed to delete E2B sandbox {sandbox_id}: {response.status_code}'
+        )
+        return False
+
+
+class E2BSandboxServiceInjector(SandboxServiceInjector):
+    """Dependency injector for E2B sandbox services."""
+
+    api_url: str = Field(
+        description=(
+            'URL of the self-hosted E2B API. '
+            'Configure via OH_E2B_API_URL environment variable.'
+        ),
+    )
+    api_key: str = Field(
+        description=(
+            'API key for E2B authentication. '
+            'Configure via OH_E2B_API_KEY environment variable.'
+        ),
+    )
+    max_num_sandboxes: int = Field(
+        default=10,
+        description='Maximum number of sandboxes allowed to run simultaneously.',
+    )
+    sandbox_timeout: int = Field(
+        default=3600,
+        description='Timeout in seconds for sandbox lifetime (default: 1 hour).',
+    )
+    webhook_url: str | None = Field(
+        default=None,
+        description=(
+            'URL for webhook callbacks from agent servers. '
+            'If not set, will use web_url if available.'
+        ),
+    )
+
+    async def inject(
+        self, state: InjectorState, request: Request | None = None
+    ) -> AsyncGenerator[SandboxService, None]:
+        from openhands.app_server.config import (
+            get_global_config,
+            get_httpx_client,
+            get_sandbox_spec_service,
+        )
+
+        config = get_global_config()
+        web_url = config.web_url
+        webhook_url = self.webhook_url or web_url
+
+        async with (
+            get_httpx_client(state) as httpx_client,
+            get_sandbox_spec_service(state) as sandbox_spec_service,
+        ):
+            yield E2BSandboxService(
+                sandbox_spec_service=sandbox_spec_service,
+                api_url=self.api_url,
+                api_key=self.api_key,
+                web_url=web_url,
+                webhook_url=webhook_url,
+                max_num_sandboxes=self.max_num_sandboxes,
+                sandbox_timeout=self.sandbox_timeout,
+                httpx_client=httpx_client,
+            )

--- a/openhands/app_server/sandbox/e2b_sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/e2b_sandbox_spec_service.py
@@ -1,0 +1,212 @@
+"""E2B Sandbox Spec Service for OpenHands V1.
+
+This module provides sandbox spec (template) management for E2B.
+It communicates with the self-hosted E2B API to list and retrieve templates.
+"""
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import AsyncGenerator
+
+import httpx
+from fastapi import Request
+from pydantic import Field
+
+from openhands.agent_server.utils import utc_now
+from openhands.app_server.sandbox.sandbox_spec_models import (
+    SandboxSpecInfo,
+    SandboxSpecInfoPage,
+)
+from openhands.app_server.sandbox.sandbox_spec_service import (
+    SandboxSpecService,
+    SandboxSpecServiceInjector,
+    get_agent_server_env,
+)
+from openhands.app_server.services.injector import InjectorState
+
+_logger = logging.getLogger(__name__)
+
+# Default E2B template for OpenHands
+DEFAULT_E2B_TEMPLATE = 'openhands'
+DEFAULT_WORKING_DIR = '/workspace'
+
+
+@dataclass
+class E2BSandboxSpecService(SandboxSpecService):
+    """Sandbox spec service that uses E2B templates.
+
+    This service communicates with the self-hosted E2B API to manage templates.
+    Templates in E2B are pre-built sandbox images that can be instantiated.
+    """
+
+    api_url: str
+    api_key: str
+    httpx_client: httpx.AsyncClient
+    default_template: str = DEFAULT_E2B_TEMPLATE
+
+    async def _send_e2b_request(
+        self,
+        method: str,
+        path: str,
+        **kwargs,
+    ) -> httpx.Response:
+        """Send a request to the E2B API."""
+        url = f'{self.api_url.rstrip("/")}{path}'
+        headers = kwargs.pop('headers', {})
+        headers['X-API-Key'] = self.api_key
+        headers['Content-Type'] = 'application/json'
+
+        try:
+            response = await self.httpx_client.request(
+                method, url, headers=headers, **kwargs
+            )
+            return response
+        except httpx.TimeoutException:
+            _logger.error(f'E2B API request timed out: {method} {url}')
+            raise
+        except httpx.HTTPError as e:
+            _logger.error(f'E2B API request failed: {method} {url} - {e}')
+            raise
+
+    def _e2b_template_to_spec(self, e2b_template: dict) -> SandboxSpecInfo:
+        """Convert E2B template response to SandboxSpecInfo."""
+        template_id = (
+            e2b_template.get('templateId')
+            or e2b_template.get('template_id')
+            or e2b_template.get('id', '')
+        )
+
+        # Get created_at timestamp
+        created_at_str = (
+            e2b_template.get('createdAt')
+            or e2b_template.get('created_at')
+            or e2b_template.get('buildFinishedAt')
+        )
+        if created_at_str:
+            try:
+                created_at = datetime.fromisoformat(
+                    created_at_str.replace('Z', '+00:00')
+                )
+            except (ValueError, AttributeError):
+                created_at = utc_now()
+        else:
+            created_at = utc_now()
+
+        # Get initial environment variables
+        initial_env = e2b_template.get('envVars', {})
+        # Merge with agent server environment variables
+        initial_env.update(get_agent_server_env())
+
+        return SandboxSpecInfo(
+            id=template_id,
+            command=None,  # E2B templates have built-in commands
+            created_at=created_at,
+            initial_env=initial_env,
+            working_dir=DEFAULT_WORKING_DIR,
+        )
+
+    async def search_sandbox_specs(
+        self, page_id: str | None = None, limit: int = 100
+    ) -> SandboxSpecInfoPage:
+        """Search for sandbox specs (E2B templates)."""
+        params: dict[str, str | int] = {'limit': limit}
+        if page_id:
+            params['cursor'] = page_id
+
+        try:
+            response = await self._send_e2b_request('GET', '/templates', params=params)
+
+            if response.status_code == 200:
+                data = response.json()
+                templates = (
+                    data.get('templates', data) if isinstance(data, dict) else data
+                )
+
+                items = [self._e2b_template_to_spec(t) for t in templates]
+
+                # Ensure default template is first if present
+                items.sort(key=lambda x: (x.id != self.default_template, x.id))
+
+                next_page_id = (
+                    data.get('nextCursor') if isinstance(data, dict) else None
+                )
+                return SandboxSpecInfoPage(items=items, next_page_id=next_page_id)
+
+        except Exception as e:
+            _logger.warning(f'Failed to fetch E2B templates: {e}')
+
+        # Return default template if API fails
+        return SandboxSpecInfoPage(
+            items=[
+                SandboxSpecInfo(
+                    id=self.default_template,
+                    command=None,
+                    initial_env=get_agent_server_env(),
+                    working_dir=DEFAULT_WORKING_DIR,
+                )
+            ]
+        )
+
+    async def get_sandbox_spec(self, sandbox_spec_id: str) -> SandboxSpecInfo | None:
+        """Get a single sandbox spec (E2B template)."""
+        try:
+            response = await self._send_e2b_request(
+                'GET', f'/templates/{sandbox_spec_id}'
+            )
+
+            if response.status_code == 200:
+                e2b_template = response.json()
+                return self._e2b_template_to_spec(e2b_template)
+
+            if response.status_code == 404:
+                return None
+
+        except Exception as e:
+            _logger.warning(f'Failed to get E2B template {sandbox_spec_id}: {e}')
+
+        # Return a basic spec for the requested ID if API fails
+        # This allows the system to attempt to use templates that might exist
+        if sandbox_spec_id == self.default_template:
+            return SandboxSpecInfo(
+                id=sandbox_spec_id,
+                command=None,
+                initial_env=get_agent_server_env(),
+                working_dir=DEFAULT_WORKING_DIR,
+            )
+
+        return None
+
+
+class E2BSandboxSpecServiceInjector(SandboxSpecServiceInjector):
+    """Dependency injector for E2B sandbox spec services."""
+
+    api_url: str = Field(
+        description=(
+            'URL of the self-hosted E2B API. '
+            'Configure via OH_E2B_API_URL environment variable.'
+        ),
+    )
+    api_key: str = Field(
+        description=(
+            'API key for E2B authentication. '
+            'Configure via OH_E2B_API_KEY environment variable.'
+        ),
+    )
+    default_template: str = Field(
+        default=DEFAULT_E2B_TEMPLATE,
+        description='Default E2B template name for OpenHands sandboxes.',
+    )
+
+    async def inject(
+        self, state: InjectorState, request: Request | None = None
+    ) -> AsyncGenerator[SandboxSpecService, None]:
+        from openhands.app_server.config import get_httpx_client
+
+        async with get_httpx_client(state) as httpx_client:
+            yield E2BSandboxSpecService(
+                api_url=self.api_url,
+                api_key=self.api_key,
+                httpx_client=httpx_client,
+                default_template=self.default_template,
+            )

--- a/openhands/app_server/sandbox/kata_sandbox_service.py
+++ b/openhands/app_server/sandbox/kata_sandbox_service.py
@@ -1,0 +1,779 @@
+"""Kata Containers sandbox service implementation.
+
+This service creates sandboxes using Kata Containers, which runs containers inside
+lightweight VMs for enhanced security and isolation. This is ideal for running
+agent-server instances that need stronger isolation than standard containers.
+
+Kata Containers integration uses containerd as the container runtime with kata-runtime
+as the container runtime class.
+"""
+
+import asyncio
+import hashlib
+import json
+import logging
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, AsyncGenerator
+
+import base62
+import httpx
+from fastapi import Request
+from pydantic import Field
+
+from openhands.agent_server.utils import utc_now
+from openhands.app_server.errors import SandboxError
+from openhands.app_server.sandbox.sandbox_models import (
+    AGENT_SERVER,
+    VSCODE,
+    WORKER_1,
+    WORKER_2,
+    ExposedUrl,
+    SandboxInfo,
+    SandboxPage,
+    SandboxStatus,
+)
+from openhands.app_server.sandbox.sandbox_service import (
+    ALLOW_CORS_ORIGINS_VARIABLE,
+    SESSION_API_KEY_VARIABLE,
+    WEBHOOK_CALLBACK_VARIABLE,
+    SandboxService,
+    SandboxServiceInjector,
+)
+from openhands.app_server.sandbox.sandbox_spec_models import SandboxSpecInfo
+from openhands.app_server.sandbox.sandbox_spec_service import SandboxSpecService
+from openhands.app_server.services.injector import InjectorState
+
+_logger = logging.getLogger(__name__)
+
+# Container label used to identify OpenHands Kata sandboxes
+KATA_SANDBOX_LABEL = 'openhands.kata.sandbox'
+KATA_SANDBOX_ID_LABEL = 'openhands.sandbox.id'
+KATA_SESSION_API_KEY_HASH_LABEL = 'openhands.session.api.key.hash'
+KATA_USER_ID_LABEL = 'openhands.user.id'
+KATA_SANDBOX_SPEC_ID_LABEL = 'openhands.sandbox.spec.id'
+KATA_CREATED_AT_LABEL = 'openhands.created.at'
+
+# Default ports for services
+AGENT_SERVER_PORT = 8000
+VSCODE_PORT = 8001
+WORKER_1_PORT = 8011
+WORKER_2_PORT = 8012
+
+
+def _hash_session_api_key(session_api_key: str) -> str:
+    """Hash a session API key using SHA-256."""
+    return hashlib.sha256(session_api_key.encode()).hexdigest()
+
+
+def _generate_session_api_key() -> str:
+    """Generate a secure session API key."""
+    return base62.encodebytes(secrets.token_bytes(32))
+
+
+@dataclass
+class KataContainerInfo:
+    """Information about a Kata container."""
+
+    container_id: str
+    sandbox_id: str
+    user_id: str | None
+    sandbox_spec_id: str
+    session_api_key_hash: str | None
+    status: str
+    ip_address: str | None
+    created_at: datetime
+    exposed_ports: dict[int, int] | None = None  # container_port -> host_port
+
+
+@dataclass
+class KataSandboxService(SandboxService):
+    """Sandbox service that uses Kata Containers for VM-based isolation.
+
+    Kata Containers provides enhanced security by running each container inside
+    a lightweight virtual machine. This service manages the lifecycle of these
+    sandboxes using containerd with the kata-runtime class.
+
+    The service supports two modes:
+    1. Direct containerd mode: Uses containerd API directly with kata-runtime
+    2. Kubernetes mode: Uses Kubernetes with Kata as a RuntimeClass
+
+    This implementation uses containerd's ctr/nerdctl commands for simplicity,
+    but can be extended to use the containerd gRPC API for more control.
+    """
+
+    sandbox_spec_service: SandboxSpecService
+    user_id: str | None
+    httpx_client: httpx.AsyncClient
+    container_name_prefix: str
+    containerd_namespace: str
+    runtime_type: str  # 'io.containerd.kata.v2' or similar
+    container_url_pattern: str
+    max_num_sandboxes: int
+    web_url: str | None
+    host_port: int
+    nerdctl_bin: str = 'nerdctl'
+    enable_host_network: bool = False
+    startup_timeout: int = 120
+    kata_config_path: str | None = None
+    _sandboxes: dict[str, KataContainerInfo] = field(default_factory=dict)
+
+    async def _run_command(
+        self,
+        cmd: list[str],
+        check: bool = True,
+        capture_output: bool = True,
+    ) -> tuple[int, str, str]:
+        """Run a command asynchronously and return exit code, stdout, stderr."""
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE if capture_output else None,
+                stderr=asyncio.subprocess.PIPE if capture_output else None,
+            )
+            stdout, stderr = await process.communicate()
+
+            stdout_str = stdout.decode() if stdout else ''
+            stderr_str = stderr.decode() if stderr else ''
+
+            if check and process.returncode != 0:
+                _logger.error(
+                    f'Command failed: {" ".join(cmd)}\n'
+                    f'Exit code: {process.returncode}\n'
+                    f'Stderr: {stderr_str}'
+                )
+
+            return process.returncode or 0, stdout_str, stderr_str
+
+        except Exception as e:
+            _logger.error(f'Failed to run command {" ".join(cmd)}: {e}')
+            raise SandboxError(f'Failed to execute command: {e}')
+
+    def _get_container_name(self, sandbox_id: str) -> str:
+        """Get the container name for a sandbox."""
+        return f'{self.container_name_prefix}{sandbox_id}'
+
+    async def _get_container_info(self, container_name: str) -> dict[str, Any] | None:
+        """Get container information using nerdctl inspect."""
+        cmd = [
+            self.nerdctl_bin,
+            '-n',
+            self.containerd_namespace,
+            'inspect',
+            container_name,
+        ]
+        exit_code, stdout, stderr = await self._run_command(cmd, check=False)
+
+        if exit_code != 0:
+            return None
+
+        try:
+            # nerdctl inspect returns a JSON array
+            data = json.loads(stdout)
+            if isinstance(data, list) and len(data) > 0:
+                return data[0]
+            return data
+        except json.JSONDecodeError:
+            _logger.error(f'Failed to parse container info: {stdout}')
+            return None
+
+    async def _list_containers(self) -> list[dict[str, Any]]:
+        """List all OpenHands Kata containers."""
+        cmd = [
+            self.nerdctl_bin,
+            '-n',
+            self.containerd_namespace,
+            'ps',
+            '-a',
+            '--filter',
+            f'label={KATA_SANDBOX_LABEL}=true',
+            '--format',
+            'json',
+        ]
+        exit_code, stdout, stderr = await self._run_command(cmd, check=False)
+
+        if exit_code != 0:
+            _logger.warning(f'Failed to list containers: {stderr}')
+            return []
+
+        containers = []
+        for line in stdout.strip().split('\n'):
+            if line:
+                try:
+                    containers.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+
+        return containers
+
+    def _container_status_to_sandbox_status(self, status: str) -> SandboxStatus:
+        """Convert container status to SandboxStatus."""
+        status_lower = status.lower()
+        if 'running' in status_lower:
+            return SandboxStatus.RUNNING
+        elif 'paused' in status_lower:
+            return SandboxStatus.PAUSED
+        elif 'created' in status_lower or 'starting' in status_lower:
+            return SandboxStatus.STARTING
+        elif 'exited' in status_lower or 'stopped' in status_lower:
+            return SandboxStatus.PAUSED
+        elif 'dead' in status_lower or 'removing' in status_lower:
+            return SandboxStatus.MISSING
+        else:
+            return SandboxStatus.ERROR
+
+    async def _parse_container_to_kata_info(
+        self, container: dict[str, Any]
+    ) -> KataContainerInfo | None:
+        """Parse container info into KataContainerInfo."""
+        try:
+            labels = container.get('Labels', {}) or {}
+            sandbox_id = labels.get(KATA_SANDBOX_ID_LABEL)
+            if not sandbox_id:
+                return None
+
+            # Get IP address from network settings
+            ip_address = None
+            networks = container.get('NetworkSettings', {})
+            if networks:
+                # Try to get IP from default network
+                ip_address = networks.get('IPAddress')
+                if not ip_address:
+                    # Try networks map
+                    networks_map = networks.get('Networks', {})
+                    for net in networks_map.values():
+                        if net.get('IPAddress'):
+                            ip_address = net['IPAddress']
+                            break
+
+            # Parse created_at
+            created_at_str = labels.get(KATA_CREATED_AT_LABEL)
+            if created_at_str:
+                try:
+                    created_at = datetime.fromisoformat(created_at_str)
+                except (ValueError, TypeError):
+                    created_at = utc_now()
+            else:
+                created_at = utc_now()
+
+            # Get container status
+            status = container.get('Status', container.get('State', 'unknown'))
+            if isinstance(status, dict):
+                status = status.get('Status', 'unknown')
+
+            return KataContainerInfo(
+                container_id=container.get('Id', container.get('ID', '')),
+                sandbox_id=sandbox_id,
+                user_id=labels.get(KATA_USER_ID_LABEL),
+                sandbox_spec_id=labels.get(KATA_SANDBOX_SPEC_ID_LABEL, ''),
+                session_api_key_hash=labels.get(KATA_SESSION_API_KEY_HASH_LABEL),
+                status=status,
+                ip_address=ip_address,
+                created_at=created_at,
+            )
+        except Exception as e:
+            _logger.error(f'Failed to parse container info: {e}')
+            return None
+
+    def _kata_info_to_sandbox_info(
+        self,
+        kata_info: KataContainerInfo,
+        session_api_key: str | None = None,
+    ) -> SandboxInfo:
+        """Convert KataContainerInfo to SandboxInfo."""
+        status = self._container_status_to_sandbox_status(kata_info.status)
+
+        exposed_urls = None
+        if status == SandboxStatus.RUNNING and kata_info.ip_address:
+            ip = kata_info.ip_address
+            exposed_urls = [
+                ExposedUrl(
+                    name=AGENT_SERVER,
+                    url=self.container_url_pattern.format(
+                        host=ip, port=AGENT_SERVER_PORT
+                    ),
+                    port=AGENT_SERVER_PORT,
+                ),
+                ExposedUrl(
+                    name=VSCODE,
+                    url=self.container_url_pattern.format(host=ip, port=VSCODE_PORT),
+                    port=VSCODE_PORT,
+                ),
+                ExposedUrl(
+                    name=WORKER_1,
+                    url=self.container_url_pattern.format(host=ip, port=WORKER_1_PORT),
+                    port=WORKER_1_PORT,
+                ),
+                ExposedUrl(
+                    name=WORKER_2,
+                    url=self.container_url_pattern.format(host=ip, port=WORKER_2_PORT),
+                    port=WORKER_2_PORT,
+                ),
+            ]
+
+        return SandboxInfo(
+            id=kata_info.sandbox_id,
+            created_by_user_id=kata_info.user_id,
+            sandbox_spec_id=kata_info.sandbox_spec_id,
+            status=status,
+            session_api_key=session_api_key,
+            exposed_urls=exposed_urls,
+            created_at=kata_info.created_at,
+        )
+
+    async def search_sandboxes(
+        self,
+        page_id: str | None = None,
+        limit: int = 100,
+    ) -> SandboxPage:
+        """Search for Kata sandboxes."""
+        containers = await self._list_containers()
+
+        # Parse containers into KataContainerInfo
+        kata_infos = []
+        for container in containers:
+            info = await self._parse_container_to_kata_info(container)
+            if info:
+                # Filter by user if applicable
+                if self.user_id and info.user_id and info.user_id != self.user_id:
+                    continue
+                kata_infos.append(info)
+
+        # Sort by creation time (newest first)
+        kata_infos.sort(key=lambda x: x.created_at, reverse=True)
+
+        # Apply pagination
+        start_idx = 0
+        if page_id:
+            try:
+                start_idx = int(page_id)
+            except ValueError:
+                start_idx = 0
+
+        end_idx = start_idx + limit
+        paginated_infos = kata_infos[start_idx:end_idx]
+
+        # Convert to SandboxInfo
+        items = [self._kata_info_to_sandbox_info(info) for info in paginated_infos]
+
+        # Determine next page ID
+        next_page_id = None
+        if end_idx < len(kata_infos):
+            next_page_id = str(end_idx)
+
+        return SandboxPage(items=items, next_page_id=next_page_id)
+
+    async def get_sandbox(self, sandbox_id: str) -> SandboxInfo | None:
+        """Get a single Kata sandbox."""
+        container_name = self._get_container_name(sandbox_id)
+        container_info = await self._get_container_info(container_name)
+
+        if not container_info:
+            return None
+
+        kata_info = await self._parse_container_to_kata_info(container_info)
+        if not kata_info:
+            return None
+
+        # Get full info with session_api_key from our local cache
+        cached = self._sandboxes.get(sandbox_id)
+        if cached:
+            # Return session_api_key only for matching users
+            if not self.user_id or cached.user_id == self.user_id:
+                # We store the key temporarily in memory for security
+                pass  # Session key is retrieved from env in the container
+
+        return self._kata_info_to_sandbox_info(kata_info)
+
+    async def get_sandbox_by_session_api_key(
+        self, session_api_key: str
+    ) -> SandboxInfo | None:
+        """Get a sandbox by its session API key."""
+        hashed_key = _hash_session_api_key(session_api_key)
+
+        containers = await self._list_containers()
+        for container in containers:
+            info = await self._parse_container_to_kata_info(container)
+            if info and info.session_api_key_hash == hashed_key:
+                return self._kata_info_to_sandbox_info(info, session_api_key)
+
+        return None
+
+    async def _prepare_environment(
+        self,
+        sandbox_spec: SandboxSpecInfo,
+        sandbox_id: str,
+        session_api_key: str,
+    ) -> dict[str, str]:
+        """Prepare environment variables for the container."""
+        env = dict(sandbox_spec.initial_env)
+        env[SESSION_API_KEY_VARIABLE] = session_api_key
+
+        # Add webhook callback URL if web_url is configured
+        if self.web_url:
+            callback_url = f'{self.web_url}/api/conversations'
+            env[WEBHOOK_CALLBACK_VARIABLE] = callback_url
+            env[ALLOW_CORS_ORIGINS_VARIABLE] = self.web_url
+
+        return env
+
+    async def start_sandbox(
+        self, sandbox_spec_id: str | None = None, sandbox_id: str | None = None
+    ) -> SandboxInfo:
+        """Start a new Kata sandbox."""
+        # Enforce sandbox limits
+        await self.pause_old_sandboxes(self.max_num_sandboxes - 1)
+
+        # Get sandbox spec
+        if sandbox_spec_id is None:
+            sandbox_spec = await self.sandbox_spec_service.get_default_sandbox_spec()
+        else:
+            sandbox_spec_maybe = await self.sandbox_spec_service.get_sandbox_spec(
+                sandbox_spec_id
+            )
+            if sandbox_spec_maybe is None:
+                raise SandboxError(f'Sandbox spec not found: {sandbox_spec_id}')
+            sandbox_spec = sandbox_spec_maybe
+
+        # Generate IDs
+        if sandbox_id is None:
+            sandbox_id = base62.encodebytes(secrets.token_bytes(16))
+        session_api_key = _generate_session_api_key()
+
+        # Prepare environment
+        env = await self._prepare_environment(sandbox_spec, sandbox_id, session_api_key)
+
+        # Prepare container labels
+        created_at = utc_now()
+        labels = {
+            KATA_SANDBOX_LABEL: 'true',
+            KATA_SANDBOX_ID_LABEL: sandbox_id,
+            KATA_SESSION_API_KEY_HASH_LABEL: _hash_session_api_key(session_api_key),
+            KATA_SANDBOX_SPEC_ID_LABEL: sandbox_spec.id,
+            KATA_CREATED_AT_LABEL: created_at.isoformat(),
+        }
+        if self.user_id:
+            labels[KATA_USER_ID_LABEL] = self.user_id
+
+        # Build the nerdctl run command
+        container_name = self._get_container_name(sandbox_id)
+        cmd = [
+            self.nerdctl_bin,
+            '-n',
+            self.containerd_namespace,
+            'run',
+            '-d',  # Detached mode
+            '--name',
+            container_name,
+            '--runtime',
+            self.runtime_type,
+        ]
+
+        # Add labels
+        for key, value in labels.items():
+            cmd.extend(['--label', f'{key}={value}'])
+
+        # Add environment variables
+        for key, value in env.items():
+            cmd.extend(['-e', f'{key}={value}'])
+
+        # Add port mappings
+        if not self.enable_host_network:
+            cmd.extend(['-p', f'{AGENT_SERVER_PORT}:{AGENT_SERVER_PORT}'])
+            cmd.extend(['-p', f'{VSCODE_PORT}:{VSCODE_PORT}'])
+            cmd.extend(['-p', f'{WORKER_1_PORT}:{WORKER_1_PORT}'])
+            cmd.extend(['-p', f'{WORKER_2_PORT}:{WORKER_2_PORT}'])
+        else:
+            cmd.append('--network=host')
+
+        # Add working directory
+        cmd.extend(['--workdir', '/workspace'])
+
+        # Add the image
+        cmd.append(sandbox_spec.id)
+
+        # Add command if specified
+        if sandbox_spec.command:
+            cmd.extend(sandbox_spec.command)
+
+        _logger.info(
+            f'Starting Kata sandbox {sandbox_id} with command: {" ".join(cmd)}'
+        )
+
+        try:
+            exit_code, stdout, stderr = await self._run_command(cmd)
+
+            if exit_code != 0:
+                raise SandboxError(f'Failed to start Kata container: {stderr}')
+
+            # Store sandbox info in local cache
+            kata_info = KataContainerInfo(
+                container_id=stdout.strip()[:12],
+                sandbox_id=sandbox_id,
+                user_id=self.user_id,
+                sandbox_spec_id=sandbox_spec.id,
+                session_api_key_hash=_hash_session_api_key(session_api_key),
+                status='running',
+                ip_address=None,
+                created_at=created_at,
+            )
+            self._sandboxes[sandbox_id] = kata_info
+
+            # Wait for container to be ready and get its IP
+            sandbox_info = await self._wait_for_container_ready(sandbox_id)
+
+            return sandbox_info
+
+        except Exception as e:
+            _logger.error(f'Failed to start Kata sandbox {sandbox_id}: {e}')
+            # Cleanup on failure
+            await self.delete_sandbox(sandbox_id)
+            raise SandboxError(f'Failed to start Kata sandbox: {e}')
+
+    async def _wait_for_container_ready(
+        self, sandbox_id: str, timeout: int | None = None
+    ) -> SandboxInfo:
+        """Wait for the Kata container to be ready and return its info."""
+        if timeout is None:
+            timeout = self.startup_timeout
+
+        container_name = self._get_container_name(sandbox_id)
+        start_time = asyncio.get_event_loop().time()
+
+        while (asyncio.get_event_loop().time() - start_time) < timeout:
+            container_info = await self._get_container_info(container_name)
+
+            if container_info:
+                kata_info = await self._parse_container_to_kata_info(container_info)
+                if kata_info:
+                    status = self._container_status_to_sandbox_status(kata_info.status)
+
+                    if status == SandboxStatus.RUNNING:
+                        # Verify the agent server is alive
+                        if kata_info.ip_address:
+                            url = f'http://{kata_info.ip_address}:{AGENT_SERVER_PORT}/alive'
+                            try:
+                                response = await self.httpx_client.get(url, timeout=5.0)
+                                if response.is_success:
+                                    return self._kata_info_to_sandbox_info(kata_info)
+                            except Exception:
+                                pass  # Server not ready yet
+
+                    elif status == SandboxStatus.ERROR:
+                        raise SandboxError(
+                            f'Kata container {sandbox_id} entered error state'
+                        )
+
+            await asyncio.sleep(2)
+
+        raise SandboxError(
+            f'Kata sandbox {sandbox_id} failed to start within {timeout}s'
+        )
+
+    async def resume_sandbox(self, sandbox_id: str) -> bool:
+        """Resume a paused Kata sandbox."""
+        await self.pause_old_sandboxes(self.max_num_sandboxes - 1)
+
+        container_name = self._get_container_name(sandbox_id)
+        container_info = await self._get_container_info(container_name)
+
+        if not container_info:
+            return False
+
+        # Determine current state
+        state = container_info.get('State', {})
+        if isinstance(state, dict):
+            if state.get('Paused'):
+                # Container is paused, unpause it
+                cmd = [
+                    self.nerdctl_bin,
+                    '-n',
+                    self.containerd_namespace,
+                    'unpause',
+                    container_name,
+                ]
+            elif state.get('Status') == 'exited' or not state.get('Running', True):
+                # Container is stopped, start it
+                cmd = [
+                    self.nerdctl_bin,
+                    '-n',
+                    self.containerd_namespace,
+                    'start',
+                    container_name,
+                ]
+            else:
+                # Container is already running
+                return True
+
+            exit_code, stdout, stderr = await self._run_command(cmd, check=False)
+            return exit_code == 0
+
+        return False
+
+    async def pause_sandbox(self, sandbox_id: str) -> bool:
+        """Pause a running Kata sandbox."""
+        container_name = self._get_container_name(sandbox_id)
+        container_info = await self._get_container_info(container_name)
+
+        if not container_info:
+            return False
+
+        state = container_info.get('State', {})
+        if isinstance(state, dict) and state.get('Running') and not state.get('Paused'):
+            cmd = [
+                self.nerdctl_bin,
+                '-n',
+                self.containerd_namespace,
+                'pause',
+                container_name,
+            ]
+            exit_code, stdout, stderr = await self._run_command(cmd, check=False)
+            return exit_code == 0
+
+        return True  # Already paused or not running
+
+    async def delete_sandbox(self, sandbox_id: str) -> bool:
+        """Delete a Kata sandbox."""
+        container_name = self._get_container_name(sandbox_id)
+
+        # First, try to stop the container
+        stop_cmd = [
+            self.nerdctl_bin,
+            '-n',
+            self.containerd_namespace,
+            'stop',
+            '-t',
+            '10',  # 10 second timeout
+            container_name,
+        ]
+        await self._run_command(stop_cmd, check=False)
+
+        # Then remove the container
+        rm_cmd = [
+            self.nerdctl_bin,
+            '-n',
+            self.containerd_namespace,
+            'rm',
+            '-f',
+            container_name,
+        ]
+        exit_code, stdout, stderr = await self._run_command(rm_cmd, check=False)
+
+        # Remove from local cache
+        self._sandboxes.pop(sandbox_id, None)
+
+        return exit_code == 0 or 'no such container' in stderr.lower()
+
+
+class KataSandboxServiceInjector(SandboxServiceInjector):
+    """Dependency injector for Kata sandbox services.
+
+    Configuration for running agent-server containers inside Kata VMs
+    for enhanced isolation and security.
+    """
+
+    container_name_prefix: str = Field(
+        default='oh-kata-sandbox-',
+        description='Prefix for Kata container names',
+    )
+    containerd_namespace: str = Field(
+        default='openhands',
+        description=(
+            'Containerd namespace for OpenHands sandboxes. '
+            'Using a dedicated namespace helps with isolation and cleanup.'
+        ),
+    )
+    runtime_type: str = Field(
+        default='io.containerd.kata.v2',
+        description=(
+            'Kata runtime type to use. Common values:\n'
+            '- io.containerd.kata.v2 (Kata Containers 2.x)\n'
+            '- io.containerd.kata-qemu.v2 (Kata with QEMU)\n'
+            '- io.containerd.kata-clh.v2 (Kata with Cloud Hypervisor)\n'
+            '- io.containerd.kata-fc.v2 (Kata with Firecracker)'
+        ),
+    )
+    container_url_pattern: str = Field(
+        default='http://{host}:{port}',
+        description=(
+            'URL pattern for accessing services in the Kata container. '
+            'Use {host} and {port} as placeholders.'
+        ),
+    )
+    host_port: int = Field(
+        default=3000,
+        description='The port on which the main OpenHands app server is running.',
+    )
+    max_num_sandboxes: int = Field(
+        default=5,
+        description=(
+            'Maximum number of Kata sandboxes allowed to run simultaneously. '
+            'Kata VMs use more resources than standard containers.'
+        ),
+    )
+    nerdctl_bin: str = Field(
+        default='nerdctl',
+        description=(
+            'Path to nerdctl binary. nerdctl is a Docker-compatible CLI for containerd.'
+        ),
+    )
+    enable_host_network: bool = Field(
+        default=False,
+        description=(
+            'Whether to use host networking mode for Kata containers. '
+            'When enabled, containers share the host network namespace.'
+        ),
+    )
+    startup_timeout: int = Field(
+        default=120,
+        description=(
+            'Maximum time in seconds to wait for a Kata sandbox to start. '
+            'Kata VMs may take longer to start than regular containers.'
+        ),
+    )
+    kata_config_path: str | None = Field(
+        default=None,
+        description=(
+            'Path to custom Kata configuration file. '
+            'If not specified, the system default is used.'
+        ),
+    )
+
+    async def inject(
+        self, state: InjectorState, request: Request | None = None
+    ) -> AsyncGenerator[SandboxService, None]:
+        # Import inline to prevent circular imports
+        from openhands.app_server.config import (
+            get_global_config,
+            get_httpx_client,
+            get_sandbox_spec_service,
+            get_user_context,
+        )
+
+        config = get_global_config()
+        web_url = config.web_url
+
+        async with (
+            get_httpx_client(state) as httpx_client,
+            get_sandbox_spec_service(state) as sandbox_spec_service,
+            get_user_context(state, request) as user_context,
+        ):
+            user_id = await user_context.get_user_id()
+
+            yield KataSandboxService(
+                sandbox_spec_service=sandbox_spec_service,
+                user_id=user_id,
+                httpx_client=httpx_client,
+                container_name_prefix=self.container_name_prefix,
+                containerd_namespace=self.containerd_namespace,
+                runtime_type=self.runtime_type,
+                container_url_pattern=self.container_url_pattern,
+                max_num_sandboxes=self.max_num_sandboxes,
+                web_url=web_url,
+                host_port=self.host_port,
+                nerdctl_bin=self.nerdctl_bin,
+                enable_host_network=self.enable_host_network,
+                startup_timeout=self.startup_timeout,
+                kata_config_path=self.kata_config_path,
+            )

--- a/third_party/containers/e2b-sandbox/Dockerfile
+++ b/third_party/containers/e2b-sandbox/Dockerfile
@@ -1,19 +1,43 @@
-FROM ubuntu:24.04
+# E2B sandbox template for OpenHands V1
+# This template uses the standard OpenHands agent-server image
+# and configures it to run within an E2B micro VM.
+#
+# Build this template using the E2B CLI:
+#   e2b template build --dockerfile ./Dockerfile --name "openhands"
+#
+# The agent server will be started automatically when the sandbox boots.
 
-# install basic packages
-RUN apt-get update && apt-get install -y \
+# Use the official OpenHands agent-server image as base
+# This can be overridden via build args for testing different versions
+ARG AGENT_SERVER_IMAGE=ghcr.io/openhands/agent-server:latest
+FROM ${AGENT_SERVER_IMAGE}
+
+# E2B requires the sandbox to run as root for some operations
+USER root
+
+# Install additional packages that E2B needs for sandbox management
+RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
-    wget \
-    git \
-    vim \
-    nano \
-    unzip \
-    zip \
-    python3 \
-    python3-pip \
-    python3-venv \
-    python3-dev \
-    build-essential \
-    openssh-server \
-    sudo \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
+
+# Set up workspace directory
+RUN mkdir -p /workspace && chmod 777 /workspace
+
+# Environment variables for the agent server
+# These can be overridden when starting the sandbox
+ENV OH_WORKSPACE_DIR=/workspace
+ENV OH_LOG_LEVEL=INFO
+
+# Expose the standard agent server ports
+# 8000 - Agent Server API
+# 8001 - VSCode Server
+# 8011 - Worker 1 (user applications)
+# 8012 - Worker 2 (user applications)
+EXPOSE 8000 8001 8011 8012
+
+# Set working directory
+WORKDIR /workspace
+
+# The agent server is started via the entrypoint from the base image
+# E2B will manage the process lifecycle

--- a/third_party/containers/e2b-sandbox/README.md
+++ b/third_party/containers/e2b-sandbox/README.md
@@ -1,15 +1,130 @@
-# How to build custom E2B sandbox for OpenHands
+# E2B Sandbox Template for OpenHands V1
 
-[E2B](https://e2b.dev) is an [open-source](https://github.com/e2b-dev/e2b) secure cloud environment (sandbox) made for running AI-generated code and agents. E2B offers [Python](https://pypi.org/project/e2b/) and [JS/TS](https://www.npmjs.com/package/e2b) SDK to spawn and control these sandboxes.
+This directory contains the E2B sandbox template for running OpenHands agent servers in E2B micro VMs.
 
+## Overview
 
-1. Install the CLI with NPM.
-    ```sh
-    npm install -g @e2b/cli@latest
-    ```
-    Full CLI API is [here](https://e2b.dev/docs/cli/installation).
+[E2B](https://e2b.dev) is an [open-source](https://github.com/e2b-dev/e2b) secure cloud environment (sandbox) made for running AI-generated code and agents. This template configures E2B to run the OpenHands agent server, enabling secure, isolated execution environments for AI agents.
 
-1. Build the sandbox
-  ```sh
-  e2b template build --dockerfile ./Dockerfile --name "openhands"
-  ```
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    OpenHands App Server                      │
+│                    (Your local machine)                      │
+└─────────────────────┬───────────────────────────────────────┘
+                      │ HTTP API calls
+                      ▼
+┌─────────────────────────────────────────────────────────────┐
+│              Self-Hosted E2B Infrastructure                  │
+│                    (GCP / Your Cloud)                        │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐          │
+│  │ E2B Micro VM│  │ E2B Micro VM│  │ E2B Micro VM│   ...    │
+│  │ ┌─────────┐ │  │ ┌─────────┐ │  │ ┌─────────┐ │          │
+│  │ │  Agent  │ │  │ │  Agent  │ │  │ │  Agent  │ │          │
+│  │ │  Server │ │  │ │  Server │ │  │ │  Server │ │          │
+│  │ └─────────┘ │  │ └─────────┘ │  │ └─────────┘ │          │
+│  └─────────────┘  └─────────────┘  └─────────────┘          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Each conversation gets its own E2B micro VM running an isolated agent server.
+
+## Prerequisites
+
+1. **Self-hosted E2B infrastructure** deployed in your cloud (see [e2b-dev/infra](https://github.com/e2b-dev/infra))
+2. **E2B CLI** installed for building templates
+
+## Building the Template
+
+1. Install the E2B CLI:
+   ```sh
+   npm install -g @e2b/cli@latest
+   ```
+
+2. Configure CLI to use your self-hosted E2B:
+   ```sh
+   export E2B_API_URL=https://api.e2b.your-domain.com
+   export E2B_API_KEY=your-api-key
+   ```
+
+3. Build and push the template:
+   ```sh
+   cd third_party/containers/e2b-sandbox
+   e2b template build --dockerfile ./Dockerfile --name "openhands"
+   ```
+
+4. Note the template ID returned by the build command.
+
+## Configuring OpenHands to Use E2B
+
+Set the following environment variables when running OpenHands:
+
+```sh
+# E2B API configuration
+export OH_E2B_API_URL=https://api.e2b.your-domain.com
+export OH_E2B_API_KEY=your-api-key
+
+# Configure sandbox service to use E2B
+export OH_SANDBOX_SERVICE=e2b
+
+# Optional: Configure webhook URL for event callbacks
+export OH_WEB_URL=https://your-openhands-server.com
+```
+
+## Exposed Ports
+
+The template exposes the following ports:
+
+| Port | Service | Description |
+|------|---------|-------------|
+| 8000 | Agent Server | Main API endpoint for agent communication |
+| 8001 | VSCode Server | Web-based IDE for code editing |
+| 8011 | Worker 1 | User application server |
+| 8012 | Worker 2 | Additional user application server |
+
+## Customizing the Template
+
+### Using a Different Agent Server Version
+
+```sh
+e2b template build \
+  --dockerfile ./Dockerfile \
+  --name "openhands" \
+  --build-arg AGENT_SERVER_IMAGE=ghcr.io/openhands/agent-server:v1.0.0
+```
+
+### Resource Configuration
+
+Edit `e2b.toml` to adjust sandbox resources:
+
+```toml
+[sandbox]
+timeout = 3600  # Sandbox lifetime in seconds
+memory = 2048   # Memory in MB
+cpus = 2        # Number of vCPUs
+```
+
+## Debugging
+
+### List running sandboxes
+```sh
+e2b sandbox list
+```
+
+### Connect to a sandbox
+```sh
+e2b sandbox connect <sandbox-id>
+```
+
+### View sandbox logs
+```sh
+e2b sandbox logs <sandbox-id>
+```
+
+## Links
+
+- [E2B Documentation](https://e2b.dev/docs)
+- [E2B GitHub](https://github.com/e2b-dev/e2b)
+- [E2B Infrastructure (Self-Hosting)](https://github.com/e2b-dev/infra)
+- [OpenHands Documentation](https://docs.all-hands.dev)

--- a/third_party/containers/e2b-sandbox/e2b.toml
+++ b/third_party/containers/e2b-sandbox/e2b.toml
@@ -1,14 +1,36 @@
-# This is a config for E2B sandbox template.
-# You can use 'template_id' (785n69crgahmz0lkdw9h) or 'template_name (openhands) from this config to spawn a sandbox:
-
-# Python SDK
-# from e2b import Sandbox
-# sandbox = Sandbox(template='openhands')
-
-# JS SDK
-# import { Sandbox } from 'e2b'
-# const sandbox = await Sandbox.create({ template: 'openhands' })
+# E2B sandbox template configuration for OpenHands V1
+#
+# This template creates an E2B micro VM running the OpenHands agent server.
+# The agent server provides a sandboxed environment for AI agents to execute
+# code, browse the web, and interact with files.
+#
+# Building the template:
+#   e2b template build --dockerfile ./Dockerfile --name "openhands"
+#
+# Using the template with self-hosted E2B:
+#   Configure your E2B API URL and use this template name to create sandboxes.
+#
+# Exposed ports:
+#   8000 - Agent Server API (main communication endpoint)
+#   8001 - VSCode Server (web-based IDE)
+#   8011 - Worker 1 (user application server)
+#   8012 - Worker 2 (user application server)
 
 dockerfile = "Dockerfile"
 template_name = "openhands"
-template_id = "785n69crgahmz0lkdw9h"
+
+# Note: template_id is assigned by E2B when the template is built.
+# For self-hosted E2B, this will be different from the cloud version.
+# The ID below is for reference only and should be updated after building.
+# template_id = "your-template-id-here"
+
+# Sandbox configuration
+[sandbox]
+# Default timeout for sandbox lifetime (1 hour)
+timeout = 3600
+
+# Memory allocation (in MB)
+memory = 2048
+
+# CPU allocation (number of vCPUs)
+cpus = 2

--- a/third_party/runtime/impl/e2b/README.md
+++ b/third_party/runtime/impl/e2b/README.md
@@ -1,35 +1,31 @@
-# How to use E2B
+# E2B Runtime (Legacy V0)
 
-[E2B](https://e2b.dev) is an [open-source](https://github.com/e2b-dev/e2b) secure cloud environment (sandbox) made for running AI-generated code and agents. E2B offers [Python](https://pypi.org/project/e2b/) and [JS/TS](https://www.npmjs.com/package/e2b) SDK to spawn and control these sandboxes.
+> **⚠️ DEPRECATED**: This is the legacy V0 E2B runtime implementation.
+> For the new V1 implementation, see:
+> - `openhands/app_server/sandbox/e2b_sandbox_service.py` - E2B sandbox service
+> - `openhands/app_server/sandbox/e2b_sandbox_spec_service.py` - E2B template service
+> - `third_party/containers/e2b-sandbox/` - E2B template configuration
 
-## Getting started
+## Overview
 
-1. [Get your API key](https://e2b.dev/docs/getting-started/api-key)
+[E2B](https://e2b.dev) is an [open-source](https://github.com/e2b-dev/e2b) secure cloud environment (sandbox) made for running AI-generated code and agents.
 
-1. Set your E2B API key to the `E2B_API_KEY` env var when starting the Docker container
+## V1 Architecture
 
-1. **Optional** - Install the CLI with NPM.
-    ```sh
-    npm install -g @e2b/cli@latest
-    ```
-    Full CLI API is [here](https://e2b.dev/docs/cli/installation).
+In OpenHands V1, E2B integration works differently:
 
-## OpenHands sandbox
-You can use the E2B CLI to create a custom sandbox with a Dockerfile. Read the full guide [here](https://e2b.dev/docs/guide/custom-sandbox). The premade OpenHands sandbox for E2B is set up in the [`containers` directory](/containers/e2b-sandbox). and it's called `openhands`.
+1. **E2B Sandbox Service** (`e2b_sandbox_service.py`) communicates with the E2B API to create/manage micro VMs
+2. **Agent Server** runs inside each E2B micro VM
+3. **App Server** communicates with agent servers via HTTP
 
-## Debugging
-You can connect to a running E2B sandbox with E2B CLI in your terminal.
+See `/third_party/containers/e2b-sandbox/README.md` for setup instructions.
 
-- List all running sandboxes (based on your API key)
-    ```sh
-    e2b sandbox list
-    ```
+## Legacy V0 Usage
 
-- Connect to a running sandbox
-    ```sh
-    e2b sandbox connect <sandbox-id>
-    ```
+The files in this directory (`e2b_runtime.py`, `sandbox.py`, `filestore.py`) are for the legacy V0 runtime and will be removed in a future version.
 
 ## Links
-- [E2B Docs](https://e2b.dev/docs)
+
+- [E2B Documentation](https://e2b.dev/docs)
 - [E2B GitHub](https://github.com/e2b-dev/e2b)
+- [E2B Infrastructure (Self-Hosting)](https://github.com/e2b-dev/infra)


### PR DESCRIPTION
## Description

This PR adds support for multiple VM-based sandbox backends for OpenHands V1:
1. **E2B Sandbox Service**: Self-hosted E2B micro VMs
2. **Kata Containers Sandbox Service**: Lightweight VMs via containerd/Kata runtime

Both services provide enhanced security isolation by running each agent-server instance inside its own VM rather than a standard container.

## Architecture

```
┌─────────────────────────────────────────────────────────────┐
│                    OpenHands App Server                      │
│                    (Your local machine)                      │
└─────────────────────┬───────────────────────────────────────┘
                      │ HTTP API calls / containerd
                      ▼
┌─────────────────────────────────────────────────────────────┐
│           VM-based Sandbox Infrastructure                    │
│                                                              │
│  ┌─────────────────┐  ┌─────────────────┐                   │
│  │   E2B Micro VM  │  │   Kata VM       │                   │
│  │   (Self-hosted) │  │   (containerd)  │                   │
│  │  ┌───────────┐  │  │  ┌───────────┐  │                   │
│  │  │   Agent   │  │  │  │   Agent   │  │                   │
│  │  │   Server  │  │  │  │   Server  │  │                   │
│  │  └───────────┘  │  │  └───────────┘  │                   │
│  └─────────────────┘  └─────────────────┘                   │
└─────────────────────────────────────────────────────────────┘
```

Each conversation gets its own VM running an isolated agent server.

## Changes

### New Files
- `openhands/app_server/sandbox/e2b_sandbox_service.py` - E2B sandbox service
- `openhands/app_server/sandbox/e2b_sandbox_spec_service.py` - E2B template service
- `openhands/app_server/sandbox/kata_sandbox_service.py` - Kata Containers sandbox service

### Updated Files
- `openhands/app_server/config.py` - Added `RUNTIME=e2b` and `RUNTIME=kata` options
- `openhands/app_server/sandbox/README.md` - Documentation for all sandbox types
- `third_party/containers/e2b-sandbox/*` - E2B template files

---

# Option 1: E2B Sandbox Service

## Prerequisites

1. **Self-hosted E2B infrastructure** deployed (see [e2b-dev/infra](https://github.com/e2b-dev/infra))
2. **E2B CLI** installed (`npm install -g @e2b/cli@latest`)

## Setup

### Step 1: Build the E2B Template

```bash
cd third_party/containers/e2b-sandbox

export E2B_API_URL=https://api.e2b.your-domain.com
export E2B_API_KEY=your-api-key

e2b template build --dockerfile ./Dockerfile --name "openhands"
```

### Step 2: Run OpenHands with E2B

```bash
export RUNTIME=e2b
export E2B_API_URL=https://api.e2b.your-domain.com
export E2B_API_KEY=your-api-key

# Optional
export E2B_MAX_SANDBOXES=10
export E2B_SANDBOX_TIMEOUT=3600

make run
```

---

# Option 2: Kata Containers Sandbox Service

## Prerequisites

1. **Linux host** with hardware virtualization (Intel VT-x / AMD-V)
2. **KVM enabled** (`/dev/kvm` must exist)
3. **containerd** installed and running
4. **Kata Containers** runtime installed
5. **nerdctl** (containerd CLI)

## Setup

### Step 1: Install containerd

```bash
# Ubuntu/Debian
sudo apt-get update
sudo apt-get install -y containerd
sudo systemctl enable --now containerd
```

### Step 2: Install Kata Containers

```bash
# Ubuntu example
ARCH=$(uname -m)
DISTRO=$(lsb_release -rs)
sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/xUbuntu_${DISTRO}/ /' > /etc/apt/sources.list.d/kata-containers.list"
curl -sL http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/xUbuntu_${DISTRO}/Release.key | sudo apt-key add -
sudo apt-get update
sudo apt-get install -y kata-runtime kata-proxy kata-shim

# Verify
kata-runtime kata-check
```

### Step 3: Configure containerd for Kata

Edit `/etc/containerd/config.toml`:

```toml
version = 2

[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
  runtime_type = "io.containerd.kata.v2"

[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
  ConfigPath = "/etc/kata-containers/configuration.toml"
```

Then restart containerd:

```bash
sudo systemctl restart containerd
```

### Step 4: Install nerdctl

```bash
NERDCTL_VERSION=$(curl -s https://api.github.com/repos/containerd/nerdctl/releases/latest | grep tag_name | cut -d '"' -f 4)
curl -LO https://github.com/containerd/nerdctl/releases/download/${NERDCTL_VERSION}/nerdctl-${NERDCTL_VERSION#v}-linux-amd64.tar.gz
sudo tar -xzf nerdctl-${NERDCTL_VERSION#v}-linux-amd64.tar.gz -C /usr/local/bin
```

### Step 5: Run OpenHands with Kata

```bash
export RUNTIME=kata

# Optional configuration
export KATA_RUNTIME_TYPE=io.containerd.kata.v2  # Default
export KATA_CONTAINERD_NAMESPACE=openhands
export KATA_MAX_NUM_SANDBOXES=5
export KATA_STARTUP_TIMEOUT=120

make run
```

## Kata Runtime Types

| Runtime Type | Hypervisor | Notes |
|-------------|------------|-------|
| `io.containerd.kata.v2` | Default (QEMU) | Most compatible |
| `io.containerd.kata-qemu.v2` | QEMU | Full featured |
| `io.containerd.kata-clh.v2` | Cloud Hypervisor | Fast startup |
| `io.containerd.kata-fc.v2` | Firecracker | Fastest, minimal |

## Verify Kata is Working

```bash
# List running Kata sandboxes
sudo nerdctl -n openhands ps

# Check for kata-runtime processes
ps aux | grep kata
```

## Troubleshooting

**KVM not available:**
```bash
sudo modprobe kvm
sudo modprobe kvm_intel  # or kvm_amd
sudo chmod 666 /dev/kvm
```

**Container startup timeout:**
- Increase `KATA_STARTUP_TIMEOUT` (VMs take longer to boot)
- Check logs: `sudo journalctl -u containerd -f`

---

# Environment Variables Reference

## E2B Variables

| Variable | Required | Default | Description |
|----------|----------|---------|-------------|
| `RUNTIME` | Yes | - | Set to `e2b` |
| `E2B_API_URL` | Yes | - | Self-hosted E2B API URL |
| `E2B_API_KEY` | Yes | - | E2B API key |
| `E2B_MAX_SANDBOXES` | No | 10 | Max concurrent sandboxes |
| `E2B_SANDBOX_TIMEOUT` | No | 3600 | Sandbox lifetime (seconds) |

## Kata Variables

| Variable | Required | Default | Description |
|----------|----------|---------|-------------|
| `RUNTIME` | Yes | - | Set to `kata` |
| `KATA_RUNTIME_TYPE` | No | `io.containerd.kata.v2` | Kata runtime/hypervisor |
| `KATA_CONTAINERD_NAMESPACE` | No | `openhands` | containerd namespace |
| `KATA_MAX_NUM_SANDBOXES` | No | 5 | Max concurrent sandboxes |
| `KATA_STARTUP_TIMEOUT` | No | 120 | Startup timeout (seconds) |
| `KATA_ENABLE_HOST_NETWORK` | No | false | Use host networking |

---

## Testing

- [ ] Manual testing with self-hosted E2B infrastructure
- [ ] Manual testing with Kata Containers
- [ ] Unit tests (future work)

## Related

- [E2B Documentation](https://e2b.dev/docs)
- [E2B Infrastructure](https://github.com/e2b-dev/infra)
- [Kata Containers](https://katacontainers.io/)
- [containerd](https://containerd.io/)
- [nerdctl](https://github.com/containerd/nerdctl)
