### PR TITLE
PLTF-330: Add automatic session_id logging via contextvars

### DIFF
--- a/enterprise/saas_server.py
+++ b/enterprise/saas_server.py
@@ -23,7 +23,10 @@ from server.auth.constants import (  # noqa: E402
 )
 from server.constants import PERMITTED_CORS_ORIGINS  # noqa: E402
 from server.logger import logger  # noqa: E402
-from server.middleware import SetAuthCookieMiddleware  # noqa: E402
+from server.middleware import (  # noqa: E402
+    SessionContextMiddleware,
+    SetAuthCookieMiddleware,
+)
 from server.rate_limit import setup_rate_limit_handler  # noqa: E402
 from server.routes.api_keys import api_router as api_keys_router  # noqa: E402
 from server.routes.auth import api_router, oauth_router  # noqa: E402
@@ -155,6 +158,9 @@ base_app.add_middleware(
 )
 base_app.add_middleware(CacheControlMiddleware)
 base_app.middleware('http')(SetAuthCookieMiddleware())
+# Session context middleware for automatic session_id logging
+# Must be added after auth middleware so user_id is available
+base_app.middleware('http')(SessionContextMiddleware())
 
 base_app.mount('/', SPAStaticFiles(directory=directory, html=True), name='dist')
 

--- a/enterprise/server/clustered_conversation_manager.py
+++ b/enterprise/server/clustered_conversation_manager.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import socketio
 from server.logger import logger
+from server.session_context import session_context
 from server.utils.conversation_callback_utils import invoke_conversation_callbacks
 from sqlalchemy import select
 from storage.database import a_session_maker
@@ -779,17 +780,19 @@ class ClusteredConversationManager(StandaloneConversationManager):
         # Add a subscriber for conversation callbacks
         def conversation_callback_handler(event):
             """Handle events by invoking conversation callbacks."""
-            try:
-                if isinstance(event, AgentStateChangedObservation):
-                    asyncio.run_coroutine_threadsafe(
-                        invoke_conversation_callbacks(sid, event), loop
+            # Set session context for logging in this callback (runs in different thread)
+            with session_context.scope(session_id=sid, user_id=user_id):
+                try:
+                    if isinstance(event, AgentStateChangedObservation):
+                        asyncio.run_coroutine_threadsafe(
+                            invoke_conversation_callbacks(sid, event), loop
+                        )
+                except Exception as e:
+                    logger.error(
+                        f'Error invoking conversation callbacks for {sid}: {str(e)}',
+                        extra={'error': str(e)},
+                        exc_info=True,
                     )
-            except Exception as e:
-                logger.error(
-                    f'Error invoking conversation callbacks for {sid}: {str(e)}',
-                    extra={'session_id': sid, 'error': str(e)},
-                    exc_info=True,
-                )
 
         # Subscribe to the event stream with our callback handler
         try:

--- a/enterprise/server/logger.py
+++ b/enterprise/server/logger.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TextIO
 
 from pythonjsonlogger.json import JsonFormatter
+from server.session_context import SessionContextFilter
 
 from openhands.core.logger import openhands_logger
 
@@ -24,6 +25,9 @@ SITE_PACKAGES_PREFIX = (
 )
 # Make the JSON easy to read in the console - useful for non cloud environments
 LOG_JSON_FOR_CONSOLE = int(os.getenv('LOG_JSON_FOR_CONSOLE', '0'))
+
+# Session context filter for automatic session_id injection
+_session_context_filter = SessionContextFilter()
 
 
 def format_stack(stack: str) -> list[str]:
@@ -79,8 +83,9 @@ def setup_json_logger(
     handler = logging.StreamHandler(_out)
     handler.setLevel(level)
 
+    # Include session_id and user_id in the format string for JSON output
     formatter = JsonFormatter(
-        '%(message)s%(levelname)s%(module)s%(funcName)s%(lineno)d',
+        '%(message)s%(levelname)s%(module)s%(funcName)s%(lineno)d%(session_id)s%(user_id)s',
         rename_fields={'levelname': 'severity'},
         json_serializer=custom_json_serializer,
         # Use 'ts' for consistency with LOG_JSON_FOR_CONSOLE mode (skip when console mode to avoid duplicates)
@@ -90,6 +95,9 @@ def setup_json_logger(
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.setLevel(level)
+
+    # Add session context filter to inject session_id and user_id
+    logger.addFilter(_session_context_filter)
 
 
 def setup_all_loggers():

--- a/enterprise/server/middleware.py
+++ b/enterprise/server/middleware.py
@@ -1,3 +1,4 @@
+import re
 from typing import Callable, cast
 
 import jwt
@@ -13,11 +14,53 @@ from server.auth.auth_error import (
 from server.auth.gitlab_sync import schedule_gitlab_repo_sync
 from server.auth.saas_user_auth import SaasUserAuth, token_manager
 from server.routes.auth import set_response_cookie
+from server.session_context import session_context
 from server.utils.url_utils import get_cookie_domain, get_cookie_samesite
 
 from openhands.core.logger import openhands_logger as logger
 from openhands.server.user_auth.user_auth import AuthType, UserAuth, get_user_auth
 from openhands.server.utils import config
+
+# Pattern to extract conversation/session ID from URL paths
+# Matches paths like /api/conversations/{id}/... or /api/v1/conversations/{id}/...
+_CONVERSATION_ID_PATTERN = re.compile(r'/api(?:/v\d+)?/conversations/([a-zA-Z0-9_-]+)')
+
+
+def _extract_session_id_from_path(path: str) -> str | None:
+    """Extract session/conversation ID from request path."""
+    match = _CONVERSATION_ID_PATTERN.search(path)
+    if match:
+        return match.group(1)
+    return None
+
+
+class SessionContextMiddleware:
+    """Middleware that sets session context for automatic logging.
+
+    This middleware extracts session/conversation ID from the request path
+    and sets it in the session context, making it automatically available
+    in all log messages within the request scope.
+    """
+
+    async def __call__(self, request: Request, call_next: Callable) -> Response:
+        # Extract session ID from path
+        session_id = _extract_session_id_from_path(request.url.path)
+
+        # Try to get user_id from request state if available
+        user_id: str | None = None
+        user_auth: UserAuth | None = getattr(request.state, 'user_auth', None)
+        if user_auth:
+            try:
+                user_id = await user_auth.get_user_id()
+            except Exception:
+                pass
+
+        # Set context and process request
+        token = session_context.set(session_id=session_id, user_id=user_id)
+        try:
+            return await call_next(request)
+        finally:
+            session_context.reset(token)
 
 
 class SetAuthCookieMiddleware:

--- a/enterprise/server/saas_nested_conversation_manager.py
+++ b/enterprise/server/saas_nested_conversation_manager.py
@@ -15,6 +15,7 @@ import socketio
 from pydantic import SecretStr
 from server.auth.token_manager import TokenManager
 from server.constants import PERMITTED_CORS_ORIGINS, WEB_HOST
+from server.session_context import session_context
 from server.utils.conversation_callback_utils import (
     process_event,
     update_conversation_metadata,
@@ -307,7 +308,7 @@ class SaasNestedConversationManager(ConversationManager):
                 # If refresh fails, use original token to prevent conversation startup failure
                 logger.warning(
                     f'Failed to refresh {provider_type.value} token: {e}',
-                    extra={'session_id': sid, 'provider': provider_type.value},
+                    extra={'provider': provider_type.value},
                     exc_info=True,
                 )
                 updated_tokens[provider_type] = provider_token
@@ -322,7 +323,6 @@ class SaasNestedConversationManager(ConversationManager):
         logger.info(
             'Updated provider tokens after runtime creation',
             extra={
-                'session_id': sid,
                 'providers': [p.value for p in updated_tokens.keys()],
                 'refreshed': tokens_refreshed,
                 'failed': tokens_failed,
@@ -333,43 +333,45 @@ class SaasNestedConversationManager(ConversationManager):
     async def _start_agent_loop(
         self, sid, settings, user_id, initial_user_msg=None, replay_json=None
     ):
-        try:
-            logger.info(f'starting_agent_loop:{sid}', extra={'session_id': sid})
-            await self.ensure_num_conversations_below_limit(sid, user_id)
-            provider_handler = self._get_provider_handler(settings)
-            runtime = await self._create_runtime(
-                sid, user_id, settings, provider_handler
-            )
-            await runtime.connect()
+        # Set session context for all logging within this method
+        with session_context.scope(session_id=sid, user_id=user_id):
+            try:
+                logger.info(f'starting_agent_loop:{sid}')
+                await self.ensure_num_conversations_below_limit(sid, user_id)
+                provider_handler = self._get_provider_handler(settings)
+                runtime = await self._create_runtime(
+                    sid, user_id, settings, provider_handler
+                )
+                await runtime.connect()
 
-            if not self._runtime_container_image:
-                self._runtime_container_image = getattr(
-                    runtime,
-                    'container_image',
-                    self.config.sandbox.runtime_container_image,
+                if not self._runtime_container_image:
+                    self._runtime_container_image = getattr(
+                        runtime,
+                        'container_image',
+                        self.config.sandbox.runtime_container_image,
+                    )
+
+                session_api_key = runtime.session.headers['X-Session-API-Key']
+
+                # Update provider tokens with fresh ones after runtime creation
+                settings = await self._refresh_provider_tokens_after_runtime_init(
+                    settings, sid, user_id
                 )
 
-            session_api_key = runtime.session.headers['X-Session-API-Key']
-
-            # Update provider tokens with fresh ones after runtime creation
-            settings = await self._refresh_provider_tokens_after_runtime_init(
-                settings, sid, user_id
-            )
-
-            await self._start_conversation(
-                sid,
-                user_id,
-                settings,
-                initial_user_msg,
-                replay_json,
-                runtime.runtime_url,
-                session_api_key,
-            )
-        finally:
-            # remove the starting entry from redis
-            redis = self._get_redis_client()
-            key = self._get_redis_conversation_key(user_id, sid)
-            await redis.delete(key)
+                await self._start_conversation(
+                    sid,
+                    user_id,
+                    settings,
+                    initial_user_msg,
+                    replay_json,
+                    runtime.runtime_url,
+                    session_api_key,
+                )
+            finally:
+                # remove the starting entry from redis
+                redis = self._get_redis_client()
+                key = self._get_redis_conversation_key(user_id, sid)
+                await redis.delete(key)
 
     async def _start_conversation(
         self,
@@ -793,10 +795,7 @@ class SaasNestedConversationManager(ConversationManager):
     async def ensure_num_conversations_below_limit(self, sid: str, user_id: str):
         response_ids = await self.get_running_agent_loops(user_id)
         if len(response_ids) >= self.config.max_concurrent_conversations:
-            logger.info(
-                f'too_many_sessions_for:{user_id or ""}',
-                extra={'session_id': sid, 'user_id': user_id},
-            )
+            logger.info(f'too_many_sessions_for:{user_id or ""}')
             # Get the conversations sorted (oldest first)
             conversation_store = await self._get_conversation_store(user_id)
             conversations = await conversation_store.get_all_metadata(response_ids)
@@ -806,7 +805,7 @@ class SaasNestedConversationManager(ConversationManager):
                 oldest_conversation_id = conversations.pop().conversation_id
                 logger.debug(
                     f'closing_from_too_many_sessions:{user_id or ""}:{oldest_conversation_id}',
-                    extra={'session_id': oldest_conversation_id, 'user_id': user_id},
+                    extra={'closing_conversation_id': oldest_conversation_id},
                 )
                 # Send status message to client and close session.
                 status_update_dict = {

--- a/enterprise/server/session_context.py
+++ b/enterprise/server/session_context.py
@@ -1,0 +1,149 @@
+"""Session context management using contextvars for automatic session ID logging.
+
+This module provides a way to set session/conversation context that is automatically
+injected into all log messages within the request scope. This eliminates the need
+to manually pass `extra={'session_id': sid}` to every log call.
+
+Usage:
+    # In middleware or at request entry point:
+    from server.session_context import session_context
+
+    token = session_context.set(session_id='abc123', user_id='user456')
+    try:
+        # All logs within this scope will automatically have session_id and user_id
+        logger.info('Processing request')  # Will include session_id='abc123', user_id='user456'
+    finally:
+        session_context.reset(token)
+
+    # Or use the context manager:
+    with session_context.scope(session_id='abc123', user_id='user456'):
+        logger.info('Processing request')
+"""
+
+import logging
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class SessionContextData:
+    """Data stored in session context."""
+
+    session_id: str | None = None
+    user_id: str | None = None
+
+
+# Context variable to store session data
+_session_context: ContextVar[SessionContextData] = ContextVar(
+    'session_context', default=SessionContextData()
+)
+
+
+class SessionContext:
+    """Manages session context for logging and request tracking."""
+
+    def set(
+        self, session_id: str | None = None, user_id: str | None = None
+    ) -> Token[SessionContextData]:
+        """Set session context values.
+
+        Args:
+            session_id: The session/conversation ID
+            user_id: The user ID
+
+        Returns:
+            A token that can be used to reset the context
+        """
+        return _session_context.set(
+            SessionContextData(session_id=session_id, user_id=user_id)
+        )
+
+    def reset(self, token: Token[SessionContextData]) -> None:
+        """Reset session context to previous value.
+
+        Args:
+            token: The token returned by set()
+        """
+        _session_context.reset(token)
+
+    def get(self) -> SessionContextData:
+        """Get current session context data."""
+        return _session_context.get()
+
+    def get_session_id(self) -> str | None:
+        """Get the current session ID."""
+        return _session_context.get().session_id
+
+    def get_user_id(self) -> str | None:
+        """Get the current user ID."""
+        return _session_context.get().user_id
+
+    def scope(self, session_id: str | None = None, user_id: str | None = None):
+        """Context manager for setting session context.
+
+        Usage:
+            with session_context.scope(session_id='abc123'):
+                logger.info('This log will have session_id')
+        """
+        return _SessionContextScope(self, session_id, user_id)
+
+
+class _SessionContextScope:
+    """Context manager for session context scope."""
+
+    def __init__(
+        self,
+        context: SessionContext,
+        session_id: str | None,
+        user_id: str | None,
+    ):
+        self._context = context
+        self._session_id = session_id
+        self._user_id = user_id
+        self._token: Token[SessionContextData] | None = None
+
+    def __enter__(self) -> 'SessionContext':
+        self._token = self._context.set(
+            session_id=self._session_id, user_id=self._user_id
+        )
+        return self._context
+
+    def __exit__(self, *args: Any) -> None:
+        if self._token is not None:
+            self._context.reset(self._token)
+
+
+class SessionContextFilter(logging.Filter):
+    """Logging filter that injects session context into log records.
+
+    This filter automatically adds session_id and user_id fields to all log
+    records when session context has been set.
+
+    Usage:
+        logger.addFilter(SessionContextFilter())
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Add session context to log record.
+
+        Args:
+            record: The log record to modify
+
+        Returns:
+            True (always allows the record through)
+        """
+        ctx = _session_context.get()
+
+        # Only set if not already present (allow explicit override via extra={})
+        if not hasattr(record, 'session_id') or record.session_id is None:  # type: ignore[attr-defined]
+            record.session_id = ctx.session_id  # type: ignore[attr-defined]
+
+        if not hasattr(record, 'user_id') or record.user_id is None:  # type: ignore[attr-defined]
+            record.user_id = ctx.user_id  # type: ignore[attr-defined]
+
+        return True
+
+
+# Global session context instance
+session_context = SessionContext()


### PR DESCRIPTION
## Summary

This PR introduces automatic `session_id` and `user_id` injection into all log messages within the enterprise server, eliminating the need for manual `extra={"session_id": sid}` in every log call.

## Changes

### New Files
- `enterprise/server/session_context.py`: Session context management using Python's `contextvars` for request-scoped session tracking

### Modified Files
- `enterprise/server/middleware.py`: Added `SessionContextMiddleware` that extracts session/conversation ID from request paths and sets context
- `enterprise/server/logger.py`: Added `SessionContextFilter` to automatically inject session_id and user_id into all log records
- `enterprise/saas_server.py`: Registered the new middleware

### Cleaned Up Manual Logging
The following files no longer need manual `extra={"session_id": ...}` as session_id is now automatically injected:
- `enterprise/server/saas_nested_conversation_manager.py`
- `enterprise/server/clustered_conversation_manager.py`

Note: `billing.py` uses `checkout_session_id` which is a Stripe checkout session, not a conversation session, so it remains unchanged.

## How It Works

1. **HTTP Requests**: `SessionContextMiddleware` extracts conversation ID from URL paths like `/api/conversations/{id}/...` and sets it in a context variable
2. **Background Tasks**: Use `session_context.scope(session_id=sid, user_id=user_id)` context manager
3. **Callbacks/Workers**: Same pattern - wrap with `session_context.scope()`
4. `SessionContextFilter` (added to all loggers) reads from the context variable and injects `session_id` and `user_id` into log records

## Usage Pattern

```python
from server.session_context import session_context

# For functions that receive sid as parameter:
async def process_conversation(sid: str, user_id: str):
    with session_context.scope(session_id=sid, user_id=user_id):
        logger.info("Processing")  # Automatically includes session_id, user_id
        await do_something()
        logger.info("Done")  # Also includes session_id, user_id
```

## Testing
- [ ] Tested locally with enterprise server
- [ ] Verified JSON logs include session_id and user_id fields
