### PR TITLE
APP-1152 Add legacy fallback variable when finding persistence directory

### DIFF
--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -67,6 +67,10 @@ def get_default_persistence_dir() -> Path:
     # Recheck env because this function is also used to generate other defaults
     persistence_dir = os.getenv('OH_PERSISTENCE_DIR')
 
+    # Legacy V0 fallback variable
+    if persistence_dir is None:
+        persistence_dir = os.getenv('FILE_STORE_PATH')
+
     if persistence_dir:
         result = Path(persistence_dir)
     else:


### PR DESCRIPTION
## Summary of PR

We now support the legacy `FILE_STORE_PATH` variable when identifying the persistence directory. We will swap over to the new variable when we remove support for V0 - for now it is still defined in the Dockerfile.

## Demo Screenshots/Videos

<img width="489" height="269" alt="image" src="https://github.com/user-attachments/assets/944fecee-860b-4c47-b803-08d0a126d290" />
<img width="562" height="376" alt="image" src="https://github.com/user-attachments/assets/da2f7af4-5bc1-42e1-a166-b9d773c311da" />


## Change Type

<!-- Choose the types that apply to your PR -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

https://github.com/OpenHands/OpenHands/issues/13578

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.
