### PR TITLE
DRAFT: feat: run .openhands/setup.sh via agent's terminal tool in V1

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -211,14 +211,16 @@ class AppConversationServiceBase(AppConversationService, ABC):
         sandbox: SandboxInfo,
         workspace: AsyncRemoteWorkspace,
         agent_server_url: str,
+        defer_setup_script: bool = False,
     ) -> AsyncGenerator[AppConversationStartTask, None]:
         task.status = AppConversationStartTaskStatus.PREPARING_REPOSITORY
         yield task
         await self.clone_or_init_git_repo(task, workspace)
 
-        task.status = AppConversationStartTaskStatus.RUNNING_SETUP_SCRIPT
-        yield task
-        await self.maybe_run_setup_script(workspace)
+        if not defer_setup_script:
+            task.status = AppConversationStartTaskStatus.RUNNING_SETUP_SCRIPT
+            yield task
+            await self.maybe_run_setup_script(workspace)
 
         task.status = AppConversationStartTaskStatus.SETTING_UP_GIT_HOOKS
         yield task
@@ -346,6 +348,55 @@ class AppConversationServiceBase(AppConversationService, ABC):
         # Add the action to the event stream as an ENVIRONMENT event
         # source = EventSource.ENVIRONMENT
         # self.event_stream.add_event(action, source)
+
+    async def run_setup_script_via_terminal_tool(
+        self,
+        workspace: AsyncRemoteWorkspace,
+        conversation_id: str,
+        session_api_key: str | None = None,
+    ) -> None:
+        """Run .openhands/setup.sh through the agent's terminal tool.
+
+        This executes the setup script in the agent's persistent terminal session,
+        ensuring that environment changes (exported variables, sourced files, etc.)
+        persist for the agent's subsequent commands.
+
+        Args:
+            workspace: The remote workspace
+            conversation_id: The conversation ID (hex string)
+            session_api_key: Optional API key for authentication
+        """
+        setup_script = workspace.working_dir + '/.openhands/setup.sh'
+        command = (
+            f'if [ -f {setup_script} ]; then '
+            f'chmod +x {setup_script} && source {setup_script}; '
+            f'fi'
+        )
+        try:
+            result = await workspace.execute_tool(
+                conversation_id=conversation_id,
+                tool_name='terminal',
+                action={'command': command, 'timeout': 600},
+                timeout=660.0,
+            )
+            is_error = result.get('is_error', False)
+            if is_error:
+                observation = result.get('observation', {})
+                _logger.warning(
+                    f'Setup script execution via terminal tool reported error: '
+                    f'{observation}'
+                )
+            else:
+                _logger.info(
+                    'Setup script executed via terminal tool (env changes persisted)'
+                )
+        except Exception as e:
+            _logger.warning(
+                f'Failed to run setup script via terminal tool, '
+                f'falling back to workspace API: {e}'
+            )
+            # Fall back to the workspace API (env changes won't persist)
+            await self.maybe_run_setup_script(workspace)
 
     async def maybe_setup_git_hooks(
         self,

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -250,18 +250,25 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             )
             assert sandbox_spec is not None
 
-            # Run setup scripts
+            # Run setup scripts (defer setup.sh to run via terminal tool later)
             remote_workspace = AsyncRemoteWorkspace(
                 host=agent_server_url,
                 api_key=sandbox.session_api_key,
                 working_dir=sandbox_spec.working_dir,
             )
             async for updated_task in self.run_setup_scripts(
-                task, sandbox, remote_workspace, agent_server_url
+                task,
+                sandbox,
+                remote_workspace,
+                agent_server_url,
+                defer_setup_script=True,
             ):
                 yield updated_task
 
-            # Build the start request
+            # Build the full start request (including initial_message with
+            # plugin params incorporated), but we'll send it WITHOUT the
+            # initial_message so we can run setup.sh through the terminal
+            # tool before the agent starts
             start_conversation_request = (
                 await self._build_start_conversation_request_for_user(
                     sandbox,
@@ -278,12 +285,18 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 )
             )
 
+            # Save the finalized initial message (with plugin params) and
+            # strip it from the start request so the conversation is created
+            # without triggering the agent loop
+            deferred_initial_message = start_conversation_request.initial_message
+            start_conversation_request.initial_message = None
+
             # update status
             task.status = AppConversationStartTaskStatus.STARTING_CONVERSATION
             task.agent_server_url = agent_server_url
             yield task
 
-            # Start conversation...
+            # Start conversation (without initial message — agent doesn't run yet)
             body_json = start_conversation_request.model_dump(
                 mode='json', context={'expose_secrets': True}
             )
@@ -296,6 +309,34 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
 
             response.raise_for_status()
             info = ConversationInfo.model_validate(response.json())
+
+            # Run setup.sh through the agent's terminal tool so environment
+            # changes persist in the agent's session
+            task.status = AppConversationStartTaskStatus.RUNNING_SETUP_SCRIPT
+            yield task
+            await self.run_setup_script_via_terminal_tool(
+                remote_workspace,
+                info.id.hex,
+                sandbox.session_api_key,
+            )
+
+            # Now send the initial message to start the agent loop
+            if deferred_initial_message:
+                initial_msg_payload = {
+                    'role': deferred_initial_message.role,
+                    'content': [
+                        c.model_dump(mode='json')
+                        for c in deferred_initial_message.content
+                    ],
+                    'run': True,
+                }
+                msg_response = await self.httpx_client.post(
+                    f'{agent_server_url}/api/conversations/{info.id.hex}/events',
+                    json=initial_msg_payload,
+                    headers={'X-Session-API-Key': sandbox.session_api_key},
+                    timeout=self.sandbox_startup_timeout,
+                )
+                msg_response.raise_for_status()
 
             # Store info...
             user_id = await self.user_context.get_user_id()


### PR DESCRIPTION
## Description

Restructure the V1 conversation startup flow to execute `setup.sh` through the agent's persistent terminal session instead of `AsyncRemoteWorkspace`'s ephemeral subprocess. This ensures environment changes (exported variables, sourced files, etc.) persist for the agent's subsequent commands.

### Problem

In V1, `.openhands/setup.sh` was executed via `AsyncRemoteWorkspace.execute_command()` which runs in an ephemeral subprocess. Environment changes from `source setup.sh` (like `export PATH=...`, `nvm use`, `pyenv activate`, etc.) were lost and not available to the agent. V0 didn't have this problem because it ran setup.sh through `CmdRunAction` in the agent's persistent bash session.

### Solution

Restructure the V1 startup flow:

1. **Clone repo, setup git hooks, load skills** (setup.sh **deferred** via `defer_setup_script=True`)
2. **Build `StartConversationRequest`** with initial message (for plugin params), then strip it
3. **`POST /api/conversations`** — creates conversation **without** triggering agent loop
4. **`POST /api/conversations/{id}/execute_tool`** — runs `setup.sh` through agent's **persistent terminal session** ✅
5. **`POST /api/conversations/{id}/events`** — sends initial message with `run=True` to start agent

### Changes

**`app_conversation_service_base.py`:**
- Added `defer_setup_script` parameter to `run_setup_scripts()` (defaults to `False` — no breaking change)
- Added `run_setup_script_via_terminal_tool()` method with graceful fallback

**`live_status_app_conversation_service.py`:**
- Defers setup.sh during `run_setup_scripts`
- Creates conversation without initial message
- Executes setup.sh via terminal tool after conversation creation
- Sends deferred initial message (with plugin params preserved) to start agent loop

### Key Design Decisions

- **Fallback safety**: If `execute_tool` fails (e.g., older SDK version), falls back to `maybe_run_setup_script()` via workspace API
- **Plugin params preserved**: The initial message is built with plugin params incorporated before being deferred
- **No breaking changes**: `defer_setup_script` defaults to `False`, existing callers are unaffected
- **File existence check**: Uses `if [ -f setup.sh ]` instead of blindly executing (improvement over original V1)

### Dependency

Requires the companion SDK PR: https://github.com/OpenHands/software-agent-sdk/pull/2356 (adds `execute_tool` API endpoint and `AsyncRemoteWorkspace.execute_tool()` method)

### Testing

- All modified files parse correctly
- No breaking changes to existing code paths

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:e5fc1d6-nikolaik   --name openhands-app-e5fc1d6   docker.openhands.dev/openhands/openhands:e5fc1d6
```