### PR TITLE
ci: add cloud-semver tag support for enterprise image

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -215,7 +215,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=match,pattern=cloud-(\d+\.\d+\.\d+),group=1
+            type=match,pattern=cloud-\d+\.\d+\.\d+
           flavor: |
             latest=auto
             prefix=


### PR DESCRIPTION
## Summary
- Adds a `type=match` pattern to the Docker metadata action in the enterprise build job so that pushing a `cloud-<semver>` git tag (e.g. `cloud-1.2.3`) produces a correspondingly tagged `enterprise-server` image (e.g. `1.2.3`).

## Test plan
- [ ] Push a `cloud-x.y.z` tag and verify the enterprise image is tagged with `x.y.z`
- [ ] Verify existing semver and branch tag behavior is unchanged

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:ded0197-nikolaik   --name openhands-app-ded0197   docker.openhands.dev/openhands/openhands:ded0197
```