### PR TITLE
fix(frontend): skip raw JSON default summaries for ThinkAction and FileEditorAction

### DIFF
--- a/frontend/__tests__/components/v1/get-event-content.test.tsx
+++ b/frontend/__tests__/components/v1/get-event-content.test.tsx
@@ -146,67 +146,163 @@ describe("getEventContent", () => {
     expect(screen.queryByText("$ git status")).not.toBeInTheDocument();
   });
 
-  describe("ThinkAction raw JSON workaround", () => {
-    const createThinkAction = (summary?: string): ActionEvent => ({
-      id: "action-think",
-      timestamp: new Date().toISOString(),
-      source: "agent",
-      thought: [],
-      thinking_blocks: [],
-      action: {
-        kind: "ThinkAction",
-        thought: "Some thought content",
-      },
-      tool_name: "think",
-      tool_call_id: "tool-think",
-      tool_call: {
-        id: "tool-think",
-        type: "function",
-        function: {
-          name: "think",
-          arguments: '{"thought":"Some thought content"}',
+  describe("Raw JSON summary workaround", () => {
+    describe("ThinkAction", () => {
+      const createThinkAction = (summary?: string): ActionEvent => ({
+        id: "action-think",
+        timestamp: new Date().toISOString(),
+        source: "agent",
+        thought: [],
+        thinking_blocks: [],
+        action: {
+          kind: "ThinkAction",
+          thought: "Some thought content",
         },
-      },
-      llm_response_id: "response-think",
-      security_risk: SecurityRisk.LOW,
-      summary,
+        tool_name: "think",
+        tool_call_id: "tool-think",
+        tool_call: {
+          id: "tool-think",
+          type: "function",
+          function: {
+            name: "think",
+            arguments: '{"thought":"Some thought content"}',
+          },
+        },
+        llm_response_id: "response-think",
+        security_risk: SecurityRisk.LOW,
+        summary,
+      });
+
+      it("skips raw JSON default summary and falls back to translation", () => {
+        // SDK generates this when LLM does not provide a summary
+        const thinkAction = createThinkAction(
+          'think: {"thought": "Some thought content"}',
+        );
+        const { title } = getEventContent(thinkAction);
+
+        render(<span>{title}</span>);
+
+        // Should fall back to the translation key, not show raw JSON
+        expect(screen.getByText("ACTION_MESSAGE$THINK")).toBeInTheDocument();
+        expect(screen.queryByText(/think: \{/)).not.toBeInTheDocument();
+      });
+
+      it("preserves good summaries", () => {
+        const thinkAction = createThinkAction(
+          "Analyzing the test failure patterns",
+        );
+        const { title } = getEventContent(thinkAction);
+
+        render(<span>{title}</span>);
+
+        expect(
+          screen.getByText("Analyzing the test failure patterns"),
+        ).toBeInTheDocument();
+      });
+
+      it("uses translation when no summary", () => {
+        const thinkAction = createThinkAction(undefined);
+        const { title } = getEventContent(thinkAction);
+
+        render(<span>{title}</span>);
+
+        expect(screen.getByText("ACTION_MESSAGE$THINK")).toBeInTheDocument();
+      });
     });
 
-    it("skips raw JSON default summary for ThinkAction and falls back to translation", () => {
-      // SDK generates this when LLM does not provide a summary
-      const thinkAction = createThinkAction(
-        'think: {"thought": "Some thought content"}',
-      );
-      const { title } = getEventContent(thinkAction);
+    describe("FileEditorAction", () => {
+      const createFileEditorAction = (
+        command: "view" | "create" | "str_replace",
+        summary?: string,
+      ): ActionEvent => ({
+        id: "action-file",
+        timestamp: new Date().toISOString(),
+        source: "agent",
+        thought: [],
+        thinking_blocks: [],
+        action: {
+          kind: "FileEditorAction",
+          command,
+          path: "/workspace/README.md",
+          file_text: null,
+          old_str: null,
+          new_str: null,
+          insert_line: null,
+          view_range: null,
+        },
+        tool_name: "file_editor",
+        tool_call_id: "tool-file",
+        tool_call: {
+          id: "tool-file",
+          type: "function",
+          function: {
+            name: "file_editor",
+            arguments: `{"command":"${command}","path":"/workspace/README.md"}`,
+          },
+        },
+        llm_response_id: "response-file",
+        security_risk: SecurityRisk.LOW,
+        summary,
+      });
 
-      render(<span>{title}</span>);
+      it("skips raw JSON default summary and falls back to translation", () => {
+        // SDK generates this when LLM does not provide a summary
+        const fileAction = createFileEditorAction(
+          "view",
+          'file_editor: {"command": "view", "path": "/workspace/README.md"}',
+        );
+        const { title } = getEventContent(fileAction);
 
-      // Should fall back to the translation key, not show raw JSON
-      expect(screen.getByText("ACTION_MESSAGE$THINK")).toBeInTheDocument();
-      expect(screen.queryByText(/think: \{/)).not.toBeInTheDocument();
-    });
+        render(<span>{title}</span>);
 
-    it("preserves good summaries for ThinkAction", () => {
-      const thinkAction = createThinkAction(
-        "Analyzing the test failure patterns",
-      );
-      const { title } = getEventContent(thinkAction);
+        // Should fall back to the translation key (ACTION_MESSAGE$READ), not raw JSON
+        expect(screen.getByText("ACTION_MESSAGE$READ")).toBeInTheDocument();
+        expect(screen.queryByText(/file_editor: \{/)).not.toBeInTheDocument();
+      });
 
-      render(<span>{title}</span>);
+      it("preserves good summaries", () => {
+        const fileAction = createFileEditorAction(
+          "view",
+          "Checking project README for setup instructions",
+        );
+        const { title } = getEventContent(fileAction);
 
-      // Good summary should be displayed
-      expect(
-        screen.getByText("Analyzing the test failure patterns"),
-      ).toBeInTheDocument();
-    });
+        render(<span>{title}</span>);
 
-    it("uses translation when ThinkAction has no summary", () => {
-      const thinkAction = createThinkAction(undefined);
-      const { title } = getEventContent(thinkAction);
+        expect(
+          screen.getByText("Checking project README for setup instructions"),
+        ).toBeInTheDocument();
+      });
 
-      render(<span>{title}</span>);
+      it("uses translation when no summary - view command", () => {
+        const fileAction = createFileEditorAction("view", undefined);
+        const { title } = getEventContent(fileAction);
 
-      expect(screen.getByText("ACTION_MESSAGE$THINK")).toBeInTheDocument();
+        render(<span>{title}</span>);
+
+        // VIEW -> ACTION_MESSAGE$READ
+        expect(screen.getByText("ACTION_MESSAGE$READ")).toBeInTheDocument();
+      });
+
+      it("uses translation when no summary - create command", () => {
+        const fileAction = createFileEditorAction("create", undefined);
+        const { title } = getEventContent(fileAction);
+
+        render(<span>{title}</span>);
+
+        // CREATE -> ACTION_MESSAGE$WRITE
+        expect(screen.getByText("ACTION_MESSAGE$WRITE")).toBeInTheDocument();
+      });
+
+      it("uses translation when no summary - str_replace command", () => {
+        const fileAction = createFileEditorAction("str_replace", undefined);
+        const { title } = getEventContent(fileAction);
+
+        render(<span>{title}</span>);
+
+        // STR_REPLACE -> ACTION_MESSAGE$EDIT
+        expect(screen.getByText("ACTION_MESSAGE$EDIT")).toBeInTheDocument();
+      });
     });
   });
 });

--- a/frontend/__tests__/components/v1/get-event-content.test.tsx
+++ b/frontend/__tests__/components/v1/get-event-content.test.tsx
@@ -145,4 +145,68 @@ describe("getEventContent", () => {
     expect(screen.getByText("Check repository status")).toBeInTheDocument();
     expect(screen.queryByText("$ git status")).not.toBeInTheDocument();
   });
+
+  describe("ThinkAction raw JSON workaround", () => {
+    const createThinkAction = (summary?: string): ActionEvent => ({
+      id: "action-think",
+      timestamp: new Date().toISOString(),
+      source: "agent",
+      thought: [],
+      thinking_blocks: [],
+      action: {
+        kind: "ThinkAction",
+        thought: "Some thought content",
+      },
+      tool_name: "think",
+      tool_call_id: "tool-think",
+      tool_call: {
+        id: "tool-think",
+        type: "function",
+        function: {
+          name: "think",
+          arguments: '{"thought":"Some thought content"}',
+        },
+      },
+      llm_response_id: "response-think",
+      security_risk: SecurityRisk.LOW,
+      summary,
+    });
+
+    it("skips raw JSON default summary for ThinkAction and falls back to translation", () => {
+      // SDK generates this when LLM does not provide a summary
+      const thinkAction = createThinkAction(
+        'think: {"thought": "Some thought content"}',
+      );
+      const { title } = getEventContent(thinkAction);
+
+      render(<span>{title}</span>);
+
+      // Should fall back to the translation key, not show raw JSON
+      expect(screen.getByText("ACTION_MESSAGE$THINK")).toBeInTheDocument();
+      expect(screen.queryByText(/think: \{/)).not.toBeInTheDocument();
+    });
+
+    it("preserves good summaries for ThinkAction", () => {
+      const thinkAction = createThinkAction(
+        "Analyzing the test failure patterns",
+      );
+      const { title } = getEventContent(thinkAction);
+
+      render(<span>{title}</span>);
+
+      // Good summary should be displayed
+      expect(
+        screen.getByText("Analyzing the test failure patterns"),
+      ).toBeInTheDocument();
+    });
+
+    it("uses translation when ThinkAction has no summary", () => {
+      const thinkAction = createThinkAction(undefined);
+      const { title } = getEventContent(thinkAction);
+
+      render(<span>{title}</span>);
+
+      expect(screen.getByText("ACTION_MESSAGE$THINK")).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/v1/chat/event-content-helpers/get-event-content.tsx
+++ b/frontend/src/components/v1/chat/event-content-helpers/get-event-content.tsx
@@ -44,6 +44,29 @@ const getSummaryTitleForActionEvent = (
   return summary || null;
 };
 
+// WORKAROUND: Detect raw JSON default summaries that the SDK generates when
+// the LLM does not provide a summary. These show as "tool: {json args}" which
+// is confusing. Better to fall through to translation keys that build titles
+// from action data (e.g., "Reading /path" instead of "file_editor: {...}").
+// See: https://github.com/OpenHands/OpenHands/issues/13690
+// TODO: Remove once SDK fix is deployed
+const isRawJsonDefaultSummary = (
+  actionType: string,
+  summary: React.ReactNode,
+): boolean => {
+  if (typeof summary !== "string") return false;
+
+  switch (actionType) {
+    case "ThinkAction":
+      return summary.startsWith("think: {");
+    case "FileEditorAction":
+    case "StrReplaceEditorAction":
+      return summary.startsWith("file_editor: {");
+    default:
+      return false;
+  }
+};
+
 // Action Event Processing
 const getActionEventTitle = (event: OpenHandsEvent): React.ReactNode => {
   // Early return if not an action event
@@ -53,21 +76,10 @@ const getActionEventTitle = (event: OpenHandsEvent): React.ReactNode => {
 
   const actionType = event.action.kind;
   const summaryTitle = getSummaryTitleForActionEvent(event);
-  if (summaryTitle) {
-    // WORKAROUND: Skip raw JSON default summaries for ThinkAction.
-    // SDK generates "think: {\"thought\": ...}" when LLM does not provide summary.
-    // Fall through to "Thinking" translation, but preserve good summaries.
-    // See: https://github.com/OpenHands/OpenHands/issues/13690
-    // TODO: Remove once SDK fix is deployed
-    const isRawJsonDefault =
-      actionType === "ThinkAction" &&
-      typeof summaryTitle === "string" &&
-      summaryTitle.startsWith("think: {");
-    if (!isRawJsonDefault) {
-      return summaryTitle;
-    }
+  if (summaryTitle && !isRawJsonDefaultSummary(actionType, summaryTitle)) {
+    return summaryTitle;
   }
-  // Falls through to ACTION_MESSAGE$THINK → "Thinking"
+  // Falls through to translation keys that build titles from action data
   let actionKey = "";
   let actionValues: Record<string, unknown> = {};
 
@@ -161,7 +173,8 @@ const getObservationEventTitle = (
 
   if (correspondingAction) {
     const summaryTitle = getSummaryTitleForActionEvent(correspondingAction);
-    if (summaryTitle) {
+    const actionType = correspondingAction.action.kind;
+    if (summaryTitle && !isRawJsonDefaultSummary(actionType, summaryTitle)) {
       return summaryTitle;
     }
   }

--- a/frontend/src/components/v1/chat/event-content-helpers/get-event-content.tsx
+++ b/frontend/src/components/v1/chat/event-content-helpers/get-event-content.tsx
@@ -51,12 +51,23 @@ const getActionEventTitle = (event: OpenHandsEvent): React.ReactNode => {
     return "";
   }
 
+  const actionType = event.action.kind;
   const summaryTitle = getSummaryTitleForActionEvent(event);
   if (summaryTitle) {
-    return summaryTitle;
+    // WORKAROUND: Skip raw JSON default summaries for ThinkAction.
+    // SDK generates "think: {\"thought\": ...}" when LLM does not provide summary.
+    // Fall through to "Thinking" translation, but preserve good summaries.
+    // See: https://github.com/OpenHands/OpenHands/issues/13690
+    // TODO: Remove once SDK fix is deployed
+    const isRawJsonDefault =
+      actionType === "ThinkAction" &&
+      typeof summaryTitle === "string" &&
+      summaryTitle.startsWith("think: {");
+    if (!isRawJsonDefault) {
+      return summaryTitle;
+    }
   }
-
-  const actionType = event.action.kind;
+  // Falls through to ACTION_MESSAGE$THINK → "Thinking"
   let actionKey = "";
   let actionValues: Record<string, unknown> = {};
 


### PR DESCRIPTION
## Summary

Frontend workaround for issue #13690 — prevents raw JSON from displaying in the UI when the SDK generates a default summary for tool calls.

## Problem

When the LLM uses tools without providing a summary, the SDK creates a default summary by concatenating the tool name with the raw JSON arguments:

```
think: {"thought": "Some thought content"}
file_editor: {"command": "view", "path": "/workspace/file.txt"}
```

This raw JSON is then displayed as the collapsed title in the UI, which is confusing and noisy for users.

## Solution

Add a workaround that detects raw JSON default summaries and skips them, falling through to the translation keys that build clean titles from action data:

| Tool | Raw JSON Default | Clean Translation Title |
|------|-----------------|------------------------|
| `think` | `think: {"thought": "..."}` | 🤔 Thinking |
| `file_editor` (view) | `file_editor: {"command": "view", ...}` | 📖 Reading `/path/to/file` |
| `file_editor` (edit) | `file_editor: {"command": "str_replace", ...}` | ✏️ Editing `/path/to/file` |

### Changes

- **`get-event-content.tsx`**: 
  - Added `isRawJsonDefaultSummary()` helper to detect raw JSON patterns
  - Applied workaround to both action and observation event title generation
  - Detailed comments explain the issue and link to #13690

- **`get-event-content.test.tsx`**: 
  - Added comprehensive tests for ThinkAction and FileEditorAction
  - Tests verify raw JSON summaries are skipped while good LLM summaries are preserved

## Key Learnings from Issue Investigation

Based on the detailed analysis in [issue #13690 comments](https://github.com/OpenHands/OpenHands/issues/13690):

1. **CLI handles this correctly** by bypassing `event.summary` and building titles from action data
2. **Translation keys already exist** (e.g., `ACTION_MESSAGE$READ` renders "Reading `/path`")
3. **The bug is** that PR #13451 made the frontend prioritize `event.summary` over translation keys

This fix follows the CLI's pattern: use action data as the primary title source, treat summary as optional enhancement.

## Testing

- All existing tests pass
- Added 8 new tests covering both tools and all edge cases
- Verified with `npm run lint:fix` and `npm run test`

## TODO

Remove this workaround once the SDK fix is deployed. Comments include `TODO` marker and issue link.

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

Closes #13690

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:ad284ff-nikolaik   --name openhands-app-ad284ff   docker.openhands.dev/openhands/openhands:ad284ff
```