### PR TITLE
fix(server): preserve cleared llm base url on settings save

### DIFF
--- a/openhands/server/routes/settings.py
+++ b/openhands/server/routes/settings.py
@@ -123,9 +123,12 @@ async def store_llm_settings(
             settings.llm_api_key = existing_settings.llm_api_key
         if settings.llm_model is None:
             settings.llm_model = existing_settings.llm_model
-        # if llm_base_url is missing or empty, try to preserve existing or determine appropriate URL
-        if not settings.llm_base_url:
-            if settings.llm_base_url is None and existing_settings.llm_base_url:
+        # Distinguish three cases for llm_base_url:
+        # - None: field omitted, so preserve existing or auto-detect if needed
+        # - "": explicitly cleared by the user, keep it empty
+        # - non-empty string: explicit user-provided value, keep it as-is
+        if settings.llm_base_url is None:
+            if existing_settings.llm_base_url:
                 # Not provided at all (e.g. MCP config save) - preserve existing
                 settings.llm_base_url = existing_settings.llm_base_url
             elif is_openhands_model(settings.llm_model):

--- a/tests/unit/server/routes/test_settings_api.py
+++ b/tests/unit/server/routes/test_settings_api.py
@@ -152,3 +152,26 @@ async def test_search_api_key_preservation(test_client):
     assert response.json()['search_api_key_set'] is True
     # Verify the other field updated correctly
     assert response.json()['llm_model'] == 'claude-3-opus'
+
+
+@pytest.mark.asyncio
+async def test_llm_base_url_can_be_explicitly_cleared(test_client):
+    """Test that sending an empty llm_base_url persists the cleared state."""
+    initial_settings = {
+        'llm_model': 'gpt-4',
+        'llm_base_url': 'https://old-proxy.example.com',
+    }
+    response = test_client.post('/api/settings', json=initial_settings)
+    assert response.status_code == 200
+
+    update_settings = {
+        'llm_model': 'gpt-4',
+        'llm_base_url': '',
+    }
+    response = test_client.post('/api/settings', json=update_settings)
+    assert response.status_code == 200
+
+    response = test_client.get('/api/settings')
+    assert response.status_code == 200
+    assert response.json()['llm_model'] == 'gpt-4'
+    assert response.json()['llm_base_url'] == ''

--- a/tests/unit/server/routes/test_settings_store_functions.py
+++ b/tests/unit/server/routes/test_settings_store_functions.py
@@ -186,13 +186,8 @@ async def test_store_llm_settings_update_existing():
 
 
 @pytest.mark.asyncio
-async def test_store_llm_settings_partial_update():
-    """Test store_llm_settings with partial update.
-
-    Note: When llm_base_url is not provided in the update and the model is NOT an
-    openhands model, we attempt to get the URL from litellm.get_api_base().
-    For OpenAI models, this returns https://api.openai.com.
-    """
+async def test_store_llm_settings_explicit_empty_base_url_stays_cleared():
+    """Test that an explicit empty llm_base_url is preserved as a user clear."""
     settings = Settings(
         llm_model='gpt-4',  # Only updating model (not an openhands model)
         llm_base_url='',  # Explicitly cleared (e.g. basic mode save)
@@ -211,9 +206,8 @@ async def test_store_llm_settings_partial_update():
     assert result.llm_model == 'gpt-4'
     # For SecretStr objects, we need to compare the secret value
     assert result.llm_api_key.get_secret_value() == 'existing-api-key'
-    # llm_base_url was explicitly cleared (""), so auto-detection runs
-    # OpenAI models: litellm.get_api_base() returns https://api.openai.com
-    assert result.llm_base_url == 'https://api.openai.com'
+    # Explicit clears must stay empty instead of being repopulated
+    assert result.llm_base_url == ''
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary of PR

- preserve an explicitly cleared `llm_base_url` instead of repopulating it during settings save
- keep existing semantics for omitted `llm_base_url` values so unrelated partial updates still preserve prior settings
- add regression coverage for both the settings helper and `/api/settings` API behavior

## Demo Screenshots/Videos

No screenshot needed.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #13420

## Release Notes

- [x] Include this change in the Release Notes.

Users can now clear a custom LLM Base URL in settings without it being restored on save.

## Validation

- `poetry run pytest tests/unit/server/routes/test_settings_store_functions.py::test_store_llm_settings_explicit_empty_base_url_stays_cleared tests/unit/server/routes/test_settings_store_functions.py::test_store_llm_settings_mcp_update_preserves_base_url tests/unit/server/routes/test_settings_store_functions.py::test_store_llm_settings_no_existing_base_url_uses_auto_detection tests/unit/server/routes/test_settings_api.py::test_llm_base_url_can_be_explicitly_cleared tests/unit/server/routes/test_settings_api.py::test_search_api_key_preservation -q`
- `poetry run pre-commit run --files openhands/server/routes/settings.py tests/unit/server/routes/test_settings_store_functions.py tests/unit/server/routes/test_settings_api.py --config ./dev_config/python/.pre-commit-config.yaml`