### PR TITLE
fix(backend): persist disabled_skills in SaaS settings store

### DIFF
--- a/enterprise/migrations/versions/104_add_disabled_skills_to_user.py
+++ b/enterprise/migrations/versions/104_add_disabled_skills_to_user.py
@@ -1,0 +1,29 @@
+"""Add disabled_skills column to user table.
+
+Migration 102 added disabled_skills to the legacy user_settings table,
+but the active SaaS flow (SaasSettingsStore) reads from/writes to the
+user table. This migration adds the column where it is actually needed.
+
+Revision ID: 104
+Revises: 103
+Create Date: 2026-03-31
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '104'
+down_revision: Union[str, None] = '103'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('user', sa.Column('disabled_skills', sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('user', 'disabled_skills')

--- a/enterprise/storage/user.py
+++ b/enterprise/storage/user.py
@@ -5,6 +5,7 @@ SQLAlchemy model for User.
 from uuid import uuid4
 
 from sqlalchemy import (
+    JSON,
     UUID,
     Boolean,
     Column,
@@ -34,6 +35,7 @@ class User(Base):  # type: ignore
     git_user_name = Column(String, nullable=True)
     git_user_email = Column(String, nullable=True)
     sandbox_grouping_strategy = Column(String, nullable=True)
+    disabled_skills = Column(JSON, nullable=True)
 
     # Relationships
     role = relationship('Role', back_populates='users')


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

<!-- Summarize what the PR does -->

Migration 102 added disabled_skills to the legacy user_settings table, but SaasSettingsStore reads from and writes to User/Org/OrgMember.

Since User lacked the column, disabled_skills was silently dropped on save and missing on load, causing skill toggles to revert after refresh.

Add disabled_skills JSON column to the User model and table.

- **Bug**: Toggling a skill off in Settings > Skills appears to save (HTTP 200, success toast), but the change reverts after page refresh
- **Root cause**: `SaasSettingsStore` persists settings via `hasattr`/`setattr` across `User`, `Org`, and `OrgMember` models. Migration 102 added `disabled_skills` to the legacy `user_settings` table, but that table is only used for one-time migration of old users — the active SaaS flow never reads from or writes to it. Since none of the hree active models had the column, the value was silently dropped on save and absent on load.
- **Fix**: Add `disabled_skills` column to the `User` model (user-level preference) and create Alembic migration 104. No frontend or API changes needed — the generic column-mapping in `SaasSettingsStore.load()` and `store()` picks it up automatically.

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

https://github.com/user-attachments/assets/69d7d010-c016-43dc-84da-3d18d5a3fbaa

## Change Type

<!-- Choose the types that apply to your PR -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:e2ea204-nikolaik   --name openhands-app-e2ea204   docker.openhands.dev/openhands/openhands:e2ea204
```