### PR TITLE
feat: add registered_marketplaces to Settings for multiple marketplace support

### DIFF
--- a/enterprise/storage/user_settings.py
+++ b/enterprise/storage/user_settings.py
@@ -43,3 +43,4 @@ class UserSettings(Base):  # type: ignore
     already_migrated = Column(
         Boolean, nullable=True, default=False
     )  # False = not migrated, True = migrated
+    registered_marketplaces = Column(JSON, nullable=True)

--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import tempfile

--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -97,6 +97,7 @@ class AppConversationServiceBase(AppConversationService, ABC):
         selected_repository: str | None,
         project_dir: str,
         agent_server_url: str,
+        registered_marketplaces: list | None = None,
     ) -> list[Skill]:
         """Load skills from all sources via the agent-server.
 
@@ -107,12 +108,16 @@ class AppConversationServiceBase(AppConversationService, ABC):
         - Organization skills (from {org}/.openhands repo)
         - Project/repo skills (from repo .agents/skills/, .openhands/microagents/, and legacy .openhands/skills/)
         - Sandbox skills (from exposed URLs)
+        - Registered marketplaces (from user settings)
 
         Args:
             sandbox: SandboxInfo containing exposed URLs and agent-server URL
             selected_repository: Repository name or None
             project_dir: Project root directory (resolved via get_project_dir).
             agent_server_url: Agent-server URL (required)
+            registered_marketplaces: Optional list of MarketplaceRegistration objects
+                from user settings. Marketplaces with auto_load='all' will have
+                their plugins loaded automatically.
 
         Returns:
             List of merged Skill objects from all sources, or empty list on failure
@@ -141,6 +146,7 @@ class AppConversationServiceBase(AppConversationService, ABC):
                 load_user=True,
                 load_project=True,
                 load_org=True,
+                registered_marketplaces=registered_marketplaces,
             )
 
             _logger.info(

--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -10,6 +10,8 @@ from uuid import UUID
 if TYPE_CHECKING:
     import httpx
 
+    from openhands.storage.data_models.settings import MarketplaceRegistration
+
 import base62
 
 from openhands.app_server.app_conversation.app_conversation_models import (
@@ -97,7 +99,7 @@ class AppConversationServiceBase(AppConversationService, ABC):
         selected_repository: str | None,
         project_dir: str,
         agent_server_url: str,
-        registered_marketplaces: list | None = None,
+        registered_marketplaces: list[MarketplaceRegistration] | None = None,
     ) -> list[Skill]:
         """Load skills from all sources via the agent-server.
 

--- a/openhands/app_server/app_conversation/skill_loader.py
+++ b/openhands/app_server/app_conversation/skill_loader.py
@@ -10,7 +10,10 @@ thin proxy that:
 All source-specific skill loading is handled by the agent-server.
 """
 
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 import httpx
 from pydantic import BaseModel
@@ -21,6 +24,9 @@ from openhands.integrations.provider import ProviderType
 from openhands.integrations.service_types import AuthenticationError
 from openhands.sdk.context.skills import Skill
 from openhands.sdk.context.skills.trigger import KeywordTrigger, TaskTrigger
+
+if TYPE_CHECKING:
+    from openhands.storage.data_models.settings import MarketplaceRegistration
 
 _logger = logging.getLogger(__name__)
 
@@ -57,6 +63,16 @@ class SkillInfo(BaseModel):
     source: str | None = None
     description: str | None = None
     is_agentskills_format: bool = False
+
+
+class MarketplaceRegistrationPayload(BaseModel):
+    """Marketplace registration for agent-server API request."""
+
+    name: str
+    source: str
+    ref: str | None = None
+    repo_path: str | None = None
+    auto_load: str | None = None
 
 
 async def _is_gitlab_repository(repo_name: str, user_context: UserContext) -> bool:
@@ -272,6 +288,7 @@ async def load_skills_from_agent_server(
     load_user: bool = True,
     load_project: bool = True,
     load_org: bool = True,
+    registered_marketplaces: list[MarketplaceRegistration] | None = None,
 ) -> list[Skill]:
     """Load all skills from the agent-server.
 
@@ -288,12 +305,27 @@ async def load_skills_from_agent_server(
         load_user: Whether to load user skills (default: True)
         load_project: Whether to load project skills (default: True)
         load_org: Whether to load organization skills (default: True)
+        registered_marketplaces: List of marketplace registrations (optional)
 
     Returns:
         List of Skill objects merged from all sources.
         Returns empty list on error.
     """
     try:
+        # Convert marketplace registrations to API payload format
+        marketplace_payloads = None
+        if registered_marketplaces:
+            marketplace_payloads = [
+                MarketplaceRegistrationPayload(
+                    name=reg.name,
+                    source=reg.source,
+                    ref=reg.ref,
+                    repo_path=reg.repo_path,
+                    auto_load=reg.auto_load,
+                ).model_dump()
+                for reg in registered_marketplaces
+            ]
+
         # Build request payload
         payload = {
             'load_public': load_public,
@@ -303,6 +335,7 @@ async def load_skills_from_agent_server(
             'project_dir': project_dir,
             'org_config': org_config.model_dump() if org_config else None,
             'sandbox_config': sandbox_config.model_dump() if sandbox_config else None,
+            'registered_marketplaces': marketplace_payloads,
         }
 
         # Build headers

--- a/openhands/app_server/app_conversation/skill_loader.py
+++ b/openhands/app_server/app_conversation/skill_loader.py
@@ -65,16 +65,6 @@ class SkillInfo(BaseModel):
     is_agentskills_format: bool = False
 
 
-class MarketplaceRegistrationPayload(BaseModel):
-    """Marketplace registration for agent-server API request."""
-
-    name: str
-    source: str
-    ref: str | None = None
-    repo_path: str | None = None
-    auto_load: str | None = None
-
-
 async def _is_gitlab_repository(repo_name: str, user_context: UserContext) -> bool:
     """Check if a repository is hosted on GitLab.
 
@@ -313,18 +303,12 @@ async def load_skills_from_agent_server(
     """
     try:
         # Convert marketplace registrations to API payload format
-        marketplace_payloads = None
-        if registered_marketplaces:
-            marketplace_payloads = [
-                MarketplaceRegistrationPayload(
-                    name=reg.name,
-                    source=reg.source,
-                    ref=reg.ref,
-                    repo_path=reg.repo_path,
-                    auto_load=reg.auto_load,
-                ).model_dump()
-                for reg in registered_marketplaces
-            ]
+        # Preserve semantic distinction: None = not specified, [] = explicitly empty
+        marketplace_payloads = (
+            [reg.model_dump() for reg in registered_marketplaces]
+            if registered_marketplaces is not None
+            else None
+        )
 
         # Build request payload
         payload = {

--- a/openhands/storage/data_models/settings.py
+++ b/openhands/storage/data_models/settings.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import (
     BaseModel,
@@ -18,6 +18,78 @@ from openhands.core.config.llm_config import LLMConfig
 from openhands.core.config.mcp_config import MCPConfig
 from openhands.core.config.utils import load_openhands_config
 from openhands.storage.data_models.secrets import Secrets
+
+
+class MarketplaceRegistration(BaseModel):
+    """Registration for a plugin marketplace.
+
+    Represents a marketplace that can be registered for plugin resolution.
+    Marketplaces can be auto-loaded (plugins loaded at conversation start)
+    or registered only (available for explicit plugin references).
+
+    Examples:
+        >>> # Auto-load all plugins from a marketplace
+        >>> MarketplaceRegistration(
+        ...     name="public",
+        ...     source="github:OpenHands/skills",
+        ...     auto_load="all"
+        ... )
+
+        >>> # Register marketplace without auto-loading
+        >>> MarketplaceRegistration(
+        ...     name="experimental",
+        ...     source="github:acme/experimental"
+        ... )
+
+        >>> # Marketplace in monorepo subdirectory
+        >>> MarketplaceRegistration(
+        ...     name="team",
+        ...     source="github:acme/monorepo",
+        ...     repo_path="marketplaces/internal",
+        ...     auto_load="all"
+        ... )
+    """
+
+    name: str = Field(description='Identifier for this marketplace registration')
+    source: str = Field(
+        description="Marketplace source: 'github:owner/repo', git URL, or local path"
+    )
+    ref: str | None = Field(
+        default=None,
+        description='Optional branch, tag, or commit (only for git sources)',
+    )
+    repo_path: str | None = Field(
+        default=None,
+        description=(
+            'Subdirectory path within the git repository containing the marketplace '
+            "(e.g., 'marketplaces/internal' for monorepos). "
+            'Only relevant for git sources, not local paths.'
+        ),
+    )
+    auto_load: Literal['all'] | None = Field(
+        default=None,
+        description=(
+            'Auto-load behavior for this marketplace. '
+            "'all' = load all plugins at conversation start. "
+            'None = registered for resolution but not auto-loaded.'
+        ),
+    )
+
+    @field_validator('repo_path')
+    @classmethod
+    def validate_repo_path(cls, v: str | None) -> str | None:
+        """Validate repo_path is a safe relative path within the repository."""
+        if v is None:
+            return v
+        # Must be relative (no absolute paths)
+        if v.startswith('/'):
+            raise ValueError('repo_path must be relative, not absolute')
+        # No parent directory traversal
+        if '..' in v:
+            raise ValueError(
+                "repo_path cannot contain '..' (parent directory traversal)"
+            )
+        return v
 
 
 class SandboxGroupingStrategy(str, Enum):
@@ -71,6 +143,17 @@ class Settings(BaseModel):
     v1_enabled: bool = True
     sandbox_grouping_strategy: SandboxGroupingStrategy = (
         SandboxGroupingStrategy.NO_GROUPING
+    )
+    # Marketplace registrations for plugin resolution
+    # Users can register multiple marketplaces with different auto-load behaviors
+    registered_marketplaces: list[MarketplaceRegistration] = Field(
+        default_factory=list,
+        description=(
+            'List of marketplace registrations for plugin resolution. '
+            "Marketplaces with auto_load='all' will have their plugins loaded "
+            'automatically at conversation start. '
+            'See MarketplaceRegistration for details.'
+        ),
     )
 
     model_config = ConfigDict(

--- a/openhands/storage/data_models/settings.py
+++ b/openhands/storage/data_models/settings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from enum import Enum
 from typing import Annotated, Literal
 
@@ -18,6 +19,16 @@ from openhands.core.config.llm_config import LLMConfig
 from openhands.core.config.mcp_config import MCPConfig
 from openhands.core.config.utils import load_openhands_config
 from openhands.storage.data_models.secrets import Secrets
+
+# Valid source patterns for MarketplaceRegistration
+# - github:owner/repo format
+_GITHUB_SOURCE_PATTERN = re.compile(r'^github:[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$')
+# - Git URLs (https, git, ssh protocols)
+_GIT_URL_PATTERN = re.compile(
+    r'^(https?://|git@|ssh://|git://)[a-zA-Z0-9_.-]+[:/][a-zA-Z0-9_./-]+$'
+)
+# - Relative local paths (no absolute paths, no parent traversal)
+_LOCAL_PATH_PATTERN = re.compile(r'^[a-zA-Z0-9_][a-zA-Z0-9_./-]*$')
 
 
 class MarketplaceRegistration(BaseModel):
@@ -74,6 +85,47 @@ class MarketplaceRegistration(BaseModel):
             'None = registered for resolution but not auto-loaded.'
         ),
     )
+
+    @field_validator('name')
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        """Validate name is non-empty and contains only valid identifier characters."""
+        if not v or not v.strip():
+            raise ValueError('name cannot be empty')
+        v = v.strip()
+        # Name should be a valid identifier (alphanumeric, hyphens, underscores)
+        if not re.match(r'^[a-zA-Z][a-zA-Z0-9_-]*$', v):
+            raise ValueError(
+                'name must start with a letter and contain only '
+                'letters, numbers, hyphens, and underscores'
+            )
+        return v
+
+    @field_validator('source')
+    @classmethod
+    def validate_source(cls, v: str) -> str:
+        """Validate source matches expected patterns (github:owner/repo, git URL, or local path)."""
+        if not v or not v.strip():
+            raise ValueError('source cannot be empty')
+        v = v.strip()
+
+        # Check for valid source patterns
+        if _GITHUB_SOURCE_PATTERN.match(v):
+            return v
+        if _GIT_URL_PATTERN.match(v):
+            return v
+        # Local path: must be relative, no parent traversal
+        if v.startswith('/'):
+            raise ValueError('local path source must be relative, not absolute')
+        if '..' in v:
+            raise ValueError("source cannot contain '..' (parent directory traversal)")
+        if _LOCAL_PATH_PATTERN.match(v):
+            return v
+
+        raise ValueError(
+            "source must be 'github:owner/repo', a git URL "
+            '(https/git/ssh), or a relative local path'
+        )
 
     @field_validator('repo_path')
     @classmethod
@@ -159,6 +211,26 @@ class Settings(BaseModel):
     model_config = ConfigDict(
         validate_assignment=True,
     )
+
+    @field_validator('registered_marketplaces')
+    @classmethod
+    def validate_unique_marketplace_names(
+        cls, v: list[MarketplaceRegistration]
+    ) -> list[MarketplaceRegistration]:
+        """Ensure marketplace names are unique within the list.
+
+        Duplicate names would cause ambiguity in plugin resolution since
+        the marketplace name is part of the lookup key (plugin-name@marketplace-name).
+        """
+        if not v:
+            return v
+        names = [reg.name for reg in v]
+        duplicates = [name for name in names if names.count(name) > 1]
+        if duplicates:
+            raise ValueError(
+                f'duplicate marketplace names are not allowed: {set(duplicates)}'
+            )
+        return v
 
     @field_serializer('llm_api_key', 'search_api_key')
     def api_key_serializer(self, api_key: SecretStr | None, info: SerializationInfo):

--- a/tests/unit/app_server/test_skill_loader.py
+++ b/tests/unit/app_server/test_skill_loader.py
@@ -691,3 +691,144 @@ class TestGetOrgRepositoryUrl:
 
         # Assert
         assert result is None
+
+
+# ===== Tests for registered_marketplaces support =====
+
+
+class TestLoadSkillsWithMarketplaces:
+    """Test load_skills_from_agent_server with registered_marketplaces parameter."""
+
+    @pytest.mark.asyncio
+    @patch('httpx.AsyncClient')
+    async def test_passes_registered_marketplaces_in_payload(self, mock_client_class):
+        """Test that registered_marketplaces is included in the API payload."""
+        from openhands.storage.data_models.settings import MarketplaceRegistration
+
+        # Arrange
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'skills': [],
+            'sources': {},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_class.return_value = mock_client
+
+        marketplaces = [
+            MarketplaceRegistration(
+                name='public',
+                source='github:OpenHands/skills',
+                auto_load='all',
+            ),
+            MarketplaceRegistration(
+                name='team',
+                source='github:acme/plugins',
+                ref='v1.0.0',
+                repo_path='marketplaces/internal',
+            ),
+        ]
+
+        # Act
+        await load_skills_from_agent_server(
+            agent_server_url='http://localhost:8000',
+            session_api_key='test-key',
+            project_dir='/workspace/project',
+            registered_marketplaces=marketplaces,
+        )
+
+        # Assert
+        mock_client.post.assert_called_once()
+        call_args = mock_client.post.call_args
+        payload = call_args[1]['json']
+
+        assert 'registered_marketplaces' in payload
+        assert len(payload['registered_marketplaces']) == 2
+
+        # Verify first marketplace
+        mp1 = payload['registered_marketplaces'][0]
+        assert mp1['name'] == 'public'
+        assert mp1['source'] == 'github:OpenHands/skills'
+        assert mp1['auto_load'] == 'all'
+        assert mp1['ref'] is None
+        assert mp1['repo_path'] is None
+
+        # Verify second marketplace
+        mp2 = payload['registered_marketplaces'][1]
+        assert mp2['name'] == 'team'
+        assert mp2['source'] == 'github:acme/plugins'
+        assert mp2['ref'] == 'v1.0.0'
+        assert mp2['repo_path'] == 'marketplaces/internal'
+        assert mp2['auto_load'] is None
+
+    @pytest.mark.asyncio
+    @patch('httpx.AsyncClient')
+    async def test_handles_none_registered_marketplaces(self, mock_client_class):
+        """Test that None registered_marketplaces is handled correctly."""
+        # Arrange
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'skills': [],
+            'sources': {},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_class.return_value = mock_client
+
+        # Act
+        await load_skills_from_agent_server(
+            agent_server_url='http://localhost:8000',
+            session_api_key='test-key',
+            project_dir='/workspace/project',
+            registered_marketplaces=None,
+        )
+
+        # Assert
+        mock_client.post.assert_called_once()
+        call_args = mock_client.post.call_args
+        payload = call_args[1]['json']
+
+        # registered_marketplaces should be None when not provided
+        assert payload.get('registered_marketplaces') is None
+
+    @pytest.mark.asyncio
+    @patch('httpx.AsyncClient')
+    async def test_handles_empty_registered_marketplaces(self, mock_client_class):
+        """Test that empty registered_marketplaces list is handled correctly."""
+        # Arrange
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'skills': [],
+            'sources': {},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_class.return_value = mock_client
+
+        # Act
+        await load_skills_from_agent_server(
+            agent_server_url='http://localhost:8000',
+            session_api_key='test-key',
+            project_dir='/workspace/project',
+            registered_marketplaces=[],
+        )
+
+        # Assert
+        mock_client.post.assert_called_once()
+        call_args = mock_client.post.call_args
+        payload = call_args[1]['json']
+
+        # Empty list should be passed as None (falsy check in code)
+        assert payload.get('registered_marketplaces') is None

--- a/tests/unit/app_server/test_skill_loader.py
+++ b/tests/unit/app_server/test_skill_loader.py
@@ -830,5 +830,6 @@ class TestLoadSkillsWithMarketplaces:
         call_args = mock_client.post.call_args
         payload = call_args[1]['json']
 
-        # Empty list should be passed as None (falsy check in code)
-        assert payload.get('registered_marketplaces') is None
+        # Empty list is now preserved (semantic distinction from None)
+        # Empty list = "explicitly no marketplaces", None = "not specified"
+        assert payload.get('registered_marketplaces') == []

--- a/tests/unit/storage/data_models/test_settings.py
+++ b/tests/unit/storage/data_models/test_settings.py
@@ -1,14 +1,15 @@
 import warnings
 from unittest.mock import patch
 
-from pydantic import SecretStr
+import pytest
+from pydantic import SecretStr, ValidationError
 
 from openhands.core.config.llm_config import LLMConfig
 from openhands.core.config.openhands_config import OpenHandsConfig
 from openhands.core.config.sandbox_config import SandboxConfig
 from openhands.core.config.security_config import SecurityConfig
 from openhands.server.routes.settings import convert_to_settings
-from openhands.storage.data_models.settings import Settings
+from openhands.storage.data_models.settings import MarketplaceRegistration, Settings
 
 
 def test_settings_from_config():
@@ -127,3 +128,153 @@ def test_settings_no_pydantic_frozen_field_warning():
         assert len(frozen_warnings) == 0, (
             f'Pydantic frozen field warnings found: {[str(w.message) for w in frozen_warnings]}'
         )
+
+
+# --- Tests for MarketplaceRegistration ---
+
+
+class TestMarketplaceRegistration:
+    """Tests for MarketplaceRegistration model."""
+
+    def test_basic_registration(self):
+        """Test creating a basic marketplace registration."""
+        reg = MarketplaceRegistration(
+            name='test-marketplace',
+            source='github:owner/repo',
+        )
+        assert reg.name == 'test-marketplace'
+        assert reg.source == 'github:owner/repo'
+        assert reg.ref is None
+        assert reg.repo_path is None
+        assert reg.auto_load is None
+
+    def test_registration_with_auto_load(self):
+        """Test registration with auto_load='all'."""
+        reg = MarketplaceRegistration(
+            name='public',
+            source='github:OpenHands/skills',
+            auto_load='all',
+        )
+        assert reg.auto_load == 'all'
+
+    def test_registration_with_ref(self):
+        """Test registration with specific ref."""
+        reg = MarketplaceRegistration(
+            name='versioned',
+            source='github:owner/repo',
+            ref='v1.0.0',
+        )
+        assert reg.ref == 'v1.0.0'
+
+    def test_registration_with_repo_path(self):
+        """Test registration with repo_path for monorepos."""
+        reg = MarketplaceRegistration(
+            name='monorepo-marketplace',
+            source='github:acme/monorepo',
+            repo_path='marketplaces/internal',
+        )
+        assert reg.repo_path == 'marketplaces/internal'
+
+    def test_repo_path_validation_rejects_absolute(self):
+        """Test that absolute repo_path is rejected."""
+        with pytest.raises(ValidationError, match='must be relative'):
+            MarketplaceRegistration(
+                name='test',
+                source='github:owner/repo',
+                repo_path='/absolute/path',
+            )
+
+    def test_repo_path_validation_rejects_traversal(self):
+        """Test that parent directory traversal is rejected."""
+        with pytest.raises(ValidationError, match="cannot contain '..'"):
+            MarketplaceRegistration(
+                name='test',
+                source='github:owner/repo',
+                repo_path='../escape/path',
+            )
+
+    def test_serialization(self):
+        """Test that MarketplaceRegistration serializes correctly."""
+        reg = MarketplaceRegistration(
+            name='test',
+            source='github:owner/repo',
+            ref='main',
+            repo_path='plugins',
+            auto_load='all',
+        )
+        data = reg.model_dump()
+        assert data == {
+            'name': 'test',
+            'source': 'github:owner/repo',
+            'ref': 'main',
+            'repo_path': 'plugins',
+            'auto_load': 'all',
+        }
+
+
+# --- Tests for Settings.registered_marketplaces ---
+
+
+class TestSettingsRegisteredMarketplaces:
+    """Tests for registered_marketplaces field in Settings."""
+
+    def test_settings_default_empty_registered_marketplaces(self):
+        """Test that Settings defaults to empty registered_marketplaces."""
+        settings = Settings()
+        assert settings.registered_marketplaces == []
+
+    def test_settings_with_registered_marketplaces(self):
+        """Test Settings with registered_marketplaces configured."""
+        marketplaces = [
+            MarketplaceRegistration(
+                name='public',
+                source='github:OpenHands/skills',
+                auto_load='all',
+            ),
+            MarketplaceRegistration(
+                name='team',
+                source='github:acme/plugins',
+            ),
+        ]
+        settings = Settings(registered_marketplaces=marketplaces)
+
+        assert len(settings.registered_marketplaces) == 2
+        assert settings.registered_marketplaces[0].name == 'public'
+        assert settings.registered_marketplaces[0].auto_load == 'all'
+        assert settings.registered_marketplaces[1].name == 'team'
+        assert settings.registered_marketplaces[1].auto_load is None
+
+    def test_settings_serialization_with_registered_marketplaces(self):
+        """Test Settings serialization includes registered_marketplaces."""
+        marketplaces = [
+            MarketplaceRegistration(
+                name='test',
+                source='github:owner/repo',
+                auto_load='all',
+            ),
+        ]
+        settings = Settings(registered_marketplaces=marketplaces)
+        data = settings.model_dump()
+
+        assert 'registered_marketplaces' in data
+        assert len(data['registered_marketplaces']) == 1
+        assert data['registered_marketplaces'][0]['name'] == 'test'
+        assert data['registered_marketplaces'][0]['auto_load'] == 'all'
+
+    def test_settings_from_dict_with_registered_marketplaces(self):
+        """Test creating Settings from dict with registered_marketplaces."""
+        data = {
+            'registered_marketplaces': [
+                {
+                    'name': 'custom',
+                    'source': 'github:custom/repo',
+                    'ref': 'v1.0.0',
+                    'auto_load': 'all',
+                }
+            ]
+        }
+        settings = Settings.model_validate(data)
+
+        assert len(settings.registered_marketplaces) == 1
+        assert settings.registered_marketplaces[0].name == 'custom'
+        assert settings.registered_marketplaces[0].ref == 'v1.0.0'

--- a/tests/unit/storage/data_models/test_settings.py
+++ b/tests/unit/storage/data_models/test_settings.py
@@ -211,6 +211,74 @@ class TestMarketplaceRegistration:
             'auto_load': 'all',
         }
 
+    # --- Name validation tests ---
+
+    def test_name_validation_rejects_empty(self):
+        """Test that empty name is rejected."""
+        with pytest.raises(ValidationError, match='name cannot be empty'):
+            MarketplaceRegistration(name='', source='github:owner/repo')
+
+    def test_name_validation_rejects_whitespace_only(self):
+        """Test that whitespace-only name is rejected."""
+        with pytest.raises(ValidationError, match='name cannot be empty'):
+            MarketplaceRegistration(name='   ', source='github:owner/repo')
+
+    def test_name_validation_rejects_invalid_chars(self):
+        """Test that names with invalid characters are rejected."""
+        with pytest.raises(ValidationError, match='must start with a letter'):
+            MarketplaceRegistration(name='123-invalid', source='github:owner/repo')
+
+    def test_name_validation_rejects_spaces(self):
+        """Test that names with spaces are rejected."""
+        with pytest.raises(ValidationError, match='must start with a letter'):
+            MarketplaceRegistration(name='invalid name', source='github:owner/repo')
+
+    def test_name_validation_strips_whitespace(self):
+        """Test that name whitespace is stripped."""
+        reg = MarketplaceRegistration(name='  valid-name  ', source='github:owner/repo')
+        assert reg.name == 'valid-name'
+
+    # --- Source validation tests ---
+
+    def test_source_validation_github_format(self):
+        """Test valid github:owner/repo source."""
+        reg = MarketplaceRegistration(name='test', source='github:my-org/my-repo')
+        assert reg.source == 'github:my-org/my-repo'
+
+    def test_source_validation_https_url(self):
+        """Test valid HTTPS git URL source."""
+        reg = MarketplaceRegistration(
+            name='test', source='https://github.com/owner/repo'
+        )
+        assert reg.source == 'https://github.com/owner/repo'
+
+    def test_source_validation_ssh_url(self):
+        """Test valid SSH git URL source."""
+        reg = MarketplaceRegistration(
+            name='test', source='git@github.com:owner/repo'
+        )
+        assert reg.source == 'git@github.com:owner/repo'
+
+    def test_source_validation_relative_path(self):
+        """Test valid relative local path source."""
+        reg = MarketplaceRegistration(name='test', source='local/path/to/skills')
+        assert reg.source == 'local/path/to/skills'
+
+    def test_source_validation_rejects_empty(self):
+        """Test that empty source is rejected."""
+        with pytest.raises(ValidationError, match='source cannot be empty'):
+            MarketplaceRegistration(name='test', source='')
+
+    def test_source_validation_rejects_absolute_path(self):
+        """Test that absolute local path is rejected."""
+        with pytest.raises(ValidationError, match='must be relative'):
+            MarketplaceRegistration(name='test', source='/absolute/path')
+
+    def test_source_validation_rejects_parent_traversal(self):
+        """Test that parent directory traversal in source is rejected."""
+        with pytest.raises(ValidationError, match="cannot contain '..'"):
+            MarketplaceRegistration(name='test', source='../escape/path')
+
 
 # --- Tests for Settings.registered_marketplaces ---
 
@@ -278,3 +346,35 @@ class TestSettingsRegisteredMarketplaces:
         assert len(settings.registered_marketplaces) == 1
         assert settings.registered_marketplaces[0].name == 'custom'
         assert settings.registered_marketplaces[0].ref == 'v1.0.0'
+
+    def test_settings_rejects_duplicate_marketplace_names(self):
+        """Test that duplicate marketplace names are rejected."""
+        with pytest.raises(ValidationError, match='duplicate marketplace names'):
+            Settings(
+                registered_marketplaces=[
+                    MarketplaceRegistration(
+                        name='same-name',
+                        source='github:owner/repo1',
+                    ),
+                    MarketplaceRegistration(
+                        name='same-name',
+                        source='github:owner/repo2',
+                    ),
+                ]
+            )
+
+    def test_settings_allows_unique_marketplace_names(self):
+        """Test that unique marketplace names are allowed."""
+        settings = Settings(
+            registered_marketplaces=[
+                MarketplaceRegistration(
+                    name='first',
+                    source='github:owner/repo1',
+                ),
+                MarketplaceRegistration(
+                    name='second',
+                    source='github:owner/repo2',
+                ),
+            ]
+        )
+        assert len(settings.registered_marketplaces) == 2

--- a/tests/unit/storage/data_models/test_settings.py
+++ b/tests/unit/storage/data_models/test_settings.py
@@ -254,9 +254,7 @@ class TestMarketplaceRegistration:
 
     def test_source_validation_ssh_url(self):
         """Test valid SSH git URL source."""
-        reg = MarketplaceRegistration(
-            name='test', source='git@github.com:owner/repo'
-        )
+        reg = MarketplaceRegistration(name='test', source='git@github.com:owner/repo')
         assert reg.source == 'git@github.com:owner/repo'
 
     def test_source_validation_relative_path(self):


### PR DESCRIPTION
## Summary

This PR introduces support for registering multiple marketplaces with explicit auto-load semantics, providing an alternative to the single `marketplace_path` approach in PR #13117.

This approach follows the direction discussed in https://github.com/OpenHands/OpenHands/pull/13117#issuecomment-4083952091 by @jpshackelford, who suggested implementing scoped `extension_settings` that support marketplace registration at instance, org, and user levels instead of adding a `marketplace_path` setting.

## Changes

### New Models

**`MarketplaceRegistration`** - Registration for a plugin marketplace:
```python
class MarketplaceRegistration(BaseModel):
    name: str                              # Identifier for this registration
    source: str                            # github:owner/repo, git URL, or local path
    ref: str | None = None                 # Optional branch/tag/commit
    repo_path: str | None = None           # Subdirectory within repo (for monorepos)
    auto_load: Literal["all"] | None = None  # "all" = load at conversation start
```

### Updated Settings Model

Added `registered_marketplaces` field to Settings (list of MarketplaceRegistration). This allows users to configure multiple marketplaces with different loading behaviors.

### Updated Skill Loading

- `skill_loader`: Added `registered_marketplaces` parameter to pass marketplace registrations to the agent-server API
- `app_conversation_service_base`: Added `registered_marketplaces` parameter to `load_and_merge_all_skills` method

### Tests

- Added comprehensive tests for `MarketplaceRegistration` model
- Added tests for `Settings.registered_marketplaces` field  
- Added tests for skill_loader marketplace handling

## Key Behaviors

- Marketplace resolution composes instance → org → user (additive only)
- `auto_load="all"` loads all plugins from marketplace at conversation start
- `auto_load=None` registers marketplace for on-demand resolution
- Path validation rejects absolute paths and directory traversal

## Dependencies

This PR is designed to work with SDK PR #2495 which provides:
- `MarketplaceRegistry` class for managing registered marketplaces with lazy fetching and caching
- Plugin resolution via `plugin-name@marketplace-name` syntax (same as Claude Code plugin syntax)
- Full implementation in the SDK for plugin resolution

## Related

- Alternative to #13117 (`marketplace_path` setting)
- Leverages SDK PR OpenHands/software-agent-sdk#2495
- Enables #12916 (org-level default resources)
- Aligns with #13188 (instance-default org proposal)
- Supports #10947 (OpenHands configuration proposal)

## Testing

```bash
# Verify files compile
python -m py_compile openhands/storage/data_models/settings.py
python -m py_compile openhands/app_server/app_conversation/skill_loader.py
python -m py_compile openhands/app_server/app_conversation/app_conversation_service_base.py

# Run tests (requires full environment)
poetry run pytest tests/unit/storage/data_models/test_settings.py tests/unit/app_server/test_skill_loader.py -v
```

## Checklist

- [ ] CI passing
- [x] Tests are minimal and pass
- [x] No unnecessary code
- [x] All files compile correctly
- [x] Documentation in code (docstrings, comments)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:83bc9bc-nikolaik   --name openhands-app-83bc9bc   docker.openhands.dev/openhands/openhands:83bc9bc
```