### PR TITLE
fix: add authorization check to feedback submission endpoint (CWE-862)

### DIFF
--- a/enterprise/server/routes/feedback.py
+++ b/enterprise/server/routes/feedback.py
@@ -14,11 +14,36 @@ from openhands.server.user_auth import get_user_id
 
 # We use the get_dependencies method here to signal to the OpenAPI docs that this endpoint
 # is protected. The actual protection is provided by SetAuthCookieMiddleware
-# TODO: It may be an error by you can actually post feedback to a conversation you don't
-# own right now - maybe this is useful in the context of public shared conversations?
 router = APIRouter(
     prefix='/feedback', tags=['feedback'], dependencies=get_dependencies()
 )
+
+
+async def _verify_conversation_ownership(
+    conversation_id: str, user_id: str
+) -> None:
+    """Verify that the conversation belongs to the authenticated user.
+
+    Args:
+        conversation_id: The ID of the conversation to verify
+        user_id: The ID of the authenticated user
+
+    Raises:
+        HTTPException: If conversation not found or not owned by user
+    """
+    async with a_session_maker() as session:
+        result = await session.execute(
+            select(StoredConversationMetadataSaas).where(
+                StoredConversationMetadataSaas.conversation_id == conversation_id,
+                StoredConversationMetadataSaas.user_id == user_id,
+            )
+        )
+        metadata = result.scalars().first()
+        if not metadata:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f'Conversation {conversation_id} not found',
+            )
 
 
 async def get_event_ids(conversation_id: str, user_id: str) -> List[int]:
@@ -36,19 +61,7 @@ async def get_event_ids(conversation_id: str, user_id: str) -> List[int]:
     """
 
     # Verify the conversation belongs to the user
-    async with a_session_maker() as session:
-        result = await session.execute(
-            select(StoredConversationMetadataSaas).where(
-                StoredConversationMetadataSaas.conversation_id == conversation_id,
-                StoredConversationMetadataSaas.user_id == user_id,
-            )
-        )
-        metadata = result.scalars().first()
-        if not metadata:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f'Conversation {conversation_id} not found',
-            )
+    await _verify_conversation_ownership(conversation_id, user_id)
 
     # Create an event store to access the events directly
     # This works even when the conversation is not running
@@ -74,13 +87,18 @@ class FeedbackRequest(BaseModel):
 
 
 @router.post('/conversation', status_code=status.HTTP_201_CREATED)
-async def submit_conversation_feedback(feedback: FeedbackRequest):
+async def submit_conversation_feedback(
+    feedback: FeedbackRequest, user_id: str = Depends(get_user_id)
+):
     """
     Submit feedback for a conversation.
 
     This endpoint accepts a rating (1-5) and optional reason for the feedback.
     The feedback is associated with a specific conversation and optionally a specific event.
     """
+    # Verify the authenticated user owns the conversation
+    await _verify_conversation_ownership(feedback.conversation_id, user_id)
+
     # Validate rating is between 1 and 5
     if feedback.rating < 1 or feedback.rating > 5:
         raise HTTPException(

--- a/enterprise/tests/unit/test_feedback.py
+++ b/enterprise/tests/unit/test_feedback.py
@@ -30,6 +30,16 @@ async def test_submit_feedback():
     mock_session = MagicMock()
     mock_session.commit = AsyncMock()
 
+    # Mock the ownership verification query to return a matching record
+    mock_metadata = MagicMock()
+    mock_metadata.conversation_id = 'test-conversation-123'
+    mock_metadata.user_id = 'test-user-id'
+    mock_result = MagicMock()
+    mock_scalars = MagicMock()
+    mock_scalars.first.return_value = mock_metadata
+    mock_result.scalars.return_value = mock_scalars
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
     # Test data
     feedback_data = FeedbackRequest(
         conversation_id='test-conversation-123',
@@ -47,7 +57,7 @@ async def test_submit_feedback():
     # Mock a_session_maker
     with patch('server.routes.feedback.a_session_maker', mock_a_session_maker):
         # Call the function
-        result = await submit_conversation_feedback(feedback_data)
+        result = await submit_conversation_feedback(feedback_data, user_id='test-user-id')
 
         # Check response
         assert result == {
@@ -76,6 +86,14 @@ async def test_invalid_rating():
     mock_session = MagicMock()
     mock_session.commit = AsyncMock()
 
+    # Mock the ownership verification query to return a matching record
+    mock_metadata = MagicMock()
+    mock_result = MagicMock()
+    mock_scalars = MagicMock()
+    mock_scalars.first.return_value = mock_metadata
+    mock_result.scalars.return_value = mock_scalars
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
     # Since Pydantic validation happens before our function is called,
     # we need to patch the validation to test our function's validation
     with patch(
@@ -101,12 +119,12 @@ async def test_invalid_rating():
         with patch('server.routes.feedback.a_session_maker', mock_a_session_maker):
             # Call the function and expect an exception
             with pytest.raises(HTTPException) as excinfo:
-                await submit_conversation_feedback(feedback_data)
+                await submit_conversation_feedback(feedback_data, user_id='test-user-id')
 
             # Check the exception details
             assert excinfo.value.status_code == 400
             assert 'Rating must be between 1 and 5' in excinfo.value.detail
 
-            # Verify no database operations were called
+            # Verify no feedback was added to the database
             mock_session.add.assert_not_called()
             mock_session.commit.assert_not_called()

--- a/enterprise/tests/unit/test_feedback_authorization.py
+++ b/enterprise/tests/unit/test_feedback_authorization.py
@@ -1,0 +1,129 @@
+"""
+Test for CWE-862: Missing authorization on feedback submission endpoint.
+
+The submit_conversation_feedback endpoint must verify that the authenticated
+user owns the conversation before allowing feedback submission.
+
+Uses AST-based analysis to work around complex enterprise dependency chains.
+"""
+import ast
+import os
+
+import pytest
+
+
+def _get_feedback_source():
+    """Read the feedback route source file."""
+    base = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    path = os.path.join(base, 'server', 'routes', 'feedback.py')
+    with open(path) as f:
+        return f.read()
+
+
+def test_submit_conversation_feedback_has_user_id_parameter():
+    """
+    Verify submit_conversation_feedback declares a user_id parameter.
+
+    Before the fix the signature was:
+        async def submit_conversation_feedback(feedback: FeedbackRequest)
+    After the fix:
+        async def submit_conversation_feedback(feedback: FeedbackRequest, user_id: str = Depends(get_user_id))
+    """
+    source = _get_feedback_source()
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name == 'submit_conversation_feedback':
+                param_names = [arg.arg for arg in node.args.args]
+                assert 'user_id' in param_names, (
+                    'submit_conversation_feedback must accept a user_id parameter '
+                    'for authorization checks (CWE-862)'
+                )
+                return
+
+    pytest.fail('submit_conversation_feedback function not found in source')
+
+
+def test_submit_conversation_feedback_performs_ownership_check():
+    """
+    Verify that submit_conversation_feedback calls an ownership verification
+    function that queries StoredConversationMetadataSaas with user_id.
+
+    The check may be inline or delegated to a helper — either way the
+    function must use user_id for an authorization-related call.
+    """
+    source = _get_feedback_source()
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name == 'submit_conversation_feedback':
+                body_source = ast.get_source_segment(source, node)
+                assert body_source is not None, 'Could not extract function source'
+
+                # The function must reference user_id in some ownership-checking call.
+                # It can either:
+                #   (a) inline the StoredConversationMetadataSaas query, or
+                #   (b) call a helper like _verify_conversation_ownership
+                has_inline_check = 'StoredConversationMetadataSaas' in body_source
+                has_helper_call = '_verify_conversation_ownership' in body_source
+
+                assert has_inline_check or has_helper_call, (
+                    'submit_conversation_feedback must verify conversation ownership '
+                    'either inline or via a helper function'
+                )
+
+                # And the helper (if used) must actually exist and do the right thing
+                if has_helper_call and not has_inline_check:
+                    # Find the helper function and verify it queries with user_id
+                    helper_found = False
+                    for other_node in ast.walk(tree):
+                        if isinstance(
+                            other_node, (ast.FunctionDef, ast.AsyncFunctionDef)
+                        ) and other_node.name == '_verify_conversation_ownership':
+                            helper_source = ast.get_source_segment(source, other_node)
+                            assert helper_source is not None
+                            assert 'StoredConversationMetadataSaas' in helper_source, (
+                                '_verify_conversation_ownership must query '
+                                'StoredConversationMetadataSaas'
+                            )
+                            assert 'user_id' in helper_source, (
+                                '_verify_conversation_ownership must filter by user_id'
+                            )
+                            helper_found = True
+                            break
+                    assert helper_found, (
+                        '_verify_conversation_ownership helper function not found'
+                    )
+                return
+
+    pytest.fail('submit_conversation_feedback function not found in source')
+
+
+def test_ownership_check_raises_404_on_missing_conversation():
+    """
+    Verify that the ownership verification raises HTTP 404 when the
+    conversation is not found for the authenticated user.
+    """
+    source = _get_feedback_source()
+    tree = ast.parse(source)
+
+    # Check the helper or inline — wherever the 404 is raised
+    ownership_functions = ['submit_conversation_feedback', '_verify_conversation_ownership']
+    found_404 = False
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name in ownership_functions:
+                body_source = ast.get_source_segment(source, node)
+                if body_source and (
+                    'HTTP_404_NOT_FOUND' in body_source or '404' in body_source
+                ):
+                    found_404 = True
+                    break
+
+    assert found_404, (
+        'The ownership verification path must raise HTTP 404 when the '
+        'conversation is not found for the authenticated user'
+    )


### PR DESCRIPTION
## Vulnerability Summary

**CWE-862: Missing Authorization** — The `submit_conversation_feedback` endpoint (`POST /feedback/conversation`) accepts feedback for any `conversation_id` without verifying that the authenticated user owns the referenced conversation. In SaaS mode, this endpoint is also effectively **unauthenticated** due to a routing gap.

**Severity:** Medium (data integrity impact; low-sensitivity data but internet-facing)

### Data Flow

1. Attacker sends `POST /feedback/conversation` with an arbitrary `conversation_id`
2. The path `/feedback/conversation` does **not** start with `/api` or `/mcp`, so `SetAuthCookieMiddleware._should_attach()` returns `False` — **no middleware auth check**
3. `get_dependencies()` in SaaS mode returns `APIKeyHeader(auto_error=False)` — **does not reject unauthenticated requests** (doc-only)
4. `submit_conversation_feedback()` had **no** `Depends(get_user_id)` — no endpoint-level auth
5. The `ConversationFeedback` row is blindly inserted into the database

### Developer Acknowledgment

The codebase contained this comment before the fix, confirming this was a known gap:

```python
# TODO: It may be an error by you can actually post feedback to a conversation you don't
# own right now - maybe this is useful in the context of public shared conversations?
```

---

## Fix Description

This PR makes two changes to `enterprise/server/routes/feedback.py`:

1. **Authentication:** Adds `user_id: str = Depends(get_user_id)` to `submit_conversation_feedback`, which triggers `SaasUserAuth.get_instance()` and raises `NoCredentialsError` if no valid cookie/bearer token is present.

2. **Authorization:** Extracts a `_verify_conversation_ownership()` helper that queries `StoredConversationMetadataSaas` filtering by both `conversation_id` AND `user_id`, raising HTTP 404 if no match. This is called before the feedback record is created.

### Rationale

- Follows the **exact same pattern** already used by the neighboring `get_batch_feedback` endpoint, which already had `Depends(get_user_id)` and ownership verification via `get_event_ids()`.
- The ownership check logic was extracted from `get_event_ids()` into a reusable `_verify_conversation_ownership()` helper, and `get_event_ids()` was refactored to call it — **no duplication**.
- The TODO comment acknowledging the gap was removed since the fix resolves it.

### Files Changed (3 files, our commit only)

| File | Change |
|------|--------|
| `enterprise/server/routes/feedback.py` | Add auth + ownership check to `submit_conversation_feedback`; extract `_verify_conversation_ownership` helper; refactor `get_event_ids` to reuse it |
| `enterprise/tests/unit/test_feedback.py` | Update existing tests to pass `user_id` and mock the ownership query |
| `enterprise/tests/unit/test_feedback_authorization.py` | New AST-based tests verifying the authorization check is structurally present |

---

## Test Results

### New Tests (`test_feedback_authorization.py`)

Three AST-based structural tests that verify the fix cannot regress:

| Test | What it checks |
|------|---------------|
| `test_submit_conversation_feedback_has_user_id_parameter` | The function signature includes a `user_id` parameter |
| `test_submit_conversation_feedback_performs_ownership_check` | The function body calls `_verify_conversation_ownership` (or inlines a `StoredConversationMetadataSaas` query) |
| `test_ownership_check_raises_404_on_missing_conversation` | The ownership verification path raises HTTP 404 for non-matching conversations |

### Updated Tests (`test_feedback.py`)

- `test_submit_feedback` — now passes `user_id='test-user-id'` and mocks the ownership query to return a matching record
- `test_invalid_rating` — same ownership mock added so the auth check passes before rating validation

---

## Disprove Analysis

We systematically attempted to invalidate this finding:

### Auth Check
The `submit_conversation_feedback` endpoint on `main` has **no** `Depends(get_user_id)` or any auth dependency. The router-level `dependencies=get_dependencies()` in SaaS mode returns `[Depends(APIKeyHeader(name='X-Access-Token', auto_error=False))]`, which is doc-only and **does not reject unauthenticated requests**.

### Network Check
The app is **internet-facing** at `https://app.all-hands.dev`. CORS restricts browser-based cross-origin requests but does **not** prevent direct `curl`/Postman/scripted attacks.

### Deployment Check
The app deploys via Docker behind nginx ingress. The middleware (`SetAuthCookieMiddleware`) **only enforces auth on paths starting with `/api` or `/mcp`**. The feedback router uses prefix `/feedback` (not `/api/feedback`), so it **completely bypasses middleware authentication**.

### Caller Trace
The frontend calls `POST /feedback/conversation` with the current `conversation_id`. In the vulnerable code, there is no server-side validation that the caller owns the referenced conversation.

### Validation Check
No input sanitization, no ownership check, no auth validation before the DB write in the original code.

### Prior Reports
No prior security reports about this specific endpoint found in GitHub issues.

### Fix Adequacy
The fix adds both **authentication** (`Depends(get_user_id)`) and **authorization** (`_verify_conversation_ownership`). This is **not cosmetic** — it addresses the root cause.

### Exploit Sketch

```bash
curl -X POST https://app.all-hands.dev/feedback/conversation \
  -H "Content-Type: application/json" \
  -d '{"conversation_id": "any-known-conversation-id", "rating": 1, "reason": "spam"}'
```

No cookies, no API key, no authentication of any kind needed.

### Mitigations Found
- **CORS** — restricts browser cross-origin only, not direct API calls
- **UUIDs** — conversation IDs are likely UUIDs (hard to enumerate blindly), but if leaked exploitation is trivial
- **Low-impact data** — feedback (rating 1-5, reason) is low-sensitivity; impact is data integrity pollution

### Verdict: **CONFIRMED_VALID** (high confidence)

---

*This fix was prepared and reviewed through a 4-stage automated security audit pipeline. Happy to discuss or adjust the approach if the team prefers a different pattern.*