### PR TITLE
Remove deprecated reset-settings endpoint

### DIFF
--- a/frontend/src/mocks/settings-handlers.ts
+++ b/frontend/src/mocks/settings-handlers.ts
@@ -126,12 +126,6 @@ export const SETTINGS_HANDLERS = [
     return HttpResponse.json(null, { status: 400 });
   }),
 
-  http.post("/api/reset-settings", async () => {
-    await delay();
-    MOCK_USER_PREFERENCES.settings = { ...MOCK_DEFAULT_USER_SETTINGS };
-    return HttpResponse.json(null, { status: 200 });
-  }),
-
   http.post("/api/add-git-providers", async ({ request }) => {
     const body = await request.json();
 

--- a/openhands/server/routes/settings.py
+++ b/openhands/server/routes/settings.py
@@ -113,24 +113,6 @@ async def load_settings(
         )
 
 
-@app.post(
-    '/reset-settings',
-    responses={
-        410: {
-            'description': 'Reset settings functionality has been removed',
-            'model': dict,
-        }
-    },
-)
-async def reset_settings() -> JSONResponse:
-    """Resets user settings. (Deprecated)"""
-    logger.warning('Deprecated endpoint /api/reset-settings called by user')
-    return JSONResponse(
-        status_code=status.HTTP_410_GONE,
-        content={'error': 'Reset settings functionality has been removed.'},
-    )
-
-
 async def store_llm_settings(
     settings: Settings, existing_settings: Settings
 ) -> Settings:


### PR DESCRIPTION
## Summary of PR

- Remove the deprecated `/api/reset-settings` route from legacy settings endpoints.
- Drop the MSW mock handler for the removed endpoint.

## Demo Screenshots/Videos

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #N/A

## Release Notes

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:bd54605-nikolaik   --name openhands-app-bd54605   docker.openhands.dev/openhands/openhands:bd54605
```