### PR TITLE
chore: increase dependabot open-pull-requests-limit to 5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     groups:
       # put packages in their own group if they have a history of breaking the build or needing to be reverted
       pre-commit:
@@ -29,7 +29,7 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     groups:
       docusaurus:
         patterns:
@@ -51,7 +51,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     groups:
       docusaurus:
         patterns:
@@ -72,9 +72,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
 
   - package-ecosystem: "docker"
     directories:
       - "containers/*"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Description
Increase the `open-pull-requests-limit` from 1 to 5 for all dependabot ecosystems and add the limit to ecosystems that were missing it.

## Changes
- **pip, npm (frontend), npm (docs)**: Changed `open-pull-requests-limit` from 1 to 5
- **github-actions, docker**: Added `open-pull-requests-limit: 5` (previously had no limit)

## Rationale
With a limit of 1, dependency groups are effectively useless since only one PR can be opened at a time - this defeats the purpose of having groups like `security-all`, `version-all`, etc.

Increasing to 5 allows multiple groups to have open PRs simultaneously while still keeping the number manageable.

For github-actions and docker, without an explicit limit, dependabot could potentially open unlimited PRs which would spam the repository.