### PR TITLE
feat: add OpenSandbox as a new sandbox backend for V1

### DIFF
--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -206,6 +206,17 @@ def config_from_env() -> AppServerConfig:
                 api_key=os.environ['SANDBOX_API_KEY'],
                 api_url=os.environ['SANDBOX_REMOTE_RUNTIME_API_URL'],
             )
+        elif os.getenv('RUNTIME') == 'opensandbox':
+            from openhands.app_server.sandbox.opensandbox_service import (
+                OpenSandboxServiceInjector,
+            )
+
+            config.sandbox = OpenSandboxServiceInjector(
+                api_key=os.environ['OPEN_SANDBOX_API_KEY'],
+                api_url=os.environ.get(
+                    'OPEN_SANDBOX_API_URL', 'http://localhost:8080/v1'
+                ),
+            )
         elif os.getenv('RUNTIME') in ('local', 'process'):
             config.sandbox = ProcessSandboxServiceInjector()
         else:
@@ -258,6 +269,12 @@ def config_from_env() -> AppServerConfig:
     if config.sandbox_spec is None:
         if os.getenv('RUNTIME') == 'remote':
             config.sandbox_spec = RemoteSandboxSpecServiceInjector()
+        elif os.getenv('RUNTIME') == 'opensandbox':
+            from openhands.app_server.sandbox.opensandbox_spec_service import (
+                OpenSandboxSpecServiceInjector,
+            )
+
+            config.sandbox_spec = OpenSandboxSpecServiceInjector()
         elif os.getenv('RUNTIME') in ('local', 'process'):
             config.sandbox_spec = ProcessSandboxSpecServiceInjector()
         else:

--- a/openhands/app_server/sandbox/opensandbox_service.py
+++ b/openhands/app_server/sandbox/opensandbox_service.py
@@ -1,0 +1,513 @@
+import hashlib
+import logging
+import secrets
+from dataclasses import dataclass
+from typing import Any, AsyncGenerator
+
+import httpx
+from fastapi import Request
+from pydantic import Field
+from sqlalchemy import Column, String, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from openhands.agent_server.utils import utc_now
+from openhands.app_server.errors import SandboxError
+from openhands.app_server.sandbox.sandbox_models import (
+    AGENT_SERVER,
+    VSCODE,
+    WORKER_1,
+    WORKER_2,
+    ExposedUrl,
+    SandboxInfo,
+    SandboxPage,
+    SandboxStatus,
+)
+from openhands.app_server.sandbox.sandbox_service import (
+    ALLOW_CORS_ORIGINS_VARIABLE,
+    SESSION_API_KEY_VARIABLE,
+    WEBHOOK_CALLBACK_VARIABLE,
+    SandboxService,
+    SandboxServiceInjector,
+)
+from openhands.app_server.sandbox.sandbox_spec_models import SandboxSpecInfo
+from openhands.app_server.sandbox.sandbox_spec_service import SandboxSpecService
+from openhands.app_server.services.injector import InjectorState
+from openhands.app_server.user.user_context import UserContext
+from openhands.app_server.utils.sql_utils import Base, UtcDateTime
+
+_logger = logging.getLogger(__name__)
+
+# OpenSandbox state -> OpenHands SandboxStatus mapping
+OPENSANDBOX_STATUS_MAPPING = {
+    'Pending': SandboxStatus.STARTING,
+    'Running': SandboxStatus.RUNNING,
+    'Pausing': SandboxStatus.RUNNING,  # Transitional state
+    'Paused': SandboxStatus.PAUSED,
+    'Stopping': SandboxStatus.MISSING,
+    'Terminated': SandboxStatus.MISSING,
+    'Failed': SandboxStatus.ERROR,
+}
+
+AGENT_SERVER_PORT = 60000
+VSCODE_PORT = 60001
+WORKER_1_PORT = 12000
+WORKER_2_PORT = 12001
+
+
+def _hash_session_api_key(session_api_key: str) -> str:
+    """Hash a session API key using SHA-256."""
+    return hashlib.sha256(session_api_key.encode()).hexdigest()
+
+
+class StoredOpenSandbox(Base):  # type: ignore
+    """Local storage for OpenSandbox sandbox info."""
+
+    __tablename__ = 'v1_opensandbox'
+    id = Column(String, primary_key=True)
+    opensandbox_id = Column(String, nullable=False, index=True)
+    created_by_user_id = Column(String, nullable=True, index=True)
+    sandbox_spec_id = Column(String, index=True)
+    session_api_key = Column(String, nullable=True)
+    session_api_key_hash = Column(String, nullable=True, index=True)
+    created_at = Column(UtcDateTime, server_default=func.now(), index=True)
+
+
+@dataclass
+class OpenSandboxService(SandboxService):
+    """Sandbox service that uses OpenSandbox Lifecycle API to manage sandboxes."""
+
+    sandbox_spec_service: SandboxSpecService
+    api_url: str
+    api_key: str
+    web_url: str | None
+    sandbox_timeout: int
+    max_num_sandboxes: int
+    user_context: UserContext
+    httpx_client: httpx.AsyncClient
+    db_session: AsyncSession
+
+    async def _send_api_request(
+        self, method: str, path: str, **kwargs: Any
+    ) -> httpx.Response:
+        """Send a request to the OpenSandbox API."""
+        try:
+            url = self.api_url.rstrip('/') + path
+            headers = kwargs.pop('headers', {})
+            headers['OPEN-SANDBOX-API-KEY'] = self.api_key
+            return await self.httpx_client.request(
+                method, url, headers=headers, **kwargs
+            )
+        except httpx.TimeoutException:
+            _logger.error(f'No response received within timeout for URL: {url}')
+            raise
+        except httpx.HTTPError as e:
+            _logger.error(f'HTTP error for URL {url}: {e}')
+            raise
+
+    def _get_sandbox_status(self, sandbox_data: dict[str, Any] | None) -> SandboxStatus:
+        """Convert OpenSandbox state to OpenHands SandboxStatus."""
+        if not sandbox_data:
+            return SandboxStatus.MISSING
+        status = sandbox_data.get('status', {})
+        state = status.get('state', '') if isinstance(status, dict) else ''
+        return OPENSANDBOX_STATUS_MAPPING.get(state, SandboxStatus.ERROR)
+
+    async def _get_endpoint_url(self, opensandbox_id: str, port: int) -> str | None:
+        """Get the public endpoint URL for a specific port."""
+        try:
+            response = await self._send_api_request(
+                'GET', f'/sandboxes/{opensandbox_id}/endpoints/{port}'
+            )
+            if response.status_code == 200:
+                data = response.json()
+                return data.get('endpoint', None)
+            return None
+        except Exception:
+            _logger.debug(
+                f'Failed to get endpoint for sandbox {opensandbox_id} port {port}'
+            )
+            return None
+
+    async def _build_exposed_urls(
+        self, opensandbox_id: str, session_api_key: str | None
+    ) -> list[ExposedUrl]:
+        """Build exposed URLs by querying OpenSandbox endpoint API."""
+        exposed_urls = []
+
+        # Get agent server endpoint
+        agent_url = await self._get_endpoint_url(opensandbox_id, AGENT_SERVER_PORT)
+        if agent_url:
+            # Ensure proper URL format
+            if not agent_url.startswith('http'):
+                agent_url = f'http://{agent_url}'
+            exposed_urls.append(
+                ExposedUrl(name=AGENT_SERVER, url=agent_url, port=AGENT_SERVER_PORT)
+            )
+
+            # Get VSCode endpoint
+            vscode_url = await self._get_endpoint_url(opensandbox_id, VSCODE_PORT)
+            if vscode_url:
+                if not vscode_url.startswith('http'):
+                    vscode_url = f'http://{vscode_url}'
+                if session_api_key:
+                    vscode_url += (
+                        f'?tkn={session_api_key}&folder=%2Fworkspace%2Fproject'
+                    )
+                exposed_urls.append(
+                    ExposedUrl(name=VSCODE, url=vscode_url, port=VSCODE_PORT)
+                )
+
+            # Get worker endpoints
+            for worker_name, worker_port in [
+                (WORKER_1, WORKER_1_PORT),
+                (WORKER_2, WORKER_2_PORT),
+            ]:
+                worker_url = await self._get_endpoint_url(opensandbox_id, worker_port)
+                if worker_url:
+                    if not worker_url.startswith('http'):
+                        worker_url = f'http://{worker_url}'
+                    exposed_urls.append(
+                        ExposedUrl(name=worker_name, url=worker_url, port=worker_port)
+                    )
+
+        return exposed_urls
+
+    def _to_sandbox_info(
+        self,
+        stored: StoredOpenSandbox,
+        sandbox_data: dict[str, Any] | None = None,
+        exposed_urls: list[ExposedUrl] | None = None,
+    ) -> SandboxInfo:
+        """Convert stored sandbox and API data to SandboxInfo."""
+        status = self._get_sandbox_status(sandbox_data)
+
+        session_api_key = (
+            stored.session_api_key if status == SandboxStatus.RUNNING else None
+        )
+
+        return SandboxInfo(
+            id=stored.id,
+            created_by_user_id=stored.created_by_user_id,
+            sandbox_spec_id=stored.sandbox_spec_id,
+            status=status,
+            session_api_key=session_api_key,
+            exposed_urls=exposed_urls if status == SandboxStatus.RUNNING else None,
+            created_at=stored.created_at,
+        )
+
+    async def _secure_select(self):
+        query = select(StoredOpenSandbox)
+        user_id = await self.user_context.get_user_id()
+        if user_id:
+            query = query.where(StoredOpenSandbox.created_by_user_id == user_id)
+        return query
+
+    async def _get_stored_sandbox(self, sandbox_id: str) -> StoredOpenSandbox | None:
+        stmt = await self._secure_select()
+        stmt = stmt.where(StoredOpenSandbox.id == sandbox_id)
+        result = await self.db_session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def _get_opensandbox_data(self, opensandbox_id: str) -> dict[str, Any] | None:
+        """Fetch sandbox data from OpenSandbox API."""
+        try:
+            response = await self._send_api_request(
+                'GET', f'/sandboxes/{opensandbox_id}'
+            )
+            if response.status_code == 404:
+                return None
+            response.raise_for_status()
+            return response.json()
+        except Exception:
+            _logger.exception(
+                f'Error getting OpenSandbox data: {opensandbox_id}', stack_info=True
+            )
+            return None
+
+    async def _init_environment(
+        self, sandbox_spec: SandboxSpecInfo, session_api_key: str
+    ) -> dict[str, str]:
+        """Initialize environment variables for the sandbox."""
+        environment = sandbox_spec.initial_env.copy()
+
+        # Inject the session API key
+        environment[SESSION_API_KEY_VARIABLE] = session_api_key
+
+        # If a public facing url is defined, add webhook callback and CORS settings
+        if self.web_url:
+            environment[WEBHOOK_CALLBACK_VARIABLE] = f'{self.web_url}/api/v1/webhooks'
+            environment[ALLOW_CORS_ORIGINS_VARIABLE] = self.web_url
+
+        # Add worker port environment variables
+        environment[WORKER_1] = str(WORKER_1_PORT)
+        environment[WORKER_2] = str(WORKER_2_PORT)
+
+        return environment
+
+    async def search_sandboxes(
+        self,
+        page_id: str | None = None,
+        limit: int = 100,
+    ) -> SandboxPage:
+        stmt = await self._secure_select()
+
+        if page_id is not None:
+            try:
+                offset = int(page_id)
+                stmt = stmt.offset(offset)
+            except ValueError:
+                offset = 0
+        else:
+            offset = 0
+
+        stmt = stmt.limit(limit + 1).order_by(StoredOpenSandbox.created_at.desc())
+        result = await self.db_session.execute(stmt)
+        stored_sandboxes = result.scalars().all()
+
+        has_more = len(stored_sandboxes) > limit
+        if has_more:
+            stored_sandboxes = stored_sandboxes[:limit]
+
+        next_page_id = str(offset + limit) if has_more else None
+
+        # Fetch sandbox data from OpenSandbox API for each stored sandbox
+        items = []
+        for stored in stored_sandboxes:
+            sandbox_data = await self._get_opensandbox_data(stored.opensandbox_id)
+            status = self._get_sandbox_status(sandbox_data)
+            exposed_urls = None
+            if status == SandboxStatus.RUNNING:
+                exposed_urls = await self._build_exposed_urls(
+                    stored.opensandbox_id, stored.session_api_key
+                )
+            items.append(self._to_sandbox_info(stored, sandbox_data, exposed_urls))
+
+        return SandboxPage(items=items, next_page_id=next_page_id)
+
+    async def get_sandbox(self, sandbox_id: str) -> SandboxInfo | None:
+        stored = await self._get_stored_sandbox(sandbox_id)
+        if stored is None:
+            return None
+
+        sandbox_data = await self._get_opensandbox_data(stored.opensandbox_id)
+        status = self._get_sandbox_status(sandbox_data)
+        exposed_urls = None
+        if status == SandboxStatus.RUNNING:
+            exposed_urls = await self._build_exposed_urls(
+                stored.opensandbox_id, stored.session_api_key
+            )
+        return self._to_sandbox_info(stored, sandbox_data, exposed_urls)
+
+    async def get_sandbox_by_session_api_key(
+        self, session_api_key: str
+    ) -> SandboxInfo | None:
+        session_api_key_hash = _hash_session_api_key(session_api_key)
+
+        stmt = await self._secure_select()
+        stmt = stmt.where(
+            StoredOpenSandbox.session_api_key_hash == session_api_key_hash
+        )
+        result = await self.db_session.execute(stmt)
+        stored = result.scalar_one_or_none()
+
+        if stored is None:
+            return None
+
+        sandbox_data = await self._get_opensandbox_data(stored.opensandbox_id)
+        status = self._get_sandbox_status(sandbox_data)
+        exposed_urls = None
+        if status == SandboxStatus.RUNNING:
+            exposed_urls = await self._build_exposed_urls(
+                stored.opensandbox_id, stored.session_api_key
+            )
+        return self._to_sandbox_info(stored, sandbox_data, exposed_urls)
+
+    async def start_sandbox(
+        self, sandbox_spec_id: str | None = None, sandbox_id: str | None = None
+    ) -> SandboxInfo:
+        try:
+            # Enforce sandbox limits
+            await self.pause_old_sandboxes(self.max_num_sandboxes - 1)
+
+            # Get sandbox spec
+            if sandbox_spec_id is None:
+                sandbox_spec = (
+                    await self.sandbox_spec_service.get_default_sandbox_spec()
+                )
+            else:
+                sandbox_spec_maybe = await self.sandbox_spec_service.get_sandbox_spec(
+                    sandbox_spec_id
+                )
+                if sandbox_spec_maybe is None:
+                    raise ValueError('Sandbox Spec not found')
+                sandbox_spec = sandbox_spec_maybe
+
+            # Generate sandbox ID and session API key
+            if sandbox_id is None:
+                sandbox_id = secrets.token_urlsafe(16)
+
+            session_api_key = secrets.token_urlsafe(32)
+            user_id = await self.user_context.get_user_id()
+
+            # Prepare environment
+            environment = await self._init_environment(sandbox_spec, session_api_key)
+
+            # Build entrypoint
+            entrypoint = sandbox_spec.command or []
+
+            # Build create request for OpenSandbox API
+            create_request: dict[str, Any] = {
+                'image': {
+                    'uri': sandbox_spec.id,
+                },
+                'timeout': self.sandbox_timeout,
+                'env': environment,
+                'metadata': {
+                    'oh_sandbox_id': sandbox_id,
+                    'oh_user_id': user_id or '',
+                },
+            }
+            if entrypoint:
+                create_request['entrypoint'] = entrypoint
+
+            # Call OpenSandbox API to create sandbox
+            response = await self._send_api_request(
+                'POST', '/sandboxes', json=create_request
+            )
+            response.raise_for_status()
+            create_data = response.json()
+            opensandbox_id = create_data.get('id', '')
+
+            # Store locally
+            stored = StoredOpenSandbox(
+                id=sandbox_id,
+                opensandbox_id=opensandbox_id,
+                created_by_user_id=user_id,
+                sandbox_spec_id=sandbox_spec.id,
+                session_api_key=session_api_key,
+                session_api_key_hash=_hash_session_api_key(session_api_key),
+                created_at=utc_now(),
+            )
+            self.db_session.add(stored)
+
+            _logger.info(
+                f'Started OpenSandbox {opensandbox_id} for sandbox {sandbox_id}'
+            )
+
+            return SandboxInfo(
+                id=sandbox_id,
+                created_by_user_id=user_id,
+                sandbox_spec_id=sandbox_spec.id,
+                status=SandboxStatus.STARTING,
+                session_api_key=None,
+                exposed_urls=None,
+                created_at=stored.created_at,
+            )
+
+        except httpx.HTTPError as e:
+            _logger.error(f'Failed to start OpenSandbox: {e}')
+            raise SandboxError(f'Failed to start sandbox: {e}')
+
+    async def resume_sandbox(self, sandbox_id: str) -> bool:
+        await self.pause_old_sandboxes(self.max_num_sandboxes - 1)
+
+        try:
+            stored = await self._get_stored_sandbox(sandbox_id)
+            if not stored:
+                return False
+            response = await self._send_api_request(
+                'POST', f'/sandboxes/{stored.opensandbox_id}/resume'
+            )
+            if response.status_code == 404:
+                return False
+            response.raise_for_status()
+            return True
+        except httpx.HTTPError as e:
+            _logger.error(f'Error resuming sandbox {sandbox_id}: {e}')
+            return False
+
+    async def pause_sandbox(self, sandbox_id: str) -> bool:
+        try:
+            stored = await self._get_stored_sandbox(sandbox_id)
+            if not stored:
+                return False
+            response = await self._send_api_request(
+                'POST', f'/sandboxes/{stored.opensandbox_id}/pause'
+            )
+            if response.status_code == 404:
+                return False
+            response.raise_for_status()
+            return True
+        except httpx.HTTPError as e:
+            _logger.error(f'Error pausing sandbox {sandbox_id}: {e}')
+            return False
+
+    async def delete_sandbox(self, sandbox_id: str) -> bool:
+        try:
+            stored = await self._get_stored_sandbox(sandbox_id)
+            if not stored:
+                return False
+            response = await self._send_api_request(
+                'DELETE', f'/sandboxes/{stored.opensandbox_id}'
+            )
+            if response.status_code != 404:
+                response.raise_for_status()
+            await self.db_session.delete(stored)
+            return True
+        except httpx.HTTPError as e:
+            _logger.error(f'Error deleting sandbox {sandbox_id}: {e}')
+            return False
+
+
+class OpenSandboxServiceInjector(SandboxServiceInjector):
+    """Dependency injector for OpenSandbox services."""
+
+    api_url: str = Field(
+        default='http://localhost:8080/v1',
+        description='The OpenSandbox API URL',
+    )
+    api_key: str = Field(description='The OpenSandbox API Key')
+    sandbox_timeout: int = Field(
+        default=3600,
+        description='Sandbox timeout in seconds (default: 1 hour)',
+    )
+    start_sandbox_timeout: int = Field(
+        default=120,
+        description='Max time to wait for sandbox to start (seconds)',
+    )
+    max_num_sandboxes: int = Field(
+        default=10,
+        description='Maximum number of sandboxes allowed to run simultaneously',
+    )
+
+    async def inject(
+        self, state: InjectorState, request: Request | None = None
+    ) -> AsyncGenerator[SandboxService, None]:
+        from openhands.app_server.config import (
+            get_db_session,
+            get_global_config,
+            get_httpx_client,
+            get_sandbox_spec_service,
+            get_user_context,
+        )
+
+        config = get_global_config()
+        web_url = config.web_url
+
+        async with (
+            get_user_context(state, request) as user_context,
+            get_sandbox_spec_service(state, request) as sandbox_spec_service,
+            get_httpx_client(state, request) as httpx_client,
+            get_db_session(state, request) as db_session,
+        ):
+            yield OpenSandboxService(
+                sandbox_spec_service=sandbox_spec_service,
+                api_url=self.api_url,
+                api_key=self.api_key,
+                web_url=web_url,
+                sandbox_timeout=self.sandbox_timeout,
+                max_num_sandboxes=self.max_num_sandboxes,
+                user_context=user_context,
+                httpx_client=httpx_client,
+                db_session=db_session,
+            )

--- a/openhands/app_server/sandbox/opensandbox_spec_service.py
+++ b/openhands/app_server/sandbox/opensandbox_spec_service.py
@@ -1,0 +1,48 @@
+from typing import AsyncGenerator
+
+from fastapi import Request
+from pydantic import Field
+
+from openhands.app_server.sandbox.preset_sandbox_spec_service import (
+    PresetSandboxSpecService,
+)
+from openhands.app_server.sandbox.sandbox_spec_models import SandboxSpecInfo
+from openhands.app_server.sandbox.sandbox_spec_service import (
+    SandboxSpecService,
+    SandboxSpecServiceInjector,
+    get_agent_server_env,
+    get_agent_server_image,
+)
+from openhands.app_server.services.injector import InjectorState
+
+
+def get_opensandbox_specs():
+    return [
+        SandboxSpecInfo(
+            id=get_agent_server_image(),
+            command=['--port', '8000'],
+            initial_env={
+                'OPENVSCODE_SERVER_ROOT': '/openhands/.openvscode-server',
+                'OH_ENABLE_VNC': '0',
+                'LOG_JSON': 'true',
+                'OH_CONVERSATIONS_PATH': '/workspace/conversations',
+                'OH_BASH_EVENTS_DIR': '/workspace/bash_events',
+                'PYTHONUNBUFFERED': '1',
+                'ENV_LOG_LEVEL': '20',
+                **get_agent_server_env(),
+            },
+            working_dir='/workspace/project',
+        )
+    ]
+
+
+class OpenSandboxSpecServiceInjector(SandboxSpecServiceInjector):
+    specs: list[SandboxSpecInfo] = Field(
+        default_factory=get_opensandbox_specs,
+        description='Preset list of sandbox specs for OpenSandbox',
+    )
+
+    async def inject(
+        self, state: InjectorState, request: Request | None = None
+    ) -> AsyncGenerator[SandboxSpecService, None]:
+        yield PresetSandboxSpecService(specs=self.specs)

--- a/tests/unit/app_server/test_opensandbox_service.py
+++ b/tests/unit/app_server/test_opensandbox_service.py
@@ -1,0 +1,734 @@
+"""Tests for OpenSandboxService.
+
+This module tests the OpenSandboxService implementation, focusing on:
+- OpenSandbox Lifecycle API communication and error handling
+- Sandbox lifecycle management (start, pause, resume, delete)
+- Status mapping from OpenSandbox states to internal sandbox statuses
+- Environment variable injection for session API keys, CORS and webhooks
+- Data transformation from OpenSandbox API to SandboxInfo objects
+- Endpoint URL building for exposed services
+"""
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from openhands.app_server.errors import SandboxError
+from openhands.app_server.sandbox.opensandbox_service import (
+    AGENT_SERVER_PORT,
+    VSCODE_PORT,
+    WORKER_1_PORT,
+    WORKER_2_PORT,
+    OpenSandboxService,
+    StoredOpenSandbox,
+    _hash_session_api_key,
+)
+from openhands.app_server.sandbox.sandbox_models import (
+    AGENT_SERVER,
+    VSCODE,
+    WORKER_1,
+    WORKER_2,
+    SandboxStatus,
+)
+from openhands.app_server.sandbox.sandbox_service import (
+    ALLOW_CORS_ORIGINS_VARIABLE,
+    SESSION_API_KEY_VARIABLE,
+    WEBHOOK_CALLBACK_VARIABLE,
+)
+from openhands.app_server.sandbox.sandbox_spec_models import SandboxSpecInfo
+from openhands.app_server.user.user_context import UserContext
+
+
+@pytest.fixture
+def mock_sandbox_spec_service():
+    mock_service = AsyncMock()
+    mock_spec = SandboxSpecInfo(
+        id='test-image:latest',
+        command=['--port', '8000'],
+        initial_env={'TEST_VAR': 'test_value'},
+        working_dir='/workspace/project',
+    )
+    mock_service.get_default_sandbox_spec.return_value = mock_spec
+    mock_service.get_sandbox_spec.return_value = mock_spec
+    return mock_service
+
+
+@pytest.fixture
+def mock_user_context():
+    mock_context = AsyncMock(spec=UserContext)
+    mock_context.get_user_id.return_value = 'test-user-123'
+    return mock_context
+
+
+@pytest.fixture
+def mock_httpx_client():
+    return AsyncMock(spec=httpx.AsyncClient)
+
+
+@pytest.fixture
+def mock_db_session():
+    return AsyncMock(spec=AsyncSession)
+
+
+@pytest.fixture
+def opensandbox_service(
+    mock_sandbox_spec_service, mock_user_context, mock_httpx_client, mock_db_session
+):
+    return OpenSandboxService(
+        sandbox_spec_service=mock_sandbox_spec_service,
+        api_url='https://api.example.com/v1',
+        api_key='test-api-key',
+        web_url='https://web.example.com',
+        sandbox_timeout=3600,
+        max_num_sandboxes=10,
+        user_context=mock_user_context,
+        httpx_client=mock_httpx_client,
+        db_session=mock_db_session,
+    )
+
+
+def create_opensandbox_data(
+    sandbox_id: str = 'os-sandbox-456',
+    state: str = 'Running',
+) -> dict[str, Any]:
+    """Helper to create OpenSandbox API response data."""
+    return {
+        'id': sandbox_id,
+        'status': {
+            'state': state,
+            'reason': None,
+            'message': None,
+        },
+        'image': {'uri': 'test-image:latest'},
+    }
+
+
+def create_stored_sandbox(
+    sandbox_id: str = 'test-sandbox-123',
+    opensandbox_id: str = 'os-sandbox-456',
+    user_id: str = 'test-user-123',
+    spec_id: str = 'test-image:latest',
+    session_api_key: str = 'test-session-key',
+    created_at: datetime | None = None,
+) -> StoredOpenSandbox:
+    if created_at is None:
+        created_at = datetime.now(timezone.utc)
+    return StoredOpenSandbox(
+        id=sandbox_id,
+        opensandbox_id=opensandbox_id,
+        created_by_user_id=user_id,
+        sandbox_spec_id=spec_id,
+        session_api_key=session_api_key,
+        session_api_key_hash=_hash_session_api_key(session_api_key),
+        created_at=created_at,
+    )
+
+
+class TestApiRequest:
+    """Test cases for OpenSandbox API communication."""
+
+    @pytest.mark.asyncio
+    async def test_send_api_request_success(self, opensandbox_service):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'result': 'success'}
+        opensandbox_service.httpx_client.request.return_value = mock_response
+
+        response = await opensandbox_service._send_api_request(
+            'GET', '/sandboxes/test-id'
+        )
+
+        assert response == mock_response
+        opensandbox_service.httpx_client.request.assert_called_once_with(
+            'GET',
+            'https://api.example.com/v1/sandboxes/test-id',
+            headers={'OPEN-SANDBOX-API-KEY': 'test-api-key'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_api_request_timeout(self, opensandbox_service):
+        opensandbox_service.httpx_client.request.side_effect = httpx.TimeoutException(
+            'Request timeout'
+        )
+
+        with pytest.raises(httpx.TimeoutException):
+            await opensandbox_service._send_api_request('GET', '/sandboxes')
+
+    @pytest.mark.asyncio
+    async def test_send_api_request_http_error(self, opensandbox_service):
+        opensandbox_service.httpx_client.request.side_effect = httpx.HTTPError(
+            'HTTP error'
+        )
+
+        with pytest.raises(httpx.HTTPError):
+            await opensandbox_service._send_api_request('GET', '/sandboxes')
+
+
+class TestStatusMapping:
+    """Test cases for OpenSandbox state to SandboxStatus mapping."""
+
+    def test_status_mapping_all_states(self, opensandbox_service):
+        test_cases = [
+            ('Pending', SandboxStatus.STARTING),
+            ('Running', SandboxStatus.RUNNING),
+            ('Pausing', SandboxStatus.RUNNING),
+            ('Paused', SandboxStatus.PAUSED),
+            ('Stopping', SandboxStatus.MISSING),
+            ('Terminated', SandboxStatus.MISSING),
+            ('Failed', SandboxStatus.ERROR),
+        ]
+
+        for state, expected in test_cases:
+            sandbox_data = create_opensandbox_data(state=state)
+            status = opensandbox_service._get_sandbox_status(sandbox_data)
+            assert status == expected, f'Failed for state: {state}'
+
+    def test_status_mapping_none_data(self, opensandbox_service):
+        status = opensandbox_service._get_sandbox_status(None)
+        assert status == SandboxStatus.MISSING
+
+    def test_status_mapping_unknown_state(self, opensandbox_service):
+        sandbox_data = create_opensandbox_data(state='UnknownState')
+        status = opensandbox_service._get_sandbox_status(sandbox_data)
+        assert status == SandboxStatus.ERROR
+
+    def test_status_mapping_empty_status(self, opensandbox_service):
+        sandbox_data: dict[str, Any] = {'id': 'test', 'status': {}}
+        status = opensandbox_service._get_sandbox_status(sandbox_data)
+        assert status == SandboxStatus.ERROR
+
+    def test_status_mapping_missing_status_key(self, opensandbox_service):
+        sandbox_data: dict[str, Any] = {'id': 'test'}
+        status = opensandbox_service._get_sandbox_status(sandbox_data)
+        assert status == SandboxStatus.ERROR
+
+
+class TestEnvironmentInitialization:
+    """Test cases for environment variable initialization."""
+
+    @pytest.mark.asyncio
+    async def test_init_environment_with_web_url(self, opensandbox_service):
+        sandbox_spec = SandboxSpecInfo(
+            id='test-image',
+            command=['test'],
+            initial_env={'EXISTING_VAR': 'existing_value'},
+            working_dir='/workspace',
+        )
+
+        environment = await opensandbox_service._init_environment(
+            sandbox_spec, 'test-session-key'
+        )
+
+        assert environment['EXISTING_VAR'] == 'existing_value'
+        assert environment[SESSION_API_KEY_VARIABLE] == 'test-session-key'
+        assert (
+            environment[WEBHOOK_CALLBACK_VARIABLE]
+            == 'https://web.example.com/api/v1/webhooks'
+        )
+        assert environment[ALLOW_CORS_ORIGINS_VARIABLE] == 'https://web.example.com'
+        assert environment[WORKER_1] == '12000'
+        assert environment[WORKER_2] == '12001'
+
+    @pytest.mark.asyncio
+    async def test_init_environment_without_web_url(self, opensandbox_service):
+        opensandbox_service.web_url = None
+        sandbox_spec = SandboxSpecInfo(
+            id='test-image',
+            command=['test'],
+            initial_env={'EXISTING_VAR': 'existing_value'},
+            working_dir='/workspace',
+        )
+
+        environment = await opensandbox_service._init_environment(
+            sandbox_spec, 'test-session-key'
+        )
+
+        assert environment['EXISTING_VAR'] == 'existing_value'
+        assert environment[SESSION_API_KEY_VARIABLE] == 'test-session-key'
+        assert WEBHOOK_CALLBACK_VARIABLE not in environment
+        assert ALLOW_CORS_ORIGINS_VARIABLE not in environment
+        assert environment[WORKER_1] == '12000'
+        assert environment[WORKER_2] == '12001'
+
+
+class TestSandboxInfoConversion:
+    """Test cases for converting stored sandbox and API data to SandboxInfo."""
+
+    def test_to_sandbox_info_running(self, opensandbox_service):
+        stored = create_stored_sandbox()
+        sandbox_data = create_opensandbox_data(state='Running')
+        from openhands.app_server.sandbox.sandbox_models import ExposedUrl
+
+        exposed_urls = [
+            ExposedUrl(name=AGENT_SERVER, url='http://agent.example.com', port=60000)
+        ]
+
+        info = opensandbox_service._to_sandbox_info(stored, sandbox_data, exposed_urls)
+
+        assert info.id == 'test-sandbox-123'
+        assert info.created_by_user_id == 'test-user-123'
+        assert info.sandbox_spec_id == 'test-image:latest'
+        assert info.status == SandboxStatus.RUNNING
+        assert info.session_api_key == 'test-session-key'
+        assert info.exposed_urls == exposed_urls
+
+    def test_to_sandbox_info_starting(self, opensandbox_service):
+        stored = create_stored_sandbox()
+        sandbox_data = create_opensandbox_data(state='Pending')
+
+        info = opensandbox_service._to_sandbox_info(stored, sandbox_data, None)
+
+        assert info.status == SandboxStatus.STARTING
+        assert info.session_api_key is None
+        assert info.exposed_urls is None
+
+    def test_to_sandbox_info_paused(self, opensandbox_service):
+        stored = create_stored_sandbox()
+        sandbox_data = create_opensandbox_data(state='Paused')
+
+        info = opensandbox_service._to_sandbox_info(stored, sandbox_data, None)
+
+        assert info.status == SandboxStatus.PAUSED
+        assert info.session_api_key is None
+        assert info.exposed_urls is None
+
+    def test_to_sandbox_info_missing(self, opensandbox_service):
+        stored = create_stored_sandbox()
+
+        info = opensandbox_service._to_sandbox_info(stored, None, None)
+
+        assert info.status == SandboxStatus.MISSING
+        assert info.session_api_key is None
+
+
+class TestBuildExposedUrls:
+    """Test cases for building exposed URLs from OpenSandbox endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_build_exposed_urls_all_endpoints(self, opensandbox_service):
+        """Test building URLs when all endpoints are available."""
+        endpoint_responses = {
+            AGENT_SERVER_PORT: 'agent.sandbox.example.com',
+            VSCODE_PORT: 'vscode.sandbox.example.com',
+            WORKER_1_PORT: 'worker1.sandbox.example.com',
+            WORKER_2_PORT: 'worker2.sandbox.example.com',
+        }
+
+        async def mock_get_endpoint(opensandbox_id, port):
+            return endpoint_responses.get(port)
+
+        opensandbox_service._get_endpoint_url = AsyncMock(side_effect=mock_get_endpoint)
+
+        urls = await opensandbox_service._build_exposed_urls(
+            'os-sandbox-456', 'test-key'
+        )
+
+        assert len(urls) == 4
+        url_names = {u.name for u in urls}
+        assert url_names == {AGENT_SERVER, VSCODE, WORKER_1, WORKER_2}
+
+        # Check agent server URL
+        agent = next(u for u in urls if u.name == AGENT_SERVER)
+        assert agent.url == 'http://agent.sandbox.example.com'
+        assert agent.port == AGENT_SERVER_PORT
+
+        # Check vscode URL includes token
+        vscode = next(u for u in urls if u.name == VSCODE)
+        assert 'tkn=test-key' in vscode.url
+
+    @pytest.mark.asyncio
+    async def test_build_exposed_urls_no_agent_server(self, opensandbox_service):
+        """Test building URLs when agent server endpoint is not available."""
+        opensandbox_service._get_endpoint_url = AsyncMock(return_value=None)
+
+        urls = await opensandbox_service._build_exposed_urls(
+            'os-sandbox-456', 'test-key'
+        )
+
+        assert len(urls) == 0
+
+    @pytest.mark.asyncio
+    async def test_build_exposed_urls_with_http_prefix(self, opensandbox_service):
+        """Test that URLs already starting with http are not double-prefixed."""
+
+        async def mock_get_endpoint(opensandbox_id, port):
+            if port == AGENT_SERVER_PORT:
+                return 'https://agent.sandbox.example.com'
+            return None
+
+        opensandbox_service._get_endpoint_url = AsyncMock(side_effect=mock_get_endpoint)
+
+        urls = await opensandbox_service._build_exposed_urls(
+            'os-sandbox-456', 'test-key'
+        )
+
+        assert len(urls) == 1
+        assert urls[0].url == 'https://agent.sandbox.example.com'
+
+
+class TestSandboxLifecycle:
+    """Test cases for sandbox lifecycle operations."""
+
+    @pytest.mark.asyncio
+    async def test_start_sandbox_success(self, opensandbox_service):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'os-sandbox-new'}
+        mock_response.raise_for_status = MagicMock()
+        opensandbox_service.httpx_client.request.return_value = mock_response
+        opensandbox_service.pause_old_sandboxes = AsyncMock(return_value=[])
+        opensandbox_service.db_session.add = MagicMock()
+
+        with patch(
+            'secrets.token_urlsafe',
+            side_effect=['custom-sandbox-id', 'session-key-abc'],
+        ):
+            sandbox_info = await opensandbox_service.start_sandbox()
+
+        assert sandbox_info.id == 'custom-sandbox-id'
+        assert sandbox_info.status == SandboxStatus.STARTING
+        assert sandbox_info.session_api_key is None
+        opensandbox_service.pause_old_sandboxes.assert_called_once_with(9)
+        opensandbox_service.db_session.add.assert_called_once()
+
+        # Verify the API request was made correctly
+        call_args = opensandbox_service.httpx_client.request.call_args
+        assert call_args[0][0] == 'POST'
+        assert '/sandboxes' in call_args[0][1]
+        request_data = call_args[1]['json']
+        assert request_data['image']['uri'] == 'test-image:latest'
+        assert request_data['timeout'] == 3600
+        assert request_data['metadata']['oh_sandbox_id'] == 'custom-sandbox-id'
+        assert request_data['metadata']['oh_user_id'] == 'test-user-123'
+        assert request_data['entrypoint'] == ['--port', '8000']
+
+    @pytest.mark.asyncio
+    async def test_start_sandbox_with_specific_spec(
+        self, opensandbox_service, mock_sandbox_spec_service
+    ):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'os-sandbox-new'}
+        mock_response.raise_for_status = MagicMock()
+        opensandbox_service.httpx_client.request.return_value = mock_response
+        opensandbox_service.pause_old_sandboxes = AsyncMock(return_value=[])
+        opensandbox_service.db_session.add = MagicMock()
+
+        await opensandbox_service.start_sandbox('custom-spec-id')
+
+        mock_sandbox_spec_service.get_sandbox_spec.assert_called_once_with(
+            'custom-spec-id'
+        )
+
+    @pytest.mark.asyncio
+    async def test_start_sandbox_spec_not_found(
+        self, opensandbox_service, mock_sandbox_spec_service
+    ):
+        mock_sandbox_spec_service.get_sandbox_spec.return_value = None
+        opensandbox_service.pause_old_sandboxes = AsyncMock(return_value=[])
+
+        with pytest.raises(ValueError, match='Sandbox Spec not found'):
+            await opensandbox_service.start_sandbox('non-existent-spec')
+
+    @pytest.mark.asyncio
+    async def test_start_sandbox_with_sandbox_id(self, opensandbox_service):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'os-sandbox-new'}
+        mock_response.raise_for_status = MagicMock()
+        opensandbox_service.httpx_client.request.return_value = mock_response
+        opensandbox_service.pause_old_sandboxes = AsyncMock(return_value=[])
+        opensandbox_service.db_session.add = MagicMock()
+
+        sandbox_info = await opensandbox_service.start_sandbox(
+            sandbox_id='my-custom-id'
+        )
+
+        assert sandbox_info.id == 'my-custom-id'
+        add_call_args = opensandbox_service.db_session.add.call_args[0][0]
+        assert add_call_args.id == 'my-custom-id'
+
+    @pytest.mark.asyncio
+    async def test_start_sandbox_http_error(self, opensandbox_service):
+        opensandbox_service.httpx_client.request.side_effect = httpx.HTTPError(
+            'API Error'
+        )
+        opensandbox_service.pause_old_sandboxes = AsyncMock(return_value=[])
+        opensandbox_service.db_session.add = MagicMock()
+
+        with pytest.raises(SandboxError, match='Failed to start sandbox'):
+            await opensandbox_service.start_sandbox()
+
+    @pytest.mark.asyncio
+    async def test_resume_sandbox_success(self, opensandbox_service):
+        stored = create_stored_sandbox()
+        opensandbox_service._get_stored_sandbox = AsyncMock(return_value=stored)
+        opensandbox_service.pause_old_sandboxes = AsyncMock(return_value=[])
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        opensandbox_service.httpx_client.request.return_value = mock_response
+
+        result = await opensandbox_service.resume_sandbox('test-sandbox-123')
+
+        assert result is True
+        opensandbox_service.pause_old_sandboxes.assert_called_once_with(9)
+        opensandbox_service.httpx_client.request.assert_called_once_with(
+            'POST',
+            'https://api.example.com/v1/sandboxes/os-sandbox-456/resume',
+            headers={'OPEN-SANDBOX-API-KEY': 'test-api-key'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_resume_sandbox_not_found(self, opensandbox_service):
+        opensandbox_service._get_stored_sandbox = AsyncMock(return_value=None)
+        opensandbox_service.pause_old_sandboxes = AsyncMock(return_value=[])
+
+        result = await opensandbox_service.resume_sandbox('non-existent')
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_resume_sandbox_404(self, opensandbox_service):
+        stored = create_stored_sandbox()
+        opensandbox_service._get_stored_sandbox = AsyncMock(return_value=stored)
+        opensandbox_service.pause_old_sandboxes = AsyncMock(return_value=[])
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        opensandbox_service.httpx_client.request.return_value = mock_response
+
+        result = await opensandbox_service.resume_sandbox('test-sandbox-123')
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_pause_sandbox_success(self, opensandbox_service):
+        stored = create_stored_sandbox()
+        opensandbox_service._get_stored_sandbox = AsyncMock(return_value=stored)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        opensandbox_service.httpx_client.request.return_value = mock_response
+
+        result = await opensandbox_service.pause_sandbox('test-sandbox-123')
+
+        assert result is True
+        opensandbox_service.httpx_client.request.assert_called_once_with(
+            'POST',
+            'https://api.example.com/v1/sandboxes/os-sandbox-456/pause',
+            headers={'OPEN-SANDBOX-API-KEY': 'test-api-key'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_pause_sandbox_not_found(self, opensandbox_service):
+        opensandbox_service._get_stored_sandbox = AsyncMock(return_value=None)
+
+        result = await opensandbox_service.pause_sandbox('non-existent')
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_sandbox_success(self, opensandbox_service):
+        stored = create_stored_sandbox()
+        opensandbox_service._get_stored_sandbox = AsyncMock(return_value=stored)
+        opensandbox_service.db_session.delete = AsyncMock()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        opensandbox_service.httpx_client.request.return_value = mock_response
+
+        result = await opensandbox_service.delete_sandbox('test-sandbox-123')
+
+        assert result is True
+        opensandbox_service.db_session.delete.assert_called_once_with(stored)
+        opensandbox_service.httpx_client.request.assert_called_once_with(
+            'DELETE',
+            'https://api.example.com/v1/sandboxes/os-sandbox-456',
+            headers={'OPEN-SANDBOX-API-KEY': 'test-api-key'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_sandbox_not_found(self, opensandbox_service):
+        opensandbox_service._get_stored_sandbox = AsyncMock(return_value=None)
+
+        result = await opensandbox_service.delete_sandbox('non-existent')
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_sandbox_404_ignored(self, opensandbox_service):
+        stored = create_stored_sandbox()
+        opensandbox_service._get_stored_sandbox = AsyncMock(return_value=stored)
+        opensandbox_service.db_session.delete = AsyncMock()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        opensandbox_service.httpx_client.request.return_value = mock_response
+
+        result = await opensandbox_service.delete_sandbox('test-sandbox-123')
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_delete_sandbox_http_error(self, opensandbox_service):
+        stored = create_stored_sandbox()
+        opensandbox_service._get_stored_sandbox = AsyncMock(return_value=stored)
+        opensandbox_service.httpx_client.request.side_effect = httpx.HTTPError(
+            'API Error'
+        )
+
+        result = await opensandbox_service.delete_sandbox('test-sandbox-123')
+
+        assert result is False
+
+
+class TestGetSandbox:
+    """Test cases for sandbox retrieval operations."""
+
+    @pytest.mark.asyncio
+    async def test_get_sandbox_running(self, opensandbox_service):
+        stored = create_stored_sandbox()
+        opensandbox_service._get_stored_sandbox = AsyncMock(return_value=stored)
+        opensandbox_service._get_opensandbox_data = AsyncMock(
+            return_value=create_opensandbox_data(state='Running')
+        )
+
+        from openhands.app_server.sandbox.sandbox_models import ExposedUrl
+
+        mock_urls = [
+            ExposedUrl(name=AGENT_SERVER, url='http://agent.example.com', port=60000)
+        ]
+        opensandbox_service._build_exposed_urls = AsyncMock(return_value=mock_urls)
+
+        info = await opensandbox_service.get_sandbox('test-sandbox-123')
+
+        assert info is not None
+        assert info.status == SandboxStatus.RUNNING
+        assert info.session_api_key == 'test-session-key'
+        assert info.exposed_urls == mock_urls
+        opensandbox_service._build_exposed_urls.assert_called_once_with(
+            'os-sandbox-456', 'test-session-key'
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_sandbox_not_found(self, opensandbox_service):
+        opensandbox_service._get_stored_sandbox = AsyncMock(return_value=None)
+
+        info = await opensandbox_service.get_sandbox('non-existent')
+
+        assert info is None
+
+    @pytest.mark.asyncio
+    async def test_get_sandbox_paused(self, opensandbox_service):
+        stored = create_stored_sandbox()
+        opensandbox_service._get_stored_sandbox = AsyncMock(return_value=stored)
+        opensandbox_service._get_opensandbox_data = AsyncMock(
+            return_value=create_opensandbox_data(state='Paused')
+        )
+
+        info = await opensandbox_service.get_sandbox('test-sandbox-123')
+
+        assert info is not None
+        assert info.status == SandboxStatus.PAUSED
+        assert info.session_api_key is None
+        assert info.exposed_urls is None
+
+    @pytest.mark.asyncio
+    async def test_get_sandbox_by_session_api_key(self, opensandbox_service):
+        stored = create_stored_sandbox()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = stored
+        opensandbox_service.db_session.execute = AsyncMock(return_value=mock_result)
+
+        opensandbox_service._get_opensandbox_data = AsyncMock(
+            return_value=create_opensandbox_data(state='Running')
+        )
+
+        from openhands.app_server.sandbox.sandbox_models import ExposedUrl
+
+        mock_urls = [
+            ExposedUrl(name=AGENT_SERVER, url='http://agent.example.com', port=60000)
+        ]
+        opensandbox_service._build_exposed_urls = AsyncMock(return_value=mock_urls)
+
+        info = await opensandbox_service.get_sandbox_by_session_api_key(
+            'test-session-key'
+        )
+
+        assert info is not None
+        assert info.status == SandboxStatus.RUNNING
+
+    @pytest.mark.asyncio
+    async def test_get_sandbox_by_session_api_key_not_found(self, opensandbox_service):
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        opensandbox_service.db_session.execute = AsyncMock(return_value=mock_result)
+
+        info = await opensandbox_service.get_sandbox_by_session_api_key(
+            'nonexistent-key'
+        )
+
+        assert info is None
+
+
+class TestSearchSandboxes:
+    """Test cases for sandbox search and pagination."""
+
+    @pytest.mark.asyncio
+    async def test_search_sandboxes_basic(self, opensandbox_service):
+        stored_sandboxes = [
+            create_stored_sandbox('sb1', 'os-1'),
+            create_stored_sandbox('sb2', 'os-2'),
+        ]
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = stored_sandboxes
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        opensandbox_service.db_session.execute = AsyncMock(return_value=mock_result)
+
+        opensandbox_service._get_opensandbox_data = AsyncMock(
+            return_value=create_opensandbox_data(state='Paused')
+        )
+
+        page = await opensandbox_service.search_sandboxes()
+
+        assert len(page.items) == 2
+        assert page.next_page_id is None
+
+    @pytest.mark.asyncio
+    async def test_search_sandboxes_with_pagination(self, opensandbox_service):
+        # Return limit+1 items to trigger pagination
+        stored_sandboxes = [
+            create_stored_sandbox(f'sb{i}', f'os-{i}') for i in range(4)
+        ]
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = stored_sandboxes
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        opensandbox_service.db_session.execute = AsyncMock(return_value=mock_result)
+
+        opensandbox_service._get_opensandbox_data = AsyncMock(
+            return_value=create_opensandbox_data(state='Paused')
+        )
+
+        page = await opensandbox_service.search_sandboxes(limit=3)
+
+        assert len(page.items) == 3
+        assert page.next_page_id == '3'
+
+
+class TestHashSessionApiKey:
+    """Test the session API key hashing utility."""
+
+    def test_hash_deterministic(self):
+        key = 'my-session-key'
+        assert _hash_session_api_key(key) == _hash_session_api_key(key)
+
+    def test_hash_different_keys(self):
+        assert _hash_session_api_key('key-a') != _hash_session_api_key('key-b')


### PR DESCRIPTION
## Summary of PR

Integrate [[OpenSandbox](https://github.com/anthropics/OpenSandbox)](https://github.com/anthropics/OpenSandbox) Lifecycle API as a fourth sandbox backend alongside Docker, Remote, and Process. This enables OpenHands to run sandboxes on the OpenSandbox platform via its REST API (`/v1/sandboxes/*`).

### What's changed

**New files:**
- `openhands/app_server/sandbox/opensandbox_service.py` — `OpenSandboxService` + `OpenSandboxServiceInjector`: implements the `SandboxService` abstract interface by calling OpenSandbox Lifecycle API endpoints (create, get, list, pause, resume, delete). Uses a local SQLite table (`v1_opensandbox`) to store sandbox metadata mappings, following the same pattern as `RemoteSandboxService`.
- `openhands/app_server/sandbox/opensandbox_spec_service.py` — `OpenSandboxSpecServiceInjector`: preset sandbox spec service returning the default agent-server image, reusing `PresetSandboxSpecService`.
- `tests/unit/app_server/test_opensandbox_service.py` — 40 unit tests covering API communication, status mapping, environment initialization, sandbox info conversion, exposed URL building, full lifecycle operations (start/pause/resume/delete), sandbox retrieval, search with pagination, and session API key hashing.

**Modified files:**
- `openhands/app_server/config.py` — Added `RUNTIME=opensandbox` branch in `config_from_env()` for both `SandboxServiceInjector` and `SandboxSpecServiceInjector`.

### Key design decisions
- Uses **httpx** to call OpenSandbox REST API directly (no SDK dependency), consistent with the existing `RemoteSandboxService` pattern.
- Uses the **default OpenHands agent-server image** (`ghcr.io/openhands/agent-server`).
- Maps OpenSandbox states to OpenHands `SandboxStatus`: Pending→STARTING, Running→RUNNING, Pausing→RUNNING, Paused→PAUSED, Stopping/Terminated→MISSING, Failed→ERROR.
- Retrieves exposed service URLs (agent-server, vscode, workers) via the OpenSandbox endpoint API (`GET /sandboxes/{id}/endpoints/{port}`).

### How to activate
```bash
export RUNTIME=opensandbox
export OPEN_SANDBOX_API_KEY=your-api-key
export OPEN_SANDBOX_API_URL=http://localhost:8080/v1  # optional, defaults to this
```

## Demo Screenshots/Videos



## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

## Release Notes

- [x] Include this change in the Release Notes.

Added OpenSandbox as a new sandbox backend. Set `RUNTIME=opensandbox` with `OPEN_SANDBOX_API_KEY` to run OpenHands sandboxes on the OpenSandbox platform.