### PR TITLE
ci: build amd64 only on PRs to skip QEMU emulation

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -33,28 +33,33 @@ jobs:
     runs-on: blacksmith
     outputs:
       base_image: ${{ steps.define-base-images.outputs.base_image }}
+      platforms: ${{ steps.define-base-images.outputs.platforms }}
     steps:
       - name: Define base images
         shell: bash
         id: define-base-images
         run: |
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            json=$(jq -n -c '[
-                { image: "nikolaik/python-nodejs:python3.12-nodejs22-slim", tag: "nikolaik" }
+            platforms="linux/amd64"
+            json=$(jq -n -c --arg platforms "$platforms" '[
+                { image: "nikolaik/python-nodejs:python3.12-nodejs22-slim", tag: "nikolaik", platforms: $platforms }
               ]')
           else
-            json=$(jq -n -c '[
-                { image: "nikolaik/python-nodejs:python3.12-nodejs22-slim", tag: "nikolaik" },
-                { image: "ubuntu:24.04", tag: "ubuntu" }
+            platforms="linux/amd64,linux/arm64"
+            json=$(jq -n -c --arg platforms "$platforms" '[
+                { image: "nikolaik/python-nodejs:python3.12-nodejs22-slim", tag: "nikolaik", platforms: $platforms },
+                { image: "ubuntu:24.04", tag: "ubuntu", platforms: $platforms }
               ]')
           fi
           echo "base_image=$json" >> "$GITHUB_OUTPUT"
+          echo "platforms=$platforms" >> "$GITHUB_OUTPUT"
 
   # Builds the OpenHands Docker images
   ghcr_build_app:
     name: Build App Image
     runs-on: blacksmith-4vcpu-ubuntu-2204
     if: "!(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/ext-v'))"
+    needs: define-matrix
     permissions:
       contents: read
       packages: write
@@ -82,7 +87,7 @@ jobs:
       - name: Build and push app image
         if: "!github.event.pull_request.head.repo.fork"
         run: |
-          ./containers/build.sh -i openhands -o ${{ env.REPO_OWNER }} --push
+          ./containers/build.sh -i openhands -o ${{ env.REPO_OWNER }} --push -p ${{ needs.define-matrix.outputs.platforms }}
 
   # Builds the runtime Docker images
   ghcr_build_runtime:
@@ -136,7 +141,7 @@ jobs:
         shell: bash
         run: |
 
-          ./containers/build.sh -i runtime -o ${{ env.REPO_OWNER }} -t ${{ matrix.base_image.tag }} --dry
+          ./containers/build.sh -i runtime -o ${{ env.REPO_OWNER }} -t ${{ matrix.base_image.tag }} --dry -p ${{ matrix.base_image.platforms }}
 
           DOCKER_BUILD_JSON=$(jq -c . < docker-build-dry.json)
           echo "DOCKER_TAGS=$(echo "$DOCKER_BUILD_JSON" | jq -r '.tags | join(",")')" >> $GITHUB_ENV

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -8,15 +8,17 @@ push=0
 load=0
 tag_suffix=""
 dry_run=0
+platform_override=""
 
 # Function to display usage information
 usage() {
-    echo "Usage: $0 -i <image_name> [-o <org_name>] [--push] [--load] [-t <tag_suffix>] [--dry]"
+    echo "Usage: $0 -i <image_name> [-o <org_name>] [--push] [--load] [-t <tag_suffix>] [-p <platform>] [--dry]"
     echo "  -i: Image name (required)"
     echo "  -o: Organization name"
     echo "  --push: Push the image"
     echo "  --load: Load the image"
     echo "  -t: Tag suffix"
+    echo "  -p: Platform(s) to build for (e.g. linux/amd64 or linux/amd64,linux/arm64)"
     echo "  --dry: Don't build, only create build-args.json"
     exit 1
 }
@@ -29,6 +31,7 @@ while [[ $# -gt 0 ]]; do
         --push) push=1; shift ;;
         --load) load=1; shift ;;
         -t) tag_suffix="$2"; shift 2 ;;
+        -p) platform_override="$2"; shift 2 ;;
         --dry) dry_run=1; shift ;;
         *) usage ;;
     esac
@@ -134,8 +137,10 @@ fi
 
 echo "Args: $args"
 
-# Modify the platform selection based on --load flag
-if [[ $load -eq 1 ]]; then
+# Determine the platform(s) to build for
+if [[ -n "$platform_override" ]]; then
+  platform="$platform_override"
+elif [[ $load -eq 1 ]]; then
   # When loading, build only for the current platform
   platform=$(docker version -f '{{.Server.Os}}/{{.Server.Arch}}')
 else


### PR DESCRIPTION
## Summary of PR

PR Docker builds were taking **3+ hours** on cache miss because the `linux/arm64` leg runs under QEMU emulation on x86_64 Blacksmith runners (~6.7× slower on CPU-bound steps like `poetry install`).

This PR centralizes the platform decision in the `define-matrix` job and restricts PR builds to `linux/amd64` only, while keeping `linux/amd64,linux/arm64` for main/tag/dispatch builds.

**Changes:**

- **`define-matrix` job**: Each matrix entry now carries a `platforms` field (`linux/amd64` for PRs, `linux/amd64,linux/arm64` otherwise). A top-level `platforms` output is also emitted for non-matrix consumers.
- **`ghcr_build_app` job**: Now `needs: define-matrix` and passes `-p ${{ needs.define-matrix.outputs.platforms }}` to `build.sh`.
- **`ghcr_build_runtime` job**: Passes `-p ${{ matrix.base_image.platforms }}` to the `build.sh --dry` invocation, which flows through the dry-run JSON → `DOCKER_PLATFORM` → `useblacksmith/build-push-action`.
- **`containers/build.sh`**: New `-p <platform>` flag overrides the default platform selection. Without `-p`, existing behavior is preserved.

| Trigger | Platforms |
|---------|-----------|
| `pull_request` | `linux/amd64` |
| `push` (main/tags) | `linux/amd64,linux/arm64` |
| `workflow_dispatch` | `linux/amd64,linux/arm64` |

## Change Type

- [x] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #13571

## Release Notes

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:0a14bd7-nikolaik   --name openhands-app-0a14bd7   docker.openhands.dev/openhands/openhands:0a14bd7
```