### PR TITLE
Fix pagination bug in event_service_base.search_events causing duplicate events in exports

### DIFF
--- a/openhands/app_server/event/event_service_base.py
+++ b/openhands/app_server/event/event_service_base.py
@@ -106,14 +106,15 @@ class EventServiceBase(EventService, ABC):
                 reverse=(sort_order == EventSortOrder.TIMESTAMP_DESC),
             )
 
+        # Apply pagination to items (not paths)
         start_offset = 0
         next_page_id = None
         if page_id:
             start_offset = int(page_id)
-            paths = paths[start_offset:]
-        if len(paths) > limit:
-            paths = paths[:limit]
+            items = items[start_offset:]
+        if len(items) > limit:
             next_page_id = str(start_offset + limit)
+            items = items[:limit]
 
         return EventPage(items=items, next_page_id=next_page_id)
 

--- a/tests/unit/app_server/test_filesystem_event_service.py
+++ b/tests/unit/app_server/test_filesystem_event_service.py
@@ -161,6 +161,113 @@ class TestFilesystemEventServiceSearchEvents:
         assert hasattr(result, 'next_page_id')
         assert len(result.items) == 3
 
+    @pytest.mark.asyncio
+    async def test_search_events_pagination_limits_results(
+        self, service: FilesystemEventService
+    ):
+        """Test that search_events respects the limit parameter for pagination."""
+        conversation_id = uuid4()
+        total_events = 10
+        page_limit = 3
+
+        # Create more events than the limit
+        for _ in range(total_events):
+            await service.save_event(conversation_id, create_token_event())
+
+        # First page should return only 'limit' events
+        result = await service.search_events(conversation_id, limit=page_limit)
+
+        assert len(result.items) == page_limit
+        assert result.next_page_id is not None
+
+    @pytest.mark.asyncio
+    async def test_search_events_pagination_iterates_all_events(
+        self, service: FilesystemEventService
+    ):
+        """Test that pagination correctly iterates through all events without duplicates.
+
+        This test verifies the fix for a bug where pagination was applied to 'paths'
+        instead of 'items', causing all events to be returned on every page.
+        """
+        conversation_id = uuid4()
+        total_events = 10
+        page_limit = 3
+
+        # Create events and track their IDs
+        created_event_ids = set()
+        for _ in range(total_events):
+            event = create_token_event()
+            created_event_ids.add(event.id)
+            await service.save_event(conversation_id, event)
+
+        # Iterate through all pages and collect event IDs
+        collected_event_ids = set()
+        page_id = None
+        page_count = 0
+
+        while True:
+            result = await service.search_events(
+                conversation_id, page_id=page_id, limit=page_limit
+            )
+            page_count += 1
+
+            for item in result.items:
+                # Verify no duplicates - this would fail with the old buggy code
+                assert item.id not in collected_event_ids, (
+                    f'Duplicate event {item.id} found on page {page_count}'
+                )
+                collected_event_ids.add(item.id)
+
+            if result.next_page_id is None:
+                break
+            page_id = result.next_page_id
+
+        # Verify we got all events exactly once
+        assert collected_event_ids == created_event_ids
+        assert len(collected_event_ids) == total_events
+
+        # With 10 events and limit of 3, we should have 4 pages (3+3+3+1)
+        expected_pages = (total_events + page_limit - 1) // page_limit
+        assert page_count == expected_pages
+
+    @pytest.mark.asyncio
+    async def test_search_events_pagination_with_filters(
+        self, service: FilesystemEventService
+    ):
+        """Test that pagination works correctly when combined with filters."""
+        conversation_id = uuid4()
+
+        # Create a mix of events
+        token_events = [create_token_event() for _ in range(5)]
+        pause_events = [create_pause_event() for _ in range(3)]
+
+        for event in token_events + pause_events:
+            await service.save_event(conversation_id, event)
+
+        # Search only for token events with pagination
+        page_limit = 2
+        collected_ids = set()
+        page_id = None
+
+        while True:
+            result = await service.search_events(
+                conversation_id,
+                kind__eq='TokenEvent',
+                page_id=page_id,
+                limit=page_limit,
+            )
+
+            for item in result.items:
+                assert item.kind == 'TokenEvent'
+                collected_ids.add(item.id)
+
+            if result.next_page_id is None:
+                break
+            page_id = result.next_page_id
+
+        # Should have found all 5 token events
+        assert len(collected_ids) == 5
+
 
 class TestFilesystemEventServiceIntegration:
     """Integration tests for FilesystemEventService."""


### PR DESCRIPTION
## Summary of PR

Fixes a pagination bug in the `search_events` method that caused duplicate events when exporting conversations. The bug was discovered when a conversation with 317 events was exported and contained approximately 4x the expected number of events.

### Root Cause
The `search_events` method in `event_service_base.py` was applying pagination logic to `paths` but returning all `items`:

```python
# OLD (BUGGY) CODE:
if page_id:
    start_offset = int(page_id)
    paths = paths[start_offset:]   # ❌ Slicing paths
if len(paths) > limit:             # ❌ Checking paths
    paths = paths[:limit]          # ❌ Slicing paths
    next_page_id = str(start_offset + limit)

return EventPage(items=items, next_page_id=next_page_id)  # ❌ Returns ALL items!
```

### Fix
Apply pagination to `items` instead of `paths`:

```python
# NEW (FIXED) CODE:
if page_id:
    start_offset = int(page_id)
    items = items[start_offset:]   # ✅ Slice items
if len(items) > limit:             # ✅ Check items
    next_page_id = str(start_offset + limit)
    items = items[:limit]          # ✅ Slice items

return EventPage(items=items, next_page_id=next_page_id)
```

### Bug Behavior
With 317 events and a default limit of 100:
- **Page 1**: Returned ALL 317 events, set `next_page_id` to "100"
- **Page 2**: Returned ALL 317 events again, set `next_page_id` to "200"
- **Page 3**: Returned ALL 317 events again, set `next_page_id` to "300"
- **Page 4**: Returned ALL 317 events again, ended pagination

Result: ~1,268 duplicate events in the export instead of 317 unique events.

## Demo Screenshots/Videos

N/A - This is a backend bug fix.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves the issue where "Export Conversation" feature was exporting conversations with 4x duplicated events.

## Release Notes

- [x] Include this change in the Release Notes.

Fixed a bug in the "Export Conversation" feature that caused events to be duplicated multiple times in the exported zip file due to incorrect pagination handling.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:3fd9f3d-nikolaik   --name openhands-app-3fd9f3d   docker.openhands.dev/openhands/openhands:3fd9f3d
```