### PR TITLE
fix: remove resolver summary language hint

### DIFF
--- a/openhands/integrations/templates/resolver/summary_prompt.j2
+++ b/openhands/integrations/templates/resolver/summary_prompt.j2
@@ -6,5 +6,3 @@ If you made changes, please think carefully about the user's request(s) and summ
 1. whether the request has been completely addressed and all of the instructions have been followed faithfully (in checklist format if appropriate).
 2. whether the changes are concise (if there are any extraneous changes not important to addressing the user's request they should be reverted).
 3. focus only on summarizing new changes since your last summary, avoiding repetition of information already covered in previous summaries.
-
-Please summarize in whatever language the user is using.


### PR DESCRIPTION
Hi! I’m OpenHands-GPT-5.4, an AI assistant helping with this fix on behalf of the user.

## Summary
This PR removes the sentence `Please summarize in whatever language the user is using.` from `openhands/integrations/templates/resolver/summary_prompt.j2`, along with the now-unneeded blank line.

## Why
We’ve recently seen Slack and GitHub resolver summaries randomly switch into Spanish, Japanese, French, and other languages even when the full conversation history is in English and the user did not write in those languages.

The most likely cause is that this instruction asks the LLM to infer “the user’s language” during the `ask_agent` summary pass. The model does not reliably know that language from context, so it sometimes hallucinates one and produces the final summary in that invented language.

Removing the instruction keeps the summary grounded in the actual conversation history instead of asking the model to infer an extra attribute.

## Context
I traced this back to PR #13377, which introduced the sentence on 2026-03-13.

Could @xingyaoww please take a look, since that PR introduced the line we’re removing here?

## Validation
- Ran `python -m pre_commit run trailing-whitespace --files openhands/integrations/templates/resolver/summary_prompt.j2 --config ./dev_config/python/.pre-commit-config.yaml`
- Ran `python -m pre_commit run end-of-file-fixer --files openhands/integrations/templates/resolver/summary_prompt.j2 --config ./dev_config/python/.pre-commit-config.yaml`

---
_This PR description was created by an AI assistant (OpenHands-GPT-5.4) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:6f267b8-nikolaik   --name openhands-app-6f267b8   docker.openhands.dev/openhands/openhands:6f267b8
```