### PR TITLE
fix: Remove N+1 request from Bitbucket Data Center integration

### DIFF
--- a/openhands/integrations/bitbucket_data_center/service/base.py
+++ b/openhands/integrations/bitbucket_data_center/service/base.py
@@ -216,13 +216,18 @@ class BitbucketDCMixinBase(BaseGitService, HTTPClient):
         )
 
     async def _parse_repository(
-        self, repo: dict, link_header: str | None = None
+        self,
+        repo: dict,
+        link_header: str | None = None,
+        fetch_default_branch: bool = False,
     ) -> Repository:
         """Parse a Bitbucket data center API repository response into a Repository object.
 
         Args:
             repo: Repository data from Bitbucket data center API
             link_header: Optional link header for pagination
+            fetch_default_branch: Whether to make an additional API call to fetch the
+                default branch. Set to False for listing endpoints to avoid N+1 queries.
 
         Returns:
             Repository object
@@ -240,14 +245,15 @@ class BitbucketDCMixinBase(BaseGitService, HTTPClient):
         is_public = repo.get('public', False)
 
         main_branch: str | None = None
-        try:
-            default_branch_url = (
-                f'{self._repo_api_base(project_key, repo_slug)}/default-branch'
-            )
-            default_branch_data, _ = await self._make_request(default_branch_url)
-            main_branch = default_branch_data.get('displayId') or None
-        except Exception as e:
-            logger.debug(f'Could not fetch default branch for {full_name}: {e}')
+        if fetch_default_branch:
+            try:
+                default_branch_url = (
+                    f'{self._repo_api_base(project_key, repo_slug)}/default-branch'
+                )
+                default_branch_data, _ = await self._make_request(default_branch_url)
+                main_branch = default_branch_data.get('displayId') or None
+            except Exception as e:
+                logger.debug(f'Could not fetch default branch for {full_name}: {e}')
 
         return Repository(
             id=str(repo.get('id', '')),
@@ -275,7 +281,7 @@ class BitbucketDCMixinBase(BaseGitService, HTTPClient):
         owner, repo = self._extract_owner_and_repo(repository)
         url = self._repo_api_base(owner, repo)
         data, _ = await self._make_request(url)
-        return await self._parse_repository(data)
+        return await self._parse_repository(data, fetch_default_branch=True)
 
     async def _get_cursorrules_url(self, repository: str) -> str:
         """Get the URL for checking .cursorrules file."""

--- a/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_repos.py
+++ b/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_repos.py
@@ -112,21 +112,15 @@ async def test_search_repositories_slash_query():
     query = 'PROJ/myrepo'
 
     mock_repo = _repo_dict('PROJ', slug='myrepo', name='My Repository')
-    mock_default_branch = {'displayId': 'main'}
 
     with patch.object(
         svc,
         '_fetch_paginated_data',
         new=AsyncMock(return_value=[mock_repo]),
     ) as mock_fetch:
-        with patch.object(
-            svc,
-            '_make_request',
-            new=AsyncMock(return_value=(mock_default_branch, {})),
-        ):
-            repos = await svc.search_repositories(
-                query, 25, 'name', 'asc', False, AppMode.SAAS
-            )
+        repos = await svc.search_repositories(
+            query, 25, 'name', 'asc', False, AppMode.SAAS
+        )
 
     mock_fetch.assert_called_once_with(
         'https://host.example.com/rest/api/1.0/projects/PROJ/repos',
@@ -135,6 +129,7 @@ async def test_search_repositories_slash_query():
     )
     assert len(repos) == 1
     assert repos[0].full_name == 'PROJ/myrepo'
+    assert repos[0].main_branch is None
 
 
 @pytest.mark.asyncio
@@ -143,24 +138,19 @@ async def test_search_repositories_slash_query_filters_by_name():
     svc = make_service()
     matching = _repo_dict('PROJ', slug='proj-alpha', name='My Repository')
     non_matching = _repo_dict('PROJ', slug='proj-beta', name='Other Repo')
-    mock_default_branch = {'displayId': 'main'}
 
     with patch.object(
         svc,
         '_fetch_paginated_data',
         new=AsyncMock(return_value=[matching, non_matching]),
     ):
-        with patch.object(
-            svc,
-            '_make_request',
-            new=AsyncMock(return_value=(mock_default_branch, {})),
-        ):
-            repos = await svc.search_repositories(
-                'PROJ/my repository', 25, 'name', 'asc', False, AppMode.SAAS
-            )
+        repos = await svc.search_repositories(
+            'PROJ/my repository', 25, 'name', 'asc', False, AppMode.SAAS
+        )
 
     assert len(repos) == 1
     assert repos[0].full_name == 'PROJ/proj-alpha'
+    assert repos[0].main_branch is None
 
 
 @pytest.mark.asyncio
@@ -169,24 +159,19 @@ async def test_search_repositories_slash_query_filters_by_slug():
     svc = make_service()
     matching = _repo_dict('PROJ', slug='my-repo', name='My Repository')
     non_matching = _repo_dict('PROJ', slug='other-repo', name='Other Repository')
-    mock_default_branch = {'displayId': 'main'}
 
     with patch.object(
         svc,
         '_fetch_paginated_data',
         new=AsyncMock(return_value=[matching, non_matching]),
     ):
-        with patch.object(
-            svc,
-            '_make_request',
-            new=AsyncMock(return_value=(mock_default_branch, {})),
-        ):
-            repos = await svc.search_repositories(
-                'PROJ/my-repo', 25, 'name', 'asc', False, AppMode.SAAS
-            )
+        repos = await svc.search_repositories(
+            'PROJ/my-repo', 25, 'name', 'asc', False, AppMode.SAAS
+        )
 
     assert len(repos) == 1
     assert repos[0].full_name == 'PROJ/my-repo'
+    assert repos[0].main_branch is None
 
 
 # ── get_paginated_repos ───────────────────────────────────────────────────────
@@ -199,18 +184,18 @@ async def test_get_paginated_repos_parses_values():
         'values': [_repo_dict()],
         'isLastPage': True,
     }
-    mock_default_branch = {'displayId': 'main'}
 
     with patch.object(
         svc,
         '_make_request',
-        side_effect=[(mock_response, {}), (mock_default_branch, {})],
+        return_value=(mock_response, {}),
     ):
         repos = await svc.get_paginated_repos(1, 25, 'name', 'PROJ')
 
     assert len(repos) == 1
     assert repos[0].full_name == 'PROJ/myrepo'
     assert repos[0].link_header == ''
+    assert repos[0].main_branch is None
 
 
 @pytest.mark.asyncio
@@ -221,17 +206,17 @@ async def test_get_paginated_repos_has_next_page():
         'isLastPage': False,
         'nextPageStart': 25,
     }
-    mock_default_branch = {'displayId': 'main'}
 
     with patch.object(
         svc,
         '_make_request',
-        side_effect=[(mock_response, {}), (mock_default_branch, {})],
+        return_value=(mock_response, {}),
     ):
         repos = await svc.get_paginated_repos(1, 25, 'name', 'PROJ')
 
     assert len(repos) == 1
     assert 'rel="next"' in repos[0].link_header
+    assert repos[0].main_branch is None
 
 
 @pytest.mark.asyncio
@@ -241,17 +226,17 @@ async def test_get_paginated_repos_last_page():
         'values': [_repo_dict()],
         'isLastPage': True,
     }
-    mock_default_branch = {'displayId': 'main'}
 
     with patch.object(
         svc,
         '_make_request',
-        side_effect=[(mock_response, {}), (mock_default_branch, {})],
+        return_value=(mock_response, {}),
     ):
         repos = await svc.get_paginated_repos(1, 25, 'name', 'PROJ')
 
     assert len(repos) == 1
     assert repos[0].link_header == ''
+    assert repos[0].main_branch is None
 
 
 @pytest.mark.asyncio
@@ -265,17 +250,17 @@ async def test_get_paginated_repos_filters_by_slug():
         ],
         'isLastPage': True,
     }
-    mock_default_branch = {'displayId': 'main'}
 
     with patch.object(
         svc,
         '_make_request',
-        side_effect=[(mock_response, {}), (mock_default_branch, {})],
+        return_value=(mock_response, {}),
     ):
         repos = await svc.get_paginated_repos(1, 25, 'name', 'PROJ', query='my-repo')
 
     assert len(repos) == 1
     assert repos[0].full_name == 'PROJ/my-repo'
+    assert repos[0].main_branch is None
 
 
 @pytest.mark.asyncio
@@ -289,12 +274,11 @@ async def test_get_paginated_repos_filters_by_name():
         ],
         'isLastPage': True,
     }
-    mock_default_branch = {'displayId': 'main'}
 
     with patch.object(
         svc,
         '_make_request',
-        side_effect=[(mock_response, {}), (mock_default_branch, {})],
+        return_value=(mock_response, {}),
     ):
         repos = await svc.get_paginated_repos(
             1, 25, 'name', 'PROJ', query='my repository'
@@ -302,6 +286,7 @@ async def test_get_paginated_repos_filters_by_name():
 
     assert len(repos) == 1
     assert repos[0].full_name == 'PROJ/proj-alpha'
+    assert repos[0].main_branch is None
 
 
 # ── get_all_repositories ──────────────────────────────────────────────────────
@@ -320,14 +305,14 @@ async def test_get_all_repositories_iterates_projects():
             return [_repo_dict('PROJ2', 'repo2')]
         return []
 
-    mock_default_branch = {'displayId': 'main'}
     with patch.object(svc, '_fetch_paginated_data', side_effect=fake_fetch):
-        with patch.object(svc, '_make_request', return_value=(mock_default_branch, {})):
-            repos = await svc.get_all_repositories('name', AppMode.SAAS)
+        repos = await svc.get_all_repositories('name', AppMode.SAAS)
 
     full_names = {r.full_name for r in repos}
     assert 'PROJ1/repo1' in full_names
     assert 'PROJ2/repo2' in full_names
+    for repo in repos:
+        assert repo.main_branch is None
 
 
 # ── get_installations ─────────────────────────────────────────────────────────
@@ -352,4 +337,4 @@ async def test_get_installations_returns_project_keys():
 async def _make_parsed_repo(svc, repo_dict):
     """Helper to create a parsed Repository from a repo dict (with mocked default branch)."""
     with patch.object(svc, '_make_request', return_value=({'displayId': 'main'}, {})):
-        return await svc._parse_repository(repo_dict)
+        return await svc._parse_repository(repo_dict, fetch_default_branch=True)


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

When listing repositories, the Bitbucket Data Center integration makes a request per repository returned by the API to the `/default-branch` endpoint. Their API does not support retrieving the default branch in the same call as retrieving the repository.

As a result, listing repos in projects with a large number of repositories is very slow.

I've removed the request to retrieve the default branch when listing repos, and now only fire the request when information on a single repo is requested.

The only user-facing side effect of this change is that when a repo is selected in the dropdown, the branch drop down doesn't automatically select the default branch. Instead, users have to manually select the branch they want to use from the dropdown.

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

In this video, I scroll through a project (`TAWNYMEADO`) that has 2000 repositories. Before this change, the call to list repositories would timeout. After my change, the call returns in < 500ms. I kept the dev console open so you can see timing.

https://github.com/user-attachments/assets/2e160cdc-205a-43f1-b2cf-0ea4414cc997

## Change Type

<!-- Choose the types that apply to your PR -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:a3d6892-nikolaik   --name openhands-app-a3d6892   docker.openhands.dev/openhands/openhands:a3d6892
```