### PR TITLE
fix: upgrade pip to fix CVE-2025-8869

### DIFF
--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -76,10 +76,13 @@ COPY --chown=openhands:openhands --chmod=770 --from=backend-builder ${VIRTUAL_EN
 # Pin pip to a known-good version (reproducible builds) and fix CVE-2025-8869
 # Pin both venv pip and system pip (Trivy scans both)
 # - `python -m pip` uses the venv because `PATH` is prefixed with `${VIRTUAL_ENV}/bin`
-# - `sudo python3 -m pip` uses the system interpreter (sudo secure_path)
+# - `/usr/local/bin/python3 -m pip` uses the system interpreter regardless of `PATH`
 ARG PIP_VERSION=26.0.1
-RUN python -m pip install --no-cache-dir "pip==${PIP_VERSION}" && \
-    sudo -H python3 -m pip install --no-cache-dir "pip==${PIP_VERSION}" --break-system-packages
+RUN python -m pip install --no-cache-dir "pip==${PIP_VERSION}"
+
+USER root
+RUN /usr/local/bin/python3 -m pip install --no-cache-dir "pip==${PIP_VERSION}" --break-system-packages
+USER openhands
 
 COPY --chown=openhands:openhands --chmod=770 ./skills ./skills
 COPY --chown=openhands:openhands --chmod=770 ./openhands ./openhands


### PR DESCRIPTION
## Description
Upgrade pip in the app Docker image to fix CVE-2025-8869 (symbolic link extraction vulnerability).

## CVE Details
- **CVE**: [CVE-2025-8869](https://nvd.nist.gov/vuln/detail/CVE-2025-8869)
- **Severity**: Medium
- **Issue**: pip missing checks on symbolic link extraction
- **Fixed in**: pip >= 25.3
- **Current version**: 25.2

## Changes
Adds a `pip install --upgrade pip` step in `containers/app/Dockerfile` after the virtual environment is copied from the builder stage.

This ensures all downstream images (openhands, enterprise-server) inherit the fix.

## Testing
- [x] Build the Docker image and verify pip version is >= 25.3
- [x] Run Trivy scan to confirm CVE-2025-8869 is no longer reported

### Evidence (docker.openhands.dev/openhands/openhands:2f599f6)

#### pip versions

```
$ docker run --rm --entrypoint bash docker.openhands.dev/openhands/openhands:2f599f6 -c 'which pip; pip --version; python -m pip --version'
/app/.venv/bin/pip
pip 26.0.1 from /app/.venv/lib/python3.13/site-packages/pip (python 3.13)
pip 26.0.1 from /app/.venv/lib/python3.13/site-packages/pip (python 3.13)

$ docker run --rm --entrypoint bash docker.openhands.dev/openhands/openhands:2f599f6 -c '/usr/local/bin/pip --version; /usr/local/bin/python3 -m pip --version'
pip 26.0.1 from /usr/local/lib/python3.13/site-packages/pip (python 3.13)
pip 26.0.1 from /usr/local/lib/python3.13/site-packages/pip (python 3.13)
```

#### Trivy (CVE-2025-8869 absent)

```
$ trivy image --no-progress --scanners vuln docker.openhands.dev/openhands/openhands:2f599f6 2>/dev/null | grep -F "CVE-2025-8869" || echo "CVE-2025-8869 not found in trivy output"
CVE-2025-8869 not found in trivy output
```

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:f10198e-nikolaik   --name openhands-app-f10198e   docker.openhands.dev/openhands/openhands:f10198e
```