### PR TITLE
fix: surface detailed MCP errors in V1 conversation start failures

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -73,6 +73,7 @@ from openhands.app_server.user.user_models import UserInfo
 from openhands.app_server.utils.docker_utils import (
     replace_localhost_hostname_for_docker,
 )
+from openhands.app_server.utils.httpx_utils import extract_error_detail
 from openhands.app_server.utils.llm_metadata import (
     get_llm_metadata,
     should_set_litellm_extra_body,
@@ -355,7 +356,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         except Exception as exc:
             _logger.exception('Error starting conversation', stack_info=True)
             task.status = AppConversationStartTaskStatus.ERROR
-            task.detail = str(exc)
+            task.detail = extract_error_detail(exc)
             yield task
 
     async def _build_app_conversations(

--- a/openhands/app_server/utils/httpx_utils.py
+++ b/openhands/app_server/utils/httpx_utils.py
@@ -1,0 +1,32 @@
+"""Utilities for working with httpx HTTP client."""
+
+import httpx
+
+
+def extract_error_detail(exc: Exception) -> str:
+    """Extract detailed error message from an exception.
+
+    For httpx.HTTPStatusError, attempts to extract the error details from
+    the response body (JSON 'exception' or 'detail' field, or raw text).
+    For other exceptions, returns str(exc).
+
+    Args:
+        exc: The exception to extract details from.
+
+    Returns:
+        A detailed error message string.
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        try:
+            error_body = exc.response.json()
+            # Prefer 'exception' field if available (contains the actual error)
+            if 'exception' in error_body:
+                return error_body['exception']
+            elif 'detail' in error_body:
+                return error_body['detail']
+            else:
+                return exc.response.text
+        except Exception:
+            # If we can't parse the response, fall back to the basic error
+            return str(exc)
+    return str(exc)

--- a/tests/unit/app_server/test_httpx_utils.py
+++ b/tests/unit/app_server/test_httpx_utils.py
@@ -1,0 +1,115 @@
+"""Tests for httpx_utils module."""
+
+import httpx
+import pytest
+
+from openhands.app_server.utils.httpx_utils import extract_error_detail
+
+
+class TestExtractErrorDetail:
+    """Tests for extract_error_detail function."""
+
+    def test_httpx_error_with_exception_field(self):
+        """Should extract 'exception' field from JSON response."""
+        response = httpx.Response(
+            500,
+            json={
+                'detail': 'Internal Server Error',
+                'exception': "Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'",
+            },
+        )
+        response._request = httpx.Request('POST', 'https://example.com/api/conversations')
+        exc = httpx.HTTPStatusError(
+            message='Server error',
+            request=response.request,
+            response=response,
+        )
+
+        result = extract_error_detail(exc)
+        assert result == "Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'"
+
+    def test_httpx_error_with_detail_field_only(self):
+        """Should extract 'detail' field when 'exception' is not present."""
+        response = httpx.Response(
+            400,
+            json={'detail': 'Bad Request: Invalid input'},
+        )
+        response._request = httpx.Request('POST', 'https://example.com/api')
+        exc = httpx.HTTPStatusError(
+            message='Client error',
+            request=response.request,
+            response=response,
+        )
+
+        result = extract_error_detail(exc)
+        assert result == 'Bad Request: Invalid input'
+
+    def test_httpx_error_with_other_json(self):
+        """Should return raw text when JSON has neither 'exception' nor 'detail'."""
+        response = httpx.Response(
+            500,
+            json={'error': 'Something went wrong', 'code': 123},
+        )
+        response._request = httpx.Request('POST', 'https://example.com/api')
+        exc = httpx.HTTPStatusError(
+            message='Server error',
+            request=response.request,
+            response=response,
+        )
+
+        result = extract_error_detail(exc)
+        assert 'Something went wrong' in result
+
+    def test_httpx_error_with_non_json_response(self):
+        """Should fall back to str(exc) when response is not JSON."""
+        response = httpx.Response(
+            500,
+            text='Internal Server Error',
+            headers={'content-type': 'text/plain'},
+        )
+        response._request = httpx.Request('POST', 'https://example.com/api')
+        exc = httpx.HTTPStatusError(
+            message='Server error',
+            request=response.request,
+            response=response,
+        )
+
+        result = extract_error_detail(exc)
+        # Should contain the URL since str(HTTPStatusError) includes it
+        assert 'example.com' in result or 'Server error' in result
+
+    def test_non_httpx_exception(self):
+        """Should return str(exc) for non-HTTPStatusError exceptions."""
+        exc = ValueError('Something went wrong')
+        result = extract_error_detail(exc)
+        assert result == 'Something went wrong'
+
+    def test_generic_exception(self):
+        """Should return str(exc) for generic exceptions."""
+        exc = Exception('Generic error')
+        result = extract_error_detail(exc)
+        assert result == 'Generic error'
+
+    def test_mcp_401_error_scenario(self):
+        """Test the actual MCP 401 error scenario that triggered this fix."""
+        response = httpx.Response(
+            500,
+            json={
+                'detail': 'Internal Server Error',
+                'exception': "Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401",
+            },
+        )
+        response._request = httpx.Request(
+            'POST', 'https://example.prod-runtime.all-hands.dev/api/conversations'
+        )
+        exc = httpx.HTTPStatusError(
+            message="Server error '500 Internal Server Error'",
+            request=response.request,
+            response=response,
+        )
+
+        result = extract_error_detail(exc)
+
+        # The result should contain the actual MCP error, not just the generic 500 message
+        assert 'mcp.atlassian.com' in result
+        assert '401 Unauthorized' in result

--- a/tests/unit/app_server/test_httpx_utils.py
+++ b/tests/unit/app_server/test_httpx_utils.py
@@ -1,7 +1,6 @@
 """Tests for httpx_utils module."""
 
 import httpx
-import pytest
 
 from openhands.app_server.utils.httpx_utils import extract_error_detail
 
@@ -14,93 +13,98 @@ class TestExtractErrorDetail:
         response = httpx.Response(
             500,
             json={
-                'detail': 'Internal Server Error',
-                'exception': "Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'",
+                "detail": "Internal Server Error",
+                "exception": "Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'",
             },
         )
-        response._request = httpx.Request('POST', 'https://example.com/api/conversations')
+        response._request = httpx.Request(
+            "POST", "https://example.com/api/conversations"
+        )
         exc = httpx.HTTPStatusError(
-            message='Server error',
+            message="Server error",
             request=response.request,
             response=response,
         )
 
         result = extract_error_detail(exc)
-        assert result == "Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'"
+        assert (
+            result
+            == "Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'"
+        )
 
     def test_httpx_error_with_detail_field_only(self):
         """Should extract 'detail' field when 'exception' is not present."""
         response = httpx.Response(
             400,
-            json={'detail': 'Bad Request: Invalid input'},
+            json={"detail": "Bad Request: Invalid input"},
         )
-        response._request = httpx.Request('POST', 'https://example.com/api')
+        response._request = httpx.Request("POST", "https://example.com/api")
         exc = httpx.HTTPStatusError(
-            message='Client error',
+            message="Client error",
             request=response.request,
             response=response,
         )
 
         result = extract_error_detail(exc)
-        assert result == 'Bad Request: Invalid input'
+        assert result == "Bad Request: Invalid input"
 
     def test_httpx_error_with_other_json(self):
         """Should return raw text when JSON has neither 'exception' nor 'detail'."""
         response = httpx.Response(
             500,
-            json={'error': 'Something went wrong', 'code': 123},
+            json={"error": "Something went wrong", "code": 123},
         )
-        response._request = httpx.Request('POST', 'https://example.com/api')
+        response._request = httpx.Request("POST", "https://example.com/api")
         exc = httpx.HTTPStatusError(
-            message='Server error',
+            message="Server error",
             request=response.request,
             response=response,
         )
 
         result = extract_error_detail(exc)
-        assert 'Something went wrong' in result
+        assert "Something went wrong" in result
 
     def test_httpx_error_with_non_json_response(self):
         """Should fall back to str(exc) when response is not JSON."""
         response = httpx.Response(
             500,
-            text='Internal Server Error',
-            headers={'content-type': 'text/plain'},
+            text="Internal Server Error",
+            headers={"content-type": "text/plain"},
         )
-        response._request = httpx.Request('POST', 'https://example.com/api')
+        response._request = httpx.Request("POST", "https://example.com/api")
         exc = httpx.HTTPStatusError(
-            message='Server error',
+            message="Server error",
             request=response.request,
             response=response,
         )
 
         result = extract_error_detail(exc)
         # Should contain the URL since str(HTTPStatusError) includes it
-        assert 'example.com' in result or 'Server error' in result
+        assert "example.com" in result or "Server error" in result
 
     def test_non_httpx_exception(self):
         """Should return str(exc) for non-HTTPStatusError exceptions."""
-        exc = ValueError('Something went wrong')
+        exc = ValueError("Something went wrong")
         result = extract_error_detail(exc)
-        assert result == 'Something went wrong'
+        assert result == "Something went wrong"
 
     def test_generic_exception(self):
         """Should return str(exc) for generic exceptions."""
-        exc = Exception('Generic error')
+        exc = Exception("Generic error")
         result = extract_error_detail(exc)
-        assert result == 'Generic error'
+        assert result == "Generic error"
 
     def test_mcp_401_error_scenario(self):
         """Test the actual MCP 401 error scenario that triggered this fix."""
         response = httpx.Response(
             500,
             json={
-                'detail': 'Internal Server Error',
-                'exception': "Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401",
+                "detail": "Internal Server Error",
+                "exception": "Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401",
             },
         )
         response._request = httpx.Request(
-            'POST', 'https://example.prod-runtime.all-hands.dev/api/conversations'
+            "POST", "https://example.prod-runtime.all-hands.dev/api/conversations"
         )
         exc = httpx.HTTPStatusError(
             message="Server error '500 Internal Server Error'",
@@ -111,5 +115,5 @@ class TestExtractErrorDetail:
         result = extract_error_detail(exc)
 
         # The result should contain the actual MCP error, not just the generic 500 message
-        assert 'mcp.atlassian.com' in result
-        assert '401 Unauthorized' in result
+        assert "mcp.atlassian.com" in result
+        assert "401 Unauthorized" in result

--- a/tests/unit/app_server/test_httpx_utils.py
+++ b/tests/unit/app_server/test_httpx_utils.py
@@ -13,15 +13,15 @@ class TestExtractErrorDetail:
         response = httpx.Response(
             500,
             json={
-                "detail": "Internal Server Error",
-                "exception": "Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'",
+                'detail': 'Internal Server Error',
+                'exception': "Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'",
             },
         )
         response._request = httpx.Request(
-            "POST", "https://example.com/api/conversations"
+            'POST', 'https://example.com/api/conversations'
         )
         exc = httpx.HTTPStatusError(
-            message="Server error",
+            message='Server error',
             request=response.request,
             response=response,
         )
@@ -36,75 +36,75 @@ class TestExtractErrorDetail:
         """Should extract 'detail' field when 'exception' is not present."""
         response = httpx.Response(
             400,
-            json={"detail": "Bad Request: Invalid input"},
+            json={'detail': 'Bad Request: Invalid input'},
         )
-        response._request = httpx.Request("POST", "https://example.com/api")
+        response._request = httpx.Request('POST', 'https://example.com/api')
         exc = httpx.HTTPStatusError(
-            message="Client error",
+            message='Client error',
             request=response.request,
             response=response,
         )
 
         result = extract_error_detail(exc)
-        assert result == "Bad Request: Invalid input"
+        assert result == 'Bad Request: Invalid input'
 
     def test_httpx_error_with_other_json(self):
         """Should return raw text when JSON has neither 'exception' nor 'detail'."""
         response = httpx.Response(
             500,
-            json={"error": "Something went wrong", "code": 123},
+            json={'error': 'Something went wrong', 'code': 123},
         )
-        response._request = httpx.Request("POST", "https://example.com/api")
+        response._request = httpx.Request('POST', 'https://example.com/api')
         exc = httpx.HTTPStatusError(
-            message="Server error",
+            message='Server error',
             request=response.request,
             response=response,
         )
 
         result = extract_error_detail(exc)
-        assert "Something went wrong" in result
+        assert 'Something went wrong' in result
 
     def test_httpx_error_with_non_json_response(self):
         """Should fall back to str(exc) when response is not JSON."""
         response = httpx.Response(
             500,
-            text="Internal Server Error",
-            headers={"content-type": "text/plain"},
+            text='Internal Server Error',
+            headers={'content-type': 'text/plain'},
         )
-        response._request = httpx.Request("POST", "https://example.com/api")
+        response._request = httpx.Request('POST', 'https://example.com/api')
         exc = httpx.HTTPStatusError(
-            message="Server error",
+            message='Server error',
             request=response.request,
             response=response,
         )
 
         result = extract_error_detail(exc)
         # Should contain the URL since str(HTTPStatusError) includes it
-        assert "example.com" in result or "Server error" in result
+        assert 'example.com' in result or 'Server error' in result
 
     def test_non_httpx_exception(self):
         """Should return str(exc) for non-HTTPStatusError exceptions."""
-        exc = ValueError("Something went wrong")
+        exc = ValueError('Something went wrong')
         result = extract_error_detail(exc)
-        assert result == "Something went wrong"
+        assert result == 'Something went wrong'
 
     def test_generic_exception(self):
         """Should return str(exc) for generic exceptions."""
-        exc = Exception("Generic error")
+        exc = Exception('Generic error')
         result = extract_error_detail(exc)
-        assert result == "Generic error"
+        assert result == 'Generic error'
 
     def test_mcp_401_error_scenario(self):
         """Test the actual MCP 401 error scenario that triggered this fix."""
         response = httpx.Response(
             500,
             json={
-                "detail": "Internal Server Error",
-                "exception": "Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401",
+                'detail': 'Internal Server Error',
+                'exception': "Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401",
             },
         )
         response._request = httpx.Request(
-            "POST", "https://example.prod-runtime.all-hands.dev/api/conversations"
+            'POST', 'https://example.prod-runtime.all-hands.dev/api/conversations'
         )
         exc = httpx.HTTPStatusError(
             message="Server error '500 Internal Server Error'",
@@ -115,5 +115,5 @@ class TestExtractErrorDetail:
         result = extract_error_detail(exc)
 
         # The result should contain the actual MCP error, not just the generic 500 message
-        assert "mcp.atlassian.com" in result
-        assert "401 Unauthorized" in result
+        assert 'mcp.atlassian.com' in result
+        assert '401 Unauthorized' in result

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -44,14 +44,14 @@ from openhands.server.types import AppMode
 from openhands.storage.data_models.conversation_metadata import ConversationTrigger
 
 # Env var used by openhands SDK LLM to skip context-window validation (e.g. for gpt-4 in tests)
-_ALLOW_SHORT_CONTEXT_WINDOWS = 'ALLOW_SHORT_CONTEXT_WINDOWS'
+_ALLOW_SHORT_CONTEXT_WINDOWS = "ALLOW_SHORT_CONTEXT_WINDOWS"
 
 
 @pytest.fixture(autouse=True)
 def allow_short_context_windows():
     """Allow small context windows so unit tests can create LLM with gpt-4 etc."""
     old = os.environ.pop(_ALLOW_SHORT_CONTEXT_WINDOWS, None)
-    os.environ[_ALLOW_SHORT_CONTEXT_WINDOWS] = 'true'
+    os.environ[_ALLOW_SHORT_CONTEXT_WINDOWS] = "true"
     try:
         yield
     finally:
@@ -93,22 +93,22 @@ class TestLiveStatusAppConversationService:
             sandbox_startup_timeout=30,
             sandbox_startup_poll_frequency=1,
             httpx_client=self.mock_httpx_client,
-            web_url='https://test.example.com',
-            openhands_provider_base_url='https://provider.example.com',
+            web_url="https://test.example.com",
+            openhands_provider_base_url="https://provider.example.com",
             access_token_hard_timeout=None,
-            app_mode='test',
+            app_mode="test",
         )
 
         # Mock user info
         self.mock_user = Mock()
-        self.mock_user.id = 'test_user_123'
-        self.mock_user.llm_model = 'gpt-4'
-        self.mock_user.llm_base_url = 'https://api.openai.com/v1'
-        self.mock_user.llm_api_key = 'test_api_key'
+        self.mock_user.id = "test_user_123"
+        self.mock_user.llm_model = "gpt-4"
+        self.mock_user.llm_base_url = "https://api.openai.com/v1"
+        self.mock_user.llm_api_key = "test_api_key"
         self.mock_user.confirmation_mode = False
         self.mock_user.search_api_key = None  # Default to None
         self.mock_user.condenser_max_size = None  # Default to None
-        self.mock_user.llm_base_url = 'https://api.openai.com/v1'
+        self.mock_user.llm_base_url = "https://api.openai.com/v1"
         self.mock_user.mcp_config = None  # Default to None to avoid error handling path
 
         # Mock sandbox
@@ -121,9 +121,9 @@ class TestLiveStatusAppConversationService:
         suggested_task = SuggestedTask(
             git_provider=ProviderType.GITHUB,
             task_type=TaskType.UNRESOLVED_COMMENTS,
-            repo='owner/repo',
+            repo="owner/repo",
             issue_number=42,
-            title='Handle review comments',
+            title="Handle review comments",
         )
         request = AppConversationStartRequest(suggested_task=suggested_task)
 
@@ -140,9 +140,9 @@ class TestLiveStatusAppConversationService:
 
     def test_apply_suggested_task_raises_if_initial_message_present(self):
         suggested_task = SuggestedTask(
-            repo='foo/bar',
+            repo="foo/bar",
             git_provider=ProviderType.GITHUB,
-            title='Some title',
+            title="Some title",
             task_type=TaskType.OPEN_ISSUE,
             issue_number=123,
         )
@@ -150,32 +150,32 @@ class TestLiveStatusAppConversationService:
         request = AppConversationStartRequest(
             suggested_task=suggested_task,
             initial_message=SendMessageRequest(
-                role='user',
-                content=[TextContent(text='User provided message')],
+                role="user",
+                content=[TextContent(text="User provided message")],
             ),
         )
 
-        with pytest.raises(ValueError, match='initial_message cannot be provided'):
+        with pytest.raises(ValueError, match="initial_message cannot be provided"):
             self.service._apply_suggested_task(request)
 
     def test_apply_suggested_task_raises_if_prompt_empty(self):
         suggested_task = SuggestedTask(
-            repo='foo/bar',
+            repo="foo/bar",
             git_provider=ProviderType.GITHUB,
-            title='Some title',
+            title="Some title",
             task_type=TaskType.OPEN_ISSUE,
             issue_number=123,
         )
         request = AppConversationStartRequest(suggested_task=suggested_task)
 
-        with patch.object(SuggestedTask, 'get_prompt_for_task', return_value=''):
-            with pytest.raises(ValueError, match='empty prompt'):
+        with patch.object(SuggestedTask, "get_prompt_for_task", return_value=""):
+            with pytest.raises(ValueError, match="empty prompt"):
                 self.service._apply_suggested_task(request)
 
     async def test_setup_secrets_for_git_providers_no_provider_tokens(self):
         """Test _setup_secrets_for_git_providers with no provider tokens."""
         # Arrange
-        base_secrets = {'existing': 'secret'}
+        base_secrets = {"existing": "secret"}
         self.mock_user_context.get_secrets.return_value = base_secrets
         self.mock_user_context.get_provider_tokens = AsyncMock(return_value=None)
 
@@ -193,12 +193,12 @@ class TestLiveStatusAppConversationService:
         # Arrange
         base_secrets = {}
         self.mock_user_context.get_secrets.return_value = base_secrets
-        self.mock_jwt_service.create_jws_token.return_value = 'test_access_token'
+        self.mock_jwt_service.create_jws_token.return_value = "test_access_token"
 
         # Mock provider tokens
         provider_tokens = {
-            ProviderType.GITHUB: ProviderToken(token=SecretStr('github_token')),
-            ProviderType.GITLAB: ProviderToken(token=SecretStr('gitlab_token')),
+            ProviderType.GITHUB: ProviderToken(token=SecretStr("github_token")),
+            ProviderType.GITLAB: ProviderToken(token=SecretStr("gitlab_token")),
         }
         self.mock_user_context.get_provider_tokens = AsyncMock(
             return_value=provider_tokens
@@ -208,18 +208,18 @@ class TestLiveStatusAppConversationService:
         result = await self.service._setup_secrets_for_git_providers(self.mock_user)
 
         # Assert
-        assert 'GITHUB_TOKEN' in result
-        assert 'GITLAB_TOKEN' in result
-        assert isinstance(result['GITHUB_TOKEN'], LookupSecret)
-        assert isinstance(result['GITLAB_TOKEN'], LookupSecret)
+        assert "GITHUB_TOKEN" in result
+        assert "GITLAB_TOKEN" in result
+        assert isinstance(result["GITHUB_TOKEN"], LookupSecret)
+        assert isinstance(result["GITLAB_TOKEN"], LookupSecret)
         assert (
-            result['GITHUB_TOKEN'].url
-            == 'https://test.example.com/api/v1/webhooks/secrets'
+            result["GITHUB_TOKEN"].url
+            == "https://test.example.com/api/v1/webhooks/secrets"
         )
-        assert result['GITHUB_TOKEN'].headers['X-Access-Token'] == 'test_access_token'
+        assert result["GITHUB_TOKEN"].headers["X-Access-Token"] == "test_access_token"
         # Verify descriptions are included
-        assert result['GITHUB_TOKEN'].description == 'GITHUB authentication token'
-        assert result['GITLAB_TOKEN'].description == 'GITLAB authentication token'
+        assert result["GITHUB_TOKEN"].description == "GITHUB authentication token"
+        assert result["GITLAB_TOKEN"].description == "GITLAB authentication token"
 
         # Should be called twice, once for each provider
         assert self.mock_jwt_service.create_jws_token.call_count == 2
@@ -228,14 +228,14 @@ class TestLiveStatusAppConversationService:
     async def test_setup_secrets_for_git_providers_with_saas_mode(self):
         """Test _setup_secrets_for_git_providers with SaaS mode uses LookupSecret with X-Access-Token."""
         # Arrange
-        self.service.app_mode = 'saas'
+        self.service.app_mode = "saas"
         base_secrets = {}
         self.mock_user_context.get_secrets.return_value = base_secrets
-        self.mock_jwt_service.create_jws_token.return_value = 'test_access_token'
+        self.mock_jwt_service.create_jws_token.return_value = "test_access_token"
 
         # Mock provider tokens
         provider_tokens = {
-            ProviderType.GITLAB: ProviderToken(token=SecretStr('gitlab_token')),
+            ProviderType.GITLAB: ProviderToken(token=SecretStr("gitlab_token")),
         }
         self.mock_user_context.get_provider_tokens = AsyncMock(
             return_value=provider_tokens
@@ -245,15 +245,15 @@ class TestLiveStatusAppConversationService:
         result = await self.service._setup_secrets_for_git_providers(self.mock_user)
 
         # Assert
-        assert 'GITLAB_TOKEN' in result
-        lookup_secret = result['GITLAB_TOKEN']
+        assert "GITLAB_TOKEN" in result
+        lookup_secret = result["GITLAB_TOKEN"]
         assert isinstance(lookup_secret, LookupSecret)
-        assert 'X-Access-Token' in lookup_secret.headers
-        assert lookup_secret.headers['X-Access-Token'] == 'test_access_token'
+        assert "X-Access-Token" in lookup_secret.headers
+        assert lookup_secret.headers["X-Access-Token"] == "test_access_token"
         # Verify no cookie is included (authentication is via X-Access-Token only)
-        assert 'Cookie' not in lookup_secret.headers
+        assert "Cookie" not in lookup_secret.headers
         # Verify description is included
-        assert lookup_secret.description == 'GITLAB authentication token'
+        assert lookup_secret.description == "GITLAB authentication token"
 
     @pytest.mark.asyncio
     async def test_setup_secrets_for_git_providers_without_web_url(self):
@@ -262,11 +262,11 @@ class TestLiveStatusAppConversationService:
         self.service.web_url = None
         base_secrets = {}
         self.mock_user_context.get_secrets.return_value = base_secrets
-        self.mock_user_context.get_latest_token.return_value = 'static_token_value'
+        self.mock_user_context.get_latest_token.return_value = "static_token_value"
 
         # Mock provider tokens
         provider_tokens = {
-            ProviderType.GITHUB: ProviderToken(token=SecretStr('github_token')),
+            ProviderType.GITHUB: ProviderToken(token=SecretStr("github_token")),
         }
         self.mock_user_context.get_provider_tokens = AsyncMock(
             return_value=provider_tokens
@@ -276,11 +276,11 @@ class TestLiveStatusAppConversationService:
         result = await self.service._setup_secrets_for_git_providers(self.mock_user)
 
         # Assert
-        assert 'GITHUB_TOKEN' in result
-        assert isinstance(result['GITHUB_TOKEN'], StaticSecret)
-        assert result['GITHUB_TOKEN'].value.get_secret_value() == 'static_token_value'
+        assert "GITHUB_TOKEN" in result
+        assert isinstance(result["GITHUB_TOKEN"], StaticSecret)
+        assert result["GITHUB_TOKEN"].value.get_secret_value() == "static_token_value"
         # Verify description is included
-        assert result['GITHUB_TOKEN'].description == 'GITHUB authentication token'
+        assert result["GITHUB_TOKEN"].description == "GITHUB authentication token"
         self.mock_user_context.get_latest_token.assert_called_once_with(
             ProviderType.GITHUB
         )
@@ -296,7 +296,7 @@ class TestLiveStatusAppConversationService:
 
         # Mock provider tokens
         provider_tokens = {
-            ProviderType.GITHUB: ProviderToken(token=SecretStr('github_token')),
+            ProviderType.GITHUB: ProviderToken(token=SecretStr("github_token")),
         }
         self.mock_user_context.get_provider_tokens = AsyncMock(
             return_value=provider_tokens
@@ -306,7 +306,7 @@ class TestLiveStatusAppConversationService:
         result = await self.service._setup_secrets_for_git_providers(self.mock_user)
 
         # Assert
-        assert 'GITHUB_TOKEN' not in result
+        assert "GITHUB_TOKEN" not in result
         assert result == base_secrets
 
     @pytest.mark.asyncio
@@ -315,13 +315,13 @@ class TestLiveStatusAppConversationService:
         # Arrange
         base_secrets = {}
         self.mock_user_context.get_secrets.return_value = base_secrets
-        self.mock_jwt_service.create_jws_token.return_value = 'test_access_token'
+        self.mock_jwt_service.create_jws_token.return_value = "test_access_token"
 
         # Mock provider tokens for multiple providers
         provider_tokens = {
-            ProviderType.GITHUB: ProviderToken(token=SecretStr('github_token')),
-            ProviderType.GITLAB: ProviderToken(token=SecretStr('gitlab_token')),
-            ProviderType.BITBUCKET: ProviderToken(token=SecretStr('bitbucket_token')),
+            ProviderType.GITHUB: ProviderToken(token=SecretStr("github_token")),
+            ProviderType.GITLAB: ProviderToken(token=SecretStr("gitlab_token")),
+            ProviderType.BITBUCKET: ProviderToken(token=SecretStr("bitbucket_token")),
         }
         self.mock_user_context.get_provider_tokens = AsyncMock(
             return_value=provider_tokens
@@ -331,17 +331,17 @@ class TestLiveStatusAppConversationService:
         result = await self.service._setup_secrets_for_git_providers(self.mock_user)
 
         # Assert - verify all secrets have correct descriptions
-        assert 'GITHUB_TOKEN' in result
-        assert isinstance(result['GITHUB_TOKEN'], LookupSecret)
-        assert result['GITHUB_TOKEN'].description == 'GITHUB authentication token'
+        assert "GITHUB_TOKEN" in result
+        assert isinstance(result["GITHUB_TOKEN"], LookupSecret)
+        assert result["GITHUB_TOKEN"].description == "GITHUB authentication token"
 
-        assert 'GITLAB_TOKEN' in result
-        assert isinstance(result['GITLAB_TOKEN'], LookupSecret)
-        assert result['GITLAB_TOKEN'].description == 'GITLAB authentication token'
+        assert "GITLAB_TOKEN" in result
+        assert isinstance(result["GITLAB_TOKEN"], LookupSecret)
+        assert result["GITLAB_TOKEN"].description == "GITLAB authentication token"
 
-        assert 'BITBUCKET_TOKEN' in result
-        assert isinstance(result['BITBUCKET_TOKEN'], LookupSecret)
-        assert result['BITBUCKET_TOKEN'].description == 'BITBUCKET authentication token'
+        assert "BITBUCKET_TOKEN" in result
+        assert isinstance(result["BITBUCKET_TOKEN"], LookupSecret)
+        assert result["BITBUCKET_TOKEN"].description == "BITBUCKET authentication token"
 
     @pytest.mark.asyncio
     async def test_setup_secrets_for_git_providers_static_secret_description(self):
@@ -350,12 +350,12 @@ class TestLiveStatusAppConversationService:
         self.service.web_url = None
         base_secrets = {}
         self.mock_user_context.get_secrets.return_value = base_secrets
-        self.mock_user_context.get_latest_token.return_value = 'static_token_value'
+        self.mock_user_context.get_latest_token.return_value = "static_token_value"
 
         # Mock provider tokens for multiple providers
         provider_tokens = {
-            ProviderType.GITHUB: ProviderToken(token=SecretStr('github_token')),
-            ProviderType.GITLAB: ProviderToken(token=SecretStr('gitlab_token')),
+            ProviderType.GITHUB: ProviderToken(token=SecretStr("github_token")),
+            ProviderType.GITLAB: ProviderToken(token=SecretStr("gitlab_token")),
         }
         self.mock_user_context.get_provider_tokens = AsyncMock(
             return_value=provider_tokens
@@ -365,13 +365,13 @@ class TestLiveStatusAppConversationService:
         result = await self.service._setup_secrets_for_git_providers(self.mock_user)
 
         # Assert - verify StaticSecret objects have descriptions
-        assert 'GITHUB_TOKEN' in result
-        assert isinstance(result['GITHUB_TOKEN'], StaticSecret)
-        assert result['GITHUB_TOKEN'].description == 'GITHUB authentication token'
+        assert "GITHUB_TOKEN" in result
+        assert isinstance(result["GITHUB_TOKEN"], StaticSecret)
+        assert result["GITHUB_TOKEN"].description == "GITHUB authentication token"
 
-        assert 'GITLAB_TOKEN' in result
-        assert isinstance(result['GITLAB_TOKEN'], StaticSecret)
-        assert result['GITLAB_TOKEN'].description == 'GITLAB authentication token'
+        assert "GITLAB_TOKEN" in result
+        assert isinstance(result["GITLAB_TOKEN"], StaticSecret)
+        assert result["GITLAB_TOKEN"].description == "GITLAB authentication token"
 
     @pytest.mark.asyncio
     async def test_setup_secrets_for_git_providers_preserves_custom_secret_descriptions(
@@ -381,23 +381,23 @@ class TestLiveStatusAppConversationService:
         # Arrange
         # Mock custom secrets with descriptions
         custom_secret_with_desc = StaticSecret(
-            value=SecretStr('custom_secret_value'),
-            description='Custom API key for external service',
+            value=SecretStr("custom_secret_value"),
+            description="Custom API key for external service",
         )
         custom_secret_no_desc = StaticSecret(
-            value=SecretStr('another_secret_value'),
+            value=SecretStr("another_secret_value"),
             description=None,
         )
         base_secrets = {
-            'CUSTOM_API_KEY': custom_secret_with_desc,
-            'ANOTHER_SECRET': custom_secret_no_desc,
+            "CUSTOM_API_KEY": custom_secret_with_desc,
+            "ANOTHER_SECRET": custom_secret_no_desc,
         }
         self.mock_user_context.get_secrets.return_value = base_secrets
-        self.mock_jwt_service.create_jws_token.return_value = 'test_access_token'
+        self.mock_jwt_service.create_jws_token.return_value = "test_access_token"
 
         # Mock provider tokens
         provider_tokens = {
-            ProviderType.GITHUB: ProviderToken(token=SecretStr('github_token')),
+            ProviderType.GITHUB: ProviderToken(token=SecretStr("github_token")),
         }
         self.mock_user_context.get_provider_tokens = AsyncMock(
             return_value=provider_tokens
@@ -407,26 +407,26 @@ class TestLiveStatusAppConversationService:
         result = await self.service._setup_secrets_for_git_providers(self.mock_user)
 
         # Assert - verify custom secrets are preserved with their descriptions
-        assert 'CUSTOM_API_KEY' in result
-        assert isinstance(result['CUSTOM_API_KEY'], StaticSecret)
+        assert "CUSTOM_API_KEY" in result
+        assert isinstance(result["CUSTOM_API_KEY"], StaticSecret)
         assert (
-            result['CUSTOM_API_KEY'].description
-            == 'Custom API key for external service'
+            result["CUSTOM_API_KEY"].description
+            == "Custom API key for external service"
         )
         assert (
-            result['CUSTOM_API_KEY'].value.get_secret_value() == 'custom_secret_value'
+            result["CUSTOM_API_KEY"].value.get_secret_value() == "custom_secret_value"
         )
 
-        assert 'ANOTHER_SECRET' in result
-        assert isinstance(result['ANOTHER_SECRET'], StaticSecret)
-        assert result['ANOTHER_SECRET'].description is None
+        assert "ANOTHER_SECRET" in result
+        assert isinstance(result["ANOTHER_SECRET"], StaticSecret)
+        assert result["ANOTHER_SECRET"].description is None
         assert (
-            result['ANOTHER_SECRET'].value.get_secret_value() == 'another_secret_value'
+            result["ANOTHER_SECRET"].value.get_secret_value() == "another_secret_value"
         )
 
         # Verify git provider token is also included
-        assert 'GITHUB_TOKEN' in result
-        assert result['GITHUB_TOKEN'].description == 'GITHUB authentication token'
+        assert "GITHUB_TOKEN" in result
+        assert result["GITHUB_TOKEN"].description == "GITHUB authentication token"
 
     @pytest.mark.asyncio
     async def test_setup_secrets_for_git_providers_custom_secret_empty_description(
@@ -435,10 +435,10 @@ class TestLiveStatusAppConversationService:
         """Test _setup_secrets_for_git_providers handles custom secrets with empty descriptions."""
         # Arrange
         custom_secret_empty_desc = StaticSecret(
-            value=SecretStr('secret_value'),
-            description='',  # Empty string description
+            value=SecretStr("secret_value"),
+            description="",  # Empty string description
         )
-        base_secrets = {'MY_SECRET': custom_secret_empty_desc}
+        base_secrets = {"MY_SECRET": custom_secret_empty_desc}
         self.mock_user_context.get_secrets.return_value = base_secrets
         self.mock_user_context.get_provider_tokens = AsyncMock(return_value=None)
 
@@ -446,17 +446,17 @@ class TestLiveStatusAppConversationService:
         result = await self.service._setup_secrets_for_git_providers(self.mock_user)
 
         # Assert - empty description should be preserved as-is
-        assert 'MY_SECRET' in result
-        assert isinstance(result['MY_SECRET'], StaticSecret)
+        assert "MY_SECRET" in result
+        assert isinstance(result["MY_SECRET"], StaticSecret)
         # Empty string description is preserved
-        assert result['MY_SECRET'].description == ''
+        assert result["MY_SECRET"].description == ""
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_with_custom_model(self):
         """Test _configure_llm_and_mcp with custom LLM model."""
         # Arrange
-        custom_model = 'gpt-3.5-turbo'
-        self.mock_user_context.get_mcp_api_key.return_value = 'mcp_api_key'
+        custom_model = "gpt-3.5-turbo"
+        self.mock_user_context.get_mcp_api_key.return_value = "mcp_api_key"
 
         # Act
         llm, mcp_config = await self.service._configure_llm_and_mcp(
@@ -468,25 +468,25 @@ class TestLiveStatusAppConversationService:
         assert llm.model == custom_model
         assert llm.base_url == self.mock_user.llm_base_url
         assert llm.api_key.get_secret_value() == self.mock_user.llm_api_key
-        assert llm.usage_id == 'agent'
+        assert llm.usage_id == "agent"
 
-        assert 'mcpServers' in mcp_config
-        assert 'default' in mcp_config['mcpServers']
+        assert "mcpServers" in mcp_config
+        assert "default" in mcp_config["mcpServers"]
         assert (
-            mcp_config['mcpServers']['default']['url']
-            == 'https://test.example.com/mcp/mcp'
+            mcp_config["mcpServers"]["default"]["url"]
+            == "https://test.example.com/mcp/mcp"
         )
         assert (
-            mcp_config['mcpServers']['default']['headers']['X-Session-API-Key']
-            == 'mcp_api_key'
+            mcp_config["mcpServers"]["default"]["headers"]["X-Session-API-Key"]
+            == "mcp_api_key"
         )
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_openhands_model_prefers_user_base_url(self):
         """openhands/* model uses user.llm_base_url when provided."""
         # Arrange
-        self.mock_user.llm_model = 'openhands/special'
-        self.mock_user.llm_base_url = 'https://user-llm.example.com'
+        self.mock_user.llm_model = "openhands/special"
+        self.mock_user.llm_base_url = "https://user-llm.example.com"
         self.mock_user_context.get_mcp_api_key.return_value = None
 
         # Act
@@ -495,13 +495,13 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        assert llm.base_url == 'https://user-llm.example.com'
+        assert llm.base_url == "https://user-llm.example.com"
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_openhands_model_uses_provider_default(self):
         """openhands/* model falls back to configured provider base URL."""
         # Arrange
-        self.mock_user.llm_model = 'openhands/default'
+        self.mock_user.llm_model = "openhands/default"
         self.mock_user.llm_base_url = None
         self.mock_user_context.get_mcp_api_key.return_value = None
 
@@ -511,13 +511,13 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        assert llm.base_url == 'https://provider.example.com'
+        assert llm.base_url == "https://provider.example.com"
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_openhands_model_no_base_urls(self):
         """openhands/* model sets base_url to None when no sources available."""
         # Arrange
-        self.mock_user.llm_model = 'openhands/default'
+        self.mock_user.llm_model = "openhands/default"
         self.mock_user.llm_base_url = None
         self.service.openhands_provider_base_url = None
         self.mock_user_context.get_mcp_api_key.return_value = None
@@ -528,22 +528,22 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        assert llm.base_url == 'https://llm-proxy.app.all-hands.dev/'
+        assert llm.base_url == "https://llm-proxy.app.all-hands.dev/"
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_non_openhands_model_ignores_provider(self):
         """Non-openhands model ignores provider base URL and uses user base URL."""
         # Arrange
-        self.mock_user.llm_model = 'gpt-4'
-        self.mock_user.llm_base_url = 'https://user-llm.example.com'
-        self.service.openhands_provider_base_url = 'https://provider.example.com'
+        self.mock_user.llm_model = "gpt-4"
+        self.mock_user.llm_base_url = "https://user-llm.example.com"
+        self.service.openhands_provider_base_url = "https://provider.example.com"
         self.mock_user_context.get_mcp_api_key.return_value = None
 
         # Act
         llm, _ = await self.service._configure_llm_and_mcp(self.mock_user, None)
 
         # Assert
-        assert llm.base_url == 'https://user-llm.example.com'
+        assert llm.base_url == "https://user-llm.example.com"
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_with_user_default_model(self):
@@ -558,9 +558,9 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert llm.model == self.mock_user.llm_model
-        assert 'mcpServers' in mcp_config
-        assert 'default' in mcp_config['mcpServers']
-        assert 'headers' not in mcp_config['mcpServers']['default']
+        assert "mcpServers" in mcp_config
+        assert "default" in mcp_config["mcpServers"]
+        assert "headers" not in mcp_config["mcpServers"]["default"]
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_without_web_url(self):
@@ -581,8 +581,8 @@ class TestLiveStatusAppConversationService:
     async def test_configure_llm_and_mcp_tavily_with_user_search_api_key(self):
         """Test _configure_llm_and_mcp adds tavily when user has search_api_key."""
         # Arrange
-        self.mock_user.search_api_key = SecretStr('user_search_key')
-        self.mock_user_context.get_mcp_api_key.return_value = 'mcp_api_key'
+        self.mock_user.search_api_key = SecretStr("user_search_key")
+        self.mock_user_context.get_mcp_api_key.return_value = "mcp_api_key"
 
         # Act
         llm, mcp_config = await self.service._configure_llm_and_mcp(
@@ -591,19 +591,19 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        assert 'mcpServers' in mcp_config
-        assert 'default' in mcp_config['mcpServers']
-        assert 'tavily' in mcp_config['mcpServers']
+        assert "mcpServers" in mcp_config
+        assert "default" in mcp_config["mcpServers"]
+        assert "tavily" in mcp_config["mcpServers"]
         assert (
-            mcp_config['mcpServers']['tavily']['url']
-            == 'https://mcp.tavily.com/mcp/?tavilyApiKey=user_search_key'
+            mcp_config["mcpServers"]["tavily"]["url"]
+            == "https://mcp.tavily.com/mcp/?tavilyApiKey=user_search_key"
         )
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_tavily_with_env_tavily_key(self):
         """Test _configure_llm_and_mcp adds tavily when service has tavily_api_key."""
         # Arrange
-        self.service.tavily_api_key = 'env_tavily_key'
+        self.service.tavily_api_key = "env_tavily_key"
         self.mock_user_context.get_mcp_api_key.return_value = None
 
         # Act
@@ -613,20 +613,20 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        assert 'mcpServers' in mcp_config
-        assert 'default' in mcp_config['mcpServers']
-        assert 'tavily' in mcp_config['mcpServers']
+        assert "mcpServers" in mcp_config
+        assert "default" in mcp_config["mcpServers"]
+        assert "tavily" in mcp_config["mcpServers"]
         assert (
-            mcp_config['mcpServers']['tavily']['url']
-            == 'https://mcp.tavily.com/mcp/?tavilyApiKey=env_tavily_key'
+            mcp_config["mcpServers"]["tavily"]["url"]
+            == "https://mcp.tavily.com/mcp/?tavilyApiKey=env_tavily_key"
         )
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_tavily_user_key_takes_precedence(self):
         """Test _configure_llm_and_mcp user search_api_key takes precedence over env key."""
         # Arrange
-        self.mock_user.search_api_key = SecretStr('user_search_key')
-        self.service.tavily_api_key = 'env_tavily_key'
+        self.mock_user.search_api_key = SecretStr("user_search_key")
+        self.service.tavily_api_key = "env_tavily_key"
         self.mock_user_context.get_mcp_api_key.return_value = None
 
         # Act
@@ -636,11 +636,11 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        assert 'mcpServers' in mcp_config
-        assert 'tavily' in mcp_config['mcpServers']
+        assert "mcpServers" in mcp_config
+        assert "tavily" in mcp_config["mcpServers"]
         assert (
-            mcp_config['mcpServers']['tavily']['url']
-            == 'https://mcp.tavily.com/mcp/?tavilyApiKey=user_search_key'
+            mcp_config["mcpServers"]["tavily"]["url"]
+            == "https://mcp.tavily.com/mcp/?tavilyApiKey=user_search_key"
         )
 
     @pytest.mark.asyncio
@@ -658,9 +658,9 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        assert 'mcpServers' in mcp_config
-        assert 'default' in mcp_config['mcpServers']
-        assert 'tavily' not in mcp_config['mcpServers']
+        assert "mcpServers" in mcp_config
+        assert "default" in mcp_config["mcpServers"]
+        assert "tavily" not in mcp_config["mcpServers"]
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_saas_mode_no_tavily_without_user_key(self):
@@ -682,9 +682,9 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        assert 'mcpServers' in mcp_config
-        assert 'default' in mcp_config['mcpServers']
-        assert 'tavily' not in mcp_config['mcpServers']
+        assert "mcpServers" in mcp_config
+        assert "default" in mcp_config["mcpServers"]
+        assert "tavily" not in mcp_config["mcpServers"]
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_saas_mode_with_user_search_key(self):
@@ -695,7 +695,7 @@ class TestLiveStatusAppConversationService:
         # Arrange - simulate SAAS mode with user having their own search key
         self.service.app_mode = AppMode.SAAS.value
         self.service.tavily_api_key = None  # In SAAS mode, this should be None
-        self.mock_user.search_api_key = SecretStr('user_search_key')
+        self.mock_user.search_api_key = SecretStr("user_search_key")
         self.mock_user_context.get_mcp_api_key.return_value = None
 
         # Act
@@ -705,20 +705,20 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        assert 'mcpServers' in mcp_config
-        assert 'default' in mcp_config['mcpServers']
-        assert 'tavily' in mcp_config['mcpServers']
+        assert "mcpServers" in mcp_config
+        assert "default" in mcp_config["mcpServers"]
+        assert "tavily" in mcp_config["mcpServers"]
         assert (
-            mcp_config['mcpServers']['tavily']['url']
-            == 'https://mcp.tavily.com/mcp/?tavilyApiKey=user_search_key'
+            mcp_config["mcpServers"]["tavily"]["url"]
+            == "https://mcp.tavily.com/mcp/?tavilyApiKey=user_search_key"
         )
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_tavily_with_empty_user_search_key(self):
         """Test _configure_llm_and_mcp handles empty user search_api_key correctly."""
         # Arrange
-        self.mock_user.search_api_key = SecretStr('')  # Empty string
-        self.service.tavily_api_key = 'env_tavily_key'
+        self.mock_user.search_api_key = SecretStr("")  # Empty string
+        self.service.tavily_api_key = "env_tavily_key"
         self.mock_user_context.get_mcp_api_key.return_value = None
 
         # Act
@@ -728,20 +728,20 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        assert 'mcpServers' in mcp_config
-        assert 'tavily' in mcp_config['mcpServers']
+        assert "mcpServers" in mcp_config
+        assert "tavily" in mcp_config["mcpServers"]
         # Should fall back to env key since user key is empty
         assert (
-            mcp_config['mcpServers']['tavily']['url']
-            == 'https://mcp.tavily.com/mcp/?tavilyApiKey=env_tavily_key'
+            mcp_config["mcpServers"]["tavily"]["url"]
+            == "https://mcp.tavily.com/mcp/?tavilyApiKey=env_tavily_key"
         )
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_tavily_with_whitespace_user_search_key(self):
         """Test _configure_llm_and_mcp handles whitespace-only user search_api_key correctly."""
         # Arrange
-        self.mock_user.search_api_key = SecretStr('   ')  # Whitespace only
-        self.service.tavily_api_key = 'env_tavily_key'
+        self.mock_user.search_api_key = SecretStr("   ")  # Whitespace only
+        self.service.tavily_api_key = "env_tavily_key"
         self.mock_user_context.get_mcp_api_key.return_value = None
 
         # Act
@@ -751,57 +751,57 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        assert 'mcpServers' in mcp_config
-        assert 'tavily' in mcp_config['mcpServers']
+        assert "mcpServers" in mcp_config
+        assert "tavily" in mcp_config["mcpServers"]
         # Should fall back to env key since user key is whitespace only
         assert (
-            mcp_config['mcpServers']['tavily']['url']
-            == 'https://mcp.tavily.com/mcp/?tavilyApiKey=env_tavily_key'
+            mcp_config["mcpServers"]["tavily"]["url"]
+            == "https://mcp.tavily.com/mcp/?tavilyApiKey=env_tavily_key"
         )
 
     def test_compute_plan_path_default_uses_agents_tmp(self):
         """Test _compute_plan_path returns .agents_tmp/PLAN.md for default/GitHub."""
         # Arrange
-        working_dir = '/workspace/project'
+        working_dir = "/workspace/project"
 
         # Act
         path_none = self.service._compute_plan_path(working_dir, None)
         path_github = self.service._compute_plan_path(working_dir, ProviderType.GITHUB)
 
         # Assert
-        assert path_none == '/workspace/project/.agents_tmp/PLAN.md'
-        assert path_github == '/workspace/project/.agents_tmp/PLAN.md'
+        assert path_none == "/workspace/project/.agents_tmp/PLAN.md"
+        assert path_github == "/workspace/project/.agents_tmp/PLAN.md"
 
     def test_compute_plan_path_gitlab_uses_agents_tmp_config(self):
         """Test _compute_plan_path returns agents-tmp-config/PLAN.md for GitLab."""
         # Arrange
-        working_dir = '/workspace/project'
+        working_dir = "/workspace/project"
 
         # Act
         path = self.service._compute_plan_path(working_dir, ProviderType.GITLAB)
 
         # Assert
-        assert path == '/workspace/project/agents-tmp-config/PLAN.md'
+        assert path == "/workspace/project/agents-tmp-config/PLAN.md"
 
     def test_compute_plan_path_azure_uses_agents_tmp_config(self):
         """Test _compute_plan_path returns agents-tmp-config/PLAN.md for Azure."""
         # Arrange
-        working_dir = '/workspace/project'
+        working_dir = "/workspace/project"
 
         # Act
         path = self.service._compute_plan_path(working_dir, ProviderType.AZURE_DEVOPS)
 
         # Assert
-        assert path == '/workspace/project/agents-tmp-config/PLAN.md'
+        assert path == "/workspace/project/agents-tmp-config/PLAN.md"
 
     @patch(
-        'openhands.app_server.app_conversation.live_status_app_conversation_service.get_planning_tools'
+        "openhands.app_server.app_conversation.live_status_app_conversation_service.get_planning_tools"
     )
     @patch(
-        'openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser'
+        "openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser"
     )
     @patch(
-        'openhands.app_server.app_conversation.live_status_app_conversation_service.format_plan_structure'
+        "openhands.app_server.app_conversation.live_status_app_conversation_service.format_plan_structure"
     )
     def test_create_agent_with_context_planning_agent(
         self, mock_format_plan, mock_create_condenser, mock_get_tools
@@ -813,15 +813,15 @@ class TestLiveStatusAppConversationService:
         mock_get_tools.return_value = []
         mock_condenser = Mock()
         mock_create_condenser.return_value = mock_condenser
-        mock_format_plan.return_value = 'test_plan_structure'
-        mcp_config = {'default': {'url': 'test'}}
-        system_message_suffix = 'Test suffix'
-        working_dir = '/workspace/project'
+        mock_format_plan.return_value = "test_plan_structure"
+        mcp_config = {"default": {"url": "test"}}
+        system_message_suffix = "Test suffix"
+        working_dir = "/workspace/project"
         git_provider = ProviderType.GITHUB
 
         # Act
         with patch(
-            'openhands.app_server.app_conversation.live_status_app_conversation_service.Agent'
+            "openhands.app_server.app_conversation.live_status_app_conversation_service.Agent"
         ) as mock_agent_class:
             mock_agent_instance = Mock()
             mock_agent_instance.model_copy.return_value = mock_agent_instance
@@ -839,28 +839,28 @@ class TestLiveStatusAppConversationService:
 
             # Assert
             mock_get_tools.assert_called_once_with(
-                plan_path='/workspace/project/.agents_tmp/PLAN.md'
+                plan_path="/workspace/project/.agents_tmp/PLAN.md"
             )
             mock_agent_class.assert_called_once()
             call_kwargs = mock_agent_class.call_args[1]
-            assert call_kwargs['llm'] == mock_llm
-            assert call_kwargs['system_prompt_filename'] == 'system_prompt_planning.j2'
+            assert call_kwargs["llm"] == mock_llm
+            assert call_kwargs["system_prompt_filename"] == "system_prompt_planning.j2"
             assert (
-                call_kwargs['system_prompt_kwargs']['plan_structure']
-                == 'test_plan_structure'
+                call_kwargs["system_prompt_kwargs"]["plan_structure"]
+                == "test_plan_structure"
             )
-            assert call_kwargs['mcp_config'] == mcp_config
-            assert call_kwargs['security_analyzer'] is None
-            assert call_kwargs['condenser'] == mock_condenser
+            assert call_kwargs["mcp_config"] == mcp_config
+            assert call_kwargs["security_analyzer"] is None
+            assert call_kwargs["condenser"] == mock_condenser
             mock_create_condenser.assert_called_once_with(
                 mock_llm, AgentType.PLAN, self.mock_user.condenser_max_size
             )
 
     @patch(
-        'openhands.app_server.app_conversation.live_status_app_conversation_service.get_default_tools'
+        "openhands.app_server.app_conversation.live_status_app_conversation_service.get_default_tools"
     )
     @patch(
-        'openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser'
+        "openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser"
     )
     def test_create_agent_with_context_default_agent(
         self, mock_create_condenser, mock_get_tools
@@ -872,11 +872,11 @@ class TestLiveStatusAppConversationService:
         mock_get_tools.return_value = []
         mock_condenser = Mock()
         mock_create_condenser.return_value = mock_condenser
-        mcp_config = {'default': {'url': 'test'}}
+        mcp_config = {"default": {"url": "test"}}
 
         # Act
         with patch(
-            'openhands.app_server.app_conversation.live_status_app_conversation_service.Agent'
+            "openhands.app_server.app_conversation.live_status_app_conversation_service.Agent"
         ) as mock_agent_class:
             mock_agent_instance = Mock()
             mock_agent_instance.model_copy.return_value = mock_agent_instance
@@ -893,23 +893,23 @@ class TestLiveStatusAppConversationService:
             # Assert
             mock_agent_class.assert_called_once()
             call_kwargs = mock_agent_class.call_args[1]
-            assert call_kwargs['llm'] == mock_llm
-            assert call_kwargs['system_prompt_kwargs']['cli_mode'] is False
-            assert call_kwargs['mcp_config'] == mcp_config
-            assert call_kwargs['condenser'] == mock_condenser
+            assert call_kwargs["llm"] == mock_llm
+            assert call_kwargs["system_prompt_kwargs"]["cli_mode"] is False
+            assert call_kwargs["mcp_config"] == mcp_config
+            assert call_kwargs["condenser"] == mock_condenser
             mock_get_tools.assert_called_once_with(enable_browser=True)
             mock_create_condenser.assert_called_once_with(
                 mock_llm, AgentType.DEFAULT, self.mock_user.condenser_max_size
             )
 
     @patch(
-        'openhands.app_server.app_conversation.live_status_app_conversation_service.get_planning_tools'
+        "openhands.app_server.app_conversation.live_status_app_conversation_service.get_planning_tools"
     )
     @patch(
-        'openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser'
+        "openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser"
     )
     @patch(
-        'openhands.app_server.app_conversation.live_status_app_conversation_service.format_plan_structure'
+        "openhands.app_server.app_conversation.live_status_app_conversation_service.format_plan_structure"
     )
     def test_create_agent_with_context_planning_agent_applies_instruction(
         self, mock_format_plan, mock_create_condenser, mock_get_tools
@@ -921,12 +921,12 @@ class TestLiveStatusAppConversationService:
         mock_get_tools.return_value = []
         mock_condenser = Mock()
         mock_create_condenser.return_value = mock_condenser
-        mock_format_plan.return_value = 'test_plan_structure'
+        mock_format_plan.return_value = "test_plan_structure"
         mcp_config = {}
 
         # Act
         with patch(
-            'openhands.app_server.app_conversation.live_status_app_conversation_service.Agent'
+            "openhands.app_server.app_conversation.live_status_app_conversation_service.Agent"
         ) as mock_agent_class:
             mock_agent_instance = Mock()
             mock_agent_instance.model_copy.return_value = mock_agent_instance
@@ -942,17 +942,17 @@ class TestLiveStatusAppConversationService:
 
             # Assert - verify model_copy was called with agent_context containing planning instruction
             model_copy_call = mock_agent_instance.model_copy.call_args
-            agent_context = model_copy_call[1]['update']['agent_context']
+            agent_context = model_copy_call[1]["update"]["agent_context"]
             assert agent_context.system_message_suffix == PLANNING_AGENT_INSTRUCTION
 
     @patch(
-        'openhands.app_server.app_conversation.live_status_app_conversation_service.get_planning_tools'
+        "openhands.app_server.app_conversation.live_status_app_conversation_service.get_planning_tools"
     )
     @patch(
-        'openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser'
+        "openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser"
     )
     @patch(
-        'openhands.app_server.app_conversation.live_status_app_conversation_service.format_plan_structure'
+        "openhands.app_server.app_conversation.live_status_app_conversation_service.format_plan_structure"
     )
     def test_create_agent_with_context_planning_agent_prepends_to_existing_suffix(
         self, mock_format_plan, mock_create_condenser, mock_get_tools
@@ -964,13 +964,13 @@ class TestLiveStatusAppConversationService:
         mock_get_tools.return_value = []
         mock_condenser = Mock()
         mock_create_condenser.return_value = mock_condenser
-        mock_format_plan.return_value = 'test_plan_structure'
+        mock_format_plan.return_value = "test_plan_structure"
         mcp_config = {}
-        existing_suffix = 'Custom user instruction from integration'
+        existing_suffix = "Custom user instruction from integration"
 
         # Act
         with patch(
-            'openhands.app_server.app_conversation.live_status_app_conversation_service.Agent'
+            "openhands.app_server.app_conversation.live_status_app_conversation_service.Agent"
         ) as mock_agent_class:
             mock_agent_instance = Mock()
             mock_agent_instance.model_copy.return_value = mock_agent_instance
@@ -986,17 +986,17 @@ class TestLiveStatusAppConversationService:
 
             # Assert - verify planning instruction is prepended to existing suffix
             model_copy_call = mock_agent_instance.model_copy.call_args
-            agent_context = model_copy_call[1]['update']['agent_context']
+            agent_context = model_copy_call[1]["update"]["agent_context"]
             assert agent_context.system_message_suffix.startswith(
                 PLANNING_AGENT_INSTRUCTION
             )
             assert existing_suffix in agent_context.system_message_suffix
 
     @patch(
-        'openhands.app_server.app_conversation.live_status_app_conversation_service.get_default_tools'
+        "openhands.app_server.app_conversation.live_status_app_conversation_service.get_default_tools"
     )
     @patch(
-        'openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser'
+        "openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser"
     )
     def test_create_agent_with_context_default_agent_no_planning_instruction(
         self, mock_create_condenser, mock_get_tools
@@ -1012,7 +1012,7 @@ class TestLiveStatusAppConversationService:
 
         # Act
         with patch(
-            'openhands.app_server.app_conversation.live_status_app_conversation_service.Agent'
+            "openhands.app_server.app_conversation.live_status_app_conversation_service.Agent"
         ) as mock_agent_class:
             mock_agent_instance = Mock()
             mock_agent_instance.model_copy.return_value = mock_agent_instance
@@ -1028,7 +1028,7 @@ class TestLiveStatusAppConversationService:
 
             # Assert - verify no planning instruction for default agent
             model_copy_call = mock_agent_instance.model_copy.call_args
-            agent_context = model_copy_call[1]['update']['agent_context']
+            agent_context = model_copy_call[1]["update"]["agent_context"]
             assert agent_context.system_message_suffix is None
 
     @pytest.mark.asyncio
@@ -1036,8 +1036,8 @@ class TestLiveStatusAppConversationService:
         """Test _finalize_conversation_request with skills loading."""
         # Create mock LLM with required attributes for _update_agent_with_llm_metadata
         mock_llm = Mock(spec=LLM)
-        mock_llm.model = 'gpt-4'  # Non-openhands model, so no metadata update
-        mock_llm.usage_id = 'agent'
+        mock_llm.model = "gpt-4"  # Non-openhands model, so no metadata update
+        mock_llm.usage_id = "agent"
 
         # Arrange
         mock_agent = Mock(spec=Agent)
@@ -1045,9 +1045,9 @@ class TestLiveStatusAppConversationService:
         mock_agent.condenser = None  # No condenser
 
         conversation_id = uuid4()
-        workspace = LocalWorkspace(working_dir='/test')
+        workspace = LocalWorkspace(working_dir="/test")
         initial_message = Mock(spec=SendMessageRequest)
-        secrets = {'test': StaticSecret(value='secret')}
+        secrets = {"test": StaticSecret(value="secret")}
         remote_workspace = Mock(spec=AsyncRemoteWorkspace)
 
         # Mock the skills loading method
@@ -1063,8 +1063,8 @@ class TestLiveStatusAppConversationService:
             secrets,
             self.mock_sandbox,
             remote_workspace,
-            'test_repo',
-            '/test/dir',
+            "test_repo",
+            "/test/dir",
         )
 
         # Assert
@@ -1081,16 +1081,16 @@ class TestLiveStatusAppConversationService:
         """Test _finalize_conversation_request without remote workspace (no skills)."""
         # Create mock LLM with required attributes for _update_agent_with_llm_metadata
         mock_llm = Mock(spec=LLM)
-        mock_llm.model = 'gpt-4'  # Non-openhands model, so no metadata update
-        mock_llm.usage_id = 'agent'
+        mock_llm.model = "gpt-4"  # Non-openhands model, so no metadata update
+        mock_llm.usage_id = "agent"
 
         # Arrange
         mock_agent = Mock(spec=Agent)
         mock_agent.llm = mock_llm
         mock_agent.condenser = None  # No condenser
 
-        workspace = LocalWorkspace(working_dir='/test')
-        secrets = {'test': StaticSecret(value='secret')}
+        workspace = LocalWorkspace(working_dir="/test")
+        secrets = {"test": StaticSecret(value="secret")}
 
         # Act
         result = await self.service._finalize_conversation_request(
@@ -1103,7 +1103,7 @@ class TestLiveStatusAppConversationService:
             self.mock_sandbox,
             None,
             None,
-            '/test/dir',
+            "/test/dir",
         )
 
         # Assert
@@ -1115,25 +1115,25 @@ class TestLiveStatusAppConversationService:
         """Test _finalize_conversation_request when skills loading fails."""
         # Create mock LLM with required attributes for _update_agent_with_llm_metadata
         mock_llm = Mock(spec=LLM)
-        mock_llm.model = 'gpt-4'  # Non-openhands model, so no metadata update
-        mock_llm.usage_id = 'agent'
+        mock_llm.model = "gpt-4"  # Non-openhands model, so no metadata update
+        mock_llm.usage_id = "agent"
 
         mock_agent = Mock(spec=Agent)
         mock_agent.llm = mock_llm
         mock_agent.condenser = None  # No condenser
 
-        workspace = LocalWorkspace(working_dir='/test')
-        secrets = {'test': StaticSecret(value='secret')}
+        workspace = LocalWorkspace(working_dir="/test")
+        secrets = {"test": StaticSecret(value="secret")}
         remote_workspace = Mock(spec=AsyncRemoteWorkspace)
 
         # Mock skills loading to raise an exception
         self.service._load_skills_and_update_agent = AsyncMock(
-            side_effect=Exception('Skills loading failed')
+            side_effect=Exception("Skills loading failed")
         )
 
         # Act
         with patch(
-            'openhands.app_server.app_conversation.live_status_app_conversation_service._logger'
+            "openhands.app_server.app_conversation.live_status_app_conversation_service._logger"
         ) as mock_logger:
             result = await self.service._finalize_conversation_request(
                 mock_agent,
@@ -1144,8 +1144,8 @@ class TestLiveStatusAppConversationService:
                 secrets,
                 self.mock_sandbox,
                 remote_workspace,
-                'test_repo',
-                '/test/dir',
+                "test_repo",
+                "/test/dir",
             )
 
             # Assert
@@ -1159,9 +1159,9 @@ class TestLiveStatusAppConversationService:
         self.mock_user_context.get_user_info.return_value = self.mock_user
 
         # Mock all the helper methods
-        mock_secrets = {'GITHUB_TOKEN': Mock()}
+        mock_secrets = {"GITHUB_TOKEN": Mock()}
         mock_llm = Mock(spec=LLM)
-        mock_mcp_config = {'default': {'url': 'test'}}
+        mock_mcp_config = {"default": {"url": "test"}}
         mock_agent = Mock(spec=Agent)
         mock_final_request = Mock(spec=StartConversationRequest)
 
@@ -1180,14 +1180,14 @@ class TestLiveStatusAppConversationService:
         result = await self.service._build_start_conversation_request_for_user(
             sandbox=self.mock_sandbox,
             initial_message=None,
-            system_message_suffix='Test suffix',
+            system_message_suffix="Test suffix",
             git_provider=ProviderType.GITHUB,
-            working_dir='/test/dir',
+            working_dir="/test/dir",
             agent_type=AgentType.DEFAULT,
-            llm_model='gpt-4',
+            llm_model="gpt-4",
             conversation_id=None,
             remote_workspace=None,
-            selected_repository='test/repo',
+            selected_repository="test/repo",
         )
 
         # Assert
@@ -1197,17 +1197,17 @@ class TestLiveStatusAppConversationService:
             self.mock_user
         )
         self.service._configure_llm_and_mcp.assert_called_once_with(
-            self.mock_user, 'gpt-4'
+            self.mock_user, "gpt-4"
         )
         self.service._create_agent_with_context.assert_called_once_with(
             mock_llm,
             AgentType.DEFAULT,
-            'Test suffix',
+            "Test suffix",
             mock_mcp_config,
             self.mock_user.condenser_max_size,
             secrets=mock_secrets,
             git_provider=ProviderType.GITHUB,
-            working_dir='/test/dir',
+            working_dir="/test/dir",
         )
         self.service._finalize_conversation_request.assert_called_once()
 
@@ -1220,12 +1220,12 @@ class TestLiveStatusAppConversationService:
         # Mock conversation info
         mock_conversation_info = Mock(spec=AppConversationInfo)
         mock_conversation_info.id = conversation_id
-        mock_conversation_info.title = 'Test Conversation'
+        mock_conversation_info.title = "Test Conversation"
         mock_conversation_info.created_at = datetime(2024, 1, 1, 12, 0, 0)
         mock_conversation_info.updated_at = datetime(2024, 1, 1, 13, 0, 0)
-        mock_conversation_info.selected_repository = 'test/repo'
-        mock_conversation_info.git_provider = 'github'
-        mock_conversation_info.selected_branch = 'main'
+        mock_conversation_info.selected_repository = "test/repo"
+        mock_conversation_info.git_provider = "github"
+        mock_conversation_info.selected_branch = "main"
         mock_conversation_info.model_dump_json = Mock(
             return_value='{"id": "test", "title": "Test Conversation"}'
         )
@@ -1238,19 +1238,19 @@ class TestLiveStatusAppConversationService:
         mock_event1 = Mock(spec=Event)
         mock_event1.id = uuid4()
         mock_event1.model_dump = Mock(
-            return_value={'id': str(mock_event1.id), 'type': 'action'}
+            return_value={"id": str(mock_event1.id), "type": "action"}
         )
 
         mock_event2 = Mock(spec=Event)
         mock_event2.id = uuid4()
         mock_event2.model_dump = Mock(
-            return_value={'id': str(mock_event2.id), 'type': 'observation'}
+            return_value={"id": str(mock_event2.id), "type": "observation"}
         )
 
         # Mock event service search_events to return paginated results
         mock_event_page1 = Mock()
         mock_event_page1.items = [mock_event1]
-        mock_event_page1.next_page_id = 'page2'
+        mock_event_page1.next_page_id = "page2"
 
         mock_event_page2 = Mock()
         mock_event_page2.items = [mock_event2]
@@ -1268,30 +1268,30 @@ class TestLiveStatusAppConversationService:
         assert isinstance(result, bytes)  # Should be bytes
 
         # Verify the zip file contents
-        with zipfile.ZipFile(io.BytesIO(result), 'r') as zipf:
+        with zipfile.ZipFile(io.BytesIO(result), "r") as zipf:
             file_list = zipf.namelist()
 
             # Should contain meta.json and event files
-            assert 'meta.json' in file_list
+            assert "meta.json" in file_list
             assert any(
-                f.startswith('event_') and f.endswith('.json') for f in file_list
+                f.startswith("event_") and f.endswith(".json") for f in file_list
             )
 
             # Check meta.json content
-            with zipf.open('meta.json') as meta_file:
-                meta_content = meta_file.read().decode('utf-8')
+            with zipf.open("meta.json") as meta_file:
+                meta_content = meta_file.read().decode("utf-8")
                 assert '"id": "test"' in meta_content
                 assert '"title": "Test Conversation"' in meta_content
 
             # Check event files
-            event_files = [f for f in file_list if f.startswith('event_')]
+            event_files = [f for f in file_list if f.startswith("event_")]
             assert len(event_files) == 2  # Should have 2 event files
 
             # Verify event file content
             with zipf.open(event_files[0]) as event_file:
-                event_content = json.loads(event_file.read().decode('utf-8'))
-                assert 'id' in event_content
-                assert 'type' in event_content
+                event_content = json.loads(event_file.read().decode("utf-8"))
+                assert "id" in event_content
+                assert "type" in event_content
 
         # Verify service calls
         self.mock_app_conversation_info_service.get_app_conversation_info.assert_called_once_with(
@@ -1311,7 +1311,7 @@ class TestLiveStatusAppConversationService:
 
         # Act & Assert
         with pytest.raises(
-            ValueError, match=f'Conversation not found: {conversation_id}'
+            ValueError, match=f"Conversation not found: {conversation_id}"
         ):
             await self.service.export_conversation(conversation_id)
 
@@ -1330,7 +1330,7 @@ class TestLiveStatusAppConversationService:
         # Mock conversation info
         mock_conversation_info = Mock(spec=AppConversationInfo)
         mock_conversation_info.id = conversation_id
-        mock_conversation_info.title = 'Empty Conversation'
+        mock_conversation_info.title = "Empty Conversation"
         mock_conversation_info.model_dump_json = Mock(
             return_value='{"id": "test", "title": "Empty Conversation"}'
         )
@@ -1354,12 +1354,12 @@ class TestLiveStatusAppConversationService:
         assert isinstance(result, bytes)  # Should be bytes
 
         # Verify the zip file contents
-        with zipfile.ZipFile(io.BytesIO(result), 'r') as zipf:
+        with zipfile.ZipFile(io.BytesIO(result), "r") as zipf:
             file_list = zipf.namelist()
 
             # Should only contain meta.json (no event files)
-            assert 'meta.json' in file_list
-            assert len([f for f in file_list if f.startswith('event_')]) == 0
+            assert "meta.json" in file_list
+            assert len([f for f in file_list if f.startswith("event_")]) == 0
 
         # Verify service calls
         self.mock_app_conversation_info_service.get_app_conversation_info.assert_called_once_with(
@@ -1383,7 +1383,7 @@ class TestLiveStatusAppConversationService:
         # Mock conversation info
         mock_conversation_info = Mock(spec=AppConversationInfo)
         mock_conversation_info.id = conversation_id
-        mock_conversation_info.model_dump_json = Mock(return_value='{}')
+        mock_conversation_info.model_dump_json = Mock(return_value="{}")
 
         self.mock_app_conversation_info_service.get_app_conversation_info = AsyncMock(
             return_value=mock_conversation_info
@@ -1403,13 +1403,13 @@ class TestLiveStatusAppConversationService:
         self.mock_event_service.search_events.assert_called()
         call_kwargs = self.mock_event_service.search_events.call_args[1]
 
-        assert 'conversation_id' in call_kwargs, (
+        assert "conversation_id" in call_kwargs, (
             "search_events should be called with 'conversation_id' parameter"
         )
-        assert 'conversation_id__eq' not in call_kwargs, (
+        assert "conversation_id__eq" not in call_kwargs, (
             "search_events should NOT be called with 'conversation_id__eq' parameter"
         )
-        assert call_kwargs['conversation_id'] == conversation_id
+        assert call_kwargs["conversation_id"] == conversation_id
 
     @pytest.mark.asyncio
     async def test_export_conversation_large_pagination(self):
@@ -1420,7 +1420,7 @@ class TestLiveStatusAppConversationService:
         # Mock conversation info
         mock_conversation_info = Mock(spec=AppConversationInfo)
         mock_conversation_info.id = conversation_id
-        mock_conversation_info.title = 'Large Conversation'
+        mock_conversation_info.title = "Large Conversation"
         mock_conversation_info.model_dump_json = Mock(
             return_value='{"id": "test", "title": "Large Conversation"}'
         )
@@ -1441,8 +1441,8 @@ class TestLiveStatusAppConversationService:
                 mock_event.id = uuid4()
                 mock_event.model_dump = Mock(
                     return_value={
-                        'id': str(mock_event.id),
-                        'type': f'event_page_{page_num}_item_{i}',
+                        "id": str(mock_event.id),
+                        "type": f"event_page_{page_num}_item_{i}",
                     }
                 )
                 page_events.append(mock_event)
@@ -1451,7 +1451,7 @@ class TestLiveStatusAppConversationService:
             mock_event_page = Mock()
             mock_event_page.items = page_events
             mock_event_page.next_page_id = (
-                f'page{page_num + 1}' if page_num < total_pages - 1 else None
+                f"page{page_num + 1}" if page_num < total_pages - 1 else None
             )
 
             if page_num == 0:
@@ -1475,12 +1475,12 @@ class TestLiveStatusAppConversationService:
         assert isinstance(result, bytes)  # Should be bytes
 
         # Verify the zip file contents
-        with zipfile.ZipFile(io.BytesIO(result), 'r') as zipf:
+        with zipfile.ZipFile(io.BytesIO(result), "r") as zipf:
             file_list = zipf.namelist()
 
             # Should contain meta.json and all event files
-            assert 'meta.json' in file_list
-            event_files = [f for f in file_list if f.startswith('event_')]
+            assert "meta.json" in file_list
+            event_files = [f for f in file_list if f.startswith("event_")]
             assert (
                 len(event_files) == total_pages * events_per_page
             )  # Should have all events
@@ -1489,10 +1489,10 @@ class TestLiveStatusAppConversationService:
         assert self.mock_event_service.search_events.call_count == total_pages
 
     @patch(
-        'openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace'
+        "openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace"
     )
     @patch(
-        'openhands.app_server.app_conversation.live_status_app_conversation_service.ConversationInfo'
+        "openhands.app_server.app_conversation.live_status_app_conversation_service.ConversationInfo"
     )
     async def test_start_app_conversation_default_title_uses_first_five_characters(
         self, mock_conversation_info_class, mock_remote_workspace_class
@@ -1501,20 +1501,20 @@ class TestLiveStatusAppConversationService:
         # Arrange
         conversation_id = uuid4()
         conversation_id_hex = conversation_id.hex
-        expected_title = f'Conversation {conversation_id_hex[:5]}'
+        expected_title = f"Conversation {conversation_id_hex[:5]}"
 
         # Mock user context
-        self.mock_user_context.get_user_id = AsyncMock(return_value='test_user_123')
+        self.mock_user_context.get_user_id = AsyncMock(return_value="test_user_123")
         self.mock_user_context.get_user_info = AsyncMock(return_value=self.mock_user)
 
         # Mock sandbox and sandbox spec
         mock_sandbox_spec = Mock(spec=SandboxSpecInfo)
-        mock_sandbox_spec.working_dir = '/test/workspace'
+        mock_sandbox_spec.working_dir = "/test/workspace"
         self.mock_sandbox.sandbox_spec_id = str(uuid4())
         self.mock_sandbox.id = str(uuid4())  # Ensure sandbox.id is a string
-        self.mock_sandbox.session_api_key = 'test_session_key'
+        self.mock_sandbox.session_api_key = "test_session_key"
         exposed_url = ExposedUrl(
-            name=AGENT_SERVER, url='http://agent-server:8000', port=60000
+            name=AGENT_SERVER, url="http://agent-server:8000", port=60000
         )
         self.mock_sandbox.exposed_urls = [exposed_url]
 
@@ -1543,10 +1543,10 @@ class TestLiveStatusAppConversationService:
         # Mock build start conversation request
         mock_agent = Mock(spec=Agent)
         mock_agent.llm = Mock(spec=LLM)
-        mock_agent.llm.model = 'gpt-4'
+        mock_agent.llm.model = "gpt-4"
         mock_start_request = Mock(spec=StartConversationRequest)
         mock_start_request.agent = mock_agent
-        mock_start_request.model_dump.return_value = {'test': 'data'}
+        mock_start_request.model_dump.return_value = {"test": "data"}
 
         self.service._build_start_conversation_request_for_user = AsyncMock(
             return_value=mock_start_request
@@ -1561,7 +1561,7 @@ class TestLiveStatusAppConversationService:
 
         # Mock HTTP response from agent server
         mock_response = Mock()
-        mock_response.json.return_value = {'id': str(conversation_id)}
+        mock_response.json.return_value = {"id": str(conversation_id)}
         mock_response.raise_for_status = Mock()
         self.mock_httpx_client.post = AsyncMock(return_value=mock_response)
 
@@ -1599,8 +1599,8 @@ class TestLiveStatusAppConversationService:
 
         self.mock_user.mcp_config = MCPConfig(
             sse_servers=[
-                MCPSSEServerConfig(url='https://linear.app/sse', api_key='linear_key'),
-                MCPSSEServerConfig(url='https://notion.com/sse'),
+                MCPSSEServerConfig(url="https://linear.app/sse", api_key="linear_key"),
+                MCPSSEServerConfig(url="https://notion.com/sse"),
             ]
         )
         self.mock_user_context.get_mcp_api_key.return_value = None
@@ -1612,27 +1612,27 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        assert 'mcpServers' in mcp_config
+        assert "mcpServers" in mcp_config
 
         # Should have default server + 2 custom SSE servers
-        mcp_servers = mcp_config['mcpServers']
-        assert 'default' in mcp_servers
+        mcp_servers = mcp_config["mcpServers"]
+        assert "default" in mcp_servers
 
         # Find SSE servers (they have sse_ prefix)
-        sse_servers = {k: v for k, v in mcp_servers.items() if k.startswith('sse_')}
+        sse_servers = {k: v for k, v in mcp_servers.items() if k.startswith("sse_")}
         assert len(sse_servers) == 2
 
         # Verify SSE server configurations
         for server_name, server_config in sse_servers.items():
-            assert server_name.startswith('sse_')
+            assert server_name.startswith("sse_")
             assert len(server_name) > 4  # Has UUID suffix
-            assert 'url' in server_config
-            assert 'transport' in server_config
-            assert server_config['transport'] == 'sse'
+            assert "url" in server_config
+            assert "transport" in server_config
+            assert server_config["transport"] == "sse"
 
             # Check if this is the Linear server (has headers)
-            if 'headers' in server_config:
-                assert server_config['headers']['Authorization'] == 'Bearer linear_key'
+            if "headers" in server_config:
+                assert server_config["headers"]["Authorization"] == "Bearer linear_key"
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_with_custom_shttp_servers(self):
@@ -1643,8 +1643,8 @@ class TestLiveStatusAppConversationService:
         self.mock_user.mcp_config = MCPConfig(
             shttp_servers=[
                 MCPSHTTPServerConfig(
-                    url='https://example.com/mcp',
-                    api_key='test_key',
+                    url="https://example.com/mcp",
+                    api_key="test_key",
                     timeout=120,
                 )
             ]
@@ -1658,17 +1658,17 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        mcp_servers = mcp_config['mcpServers']
+        mcp_servers = mcp_config["mcpServers"]
 
         # Find SHTTP servers
-        shttp_servers = {k: v for k, v in mcp_servers.items() if k.startswith('shttp_')}
+        shttp_servers = {k: v for k, v in mcp_servers.items() if k.startswith("shttp_")}
         assert len(shttp_servers) == 1
 
         server_config = list(shttp_servers.values())[0]
-        assert server_config['url'] == 'https://example.com/mcp'
-        assert server_config['transport'] == 'streamable-http'
-        assert server_config['headers']['Authorization'] == 'Bearer test_key'
-        assert server_config['timeout'] == 120
+        assert server_config["url"] == "https://example.com/mcp"
+        assert server_config["transport"] == "streamable-http"
+        assert server_config["headers"]["Authorization"] == "Bearer test_key"
+        assert server_config["timeout"] == 120
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_with_custom_stdio_servers(self):
@@ -1679,10 +1679,10 @@ class TestLiveStatusAppConversationService:
         self.mock_user.mcp_config = MCPConfig(
             stdio_servers=[
                 MCPStdioServerConfig(
-                    name='my-custom-server',
-                    command='npx',
-                    args=['-y', 'my-package'],
-                    env={'API_KEY': 'secret'},
+                    name="my-custom-server",
+                    command="npx",
+                    args=["-y", "my-package"],
+                    env={"API_KEY": "secret"},
                 )
             ]
         )
@@ -1695,14 +1695,14 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        mcp_servers = mcp_config['mcpServers']
+        mcp_servers = mcp_config["mcpServers"]
 
         # STDIO server should use its explicit name
-        assert 'my-custom-server' in mcp_servers
-        server_config = mcp_servers['my-custom-server']
-        assert server_config['command'] == 'npx'
-        assert server_config['args'] == ['-y', 'my-package']
-        assert server_config['env'] == {'API_KEY': 'secret'}
+        assert "my-custom-server" in mcp_servers
+        server_config = mcp_servers["my-custom-server"]
+        assert server_config["command"] == "npx"
+        assert server_config["args"] == ["-y", "my-package"]
+        assert server_config["env"] == {"API_KEY": "secret"}
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_merges_system_and_custom_servers(self):
@@ -1714,16 +1714,16 @@ class TestLiveStatusAppConversationService:
             MCPStdioServerConfig,
         )
 
-        self.mock_user.search_api_key = SecretStr('tavily_key')
+        self.mock_user.search_api_key = SecretStr("tavily_key")
         self.mock_user.mcp_config = MCPConfig(
-            sse_servers=[MCPSSEServerConfig(url='https://custom.com/sse')],
+            sse_servers=[MCPSSEServerConfig(url="https://custom.com/sse")],
             stdio_servers=[
                 MCPStdioServerConfig(
-                    name='custom-stdio', command='node', args=['app.js']
+                    name="custom-stdio", command="node", args=["app.js"]
                 )
             ],
         )
-        self.mock_user_context.get_mcp_api_key.return_value = 'mcp_api_key'
+        self.mock_user_context.get_mcp_api_key.return_value = "mcp_api_key"
 
         # Act
         llm, mcp_config = await self.service._configure_llm_and_mcp(
@@ -1731,18 +1731,18 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        mcp_servers = mcp_config['mcpServers']
+        mcp_servers = mcp_config["mcpServers"]
 
         # Should have system servers
-        assert 'default' in mcp_servers
-        assert 'tavily' in mcp_servers
+        assert "default" in mcp_servers
+        assert "tavily" in mcp_servers
 
         # Should have custom SSE server with UUID name
-        sse_servers = [k for k in mcp_servers if k.startswith('sse_')]
+        sse_servers = [k for k in mcp_servers if k.startswith("sse_")]
         assert len(sse_servers) == 1
 
         # Should have custom STDIO server with explicit name
-        assert 'custom-stdio' in mcp_servers
+        assert "custom-stdio" in mcp_servers
 
         # Total: default + tavily + 1 SSE + 1 STDIO = 4 servers
         assert len(mcp_servers) == 4
@@ -1754,7 +1754,7 @@ class TestLiveStatusAppConversationService:
         self.mock_user.mcp_config = Mock()
         # Simulate error when accessing sse_servers
         self.mock_user.mcp_config.sse_servers = property(
-            lambda self: (_ for _ in ()).throw(Exception('Config error'))
+            lambda self: (_ for _ in ()).throw(Exception("Config error"))
         )
         self.mock_user_context.get_mcp_api_key.return_value = None
 
@@ -1765,15 +1765,15 @@ class TestLiveStatusAppConversationService:
 
         # Assert - should still return valid config with system servers only
         assert isinstance(llm, LLM)
-        mcp_servers = mcp_config['mcpServers']
-        assert 'default' in mcp_servers
+        mcp_servers = mcp_config["mcpServers"]
+        assert "default" in mcp_servers
         # Custom servers should not be added due to error
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_sdk_format_with_mcpservers_wrapper(self):
         """Test _configure_llm_and_mcp returns SDK-required format with mcpServers key."""
         # Arrange
-        self.mock_user_context.get_mcp_api_key.return_value = 'mcp_key'
+        self.mock_user_context.get_mcp_api_key.return_value = "mcp_key"
 
         # Act
         llm, mcp_config = await self.service._configure_llm_and_mcp(
@@ -1781,11 +1781,11 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert - SDK expects {'mcpServers': {...}} format
-        assert 'mcpServers' in mcp_config
-        assert isinstance(mcp_config['mcpServers'], dict)
+        assert "mcpServers" in mcp_config
+        assert isinstance(mcp_config["mcpServers"], dict)
 
         # Verify structure matches SDK expectations
-        for server_name, server_config in mcp_config['mcpServers'].items():
+        for server_name, server_config in mcp_config["mcpServers"].items():
             assert isinstance(server_name, str)
             assert isinstance(server_config, dict)
 
@@ -1806,9 +1806,9 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        mcp_servers = mcp_config['mcpServers']
+        mcp_servers = mcp_config["mcpServers"]
         # Should only have system default server
-        assert 'default' in mcp_servers
+        assert "default" in mcp_servers
         assert len(mcp_servers) == 1
 
     @pytest.mark.asyncio
@@ -1818,7 +1818,7 @@ class TestLiveStatusAppConversationService:
         from openhands.core.config.mcp_config import MCPConfig, MCPSSEServerConfig
 
         self.mock_user.mcp_config = MCPConfig(
-            sse_servers=[MCPSSEServerConfig(url='https://public.com/sse')]
+            sse_servers=[MCPSSEServerConfig(url="https://public.com/sse")]
         )
         self.mock_user_context.get_mcp_api_key.return_value = None
 
@@ -1828,15 +1828,15 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        mcp_servers = mcp_config['mcpServers']
-        sse_servers = {k: v for k, v in mcp_servers.items() if k.startswith('sse_')}
+        mcp_servers = mcp_config["mcpServers"]
+        sse_servers = {k: v for k, v in mcp_servers.items() if k.startswith("sse_")}
 
         # Server should exist but without headers
         assert len(sse_servers) == 1
         server_config = list(sse_servers.values())[0]
-        assert 'headers' not in server_config
-        assert server_config['url'] == 'https://public.com/sse'
-        assert server_config['transport'] == 'sse'
+        assert "headers" not in server_config
+        assert server_config["url"] == "https://public.com/sse"
+        assert server_config["transport"] == "sse"
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_shttp_server_without_timeout(self):
@@ -1845,7 +1845,7 @@ class TestLiveStatusAppConversationService:
         from openhands.core.config.mcp_config import MCPConfig, MCPSHTTPServerConfig
 
         self.mock_user.mcp_config = MCPConfig(
-            shttp_servers=[MCPSHTTPServerConfig(url='https://example.com/mcp')]
+            shttp_servers=[MCPSHTTPServerConfig(url="https://example.com/mcp")]
         )
         self.mock_user_context.get_mcp_api_key.return_value = None
 
@@ -1855,13 +1855,13 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        mcp_servers = mcp_config['mcpServers']
-        shttp_servers = {k: v for k, v in mcp_servers.items() if k.startswith('shttp_')}
+        mcp_servers = mcp_config["mcpServers"]
+        shttp_servers = {k: v for k, v in mcp_servers.items() if k.startswith("shttp_")}
 
         assert len(shttp_servers) == 1
         server_config = list(shttp_servers.values())[0]
         # Timeout should be included even if None (defaults to 60)
-        assert 'timeout' in server_config
+        assert "timeout" in server_config
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_stdio_server_without_env(self):
@@ -1872,7 +1872,7 @@ class TestLiveStatusAppConversationService:
         self.mock_user.mcp_config = MCPConfig(
             stdio_servers=[
                 MCPStdioServerConfig(
-                    name='simple-server', command='node', args=['app.js']
+                    name="simple-server", command="node", args=["app.js"]
                 )
             ]
         )
@@ -1884,14 +1884,14 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        mcp_servers = mcp_config['mcpServers']
-        assert 'simple-server' in mcp_servers
-        server_config = mcp_servers['simple-server']
+        mcp_servers = mcp_config["mcpServers"]
+        assert "simple-server" in mcp_servers
+        server_config = mcp_servers["simple-server"]
 
         # Should not have env key if not provided
-        assert 'env' not in server_config
-        assert server_config['command'] == 'node'
-        assert server_config['args'] == ['app.js']
+        assert "env" not in server_config
+        assert server_config["command"] == "node"
+        assert server_config["args"] == ["app.js"]
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_multiple_servers_same_type(self):
@@ -1901,9 +1901,9 @@ class TestLiveStatusAppConversationService:
 
         self.mock_user.mcp_config = MCPConfig(
             sse_servers=[
-                MCPSSEServerConfig(url='https://server1.com/sse'),
-                MCPSSEServerConfig(url='https://server2.com/sse'),
-                MCPSSEServerConfig(url='https://server3.com/sse'),
+                MCPSSEServerConfig(url="https://server1.com/sse"),
+                MCPSSEServerConfig(url="https://server2.com/sse"),
+                MCPSSEServerConfig(url="https://server3.com/sse"),
             ]
         )
         self.mock_user_context.get_mcp_api_key.return_value = None
@@ -1914,8 +1914,8 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        mcp_servers = mcp_config['mcpServers']
-        sse_servers = {k: v for k, v in mcp_servers.items() if k.startswith('sse_')}
+        mcp_servers = mcp_config["mcpServers"]
+        sse_servers = {k: v for k, v in mcp_servers.items() if k.startswith("sse_")}
 
         # All 3 servers should be present with unique UUID-based names
         assert len(sse_servers) == 3
@@ -1925,10 +1925,10 @@ class TestLiveStatusAppConversationService:
         assert len(set(server_names)) == 3  # All names are unique
 
         # Verify all URLs are preserved
-        urls = [v['url'] for v in sse_servers.values()]
-        assert 'https://server1.com/sse' in urls
-        assert 'https://server2.com/sse' in urls
-        assert 'https://server3.com/sse' in urls
+        urls = [v["url"] for v in sse_servers.values()]
+        assert "https://server1.com/sse" in urls
+        assert "https://server2.com/sse" in urls
+        assert "https://server3.com/sse" in urls
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_mixed_server_types(self):
@@ -1943,17 +1943,17 @@ class TestLiveStatusAppConversationService:
 
         self.mock_user.mcp_config = MCPConfig(
             sse_servers=[
-                MCPSSEServerConfig(url='https://sse.example.com/sse', api_key='sse_key')
+                MCPSSEServerConfig(url="https://sse.example.com/sse", api_key="sse_key")
             ],
             shttp_servers=[
-                MCPSHTTPServerConfig(url='https://shttp.example.com/mcp', timeout=90)
+                MCPSHTTPServerConfig(url="https://shttp.example.com/mcp", timeout=90)
             ],
             stdio_servers=[
                 MCPStdioServerConfig(
-                    name='stdio-server',
-                    command='npx',
-                    args=['mcp-server'],
-                    env={'TOKEN': 'value'},
+                    name="stdio-server",
+                    command="npx",
+                    args=["mcp-server"],
+                    env={"TOKEN": "value"},
                 )
             ],
         )
@@ -1965,33 +1965,33 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        mcp_servers = mcp_config['mcpServers']
+        mcp_servers = mcp_config["mcpServers"]
 
         # Check all server types are present
-        sse_count = len([k for k in mcp_servers if k.startswith('sse_')])
-        shttp_count = len([k for k in mcp_servers if k.startswith('shttp_')])
-        stdio_count = 1 if 'stdio-server' in mcp_servers else 0
+        sse_count = len([k for k in mcp_servers if k.startswith("sse_")])
+        shttp_count = len([k for k in mcp_servers if k.startswith("shttp_")])
+        stdio_count = 1 if "stdio-server" in mcp_servers else 0
 
         assert sse_count == 1
         assert shttp_count == 1
         assert stdio_count == 1
 
         # Verify each type has correct configuration
-        sse_server = next(v for k, v in mcp_servers.items() if k.startswith('sse_'))
-        assert sse_server['transport'] == 'sse'
-        assert sse_server['headers']['Authorization'] == 'Bearer sse_key'
+        sse_server = next(v for k, v in mcp_servers.items() if k.startswith("sse_"))
+        assert sse_server["transport"] == "sse"
+        assert sse_server["headers"]["Authorization"] == "Bearer sse_key"
 
-        shttp_server = next(v for k, v in mcp_servers.items() if k.startswith('shttp_'))
-        assert shttp_server['transport'] == 'streamable-http'
-        assert shttp_server['timeout'] == 90
+        shttp_server = next(v for k, v in mcp_servers.items() if k.startswith("shttp_"))
+        assert shttp_server["transport"] == "streamable-http"
+        assert shttp_server["timeout"] == 90
 
-        stdio_server = mcp_servers['stdio-server']
-        assert stdio_server['command'] == 'npx'
-        assert stdio_server['env'] == {'TOKEN': 'value'}
+        stdio_server = mcp_servers["stdio-server"]
+        assert stdio_server["command"] == "npx"
+        assert stdio_server["env"] == {"TOKEN": "value"}
 
     @pytest.mark.asyncio
     @patch(
-        'openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace'
+        "openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace"
     )
     async def test_start_app_conversation_exception_uses_extract_error_detail(
         self, mock_remote_workspace_class
@@ -2004,20 +2004,18 @@ class TestLiveStatusAppConversationService:
         )
 
         # Arrange
-        conversation_id = uuid4()
-
         # Mock user context
-        self.mock_user_context.get_user_id = AsyncMock(return_value='test_user_123')
+        self.mock_user_context.get_user_id = AsyncMock(return_value="test_user_123")
         self.mock_user_context.get_user_info = AsyncMock(return_value=self.mock_user)
 
         # Mock sandbox and sandbox spec
         mock_sandbox_spec = Mock(spec=SandboxSpecInfo)
-        mock_sandbox_spec.working_dir = '/test/workspace'
+        mock_sandbox_spec.working_dir = "/test/workspace"
         self.mock_sandbox.sandbox_spec_id = str(uuid4())
         self.mock_sandbox.id = str(uuid4())
-        self.mock_sandbox.session_api_key = 'test_session_key'
+        self.mock_sandbox.session_api_key = "test_session_key"
         exposed_url = ExposedUrl(
-            name=AGENT_SERVER, url='http://agent-server:8000', port=60000
+            name=AGENT_SERVER, url="http://agent-server:8000", port=60000
         )
         self.mock_sandbox.exposed_urls = [exposed_url]
 
@@ -2046,10 +2044,10 @@ class TestLiveStatusAppConversationService:
         # Mock build start conversation request
         mock_agent = Mock(spec=Agent)
         mock_agent.llm = Mock(spec=LLM)
-        mock_agent.llm.model = 'gpt-4'
+        mock_agent.llm.model = "gpt-4"
         mock_start_request = Mock(spec=StartConversationRequest)
         mock_start_request.agent = mock_agent
-        mock_start_request.model_dump.return_value = {'test': 'data'}
+        mock_start_request.model_dump.return_value = {"test": "data"}
 
         self.service._build_start_conversation_request_for_user = AsyncMock(
             return_value=mock_start_request
@@ -2059,12 +2057,12 @@ class TestLiveStatusAppConversationService:
         mock_response = httpx.Response(
             500,
             json={
-                'detail': 'Internal Server Error',
-                'exception': "Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'",
+                "detail": "Internal Server Error",
+                "exception": "Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'",
             },
         )
         mock_response._request = httpx.Request(
-            'POST', 'http://agent-server:8000/api/conversations'
+            "POST", "http://agent-server:8000/api/conversations"
         )
         http_error = httpx.HTTPStatusError(
             message="Server error '500 Internal Server Error'",
@@ -2087,12 +2085,12 @@ class TestLiveStatusAppConversationService:
         final_task = tasks[-1]
         assert final_task.status == AppConversationStartTaskStatus.ERROR
         # The extract_error_detail function should extract the 'exception' field from JSON
-        assert 'mcp.atlassian.com' in final_task.detail
-        assert '401 Unauthorized' in final_task.detail
+        assert "mcp.atlassian.com" in final_task.detail
+        assert "401 Unauthorized" in final_task.detail
 
     @pytest.mark.asyncio
     @patch(
-        'openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace'
+        "openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace"
     )
     async def test_start_app_conversation_generic_exception_uses_extract_error_detail(
         self, mock_remote_workspace_class
@@ -2103,20 +2101,18 @@ class TestLiveStatusAppConversationService:
         )
 
         # Arrange
-        conversation_id = uuid4()
-
         # Mock user context
-        self.mock_user_context.get_user_id = AsyncMock(return_value='test_user_123')
+        self.mock_user_context.get_user_id = AsyncMock(return_value="test_user_123")
         self.mock_user_context.get_user_info = AsyncMock(return_value=self.mock_user)
 
         # Mock sandbox and sandbox spec
         mock_sandbox_spec = Mock(spec=SandboxSpecInfo)
-        mock_sandbox_spec.working_dir = '/test/workspace'
+        mock_sandbox_spec.working_dir = "/test/workspace"
         self.mock_sandbox.sandbox_spec_id = str(uuid4())
         self.mock_sandbox.id = str(uuid4())
-        self.mock_sandbox.session_api_key = 'test_session_key'
+        self.mock_sandbox.session_api_key = "test_session_key"
         exposed_url = ExposedUrl(
-            name=AGENT_SERVER, url='http://agent-server:8000', port=60000
+            name=AGENT_SERVER, url="http://agent-server:8000", port=60000
         )
         self.mock_sandbox.exposed_urls = [exposed_url]
 
@@ -2145,10 +2141,10 @@ class TestLiveStatusAppConversationService:
         # Mock build start conversation request
         mock_agent = Mock(spec=Agent)
         mock_agent.llm = Mock(spec=LLM)
-        mock_agent.llm.model = 'gpt-4'
+        mock_agent.llm.model = "gpt-4"
         mock_start_request = Mock(spec=StartConversationRequest)
         mock_start_request.agent = mock_agent
-        mock_start_request.model_dump.return_value = {'test': 'data'}
+        mock_start_request.model_dump.return_value = {"test": "data"}
 
         self.service._build_start_conversation_request_for_user = AsyncMock(
             return_value=mock_start_request
@@ -2156,7 +2152,7 @@ class TestLiveStatusAppConversationService:
 
         # Make the HTTP post call raise a generic exception
         self.mock_httpx_client.post = AsyncMock(
-            side_effect=RuntimeError('Connection timeout')
+            side_effect=RuntimeError("Connection timeout")
         )
 
         # Create request
@@ -2171,7 +2167,7 @@ class TestLiveStatusAppConversationService:
         final_task = tasks[-1]
         assert final_task.status == AppConversationStartTaskStatus.ERROR
         # For non-httpx exceptions, extract_error_detail returns str(exc)
-        assert 'Connection timeout' in final_task.detail
+        assert "Connection timeout" in final_task.detail
 
 
 class TestPluginHandling:
@@ -2206,18 +2202,18 @@ class TestPluginHandling:
             sandbox_startup_timeout=30,
             sandbox_startup_poll_frequency=1,
             httpx_client=self.mock_httpx_client,
-            web_url='https://test.example.com',
-            openhands_provider_base_url='https://provider.example.com',
+            web_url="https://test.example.com",
+            openhands_provider_base_url="https://provider.example.com",
             access_token_hard_timeout=None,
-            app_mode='test',
+            app_mode="test",
         )
 
         # Mock user info
         self.mock_user = Mock()
-        self.mock_user.id = 'test_user_123'
-        self.mock_user.llm_model = 'gpt-4'
-        self.mock_user.llm_base_url = 'https://api.openai.com/v1'
-        self.mock_user.llm_api_key = 'test_api_key'
+        self.mock_user.id = "test_user_123"
+        self.mock_user.llm_model = "gpt-4"
+        self.mock_user.llm_base_url = "https://api.openai.com/v1"
+        self.mock_user.llm_api_key = "test_api_key"
         self.mock_user.confirmation_mode = False
         self.mock_user.search_api_key = None
         self.mock_user.condenser_max_size = None
@@ -2242,7 +2238,7 @@ class TestPluginHandling:
         assert result is None
 
         # Test with initial message but None plugins
-        initial_msg = SendMessageRequest(content=[TextContent(text='Hello world')])
+        initial_msg = SendMessageRequest(content=[TextContent(text="Hello world")])
         result = self.service._construct_initial_message_with_plugin_params(
             initial_msg, None
         )
@@ -2256,7 +2252,7 @@ class TestPluginHandling:
         )
 
         # Plugin with no parameters
-        plugins = [PluginSpec(source='github:owner/repo')]
+        plugins = [PluginSpec(source="github:owner/repo")]
 
         # Test with None initial message
         result = self.service._construct_initial_message_with_plugin_params(
@@ -2265,7 +2261,7 @@ class TestPluginHandling:
         assert result is None
 
         # Test with initial message
-        initial_msg = SendMessageRequest(content=[TextContent(text='Hello world')])
+        initial_msg = SendMessageRequest(content=[TextContent(text="Hello world")])
         result = self.service._construct_initial_message_with_plugin_params(
             initial_msg, plugins
         )
@@ -2280,8 +2276,8 @@ class TestPluginHandling:
 
         plugins = [
             PluginSpec(
-                source='github:owner/repo',
-                parameters={'api_key': 'test123', 'debug': True},
+                source="github:owner/repo",
+                parameters={"api_key": "test123", "debug": True},
             )
         ]
 
@@ -2292,9 +2288,9 @@ class TestPluginHandling:
         assert result is not None
         assert len(result.content) == 1
         assert isinstance(result.content[0], TextContent)
-        assert 'Plugin Configuration Parameters:' in result.content[0].text
-        assert '- api_key: test123' in result.content[0].text
-        assert '- debug: True' in result.content[0].text
+        assert "Plugin Configuration Parameters:" in result.content[0].text
+        assert "- api_key: test123" in result.content[0].text
+        assert "- debug: True" in result.content[0].text
         assert result.run is True
 
     def test_construct_initial_message_with_plugin_params_appends_to_message(self):
@@ -2305,14 +2301,14 @@ class TestPluginHandling:
         )
 
         initial_msg = SendMessageRequest(
-            content=[TextContent(text='Please analyze this codebase')],
+            content=[TextContent(text="Please analyze this codebase")],
             run=False,
         )
         plugins = [
             PluginSpec(
-                source='github:owner/repo',
-                ref='v1.0.0',
-                parameters={'target_dir': '/src', 'verbose': True},
+                source="github:owner/repo",
+                ref="v1.0.0",
+                parameters={"target_dir": "/src", "verbose": True},
             )
         ]
 
@@ -2323,10 +2319,10 @@ class TestPluginHandling:
         assert result is not None
         assert len(result.content) == 1
         text = result.content[0].text
-        assert text.startswith('Please analyze this codebase')
-        assert 'Plugin Configuration Parameters:' in text
-        assert '- target_dir: /src' in text
-        assert '- verbose: True' in text
+        assert text.startswith("Please analyze this codebase")
+        assert "Plugin Configuration Parameters:" in text
+        assert "- target_dir: /src" in text
+        assert "- verbose: True" in text
         assert result.run is False
 
     def test_construct_initial_message_with_plugin_params_preserves_role(self):
@@ -2337,17 +2333,17 @@ class TestPluginHandling:
         )
 
         initial_msg = SendMessageRequest(
-            role='system',
-            content=[TextContent(text='System message')],
+            role="system",
+            content=[TextContent(text="System message")],
         )
-        plugins = [PluginSpec(source='github:owner/repo', parameters={'key': 'value'})]
+        plugins = [PluginSpec(source="github:owner/repo", parameters={"key": "value"})]
 
         result = self.service._construct_initial_message_with_plugin_params(
             initial_msg, plugins
         )
 
         assert result is not None
-        assert result.role == 'system'
+        assert result.role == "system"
 
     def test_construct_initial_message_with_plugin_params_empty_content(self):
         """Test _construct_initial_message_with_plugin_params handles empty content list."""
@@ -2357,7 +2353,7 @@ class TestPluginHandling:
         )
 
         initial_msg = SendMessageRequest(content=[])
-        plugins = [PluginSpec(source='github:owner/repo', parameters={'key': 'value'})]
+        plugins = [PluginSpec(source="github:owner/repo", parameters={"key": "value"})]
 
         result = self.service._construct_initial_message_with_plugin_params(
             initial_msg, plugins
@@ -2366,7 +2362,7 @@ class TestPluginHandling:
         assert result is not None
         assert len(result.content) == 1
         assert isinstance(result.content[0], TextContent)
-        assert 'Plugin Configuration Parameters:' in result.content[0].text
+        assert "Plugin Configuration Parameters:" in result.content[0].text
 
     def test_construct_initial_message_with_multiple_plugins(self):
         """Test _construct_initial_message_with_plugin_params handles multiple plugins."""
@@ -2377,12 +2373,12 @@ class TestPluginHandling:
 
         plugins = [
             PluginSpec(
-                source='github:owner/plugin1',
-                parameters={'key1': 'value1'},
+                source="github:owner/plugin1",
+                parameters={"key1": "value1"},
             ),
             PluginSpec(
-                source='github:owner/plugin2',
-                parameters={'key2': 'value2'},
+                source="github:owner/plugin2",
+                parameters={"key2": "value2"},
             ),
         ]
 
@@ -2394,12 +2390,12 @@ class TestPluginHandling:
         assert len(result.content) == 1
         assert isinstance(result.content[0], TextContent)
         text = result.content[0].text
-        assert 'Plugin Configuration Parameters:' in text
+        assert "Plugin Configuration Parameters:" in text
         # Multiple plugins should show grouped by plugin name
-        assert 'plugin1' in text
-        assert 'plugin2' in text
-        assert 'key1: value1' in text
-        assert 'key2: value2' in text
+        assert "plugin1" in text
+        assert "plugin2" in text
+        assert "key1: value1" in text
+        assert "key2: value2" in text
 
     @pytest.mark.asyncio
     async def test_finalize_conversation_request_with_plugins(self):
@@ -2411,8 +2407,8 @@ class TestPluginHandling:
         # Arrange
         mock_agent = Mock(spec=Agent)
         mock_llm = Mock(spec=LLM)
-        mock_llm.model = 'gpt-4'
-        mock_llm.usage_id = 'agent'
+        mock_llm.model = "gpt-4"
+        mock_llm.usage_id = "agent"
         mock_agent.llm = mock_llm
         mock_agent.condenser = None
 
@@ -2421,14 +2417,14 @@ class TestPluginHandling:
         mock_updated_agent.condenser = None
         mock_agent.model_copy = Mock(return_value=mock_updated_agent)
 
-        workspace = LocalWorkspace(working_dir='/test')
-        secrets = {'test': StaticSecret(value='secret')}
+        workspace = LocalWorkspace(working_dir="/test")
+        secrets = {"test": StaticSecret(value="secret")}
 
         plugins = [
             PluginSpec(
-                source='github:owner/my-plugin',
-                ref='v1.0.0',
-                parameters={'api_key': 'test123'},
+                source="github:owner/my-plugin",
+                ref="v1.0.0",
+                parameters={"api_key": "test123"},
             )
         ]
 
@@ -2443,7 +2439,7 @@ class TestPluginHandling:
             self.mock_sandbox,
             None,
             None,
-            '/test/dir',
+            "/test/dir",
             plugins=plugins,
         )
 
@@ -2451,14 +2447,14 @@ class TestPluginHandling:
         assert isinstance(result, StartConversationRequest)
         assert result.plugins is not None
         assert len(result.plugins) == 1
-        assert result.plugins[0].source == 'github:owner/my-plugin'
-        assert result.plugins[0].ref == 'v1.0.0'
+        assert result.plugins[0].source == "github:owner/my-plugin"
+        assert result.plugins[0].ref == "v1.0.0"
         # Also verify initial message contains plugin params
         assert result.initial_message is not None
         assert (
-            'Plugin Configuration Parameters:' in result.initial_message.content[0].text
+            "Plugin Configuration Parameters:" in result.initial_message.content[0].text
         )
-        assert '- api_key: test123' in result.initial_message.content[0].text
+        assert "- api_key: test123" in result.initial_message.content[0].text
 
     @pytest.mark.asyncio
     async def test_finalize_conversation_request_without_plugins(self):
@@ -2466,8 +2462,8 @@ class TestPluginHandling:
         # Arrange
         mock_agent = Mock(spec=Agent)
         mock_llm = Mock(spec=LLM)
-        mock_llm.model = 'gpt-4'
-        mock_llm.usage_id = 'agent'
+        mock_llm.model = "gpt-4"
+        mock_llm.usage_id = "agent"
         mock_agent.llm = mock_llm
         mock_agent.condenser = None
 
@@ -2476,7 +2472,7 @@ class TestPluginHandling:
         mock_updated_agent.condenser = None
         mock_agent.model_copy = Mock(return_value=mock_updated_agent)
 
-        workspace = LocalWorkspace(working_dir='/test')
+        workspace = LocalWorkspace(working_dir="/test")
         secrets = {}
 
         # Act
@@ -2490,7 +2486,7 @@ class TestPluginHandling:
             self.mock_sandbox,
             None,
             None,
-            '/test/dir',
+            "/test/dir",
             plugins=None,
         )
 
@@ -2508,8 +2504,8 @@ class TestPluginHandling:
         # Arrange
         mock_agent = Mock(spec=Agent)
         mock_llm = Mock(spec=LLM)
-        mock_llm.model = 'gpt-4'
-        mock_llm.usage_id = 'agent'
+        mock_llm.model = "gpt-4"
+        mock_llm.usage_id = "agent"
         mock_agent.llm = mock_llm
         mock_agent.condenser = None
 
@@ -2518,11 +2514,11 @@ class TestPluginHandling:
         mock_updated_agent.condenser = None
         mock_agent.model_copy = Mock(return_value=mock_updated_agent)
 
-        workspace = LocalWorkspace(working_dir='/test')
+        workspace = LocalWorkspace(working_dir="/test")
         secrets = {}
 
         # Plugin without ref or parameters
-        plugins = [PluginSpec(source='github:owner/my-plugin')]
+        plugins = [PluginSpec(source="github:owner/my-plugin")]
 
         # Act
         result = await self.service._finalize_conversation_request(
@@ -2535,7 +2531,7 @@ class TestPluginHandling:
             self.mock_sandbox,
             None,
             None,
-            '/test/dir',
+            "/test/dir",
             plugins=plugins,
         )
 
@@ -2543,7 +2539,7 @@ class TestPluginHandling:
         assert isinstance(result, StartConversationRequest)
         assert result.plugins is not None
         assert len(result.plugins) == 1
-        assert result.plugins[0].source == 'github:owner/my-plugin'
+        assert result.plugins[0].source == "github:owner/my-plugin"
         assert result.plugins[0].ref is None
         # No parameters, so initial message should be None
         assert result.initial_message is None
@@ -2558,8 +2554,8 @@ class TestPluginHandling:
         # Arrange
         mock_agent = Mock(spec=Agent)
         mock_llm = Mock(spec=LLM)
-        mock_llm.model = 'gpt-4'
-        mock_llm.usage_id = 'agent'
+        mock_llm.model = "gpt-4"
+        mock_llm.usage_id = "agent"
         mock_agent.llm = mock_llm
         mock_agent.condenser = None
 
@@ -2568,15 +2564,15 @@ class TestPluginHandling:
         mock_updated_agent.condenser = None
         mock_agent.model_copy = Mock(return_value=mock_updated_agent)
 
-        workspace = LocalWorkspace(working_dir='/test')
+        workspace = LocalWorkspace(working_dir="/test")
         secrets = {}
 
         # Plugin with repo_path (for marketplace repos containing multiple plugins)
         plugins = [
             PluginSpec(
-                source='github:owner/marketplace-repo',
-                ref='main',
-                repo_path='plugins/city-weather',
+                source="github:owner/marketplace-repo",
+                ref="main",
+                repo_path="plugins/city-weather",
             )
         ]
 
@@ -2591,7 +2587,7 @@ class TestPluginHandling:
             self.mock_sandbox,
             None,
             None,
-            '/test/dir',
+            "/test/dir",
             plugins=plugins,
         )
 
@@ -2599,9 +2595,9 @@ class TestPluginHandling:
         assert isinstance(result, StartConversationRequest)
         assert result.plugins is not None
         assert len(result.plugins) == 1
-        assert result.plugins[0].source == 'github:owner/marketplace-repo'
-        assert result.plugins[0].ref == 'main'
-        assert result.plugins[0].repo_path == 'plugins/city-weather'
+        assert result.plugins[0].source == "github:owner/marketplace-repo"
+        assert result.plugins[0].ref == "main"
+        assert result.plugins[0].repo_path == "plugins/city-weather"
 
     @pytest.mark.asyncio
     async def test_finalize_conversation_request_multiple_plugins(self):
@@ -2613,8 +2609,8 @@ class TestPluginHandling:
         # Arrange
         mock_agent = Mock(spec=Agent)
         mock_llm = Mock(spec=LLM)
-        mock_llm.model = 'gpt-4'
-        mock_llm.usage_id = 'agent'
+        mock_llm.model = "gpt-4"
+        mock_llm.usage_id = "agent"
         mock_agent.llm = mock_llm
         mock_agent.condenser = None
 
@@ -2623,17 +2619,17 @@ class TestPluginHandling:
         mock_updated_agent.condenser = None
         mock_agent.model_copy = Mock(return_value=mock_updated_agent)
 
-        workspace = LocalWorkspace(working_dir='/test')
+        workspace = LocalWorkspace(working_dir="/test")
         secrets = {}
 
         # Multiple plugins
         plugins = [
-            PluginSpec(source='github:owner/security-plugin', ref='v2.0.0'),
+            PluginSpec(source="github:owner/security-plugin", ref="v2.0.0"),
             PluginSpec(
-                source='github:owner/monorepo',
-                repo_path='plugins/logging',
+                source="github:owner/monorepo",
+                repo_path="plugins/logging",
             ),
-            PluginSpec(source='/local/path/to/plugin'),
+            PluginSpec(source="/local/path/to/plugin"),
         ]
 
         # Act
@@ -2647,7 +2643,7 @@ class TestPluginHandling:
             self.mock_sandbox,
             None,
             None,
-            '/test/dir',
+            "/test/dir",
             plugins=plugins,
         )
 
@@ -2655,11 +2651,11 @@ class TestPluginHandling:
         assert isinstance(result, StartConversationRequest)
         assert result.plugins is not None
         assert len(result.plugins) == 3
-        assert result.plugins[0].source == 'github:owner/security-plugin'
-        assert result.plugins[0].ref == 'v2.0.0'
-        assert result.plugins[1].source == 'github:owner/monorepo'
-        assert result.plugins[1].repo_path == 'plugins/logging'
-        assert result.plugins[2].source == '/local/path/to/plugin'
+        assert result.plugins[0].source == "github:owner/security-plugin"
+        assert result.plugins[0].ref == "v2.0.0"
+        assert result.plugins[1].source == "github:owner/monorepo"
+        assert result.plugins[1].repo_path == "plugins/logging"
+        assert result.plugins[2].source == "/local/path/to/plugin"
 
     @pytest.mark.asyncio
     async def test_build_start_conversation_request_for_user_with_plugins(self):
@@ -2676,9 +2672,9 @@ class TestPluginHandling:
 
         plugins = [
             PluginSpec(
-                source='https://github.com/org/plugin.git',
-                ref='main',
-                parameters={'config_file': 'custom.yaml'},
+                source="https://github.com/org/plugin.git",
+                ref="main",
+                parameters={"config_file": "custom.yaml"},
             )
         ]
 
@@ -2692,14 +2688,14 @@ class TestPluginHandling:
             None,
             None,
             None,
-            '/workspace',
+            "/workspace",
             plugins=plugins,
         )
 
         # Assert
         mock_finalize.assert_called_once()
         call_kwargs = mock_finalize.call_args.kwargs
-        assert call_kwargs['plugins'] == plugins
+        assert call_kwargs["plugins"] == plugins
 
     @pytest.mark.asyncio
     async def test_build_start_conversation_request_for_user_without_plugins(self):
@@ -2720,13 +2716,13 @@ class TestPluginHandling:
             None,
             None,
             None,
-            '/workspace',
+            "/workspace",
         )
 
         # Assert
         mock_finalize.assert_called_once()
         call_kwargs = mock_finalize.call_args.kwargs
-        assert call_kwargs.get('plugins') is None
+        assert call_kwargs.get("plugins") is None
 
 
 class TestPluginSpecModel:
@@ -2739,16 +2735,16 @@ class TestPluginSpecModel:
         )
 
         plugin = PluginSpec(
-            source='github:owner/repo',
-            ref='v1.0.0',
-            repo_path='plugins/my-plugin',
-            parameters={'key1': 'value1', 'key2': 123, 'key3': True},
+            source="github:owner/repo",
+            ref="v1.0.0",
+            repo_path="plugins/my-plugin",
+            parameters={"key1": "value1", "key2": 123, "key3": True},
         )
 
-        assert plugin.source == 'github:owner/repo'
-        assert plugin.ref == 'v1.0.0'
-        assert plugin.repo_path == 'plugins/my-plugin'
-        assert plugin.parameters == {'key1': 'value1', 'key2': 123, 'key3': True}
+        assert plugin.source == "github:owner/repo"
+        assert plugin.ref == "v1.0.0"
+        assert plugin.repo_path == "plugins/my-plugin"
+        assert plugin.parameters == {"key1": "value1", "key2": 123, "key3": True}
 
     def test_plugin_spec_with_only_source(self):
         """Test PluginSpec with only source provided."""
@@ -2756,9 +2752,9 @@ class TestPluginSpecModel:
             PluginSpec,
         )
 
-        plugin = PluginSpec(source='https://github.com/owner/repo.git')
+        plugin = PluginSpec(source="https://github.com/owner/repo.git")
 
-        assert plugin.source == 'https://github.com/owner/repo.git'
+        assert plugin.source == "https://github.com/owner/repo.git"
         assert plugin.ref is None
         assert plugin.repo_path is None
         assert plugin.parameters is None
@@ -2770,18 +2766,18 @@ class TestPluginSpecModel:
         )
 
         plugin = PluginSpec(
-            source='github:owner/repo',
-            ref='main',
-            repo_path='plugins/my-plugin',
-            parameters={'debug': True},
+            source="github:owner/repo",
+            ref="main",
+            repo_path="plugins/my-plugin",
+            parameters={"debug": True},
         )
 
         json_data = plugin.model_dump()
         assert json_data == {
-            'source': 'github:owner/repo',
-            'ref': 'main',
-            'repo_path': 'plugins/my-plugin',
-            'parameters': {'debug': True},
+            "source": "github:owner/repo",
+            "ref": "main",
+            "repo_path": "plugins/my-plugin",
+            "parameters": {"debug": True},
         }
 
     def test_plugin_spec_deserialization(self):
@@ -2791,18 +2787,18 @@ class TestPluginSpecModel:
         )
 
         data = {
-            'source': 'github:owner/repo',
-            'ref': 'v2.0.0',
-            'repo_path': 'plugins/weather',
-            'parameters': {'timeout': 30},
+            "source": "github:owner/repo",
+            "ref": "v2.0.0",
+            "repo_path": "plugins/weather",
+            "parameters": {"timeout": 30},
         }
 
         plugin = PluginSpec.model_validate(data)
 
-        assert plugin.source == 'github:owner/repo'
-        assert plugin.ref == 'v2.0.0'
-        assert plugin.repo_path == 'plugins/weather'
-        assert plugin.parameters == {'timeout': 30}
+        assert plugin.source == "github:owner/repo"
+        assert plugin.ref == "v2.0.0"
+        assert plugin.repo_path == "plugins/weather"
+        assert plugin.parameters == {"timeout": 30}
 
     def test_plugin_spec_display_name_github_format(self):
         """Test display_name extracts repo name from github:owner/repo format."""
@@ -2810,8 +2806,8 @@ class TestPluginSpecModel:
             PluginSpec,
         )
 
-        plugin = PluginSpec(source='github:owner/my-plugin')
-        assert plugin.display_name == 'my-plugin'
+        plugin = PluginSpec(source="github:owner/my-plugin")
+        assert plugin.display_name == "my-plugin"
 
     def test_plugin_spec_display_name_git_url(self):
         """Test display_name extracts repo name from git URL."""
@@ -2819,8 +2815,8 @@ class TestPluginSpecModel:
             PluginSpec,
         )
 
-        plugin = PluginSpec(source='https://github.com/owner/repo.git')
-        assert plugin.display_name == 'repo.git'
+        plugin = PluginSpec(source="https://github.com/owner/repo.git")
+        assert plugin.display_name == "repo.git"
 
     def test_plugin_spec_display_name_local_path(self):
         """Test display_name extracts directory name from local path."""
@@ -2828,8 +2824,8 @@ class TestPluginSpecModel:
             PluginSpec,
         )
 
-        plugin = PluginSpec(source='/local/path/to/plugin')
-        assert plugin.display_name == 'plugin'
+        plugin = PluginSpec(source="/local/path/to/plugin")
+        assert plugin.display_name == "plugin"
 
     def test_plugin_spec_display_name_no_slash(self):
         """Test display_name returns source as-is when no slash present."""
@@ -2837,8 +2833,8 @@ class TestPluginSpecModel:
             PluginSpec,
         )
 
-        plugin = PluginSpec(source='local-plugin')
-        assert plugin.display_name == 'local-plugin'
+        plugin = PluginSpec(source="local-plugin")
+        assert plugin.display_name == "local-plugin"
 
     def test_plugin_spec_format_params_as_text(self):
         """Test format_params_as_text formats parameters as text."""
@@ -2847,12 +2843,12 @@ class TestPluginSpecModel:
         )
 
         plugin = PluginSpec(
-            source='github:owner/repo',
-            parameters={'key1': 'value1', 'key2': 123},
+            source="github:owner/repo",
+            parameters={"key1": "value1", "key2": 123},
         )
 
         result = plugin.format_params_as_text()
-        assert result == '- key1: value1\n- key2: 123'
+        assert result == "- key1: value1\n- key2: 123"
 
     def test_plugin_spec_format_params_as_text_with_indent(self):
         """Test format_params_as_text with custom indent."""
@@ -2861,12 +2857,12 @@ class TestPluginSpecModel:
         )
 
         plugin = PluginSpec(
-            source='github:owner/repo',
-            parameters={'debug': True},
+            source="github:owner/repo",
+            parameters={"debug": True},
         )
 
-        result = plugin.format_params_as_text(indent='  ')
-        assert result == '  - debug: True'
+        result = plugin.format_params_as_text(indent="  ")
+        assert result == "  - debug: True"
 
     def test_plugin_spec_format_params_as_text_no_params(self):
         """Test format_params_as_text returns None when no parameters."""
@@ -2874,7 +2870,7 @@ class TestPluginSpecModel:
             PluginSpec,
         )
 
-        plugin = PluginSpec(source='github:owner/repo')
+        plugin = PluginSpec(source="github:owner/repo")
         assert plugin.format_params_as_text() is None
 
     def test_plugin_spec_inherits_repo_path_validation(self):
@@ -2886,12 +2882,12 @@ class TestPluginSpecModel:
         )
 
         # Should reject absolute paths
-        with pytest.raises(ValueError, match='must be relative'):
-            PluginSpec(source='github:owner/repo', repo_path='/absolute/path')
+        with pytest.raises(ValueError, match="must be relative"):
+            PluginSpec(source="github:owner/repo", repo_path="/absolute/path")
 
         # Should reject parent traversal
         with pytest.raises(ValueError, match="cannot contain '..'"):
-            PluginSpec(source='github:owner/repo', repo_path='../parent/path')
+            PluginSpec(source="github:owner/repo", repo_path="../parent/path")
 
 
 class TestAppConversationStartRequestWithPlugins:
@@ -2906,22 +2902,22 @@ class TestAppConversationStartRequestWithPlugins:
 
         plugins = [
             PluginSpec(
-                source='github:owner/my-plugin',
-                ref='v1.0.0',
-                parameters={'api_key': 'test'},
+                source="github:owner/my-plugin",
+                ref="v1.0.0",
+                parameters={"api_key": "test"},
             )
         ]
 
         request = AppConversationStartRequest(
-            title='Test conversation',
+            title="Test conversation",
             plugins=plugins,
         )
 
         assert request.plugins is not None
         assert len(request.plugins) == 1
-        assert request.plugins[0].source == 'github:owner/my-plugin'
-        assert request.plugins[0].ref == 'v1.0.0'
-        assert request.plugins[0].parameters == {'api_key': 'test'}
+        assert request.plugins[0].source == "github:owner/my-plugin"
+        assert request.plugins[0].ref == "v1.0.0"
+        assert request.plugins[0].parameters == {"api_key": "test"}
 
     def test_start_request_without_plugins(self):
         """Test AppConversationStartRequest without plugins field (backwards compatible)."""
@@ -2930,7 +2926,7 @@ class TestAppConversationStartRequestWithPlugins:
         )
 
         request = AppConversationStartRequest(
-            title='Test conversation',
+            title="Test conversation",
         )
 
         assert request.plugins is None
@@ -2942,14 +2938,14 @@ class TestAppConversationStartRequestWithPlugins:
             PluginSpec,
         )
 
-        plugins = [PluginSpec(source='github:owner/repo')]
+        plugins = [PluginSpec(source="github:owner/repo")]
         request = AppConversationStartRequest(plugins=plugins)
 
         json_data = request.model_dump()
 
-        assert 'plugins' in json_data
-        assert len(json_data['plugins']) == 1
-        assert json_data['plugins'][0]['source'] == 'github:owner/repo'
+        assert "plugins" in json_data
+        assert len(json_data["plugins"]) == 1
+        assert json_data["plugins"][0]["source"] == "github:owner/repo"
 
     def test_start_request_deserialization_with_plugins(self):
         """Test AppConversationStartRequest deserialization from JSON with plugins."""
@@ -2958,12 +2954,12 @@ class TestAppConversationStartRequestWithPlugins:
         )
 
         data = {
-            'title': 'Test',
-            'plugins': [
+            "title": "Test",
+            "plugins": [
                 {
-                    'source': 'github:owner/plugin',
-                    'ref': 'main',
-                    'parameters': {'key': 'value'},
+                    "source": "github:owner/plugin",
+                    "ref": "main",
+                    "parameters": {"key": "value"},
                 },
             ],
         }
@@ -2972,9 +2968,9 @@ class TestAppConversationStartRequestWithPlugins:
 
         assert request.plugins is not None
         assert len(request.plugins) == 1
-        assert request.plugins[0].source == 'github:owner/plugin'
-        assert request.plugins[0].ref == 'main'
-        assert request.plugins[0].parameters == {'key': 'value'}
+        assert request.plugins[0].source == "github:owner/plugin"
+        assert request.plugins[0].ref == "main"
+        assert request.plugins[0].parameters == {"key": "value"}
 
     def test_start_request_with_multiple_plugins(self):
         """Test AppConversationStartRequest with multiple plugins."""
@@ -2984,18 +2980,18 @@ class TestAppConversationStartRequestWithPlugins:
         )
 
         plugins = [
-            PluginSpec(source='github:owner/plugin1', ref='v1.0.0'),
-            PluginSpec(source='github:owner/plugin2', repo_path='plugins/sub'),
-            PluginSpec(source='/local/path'),
+            PluginSpec(source="github:owner/plugin1", ref="v1.0.0"),
+            PluginSpec(source="github:owner/plugin2", repo_path="plugins/sub"),
+            PluginSpec(source="/local/path"),
         ]
 
         request = AppConversationStartRequest(
-            title='Test conversation',
+            title="Test conversation",
             plugins=plugins,
         )
 
         assert request.plugins is not None
         assert len(request.plugins) == 3
-        assert request.plugins[0].source == 'github:owner/plugin1'
-        assert request.plugins[1].repo_path == 'plugins/sub'
-        assert request.plugins[2].source == '/local/path'
+        assert request.plugins[0].source == "github:owner/plugin1"
+        assert request.plugins[1].repo_path == "plugins/sub"
+        assert request.plugins[2].source == "/local/path"

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -1989,6 +1989,190 @@ class TestLiveStatusAppConversationService:
         assert stdio_server['command'] == 'npx'
         assert stdio_server['env'] == {'TOKEN': 'value'}
 
+    @pytest.mark.asyncio
+    @patch(
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace'
+    )
+    async def test_start_app_conversation_exception_uses_extract_error_detail(
+        self, mock_remote_workspace_class
+    ):
+        """Test that _start_app_conversation uses extract_error_detail for exception handling."""
+        import httpx
+
+        from openhands.app_server.app_conversation.app_conversation_models import (
+            AppConversationStartTaskStatus,
+        )
+
+        # Arrange
+        conversation_id = uuid4()
+
+        # Mock user context
+        self.mock_user_context.get_user_id = AsyncMock(return_value='test_user_123')
+        self.mock_user_context.get_user_info = AsyncMock(return_value=self.mock_user)
+
+        # Mock sandbox and sandbox spec
+        mock_sandbox_spec = Mock(spec=SandboxSpecInfo)
+        mock_sandbox_spec.working_dir = '/test/workspace'
+        self.mock_sandbox.sandbox_spec_id = str(uuid4())
+        self.mock_sandbox.id = str(uuid4())
+        self.mock_sandbox.session_api_key = 'test_session_key'
+        exposed_url = ExposedUrl(
+            name=AGENT_SERVER, url='http://agent-server:8000', port=60000
+        )
+        self.mock_sandbox.exposed_urls = [exposed_url]
+
+        self.mock_sandbox_service.get_sandbox = AsyncMock(
+            return_value=self.mock_sandbox
+        )
+        self.mock_sandbox_spec_service.get_sandbox_spec = AsyncMock(
+            return_value=mock_sandbox_spec
+        )
+
+        # Mock remote workspace
+        mock_remote_workspace = Mock()
+        mock_remote_workspace_class.return_value = mock_remote_workspace
+
+        # Mock the wait for sandbox and setup scripts
+        async def mock_wait_for_sandbox(task):
+            task.sandbox_id = self.mock_sandbox.id
+            yield task
+
+        async def mock_run_setup_scripts(task, sandbox, workspace, agent_server_url):
+            yield task
+
+        self.service._wait_for_sandbox_start = mock_wait_for_sandbox
+        self.service.run_setup_scripts = mock_run_setup_scripts
+
+        # Mock build start conversation request
+        mock_agent = Mock(spec=Agent)
+        mock_agent.llm = Mock(spec=LLM)
+        mock_agent.llm.model = 'gpt-4'
+        mock_start_request = Mock(spec=StartConversationRequest)
+        mock_start_request.agent = mock_agent
+        mock_start_request.model_dump.return_value = {'test': 'data'}
+
+        self.service._build_start_conversation_request_for_user = AsyncMock(
+            return_value=mock_start_request
+        )
+
+        # Create an httpx.HTTPStatusError to simulate an MCP auth failure
+        mock_response = httpx.Response(
+            500,
+            json={
+                'detail': 'Internal Server Error',
+                'exception': "Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'",
+            },
+        )
+        mock_response._request = httpx.Request(
+            'POST', 'http://agent-server:8000/api/conversations'
+        )
+        http_error = httpx.HTTPStatusError(
+            message="Server error '500 Internal Server Error'",
+            request=mock_response.request,
+            response=mock_response,
+        )
+
+        # Make the HTTP post call raise the exception
+        self.mock_httpx_client.post = AsyncMock(side_effect=http_error)
+
+        # Create request
+        request = AppConversationStartRequest()
+
+        # Act
+        tasks = []
+        async for task in self.service._start_app_conversation(request):
+            tasks.append(task)
+
+        # Assert
+        final_task = tasks[-1]
+        assert final_task.status == AppConversationStartTaskStatus.ERROR
+        # The extract_error_detail function should extract the 'exception' field from JSON
+        assert 'mcp.atlassian.com' in final_task.detail
+        assert '401 Unauthorized' in final_task.detail
+
+    @pytest.mark.asyncio
+    @patch(
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace'
+    )
+    async def test_start_app_conversation_generic_exception_uses_extract_error_detail(
+        self, mock_remote_workspace_class
+    ):
+        """Test that _start_app_conversation uses extract_error_detail for generic exceptions."""
+        from openhands.app_server.app_conversation.app_conversation_models import (
+            AppConversationStartTaskStatus,
+        )
+
+        # Arrange
+        conversation_id = uuid4()
+
+        # Mock user context
+        self.mock_user_context.get_user_id = AsyncMock(return_value='test_user_123')
+        self.mock_user_context.get_user_info = AsyncMock(return_value=self.mock_user)
+
+        # Mock sandbox and sandbox spec
+        mock_sandbox_spec = Mock(spec=SandboxSpecInfo)
+        mock_sandbox_spec.working_dir = '/test/workspace'
+        self.mock_sandbox.sandbox_spec_id = str(uuid4())
+        self.mock_sandbox.id = str(uuid4())
+        self.mock_sandbox.session_api_key = 'test_session_key'
+        exposed_url = ExposedUrl(
+            name=AGENT_SERVER, url='http://agent-server:8000', port=60000
+        )
+        self.mock_sandbox.exposed_urls = [exposed_url]
+
+        self.mock_sandbox_service.get_sandbox = AsyncMock(
+            return_value=self.mock_sandbox
+        )
+        self.mock_sandbox_spec_service.get_sandbox_spec = AsyncMock(
+            return_value=mock_sandbox_spec
+        )
+
+        # Mock remote workspace
+        mock_remote_workspace = Mock()
+        mock_remote_workspace_class.return_value = mock_remote_workspace
+
+        # Mock the wait for sandbox and setup scripts
+        async def mock_wait_for_sandbox(task):
+            task.sandbox_id = self.mock_sandbox.id
+            yield task
+
+        async def mock_run_setup_scripts(task, sandbox, workspace, agent_server_url):
+            yield task
+
+        self.service._wait_for_sandbox_start = mock_wait_for_sandbox
+        self.service.run_setup_scripts = mock_run_setup_scripts
+
+        # Mock build start conversation request
+        mock_agent = Mock(spec=Agent)
+        mock_agent.llm = Mock(spec=LLM)
+        mock_agent.llm.model = 'gpt-4'
+        mock_start_request = Mock(spec=StartConversationRequest)
+        mock_start_request.agent = mock_agent
+        mock_start_request.model_dump.return_value = {'test': 'data'}
+
+        self.service._build_start_conversation_request_for_user = AsyncMock(
+            return_value=mock_start_request
+        )
+
+        # Make the HTTP post call raise a generic exception
+        self.mock_httpx_client.post = AsyncMock(
+            side_effect=RuntimeError('Connection timeout')
+        )
+
+        # Create request
+        request = AppConversationStartRequest()
+
+        # Act
+        tasks = []
+        async for task in self.service._start_app_conversation(request):
+            tasks.append(task)
+
+        # Assert
+        final_task = tasks[-1]
+        assert final_task.status == AppConversationStartTaskStatus.ERROR
+        # For non-httpx exceptions, extract_error_detail returns str(exc)
+        assert 'Connection timeout' in final_task.detail
+
 
 class TestPluginHandling:
     """Test cases for plugin-related functionality in LiveStatusAppConversationService."""

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -44,14 +44,14 @@ from openhands.server.types import AppMode
 from openhands.storage.data_models.conversation_metadata import ConversationTrigger
 
 # Env var used by openhands SDK LLM to skip context-window validation (e.g. for gpt-4 in tests)
-_ALLOW_SHORT_CONTEXT_WINDOWS = "ALLOW_SHORT_CONTEXT_WINDOWS"
+_ALLOW_SHORT_CONTEXT_WINDOWS = 'ALLOW_SHORT_CONTEXT_WINDOWS'
 
 
 @pytest.fixture(autouse=True)
 def allow_short_context_windows():
     """Allow small context windows so unit tests can create LLM with gpt-4 etc."""
     old = os.environ.pop(_ALLOW_SHORT_CONTEXT_WINDOWS, None)
-    os.environ[_ALLOW_SHORT_CONTEXT_WINDOWS] = "true"
+    os.environ[_ALLOW_SHORT_CONTEXT_WINDOWS] = 'true'
     try:
         yield
     finally:
@@ -93,22 +93,22 @@ class TestLiveStatusAppConversationService:
             sandbox_startup_timeout=30,
             sandbox_startup_poll_frequency=1,
             httpx_client=self.mock_httpx_client,
-            web_url="https://test.example.com",
-            openhands_provider_base_url="https://provider.example.com",
+            web_url='https://test.example.com',
+            openhands_provider_base_url='https://provider.example.com',
             access_token_hard_timeout=None,
-            app_mode="test",
+            app_mode='test',
         )
 
         # Mock user info
         self.mock_user = Mock()
-        self.mock_user.id = "test_user_123"
-        self.mock_user.llm_model = "gpt-4"
-        self.mock_user.llm_base_url = "https://api.openai.com/v1"
-        self.mock_user.llm_api_key = "test_api_key"
+        self.mock_user.id = 'test_user_123'
+        self.mock_user.llm_model = 'gpt-4'
+        self.mock_user.llm_base_url = 'https://api.openai.com/v1'
+        self.mock_user.llm_api_key = 'test_api_key'
         self.mock_user.confirmation_mode = False
         self.mock_user.search_api_key = None  # Default to None
         self.mock_user.condenser_max_size = None  # Default to None
-        self.mock_user.llm_base_url = "https://api.openai.com/v1"
+        self.mock_user.llm_base_url = 'https://api.openai.com/v1'
         self.mock_user.mcp_config = None  # Default to None to avoid error handling path
 
         # Mock sandbox
@@ -121,9 +121,9 @@ class TestLiveStatusAppConversationService:
         suggested_task = SuggestedTask(
             git_provider=ProviderType.GITHUB,
             task_type=TaskType.UNRESOLVED_COMMENTS,
-            repo="owner/repo",
+            repo='owner/repo',
             issue_number=42,
-            title="Handle review comments",
+            title='Handle review comments',
         )
         request = AppConversationStartRequest(suggested_task=suggested_task)
 
@@ -140,9 +140,9 @@ class TestLiveStatusAppConversationService:
 
     def test_apply_suggested_task_raises_if_initial_message_present(self):
         suggested_task = SuggestedTask(
-            repo="foo/bar",
+            repo='foo/bar',
             git_provider=ProviderType.GITHUB,
-            title="Some title",
+            title='Some title',
             task_type=TaskType.OPEN_ISSUE,
             issue_number=123,
         )
@@ -150,32 +150,32 @@ class TestLiveStatusAppConversationService:
         request = AppConversationStartRequest(
             suggested_task=suggested_task,
             initial_message=SendMessageRequest(
-                role="user",
-                content=[TextContent(text="User provided message")],
+                role='user',
+                content=[TextContent(text='User provided message')],
             ),
         )
 
-        with pytest.raises(ValueError, match="initial_message cannot be provided"):
+        with pytest.raises(ValueError, match='initial_message cannot be provided'):
             self.service._apply_suggested_task(request)
 
     def test_apply_suggested_task_raises_if_prompt_empty(self):
         suggested_task = SuggestedTask(
-            repo="foo/bar",
+            repo='foo/bar',
             git_provider=ProviderType.GITHUB,
-            title="Some title",
+            title='Some title',
             task_type=TaskType.OPEN_ISSUE,
             issue_number=123,
         )
         request = AppConversationStartRequest(suggested_task=suggested_task)
 
-        with patch.object(SuggestedTask, "get_prompt_for_task", return_value=""):
-            with pytest.raises(ValueError, match="empty prompt"):
+        with patch.object(SuggestedTask, 'get_prompt_for_task', return_value=''):
+            with pytest.raises(ValueError, match='empty prompt'):
                 self.service._apply_suggested_task(request)
 
     async def test_setup_secrets_for_git_providers_no_provider_tokens(self):
         """Test _setup_secrets_for_git_providers with no provider tokens."""
         # Arrange
-        base_secrets = {"existing": "secret"}
+        base_secrets = {'existing': 'secret'}
         self.mock_user_context.get_secrets.return_value = base_secrets
         self.mock_user_context.get_provider_tokens = AsyncMock(return_value=None)
 
@@ -193,12 +193,12 @@ class TestLiveStatusAppConversationService:
         # Arrange
         base_secrets = {}
         self.mock_user_context.get_secrets.return_value = base_secrets
-        self.mock_jwt_service.create_jws_token.return_value = "test_access_token"
+        self.mock_jwt_service.create_jws_token.return_value = 'test_access_token'
 
         # Mock provider tokens
         provider_tokens = {
-            ProviderType.GITHUB: ProviderToken(token=SecretStr("github_token")),
-            ProviderType.GITLAB: ProviderToken(token=SecretStr("gitlab_token")),
+            ProviderType.GITHUB: ProviderToken(token=SecretStr('github_token')),
+            ProviderType.GITLAB: ProviderToken(token=SecretStr('gitlab_token')),
         }
         self.mock_user_context.get_provider_tokens = AsyncMock(
             return_value=provider_tokens
@@ -208,18 +208,18 @@ class TestLiveStatusAppConversationService:
         result = await self.service._setup_secrets_for_git_providers(self.mock_user)
 
         # Assert
-        assert "GITHUB_TOKEN" in result
-        assert "GITLAB_TOKEN" in result
-        assert isinstance(result["GITHUB_TOKEN"], LookupSecret)
-        assert isinstance(result["GITLAB_TOKEN"], LookupSecret)
+        assert 'GITHUB_TOKEN' in result
+        assert 'GITLAB_TOKEN' in result
+        assert isinstance(result['GITHUB_TOKEN'], LookupSecret)
+        assert isinstance(result['GITLAB_TOKEN'], LookupSecret)
         assert (
-            result["GITHUB_TOKEN"].url
-            == "https://test.example.com/api/v1/webhooks/secrets"
+            result['GITHUB_TOKEN'].url
+            == 'https://test.example.com/api/v1/webhooks/secrets'
         )
-        assert result["GITHUB_TOKEN"].headers["X-Access-Token"] == "test_access_token"
+        assert result['GITHUB_TOKEN'].headers['X-Access-Token'] == 'test_access_token'
         # Verify descriptions are included
-        assert result["GITHUB_TOKEN"].description == "GITHUB authentication token"
-        assert result["GITLAB_TOKEN"].description == "GITLAB authentication token"
+        assert result['GITHUB_TOKEN'].description == 'GITHUB authentication token'
+        assert result['GITLAB_TOKEN'].description == 'GITLAB authentication token'
 
         # Should be called twice, once for each provider
         assert self.mock_jwt_service.create_jws_token.call_count == 2
@@ -228,14 +228,14 @@ class TestLiveStatusAppConversationService:
     async def test_setup_secrets_for_git_providers_with_saas_mode(self):
         """Test _setup_secrets_for_git_providers with SaaS mode uses LookupSecret with X-Access-Token."""
         # Arrange
-        self.service.app_mode = "saas"
+        self.service.app_mode = 'saas'
         base_secrets = {}
         self.mock_user_context.get_secrets.return_value = base_secrets
-        self.mock_jwt_service.create_jws_token.return_value = "test_access_token"
+        self.mock_jwt_service.create_jws_token.return_value = 'test_access_token'
 
         # Mock provider tokens
         provider_tokens = {
-            ProviderType.GITLAB: ProviderToken(token=SecretStr("gitlab_token")),
+            ProviderType.GITLAB: ProviderToken(token=SecretStr('gitlab_token')),
         }
         self.mock_user_context.get_provider_tokens = AsyncMock(
             return_value=provider_tokens
@@ -245,15 +245,15 @@ class TestLiveStatusAppConversationService:
         result = await self.service._setup_secrets_for_git_providers(self.mock_user)
 
         # Assert
-        assert "GITLAB_TOKEN" in result
-        lookup_secret = result["GITLAB_TOKEN"]
+        assert 'GITLAB_TOKEN' in result
+        lookup_secret = result['GITLAB_TOKEN']
         assert isinstance(lookup_secret, LookupSecret)
-        assert "X-Access-Token" in lookup_secret.headers
-        assert lookup_secret.headers["X-Access-Token"] == "test_access_token"
+        assert 'X-Access-Token' in lookup_secret.headers
+        assert lookup_secret.headers['X-Access-Token'] == 'test_access_token'
         # Verify no cookie is included (authentication is via X-Access-Token only)
-        assert "Cookie" not in lookup_secret.headers
+        assert 'Cookie' not in lookup_secret.headers
         # Verify description is included
-        assert lookup_secret.description == "GITLAB authentication token"
+        assert lookup_secret.description == 'GITLAB authentication token'
 
     @pytest.mark.asyncio
     async def test_setup_secrets_for_git_providers_without_web_url(self):
@@ -262,11 +262,11 @@ class TestLiveStatusAppConversationService:
         self.service.web_url = None
         base_secrets = {}
         self.mock_user_context.get_secrets.return_value = base_secrets
-        self.mock_user_context.get_latest_token.return_value = "static_token_value"
+        self.mock_user_context.get_latest_token.return_value = 'static_token_value'
 
         # Mock provider tokens
         provider_tokens = {
-            ProviderType.GITHUB: ProviderToken(token=SecretStr("github_token")),
+            ProviderType.GITHUB: ProviderToken(token=SecretStr('github_token')),
         }
         self.mock_user_context.get_provider_tokens = AsyncMock(
             return_value=provider_tokens
@@ -276,11 +276,11 @@ class TestLiveStatusAppConversationService:
         result = await self.service._setup_secrets_for_git_providers(self.mock_user)
 
         # Assert
-        assert "GITHUB_TOKEN" in result
-        assert isinstance(result["GITHUB_TOKEN"], StaticSecret)
-        assert result["GITHUB_TOKEN"].value.get_secret_value() == "static_token_value"
+        assert 'GITHUB_TOKEN' in result
+        assert isinstance(result['GITHUB_TOKEN'], StaticSecret)
+        assert result['GITHUB_TOKEN'].value.get_secret_value() == 'static_token_value'
         # Verify description is included
-        assert result["GITHUB_TOKEN"].description == "GITHUB authentication token"
+        assert result['GITHUB_TOKEN'].description == 'GITHUB authentication token'
         self.mock_user_context.get_latest_token.assert_called_once_with(
             ProviderType.GITHUB
         )
@@ -296,7 +296,7 @@ class TestLiveStatusAppConversationService:
 
         # Mock provider tokens
         provider_tokens = {
-            ProviderType.GITHUB: ProviderToken(token=SecretStr("github_token")),
+            ProviderType.GITHUB: ProviderToken(token=SecretStr('github_token')),
         }
         self.mock_user_context.get_provider_tokens = AsyncMock(
             return_value=provider_tokens
@@ -306,7 +306,7 @@ class TestLiveStatusAppConversationService:
         result = await self.service._setup_secrets_for_git_providers(self.mock_user)
 
         # Assert
-        assert "GITHUB_TOKEN" not in result
+        assert 'GITHUB_TOKEN' not in result
         assert result == base_secrets
 
     @pytest.mark.asyncio
@@ -315,13 +315,13 @@ class TestLiveStatusAppConversationService:
         # Arrange
         base_secrets = {}
         self.mock_user_context.get_secrets.return_value = base_secrets
-        self.mock_jwt_service.create_jws_token.return_value = "test_access_token"
+        self.mock_jwt_service.create_jws_token.return_value = 'test_access_token'
 
         # Mock provider tokens for multiple providers
         provider_tokens = {
-            ProviderType.GITHUB: ProviderToken(token=SecretStr("github_token")),
-            ProviderType.GITLAB: ProviderToken(token=SecretStr("gitlab_token")),
-            ProviderType.BITBUCKET: ProviderToken(token=SecretStr("bitbucket_token")),
+            ProviderType.GITHUB: ProviderToken(token=SecretStr('github_token')),
+            ProviderType.GITLAB: ProviderToken(token=SecretStr('gitlab_token')),
+            ProviderType.BITBUCKET: ProviderToken(token=SecretStr('bitbucket_token')),
         }
         self.mock_user_context.get_provider_tokens = AsyncMock(
             return_value=provider_tokens
@@ -331,17 +331,17 @@ class TestLiveStatusAppConversationService:
         result = await self.service._setup_secrets_for_git_providers(self.mock_user)
 
         # Assert - verify all secrets have correct descriptions
-        assert "GITHUB_TOKEN" in result
-        assert isinstance(result["GITHUB_TOKEN"], LookupSecret)
-        assert result["GITHUB_TOKEN"].description == "GITHUB authentication token"
+        assert 'GITHUB_TOKEN' in result
+        assert isinstance(result['GITHUB_TOKEN'], LookupSecret)
+        assert result['GITHUB_TOKEN'].description == 'GITHUB authentication token'
 
-        assert "GITLAB_TOKEN" in result
-        assert isinstance(result["GITLAB_TOKEN"], LookupSecret)
-        assert result["GITLAB_TOKEN"].description == "GITLAB authentication token"
+        assert 'GITLAB_TOKEN' in result
+        assert isinstance(result['GITLAB_TOKEN'], LookupSecret)
+        assert result['GITLAB_TOKEN'].description == 'GITLAB authentication token'
 
-        assert "BITBUCKET_TOKEN" in result
-        assert isinstance(result["BITBUCKET_TOKEN"], LookupSecret)
-        assert result["BITBUCKET_TOKEN"].description == "BITBUCKET authentication token"
+        assert 'BITBUCKET_TOKEN' in result
+        assert isinstance(result['BITBUCKET_TOKEN'], LookupSecret)
+        assert result['BITBUCKET_TOKEN'].description == 'BITBUCKET authentication token'
 
     @pytest.mark.asyncio
     async def test_setup_secrets_for_git_providers_static_secret_description(self):
@@ -350,12 +350,12 @@ class TestLiveStatusAppConversationService:
         self.service.web_url = None
         base_secrets = {}
         self.mock_user_context.get_secrets.return_value = base_secrets
-        self.mock_user_context.get_latest_token.return_value = "static_token_value"
+        self.mock_user_context.get_latest_token.return_value = 'static_token_value'
 
         # Mock provider tokens for multiple providers
         provider_tokens = {
-            ProviderType.GITHUB: ProviderToken(token=SecretStr("github_token")),
-            ProviderType.GITLAB: ProviderToken(token=SecretStr("gitlab_token")),
+            ProviderType.GITHUB: ProviderToken(token=SecretStr('github_token')),
+            ProviderType.GITLAB: ProviderToken(token=SecretStr('gitlab_token')),
         }
         self.mock_user_context.get_provider_tokens = AsyncMock(
             return_value=provider_tokens
@@ -365,13 +365,13 @@ class TestLiveStatusAppConversationService:
         result = await self.service._setup_secrets_for_git_providers(self.mock_user)
 
         # Assert - verify StaticSecret objects have descriptions
-        assert "GITHUB_TOKEN" in result
-        assert isinstance(result["GITHUB_TOKEN"], StaticSecret)
-        assert result["GITHUB_TOKEN"].description == "GITHUB authentication token"
+        assert 'GITHUB_TOKEN' in result
+        assert isinstance(result['GITHUB_TOKEN'], StaticSecret)
+        assert result['GITHUB_TOKEN'].description == 'GITHUB authentication token'
 
-        assert "GITLAB_TOKEN" in result
-        assert isinstance(result["GITLAB_TOKEN"], StaticSecret)
-        assert result["GITLAB_TOKEN"].description == "GITLAB authentication token"
+        assert 'GITLAB_TOKEN' in result
+        assert isinstance(result['GITLAB_TOKEN'], StaticSecret)
+        assert result['GITLAB_TOKEN'].description == 'GITLAB authentication token'
 
     @pytest.mark.asyncio
     async def test_setup_secrets_for_git_providers_preserves_custom_secret_descriptions(
@@ -381,23 +381,23 @@ class TestLiveStatusAppConversationService:
         # Arrange
         # Mock custom secrets with descriptions
         custom_secret_with_desc = StaticSecret(
-            value=SecretStr("custom_secret_value"),
-            description="Custom API key for external service",
+            value=SecretStr('custom_secret_value'),
+            description='Custom API key for external service',
         )
         custom_secret_no_desc = StaticSecret(
-            value=SecretStr("another_secret_value"),
+            value=SecretStr('another_secret_value'),
             description=None,
         )
         base_secrets = {
-            "CUSTOM_API_KEY": custom_secret_with_desc,
-            "ANOTHER_SECRET": custom_secret_no_desc,
+            'CUSTOM_API_KEY': custom_secret_with_desc,
+            'ANOTHER_SECRET': custom_secret_no_desc,
         }
         self.mock_user_context.get_secrets.return_value = base_secrets
-        self.mock_jwt_service.create_jws_token.return_value = "test_access_token"
+        self.mock_jwt_service.create_jws_token.return_value = 'test_access_token'
 
         # Mock provider tokens
         provider_tokens = {
-            ProviderType.GITHUB: ProviderToken(token=SecretStr("github_token")),
+            ProviderType.GITHUB: ProviderToken(token=SecretStr('github_token')),
         }
         self.mock_user_context.get_provider_tokens = AsyncMock(
             return_value=provider_tokens
@@ -407,26 +407,26 @@ class TestLiveStatusAppConversationService:
         result = await self.service._setup_secrets_for_git_providers(self.mock_user)
 
         # Assert - verify custom secrets are preserved with their descriptions
-        assert "CUSTOM_API_KEY" in result
-        assert isinstance(result["CUSTOM_API_KEY"], StaticSecret)
+        assert 'CUSTOM_API_KEY' in result
+        assert isinstance(result['CUSTOM_API_KEY'], StaticSecret)
         assert (
-            result["CUSTOM_API_KEY"].description
-            == "Custom API key for external service"
+            result['CUSTOM_API_KEY'].description
+            == 'Custom API key for external service'
         )
         assert (
-            result["CUSTOM_API_KEY"].value.get_secret_value() == "custom_secret_value"
+            result['CUSTOM_API_KEY'].value.get_secret_value() == 'custom_secret_value'
         )
 
-        assert "ANOTHER_SECRET" in result
-        assert isinstance(result["ANOTHER_SECRET"], StaticSecret)
-        assert result["ANOTHER_SECRET"].description is None
+        assert 'ANOTHER_SECRET' in result
+        assert isinstance(result['ANOTHER_SECRET'], StaticSecret)
+        assert result['ANOTHER_SECRET'].description is None
         assert (
-            result["ANOTHER_SECRET"].value.get_secret_value() == "another_secret_value"
+            result['ANOTHER_SECRET'].value.get_secret_value() == 'another_secret_value'
         )
 
         # Verify git provider token is also included
-        assert "GITHUB_TOKEN" in result
-        assert result["GITHUB_TOKEN"].description == "GITHUB authentication token"
+        assert 'GITHUB_TOKEN' in result
+        assert result['GITHUB_TOKEN'].description == 'GITHUB authentication token'
 
     @pytest.mark.asyncio
     async def test_setup_secrets_for_git_providers_custom_secret_empty_description(
@@ -435,10 +435,10 @@ class TestLiveStatusAppConversationService:
         """Test _setup_secrets_for_git_providers handles custom secrets with empty descriptions."""
         # Arrange
         custom_secret_empty_desc = StaticSecret(
-            value=SecretStr("secret_value"),
-            description="",  # Empty string description
+            value=SecretStr('secret_value'),
+            description='',  # Empty string description
         )
-        base_secrets = {"MY_SECRET": custom_secret_empty_desc}
+        base_secrets = {'MY_SECRET': custom_secret_empty_desc}
         self.mock_user_context.get_secrets.return_value = base_secrets
         self.mock_user_context.get_provider_tokens = AsyncMock(return_value=None)
 
@@ -446,17 +446,17 @@ class TestLiveStatusAppConversationService:
         result = await self.service._setup_secrets_for_git_providers(self.mock_user)
 
         # Assert - empty description should be preserved as-is
-        assert "MY_SECRET" in result
-        assert isinstance(result["MY_SECRET"], StaticSecret)
+        assert 'MY_SECRET' in result
+        assert isinstance(result['MY_SECRET'], StaticSecret)
         # Empty string description is preserved
-        assert result["MY_SECRET"].description == ""
+        assert result['MY_SECRET'].description == ''
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_with_custom_model(self):
         """Test _configure_llm_and_mcp with custom LLM model."""
         # Arrange
-        custom_model = "gpt-3.5-turbo"
-        self.mock_user_context.get_mcp_api_key.return_value = "mcp_api_key"
+        custom_model = 'gpt-3.5-turbo'
+        self.mock_user_context.get_mcp_api_key.return_value = 'mcp_api_key'
 
         # Act
         llm, mcp_config = await self.service._configure_llm_and_mcp(
@@ -468,25 +468,25 @@ class TestLiveStatusAppConversationService:
         assert llm.model == custom_model
         assert llm.base_url == self.mock_user.llm_base_url
         assert llm.api_key.get_secret_value() == self.mock_user.llm_api_key
-        assert llm.usage_id == "agent"
+        assert llm.usage_id == 'agent'
 
-        assert "mcpServers" in mcp_config
-        assert "default" in mcp_config["mcpServers"]
+        assert 'mcpServers' in mcp_config
+        assert 'default' in mcp_config['mcpServers']
         assert (
-            mcp_config["mcpServers"]["default"]["url"]
-            == "https://test.example.com/mcp/mcp"
+            mcp_config['mcpServers']['default']['url']
+            == 'https://test.example.com/mcp/mcp'
         )
         assert (
-            mcp_config["mcpServers"]["default"]["headers"]["X-Session-API-Key"]
-            == "mcp_api_key"
+            mcp_config['mcpServers']['default']['headers']['X-Session-API-Key']
+            == 'mcp_api_key'
         )
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_openhands_model_prefers_user_base_url(self):
         """openhands/* model uses user.llm_base_url when provided."""
         # Arrange
-        self.mock_user.llm_model = "openhands/special"
-        self.mock_user.llm_base_url = "https://user-llm.example.com"
+        self.mock_user.llm_model = 'openhands/special'
+        self.mock_user.llm_base_url = 'https://user-llm.example.com'
         self.mock_user_context.get_mcp_api_key.return_value = None
 
         # Act
@@ -495,13 +495,13 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        assert llm.base_url == "https://user-llm.example.com"
+        assert llm.base_url == 'https://user-llm.example.com'
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_openhands_model_uses_provider_default(self):
         """openhands/* model falls back to configured provider base URL."""
         # Arrange
-        self.mock_user.llm_model = "openhands/default"
+        self.mock_user.llm_model = 'openhands/default'
         self.mock_user.llm_base_url = None
         self.mock_user_context.get_mcp_api_key.return_value = None
 
@@ -511,13 +511,13 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        assert llm.base_url == "https://provider.example.com"
+        assert llm.base_url == 'https://provider.example.com'
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_openhands_model_no_base_urls(self):
         """openhands/* model sets base_url to None when no sources available."""
         # Arrange
-        self.mock_user.llm_model = "openhands/default"
+        self.mock_user.llm_model = 'openhands/default'
         self.mock_user.llm_base_url = None
         self.service.openhands_provider_base_url = None
         self.mock_user_context.get_mcp_api_key.return_value = None
@@ -528,22 +528,22 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        assert llm.base_url == "https://llm-proxy.app.all-hands.dev/"
+        assert llm.base_url == 'https://llm-proxy.app.all-hands.dev/'
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_non_openhands_model_ignores_provider(self):
         """Non-openhands model ignores provider base URL and uses user base URL."""
         # Arrange
-        self.mock_user.llm_model = "gpt-4"
-        self.mock_user.llm_base_url = "https://user-llm.example.com"
-        self.service.openhands_provider_base_url = "https://provider.example.com"
+        self.mock_user.llm_model = 'gpt-4'
+        self.mock_user.llm_base_url = 'https://user-llm.example.com'
+        self.service.openhands_provider_base_url = 'https://provider.example.com'
         self.mock_user_context.get_mcp_api_key.return_value = None
 
         # Act
         llm, _ = await self.service._configure_llm_and_mcp(self.mock_user, None)
 
         # Assert
-        assert llm.base_url == "https://user-llm.example.com"
+        assert llm.base_url == 'https://user-llm.example.com'
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_with_user_default_model(self):
@@ -558,9 +558,9 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert llm.model == self.mock_user.llm_model
-        assert "mcpServers" in mcp_config
-        assert "default" in mcp_config["mcpServers"]
-        assert "headers" not in mcp_config["mcpServers"]["default"]
+        assert 'mcpServers' in mcp_config
+        assert 'default' in mcp_config['mcpServers']
+        assert 'headers' not in mcp_config['mcpServers']['default']
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_without_web_url(self):
@@ -581,8 +581,8 @@ class TestLiveStatusAppConversationService:
     async def test_configure_llm_and_mcp_tavily_with_user_search_api_key(self):
         """Test _configure_llm_and_mcp adds tavily when user has search_api_key."""
         # Arrange
-        self.mock_user.search_api_key = SecretStr("user_search_key")
-        self.mock_user_context.get_mcp_api_key.return_value = "mcp_api_key"
+        self.mock_user.search_api_key = SecretStr('user_search_key')
+        self.mock_user_context.get_mcp_api_key.return_value = 'mcp_api_key'
 
         # Act
         llm, mcp_config = await self.service._configure_llm_and_mcp(
@@ -591,19 +591,19 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        assert "mcpServers" in mcp_config
-        assert "default" in mcp_config["mcpServers"]
-        assert "tavily" in mcp_config["mcpServers"]
+        assert 'mcpServers' in mcp_config
+        assert 'default' in mcp_config['mcpServers']
+        assert 'tavily' in mcp_config['mcpServers']
         assert (
-            mcp_config["mcpServers"]["tavily"]["url"]
-            == "https://mcp.tavily.com/mcp/?tavilyApiKey=user_search_key"
+            mcp_config['mcpServers']['tavily']['url']
+            == 'https://mcp.tavily.com/mcp/?tavilyApiKey=user_search_key'
         )
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_tavily_with_env_tavily_key(self):
         """Test _configure_llm_and_mcp adds tavily when service has tavily_api_key."""
         # Arrange
-        self.service.tavily_api_key = "env_tavily_key"
+        self.service.tavily_api_key = 'env_tavily_key'
         self.mock_user_context.get_mcp_api_key.return_value = None
 
         # Act
@@ -613,20 +613,20 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        assert "mcpServers" in mcp_config
-        assert "default" in mcp_config["mcpServers"]
-        assert "tavily" in mcp_config["mcpServers"]
+        assert 'mcpServers' in mcp_config
+        assert 'default' in mcp_config['mcpServers']
+        assert 'tavily' in mcp_config['mcpServers']
         assert (
-            mcp_config["mcpServers"]["tavily"]["url"]
-            == "https://mcp.tavily.com/mcp/?tavilyApiKey=env_tavily_key"
+            mcp_config['mcpServers']['tavily']['url']
+            == 'https://mcp.tavily.com/mcp/?tavilyApiKey=env_tavily_key'
         )
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_tavily_user_key_takes_precedence(self):
         """Test _configure_llm_and_mcp user search_api_key takes precedence over env key."""
         # Arrange
-        self.mock_user.search_api_key = SecretStr("user_search_key")
-        self.service.tavily_api_key = "env_tavily_key"
+        self.mock_user.search_api_key = SecretStr('user_search_key')
+        self.service.tavily_api_key = 'env_tavily_key'
         self.mock_user_context.get_mcp_api_key.return_value = None
 
         # Act
@@ -636,11 +636,11 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        assert "mcpServers" in mcp_config
-        assert "tavily" in mcp_config["mcpServers"]
+        assert 'mcpServers' in mcp_config
+        assert 'tavily' in mcp_config['mcpServers']
         assert (
-            mcp_config["mcpServers"]["tavily"]["url"]
-            == "https://mcp.tavily.com/mcp/?tavilyApiKey=user_search_key"
+            mcp_config['mcpServers']['tavily']['url']
+            == 'https://mcp.tavily.com/mcp/?tavilyApiKey=user_search_key'
         )
 
     @pytest.mark.asyncio
@@ -658,9 +658,9 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        assert "mcpServers" in mcp_config
-        assert "default" in mcp_config["mcpServers"]
-        assert "tavily" not in mcp_config["mcpServers"]
+        assert 'mcpServers' in mcp_config
+        assert 'default' in mcp_config['mcpServers']
+        assert 'tavily' not in mcp_config['mcpServers']
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_saas_mode_no_tavily_without_user_key(self):
@@ -682,9 +682,9 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        assert "mcpServers" in mcp_config
-        assert "default" in mcp_config["mcpServers"]
-        assert "tavily" not in mcp_config["mcpServers"]
+        assert 'mcpServers' in mcp_config
+        assert 'default' in mcp_config['mcpServers']
+        assert 'tavily' not in mcp_config['mcpServers']
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_saas_mode_with_user_search_key(self):
@@ -695,7 +695,7 @@ class TestLiveStatusAppConversationService:
         # Arrange - simulate SAAS mode with user having their own search key
         self.service.app_mode = AppMode.SAAS.value
         self.service.tavily_api_key = None  # In SAAS mode, this should be None
-        self.mock_user.search_api_key = SecretStr("user_search_key")
+        self.mock_user.search_api_key = SecretStr('user_search_key')
         self.mock_user_context.get_mcp_api_key.return_value = None
 
         # Act
@@ -705,20 +705,20 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        assert "mcpServers" in mcp_config
-        assert "default" in mcp_config["mcpServers"]
-        assert "tavily" in mcp_config["mcpServers"]
+        assert 'mcpServers' in mcp_config
+        assert 'default' in mcp_config['mcpServers']
+        assert 'tavily' in mcp_config['mcpServers']
         assert (
-            mcp_config["mcpServers"]["tavily"]["url"]
-            == "https://mcp.tavily.com/mcp/?tavilyApiKey=user_search_key"
+            mcp_config['mcpServers']['tavily']['url']
+            == 'https://mcp.tavily.com/mcp/?tavilyApiKey=user_search_key'
         )
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_tavily_with_empty_user_search_key(self):
         """Test _configure_llm_and_mcp handles empty user search_api_key correctly."""
         # Arrange
-        self.mock_user.search_api_key = SecretStr("")  # Empty string
-        self.service.tavily_api_key = "env_tavily_key"
+        self.mock_user.search_api_key = SecretStr('')  # Empty string
+        self.service.tavily_api_key = 'env_tavily_key'
         self.mock_user_context.get_mcp_api_key.return_value = None
 
         # Act
@@ -728,20 +728,20 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        assert "mcpServers" in mcp_config
-        assert "tavily" in mcp_config["mcpServers"]
+        assert 'mcpServers' in mcp_config
+        assert 'tavily' in mcp_config['mcpServers']
         # Should fall back to env key since user key is empty
         assert (
-            mcp_config["mcpServers"]["tavily"]["url"]
-            == "https://mcp.tavily.com/mcp/?tavilyApiKey=env_tavily_key"
+            mcp_config['mcpServers']['tavily']['url']
+            == 'https://mcp.tavily.com/mcp/?tavilyApiKey=env_tavily_key'
         )
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_tavily_with_whitespace_user_search_key(self):
         """Test _configure_llm_and_mcp handles whitespace-only user search_api_key correctly."""
         # Arrange
-        self.mock_user.search_api_key = SecretStr("   ")  # Whitespace only
-        self.service.tavily_api_key = "env_tavily_key"
+        self.mock_user.search_api_key = SecretStr('   ')  # Whitespace only
+        self.service.tavily_api_key = 'env_tavily_key'
         self.mock_user_context.get_mcp_api_key.return_value = None
 
         # Act
@@ -751,57 +751,57 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        assert "mcpServers" in mcp_config
-        assert "tavily" in mcp_config["mcpServers"]
+        assert 'mcpServers' in mcp_config
+        assert 'tavily' in mcp_config['mcpServers']
         # Should fall back to env key since user key is whitespace only
         assert (
-            mcp_config["mcpServers"]["tavily"]["url"]
-            == "https://mcp.tavily.com/mcp/?tavilyApiKey=env_tavily_key"
+            mcp_config['mcpServers']['tavily']['url']
+            == 'https://mcp.tavily.com/mcp/?tavilyApiKey=env_tavily_key'
         )
 
     def test_compute_plan_path_default_uses_agents_tmp(self):
         """Test _compute_plan_path returns .agents_tmp/PLAN.md for default/GitHub."""
         # Arrange
-        working_dir = "/workspace/project"
+        working_dir = '/workspace/project'
 
         # Act
         path_none = self.service._compute_plan_path(working_dir, None)
         path_github = self.service._compute_plan_path(working_dir, ProviderType.GITHUB)
 
         # Assert
-        assert path_none == "/workspace/project/.agents_tmp/PLAN.md"
-        assert path_github == "/workspace/project/.agents_tmp/PLAN.md"
+        assert path_none == '/workspace/project/.agents_tmp/PLAN.md'
+        assert path_github == '/workspace/project/.agents_tmp/PLAN.md'
 
     def test_compute_plan_path_gitlab_uses_agents_tmp_config(self):
         """Test _compute_plan_path returns agents-tmp-config/PLAN.md for GitLab."""
         # Arrange
-        working_dir = "/workspace/project"
+        working_dir = '/workspace/project'
 
         # Act
         path = self.service._compute_plan_path(working_dir, ProviderType.GITLAB)
 
         # Assert
-        assert path == "/workspace/project/agents-tmp-config/PLAN.md"
+        assert path == '/workspace/project/agents-tmp-config/PLAN.md'
 
     def test_compute_plan_path_azure_uses_agents_tmp_config(self):
         """Test _compute_plan_path returns agents-tmp-config/PLAN.md for Azure."""
         # Arrange
-        working_dir = "/workspace/project"
+        working_dir = '/workspace/project'
 
         # Act
         path = self.service._compute_plan_path(working_dir, ProviderType.AZURE_DEVOPS)
 
         # Assert
-        assert path == "/workspace/project/agents-tmp-config/PLAN.md"
+        assert path == '/workspace/project/agents-tmp-config/PLAN.md'
 
     @patch(
-        "openhands.app_server.app_conversation.live_status_app_conversation_service.get_planning_tools"
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.get_planning_tools'
     )
     @patch(
-        "openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser"
+        'openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser'
     )
     @patch(
-        "openhands.app_server.app_conversation.live_status_app_conversation_service.format_plan_structure"
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.format_plan_structure'
     )
     def test_create_agent_with_context_planning_agent(
         self, mock_format_plan, mock_create_condenser, mock_get_tools
@@ -813,15 +813,15 @@ class TestLiveStatusAppConversationService:
         mock_get_tools.return_value = []
         mock_condenser = Mock()
         mock_create_condenser.return_value = mock_condenser
-        mock_format_plan.return_value = "test_plan_structure"
-        mcp_config = {"default": {"url": "test"}}
-        system_message_suffix = "Test suffix"
-        working_dir = "/workspace/project"
+        mock_format_plan.return_value = 'test_plan_structure'
+        mcp_config = {'default': {'url': 'test'}}
+        system_message_suffix = 'Test suffix'
+        working_dir = '/workspace/project'
         git_provider = ProviderType.GITHUB
 
         # Act
         with patch(
-            "openhands.app_server.app_conversation.live_status_app_conversation_service.Agent"
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.Agent'
         ) as mock_agent_class:
             mock_agent_instance = Mock()
             mock_agent_instance.model_copy.return_value = mock_agent_instance
@@ -839,28 +839,28 @@ class TestLiveStatusAppConversationService:
 
             # Assert
             mock_get_tools.assert_called_once_with(
-                plan_path="/workspace/project/.agents_tmp/PLAN.md"
+                plan_path='/workspace/project/.agents_tmp/PLAN.md'
             )
             mock_agent_class.assert_called_once()
             call_kwargs = mock_agent_class.call_args[1]
-            assert call_kwargs["llm"] == mock_llm
-            assert call_kwargs["system_prompt_filename"] == "system_prompt_planning.j2"
+            assert call_kwargs['llm'] == mock_llm
+            assert call_kwargs['system_prompt_filename'] == 'system_prompt_planning.j2'
             assert (
-                call_kwargs["system_prompt_kwargs"]["plan_structure"]
-                == "test_plan_structure"
+                call_kwargs['system_prompt_kwargs']['plan_structure']
+                == 'test_plan_structure'
             )
-            assert call_kwargs["mcp_config"] == mcp_config
-            assert call_kwargs["security_analyzer"] is None
-            assert call_kwargs["condenser"] == mock_condenser
+            assert call_kwargs['mcp_config'] == mcp_config
+            assert call_kwargs['security_analyzer'] is None
+            assert call_kwargs['condenser'] == mock_condenser
             mock_create_condenser.assert_called_once_with(
                 mock_llm, AgentType.PLAN, self.mock_user.condenser_max_size
             )
 
     @patch(
-        "openhands.app_server.app_conversation.live_status_app_conversation_service.get_default_tools"
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.get_default_tools'
     )
     @patch(
-        "openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser"
+        'openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser'
     )
     def test_create_agent_with_context_default_agent(
         self, mock_create_condenser, mock_get_tools
@@ -872,11 +872,11 @@ class TestLiveStatusAppConversationService:
         mock_get_tools.return_value = []
         mock_condenser = Mock()
         mock_create_condenser.return_value = mock_condenser
-        mcp_config = {"default": {"url": "test"}}
+        mcp_config = {'default': {'url': 'test'}}
 
         # Act
         with patch(
-            "openhands.app_server.app_conversation.live_status_app_conversation_service.Agent"
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.Agent'
         ) as mock_agent_class:
             mock_agent_instance = Mock()
             mock_agent_instance.model_copy.return_value = mock_agent_instance
@@ -893,23 +893,23 @@ class TestLiveStatusAppConversationService:
             # Assert
             mock_agent_class.assert_called_once()
             call_kwargs = mock_agent_class.call_args[1]
-            assert call_kwargs["llm"] == mock_llm
-            assert call_kwargs["system_prompt_kwargs"]["cli_mode"] is False
-            assert call_kwargs["mcp_config"] == mcp_config
-            assert call_kwargs["condenser"] == mock_condenser
+            assert call_kwargs['llm'] == mock_llm
+            assert call_kwargs['system_prompt_kwargs']['cli_mode'] is False
+            assert call_kwargs['mcp_config'] == mcp_config
+            assert call_kwargs['condenser'] == mock_condenser
             mock_get_tools.assert_called_once_with(enable_browser=True)
             mock_create_condenser.assert_called_once_with(
                 mock_llm, AgentType.DEFAULT, self.mock_user.condenser_max_size
             )
 
     @patch(
-        "openhands.app_server.app_conversation.live_status_app_conversation_service.get_planning_tools"
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.get_planning_tools'
     )
     @patch(
-        "openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser"
+        'openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser'
     )
     @patch(
-        "openhands.app_server.app_conversation.live_status_app_conversation_service.format_plan_structure"
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.format_plan_structure'
     )
     def test_create_agent_with_context_planning_agent_applies_instruction(
         self, mock_format_plan, mock_create_condenser, mock_get_tools
@@ -921,12 +921,12 @@ class TestLiveStatusAppConversationService:
         mock_get_tools.return_value = []
         mock_condenser = Mock()
         mock_create_condenser.return_value = mock_condenser
-        mock_format_plan.return_value = "test_plan_structure"
+        mock_format_plan.return_value = 'test_plan_structure'
         mcp_config = {}
 
         # Act
         with patch(
-            "openhands.app_server.app_conversation.live_status_app_conversation_service.Agent"
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.Agent'
         ) as mock_agent_class:
             mock_agent_instance = Mock()
             mock_agent_instance.model_copy.return_value = mock_agent_instance
@@ -942,17 +942,17 @@ class TestLiveStatusAppConversationService:
 
             # Assert - verify model_copy was called with agent_context containing planning instruction
             model_copy_call = mock_agent_instance.model_copy.call_args
-            agent_context = model_copy_call[1]["update"]["agent_context"]
+            agent_context = model_copy_call[1]['update']['agent_context']
             assert agent_context.system_message_suffix == PLANNING_AGENT_INSTRUCTION
 
     @patch(
-        "openhands.app_server.app_conversation.live_status_app_conversation_service.get_planning_tools"
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.get_planning_tools'
     )
     @patch(
-        "openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser"
+        'openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser'
     )
     @patch(
-        "openhands.app_server.app_conversation.live_status_app_conversation_service.format_plan_structure"
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.format_plan_structure'
     )
     def test_create_agent_with_context_planning_agent_prepends_to_existing_suffix(
         self, mock_format_plan, mock_create_condenser, mock_get_tools
@@ -964,13 +964,13 @@ class TestLiveStatusAppConversationService:
         mock_get_tools.return_value = []
         mock_condenser = Mock()
         mock_create_condenser.return_value = mock_condenser
-        mock_format_plan.return_value = "test_plan_structure"
+        mock_format_plan.return_value = 'test_plan_structure'
         mcp_config = {}
-        existing_suffix = "Custom user instruction from integration"
+        existing_suffix = 'Custom user instruction from integration'
 
         # Act
         with patch(
-            "openhands.app_server.app_conversation.live_status_app_conversation_service.Agent"
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.Agent'
         ) as mock_agent_class:
             mock_agent_instance = Mock()
             mock_agent_instance.model_copy.return_value = mock_agent_instance
@@ -986,17 +986,17 @@ class TestLiveStatusAppConversationService:
 
             # Assert - verify planning instruction is prepended to existing suffix
             model_copy_call = mock_agent_instance.model_copy.call_args
-            agent_context = model_copy_call[1]["update"]["agent_context"]
+            agent_context = model_copy_call[1]['update']['agent_context']
             assert agent_context.system_message_suffix.startswith(
                 PLANNING_AGENT_INSTRUCTION
             )
             assert existing_suffix in agent_context.system_message_suffix
 
     @patch(
-        "openhands.app_server.app_conversation.live_status_app_conversation_service.get_default_tools"
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.get_default_tools'
     )
     @patch(
-        "openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser"
+        'openhands.app_server.app_conversation.app_conversation_service_base.AppConversationServiceBase._create_condenser'
     )
     def test_create_agent_with_context_default_agent_no_planning_instruction(
         self, mock_create_condenser, mock_get_tools
@@ -1012,7 +1012,7 @@ class TestLiveStatusAppConversationService:
 
         # Act
         with patch(
-            "openhands.app_server.app_conversation.live_status_app_conversation_service.Agent"
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.Agent'
         ) as mock_agent_class:
             mock_agent_instance = Mock()
             mock_agent_instance.model_copy.return_value = mock_agent_instance
@@ -1028,7 +1028,7 @@ class TestLiveStatusAppConversationService:
 
             # Assert - verify no planning instruction for default agent
             model_copy_call = mock_agent_instance.model_copy.call_args
-            agent_context = model_copy_call[1]["update"]["agent_context"]
+            agent_context = model_copy_call[1]['update']['agent_context']
             assert agent_context.system_message_suffix is None
 
     @pytest.mark.asyncio
@@ -1036,8 +1036,8 @@ class TestLiveStatusAppConversationService:
         """Test _finalize_conversation_request with skills loading."""
         # Create mock LLM with required attributes for _update_agent_with_llm_metadata
         mock_llm = Mock(spec=LLM)
-        mock_llm.model = "gpt-4"  # Non-openhands model, so no metadata update
-        mock_llm.usage_id = "agent"
+        mock_llm.model = 'gpt-4'  # Non-openhands model, so no metadata update
+        mock_llm.usage_id = 'agent'
 
         # Arrange
         mock_agent = Mock(spec=Agent)
@@ -1045,9 +1045,9 @@ class TestLiveStatusAppConversationService:
         mock_agent.condenser = None  # No condenser
 
         conversation_id = uuid4()
-        workspace = LocalWorkspace(working_dir="/test")
+        workspace = LocalWorkspace(working_dir='/test')
         initial_message = Mock(spec=SendMessageRequest)
-        secrets = {"test": StaticSecret(value="secret")}
+        secrets = {'test': StaticSecret(value='secret')}
         remote_workspace = Mock(spec=AsyncRemoteWorkspace)
 
         # Mock the skills loading method
@@ -1063,8 +1063,8 @@ class TestLiveStatusAppConversationService:
             secrets,
             self.mock_sandbox,
             remote_workspace,
-            "test_repo",
-            "/test/dir",
+            'test_repo',
+            '/test/dir',
         )
 
         # Assert
@@ -1081,16 +1081,16 @@ class TestLiveStatusAppConversationService:
         """Test _finalize_conversation_request without remote workspace (no skills)."""
         # Create mock LLM with required attributes for _update_agent_with_llm_metadata
         mock_llm = Mock(spec=LLM)
-        mock_llm.model = "gpt-4"  # Non-openhands model, so no metadata update
-        mock_llm.usage_id = "agent"
+        mock_llm.model = 'gpt-4'  # Non-openhands model, so no metadata update
+        mock_llm.usage_id = 'agent'
 
         # Arrange
         mock_agent = Mock(spec=Agent)
         mock_agent.llm = mock_llm
         mock_agent.condenser = None  # No condenser
 
-        workspace = LocalWorkspace(working_dir="/test")
-        secrets = {"test": StaticSecret(value="secret")}
+        workspace = LocalWorkspace(working_dir='/test')
+        secrets = {'test': StaticSecret(value='secret')}
 
         # Act
         result = await self.service._finalize_conversation_request(
@@ -1103,7 +1103,7 @@ class TestLiveStatusAppConversationService:
             self.mock_sandbox,
             None,
             None,
-            "/test/dir",
+            '/test/dir',
         )
 
         # Assert
@@ -1115,25 +1115,25 @@ class TestLiveStatusAppConversationService:
         """Test _finalize_conversation_request when skills loading fails."""
         # Create mock LLM with required attributes for _update_agent_with_llm_metadata
         mock_llm = Mock(spec=LLM)
-        mock_llm.model = "gpt-4"  # Non-openhands model, so no metadata update
-        mock_llm.usage_id = "agent"
+        mock_llm.model = 'gpt-4'  # Non-openhands model, so no metadata update
+        mock_llm.usage_id = 'agent'
 
         mock_agent = Mock(spec=Agent)
         mock_agent.llm = mock_llm
         mock_agent.condenser = None  # No condenser
 
-        workspace = LocalWorkspace(working_dir="/test")
-        secrets = {"test": StaticSecret(value="secret")}
+        workspace = LocalWorkspace(working_dir='/test')
+        secrets = {'test': StaticSecret(value='secret')}
         remote_workspace = Mock(spec=AsyncRemoteWorkspace)
 
         # Mock skills loading to raise an exception
         self.service._load_skills_and_update_agent = AsyncMock(
-            side_effect=Exception("Skills loading failed")
+            side_effect=Exception('Skills loading failed')
         )
 
         # Act
         with patch(
-            "openhands.app_server.app_conversation.live_status_app_conversation_service._logger"
+            'openhands.app_server.app_conversation.live_status_app_conversation_service._logger'
         ) as mock_logger:
             result = await self.service._finalize_conversation_request(
                 mock_agent,
@@ -1144,8 +1144,8 @@ class TestLiveStatusAppConversationService:
                 secrets,
                 self.mock_sandbox,
                 remote_workspace,
-                "test_repo",
-                "/test/dir",
+                'test_repo',
+                '/test/dir',
             )
 
             # Assert
@@ -1159,9 +1159,9 @@ class TestLiveStatusAppConversationService:
         self.mock_user_context.get_user_info.return_value = self.mock_user
 
         # Mock all the helper methods
-        mock_secrets = {"GITHUB_TOKEN": Mock()}
+        mock_secrets = {'GITHUB_TOKEN': Mock()}
         mock_llm = Mock(spec=LLM)
-        mock_mcp_config = {"default": {"url": "test"}}
+        mock_mcp_config = {'default': {'url': 'test'}}
         mock_agent = Mock(spec=Agent)
         mock_final_request = Mock(spec=StartConversationRequest)
 
@@ -1180,14 +1180,14 @@ class TestLiveStatusAppConversationService:
         result = await self.service._build_start_conversation_request_for_user(
             sandbox=self.mock_sandbox,
             initial_message=None,
-            system_message_suffix="Test suffix",
+            system_message_suffix='Test suffix',
             git_provider=ProviderType.GITHUB,
-            working_dir="/test/dir",
+            working_dir='/test/dir',
             agent_type=AgentType.DEFAULT,
-            llm_model="gpt-4",
+            llm_model='gpt-4',
             conversation_id=None,
             remote_workspace=None,
-            selected_repository="test/repo",
+            selected_repository='test/repo',
         )
 
         # Assert
@@ -1197,17 +1197,17 @@ class TestLiveStatusAppConversationService:
             self.mock_user
         )
         self.service._configure_llm_and_mcp.assert_called_once_with(
-            self.mock_user, "gpt-4"
+            self.mock_user, 'gpt-4'
         )
         self.service._create_agent_with_context.assert_called_once_with(
             mock_llm,
             AgentType.DEFAULT,
-            "Test suffix",
+            'Test suffix',
             mock_mcp_config,
             self.mock_user.condenser_max_size,
             secrets=mock_secrets,
             git_provider=ProviderType.GITHUB,
-            working_dir="/test/dir",
+            working_dir='/test/dir',
         )
         self.service._finalize_conversation_request.assert_called_once()
 
@@ -1220,12 +1220,12 @@ class TestLiveStatusAppConversationService:
         # Mock conversation info
         mock_conversation_info = Mock(spec=AppConversationInfo)
         mock_conversation_info.id = conversation_id
-        mock_conversation_info.title = "Test Conversation"
+        mock_conversation_info.title = 'Test Conversation'
         mock_conversation_info.created_at = datetime(2024, 1, 1, 12, 0, 0)
         mock_conversation_info.updated_at = datetime(2024, 1, 1, 13, 0, 0)
-        mock_conversation_info.selected_repository = "test/repo"
-        mock_conversation_info.git_provider = "github"
-        mock_conversation_info.selected_branch = "main"
+        mock_conversation_info.selected_repository = 'test/repo'
+        mock_conversation_info.git_provider = 'github'
+        mock_conversation_info.selected_branch = 'main'
         mock_conversation_info.model_dump_json = Mock(
             return_value='{"id": "test", "title": "Test Conversation"}'
         )
@@ -1238,19 +1238,19 @@ class TestLiveStatusAppConversationService:
         mock_event1 = Mock(spec=Event)
         mock_event1.id = uuid4()
         mock_event1.model_dump = Mock(
-            return_value={"id": str(mock_event1.id), "type": "action"}
+            return_value={'id': str(mock_event1.id), 'type': 'action'}
         )
 
         mock_event2 = Mock(spec=Event)
         mock_event2.id = uuid4()
         mock_event2.model_dump = Mock(
-            return_value={"id": str(mock_event2.id), "type": "observation"}
+            return_value={'id': str(mock_event2.id), 'type': 'observation'}
         )
 
         # Mock event service search_events to return paginated results
         mock_event_page1 = Mock()
         mock_event_page1.items = [mock_event1]
-        mock_event_page1.next_page_id = "page2"
+        mock_event_page1.next_page_id = 'page2'
 
         mock_event_page2 = Mock()
         mock_event_page2.items = [mock_event2]
@@ -1268,30 +1268,30 @@ class TestLiveStatusAppConversationService:
         assert isinstance(result, bytes)  # Should be bytes
 
         # Verify the zip file contents
-        with zipfile.ZipFile(io.BytesIO(result), "r") as zipf:
+        with zipfile.ZipFile(io.BytesIO(result), 'r') as zipf:
             file_list = zipf.namelist()
 
             # Should contain meta.json and event files
-            assert "meta.json" in file_list
+            assert 'meta.json' in file_list
             assert any(
-                f.startswith("event_") and f.endswith(".json") for f in file_list
+                f.startswith('event_') and f.endswith('.json') for f in file_list
             )
 
             # Check meta.json content
-            with zipf.open("meta.json") as meta_file:
-                meta_content = meta_file.read().decode("utf-8")
+            with zipf.open('meta.json') as meta_file:
+                meta_content = meta_file.read().decode('utf-8')
                 assert '"id": "test"' in meta_content
                 assert '"title": "Test Conversation"' in meta_content
 
             # Check event files
-            event_files = [f for f in file_list if f.startswith("event_")]
+            event_files = [f for f in file_list if f.startswith('event_')]
             assert len(event_files) == 2  # Should have 2 event files
 
             # Verify event file content
             with zipf.open(event_files[0]) as event_file:
-                event_content = json.loads(event_file.read().decode("utf-8"))
-                assert "id" in event_content
-                assert "type" in event_content
+                event_content = json.loads(event_file.read().decode('utf-8'))
+                assert 'id' in event_content
+                assert 'type' in event_content
 
         # Verify service calls
         self.mock_app_conversation_info_service.get_app_conversation_info.assert_called_once_with(
@@ -1311,7 +1311,7 @@ class TestLiveStatusAppConversationService:
 
         # Act & Assert
         with pytest.raises(
-            ValueError, match=f"Conversation not found: {conversation_id}"
+            ValueError, match=f'Conversation not found: {conversation_id}'
         ):
             await self.service.export_conversation(conversation_id)
 
@@ -1330,7 +1330,7 @@ class TestLiveStatusAppConversationService:
         # Mock conversation info
         mock_conversation_info = Mock(spec=AppConversationInfo)
         mock_conversation_info.id = conversation_id
-        mock_conversation_info.title = "Empty Conversation"
+        mock_conversation_info.title = 'Empty Conversation'
         mock_conversation_info.model_dump_json = Mock(
             return_value='{"id": "test", "title": "Empty Conversation"}'
         )
@@ -1354,12 +1354,12 @@ class TestLiveStatusAppConversationService:
         assert isinstance(result, bytes)  # Should be bytes
 
         # Verify the zip file contents
-        with zipfile.ZipFile(io.BytesIO(result), "r") as zipf:
+        with zipfile.ZipFile(io.BytesIO(result), 'r') as zipf:
             file_list = zipf.namelist()
 
             # Should only contain meta.json (no event files)
-            assert "meta.json" in file_list
-            assert len([f for f in file_list if f.startswith("event_")]) == 0
+            assert 'meta.json' in file_list
+            assert len([f for f in file_list if f.startswith('event_')]) == 0
 
         # Verify service calls
         self.mock_app_conversation_info_service.get_app_conversation_info.assert_called_once_with(
@@ -1383,7 +1383,7 @@ class TestLiveStatusAppConversationService:
         # Mock conversation info
         mock_conversation_info = Mock(spec=AppConversationInfo)
         mock_conversation_info.id = conversation_id
-        mock_conversation_info.model_dump_json = Mock(return_value="{}")
+        mock_conversation_info.model_dump_json = Mock(return_value='{}')
 
         self.mock_app_conversation_info_service.get_app_conversation_info = AsyncMock(
             return_value=mock_conversation_info
@@ -1403,13 +1403,13 @@ class TestLiveStatusAppConversationService:
         self.mock_event_service.search_events.assert_called()
         call_kwargs = self.mock_event_service.search_events.call_args[1]
 
-        assert "conversation_id" in call_kwargs, (
+        assert 'conversation_id' in call_kwargs, (
             "search_events should be called with 'conversation_id' parameter"
         )
-        assert "conversation_id__eq" not in call_kwargs, (
+        assert 'conversation_id__eq' not in call_kwargs, (
             "search_events should NOT be called with 'conversation_id__eq' parameter"
         )
-        assert call_kwargs["conversation_id"] == conversation_id
+        assert call_kwargs['conversation_id'] == conversation_id
 
     @pytest.mark.asyncio
     async def test_export_conversation_large_pagination(self):
@@ -1420,7 +1420,7 @@ class TestLiveStatusAppConversationService:
         # Mock conversation info
         mock_conversation_info = Mock(spec=AppConversationInfo)
         mock_conversation_info.id = conversation_id
-        mock_conversation_info.title = "Large Conversation"
+        mock_conversation_info.title = 'Large Conversation'
         mock_conversation_info.model_dump_json = Mock(
             return_value='{"id": "test", "title": "Large Conversation"}'
         )
@@ -1441,8 +1441,8 @@ class TestLiveStatusAppConversationService:
                 mock_event.id = uuid4()
                 mock_event.model_dump = Mock(
                     return_value={
-                        "id": str(mock_event.id),
-                        "type": f"event_page_{page_num}_item_{i}",
+                        'id': str(mock_event.id),
+                        'type': f'event_page_{page_num}_item_{i}',
                     }
                 )
                 page_events.append(mock_event)
@@ -1451,7 +1451,7 @@ class TestLiveStatusAppConversationService:
             mock_event_page = Mock()
             mock_event_page.items = page_events
             mock_event_page.next_page_id = (
-                f"page{page_num + 1}" if page_num < total_pages - 1 else None
+                f'page{page_num + 1}' if page_num < total_pages - 1 else None
             )
 
             if page_num == 0:
@@ -1475,12 +1475,12 @@ class TestLiveStatusAppConversationService:
         assert isinstance(result, bytes)  # Should be bytes
 
         # Verify the zip file contents
-        with zipfile.ZipFile(io.BytesIO(result), "r") as zipf:
+        with zipfile.ZipFile(io.BytesIO(result), 'r') as zipf:
             file_list = zipf.namelist()
 
             # Should contain meta.json and all event files
-            assert "meta.json" in file_list
-            event_files = [f for f in file_list if f.startswith("event_")]
+            assert 'meta.json' in file_list
+            event_files = [f for f in file_list if f.startswith('event_')]
             assert (
                 len(event_files) == total_pages * events_per_page
             )  # Should have all events
@@ -1489,10 +1489,10 @@ class TestLiveStatusAppConversationService:
         assert self.mock_event_service.search_events.call_count == total_pages
 
     @patch(
-        "openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace"
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace'
     )
     @patch(
-        "openhands.app_server.app_conversation.live_status_app_conversation_service.ConversationInfo"
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.ConversationInfo'
     )
     async def test_start_app_conversation_default_title_uses_first_five_characters(
         self, mock_conversation_info_class, mock_remote_workspace_class
@@ -1501,20 +1501,20 @@ class TestLiveStatusAppConversationService:
         # Arrange
         conversation_id = uuid4()
         conversation_id_hex = conversation_id.hex
-        expected_title = f"Conversation {conversation_id_hex[:5]}"
+        expected_title = f'Conversation {conversation_id_hex[:5]}'
 
         # Mock user context
-        self.mock_user_context.get_user_id = AsyncMock(return_value="test_user_123")
+        self.mock_user_context.get_user_id = AsyncMock(return_value='test_user_123')
         self.mock_user_context.get_user_info = AsyncMock(return_value=self.mock_user)
 
         # Mock sandbox and sandbox spec
         mock_sandbox_spec = Mock(spec=SandboxSpecInfo)
-        mock_sandbox_spec.working_dir = "/test/workspace"
+        mock_sandbox_spec.working_dir = '/test/workspace'
         self.mock_sandbox.sandbox_spec_id = str(uuid4())
         self.mock_sandbox.id = str(uuid4())  # Ensure sandbox.id is a string
-        self.mock_sandbox.session_api_key = "test_session_key"
+        self.mock_sandbox.session_api_key = 'test_session_key'
         exposed_url = ExposedUrl(
-            name=AGENT_SERVER, url="http://agent-server:8000", port=60000
+            name=AGENT_SERVER, url='http://agent-server:8000', port=60000
         )
         self.mock_sandbox.exposed_urls = [exposed_url]
 
@@ -1543,10 +1543,10 @@ class TestLiveStatusAppConversationService:
         # Mock build start conversation request
         mock_agent = Mock(spec=Agent)
         mock_agent.llm = Mock(spec=LLM)
-        mock_agent.llm.model = "gpt-4"
+        mock_agent.llm.model = 'gpt-4'
         mock_start_request = Mock(spec=StartConversationRequest)
         mock_start_request.agent = mock_agent
-        mock_start_request.model_dump.return_value = {"test": "data"}
+        mock_start_request.model_dump.return_value = {'test': 'data'}
 
         self.service._build_start_conversation_request_for_user = AsyncMock(
             return_value=mock_start_request
@@ -1561,7 +1561,7 @@ class TestLiveStatusAppConversationService:
 
         # Mock HTTP response from agent server
         mock_response = Mock()
-        mock_response.json.return_value = {"id": str(conversation_id)}
+        mock_response.json.return_value = {'id': str(conversation_id)}
         mock_response.raise_for_status = Mock()
         self.mock_httpx_client.post = AsyncMock(return_value=mock_response)
 
@@ -1599,8 +1599,8 @@ class TestLiveStatusAppConversationService:
 
         self.mock_user.mcp_config = MCPConfig(
             sse_servers=[
-                MCPSSEServerConfig(url="https://linear.app/sse", api_key="linear_key"),
-                MCPSSEServerConfig(url="https://notion.com/sse"),
+                MCPSSEServerConfig(url='https://linear.app/sse', api_key='linear_key'),
+                MCPSSEServerConfig(url='https://notion.com/sse'),
             ]
         )
         self.mock_user_context.get_mcp_api_key.return_value = None
@@ -1612,27 +1612,27 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        assert "mcpServers" in mcp_config
+        assert 'mcpServers' in mcp_config
 
         # Should have default server + 2 custom SSE servers
-        mcp_servers = mcp_config["mcpServers"]
-        assert "default" in mcp_servers
+        mcp_servers = mcp_config['mcpServers']
+        assert 'default' in mcp_servers
 
         # Find SSE servers (they have sse_ prefix)
-        sse_servers = {k: v for k, v in mcp_servers.items() if k.startswith("sse_")}
+        sse_servers = {k: v for k, v in mcp_servers.items() if k.startswith('sse_')}
         assert len(sse_servers) == 2
 
         # Verify SSE server configurations
         for server_name, server_config in sse_servers.items():
-            assert server_name.startswith("sse_")
+            assert server_name.startswith('sse_')
             assert len(server_name) > 4  # Has UUID suffix
-            assert "url" in server_config
-            assert "transport" in server_config
-            assert server_config["transport"] == "sse"
+            assert 'url' in server_config
+            assert 'transport' in server_config
+            assert server_config['transport'] == 'sse'
 
             # Check if this is the Linear server (has headers)
-            if "headers" in server_config:
-                assert server_config["headers"]["Authorization"] == "Bearer linear_key"
+            if 'headers' in server_config:
+                assert server_config['headers']['Authorization'] == 'Bearer linear_key'
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_with_custom_shttp_servers(self):
@@ -1643,8 +1643,8 @@ class TestLiveStatusAppConversationService:
         self.mock_user.mcp_config = MCPConfig(
             shttp_servers=[
                 MCPSHTTPServerConfig(
-                    url="https://example.com/mcp",
-                    api_key="test_key",
+                    url='https://example.com/mcp',
+                    api_key='test_key',
                     timeout=120,
                 )
             ]
@@ -1658,17 +1658,17 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        mcp_servers = mcp_config["mcpServers"]
+        mcp_servers = mcp_config['mcpServers']
 
         # Find SHTTP servers
-        shttp_servers = {k: v for k, v in mcp_servers.items() if k.startswith("shttp_")}
+        shttp_servers = {k: v for k, v in mcp_servers.items() if k.startswith('shttp_')}
         assert len(shttp_servers) == 1
 
         server_config = list(shttp_servers.values())[0]
-        assert server_config["url"] == "https://example.com/mcp"
-        assert server_config["transport"] == "streamable-http"
-        assert server_config["headers"]["Authorization"] == "Bearer test_key"
-        assert server_config["timeout"] == 120
+        assert server_config['url'] == 'https://example.com/mcp'
+        assert server_config['transport'] == 'streamable-http'
+        assert server_config['headers']['Authorization'] == 'Bearer test_key'
+        assert server_config['timeout'] == 120
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_with_custom_stdio_servers(self):
@@ -1679,10 +1679,10 @@ class TestLiveStatusAppConversationService:
         self.mock_user.mcp_config = MCPConfig(
             stdio_servers=[
                 MCPStdioServerConfig(
-                    name="my-custom-server",
-                    command="npx",
-                    args=["-y", "my-package"],
-                    env={"API_KEY": "secret"},
+                    name='my-custom-server',
+                    command='npx',
+                    args=['-y', 'my-package'],
+                    env={'API_KEY': 'secret'},
                 )
             ]
         )
@@ -1695,14 +1695,14 @@ class TestLiveStatusAppConversationService:
 
         # Assert
         assert isinstance(llm, LLM)
-        mcp_servers = mcp_config["mcpServers"]
+        mcp_servers = mcp_config['mcpServers']
 
         # STDIO server should use its explicit name
-        assert "my-custom-server" in mcp_servers
-        server_config = mcp_servers["my-custom-server"]
-        assert server_config["command"] == "npx"
-        assert server_config["args"] == ["-y", "my-package"]
-        assert server_config["env"] == {"API_KEY": "secret"}
+        assert 'my-custom-server' in mcp_servers
+        server_config = mcp_servers['my-custom-server']
+        assert server_config['command'] == 'npx'
+        assert server_config['args'] == ['-y', 'my-package']
+        assert server_config['env'] == {'API_KEY': 'secret'}
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_merges_system_and_custom_servers(self):
@@ -1714,16 +1714,16 @@ class TestLiveStatusAppConversationService:
             MCPStdioServerConfig,
         )
 
-        self.mock_user.search_api_key = SecretStr("tavily_key")
+        self.mock_user.search_api_key = SecretStr('tavily_key')
         self.mock_user.mcp_config = MCPConfig(
-            sse_servers=[MCPSSEServerConfig(url="https://custom.com/sse")],
+            sse_servers=[MCPSSEServerConfig(url='https://custom.com/sse')],
             stdio_servers=[
                 MCPStdioServerConfig(
-                    name="custom-stdio", command="node", args=["app.js"]
+                    name='custom-stdio', command='node', args=['app.js']
                 )
             ],
         )
-        self.mock_user_context.get_mcp_api_key.return_value = "mcp_api_key"
+        self.mock_user_context.get_mcp_api_key.return_value = 'mcp_api_key'
 
         # Act
         llm, mcp_config = await self.service._configure_llm_and_mcp(
@@ -1731,18 +1731,18 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        mcp_servers = mcp_config["mcpServers"]
+        mcp_servers = mcp_config['mcpServers']
 
         # Should have system servers
-        assert "default" in mcp_servers
-        assert "tavily" in mcp_servers
+        assert 'default' in mcp_servers
+        assert 'tavily' in mcp_servers
 
         # Should have custom SSE server with UUID name
-        sse_servers = [k for k in mcp_servers if k.startswith("sse_")]
+        sse_servers = [k for k in mcp_servers if k.startswith('sse_')]
         assert len(sse_servers) == 1
 
         # Should have custom STDIO server with explicit name
-        assert "custom-stdio" in mcp_servers
+        assert 'custom-stdio' in mcp_servers
 
         # Total: default + tavily + 1 SSE + 1 STDIO = 4 servers
         assert len(mcp_servers) == 4
@@ -1754,7 +1754,7 @@ class TestLiveStatusAppConversationService:
         self.mock_user.mcp_config = Mock()
         # Simulate error when accessing sse_servers
         self.mock_user.mcp_config.sse_servers = property(
-            lambda self: (_ for _ in ()).throw(Exception("Config error"))
+            lambda self: (_ for _ in ()).throw(Exception('Config error'))
         )
         self.mock_user_context.get_mcp_api_key.return_value = None
 
@@ -1765,15 +1765,15 @@ class TestLiveStatusAppConversationService:
 
         # Assert - should still return valid config with system servers only
         assert isinstance(llm, LLM)
-        mcp_servers = mcp_config["mcpServers"]
-        assert "default" in mcp_servers
+        mcp_servers = mcp_config['mcpServers']
+        assert 'default' in mcp_servers
         # Custom servers should not be added due to error
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_sdk_format_with_mcpservers_wrapper(self):
         """Test _configure_llm_and_mcp returns SDK-required format with mcpServers key."""
         # Arrange
-        self.mock_user_context.get_mcp_api_key.return_value = "mcp_key"
+        self.mock_user_context.get_mcp_api_key.return_value = 'mcp_key'
 
         # Act
         llm, mcp_config = await self.service._configure_llm_and_mcp(
@@ -1781,11 +1781,11 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert - SDK expects {'mcpServers': {...}} format
-        assert "mcpServers" in mcp_config
-        assert isinstance(mcp_config["mcpServers"], dict)
+        assert 'mcpServers' in mcp_config
+        assert isinstance(mcp_config['mcpServers'], dict)
 
         # Verify structure matches SDK expectations
-        for server_name, server_config in mcp_config["mcpServers"].items():
+        for server_name, server_config in mcp_config['mcpServers'].items():
             assert isinstance(server_name, str)
             assert isinstance(server_config, dict)
 
@@ -1806,9 +1806,9 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        mcp_servers = mcp_config["mcpServers"]
+        mcp_servers = mcp_config['mcpServers']
         # Should only have system default server
-        assert "default" in mcp_servers
+        assert 'default' in mcp_servers
         assert len(mcp_servers) == 1
 
     @pytest.mark.asyncio
@@ -1818,7 +1818,7 @@ class TestLiveStatusAppConversationService:
         from openhands.core.config.mcp_config import MCPConfig, MCPSSEServerConfig
 
         self.mock_user.mcp_config = MCPConfig(
-            sse_servers=[MCPSSEServerConfig(url="https://public.com/sse")]
+            sse_servers=[MCPSSEServerConfig(url='https://public.com/sse')]
         )
         self.mock_user_context.get_mcp_api_key.return_value = None
 
@@ -1828,15 +1828,15 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        mcp_servers = mcp_config["mcpServers"]
-        sse_servers = {k: v for k, v in mcp_servers.items() if k.startswith("sse_")}
+        mcp_servers = mcp_config['mcpServers']
+        sse_servers = {k: v for k, v in mcp_servers.items() if k.startswith('sse_')}
 
         # Server should exist but without headers
         assert len(sse_servers) == 1
         server_config = list(sse_servers.values())[0]
-        assert "headers" not in server_config
-        assert server_config["url"] == "https://public.com/sse"
-        assert server_config["transport"] == "sse"
+        assert 'headers' not in server_config
+        assert server_config['url'] == 'https://public.com/sse'
+        assert server_config['transport'] == 'sse'
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_shttp_server_without_timeout(self):
@@ -1845,7 +1845,7 @@ class TestLiveStatusAppConversationService:
         from openhands.core.config.mcp_config import MCPConfig, MCPSHTTPServerConfig
 
         self.mock_user.mcp_config = MCPConfig(
-            shttp_servers=[MCPSHTTPServerConfig(url="https://example.com/mcp")]
+            shttp_servers=[MCPSHTTPServerConfig(url='https://example.com/mcp')]
         )
         self.mock_user_context.get_mcp_api_key.return_value = None
 
@@ -1855,13 +1855,13 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        mcp_servers = mcp_config["mcpServers"]
-        shttp_servers = {k: v for k, v in mcp_servers.items() if k.startswith("shttp_")}
+        mcp_servers = mcp_config['mcpServers']
+        shttp_servers = {k: v for k, v in mcp_servers.items() if k.startswith('shttp_')}
 
         assert len(shttp_servers) == 1
         server_config = list(shttp_servers.values())[0]
         # Timeout should be included even if None (defaults to 60)
-        assert "timeout" in server_config
+        assert 'timeout' in server_config
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_stdio_server_without_env(self):
@@ -1872,7 +1872,7 @@ class TestLiveStatusAppConversationService:
         self.mock_user.mcp_config = MCPConfig(
             stdio_servers=[
                 MCPStdioServerConfig(
-                    name="simple-server", command="node", args=["app.js"]
+                    name='simple-server', command='node', args=['app.js']
                 )
             ]
         )
@@ -1884,14 +1884,14 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        mcp_servers = mcp_config["mcpServers"]
-        assert "simple-server" in mcp_servers
-        server_config = mcp_servers["simple-server"]
+        mcp_servers = mcp_config['mcpServers']
+        assert 'simple-server' in mcp_servers
+        server_config = mcp_servers['simple-server']
 
         # Should not have env key if not provided
-        assert "env" not in server_config
-        assert server_config["command"] == "node"
-        assert server_config["args"] == ["app.js"]
+        assert 'env' not in server_config
+        assert server_config['command'] == 'node'
+        assert server_config['args'] == ['app.js']
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_multiple_servers_same_type(self):
@@ -1901,9 +1901,9 @@ class TestLiveStatusAppConversationService:
 
         self.mock_user.mcp_config = MCPConfig(
             sse_servers=[
-                MCPSSEServerConfig(url="https://server1.com/sse"),
-                MCPSSEServerConfig(url="https://server2.com/sse"),
-                MCPSSEServerConfig(url="https://server3.com/sse"),
+                MCPSSEServerConfig(url='https://server1.com/sse'),
+                MCPSSEServerConfig(url='https://server2.com/sse'),
+                MCPSSEServerConfig(url='https://server3.com/sse'),
             ]
         )
         self.mock_user_context.get_mcp_api_key.return_value = None
@@ -1914,8 +1914,8 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        mcp_servers = mcp_config["mcpServers"]
-        sse_servers = {k: v for k, v in mcp_servers.items() if k.startswith("sse_")}
+        mcp_servers = mcp_config['mcpServers']
+        sse_servers = {k: v for k, v in mcp_servers.items() if k.startswith('sse_')}
 
         # All 3 servers should be present with unique UUID-based names
         assert len(sse_servers) == 3
@@ -1925,10 +1925,10 @@ class TestLiveStatusAppConversationService:
         assert len(set(server_names)) == 3  # All names are unique
 
         # Verify all URLs are preserved
-        urls = [v["url"] for v in sse_servers.values()]
-        assert "https://server1.com/sse" in urls
-        assert "https://server2.com/sse" in urls
-        assert "https://server3.com/sse" in urls
+        urls = [v['url'] for v in sse_servers.values()]
+        assert 'https://server1.com/sse' in urls
+        assert 'https://server2.com/sse' in urls
+        assert 'https://server3.com/sse' in urls
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_mixed_server_types(self):
@@ -1943,17 +1943,17 @@ class TestLiveStatusAppConversationService:
 
         self.mock_user.mcp_config = MCPConfig(
             sse_servers=[
-                MCPSSEServerConfig(url="https://sse.example.com/sse", api_key="sse_key")
+                MCPSSEServerConfig(url='https://sse.example.com/sse', api_key='sse_key')
             ],
             shttp_servers=[
-                MCPSHTTPServerConfig(url="https://shttp.example.com/mcp", timeout=90)
+                MCPSHTTPServerConfig(url='https://shttp.example.com/mcp', timeout=90)
             ],
             stdio_servers=[
                 MCPStdioServerConfig(
-                    name="stdio-server",
-                    command="npx",
-                    args=["mcp-server"],
-                    env={"TOKEN": "value"},
+                    name='stdio-server',
+                    command='npx',
+                    args=['mcp-server'],
+                    env={'TOKEN': 'value'},
                 )
             ],
         )
@@ -1965,33 +1965,33 @@ class TestLiveStatusAppConversationService:
         )
 
         # Assert
-        mcp_servers = mcp_config["mcpServers"]
+        mcp_servers = mcp_config['mcpServers']
 
         # Check all server types are present
-        sse_count = len([k for k in mcp_servers if k.startswith("sse_")])
-        shttp_count = len([k for k in mcp_servers if k.startswith("shttp_")])
-        stdio_count = 1 if "stdio-server" in mcp_servers else 0
+        sse_count = len([k for k in mcp_servers if k.startswith('sse_')])
+        shttp_count = len([k for k in mcp_servers if k.startswith('shttp_')])
+        stdio_count = 1 if 'stdio-server' in mcp_servers else 0
 
         assert sse_count == 1
         assert shttp_count == 1
         assert stdio_count == 1
 
         # Verify each type has correct configuration
-        sse_server = next(v for k, v in mcp_servers.items() if k.startswith("sse_"))
-        assert sse_server["transport"] == "sse"
-        assert sse_server["headers"]["Authorization"] == "Bearer sse_key"
+        sse_server = next(v for k, v in mcp_servers.items() if k.startswith('sse_'))
+        assert sse_server['transport'] == 'sse'
+        assert sse_server['headers']['Authorization'] == 'Bearer sse_key'
 
-        shttp_server = next(v for k, v in mcp_servers.items() if k.startswith("shttp_"))
-        assert shttp_server["transport"] == "streamable-http"
-        assert shttp_server["timeout"] == 90
+        shttp_server = next(v for k, v in mcp_servers.items() if k.startswith('shttp_'))
+        assert shttp_server['transport'] == 'streamable-http'
+        assert shttp_server['timeout'] == 90
 
-        stdio_server = mcp_servers["stdio-server"]
-        assert stdio_server["command"] == "npx"
-        assert stdio_server["env"] == {"TOKEN": "value"}
+        stdio_server = mcp_servers['stdio-server']
+        assert stdio_server['command'] == 'npx'
+        assert stdio_server['env'] == {'TOKEN': 'value'}
 
     @pytest.mark.asyncio
     @patch(
-        "openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace"
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace'
     )
     async def test_start_app_conversation_exception_uses_extract_error_detail(
         self, mock_remote_workspace_class
@@ -2005,17 +2005,17 @@ class TestLiveStatusAppConversationService:
 
         # Arrange
         # Mock user context
-        self.mock_user_context.get_user_id = AsyncMock(return_value="test_user_123")
+        self.mock_user_context.get_user_id = AsyncMock(return_value='test_user_123')
         self.mock_user_context.get_user_info = AsyncMock(return_value=self.mock_user)
 
         # Mock sandbox and sandbox spec
         mock_sandbox_spec = Mock(spec=SandboxSpecInfo)
-        mock_sandbox_spec.working_dir = "/test/workspace"
+        mock_sandbox_spec.working_dir = '/test/workspace'
         self.mock_sandbox.sandbox_spec_id = str(uuid4())
         self.mock_sandbox.id = str(uuid4())
-        self.mock_sandbox.session_api_key = "test_session_key"
+        self.mock_sandbox.session_api_key = 'test_session_key'
         exposed_url = ExposedUrl(
-            name=AGENT_SERVER, url="http://agent-server:8000", port=60000
+            name=AGENT_SERVER, url='http://agent-server:8000', port=60000
         )
         self.mock_sandbox.exposed_urls = [exposed_url]
 
@@ -2044,10 +2044,10 @@ class TestLiveStatusAppConversationService:
         # Mock build start conversation request
         mock_agent = Mock(spec=Agent)
         mock_agent.llm = Mock(spec=LLM)
-        mock_agent.llm.model = "gpt-4"
+        mock_agent.llm.model = 'gpt-4'
         mock_start_request = Mock(spec=StartConversationRequest)
         mock_start_request.agent = mock_agent
-        mock_start_request.model_dump.return_value = {"test": "data"}
+        mock_start_request.model_dump.return_value = {'test': 'data'}
 
         self.service._build_start_conversation_request_for_user = AsyncMock(
             return_value=mock_start_request
@@ -2057,12 +2057,12 @@ class TestLiveStatusAppConversationService:
         mock_response = httpx.Response(
             500,
             json={
-                "detail": "Internal Server Error",
-                "exception": "Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'",
+                'detail': 'Internal Server Error',
+                'exception': "Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'",
             },
         )
         mock_response._request = httpx.Request(
-            "POST", "http://agent-server:8000/api/conversations"
+            'POST', 'http://agent-server:8000/api/conversations'
         )
         http_error = httpx.HTTPStatusError(
             message="Server error '500 Internal Server Error'",
@@ -2085,12 +2085,12 @@ class TestLiveStatusAppConversationService:
         final_task = tasks[-1]
         assert final_task.status == AppConversationStartTaskStatus.ERROR
         # The extract_error_detail function should extract the 'exception' field from JSON
-        assert "mcp.atlassian.com" in final_task.detail
-        assert "401 Unauthorized" in final_task.detail
+        assert 'mcp.atlassian.com' in final_task.detail
+        assert '401 Unauthorized' in final_task.detail
 
     @pytest.mark.asyncio
     @patch(
-        "openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace"
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace'
     )
     async def test_start_app_conversation_generic_exception_uses_extract_error_detail(
         self, mock_remote_workspace_class
@@ -2102,17 +2102,17 @@ class TestLiveStatusAppConversationService:
 
         # Arrange
         # Mock user context
-        self.mock_user_context.get_user_id = AsyncMock(return_value="test_user_123")
+        self.mock_user_context.get_user_id = AsyncMock(return_value='test_user_123')
         self.mock_user_context.get_user_info = AsyncMock(return_value=self.mock_user)
 
         # Mock sandbox and sandbox spec
         mock_sandbox_spec = Mock(spec=SandboxSpecInfo)
-        mock_sandbox_spec.working_dir = "/test/workspace"
+        mock_sandbox_spec.working_dir = '/test/workspace'
         self.mock_sandbox.sandbox_spec_id = str(uuid4())
         self.mock_sandbox.id = str(uuid4())
-        self.mock_sandbox.session_api_key = "test_session_key"
+        self.mock_sandbox.session_api_key = 'test_session_key'
         exposed_url = ExposedUrl(
-            name=AGENT_SERVER, url="http://agent-server:8000", port=60000
+            name=AGENT_SERVER, url='http://agent-server:8000', port=60000
         )
         self.mock_sandbox.exposed_urls = [exposed_url]
 
@@ -2141,10 +2141,10 @@ class TestLiveStatusAppConversationService:
         # Mock build start conversation request
         mock_agent = Mock(spec=Agent)
         mock_agent.llm = Mock(spec=LLM)
-        mock_agent.llm.model = "gpt-4"
+        mock_agent.llm.model = 'gpt-4'
         mock_start_request = Mock(spec=StartConversationRequest)
         mock_start_request.agent = mock_agent
-        mock_start_request.model_dump.return_value = {"test": "data"}
+        mock_start_request.model_dump.return_value = {'test': 'data'}
 
         self.service._build_start_conversation_request_for_user = AsyncMock(
             return_value=mock_start_request
@@ -2152,7 +2152,7 @@ class TestLiveStatusAppConversationService:
 
         # Make the HTTP post call raise a generic exception
         self.mock_httpx_client.post = AsyncMock(
-            side_effect=RuntimeError("Connection timeout")
+            side_effect=RuntimeError('Connection timeout')
         )
 
         # Create request
@@ -2167,7 +2167,7 @@ class TestLiveStatusAppConversationService:
         final_task = tasks[-1]
         assert final_task.status == AppConversationStartTaskStatus.ERROR
         # For non-httpx exceptions, extract_error_detail returns str(exc)
-        assert "Connection timeout" in final_task.detail
+        assert 'Connection timeout' in final_task.detail
 
 
 class TestPluginHandling:
@@ -2202,18 +2202,18 @@ class TestPluginHandling:
             sandbox_startup_timeout=30,
             sandbox_startup_poll_frequency=1,
             httpx_client=self.mock_httpx_client,
-            web_url="https://test.example.com",
-            openhands_provider_base_url="https://provider.example.com",
+            web_url='https://test.example.com',
+            openhands_provider_base_url='https://provider.example.com',
             access_token_hard_timeout=None,
-            app_mode="test",
+            app_mode='test',
         )
 
         # Mock user info
         self.mock_user = Mock()
-        self.mock_user.id = "test_user_123"
-        self.mock_user.llm_model = "gpt-4"
-        self.mock_user.llm_base_url = "https://api.openai.com/v1"
-        self.mock_user.llm_api_key = "test_api_key"
+        self.mock_user.id = 'test_user_123'
+        self.mock_user.llm_model = 'gpt-4'
+        self.mock_user.llm_base_url = 'https://api.openai.com/v1'
+        self.mock_user.llm_api_key = 'test_api_key'
         self.mock_user.confirmation_mode = False
         self.mock_user.search_api_key = None
         self.mock_user.condenser_max_size = None
@@ -2238,7 +2238,7 @@ class TestPluginHandling:
         assert result is None
 
         # Test with initial message but None plugins
-        initial_msg = SendMessageRequest(content=[TextContent(text="Hello world")])
+        initial_msg = SendMessageRequest(content=[TextContent(text='Hello world')])
         result = self.service._construct_initial_message_with_plugin_params(
             initial_msg, None
         )
@@ -2252,7 +2252,7 @@ class TestPluginHandling:
         )
 
         # Plugin with no parameters
-        plugins = [PluginSpec(source="github:owner/repo")]
+        plugins = [PluginSpec(source='github:owner/repo')]
 
         # Test with None initial message
         result = self.service._construct_initial_message_with_plugin_params(
@@ -2261,7 +2261,7 @@ class TestPluginHandling:
         assert result is None
 
         # Test with initial message
-        initial_msg = SendMessageRequest(content=[TextContent(text="Hello world")])
+        initial_msg = SendMessageRequest(content=[TextContent(text='Hello world')])
         result = self.service._construct_initial_message_with_plugin_params(
             initial_msg, plugins
         )
@@ -2276,8 +2276,8 @@ class TestPluginHandling:
 
         plugins = [
             PluginSpec(
-                source="github:owner/repo",
-                parameters={"api_key": "test123", "debug": True},
+                source='github:owner/repo',
+                parameters={'api_key': 'test123', 'debug': True},
             )
         ]
 
@@ -2288,9 +2288,9 @@ class TestPluginHandling:
         assert result is not None
         assert len(result.content) == 1
         assert isinstance(result.content[0], TextContent)
-        assert "Plugin Configuration Parameters:" in result.content[0].text
-        assert "- api_key: test123" in result.content[0].text
-        assert "- debug: True" in result.content[0].text
+        assert 'Plugin Configuration Parameters:' in result.content[0].text
+        assert '- api_key: test123' in result.content[0].text
+        assert '- debug: True' in result.content[0].text
         assert result.run is True
 
     def test_construct_initial_message_with_plugin_params_appends_to_message(self):
@@ -2301,14 +2301,14 @@ class TestPluginHandling:
         )
 
         initial_msg = SendMessageRequest(
-            content=[TextContent(text="Please analyze this codebase")],
+            content=[TextContent(text='Please analyze this codebase')],
             run=False,
         )
         plugins = [
             PluginSpec(
-                source="github:owner/repo",
-                ref="v1.0.0",
-                parameters={"target_dir": "/src", "verbose": True},
+                source='github:owner/repo',
+                ref='v1.0.0',
+                parameters={'target_dir': '/src', 'verbose': True},
             )
         ]
 
@@ -2319,10 +2319,10 @@ class TestPluginHandling:
         assert result is not None
         assert len(result.content) == 1
         text = result.content[0].text
-        assert text.startswith("Please analyze this codebase")
-        assert "Plugin Configuration Parameters:" in text
-        assert "- target_dir: /src" in text
-        assert "- verbose: True" in text
+        assert text.startswith('Please analyze this codebase')
+        assert 'Plugin Configuration Parameters:' in text
+        assert '- target_dir: /src' in text
+        assert '- verbose: True' in text
         assert result.run is False
 
     def test_construct_initial_message_with_plugin_params_preserves_role(self):
@@ -2333,17 +2333,17 @@ class TestPluginHandling:
         )
 
         initial_msg = SendMessageRequest(
-            role="system",
-            content=[TextContent(text="System message")],
+            role='system',
+            content=[TextContent(text='System message')],
         )
-        plugins = [PluginSpec(source="github:owner/repo", parameters={"key": "value"})]
+        plugins = [PluginSpec(source='github:owner/repo', parameters={'key': 'value'})]
 
         result = self.service._construct_initial_message_with_plugin_params(
             initial_msg, plugins
         )
 
         assert result is not None
-        assert result.role == "system"
+        assert result.role == 'system'
 
     def test_construct_initial_message_with_plugin_params_empty_content(self):
         """Test _construct_initial_message_with_plugin_params handles empty content list."""
@@ -2353,7 +2353,7 @@ class TestPluginHandling:
         )
 
         initial_msg = SendMessageRequest(content=[])
-        plugins = [PluginSpec(source="github:owner/repo", parameters={"key": "value"})]
+        plugins = [PluginSpec(source='github:owner/repo', parameters={'key': 'value'})]
 
         result = self.service._construct_initial_message_with_plugin_params(
             initial_msg, plugins
@@ -2362,7 +2362,7 @@ class TestPluginHandling:
         assert result is not None
         assert len(result.content) == 1
         assert isinstance(result.content[0], TextContent)
-        assert "Plugin Configuration Parameters:" in result.content[0].text
+        assert 'Plugin Configuration Parameters:' in result.content[0].text
 
     def test_construct_initial_message_with_multiple_plugins(self):
         """Test _construct_initial_message_with_plugin_params handles multiple plugins."""
@@ -2373,12 +2373,12 @@ class TestPluginHandling:
 
         plugins = [
             PluginSpec(
-                source="github:owner/plugin1",
-                parameters={"key1": "value1"},
+                source='github:owner/plugin1',
+                parameters={'key1': 'value1'},
             ),
             PluginSpec(
-                source="github:owner/plugin2",
-                parameters={"key2": "value2"},
+                source='github:owner/plugin2',
+                parameters={'key2': 'value2'},
             ),
         ]
 
@@ -2390,12 +2390,12 @@ class TestPluginHandling:
         assert len(result.content) == 1
         assert isinstance(result.content[0], TextContent)
         text = result.content[0].text
-        assert "Plugin Configuration Parameters:" in text
+        assert 'Plugin Configuration Parameters:' in text
         # Multiple plugins should show grouped by plugin name
-        assert "plugin1" in text
-        assert "plugin2" in text
-        assert "key1: value1" in text
-        assert "key2: value2" in text
+        assert 'plugin1' in text
+        assert 'plugin2' in text
+        assert 'key1: value1' in text
+        assert 'key2: value2' in text
 
     @pytest.mark.asyncio
     async def test_finalize_conversation_request_with_plugins(self):
@@ -2407,8 +2407,8 @@ class TestPluginHandling:
         # Arrange
         mock_agent = Mock(spec=Agent)
         mock_llm = Mock(spec=LLM)
-        mock_llm.model = "gpt-4"
-        mock_llm.usage_id = "agent"
+        mock_llm.model = 'gpt-4'
+        mock_llm.usage_id = 'agent'
         mock_agent.llm = mock_llm
         mock_agent.condenser = None
 
@@ -2417,14 +2417,14 @@ class TestPluginHandling:
         mock_updated_agent.condenser = None
         mock_agent.model_copy = Mock(return_value=mock_updated_agent)
 
-        workspace = LocalWorkspace(working_dir="/test")
-        secrets = {"test": StaticSecret(value="secret")}
+        workspace = LocalWorkspace(working_dir='/test')
+        secrets = {'test': StaticSecret(value='secret')}
 
         plugins = [
             PluginSpec(
-                source="github:owner/my-plugin",
-                ref="v1.0.0",
-                parameters={"api_key": "test123"},
+                source='github:owner/my-plugin',
+                ref='v1.0.0',
+                parameters={'api_key': 'test123'},
             )
         ]
 
@@ -2439,7 +2439,7 @@ class TestPluginHandling:
             self.mock_sandbox,
             None,
             None,
-            "/test/dir",
+            '/test/dir',
             plugins=plugins,
         )
 
@@ -2447,14 +2447,14 @@ class TestPluginHandling:
         assert isinstance(result, StartConversationRequest)
         assert result.plugins is not None
         assert len(result.plugins) == 1
-        assert result.plugins[0].source == "github:owner/my-plugin"
-        assert result.plugins[0].ref == "v1.0.0"
+        assert result.plugins[0].source == 'github:owner/my-plugin'
+        assert result.plugins[0].ref == 'v1.0.0'
         # Also verify initial message contains plugin params
         assert result.initial_message is not None
         assert (
-            "Plugin Configuration Parameters:" in result.initial_message.content[0].text
+            'Plugin Configuration Parameters:' in result.initial_message.content[0].text
         )
-        assert "- api_key: test123" in result.initial_message.content[0].text
+        assert '- api_key: test123' in result.initial_message.content[0].text
 
     @pytest.mark.asyncio
     async def test_finalize_conversation_request_without_plugins(self):
@@ -2462,8 +2462,8 @@ class TestPluginHandling:
         # Arrange
         mock_agent = Mock(spec=Agent)
         mock_llm = Mock(spec=LLM)
-        mock_llm.model = "gpt-4"
-        mock_llm.usage_id = "agent"
+        mock_llm.model = 'gpt-4'
+        mock_llm.usage_id = 'agent'
         mock_agent.llm = mock_llm
         mock_agent.condenser = None
 
@@ -2472,7 +2472,7 @@ class TestPluginHandling:
         mock_updated_agent.condenser = None
         mock_agent.model_copy = Mock(return_value=mock_updated_agent)
 
-        workspace = LocalWorkspace(working_dir="/test")
+        workspace = LocalWorkspace(working_dir='/test')
         secrets = {}
 
         # Act
@@ -2486,7 +2486,7 @@ class TestPluginHandling:
             self.mock_sandbox,
             None,
             None,
-            "/test/dir",
+            '/test/dir',
             plugins=None,
         )
 
@@ -2504,8 +2504,8 @@ class TestPluginHandling:
         # Arrange
         mock_agent = Mock(spec=Agent)
         mock_llm = Mock(spec=LLM)
-        mock_llm.model = "gpt-4"
-        mock_llm.usage_id = "agent"
+        mock_llm.model = 'gpt-4'
+        mock_llm.usage_id = 'agent'
         mock_agent.llm = mock_llm
         mock_agent.condenser = None
 
@@ -2514,11 +2514,11 @@ class TestPluginHandling:
         mock_updated_agent.condenser = None
         mock_agent.model_copy = Mock(return_value=mock_updated_agent)
 
-        workspace = LocalWorkspace(working_dir="/test")
+        workspace = LocalWorkspace(working_dir='/test')
         secrets = {}
 
         # Plugin without ref or parameters
-        plugins = [PluginSpec(source="github:owner/my-plugin")]
+        plugins = [PluginSpec(source='github:owner/my-plugin')]
 
         # Act
         result = await self.service._finalize_conversation_request(
@@ -2531,7 +2531,7 @@ class TestPluginHandling:
             self.mock_sandbox,
             None,
             None,
-            "/test/dir",
+            '/test/dir',
             plugins=plugins,
         )
 
@@ -2539,7 +2539,7 @@ class TestPluginHandling:
         assert isinstance(result, StartConversationRequest)
         assert result.plugins is not None
         assert len(result.plugins) == 1
-        assert result.plugins[0].source == "github:owner/my-plugin"
+        assert result.plugins[0].source == 'github:owner/my-plugin'
         assert result.plugins[0].ref is None
         # No parameters, so initial message should be None
         assert result.initial_message is None
@@ -2554,8 +2554,8 @@ class TestPluginHandling:
         # Arrange
         mock_agent = Mock(spec=Agent)
         mock_llm = Mock(spec=LLM)
-        mock_llm.model = "gpt-4"
-        mock_llm.usage_id = "agent"
+        mock_llm.model = 'gpt-4'
+        mock_llm.usage_id = 'agent'
         mock_agent.llm = mock_llm
         mock_agent.condenser = None
 
@@ -2564,15 +2564,15 @@ class TestPluginHandling:
         mock_updated_agent.condenser = None
         mock_agent.model_copy = Mock(return_value=mock_updated_agent)
 
-        workspace = LocalWorkspace(working_dir="/test")
+        workspace = LocalWorkspace(working_dir='/test')
         secrets = {}
 
         # Plugin with repo_path (for marketplace repos containing multiple plugins)
         plugins = [
             PluginSpec(
-                source="github:owner/marketplace-repo",
-                ref="main",
-                repo_path="plugins/city-weather",
+                source='github:owner/marketplace-repo',
+                ref='main',
+                repo_path='plugins/city-weather',
             )
         ]
 
@@ -2587,7 +2587,7 @@ class TestPluginHandling:
             self.mock_sandbox,
             None,
             None,
-            "/test/dir",
+            '/test/dir',
             plugins=plugins,
         )
 
@@ -2595,9 +2595,9 @@ class TestPluginHandling:
         assert isinstance(result, StartConversationRequest)
         assert result.plugins is not None
         assert len(result.plugins) == 1
-        assert result.plugins[0].source == "github:owner/marketplace-repo"
-        assert result.plugins[0].ref == "main"
-        assert result.plugins[0].repo_path == "plugins/city-weather"
+        assert result.plugins[0].source == 'github:owner/marketplace-repo'
+        assert result.plugins[0].ref == 'main'
+        assert result.plugins[0].repo_path == 'plugins/city-weather'
 
     @pytest.mark.asyncio
     async def test_finalize_conversation_request_multiple_plugins(self):
@@ -2609,8 +2609,8 @@ class TestPluginHandling:
         # Arrange
         mock_agent = Mock(spec=Agent)
         mock_llm = Mock(spec=LLM)
-        mock_llm.model = "gpt-4"
-        mock_llm.usage_id = "agent"
+        mock_llm.model = 'gpt-4'
+        mock_llm.usage_id = 'agent'
         mock_agent.llm = mock_llm
         mock_agent.condenser = None
 
@@ -2619,17 +2619,17 @@ class TestPluginHandling:
         mock_updated_agent.condenser = None
         mock_agent.model_copy = Mock(return_value=mock_updated_agent)
 
-        workspace = LocalWorkspace(working_dir="/test")
+        workspace = LocalWorkspace(working_dir='/test')
         secrets = {}
 
         # Multiple plugins
         plugins = [
-            PluginSpec(source="github:owner/security-plugin", ref="v2.0.0"),
+            PluginSpec(source='github:owner/security-plugin', ref='v2.0.0'),
             PluginSpec(
-                source="github:owner/monorepo",
-                repo_path="plugins/logging",
+                source='github:owner/monorepo',
+                repo_path='plugins/logging',
             ),
-            PluginSpec(source="/local/path/to/plugin"),
+            PluginSpec(source='/local/path/to/plugin'),
         ]
 
         # Act
@@ -2643,7 +2643,7 @@ class TestPluginHandling:
             self.mock_sandbox,
             None,
             None,
-            "/test/dir",
+            '/test/dir',
             plugins=plugins,
         )
 
@@ -2651,11 +2651,11 @@ class TestPluginHandling:
         assert isinstance(result, StartConversationRequest)
         assert result.plugins is not None
         assert len(result.plugins) == 3
-        assert result.plugins[0].source == "github:owner/security-plugin"
-        assert result.plugins[0].ref == "v2.0.0"
-        assert result.plugins[1].source == "github:owner/monorepo"
-        assert result.plugins[1].repo_path == "plugins/logging"
-        assert result.plugins[2].source == "/local/path/to/plugin"
+        assert result.plugins[0].source == 'github:owner/security-plugin'
+        assert result.plugins[0].ref == 'v2.0.0'
+        assert result.plugins[1].source == 'github:owner/monorepo'
+        assert result.plugins[1].repo_path == 'plugins/logging'
+        assert result.plugins[2].source == '/local/path/to/plugin'
 
     @pytest.mark.asyncio
     async def test_build_start_conversation_request_for_user_with_plugins(self):
@@ -2672,9 +2672,9 @@ class TestPluginHandling:
 
         plugins = [
             PluginSpec(
-                source="https://github.com/org/plugin.git",
-                ref="main",
-                parameters={"config_file": "custom.yaml"},
+                source='https://github.com/org/plugin.git',
+                ref='main',
+                parameters={'config_file': 'custom.yaml'},
             )
         ]
 
@@ -2688,14 +2688,14 @@ class TestPluginHandling:
             None,
             None,
             None,
-            "/workspace",
+            '/workspace',
             plugins=plugins,
         )
 
         # Assert
         mock_finalize.assert_called_once()
         call_kwargs = mock_finalize.call_args.kwargs
-        assert call_kwargs["plugins"] == plugins
+        assert call_kwargs['plugins'] == plugins
 
     @pytest.mark.asyncio
     async def test_build_start_conversation_request_for_user_without_plugins(self):
@@ -2716,13 +2716,13 @@ class TestPluginHandling:
             None,
             None,
             None,
-            "/workspace",
+            '/workspace',
         )
 
         # Assert
         mock_finalize.assert_called_once()
         call_kwargs = mock_finalize.call_args.kwargs
-        assert call_kwargs.get("plugins") is None
+        assert call_kwargs.get('plugins') is None
 
 
 class TestPluginSpecModel:
@@ -2735,16 +2735,16 @@ class TestPluginSpecModel:
         )
 
         plugin = PluginSpec(
-            source="github:owner/repo",
-            ref="v1.0.0",
-            repo_path="plugins/my-plugin",
-            parameters={"key1": "value1", "key2": 123, "key3": True},
+            source='github:owner/repo',
+            ref='v1.0.0',
+            repo_path='plugins/my-plugin',
+            parameters={'key1': 'value1', 'key2': 123, 'key3': True},
         )
 
-        assert plugin.source == "github:owner/repo"
-        assert plugin.ref == "v1.0.0"
-        assert plugin.repo_path == "plugins/my-plugin"
-        assert plugin.parameters == {"key1": "value1", "key2": 123, "key3": True}
+        assert plugin.source == 'github:owner/repo'
+        assert plugin.ref == 'v1.0.0'
+        assert plugin.repo_path == 'plugins/my-plugin'
+        assert plugin.parameters == {'key1': 'value1', 'key2': 123, 'key3': True}
 
     def test_plugin_spec_with_only_source(self):
         """Test PluginSpec with only source provided."""
@@ -2752,9 +2752,9 @@ class TestPluginSpecModel:
             PluginSpec,
         )
 
-        plugin = PluginSpec(source="https://github.com/owner/repo.git")
+        plugin = PluginSpec(source='https://github.com/owner/repo.git')
 
-        assert plugin.source == "https://github.com/owner/repo.git"
+        assert plugin.source == 'https://github.com/owner/repo.git'
         assert plugin.ref is None
         assert plugin.repo_path is None
         assert plugin.parameters is None
@@ -2766,18 +2766,18 @@ class TestPluginSpecModel:
         )
 
         plugin = PluginSpec(
-            source="github:owner/repo",
-            ref="main",
-            repo_path="plugins/my-plugin",
-            parameters={"debug": True},
+            source='github:owner/repo',
+            ref='main',
+            repo_path='plugins/my-plugin',
+            parameters={'debug': True},
         )
 
         json_data = plugin.model_dump()
         assert json_data == {
-            "source": "github:owner/repo",
-            "ref": "main",
-            "repo_path": "plugins/my-plugin",
-            "parameters": {"debug": True},
+            'source': 'github:owner/repo',
+            'ref': 'main',
+            'repo_path': 'plugins/my-plugin',
+            'parameters': {'debug': True},
         }
 
     def test_plugin_spec_deserialization(self):
@@ -2787,18 +2787,18 @@ class TestPluginSpecModel:
         )
 
         data = {
-            "source": "github:owner/repo",
-            "ref": "v2.0.0",
-            "repo_path": "plugins/weather",
-            "parameters": {"timeout": 30},
+            'source': 'github:owner/repo',
+            'ref': 'v2.0.0',
+            'repo_path': 'plugins/weather',
+            'parameters': {'timeout': 30},
         }
 
         plugin = PluginSpec.model_validate(data)
 
-        assert plugin.source == "github:owner/repo"
-        assert plugin.ref == "v2.0.0"
-        assert plugin.repo_path == "plugins/weather"
-        assert plugin.parameters == {"timeout": 30}
+        assert plugin.source == 'github:owner/repo'
+        assert plugin.ref == 'v2.0.0'
+        assert plugin.repo_path == 'plugins/weather'
+        assert plugin.parameters == {'timeout': 30}
 
     def test_plugin_spec_display_name_github_format(self):
         """Test display_name extracts repo name from github:owner/repo format."""
@@ -2806,8 +2806,8 @@ class TestPluginSpecModel:
             PluginSpec,
         )
 
-        plugin = PluginSpec(source="github:owner/my-plugin")
-        assert plugin.display_name == "my-plugin"
+        plugin = PluginSpec(source='github:owner/my-plugin')
+        assert plugin.display_name == 'my-plugin'
 
     def test_plugin_spec_display_name_git_url(self):
         """Test display_name extracts repo name from git URL."""
@@ -2815,8 +2815,8 @@ class TestPluginSpecModel:
             PluginSpec,
         )
 
-        plugin = PluginSpec(source="https://github.com/owner/repo.git")
-        assert plugin.display_name == "repo.git"
+        plugin = PluginSpec(source='https://github.com/owner/repo.git')
+        assert plugin.display_name == 'repo.git'
 
     def test_plugin_spec_display_name_local_path(self):
         """Test display_name extracts directory name from local path."""
@@ -2824,8 +2824,8 @@ class TestPluginSpecModel:
             PluginSpec,
         )
 
-        plugin = PluginSpec(source="/local/path/to/plugin")
-        assert plugin.display_name == "plugin"
+        plugin = PluginSpec(source='/local/path/to/plugin')
+        assert plugin.display_name == 'plugin'
 
     def test_plugin_spec_display_name_no_slash(self):
         """Test display_name returns source as-is when no slash present."""
@@ -2833,8 +2833,8 @@ class TestPluginSpecModel:
             PluginSpec,
         )
 
-        plugin = PluginSpec(source="local-plugin")
-        assert plugin.display_name == "local-plugin"
+        plugin = PluginSpec(source='local-plugin')
+        assert plugin.display_name == 'local-plugin'
 
     def test_plugin_spec_format_params_as_text(self):
         """Test format_params_as_text formats parameters as text."""
@@ -2843,12 +2843,12 @@ class TestPluginSpecModel:
         )
 
         plugin = PluginSpec(
-            source="github:owner/repo",
-            parameters={"key1": "value1", "key2": 123},
+            source='github:owner/repo',
+            parameters={'key1': 'value1', 'key2': 123},
         )
 
         result = plugin.format_params_as_text()
-        assert result == "- key1: value1\n- key2: 123"
+        assert result == '- key1: value1\n- key2: 123'
 
     def test_plugin_spec_format_params_as_text_with_indent(self):
         """Test format_params_as_text with custom indent."""
@@ -2857,12 +2857,12 @@ class TestPluginSpecModel:
         )
 
         plugin = PluginSpec(
-            source="github:owner/repo",
-            parameters={"debug": True},
+            source='github:owner/repo',
+            parameters={'debug': True},
         )
 
-        result = plugin.format_params_as_text(indent="  ")
-        assert result == "  - debug: True"
+        result = plugin.format_params_as_text(indent='  ')
+        assert result == '  - debug: True'
 
     def test_plugin_spec_format_params_as_text_no_params(self):
         """Test format_params_as_text returns None when no parameters."""
@@ -2870,7 +2870,7 @@ class TestPluginSpecModel:
             PluginSpec,
         )
 
-        plugin = PluginSpec(source="github:owner/repo")
+        plugin = PluginSpec(source='github:owner/repo')
         assert plugin.format_params_as_text() is None
 
     def test_plugin_spec_inherits_repo_path_validation(self):
@@ -2882,12 +2882,12 @@ class TestPluginSpecModel:
         )
 
         # Should reject absolute paths
-        with pytest.raises(ValueError, match="must be relative"):
-            PluginSpec(source="github:owner/repo", repo_path="/absolute/path")
+        with pytest.raises(ValueError, match='must be relative'):
+            PluginSpec(source='github:owner/repo', repo_path='/absolute/path')
 
         # Should reject parent traversal
         with pytest.raises(ValueError, match="cannot contain '..'"):
-            PluginSpec(source="github:owner/repo", repo_path="../parent/path")
+            PluginSpec(source='github:owner/repo', repo_path='../parent/path')
 
 
 class TestAppConversationStartRequestWithPlugins:
@@ -2902,22 +2902,22 @@ class TestAppConversationStartRequestWithPlugins:
 
         plugins = [
             PluginSpec(
-                source="github:owner/my-plugin",
-                ref="v1.0.0",
-                parameters={"api_key": "test"},
+                source='github:owner/my-plugin',
+                ref='v1.0.0',
+                parameters={'api_key': 'test'},
             )
         ]
 
         request = AppConversationStartRequest(
-            title="Test conversation",
+            title='Test conversation',
             plugins=plugins,
         )
 
         assert request.plugins is not None
         assert len(request.plugins) == 1
-        assert request.plugins[0].source == "github:owner/my-plugin"
-        assert request.plugins[0].ref == "v1.0.0"
-        assert request.plugins[0].parameters == {"api_key": "test"}
+        assert request.plugins[0].source == 'github:owner/my-plugin'
+        assert request.plugins[0].ref == 'v1.0.0'
+        assert request.plugins[0].parameters == {'api_key': 'test'}
 
     def test_start_request_without_plugins(self):
         """Test AppConversationStartRequest without plugins field (backwards compatible)."""
@@ -2926,7 +2926,7 @@ class TestAppConversationStartRequestWithPlugins:
         )
 
         request = AppConversationStartRequest(
-            title="Test conversation",
+            title='Test conversation',
         )
 
         assert request.plugins is None
@@ -2938,14 +2938,14 @@ class TestAppConversationStartRequestWithPlugins:
             PluginSpec,
         )
 
-        plugins = [PluginSpec(source="github:owner/repo")]
+        plugins = [PluginSpec(source='github:owner/repo')]
         request = AppConversationStartRequest(plugins=plugins)
 
         json_data = request.model_dump()
 
-        assert "plugins" in json_data
-        assert len(json_data["plugins"]) == 1
-        assert json_data["plugins"][0]["source"] == "github:owner/repo"
+        assert 'plugins' in json_data
+        assert len(json_data['plugins']) == 1
+        assert json_data['plugins'][0]['source'] == 'github:owner/repo'
 
     def test_start_request_deserialization_with_plugins(self):
         """Test AppConversationStartRequest deserialization from JSON with plugins."""
@@ -2954,12 +2954,12 @@ class TestAppConversationStartRequestWithPlugins:
         )
 
         data = {
-            "title": "Test",
-            "plugins": [
+            'title': 'Test',
+            'plugins': [
                 {
-                    "source": "github:owner/plugin",
-                    "ref": "main",
-                    "parameters": {"key": "value"},
+                    'source': 'github:owner/plugin',
+                    'ref': 'main',
+                    'parameters': {'key': 'value'},
                 },
             ],
         }
@@ -2968,9 +2968,9 @@ class TestAppConversationStartRequestWithPlugins:
 
         assert request.plugins is not None
         assert len(request.plugins) == 1
-        assert request.plugins[0].source == "github:owner/plugin"
-        assert request.plugins[0].ref == "main"
-        assert request.plugins[0].parameters == {"key": "value"}
+        assert request.plugins[0].source == 'github:owner/plugin'
+        assert request.plugins[0].ref == 'main'
+        assert request.plugins[0].parameters == {'key': 'value'}
 
     def test_start_request_with_multiple_plugins(self):
         """Test AppConversationStartRequest with multiple plugins."""
@@ -2980,18 +2980,18 @@ class TestAppConversationStartRequestWithPlugins:
         )
 
         plugins = [
-            PluginSpec(source="github:owner/plugin1", ref="v1.0.0"),
-            PluginSpec(source="github:owner/plugin2", repo_path="plugins/sub"),
-            PluginSpec(source="/local/path"),
+            PluginSpec(source='github:owner/plugin1', ref='v1.0.0'),
+            PluginSpec(source='github:owner/plugin2', repo_path='plugins/sub'),
+            PluginSpec(source='/local/path'),
         ]
 
         request = AppConversationStartRequest(
-            title="Test conversation",
+            title='Test conversation',
             plugins=plugins,
         )
 
         assert request.plugins is not None
         assert len(request.plugins) == 3
-        assert request.plugins[0].source == "github:owner/plugin1"
-        assert request.plugins[1].repo_path == "plugins/sub"
-        assert request.plugins[2].source == "/local/path"
+        assert request.plugins[0].source == 'github:owner/plugin1'
+        assert request.plugins[1].repo_path == 'plugins/sub'
+        assert request.plugins[2].source == '/local/path'


### PR DESCRIPTION
## Problem

When V1 conversation creation fails due to agent server errors (e.g., MCP authentication failures like a 401 from Atlassian), users only see a generic error message:

```
Server error '500 Internal Server Error' for url 'https://xxx.prod-runtime.all-hands.dev/api/conversations'
```

The actual error details are in the response body but were being lost because `str(httpx.HTTPStatusError)` was used, which doesn't include the response content.

## Solution

This PR adds an `extract_error_detail()` utility that extracts the detailed error from httpx response bodies and uses it in the conversation start task error details.

**Before:** `Server error '500 Internal Server Error' for url '...'`  
**After:** `Client error '401 Unauthorized' for url 'https://mcp.atlassian.com/v1/sse'`

## Changes

- `openhands/app_server/utils/httpx_utils.py`: New utility function `extract_error_detail()`
- `openhands/app_server/app_conversation/live_status_app_conversation_service.py`: Use the utility in exception handling
- `tests/unit/app_server/test_httpx_utils.py`: Comprehensive tests including the MCP 401 scenario

## Context

This is related to #9805 (Better logging of MCP Errors) but addresses a more severe regression introduced with FastMCP 3.x. Previously, broken MCP configurations were silently ignored. Now they actively block conversation startup. This PR ensures users see the actual error message so they can fix their MCP configuration.

## Future Work: Graceful Degradation

While this PR surfaces the error, conversations still fail to start when any MCP server fails. A follow-up change in `openhands-sdk` could implement per-server graceful degradation. See comment below for implementation details.

---

Related to #9805

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:7f658d9-nikolaik   --name openhands-app-7f658d9   docker.openhands.dev/openhands/openhands:7f658d9
```