### PR TITLE
docs: add cross-repo testing skill for SDK ↔ OH Cloud e2e workflow

### DIFF
--- a/.agents/skills/cross-repo-testing/SKILL.md
+++ b/.agents/skills/cross-repo-testing/SKILL.md
@@ -176,11 +176,13 @@ python examples/02_remote_agent_server/10_cloud_workspace_saas_credentials.py
 
 ### Recording results
 
-Push test output to the SDK PR's `.pr/logs/` directory:
+Both repos support a `.pr/` directory for temporary PR artifacts (design docs, test logs, scripts). These files are automatically removed when the PR is approved — see `.github/workflows/pr-artifacts.yml` and the "PR-Specific Artifacts" section in each repo's `AGENTS.md`.
+
+Push test output to the `.pr/logs/` directory of whichever repo you're working in:
 ```bash
-cd software-agent-sdk
+mkdir -p .pr/logs
 python test_script.py 2>&1 | tee .pr/logs/<test_name>.log
-git add -f .pr/logs/<test_name>.log .pr/README.md
+git add -f .pr/logs/
 git commit -m "docs: add e2e test results" && git push
 ```
 

--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -1,0 +1,136 @@
+---
+name: PR Artifacts
+
+on:
+    workflow_dispatch: # Manual trigger for testing
+    pull_request:
+        types: [opened, synchronize, reopened]
+        branches: [main]
+    pull_request_review:
+        types: [submitted]
+
+jobs:
+  # Auto-remove .pr/ directory when a reviewer approves
+    cleanup-on-approval:
+        concurrency:
+            group: cleanup-pr-artifacts-${{ github.event.pull_request.number }}
+            cancel-in-progress: false
+        if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            - name: Check if fork PR
+              id: check-fork
+              run: |
+                  if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]; then
+                    echo "is_fork=true" >> $GITHUB_OUTPUT
+                    echo "::notice::Fork PR detected - skipping auto-cleanup (manual removal required)"
+                  else
+                    echo "is_fork=false" >> $GITHUB_OUTPUT
+                  fi
+
+            - uses: actions/checkout@v5
+              if: steps.check-fork.outputs.is_fork == 'false'
+              with:
+                  ref: ${{ github.event.pull_request.head.ref }}
+                  token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+
+            - name: Remove .pr/ directory
+              id: remove
+              if: steps.check-fork.outputs.is_fork == 'false'
+              run: |
+                  if [ -d ".pr" ]; then
+                    git config user.name "allhands-bot"
+                    git config user.email "allhands-bot@users.noreply.github.com"
+                    git rm -rf .pr/
+                    git commit -m "chore: Remove PR-only artifacts [automated]"
+                    git push || {
+                      echo "::error::Failed to push cleanup commit. Check branch protection rules."
+                      exit 1
+                    }
+                    echo "removed=true" >> $GITHUB_OUTPUT
+                    echo "::notice::Removed .pr/ directory"
+                  else
+                    echo "removed=false" >> $GITHUB_OUTPUT
+                    echo "::notice::No .pr/ directory to remove"
+                  fi
+
+            - name: Update PR comment after cleanup
+              if: steps.check-fork.outputs.is_fork == 'false' && steps.remove.outputs.removed == 'true'
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const marker = '<!-- pr-artifacts-notice -->';
+                      const body = `${marker}
+                      ✅ **PR Artifacts Cleaned Up**
+
+                      The \`.pr/\` directory has been automatically removed.
+                      `;
+
+                      const { data: comments } = await github.rest.issues.listComments({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.issue.number,
+                      });
+
+                      const existing = comments.find(c => c.body.includes(marker));
+                      if (existing) {
+                        await github.rest.issues.updateComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          comment_id: existing.id,
+                          body: body,
+                        });
+                      }
+
+  # Warn if .pr/ directory exists (will be auto-removed on approval)
+    check-pr-artifacts:
+        if: github.event_name == 'pull_request'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: write
+        steps:
+            - uses: actions/checkout@v5
+
+            - name: Check for .pr/ directory
+              id: check
+              run: |
+                  if [ -d ".pr" ]; then
+                    echo "exists=true" >> $GITHUB_OUTPUT
+                    echo "::warning::.pr/ directory exists and will be automatically removed when the PR is approved. For fork PRs, manual removal is required before merging."
+                  else
+                    echo "exists=false" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Post or update PR comment
+              if: steps.check.outputs.exists == 'true'
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const marker = '<!-- pr-artifacts-notice -->';
+                      const body = `${marker}
+                      📁 **PR Artifacts Notice**
+
+                      This PR contains a \`.pr/\` directory with PR-specific documents. This directory will be **automatically removed** when the PR is approved.
+
+                      > For fork PRs: Manual removal is required before merging.
+                      `;
+
+                      const { data: comments } = await github.rest.issues.listComments({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.issue.number,
+                      });
+
+                      const existing = comments.find(c => c.body.includes(marker));
+                      if (!existing) {
+                        await github.rest.issues.createComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.issue.number,
+                          body: body,
+                        });
+                      }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,40 @@ then re-run the command to ensure it passes. Common issues include:
 - Be especially careful with `git reset --hard` after staging files, as it will remove accidentally staged files
 - When remote has new changes, use `git fetch upstream && git rebase upstream/<branch>` on the same branch
 
+## PR-Specific Artifacts (`.pr/` directory)
+
+When working on a PR that requires design documents, scripts meant for development-only, or other temporary artifacts that should NOT be merged to main, store them in a `.pr/` directory at the repository root.
+
+### Usage
+
+```
+.pr/
+├── design.md       # Design decisions and architecture notes
+├── analysis.md     # Investigation or debugging notes
+├── logs/           # Test output or CI logs for reviewer reference
+└── notes.md        # Any other PR-specific content
+```
+
+### How It Works
+
+1. **Notification**: When `.pr/` exists, a comment is posted to the PR conversation alerting reviewers
+2. **Auto-cleanup**: When the PR is approved, the `.pr/` directory is automatically removed via `.github/workflows/pr-artifacts.yml`
+3. **Fork PRs**: Auto-cleanup cannot push to forks, so manual removal is required before merging
+
+### Important Notes
+
+- Do NOT put anything in `.pr/` that needs to be preserved after merge
+- The `.pr/` check passes (green ✅) during development — it only posts a notification, not a blocking error
+- For fork PRs: You must manually remove `.pr/` before the PR can be merged
+
+### When to Use
+
+- Complex refactoring that benefits from written design rationale
+- Debugging sessions where you want to document your investigation
+- E2E test results or logs that demonstrate a cross-repo feature works
+- Feature implementations that need temporary planning docs
+- Any analysis that helps reviewers understand the PR but isn't needed long-term
+
 ## Repository Structure
 Backend:
 - Located in the `openhands` directory


### PR DESCRIPTION
## Summary

Adds `.agents/skills/cross-repo-testing/SKILL.md` — a skill that guides AI agents through the end-to-end testing workflow when an SDK feature requires coordinated changes in the OpenHands Cloud backend.

## What it covers

1. **Repository map** — explains the relationship between `software-agent-sdk` (agent core), `OpenHands` (Cloud backend), and `deploy` (infrastructure)
2. **Step-by-step workflow** — from writing server-side changes, to deploying a staging feature environment, to running SDK e2e tests against it
3. **Key gotchas** — feature-env auth isolation, dual SHA updates in deploy.yaml, DNS propagation, enterprise Docker image prerequisites

## Why both repos?

This same skill is being added to the `software-agent-sdk` repo in a companion PR (OpenHands/software-agent-sdk#2477). Agents working from either side of a cross-repo feature need this guide:
- Server agents need it when their API changes must be validated end-to-end with the SDK client
- SDK agents need it when building features like `OpenHandsCloudWorkspace.get_llm()` that call Cloud APIs

## Context

This skill was distilled from the real cross-repo testing workflow performed for SDK PR OpenHands/software-agent-sdk#2409 + Server PR #13383 (SaaS credentials inheritance for SDK-created conversations).

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:7443148-nikolaik   --name openhands-app-7443148   docker.openhands.dev/openhands/openhands:7443148
```