### PR TITLE
Add contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,19 @@ If you need help with anything, or just want to chat, [come find us on Slack](ht
 
 <hr>
 
+### Thank You to Our Contributors
+
 <div align="center">
-  <strong>Trusted by engineers at</strong>
+
+[![OpenHands Contributors](https://assets.openhands.dev/readme/openhands-openhands-contributors.svg)](https://github.com/OpenHands/OpenHands/graphs/contributors)
+
+</div>
+
+<hr>
+
+### Trusted by Engineers at
+
+<div align="center">
   <br/><br/>
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://assets.openhands.dev/logos/external/white/tiktok.svg">
@@ -138,13 +149,5 @@ If you need help with anything, or just want to chat, [come find us on Slack](ht
     <img src="https://assets.openhands.dev/logos/external/black/google.svg" alt="Google" height="17" hspace="5">
   </picture>
 </div>
-
-## Contributors
-
-<div align="center">
-
-Thanks to all the contributors!
-
-[![OpenHands Contributors](https://assets.openhands.dev/readme/openhands-openhands-contributors.svg)](https://github.com/OpenHands/OpenHands/graphs/contributors)
 
 </div>


### PR DESCRIPTION
Adds a contributors section at the end of the README with an SVG image showing all contributors.

---
Preview of Production
<img width="1583" height="1322" alt="image" src="https://github.com/user-attachments/assets/613e1b4b-1dec-4924-a680-e10244ee7510" />

<img width="1569" height="1267" alt="image" src="https://github.com/user-attachments/assets/9afa7aea-9661-4e91-95c1-7e327671396f" />


---

*This PR was created by an AI assistant (OpenHands).*