### PR TITLE
docs: add dockerless local GUI quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ The experience will be familiar to anyone who has used Devin or Jules.
 
 [Check out the docs](https://docs.openhands.dev/openhands/usage/run-openhands/local-setup) or view the source in this repo.
 
+#### Run without Docker (quick start)
+
+If you prefer a dockerless setup, you can run OpenHands with the local runtime:
+
+```bash
+export INSTALL_DOCKER=0
+export RUNTIME=local
+make build && make run
+```
+
+This starts the app at `http://localhost:3001` and skips Docker runtime setup.
+For full prerequisites and troubleshooting, see:
+
+- [Development guide](./Development.md#5-running-openhands-with-openhands)
+- [Local runtime docs](https://docs.openhands.dev/openhands/usage/runtimes/local)
+
 ### OpenHands Cloud
 This is a deployment of OpenHands GUI, running on hosted infrastructure.
 


### PR DESCRIPTION
## Summary of PR

- add a concise "Run without Docker" section to the main README Local GUI area
- document the minimal env vars and command to start OpenHands with local runtime
- link to the detailed Development guide and local runtime docs for prerequisites and troubleshooting

Fixes OpenHands/docs#656

Validation
- docs-only change (README links + commands reviewed)

## Demo Screenshots/Videos

Not included for this change.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Fixes OpenHands/docs#656

## Release Notes

- [ ] Include this change in the Release Notes.