### PR TITLE
feat: add custom docker run options to sandbox service

### DIFF
--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -239,6 +239,22 @@ def config_from_env() -> AppServerConfig:
                         )
                 if mounts:
                     docker_sandbox_kwargs['mounts'] = mounts
+            # Parse SANDBOX_DOCKER_RUNTIME_KWARGS for custom docker run arguments
+            # This allows passing devices, cap_add, security_opt, etc.
+            if os.getenv('SANDBOX_DOCKER_RUNTIME_KWARGS'):
+                import json
+
+                docker_run_kwargs = json.loads(
+                    os.environ['SANDBOX_DOCKER_RUNTIME_KWARGS']
+                )
+                if 'devices' in docker_run_kwargs:
+                    docker_sandbox_kwargs['devices'] = docker_run_kwargs['devices']
+                if 'cap_add' in docker_run_kwargs:
+                    docker_sandbox_kwargs['cap_add'] = docker_run_kwargs['cap_add']
+                if 'security_opt' in docker_run_kwargs:
+                    docker_sandbox_kwargs['security_opt'] = docker_run_kwargs[
+                        'security_opt'
+                    ]
             config.sandbox = DockerSandboxServiceInjector(**docker_sandbox_kwargs)
 
     if config.sandbox_spec is None:

--- a/openhands/app_server/sandbox/docker_sandbox_service.py
+++ b/openhands/app_server/sandbox/docker_sandbox_service.py
@@ -85,6 +85,9 @@ class DockerSandboxService(SandboxService):
     docker_client: docker.DockerClient = field(default_factory=get_docker_client)
     startup_grace_seconds: int = STARTUP_GRACE_SECONDS
     use_host_network: bool = False
+    devices: list[str] = field(default_factory=list)
+    cap_add: list[str] = field(default_factory=list)
+    security_opt: list[str] = field(default_factory=list)
 
     def _find_unused_port(self) -> int:
         """Find an unused port on the host machine."""
@@ -411,7 +414,7 @@ class DockerSandboxService(SandboxService):
 
         try:
             # Create and start the container
-            container = self.docker_client.containers.run(  # type: ignore[call-overload]
+            container = self.docker_client.containers.run(  # type: ignore[call-overload,misc]
                 image=sandbox_spec.id,
                 command=sandbox_spec.command,  # Use default command from image
                 remove=False,
@@ -433,6 +436,10 @@ class DockerSandboxService(SandboxService):
                 else None,
                 # Network mode: 'host' for host networking, None for default bridge
                 network_mode=network_mode,
+                # Additional docker run options for specialized use cases (e.g., KVM passthrough)
+                devices=self.devices or None,
+                cap_add=self.cap_add or None,
+                security_opt=self.security_opt or None,
             )
 
             sandbox_info = await self._container_to_sandbox_info(container)
@@ -599,6 +606,31 @@ class DockerSandboxServiceInjector(SandboxServiceInjector):
             'is problematic. Configure via OH_SANDBOX_USE_HOST_NETWORK environment variable.'
         ),
     )
+    devices: list[str] = Field(
+        default_factory=list,
+        description=(
+            'List of device mappings to pass to the container. '
+            'Format: "host_device:container_device[:permissions]". '
+            'Example: ["/dev/kvm:/dev/kvm"]. '
+            'Configure via OH_SANDBOX_DEVICES_0, OH_SANDBOX_DEVICES_1, etc.'
+        ),
+    )
+    cap_add: list[str] = Field(
+        default_factory=list,
+        description=(
+            'List of Linux capabilities to add to the container. '
+            'Example: ["SYS_ADMIN", "NET_ADMIN"]. '
+            'Configure via OH_SANDBOX_CAP_ADD_0, OH_SANDBOX_CAP_ADD_1, etc.'
+        ),
+    )
+    security_opt: list[str] = Field(
+        default_factory=list,
+        description=(
+            'List of security options for the container. '
+            'Example: ["seccomp=unconfined", "apparmor=unconfined"]. '
+            'Configure via OH_SANDBOX_SECURITY_OPT_0, OH_SANDBOX_SECURITY_OPT_1, etc.'
+        ),
+    )
 
     async def inject(
         self, state: InjectorState, request: Request | None = None
@@ -632,4 +664,7 @@ class DockerSandboxServiceInjector(SandboxServiceInjector):
                 extra_hosts=self.extra_hosts,
                 startup_grace_seconds=self.startup_grace_seconds,
                 use_host_network=self.use_host_network,
+                devices=self.devices,
+                cap_add=self.cap_add,
+                security_opt=self.security_opt,
             )

--- a/tests/unit/app_server/test_docker_sandbox_service.py
+++ b/tests/unit/app_server/test_docker_sandbox_service.py
@@ -554,6 +554,73 @@ class TestDockerSandboxService:
 
     @patch('openhands.app_server.sandbox.docker_sandbox_service.base62.encodebytes')
     @patch('os.urandom')
+    async def test_start_sandbox_with_docker_run_kwargs(
+        self,
+        mock_urandom,
+        mock_encodebytes,
+        mock_sandbox_spec_service,
+        mock_httpx_client,
+        mock_docker_client,
+    ):
+        """Test that devices, cap_add, and security_opt are passed to container creation."""
+        # Setup
+        mock_urandom.side_effect = [b'container_id', b'session_key']
+        mock_encodebytes.side_effect = ['test_container_id', 'test_session_key']
+
+        mock_container = MagicMock()
+        mock_container.name = 'oh-test-test_container_id'
+        mock_container.status = 'running'
+        mock_container.image.tags = ['test-image:latest']
+        mock_container.attrs = {
+            'Created': '2024-01-15T10:30:00.000000000Z',
+            'Config': {
+                'Env': ['OH_SESSION_API_KEYS_0=test_session_key', 'TEST_VAR=test_value']
+            },
+            'NetworkSettings': {'Ports': {}},
+        }
+        mock_docker_client.containers.run.return_value = mock_container
+
+        # Create service with custom docker options
+        service_with_docker_options = DockerSandboxService(
+            sandbox_spec_service=mock_sandbox_spec_service,
+            container_name_prefix='oh-test-',
+            host_port=3000,
+            container_url_pattern='http://localhost:{port}',
+            mounts=[],
+            exposed_ports=[
+                ExposedPort(
+                    name=AGENT_SERVER, description='Agent server', container_port=8000
+                ),
+            ],
+            health_check_path='/health',
+            httpx_client=mock_httpx_client,
+            max_num_sandboxes=3,
+            docker_client=mock_docker_client,
+            devices=['/dev/kvm:/dev/kvm'],
+            cap_add=['SYS_ADMIN'],
+            security_opt=['seccomp=unconfined'],
+        )
+
+        with (
+            patch.object(
+                service_with_docker_options, '_find_unused_port', return_value=12345
+            ),
+            patch.object(
+                service_with_docker_options, 'pause_old_sandboxes', return_value=[]
+            ),
+        ):
+            # Execute
+            await service_with_docker_options.start_sandbox()
+
+        # Verify docker options were passed to container creation
+        mock_docker_client.containers.run.assert_called_once()
+        call_args = mock_docker_client.containers.run.call_args
+        assert call_args[1]['devices'] == ['/dev/kvm:/dev/kvm']
+        assert call_args[1]['cap_add'] == ['SYS_ADMIN']
+        assert call_args[1]['security_opt'] == ['seccomp=unconfined']
+
+    @patch('openhands.app_server.sandbox.docker_sandbox_service.base62.encodebytes')
+    @patch('os.urandom')
     async def test_start_sandbox_without_extra_hosts(
         self,
         mock_urandom,
@@ -1264,6 +1331,35 @@ class TestDockerSandboxServiceInjectorFromEnv:
             assert config.sandbox is not None
             assert config.sandbox.host_port == 4000
             assert config.sandbox.container_url_pattern == 'http://192.168.1.100:{port}'
+
+    def test_config_from_env_with_sandbox_docker_options(self):
+        """Test that SANDBOX_DOCKER_RUNTIME_KWARGS environment variable is respected."""
+        import json
+        import os
+        from unittest.mock import patch
+
+        docker_kwargs = {
+            'devices': ['/dev/kvm:/dev/kvm'],
+            'cap_add': ['SYS_ADMIN'],
+            'security_opt': ['seccomp=unconfined'],
+        }
+        env_vars = {
+            'SANDBOX_DOCKER_RUNTIME_KWARGS': json.dumps(docker_kwargs),
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            # Clear the global config to force reload
+            import openhands.app_server.config as config_module
+            from openhands.app_server.config import config_from_env
+
+            config_module._global_config = None
+
+            config = config_from_env()
+            assert config.sandbox is not None
+            # Verify individual fields are set from the JSON
+            assert config.sandbox.devices == ['/dev/kvm:/dev/kvm']
+            assert config.sandbox.cap_add == ['SYS_ADMIN']
+            assert config.sandbox.security_opt == ['seccomp=unconfined']
 
 
 class TestDockerSandboxServiceHostNetwork:


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

<!-- Summarize what the PR does -->
Add support for passing custom Docker container options (devices, cap_add, security_opt) to V1 sandbox service via three explicit typed fields.

- Add devices, cap_add, security_opt fields to DockerSandboxService dataclass
- Add corresponding Pydantic fields to DockerSandboxServiceInjector with descriptions
- Update start_sandbox() to pass options to containers.run()
- Add legacy SANDBOX_DOCKER_RUNTIME_KWARGS variable to set these.

This enables use cases like KVM/QEMU passthrough:

SANDBOX_DOCKER_RUN_KWARGS='{"devices": ["/dev/kvm:/dev/kvm"], "cap_add": ["SYS_ADMIN"], "security_opt": ["seccomp=unconfined"]}'

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->
Using SANDBOX_VOLUMES to pass in /dev/kvm is not good enough.

<img width="341" height="253" alt="image" src="https://github.com/user-attachments/assets/2bbedd22-17f8-40b0-93e3-6e2b20d3a7e8" />

Using these changes with SANDBOX_DOCKER_RUNTIME_KWARGS from above allows it to start working.

<img width="333" height="260" alt="image" src="https://github.com/user-attachments/assets/b103ad48-a098-4762-9392-44d6f43adfda" />

## Change Type

<!-- Choose the types that apply to your PR -->

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [X] I have read and reviewed the code and I understand what the code is doing.
- [X] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.
