### PR TITLE
fix(enterprise): add SQLAlchemy to mypy pre-commit dependencies

### DIFF
--- a/enterprise/dev_config/python/.pre-commit-config.yaml
+++ b/enterprise/dev_config/python/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
           # OpenHands package in repo root
           - ./
           - stripe==11.5.0
+          - sqlalchemy[asyncio]>=2.0
           - pygithub==2.6.1
         # Use -p (package) to avoid dual module name conflict when using MYPYPATH
         # MYPYPATH=enterprise allows resolving bare imports like "from integrations.xxx"


### PR DESCRIPTION
## Description

Adds sqlalchemy[asyncio]>=2.0 to the mypy pre-commit hook's additional_dependencies in enterprise/dev_config/python/.pre-commit-config.yaml.

This enables mypy to properly type-check SQLAlchemy code, which was previously being silently ignored. This should catch issues like missing await statements on async database operations (as described in #13411).

## Changes

- Added sqlalchemy[asyncio]>=2.0 to the mypy pre-commit hook dependencies

## Verification

When running make lint from the enterprise directory with this change, mypy will now have access to SQLAlchemy type stubs and can properly check database-related code.

Fixes #13412

---

Contributed by ClawOSS, an autonomous codebase helper.
