### PR TITLE
WebSocket Gateway

### DIFF
--- a/frontend/.env.sample
+++ b/frontend/.env.sample
@@ -5,4 +5,5 @@ VITE_MOCK_SAAS="false" # Simulate SaaS mode in development (true or false)
 VITE_USE_TLS="false" # Use HTTPS/WSS for backend connections (true or false)
 VITE_FRONTEND_PORT="3001" # Port to run the frontend application
 VITE_INSECURE_SKIP_VERIFY="false" # Skip TLS certificate verification (true or false)
+VITE_ENABLE_WEBSOCKET_GATEWAY="true" # See: https://github.com/OpenHands/OpenHands/issues/13504
 # VITE_GITHUB_TOKEN="" # GitHub token for repository access (used in some tests)

--- a/frontend/src/utils/websocket-url.ts
+++ b/frontend/src/utils/websocket-url.ts
@@ -79,6 +79,15 @@ export function buildWebSocketUrl(
     return null;
   }
 
+  // Check if centralized WebSocket gateway is enabled via environment variable
+  const useGateway = import.meta.env.VITE_ENABLE_WEBSOCKET_GATEWAY === "true";
+
+  if (useGateway && conversationUrl) {
+    // Use relative URL for the centralized gateway endpoint
+    // The browser will automatically resolve this to wss://<current-host>/ws/events/<id>
+    return `/ws/events/${conversationId}`;
+  }
+
   const baseHost = extractBaseHost(conversationUrl);
   const pathPrefix = extractPathPrefix(conversationUrl);
 

--- a/openhands/app_server/v1_router.py
+++ b/openhands/app_server/v1_router.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi import APIRouter
 
 from openhands.app_server.app_conversation import app_conversation_router
@@ -22,3 +24,16 @@ router.include_router(sandbox_spec_router.router)
 router.include_router(user_router.router)
 router.include_router(webhook_router.router)
 router.include_router(web_client_router.router)
+
+# WebSocket gateway support (optional, enabled via environment variable)
+WEBSOCKET_GATEWAY_ENABLED = os.getenv('ENABLE_WEBSOCKET_GATEWAY', 'false').lower() in (
+    'true',
+    '1',
+)
+
+if WEBSOCKET_GATEWAY_ENABLED:
+    from openhands.app_server.websocket_router import router as websocket_router
+
+    # Create a separate router for WebSocket endpoints (no prefix, mounted at /ws)
+    websocket_routes = APIRouter()
+    websocket_routes.include_router(websocket_router)

--- a/openhands/app_server/websocket_router.py
+++ b/openhands/app_server/websocket_router.py
@@ -1,0 +1,175 @@
+"""WebSocket router for OpenHands App Server.
+
+This module provides a centralized WebSocket endpoint that proxies connections
+to the appropriate sandbox's agent_server. This allows WebSocket connections
+to work through a proxy without needing to expose individual sandbox URLs.
+"""
+
+import asyncio
+import logging
+from typing import Annotated
+from uuid import UUID
+
+import websockets
+import websockets.exceptions
+from fastapi import APIRouter, Query, WebSocket
+from starlette.websockets import WebSocketState
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()  # No prefix - will be mounted at /ws in listen.py
+
+
+async def _proxy_websocket_messages(
+    client_ws: WebSocket,
+    agent_server_ws: websockets.WebSocketClientProtocol,
+):
+    """Proxy messages bidirectionally between client and agent server."""
+
+    async def client_to_agent():
+        try:
+            while True:
+                data = await client_ws.receive_text()
+                await agent_server_ws.send(data)
+        except Exception as e:
+            logger.error(f'Error proxying client->agent: {e}')
+
+    async def agent_to_client():
+        try:
+            while True:
+                data = await agent_server_ws.recv()
+                if client_ws.client_state == WebSocketState.CONNECTED:
+                    await client_ws.send_text(data)
+        except websockets.exceptions.ConnectionClosed:
+            logger.info('Agent server WebSocket closed')
+        except Exception as e:
+            logger.error(f'Error proxying agent->client: {e}')
+
+    # Run both proxies concurrently
+    tasks = [
+        asyncio.create_task(client_to_agent()),
+        asyncio.create_task(agent_to_client()),
+    ]
+
+    try:
+        await asyncio.gather(*tasks, return_exceptions=True)
+    except Exception as e:
+        logger.error(f'Error in WebSocket proxy: {e}')
+
+
+@router.websocket('/events/{conversation_id}')
+async def websocket_endpoint(
+    conversation_id: str,
+    websocket: WebSocket,
+    session_api_key: Annotated[str | None, Query(alias='session_api_key')] = None,
+    resend_all: Annotated[bool, Query()] = False,
+):
+    """Centralized WebSocket endpoint that proxies to sandbox agent servers.
+
+    This endpoint accepts WebSocket connections and proxies them directly to the
+    appropriate sandbox's agent_server without any modification. The conversation_id
+    from the URL path is normalized to UUID format with dashes before being used.
+
+    Args:
+        conversation_id: The conversation ID (UUID string, may or may not have dashes)
+        websocket: The WebSocket connection from the client
+        session_api_key: Session API key for authentication
+        resend_all: Whether to resend all events
+    """
+    # Normalize conversation_id to UUID format with dashes
+    try:
+        parsed_uuid = str(UUID(conversation_id.replace('-', '')))
+    except (ValueError, TypeError) as e:
+        logger.error(f'Invalid conversation ID {conversation_id}: {e}')
+        await websocket.accept()
+        await websocket.close(code=4003, reason='Invalid conversation ID')
+        return
+
+    # Get the conversation to find the agent server URL
+    from openhands.app_server.config import get_app_conversation_service
+    from openhands.app_server.services.injector import InjectorState
+    from openhands.app_server.user.specifiy_user_context import ADMIN, USER_CONTEXT_ATTR
+
+    state = InjectorState()
+    setattr(state, USER_CONTEXT_ATTR, ADMIN)
+
+    app_conversation_service = get_app_conversation_service(state)
+
+    try:
+        async with app_conversation_service as service:
+            logger.info(f'Fetching conversation {parsed_uuid}')
+            from uuid import UUID as UUIDType
+
+            conversation = await service.get_app_conversation(UUIDType(parsed_uuid))
+
+            if not conversation:
+                logger.error(f'Conversation {parsed_uuid} not found')
+                await websocket.accept()
+                await websocket.close(code=4004, reason='Conversation not found')
+                return
+
+            logger.info(
+                f'Found conversation: id={conversation.id}, url={conversation.conversation_url}'
+            )
+
+            if not conversation.conversation_url:
+                logger.error(f'Conversation {parsed_uuid} has no URL')
+                await websocket.accept()
+                await websocket.close(
+                    code=4004, reason='Conversation URL not available'
+                )
+                return
+
+            # Build the agent server WebSocket URL
+            from urllib.parse import urlencode, urlparse
+
+            parsed = urlparse(conversation.conversation_url)
+
+            scheme = 'wss' if parsed.scheme == 'https' else 'ws'
+
+            full_path = parsed.path.rstrip('/')
+
+            # Remove trailing conversation path to get base URL, then add socket endpoint
+            if '/api/conversations/' in full_path:
+                full_path.split('/api/conversations/')
+                path = f'/sockets/events/{parsed_uuid}'
+            else:
+                path = (
+                    f'{full_path}/sockets/events/{parsed_uuid}'
+                    if full_path
+                    else f'/sockets/events/{parsed_uuid}'
+                )
+
+            # Build query parameters
+            query_params = {'resend_all': str(resend_all).lower()}
+            if session_api_key:
+                query_params['session_api_key'] = session_api_key
+
+            logger.info(f'Query params: {query_params}')
+
+            full_url = f'{scheme}://{parsed.netloc}{path}?{urlencode(query_params)}'
+
+            logger.info('=== DESTINATION WEBSOCKET URL ===')
+            logger.info(f'Destination: {full_url}')
+            logger.info(f'Source conversation URL: {conversation.conversation_url}')
+
+            await websocket.accept()
+
+            try:
+                async with websockets.connect(full_url) as agent_server_ws:
+                    logger.info(f'Connected to destination: {full_url}')
+
+                    # Proxy messages in both directions
+                    client_to_agent_task = asyncio.create_task(
+                        _proxy_websocket_messages(websocket, agent_server_ws)
+                    )
+
+                    await client_to_agent_task
+
+            except Exception as e:
+                logger.exception(f'Error connecting to {full_url}: {e}')
+                if websocket.client_state == WebSocketState.CONNECTED:
+                    await websocket.close(code=1011, reason=str(e))
+
+    except Exception as e:
+        logger.exception(f'WebSocket endpoint error: {e}')

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -20,6 +20,12 @@ from openhands.server.middleware import (
 )
 from openhands.server.static import SPAStaticFiles
 
+# Mount WebSocket routes at /ws BEFORE static files to ensure WebSockets are handled properly
+if os.getenv('ENABLE_WEBSOCKET_GATEWAY', 'false').lower() in ('true', '1'):
+    from openhands.app_server.v1_router import websocket_routes
+
+    base_app.mount('/ws', websocket_routes, name='websocket')
+
 if os.getenv('SERVE_FRONTEND', 'true').lower() == 'true':
     base_app.mount(
         '/', SPAStaticFiles(directory='./frontend/build', html=True), name='dist'


### PR DESCRIPTION
## Update

The latest version of the WebSocket Gateway + other V1 routers is included in:
https://github.com/OpenHands/OpenHands/pull/14909

---

Similar PRs:
- https://github.com/OpenHands/OpenHands/pull/13551
- https://github.com/OpenHands/OpenHands/pull/12591

## Problem

In v0, a single endpoint (port 3000) handled all traffic, including WebSocket connections for every sandbox.

In v1, this endpoint no longer supports WebSockets. Instead, the browser is required to connect directly to each sandbox’s WebSocket endpoint.

This new approach introduces several issues: It relies on non-standard ports that may be blocked by ISPs and increases the complexity of firewall and reverse proxy configurations. Because sandboxes are created dynamically, these network rules must also be dynamic.

Issue: https://github.com/OpenHands/OpenHands/issues/13504

## Solution

This PR introduces a WebSocket gateway for v1 messaging that:

1. handles all conversation WebSocket connections through a single endpoint running on the same port as the web app, and
2. routes each connection to the appropriate sandbox agent server endpoint.

## Setup

- Run OH with env var `ENABLE_WEBSOCKET_GATEWAY=true`. This enables the websocket gateway on the backend.
- Set `VITE_ENABLE_WEBSOCKET_GATEWAY="true"` in `frontend/.env` and rebuild the front end. This makes the websockets use relative urls and use the same host and port of the web app.
- Depending on your setup, if your sandboxes are somehow not reachable by the OH app-server (see OH logs), set the env var `SANDBOX_CONTAINER_URL_PATTERN="http://127.0.0.1:{port}"` (change to the IP of your dockerd host).

## Change Type

<!-- Choose the types that apply to your PR -->

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves https://github.com/OpenHands/OpenHands/issues/13504

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [x] Include this change in the Release Notes.
