### PR TITLE
fix: [Bug]: Frequent logout in cloud environment (SaaS)

### DIFF
--- a/enterprise/server/routes/auth.py
+++ b/enterprise/server/routes/auth.py
@@ -60,6 +60,9 @@ oauth_router = APIRouter(prefix='/oauth')
 token_manager = TokenManager()
 
 
+COOKIE_MAX_AGE = 30 * 24 * 60 * 60  # 30 days in seconds
+
+
 def set_response_cookie(
     request: Request,
     response: Response,
@@ -86,6 +89,7 @@ def set_response_cookie(
             httponly=True,
             secure=secure,
             samesite=get_cookie_samesite(),
+            max_age=COOKIE_MAX_AGE,
         )
     else:
         response.set_cookie(
@@ -94,6 +98,7 @@ def set_response_cookie(
             httponly=True,
             secure=secure,
             samesite=get_cookie_samesite(),
+            max_age=COOKIE_MAX_AGE,
         )
 
 


### PR DESCRIPTION
Closes #12467

**Fix**: Set `max_age` to 30 days (2,592,000 seconds) on the cookie. The actual authentication lifetime is still controlled by Keycloak's token refresh mechanism — the cookie just needs to persist long enough for the refresh flow to work. When the refresh token eventually expires on the Keycloak sid

*Submitted via Gittensor mining agent*