### PR TITLE
APP-1154 : fix(migration): serialize dict to JSON string in migration 103 

### DIFF
--- a/enterprise/migrations/versions/103_add_mcp_config_to_org_member.py
+++ b/enterprise/migrations/versions/103_add_mcp_config_to_org_member.py
@@ -6,6 +6,7 @@ Create Date: 2026-03-26
 
 """
 
+import json
 from typing import Sequence, Union
 
 import sqlalchemy as sa
@@ -33,7 +34,7 @@ def upgrade() -> None:
             sa.text(
                 'UPDATE org_member SET mcp_config = :config WHERE org_id = :org_id'
             ),
-            {'config': mcp_config, 'org_id': str(org_id)},
+            {'config': json.dumps(mcp_config), 'org_id': str(org_id)},
         )
 
 


### PR DESCRIPTION
## Summary of PR

Fixes migration 103 (`103_add_mcp_config_to_org_member.py`) which was failing with `psycopg2.ProgrammingError: can't adapt type 'dict'`.

The issue was that when copying `mcp_config` from the `org` table to the `org_member` table, the Python dict returned by SQLAlchemy wasn't being serialized to a JSON string before passing to psycopg2. Added `json.dumps()` to properly serialize the dict.

## Change Type

- [x] Bug fix

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:57b985c-nikolaik   --name openhands-app-57b985c   docker.openhands.dev/openhands/openhands:57b985c
```