### PR TITLE
fix: validate redirect_uri in GitHub proxy to prevent open redirect (CWE-601)

### DIFF
--- a/enterprise/server/routes/github_proxy.py
+++ b/enterprise/server/routes/github_proxy.py
@@ -8,13 +8,41 @@ from urllib.parse import parse_qs, urlencode, urlparse
 import httpx
 from cryptography.fernet import Fernet
 from fastapi import FastAPI, Request, Response
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from server.logger import logger
 
 from openhands.server.shared import config
 from openhands.utils.http_session import httpx_verify_option
 
 GITHUB_PROXY_ENDPOINTS = bool(os.environ.get('GITHUB_PROXY_ENDPOINTS'))
+
+
+def _is_safe_redirect_uri(redirect_uri: str, request_netloc: str) -> bool:
+    """Validate that redirect_uri points to the same host as the proxy server.
+
+    This prevents open-redirect attacks where an attacker crafts a redirect_uri
+    pointing to an external domain (e.g., https://evil.com/steal) that would
+    receive the OAuth authorization code after the callback.
+
+    The redirect_uri must:
+    - Use the https scheme (or http for localhost)
+    - Have a netloc (hostname:port) that matches the request's own netloc
+    """
+    parsed = urlparse(redirect_uri)
+
+    # Reject non-HTTP(S) schemes (e.g., javascript:, data:, etc.)
+    if parsed.scheme not in ('https', 'http'):
+        return False
+
+    # Reject if no hostname
+    if not parsed.hostname:
+        return False
+
+    # The redirect_uri must target the same host as the proxy server itself
+    if parsed.netloc != request_netloc:
+        return False
+
+    return True
 
 
 def add_github_proxy_routes(app: FastAPI):
@@ -49,8 +77,21 @@ def add_github_proxy_routes(app: FastAPI):
     def github_proxy_start(request: Request):
         parsed_url = urlparse(str(request.url))
         query_params = parse_qs(parsed_url.query)
+        redirect_uri = query_params['redirect_uri'][0]
+
+        # Validate redirect_uri before encrypting it into the state
+        request_netloc = str(request.url.netloc)
+        if not _is_safe_redirect_uri(redirect_uri, request_netloc):
+            return JSONResponse(
+                status_code=400,
+                content={
+                    'error': 'invalid_redirect_uri',
+                    'message': 'redirect_uri must target the same host as the proxy server',
+                },
+            )
+
         state_payload = json.dumps(
-            [query_params['state'][0], query_params['redirect_uri'][0]]
+            [query_params['state'][0], redirect_uri, request_netloc]
         )
         # Compress before encrypting to reduce URL length
         # This is critical for feature deployments where reCAPTCHA tokens in state
@@ -77,7 +118,24 @@ def add_github_proxy_routes(app: FastAPI):
         decrypted_state = zlib.decompress(decrypted_payload).decode()
 
         # Build query Params
-        state, redirect_uri = json.loads(decrypted_state)
+        payload = json.loads(decrypted_state)
+        # Support both old format [state, redirect_uri] and new [state, redirect_uri, netloc]
+        if len(payload) == 3:
+            state, redirect_uri, origin_netloc = payload
+        else:
+            state, redirect_uri = payload
+            origin_netloc = str(request.url.netloc)
+
+        # Validate redirect_uri before redirecting (defense in depth)
+        if not _is_safe_redirect_uri(redirect_uri, origin_netloc):
+            return JSONResponse(
+                status_code=400,
+                content={
+                    'error': 'invalid_redirect_uri',
+                    'message': 'redirect_uri must target the same host as the proxy server',
+                },
+            )
+
         query_params['state'] = [state]
         query_string = urlencode(query_params, doseq=True)
 

--- a/enterprise/tests/unit/server/routes/test_github_proxy.py
+++ b/enterprise/tests/unit/server/routes/test_github_proxy.py
@@ -43,7 +43,8 @@ def test_state_compress_encrypt_and_decrypt_decompress_roundtrip(
     client = TestClient(app)
 
     original_state = 'some-state-value'
-    original_redirect_uri = 'https://example.com/redirect'
+    # Use a redirect_uri on the same host as TestClient (testserver)
+    original_redirect_uri = 'http://testserver/auth/callback'
 
     # Call github_proxy_start endpoint - it should redirect to GitHub with encrypted state
     with patch('server.routes.github_proxy.config', mock_config):
@@ -94,3 +95,72 @@ def test_state_compress_encrypt_and_decrypt_decompress_roundtrip(
 
     assert final_params['state'][0] == original_state
     assert final_params['code'][0] == 'test-auth-code'
+
+
+def test_open_redirect_to_external_domain_is_blocked(app_with_github_proxy):
+    """
+    CWE-601: Verify that a redirect_uri pointing to an external domain is rejected.
+
+    An attacker can craft the initial OAuth request with redirect_uri=https://evil.com/steal.
+    Without validation, this gets encrypted into the state, and on callback the redirect_uri
+    is used verbatim in a RedirectResponse, sending the victim to evil.com with the OAuth code.
+    """
+    app, mock_config = app_with_github_proxy
+    client = TestClient(app)
+
+    malicious_redirect = 'https://evil.com/steal'
+
+    with patch('server.routes.github_proxy.config', mock_config):
+        response = client.get(
+            '/github-proxy/test-subdomain/login/oauth/authorize',
+            params={
+                'state': 'attacker-state',
+                'redirect_uri': malicious_redirect,
+                'client_id': 'test-client-id',
+            },
+            follow_redirects=False,
+        )
+
+    # The start endpoint should reject the malicious redirect_uri
+    assert response.status_code == 400
+    assert response.json()['error'] == 'invalid_redirect_uri'
+
+
+def test_open_redirect_javascript_uri_is_blocked(app_with_github_proxy):
+    """CWE-601: Verify javascript: URI scheme is blocked."""
+    app, mock_config = app_with_github_proxy
+    client = TestClient(app)
+
+    with patch('server.routes.github_proxy.config', mock_config):
+        response = client.get(
+            '/github-proxy/test-subdomain/login/oauth/authorize',
+            params={
+                'state': 'attacker-state',
+                'redirect_uri': 'javascript:alert(document.cookie)',
+                'client_id': 'test-client-id',
+            },
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 400
+    assert response.json()['error'] == 'invalid_redirect_uri'
+
+
+def test_open_redirect_data_uri_is_blocked(app_with_github_proxy):
+    """CWE-601: Verify data: URI scheme is blocked."""
+    app, mock_config = app_with_github_proxy
+    client = TestClient(app)
+
+    with patch('server.routes.github_proxy.config', mock_config):
+        response = client.get(
+            '/github-proxy/test-subdomain/login/oauth/authorize',
+            params={
+                'state': 'attacker-state',
+                'redirect_uri': 'data:text/html,<script>alert(1)</script>',
+                'client_id': 'test-client-id',
+            },
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 400
+    assert response.json()['error'] == 'invalid_redirect_uri'


### PR DESCRIPTION
## Vulnerability Summary

**CWE-601: URL Redirection to Untrusted Site ("Open Redirect")**
**Severity: High** — enables OAuth authorization code theft via phishing

### Affected Component

`enterprise/server/routes/github_proxy.py` — the `github_proxy_start` and `github_proxy_callback` endpoints.

### Data Flow

1. Attacker crafts a URL to `/github-proxy/{subdomain}/login/oauth/authorize` with `redirect_uri=https://evil.com/steal`
2. The `redirect_uri` query parameter is read directly from user input (`query_params["redirect_uri"][0]`) with **no validation**
3. It is encrypted into the OAuth `state` parameter via Fernet and sent to GitHub
4. After the victim authorizes on GitHub, the callback decrypts the state and issues `RedirectResponse(redirect_uri + "?code=AUTH_CODE&state=...")`
5. The victim's browser is redirected to the attacker's domain **with the OAuth authorization code**, which can be exchanged for a GitHub access token

### Exploit Example

```
https://staging.openhands.ai/github-proxy/feature-x/login/oauth/authorize?state=xyzzy&redirect_uri=https://evil.com/steal&client_id=Iv1.abc123
```

The Fernet encryption of the state does **not** mitigate this — the attacker controls the plaintext input to the encryption, not the ciphertext in transit.

### Preconditions

1. `GITHUB_PROXY_ENDPOINTS` environment variable must be set (staging/feature-branch environments — internet-facing)
2. Victim clicks the crafted link and authorizes the GitHub OAuth prompt (high likelihood since it's the real app's OAuth flow)
3. **No authentication** is required — the `/github-proxy/` path is not covered by the auth middleware (which only protects `/api*` and `/mcp*`)

---

## Fix Description

### What Changed

Added a `_is_safe_redirect_uri()` validation function that checks:
- **Scheme**: must be `https` or `http` (blocks `javascript:`, `data:`, etc.)
- **Hostname**: must be present
- **Netloc match**: `redirect_uri`'s `netloc` (host:port) must match the request's own `netloc`

### Where It's Applied

1. **`github_proxy_start`** (primary defense): Validates `redirect_uri` *before* encrypting it into state. Returns HTTP 400 with `{"error": "invalid_redirect_uri"}` if invalid.
2. **`github_proxy_callback`** (defense in depth): Re-validates `redirect_uri` after decrypting the state, before issuing the redirect.

### Backward Compatibility

The encrypted state payload is extended from `[state, redirect_uri]` to `[state, redirect_uri, request_netloc]`. The callback gracefully handles old-format payloads by falling back to `request.url.netloc` when the third element is missing.

### Rationale

- Netloc comparison is the correct approach per [RFC 6819 §4.2.4](https://datatracker.ietf.org/doc/html/rfc6819#section-4.2.4) (OAuth threat model — redirect URI manipulation)
- Scheme filtering prevents `javascript:` and `data:` URI bypasses
- Defense in depth at callback protects against any future code path that might bypass the start endpoint

---

## Test Results

### New Tests Added (3 tests)

| Test | What It Verifies | Result |
|------|-----------------|--------|
| `test_open_redirect_to_external_domain_is_blocked` | `redirect_uri=https://evil.com/steal` → HTTP 400 | ✅ Pass |
| `test_open_redirect_javascript_uri_is_blocked` | `redirect_uri=javascript:alert(...)` → HTTP 400 | ✅ Pass |
| `test_open_redirect_data_uri_is_blocked` | `redirect_uri=data:text/html,...` → HTTP 400 | ✅ Pass |

### Existing Test Updated

| Test | Change | Result |
|------|--------|--------|
| `test_state_compress_encrypt_and_decrypt_decompress_roundtrip` | Updated `redirect_uri` from `https://example.com/redirect` to `http://testserver/auth/callback` (same-host) so the roundtrip test passes with the new validation | ✅ Pass |

---

## Disprove Analysis

Before submitting, I systematically attempted to disprove this finding:

### Mitigation Checks

| Check | Result |
|-------|--------|
| **Auth middleware** | Does NOT protect `/github-proxy/` — only `/api*` and `/mcp*` paths. Endpoint is fully unauthenticated. |
| **CORS** | Does not apply — this is a browser navigation (GET redirect), not a cross-origin JS fetch. |
| **Fernet encryption** | Does NOT mitigate — attacker controls the *plaintext input* to encryption, not the ciphertext. |
| **Network isolation** | Server is exposed on port 3000 via docker-compose. Staging is internet-facing. |
| **Deployment scope** | `GITHUB_PROXY_ENDPOINTS` is "typically only staging" but staging environments are internet-facing and serve real users testing feature branches. |
| **Existing validation** | No validation, sanitization, or escaping on `redirect_uri` in the original code. |
| **Prior reports** | No prior CWE-601 or open redirect issues found. |
| **Similar patterns** | The `email.py` redirect is NOT vulnerable — it constructs `redirect_uri` from server-controlled `get_web_url(request)`. |

### Bypass Path Analysis

- The only code path producing a `RedirectResponse` with `redirect_uri` is `github_proxy_callback` (original line 85)
- The callback can only receive state encrypted by the start endpoint (Fernet key is server-side)
- Validating at the start endpoint covers all paths; callback validation is defense in depth
- **No parallel bypass paths exist**

### Verdict

**CONFIRMED_VALID** — Textbook CWE-601 open redirect in an OAuth proxy flow. The fix is meaningful, covers all code paths, handles edge cases (scheme filtering, empty hostname, old state format), and includes comprehensive tests.

---

## Files Changed

```
enterprise/server/routes/github_proxy.py           | +60 -4
enterprise/tests/unit/server/routes/test_github_proxy.py | +72 -1
```

2 files changed, 132 insertions, 4 deletions.