### PR TITLE
fix: reject API endpoint paths in base_url with clear error message

### DIFF
--- a/openhands/core/config/llm_config.py
+++ b/openhands/core/config/llm_config.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import os
 from typing import Any
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, ValidationError, field_validator
 
 from openhands.core.logger import LOG_DIR
 from openhands.core.logger import openhands_logger as logger
@@ -110,6 +111,35 @@ class LLMConfig(BaseModel):
     )
 
     model_config = ConfigDict(extra='forbid')
+
+    @field_validator('base_url')
+    @classmethod
+    def validate_base_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        # Common API endpoint path suffixes that should not be included in
+        # the base URL.  When present they cause litellm to construct a
+        # broken URL, resulting in a cryptic 404 from the provider.
+        endpoint_suffixes = (
+            '/chat/completions',
+            '/completions',
+            '/messages',
+            '/embeddings',
+            '/models',
+            '/generations',
+        )
+        try:
+            path = urlparse(v).path.rstrip('/')
+        except Exception:
+            return v
+        for suffix in endpoint_suffixes:
+            if path.endswith(suffix):
+                raise ValueError(
+                    f'base_url must not include the API endpoint path '
+                    f'{suffix}. Use only the base URL '
+                    f'(e.g. https://my-proxy.com/v1).'
+                )
+        return v
 
     @classmethod
     def from_toml_section(cls, data: dict) -> dict[str, LLMConfig]:

--- a/openhands/storage/data_models/settings.py
+++ b/openhands/storage/data_models/settings.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Annotated
 
+from urllib.parse import urlparse
+
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -114,6 +116,35 @@ class Settings(BaseModel):
             )
         data['secret_store'] = secret_store
         return data
+
+    @field_validator('llm_base_url')
+    @classmethod
+    def validate_llm_base_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        # Common API endpoint path suffixes that should not be included in
+        # the base URL.  When present they cause litellm to construct a
+        # broken URL, resulting in a cryptic 404 from the provider.
+        endpoint_suffixes = (
+            '/chat/completions',
+            '/completions',
+            '/messages',
+            '/embeddings',
+            '/models',
+            '/generations',
+        )
+        try:
+            path = urlparse(v).path.rstrip('/')
+        except Exception:
+            return v
+        for suffix in endpoint_suffixes:
+            if path.endswith(suffix):
+                raise ValueError(
+                    f'llm_base_url must not include the API endpoint path '
+                    f'{suffix}. Use only the base URL '
+                    f'(e.g. https://my-proxy.com/v1).'
+                )
+        return v
 
     @field_validator('condenser_max_size')
     @classmethod

--- a/tests/unit/core/config/test_llm_config.py
+++ b/tests/unit/core/config/test_llm_config.py
@@ -1,8 +1,10 @@
 import pathlib
 
 import pytest
+from pydantic import ValidationError
 
 from openhands.core.config import OpenHandsConfig
+from openhands.core.config.llm_config import LLMConfig
 from openhands.core.config.utils import load_from_toml
 
 
@@ -254,3 +256,73 @@ api_key = "test-api-key"
     non_azure_llm = default_config.get_llm_config('llm')
     assert non_azure_llm.model == 'anthropic/claude-3-sonnet'
     assert non_azure_llm.api_version is None
+
+
+class TestBaseUrlValidation:
+    """Tests for base_url validation that rejects API endpoint paths."""
+
+    @pytest.mark.parametrize(
+        'bad_url',
+        [
+            'https://my-proxy.com/v1/chat/completions',
+            'https://api.openai.com/v1/completions',
+            'https://api.anthropic.com/v1/messages',
+            'https://my-proxy.com/v1/embeddings',
+            'https://my-proxy.com/v1/models',
+            'https://my-proxy.com/v1/generations',
+            'http://localhost:8080/v1/chat/completions',
+            'https://my-proxy.com/v1/chat/completions/',
+        ],
+    )
+    def test_rejects_endpoint_paths(self, bad_url: str) -> None:
+        with pytest.raises(
+            ValidationError, match='must not include the API endpoint path'
+        ):
+            LLMConfig(base_url=bad_url)
+
+    @pytest.mark.parametrize(
+        'good_url',
+        [
+            'https://my-proxy.com/v1',
+            'https://api.openai.com/v1',
+            'https://api.anthropic.com',
+            'http://localhost:8080',
+            'http://localhost:11434',
+            'https://my-company.com/llm-proxy',
+            None,
+        ],
+    )
+    def test_accepts_valid_base_urls(self, good_url: str | None) -> None:
+        config = LLMConfig(base_url=good_url)
+        assert config.base_url == good_url
+
+    def test_toml_with_bad_base_url_is_skipped(
+        self, default_config: OpenHandsConfig, tmp_path: pathlib.Path
+    ) -> None:
+        """A custom LLM section with an invalid base_url should be skipped gracefully."""
+        toml_content = """
+[core]
+workspace_base = "./workspace"
+
+[llm]
+model = "base-model"
+api_key = "base-api-key"
+
+[llm.bad_base]
+model = "custom-model"
+api_key = "custom-api-key"
+base_url = "https://my-proxy.com/v1/chat/completions"
+        """
+        toml_file = tmp_path / 'bad_base_url_llm.toml'
+        toml_file.write_text(toml_content)
+
+        load_from_toml(default_config, str(toml_file))
+
+        # The base config should still load correctly
+        generic_llm = default_config.get_llm_config('llm')
+        assert generic_llm.model == 'base-model'
+
+        # The invalid custom section should be skipped — accessing it falls
+        # back to the generic config
+        bad_base = default_config.get_llm_config('bad_base')
+        assert bad_base.model == 'base-model'

--- a/tests/unit/storage/data_models/test_settings.py
+++ b/tests/unit/storage/data_models/test_settings.py
@@ -1,7 +1,8 @@
 import warnings
 from unittest.mock import patch
 
-from pydantic import SecretStr
+import pytest
+from pydantic import SecretStr, ValidationError
 
 from openhands.core.config.llm_config import LLMConfig
 from openhands.core.config.openhands_config import OpenHandsConfig
@@ -127,3 +128,41 @@ def test_settings_no_pydantic_frozen_field_warning():
         assert len(frozen_warnings) == 0, (
             f'Pydantic frozen field warnings found: {[str(w.message) for w in frozen_warnings]}'
         )
+
+
+class TestLlmBaseUrlValidation:
+    """Tests for llm_base_url validation that rejects API endpoint paths."""
+
+    @pytest.mark.parametrize(
+        'bad_url',
+        [
+            'https://my-proxy.com/v1/chat/completions',
+            'https://api.openai.com/v1/completions',
+            'https://api.anthropic.com/v1/messages',
+            'https://my-proxy.com/v1/embeddings',
+            'https://my-proxy.com/v1/models',
+            'https://my-proxy.com/v1/generations',
+            'http://localhost:8080/v1/chat/completions',
+            # Trailing slash should also be caught
+            'https://my-proxy.com/v1/chat/completions/',
+        ],
+    )
+    def test_rejects_endpoint_paths(self, bad_url: str) -> None:
+        with pytest.raises(ValidationError, match='must not include the API endpoint path'):
+            Settings(llm_base_url=bad_url)
+
+    @pytest.mark.parametrize(
+        'good_url',
+        [
+            'https://my-proxy.com/v1',
+            'https://api.openai.com/v1',
+            'https://api.anthropic.com',
+            'http://localhost:8080',
+            'http://localhost:11434',
+            'https://my-company.com/llm-proxy',
+            None,
+        ],
+    )
+    def test_accepts_valid_base_urls(self, good_url: str | None) -> None:
+        settings = Settings(llm_base_url=good_url)
+        assert settings.llm_base_url == good_url


### PR DESCRIPTION
## Summary

Fixes #13079.

When a user configures `base_url` with a full API endpoint path (e.g. `https://my-proxy.com/v1/chat/completions`), litellm silently constructs a broken URL and the provider returns a cryptic `NotFoundError` with no indication that the base URL is misconfigured.

This PR adds `field_validator`s to both `LLMConfig.base_url` and `Settings.llm_base_url` that detect common API endpoint suffixes and raise a clear `ValueError` explaining that only the base URL should be provided.

**Detected endpoint suffixes:**
- `/chat/completions`
- `/completions`
- `/messages`
- `/embeddings`
- `/models`
- `/generations`

**Error message example:**
```
base_url must not include the API endpoint path /v1/chat/completions.
Use only the base URL (e.g. https://my-proxy.com/v1).
```

**Entry points covered:**
- `LLMConfig` — catches misconfiguration via `config.toml` and CLI (`make setup-config`)
- `Settings` — catches misconfiguration via web UI settings (POST /api/settings) and V1 user context
- Invalid custom LLM sections in TOML are gracefully skipped (existing `from_toml_section` behavior)

## Test plan

- [x] Added parametrized tests for `LLMConfig.base_url` validation (8 rejected URLs, 7 accepted URLs)
- [x] Added parametrized tests for `Settings.llm_base_url` validation (8 rejected URLs, 7 accepted URLs)
- [x] Added integration test verifying invalid TOML custom LLM sections are skipped gracefully
- [x] Verified trailing slashes are handled (e.g. `.../completions/`)
- [x] Verified `None` base_url passes validation (default case)

**Disclosure: This PR was authored by Claude Opus 4.6 (an AI). I am pursuing employment as an AI contributor — transparently, not impersonating a human. See https://github.com/MaxwellCalkin/career for context.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)