### PR TITLE
feat(frontend): Add unified Spinner component to consolidate loading indicators

### DIFF
--- a/frontend/src/components/shared/__tests__/spinner.test.tsx
+++ b/frontend/src/components/shared/__tests__/spinner.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Spinner } from "#/components/shared/spinner";
+
+describe("Spinner", () => {
+  it("renders with default props", () => {
+    render(<Spinner />);
+    const spinner = screen.getByTestId("spinner");
+    expect(spinner).toBeInTheDocument();
+    expect(spinner.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("renders with different sizes", () => {
+    const { rerender } = render(<Spinner size="sm" />);
+    let spinner = screen.getByTestId("spinner");
+    expect(spinner.querySelector("svg")).toHaveClass("w-4", "h-4");
+
+    rerender(<Spinner size="md" />);
+    spinner = screen.getByTestId("spinner");
+    expect(spinner.querySelector("svg")).toHaveClass("w-6", "h-6");
+
+    rerender(<Spinner size="lg" />);
+    spinner = screen.getByTestId("spinner");
+    expect(spinner.querySelector("svg")).toHaveClass("w-8", "h-8");
+
+    rerender(<Spinner size="xl" />);
+    spinner = screen.getByTestId("spinner");
+    expect(spinner.querySelector("svg")).toHaveClass("w-12", "h-12");
+  });
+
+  it("renders with label", () => {
+    render(<Spinner label="Loading..." />);
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    render(<Spinner className="custom-class" />);
+    const spinner = screen.getByTestId("spinner");
+    expect(spinner).toHaveClass("custom-class");
+  });
+
+  it("applies custom color style", () => {
+    render(<Spinner color="#6366f1" />);
+    const svg = screen.getByTestId("spinner").querySelector("svg");
+    expect(svg).toHaveStyle({ color: "#6366f1" });
+  });
+
+  it("uses custom testId", () => {
+    render(<Spinner data-testid="custom-spinner" />);
+    expect(screen.getByTestId("custom-spinner")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/shared/spinner.tsx
+++ b/frontend/src/components/shared/spinner.tsx
@@ -1,0 +1,110 @@
+import { LoaderCircle } from "lucide-react";
+import { cn } from "#/utils/utils";
+
+export type SpinnerSize = "sm" | "md" | "lg" | "xl";
+
+interface SpinnerProps {
+  /**
+   * Size of the spinner
+   * - sm: 16px (w-4 h-4)
+   * - md: 24px (w-6 h-6) - default
+   * - lg: 32px (w-8 h-8)
+   * - xl: 48px (w-12 h-12)
+   */
+  size?: SpinnerSize;
+  /**
+   * Optional label text displayed below the spinner
+   */
+  label?: string;
+  /**
+   * Additional CSS classes for the spinner container
+   */
+  className?: string;
+  /**
+   * Color of the spinner. Defaults to current text color
+   */
+  color?: string;
+  /**
+   * Test ID for testing purposes
+   */
+  "data-testid"?: string;
+}
+
+/**
+ * Unified Spinner component to replace multiple loading spinner implementations.
+ * 
+ * This component consolidates the various spinner implementations found across
+ * the codebase:
+ * - AgentLoading (uses Lucide LoaderCircle)
+ * - ConversationLoading (uses Lucide LoaderCircle with text)
+ * - LoadingMicroagentBody (uses HeroUI Spinner)
+ * - BranchLoadingState (uses HeroUI Spinner)
+ * - RepositoryLoadingState (uses HeroUI Spinner)
+ * - SkillsLoadingState (uses CSS border animation)
+ * - Home LoadingSpinner (uses CSS border animation)
+ * 
+ * Migration plan:
+ * - Replace AgentLoading: <Spinner size="sm" color="white" />
+ * - Replace ConversationLoading: <Spinner size="md" label="Loading..." />
+ * - Replace LoadingMicroagentBody: <Spinner size="lg" />
+ * - Replace BranchLoadingState: <Spinner size="md" />
+ * - Replace RepositoryLoadingState: <Spinner size="lg" />
+ * - Replace SkillsLoadingState: <Spinner size="md" />
+ * - Replace Home LoadingSpinner: <Spinner size="lg" />
+ * 
+ * @example
+ * ```tsx
+ * // Basic usage
+ * <Spinner />
+ * 
+ * // With label
+ * <Spinner label="Loading conversation..." />
+ * 
+ * // Custom size
+ * <Spinner size="xl" />
+ * 
+ * // Custom color
+ * <Spinner color="#6366f1" />
+ * ```
+ */
+export function Spinner({
+  size = "md",
+  label,
+  className,
+  color,
+  "data-testid": testId = "spinner",
+}: SpinnerProps) {
+  const sizeClasses: Record<SpinnerSize, string> = {
+    sm: "w-4 h-4",
+    md: "w-6 h-6",
+    lg: "w-8 h-8",
+    xl: "w-12 h-12",
+  };
+
+  const labelSizeClasses: Record<SpinnerSize, string> = {
+    sm: "text-xs",
+    md: "text-sm",
+    lg: "text-base",
+    xl: "text-lg",
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-2",
+        className
+      )}
+      data-testid={testId}
+    >
+      <LoaderCircle
+        className={cn("animate-spin", sizeClasses[size])}
+        style={{ color }}
+      />
+      {label && (
+        <span className={cn("text-neutral-600", labelSizeClasses[size])}>
+          {label}
+        </span>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Hi team! 👋

This PR addresses issue #12550 by introducing a unified `Spinner` component that consolidates the 8 different loading spinner implementations scattered across the codebase.

## What's Changed

- ✅ Created new `Spinner` component in `src/components/shared/spinner.tsx`
- ✅ Added comprehensive TypeScript types and JSDoc documentation
- ✅ Included unit tests with complete coverage
- 🔄 Provided migration guide for existing components (to be done in follow-up PRs)

## Design Decisions

I chose to use **Lucide React's `LoaderCircle`** as the base because:
1. It's already a project dependency
2. It provides consistent, accessible SVG icons
3. It's lightweight and well-maintained

The component supports 4 size variants (sm/md/lg/xl) which should cover all current use cases. I mapped the existing sizes as follows:
- `AgentLoading` → `<Spinner size="sm" color="white" />`
- `ConversationLoading` → `<Spinner size="md" label="..." />`
- `LoadingMicroagentBody` → `<Spinner size="lg" />`

## Testing

All tests pass ✅

## Migration Plan

I'd recommend doing the migration in phases to keep PRs small and reviewable:
1. This PR - Add the new component
2. Follow-up PRs - Migrate 1-2 components at a time
3. Final PR - Remove deprecated implementations

Happy to adjust anything based on feedback! 😊

---

Fixes #12550