### PR TITLE
feat(frontend): add contextual info messages on LLM settings page (org project)

### DIFF
--- a/frontend/__tests__/routes/llm-settings.test.tsx
+++ b/frontend/__tests__/routes/llm-settings.test.tsx
@@ -73,6 +73,12 @@ vi.mock("#/hooks/query/use-config", () => ({
   useConfig: () => mockUseConfig(),
 }));
 
+// Mock useOrgTypeAndAccess hook
+const mockUseOrgTypeAndAccess = vi.fn();
+vi.mock("#/hooks/use-org-type-and-access", () => ({
+  useOrgTypeAndAccess: () => mockUseOrgTypeAndAccess(),
+}));
+
 const renderLlmSettingsScreen = (
   orgId: string | null = null,
   meData?: {
@@ -163,6 +169,15 @@ beforeEach(() => {
 
   // Reset organization store
   useSelectedOrganizationStore.setState({ organizationId: "1" });
+
+  // Default mock for useOrgTypeAndAccess - returns team org by default
+  mockUseOrgTypeAndAccess.mockReturnValue({
+    selectedOrg: createMockOrganization({ id: "1", name: "Test Org", is_personal: false }),
+    isPersonalOrg: false,
+    isTeamOrg: true,
+    canViewOrgRoutes: true,
+    organizationId: "1",
+  });
 });
 
 describe("Content", () => {
@@ -1783,6 +1798,122 @@ describe("Role-based permissions", () => {
         expect(saveSettingsSpy).toHaveBeenCalled();
       });
     });
+  });
+});
+
+describe("Contextual info messages", () => {
+  it("should show admin info message for admin user in team organization", async () => {
+    // Arrange: SaaS mode with team org and admin role
+    mockUseConfig.mockReturnValue({
+      data: { app_mode: "saas" },
+      isLoading: false,
+    });
+    mockUseOrgTypeAndAccess.mockReturnValue({
+      selectedOrg: createMockOrganization({ id: "1", name: "Test Org", is_personal: false }),
+      isPersonalOrg: false,
+      isTeamOrg: true,
+      canViewOrgRoutes: true,
+      organizationId: "1",
+    });
+    const adminData = {
+      org_id: "1",
+      user_id: "99",
+      email: "admin@example.com",
+      role: "admin",
+      status: "active",
+      llm_api_key: "",
+      max_iterations: 20,
+      llm_model: "",
+      llm_api_key_for_byor: null,
+      llm_base_url: "",
+    };
+
+    // Act
+    renderLlmSettingsScreen("1", adminData);
+    await screen.findByTestId("llm-settings-screen");
+
+    // Assert
+    const infoMessage = screen.getByTestId("llm-settings-info-message");
+    expect(infoMessage).toHaveTextContent("SETTINGS$LLM_ADMIN_INFO");
+  });
+
+  it("should show member info message for member user in team organization", async () => {
+    // Arrange: SaaS mode with team org and member role
+    mockUseConfig.mockReturnValue({
+      data: { app_mode: "saas" },
+      isLoading: false,
+    });
+    mockUseOrgTypeAndAccess.mockReturnValue({
+      selectedOrg: createMockOrganization({ id: "1", name: "Test Org", is_personal: false }),
+      isPersonalOrg: false,
+      isTeamOrg: true,
+      canViewOrgRoutes: true,
+      organizationId: "1",
+    });
+    const memberData = {
+      org_id: "1",
+      user_id: "99",
+      email: "member@example.com",
+      role: "member",
+      status: "active",
+      llm_api_key: "",
+      max_iterations: 20,
+      llm_model: "",
+      llm_api_key_for_byor: null,
+      llm_base_url: "",
+    };
+
+    // Act
+    renderLlmSettingsScreen("1", memberData);
+    await screen.findByTestId("llm-settings-screen");
+
+    // Assert
+    const infoMessage = screen.getByTestId("llm-settings-info-message");
+    expect(infoMessage).toHaveTextContent("SETTINGS$LLM_MEMBER_INFO");
+  });
+
+  it("should not show info message for personal workspace", async () => {
+    // Arrange: SaaS mode with personal org
+    mockUseConfig.mockReturnValue({
+      data: { app_mode: "saas" },
+      isLoading: false,
+    });
+    mockUseOrgTypeAndAccess.mockReturnValue({
+      selectedOrg: createMockOrganization({ id: "1", name: "Personal Org", is_personal: true }),
+      isPersonalOrg: true,
+      isTeamOrg: false,
+      canViewOrgRoutes: false,
+      organizationId: "1",
+    });
+
+    // Act
+    renderLlmSettingsScreen("1");
+    await screen.findByTestId("llm-settings-screen");
+
+    // Assert
+    expect(screen.queryByTestId("llm-settings-info-message")).not.toBeInTheDocument();
+  });
+
+  it("should not show info message in OSS mode", async () => {
+    // Arrange: OSS mode
+    mockUseConfig.mockReturnValue({
+      data: { app_mode: "oss" },
+      isLoading: false,
+    });
+    mockUseOrgTypeAndAccess.mockReturnValue({
+      selectedOrg: createMockOrganization({ id: "1", name: "Test Org", is_personal: false }),
+      isPersonalOrg: false,
+      isTeamOrg: true,
+      canViewOrgRoutes: true,
+      organizationId: "1",
+    });
+
+    // Act
+    renderLlmSettingsScreen("1");
+    await screen.findByTestId("llm-settings-screen");
+
+    // Assert
+    expect(screen.queryByTestId("llm-settings-info-message")).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/routes/llm-settings.tsx
+++ b/frontend/src/routes/llm-settings.tsx
@@ -31,6 +31,7 @@ import { getProviderId } from "#/utils/map-provider";
 import { DEFAULT_OPENHANDS_MODEL } from "#/utils/verified-models";
 import { useMe } from "#/hooks/query/use-me";
 import { usePermission } from "#/hooks/organizations/use-permissions";
+import { useOrgTypeAndAccess } from "#/hooks/use-org-type-and-access";
 
 interface OpenHandsApiKeyHelpProps {
   testId: string;
@@ -79,6 +80,20 @@ function LlmSettingsScreen() {
   // In SaaS mode, check role-based permissions (members can only view, owners and admins can edit)
   const isOssMode = config?.app_mode === "oss";
   const isReadOnly = isOssMode ? false : !hasPermission("edit_llm_settings");
+
+  // Get organization type for contextual info messages
+  const { isTeamOrg } = useOrgTypeAndAccess();
+  const isAdminOrOwner = me?.role === "admin" || me?.role === "owner";
+
+  const getLlmSettingsInfoMessage = (): I18nKey | null => {
+    if (isOssMode) return null;
+    if (!isTeamOrg) return null;
+    return isAdminOrOwner
+      ? I18nKey.SETTINGS$LLM_ADMIN_INFO
+      : I18nKey.SETTINGS$LLM_MEMBER_INFO;
+  };
+
+  const infoMessageKey = getLlmSettingsInfoMessage();
 
   const [view, setView] = React.useState<"basic" | "advanced">("basic");
 
@@ -504,6 +519,15 @@ function LlmSettingsScreen() {
         className="flex flex-col h-full justify-between"
       >
         <div className="flex flex-col gap-6">
+          {infoMessageKey && (
+            <p
+              data-testid="llm-settings-info-message"
+              className="text-sm text-tertiary-alt"
+            >
+              {t(infoMessageKey)}
+            </p>
+          )}
+
           <SettingsSwitch
             testId="advanced-settings-switch"
             defaultIsToggled={view === "advanced"}


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

<!-- Summarize what the PR does -->

Add user-role-based informational messages on the Settings → LLM configuration page to clarify permission scope and management responsibilities:

- Organization admins/owners see: "The LLM settings configured below will apply to all users of the organization."
- Organization members see: "LLM settings are managed by your organization's administrator."
- Personal workspace and OSS mode users see no message

Implementation uses the existing useOrgTypeAndAccess hook to determine organization type and checks user role from useMe hook.

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

https://github.com/user-attachments/assets/445b1b64-ff0d-4992-b896-10ca4eb2914e

## Change Type

<!-- Choose the types that apply to your PR -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:507781a-nikolaik   --name openhands-app-507781a   docker.openhands.dev/openhands/openhands:507781a
```