### PR TITLE
feat: add Novita AI as an LLM provider

### DIFF
--- a/frontend/__tests__/utils/extract-model-and-provider.test.ts
+++ b/frontend/__tests__/utils/extract-model-and-provider.test.ts
@@ -101,4 +101,28 @@ describe("extractModelAndProvider", () => {
       separator: "/",
     });
   });
+
+  it("should extract novita provider and model", () => {
+    expect(
+      extractModelAndProvider("novita/moonshotai/kimi-k2.5"),
+    ).toEqual({
+      provider: "novita",
+      model: "moonshotai/kimi-k2.5",
+      separator: "/",
+    });
+
+    expect(extractModelAndProvider("novita/zai-org/glm-5")).toEqual({
+      provider: "novita",
+      model: "zai-org/glm-5",
+      separator: "/",
+    });
+
+    expect(
+      extractModelAndProvider("novita/minimax/minimax-m2.5"),
+    ).toEqual({
+      provider: "novita",
+      model: "minimax/minimax-m2.5",
+      separator: "/",
+    });
+  });
 });

--- a/frontend/__tests__/utils/map-provider.test.ts
+++ b/frontend/__tests__/utils/map-provider.test.ts
@@ -25,4 +25,5 @@ test("mapProvider", () => {
   expect(mapProvider("voyage")).toBe("Voyage AI");
   expect(mapProvider("openrouter")).toBe("OpenRouter");
   expect(mapProvider("clarifai")).toBe("Clarifai");
+  expect(mapProvider("novita")).toBe("Novita AI");
 });

--- a/frontend/src/utils/map-provider.ts
+++ b/frontend/src/utils/map-provider.ts
@@ -26,6 +26,7 @@ export const MAP_PROVIDER = {
   openhands: "OpenHands",
   lemonade: "Lemonade",
   clarifai: "Clarifai",
+  novita: "Novita AI",
 };
 
 export const mapProvider = (provider: string) =>

--- a/frontend/src/utils/verified-models.ts
+++ b/frontend/src/utils/verified-models.ts
@@ -6,6 +6,7 @@ export const VERIFIED_PROVIDERS = [
   "mistral",
   "lemonade",
   "clarifai",
+  "novita",
 ];
 export const VERIFIED_MODELS = [
   "claude-opus-4-6",

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -141,6 +141,16 @@ class LLM(RetryMixin, DebugMixin):
                 f'Rewrote openhands/{model_name} to {self.config.model} with base URL {self.config.base_url}'
             )
 
+        # Handle Novita AI provider - rewrite to openai-compatible endpoint
+        if self.config.model.startswith('novita/'):
+            model_name = self.config.model.removeprefix('novita/')
+            self.config.model = f'openai/{model_name}'
+            if not self.config.base_url:
+                self.config.base_url = 'https://api.novita.ai/openai'
+            logger.debug(
+                f'Rewrote novita/{model_name} to {self.config.model} with base URL {self.config.base_url}'
+            )
+
         features = get_features(self.config.model)
         if features.supports_reasoning_effort:
             # For Gemini models, only map 'low' to optimized thinking budget

--- a/openhands/llm/model_features.py
+++ b/openhands/llm/model_features.py
@@ -101,6 +101,8 @@ FUNCTION_CALLING_PATTERNS: list[str] = [
     # GLM series - verified via official docs and litellm config
     'glm-4*',
     'glm-5*',
+    # MiniMax series
+    'minimax-m2.5',
 ]
 
 REASONING_EFFORT_PATTERNS: list[str] = [
@@ -127,6 +129,8 @@ REASONING_EFFORT_PATTERNS: list[str] = [
     # GLM series - verified via litellm config
     'glm-4*',
     'glm-5*',
+    # MiniMax series
+    'minimax-m2.5',
 ]
 
 PROMPT_CACHE_PATTERNS: list[str] = [

--- a/openhands/utils/llm.py
+++ b/openhands/utils/llm.py
@@ -34,6 +34,12 @@ OPENHANDS_MODELS = [
     'openhands/glm-5',
 ]
 
+NOVITA_MODELS = [
+    'novita/moonshotai/kimi-k2.5',
+    'novita/zai-org/glm-5',
+    'novita/minimax/minimax-m2.5',
+]
+
 CLARIFAI_MODELS = [
     'clarifai/openai.chat-completion.gpt-oss-120b',
     'clarifai/openai.chat-completion.gpt-oss-20b',
@@ -158,6 +164,6 @@ def get_supported_llm_models(
 
     # Use database-backed models if provided (SaaS), otherwise use hardcoded list
     openhands_models = verified_models if verified_models else OPENHANDS_MODELS
-    model_list = openhands_models + CLARIFAI_MODELS + model_list
+    model_list = openhands_models + CLARIFAI_MODELS + NOVITA_MODELS + model_list
 
     return sorted(set(model_list))

--- a/tests/unit/llm/test_model_features.py
+++ b/tests/unit/llm/test_model_features.py
@@ -194,6 +194,8 @@ def test_get_features(model, expect):
         'kimi-k2-instruct',
         'qwen3-coder',
         'qwen3-coder-480b-a35b-instruct',
+        # MiniMax
+        'minimax-m2.5',
     ],
 )
 def test_function_calling_models(model):
@@ -211,6 +213,8 @@ def test_function_calling_models(model):
         'gemini-2.5-pro',
         'gpt-5',
         'gpt-5-mini-2025-08-07',
+        # MiniMax
+        'minimax-m2.5',
     ],
 )
 def test_reasoning_effort_models(model):


### PR DESCRIPTION
## Summary

Adds [Novita AI](https://novita.ai) as an LLM provider using their OpenAI-compatible API endpoint.

### Changes

**Backend**
- `openhands/utils/llm.py`: Add `NOVITA_MODELS` list (`kimi-k2.5`, `glm-5`, `minimax-m2.5`) exposed in the model registry alongside existing providers
- `openhands/llm/llm.py`: Rewrite `novita/<model>` prefix to `openai/<model>` with `https://api.novita.ai/openai` as the base URL, following the same pattern as the existing `openhands/` prefix handler
- `openhands/llm/model_features.py`: Add `minimax-m2.5` to `FUNCTION_CALLING_PATTERNS` and `REASONING_EFFORT_PATTERNS` (kimi-k2.5 and glm-5 were already covered)

**Frontend**
- `frontend/src/utils/verified-models.ts`: Add `"novita"` to `VERIFIED_PROVIDERS` so Novita appears in the verified section of the provider dropdown
- `frontend/src/utils/map-provider.ts`: Add `novita: "Novita AI"` display name

**Tests**
- `tests/unit/llm/test_model_features.py`: Add `minimax-m2.5` to function-calling and reasoning-effort model test cases
- `frontend/__tests__/utils/map-provider.test.ts`: Assert `mapProvider("novita") === "Novita AI"`
- `frontend/__tests__/utils/extract-model-and-provider.test.ts`: Assert correct provider/model extraction for all three Novita model strings

### Usage

Users can configure Novita AI models via the standard LLM settings:

```toml
[llm]
model = "novita/moonshotai/kimi-k2.5"
api_key = "your-novita-api-key"
```

Or in the UI: select **Novita AI** from the provider dropdown, then choose a model. The API key field accepts a `NOVITA_API_KEY`. A custom `base_url` can be provided to override the default endpoint.

### Novita API

- OpenAI-compatible base URL: `https://api.novita.ai/openai`
- Docs: https://novita.ai/docs