### PR TITLE
fix: upgrade docker-compose to v5.1.0 to fix CVE-2025-68121

### DIFF
--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -128,7 +128,12 @@ RUN \
     apt-get update && \
     apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    # Upgrade docker-compose to latest version to fix CVE-2025-68121 (Go crypto/tls vulnerability)
+    ARCH=$(uname -m) && \
+    if [ "$ARCH" = "aarch64" ]; then ARCH="aarch64"; elif [ "$ARCH" = "x86_64" ]; then ARCH="x86_64"; fi && \
+    curl -SL "https://github.com/docker/compose/releases/download/v5.1.0/docker-compose-linux-${ARCH}" -o /usr/libexec/docker/cli-plugins/docker-compose && \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose
 
 # Configure Docker daemon with MTU 1450 to prevent packet fragmentation issues
 RUN mkdir -p /etc/docker && \


### PR DESCRIPTION
## Description
Upgrade docker-compose plugin to v5.1.0 which is built with Go 1.25.7, fixing CVE-2025-68121 (CRITICAL) - a TLS session resumption vulnerability in Go's crypto/tls package.

## Problem
The apt-installed `docker-compose-plugin` in the runtime Docker image was compiled with Go 1.24.9 which contains a vulnerability in `crypto/tls` that can cause improper TLS session resumption.

**Trivy Scan Finding:** https://github.com/All-Hands-AI/OpenHands-Cloud/security/code-scanning/5338

| Field | Value |
|-------|-------|
| **CVE** | [CVE-2025-68121](https://avd.aquasec.com/nvd/cve-2025-68121) |
| **Severity** | CRITICAL |
| **Package** | Go stdlib (crypto/tls) |
| **Installed Version** | v1.24.9 |
| **Fixed Version** | 1.24.13, 1.25.7, or 1.26.0-rc.3+ |
| **Affected Binary** | `usr/libexec/docker/cli-plugins/docker-compose` |

## Solution
After the apt install of `docker-compose-plugin`, download and replace it with Docker Compose v5.1.0 from GitHub releases. This version was [built with Go 1.25.7](https://github.com/docker/compose/pull/13573), which contains the fix.

## Testing
- [ ] Rebuilt runtime image passes Trivy scan without CVE-2025-68121
- [ ] Docker Compose functionality - [ ] Docrectly in runtime container