### PR TITLE
fix: recover malformed V0 conversation metadata.json

### DIFF
--- a/openhands/storage/conversation/file_conversation_store.py
+++ b/openhands/storage/conversation/file_conversation_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from json import JSONDecodeError
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -38,14 +39,16 @@ class FileConversationStore(ConversationStore):
         path = self.get_conversation_metadata_filename(conversation_id)
         json_str = await call_sync_from_async(self.file_store.read, path)
 
-        # Validate the JSON
-        json_obj = json.loads(json_str)
+        json_obj, normalized_json_str = self._load_metadata_json(path, json_str)
         if 'created_at' not in json_obj:
             raise FileNotFoundError(path)
 
         # Remove github_user_id if it exists
         if 'github_user_id' in json_obj:
             json_obj.pop('github_user_id')
+
+        if normalized_json_str is not None:
+            await call_sync_from_async(self.file_store.write, path, normalized_json_str)
 
         result = conversation_metadata_type_adapter.validate_python(json_obj)
         return result
@@ -113,6 +116,32 @@ class FileConversationStore(ConversationStore):
             file_store_web_hook_batch=config.file_store_web_hook_batch,
         )
         return FileConversationStore(file_store)
+
+    def _load_metadata_json(
+        self, path: str, json_str: str
+    ) -> tuple[dict, str | None]:
+        try:
+            return json.loads(json_str), None
+        except JSONDecodeError as exc:
+            decoder = json.JSONDecoder()
+            try:
+                json_obj, end = decoder.raw_decode(json_str)
+            except JSONDecodeError:
+                raise exc
+
+            trailing = json_str[end:].strip()
+            if not trailing or not isinstance(json_obj, dict):
+                raise exc
+
+            logger.warning(
+                'Recovered malformed conversation metadata with trailing characters',
+                extra={
+                    'path': path,
+                    'trailing_length': len(trailing),
+                },
+            )
+            normalized_json_str = json.dumps(json_obj, separators=(',', ':'))
+            return json_obj, normalized_json_str
 
 
 def _sort_key(conversation: ConversationMetadata) -> str:

--- a/tests/unit/storage/conversation/test_file_conversation_store.py
+++ b/tests/unit/storage/conversation/test_file_conversation_store.py
@@ -44,6 +44,48 @@ async def test_load_int_user_id():
 
 
 @pytest.mark.asyncio
+async def test_load_recovers_metadata_with_duplicated_trailing_characters():
+    valid_metadata = {
+        'conversation_id': 'some-conversation-id',
+        'selected_repository': 'some-repo',
+        'user_id': None,
+        'selected_branch': 'main',
+        'git_provider': 'github',
+        'title': 'A conversation',
+        'last_updated_at': '2026-03-23T02:59:22.445043Z',
+        'trigger': 'gui',
+        'pr_number': [],
+        'created_at': '2026-03-06T06:22:32.162408Z',
+        'llm_model': None,
+        'accumulated_cost': 0.0,
+        'prompt_tokens': 0,
+        'completion_tokens': 0,
+        'total_tokens': 0,
+        'sandbox_id': None,
+        'conversation_version': None,
+        'public': None,
+    }
+    valid_json = json.dumps(valid_metadata, separators=(',', ':'))
+    corrupted_json = valid_json + 'rsion":null,"public":null}'
+    file_store = InMemoryFileStore(
+        {
+            get_conversation_metadata_filename('some-conversation-id'): corrupted_json,
+        }
+    )
+    store = FileConversationStore(file_store)
+
+    found = await store.get_metadata('some-conversation-id')
+
+    assert found.conversation_id == 'some-conversation-id'
+    assert found.selected_branch == 'main'
+    assert found.title == 'A conversation'
+    assert (
+        file_store.read(get_conversation_metadata_filename('some-conversation-id'))
+        == valid_json
+    )
+
+
+@pytest.mark.asyncio
 async def test_search_empty():
     store = FileConversationStore(InMemoryFileStore({}))
     result = await store.search()


### PR DESCRIPTION
## Summary
Fixes malformed trailing characters in V0 `metadata.json` files and automatically rewrites the cleaned metadata once detected.

## Root Cause
V0 conversation loading treated `metadata.json` as all-or-nothing JSON. When a file ended up with duplicated trailing bytes (the exact `Extra data` failure reported in #13541), `get_metadata()` raised `JSONDecodeError` and the conversation became unreadable.

## Changes
- recover the first complete JSON object when `metadata.json` contains duplicated trailing characters
- rewrite the normalized metadata back to storage after successful recovery so the file heals itself
- add a regression test covering the duplicated-tail corruption pattern from the bug report

## Verification
- `uv run pytest -q tests/unit/storage/conversation/test_file_conversation_store.py`

Closes #13541
