### PR TITLE
Fix when budgets are None

### DIFF
--- a/enterprise/storage/lite_llm_manager.py
+++ b/enterprise/storage/lite_llm_manager.py
@@ -530,20 +530,26 @@ class LiteLlmManager:
         if LITE_LLM_API_KEY is None or LITE_LLM_API_URL is None:
             logger.warning('LiteLLM API configuration not found')
             return
+
+        json_data: dict[str, Any] = {
+            'team_id': team_id,
+            'team_alias': team_alias,
+            'models': [],
+            'spend': 0,
+            'metadata': {
+                'version': ORG_SETTINGS_VERSION,
+                'model': get_default_litellm_model(),
+            },
+        }
+
+        if max_budget is not None:
+            json_data['max_budget'] = max_budget
+
         response = await client.post(
             f'{LITE_LLM_API_URL}/team/new',
-            json={
-                'team_id': team_id,
-                'team_alias': team_alias,
-                'models': [],
-                'max_budget': max_budget,
-                'spend': 0,
-                'metadata': {
-                    'version': ORG_SETTINGS_VERSION,
-                    'model': get_default_litellm_model(),
-                },
-            },
+            json=json_data,
         )
+
         # Team failed to create in litellm - this is an unforseen error state...
         if not response.is_success:
             if (
@@ -923,14 +929,20 @@ class LiteLlmManager:
         if LITE_LLM_API_KEY is None or LITE_LLM_API_URL is None:
             logger.warning('LiteLLM API configuration not found')
             return
+
+        json_data: dict[str, Any] = {
+            'team_id': team_id,
+            'member': {'user_id': keycloak_user_id, 'role': 'user'},
+        }
+
+        if max_budget is not None:
+            json_data['max_budget_in_team'] = max_budget
+
         response = await client.post(
             f'{LITE_LLM_API_URL}/team/member_add',
-            json={
-                'team_id': team_id,
-                'member': {'user_id': keycloak_user_id, 'role': 'user'},
-                'max_budget_in_team': max_budget,
-            },
+            json=json_data,
         )
+
         # Failed to add user to team - this is an unforseen error state...
         if not response.is_success:
             if (
@@ -1003,14 +1015,20 @@ class LiteLlmManager:
         if LITE_LLM_API_KEY is None or LITE_LLM_API_URL is None:
             logger.warning('LiteLLM API configuration not found')
             return
+
+        json_data: dict[str, Any] = {
+            'team_id': team_id,
+            'user_id': keycloak_user_id,
+        }
+
+        if max_budget is not None:
+            json_data['max_budget_in_team'] = max_budget
+
         response = await client.post(
             f'{LITE_LLM_API_URL}/team/member_update',
-            json={
-                'team_id': team_id,
-                'user_id': keycloak_user_id,
-                'max_budget_in_team': max_budget,
-            },
+            json=json_data,
         )
+
         # Failed to update user in team - this is an unforseen error state...
         if not response.is_success:
             logger.error(


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

<!-- Summarize what the PR does -->

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

## Change Type

<!-- Choose the types that apply to your PR -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:417f56a-nikolaik   --name openhands-app-417f56a   docker.openhands.dev/openhands/openhands:417f56a
```