### PR TITLE
app_server: add env guard for default SetTitleCallbackProcessor

### DIFF
--- a/LOCAL_PATCH_TRACKING.md
+++ b/LOCAL_PATCH_TRACKING.md
@@ -1,0 +1,28 @@
+# Local Patch Tracking (andyelka-creator fork)
+
+This fork is used as a temporary integration carrier for reproducible fixes and documentation before upstream merge.
+
+## Why this exists
+
+Our deployment runs OpenHands in a remote VM with an external OpenAI-compatible gateway (LiteLLM), mixed local and premium model lanes, and stricter operational constraints than a default single-host setup.
+
+## Branch policy
+
+- `main`: mirror of upstream `OpenHands/OpenHands` (no long-lived local drift).
+- `patch/*`: short-lived branches, one issue/fix per branch.
+- every patch branch must have:
+  - reproducible steps;
+  - before/after behavior;
+  - rollback note.
+
+## Current upstream references
+
+- https://github.com/OpenHands/OpenHands/issues/13475
+- https://github.com/OpenHands/OpenHands/issues/13476
+- https://github.com/OpenHands/OpenHands/issues/13477
+- https://github.com/OpenHands/OpenHands/issues/13478
+- https://github.com/OpenHands/OpenHands/issues/13479
+
+## Contribution rule
+
+Local patches are temporary. The target state is upstream merge or local patch removal.

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -145,6 +145,19 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
     app_mode: str | None = None
     tavily_api_key: str | None = None
 
+    def _ensure_default_callback_processors(self, processors: list[Any]) -> None:
+        disable_set_title_processor = os.environ.get(
+            'OH_DISABLE_SET_TITLE_PROCESSOR', '0'
+        ).lower() in ('1', 'true', 'yes')
+        if disable_set_title_processor:
+            return
+
+        has_set_title_processor = any(
+            isinstance(processor, SetTitleCallbackProcessor) for processor in processors
+        )
+        if not has_set_title_processor:
+            processors.append(SetTitleCallbackProcessor())
+
     async def _get_sandbox_grouping_strategy(self) -> SandboxGroupingStrategy:
         """Get the sandbox grouping strategy from user settings."""
         user_info = await self.user_context.get_user_info()
@@ -354,18 +367,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
 
             # Setup default processors
             processors = request.processors or []
-
-            disable_set_title_processor = os.environ.get(
-                'OH_DISABLE_SET_TITLE_PROCESSOR', '0'
-            ).lower() in ('1', 'true', 'yes')
-            if not disable_set_title_processor:
-                # Always ensure SetTitleCallbackProcessor is included
-                has_set_title_processor = any(
-                    isinstance(processor, SetTitleCallbackProcessor)
-                    for processor in processors
-                )
-                if not has_set_title_processor:
-                    processors.append(SetTitleCallbackProcessor())
+            self._ensure_default_callback_processors(processors)
 
             # Save processors
             for processor in processors:

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -355,13 +355,17 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             # Setup default processors
             processors = request.processors or []
 
-            # Always ensure SetTitleCallbackProcessor is included
-            has_set_title_processor = any(
-                isinstance(processor, SetTitleCallbackProcessor)
-                for processor in processors
-            )
-            if not has_set_title_processor:
-                processors.append(SetTitleCallbackProcessor())
+            disable_set_title_processor = os.environ.get(
+                'OH_DISABLE_SET_TITLE_PROCESSOR', '0'
+            ).lower() in ('1', 'true', 'yes')
+            if not disable_set_title_processor:
+                # Always ensure SetTitleCallbackProcessor is included
+                has_set_title_processor = any(
+                    isinstance(processor, SetTitleCallbackProcessor)
+                    for processor in processors
+                )
+                if not has_set_title_processor:
+                    processors.append(SetTitleCallbackProcessor())
 
             # Save processors
             for processor in processors:

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -25,6 +25,9 @@ from openhands.app_server.app_conversation.live_status_app_conversation_service 
     PLANNING_AGENT_INSTRUCTION,
     LiveStatusAppConversationService,
 )
+from openhands.app_server.event_callback.set_title_callback_processor import (
+    SetTitleCallbackProcessor,
+)
 from openhands.app_server.sandbox.sandbox_models import (
     AGENT_SERVER,
     ExposedUrl,
@@ -1699,6 +1702,95 @@ class TestLiveStatusAppConversationService:
             f'but got "{saved_info.title}"'
         )
         assert saved_info.id == conversation_id
+
+        saved_callbacks = [
+            call.args[0]
+            for call in self.mock_event_callback_service.save_event_callback.call_args_list
+        ]
+        assert any(
+            isinstance(callback.processor, SetTitleCallbackProcessor)
+            for callback in saved_callbacks
+        )
+
+    @patch(
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace'
+    )
+    @patch(
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.ConversationInfo'
+    )
+    async def test_start_app_conversation_can_disable_default_set_title_processor(
+        self, mock_conversation_info_class, mock_remote_workspace_class
+    ):
+        # Arrange
+        conversation_id = uuid4()
+
+        self.mock_user_context.get_user_id = AsyncMock(return_value='test_user_123')
+        self.mock_user_context.get_user_info = AsyncMock(return_value=self.mock_user)
+
+        mock_sandbox_spec = Mock(spec=SandboxSpecInfo)
+        mock_sandbox_spec.working_dir = '/test/workspace'
+        self.mock_sandbox.sandbox_spec_id = str(uuid4())
+        self.mock_sandbox.id = str(uuid4())
+        self.mock_sandbox.session_api_key = 'test_session_key'
+        exposed_url = ExposedUrl(
+            name=AGENT_SERVER, url='http://agent-server:8000', port=60000
+        )
+        self.mock_sandbox.exposed_urls = [exposed_url]
+
+        self.mock_sandbox_service.get_sandbox = AsyncMock(
+            return_value=self.mock_sandbox
+        )
+        self.mock_sandbox_spec_service.get_sandbox_spec = AsyncMock(
+            return_value=mock_sandbox_spec
+        )
+
+        mock_remote_workspace = Mock()
+        mock_remote_workspace_class.return_value = mock_remote_workspace
+
+        async def mock_wait_for_sandbox(task):
+            task.sandbox_id = self.mock_sandbox.id
+            yield task
+
+        async def mock_run_setup_scripts(task, sandbox, workspace, agent_server_url):
+            yield task
+
+        self.service._wait_for_sandbox_start = mock_wait_for_sandbox
+        self.service.run_setup_scripts = mock_run_setup_scripts
+
+        mock_agent = Mock(spec=Agent)
+        mock_agent.llm = Mock(spec=LLM)
+        mock_agent.llm.model = 'gpt-4'
+        mock_start_request = Mock(spec=StartConversationRequest)
+        mock_start_request.agent = mock_agent
+        mock_start_request.model_dump.return_value = {'test': 'data'}
+        self.service._build_start_conversation_request_for_user = AsyncMock(
+            return_value=mock_start_request
+        )
+
+        mock_conversation_info = Mock()
+        mock_conversation_info.id = conversation_id
+        mock_conversation_info_class.model_validate.return_value = (
+            mock_conversation_info
+        )
+
+        mock_response = Mock()
+        mock_response.json.return_value = {'id': str(conversation_id)}
+        mock_response.raise_for_status = Mock()
+        self.mock_httpx_client.post = AsyncMock(return_value=mock_response)
+
+        self.mock_event_callback_service.save_event_callback = AsyncMock()
+
+        request = AppConversationStartRequest()
+
+        # Act
+        with patch.dict(
+            os.environ, {'OH_DISABLE_SET_TITLE_PROCESSOR': 'true'}, clear=False
+        ):
+            async for _ in self.service._start_app_conversation(request):
+                pass
+
+        # Assert
+        assert self.mock_event_callback_service.save_event_callback.call_count == 0
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_with_custom_sse_servers(self):

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -1703,94 +1703,27 @@ class TestLiveStatusAppConversationService:
         )
         assert saved_info.id == conversation_id
 
-        saved_callbacks = [
-            call.args[0]
-            for call in self.mock_event_callback_service.save_event_callback.call_args_list
-        ]
+    def test_default_set_title_processor_is_added_when_env_flag_is_absent(self):
+        processors = []
+
+        with patch.dict(os.environ, {}, clear=False):
+            self.service._ensure_default_callback_processors(processors)
+
         assert any(
-            isinstance(callback.processor, SetTitleCallbackProcessor)
-            for callback in saved_callbacks
+            isinstance(processor, SetTitleCallbackProcessor) for processor in processors
         )
 
-    @patch(
-        'openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace'
-    )
-    @patch(
-        'openhands.app_server.app_conversation.live_status_app_conversation_service.ConversationInfo'
-    )
-    async def test_start_app_conversation_can_disable_default_set_title_processor(
-        self, mock_conversation_info_class, mock_remote_workspace_class
-    ):
-        # Arrange
-        conversation_id = uuid4()
+    def test_default_set_title_processor_can_be_disabled_via_env(self):
+        processors = []
 
-        self.mock_user_context.get_user_id = AsyncMock(return_value='test_user_123')
-        self.mock_user_context.get_user_info = AsyncMock(return_value=self.mock_user)
-
-        mock_sandbox_spec = Mock(spec=SandboxSpecInfo)
-        mock_sandbox_spec.working_dir = '/test/workspace'
-        self.mock_sandbox.sandbox_spec_id = str(uuid4())
-        self.mock_sandbox.id = str(uuid4())
-        self.mock_sandbox.session_api_key = 'test_session_key'
-        exposed_url = ExposedUrl(
-            name=AGENT_SERVER, url='http://agent-server:8000', port=60000
-        )
-        self.mock_sandbox.exposed_urls = [exposed_url]
-
-        self.mock_sandbox_service.get_sandbox = AsyncMock(
-            return_value=self.mock_sandbox
-        )
-        self.mock_sandbox_spec_service.get_sandbox_spec = AsyncMock(
-            return_value=mock_sandbox_spec
-        )
-
-        mock_remote_workspace = Mock()
-        mock_remote_workspace_class.return_value = mock_remote_workspace
-
-        async def mock_wait_for_sandbox(task):
-            task.sandbox_id = self.mock_sandbox.id
-            yield task
-
-        async def mock_run_setup_scripts(task, sandbox, workspace, agent_server_url):
-            yield task
-
-        self.service._wait_for_sandbox_start = mock_wait_for_sandbox
-        self.service.run_setup_scripts = mock_run_setup_scripts
-
-        mock_agent = Mock(spec=Agent)
-        mock_agent.llm = Mock(spec=LLM)
-        mock_agent.llm.model = 'gpt-4'
-        mock_start_request = Mock(spec=StartConversationRequest)
-        mock_start_request.agent = mock_agent
-        mock_start_request.model_dump.return_value = {'test': 'data'}
-        self.service._build_start_conversation_request_for_user = AsyncMock(
-            return_value=mock_start_request
-        )
-
-        mock_conversation_info = Mock()
-        mock_conversation_info.id = conversation_id
-        mock_conversation_info_class.model_validate.return_value = (
-            mock_conversation_info
-        )
-
-        mock_response = Mock()
-        mock_response.json.return_value = {'id': str(conversation_id)}
-        mock_response.raise_for_status = Mock()
-        self.mock_httpx_client.post = AsyncMock(return_value=mock_response)
-
-        self.mock_event_callback_service.save_event_callback = AsyncMock()
-
-        request = AppConversationStartRequest()
-
-        # Act
         with patch.dict(
             os.environ, {'OH_DISABLE_SET_TITLE_PROCESSOR': 'true'}, clear=False
         ):
-            async for _ in self.service._start_app_conversation(request):
-                pass
+            self.service._ensure_default_callback_processors(processors)
 
-        # Assert
-        assert self.mock_event_callback_service.save_event_callback.call_count == 0
+        assert not any(
+            isinstance(processor, SetTitleCallbackProcessor) for processor in processors
+        )
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_with_custom_sse_servers(self):


### PR DESCRIPTION
Summary:\nThis PR adds an opt-out env flag for automatic insertion of SetTitleCallbackProcessor in LiveStatusAppConversationService._start_app_conversation.\n\n- New env var: OH_DISABLE_SET_TITLE_PROCESSOR\n- Truthy values: 1, true, yes\n- Default behavior is unchanged (processor is still auto-added)\n\nWhy:\nIn self-hosted and remote-gateway setups, operators sometimes need to disable title-side effects while keeping the rest of conversation startup unchanged. This keeps current defaults intact and adds an explicit runtime escape hatch.\n\nTests:\n- Added assertion that default flow still includes SetTitleCallbackProcessor\n- Added test that setting OH_DISABLE_SET_TITLE_PROCESSOR=true prevents automatic insertion\n