### PR TITLE
fix: replace deprecated libtmux Session.attached_pane with active_pane

### DIFF
--- a/openhands/runtime/impl/local/local_runtime.py
+++ b/openhands/runtime/impl/local/local_runtime.py
@@ -115,7 +115,7 @@ def check_dependencies(code_repo_path: str, check_browser: bool) -> None:
             session = server.new_session(session_name='test-session')
         except Exception:
             raise ValueError('tmux is not properly installed or available on the path.')
-        pane = session.attached_pane
+        pane = session.active_pane
         pane.send_keys('echo "test"')
         pane_output = '\n'.join(pane.cmd('capture-pane', '-p').stdout)
         session.kill_session()


### PR DESCRIPTION
## Summary

One-line fix: `session.attached_pane` → `session.active_pane` in `openhands/runtime/impl/local/local_runtime.py`.

`Session.attached_pane` was deprecated in libtmux 0.31.0 and has been fully removed. This causes `RUNTIME=local` to crash immediately on startup with `DeprecatedError`, making the "Running OpenHands with OpenHands" development workflow completely broken.

## Change

```diff
- pane = session.attached_pane
+ pane = session.active_pane
```

## Steps to Reproduce (before fix)

```bash
export INSTALL_DOCKER=0
export RUNTIME=local
make build && make run
# Crashes with: libtmux.exc.DeprecatedError: Session.attached_pane was deprecated in 0.31.0
```

Fixes #13433