### PR TITLE
Add type annotations to SQLAlchemy Column definitions

### DIFF
--- a/enterprise/storage/billing_session.py
+++ b/enterprise/storage/billing_session.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from decimal import Decimal
 
 from sqlalchemy import DECIMAL, Column, DateTime, Enum, ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID
@@ -16,7 +17,7 @@ class BillingSession(Base):  # type: ignore
     id = Column(String, primary_key=True)
     user_id = Column(String, nullable=False)
     org_id = Column(UUID(as_uuid=True), ForeignKey('org.id'), nullable=True)
-    status = Column(
+    status: Column[str] = Column(
         Enum(
             'in_progress',
             'completed',
@@ -26,7 +27,7 @@ class BillingSession(Base):  # type: ignore
         ),
         default='in_progress',
     )
-    price = Column(DECIMAL(19, 4), nullable=False)
+    price: Column[Decimal] = Column(DECIMAL(19, 4), nullable=False)
     price_code = Column(String, nullable=False)
     created_at = Column(
         DateTime(timezone=True),

--- a/enterprise/storage/conversation_callback.py
+++ b/enterprise/storage/conversation_callback.py
@@ -71,7 +71,7 @@ class ConversationCallback(Base):  # type: ignore
         nullable=False,
         index=True,
     )
-    status = Column(
+    status: Column[CallbackStatus] = Column(
         SQLEnum(CallbackStatus), nullable=False, default=CallbackStatus.ACTIVE
     )
     processor_type = Column(String, nullable=False)

--- a/enterprise/storage/feedback.py
+++ b/enterprise/storage/feedback.py
@@ -9,10 +9,10 @@ class Feedback(Base):  # type: ignore
     id = Column(String, primary_key=True)
     version = Column(String, nullable=False)
     email = Column(String, nullable=False)
-    polarity = Column(
+    polarity: Column[str] = Column(
         Enum('positive', 'negative', name='polarity_enum'), nullable=False
     )
-    permissions = Column(
+    permissions: Column[str] = Column(
         Enum('public', 'private', name='permissions_enum'), nullable=False
     )
     trajectory = Column(JSON, nullable=True)

--- a/enterprise/storage/maintenance_task.py
+++ b/enterprise/storage/maintenance_task.py
@@ -60,7 +60,7 @@ class MaintenanceTask(Base):  # type: ignore
     __tablename__ = 'maintenance_tasks'
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    status = Column(
+    status: Column[MaintenanceTaskStatus] = Column(
         SQLEnum(MaintenanceTaskStatus),
         nullable=False,
         default=MaintenanceTaskStatus.INACTIVE,

--- a/enterprise/storage/openhands_pr.py
+++ b/enterprise/storage/openhands_pr.py
@@ -22,7 +22,7 @@ class OpenhandsPR(Base):  # type: ignore
     repo_id = Column(String, nullable=False, index=True)
     repo_name = Column(String, nullable=False)
     pr_number = Column(Integer, nullable=False, index=True)
-    status = Column(
+    status: Column[PRStatus] = Column(
         Enum(PRStatus),
         nullable=False,
         index=True,

--- a/enterprise/storage/subscription_access.py
+++ b/enterprise/storage/subscription_access.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from decimal import Decimal
 
 from sqlalchemy import DECIMAL, Column, DateTime, Enum, Integer, String
 from storage.base import Base
@@ -13,7 +14,7 @@ class SubscriptionAccess(Base):  # type: ignore
     __tablename__ = 'subscription_access'
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    status = Column(
+    status: Column[str] = Column(
         Enum(
             'ACTIVE',
             'DISABLED',
@@ -25,7 +26,7 @@ class SubscriptionAccess(Base):  # type: ignore
     user_id = Column(String, nullable=False, index=True)
     start_at = Column(DateTime(timezone=True), nullable=True)
     end_at = Column(DateTime(timezone=True), nullable=True)
-    amount_paid = Column(DECIMAL(19, 4), nullable=True)
+    amount_paid: Column[Decimal] = Column(DECIMAL(19, 4), nullable=True)
     stripe_invoice_payment_id = Column(String, nullable=False)
     cancelled_at = Column(DateTime(timezone=True), nullable=True)
     stripe_subscription_id = Column(String, nullable=True, index=True)

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -79,7 +79,7 @@ class StoredConversationMetadata(Base):  # type: ignore
     created_at = Column(DateTime(timezone=True), default=utc_now)  # type: ignore[attr-defined]
 
     trigger = Column(String, nullable=True)
-    pr_number = Column(create_json_type_decorator(list[int]))
+    pr_number: Column[list[int]] = Column(create_json_type_decorator(list[int]))
 
     # Cost and token metrics
     accumulated_cost = Column(Float, default=0.0)

--- a/openhands/app_server/app_conversation/sql_app_conversation_start_task_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_start_task_service.py
@@ -54,12 +54,16 @@ class StoredAppConversationStartTask(Base):  # type: ignore
     __tablename__ = 'app_conversation_start_task'
     id = Column(SQLUUID, primary_key=True)
     created_by_user_id = Column(String, index=True)
-    status = Column(Enum(AppConversationStartTaskStatus), nullable=True)
+    status: Column[AppConversationStartTaskStatus] = Column(
+        Enum(AppConversationStartTaskStatus), nullable=True
+    )
     detail = Column(String, nullable=True)
     app_conversation_id = Column(SQLUUID, nullable=True)
     sandbox_id = Column(String, nullable=True)
     agent_server_url = Column(String, nullable=True)
-    request = Column(create_json_type_decorator(AppConversationStartRequest))
+    request: Column[AppConversationStartRequest] = Column(
+        create_json_type_decorator(AppConversationStartRequest)
+    )
     created_at = Column(UtcDateTime, server_default=func.now(), index=True)
     updated_at = Column(UtcDateTime, onupdate=func.now(), index=True)
 

--- a/openhands/app_server/event_callback/sql_event_callback_service.py
+++ b/openhands/app_server/event_callback/sql_event_callback_service.py
@@ -48,10 +48,12 @@ class StoredEventCallback(Base):  # type: ignore
     __tablename__ = 'event_callback'
     id = Column(SQLUUID, primary_key=True)
     conversation_id = Column(SQLUUID, nullable=True)
-    status = Column(
+    status: Column[EventCallbackStatus] = Column(
         Enum(EventCallbackStatus), nullable=False, default=EventCallbackStatus.ACTIVE
     )
-    processor = Column(create_json_type_decorator(EventCallbackProcessor))
+    processor: Column[EventCallbackProcessor] = Column(
+        create_json_type_decorator(EventCallbackProcessor)
+    )
     event_kind = Column(String, nullable=True)
     created_at = Column(UtcDateTime, server_default=func.now(), index=True)
     updated_at = Column(UtcDateTime, server_default=func.now(), index=True)
@@ -60,7 +62,9 @@ class StoredEventCallback(Base):  # type: ignore
 class StoredEventCallbackResult(Base):  # type: ignore
     __tablename__ = 'event_callback_result'
     id = Column(SQLUUID, primary_key=True, default=uuid4)
-    status = Column(Enum(EventCallbackResultStatus), nullable=True)
+    status: Column[EventCallbackResultStatus] = Column(
+        Enum(EventCallbackResultStatus), nullable=True
+    )
     event_callback_id = Column(SQLUUID, index=True)
     event_id = Column(String, index=True)
     conversation_id = Column(SQLUUID, index=True)


### PR DESCRIPTION
## Summary of PR

This PR fixes 15 mypy `var-annotated` errors by adding explicit type annotations to SQLAlchemy Column definitions that use Enum, JSON, or DECIMAL types.

These annotations prepare the codebase for stricter type checking when `sqlalchemy>=2.0` stubs are added to the mypy configuration. The current enterprise CI doesn't include sqlalchemy stubs in the mypy dependencies, so these changes are forward-compatible.

### Files changed:

**openhands/app_server/ (3 files)**
- `sql_event_callback_service.py` - Added `Column[EventCallbackStatus]`, `Column[EventCallbackProcessor]`, `Column[EventCallbackResultStatus]`
- `sql_app_conversation_start_task_service.py` - Added `Column[AppConversationStartTaskStatus]`, `Column[AppConversationStartRequest]`
- `sql_app_conversation_info_service.py` - Added `Column[list[int]]`

**enterprise/storage/ (6 files)**
- `subscription_access.py` - Added `Column[str]`, `Column[Decimal]`
- `openhands_pr.py` - Added `Column[PRStatus]`
- `maintenance_task.py` - Added `Column[MaintenanceTaskStatus]`
- `feedback.py` - Added `Column[str]` (2x)
- `conversation_callback.py` - Added `Column[CallbackStatus]`
- `billing_session.py` - Added `Column[str]`, `Column[Decimal]`

### Verification
- `make lint` passes in the enterprise directory
- When temporarily adding `sqlalchemy>=2.0` to mypy dependencies, error count drops from 252 → 237 (exactly 15 errors fixed)

## Demo Screenshots/Videos

N/A - This is a type annotation fix with no runtime behavior changes.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Part of incremental enterprise mypy type checking improvements.

## Release Notes

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:679b04e-nikolaik   --name openhands-app-679b04e   docker.openhands.dev/openhands/openhands:679b04e
```