### PR TITLE
chore(docker): remove system pip from app image (venv-only)

### DIFF
--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -73,11 +73,9 @@ ENV VIRTUAL_ENV=/app/.venv \
 
 COPY --chown=openhands:openhands --chmod=770 --from=backend-builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
-# Pin pip to a known-good version (reproducible builds) and fix CVE-2025-8869.
+# Remove system pip from the image (leave venv pip intact).
 # The runtime uses the venv pip because PATH is prefixed with ${VIRTUAL_ENV}/bin.
-ARG PIP_VERSION=26.0.1
-RUN python -m pip install --no-cache-dir "pip==${PIP_VERSION}" && \
-    sudo /usr/local/bin/python3 - <<'PY'
+RUN sudo /usr/local/bin/python3 - <<'PY'
 import ensurepip
 import shutil
 import sysconfig


### PR DESCRIPTION
Goal: reduce attack surface + stop carrying/scanning a second pip install in the app image.

This is **related to** #13640 (pip CVE fix): #13640 pins/upgrades pip to address CVE-2025-8869; this PR is a follow-up hardening step that *removes system pip entirely* if we don't need it at runtime.

What this does:
- Removes *system* pip (site-packages + `/usr/local/bin/pip*` + `ensurepip/_bundled` pip wheels).
- Does **not** upgrade/pin pip (leaves the venv untouched).

Why:
- The image already prepends `${VIRTUAL_ENV}/bin` to `PATH`, so `pip` used by the entrypoint (e.g. `pip install openhands-ai[third_party_runtimes]`) is the venv pip.

Tradeoff:
- `python3 -m pip` and `/usr/local/bin/pip*` will no longer work inside the container.

Merge guidance:
- Only merge if we confirm nobody relies on system pip inside the app image.

_(This PR was created/updated by an AI assistant (OpenHands) on behalf of the user.)_

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:af3c2a6-nikolaik   --name openhands-app-af3c2a6   docker.openhands.dev/openhands/openhands:af3c2a6
```