### PR TITLE
fix(frontend): make conversation header sticky at narrow window widths

### DIFF
--- a/frontend/src/components/features/conversation/conversation-main/conversation-main.tsx
+++ b/frontend/src/components/features/conversation/conversation-main/conversation-main.tsx
@@ -32,7 +32,7 @@ export function ConversationMain() {
     <div
       className={cn(
         isMobile
-          ? "relative flex-1 flex flex-col"
+          ? "flex-1 flex flex-col"
           : "h-full flex flex-col overflow-hidden",
       )}
     >
@@ -80,12 +80,7 @@ export function ConversationMain() {
           className={cn(
             "transition-all duration-300 ease-in-out overflow-hidden",
             isMobile
-              ? cn(
-                  "absolute bottom-4 left-0 right-0 top-160",
-                  isRightPanelShown
-                    ? "h-160 translate-y-0 opacity-100"
-                    : "h-0 translate-y-full opacity-0",
-                )
+              ? cn(isRightPanelShown ? "h-160 opacity-100" : "h-0 opacity-0")
               : getDesktopTabPanelClass(isRightPanelShown),
           )}
           style={

--- a/frontend/src/routes/conversation.tsx
+++ b/frontend/src/routes/conversation.tsx
@@ -97,9 +97,9 @@ function AppContent() {
       <EventHandler>
         <div
           data-testid="app-route"
-          className="p-3 md:p-0 flex flex-col min-h-full lg:h-full gap-3"
+          className="px-3 pb-3 md:p-0 flex flex-col min-h-full lg:h-full gap-3"
         >
-          <div className="sticky top-0 z-10 bg-base shrink-0 flex flex-col lg:flex-row lg:items-center justify-between gap-4.5 pt-2 lg:pt-0">
+          <div className="sticky top-0 z-10 bg-base shrink-0 flex flex-col lg:flex-row lg:items-center justify-between gap-4.5 py-2 lg:pt-0">
             <ConversationNameWithStatus />
             <ConversationTabs />
           </div>

--- a/frontend/src/routes/conversation.tsx
+++ b/frontend/src/routes/conversation.tsx
@@ -97,7 +97,7 @@ function AppContent() {
       <EventHandler>
         <div
           data-testid="app-route"
-          className="p-3 md:p-0 flex flex-col h-full gap-3"
+          className="p-3 md:p-0 flex flex-col min-h-full lg:h-full gap-3"
         >
           <div className="sticky top-0 z-10 bg-base shrink-0 flex flex-col lg:flex-row lg:items-center justify-between gap-4.5 pt-2 lg:pt-0">
             <ConversationNameWithStatus />

--- a/frontend/src/routes/conversation.tsx
+++ b/frontend/src/routes/conversation.tsx
@@ -99,7 +99,7 @@ function AppContent() {
           data-testid="app-route"
           className="p-3 md:p-0 flex flex-col h-full gap-3"
         >
-          <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4.5 pt-2 lg:pt-0">
+          <div className="sticky top-0 z-10 bg-base shrink-0 flex flex-col lg:flex-row lg:items-center justify-between gap-4.5 pt-2 lg:pt-0">
             <ConversationNameWithStatus />
             <ConversationTabs />
           </div>


### PR DESCRIPTION
## Problem

At window widths ≤ 1024px the conversation layout switches to a mobile
variant. In this layout `ConversationMain` does not carry `overflow-hidden`
(unlike the desktop path), which can allow content to overflow the
`#root-outlet` scroll container. When that happens the header — containing
the conversation title and the tab buttons (Planner / Changes / Code /
Terminal / etc.) — scrolls out of view, forcing the user to scroll all the
way back to the top to interact with it.

## Fix

Add `sticky top-0` to the header div so it remains pinned to the top of
the scroll container whenever overflow-driven scrolling occurs.

- `sticky top-0` — keeps the header visible during scroll
- `bg-base` — solid background so scrolled content doesn't bleed through
- `z-10` — layers the header above the scrolled content
- `shrink-0` — prevents the header from shrinking in the flex layout

On desktop (> 1024px) the layout already prevents overflow, so `sticky`
is a no-op there.

## Testing

Reproduced at ~800 px window width with a long conversation and no side
pane active: header previously scrolled away, now remains visible.