### PR TITLE
fix(containers): run docker-dev with host user to prevent root-owned files

### DIFF
--- a/containers/dev/dev.sh
+++ b/containers/dev/dev.sh
@@ -34,6 +34,6 @@ export BACKEND_HOST="0.0.0.0"
 export SANDBOX_USER_ID=$(id -u)
 export WORKSPACE_BASE=${WORKSPACE_BASE:-$OPENHANDS_WORKSPACE/workspace}
 
-docker compose run --rm --service-ports "$@" dev
+docker compose run --rm --service-ports --user "$(id -u):$(id -g)" "$@" dev
 
 ##


### PR DESCRIPTION
Running `make docker-dev` creates files in the mounted source tree as root, breaking subsequent host builds. Added `--user &quot;$(id -u):$(id -g)\u0026quot;` to the docker compose run command so files are created with the host user's ownership.

Fixes #13434