### PR TITLE
refactor: consolidate loading spinner implementations

### DIFF
--- a/frontend/src/components/features/chat/microagent/loading-microagent-body.tsx
+++ b/frontend/src/components/features/chat/microagent/loading-microagent-body.tsx
@@ -1,7 +1,7 @@
-import { Spinner } from "@heroui/react";
 import { useTranslation } from "react-i18next";
 import { ModalBody } from "#/components/shared/modals/modal-body";
 import { Typography } from "#/ui/typography";
+import { LoadingSpinner } from "#/components/shared/loading-spinner";
 
 export function LoadingMicroagentBody() {
   const { t } = useTranslation();
@@ -10,7 +10,7 @@ export function LoadingMicroagentBody() {
       <h2 className="font-bold text-[20px] leading-6 -tracking-[0.01em] flex items-center gap-2">
         {t("MICROAGENT$ADD_TO_MICROAGENT")}
       </h2>
-      <Spinner size="lg" />
+      <LoadingSpinner size="large" />
       <Typography.Text>{t("MICROAGENT$WAIT_FOR_RUNTIME")}</Typography.Text>
     </ModalBody>
   );

--- a/frontend/src/components/features/chat/uploaded-file.tsx
+++ b/frontend/src/components/features/chat/uploaded-file.tsx
@@ -1,5 +1,5 @@
-import { LoaderCircle } from "lucide-react";
 import FileIcon from "#/icons/file.svg?react";
+import { LoadingSpinner } from "#/components/shared/loading-spinner";
 import { RemoveFileButton } from "./remove-file-button";
 import { cn, getFileExtension } from "#/utils/utils";
 
@@ -39,7 +39,7 @@ export function UploadedFile({
       </div>
       {isLoading && (
         <div className="flex items-center justify-center">
-          <LoaderCircle className="animate-spin w-5 h-5" color="white" />
+          <LoadingSpinner className="w-5 h-5 text-white" />
         </div>
       )}
     </div>

--- a/frontend/src/components/features/chat/uploaded-image.tsx
+++ b/frontend/src/components/features/chat/uploaded-image.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { LoaderCircle } from "lucide-react";
 import { RemoveFileButton } from "./remove-file-button";
+import { LoadingSpinner } from "#/components/shared/loading-spinner";
 
 interface UploadedImageProps {
   image: File;
@@ -30,7 +30,7 @@ export function UploadedImage({
     <div className="group min-w-[51px] min-h-[49px] w-[51px] h-[49px] rounded-lg bg-[#525252] relative flex items-center justify-center">
       <RemoveFileButton onClick={onRemove} />
       {isLoading ? (
-        <LoaderCircle className="animate-spin w-5 h-5" color="white" />
+        <LoadingSpinner className="w-5 h-5 text-white" />
       ) : (
         imageUrl && (
           <img

--- a/frontend/src/components/features/controls/agent-loading.tsx
+++ b/frontend/src/components/features/controls/agent-loading.tsx
@@ -1,9 +1,9 @@
-import { LoaderCircle } from "lucide-react";
+import { LoadingSpinner } from "#/components/shared/loading-spinner";
 
 export function AgentLoading() {
   return (
     <div data-testid="agent-loading-spinner">
-      <LoaderCircle className="animate-spin w-4 h-4" color="white" />
+      <LoadingSpinner className="w-4 h-4 text-white" />
     </div>
   );
 }

--- a/frontend/src/components/features/conversation-panel/hooks-loading-state.tsx
+++ b/frontend/src/components/features/conversation-panel/hooks-loading-state.tsx
@@ -1,7 +1,9 @@
+import { LoadingSpinner } from "#/components/shared/loading-spinner";
+
 export function HooksLoadingState() {
   return (
     <div className="flex justify-center items-center py-8">
-      <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary" />
+      <LoadingSpinner className="h-8 w-8" />
     </div>
   );
 }

--- a/frontend/src/components/features/conversation-panel/skills-loading-state.tsx
+++ b/frontend/src/components/features/conversation-panel/skills-loading-state.tsx
@@ -1,7 +1,9 @@
+import { LoadingSpinner } from "#/components/shared/loading-spinner";
+
 export function SkillsLoadingState() {
   return (
     <div className="flex justify-center items-center py-8">
-      <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary" />
+      <LoadingSpinner size="small" className="h-8 w-8" />
     </div>
   );
 }

--- a/frontend/src/components/features/conversation/conversation-loading.tsx
+++ b/frontend/src/components/features/conversation/conversation-loading.tsx
@@ -1,7 +1,7 @@
-import { LoaderCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
 import { cn } from "#/utils/utils";
+import { LoadingSpinner } from "#/components/shared/loading-spinner";
 
 type ConversationLoadingProps = {
   className?: string;
@@ -17,7 +17,7 @@ export function ConversationLoading({ className }: ConversationLoadingProps) {
         className,
       )}
     >
-      <LoaderCircle className="animate-spin w-16 h-16" color="white" />
+      <LoadingSpinner className="w-16 h-16 text-white" />
       <span className="text-2xl font-normal leading-5 text-white p-4">
         {t(I18nKey.HOME$LOADING)}
       </span>

--- a/frontend/src/components/features/diff-viewer/file-diff-viewer.tsx
+++ b/frontend/src/components/features/diff-viewer/file-diff-viewer.tsx
@@ -8,26 +8,7 @@ import { getLanguageFromPath } from "#/utils/get-language-from-path";
 import { cn } from "#/utils/utils";
 import ChevronUp from "#/icons/chveron-up.svg?react";
 import { useUnifiedGitDiff } from "#/hooks/query/use-unified-git-diff";
-
-interface LoadingSpinnerProps {
-  className?: string;
-}
-
-// TODO: Move out of this file and replace the current spinner with this one
-function LoadingSpinner({ className }: LoadingSpinnerProps) {
-  return (
-    <div className="flex items-center justify-center">
-      <div
-        className={cn(
-          "animate-spin rounded-full border-4 border-gray-200 border-t-blue-500",
-          className,
-        )}
-        role="status"
-        aria-label="Loading"
-      />
-    </div>
-  );
-}
+import { LoadingSpinner } from "#/components/shared/loading-spinner";
 
 const STATUS_MAP: Record<GitChangeStatus, string | IconType> = {
   A: LuFilePlus,

--- a/frontend/src/components/features/home/git-branch-dropdown/git-branch-dropdown.tsx
+++ b/frontend/src/components/features/home/git-branch-dropdown/git-branch-dropdown.tsx
@@ -10,6 +10,7 @@ import { Branch } from "#/types/git";
 import { Provider } from "#/types/settings";
 import { useDebounce } from "#/hooks/use-debounce";
 import { cn } from "#/utils/utils";
+import { LoadingSpinner } from "#/components/shared/loading-spinner";
 import { useBranchData } from "#/hooks/query/use-branch-data";
 
 import { ClearButton } from "../shared/clear-button";
@@ -186,7 +187,7 @@ export function GitBranchDropdown({
       <div className="relative">
         <div className="absolute left-2 top-1/2 transform -translate-y-1/2 z-10">
           {isLoadingState ? (
-            <div className="animate-spin h-4 w-4 border-2 border-blue-500 border-t-transparent rounded-full" />
+            <LoadingSpinner className="h-4 w-4" />
           ) : (
             <BranchIcon width={16} height={16} />
           )}

--- a/frontend/src/components/features/home/git-repo-dropdown/git-repo-dropdown.tsx
+++ b/frontend/src/components/features/home/git-repo-dropdown/git-repo-dropdown.tsx
@@ -11,6 +11,7 @@ import { Provider, ProviderOptions } from "#/types/settings";
 import { GitRepository } from "#/types/git";
 import { useDebounce } from "#/hooks/use-debounce";
 import { cn } from "#/utils/utils";
+import { LoadingSpinner } from "#/components/shared/loading-spinner";
 
 import { ClearButton } from "../shared/clear-button";
 import { ToggleButton } from "../shared/toggle-button";
@@ -322,7 +323,7 @@ export function GitRepoDropdown({
       <div className="relative">
         <div className="absolute left-2 top-1/2 transform -translate-y-1/2 z-10">
           {isLoadingState ? (
-            <div className="animate-spin h-4 w-4 border-2 border-blue-500 border-t-transparent rounded-full" />
+            <LoadingSpinner className="h-4 w-4" />
           ) : (
             <RepoIcon width={16} height={16} />
           )}

--- a/frontend/src/components/features/home/repository-selection/branch-loading-state.tsx
+++ b/frontend/src/components/features/home/repository-selection/branch-loading-state.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
-import { Spinner } from "@heroui/react";
 import { cn } from "#/utils/utils";
+import { LoadingSpinner } from "#/components/shared/loading-spinner";
 
 interface BranchLoadingStateProps {
   wrapperClassName?: string;
@@ -18,7 +18,7 @@ export function BranchLoadingState({
         wrapperClassName,
       )}
     >
-      <Spinner size="sm" />
+      <LoadingSpinner className="w-4 h-4" />
       <span className="text-sm">{t("HOME$LOADING_BRANCHES")}</span>
     </div>
   );

--- a/frontend/src/components/features/home/repository-selection/repository-loading-state.tsx
+++ b/frontend/src/components/features/home/repository-selection/repository-loading-state.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
-import { Spinner } from "@heroui/react";
 import { cn } from "#/utils/utils";
+import { LoadingSpinner } from "#/components/shared/loading-spinner";
 
 export interface RepositoryLoadingStateProps {
   wrapperClassName?: string;
@@ -18,7 +18,7 @@ export function RepositoryLoadingState({
         wrapperClassName,
       )}
     >
-      <Spinner size="sm" />
+      <LoadingSpinner className="w-4 h-4" />
       <span className="text-sm">{t("HOME$LOADING_REPOSITORIES")}</span>
     </div>
   );

--- a/frontend/src/components/features/home/shared/loading-spinner.tsx
+++ b/frontend/src/components/features/home/shared/loading-spinner.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { cn } from "#/utils/utils";
+import { LoadingSpinner as SharedLoadingSpinner } from "#/components/shared/loading-spinner";
 
 interface LoadingSpinnerProps {
   hasSelection: boolean;
@@ -17,10 +17,9 @@ export function LoadingSpinner({
         hasSelection ? "right-11" : "right-6",
       )}
     >
-      <div
-        className="animate-spin h-4 w-4 border-2 border-blue-500 border-t-transparent rounded-full"
-        data-testid={testId}
-      />
+      <div data-testid={testId}>
+        <SharedLoadingSpinner className="w-4 h-4" />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/shared/loader.tsx
+++ b/frontend/src/components/shared/loader.tsx
@@ -1,25 +1,24 @@
 import { cn } from "#/utils/utils";
+import { LoadingSpinner } from "#/components/shared/loading-spinner";
 
 interface LoaderProps {
   size?: "small" | "medium" | "large";
   className?: string;
 }
 
+const loaderSizeClasses = {
+  small: "w-3 h-3",
+  medium: "w-4 h-4",
+  large: "w-5 h-5",
+};
+
 export function Loader({ size = "medium", className }: LoaderProps) {
-  const sizeClasses = {
-    small: "w-3 h-3",
-    medium: "w-4 h-4",
-    large: "w-5 h-5",
-  };
-
-  const dotSize = sizeClasses[size];
-
   return (
     <div
       data-testid="loader"
       className={cn("flex items-center justify-center", className)}
     >
-      <div className={cn("loader rounded-full", dotSize)} />
+      <LoadingSpinner className={loaderSizeClasses[size]} />
     </div>
   );
 }

--- a/frontend/src/components/shared/loading-spinner.tsx
+++ b/frontend/src/components/shared/loading-spinner.tsx
@@ -4,6 +4,7 @@ import { cn } from "#/utils/utils";
 interface LoadingSpinnerProps {
   size?: "small" | "large";
   className?: string;
+  "aria-label"?: string;
 }
 
 const sizeClasses = {
@@ -14,10 +15,13 @@ const sizeClasses = {
 export function LoadingSpinner({
   size = "small",
   className,
+  "aria-label": ariaLabel = "Loading",
 }: LoadingSpinnerProps) {
   return (
     <LoaderCircle
       data-testid="loading-spinner"
+      role="status"
+      aria-label={ariaLabel}
       className={cn("animate-spin", sizeClasses[size], className)}
     />
   );

--- a/frontend/src/components/shared/loading-spinner.tsx
+++ b/frontend/src/components/shared/loading-spinner.tsx
@@ -1,37 +1,24 @@
-import LoadingSpinnerOuter from "#/icons/loading-outer.svg?react";
+import { LoaderCircle } from "lucide-react";
 import { cn } from "#/utils/utils";
 
 interface LoadingSpinnerProps {
-  size: "small" | "large";
+  size?: "small" | "large";
   className?: string;
-  innerClassName?: string;
-  outerClassName?: string;
 }
 
-export function LoadingSpinner({
-  size,
-  className,
-  innerClassName,
-  outerClassName,
-}: LoadingSpinnerProps) {
-  const sizeStyle =
-    size === "small" ? "w-[25px] h-[25px]" : "w-[50px] h-[50px]";
+const sizeClasses = {
+  small: "w-[25px] h-[25px]",
+  large: "w-[50px] h-[50px]",
+};
 
+export function LoadingSpinner({
+  size = "small",
+  className,
+}: LoadingSpinnerProps) {
   return (
-    <div
+    <LoaderCircle
       data-testid="loading-spinner"
-      className={cn("relative", sizeStyle, className)}
-    >
-      <div
-        className={cn(
-          "rounded-full border-4 border-[#525252] absolute",
-          sizeStyle,
-          innerClassName,
-        )}
-      />
-      <LoadingSpinnerOuter
-        className={cn("absolute animate-spin", sizeStyle, outerClassName)}
-      />
-    </div>
+      className={cn("animate-spin", sizeClasses[size], className)}
+    />
   );
 }

--- a/frontend/src/components/shared/modals/modal-button-group.tsx
+++ b/frontend/src/components/shared/modals/modal-button-group.tsx
@@ -48,8 +48,6 @@ export function ModalButtonGroup({
           <LoadingSpinner
             size="small"
             className="w-5 h-5"
-            innerClassName="hidden"
-            outerClassName="w-5 h-5"
           />
         ) : (
           primaryText

--- a/frontend/src/components/shared/modals/modal-button-group.tsx
+++ b/frontend/src/components/shared/modals/modal-button-group.tsx
@@ -45,10 +45,7 @@ export function ModalButtonGroup({
         isDisabled={isLoading}
       >
         {isLoading ? (
-          <LoadingSpinner
-            size="small"
-            className="w-5 h-5"
-          />
+          <LoadingSpinner size="small" className="w-5 h-5" />
         ) : (
           primaryText
         )}

--- a/frontend/src/routes/device-verify.tsx
+++ b/frontend/src/routes/device-verify.tsx
@@ -5,6 +5,7 @@ import { useIsAuthed } from "#/hooks/query/use-is-authed";
 import { EnterpriseBanner } from "#/components/features/device-verify/enterprise-banner";
 import { I18nKey } from "#/i18n/declaration";
 import { H1 } from "#/ui/typography";
+import { LoadingSpinner } from "#/components/shared/loading-spinner";
 import { ENABLE_PROJ_USER_JOURNEY } from "#/utils/feature-flags";
 
 export default function DeviceVerify() {
@@ -136,7 +137,7 @@ export default function DeviceVerify() {
       <div className="min-h-screen flex items-center justify-center bg-background">
         <div className="max-w-md w-full mx-auto p-6 bg-card rounded-lg shadow-lg">
           <div className="text-center">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4" />
+            <LoadingSpinner className="h-8 w-8 mx-auto mb-4" />
             <p className="text-muted-foreground">
               {t(I18nKey.DEVICE$PROCESSING)}
             </p>

--- a/frontend/src/routes/device-verify.tsx
+++ b/frontend/src/routes/device-verify.tsx
@@ -250,7 +250,7 @@ export default function DeviceVerify() {
     return (
       <div className="min-h-screen flex items-center justify-center bg-background">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4" />
+          <LoadingSpinner className="h-8 w-8 mx-auto mb-4" />
           <p className="text-muted-foreground">
             {t(I18nKey.DEVICE$PROCESSING)}
           </p>

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -5,6 +5,7 @@ import { useConfig } from "#/hooks/query/use-config";
 import { useGitHubAuthUrl } from "#/hooks/use-github-auth-url";
 import { useEmailVerification } from "#/hooks/use-email-verification";
 import { useInvitation } from "#/hooks/use-invitation";
+import { LoadingSpinner } from "#/components/shared/loading-spinner";
 import { LoginContent } from "#/components/features/auth/login-content";
 import { EmailVerificationModal } from "#/components/features/waitlist/email-verification-modal";
 import { RequestSubmittedModal } from "#/components/features/onboarding/request-submitted-modal";
@@ -72,7 +73,7 @@ export default function LoginPage() {
   if (isAuthLoading || config.isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-base">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white" />
+        <LoadingSpinner className="h-8 w-8 text-white" />
       </div>
     );
   }

--- a/frontend/src/routes/manage-organization-members.tsx
+++ b/frontend/src/routes/manage-organization-members.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { useTranslation } from "react-i18next";
-import { LoaderCircle, Plus, Search } from "lucide-react";
+import { Plus, Search } from "lucide-react";
+import { LoadingSpinner } from "#/components/shared/loading-spinner";
 import { InviteOrganizationMemberModal } from "#/components/features/org/invite-organization-member-modal";
 import { ConfirmRemoveMemberModal } from "#/components/features/org/confirm-remove-member-modal";
 import { ConfirmUpdateRoleModal } from "#/components/features/org/confirm-update-role-modal";
@@ -158,10 +159,9 @@ function ManageOrganizationMembers() {
           className="w-full leading-4 font-normal bg-transparent placeholder:italic placeholder:text-tertiary-alt outline-none"
         />
         {isFetching && debouncedEmailFilter && (
-          <LoaderCircle
-            size={16}
-            className="text-tertiary-alt animate-spin"
-            data-testid="search-loading-indicator"
+          <LoadingSpinner
+            className="w-4 h-4 text-tertiary-alt"
+            aria-label="Searching"
           />
         )}
       </div>

--- a/frontend/src/tailwind.css
+++ b/frontend/src/tailwind.css
@@ -211,38 +211,6 @@
   background: rgba(255, 255, 255, 0.2);
 }
 
-.loader {
-  background: #c9b974;
-  animation: l5 1s infinite linear alternate;
-}
-
-@keyframes l5 {
-  0% {
-    box-shadow:
-      20px 0 #c9b974,
-      -20px 0 rgba(201, 185, 116, 0.1);
-    background: #c9b974;
-  }
-  33% {
-    box-shadow:
-      20px 0 #c9b974,
-      -20px 0 rgba(201, 185, 116, 0.1);
-    background: rgba(201, 185, 116, 0.1);
-  }
-  66% {
-    box-shadow:
-      20px 0 rgba(201, 185, 116, 0.1),
-      -20px 0 #c9b974;
-    background: rgba(201, 185, 116, 0.1);
-  }
-  100% {
-    box-shadow:
-      20px 0 rgba(201, 185, 116, 0.1),
-      -20px 0 #c9b974;
-    background: #c9b974;
-  }
-}
-
 /* Custom styling for xterm */
 /* XTerm.js scrollbar styling - follows custom-scrollbar pattern */
 .xterm-viewport::-webkit-scrollbar {

--- a/frontend/src/ui/dropdown/loading-spinner.tsx
+++ b/frontend/src/ui/dropdown/loading-spinner.tsx
@@ -1,8 +1,9 @@
+import { LoadingSpinner as SharedLoadingSpinner } from "#/components/shared/loading-spinner";
+
 export function LoadingSpinner() {
   return (
-    <div
-      className="animate-spin h-4 w-4 border-2 border-blue-500 border-t-transparent rounded-full"
-      data-testid="dropdown-loading"
-    />
+    <div data-testid="dropdown-loading">
+      <SharedLoadingSpinner className="w-4 h-4" />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #12550

Replaces 8 different spinner/loading implementations with a single canonical `LoadingSpinner` component. All existing file names and exports are preserved so no downstream imports need to change.

## Changes

| File | Change |
|------|--------|
| `shared/loading-spinner.tsx` | Rewritten as canonical component using `LoaderCircle` from lucide-react, accepts `size` and `className` props |
| `shared/loader.tsx` | Now delegates to `LoadingSpinner` internally |
| `agent-loading.tsx` | Replaced `LoaderCircle` with `LoadingSpinner` |
| `conversation-loading.tsx` | Replaced `LoaderCircle` with `LoadingSpinner` |
| `loading-microagent-body.tsx` | Replaced `@heroui/react` `Spinner` with `LoadingSpinner` |
| `branch-loading-state.tsx` | Replaced `@heroui/react` `Spinner` with `LoadingSpinner` |
| `repository-loading-state.tsx` | Replaced `@heroui/react` `Spinner` with `LoadingSpinner` |
| `home/shared/loading-spinner.tsx` | Now wraps canonical `LoadingSpinner` |
| `ui/dropdown/loading-spinner.tsx` | Now wraps canonical `LoadingSpinner` |
| `file-diff-viewer.tsx` | Removed inline spinner, imports canonical `LoadingSpinner` (resolves TODO) |

Net result: -33 lines of code removed.