### PR TITLE
Added Falsy check for base url

### DIFF
--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -179,7 +179,7 @@ class SaasSettingsStore(SettingsStore):
                 return None
 
             # Check if we need to generate an LLM key.
-            if item.llm_base_url == LITE_LLM_API_URL:
+            if not item.llm_base_url or item.llm_base_url == LITE_LLM_API_URL:
                 await self._ensure_api_key(
                     item, str(org_id), openhands_type=is_openhands_model(item.llm_model)
                 )


### PR DESCRIPTION
## Summary of PR

When you switch back from advanced mode to basic, the llm_api_url becomes None, so we need to check if the key should be regenerated if this value is falsy

## Demo Screenshots/Videos

Switching from...
<img width="1028" height="756" alt="image" src="https://github.com/user-attachments/assets/fe4937e7-6f59-4ca2-b054-34410a2eb4d7" />

To...
<img width="1366" height="790" alt="image" src="https://github.com/user-attachments/assets/5bd7275c-189f-4bad-a3d3-2022e73ed548" />

The api key should be checked if the llm_base_url is falsy...
<img width="1175" height="337" alt="image" src="https://github.com/user-attachments/assets/5d597018-d42d-44a4-a94e-43d47f1f5cc4" />

## Change Type

<!-- Choose the types that apply to your PR -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:c34a154-nikolaik   --name openhands-app-c34a154   docker.openhands.dev/openhands/openhands:c34a154
```