### PR TITLE
Fix CVE-2026-33151: Update socket.io-parser to 4.2.6

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15325,9 +15325,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
-      "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",


### PR DESCRIPTION
## Security Fix for CVE-2026-33151

### Summary
This PR addresses the CVE-2026-33151 vulnerability in the `socket.io-parser` package.

### Changes
- Updated `socket.io-parser` from version 4.2.5 to 4.2.6 in `frontend/package-lock.json`

### Details
- **CVE ID**: CVE-2026-33151
- **Package**: socket.io-parser
- **Vulnerable Version**: 4.2.5
- **Fixed Version**: 4.2.6
- **Location**: frontend/package-lock.json (transitive dependency via socket.io-client)

### Testing
The package-lock.json has been regenerated using `npm update socket.io-parser` to ensure compatibility.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:8901094-nikolaik   --name openhands-app-8901094   docker.openhands.dev/openhands/openhands:8901094
```