### PR TITLE
fix: stale useMemo closures in git hooks and incorrect SQLAlchemy result handling

### DIFF
--- a/frontend/src/hooks/query/use-unified-get-git-changes.ts
+++ b/frontend/src/hooks/query/use-unified-get-git-changes.ts
@@ -28,7 +28,7 @@ export const useUnifiedGetGitChanges = () => {
   // Calculate git path based on selected repository
   const gitPath = React.useMemo(
     () => getGitPath(conversationId, selectedRepository),
-    [selectedRepository],
+    [conversationId, selectedRepository],
   );
 
   const result = useQuery({

--- a/frontend/src/hooks/query/use-unified-git-diff.ts
+++ b/frontend/src/hooks/query/use-unified-git-diff.ts
@@ -34,7 +34,7 @@ export const useUnifiedGitDiff = (config: UseUnifiedGitDiffConfig) => {
 
     const gitPath = getGitPath(conversationId, selectedRepository);
     return `${gitPath}/${config.filePath}`;
-  }, [isV1Conversation, selectedRepository, config.filePath]);
+  }, [isV1Conversation, conversationId, selectedRepository, config.filePath]);
 
   return useQuery({
     queryKey: [

--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -598,7 +598,8 @@ class RemoteSandboxService(SandboxService):
         query = query.filter(StoredRemoteSandbox.id.in_(running_session_ids)).order_by(
             StoredRemoteSandbox.created_at.desc()
         )
-        running_sandboxes = list(await self.db_session.execute(query))
+        result = await self.db_session.execute(query)
+        running_sandboxes = result.scalars().all()
 
         # If we're within the limit, no cleanup needed
         if len(running_sandboxes) <= max_num_sandboxes:


### PR DESCRIPTION
## Summary of PR

- **Fix stale `conversationId` closures in git hooks**: Both `useUnifiedGetGitChanges` and `useUnifiedGitDiff` call `getGitPath(conversationId, selectedRepository)` inside `useMemo` but omit `conversationId` from their dependency arrays. When switching conversations, `gitPath` / `absoluteFilePath` remain stale, causing V1 git API calls to use the wrong workspace path.
- **Fix SQLAlchemy `Row` vs ORM model mismatch in `pause_oldest_sandboxes`**: `list(db_session.execute(query))` yields `Row` tuples, not `StoredRemoteSandbox` model instances. Subsequent `sandbox.id` access on a `Row` object fails. Every other call site in the same file correctly uses `result.scalars().all()`.

## Change Type

- [x] Bug fix

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Details

### 1. `useUnifiedGetGitChanges` — missing `conversationId` in useMemo deps
**File:** `frontend/src/hooks/query/use-unified-get-git-changes.ts`

`getGitPath(conversationId, selectedRepository)` produces paths like `/workspace/project/{conversationId}/{repoName}`. The `useMemo` dependency array only included `[selectedRepository]`, so switching conversations would not recompute `gitPath`.

### 2. `useUnifiedGitDiff` — missing `conversationId` in useMemo deps
**File:** `frontend/src/hooks/query/use-unified-git-diff.ts`

Same pattern: `getGitPath(conversationId, selectedRepository)` is called inside `useMemo`, but `conversationId` was missing from `[isV1Conversation, selectedRepository, config.filePath]`.

### 3. `pause_oldest_sandboxes` — `list(execute())` instead of `scalars().all()`
**File:** `openhands/app_server/sandbox/remote_sandbox_service.py`

`_secure_select()` returns `select(StoredRemoteSandbox)`. Calling `list(result)` yields `Row[tuple[StoredRemoteSandbox]]` objects. The code then accesses `sandbox.id` on these Row objects, which fails. The same file uses `result.scalars().all()` at lines 301, 379, etc. — this line was an inconsistency.