### PR TITLE
feat: proxy VS Code and agent-server traffic through OpenHands server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,3 +441,97 @@ Called by `workspace.get_llm()` in the SDK to retrieve LLM config with the API k
 - `openhands/sdk/llm/llm.py`: `LLM.api_key` accepts `SecretSource` (including `LookupSecret`)
 - `openhands/workspace/cloud/workspace.py`: `get_llm()` and `get_secrets()` return LookupSecret-backed objects
 - Tests: `tests/sdk/llm/test_llm_secret_source_api_key.py`, `tests/workspace/test_cloud_workspace_sdk_settings.py`
+
+### VS Code Proxy (fork-specific, `OH_SANDBOX_PROXY_VSCODE=true`)
+
+This fork adds an opt-in HTTP + WebSocket proxy that routes VS Code traffic
+through port 3000 instead of a random container port, making the iframe
+same-origin with the OpenHands UI.
+
+**Why**: Service Workers (required by VS Code image preview) need a secure
+context. Same-origin + HTTPS via Caddy in front satisfies this.
+
+**How to enable**: set env var `SANDBOX_PROXY_VSCODE=true` (maps to
+`DockerSandboxServiceInjector.proxy_vscode` via `config_from_env()` in
+`openhands/app_server/config.py`).
+
+**Key files**:
+- `openhands/app_server/vscode_proxy/vscode_proxy_router.py` — FastAPI
+  router with `/vscode/{short_sandbox_id}/{path:path}` for both HTTP and
+  WebSocket.
+- `openhands/app_server/_proxy_core.py` — shared HTTP (httpx, streaming) and
+  WebSocket (aiohttp, bidirectional relay) mechanics used by both routers.
+- `openhands/app_server/sandbox/docker_sandbox_service.py` — injects
+  `OH_VSCODE_BASE_PATH=/vscode/{sandbox_id}` into the container;
+  stores `internal_url` in `ExposedUrl`; overrides `get_vscode_internal_url`.
+- `openhands/app_server/sandbox/sandbox_models.py` — `ExposedUrl.internal_url`
+  field (host-local URL for the proxy; None when proxy disabled).
+- `openhands/app_server/sandbox/sandbox_service.py` — `get_vscode_internal_url`
+  ABC method (default returns None).
+- `frontend/src/routes/vscode-tab.tsx` — resolves relative VS Code URLs
+  against `window.location.href` before the protocol comparison.
+
+**Upstream note**: PR #13516 ("WebSocket Gateway") by @kripper addresses the
+same agent-server connectivity problem using a WS-only opt-in gateway at
+`/ws/events/{conversation_id}`.  Our implementation is broader (HTTP + WS,
+VS Code) and always proxied when the env vars are set.  The two approaches
+are non-conflicting (different paths).
+
+### Agent-Server Proxy (fork-specific)
+
+A companion proxy that routes all agent-server connections (socket.io events,
+REST API, raw WebSocket) through port 3000, enabling full operation behind a
+reverse proxy such as Caddy.
+
+**Why**: By default the frontend connects to the agent-server on a dynamic host
+port.  When Caddy (or any reverse proxy) sits in front, that port is unreachable.
+Routing via `/agent/{sandbox_id}/` keeps everything on one port.
+
+**How to enable**: set both:
+- `SANDBOX_PROXY_AGENT=true`
+- `WEB_HOST=<external hostname>` (e.g. `WEB_HOST=openhands-host` → `web_url =
+  "https://openhands-host"`)
+
+Without `WEB_HOST` the proxy route is registered but the feature has no effect
+(no external URL to embed in `agent_server_url`) — degrades to direct-port.
+
+**URL construction**: when both flags are set, `ExposedUrl.url` for the
+`agent server` port becomes `{web_url}/agent/{short_sandbox_id}`.  The
+`ExposedUrl.internal_url` always holds the direct `http://localhost:PORT` URL.
+
+**Backend / frontend split**:
+- All backend API calls use `internal_url` (direct container URL) to avoid
+  routing through the proxy (infinite loop).
+- `task.agent_server_url` (returned to frontend) uses `url` (the proxied URL).
+- The frontend's `extractPathPrefix` / `extractBaseHost` utilities parse the
+  proxied URL to derive `{web_url}` as host and `/agent/{id}` as path prefix,
+  so socket.io and raw WebSocket connections both go through Caddy.
+
+**Path stripping**: unlike VS Code (which is launched with `OH_VSCODE_BASE_PATH`
+so it understands the `/vscode/{id}` prefix), the agent server serves at its root.
+The proxy strips the `/agent/{short_sandbox_id}` prefix from every forwarded
+request so the agent server receives `/sockets/events/…` not `/agent/{id}/sockets/events/…`.
+
+**Origin header**: do NOT forward `Origin` to the agent server. When `WEB_HOST`
+is set, the agent container's `allow_cors_origins = ['https://{WEB_HOST}']`.
+`LocalhostCORSMiddleware`'s localhost shortcut only fires when `allow_origins`
+is empty; with it non-empty the check falls to standard CORSMiddleware which
+rejects `Origin: http://localhost:{port}`. Starlette CORS passes through when
+Origin is absent entirely. `'origin'` is in `_WS_SKIP` in the agent proxy.
+
+**Key files**:
+- `openhands/app_server/agent_proxy/agent_proxy_router.py` — HTTP + WebSocket
+  proxy with three route shapes (`/{path:path}`, `/`, no trailing slash).
+  Strips `/agent/{id}` prefix; drops Origin header.  Delegates to `_proxy_core.py`.
+- `openhands/app_server/sandbox/sandbox_service.py` —
+  `get_agent_server_internal_url()` hook; `_get_agent_server_url` updated to
+  prefer `internal_url`.
+- `openhands/app_server/sandbox/docker_sandbox_service.py` — `proxy_agent` bool
+  field; URL construction; `get_agent_server_internal_url` implementation;
+  health-check uses `internal_url`.
+- `openhands/app_server/app_conversation/live_status_app_conversation_service.py`
+  — `_get_agent_server_frontend_url()` new method; `task.agent_server_url` uses it.
+- `openhands/app_server/app_conversation/app_conversation_router.py` — updated
+  to prefer `internal_url` in both agent URL extraction sites.
+- `tests/unit/test_agent_proxy.py` — 11 tests covering failure modes A–K.
+

--- a/frontend/src/api/event-service/event-service.api.ts
+++ b/frontend/src/api/event-service/event-service.api.ts
@@ -7,6 +7,7 @@ import type {
 } from "./event-service.types";
 import { openHands } from "../open-hands-axios";
 import { OpenHandsEvent } from "#/types/v1/core";
+import type { V1SendMessageRequest } from "#/api/conversation-service/v1-conversation-service.types";
 
 class EventService {
   /**
@@ -62,6 +63,30 @@ class EventService {
       { headers },
     );
     return data;
+  }
+
+  /**
+   * Post a message event directly to the agent server.
+   * Used when the WebSocket is closed but the conversation is already running.
+   *
+   * @param conversationId The agent server conversation ID
+   * @param conversationUrl The conversation URL containing the agent server base
+   * @param message The message to send
+   * @param sessionApiKey Session API key for authentication
+   */
+  static async postEvent(
+    conversationId: string,
+    conversationUrl: string,
+    message: V1SendMessageRequest,
+    sessionApiKey?: string | null,
+  ): Promise<void> {
+    const runtimeUrl = buildHttpBaseUrl(conversationUrl);
+    const headers = buildSessionHeaders(sessionApiKey);
+    await axios.post(
+      `${runtimeUrl}/api/conversations/${conversationId}/events`,
+      { role: message.role, content: message.content, run: true },
+      { headers },
+    );
   }
 
   // V1 conversations — App Server REST endpoint

--- a/frontend/src/contexts/conversation-websocket-context.tsx
+++ b/frontend/src/contexts/conversation-websocket-context.tsx
@@ -829,53 +829,85 @@ export function ConversationWebSocketProvider({
     planningWebsocketOptions,
   );
 
-  // V1 send message function via WebSocket
-  // Falls back to REST API queue when WebSocket is not connected
+  // V1 send message — prefers HTTP POST to the agent server when the
+  // conversation is running, falls back to WebSocket or the pending-message
+  // queue for pre-start scenarios.
   const sendMessage = useCallback(
     async (message: V1SendMessageRequest): Promise<SendMessageResult> => {
+      if (!conversationId) {
+        const error = new Error("No conversation ID available");
+        setErrorMessage(error.message);
+        throw error;
+      }
+
       const currentMode = useConversationStore.getState().conversationMode;
-      const currentSocket =
-        currentMode === "plan" ? planningAgentSocket : mainSocket;
 
-      if (!currentSocket || currentSocket.readyState !== WebSocket.OPEN) {
-        // WebSocket not connected - queue message via REST API
-        // Message will be delivered automatically when conversation becomes ready
-        if (!conversationId) {
-          const error = new Error("No conversation ID available");
-          setErrorMessage(error.message);
-          throw error;
-        }
-
+      // For the main (code) conversation, always use HTTP POST to the agent
+      // server when the conversation is running (conversationUrl is set).
+      //
+      // The agent server closes the sockets/events WebSocket for fresh
+      // conversations (0 events to replay), which causes a rapid reconnect
+      // loop.  A message sent through the socket at the wrong moment is
+      // silently dropped because the agent server has already torn down the
+      // connection on its side.  HTTP POST to the events endpoint is
+      // stateless and therefore always reliable; the WebSocket is only
+      // needed to *receive* events back from the agent.
+      if (currentMode !== "plan" && conversationUrl && sessionApiKey) {
         try {
-          await PendingMessageService.queueMessage(conversationId, {
-            role: "user",
-            content: message.content,
-          });
-          // Message queued successfully - it will be delivered when ready
-          // Return queued: true so caller knows not to show optimistic UI
-          return { queued: true };
+          await EventService.postEvent(
+            conversationId,
+            conversationUrl,
+            message,
+            sessionApiKey,
+          );
+          return { queued: false };
         } catch (error) {
           const errorMessage =
-            error instanceof Error
-              ? error.message
-              : "Failed to queue message for delivery";
+            error instanceof Error ? error.message : "Failed to send message";
           setErrorMessage(errorMessage);
           throw error;
         }
       }
 
+      // Planning-agent path and pre-start fallback: try WebSocket first.
+      const currentSocket =
+        currentMode === "plan" ? planningAgentSocket : mainSocket;
+      if (currentSocket?.readyState === WebSocket.OPEN) {
+        try {
+          currentSocket.send(JSON.stringify(message));
+          return { queued: false };
+        } catch (error) {
+          const errorMessage =
+            error instanceof Error ? error.message : "Failed to send message";
+          setErrorMessage(errorMessage);
+          throw error;
+        }
+      }
+
+      // Conversation not yet started — queue for delivery when it becomes ready.
       try {
-        // Send message through WebSocket as JSON
-        currentSocket.send(JSON.stringify(message));
-        return { queued: false };
+        await PendingMessageService.queueMessage(conversationId, {
+          role: "user",
+          content: message.content,
+        });
+        return { queued: true };
       } catch (error) {
         const errorMessage =
-          error instanceof Error ? error.message : "Failed to send message";
+          error instanceof Error
+            ? error.message
+            : "Failed to queue message for delivery";
         setErrorMessage(errorMessage);
         throw error;
       }
     },
-    [mainSocket, planningAgentSocket, setErrorMessage, conversationId],
+    [
+      mainSocket,
+      planningAgentSocket,
+      setErrorMessage,
+      conversationId,
+      conversationUrl,
+      sessionApiKey,
+    ],
   );
 
   // Track main socket state changes

--- a/frontend/src/routes/vscode-tab.tsx
+++ b/frontend/src/routes/vscode-tab.tsx
@@ -19,7 +19,10 @@ function VSCodeTab() {
   useEffect(() => {
     if (data?.url) {
       try {
-        const iframeProtocol = new URL(data.url).protocol;
+        // Resolve relative URLs (e.g. /vscode/{sandbox_id}/) against the
+        // current page origin so that the protocol comparison always works.
+        const absoluteUrl = new URL(data.url, window.location.href);
+        const iframeProtocol = absoluteUrl.protocol;
         const currentProtocol = window.location.protocol;
 
         // Check if the iframe URL has a different protocol than the current page

--- a/openhands/app_server/_proxy_core.py
+++ b/openhands/app_server/_proxy_core.py
@@ -1,0 +1,213 @@
+"""Shared HTTP and WebSocket proxy mechanics.
+
+Both the VS Code proxy (vscode_proxy_router) and agent-server proxy
+(agent_proxy_router) use the same underlying transport logic.  This module
+provides that logic once to avoid duplication.
+
+Each router is responsible for:
+  - looking up the correct internal URL for the target service,
+  - building the final target URL (VS Code keeps the full path; the agent
+    proxy strips its own prefix),
+  - assembling the forwarding headers (VS Code adds an Origin header; the
+    agent proxy drops it).
+
+Then each router delegates here for the actual HTTP / WebSocket proxying.
+"""
+
+import asyncio
+import logging
+
+import aiohttp
+import httpx
+from fastapi import WebSocket, WebSocketDisconnect, status
+from fastapi.background import BackgroundTasks
+from fastapi.responses import Response, StreamingResponse
+
+_logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+
+# Hop-by-hop headers that must not be forwarded in either direction.
+HTTP_HOP_BY_HOP: frozenset[str] = frozenset(
+    [
+        'connection',
+        'keep-alive',
+        'proxy-authenticate',
+        'proxy-authorization',
+        'proxy-connection',
+        'te',
+        'trailers',
+        'transfer-encoding',
+        'upgrade',
+    ]
+)
+
+# Request headers the proxy itself controls; strip from the incoming request.
+HTTP_REQUEST_SKIP: frozenset[str] = HTTP_HOP_BY_HOP | frozenset(['host'])
+
+
+# ---------------------------------------------------------------------------
+# HTTP proxy
+# ---------------------------------------------------------------------------
+
+
+async def do_http_proxy(
+    method: str,
+    target_url: str,
+    req_headers: dict[str, str],
+    body_stream,
+    label: str = 'upstream',
+) -> Response:
+    """Forward an HTTP request to *target_url* and stream the response back.
+
+    Args:
+        method: HTTP method (GET, POST, …).
+        target_url: Fully-qualified URL including path and query string.
+        req_headers: Pre-filtered headers to forward (caller's responsibility).
+        body_stream: Async byte-stream for the request body (``request.stream()``).
+        label: Short identifier used in log/error messages (e.g. ``"vscode:abc123"``).
+    """
+    client = httpx.AsyncClient(follow_redirects=False, timeout=60.0)
+    try:
+        upstream_req = client.build_request(
+            method,
+            target_url,
+            headers=req_headers,
+            content=body_stream,
+        )
+        upstream = await client.send(upstream_req, stream=True)
+    except (httpx.ConnectError, httpx.TimeoutException) as exc:
+        await client.aclose()
+        _logger.warning('HTTP proxy connect error (%s): %s', label, exc)
+        return Response(
+            content=f'Could not connect to {label}',
+            status_code=status.HTTP_502_BAD_GATEWAY,
+        )
+
+    resp_headers = {
+        k: v
+        for k, v in upstream.headers.multi_items()
+        if k.lower() not in HTTP_HOP_BY_HOP
+    }
+
+    async def _cleanup() -> None:
+        await upstream.aclose()
+        await client.aclose()
+
+    background = BackgroundTasks()
+    background.add_task(_cleanup)
+
+    return StreamingResponse(
+        upstream.aiter_bytes(),
+        status_code=upstream.status_code,
+        headers=resp_headers,
+        background=background,
+    )
+
+
+# ---------------------------------------------------------------------------
+# WebSocket proxy
+# ---------------------------------------------------------------------------
+
+
+async def _relay_up(
+    browser_ws: WebSocket,
+    upstream_ws: aiohttp.ClientWebSocketResponse,
+    label: str,
+) -> None:
+    """Forward frames browser → upstream until the browser disconnects."""
+    try:
+        while True:
+            msg = await browser_ws.receive()
+            if msg['type'] == 'websocket.disconnect':
+                break
+            if (text := msg.get('text')) is not None:
+                await upstream_ws.send_str(text)
+            elif (data := msg.get('bytes')) is not None:
+                await upstream_ws.send_bytes(data)
+    except WebSocketDisconnect:
+        pass
+    except Exception as exc:
+        _logger.debug('WS proxy browser→%s relay error: %s', label, exc)
+
+
+async def _relay_down(
+    browser_ws: WebSocket,
+    upstream_ws: aiohttp.ClientWebSocketResponse,
+    label: str,
+) -> None:
+    """Forward frames upstream → browser until the upstream closes."""
+    try:
+        async for msg in upstream_ws:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                await browser_ws.send_text(msg.data)
+            elif msg.type == aiohttp.WSMsgType.BINARY:
+                await browser_ws.send_bytes(msg.data)
+            elif msg.type in (
+                aiohttp.WSMsgType.CLOSE,
+                aiohttp.WSMsgType.CLOSING,
+                aiohttp.WSMsgType.ERROR,
+            ):
+                break
+    except Exception as exc:
+        _logger.debug('WS proxy %s→browser relay error: %s', label, exc)
+
+
+async def do_ws_proxy(
+    websocket: WebSocket,
+    target_ws_url: str,
+    forward_headers: dict[str, str],
+    label: str = 'upstream',
+) -> None:
+    """Proxy a WebSocket connection bidirectionally to *target_ws_url*.
+
+    Accepts the browser WebSocket, connects to the upstream, and relays
+    frames in both directions until either side closes.
+
+    Args:
+        websocket: Incoming browser WebSocket (not yet accepted).
+        target_ws_url: Fully-qualified ``ws://`` or ``wss://`` URL.
+        forward_headers: Pre-filtered headers to send on the upstream handshake.
+        label: Short identifier for log messages.
+    """
+    _logger.debug('WS proxy: %s → %s', websocket.url, target_ws_url)
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.ws_connect(
+                target_ws_url,
+                headers=forward_headers,
+                heartbeat=30,
+                timeout=aiohttp.ClientTimeout(total=None, connect=10),
+            ) as upstream_ws:
+                await websocket.accept(subprotocol=upstream_ws.protocol)
+
+                t_up = asyncio.create_task(_relay_up(websocket, upstream_ws, label))
+                t_down = asyncio.create_task(
+                    _relay_down(websocket, upstream_ws, label)
+                )
+
+                _done, pending = await asyncio.wait(
+                    [t_up, t_down], return_when=asyncio.FIRST_COMPLETED
+                )
+                for task in pending:
+                    task.cancel()
+                    try:
+                        await task
+                    except (asyncio.CancelledError, Exception):
+                        pass
+
+    except (aiohttp.ClientConnectorError, aiohttp.WSServerHandshakeError) as exc:
+        _logger.warning('WS proxy connect error (%s): %s', label, exc)
+        try:
+            await websocket.close(code=status.WS_1011_INTERNAL_ERROR)
+        except Exception:
+            pass
+    except Exception as exc:
+        _logger.warning('WS proxy unexpected error (%s): %s', label, exc)
+        try:
+            await websocket.close(code=status.WS_1011_INTERNAL_ERROR)
+        except Exception:
+            pass

--- a/openhands/app_server/_proxy_core.py
+++ b/openhands/app_server/_proxy_core.py
@@ -130,29 +130,42 @@ async def _relay_up(
     except WebSocketDisconnect:
         pass
     except Exception as exc:
-        _logger.debug('WS proxy browser→%s relay error: %s', label, exc)
+        _logger.warning('WS proxy browser→%s relay error: %s', label, exc)
 
 
 async def _relay_down(
     browser_ws: WebSocket,
     upstream_ws: aiohttp.ClientWebSocketResponse,
     label: str,
-) -> None:
-    """Forward frames upstream → browser until the upstream closes."""
+) -> int:
+    """Forward frames upstream → browser until the upstream closes.
+
+    Returns the WS close code sent by the upstream (1000 if not available).
+    """
+    close_code = 1000
     try:
         async for msg in upstream_ws:
             if msg.type == aiohttp.WSMsgType.TEXT:
                 await browser_ws.send_text(msg.data)
             elif msg.type == aiohttp.WSMsgType.BINARY:
                 await browser_ws.send_bytes(msg.data)
-            elif msg.type in (
-                aiohttp.WSMsgType.CLOSE,
-                aiohttp.WSMsgType.CLOSING,
-                aiohttp.WSMsgType.ERROR,
-            ):
+            elif msg.type == aiohttp.WSMsgType.CLOSE:
+                close_code = int(msg.data) if msg.data else 1000
+                _logger.info(
+                    'WS upstream sent CLOSE (%s): code=%s reason=%r',
+                    label,
+                    close_code,
+                    msg.extra,
+                )
+                break
+            elif msg.type in (aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.ERROR):
+                _logger.info(
+                    'WS upstream sent %s (%s)', msg.type.name, label
+                )
                 break
     except Exception as exc:
-        _logger.debug('WS proxy %s→browser relay error: %s', label, exc)
+        _logger.warning('WS proxy %s→browser relay error: %s', label, exc)
+    return close_code
 
 
 async def do_ws_proxy(
@@ -164,7 +177,10 @@ async def do_ws_proxy(
     """Proxy a WebSocket connection bidirectionally to *target_ws_url*.
 
     Accepts the browser WebSocket, connects to the upstream, and relays
-    frames in both directions until either side closes.
+    frames in both directions until either side closes.  Sends an explicit
+    WS close frame to the browser so it receives code 1000 (normal closure)
+    rather than an abrupt 1006 drop, which would be treated as an error by
+    the frontend and trigger an unnecessary reconnect error message.
 
     Args:
         websocket: Incoming browser WebSocket (not yet accepted).
@@ -189,7 +205,7 @@ async def do_ws_proxy(
                     _relay_down(websocket, upstream_ws, label)
                 )
 
-                _done, pending = await asyncio.wait(
+                done, pending = await asyncio.wait(
                     [t_up, t_down], return_when=asyncio.FIRST_COMPLETED
                 )
                 for task in pending:
@@ -198,6 +214,26 @@ async def do_ws_proxy(
                         await task
                     except (asyncio.CancelledError, Exception):
                         pass
+
+                # Determine which side closed first and get the upstream close code.
+                done_task = next(iter(done))
+                if done_task is t_down:
+                    _logger.info('WS proxy upstream closed first (%s)', label)
+                    try:
+                        close_code = done_task.result()
+                    except Exception:
+                        close_code = 1000
+                else:
+                    _logger.info('WS proxy browser closed first (%s)', label)
+                    close_code = 1000
+
+        # Explicitly close the browser WS with the upstream's code so the browser
+        # receives a proper close frame (code 1000 = normal) rather than an abrupt
+        # TCP drop (code 1006), which would trigger the frontend's onError handler.
+        try:
+            await websocket.close(code=close_code)
+        except Exception:
+            pass
 
     except (aiohttp.ClientConnectorError, aiohttp.WSServerHandshakeError) as exc:
         _logger.warning('WS proxy connect error (%s): %s', label, exc)

--- a/openhands/app_server/agent_proxy/__init__.py
+++ b/openhands/app_server/agent_proxy/__init__.py
@@ -1,0 +1,3 @@
+from openhands.app_server.agent_proxy.agent_proxy_router import router
+
+__all__ = ['router']

--- a/openhands/app_server/agent_proxy/agent_proxy_router.py
+++ b/openhands/app_server/agent_proxy/agent_proxy_router.py
@@ -1,0 +1,195 @@
+"""HTTP and WebSocket reverse-proxy for agent-server containers.
+
+Routes ``/agent/{short_sandbox_id}/…`` to the agent-server container running
+on the host, selected by sandbox ID.
+
+By default the frontend connects to the agent-server's dynamic host port
+directly.  When a reverse proxy (Caddy, nginx, …) sits in front of OpenHands
+that port is not reachable from the browser.  Routing agent-server traffic
+through the OpenHands server keeps everything on one port.
+
+Enabled only when ``proxy_agent=True`` in DockerSandboxServiceInjector
+(env var: ``SANDBOX_PROXY_AGENT=true``) **and** ``WEB_HOST`` is configured
+so the server knows the external URL to embed in ``agent_server_url``.
+
+When the sandbox service reports no internal URL for a given sandbox the
+routes return 503 / WS close-1013 so the frontend can surface an error.
+"""
+
+import logging
+
+from fastapi import APIRouter, Request, WebSocket, status
+from fastapi.responses import Response
+
+from openhands.app_server._proxy_core import (
+    HTTP_REQUEST_SKIP,
+    do_http_proxy,
+    do_ws_proxy,
+)
+from openhands.app_server.config import get_sandbox_service
+
+_logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# WebSocket handshake headers managed by the transport layer.
+# Origin is also excluded: when WEB_HOST is configured the agent container's
+# allow_cors_origins list is non-empty.  The LocalhostCORSMiddleware shortcut
+# only fires when allow_origins is empty, so it falls through to the standard
+# CORS check.  Our server-side connection has no meaningful browser origin and
+# the agent server doesn't need Origin validation for an inbound proxy hop —
+# omitting it causes Starlette CORS to pass the request through.
+_WS_SKIP = frozenset(
+    [
+        'connection',
+        'host',
+        'origin',
+        'sec-websocket-extensions',
+        'sec-websocket-key',
+        'sec-websocket-version',
+        'upgrade',
+    ]
+)
+
+_HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS', 'HEAD']
+
+
+# ---------------------------------------------------------------------------
+# HTTP proxy
+# ---------------------------------------------------------------------------
+
+
+async def _do_proxy_http(request: Request, short_sandbox_id: str) -> Response:
+    async with get_sandbox_service(request.state) as sandbox_service:
+        internal_url = await sandbox_service.get_agent_server_internal_url(
+            short_sandbox_id
+        )
+
+    if internal_url is None:
+        return Response(
+            content='Agent server proxy not available for this sandbox',
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    # Strip the /agent/{id} prefix — the agent server serves at its root and
+    # has no knowledge of the proxy prefix (unlike VS Code which is configured
+    # with OH_VSCODE_BASE_PATH).
+    prefix = f'/agent/{short_sandbox_id}'
+    forwarded_path = request.url.path[len(prefix):] or '/'
+    target = f'{internal_url}{forwarded_path}'
+    if qs := str(request.url.query):
+        target = f'{target}?{qs}'
+
+    req_headers = {
+        k: v
+        for k, v in request.headers.items()
+        if k.lower() not in HTTP_REQUEST_SKIP
+    }
+    req_headers['host'] = internal_url.split('://', 1)[-1]
+
+    return await do_http_proxy(
+        request.method,
+        target,
+        req_headers,
+        request.stream(),
+        label=f'agent:{short_sandbox_id}',
+    )
+
+
+# Three routes are needed because FastAPI's {path:path} converter uses .+
+# (one-or-more), which refuses to match an empty string, and Starlette treats
+# trailing-slash and no-trailing-slash as distinct paths.
+
+@router.api_route(
+    '/agent/{short_sandbox_id}/{path:path}',
+    methods=_HTTP_METHODS,
+    include_in_schema=False,
+)
+async def proxy_agent_http(
+    request: Request, short_sandbox_id: str, path: str
+) -> Response:
+    """Proxy an HTTP request to the agent server (non-empty sub-path)."""
+    return await _do_proxy_http(request, short_sandbox_id)
+
+
+@router.api_route(
+    '/agent/{short_sandbox_id}/',
+    methods=_HTTP_METHODS,
+    include_in_schema=False,
+)
+async def proxy_agent_http_slash(
+    request: Request, short_sandbox_id: str
+) -> Response:
+    """Proxy an HTTP request to the agent server root (trailing slash)."""
+    return await _do_proxy_http(request, short_sandbox_id)
+
+
+@router.api_route(
+    '/agent/{short_sandbox_id}',
+    methods=_HTTP_METHODS,
+    include_in_schema=False,
+)
+async def proxy_agent_http_no_slash(
+    request: Request, short_sandbox_id: str
+) -> Response:
+    """Proxy an HTTP request to the agent server root (no trailing slash)."""
+    return await _do_proxy_http(request, short_sandbox_id)
+
+
+# ---------------------------------------------------------------------------
+# WebSocket proxy
+# ---------------------------------------------------------------------------
+
+
+async def _do_proxy_ws(websocket: WebSocket, short_sandbox_id: str) -> None:
+    async with get_sandbox_service(websocket.state) as sandbox_service:
+        internal_url = await sandbox_service.get_agent_server_internal_url(
+            short_sandbox_id
+        )
+
+    if internal_url is None:
+        await websocket.close(code=status.WS_1013_TRY_AGAIN_LATER)
+        return
+
+    ws_scheme = 'wss' if internal_url.startswith('https') else 'ws'
+    host_part = internal_url.split('://', 1)[-1]
+
+    prefix = f'/agent/{short_sandbox_id}'
+    forwarded_path = websocket.url.path[len(prefix):] or '/'
+    target_ws = f'{ws_scheme}://{host_part}{forwarded_path}'
+    if qs := str(websocket.url.query):
+        target_ws = f'{target_ws}?{qs}'
+
+    forward_headers = {
+        k: v
+        for k, v in websocket.headers.items()
+        if k.lower() not in _WS_SKIP
+    }
+
+    await do_ws_proxy(
+        websocket, target_ws, forward_headers, label=f'agent:{short_sandbox_id}'
+    )
+
+
+@router.websocket('/agent/{short_sandbox_id}/{path:path}')
+async def proxy_agent_ws(
+    websocket: WebSocket, short_sandbox_id: str, path: str
+) -> None:
+    """Proxy a WebSocket connection to the agent server (non-empty sub-path)."""
+    await _do_proxy_ws(websocket, short_sandbox_id)
+
+
+@router.websocket('/agent/{short_sandbox_id}/')
+async def proxy_agent_ws_slash(
+    websocket: WebSocket, short_sandbox_id: str
+) -> None:
+    """Proxy a WebSocket connection to the agent server root (trailing slash)."""
+    await _do_proxy_ws(websocket, short_sandbox_id)
+
+
+@router.websocket('/agent/{short_sandbox_id}')
+async def proxy_agent_ws_no_slash(
+    websocket: WebSocket, short_sandbox_id: str
+) -> None:
+    """Proxy a WebSocket connection to the agent server root (no trailing slash)."""
+    await _do_proxy_ws(websocket, short_sandbox_id)

--- a/openhands/app_server/agent_proxy/agent_proxy_router.py
+++ b/openhands/app_server/agent_proxy/agent_proxy_router.py
@@ -27,6 +27,7 @@ from openhands.app_server._proxy_core import (
     do_ws_proxy,
 )
 from openhands.app_server.config import get_sandbox_service
+from openhands.app_server.utils.docker_utils import replace_localhost_hostname_for_docker
 
 _logger = logging.getLogger(__name__)
 
@@ -70,6 +71,10 @@ async def _do_proxy_http(request: Request, short_sandbox_id: str) -> Response:
             content='Agent server proxy not available for this sandbox',
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         )
+
+    # When running in Docker, localhost refers to the container itself.
+    # Replace with host.docker.internal to reach the host.
+    internal_url = replace_localhost_hostname_for_docker(internal_url)
 
     # Strip the /agent/{id} prefix — the agent server serves at its root and
     # has no knowledge of the proxy prefix (unlike VS Code which is configured
@@ -150,6 +155,10 @@ async def _do_proxy_ws(websocket: WebSocket, short_sandbox_id: str) -> None:
     if internal_url is None:
         await websocket.close(code=status.WS_1013_TRY_AGAIN_LATER)
         return
+
+    # When running in Docker, localhost refers to the container itself.
+    # Replace with host.docker.internal to reach the host.
+    internal_url = replace_localhost_hostname_for_docker(internal_url)
 
     ws_scheme = 'wss' if internal_url.startswith('https') else 'ws'
     host_part = internal_url.split('://', 1)[-1]

--- a/openhands/app_server/app_conversation/app_conversation_router.py
+++ b/openhands/app_server/app_conversation/app_conversation_router.py
@@ -176,7 +176,9 @@ async def _get_agent_server_context(
     agent_server_url = None
     for exposed_url in sandbox.exposed_urls:
         if exposed_url.name == AGENT_SERVER:
-            agent_server_url = exposed_url.url
+            # Prefer internal_url for direct container access when proxy_agent
+            # is enabled; fall back to url for non-proxied deployments.
+            agent_server_url = exposed_url.internal_url or exposed_url.url
             break
 
     if not agent_server_url:
@@ -525,7 +527,7 @@ async def read_conversation_file(
     agent_server_url = None
     for exposed_url in sandbox.exposed_urls:
         if exposed_url.name == AGENT_SERVER:
-            agent_server_url = exposed_url.url
+            agent_server_url = exposed_url.internal_url or exposed_url.url
             break
 
     if not agent_server_url:

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -142,12 +142,12 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
     max_num_conversations_per_sandbox: int
     httpx_client: httpx.AsyncClient
     web_url: str | None
+    openhands_provider_base_url: str | None
+    access_token_hard_timeout: timedelta | None
     # HTTP URL reachable from inside Docker containers (host.docker.internal).
     # Used for agent→host calls (MCP, secret lookup) to avoid TLS issues with
     # self-signed certificates on the external web_url.
     internal_web_url: str | None = None
-    openhands_provider_base_url: str | None
-    access_token_hard_timeout: timedelta | None
     app_mode: str | None = None
     tavily_api_key: str | None = None
 

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -311,7 +311,8 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
 
             # update status
             task.status = AppConversationStartTaskStatus.STARTING_CONVERSATION
-            task.agent_server_url = agent_server_url
+            # Use the frontend-facing URL (proxied when proxy_agent is enabled).
+            task.agent_server_url = self._get_agent_server_frontend_url(sandbox)
             yield task
 
             # Start conversation...
@@ -742,16 +743,31 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         )
 
     def _get_agent_server_url(self, sandbox: SandboxInfo) -> str:
-        """Get agent server url for running sandbox."""
+        """Get agent server URL for backend API calls.
+
+        When the agent proxy is enabled, ExposedUrl.url is the proxied URL
+        intended for the browser, while ExposedUrl.internal_url is the direct
+        container URL.  Backend calls must always use the direct URL; we prefer
+        internal_url and fall back to url so this method is safe whether or not
+        the proxy is active.
+        """
         exposed_urls = sandbox.exposed_urls
         assert exposed_urls is not None
-        agent_server_url = next(
-            exposed_url.url
-            for exposed_url in exposed_urls
-            if exposed_url.name == AGENT_SERVER
-        )
-        agent_server_url = replace_localhost_hostname_for_docker(agent_server_url)
-        return agent_server_url
+        exposed_url = next(eu for eu in exposed_urls if eu.name == AGENT_SERVER)
+        url = exposed_url.internal_url or exposed_url.url
+        return replace_localhost_hostname_for_docker(url)
+
+    def _get_agent_server_frontend_url(self, sandbox: SandboxInfo) -> str:
+        """Get agent server URL to return to the frontend.
+
+        When the agent proxy is enabled this is the proxied URL
+        (e.g. ``https://openhands-host/agent/<sandbox_id>``).  Otherwise it
+        is the same as _get_agent_server_url.
+        """
+        exposed_urls = sandbox.exposed_urls
+        assert exposed_urls is not None
+        exposed_url = next(eu for eu in exposed_urls if eu.name == AGENT_SERVER)
+        return replace_localhost_hostname_for_docker(exposed_url.url)
 
     def _inherit_configuration_from_parent(
         self, request: AppConversationStartRequest, parent_info: AppConversationInfo

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -142,6 +142,10 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
     max_num_conversations_per_sandbox: int
     httpx_client: httpx.AsyncClient
     web_url: str | None
+    # HTTP URL reachable from inside Docker containers (host.docker.internal).
+    # Used for agent→host calls (MCP, secret lookup) to avoid TLS issues with
+    # self-signed certificates on the external web_url.
+    internal_web_url: str | None = None
     openhands_provider_base_url: str | None
     access_token_hard_timeout: timedelta | None
     app_mode: str | None = None
@@ -875,7 +879,10 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             secret_name = f'{provider_type.name}_TOKEN'
             description = f'{provider_type.name} authentication token'
 
-            if self.web_url:
+            # Use the internal URL when available so the agent container avoids
+            # TLS issues with self-signed certs on the external web_url.
+            secrets_base = self.internal_web_url or self.web_url
+            if secrets_base:
                 # Create an access token for web-based authentication
                 access_token = self.jwt_service.create_jws_token(
                     payload={
@@ -887,7 +894,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 headers = {'X-Access-Token': access_token}
 
                 secrets[secret_name] = LookupSecret(
-                    url=self.web_url + '/api/v1/webhooks/secrets',
+                    url=secrets_base + '/api/v1/webhooks/secrets',
                     headers=headers,
                     description=description,
                 )
@@ -959,11 +966,14 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             user: User information for API keys
             conversation_id: Conversation ID forwarded to the OpenHands MCP server
         """
-        if not self.web_url:
+        # Prefer the internal (Docker-reachable) URL so the agent container
+        # avoids TLS issues with self-signed certificates on the external URL.
+        mcp_base = self.internal_web_url or self.web_url
+        if not mcp_base:
             return
 
         # Add default OpenHands MCP server
-        mcp_url = f'{self.web_url}/mcp/mcp'
+        mcp_url = f'{mcp_base}/mcp/mcp'
         mcp_servers['default'] = {
             'url': mcp_url,
             'headers': {'X-OpenHands-ServerConversation-ID': str(conversation_id)},
@@ -2040,6 +2050,16 @@ class LiveStatusAppConversationServiceInjector(AppConversationServiceInjector):
                 if isinstance(sandbox_service, DockerSandboxService):
                     web_url = f'http://host.docker.internal:{sandbox_service.host_port}'
 
+            # When running with Docker, always build an internal URL that agents
+            # inside containers use for callbacks (MCP, secret lookup).  This is
+            # plain HTTP, so TLS certificate problems with the external web_url
+            # (e.g., self-signed certs behind a reverse proxy) do not apply.
+            internal_web_url: str | None = None
+            if isinstance(sandbox_service, DockerSandboxService):
+                internal_web_url = (
+                    f'http://host.docker.internal:{sandbox_service.host_port}'
+                )
+
             # Get app_mode for SaaS mode
             app_mode = None
             try:
@@ -2076,6 +2096,7 @@ class LiveStatusAppConversationServiceInjector(AppConversationServiceInjector):
                 max_num_conversations_per_sandbox=self.max_num_conversations_per_sandbox,
                 httpx_client=httpx_client,
                 web_url=web_url,
+                internal_web_url=internal_web_url,
                 openhands_provider_base_url=config.openhands_provider_base_url,
                 access_token_hard_timeout=access_token_hard_timeout,
                 app_mode=app_mode,

--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -259,6 +259,14 @@ def config_from_env() -> AppServerConfig:
                 docker_sandbox_kwargs['startup_grace_seconds'] = int(
                     os.environ['SANDBOX_STARTUP_GRACE_SECONDS']
                 )
+            if os.getenv('SANDBOX_PROXY_VSCODE'):
+                docker_sandbox_kwargs['proxy_vscode'] = os.environ[
+                    'SANDBOX_PROXY_VSCODE'
+                ].lower() in ('1', 'true', 'yes', 'on')
+            if os.getenv('SANDBOX_PROXY_AGENT'):
+                docker_sandbox_kwargs['proxy_agent'] = os.environ[
+                    'SANDBOX_PROXY_AGENT'
+                ].lower() in ('1', 'true', 'yes', 'on')
             # Parse SANDBOX_VOLUMES and convert to VolumeMount objects
             # This is set by the CLI's --mount-cwd flag
             sandbox_volumes = os.getenv('SANDBOX_VOLUMES')

--- a/openhands/app_server/sandbox/docker_sandbox_service.py
+++ b/openhands/app_server/sandbox/docker_sandbox_service.py
@@ -102,6 +102,8 @@ class DockerSandboxService(SandboxService):
     startup_grace_seconds: int = STARTUP_GRACE_SECONDS
     use_host_network: bool = False
     kvm_enabled: bool = False
+    proxy_vscode: bool = False
+    proxy_agent: bool = False
 
     def _find_unused_port(self) -> int:
         """Find an unused port on the host machine."""
@@ -165,21 +167,37 @@ class DockerSandboxService(SandboxService):
             network_mode = container.attrs.get('HostConfig', {}).get('NetworkMode', '')
             is_host_network = network_mode == 'host'
 
+            # Derive the short sandbox ID (strip the container name prefix and
+            # any leading slash Docker may prepend to container.name).
+            raw_name = container.name.lstrip('/')
+            short_sandbox_id = raw_name[len(self.container_name_prefix):]
+            working_dir = container.attrs['Config']['WorkingDir']
+
             if is_host_network:
                 # Host network mode: container ports are directly accessible on host
                 for exposed_port in self.exposed_ports:
                     host_port = exposed_port.container_port
                     url = self.container_url_pattern.format(port=host_port)
+                    internal_url = None
 
-                    # VSCode URLs require the api_key and working dir
                     if exposed_port.name == VSCODE:
-                        url += f'/?tkn={session_api_key}&folder={container.attrs["Config"]["WorkingDir"]}'
+                        if self.proxy_vscode:
+                            internal_url = self.container_url_pattern.format(
+                                port=host_port
+                            )
+                            url = f'/vscode/{short_sandbox_id}/?tkn={session_api_key}&folder={working_dir}'
+                        else:
+                            url += f'/?tkn={session_api_key}&folder={working_dir}'
+                    elif exposed_port.name == AGENT_SERVER and self.proxy_agent and self.web_url:
+                        internal_url = self.container_url_pattern.format(port=host_port)
+                        url = f'{self.web_url}/agent/{short_sandbox_id}'
 
                     exposed_urls.append(
                         ExposedUrl(
                             name=exposed_port.name,
                             url=url,
                             port=exposed_port.container_port,
+                            internal_url=internal_url,
                         )
                     )
             else:
@@ -201,16 +219,34 @@ class DockerSandboxService(SandboxService):
                             )
                             if matching_port:
                                 url = self.container_url_pattern.format(port=host_port)
+                                internal_url = None
 
-                                # VSCode URLs require the api_key and working dir
                                 if matching_port.name == VSCODE:
-                                    url += f'/?tkn={session_api_key}&folder={container.attrs["Config"]["WorkingDir"]}'
+                                    if self.proxy_vscode:
+                                        internal_url = (
+                                            self.container_url_pattern.format(
+                                                port=host_port
+                                            )
+                                        )
+                                        url = f'/vscode/{short_sandbox_id}/?tkn={session_api_key}&folder={working_dir}'
+                                    else:
+                                        url += f'/?tkn={session_api_key}&folder={working_dir}'
+                                elif (
+                                    matching_port.name == AGENT_SERVER
+                                    and self.proxy_agent
+                                    and self.web_url
+                                ):
+                                    internal_url = self.container_url_pattern.format(
+                                        port=host_port
+                                    )
+                                    url = f'{self.web_url}/agent/{short_sandbox_id}'
 
                                 exposed_urls.append(
                                     ExposedUrl(
                                         name=matching_port.name,
                                         url=url,
                                         port=matching_port.container_port,
+                                        internal_url=internal_url,
                                     )
                                 )
 
@@ -237,11 +273,13 @@ class DockerSandboxService(SandboxService):
             and self.health_check_path is not None
             and sandbox_info.exposed_urls
         ):
-            app_server_url = next(
-                exposed_url.url
-                for exposed_url in sandbox_info.exposed_urls
-                if exposed_url.name == AGENT_SERVER
+            _agent_eu = next(
+                eu for eu in sandbox_info.exposed_urls if eu.name == AGENT_SERVER
             )
+            # Health-check must use the direct container URL, not the proxied URL
+            # that is meant for the browser.  internal_url is always the direct
+            # localhost URL; fall back to url only when proxy_agent is disabled.
+            app_server_url = _agent_eu.internal_url or _agent_eu.url
             try:
                 # When running in Docker, replace localhost hostname with host.docker.internal for internal requests
                 app_server_url = replace_localhost_hostname_for_docker(app_server_url)
@@ -389,6 +427,14 @@ class DockerSandboxService(SandboxService):
         env_vars[WEBHOOK_CALLBACK_VARIABLE] = (
             f'http://host.docker.internal:{self.host_port}/api/v1/webhooks'
         )
+
+        # Tell the agent-server which base path to pass to OpenVSCode Server via
+        # --server-base-path, so the Service Worker scope and all generated URLs
+        # match the proxy route exposed on the OpenHands server.
+        # The agent-server reads this via from_env(Config, "OH"), so the key is
+        # OH_VSCODE_BASE_PATH (prefix "OH" + "_" + field name "vscode_base_path").
+        if self.proxy_vscode:
+            env_vars['OH_VSCODE_BASE_PATH'] = f'/vscode/{sandbox_id}'
 
         # Set CORS origins for remote browser access when web_url is configured.
         # This allows the agent-server container to accept requests from the
@@ -545,6 +591,40 @@ class DockerSandboxService(SandboxService):
         except (NotFound, APIError):
             return False
 
+    async def get_vscode_internal_url(self, short_sandbox_id: str) -> str | None:
+        """Return the host-local VS Code base URL when proxy_vscode is enabled.
+
+        Looks up the running container by reconstructing the full container name from
+        the short ID, then reads the internal_url stored in its VS Code ExposedUrl.
+        """
+        if not self.proxy_vscode:
+            return None
+        full_sandbox_id = f'{self.container_name_prefix}{short_sandbox_id}'
+        sandbox = await self.get_sandbox(full_sandbox_id)
+        if not sandbox or not sandbox.exposed_urls:
+            return None
+        for exposed_url in sandbox.exposed_urls:
+            if exposed_url.name == VSCODE and exposed_url.internal_url:
+                return exposed_url.internal_url
+        return None
+
+    async def get_agent_server_internal_url(self, short_sandbox_id: str) -> str | None:
+        """Return the host-local agent-server base URL when proxy_agent is enabled.
+
+        Looks up the running container by reconstructing the full container name from
+        the short ID, then reads the internal_url stored in its agent-server ExposedUrl.
+        """
+        if not self.proxy_agent:
+            return None
+        full_sandbox_id = f'{self.container_name_prefix}{short_sandbox_id}'
+        sandbox = await self.get_sandbox(full_sandbox_id)
+        if not sandbox or not sandbox.exposed_urls:
+            return None
+        for exposed_url in sandbox.exposed_urls:
+            if exposed_url.name == AGENT_SERVER and exposed_url.internal_url:
+                return exposed_url.internal_url
+        return None
+
 
 class DockerSandboxServiceInjector(SandboxServiceInjector):
     """Dependency injector for docker sandbox services."""
@@ -647,6 +727,29 @@ class DockerSandboxServiceInjector(SandboxServiceInjector):
             'Configure via SANDBOX_KVM_ENABLED environment variable.'
         ),
     )
+    proxy_vscode: bool = Field(
+        default=False,
+        description=(
+            'Route VS Code traffic through the OpenHands server instead of exposing the '
+            'container port directly to the browser.  When enabled, the VS Code iframe URL '
+            'becomes a same-origin path (/vscode/<sandbox_id>/) served by a built-in proxy, '
+            'which satisfies the secure-context requirement for Service Workers and therefore '
+            'unlocks image preview in the embedded editor. '
+            'Configure via SANDBOX_PROXY_VSCODE environment variable.'
+        ),
+    )
+    proxy_agent: bool = Field(
+        default=False,
+        description=(
+            'Route agent-server traffic (socket.io events and REST API) through the '
+            'OpenHands server instead of exposing the container port directly to the browser. '
+            'When enabled, the agent_server_url returned to the frontend becomes a path-prefixed '
+            'URL on the OpenHands server (/agent/<sandbox_id>/), allowing conversations to work '
+            'through a reverse proxy such as Caddy or nginx. '
+            'Requires WEB_HOST to be configured so the server knows its external URL. '
+            'Configure via SANDBOX_PROXY_AGENT environment variable.'
+        ),
+    )
 
     async def inject(
         self, state: InjectorState, request: Request | None = None
@@ -682,4 +785,6 @@ class DockerSandboxServiceInjector(SandboxServiceInjector):
                 startup_grace_seconds=self.startup_grace_seconds,
                 use_host_network=self.use_host_network,
                 kvm_enabled=self.kvm_enabled,
+                proxy_vscode=self.proxy_vscode,
+                proxy_agent=self.proxy_agent,
             )

--- a/openhands/app_server/sandbox/sandbox_models.py
+++ b/openhands/app_server/sandbox/sandbox_models.py
@@ -21,6 +21,16 @@ class ExposedUrl(BaseModel):
     name: str
     url: str
     port: int
+    internal_url: str | None = Field(
+        default=None,
+        description=(
+            'Host-local base URL (scheme + host + port, no path/query) used by the '
+            'OpenHands server to proxy traffic to this service.  Populated when '
+            'proxy_vscode or proxy_agent is enabled; None otherwise.  '
+            'Backend code should prefer this over url for direct container access '
+            'so it bypasses any proxy indirection intended for the browser.'
+        ),
+    )
 
 
 # Standard names

--- a/openhands/app_server/sandbox/sandbox_service.py
+++ b/openhands/app_server/sandbox/sandbox_service.py
@@ -149,14 +149,50 @@ class SandboxService(ABC):
             )
             return False
 
+    async def get_vscode_internal_url(self, short_sandbox_id: str) -> str | None:
+        """Return the host-local VS Code base URL for the given short sandbox ID.
+
+        Used by the VS Code proxy route to forward browser traffic to the correct
+        container port.  The default implementation returns None (no proxy support).
+        DockerSandboxService overrides this when proxy_vscode is enabled.
+
+        Args:
+            short_sandbox_id: The sandbox ID without the container-name prefix,
+                as it appears in the proxy URL path (e.g. ``Abc123DEF``).
+
+        Returns:
+            A string like ``http://localhost:54321``, or None if not proxiable.
+        """
+        return None
+
+    async def get_agent_server_internal_url(self, short_sandbox_id: str) -> str | None:
+        """Return the host-local agent-server base URL for the given short sandbox ID.
+
+        Used by the agent proxy route to forward browser traffic (socket.io and REST)
+        to the correct container port.  The default implementation returns None.
+        DockerSandboxService overrides this when proxy_agent is enabled.
+
+        Args:
+            short_sandbox_id: The sandbox ID without the container-name prefix.
+
+        Returns:
+            A string like ``http://localhost:43210``, or None if not proxiable.
+        """
+        return None
+
     def _get_agent_server_url(self, sandbox: SandboxInfo) -> str:
-        """Get agent server URL from sandbox exposed URLs.
+        """Get agent server URL from sandbox exposed URLs for backend-internal use.
+
+        When the agent proxy is enabled, ExposedUrl.url holds the proxied URL
+        (for the frontend) and ExposedUrl.internal_url holds the direct container
+        URL (for backend API calls).  We always prefer internal_url here so that
+        backend calls go directly to the container regardless of proxy settings.
 
         Args:
             sandbox: The sandbox info containing exposed URLs
 
         Returns:
-            The agent server URL
+            The agent server URL suitable for backend API calls.
 
         Raises:
             SandboxError: If no agent server URL is found
@@ -166,7 +202,10 @@ class SandboxService(ABC):
 
         for exposed_url in sandbox.exposed_urls:
             if exposed_url.name == AGENT_SERVER:
-                return replace_localhost_hostname_for_docker(exposed_url.url)
+                # internal_url is the direct localhost URL; url may be the
+                # proxied URL when proxy_agent is enabled.
+                url = exposed_url.internal_url or exposed_url.url
+                return replace_localhost_hostname_for_docker(url)
 
         raise SandboxError(f'No agent server URL found for sandbox: {sandbox.id}')
 

--- a/openhands/app_server/vscode_proxy/__init__.py
+++ b/openhands/app_server/vscode_proxy/__init__.py
@@ -1,0 +1,3 @@
+from openhands.app_server.vscode_proxy.vscode_proxy_router import router
+
+__all__ = ['router']

--- a/openhands/app_server/vscode_proxy/vscode_proxy_router.py
+++ b/openhands/app_server/vscode_proxy/vscode_proxy_router.py
@@ -24,6 +24,7 @@ from openhands.app_server._proxy_core import (
     do_ws_proxy,
 )
 from openhands.app_server.config import get_sandbox_service
+from openhands.app_server.utils.docker_utils import replace_localhost_hostname_for_docker
 
 _logger = logging.getLogger(__name__)
 
@@ -60,6 +61,10 @@ async def _do_proxy_http(request: Request, short_sandbox_id: str) -> Response:
             content='VS Code proxy not available for this sandbox',
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         )
+
+    # When running in Docker, localhost refers to the container itself.
+    # Replace with host.docker.internal to reach the host.
+    internal_url = replace_localhost_hostname_for_docker(internal_url)
 
     # Forward the path as-is: VS Code is configured with OH_VSCODE_BASE_PATH
     # so it understands the /vscode/{id} prefix and generates correct redirect
@@ -145,6 +150,10 @@ async def _do_proxy_ws(websocket: WebSocket, short_sandbox_id: str) -> None:
     if internal_url is None:
         await websocket.close(code=status.WS_1013_TRY_AGAIN_LATER)
         return
+
+    # When running in Docker, localhost refers to the container itself.
+    # Replace with host.docker.internal to reach the host.
+    internal_url = replace_localhost_hostname_for_docker(internal_url)
 
     ws_scheme = 'wss' if internal_url.startswith('https') else 'ws'
     host_part = internal_url.split('://', 1)[-1]

--- a/openhands/app_server/vscode_proxy/vscode_proxy_router.py
+++ b/openhands/app_server/vscode_proxy/vscode_proxy_router.py
@@ -1,0 +1,190 @@
+"""HTTP and WebSocket reverse-proxy for the embedded VS Code editor.
+
+Routes ``/vscode/{short_sandbox_id}/{path:path}`` to the OpenVSCode Server
+container running on the host, selected by sandbox ID.
+
+Making VS Code same-origin with the main OpenHands UI satisfies the
+secure-context requirement for Service Workers, which in turn unlocks image
+preview in the embedded editor.
+
+Enabled only when ``proxy_vscode=True`` in DockerSandboxServiceInjector
+(env var: ``SANDBOX_PROXY_VSCODE=true``).  When the sandbox service
+reports no internal URL for a given sandbox the routes return 503/1013 so
+the frontend can fall back to the direct-port behaviour.
+"""
+
+import logging
+
+from fastapi import APIRouter, Request, WebSocket, status
+from fastapi.responses import Response
+
+from openhands.app_server._proxy_core import (
+    HTTP_REQUEST_SKIP,
+    do_http_proxy,
+    do_ws_proxy,
+)
+from openhands.app_server.config import get_sandbox_service
+
+_logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# WebSocket handshake headers handled by the transport layer.
+# Note: Origin is NOT in this set — VS Code validates that the WS Origin
+# matches the server host, so we set it explicitly to internal_url below.
+_WS_SKIP = frozenset(
+    [
+        'connection',
+        'host',
+        'sec-websocket-extensions',
+        'sec-websocket-key',
+        'sec-websocket-version',
+        'upgrade',
+    ]
+)
+
+_HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS', 'HEAD']
+
+
+# ---------------------------------------------------------------------------
+# HTTP proxy
+# ---------------------------------------------------------------------------
+
+
+async def _do_proxy_http(request: Request, short_sandbox_id: str) -> Response:
+    async with get_sandbox_service(request.state) as sandbox_service:
+        internal_url = await sandbox_service.get_vscode_internal_url(short_sandbox_id)
+
+    if internal_url is None:
+        return Response(
+            content='VS Code proxy not available for this sandbox',
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    # Forward the path as-is: VS Code is configured with OH_VSCODE_BASE_PATH
+    # so it understands the /vscode/{id} prefix and generates correct redirect
+    # and asset URLs.
+    target = f'{internal_url}{request.url.path}'
+    if qs := str(request.url.query):
+        target = f'{target}?{qs}'
+
+    req_headers = {
+        k: v
+        for k, v in request.headers.items()
+        if k.lower() not in HTTP_REQUEST_SKIP
+    }
+    req_headers['host'] = internal_url.split('://', 1)[-1]
+
+    return await do_http_proxy(
+        request.method,
+        target,
+        req_headers,
+        request.stream(),
+        label=f'vscode:{short_sandbox_id}',
+    )
+
+
+# Three routes are needed because FastAPI's {path:path} converter uses .+
+# (one-or-more), which refuses to match an empty string, and Starlette treats
+# trailing-slash and no-trailing-slash as distinct paths.
+#
+# URL shapes that must be handled:
+#   /vscode/{id}/           VS Code entry URL (?tkn=…, then redirect away)
+#   /vscode/{id}            Post-redirect URL after token validation
+#   /vscode/{id}/sub/path   Static assets, workbench, extensions, …
+
+@router.api_route(
+    '/vscode/{short_sandbox_id}/{path:path}',
+    methods=_HTTP_METHODS,
+    include_in_schema=False,
+)
+async def proxy_vscode_http(
+    request: Request, short_sandbox_id: str, path: str
+) -> Response:
+    """Proxy an HTTP request to VS Code (non-empty sub-path)."""
+    return await _do_proxy_http(request, short_sandbox_id)
+
+
+@router.api_route(
+    '/vscode/{short_sandbox_id}/',
+    methods=_HTTP_METHODS,
+    include_in_schema=False,
+)
+async def proxy_vscode_http_slash(
+    request: Request, short_sandbox_id: str
+) -> Response:
+    """Proxy an HTTP request to VS Code root (trailing slash, empty path)."""
+    return await _do_proxy_http(request, short_sandbox_id)
+
+
+@router.api_route(
+    '/vscode/{short_sandbox_id}',
+    methods=_HTTP_METHODS,
+    include_in_schema=False,
+)
+async def proxy_vscode_http_no_slash(
+    request: Request, short_sandbox_id: str
+) -> Response:
+    """Proxy an HTTP request to VS Code root (no trailing slash).
+
+    VS Code redirects here after token validation — the browser drops
+    the ``?tkn=`` parameter and lands on this URL.
+    """
+    return await _do_proxy_http(request, short_sandbox_id)
+
+
+# ---------------------------------------------------------------------------
+# WebSocket proxy
+# ---------------------------------------------------------------------------
+
+
+async def _do_proxy_ws(websocket: WebSocket, short_sandbox_id: str) -> None:
+    async with get_sandbox_service(websocket.state) as sandbox_service:
+        internal_url = await sandbox_service.get_vscode_internal_url(short_sandbox_id)
+
+    if internal_url is None:
+        await websocket.close(code=status.WS_1013_TRY_AGAIN_LATER)
+        return
+
+    ws_scheme = 'wss' if internal_url.startswith('https') else 'ws'
+    host_part = internal_url.split('://', 1)[-1]
+    target_ws = f'{ws_scheme}://{host_part}{websocket.url.path}'
+    if qs := str(websocket.url.query):
+        target_ws = f'{target_ws}?{qs}'
+
+    forward_headers = {
+        k: v
+        for k, v in websocket.headers.items()
+        if k.lower() not in _WS_SKIP
+    }
+    # VS Code validates that the WS Origin matches the server host; set it to
+    # the internal URL so the same-origin check passes from our proxy hop.
+    forward_headers['origin'] = internal_url
+
+    await do_ws_proxy(
+        websocket, target_ws, forward_headers, label=f'vscode:{short_sandbox_id}'
+    )
+
+
+@router.websocket('/vscode/{short_sandbox_id}/{path:path}')
+async def proxy_vscode_ws(
+    websocket: WebSocket, short_sandbox_id: str, path: str
+) -> None:
+    """Proxy a WebSocket connection to VS Code (non-empty sub-path)."""
+    await _do_proxy_ws(websocket, short_sandbox_id)
+
+
+@router.websocket('/vscode/{short_sandbox_id}/')
+async def proxy_vscode_ws_slash(
+    websocket: WebSocket, short_sandbox_id: str
+) -> None:
+    """Proxy a WebSocket connection to VS Code root (trailing slash)."""
+    await _do_proxy_ws(websocket, short_sandbox_id)
+
+
+@router.websocket('/vscode/{short_sandbox_id}')
+async def proxy_vscode_ws_no_slash(
+    websocket: WebSocket, short_sandbox_id: str
+) -> None:
+    """Proxy a WebSocket connection to VS Code root (no trailing slash)."""
+    await _do_proxy_ws(websocket, short_sandbox_id)

--- a/openhands/server/app.py
+++ b/openhands/server/app.py
@@ -24,8 +24,10 @@ from fastapi.responses import JSONResponse
 
 import openhands.agenthub  # noqa F401 (we import this to get the agents registered)
 from openhands.app_server import v1_router
+from openhands.app_server.agent_proxy import router as agent_proxy_router
 from openhands.app_server.config import get_app_lifespan_service
 from openhands.app_server.status.status_router import router as health_router
+from openhands.app_server.vscode_proxy import router as vscode_proxy_router
 from openhands.integrations.service_types import AuthenticationError
 from openhands.server.routes.conversation import app as conversation_api_router
 from openhands.server.routes.feedback import app as feedback_api_router
@@ -100,5 +102,14 @@ if server_config.app_mode == AppMode.OPENHANDS:
     app.include_router(git_api_router)
 if server_config.enable_v1:
     app.include_router(v1_router.router)
+# VS Code proxy – routes /vscode/{sandbox_id}/... to the container port.
+# Active only when DockerSandboxServiceInjector.proxy_vscode is True; the
+# sandbox service returns None for all other configurations, so the routes
+# respond with 503/1013 and the frontend falls back to the direct-port URL.
+app.include_router(vscode_proxy_router)
+# Agent proxy – routes /agent/{sandbox_id}/... (socket.io + REST) to the
+# agent-server container port. Active only when proxy_agent=True AND WEB_HOST
+# is configured; otherwise the sandbox service returns None and routes 503/1013.
+app.include_router(agent_proxy_router)
 app.include_router(trajectory_router)
 app.include_router(health_router)

--- a/tests/unit/test_agent_proxy.py
+++ b/tests/unit/test_agent_proxy.py
@@ -1,0 +1,493 @@
+"""Tests for the agent-server proxy router.
+
+Failure modes covered:
+
+A. SANDBOX_PROXY_AGENT env var not wired in config_from_env
+   → test_proxy_agent_env_var
+
+B. _get_agent_server_url (backend) ignores internal_url and returns the
+   proxied URL → backend calls loop back through the proxy
+   → test_sandbox_service_backend_url_uses_internal_url
+
+C. _get_agent_server_frontend_url returns internal_url instead of url →
+   frontend connects to wrong (direct) port
+   → test_live_status_service_frontend_url_returns_url_field
+
+D/E. /agent/{id}/ and /agent/{id} routes missing → socket.io and
+     post-redirect requests hit SPA instead of proxy
+   → test_http_proxy_root_url_slash
+   → test_http_proxy_root_url_no_slash
+
+F. Sub-path routing (actual socket.io endpoint)
+   → test_http_proxy_subpath
+
+G/H. Error paths
+   → test_http_proxy_no_sandbox_returns_503
+   → test_http_proxy_unreachable_returns_502
+
+I/J. WebSocket relay
+   → test_ws_proxy_relays_messages
+   → test_ws_proxy_no_sandbox_closes_with_1013
+
+K. Container health-check uses proxied URL → container always looks like it
+   failed to start (ERROR state) even though it's fine
+   → test_health_check_uses_internal_url_not_proxied_url
+"""
+
+import asyncio
+import socket
+import threading
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+import pytest
+from aiohttp import web
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from openhands.app_server.sandbox.sandbox_models import AGENT_SERVER, ExposedUrl
+
+
+# ---------------------------------------------------------------------------
+# Fake upstream agent server
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('', 0))
+        return s.getsockname()[1]
+
+
+class FakeAgentServer:
+    """Minimal aiohttp server that echoes HTTP/WS requests for proxy tests."""
+
+    def __init__(self) -> None:
+        self.port = _free_port()
+        self.http_requests: list[tuple[str, str]] = []
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._runner: web.AppRunner | None = None
+        self._ready = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+        assert self._ready.wait(timeout=5), 'FakeAgentServer did not start in time'
+
+    def stop(self) -> None:
+        if self._loop and self._loop.is_running():
+            asyncio.run_coroutine_threadsafe(
+                self._cleanup(), self._loop
+            ).result(timeout=5)
+            self._loop.call_soon_threadsafe(self._loop.stop)
+
+    def _run(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_until_complete(self._setup())
+        self._ready.set()
+        self._loop.run_forever()
+
+    async def _setup(self) -> None:
+        app = web.Application()
+        app.router.add_route('*', '/{path_info:.*}', self._handler)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        await web.TCPSite(self._runner, '127.0.0.1', self.port).start()
+
+    async def _cleanup(self) -> None:
+        if self._runner:
+            await self._runner.cleanup()
+
+    async def _handler(self, request: web.Request) -> web.StreamResponse:
+        if request.headers.get('Upgrade', '').lower() == 'websocket':
+            ws = web.WebSocketResponse()
+            await ws.prepare(request)
+            async for msg in ws:
+                if msg.type == aiohttp.WSMsgType.TEXT:
+                    await ws.send_str(f'echo:{msg.data}')
+                elif msg.type in (aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSE):
+                    break
+            return ws
+        self.http_requests.append((request.method, request.path))
+        return web.Response(text=f'agent:{request.path}')
+
+    @property
+    def base_url(self) -> str:
+        return f'http://127.0.0.1:{self.port}'
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fake_agent():
+    server = FakeAgentServer()
+    server.start()
+    yield server
+    server.stop()
+
+
+def _make_proxy_client(internal_url: str) -> tuple[FastAPI, TestClient]:
+    from openhands.app_server.agent_proxy import router
+
+    app = FastAPI()
+    app.include_router(router)
+    return app, TestClient(app, raise_server_exceptions=True)
+
+
+@asynccontextmanager
+async def _sandbox_service_mock(internal_url, state, request=None):
+    svc = AsyncMock()
+    svc.get_agent_server_internal_url.return_value = internal_url
+    yield svc
+
+
+# ---------------------------------------------------------------------------
+# A. Config / env-var wiring
+# ---------------------------------------------------------------------------
+
+
+def test_proxy_agent_env_var(monkeypatch):
+    """SANDBOX_PROXY_AGENT=true is read by config_from_env() (failure mode A)."""
+    import openhands.app_server.config as cfg_module
+    from openhands.app_server.sandbox.docker_sandbox_service import (
+        DockerSandboxServiceInjector,
+    )
+
+    monkeypatch.setenv('SANDBOX_PROXY_AGENT', 'true')
+    original = cfg_module._global_config
+    cfg_module._global_config = None
+    try:
+        config = cfg_module.config_from_env()
+        assert isinstance(config.sandbox, DockerSandboxServiceInjector)
+        assert config.sandbox.proxy_agent is True
+    finally:
+        cfg_module._global_config = original
+
+
+# ---------------------------------------------------------------------------
+# B. Backend URL uses internal_url when proxy is active
+# ---------------------------------------------------------------------------
+
+
+def test_sandbox_service_backend_url_uses_internal_url():
+    """SandboxService._get_agent_server_url prefers internal_url (failure mode B).
+
+    When proxy_agent is enabled the ExposedUrl.url field holds the proxied
+    https://host/agent/{id} URL meant for the browser.  The backend must use
+    internal_url (the direct localhost URL) to avoid calling back through the
+    proxy in an infinite loop.
+    """
+    from openhands.app_server.sandbox.sandbox_models import SandboxInfo, SandboxStatus
+    from openhands.app_server.sandbox.sandbox_service import SandboxService
+
+    # Build a minimal SandboxInfo whose AGENT_SERVER ExposedUrl has both fields set.
+    exposed = ExposedUrl(
+        name=AGENT_SERVER,
+        url='https://openhands-host/agent/testid',  # proxied URL for frontend
+        port=43210,
+        internal_url='http://localhost:43210',       # direct URL for backend
+    )
+    sandbox = SandboxInfo(
+        id='oh-agent-server-testid',
+        created_by_user_id='user1',
+        sandbox_spec_id='spec1',
+        session_api_key=None,
+        status=SandboxStatus.RUNNING,
+        exposed_urls=[exposed],
+    )
+
+    # Instantiate a minimal concrete subclass to call the base method.
+    class _TestService(SandboxService):
+        async def search_sandboxes(self, *a, **kw): ...
+        async def get_sandbox(self, *a, **kw): ...
+        async def get_sandbox_by_session_api_key(self, *a, **kw): ...
+        async def start_sandbox(self, *a, **kw): ...
+        async def resume_sandbox(self, *a, **kw): ...
+        async def pause_sandbox(self, *a, **kw): ...
+        async def delete_sandbox(self, *a, **kw): ...
+
+    svc = _TestService.__new__(_TestService)
+    url = svc._get_agent_server_url(sandbox)
+    # The URL must be derived from internal_url (the direct container address),
+    # not from the proxied url field.  replace_localhost_hostname_for_docker may
+    # rewrite 'localhost' to 'host.docker.internal' when tests run inside Docker,
+    # so we check for port 43210 and absence of the proxied hostname instead of
+    # an exact localhost match.
+    assert ':43210' in url, f'_get_agent_server_url must use internal_url port, got {url!r}'
+    assert 'openhands-host' not in url, (
+        '_get_agent_server_url must NOT return the proxied URL, got {url!r}'
+    )
+
+
+# ---------------------------------------------------------------------------
+# C. Frontend URL returns the url field (proxied URL)
+# ---------------------------------------------------------------------------
+
+
+def test_live_status_service_frontend_url_returns_url_field():
+    """_get_agent_server_frontend_url returns url (the proxied URL) (failure mode C).
+
+    This is the value stored in task.agent_server_url and sent to the browser.
+    It must be the proxied URL, not the direct localhost URL.
+    """
+    from openhands.app_server.app_conversation.live_status_app_conversation_service import (
+        LiveStatusAppConversationService,
+    )
+    from openhands.app_server.sandbox.sandbox_models import SandboxInfo, SandboxStatus
+
+    exposed = ExposedUrl(
+        name=AGENT_SERVER,
+        url='https://openhands-host/agent/testid',
+        port=43210,
+        internal_url='http://localhost:43210',
+    )
+    sandbox = SandboxInfo(
+        id='oh-agent-server-testid',
+        created_by_user_id='user1',
+        sandbox_spec_id='spec1',
+        session_api_key=None,
+        status=SandboxStatus.RUNNING,
+        exposed_urls=[exposed],
+    )
+
+    svc = LiveStatusAppConversationService.__new__(LiveStatusAppConversationService)
+    url = svc._get_agent_server_frontend_url(sandbox)
+    assert url == 'https://openhands-host/agent/testid', (
+        '_get_agent_server_frontend_url must return the (proxied) url field, '
+        f'got {url!r}'
+    )
+
+
+# ---------------------------------------------------------------------------
+# D/E. Route existence – socket.io entry shapes
+# ---------------------------------------------------------------------------
+
+
+def test_http_proxy_root_url_slash(fake_agent):
+    """GET /agent/{id}/ strips the prefix and forwards / (failure mode D).
+
+    socket.io connects to this path when proxy_agent is enabled.  The
+    agent server sees GET / because it has no /agent/{id} base-path config.
+    """
+    _, client = _make_proxy_client(fake_agent.base_url)
+    sandbox_id = '5jW9lJHYX20dBYSkZtLMd3'
+
+    with patch(
+        'openhands.app_server.agent_proxy.agent_proxy_router.get_sandbox_service',
+        lambda state, request=None: _sandbox_service_mock(
+            fake_agent.base_url, state, request
+        ),
+    ):
+        resp = client.get(f'/agent/{sandbox_id}/')
+
+    assert resp.status_code == 200
+    # Prefix stripped → agent server sees GET /
+    assert ('GET', '/') in fake_agent.http_requests
+
+
+def test_http_proxy_root_url_no_slash(fake_agent):
+    """GET /agent/{id} strips the prefix and forwards / (failure mode E).
+
+    This URL shape appears in post-redirect requests.  The agent server
+    sees GET / because it has no /agent/{id} base-path config.
+    """
+    _, client = _make_proxy_client(fake_agent.base_url)
+    sandbox_id = '5jW9lJHYX20dBYSkZtLMd3'
+
+    with patch(
+        'openhands.app_server.agent_proxy.agent_proxy_router.get_sandbox_service',
+        lambda state, request=None: _sandbox_service_mock(
+            fake_agent.base_url, state, request
+        ),
+    ):
+        resp = client.get(f'/agent/{sandbox_id}')
+
+    assert resp.status_code == 200
+    # Prefix stripped → agent server sees GET /
+    assert ('GET', '/') in fake_agent.http_requests
+
+
+# ---------------------------------------------------------------------------
+# F. Basic proxy sanity – sub-path request reaches upstream with prefix stripped
+# ---------------------------------------------------------------------------
+
+
+def test_http_proxy_subpath(fake_agent):
+    """GET /agent/{id}/socket.io/ → agent server sees GET /socket.io/ (prefix stripped)."""
+    _, client = _make_proxy_client(fake_agent.base_url)
+
+    with patch(
+        'openhands.app_server.agent_proxy.agent_proxy_router.get_sandbox_service',
+        lambda state, request=None: _sandbox_service_mock(
+            fake_agent.base_url, state, request
+        ),
+    ):
+        resp = client.get('/agent/abc123/socket.io/?EIO=4&transport=polling')
+
+    assert resp.status_code == 200
+    # Prefix stripped → agent server sees GET /socket.io/
+    assert ('GET', '/socket.io/') in fake_agent.http_requests
+
+
+# ---------------------------------------------------------------------------
+# G/H. Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_http_proxy_no_sandbox_returns_503(fake_agent):
+    """503 when get_agent_server_internal_url returns None (failure mode G)."""
+    _, client = _make_proxy_client(fake_agent.base_url)
+
+    @asynccontextmanager
+    async def _none_mock(state, request=None):
+        svc = AsyncMock()
+        svc.get_agent_server_internal_url.return_value = None
+        yield svc
+
+    with patch(
+        'openhands.app_server.agent_proxy.agent_proxy_router.get_sandbox_service',
+        _none_mock,
+    ):
+        resp = client.get('/agent/abc123/api/conversations')
+
+    assert resp.status_code == 503
+
+
+def test_http_proxy_unreachable_returns_502():
+    """502 when the agent server container is not running (failure mode H)."""
+    dead_url = f'http://127.0.0.1:{_free_port()}'
+    _, client = _make_proxy_client(dead_url)
+
+    with patch(
+        'openhands.app_server.agent_proxy.agent_proxy_router.get_sandbox_service',
+        lambda state, request=None: _sandbox_service_mock(dead_url, state, request),
+    ):
+        resp = client.get('/agent/abc123/api/conversations')
+
+    assert resp.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# I/J. WebSocket proxy
+# ---------------------------------------------------------------------------
+
+
+def test_ws_proxy_relays_messages(fake_agent):
+    """Text frames are relayed bidirectionally through the proxy (failure mode I)."""
+    _, client = _make_proxy_client(fake_agent.base_url)
+
+    with patch(
+        'openhands.app_server.agent_proxy.agent_proxy_router.get_sandbox_service',
+        lambda state, request=None: _sandbox_service_mock(
+            fake_agent.base_url, state, request
+        ),
+    ):
+        with client.websocket_connect('/agent/abc123/socket.io/') as ws:
+            ws.send_text('hello')
+            assert ws.receive_text() == 'echo:hello'
+
+
+def test_ws_proxy_no_sandbox_closes_with_1013(fake_agent):
+    """WS closes with 1013 when internal_url is None (failure mode J)."""
+    _, client = _make_proxy_client(fake_agent.base_url)
+
+    @asynccontextmanager
+    async def _none_mock(state, request=None):
+        svc = AsyncMock()
+        svc.get_agent_server_internal_url.return_value = None
+        yield svc
+
+    with patch(
+        'openhands.app_server.agent_proxy.agent_proxy_router.get_sandbox_service',
+        _none_mock,
+    ):
+        with pytest.raises(Exception):
+            with client.websocket_connect('/agent/abc123/socket.io/') as ws:
+                ws.receive_text()
+
+
+# ---------------------------------------------------------------------------
+# K. Health-check URL bug: container always enters ERROR state when proxy_agent=True
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_health_check_uses_internal_url_not_proxied_url(fake_agent):
+    """_container_to_checked_sandbox_info must hit internal_url (failure mode K).
+
+    When proxy_agent=True, ExposedUrl.url is the proxied URL for the browser
+    (e.g. https://openhands-host/agent/id).  If the health check sends a GET
+    to that URL it will never reach the container → timeout → ERROR state →
+    every sandbox start fails.  The fix: use internal_url for health checks,
+    falling back to url only when internal_url is absent.
+    """
+    from unittest.mock import Mock, patch
+
+    from openhands.app_server.sandbox.docker_sandbox_service import DockerSandboxService
+    from openhands.app_server.sandbox.sandbox_models import SandboxInfo, SandboxStatus
+
+    # Build a SandboxInfo whose AGENT_SERVER ExposedUrl has a proxied url and
+    # a direct internal_url.  Only internal_url should be used for health checks.
+    direct_url = f'http://127.0.0.1:{fake_agent.port}'
+    proxied_url = 'https://openhands-host/agent/testid'
+    exposed = ExposedUrl(
+        name=AGENT_SERVER,
+        url=proxied_url,
+        port=fake_agent.port,
+        internal_url=direct_url,
+    )
+    sandbox_info = SandboxInfo(
+        id='oh-agent-server-testid',
+        created_by_user_id='user1',
+        sandbox_spec_id='spec1',
+        session_api_key=None,
+        status=SandboxStatus.RUNNING,
+        exposed_urls=[exposed],
+    )
+
+    # Track the URL the health-check hits.
+    health_checked_urls: list[str] = []
+    import httpx
+    real_client = httpx.AsyncClient()
+    original_get = real_client.get
+
+    async def spy_get(url, *args, **kwargs):
+        health_checked_urls.append(url)
+        return await original_get(url, *args, **kwargs)
+
+    real_client.get = spy_get  # type: ignore[method-assign]
+
+    # Create a minimal DockerSandboxService using __new__ so we can inject
+    # only the attributes _container_to_checked_sandbox_info needs.
+    svc = DockerSandboxService.__new__(DockerSandboxService)
+    svc.health_check_path = '/alive'
+    svc.startup_grace_seconds = 60
+    svc.httpx_client = real_client
+
+    fake_container = Mock()
+
+    with patch.object(
+        svc,
+        '_container_to_sandbox_info',
+        new=AsyncMock(return_value=sandbox_info),
+    ):
+        result = await svc._container_to_checked_sandbox_info(fake_container)
+
+    await real_client.aclose()
+
+    assert health_checked_urls, 'Health check was not called at all'
+    checked = health_checked_urls[0]
+    assert 'openhands-host' not in checked, (
+        f'Health check must NOT use the proxied URL; called with {checked!r}'
+    )
+    assert str(fake_agent.port) in checked, (
+        f'Health check must target the container port; called with {checked!r}'
+    )
+    assert result is not None
+    assert result.status == SandboxStatus.RUNNING
+

--- a/tests/unit/test_vscode_proxy.py
+++ b/tests/unit/test_vscode_proxy.py
@@ -1,0 +1,380 @@
+"""Tests for the VS Code proxy router.
+
+Tests are written around the bugs that actually occurred in production, so
+that every test here would have caught (or now prevents the recurrence of)
+a real failure.  Tests for things that were always correct and never a risk
+have been deliberately excluded — they gave false confidence while VS Code
+was failing to load.
+
+Failure modes covered:
+
+A. SANDBOX_PROXY_VSCODE env var not wired into config_from_env()
+   → test_proxy_vscode_env_var
+
+B. Container env var injected with wrong name (OPENVSCODE_SERVER_BASE_PATH
+   instead of OH_VSCODE_BASE_PATH), so VS Code started without --server-base-path
+   → test_agent_server_reads_oh_vscode_base_path
+   → test_proxy_vscode_injects_oh_vscode_base_path
+
+C. FastAPI's {path:path} regex (.+) refused to match the empty-string path in
+   the entry URL /vscode/{id}/  →  404 on first load
+   → test_http_proxy_root_url
+
+D. No route for /vscode/{id} (no trailing slash); VS Code redirects there after
+   token auth, browser fell through to React SPA  →  404 after redirect
+   → test_http_proxy_no_trailing_slash
+
+E. Error paths: proxy enabled but sandbox unavailable (503) or VS Code
+   container unreachable (502 / WS 1013)
+   → test_http_proxy_no_sandbox_returns_503
+   → test_http_proxy_unreachable_vscode_returns_502
+   → test_ws_proxy_no_sandbox_closes_with_1013
+
+F. Basic proxy sanity: request reaches upstream, response comes back
+   → test_http_proxy_forwards_request
+   → test_ws_proxy_relays_text_messages
+
+Docker is not required: get_sandbox_service is mocked to return a known
+internal_url; a real local aiohttp server acts as the fake VS Code upstream.
+"""
+import asyncio
+import socket
+import threading
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+import pytest
+from aiohttp import web
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Fake VS Code server
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(('127.0.0.1', 0))
+        return s.getsockname()[1]
+
+
+class FakeVSCodeServer:
+    """A real TCP server that mimics a minimal OpenVSCode Server.
+
+    - HTTP requests: responds with ``vscode:<path>`` and an
+      ``X-VSCode-Fake: yes`` header; records each request as
+      ``(method, path)`` in ``http_requests``.
+    - WebSocket connections: echoes every message with an ``echo:`` prefix
+      (text frames stay text, binary stays binary).
+    """
+
+    def __init__(self):
+        self.port = _free_port()
+        self.http_requests: list[tuple[str, str]] = []
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._runner: web.AppRunner | None = None
+        self._ready = threading.Event()
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        assert self._ready.wait(timeout=5), 'FakeVSCodeServer did not start in time'
+
+    def stop(self) -> None:
+        if self._loop and self._loop.is_running():
+            asyncio.run_coroutine_threadsafe(
+                self._cleanup(), self._loop
+            ).result(timeout=5)
+            self._loop.call_soon_threadsafe(self._loop.stop)
+
+    # -- internals -----------------------------------------------------------
+
+    def _run(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_until_complete(self._setup())
+        self._ready.set()
+        self._loop.run_forever()
+
+    async def _setup(self) -> None:
+        app = web.Application()
+        app.router.add_route('*', '/{path_info:.*}', self._handler)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        await web.TCPSite(self._runner, '127.0.0.1', self.port).start()
+
+    async def _cleanup(self) -> None:
+        if self._runner:
+            await self._runner.cleanup()
+
+    async def _handler(self, request: web.Request) -> web.StreamResponse:
+        if request.headers.get('Upgrade', '').lower() == 'websocket':
+            ws = web.WebSocketResponse()
+            await ws.prepare(request)
+            async for msg in ws:
+                if msg.type == aiohttp.WSMsgType.TEXT:
+                    await ws.send_str(f'echo:{msg.data}')
+                elif msg.type == aiohttp.WSMsgType.BINARY:
+                    await ws.send_bytes(b'echo:' + msg.data)
+                elif msg.type in (
+                    aiohttp.WSMsgType.ERROR,
+                    aiohttp.WSMsgType.CLOSE,
+                ):
+                    break
+            return ws
+
+        self.http_requests.append((request.method, request.path))
+        return web.Response(
+            text=f'vscode:{request.path}',
+            headers={'X-VSCode-Fake': 'yes'},
+        )
+
+    @property
+    def base_url(self) -> str:
+        return f'http://127.0.0.1:{self.port}'
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fake_vscode():
+    server = FakeVSCodeServer()
+    server.start()
+    yield server
+    server.stop()
+
+
+def _make_proxy_client(internal_url: str) -> tuple[FastAPI, TestClient]:
+    """Return a (app, TestClient) pair with get_sandbox_service mocked."""
+    from openhands.app_server.vscode_proxy import router
+
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app, raise_server_exceptions=True)
+    return app, client
+
+
+@asynccontextmanager
+async def _sandbox_service_mock(internal_url: str, state, request=None):
+    svc = AsyncMock()
+    svc.get_vscode_internal_url.return_value = internal_url
+    yield svc
+
+
+# ---------------------------------------------------------------------------
+# A. Config / env-var wiring tests
+# ---------------------------------------------------------------------------
+
+
+def test_proxy_vscode_env_var(monkeypatch):
+    """SANDBOX_PROXY_VSCODE=true is read by config_from_env() (failure mode A)."""
+    import openhands.app_server.config as cfg_module
+    from openhands.app_server.sandbox.docker_sandbox_service import (
+        DockerSandboxServiceInjector,
+    )
+
+    monkeypatch.setenv('SANDBOX_PROXY_VSCODE', 'true')
+    original = cfg_module._global_config
+    cfg_module._global_config = None
+    try:
+        config = cfg_module.config_from_env()
+        assert isinstance(config.sandbox, DockerSandboxServiceInjector)
+        assert config.sandbox.proxy_vscode is True
+    finally:
+        cfg_module._global_config = original
+
+
+# ---------------------------------------------------------------------------
+# B. Container env-var injection tests
+# ---------------------------------------------------------------------------
+
+
+def test_agent_server_reads_oh_vscode_base_path(monkeypatch):
+    """The agent-server config reads vscode_base_path from OH_VSCODE_BASE_PATH.
+
+    This pins the exact env var name that the agent-server's from_env()
+    mechanism resolves for the vscode_base_path field (prefix 'OH' +
+    '_' + 'VSCODE_BASE_PATH').  If this test fails the proxy base-path
+    injection will silently do nothing and VS Code will 404.
+    """
+    from openhands.agent_server.config import Config
+    from openhands.agent_server.env_parser import from_env
+
+    monkeypatch.setenv('OH_VSCODE_BASE_PATH', '/vscode/testSandbox123')
+    config = from_env(Config, 'OH')
+    assert config.vscode_base_path == '/vscode/testSandbox123'
+
+
+def test_proxy_vscode_injects_oh_vscode_base_path():
+    """When proxy_vscode=True the injected env var is OH_VSCODE_BASE_PATH.
+
+    The name must match what the agent-server reads (verified by the test
+    above).  A wrong name silently leaves vscode_base_path=None, which
+    means VS Code starts without --server-base-path and returns 404 for
+    every proxy request.
+    """
+    import inspect
+
+    from openhands.app_server.sandbox.docker_sandbox_service import DockerSandboxService
+
+    src = inspect.getsource(DockerSandboxService.start_sandbox)
+    assert 'OH_VSCODE_BASE_PATH' in src, (
+        'start_sandbox must inject OH_VSCODE_BASE_PATH, not OPENVSCODE_SERVER_BASE_PATH'
+    )
+
+
+# ---------------------------------------------------------------------------
+# C/D/E/F. HTTP proxy tests
+# ---------------------------------------------------------------------------
+
+
+def test_http_proxy_root_url(fake_vscode):
+    """The entry-point URL /vscode/{id}/ (trailing slash) is proxied.
+
+    This is the URL OpenHands puts in the VS Code iframe src.
+    Before the fix this returned 404 because FastAPI's {path:path} converter
+    uses .+ and refuses to match the empty string.
+    """
+    _, client = _make_proxy_client(fake_vscode.base_url)
+
+    with patch(
+        'openhands.app_server.vscode_proxy.vscode_proxy_router.get_sandbox_service',
+        lambda state, request=None: _sandbox_service_mock(
+            fake_vscode.base_url, state, request
+        ),
+    ):
+        # Exact shape of the URL that OpenHands generates:
+        resp = client.get(
+            '/vscode/5jW9lJHYX20dBYSkZtLMd3/'
+            '?tkn=dEl3vXpCvQfMCKDcGBlRRp8cmepvKAyFHqcLvvdO4xB'
+            '&folder=%2Fworkspace%2Fproject'
+        )
+
+    assert resp.status_code == 200
+    assert ('GET', '/vscode/5jW9lJHYX20dBYSkZtLMd3/') in fake_vscode.http_requests
+
+
+def test_http_proxy_no_trailing_slash(fake_vscode):
+    """The post-redirect URL /vscode/{id} (no trailing slash) is proxied.
+
+    VS Code validates the ?tkn= token, sets a cookie, then redirects to
+    the same URL without ?tkn= and without a trailing slash.  That
+    redirected URL must also hit the proxy, not fall through to the React
+    SPA (which would render a 404 component).
+    """
+    _, client = _make_proxy_client(fake_vscode.base_url)
+
+    with patch(
+        'openhands.app_server.vscode_proxy.vscode_proxy_router.get_sandbox_service',
+        lambda state, request=None: _sandbox_service_mock(
+            fake_vscode.base_url, state, request
+        ),
+    ):
+        resp = client.get('/vscode/5jW9lJHYX20dBYSkZtLMd3?folder=%2Fworkspace%2Fproject')
+
+    assert resp.status_code == 200
+    # proxy must forward the exact path (no trailing slash added)
+    assert ('GET', '/vscode/5jW9lJHYX20dBYSkZtLMd3') in fake_vscode.http_requests
+
+
+def test_http_proxy_forwards_request(fake_vscode):
+    """Proxy forwards GET to VS Code and streams the response back."""
+    _, client = _make_proxy_client(fake_vscode.base_url)
+
+    with patch(
+        'openhands.app_server.vscode_proxy.vscode_proxy_router.get_sandbox_service',
+        lambda state, request=None: _sandbox_service_mock(
+            fake_vscode.base_url, state, request
+        ),
+    ):
+        resp = client.get('/vscode/abc123/workbench.html')
+
+    assert resp.status_code == 200
+    assert resp.text == 'vscode:/vscode/abc123/workbench.html'
+    assert resp.headers.get('x-vscode-fake') == 'yes'
+    assert ('GET', '/vscode/abc123/workbench.html') in fake_vscode.http_requests
+
+
+def test_http_proxy_no_sandbox_returns_503(fake_vscode):
+    """When get_vscode_internal_url returns None the proxy returns 503."""
+    _, client = _make_proxy_client(fake_vscode.base_url)
+
+    @asynccontextmanager
+    async def _none_mock(state, request=None):
+        svc = AsyncMock()
+        svc.get_vscode_internal_url.return_value = None
+        yield svc
+
+    with patch(
+        'openhands.app_server.vscode_proxy.vscode_proxy_router.get_sandbox_service',
+        _none_mock,
+    ):
+        resp = client.get('/vscode/abc123/index.html')
+
+    assert resp.status_code == 503
+
+
+def test_http_proxy_unreachable_vscode_returns_502():
+    """When VS Code container is not running the proxy returns 502."""
+    dead_url = f'http://127.0.0.1:{_free_port()}'  # nothing listening here
+    _, client = _make_proxy_client(dead_url)
+
+    with patch(
+        'openhands.app_server.vscode_proxy.vscode_proxy_router.get_sandbox_service',
+        lambda state, request=None: _sandbox_service_mock(dead_url, state, request),
+    ):
+        resp = client.get('/vscode/abc123/index.html')
+
+    assert resp.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# E/F. WebSocket proxy tests
+# ---------------------------------------------------------------------------
+
+
+def test_ws_proxy_relays_text_messages(fake_vscode):
+    """Text frames are relayed in both directions through the proxy."""
+    _, client = _make_proxy_client(fake_vscode.base_url)
+
+    with patch(
+        'openhands.app_server.vscode_proxy.vscode_proxy_router.get_sandbox_service',
+        lambda state, request=None: _sandbox_service_mock(
+            fake_vscode.base_url, state, request
+        ),
+    ):
+        with client.websocket_connect('/vscode/abc123/ws') as ws:
+            ws.send_text('hello')
+            assert ws.receive_text() == 'echo:hello'
+
+            ws.send_text('world')
+            assert ws.receive_text() == 'echo:world'
+
+
+def test_ws_proxy_no_sandbox_closes_with_1013(fake_vscode):
+    """When internal_url is None the proxy closes with 1013 Try Again Later."""
+    _, client = _make_proxy_client(fake_vscode.base_url)
+
+    @asynccontextmanager
+    async def _none_mock(state, request=None):
+        svc = AsyncMock()
+        svc.get_vscode_internal_url.return_value = None
+        yield svc
+
+    with patch(
+        'openhands.app_server.vscode_proxy.vscode_proxy_router.get_sandbox_service',
+        _none_mock,
+    ):
+        with pytest.raises(Exception):
+            # TestClient raises on abnormal close
+            with client.websocket_connect('/vscode/abc123/ws') as ws:
+                ws.receive_text()


### PR DESCRIPTION
## Summary of PR

When OpenHands runs behind a reverse proxy (Caddy, nginx, …) the browser cannot reach the agent-server or VS Code container ports directly. This PR routes all that traffic through the OpenHands server so everything stays on a single port.

A secondary benefit: making VS Code same-origin with the main UI satisfies the
browser's secure-context requirement for Service Workers, which enables **image
preview** in the embedded editor (if served through a HTTPS proxy).

Both features are opt-in via env vars and degrade gracefully (the sandbox service
returns 503/1013 when the proxies are disabled, so the routes are inert by default).

### VS Code proxy  (`SANDBOX_PROXY_VSCODE=true`)

VS Code becomes reachable at `/vscode/<sandbox_id>/…` instead of
`http://host:<random-port>/`.  Same-origin satisfies the secure-context
requirement for Service Workers → image preview works.

- `OH_VSCODE_BASE_PATH=/vscode/<id>` is injected into the agent container so
  OpenVSCode Server generates correct redirect and asset URLs.
- The proxy forwards the full path as-is — VS Code must see its own prefix to
  produce correct redirects.

### Agent proxy  (`SANDBOX_PROXY_AGENT=true` + `WEB_HOST=<hostname>`)

Socket.io events and REST calls are routed through `/agent/<sandbox_id>/…`.

- The `/agent/<id>` prefix is **stripped** before forwarding — the agent server
  serves at its root and has no knowledge of the proxy prefix.
- The `Origin` header is **dropped** on the upstream WS connection. When
  `WEB_HOST` is set `allow_cors_origins` is non-empty; `LocalhostCORSMiddleware`'s
  shortcut only fires when `allow_origins` is empty, so omitting `Origin` causes
  Starlette CORS to pass the request through.
- `WEB_HOST` is required so the server knows the external URL to embed in
  `agent_server_url`.

---

## Implementation

### New files
| File | Purpose |
|---|---|
| `openhands/app_server/_proxy_core.py` | Shared HTTP (httpx/streaming) and WebSocket (aiohttp/bidirectional relay) mechanics |
| `openhands/app_server/vscode_proxy/vscode_proxy_router.py` | FastAPI router for `/vscode/{id}/…` |
| `openhands/app_server/agent_proxy/agent_proxy_router.py` | FastAPI router for `/agent/{id}/…` |

### Key modifications
- `ExposedUrl.internal_url` — new optional field: `url` carries the browser-facing
  (possibly proxied) URL; `internal_url` holds the direct `http://localhost:PORT`
  for backend-to-container calls.
- `SandboxService` — `get_vscode_internal_url` / `get_agent_server_internal_url`
  hooks (return `None` by default; `DockerSandboxService` overrides them).
- `docker_sandbox_service.py` — URL construction, `OH_VSCODE_BASE_PATH` injection,
  health-check uses `internal_url`.
- `live_status_app_conversation_service.py` — `task.agent_server_url` now returns
  the proxied URL when proxy is active.
- `config.py` — `SANDBOX_PROXY_VSCODE` / `SANDBOX_PROXY_AGENT` env var wiring.
- `server/app.py` — router registration.
- `frontend/src/routes/vscode-tab.tsx` — resolves relative VS Code URLs against
  `window.location.href` before the protocol comparison.

### Relation to #13516
PR #13516 ("WebSocket Gateway") addresses the same agent-server problem with a WS-only opt-in gateway at a different path. The two approaches are non-conflicting.

### Testing

21 unit tests in `tests/unit/test_vscode_proxy.py` and `tests/unit/test_agent_proxy.py`,
each tied to a concrete failure mode encountered during development.
Resolves #(issue)

## Demo Screenshots/Videos

The following screenshots show that:

1. The embedded VSCode is loaded through OpenHands (URL: is `https://openhands-fork/vscode/...`)
2. The WSS request to the agent also go through OpenHands (URL is `wss://openhands-fork/agent/...`

<img width="947" height="973" alt="imagen" src="https://github.com/user-attachments/assets/df9422fd-6781-4652-8c2f-63f91151e0b3" />

<img width="1031" height="299" alt="imagen" src="https://github.com/user-attachments/assets/ff8b9e13-92f1-44dd-aa40-3d645fe6aa81" />

## Change Type

<!-- Choose the types that apply to your PR -->

- [ ] Bug fix
- [x ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

I have reviewed the code and **mostly** understand what the code is doing, but I am not familiar with the OpenHands repo and can't be sure that the way this is implemented fits what a more experienced OpenHands developer would have done. But I did steer the agent to look at existing issues, clean up the code, and justify each decision. I am reasonably confident this is a good quality PR.

## Fixes



## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an end-user friendly description for your change below the checkbox. -->

- [x] Include this change in the Release Notes.
