### PR TITLE
fix(frontend): hide right panel when active tab is unpinned

### DIFF
--- a/frontend/__tests__/components/features/conversation/conversation-tabs-context-menu.test.tsx
+++ b/frontend/__tests__/components/features/conversation/conversation-tabs-context-menu.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ConversationTabsContextMenu } from "#/components/features/conversation/conversation-tabs/conversation-tabs-context-menu";
+import { useConversationStore } from "#/stores/conversation-store";
 
 const CONVERSATION_ID = "conv-abc123";
 
@@ -21,6 +22,11 @@ describe("ConversationTabsContextMenu", () => {
   beforeEach(() => {
     localStorage.clear();
     mockHasTaskList = false;
+    useConversationStore.setState({
+      selectedTab: "editor",
+      isRightPanelShown: true,
+      hasRightPanelToggled: true,
+    });
   });
 
   it("should render nothing when isOpen is false", () => {
@@ -67,6 +73,33 @@ describe("ConversationTabsContextMenu", () => {
       localStorage.getItem(`conversation-state-${CONVERSATION_ID}`)!,
     );
     expect(storedState.unpinnedTabs).not.toContain("terminal");
+  });
+
+  it("should close the right panel when unpinning the currently active tab", async () => {
+    const user = userEvent.setup();
+
+    render(<ConversationTabsContextMenu isOpen={true} onClose={vi.fn()} />);
+
+    await user.click(screen.getByText("COMMON$CHANGES"));
+
+    const storeState = useConversationStore.getState();
+    expect(storeState.hasRightPanelToggled).toBe(false);
+
+    const storedState = JSON.parse(
+      localStorage.getItem(`conversation-state-${CONVERSATION_ID}`)!,
+    );
+    expect(storedState.rightPanelShown).toBe(false);
+  });
+
+  it("should not close the right panel when unpinning a non-active tab", async () => {
+    const user = userEvent.setup();
+
+    render(<ConversationTabsContextMenu isOpen={true} onClose={vi.fn()} />);
+
+    await user.click(screen.getByText("COMMON$TERMINAL"));
+
+    const storeState = useConversationStore.getState();
+    expect(storeState.hasRightPanelToggled).toBe(true);
   });
 
   describe("with tasklist", () => {

--- a/frontend/src/components/features/conversation/conversation-tabs/conversation-tabs-context-menu.tsx
+++ b/frontend/src/components/features/conversation/conversation-tabs/conversation-tabs-context-menu.tsx
@@ -4,6 +4,7 @@ import { ContextMenuListItem } from "../../context-menu/context-menu-list-item";
 import { useClickOutsideElement } from "#/hooks/use-click-outside-element";
 import { useConversationId } from "#/hooks/use-conversation-id";
 import { useConversationLocalStorageState } from "#/utils/conversation-local-storage";
+import { useConversationStore } from "#/stores/conversation-store";
 import { I18nKey } from "#/i18n/declaration";
 import TerminalIcon from "#/icons/terminal.svg?react";
 import GlobeIcon from "#/icons/globe.svg?react";
@@ -28,8 +29,10 @@ export function ConversationTabsContextMenu({
   const ref = useClickOutsideElement<HTMLUListElement>(onClose);
   const { t } = useTranslation();
   const { conversationId } = useConversationId();
-  const { state, setUnpinnedTabs } =
+  const { state, setUnpinnedTabs, setRightPanelShown } =
     useConversationLocalStorageState(conversationId);
+  const { selectedTab, isRightPanelShown, setHasRightPanelToggled } =
+    useConversationStore();
 
   const { hasTaskList } = useTaskList();
 
@@ -61,6 +64,10 @@ export function ConversationTabsContextMenu({
       setUnpinnedTabs(state.unpinnedTabs.filter((item) => item !== tab));
     } else {
       setUnpinnedTabs([...state.unpinnedTabs, tab]);
+      if (selectedTab === tab && isRightPanelShown) {
+        setHasRightPanelToggled(false);
+        setRightPanelShown(false);
+      }
     }
   };
 


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

<!-- Summarize what the PR does -->

<img width="1440" height="752" alt="app-1161-issue" src="https://github.com/user-attachments/assets/14f1ef75-140b-4210-9f84-f3162b02b6e8" />

When unpinning the currently selected tab via the context menu, the tab button was removed but the panel remained visible. Now closing the panel when the unpinned tab is the active one.

- Fix bug where unpinning the currently active tab via the ⋮ context menu removed the tab button but left the right panel visible
- When a tab is unpinned, check if it's the active tab and close the panel if so, updating both the Zustand store and localStorage

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

https://github.com/user-attachments/assets/41313e26-84c3-437c-ae42-16e91f16817f

## Change Type

<!-- Choose the types that apply to your PR -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:11feb31-nikolaik   --name openhands-app-11feb31   docker.openhands.dev/openhands/openhands:11feb31
```