### PR TITLE
fix(app_server): reject non-object pending message bodies

### DIFF
--- a/openhands/app_server/pending_messages/pending_message_router.py
+++ b/openhands/app_server/pending_messages/pending_message_router.py
@@ -63,6 +63,11 @@ async def queue_pending_message(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail='Invalid request body',
         )
+    if not isinstance(body, dict):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='Invalid request body',
+        )
 
     raw_content = body.get('content')
     role = body.get('role', 'user')

--- a/tests/unit/app_server/test_pending_message_router.py
+++ b/tests/unit/app_server/test_pending_message_router.py
@@ -126,6 +126,22 @@ class TestQueuePendingMessage:
         assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
         assert 'Invalid request body' in exc_info.value.detail
 
+    async def test_returns_400_for_non_object_json_body(self):
+        """Test that non-object JSON bodies return 400 instead of failing later."""
+        conversation_id = f'task-{uuid4().hex}'
+        mock_service = _make_mock_service()
+        mock_request = _make_mock_request([{'type': 'text', 'text': 'hello'}])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await queue_pending_message(
+                conversation_id=conversation_id,
+                request=mock_request,
+                pending_service=mock_service,
+            )
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'Invalid request body' in exc_info.value.detail
+
     async def test_returns_400_when_content_is_missing(self):
         """Test that missing content returns 400 Bad Request."""
         # Arrange


### PR DESCRIPTION
## Summary
- reject top-level JSON bodies that are not objects in `queue_pending_message`
- return a 400 instead of falling through to an AttributeError/500 when clients send a JSON array
- add router coverage for the non-object request-body case

## Testing
- `git diff --check`
- `python3 -m py_compile openhands/app_server/pending_messages/pending_message_router.py tests/unit/app_server/test_pending_message_router.py`
- `env -u http_proxy -u https_proxy -u all_proxy -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY uv run python -m pytest -q tests/unit/app_server/test_pending_message_router.py`