### PR TITLE
docs: fix stale internal README links

### DIFF
--- a/openhands/resolver/README.md
+++ b/openhands/resolver/README.md
@@ -215,4 +215,4 @@ You can customize how the AI agent approaches issue resolution by adding a repos
 ## Troubleshooting
 
 If you have any issues, please open an issue on this GitHub, GitLab, or Bitbucket repo, we're happy to help!
-Alternatively, you can [email us](mailto:contact@openhands.dev) or join the OpenHands Slack workspace (see [the README](/README.md) for an invite link).
+Alternatively, you can [email us](mailto:contact@openhands.dev) or join the OpenHands Slack workspace (see [the README](../../README.md) for an invite link).

--- a/openhands/security/README.md
+++ b/openhands/security/README.md
@@ -45,11 +45,11 @@ provides).
 
 ## How to implement your own Security Analyzer
 
-1. Create a submodule in [security](/openhands/security/) with your analyzer's desired name
-    * Have your main class inherit from [SecurityAnalyzer](/openhands/security/analyzer.py)
+1. Create a submodule in [security](.) with your analyzer's desired name
+    * Have your main class inherit from [SecurityAnalyzer](./analyzer.py)
     * Optional: define API endpoints for `/api/security/{path:path}` to manage settings,
-2. Add your analyzer class to the [options](/openhands/security/options.py) to have it be visible from the frontend combobox
-3. Optional: implement your modal frontend (for when you click on the lock) in [security](/frontend/src/components/modals/security/) and add your component to [Security.tsx](/frontend/src/components/modals/security/Security.tsx)
+2. Add your analyzer class to the [options](./options.py) to have it be visible from the frontend combobox
+3. Optional: wire any related frontend changes into the settings / confirmation-mode UI, such as the [security lock control](../../frontend/src/components/features/controls/security-lock.tsx)
 
 ## Implemented Security Analyzers
 

--- a/third_party/runtime/impl/e2b/README.md
+++ b/third_party/runtime/impl/e2b/README.md
@@ -15,7 +15,7 @@
     Full CLI API is [here](https://e2b.dev/docs/cli/installation).
 
 ## OpenHands sandbox
-You can use the E2B CLI to create a custom sandbox with a Dockerfile. Read the full guide [here](https://e2b.dev/docs/guide/custom-sandbox). The premade OpenHands sandbox for E2B is set up in the [`containers` directory](/containers/e2b-sandbox). and it's called `openhands`.
+You can use the E2B CLI to create a custom sandbox with a Dockerfile. Read the full guide [here](https://e2b.dev/docs/guide/custom-sandbox). The premade OpenHands sandbox for E2B is set up in the [`third_party/containers/e2b-sandbox` directory](../../../containers/e2b-sandbox), and it's called `openhands`.
 
 ## Debugging
 You can connect to a running E2B sandbox with E2B CLI in your terminal.


### PR DESCRIPTION
## Summary of PR

This PR fixes a small set of stale repository-internal links in OpenHands documentation.

Specifically, it:
- replaces broken absolute repo paths in `openhands/security/README.md` with working links to the current code locations
- fixes the root README link in `openhands/resolver/README.md`
- updates the E2B sandbox link in `third_party/runtime/impl/e2b/README.md` to point at the current `third_party/containers/e2b-sandbox` location

## Demo Screenshots/Videos

N/A

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #(issue)

## Release Notes

- [ ] Include this change in the Release Notes.