### PR TITLE
Fix variable shadowing of start_id in StateTracker._init_history

### DIFF
--- a/openhands/controller/state/state_tracker.py
+++ b/openhands/controller/state/state_tracker.py
@@ -170,25 +170,33 @@ class StateTracker:
                 action_id = delegate_action_ids.pop()
                 delegate_ranges.append((action_id, event.id))
 
+        # Save original start_id before delegate filtering loop
+        original_start_id = start_id
+
         # Filter out events between delegate action/observation pairs
         if delegate_ranges:
             filtered_events: list[Event] = []
             current_idx = 0
 
-            for start_id, end_id in sorted(delegate_ranges):
+            for delegate_start, delegate_end in sorted(delegate_ranges):
                 # Add events before delegate range
                 filtered_events.extend(
-                    event for event in events[current_idx:] if event.id < start_id
+                    event
+                    for event in events[current_idx:]
+                    if event.id < delegate_start
                 )
 
                 # Add delegate action and observation
                 filtered_events.extend(
-                    event for event in events if event.id in (start_id, end_id)
+                    event
+                    for event in events
+                    if event.id in (delegate_start, delegate_end)
                 )
 
                 # Update index to after delegate range
                 current_idx = next(
-                    (i for i, e in enumerate(events) if e.id > end_id), len(events)
+                    (i for i, e in enumerate(events) if e.id > delegate_end),
+                    len(events),
                 )
 
             # Add any remaining events after last delegate range
@@ -199,7 +207,7 @@ class StateTracker:
             self.state.history = events
 
         # make sure history is in sync
-        self.state.start_id = start_id
+        self.state.start_id = original_start_id
 
     def close(self, event_stream: EventStream):
         # we made history, now is the time to rewrite it!


### PR DESCRIPTION
## Summary

- Fix a variable shadowing bug in `StateTracker._init_history()` where the `for start_id, end_id in sorted(delegate_ranges):` loop overwrites the `start_id` variable that was set earlier from `self.state.start_id`
- After the loop completes, `self.state.start_id = start_id` incorrectly sets the state's start_id to the **last delegate range's start ID** instead of the original start position
- This can cause the agent to lose history events preceding the last delegate action when restoring state in multi-agent (delegate) scenarios

## Details

In `_init_history()`, `start_id` is initialized at line 124:
```python
start_id = self.state.start_id if self.state.start_id >= 0 else 0
```

Then at line 178, the same variable name is reused as a loop variable:
```python
for start_id, end_id in sorted(delegate_ranges):
```

After the loop, at line 202:
```python
self.state.start_id = start_id  # now contains the last delegate's start ID!
```

The fix saves the original `start_id` before the loop and renames the loop variables to `delegate_start` and `delegate_end` to prevent shadowing.

## Test plan

- [ ] Verify existing tests pass (the fix is a safe rename of loop variables + preserving the original value)
- [ ] Test multi-agent delegate scenarios to confirm history is properly preserved across session restores
