### PR TITLE
fix: validate base_url rejects API endpoint paths

### DIFF
--- a/openhands/core/config/llm_config.py
+++ b/openhands/core/config/llm_config.py
@@ -10,7 +10,14 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr, ValidationError
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    ValidationError,
+    field_validator,
+)
 
 from openhands.core.logger import LOG_DIR
 from openhands.core.logger import openhands_logger as logger
@@ -110,6 +117,27 @@ class LLMConfig(BaseModel):
     )
 
     model_config = ConfigDict(extra='forbid')
+
+    @field_validator('base_url')
+    @classmethod
+    def validate_base_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        endpoint_suffixes = [
+            '/chat/completions',
+            '/completions',
+            '/messages',
+            '/v1/chat/completions',
+            '/v1/completions',
+        ]
+        url = v.rstrip('/')
+        for suffix in endpoint_suffixes:
+            if url.endswith(suffix):
+                raise ValueError(
+                    f"base_url should be the API base URL, not a specific endpoint. "
+                    f"Remove the trailing '{suffix}' from '{v}'"
+                )
+        return v
 
     @classmethod
     def from_toml_section(cls, data: dict) -> dict[str, LLMConfig]:

--- a/openhands/core/config/llm_config.py
+++ b/openhands/core/config/llm_config.py
@@ -134,7 +134,7 @@ class LLMConfig(BaseModel):
         for suffix in endpoint_suffixes:
             if url.endswith(suffix):
                 raise ValueError(
-                    f"base_url should be the API base URL, not a specific endpoint. "
+                    f'base_url should be the API base URL, not a specific endpoint. '
                     f"Remove the trailing '{suffix}' from '{v}'"
                 )
         return v

--- a/tests/unit/core/config/test_llm_config.py
+++ b/tests/unit/core/config/test_llm_config.py
@@ -3,6 +3,7 @@ import pathlib
 import pytest
 
 from openhands.core.config import OpenHandsConfig
+from openhands.core.config.llm_config import LLMConfig
 from openhands.core.config.utils import load_from_toml
 
 
@@ -254,3 +255,35 @@ api_key = "test-api-key"
     non_azure_llm = default_config.get_llm_config('llm')
     assert non_azure_llm.model == 'anthropic/claude-3-sonnet'
     assert non_azure_llm.api_version is None
+
+
+@pytest.mark.parametrize(
+    'url',
+    [
+        'https://api.openai.com/v1/chat/completions',
+        'https://api.openai.com/v1/completions',
+        'https://api.anthropic.com/v1/messages',
+        'http://localhost:8000/v1/chat/completions/',
+        'https://example.com/completions',
+    ],
+)
+def test_base_url_rejects_endpoint_paths(url: str) -> None:
+    """Test that base_url rejects URLs ending in API endpoint paths."""
+    with pytest.raises(ValueError, match='not a specific endpoint'):
+        LLMConfig(base_url=url)
+
+
+@pytest.mark.parametrize(
+    'url',
+    [
+        'https://api.openai.com/v1',
+        'https://api.anthropic.com',
+        'http://localhost:11434',
+        'https://my-proxy.example.com/v1',
+        None,
+    ],
+)
+def test_base_url_accepts_valid_urls(url: str | None) -> None:
+    """Test that base_url accepts valid base URLs."""
+    config = LLMConfig(base_url=url)
+    assert config.base_url == url


### PR DESCRIPTION
## Summary
- Added a Pydantic `field_validator` for `base_url` in `LLMConfig`
- Rejects URLs ending in common API endpoint suffixes (`/chat/completions`, `/completions`, `/messages`)
- Provides a clear error message telling users to remove the endpoint suffix
- Added parametrized tests for both rejection and acceptance cases

Fixes #13079