### PR TITLE
chore: disable Dependabot PRs for Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,14 @@
 version: 2
 updates:
+  # Python dependencies: Disable both version and security updates
+  # Security updates are managed manually to avoid automated PRs
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 1
-    groups:
-      # put packages in their own group if they have a history of breaking the build or needing to be reverted
-      pre-commit:
-        patterns:
-          - "pre-commit"
-      browsergym:
-        patterns:
-          - "browsergym*"
-      mcp-packages:
-        patterns:
-          - "mcp"
-      security-all:
-        applies-to: "security-updates"
-        patterns:
-          - "*"
-      version-all:
-        applies-to: "version-updates"
-        patterns:
-          - "*"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
 
   - package-ecosystem: "npm"
     directory: "/frontend"


### PR DESCRIPTION
## Summary
Disable both version and security update PRs for Python (pip) dependencies while keeping npm dependencies receiving automatic updates.

## Changes
- Set `open-pull-requests-limit` to 0 for pip ecosystem
- Add `ignore` rule for all Python dependencies (`*`) to prevent security update PRs
- Keep npm (frontend, docs), github-actions, and docker ecosystems unchanged

## Why
- npm dependencies should continue receiving automatic security and version update PRs
- Python dependencies will be managed manually to avoid automated PRs

## Note
The "Grouped security updates" setting on GitHub's security settings page is a separate feature from Dependabot's configuration. This change explicitly disables security PRs through the dependabot.yml configuration itself.