### PR TITLE
fix: treat llm_base_url="" as explicit clear in store_llm_settings

### DIFF
--- a/openhands/server/routes/settings.py
+++ b/openhands/server/routes/settings.py
@@ -34,18 +34,18 @@ from openhands.storage.settings.settings_store import SettingsStore
 from openhands.utils.llm import get_provider_api_base, is_openhands_model
 
 LITE_LLM_API_URL = os.environ.get(
-    "LITE_LLM_API_URL", "https://llm-proxy.app.all-hands.dev"
+    'LITE_LLM_API_URL', 'https://llm-proxy.app.all-hands.dev'
 )
 
-app = APIRouter(prefix="/api", dependencies=get_dependencies())
+app = APIRouter(prefix='/api', dependencies=get_dependencies())
 
 
 @app.get(
-    "/settings",
+    '/settings',
     response_model=GETSettingsModel,
     responses={
-        404: {"description": "Settings not found", "model": dict},
-        401: {"description": "Invalid token", "model": dict},
+        404: {'description': 'Settings not found', 'model': dict},
+        401: {'description': 'Invalid token', 'model': dict},
     },
 )
 async def load_settings(
@@ -58,7 +58,7 @@ async def load_settings(
         if not settings:
             return JSONResponse(
                 status_code=status.HTTP_404_NOT_FOUND,
-                content={"error": "Settings not found"},
+                content={'error': 'Settings not found'},
             )
 
         # On initial load, user secrets may not be populated with values migrated from settings store
@@ -78,7 +78,7 @@ async def load_settings(
                     provider_tokens_set[provider_type] = provider_token.host
 
         settings_with_token_data = GETSettingsModel(
-            **settings.model_dump(exclude={"secrets_store"}),
+            **settings.model_dump(exclude={'secrets_store'}),
             llm_api_key_set=settings.llm_api_key is not None
             and bool(settings.llm_api_key),
             search_api_key_set=settings.search_api_key is not None
@@ -101,15 +101,15 @@ async def load_settings(
         settings_with_token_data.sandbox_api_key = None
         return settings_with_token_data
     except Exception as e:
-        logger.warning(f"Invalid token: {e}")
+        logger.warning(f'Invalid token: {e}')
         # Get user_id from settings if available
-        user_id = getattr(settings, "user_id", "unknown") if settings else "unknown"
+        user_id = getattr(settings, 'user_id', 'unknown') if settings else 'unknown'
         logger.info(
-            f"Returning 401 Unauthorized - Invalid token for user_id: {user_id}"
+            f'Returning 401 Unauthorized - Invalid token for user_id: {user_id}'
         )
         return JSONResponse(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            content={"error": "Invalid token"},
+            content={'error': 'Invalid token'},
         )
 
 
@@ -138,13 +138,13 @@ async def store_llm_settings(
                         settings.llm_base_url = api_base
                     else:
                         logger.debug(
-                            f"No api_base found in litellm for model: {settings.llm_model}"
+                            f'No api_base found in litellm for model: {settings.llm_model}'
                         )
                 except Exception as e:
                     logger.error(
-                        f"Failed to get api_base from litellm for model {settings.llm_model}: {e}"
+                        f'Failed to get api_base from litellm for model {settings.llm_model}: {e}'
                     )
-        elif settings.llm_base_url == "":
+        elif settings.llm_base_url == '':
             # Explicitly cleared by the user (basic view save or advanced view clear)
             settings.llm_base_url = None
         # Keep search API key if missing or empty
@@ -159,11 +159,11 @@ async def store_llm_settings(
 # a response object directly. We document the possible responses using the 'responses'
 # parameter and maintain proper type annotations for mypy.
 @app.post(
-    "/settings",
+    '/settings',
     response_model=None,
     responses={
-        200: {"description": "Settings stored successfully", "model": dict},
-        500: {"description": "Error storing settings", "model": dict},
+        200: {'description': 'Settings stored successfully', 'model': dict},
+        500: {'description': 'Error storing settings', 'model': dict},
     },
 )
 async def store_settings(
@@ -203,20 +203,20 @@ async def store_settings(
         # Existing sessions will continue with their current git configuration
         if git_config_updated:
             logger.info(
-                f"Updated global git configuration: name={config.git_user_name}, email={config.git_user_email}"
+                f'Updated global git configuration: name={config.git_user_name}, email={config.git_user_email}'
             )
 
         settings = convert_to_settings(settings)
         await settings_store.store(settings)
         return JSONResponse(
             status_code=status.HTTP_200_OK,
-            content={"message": "Settings stored"},
+            content={'message': 'Settings stored'},
         )
     except Exception as e:
-        logger.warning(f"Something went wrong storing settings: {e}")
+        logger.warning(f'Something went wrong storing settings: {e}')
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content={"error": "Something went wrong storing settings"},
+            content={'error': 'Something went wrong storing settings'},
         )
 
 
@@ -231,8 +231,8 @@ def convert_to_settings(settings_with_token_data: Settings) -> Settings:
     }
 
     # Convert the API keys to `SecretStr` instances
-    filtered_settings_data["llm_api_key"] = settings_with_token_data.llm_api_key
-    filtered_settings_data["search_api_key"] = settings_with_token_data.search_api_key
+    filtered_settings_data['llm_api_key'] = settings_with_token_data.llm_api_key
+    filtered_settings_data['search_api_key'] = settings_with_token_data.search_api_key
 
     # Create a new Settings instance
     settings = Settings(**filtered_settings_data)

--- a/tests/unit/server/routes/test_settings_store_functions.py
+++ b/tests/unit/server/routes/test_settings_store_functions.py
@@ -38,11 +38,11 @@ def test_client():
     test_app.include_router(secrets_router)
 
     with (
-        patch.dict(os.environ, {"SESSION_API_KEY": ""}, clear=False),
-        patch("openhands.server.dependencies._SESSION_API_KEY", None),
+        patch.dict(os.environ, {'SESSION_API_KEY': ''}, clear=False),
+        patch('openhands.server.dependencies._SESSION_API_KEY', None),
         patch(
-            "openhands.server.routes.secrets.check_provider_tokens",
-            AsyncMock(return_value=""),
+            'openhands.server.routes.secrets.check_provider_tokens',
+            AsyncMock(return_value=''),
         ),
     ):
         client = TestClient(test_app)
@@ -51,15 +51,15 @@ def test_client():
 
 @pytest.fixture
 def temp_dir(tmp_path_factory: pytest.TempPathFactory) -> str:
-    return str(tmp_path_factory.mktemp("secrets_store"))
+    return str(tmp_path_factory.mktemp('secrets_store'))
 
 
 @pytest.fixture
 def file_secrets_store(temp_dir):
-    file_store = get_file_store("local", temp_dir)
+    file_store = get_file_store('local', temp_dir)
     store = FileSecretsStore(file_store)
     with patch(
-        "openhands.storage.secrets.file_secrets_store.FileSecretsStore.get_instance",
+        'openhands.storage.secrets.file_secrets_store.FileSecretsStore.get_instance',
         AsyncMock(return_value=store),
     ):
         yield store
@@ -69,7 +69,7 @@ def file_secrets_store(temp_dir):
 @pytest.mark.asyncio
 async def test_check_provider_tokens_valid():
     """Test check_provider_tokens with valid tokens."""
-    provider_token = ProviderToken(token=SecretStr("valid-token"))
+    provider_token = ProviderToken(token=SecretStr('valid-token'))
     providers = POSTProviderModel(provider_tokens={ProviderType.GITHUB: provider_token})
 
     # Empty existing provider tokens
@@ -77,21 +77,21 @@ async def test_check_provider_tokens_valid():
 
     # Mock the validate_provider_token function to return GITHUB for valid tokens
     with patch(
-        "openhands.server.routes.secrets.validate_provider_token"
+        'openhands.server.routes.secrets.validate_provider_token'
     ) as mock_validate:
         mock_validate.return_value = ProviderType.GITHUB
 
         result = await check_provider_tokens(providers, existing_provider_tokens)
 
         # Should return empty string for valid token
-        assert result == ""
+        assert result == ''
         mock_validate.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_check_provider_tokens_invalid():
     """Test check_provider_tokens with invalid tokens."""
-    provider_token = ProviderToken(token=SecretStr("invalid-token"))
+    provider_token = ProviderToken(token=SecretStr('invalid-token'))
     providers = POSTProviderModel(provider_tokens={ProviderType.GITHUB: provider_token})
 
     # Empty existing provider tokens
@@ -99,14 +99,14 @@ async def test_check_provider_tokens_invalid():
 
     # Mock the validate_provider_token function to return None for invalid tokens
     with patch(
-        "openhands.server.routes.secrets.validate_provider_token"
+        'openhands.server.routes.secrets.validate_provider_token'
     ) as mock_validate:
         mock_validate.return_value = None
 
         result = await check_provider_tokens(providers, existing_provider_tokens)
 
         # Should return error message for invalid token
-        assert "Invalid token" in result
+        assert 'Invalid token' in result
         mock_validate.assert_called_once()
 
 
@@ -123,7 +123,7 @@ async def test_check_provider_tokens_wrong_type():
     result = await check_provider_tokens(providers, existing_provider_tokens)
 
     # Should return empty string for no providers
-    assert result == ""
+    assert result == ''
 
 
 @pytest.mark.asyncio
@@ -137,7 +137,7 @@ async def test_check_provider_tokens_no_tokens():
     result = await check_provider_tokens(providers, existing_provider_tokens)
 
     # Should return empty string when no tokens provided
-    assert result == ""
+    assert result == ''
 
 
 # Tests for store_llm_settings
@@ -145,9 +145,9 @@ async def test_check_provider_tokens_no_tokens():
 async def test_store_llm_settings_new_settings():
     """Test store_llm_settings with new settings."""
     settings = Settings(
-        llm_model="gpt-4",
-        llm_api_key="test-api-key",
-        llm_base_url="https://api.example.com",
+        llm_model='gpt-4',
+        llm_api_key='test-api-key',
+        llm_base_url='https://api.example.com',
     )
 
     # No existing settings
@@ -156,33 +156,33 @@ async def test_store_llm_settings_new_settings():
     result = await store_llm_settings(settings, existing_settings)
 
     # Should return settings with the provided values
-    assert result.llm_model == "gpt-4"
-    assert result.llm_api_key.get_secret_value() == "test-api-key"
-    assert result.llm_base_url == "https://api.example.com"
+    assert result.llm_model == 'gpt-4'
+    assert result.llm_api_key.get_secret_value() == 'test-api-key'
+    assert result.llm_base_url == 'https://api.example.com'
 
 
 @pytest.mark.asyncio
 async def test_store_llm_settings_update_existing():
     """Test store_llm_settings updates existing settings."""
     settings = Settings(
-        llm_model="gpt-4",
-        llm_api_key="new-api-key",
-        llm_base_url="https://new.example.com",
+        llm_model='gpt-4',
+        llm_api_key='new-api-key',
+        llm_base_url='https://new.example.com',
     )
 
     # Create existing settings
     existing_settings = Settings(
-        llm_model="gpt-3.5",
-        llm_api_key=SecretStr("old-api-key"),
-        llm_base_url="https://old.example.com",
+        llm_model='gpt-3.5',
+        llm_api_key=SecretStr('old-api-key'),
+        llm_base_url='https://old.example.com',
     )
 
     result = await store_llm_settings(settings, existing_settings)
 
     # Should return settings with the updated values
-    assert result.llm_model == "gpt-4"
-    assert result.llm_api_key.get_secret_value() == "new-api-key"
-    assert result.llm_base_url == "https://new.example.com"
+    assert result.llm_model == 'gpt-4'
+    assert result.llm_api_key.get_secret_value() == 'new-api-key'
+    assert result.llm_base_url == 'https://new.example.com'
 
 
 @pytest.mark.asyncio
@@ -194,23 +194,23 @@ async def test_store_llm_settings_partial_update():
     For OpenAI models, this returns https://api.openai.com.
     """
     settings = Settings(
-        llm_model="gpt-4",  # Only updating model (not an openhands model)
-        llm_base_url="",  # Explicitly cleared (e.g. basic mode save)
+        llm_model='gpt-4',  # Only updating model (not an openhands model)
+        llm_base_url='',  # Explicitly cleared (e.g. basic mode save)
     )
 
     # Create existing settings
     existing_settings = Settings(
-        llm_model="gpt-3.5",
-        llm_api_key=SecretStr("existing-api-key"),
-        llm_base_url="https://existing.example.com",
+        llm_model='gpt-3.5',
+        llm_api_key=SecretStr('existing-api-key'),
+        llm_base_url='https://existing.example.com',
     )
 
     result = await store_llm_settings(settings, existing_settings)
 
     # Should return settings with updated model but keep API key
-    assert result.llm_model == "gpt-4"
+    assert result.llm_model == 'gpt-4'
     # For SecretStr objects, we need to compare the secret value
-    assert result.llm_api_key.get_secret_value() == "existing-api-key"
+    assert result.llm_api_key.get_secret_value() == 'existing-api-key'
     # llm_base_url="" is an explicit clear — must not be repopulated via auto-detection
     assert result.llm_base_url is None
 
@@ -223,14 +223,14 @@ async def test_store_llm_settings_advanced_view_clear_removes_base_url():
     causing the backend to re-run auto-detection and overwrite the user's intent.
     """
     settings = Settings(
-        llm_model="gpt-4",
-        llm_base_url="",  # User deleted the field in Advanced view
+        llm_model='gpt-4',
+        llm_base_url='',  # User deleted the field in Advanced view
     )
 
     existing_settings = Settings(
-        llm_model="gpt-4",
-        llm_api_key=SecretStr("my-api-key"),
-        llm_base_url="https://my-custom-proxy.example.com",
+        llm_model='gpt-4',
+        llm_api_key=SecretStr('my-api-key'),
+        llm_base_url='https://my-custom-proxy.example.com',
     )
 
     result = await store_llm_settings(settings, existing_settings)
@@ -251,10 +251,10 @@ async def test_store_llm_settings_mcp_update_preserves_base_url():
         mcp_config=MCPConfig(
             stdio_servers=[
                 MCPStdioServerConfig(
-                    name="my-server",
-                    command="npx",
-                    args=["-y", "@my/mcp-server"],
-                    env={"API_TOKEN": "secret123", "ENDPOINT": "https://example.com"},
+                    name='my-server',
+                    command='npx',
+                    args=['-y', '@my/mcp-server'],
+                    env={'API_TOKEN': 'secret123', 'ENDPOINT': 'https://example.com'},
                 )
             ],
         ),
@@ -262,17 +262,17 @@ async def test_store_llm_settings_mcp_update_preserves_base_url():
 
     # Create existing settings with a custom base URL
     existing_settings = Settings(
-        llm_model="anthropic/claude-sonnet-4-5-20250929",
-        llm_api_key=SecretStr("existing-api-key"),
-        llm_base_url="https://my-custom-proxy.example.com",
+        llm_model='anthropic/claude-sonnet-4-5-20250929',
+        llm_api_key=SecretStr('existing-api-key'),
+        llm_base_url='https://my-custom-proxy.example.com',
     )
 
     result = await store_llm_settings(settings, existing_settings)
 
     # All existing LLM settings should be preserved
-    assert result.llm_model == "anthropic/claude-sonnet-4-5-20250929"
-    assert result.llm_api_key.get_secret_value() == "existing-api-key"
-    assert result.llm_base_url == "https://my-custom-proxy.example.com"
+    assert result.llm_model == 'anthropic/claude-sonnet-4-5-20250929'
+    assert result.llm_api_key.get_secret_value() == 'existing-api-key'
+    assert result.llm_base_url == 'https://my-custom-proxy.example.com'
 
 
 @pytest.mark.asyncio
@@ -283,21 +283,21 @@ async def test_store_llm_settings_no_existing_base_url_uses_auto_detection():
     auto-detection from litellm should be used.
     """
     settings = Settings(
-        llm_model="gpt-4"  # Not an openhands model
+        llm_model='gpt-4'  # Not an openhands model
     )
 
     # Existing settings without a base URL
     existing_settings = Settings(
-        llm_model="gpt-3.5",
-        llm_api_key=SecretStr("existing-api-key"),
+        llm_model='gpt-3.5',
+        llm_api_key=SecretStr('existing-api-key'),
     )
 
     result = await store_llm_settings(settings, existing_settings)
 
-    assert result.llm_model == "gpt-4"
-    assert result.llm_api_key.get_secret_value() == "existing-api-key"
+    assert result.llm_model == 'gpt-4'
+    assert result.llm_api_key.get_secret_value() == 'existing-api-key'
     # No existing base URL, so auto-detection should set it
-    assert result.llm_base_url == "https://api.openai.com"
+    assert result.llm_base_url == 'https://api.openai.com'
 
 
 @pytest.mark.asyncio
@@ -308,20 +308,20 @@ async def test_store_llm_settings_anthropic_model_gets_api_base():
     via ProviderConfigManager.get_provider_model_info().
     """
     settings = Settings(
-        llm_model="anthropic/claude-sonnet-4-5-20250929"  # Anthropic model
+        llm_model='anthropic/claude-sonnet-4-5-20250929'  # Anthropic model
     )
 
     existing_settings = Settings(
-        llm_model="gpt-3.5",
-        llm_api_key=SecretStr("existing-api-key"),
+        llm_model='gpt-3.5',
+        llm_api_key=SecretStr('existing-api-key'),
     )
 
     result = await store_llm_settings(settings, existing_settings)
 
-    assert result.llm_model == "anthropic/claude-sonnet-4-5-20250929"
-    assert result.llm_api_key.get_secret_value() == "existing-api-key"
+    assert result.llm_model == 'anthropic/claude-sonnet-4-5-20250929'
+    assert result.llm_api_key.get_secret_value() == 'existing-api-key'
     # Anthropic models get https://api.anthropic.com via ProviderConfigManager
-    assert result.llm_base_url == "https://api.anthropic.com"
+    assert result.llm_base_url == 'https://api.anthropic.com'
 
 
 @pytest.mark.asyncio
@@ -330,16 +330,16 @@ async def test_store_llm_settings_litellm_error_logged():
     from unittest.mock import patch
 
     settings = Settings(
-        llm_model="unknown-model-xyz"  # A model that litellm won't recognize
+        llm_model='unknown-model-xyz'  # A model that litellm won't recognize
     )
 
     existing_settings = Settings(
-        llm_model="gpt-3.5",
-        llm_api_key=SecretStr("existing-api-key"),
+        llm_model='gpt-3.5',
+        llm_api_key=SecretStr('existing-api-key'),
     )
 
     # The function should not raise even if litellm fails
-    with patch("openhands.server.routes.settings.logger") as mock_logger:
+    with patch('openhands.server.routes.settings.logger') as mock_logger:
         result = await store_llm_settings(settings, existing_settings)
 
         # llm_base_url should remain None since litellm couldn't find the model
@@ -358,24 +358,24 @@ async def test_store_llm_settings_openhands_model_gets_default_url():
     import os
 
     settings = Settings(
-        llm_model="openhands/claude-sonnet-4-5-20250929"  # openhands model
+        llm_model='openhands/claude-sonnet-4-5-20250929'  # openhands model
     )
 
     # Create existing settings
     existing_settings = Settings(
-        llm_model="gpt-3.5",
-        llm_api_key=SecretStr("existing-api-key"),
+        llm_model='gpt-3.5',
+        llm_api_key=SecretStr('existing-api-key'),
     )
 
     result = await store_llm_settings(settings, existing_settings)
 
     # Should return settings with updated model
-    assert result.llm_model == "openhands/claude-sonnet-4-5-20250929"
+    assert result.llm_model == 'openhands/claude-sonnet-4-5-20250929'
     # For SecretStr objects, we need to compare the secret value
-    assert result.llm_api_key.get_secret_value() == "existing-api-key"
+    assert result.llm_api_key.get_secret_value() == 'existing-api-key'
     # openhands models get the LiteLLM proxy URL
     expected_base_url = os.environ.get(
-        "LITE_LLM_API_URL", "https://llm-proxy.app.all-hands.dev"
+        'LITE_LLM_API_URL', 'https://llm-proxy.app.all-hands.dev'
     )
     assert result.llm_base_url == expected_base_url
 
@@ -384,7 +384,7 @@ async def test_store_llm_settings_openhands_model_gets_default_url():
 @pytest.mark.asyncio
 async def test_store_provider_tokens_new_tokens(test_client, file_secrets_store):
     """Test store_provider_tokens with new tokens."""
-    provider_tokens = {"provider_tokens": {"github": {"token": "new-token"}}}
+    provider_tokens = {'provider_tokens': {'github': {'token': 'new-token'}}}
 
     # Mock the settings store
     mock_store = MagicMock()
@@ -394,14 +394,14 @@ async def test_store_provider_tokens_new_tokens(test_client, file_secrets_store)
 
     user_secrets = await file_secrets_store.store(Secrets())
 
-    response = test_client.post("/api/add-git-providers", json=provider_tokens)
+    response = test_client.post('/api/add-git-providers', json=provider_tokens)
     assert response.status_code == 200
 
     user_secrets = await file_secrets_store.load()
 
     assert (
         user_secrets.provider_tokens[ProviderType.GITHUB].token.get_secret_value()
-        == "new-token"
+        == 'new-token'
     )
 
 
@@ -409,7 +409,7 @@ async def test_store_provider_tokens_new_tokens(test_client, file_secrets_store)
 async def test_store_provider_tokens_update_existing(test_client, file_secrets_store):
     """Test store_provider_tokens updates existing tokens."""
     # Create existing settings with a GitHub token
-    github_token = ProviderToken(token=SecretStr("old-token"))
+    github_token = ProviderToken(token=SecretStr('old-token'))
     provider_tokens = {ProviderType.GITHUB: github_token}
 
     # Create a Secrets with the provider tokens
@@ -418,8 +418,8 @@ async def test_store_provider_tokens_update_existing(test_client, file_secrets_s
     await file_secrets_store.store(user_secrets)
 
     response = test_client.post(
-        "/api/add-git-providers",
-        json={"provider_tokens": {"github": {"token": "updated-token"}}},
+        '/api/add-git-providers',
+        json={'provider_tokens': {'github': {'token': 'updated-token'}}},
     )
 
     assert response.status_code == 200
@@ -428,7 +428,7 @@ async def test_store_provider_tokens_update_existing(test_client, file_secrets_s
 
     assert (
         user_secrets.provider_tokens[ProviderType.GITHUB].token.get_secret_value()
-        == "updated-token"
+        == 'updated-token'
     )
 
 
@@ -436,15 +436,15 @@ async def test_store_provider_tokens_update_existing(test_client, file_secrets_s
 async def test_store_provider_tokens_keep_existing(test_client, file_secrets_store):
     """Test store_provider_tokens keeps existing tokens when empty string provided."""
     # Create existing secrets with a GitHub token
-    github_token = ProviderToken(token=SecretStr("existing-token"))
+    github_token = ProviderToken(token=SecretStr('existing-token'))
     provider_tokens = {ProviderType.GITHUB: github_token}
     user_secrets = Secrets(provider_tokens=provider_tokens)
 
     await file_secrets_store.store(user_secrets)
 
     response = test_client.post(
-        "/api/add-git-providers",
-        json={"provider_tokens": {"github": {"token": ""}}},
+        '/api/add-git-providers',
+        json={'provider_tokens': {'github': {'token': ''}}},
     )
     assert response.status_code == 200
 
@@ -452,5 +452,5 @@ async def test_store_provider_tokens_keep_existing(test_client, file_secrets_sto
 
     assert (
         user_secrets.provider_tokens[ProviderType.GITHUB].token.get_secret_value()
-        == "existing-token"
+        == 'existing-token'
     )


### PR DESCRIPTION
## Summary

Fixes #13420 — it is currently impossible to persist an empty `llm_base_url` from the settings UI.

**Root cause:** `store_llm_settings` used `if not settings.llm_base_url:` which catches both `None` (field not provided at all) and `""` (explicitly cleared by the user). When the user:
- saves from Basic view (which intentionally sends `llm_base_url: ""` to clear advanced settings), or
- deletes the Base URL field in Advanced view and saves,

the backend treated `""` the same as "not provided", triggering auto-detection via `get_provider_api_base()` and overwriting the user's intent. The old base URL kept coming back.

**Fix:** Split the condition into two explicit branches:

```python
# Before
if not settings.llm_base_url:
    if settings.llm_base_url is None and existing_settings.llm_base_url:
        ...  # preserve existing

# After
if settings.llm_base_url is None:
    ...  # not provided — preserve existing or auto-detect (no behavior change)
elif settings.llm_base_url == "":
    settings.llm_base_url = None  # explicit clear — honor the intent
```

The `None` path has identical behavior to before. Only `""` changes: instead of triggering auto-detection, it now normalizes to `None` and returns.

## Test plan

- Updated `test_store_llm_settings_partial_update` to assert `None` (the correct post-fix behavior) instead of the auto-detected URL
- Added `test_store_llm_settings_advanced_view_clear_removes_base_url` as a named regression test for this issue
- All 16 tests in `test_settings_store_functions.py` pass
- Existing MCP save test (`test_store_llm_settings_mcp_update_preserves_base_url`) continues to pass — the `None` path (field not sent) is unchanged

🤖 Generated with [Claude Code](https://claude.ai/claude-code)