### PR TITLE
ci: upgrade useblacksmith/build-push-action v1 to v2

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -111,9 +111,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Setup Docker Builder
+        uses: useblacksmith/setup-docker-builder@v1
       - name: Install poetry via pipx
         run: pipx install poetry
       - name: Set up Python
@@ -144,21 +143,18 @@ jobs:
           echo "DOCKER_BUILD_ARGS=$(echo "$DOCKER_BUILD_JSON" | jq -r '.build_args | join(",")')" >> $GITHUB_ENV
       - name: Build and push runtime image ${{ matrix.base_image.image }}
         if: github.event.pull_request.head.repo.fork != true
-        uses: useblacksmith/build-push-action@v1
+        uses: useblacksmith/build-push-action@v2
         with:
           push: true
           tags: ${{ env.DOCKER_TAGS }}
           platforms: ${{ env.DOCKER_PLATFORM }}
-          # Caching directives to boost performance
-          cache-from: type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/runtime:buildcache-${{ matrix.base_image.tag }}
-          cache-to: type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/runtime:buildcache-${{ matrix.base_image.tag }},mode=max
           build-args: ${{ env.DOCKER_BUILD_ARGS }}
           context: containers/runtime
           provenance: false
       # Forked repos can't push to GHCR, so we just build in order to populate the cache for rebuilding
       - name: Build runtime image ${{ matrix.base_image.image }} for fork
         if: github.event.pull_request.head.repo.fork
-        uses: useblacksmith/build-push-action@v1
+        uses: useblacksmith/build-push-action@v2
         with:
           tags: ghcr.io/${{ env.REPO_OWNER }}/runtime:${{ env.RELEVANT_SHA }}-${{ matrix.base_image.tag }}
           context: containers/runtime
@@ -184,11 +180,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      # Set up Docker Buildx for better performance
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: network=host
+      - name: Setup Docker Builder
+        uses: useblacksmith/setup-docker-builder@v1
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -223,7 +216,7 @@ jobs:
           # rather than a mutable branch tag like "main" which can serve stale cached layers.
           echo "OPENHANDS_DOCKER_TAG=${RELEVANT_SHA}" >> $GITHUB_ENV
       - name: Build and push Docker image
-        uses: useblacksmith/build-push-action@v1
+        uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: enterprise/Dockerfile


### PR DESCRIPTION
## Summary of PR

Addresses the deprecation warning in the GHCR build workflow:

> ⚠️ DEPRECATION WARNING: useblacksmith/build-push-action@v1.x is no longer maintained.
> Please upgrade to the newer actions outlined at: https://docs.blacksmith.sh/blacksmith-caching/docker-builds

Per the [Blacksmith migration docs](https://docs.blacksmith.sh/blacksmith-caching/docker-builds), this PR:

- **Upgrades `useblacksmith/build-push-action@v1` → `@v2`** across all 3 usages (runtime push, runtime fork build, enterprise push)
- **Replaces `docker/setup-buildx-action@v3` with `useblacksmith/setup-docker-builder@v1`** in the `ghcr_build_runtime` and `ghcr_build_enterprise` jobs — required for v2's NVMe-backed layer caching
- **Removes `cache-from` / `cache-to` registry-based cache directives** from the runtime build step — Blacksmith v2 handles caching automatically via sticky disks, so external cache configuration is no longer needed

The `ghcr_build_app` job is unchanged since it uses `./containers/build.sh` directly (not `build-push-action`).

## Demo Screenshots/Videos

N/A — CI workflow change only.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

N/A

## Release Notes

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:1e45d35-nikolaik   --name openhands-app-1e45d35   docker.openhands.dev/openhands/openhands:1e45d35
```