### PR TITLE
Add message queue support for V1 WebSocket connections

### DIFF
--- a/frontend/__tests__/conversation-websocket-handler.test.tsx
+++ b/frontend/__tests__/conversation-websocket-handler.test.tsx
@@ -1084,4 +1084,232 @@ describe("Conversation WebSocket Handler", () => {
       );
     });
   });
+
+  // 5. Message Queue Tests
+  describe("Message Queue", () => {
+    it("should queue messages when WebSocket is not connected", async () => {
+      // Create a SendMessageComponent to test message sending
+      const SendMessageComponent = () => {
+        const ws = useConversationWebSocket();
+
+        const handleSendMessage = () => {
+          if (ws) {
+            ws.sendMessage({ message: "test message before connection" });
+          }
+        };
+
+        return (
+          <div>
+            <button type="button" onClick={handleSendMessage} data-testid="send-message-btn">
+              Send Message
+            </button>
+            <div data-testid="connection-state">{ws?.connectionState || "no-context"}</div>
+          </div>
+        );
+      };
+
+      renderWithWebSocketContext(<SendMessageComponent />);
+
+      // Initially should be CONNECTING
+      expect(screen.getByTestId("connection-state")).toHaveTextContent(
+        "CONNECTING",
+      );
+
+      // Send message while still connecting - should not throw
+      const sendButton = screen.getByTestId("send-message-btn");
+      expect(() => {
+        sendButton.click();
+      }).not.toThrow();
+
+      // Wait for connection to be established
+      await waitFor(() => {
+        expect(screen.getByTestId("connection-state")).toHaveTextContent("OPEN");
+      });
+    });
+
+    it("should flush queued messages when WebSocket connection opens", async () => {
+      // Track messages sent through WebSocket
+      const sentMessages: string[] = [];
+
+      // Set up MSW to capture sent messages
+      mswServer.use(
+        wsLink.addEventListener("connection", ({ client, server }) => {
+          server.connect();
+
+          // Listen for messages sent from client
+          client.addEventListener("message", (event) => {
+            sentMessages.push(event.data.toString());
+          });
+        }),
+      );
+
+      // Create a SendMessageComponent
+      const SendMessageComponent = () => {
+        const ws = useConversationWebSocket();
+        const [messageCount, setMessageCount] = React.useState(0);
+
+        const handleSendMessage = () => {
+          if (ws) {
+            ws.sendMessage({ message: `test message ${messageCount}` });
+            setMessageCount((c) => c + 1);
+          }
+        };
+
+        return (
+          <div>
+            <button type="button" onClick={handleSendMessage} data-testid="send-message-btn">
+              Send Message
+            </button>
+            <div data-testid="connection-state">{ws?.connectionState || "no-context"}</div>
+            <div data-testid="message-count">{messageCount}</div>
+          </div>
+        );
+      };
+
+      renderWithWebSocketContext(<SendMessageComponent />);
+
+      // Send multiple messages while connecting
+      const sendButton = screen.getByTestId("send-message-btn");
+      sendButton.click(); // Send message 0
+      sendButton.click(); // Send message 1
+      sendButton.click(); // Send message 2
+
+      // Wait for connection and message flushing
+      await waitFor(() => {
+        expect(screen.getByTestId("connection-state")).toHaveTextContent("OPEN");
+      });
+
+      // Wait for messages to be flushed
+      await waitFor(() => {
+        expect(sentMessages.length).toBe(3);
+      });
+
+      // Verify messages were sent in order
+      expect(JSON.parse(sentMessages[0]).message).toBe("test message 0");
+      expect(JSON.parse(sentMessages[1]).message).toBe("test message 1");
+      expect(JSON.parse(sentMessages[2]).message).toBe("test message 2");
+    });
+
+    it("should clear pending messages when conversation changes", async () => {
+      // Track messages sent through WebSocket
+      const sentMessages: string[] = [];
+
+      // Set up MSW to capture sent messages
+      mswServer.use(
+        wsLink.addEventListener("connection", ({ client, server }) => {
+          server.connect();
+
+          // Listen for messages sent from client
+          client.addEventListener("message", (event) => {
+            sentMessages.push(event.data.toString());
+          });
+        }),
+      );
+
+      // Create a SendMessageComponent
+      const SendMessageComponent = ({ convId }: { convId: string }) => {
+        const ws = useConversationWebSocket();
+
+        const handleSendMessage = () => {
+          if (ws) {
+            ws.sendMessage({ message: "test message" });
+          }
+        };
+
+        return (
+          <div>
+            <button type="button" onClick={handleSendMessage} data-testid="send-message-btn">
+              Send Message
+            </button>
+            <div data-testid="connection-state">{ws?.connectionState || "no-context"}</div>
+          </div>
+        );
+      };
+
+      // Create a wrapper that can change conversationId
+      const WrapperComponent = ({ convId }: { convId: string }) => {
+        return renderWithWebSocketContext(<SendMessageComponent convId={convId} />, convId);
+      };
+
+      const { rerender } = WrapperComponent("conversation-1");
+
+      // Send message while connecting in first conversation
+      const sendButton = screen.getByTestId("send-message-btn");
+      sendButton.click();
+
+      // Change to a different conversation (this should clear pending messages)
+      rerender(WrapperComponent("conversation-2"));
+
+      // Wait for connection
+      await waitFor(() => {
+        expect(screen.getByTestId("connection-state")).toHaveTextContent("OPEN");
+      });
+
+      // Wait a bit to ensure no messages are sent
+      await new Promise((resolve) => {
+        setTimeout(resolve, 100);
+      });
+
+      // No messages should have been sent (pending queue was cleared)
+      expect(sentMessages.length).toBe(0);
+    });
+
+    it("should send messages immediately when WebSocket is already open", async () => {
+      // Track messages sent through WebSocket
+      const sentMessages: string[] = [];
+
+      // Set up MSW to capture sent messages
+      mswServer.use(
+        wsLink.addEventListener("connection", ({ client, server }) => {
+          server.connect();
+
+          // Listen for messages sent from client
+          client.addEventListener("message", (event) => {
+            sentMessages.push(event.data.toString());
+          });
+        }),
+      );
+
+      // Create a SendMessageComponent
+      const SendMessageComponent = () => {
+        const ws = useConversationWebSocket();
+
+        const handleSendMessage = () => {
+          if (ws) {
+            ws.sendMessage({ message: "test message after connection" });
+          }
+        };
+
+        return (
+          <div>
+            <button type="button" onClick={handleSendMessage} data-testid="send-message-btn">
+              Send Message
+            </button>
+            <div data-testid="connection-state">{ws?.connectionState || "no-context"}</div>
+          </div>
+        );
+      };
+
+      renderWithWebSocketContext(<SendMessageComponent />);
+
+      // Wait for connection to be established
+      await waitFor(() => {
+        expect(screen.getByTestId("connection-state")).toHaveTextContent("OPEN");
+      });
+
+      // Send message after connection is open
+      const sendButton = screen.getByTestId("send-message-btn");
+      sendButton.click();
+
+      // Wait for message to be sent
+      await waitFor(() => {
+        expect(sentMessages.length).toBe(1);
+      });
+
+      // Verify message was sent
+      expect(JSON.parse(sentMessages[0]).message).toBe(
+        "test message after connection",
+      );
+    });
+  });
 });

--- a/frontend/src/contexts/conversation-websocket-context.tsx
+++ b/frontend/src/contexts/conversation-websocket-context.tsx
@@ -93,6 +93,9 @@ export function ConversationWebSocketProvider({
   const hasConnectedRefMain = React.useRef(false);
   const hasConnectedRefPlanning = React.useRef(false);
 
+  // Queue for pending messages when WebSocket is not yet connected
+  const pendingMessagesRef = React.useRef<V1SendMessageRequest[]>([]);
+
   const posthog = usePostHog();
   const queryClient = useQueryClient();
   const { addEvent } = useEventStore();
@@ -290,6 +293,8 @@ export function ConversationWebSocketProvider({
     receivedEventCountRefPlanning.current = 0;
     // Reset the tracked event ref when sub-conversations change
     latestPlanningFileEventRef.current = null;
+    // Clear any pending messages when sub-conversations change
+    pendingMessagesRef.current = [];
   }, [subConversationIds]);
 
   // Merged loading history state - true if either connection is still loading
@@ -306,6 +311,8 @@ export function ConversationWebSocketProvider({
     receivedEventCountRefMain.current = 0;
     // Reset the tracked event ref when conversation changes
     latestPlanningFileEventRef.current = null;
+    // Clear any pending messages when conversation changes
+    pendingMessagesRef.current = [];
   }, [conversationId]);
 
   const { data: preloadedEvents } = useConversationHistory(conversationId);
@@ -809,6 +816,28 @@ export function ConversationWebSocketProvider({
     planningWebsocketOptions,
   );
 
+  // Flush pending messages when WebSocket connection opens
+  const flushPendingMessages = useCallback(
+    (socket: WebSocket | null) => {
+      if (!socket || pendingMessagesRef.current.length === 0) {
+        return;
+      }
+
+      // Send all queued messages in order
+      pendingMessagesRef.current.forEach((queuedMessage) => {
+        try {
+          socket.send(JSON.stringify(queuedMessage));
+        } catch (error) {
+          // Log error but continue flushing remaining messages
+          console.error("Failed to send queued message:", error);
+        }
+      });
+      // Clear the queue after flushing
+      pendingMessagesRef.current = [];
+    },
+    [],
+  );
+
   // V1 send message function via WebSocket
   const sendMessage = useCallback(
     async (message: V1SendMessageRequest) => {
@@ -817,9 +846,9 @@ export function ConversationWebSocketProvider({
         currentMode === "plan" ? planningAgentSocket : mainSocket;
 
       if (!currentSocket || currentSocket.readyState !== WebSocket.OPEN) {
-        const error = "WebSocket is not connected";
-        setErrorMessage(error);
-        throw new Error(error);
+        // Queue the message to be sent when the connection opens
+        pendingMessagesRef.current.push(message);
+        return;
       }
 
       try {
@@ -847,6 +876,8 @@ export function ConversationWebSocketProvider({
             break;
           case WebSocket.OPEN:
             setMainConnectionState("OPEN");
+            // Flush any pending messages when connection opens
+            flushPendingMessages(mainSocket);
             break;
           case WebSocket.CLOSING:
             setMainConnectionState("CLOSING");
@@ -862,7 +893,7 @@ export function ConversationWebSocketProvider({
 
       updateState();
     }
-  }, [mainSocket, wsUrl]);
+  }, [mainSocket, wsUrl, flushPendingMessages]);
 
   // Track planning agent socket state changes
   useEffect(() => {
@@ -876,6 +907,8 @@ export function ConversationWebSocketProvider({
             break;
           case WebSocket.OPEN:
             setPlanningConnectionState("OPEN");
+            // Flush any pending messages when connection opens
+            flushPendingMessages(planningAgentSocket);
             break;
           case WebSocket.CLOSING:
             setPlanningConnectionState("CLOSING");
@@ -891,7 +924,7 @@ export function ConversationWebSocketProvider({
 
       updateState();
     }
-  }, [planningAgentSocket, planningAgentWsUrl]);
+  }, [planningAgentSocket, planningAgentWsUrl, flushPendingMessages]);
 
   const contextValue = useMemo(
     () => ({ connectionState, sendMessage, isLoadingHistory }),


### PR DESCRIPTION
Fixes #12279

## Summary of PR

This PR adds message queue support for V1 conversations in the ConversationWebSocketProvider, enabling users to submit messages before the WebSocket connection is fully established. Previously, V1 conversations would throw an error when attempting to send messages during connection startup, while V0 conversations (using Socket.IO) already had this queuing functionality.

The implementation mirrors the V0 approach by maintaining a queue of pending messages that are automatically flushed when the WebSocket connection opens.

## Demo Screenshots/Videos

N/A - This is a backend behavior change that improves user experience by allowing message submission during WebSocket connection establishment.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #12279

## Release Notes

- [ ] Include this change in the Release Notes.

**If checked, add description here:**
Fixed V1 WebSocket conversations to queue messages during connection startup, matching V0 behavior and improving user experience.

---

## Technical Details

### Changes Made

1. **Added message queue infrastructure**:
   - Created `pendingMessagesRef` to store queued messages
   - Implemented `flushPendingMessages()` function to send queued messages

2. **Modified message sending behavior**:
   - Updated `sendMessage()` to queue messages when WebSocket is not open instead of throwing an error
   - Messages are now automatically sent when the connection opens

3. **Added queue cleanup**:
   - Pending messages are cleared when `conversationId` changes
   - Pending messages are cleared when `subConversationIds` changes

4. **Comprehensive test coverage**:
   - Test: Messages are queued when WebSocket is not connected
   - Test: Queued messages are flushed when connection opens
   - Test: Pending messages are cleared when conversation changes
   - Test: Messages are sent immediately when connection is already open

### Files Modified

- `frontend/src/contexts/conversation-websocket-context.tsx`: Core implementation
- `frontend/__tests__/conversation-websocket-handler.test.tsx`: Test coverage

### Testing

Added 4 new unit tests to verify:
- Messages can be queued before connection is established
- Queued messages are sent in order when connection opens
- Queue is cleared when conversation changes
- Normal message sending works when connection is already open

All tests follow the existing test patterns in the codebase and use the MSW WebSocket mocking infrastructure.