### PR TITLE
refactor(enterprise): Migrate enterprise tests from SQLite to PostgreSQL via testcontainers

### DIFF
--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -95,6 +95,7 @@ jobs:
         run: PYTHONPATH=".:$PYTHONPATH" poetry run --project=enterprise pytest --forked -n auto -s -p no:ddtrace -p no:ddtrace.pytest_bdd -p no:ddtrace.pytest_benchmark ./enterprise/tests/unit --cov=enterprise --cov-branch
         env:
           COVERAGE_FILE: ".coverage.enterprise.${{ matrix.python_version }}"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
       - name: Store coverage file
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - jl/testcontainers
   pull_request:
 
 # If triggered by a PR, it will be in the same group. However, each commit on main will be in its own unique group

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - jl/testcontainers
   pull_request:
 
 # If triggered by a PR, it will be in the same group. However, each commit on main will be in its own unique group

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -95,7 +95,6 @@ jobs:
         run: PYTHONPATH=".:$PYTHONPATH" poetry run --project=enterprise pytest --forked -n auto -s -p no:ddtrace -p no:ddtrace.pytest_bdd -p no:ddtrace.pytest_benchmark ./enterprise/tests/unit --cov=enterprise --cov-branch
         env:
           COVERAGE_FILE: ".coverage.enterprise.${{ matrix.python_version }}"
-          TESTCONTAINERS_RYUK_DISABLED: "true"
       - name: Store coverage file
         uses: actions/upload-artifact@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.pytest_pg_info.json
 cover/
 
 # Translations

--- a/enterprise/poetry.lock
+++ b/enterprise/poetry.lock
@@ -2057,7 +2057,7 @@ version = "7.1.0"
 description = "A Python library for the Docker Engine API."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0"},
     {file = "docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c"},
@@ -11777,7 +11777,7 @@ version = "1.2.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61"},
     {file = "python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6"},
@@ -11946,8 +11946,7 @@ version = "311"
 description = "Python for Window Extensions"
 optional = false
 python-versions = "*"
-groups = ["main"]
-markers = "sys_platform == \"win32\" or platform_system == \"Windows\""
+groups = ["main", "test"]
 files = [
     {file = "pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3"},
     {file = "pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b"},
@@ -11970,6 +11969,7 @@ files = [
     {file = "pywin32-311-cp39-cp39-win_amd64.whl", hash = "sha256:e0c4cfb0621281fe40387df582097fd796e80430597cb9944f0ae70447bacd91"},
     {file = "pywin32-311-cp39-cp39-win_arm64.whl", hash = "sha256:62ea666235135fee79bb154e695f3ff67370afefd71bd7fea7512fc70ef31e3d"},
 ]
+markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", test = "sys_platform == \"win32\""}
 
 [[package]]
 name = "pywin32-ctypes"
@@ -12536,7 +12536,7 @@ version = "2.32.5"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
     {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
@@ -13574,6 +13574,60 @@ test = ["pre-commit", "pytest (>=7.0)", "pytest-timeout"]
 typing = ["mypy (>=1.6,<2.0)", "traitlets (>=5.11.1)"]
 
 [[package]]
+name = "testcontainers"
+version = "4.14.1"
+description = "Python library for throwaway instances of anything that can run in a Docker container"
+optional = false
+python-versions = ">=3.10"
+groups = ["test"]
+files = [
+    {file = "testcontainers-4.14.1-py3-none-any.whl", hash = "sha256:03dfef4797b31c82e7b762a454b6afec61a2a512ad54af47ab41e4fa5415f891"},
+    {file = "testcontainers-4.14.1.tar.gz", hash = "sha256:316f1bb178d829c003acd650233e3ff3c59a833a08d8661c074f58a4fbd42a64"},
+]
+
+[package.dependencies]
+docker = "*"
+python-dotenv = "*"
+typing-extensions = "*"
+urllib3 = "*"
+wrapt = "*"
+
+[package.extras]
+arangodb = ["python-arango (>=8,<9)"]
+aws = ["boto3 (>=1,<2)", "httpx"]
+azurite = ["azure-storage-blob (>=12,<13)"]
+chroma = ["chromadb-client (>=1,<2)"]
+cosmosdb = ["azure-cosmos (>=4,<5)"]
+db2 = ["ibm_db_sa ; platform_machine != \"aarch64\" and platform_machine != \"arm64\"", "sqlalchemy (>=2,<3)"]
+generic = ["httpx", "redis (>=7,<8)"]
+google = ["google-cloud-datastore (>=2,<3)", "google-cloud-pubsub (>=2,<3)"]
+influxdb = ["influxdb (>=5,<6)", "influxdb-client (>=1,<2)"]
+k3s = ["kubernetes", "pyyaml (>=6.0.3)"]
+keycloak = ["python-keycloak (>=6,<7) ; python_version < \"4.0\""]
+localstack = ["boto3 (>=1,<2)"]
+mailpit = ["cryptography"]
+minio = ["minio (>=7,<8)"]
+mongodb = ["pymongo (>=4,<5)"]
+mssql = ["pymssql (>=2,<3)", "sqlalchemy (>=2,<3)"]
+mysql = ["pymysql[rsa] (>=1,<2)", "sqlalchemy (>=2,<3)"]
+nats = ["nats-py (>=2,<3)"]
+neo4j = ["neo4j (>=6,<7)"]
+openfga = ["openfga-sdk"]
+opensearch = ["opensearch-py (>=3,<4) ; python_version < \"4.0\""]
+oracle = ["oracledb (>=3,<4)", "sqlalchemy (>=2,<3)"]
+oracle-free = ["oracledb (>=3,<4)", "sqlalchemy (>=2,<3)"]
+qdrant = ["qdrant-client (>=1,<2)"]
+rabbitmq = ["pika (>=1,<2)"]
+redis = ["redis (>=7,<8)"]
+registry = ["bcrypt (>=5,<6)"]
+scylla = ["cassandra-driver (>=3,<4)"]
+selenium = ["selenium (>=4,<5)"]
+sftp = ["cryptography"]
+test-module-import = ["httpx"]
+trino = ["trino"]
+weaviate = ["weaviate-client (>=4,<5)"]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 description = "threadpoolctl"
@@ -14100,7 +14154,7 @@ version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main", "dev", "test"]
 files = [
     {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
     {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
@@ -14448,7 +14502,7 @@ version = "1.17.3"
 description = "Module for decorators, wrappers and monkey patching."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "wrapt-1.17.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:88bbae4d40d5a46142e70d58bf664a89b6b4befaea7b2ecc14e03cedb8e06c04"},
     {file = "wrapt-1.17.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6b13af258d6a9ad602d57d889f83b9d5543acd471eee12eb51f5b01f8eb1bc2"},
@@ -15011,4 +15065,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12,<3.14"
-content-hash = "ef037f6d6085d26166d35c56ce266439f8f1a4fea90bc43ccf15cfeaf116cae5"
+content-hash = "736db5eecbeda2d24e8e66f9e1eae6594b98fbadc096923da65f1fa693253ce1"

--- a/enterprise/pyproject.toml
+++ b/enterprise/pyproject.toml
@@ -69,6 +69,7 @@ opencv-python = "*"
 pandas = "*"
 reportlab = "*"
 gevent = ">=24.2.1,<26.0.0"
+testcontainers = "*"
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/enterprise/tests/unit/conftest.py
+++ b/enterprise/tests/unit/conftest.py
@@ -73,17 +73,19 @@ def _import_all_models():
     them here — inside the controller only — avoids that problem.
     """
     import importlib
+    import logging
     import pkgutil
 
     import storage as _storage_pkg
 
+    log = logging.getLogger(__name__)
     for _importer, modname, _ispkg in pkgutil.walk_packages(
         _storage_pkg.__path__, prefix='storage.'
     ):
         try:
             importlib.import_module(modname)
-        except Exception:
-            pass  # skip modules with unsatisfied dependencies
+        except ImportError as e:
+            log.warning('Failed to import %s: %s', modname, e)
 
 
 def _create_template_db(info):

--- a/enterprise/tests/unit/conftest.py
+++ b/enterprise/tests/unit/conftest.py
@@ -178,6 +178,62 @@ async def async_session_maker(async_engine):
 
 def add_minimal_fixtures(session_maker):
     with session_maker() as session:
+        # Insert FK parent rows first: Org, Role, User
+        session.add(
+            Org(
+                id=uuid.UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
+                name='mock-org',
+                org_version=ORG_SETTINGS_VERSION,
+                enable_default_condenser=True,
+                enable_proactive_conversation_starters=True,
+            )
+        )
+        session.add(
+            Role(
+                id=1,
+                name='admin',
+                rank=1,
+            )
+        )
+        session.flush()
+        session.add(
+            User(
+                id=uuid.UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
+                current_org_id=uuid.UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
+                user_consents_to_analytics=True,
+            )
+        )
+        session.flush()
+
+        # Now insert rows that depend on Org/Role/User
+        session.add(
+            OrgMember(
+                org_id=uuid.UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
+                user_id=uuid.UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
+                role_id=1,
+                llm_api_key='mock-api-key',
+                status='active',
+            )
+        )
+        session.add(
+            StoredConversationMetadata(
+                conversation_id='mock-conversation-id',
+                created_at=datetime.fromisoformat('2025-03-07'),
+                last_updated_at=datetime.fromisoformat('2025-03-08'),
+                accumulated_cost=5.25,
+                prompt_tokens=500,
+                completion_tokens=250,
+                total_tokens=750,
+            )
+        )
+        session.flush()
+        session.add(
+            StoredConversationMetadataSaas(
+                conversation_id='mock-conversation-id',
+                user_id=UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
+                org_id=UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
+            )
+        )
         session.add(
             BillingSession(
                 id='mock-billing-session-id',
@@ -208,61 +264,11 @@ def add_minimal_fixtures(session_maker):
             )
         )
         session.add(
-            StoredConversationMetadata(
-                conversation_id='mock-conversation-id',
-                created_at=datetime.fromisoformat('2025-03-07'),
-                last_updated_at=datetime.fromisoformat('2025-03-08'),
-                accumulated_cost=5.25,
-                prompt_tokens=500,
-                completion_tokens=250,
-                total_tokens=750,
-            )
-        )
-        session.add(
-            StoredConversationMetadataSaas(
-                conversation_id='mock-conversation-id',
-                user_id=UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
-                org_id=UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
-            )
-        )
-        session.add(
             StoredOfflineToken(
                 user_id='mock-user-id',
                 offline_token='mock-offline-token',
                 created_at=datetime.fromisoformat('2025-03-07'),
                 updated_at=datetime.fromisoformat('2025-03-08'),
-            )
-        )
-        session.add(
-            Org(
-                id=uuid.UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
-                name='mock-org',
-                org_version=ORG_SETTINGS_VERSION,
-                enable_default_condenser=True,
-                enable_proactive_conversation_starters=True,
-            )
-        )
-        session.add(
-            Role(
-                id=1,
-                name='admin',
-                rank=1,
-            )
-        )
-        session.add(
-            User(
-                id=uuid.UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
-                current_org_id=uuid.UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
-                user_consents_to_analytics=True,
-            )
-        )
-        session.add(
-            OrgMember(
-                org_id=uuid.UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
-                user_id=uuid.UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
-                role_id=1,
-                llm_api_key='mock-api-key',
-                status='active',
             )
         )
         session.add(

--- a/enterprise/tests/unit/conftest.py
+++ b/enterprise/tests/unit/conftest.py
@@ -17,9 +17,6 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 from sqlalchemy.orm import sessionmaker
-from testcontainers.postgres import PostgresContainer
-from xdist import is_xdist_controller
-
 from storage.api_key import ApiKey  # noqa: F401
 from storage.base import Base
 from storage.billing_session import BillingSession
@@ -38,7 +35,8 @@ from storage.stored_conversation_metadata_saas import (
 from storage.stored_offline_token import StoredOfflineToken
 from storage.stripe_customer import StripeCustomer
 from storage.user import User
-
+from testcontainers.postgres import PostgresContainer
+from xdist import is_xdist_controller
 
 # ---------------------------------------------------------------------------
 # PostgreSQL container lifecycle — managed by the xdist controller
@@ -144,6 +142,7 @@ def pytest_sessionfinish(session, exitstatus):
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def create_keycloak_user_info():
     """Fixture that returns a factory function to create KeycloakUserInfo models.
@@ -174,6 +173,7 @@ def _pg_template_db(request):
 # Function-scoped: one cloned database per test
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(scope='function')
 def _test_db(_pg_template_db):
     """Clone the template database for a single test."""
@@ -196,7 +196,7 @@ def _test_db(_pg_template_db):
     with default_engine.connect() as conn:
         conn.execute(
             text(
-                f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                f'SELECT pg_terminate_backend(pid) FROM pg_stat_activity '
                 f"WHERE datname = '{db_name}' AND pid <> pg_backend_pid()"
             )
         )

--- a/enterprise/tests/unit/conftest.py
+++ b/enterprise/tests/unit/conftest.py
@@ -1,3 +1,5 @@
+import json
+import pathlib
 import uuid
 from datetime import datetime
 from uuid import UUID
@@ -16,8 +18,9 @@ from sqlalchemy.ext.asyncio import (
 )
 from sqlalchemy.orm import sessionmaker
 from testcontainers.postgres import PostgresContainer
+from xdist import is_xdist_controller
 
-# Anything not loaded here may not have a table created for it.
+# Models used by add_minimal_fixtures or directly by conftest.
 from storage.api_key import ApiKey  # noqa: F401
 from storage.base import Base
 from storage.billing_session import BillingSession
@@ -37,6 +40,108 @@ from storage.stored_offline_token import StoredOfflineToken
 from storage.stripe_customer import StripeCustomer
 from storage.user import User
 
+
+# ---------------------------------------------------------------------------
+# PostgreSQL container lifecycle — managed by the xdist controller
+# ---------------------------------------------------------------------------
+
+_PG_INFO_FILE = '.pytest_pg_info.json'
+
+
+def _pg_info_path(session):
+    """Return the path to the shared PG connection info file."""
+    return pathlib.Path(session.config.rootpath) / _PG_INFO_FILE
+
+
+def _extract_pg_info(pg):
+    """Extract connection info dict from a running PostgresContainer."""
+    return {
+        'host': pg.get_container_host_ip(),
+        'port': pg.get_exposed_port(5432),
+        'user': pg.username,
+        'password': pg.password,
+        'default_dbname': pg.dbname,
+    }
+
+
+def _import_all_models():
+    """Import every Base subclass so Base.metadata knows about all tables.
+
+    These imports are deliberately kept out of module scope because some
+    transitively load C-extension modules that spawn threads, which makes
+    the process unsafe to fork() (used by pytest --forked).  Importing
+    them here — inside the controller only — avoids that problem.
+    """
+    import importlib
+    import pkgutil
+
+    import storage as _storage_pkg
+
+    for _importer, modname, _ispkg in pkgutil.walk_packages(
+        _storage_pkg.__path__, prefix='storage.'
+    ):
+        try:
+            importlib.import_module(modname)
+        except Exception:
+            pass  # skip modules with unsatisfied dependencies
+
+
+def _create_template_db(info):
+    """Create a template database with all tables via Base.metadata.create_all()."""
+    _import_all_models()
+
+    default_url = (
+        f"postgresql+psycopg2://{info['user']}:{info['password']}"
+        f"@{info['host']}:{info['port']}/{info['default_dbname']}"
+    )
+    default_engine = create_engine(default_url, isolation_level='AUTOCOMMIT')
+    with default_engine.connect() as conn:
+        conn.execute(text('CREATE DATABASE template_test'))
+    default_engine.dispose()
+
+    template_url = (
+        f"postgresql+psycopg2://{info['user']}:{info['password']}"
+        f"@{info['host']}:{info['port']}/template_test"
+    )
+    template_engine = create_engine(template_url)
+    Base.metadata.create_all(template_engine)
+    template_engine.dispose()
+
+
+def pytest_sessionstart(session):
+    """Start the PostgreSQL container on the controller and create the template DB.
+
+    The controller (or non-xdist process) starts the container, creates the
+    template database, and writes connection info to a file.  Workers read the
+    file to discover the shared container.
+    """
+    if is_xdist_controller(session) or not hasattr(session.config, 'workerinput'):
+        # Controller or non-xdist: start container and create template DB
+        pg = PostgresContainer('postgres:16-alpine')
+        pg.start()
+        session.config._pg_container = pg
+        info = _extract_pg_info(pg)
+        _create_template_db(info)
+        _pg_info_path(session).write_text(json.dumps(info))
+        session.config._pg_info = info
+    else:
+        # xdist worker: read connection info written by the controller
+        session.config._pg_info = json.loads(_pg_info_path(session).read_text())
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Stop the PostgreSQL container and clean up the info file."""
+    pg = getattr(session.config, '_pg_container', None)
+    if pg is not None:
+        pg.stop()
+        info_path = _pg_info_path(session)
+        if info_path.exists():
+            info_path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
 @pytest.fixture
 def create_keycloak_user_info():
@@ -58,47 +163,10 @@ def create_keycloak_user_info():
     return _create
 
 
-# ---------------------------------------------------------------------------
-# Session-scoped: one PostgreSQL container per xdist worker (= per process)
-# ---------------------------------------------------------------------------
-
 @pytest.fixture(scope='session')
-def _pg_container():
-    """Start a PostgreSQL container for the test session."""
-    with PostgresContainer('postgres:16-alpine') as pg:
-        yield pg
-
-
-@pytest.fixture(scope='session')
-def _pg_template_db(_pg_container):
-    """Create a template database with all tables via Base.metadata.create_all()."""
-    pg = _pg_container
-    host = pg.get_container_host_ip()
-    port = pg.get_exposed_port(5432)
-    user = pg.username
-    password = pg.password
-    dbname = pg.dbname
-
-    # Connect to the default database and create the template
-    default_url = f'postgresql+psycopg2://{user}:{password}@{host}:{port}/{dbname}'
-    default_engine = create_engine(default_url, isolation_level='AUTOCOMMIT')
-    with default_engine.connect() as conn:
-        conn.execute(text('CREATE DATABASE template_test'))
-    default_engine.dispose()
-
-    # Create all tables in the template database
-    template_url = f'postgresql+psycopg2://{user}:{password}@{host}:{port}/template_test'
-    template_engine = create_engine(template_url)
-    Base.metadata.create_all(template_engine)
-    template_engine.dispose()
-
-    yield {
-        'host': host,
-        'port': port,
-        'user': user,
-        'password': password,
-        'default_dbname': dbname,
-    }
+def _pg_template_db(request):
+    """Return the shared PostgreSQL connection info from config."""
+    return request.config._pg_info
 
 
 # ---------------------------------------------------------------------------

--- a/enterprise/tests/unit/conftest.py
+++ b/enterprise/tests/unit/conftest.py
@@ -20,7 +20,6 @@ from sqlalchemy.orm import sessionmaker
 from testcontainers.postgres import PostgresContainer
 from xdist import is_xdist_controller
 
-# Models used by add_minimal_fixtures or directly by conftest.
 from storage.api_key import ApiKey  # noqa: F401
 from storage.base import Base
 from storage.billing_session import BillingSession

--- a/enterprise/tests/unit/conftest.py
+++ b/enterprise/tests/unit/conftest.py
@@ -8,13 +8,14 @@ from server.constants import ORG_SETTINGS_VERSION
 from server.verified_models.verified_model_service import (
     StoredVerifiedModel,  # noqa: F401
 )
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
     async_sessionmaker,
     create_async_engine,
 )
 from sqlalchemy.orm import sessionmaker
+from testcontainers.postgres import PostgresContainer
 
 # Anything not loaded here may not have a table created for it.
 from storage.api_key import ApiKey  # noqa: F401
@@ -57,20 +58,107 @@ def create_keycloak_user_info():
     return _create
 
 
+# ---------------------------------------------------------------------------
+# Session-scoped: one PostgreSQL container per xdist worker (= per process)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope='session')
+def _pg_container():
+    """Start a PostgreSQL container for the test session."""
+    with PostgresContainer('postgres:16-alpine') as pg:
+        yield pg
+
+
+@pytest.fixture(scope='session')
+def _pg_template_db(_pg_container):
+    """Create a template database with all tables via Base.metadata.create_all()."""
+    pg = _pg_container
+    host = pg.get_container_host_ip()
+    port = pg.get_exposed_port(5432)
+    user = pg.username
+    password = pg.password
+    dbname = pg.dbname
+
+    # Connect to the default database and create the template
+    default_url = f'postgresql+psycopg2://{user}:{password}@{host}:{port}/{dbname}'
+    default_engine = create_engine(default_url, isolation_level='AUTOCOMMIT')
+    with default_engine.connect() as conn:
+        conn.execute(text('CREATE DATABASE template_test'))
+    default_engine.dispose()
+
+    # Create all tables in the template database
+    template_url = f'postgresql+psycopg2://{user}:{password}@{host}:{port}/template_test'
+    template_engine = create_engine(template_url)
+    Base.metadata.create_all(template_engine)
+    template_engine.dispose()
+
+    yield {
+        'host': host,
+        'port': port,
+        'user': user,
+        'password': password,
+        'default_dbname': dbname,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Function-scoped: one cloned database per test
+# ---------------------------------------------------------------------------
+
 @pytest.fixture(scope='function')
-def db_path(tmp_path):
-    """Create a unique temp file path for each test."""
-    return str(tmp_path / 'test.db')
+def _test_db(_pg_template_db):
+    """Clone the template database for a single test."""
+    info = _pg_template_db
+    db_name = f'test_{uuid.uuid4().hex[:12]}'
+    default_url = (
+        f"postgresql+psycopg2://{info['user']}:{info['password']}"
+        f"@{info['host']}:{info['port']}/{info['default_dbname']}"
+    )
+
+    default_engine = create_engine(default_url, isolation_level='AUTOCOMMIT')
+    with default_engine.connect() as conn:
+        conn.execute(text(f'CREATE DATABASE "{db_name}" TEMPLATE template_test'))
+    default_engine.dispose()
+
+    yield {**info, 'dbname': db_name}
+
+    # Teardown: terminate connections then drop the test database
+    default_engine = create_engine(default_url, isolation_level='AUTOCOMMIT')
+    with default_engine.connect() as conn:
+        conn.execute(
+            text(
+                f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                f"WHERE datname = '{db_name}' AND pid <> pg_backend_pid()"
+            )
+        )
+        conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+    default_engine.dispose()
 
 
 @pytest.fixture
-def engine(db_path):
-    """Create a sync engine with tables using file-based DB."""
-    engine = create_engine(
-        f'sqlite:///{db_path}', connect_args={'check_same_thread': False}
+def engine(_test_db):
+    """Create a sync engine pointing at the per-test PostgreSQL database."""
+    info = _test_db
+    url = (
+        f"postgresql+psycopg2://{info['user']}:{info['password']}"
+        f"@{info['host']}:{info['port']}/{info['dbname']}"
     )
-    Base.metadata.create_all(engine)
-    return engine
+    eng = create_engine(url)
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+async def async_engine(_test_db):
+    """Create an async engine pointing at the per-test PostgreSQL database."""
+    info = _test_db
+    url = (
+        f"postgresql+asyncpg://{info['user']}:{info['password']}"
+        f"@{info['host']}:{info['port']}/{info['dbname']}"
+    )
+    eng = create_async_engine(url)
+    yield eng
+    await eng.dispose()
 
 
 @pytest.fixture
@@ -79,33 +167,13 @@ def session_maker(engine):
 
 
 @pytest.fixture
-def async_engine(db_path):
-    """Create an async engine using the SAME file-based database."""
-    async_engine = create_async_engine(
-        f'sqlite+aiosqlite:///{db_path}',
-        connect_args={'check_same_thread': False},
-    )
-
-    async def create_tables():
-        async with async_engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-
-    # Run the async function synchronously
-    import asyncio
-
-    asyncio.run(create_tables())
-    return async_engine
-
-
-@pytest.fixture
 async def async_session_maker(async_engine):
     """Create an async session maker bound to the async engine."""
-    async_session_maker = async_sessionmaker(
+    return async_sessionmaker(
         bind=async_engine,
         class_=AsyncSession,
         expire_on_commit=False,
     )
-    return async_session_maker
 
 
 def add_minimal_fixtures(session_maker):

--- a/enterprise/tests/unit/storage/test_auth_token_store.py
+++ b/enterprise/tests/unit/storage/test_auth_token_store.py
@@ -1,46 +1,18 @@
-"""Unit tests for AuthTokenStore using SQLite in-memory database."""
+"""Unit tests for AuthTokenStore using PostgreSQL via testcontainers."""
 
 import time
 from unittest.mock import patch
 
 import pytest
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.pool import StaticPool
 from storage.auth_token_store import (
     ACCESS_TOKEN_EXPIRY_BUFFER,
     LOCK_TIMEOUT_SECONDS,
     AuthTokenStore,
 )
 from storage.auth_tokens import AuthTokens
-from storage.base import Base
 
 from openhands.integrations.service_types import ProviderType
-
-
-@pytest.fixture
-async def async_engine():
-    """Create an async SQLite engine for testing."""
-    engine = create_async_engine(
-        'sqlite+aiosqlite:///:memory:',
-        poolclass=StaticPool,
-        connect_args={'check_same_thread': False},
-    )
-    return engine
-
-
-@pytest.fixture
-async def async_session_maker(async_engine):
-    """Create an async session maker bound to the async engine."""
-    async_session_maker = async_sessionmaker(
-        bind=async_engine,
-        class_=AsyncSession,
-        expire_on_commit=False,
-    )
-    # Create all tables
-    async with async_engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    return async_session_maker
 
 
 class TestIsTokenExpired:

--- a/enterprise/tests/unit/storage/test_gitlab_webhook_store.py
+++ b/enterprise/tests/unit/storage/test_gitlab_webhook_store.py
@@ -3,55 +3,8 @@
 import pytest
 from integrations.types import GitLabResourceType
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.pool import StaticPool
-from storage.base import Base
 from storage.gitlab_webhook import GitlabWebhook
 from storage.gitlab_webhook_store import GitlabWebhookStore
-
-# Use module-scoped engine to share database across fixtures
-_test_engine = None
-
-
-@pytest.fixture(scope='function')
-def event_loop():
-    """Create an instance of the default event loop for each test case."""
-    import asyncio
-
-    loop = asyncio.get_event_loop_policy().new_event_loop()
-    yield loop
-    loop.close()
-
-
-@pytest.fixture(scope='function')
-async def async_engine(event_loop):
-    """Create an async SQLite engine for testing.
-
-    This fixture creates an in-memory SQLite database and ensures
-    all tables are created before tests run.
-    """
-    global _test_engine
-    engine = create_async_engine(
-        'sqlite+aiosqlite:///:memory:',
-        poolclass=StaticPool,
-        connect_args={'check_same_thread': False},
-        echo=False,
-    )
-    _test_engine = engine
-
-    # Create all tables
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    yield engine
-
-    await engine.dispose()
-
-
-@pytest.fixture(scope='function')
-async def async_session_maker(async_engine):
-    """Create an async session maker for testing."""
-    return async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
 
 
 @pytest.fixture

--- a/enterprise/tests/unit/storage/test_org_app_settings_store.py
+++ b/enterprise/tests/unit/storage/test_org_app_settings_store.py
@@ -8,33 +8,9 @@ import uuid
 
 import pytest
 from server.routes.org_models import OrgAppSettingsUpdate
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.pool import StaticPool
-from storage.base import Base
 from storage.org import Org
 from storage.org_app_settings_store import OrgAppSettingsStore
 from storage.user import User
-
-
-@pytest.fixture
-async def async_engine():
-    """Create an async SQLite engine for testing."""
-    engine = create_async_engine(
-        'sqlite+aiosqlite:///:memory:',
-        poolclass=StaticPool,
-        connect_args={'check_same_thread': False},
-        echo=False,
-    )
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    yield engine
-    await engine.dispose()
-
-
-@pytest.fixture
-async def async_session_maker(async_engine):
-    """Create an async session maker for testing."""
-    return async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
 
 
 @pytest.mark.asyncio

--- a/enterprise/tests/unit/storage/test_org_llm_settings_store.py
+++ b/enterprise/tests/unit/storage/test_org_llm_settings_store.py
@@ -9,33 +9,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from server.routes.org_models import OrgLLMSettingsUpdate
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.pool import StaticPool
-from storage.base import Base
 from storage.org import Org
 from storage.org_llm_settings_store import OrgLLMSettingsStore
 from storage.user import User
-
-
-@pytest.fixture
-async def async_engine():
-    """Create an async SQLite engine for testing."""
-    engine = create_async_engine(
-        'sqlite+aiosqlite:///:memory:',
-        poolclass=StaticPool,
-        connect_args={'check_same_thread': False},
-        echo=False,
-    )
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    yield engine
-    await engine.dispose()
-
-
-@pytest.fixture
-async def async_session_maker(async_engine):
-    """Create an async session maker for testing."""
-    return async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
 
 
 @pytest.mark.asyncio

--- a/enterprise/tests/unit/storage/test_saas_sql_app_conversation_info_service.py
+++ b/enterprise/tests/unit/storage/test_saas_sql_app_conversation_info_service.py
@@ -40,7 +40,9 @@ async def async_session(async_session_maker) -> AsyncGenerator[AsyncSession, Non
 
 
 @pytest.fixture
-async def async_session_with_users(async_session_maker) -> AsyncGenerator[AsyncSession, None]:
+async def async_session_with_users(
+    async_session_maker,
+) -> AsyncGenerator[AsyncSession, None]:
     """Create an async session with pre-populated Org and User rows for testing."""
 
     async with async_session_maker() as db_session:

--- a/enterprise/tests/unit/storage/test_saas_sql_app_conversation_info_service.py
+++ b/enterprise/tests/unit/storage/test_saas_sql_app_conversation_info_service.py
@@ -14,9 +14,7 @@ from server.utils.saas_app_conversation_info_injector import (
     SaasSQLAppConversationInfoService,
 )
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.pool import StaticPool
-from storage.base import Base
+from sqlalchemy.ext.asyncio import AsyncSession
 from storage.org import Org
 from storage.user import User
 
@@ -35,41 +33,15 @@ ORG2_ID = UUID('d2222222-2222-2222-2222-222222222222')
 
 
 @pytest.fixture
-async def async_engine():
-    """Create an async SQLite engine for testing."""
-    engine = create_async_engine(
-        'sqlite+aiosqlite:///:memory:',
-        poolclass=StaticPool,
-        connect_args={'check_same_thread': False},
-        echo=False,
-    )
-
-    # Create all tables
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    yield engine
-
-    await engine.dispose()
-
-
-@pytest.fixture
-async def async_session(async_engine) -> AsyncGenerator[AsyncSession, None]:
+async def async_session(async_session_maker) -> AsyncGenerator[AsyncSession, None]:
     """Create an async session for testing."""
-    async_session_maker = async_sessionmaker(
-        async_engine, class_=AsyncSession, expire_on_commit=False
-    )
-
     async with async_session_maker() as db_session:
         yield db_session
 
 
 @pytest.fixture
-async def async_session_with_users(async_engine) -> AsyncGenerator[AsyncSession, None]:
+async def async_session_with_users(async_session_maker) -> AsyncGenerator[AsyncSession, None]:
     """Create an async session with pre-populated Org and User rows for testing."""
-    async_session_maker = async_sessionmaker(
-        async_engine, class_=AsyncSession, expire_on_commit=False
-    )
 
     async with async_session_maker() as db_session:
         # Insert Orgs first (required for User foreign key)

--- a/enterprise/tests/unit/storage/test_user_app_settings_store.py
+++ b/enterprise/tests/unit/storage/test_user_app_settings_store.py
@@ -8,33 +8,9 @@ import uuid
 
 import pytest
 from server.routes.user_app_settings_models import UserAppSettingsUpdate
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.pool import StaticPool
-from storage.base import Base
 from storage.org import Org
 from storage.user import User
 from storage.user_app_settings_store import UserAppSettingsStore
-
-
-@pytest.fixture
-async def async_engine():
-    """Create an async SQLite engine for testing."""
-    engine = create_async_engine(
-        'sqlite+aiosqlite:///:memory:',
-        poolclass=StaticPool,
-        connect_args={'check_same_thread': False},
-        echo=False,
-    )
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    yield engine
-    await engine.dispose()
-
-
-@pytest.fixture
-async def async_session_maker(async_engine):
-    """Create an async session maker for testing."""
-    return async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
 
 
 @pytest.mark.asyncio

--- a/enterprise/tests/unit/storage/test_user_authorization_store.py
+++ b/enterprise/tests/unit/storage/test_user_authorization_store.py
@@ -1,37 +1,10 @@
-"""Unit tests for UserAuthorizationStore using SQLite in-memory database."""
+"""Unit tests for UserAuthorizationStore using PostgreSQL via testcontainers."""
 
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.pool import StaticPool
-from storage.base import Base
 from storage.user_authorization import UserAuthorization, UserAuthorizationType
 from storage.user_authorization_store import UserAuthorizationStore
-
-
-@pytest.fixture
-async def async_engine():
-    """Create an async SQLite engine for testing."""
-    engine = create_async_engine(
-        'sqlite+aiosqlite:///:memory:',
-        poolclass=StaticPool,
-        connect_args={'check_same_thread': False},
-    )
-    return engine
-
-
-@pytest.fixture
-async def async_session_maker(async_engine):
-    """Create an async session maker bound to the async engine."""
-    session_maker = async_sessionmaker(
-        bind=async_engine,
-        class_=AsyncSession,
-        expire_on_commit=False,
-    )
-    async with async_engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    return session_maker
 
 
 class TestGetMatchingAuthorizations:

--- a/enterprise/tests/unit/test_api_key_store.py
+++ b/enterprise/tests/unit/test_api_key_store.py
@@ -6,13 +6,24 @@ import pytest
 from sqlalchemy import select
 from storage.api_key import ApiKey
 from storage.api_key_store import ApiKeyStore
+from storage.org import Org
 
 
 @pytest.fixture
-def mock_user():
-    """Mock user with org_id."""
+async def test_org(async_session_maker):
+    """Create a test Org in the database for FK constraints."""
+    _id = uuid.uuid4()
+    async with async_session_maker() as session:
+        session.add(Org(id=_id, name='test-org'))
+        await session.commit()
+    return _id
+
+
+@pytest.fixture
+async def mock_user(test_org):
+    """Mock user with org_id backed by a real Org record."""
     user = MagicMock()
-    user.current_org_id = uuid.uuid4()
+    user.current_org_id = test_org
     return user
 
 
@@ -109,11 +120,11 @@ async def test_create_api_key(
 
 
 @pytest.mark.asyncio
-async def test_validate_api_key_valid(api_key_store, async_session_maker):
+async def test_validate_api_key_valid(api_key_store, async_session_maker, test_org):
     """Test validating a valid API key."""
     # Setup - create an API key in the database
     user_id = str(uuid.uuid4())
-    org_id = uuid.uuid4()
+    org_id = test_org
     api_key_value = 'test-api-key'
 
     async with async_session_maker() as session:
@@ -136,11 +147,11 @@ async def test_validate_api_key_valid(api_key_store, async_session_maker):
 
 
 @pytest.mark.asyncio
-async def test_validate_api_key_expired(api_key_store, async_session_maker):
+async def test_validate_api_key_expired(api_key_store, async_session_maker, test_org):
     """Test validating an expired API key."""
     # Setup - create an expired API key in the database
     user_id = str(uuid.uuid4())
-    org_id = uuid.uuid4()
+    org_id = test_org
     api_key_value = 'test-expired-key'
 
     async with async_session_maker() as session:
@@ -149,7 +160,7 @@ async def test_validate_api_key_expired(api_key_store, async_session_maker):
             user_id=user_id,
             org_id=org_id,
             name='Test Key',
-            expires_at=datetime.now(UTC) - timedelta(days=1),
+            expires_at=datetime.now() - timedelta(days=1),
         )
         session.add(key_record)
         await session.commit()
@@ -164,12 +175,12 @@ async def test_validate_api_key_expired(api_key_store, async_session_maker):
 
 @pytest.mark.asyncio
 async def test_validate_api_key_expired_timezone_naive(
-    api_key_store, async_session_maker
+    api_key_store, async_session_maker, test_org
 ):
     """Test validating an expired API key with timezone-naive datetime from database."""
     # Setup - create an expired API key with timezone-naive datetime
     user_id = str(uuid.uuid4())
-    org_id = uuid.uuid4()
+    org_id = test_org
     api_key_value = 'test-expired-naive-key'
 
     async with async_session_maker() as session:
@@ -194,12 +205,12 @@ async def test_validate_api_key_expired_timezone_naive(
 
 @pytest.mark.asyncio
 async def test_validate_api_key_valid_timezone_naive(
-    api_key_store, async_session_maker
+    api_key_store, async_session_maker, test_org
 ):
     """Test validating a valid API key with timezone-naive datetime from database."""
     # Setup - create a valid API key with timezone-naive datetime (future date)
     user_id = str(uuid.uuid4())
-    org_id = uuid.uuid4()
+    org_id = test_org
     api_key_value = 'test-valid-naive-key'
 
     async with async_session_maker() as session:
@@ -235,12 +246,12 @@ async def test_validate_api_key_not_found(api_key_store, async_session_maker):
 
 @pytest.mark.asyncio
 async def test_validate_api_key_stores_timezone_naive_last_used_at(
-    api_key_store, async_session_maker
+    api_key_store, async_session_maker, test_org
 ):
     """Test that validate_api_key stores a timezone-naive datetime for last_used_at."""
     # Arrange
     user_id = str(uuid.uuid4())
-    org_id = uuid.uuid4()
+    org_id = test_org
     api_key_value = 'test-timezone-naive-key'
 
     async with async_session_maker() as session:
@@ -269,11 +280,11 @@ async def test_validate_api_key_stores_timezone_naive_last_used_at(
 
 
 @pytest.mark.asyncio
-async def test_delete_api_key(api_key_store, async_session_maker):
+async def test_delete_api_key(api_key_store, async_session_maker, test_org):
     """Test deleting an API key."""
     # Setup - create an API key in the database
     user_id = str(uuid.uuid4())
-    org_id = uuid.uuid4()
+    org_id = test_org
     api_key_value = 'test-delete-key'
 
     async with async_session_maker() as session:
@@ -314,11 +325,11 @@ async def test_delete_api_key_not_found(api_key_store, async_session_maker):
 
 
 @pytest.mark.asyncio
-async def test_delete_api_key_by_id(api_key_store, async_session_maker):
+async def test_delete_api_key_by_id(api_key_store, async_session_maker, test_org):
     """Test deleting an API key by ID."""
     # Setup - create an API key in the database
     user_id = str(uuid.uuid4())
-    org_id = uuid.uuid4()
+    org_id = test_org
 
     async with async_session_maker() as session:
         key_record = ApiKey(
@@ -354,7 +365,7 @@ async def test_list_api_keys(
     # Setup
     user_id = str(uuid.uuid4())
     mock_get_user.return_value = mock_user
-    now = datetime.now(UTC)
+    now = datetime.now()
 
     # Create API keys in the database
     async with async_session_maker() as session:
@@ -407,7 +418,7 @@ async def test_retrieve_mcp_api_key(
     # Setup
     user_id = str(uuid.uuid4())
     mock_get_user.return_value = mock_user
-    now = datetime.now(UTC)
+    now = datetime.now()
 
     # Create API keys in the database
     async with async_session_maker() as session:
@@ -446,7 +457,7 @@ async def test_retrieve_mcp_api_key_not_found(
     # Setup
     user_id = str(uuid.uuid4())
     mock_get_user.return_value = mock_user
-    now = datetime.now(UTC)
+    now = datetime.now()
 
     # Create only non-MCP keys in the database
     async with async_session_maker() as session:
@@ -470,11 +481,11 @@ async def test_retrieve_mcp_api_key_not_found(
 
 
 @pytest.mark.asyncio
-async def test_retrieve_api_key_by_name(api_key_store, async_session_maker):
+async def test_retrieve_api_key_by_name(api_key_store, async_session_maker, test_org):
     """Test retrieving an API key by name."""
     # Setup
     user_id = str(uuid.uuid4())
-    org_id = uuid.uuid4()
+    org_id = test_org
     key_name = 'Test Key'
     key_value = 'test-key-by-name'
 
@@ -510,11 +521,11 @@ async def test_retrieve_api_key_by_name_not_found(api_key_store, async_session_m
 
 
 @pytest.mark.asyncio
-async def test_delete_api_key_by_name(api_key_store, async_session_maker):
+async def test_delete_api_key_by_name(api_key_store, async_session_maker, test_org):
     """Test deleting an API key by name."""
     # Setup
     user_id = str(uuid.uuid4())
-    org_id = uuid.uuid4()
+    org_id = test_org
     key_name = 'Test Key to Delete'
     key_value = 'test-delete-by-name'
 

--- a/enterprise/tests/unit/test_conversation_callback_processor.py
+++ b/enterprise/tests/unit/test_conversation_callback_processor.py
@@ -90,7 +90,9 @@ class TestConversationCallback:
             org = Org(id=UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'), name='test-org')
             session.add(org)
             session.flush()
-            user = User(id=UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'), current_org_id=org.id)
+            user = User(
+                id=UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'), current_org_id=org.id
+            )
             session.add(user)
             session.flush()
 

--- a/enterprise/tests/unit/test_conversation_callback_processor.py
+++ b/enterprise/tests/unit/test_conversation_callback_processor.py
@@ -83,6 +83,17 @@ class TestConversationCallback:
     def conversation_metadata(self, session_maker):
         """Create a test conversation metadata record."""
         with session_maker() as session:
+            # Create FK parents first
+            from storage.org import Org
+            from storage.user import User
+
+            org = Org(id=UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'), name='test-org')
+            session.add(org)
+            session.flush()
+            user = User(id=UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'), current_org_id=org.id)
+            session.add(user)
+            session.flush()
+
             metadata = StoredConversationMetadata(
                 conversation_id='test_conversation_123'
             )

--- a/enterprise/tests/unit/test_models.py
+++ b/enterprise/tests/unit/test_models.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import pytest
 from storage.org import Org
 from storage.org_member import OrgMember
+from storage.role import Role
 from storage.user import User
 
 
@@ -22,6 +23,11 @@ def test_user_model(session_maker):
         test_user_id = uuid4()
         user = User(id=test_user_id, current_org_id=org.id, language='en')
         session.add(user)
+        session.flush()
+
+        # Create role (FK parent for OrgMember)
+        role = Role(id=1, name='admin', rank=1)
+        session.add(role)
         session.flush()
 
         # Create org_member relationship

--- a/enterprise/tests/unit/test_models.py
+++ b/enterprise/tests/unit/test_models.py
@@ -4,7 +4,6 @@ Test that the models are correctly defined.
 
 from uuid import uuid4
 
-import pytest
 from storage.org import Org
 from storage.org_member import OrgMember
 from storage.role import Role

--- a/enterprise/tests/unit/test_models.py
+++ b/enterprise/tests/unit/test_models.py
@@ -5,24 +5,9 @@ Test that the models are correctly defined.
 from uuid import uuid4
 
 import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from storage.base import Base
 from storage.org import Org
 from storage.org_member import OrgMember
 from storage.user import User
-
-
-@pytest.fixture
-def engine():
-    engine = create_engine('sqlite:///:memory:')
-    Base.metadata.create_all(engine)
-    return engine
-
-
-@pytest.fixture
-def session_maker(engine):
-    return sessionmaker(bind=engine)
 
 
 def test_user_model(session_maker):

--- a/enterprise/tests/unit/test_org_member_store.py
+++ b/enterprise/tests/unit/test_org_member_store.py
@@ -2,39 +2,11 @@ import uuid
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.pool import StaticPool
-from storage.base import Base
 from storage.org import Org
 from storage.org_member import OrgMember
 from storage.org_member_store import OrgMemberStore
 from storage.role import Role
 from storage.user import User
-
-
-@pytest.fixture
-async def async_engine():
-    """Create an async SQLite engine for testing."""
-    engine = create_async_engine(
-        'sqlite+aiosqlite:///:memory:',
-        poolclass=StaticPool,
-        connect_args={'check_same_thread': False},
-        echo=False,
-    )
-
-    # Create all tables
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    yield engine
-
-    await engine.dispose()
-
-
-@pytest.fixture
-async def async_session_maker(async_engine):
-    """Create an async session maker for testing."""
-    return async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
 
 
 @pytest.mark.asyncio

--- a/enterprise/tests/unit/test_org_service.py
+++ b/enterprise/tests/unit/test_org_service.py
@@ -124,6 +124,9 @@ async def test_create_org_with_owner_success(
 
     # Create user in database first
     with session_maker() as session:
+        org = Org(id=temp_org_id, name='temp-org')
+        session.add(org)
+        session.flush()
         user = User(id=user_id, current_org_id=temp_org_id)
         session.add(user)
         session.commit()

--- a/enterprise/tests/unit/test_org_store.py
+++ b/enterprise/tests/unit/test_org_store.py
@@ -229,7 +229,10 @@ async def test_persist_org_with_owner_success(async_session_maker, mock_litellm_
 
     # Create user and role first
     async with async_session_maker() as session:
-        user = User(id=user_id, current_org_id=org_id)
+        placeholder_org = Org(name='placeholder')
+        session.add(placeholder_org)
+        await session.flush()
+        user = User(id=user_id, current_org_id=placeholder_org.id)
         role = Role(id=1, name='owner', rank=1)
         session.add(user)
         session.add(role)
@@ -288,7 +291,10 @@ async def test_persist_org_with_owner_returns_refreshed_org(
     user_id = uuid.uuid4()
 
     async with async_session_maker() as session:
-        user = User(id=user_id, current_org_id=org_id)
+        placeholder_org = Org(name='placeholder')
+        session.add(placeholder_org)
+        await session.flush()
+        user = User(id=user_id, current_org_id=placeholder_org.id)
         role = Role(id=1, name='owner', rank=1)
         session.add(user)
         session.add(role)
@@ -336,7 +342,10 @@ async def test_persist_org_with_owner_transaction_atomicity(
     user_id = uuid.uuid4()
 
     async with async_session_maker() as session:
-        user = User(id=user_id, current_org_id=org_id)
+        placeholder_org = Org(name='placeholder')
+        session.add(placeholder_org)
+        await session.flush()
+        user = User(id=user_id, current_org_id=placeholder_org.id)
         role = Role(id=1, name='owner', rank=1)
         session.add(user)
         session.add(role)
@@ -389,7 +398,10 @@ async def test_persist_org_with_owner_with_multiple_fields(
     user_id = uuid.uuid4()
 
     async with async_session_maker() as session:
-        user = User(id=user_id, current_org_id=org_id)
+        placeholder_org = Org(name='placeholder')
+        session.add(placeholder_org)
+        await session.flush()
+        user = User(id=user_id, current_org_id=placeholder_org.id)
         role = Role(id=1, name='owner', rank=1)
         session.add(user)
         session.add(role)
@@ -511,14 +523,19 @@ async def test_delete_org_cascade_litellm_failure_causes_rollback(
     user_id = uuid.uuid4()
 
     async with async_session_maker() as session:
-        role = Role(id=1, name='owner', rank=1)
-        user = User(id=user_id, current_org_id=org_id)
         org = Org(
             id=org_id,
             name='Test Organization',
             contact_name='John Doe',
             contact_email='john@example.com',
         )
+        role = Role(id=1, name='owner', rank=1)
+        session.add(org)
+        session.add(role)
+        await session.flush()
+        user = User(id=user_id, current_org_id=org_id)
+        session.add(user)
+        await session.flush()
         org_member = OrgMember(
             org_id=org_id,
             user_id=user_id,
@@ -526,7 +543,7 @@ async def test_delete_org_cascade_litellm_failure_causes_rollback(
             status='active',
             llm_api_key='test-key',
         )
-        session.add_all([role, user, org, org_member])
+        session.add(org_member)
         await session.commit()
 
     # Mock delete_org_cascade to simulate LiteLLM failure

--- a/enterprise/tests/unit/test_role_store.py
+++ b/enterprise/tests/unit/test_role_store.py
@@ -1,36 +1,8 @@
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.pool import StaticPool
-from storage.base import Base
 from storage.role import Role
 from storage.role_store import RoleStore
-
-
-@pytest.fixture
-async def async_engine():
-    """Create an async SQLite engine for testing."""
-    engine = create_async_engine(
-        'sqlite+aiosqlite:///:memory:',
-        poolclass=StaticPool,
-        connect_args={'check_same_thread': False},
-        echo=False,
-    )
-
-    # Create all tables
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    yield engine
-
-    await engine.dispose()
-
-
-@pytest.fixture
-async def async_session_maker(async_engine):
-    """Create an async session maker for testing."""
-    return async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
 
 
 @pytest.mark.asyncio

--- a/enterprise/tests/unit/test_saas_conversation_store.py
+++ b/enterprise/tests/unit/test_saas_conversation_store.py
@@ -34,11 +34,11 @@ def mock_user_store():
 
 
 @pytest.mark.asyncio
-async def test_save_and_get(session_maker):
+async def test_save_and_get(session_maker_with_minimal_fixtures):
     store = SaasConversationStore(
         '5594c7b6-f959-4b81-92e9-b09c206f5081',
         UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
-        session_maker,
+        session_maker_with_minimal_fixtures,
     )
     metadata = ConversationMetadata(
         conversation_id='my-conversation-id',
@@ -63,11 +63,11 @@ async def test_save_and_get(session_maker):
 
 
 @pytest.mark.asyncio
-async def test_search(session_maker):
+async def test_search(session_maker_with_minimal_fixtures):
     store = SaasConversationStore(
         '5594c7b6-f959-4b81-92e9-b09c206f5081',
         UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
-        session_maker,
+        session_maker_with_minimal_fixtures,
     )
 
     # Create test conversations with different timestamps
@@ -88,9 +88,12 @@ async def test_search(session_maker):
         await store.save_metadata(conv)
 
     # Test basic search - should return all valid conversations sorted by created_at
+    # Note: session_maker_with_minimal_fixtures pre-populates a 'mock-conversation-id'
+    # record, so we expect 6 results (1 fixture + 5 test conversations)
     result = await store.search(limit=10)
-    assert len(result.results) == 5
+    assert len(result.results) == 6
     assert [c.conversation_id for c in result.results] == [
+        'mock-conversation-id',
         'conv-4',
         'conv-3',
         'conv-2',
@@ -102,21 +105,24 @@ async def test_search(session_maker):
     # Test pagination
     result = await store.search(limit=2)
     assert len(result.results) == 2
-    assert [c.conversation_id for c in result.results] == ['conv-4', 'conv-3']
+    assert [c.conversation_id for c in result.results] == [
+        'mock-conversation-id',
+        'conv-4',
+    ]
     assert result.next_page_id is not None
 
     # Test next page
     result = await store.search(page_id=result.next_page_id, limit=2)
     assert len(result.results) == 2
-    assert [c.conversation_id for c in result.results] == ['conv-2', 'conv-1']
+    assert [c.conversation_id for c in result.results] == ['conv-3', 'conv-2']
 
 
 @pytest.mark.asyncio
-async def test_delete_metadata(session_maker):
+async def test_delete_metadata(session_maker_with_minimal_fixtures):
     store = SaasConversationStore(
         '5594c7b6-f959-4b81-92e9-b09c206f5081',
         UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
-        session_maker,
+        session_maker_with_minimal_fixtures,
     )
     metadata = ConversationMetadata(
         conversation_id='to-delete',
@@ -136,22 +142,22 @@ async def test_delete_metadata(session_maker):
 
 
 @pytest.mark.asyncio
-async def test_get_nonexistent_metadata(session_maker):
+async def test_get_nonexistent_metadata(session_maker_with_minimal_fixtures):
     store = SaasConversationStore(
         '5594c7b6-f959-4b81-92e9-b09c206f5081',
         UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
-        session_maker,
+        session_maker_with_minimal_fixtures,
     )
     with pytest.raises(FileNotFoundError):
         await store.get_metadata('nonexistent-id')
 
 
 @pytest.mark.asyncio
-async def test_exists(session_maker):
+async def test_exists(session_maker_with_minimal_fixtures):
     store = SaasConversationStore(
         '5594c7b6-f959-4b81-92e9-b09c206f5081',
         UUID('5594c7b6-f959-4b81-92e9-b09c206f5081'),
-        session_maker,
+        session_maker_with_minimal_fixtures,
     )
     metadata = ConversationMetadata(
         conversation_id='exists-test',

--- a/enterprise/tests/unit/test_saas_secrets_store.py
+++ b/enterprise/tests/unit/test_saas_secrets_store.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 import pytest
 from pydantic import SecretStr
+from storage.org import Org
 from storage.saas_secrets_store import SaasSecretsStore
 from storage.stored_custom_secrets import StoredCustomSecrets
 
@@ -29,7 +30,12 @@ def mock_user():
 
 
 @pytest.fixture
-def secrets_store(async_session_maker, mock_config):
+def secrets_store(async_session_maker, session_maker, mock_config, mock_user):
+    # Create Org for mock_user's org_id to satisfy FK constraints
+    with session_maker() as session:
+        session.add(Org(id=mock_user.current_org_id, name='test-org'))
+        session.commit()
+
     # Inject the test session maker into the store module
     import storage.saas_secrets_store as store_module
 

--- a/enterprise/tests/unit/test_sharing/test_sharing_shared_conversation_info_service.py
+++ b/enterprise/tests/unit/test_sharing/test_sharing_shared_conversation_info_service.py
@@ -11,8 +11,7 @@ from server.sharing.shared_conversation_models import (
 from server.sharing.sql_shared_conversation_info_service import (
     SQLSharedConversationInfoService,
 )
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.pool import StaticPool
+from sqlalchemy.ext.asyncio import AsyncSession
 from storage.org import Org
 from storage.stored_conversation_metadata_saas import StoredConversationMetadataSaas
 from storage.user import User
@@ -24,7 +23,6 @@ from openhands.app_server.app_conversation.sql_app_conversation_info_service imp
     SQLAppConversationInfoService,
 )
 from openhands.app_server.user.specifiy_user_context import SpecifyUserContext
-from openhands.app_server.utils.sql_utils import Base
 from openhands.integrations.provider import ProviderType
 from openhands.sdk.llm import MetricsSnapshot
 from openhands.sdk.llm.utils.metrics import TokenUsage
@@ -32,31 +30,8 @@ from openhands.storage.data_models.conversation_metadata import ConversationTrig
 
 
 @pytest.fixture
-async def async_engine():
-    """Create an async SQLite engine for testing."""
-    engine = create_async_engine(
-        'sqlite+aiosqlite:///:memory:',
-        poolclass=StaticPool,
-        connect_args={'check_same_thread': False},
-        echo=False,
-    )
-
-    # Create all tables
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    yield engine
-
-    await engine.dispose()
-
-
-@pytest.fixture
-async def async_session(async_engine) -> AsyncGenerator[AsyncSession, None]:
+async def async_session(async_session_maker) -> AsyncGenerator[AsyncSession, None]:
     """Create an async session for testing."""
-    async_session_maker = async_sessionmaker(
-        async_engine, class_=AsyncSession, expire_on_commit=False
-    )
-
     async with async_session_maker() as db_session:
         yield db_session
 
@@ -441,30 +416,10 @@ class TestSharedConversationInfoServiceWithSaasMetadata:
     """
 
     @pytest.fixture
-    async def async_engine_with_saas(self):
-        """Create an async SQLite engine with all SAAS tables."""
-        engine = create_async_engine(
-            'sqlite+aiosqlite:///:memory:',
-            poolclass=StaticPool,
-            connect_args={'check_same_thread': False},
-            echo=False,
-        )
-
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-
-        yield engine
-        await engine.dispose()
-
-    @pytest.fixture
     async def async_session_with_saas(
-        self, async_engine_with_saas
+        self, async_session_maker
     ) -> AsyncGenerator[AsyncSession, None]:
         """Create an async session for testing with SAAS tables."""
-        async_session_maker = async_sessionmaker(
-            async_engine_with_saas, class_=AsyncSession, expire_on_commit=False
-        )
-
         async with async_session_maker() as db_session:
             yield db_session
 

--- a/enterprise/tests/unit/test_stripe_service_db.py
+++ b/enterprise/tests/unit/test_stripe_service_db.py
@@ -27,10 +27,12 @@ def add_test_org_and_user(session_maker):
     from storage.user import User
 
     with session_maker() as session:
-        # Create role first
-        role = Role(name='test-role', rank=1)
-        session.add(role)
-        session.flush()
+        # Use existing role from minimal fixtures (id=1, 'admin')
+        role = session.query(Role).filter(Role.id == 1).first()
+        if not role:
+            role = Role(name='test-role', rank=1)
+            session.add(role)
+            session.flush()
 
         # Create org
         org = Org(id=test_org_id, name='test-org', contact_email='testy@tester.com')

--- a/enterprise/tests/unit/test_user_store.py
+++ b/enterprise/tests/unit/test_user_store.py
@@ -1236,10 +1236,11 @@ async def test_migrate_user_sql_multiple_conversations(async_session_maker):
         assert len(saas_rows) == 3, 'All 3 conversations should be migrated'
 
         # Verify the user_id and org_id values
+        # PostgreSQL returns UUID types from UUID columns, so compare with str()
         for row in saas_rows:
             assert (
-                row.user_id == user_uuid_str
+                str(row.user_id) == user_uuid_str
             ), f'user_id should match: {row.user_id} vs {user_uuid_str}'
             assert (
-                row.org_id == user_uuid_str
+                str(row.org_id) == user_uuid_str
             ), f'org_id should match: {row.org_id} vs {user_uuid_str}'

--- a/enterprise/tests/unit/test_verified_model/test_verified_model_service.py
+++ b/enterprise/tests/unit/test_verified_model/test_verified_model_service.py
@@ -4,34 +4,6 @@ import pytest
 from server.verified_models.verified_model_service import (
     VerifiedModelService,
 )
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.pool import StaticPool
-from storage.base import Base
-
-
-@pytest.fixture
-async def async_engine():
-    """Create an async SQLite engine for testing."""
-    engine = create_async_engine(
-        'sqlite+aiosqlite:///:memory:',
-        poolclass=StaticPool,
-        connect_args={'check_same_thread': False},
-        echo=False,
-    )
-
-    # Create all tables
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    yield engine
-
-    await engine.dispose()
-
-
-@pytest.fixture
-async def async_session_maker(async_engine):
-    """Create an async session maker for testing."""
-    return async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

Enterprise unit tests were running against SQLite, which silently ignores FK constraints, accepts type mismatches, and uses a different SQL dialect than production PostgreSQL. This meant tests could pass while the code they exercised would fail in production.

This PR replaces SQLite with a real PostgreSQL instance managed by `testcontainers`. A single container is started by before executing the tests, a template database is created with all tables, and each test gets its own database cloned via `CREATE DATABASE ... TEMPLATE` for fast, isolated setup.

**What changed**
- `conftest.py`: Replaced SQLite engine/async_engine fixtures with PostgreSQL equivalents backed by `testcontainers`.
- ~12 test files: Removed duplicate local async_engine/async_session_maker fixtures that created their own SQLite databases. They now use the shared `conftest` fixtures.
- Test fixes: Fixed tests that were silently relying on SQLite's lax behavior — missing FK parent rows, tz-aware datetimes in `TIMESTAMP WITHOUT TIME ZONE` columns, UUID-vs-string comparisons, and fixture data ordering assumptions.
  

A nice follow up on this PR would be to use the actual `alembic` database migrations rather than `Base.metadata.create_all()`. Using real migrations helps to catch that the migration chain actually produces the expected schema, and serves as another warning when executing a migration will produce application-level errors.
* I did attempt to do this, but most of the tests assume a clean database with no existing data. Our migrations seed the database.

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

Performance is comparable to the existing SQLite setup:
```
========== 2000 passed, 3 skipped, 2008 warnings in 85.84s (0:01:25) ===========
```

## Change Type

<!-- Choose the types that apply to your PR -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Fixes #13470

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:3afc946-nikolaik   --name openhands-app-3afc946   docker.openhands.dev/openhands/openhands:3afc946
```