### PR TITLE
Fix: Prevent auto-logout on 401 errors in oss mode

### DIFF
--- a/frontend/__tests__/components/features/user/user-context-menu.test.tsx
+++ b/frontend/__tests__/components/features/user/user-context-menu.test.tsx
@@ -156,11 +156,19 @@ describe("UserContextMenu", () => {
     useSelectedOrganizationStore.setState({ organizationId: null });
   });
 
-  it("should render the default context items for a user", () => {
+  it("should render the default context items for a user", async () => {
+    vi.spyOn(OptionService, "getConfig").mockResolvedValue(
+      createMockWebClientConfig({ app_mode: "saas" }),
+    );
+
     renderUserContextMenu({ type: "member", onClose: vi.fn, onOpenInviteModal: vi.fn });
 
     screen.getByTestId("org-selector");
-    screen.getByText("ACCOUNT_SETTINGS$LOGOUT");
+
+    // Wait for config to load so logout button appears
+    await waitFor(() => {
+      expect(screen.getByText("ACCOUNT_SETTINGS$LOGOUT")).toBeInTheDocument();
+    });
 
     expect(
       screen.queryByText("ORG$INVITE_ORG_MEMBERS"),
@@ -304,6 +312,20 @@ describe("UserContextMenu", () => {
         screen.queryByText("Organization Members"),
       ).not.toBeInTheDocument();
     });
+
+    it("should not display logout button in OSS mode", async () => {
+      renderUserContextMenu({ type: "member", onClose: vi.fn, onOpenInviteModal: vi.fn });
+
+      // Wait for the config to load
+      await waitFor(() => {
+        expect(screen.getByText("SETTINGS$NAV_LLM")).toBeInTheDocument();
+      });
+
+      // Verify logout button is NOT rendered in OSS mode
+      expect(
+        screen.queryByText("ACCOUNT_SETTINGS$LOGOUT"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe("HIDE_LLM_SETTINGS feature flag", () => {
@@ -382,10 +404,15 @@ describe("UserContextMenu", () => {
   });
 
   it("should call the logout handler when Logout is clicked", async () => {
+    vi.spyOn(OptionService, "getConfig").mockResolvedValue(
+      createMockWebClientConfig({ app_mode: "saas" }),
+    );
+
     const logoutSpy = vi.spyOn(AuthService, "logout");
     renderUserContextMenu({ type: "member", onClose: vi.fn, onOpenInviteModal: vi.fn });
 
-    const logoutButton = screen.getByText("ACCOUNT_SETTINGS$LOGOUT");
+    // Wait for config to load so logout button appears
+    const logoutButton = await screen.findByText("ACCOUNT_SETTINGS$LOGOUT");
     await userEvent.click(logoutButton);
 
     expect(logoutSpy).toHaveBeenCalledOnce();
@@ -488,6 +515,10 @@ describe("UserContextMenu", () => {
   });
 
   it("should call the onClose handler after each action", async () => {
+    vi.spyOn(OptionService, "getConfig").mockResolvedValue(
+      createMockWebClientConfig({ app_mode: "saas" }),
+    );
+
     // Mock a team org so org management buttons are visible
     vi.spyOn(organizationService, "getOrganizations").mockResolvedValue({
       items: [MOCK_TEAM_ORG_ACME],
@@ -497,7 +528,8 @@ describe("UserContextMenu", () => {
     const onCloseMock = vi.fn();
     renderUserContextMenu({ type: "owner", onClose: onCloseMock, onOpenInviteModal: vi.fn });
 
-    const logoutButton = screen.getByText("ACCOUNT_SETTINGS$LOGOUT");
+    // Wait for config to load so logout button appears
+    const logoutButton = await screen.findByText("ACCOUNT_SETTINGS$LOGOUT");
     await userEvent.click(logoutButton);
     expect(onCloseMock).toHaveBeenCalledTimes(1);
 

--- a/frontend/src/components/features/user/user-context-menu.tsx
+++ b/frontend/src/components/features/user/user-context-menu.tsx
@@ -156,13 +156,16 @@ export function UserContextMenu({
               {t(I18nKey.SIDEBAR$DOCS)}
             </a>
 
-            <ContextMenuListItem
-              onClick={handleLogout}
-              className={contextMenuListItemClassName}
-            >
-              <IoLogOutOutline className="text-white" size={16} />
-              {t(I18nKey.ACCOUNT_SETTINGS$LOGOUT)}
-            </ContextMenuListItem>
+            {/* Only show logout in saas mode - oss mode has no session to invalidate */}
+            {isSaasMode && (
+              <ContextMenuListItem
+                onClick={handleLogout}
+                className={contextMenuListItemClassName}
+              >
+                <IoLogOutOutline className="text-white" size={16} />
+                {t(I18nKey.ACCOUNT_SETTINGS$LOGOUT)}
+              </ContextMenuListItem>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/hooks/query/use-git-user.ts
+++ b/frontend/src/hooks/query/use-git-user.ts
@@ -35,13 +35,14 @@ export const useGitUser = () => {
     }
   }, [user.data]);
 
-  // If we get a 401 here, it means that the integration tokens need to be
+  // In saas mode, a 401 means that the integration tokens need to be
   // refreshed. Since this happens at login, we log out.
+  // In oss mode, skip auto-logout since there's no token refresh mechanism
   React.useEffect(() => {
-    if (user?.error?.response?.status === 401) {
+    if (user?.error?.response?.status === 401 && config?.app_mode === "saas") {
       logout.mutate();
     }
-  }, [user.status]);
+  }, [user.status, config?.app_mode]);
 
   return user;
 };


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

<!-- Summarize what the PR does -->
Backend does not currently distinguish between transient network issues and real authentication issues.

    21:46:40 - openhands:WARNING: http_client.py:101 - HTTP error on bitbucket_data_center API: ConnectTimeout :
    21:46:40 - openhands:WARNING: provider.py:238 - Failed to get bitbucket data center projects bitbucket_data_center API request timed out: ConnectTimeout
    INFO:     10.14.16.62:60234 - "GET /api/user/info HTTP/1.1" 401 Unauthorized

In oss mode, 401 errors from git providers were triggering automatic
logout, which permanently deleted user credentials via the
/api/unset-provider-tokens endpoint. This was an over reaction
since transient network failures are lumped into 401 as well as
oss mode having no session to invalidate.

This change prevents auto-logout in oss mode while preserving the
behavior in saas mode where it's needed for OAuth token refresh.

In addition, logout menu option is now hidden in oss mode since
there is no session to invalidate and user would not except
that option to wipe out both tokens and URL configuration.

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

## Change Type

<!-- Choose the types that apply to your PR -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [X] I have read and reviewed the code and I understand what the code is doing.
- [X] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.
