### PR TITLE
fix(frontend): normalize null llm base url from settings api

### DIFF
--- a/frontend/__tests__/hooks/query/organization-scoped-queries.test.tsx
+++ b/frontend/__tests__/hooks/query/organization-scoped-queries.test.tsx
@@ -10,7 +10,6 @@ import { SecretsService } from "#/api/secrets-service";
 import ApiKeysClient from "#/api/api-keys";
 import { MOCK_DEFAULT_USER_SETTINGS } from "#/mocks/handlers";
 import { useSelectedOrganizationStore } from "#/stores/selected-organization-store";
-import type { ApiSettings } from "#/types/settings";
 
 vi.mock("#/hooks/query/use-config", () => ({
   useConfig: () => ({
@@ -67,27 +66,6 @@ describe("Organization-scoped query hooks", () => {
       // Verify no data is cached under the old key without org ID
       const oldKeyData = queryClient.getQueryData(["settings"]);
       expect(oldKeyData).toBeUndefined();
-    });
-
-    it('should normalize a null llm_base_url from the API to an empty string', async () => {
-      const getSettingsSpy = vi.spyOn(SettingsService, "getSettings");
-      const apiSettings: ApiSettings = {
-        ...MOCK_DEFAULT_USER_SETTINGS,
-        llm_base_url: null,
-      };
-      getSettingsSpy.mockResolvedValue(apiSettings);
-
-      const { result } = renderHook(() => useSettings(), {
-        wrapper: createWrapper(),
-      });
-
-      await waitFor(() => expect(result.current.isFetched).toBe(true));
-
-      expect(result.current.data?.llm_base_url).toBe("");
-      const cachedData = queryClient.getQueryData(["settings", "org-1"]) as {
-        llm_base_url?: string;
-      } | null;
-      expect(cachedData?.llm_base_url).toBe("");
     });
 
     it("should refetch when organization changes", async () => {

--- a/frontend/__tests__/hooks/query/organization-scoped-queries.test.tsx
+++ b/frontend/__tests__/hooks/query/organization-scoped-queries.test.tsx
@@ -10,6 +10,7 @@ import { SecretsService } from "#/api/secrets-service";
 import ApiKeysClient from "#/api/api-keys";
 import { MOCK_DEFAULT_USER_SETTINGS } from "#/mocks/handlers";
 import { useSelectedOrganizationStore } from "#/stores/selected-organization-store";
+import type { ApiSettings } from "#/types/settings";
 
 vi.mock("#/hooks/query/use-config", () => ({
   useConfig: () => ({
@@ -66,6 +67,27 @@ describe("Organization-scoped query hooks", () => {
       // Verify no data is cached under the old key without org ID
       const oldKeyData = queryClient.getQueryData(["settings"]);
       expect(oldKeyData).toBeUndefined();
+    });
+
+    it('should normalize a null llm_base_url from the API to an empty string', async () => {
+      const getSettingsSpy = vi.spyOn(SettingsService, "getSettings");
+      const apiSettings: ApiSettings = {
+        ...MOCK_DEFAULT_USER_SETTINGS,
+        llm_base_url: null,
+      };
+      getSettingsSpy.mockResolvedValue(apiSettings);
+
+      const { result } = renderHook(() => useSettings(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isFetched).toBe(true));
+
+      expect(result.current.data?.llm_base_url).toBe("");
+      const cachedData = queryClient.getQueryData(["settings", "org-1"]) as {
+        llm_base_url?: string;
+      } | null;
+      expect(cachedData?.llm_base_url).toBe("");
     });
 
     it("should refetch when organization changes", async () => {

--- a/frontend/__tests__/hooks/query/use-settings.test.tsx
+++ b/frontend/__tests__/hooks/query/use-settings.test.tsx
@@ -1,0 +1,64 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useSettings } from "#/hooks/query/use-settings";
+import SettingsService from "#/api/settings-service/settings-service.api";
+import { MOCK_DEFAULT_USER_SETTINGS } from "#/mocks/handlers";
+import { useSelectedOrganizationStore } from "#/stores/selected-organization-store";
+import type { ApiSettings } from "#/types/settings";
+
+vi.mock("#/hooks/query/use-config", () => ({
+  useConfig: () => ({
+    data: { app_mode: "saas" },
+  }),
+}));
+
+vi.mock("#/hooks/query/use-is-authed", () => ({
+  useIsAuthed: () => ({
+    data: true,
+  }),
+}));
+
+vi.mock("#/hooks/use-is-on-intermediate-page", () => ({
+  useIsOnIntermediatePage: () => false,
+}));
+
+describe("useSettings", () => {
+  let queryClient: QueryClient;
+
+  const createWrapper = () => {
+    return ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+    useSelectedOrganizationStore.setState({ organizationId: "org-1" });
+    vi.clearAllMocks();
+  });
+
+  it("should normalize a null llm_base_url from the API to an empty string", async () => {
+    const getSettingsSpy = vi.spyOn(SettingsService, "getSettings");
+    const apiSettings: ApiSettings = {
+      ...MOCK_DEFAULT_USER_SETTINGS,
+      llm_base_url: null,
+    };
+    getSettingsSpy.mockResolvedValue(apiSettings);
+
+    const { result } = renderHook(() => useSettings(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isFetched).toBe(true));
+
+    expect(result.current.data?.llm_base_url).toBe("");
+  });
+});

--- a/frontend/src/api/settings-service/settings-service.api.ts
+++ b/frontend/src/api/settings-service/settings-service.api.ts
@@ -1,5 +1,5 @@
 import { openHands } from "../open-hands-axios";
-import { Settings } from "#/types/settings";
+import { ApiSettings, Settings } from "#/types/settings";
 
 /**
  * Settings service for managing application settings
@@ -8,8 +8,8 @@ class SettingsService {
   /**
    * Get the settings from the server or use the default settings if not found
    */
-  static async getSettings(): Promise<Settings> {
-    const { data } = await openHands.get<Settings>("/api/settings");
+  static async getSettings(): Promise<ApiSettings> {
+    const { data } = await openHands.get<ApiSettings>("/api/settings");
     return data;
   }
 

--- a/frontend/src/hooks/query/use-settings.ts
+++ b/frontend/src/hooks/query/use-settings.ts
@@ -12,6 +12,7 @@ export const getSettingsQueryFn = async (): Promise<Settings> => {
 
   return {
     ...settings,
+    llm_base_url: settings.llm_base_url ?? DEFAULT_SETTINGS.llm_base_url,
     condenser_max_size:
       settings.condenser_max_size ?? DEFAULT_SETTINGS.condenser_max_size,
     search_api_key: settings.search_api_key || "",

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -88,3 +88,7 @@ export type Settings = {
   v1_enabled?: boolean;
   sandbox_grouping_strategy?: SandboxGroupingStrategy;
 };
+
+export type ApiSettings = Omit<Settings, "llm_base_url"> & {
+  llm_base_url: string | null;
+};

--- a/tests/unit/app_server/test_settings_api.py
+++ b/tests/unit/app_server/test_settings_api.py
@@ -195,3 +195,26 @@ async def test_disabled_skills_persistence(test_client):
     assert response.status_code == 200
     data = response.json()
     assert data['disabled_skills'] == []
+
+
+@pytest.mark.asyncio
+async def test_llm_base_url_clear_round_trips_as_null(test_client):
+    """Test that clearing llm_base_url persists and loads back as a basic-mode null."""
+    initial_settings = {
+        'llm_model': 'gpt-4',
+        'llm_base_url': 'https://old-proxy.example.com',
+    }
+    response = test_client.post('/api/settings', json=initial_settings)
+    assert response.status_code == 200
+
+    update_settings = {
+        'llm_model': 'gpt-4',
+        'llm_base_url': '',
+    }
+    response = test_client.post('/api/settings', json=update_settings)
+    assert response.status_code == 200
+
+    response = test_client.get('/api/settings')
+    assert response.status_code == 200
+    assert response.json()['llm_model'] == 'gpt-4'
+    assert response.json()['llm_base_url'] is None

--- a/tests/unit/app_server/test_settings_api.py
+++ b/tests/unit/app_server/test_settings_api.py
@@ -204,17 +204,17 @@ async def test_llm_base_url_clear_round_trips_as_null(test_client):
         'llm_model': 'gpt-4',
         'llm_base_url': 'https://old-proxy.example.com',
     }
-    response = test_client.post('/api/settings', json=initial_settings)
+    response = test_client.post('/api/v1/settings', json=initial_settings)
     assert response.status_code == 200
 
     update_settings = {
         'llm_model': 'gpt-4',
         'llm_base_url': '',
     }
-    response = test_client.post('/api/settings', json=update_settings)
+    response = test_client.post('/api/v1/settings', json=update_settings)
     assert response.status_code == 200
 
-    response = test_client.get('/api/settings')
+    response = test_client.get('/api/v1/settings')
     assert response.status_code == 200
     assert response.json()['llm_model'] == 'gpt-4'
     assert response.json()['llm_base_url'] is None


### PR DESCRIPTION
## Summary of PR

Follow-up to #13471 to make the cleared `llm_base_url` contract explicit across the settings API and frontend.

This PR keeps the backend behavior already accepted in `main` (`GET /api/settings` may return `llm_base_url = null` for basic-mode/default URLs), and tightens the frontend side so the UI always receives a normalized string value.

Changes:
- add an `ApiSettings` type with `llm_base_url: string | null`
- type `SettingsService.getSettings()` against the API shape instead of the UI shape
- normalize `null -> ""` in `useSettings()` before data reaches UI consumers
- add a frontend regression test for that normalization
- add an API round-trip regression test that clearing the base URL loads back as `null`

## Demo Screenshots/Videos

No screenshot needed.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Follow-up to #13471

## Release Notes

- [ ] Include this change in the Release Notes.

## Validation

- `INSTALL_PLAYWRIGHT=0 make install-pre-commit-hooks`
- `/home/openclaw/.local/bin/poetry run pytest tests/unit/server/routes/test_settings_api.py::test_search_api_key_preservation tests/unit/server/routes/test_settings_api.py::test_llm_base_url_clear_round_trips_as_null -q`
- `cd frontend && npx vitest run __tests__/hooks/query/organization-scoped-queries.test.tsx`
- `cd frontend && npm run lint:fix`
- `cd frontend && npm run build`
- `/home/openclaw/.local/bin/poetry run pre-commit run --files tests/unit/server/routes/test_settings_api.py --config ./dev_config/python/.pre-commit-config.yaml`