### PR TITLE
Add Enterprise SSO login button to V1 login page

### DIFF
--- a/frontend/__tests__/components/features/auth/login-content.test.tsx
+++ b/frontend/__tests__/components/features/auth/login-content.test.tsx
@@ -15,6 +15,7 @@ vi.mock("#/hooks/use-auth-url", () => ({
       bitbucket: "https://bitbucket.org/site/oauth2/authorize",
       bitbucket_data_center:
         "https://bitbucket-dc.example.com/site/oauth2/authorize",
+      enterprise_sso: "https://auth.example.com/realms/test/protocol/openid-connect/auth",
     };
     if (config.appMode === "saas") {
       return urls[config.identityProvider] || null;
@@ -115,6 +116,74 @@ describe("LoginContent", () => {
     expect(
       screen.queryByRole("button", { name: "GITLAB$CONNECT_TO_GITLAB" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("should display Enterprise SSO button when configured", () => {
+    render(
+      <MemoryRouter>
+        <LoginContent
+          githubAuthUrl="https://github.com/oauth/authorize"
+          appMode="saas"
+          authUrl="https://auth.example.com"
+          providersConfigured={["enterprise_sso"]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /ENTERPRISE_SSO\$CONNECT_TO_ENTERPRISE_SSO/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("should display Enterprise SSO alongside other providers when all configured", () => {
+    render(
+      <MemoryRouter>
+        <LoginContent
+          githubAuthUrl="https://github.com/oauth/authorize"
+          appMode="saas"
+          authUrl="https://auth.example.com"
+          providersConfigured={["github", "gitlab", "bitbucket", "enterprise_sso"]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "GITHUB$CONNECT_TO_GITHUB" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "GITLAB$CONNECT_TO_GITLAB" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /BITBUCKET\$CONNECT_TO_BITBUCKET/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /ENTERPRISE_SSO\$CONNECT_TO_ENTERPRISE_SSO/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("should redirect to Enterprise SSO auth URL when Enterprise SSO button is clicked", async () => {
+    const user = userEvent.setup();
+    const mockUrl = "https://auth.example.com/realms/test/protocol/openid-connect/auth";
+
+    render(
+      <MemoryRouter>
+        <LoginContent
+          githubAuthUrl="https://github.com/oauth/authorize"
+          appMode="saas"
+          authUrl="https://auth.example.com"
+          providersConfigured={["enterprise_sso"]}
+        />
+      </MemoryRouter>,
+    );
+
+    const enterpriseSsoButton = screen.getByRole("button", {
+      name: /ENTERPRISE_SSO\$CONNECT_TO_ENTERPRISE_SSO/i,
+    });
+    await user.click(enterpriseSsoButton);
+
+    await waitFor(() => {
+      expect(window.location.href).toContain(mockUrl);
+    });
   });
 
   it("should display message when no providers are configured", () => {

--- a/frontend/src/components/features/auth/login-content.tsx
+++ b/frontend/src/components/features/auth/login-content.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { FaUserShield } from "react-icons/fa";
 import { I18nKey } from "#/i18n/declaration";
 import OpenHandsLogoWhite from "#/assets/branding/openhands-logo-white.svg?react";
 import GitHubLogo from "#/assets/branding/github-logo.svg?react";
@@ -65,6 +66,12 @@ export function LoginContent({
     authUrl,
   });
 
+  const enterpriseSsoAuthUrl = useAuthUrl({
+    appMode: appMode || null,
+    identityProvider: "enterprise_sso",
+    authUrl,
+  });
+
   const handleAuthRedirect = async (
     redirectUrl: string,
     provider: Provider,
@@ -127,6 +134,12 @@ export function LoginContent({
     }
   };
 
+  const handleEnterpriseSsoAuth = () => {
+    if (enterpriseSsoAuthUrl) {
+      handleAuthRedirect(enterpriseSsoAuthUrl, "enterprise_sso");
+    }
+  };
+
   const showGithub =
     providersConfigured &&
     providersConfigured.length > 0 &&
@@ -143,6 +156,10 @@ export function LoginContent({
     providersConfigured &&
     providersConfigured.length > 0 &&
     providersConfigured.includes("bitbucket_data_center");
+  const showEnterpriseSso =
+    providersConfigured &&
+    providersConfigured.length > 0 &&
+    providersConfigured.includes("enterprise_sso");
 
   const noProvidersConfigured =
     !providersConfigured || providersConfigured.length === 0;
@@ -258,6 +275,19 @@ export function LoginContent({
                   {t(
                     I18nKey.BITBUCKET_DATA_CENTER$CONNECT_TO_BITBUCKET_DATA_CENTER,
                   )}
+                </span>
+              </button>
+            )}
+
+            {showEnterpriseSso && (
+              <button
+                type="button"
+                onClick={handleEnterpriseSsoAuth}
+                className={`${buttonBaseClasses} bg-[#374151] text-white`}
+              >
+                <FaUserShield size={14} className="shrink-0" />
+                <span className={buttonLabelClasses}>
+                  {t(I18nKey.ENTERPRISE_SSO$CONNECT_TO_ENTERPRISE_SSO)}
                 </span>
               </button>
             )}


### PR DESCRIPTION
## Summary of PR

The Enterprise SSO login button was missing from the V1 login page, causing deployments with ENABLE_ENTERPRISE_SSO env var to not show the SSO option.

Changes:
- Add Enterprise SSO button to LoginContent component with FaUserShield icon
- Use existing auth URL generation for enterprise_sso identity provider
- Add showEnterpriseSso flag based on providers_configured prop
- Add handleEnterpriseSsoAuth handler function
- Add comprehensive test cases for Enterprise SSO button functionality

To enable Enterprise SSO in OpenHands-Cloud helm chart deployments, add the following to your values.yaml:

  env:
    ENABLE_ENTERPRISE_SSO: "true"


## Demo Screenshots/Videos
<img width="557" height="474" alt="image" src="https://github.com/user-attachments/assets/4542b4ac-1ae2-473a-8110-5a81a321432e" />

## Change Type

<!-- Choose the types that apply to your PR -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:1d929b7-nikolaik   --name openhands-app-1d929b7   docker.openhands.dev/openhands/openhands:1d929b7
```