### PR TITLE
fix: recover corrupted V0 metadata.json files

### DIFF
--- a/openhands/storage/conversation/file_conversation_store.py
+++ b/openhands/storage/conversation/file_conversation_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from json import JSONDecodeError
 from pathlib import Path
 
 from pydantic import TypeAdapter
@@ -38,8 +39,16 @@ class FileConversationStore(ConversationStore):
         path = self.get_conversation_metadata_filename(conversation_id)
         json_str = await call_sync_from_async(self.file_store.read, path)
 
-        # Validate the JSON
-        json_obj = json.loads(json_str)
+        # Validate the JSON, while tolerating a known corruption mode where
+        # duplicated trailing characters are appended after an otherwise-valid
+        # JSON object.
+        json_obj, repaired_json = self._load_metadata_json(json_str)
+        if repaired_json is not None:
+            logger.warning(
+                'Recovered conversation metadata with trailing characters',
+                extra={'conversation_id': conversation_id},
+            )
+            await call_sync_from_async(self.file_store.write, path, repaired_json)
         if 'created_at' not in json_obj:
             raise FileNotFoundError(path)
 
@@ -49,6 +58,22 @@ class FileConversationStore(ConversationStore):
 
         result = conversation_metadata_type_adapter.validate_python(json_obj)
         return result
+
+    def _load_metadata_json(self, json_str: str) -> tuple[dict, bytes | None]:
+        try:
+            return json.loads(json_str), None
+        except JSONDecodeError:
+            decoder = json.JSONDecoder()
+            json_obj, end = decoder.raw_decode(json_str)
+            trailing = json_str[end:]
+            if not trailing or trailing.isspace():
+                return json_obj, None
+
+            canonical_json = json.dumps(json_obj, separators=(',', ':'))
+            if not canonical_json.endswith(trailing):
+                raise
+
+            return json_obj, canonical_json.encode('utf-8')
 
     async def delete_metadata(self, conversation_id: str) -> None:
         path = str(

--- a/tests/unit/storage/conversation/test_file_conversation_store.py
+++ b/tests/unit/storage/conversation/test_file_conversation_store.py
@@ -44,6 +44,27 @@ async def test_load_int_user_id():
 
 
 @pytest.mark.asyncio
+async def test_load_metadata_with_duplicated_trailing_characters_repairs_file():
+    metadata = {
+        'conversation_id': 'some-conversation-id',
+        'user_id': '67890',
+        'selected_repository': 'some-repo',
+        'title': "Let's talk about trains",
+        'created_at': '2025-01-16T19:51:04.886331Z',
+    }
+    valid_json = json.dumps(metadata)
+    corrupted_json = valid_json + valid_json[-24:]
+    file_path = get_conversation_metadata_filename('some-conversation-id')
+    file_store = InMemoryFileStore({file_path: corrupted_json})
+    store = FileConversationStore(file_store)
+
+    found = await store.get_metadata('some-conversation-id')
+
+    assert found.user_id == '67890'
+    assert json.loads(file_store.read(file_path)) == metadata
+
+
+@pytest.mark.asyncio
 async def test_search_empty():
     store = FileConversationStore(InMemoryFileStore({}))
     result = await store.search()


### PR DESCRIPTION
## Summary\n- recover V0 conversation metadata when duplicated trailing characters are appended after a valid JSON object\n- rewrite the repaired metadata back to the file store so future reads stay clean\n- add a regression test covering the duplicated-suffix corruption pattern from #13541\n\n## Testing\n- uv run --group test pytest -q tests/unit/storage/conversation/test_file_conversation_store.py\n\nFixes #13541