### PR TITLE
chore(deps): make pythonnet Windows-only dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -14835,4 +14835,4 @@ third-party-runtimes = ["daytona", "e2b-code-interpreter", "modal", "runloop-api
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12,<3.14"
-content-hash = "1eca2c63c2d63e5d0fe58f40170af2373ace8d6c1088d3ed85669bd7bc753ff2"
+content-hash = "27133f26b38ca7c234ff6f3ade24067804ec47776cae8c24d48657cf1dcd7280"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1335,6 +1335,7 @@ description = "Generic pure Python loader for .NET runtimes"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "sys_platform == \"win32\""
 files = [
     {file = "clr_loader-0.2.10-py3-none-any.whl", hash = "sha256:ebbbf9d511a7fe95fa28a95a4e04cd195b097881dfe66158dc2c281d3536f282"},
     {file = "clr_loader-0.2.10.tar.gz", hash = "sha256:81f114afbc5005bafc5efe5af1341d400e22137e275b042a8979f3feb9fc9446"},
@@ -11934,6 +11935,7 @@ description = ".NET and Mono integration for Python"
 optional = false
 python-versions = "<3.14,>=3.7"
 groups = ["main"]
+markers = "sys_platform == \"win32\""
 files = [
     {file = "pythonnet-3.0.5-py3-none-any.whl", hash = "sha256:f6702d694d5d5b163c9f3f5cc34e0bed8d6857150237fae411fefb883a656d20"},
     {file = "pythonnet-3.0.5.tar.gz", hash = "sha256:48e43ca463941b3608b32b4e236db92d8d40db4c58a75ace902985f76dac21cf"},
@@ -14833,4 +14835,4 @@ third-party-runtimes = ["daytona", "e2b-code-interpreter", "modal", "runloop-api
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12,<3.14"
-content-hash = "1d1661870075ed85d87818cc3f3bd30bf23dcd00d1604be57f616f60b583c758"
+content-hash = "1eca2c63c2d63e5d0fe58f40170af2373ace8d6c1088d3ed85669bd7bc753ff2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ dependencies = [
   "python-multipart>=0.0.22",
   "python-pptx",
   "python-socketio==5.14",
-  "pythonnet",
+  "pythonnet; sys_platform == 'win32'",
   "pyyaml>=6.0.2",
   "qtconsole>=5.6.1",
   "rapidfuzz>=3.9",
@@ -211,7 +211,7 @@ python-json-logger = "^3.2.1"
 prompt-toolkit = "^3.0.50"
 poetry = "^2.1.2"
 anyio = "4.9.0"
-pythonnet = "*"
+pythonnet = { version = "*", markers = "sys_platform == 'win32'" }
 fastmcp = ">=3,<4"
 python-frontmatter = "^1.1.0"
 shellingham = "^1.5.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ dependencies = [
   "python-multipart>=0.0.22",
   "python-pptx",
   "python-socketio==5.14",
-  "pythonnet; sys_platform == 'win32'",
+  "pythonnet; sys_platform=='win32'",
   "pyyaml>=6.0.2",
   "qtconsole>=5.6.1",
   "rapidfuzz>=3.9",


### PR DESCRIPTION
## Summary

This PR makes pythonnet a Windows-only dependency using platform markers.

### Why This Is Needed

pythonnet is only used on Windows for PowerShell support via windows_bash.py. All imports are already guarded with sys.platform == win32.

The current stable pythonnet 3.0.5 has requires-python: <3.14, which blocks Python 3.14 installation on all platforms, even though pythonnet is never used on Linux/macOS.

### Unblocks

- #12804 (Python 3.14 container upgrade)

### Impact

- Linux/macOS: pythonnet no longer installed (was unused)
- Windows: pythonnet still installed (no change)

### Related

- pythonnet Python 3.14 support: pythonnet/pythonnet#2610
- pythonnet 3.1.0rc0 has Python 3.14 support but is not yet stable

### Note

The windows_bash.py file is marked as legacy V0 code scheduled for removal April 1, 2026.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:db239f3-nikolaik   --name openhands-app-db239f3   docker.openhands.dev/openhands/openhands:db239f3
```