### PR TITLE
fix(security): suppress SQLAlchemy DEBUG logging that leaks credentials

### DIFF
--- a/enterprise/alembic.ini
+++ b/enterprise/alembic.ini
@@ -59,7 +59,7 @@ handlers = console
 qualname =
 
 [logger_sqlalchemy]
-level = DEBUG
+level = WARNING
 handlers =
 qualname = sqlalchemy.engine
 

--- a/enterprise/migrations/env.py
+++ b/enterprise/migrations/env.py
@@ -6,6 +6,12 @@ from logging.config import fileConfig
 # These plugin setup messages would otherwise appear before logging is configured
 logging.getLogger('alembic.runtime.plugins').setLevel(logging.WARNING)
 
+# Prevent SQLAlchemy engine from logging SQL results at DEBUG level, which can
+# leak sensitive column data (e.g. API keys, tokens) into log aggregators.
+# This is set before any engine is created so it takes effect immediately.
+logging.getLogger('sqlalchemy.engine').setLevel(logging.WARNING)
+logging.getLogger('sqlalchemy.engine.Engine').setLevel(logging.WARNING)
+
 from alembic import context  # noqa: E402
 from google.cloud.sql.connector import Connector  # noqa: E402
 from sqlalchemy import create_engine, text  # noqa: E402
@@ -69,6 +75,12 @@ config = context.config
 # This line sets up loggers basically.
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
+
+# Re-apply SQLAlchemy engine log suppression after fileConfig, which may override
+# our earlier settings from alembic.ini. This ensures DEBUG-level SQL result logging
+# is always suppressed, preventing sensitive data from leaking into log aggregators.
+logging.getLogger('sqlalchemy.engine').setLevel(logging.WARNING)
+logging.getLogger('sqlalchemy.engine.Engine').setLevel(logging.WARNING)
 
 
 def run_migrations_offline() -> None:

--- a/enterprise/migrations/versions/103_add_mcp_config_to_org_member.py
+++ b/enterprise/migrations/versions/103_add_mcp_config_to_org_member.py
@@ -6,7 +6,6 @@ Create Date: 2026-03-26
 
 """
 
-import json
 from typing import Sequence, Union
 
 import sqlalchemy as sa
@@ -24,18 +23,18 @@ def upgrade() -> None:
 
     # Migrate existing org-level MCP configs to all members in each org.
     # This preserves existing configurations while transitioning to user-specific settings.
-    conn = op.get_bind()
-    orgs_with_config = conn.execute(
-        sa.text('SELECT id, mcp_config FROM org WHERE mcp_config IS NOT NULL')
-    ).fetchall()
-
-    for org_id, mcp_config in orgs_with_config:
-        conn.execute(
-            sa.text(
-                'UPDATE org_member SET mcp_config = :config WHERE org_id = :org_id'
-            ),
-            {'config': json.dumps(mcp_config), 'org_id': str(org_id)},
+    # Uses server-side SQL to avoid pulling sensitive config data into the Python process.
+    op.execute(
+        sa.text(
+            """
+            UPDATE org_member
+            SET mcp_config = org.mcp_config
+            FROM org
+            WHERE org_member.org_id = org.id
+              AND org.mcp_config IS NOT NULL
+            """
         )
+    )
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Summary

- **P0 fix**: Set `sqlalchemy.engine` logger to `WARNING` in both `alembic.ini` and programmatically in `env.py` (with post-`fileConfig` re-application) to prevent SQLAlchemy from logging SQL result rows at DEBUG level. This stops sensitive column data (API keys, tokens, credentials) from being emitted to log aggregators during database migrations.
- **P1 fix**: Refactored migration 103 (`add_mcp_config_to_org_member`) to use a single server-side `UPDATE...FROM` statement instead of client-side `fetchall()` + Python loop. This ensures `mcp_config` JSON (which contains user API keys and tokens) never enters the Python process at all.

### Files changed

| File | Change |
|------|--------|
| `enterprise/alembic.ini` | `logger_sqlalchemy` level `DEBUG` → `WARNING` |
| `enterprise/migrations/env.py` | Added programmatic `logging.getLogger('sqlalchemy.engine').setLevel(WARNING)` before engine creation and after `fileConfig()` |
| `enterprise/migrations/versions/103_add_mcp_config_to_org_member.py` | Replaced client-side row iteration with server-side `UPDATE org_member SET mcp_config = org.mcp_config FROM org WHERE ...` |

### Why both `alembic.ini` and `env.py`?

The `alembic.ini` change is the canonical configuration, but `fileConfig()` in `env.py` reads it at runtime and could be overridden. The programmatic `setLevel(WARNING)` calls in `env.py` act as a defense-in-depth measure — they run both before any engine is created and after `fileConfig()` completes, ensuring the suppression cannot be accidentally reverted.

Fixes OpenHands/evaluation#392

## Test plan

- [ ] Verify `alembic upgrade head` still completes successfully against a test database
- [ ] Verify migration 103 correctly copies `mcp_config` from `org` to `org_member` rows
- [ ] Confirm no `sqlalchemy.engine` DEBUG logs appear in migration output
- [ ] Run existing enterprise migration tests if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:f6305d1-nikolaik   --name openhands-app-f6305d1   docker.openhands.dev/openhands/openhands:f6305d1
```