### PR TITLE
ci: skip PyPI release for cloud- tags

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -18,10 +18,10 @@ on:
 jobs:
   release:
     runs-on: blacksmith-4vcpu-ubuntu-2204
-    # Run when manually dispatched for "app server" OR for tag pushes that don't contain '-cli'
+    # Run when manually dispatched for "app server" OR for tag pushes that don't contain '-cli' and don't start with 'cloud-'
     if: |
       (github.event_name == 'workflow_dispatch' && github.event.inputs.reason == 'app server')
-      || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-cli'))
+      || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-cli') && !startsWith(github.ref, 'refs/tags/cloud-'))
     steps:
       - uses: actions/checkout@v6
       - uses: useblacksmith/setup-python@v6


### PR DESCRIPTION
Human: We don't want to run this pypi workflow when we tag with `cloud-`.

## Summary of PR

When a tag starting with `cloud-` is pushed:
- **`ghcr-build.yml` (Docker)** — already runs on all tags (`tags: ["*"]`), so `cloud-*` tags are already covered. No change needed.
- **`pypi-release.yml` (Publish PyPi Package)** — previously would trigger on any tag push. This PR adds `!startsWith(github.ref, 'refs/tags/cloud-')` to the job-level `if` condition so that `cloud-` prefixed tags do **not** trigger a PyPI publish.

### What changed

`pypi-release.yml`: Added `!startsWith(github.ref, 'refs/tags/cloud-')` to the existing `if` guard on the `release` job, alongside the existing `!contains(github.ref, '-cli')` exclusion.

## Demo Screenshots/Videos

N/A — CI-only change.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Release Notes

- [ ] Include this change in the Release Notes.

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:088b070-nikolaik   --name openhands-app-088b070   docker.openhands.dev/openhands/openhands:088b070
```