### PR TITLE
fix: add missing params to TestLoadHooksFromWorkspace setup

### DIFF
--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3168,6 +3168,7 @@ class TestLoadHooksFromWorkspace:
         self.mock_event_callback_service = Mock()
         self.mock_event_service = Mock()
         self.mock_httpx_client = AsyncMock()
+        self.mock_pending_message_service = Mock()
 
         # Create service instance
         self.service = LiveStatusAppConversationService(
@@ -3180,8 +3181,10 @@ class TestLoadHooksFromWorkspace:
             sandbox_service=self.mock_sandbox_service,
             sandbox_spec_service=self.mock_sandbox_spec_service,
             jwt_service=self.mock_jwt_service,
+            pending_message_service=self.mock_pending_message_service,
             sandbox_startup_timeout=30,
             sandbox_startup_poll_frequency=1,
+            max_num_conversations_per_sandbox=20,
             httpx_client=self.mock_httpx_client,
             web_url='https://test.example.com',
             openhands_provider_base_url='https://provider.example.com',


### PR DESCRIPTION
## Description

Fixes the CI failure on `main` introduced by #12773 (commit 00daaa41d). The `TestLoadHooksFromWorkspace` class was missing `pending_message_service` and `max_num_conversations_per_sandbox` parameters when constructing `LiveStatusAppConversationService`, causing all 9 tests in that class to fail with:

```
TypeError: LiveStatusAppConversationService.__init__() missing 2 required positional arguments: 'pending_message_service' and 'max_num_conversations_per_sandbox'
```

## Changes

Added the two missing constructor parameters to `TestLoadHooksFromWorkspace.setup_method()`, matching the pattern already used by other test classes in the same file.

## Tests

All 9 previously failing tests now pass:
- `test_load_hooks_from_workspace_success`
- `test_load_hooks_from_workspace_file_not_found`
- `test_load_hooks_from_workspace_empty_hooks`
- `test_load_hooks_from_workspace_http_error`
- `test_get_project_dir_for_hooks_with_selected_repository`
- `test_get_project_dir_for_hooks_without_selected_repository`
- `test_get_project_dir_for_hooks_with_empty_string`
- `test_load_hooks_from_workspace_with_project_dir`
- `test_load_hooks_from_workspace_base_dir`

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:3e0800c-nikolaik   --name openhands-app-3e0800c   docker.openhands.dev/openhands/openhands:3e0800c
```