### PR TITLE
fix: prioritize paused/stopped status over pod_status for sandbox state

### DIFF
--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -192,20 +192,31 @@ class RemoteSandboxService(SandboxService):
         the status of a runtime is inconsistent. It is divided between a "status" which
         cannot be trusted (It sometimes returns  "running" for cases when the pod is
         still starting) and a "pod_status" which is not returned for list
-        operations."""
+        operations.
+
+        Note: We check for "paused" status first because pod_status doesn't track
+        paused state - a paused sandbox may still have pod_status "ready" which
+        would incorrectly map to RUNNING.
+        """
         if not runtime:
             return SandboxStatus.MISSING
 
+        # Check runtime status first for paused/stopped states that pod_status doesn't track
+        runtime_status = (runtime.get('status') or '').lower()
+        if runtime_status in ('paused', 'stopped'):
+            mapped_status = STATUS_MAPPING.get(runtime_status)
+            if mapped_status is not None:
+                return mapped_status
+
+        # Use pod_status for running/starting/error states (more reliable for these)
         status = None
         pod_status = (runtime.get('pod_status') or '').lower()
         if pod_status:
             status = POD_STATUS_MAPPING.get(pod_status, None)
 
-        # If we failed to get the status from the pod status, fall back to status
-        if status is None:
-            runtime_status = runtime.get('status')
-            if runtime_status:
-                status = STATUS_MAPPING.get(runtime_status.lower(), None)
+        # Fall back to runtime status for remaining cases
+        if status is None and runtime_status:
+            status = STATUS_MAPPING.get(runtime_status, None)
 
         if status is None:
             return SandboxStatus.MISSING


### PR DESCRIPTION
## Problem
When a user pauses a conversation from the conversation list:
1. Click ellipsis → "Close conversation" → Conversation closes successfully
2. Status indicator turns **grey** (correct - from optimistic cache update)
3. Close and re-open the conversation panel
4. Status indicator turns **green** (incorrect - should remain grey)

## Root Cause Analysis

The `_get_sandbox_status_from_runtime` function in `remote_sandbox_service.py` determines sandbox status by checking two fields from the Runtime API:

| Field | Purpose | Limitation |
|-------|---------|------------|
| `pod_status` | Kubernetes pod state (ready, pending, failed) | **Does not track "paused" state** |
| `status` | Runtime state (running, paused, stopped) | Less reliable for running/starting states |

**The bug:** `pod_status` was checked **first**. When a sandbox is paused:
- Runtime API returns `status: "paused"` ✓
- Runtime API may still return `pod_status: "ready"` (pod is technically ready)
- Code mapped `pod_status: "ready"` → `SandboxStatus.RUNNING` → **green dot**

The `POD_STATUS_MAPPING` has no entry for "paused":
```python
POD_STATUS_MAPPING = {
    'ready': SandboxStatus.RUNNING,  # ← paused sandbox hits this!
    'pending': SandboxStatus.STARTING,
    'running': SandboxStatus.STARTING,
    'failed': SandboxStatus.ERROR,
    ...
}
```

## Solution

Prioritize checking `status` for "paused" and "stopped" states **before** checking `pod_status`, since these states are not represented in pod status.

**Before:**
```python
# Check pod_status first
pod_status = runtime.get('pod_status')
if pod_status:
    status = POD_STATUS_MAPPING.get(pod_status)  # "ready" → RUNNING ✗

# Fall back to status
if status is None:
    runtime_status = runtime.get('status')  # Never reached for paused
```

**After:**
```python
# Check runtime status first for paused/stopped (not tracked by pod_status)
runtime_status = runtime.get('status')
if runtime_status in ('paused', 'stopped'):
    return STATUS_MAPPING.get(runtime_status)  # "paused" → PAUSED ✓

# Use pod_status for running/starting/error (more reliable for these)
pod_status = runtime.get('pod_status')
if pod_status:
    status = POD_STATUS_MAPPING.get(pod_status)
```

## Why This Approach

| Alternative | Pros | Cons |
|-------------|------|------|
| **This fix (status priority)** | Simple, surgical change; fixes root cause | Relies on Runtime API returning correct `status` |
| Store pause state in DB | Doesn't rely on Runtime API | Requires DB migration; state sync complexity |
| Frontend polling/retry | No backend changes | Workaround, not a fix; adds latency |
| Fix Runtime API | True fix | Out of scope; separate service |

This approach was chosen because:
1. **Minimal change** - Only modifies status determination logic
2. **Fixes root cause** - Correctly interprets Runtime API response
3. **No breaking changes** - Other states (running, starting, error) still use `pod_status`
4. **Documented behavior** - Code comment explains the reasoning

## Testing
- Verified with pre-commit hooks (ruff, mypy pass)
- Manual testing: Pause conversation → close panel → re-open panel → status should remain grey

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:9da582a-nikolaik   --name openhands-app-9da582a   docker.openhands.dev/openhands/openhands:9da582a
```