### PR TITLE
APP-1204 Add git to app container runtime dependencies

### DIFF
--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -50,7 +50,7 @@ RUN mkdir -p $FILE_STORE_PATH
 RUN mkdir -p $WORKSPACE_BASE
 
 RUN apt-get update -y \
-    && apt-get install -y curl ssh sudo \
+    && apt-get install -y curl git ssh sudo \
     && rm -rf /var/lib/apt/lists/*
 
 # Default is 1000, but OSX is often 501


### PR DESCRIPTION
## Summary of PR

This PR adds `git` to the app container's runtime dependencies to fix a `FileNotFoundError` when validating git branch names.

The git branch validation introduced in PR #13667 calls `git check-ref-format` via subprocess, but `git` was not installed in the app container's runtime image. This caused the following error:

```
FileNotFoundError: [Errno 2] No such file or directory: 'git'
```

The `backend-builder` stage had git installed for building, but the final `openhands-app` stage only had `curl`, `ssh`, and `sudo`.

## Demo Screenshots/Videos

N/A - This is a simple dependency fix.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Fixes the `FileNotFoundError: [Errno 2] No such file or directory: 'git'` error introduced by #13667.

## Release Notes

- [x] Include this change in the Release Notes.

Fixed app container missing `git` dependency which caused branch name validation to fail.

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a851f7d6-805f-4052-b5b8-55e94725cd35)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:7e1d0dc-nikolaik   --name openhands-app-7e1d0dc   docker.openhands.dev/openhands/openhands:7e1d0dc
```