### PR TITLE
feat(frontend): use LoginCTA in device verify with source-specific Learn more behavior

### DIFF
--- a/frontend/__tests__/components/features/auth/login-cta.test.tsx
+++ b/frontend/__tests__/components/features/auth/login-cta.test.tsx
@@ -17,11 +17,11 @@ describe("LoginCTA", () => {
     vi.clearAllMocks();
   });
 
-  const renderWithRouter = () => {
+  const renderWithRouter = (source?: "login_page" | "device_verify") => {
     const Stub = createRoutesStub([
       {
         path: "/",
-        Component: LoginCTA,
+        Component: () => <LoginCTA source={source} />,
       },
       {
         path: "/information-request",
@@ -74,5 +74,33 @@ describe("LoginCTA", () => {
       "href",
       "/information-request",
     );
+  });
+
+  it("should render external enterprise URL in device verify mode", () => {
+    renderWithRouter("device_verify");
+
+    const learnMoreLink = screen.getByRole("link", {
+      name: "CTA$LEARN_MORE",
+    });
+    expect(learnMoreLink).toHaveAttribute(
+      "href",
+      "https://openhands.dev/enterprise",
+    );
+    expect(learnMoreLink).toHaveAttribute("target", "_blank");
+    expect(learnMoreLink).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("should track device_verify location when Learn More is clicked in device verify mode", async () => {
+    const user = userEvent.setup();
+    renderWithRouter("device_verify");
+
+    const learnMoreLink = screen.getByRole("link", {
+      name: "CTA$LEARN_MORE",
+    });
+    await user.click(learnMoreLink);
+
+    expect(mockTrackSaasSelfhostedInquiry).toHaveBeenCalledWith({
+      location: "device_verify",
+    });
   });
 });

--- a/frontend/__tests__/routes/device-verify.test.tsx
+++ b/frontend/__tests__/routes/device-verify.test.tsx
@@ -235,7 +235,7 @@ describe("DeviceVerify", () => {
       });
     });
 
-    it("should include the EnterpriseBanner component when feature flag is enabled", async () => {
+    it("should include the LoginCTA component when feature flag is enabled", async () => {
       useIsAuthedMock.mockReturnValue({
         data: true,
         isLoading: false,
@@ -249,11 +249,11 @@ describe("DeviceVerify", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("ENTERPRISE$TITLE")).toBeInTheDocument();
+        expect(screen.getByTestId("login-cta")).toBeInTheDocument();
       });
     });
 
-    it("should not include the EnterpriseBanner and be center-aligned when feature flag is disabled", async () => {
+    it("should not include the LoginCTA and be center-aligned when feature flag is disabled", async () => {
       ENABLE_PROJ_USER_JOURNEY_MOCK.mockReturnValue(false);
       useIsAuthedMock.mockReturnValue({
         data: true,
@@ -273,8 +273,8 @@ describe("DeviceVerify", () => {
         ).toBeInTheDocument();
       });
 
-      // Banner should not be rendered
-      expect(screen.queryByText("ENTERPRISE$TITLE")).not.toBeInTheDocument();
+      // CTA should not be rendered
+      expect(screen.queryByTestId("login-cta")).not.toBeInTheDocument();
 
       // Container should use max-w-md (centered layout) instead of max-w-4xl
       const container = document.querySelector(".max-w-md");

--- a/frontend/src/components/features/auth/login-cta.tsx
+++ b/frontend/src/components/features/auth/login-cta.tsx
@@ -8,21 +8,45 @@ import { cn } from "#/utils/utils";
 import StackedIcon from "#/icons/stacked.svg?react";
 import { useTracking } from "#/hooks/use-tracking";
 
-export function LoginCTA() {
+type LoginCTAProps = {
+  className?: string;
+  source?: "login_page" | "device_verify";
+};
+
+const ENTERPRISE_URL = "https://openhands.dev/enterprise";
+const INFORMATION_REQUEST_PATH = "/information-request";
+
+export function LoginCTA({
+  className,
+  source = "login_page",
+}: LoginCTAProps = {}) {
   const { t } = useTranslation();
   const { trackSaasSelfhostedInquiry } = useTracking();
+  const isDeviceVerifySource = source === "device_verify";
+  const learnMoreButtonClassName = cn(
+    "inline-flex items-center justify-center",
+    "h-10 px-4 rounded",
+    "bg-[#050505] border border-[#242424]",
+    "text-white hover:bg-white hover:text-black",
+    "font-semibold text-sm",
+    "transition-colors",
+  );
 
   const handleLearnMoreClick = () => {
-    trackSaasSelfhostedInquiry({ location: "login_page" });
+    trackSaasSelfhostedInquiry({ location: source });
   };
 
   return (
     <Card
       testId="login-cta"
       theme="dark"
-      className={cn("w-full max-w-80 h-auto flex-col", "cta-card-gradient")}
+      className={cn(
+        "w-full max-w-80 h-auto flex-col",
+        "cta-card-gradient",
+        className,
+      )}
     >
-      <div className={cn("flex flex-col gap-[11px] p-6")}>
+      <div className={cn("flex h-full flex-col gap-[11px] p-6")}>
         <div className={cn("size-10")}>
           <StackedIcon width={40} height={40} />
         </div>
@@ -44,21 +68,27 @@ export function LoginCTA() {
           <li>{t(I18nKey.CTA$FEATURE_SUPPORT)}</li>
         </ul>
 
-        <div className={cn("h-10 flex justify-start")}>
-          <Link
-            to="/information-request"
-            onClick={handleLearnMoreClick}
-            className={cn(
-              "inline-flex items-center justify-center",
-              "h-10 px-4 rounded",
-              "bg-[#050505] border border-[#242424]",
-              "text-white hover:bg-white hover:text-black",
-              "font-semibold text-sm",
-              "transition-colors",
-            )}
-          >
-            {t(I18nKey.CTA$LEARN_MORE)}
-          </Link>
+        <div className={cn("mt-auto h-10 flex justify-start")}>
+          {/* Use <a> for external destination; react-router <Link> is only for internal app routes. */}
+          {isDeviceVerifySource ? (
+            <a
+              href={ENTERPRISE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={handleLearnMoreClick}
+              className={learnMoreButtonClassName}
+            >
+              {t(I18nKey.CTA$LEARN_MORE)}
+            </a>
+          ) : (
+            <Link
+              to={INFORMATION_REQUEST_PATH}
+              onClick={handleLearnMoreClick}
+              className={learnMoreButtonClassName}
+            >
+              {t(I18nKey.CTA$LEARN_MORE)}
+            </Link>
+          )}
         </div>
       </div>
     </Card>

--- a/frontend/src/routes/device-verify.tsx
+++ b/frontend/src/routes/device-verify.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useSearchParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useIsAuthed } from "#/hooks/query/use-is-authed";
-import { EnterpriseBanner } from "#/components/features/device-verify/enterprise-banner";
+import { LoginCTA } from "#/components/features/auth/login-cta";
 import { I18nKey } from "#/i18n/declaration";
 import { H1 } from "#/ui/typography";
 import { ENABLE_PROJ_USER_JOURNEY } from "#/utils/feature-flags";
@@ -151,11 +151,11 @@ export default function DeviceVerify() {
     return (
       <div className="min-h-screen flex items-center justify-center bg-background p-4">
         <div
-          className={`flex flex-col lg:flex-row items-center lg:items-start gap-6 w-full ${showEnterpriseBanner ? "max-w-4xl" : "max-w-md"}`}
+          className={`flex flex-col lg:flex-row items-center lg:items-stretch gap-6 w-full ${showEnterpriseBanner ? "max-w-4xl" : "max-w-md"}`}
         >
           {/* Device Authorization Card */}
           <div
-            className={`flex-1 min-w-0 max-w-md w-full mx-auto p-6 bg-card rounded-lg shadow-lg border border-neutral-700 ${showEnterpriseBanner ? "lg:mx-0" : ""}`}
+            className={`flex-1 min-w-0 max-w-md w-full mx-auto p-6 bg-card rounded-2xl shadow-lg border border-[#242424] ${showEnterpriseBanner ? "lg:mx-0 lg:self-stretch" : ""}`}
           >
             <H1 className="text-2xl mb-4 text-center">
               {t(I18nKey.DEVICE$AUTHORIZATION_REQUEST)}
@@ -197,8 +197,10 @@ export default function DeviceVerify() {
             </div>
           </div>
 
-          {/* Enterprise Banner */}
-          {showEnterpriseBanner && <EnterpriseBanner />}
+          {/* Login CTA */}
+          {showEnterpriseBanner && (
+            <LoginCTA source="device_verify" className="lg:self-stretch" />
+          )}
         </div>
       </div>
     );


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

<!-- Summarize what the PR does -->

- Replaced EnterpriseBanner with LoginCTA in the device verification page behind the existing feature flag.
- Extended LoginCTA with a source prop:
  - source="device_verify" opens https://openhands.dev/enterprise in a new tab.
  - default login usage continues to route to /information-request.
- Updated layout classes so the CTA card stretches to match the device authorization card height on larger screens.
- Updated device-verify tests to assert LoginCTA presence (data-testid="login-cta") instead of old enterprise banner text.
- Refactored duplicated Learn More button classes into a shared local constant and added a clarifying comment for <a> vs Link.

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

https://github.com/user-attachments/assets/807bbce9-f318-4d49-a9b4-40773b048649

## Change Type

<!-- Choose the types that apply to your PR -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:1b7731b-nikolaik   --name openhands-app-1b7731b   docker.openhands.dev/openhands/openhands:1b7731b
```