### PR TITLE
feat(enterprise): Add plugin-directory Keycloak client

### DIFF
--- a/enterprise/allhands-realm-github-provider.json.tmpl
+++ b/enterprise/allhands-realm-github-provider.json.tmpl
@@ -894,6 +894,64 @@
         "organization",
         "microprofile-jwt"
       ]
+    },
+    {
+      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+      "clientId": "plugin-directory",
+      "name": "Plugin Directory",
+      "description": "Plugin marketplace for discovering and reviewing agent plugins",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "$PLUGIN_DIRECTORY_CLIENT_SECRET",
+      "redirectUris": [
+        "https://$PLUGIN_DIRECTORY_HOST/auth/callback"
+      ],
+      "webOrigins": [
+        "https://$PLUGIN_DIRECTORY_HOST"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "frontchannel.logout.session.required": "true",
+        "post.logout.redirect.uris": "+",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "display.on.consent.screen": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
     }
   ],
   "clientScopes": [


### PR DESCRIPTION
## Summary

Adds the plugin-directory OIDC client to the Keycloak realm template for SSO authentication with the [Plugin Directory](https://github.com/OpenHands/plugin-directory) marketplace app.

Related: All-Hands-AI/OpenHands-Cloud#306

## Changes

Adds a new client entry to `enterprise/allhands-realm-github-provider.json.tmpl`:

```json
{
  "clientId": "plugin-directory",
  "name": "Plugin Directory",
  "secret": "$PLUGIN_DIRECTORY_CLIENT_SECRET",
  "redirectUris": ["https://$PLUGIN_DIRECTORY_HOST/auth/callback"],
  "webOrigins": ["https://$PLUGIN_DIRECTORY_HOST"],
  ...
}
```

## New Environment Variables

These variables need to be added to the `envsubst` command in the Helm chart's `keycloak-config-script.yaml`:

| Variable | Description |
|----------|-------------|
| `$PLUGIN_DIRECTORY_HOST` | Hostname for the plugin directory (e.g., `plugins.example.com`) |
| `$PLUGIN_DIRECTORY_CLIENT_SECRET` | OIDC client secret for authentication |

## ⚠️ Merge Order

> **Important**: The Helm chart changes in [All-Hands-AI/OpenHands-Cloud#308](https://github.com/All-Hands-AI/OpenHands-Cloud/pull/308) should be merged **before** this PR.

The chart PR adds these environment variables to the `envsubst` command. If this PR is merged first:
- The variables will not be substituted
- Keycloak will receive literal `$PLUGIN_DIRECTORY_HOST` strings instead of empty values
- This won't break anything, but results in messy data until the charts are updated

Merging the charts first ensures clean empty-string substitution when plugin-directory is disabled.

## Testing

When plugin-directory is disabled in the Helm chart:
- `$PLUGIN_DIRECTORY_HOST` → `""` (empty string)
- `$PLUGIN_DIRECTORY_CLIENT_SECRET` → `""` (empty string)
- Keycloak client is created with empty redirect URIs (harmless - non-functional)

When plugin-directory is enabled:
- Variables have real values
- Keycloak client works for OIDC authentication

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:3624e5b-nikolaik   --name openhands-app-3624e5b   docker.openhands.dev/openhands/openhands:3624e5b
```