### PR TITLE
security: pin litellm<=1.82.6 to mitigate supply chain attack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
   "jwcrypto>=1.5.6",
   "kubernetes>=33.1",
   "libtmux>=0.46.2",
-  "litellm!=1.64.4,!=1.67.*,>=1.74.3",
+  "litellm>=1.74.3,<=1.82.6,!=1.64.4,!=1.67.*",  # Pin <=1.82.6 due to supply chain attack in 1.82.7/1.82.8 (BerriAI/litellm#24512)
   "lmnr>=0.7.20",
   "mcp>=1.25",
   "memory-profiler>=0.61",
@@ -165,7 +165,7 @@ include = [
 python = "^3.12,<3.14"
 authlib = ">=1.6.9"                                # CVE-2026-27962 (fixed in 1.6.9)
 orjson = ">=3.11.6"                                # Pinned to fix CVE-2025-67221
-litellm = ">=1.74.3, !=1.64.4, !=1.67.*"           # avoid 1.64.4 (known bug) & 1.67.* (known bug #10272)
+litellm = ">=1.74.3, <=1.82.6, !=1.64.4, !=1.67.*"  # Pin <=1.82.6 due to supply chain attack in 1.82.7/1.82.8 (BerriAI/litellm#24512)
 openai = "2.8.0"                                   # Pin due to litellm incompatibility with >=1.100.0 (BerriAI/litellm#13711)
 aiohttp = ">=3.13.3"                               # Pin to avoid CVE-2025-69223 (vulnerable versions < 3.13.3)
 google-genai = "*"                                 # To use litellm with Gemini Pro API


### PR DESCRIPTION
## Summary

This PR pins LiteLLM to `<=1.82.6` to protect against a critical supply chain attack affecting versions 1.82.7 and 1.82.8.

## Security Issue

LiteLLM versions **1.82.7** and **1.82.8** on PyPI contain a malicious `.pth` file (`litellm_init.pth`) that automatically executes a credential-stealing payload whenever the Python interpreter starts — no `import litellm` required.

### What the malicious payload does:
- Collects sensitive data: SSH keys, AWS/GCP/Azure credentials, API keys, environment variables, Kubernetes secrets, crypto wallets, shell history, and more
- Encrypts the data with AES-256 + RSA
- Exfiltrates to an attacker-controlled server (`https://models.litellm.cloud/`)

### Trigger mechanism:
Python's `.pth` files in `site-packages/` are executed automatically on interpreter startup ([Python docs](https://docs.python.org/3/library/site.html)). This means any system that installed the compromised versions is affected, including:
- Local development machines
- CI/CD pipelines
- Docker containers
- Production servers

## Changes

Updated `pyproject.toml` to pin litellm to `<=1.82.6` in both:
- `[project]` dependencies (for UV compatibility)
- `[tool.poetry.dependencies]` (for Poetry)

## Reference

- https://github.com/BerriAI/litellm/issues/24512

## Recommended User Actions

If you have already installed litellm 1.82.7 or 1.82.8:
1. Check for the malicious file: `ls $(python -c "import site; print(site.getsitepackages()[0])")/litellm_init.pth`
2. Downgrade immediately: `pip install litellm==1.82.6`
3. **Rotate ALL credentials** that were present as environment variables or in config files on the affected system