### PR TITLE
fix(app_server): use unique cursor for skills pagination

### DIFF
--- a/openhands/app_server/user/skills_router.py
+++ b/openhands/app_server/user/skills_router.py
@@ -32,6 +32,16 @@ class SkillPage(BaseModel):
     next_page_id: str | None = None
 
 
+def _make_page_cursor(skill: SkillInfo) -> str:
+    """Create an opaque cursor that stays unique across sources."""
+    return f'{skill.source}:{skill.name}'
+
+
+def _matches_page_cursor(skill: SkillInfo, page_id: str) -> bool:
+    """Match both new opaque cursors and legacy name-only cursors."""
+    return page_id == _make_page_cursor(skill) or page_id == skill.name
+
+
 def _parse_skill_frontmatter(file_path: Path) -> dict | None:
     """Parse YAML frontmatter from a skill markdown file.
 
@@ -143,13 +153,15 @@ async def search_skills(
     start = 0
     if page_id is not None:
         for i, skill in enumerate(skills):
-            if skill.name == page_id:
+            if _matches_page_cursor(skill, page_id):
                 start = i + 1
                 break
 
     page = skills[start : start + limit]
     next_page_id = (
-        page[-1].name if len(page) == limit and start + limit < len(skills) else None
+        _make_page_cursor(page[-1])
+        if len(page) == limit and start + limit < len(skills)
+        else None
     )
 
     return SkillPage(items=page, next_page_id=next_page_id)

--- a/tests/unit/app_server/test_skills_router.py
+++ b/tests/unit/app_server/test_skills_router.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import pytest
+
+from openhands.app_server.user import skills_router
+
+
+def _write_skill(directory: Path, name: str, *, frontmatter_name: str | None = None):
+    skill_name = frontmatter_name or name
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / f'{name}.md').write_text(
+        f"---\nname: {skill_name}\ntype: knowledge\ntriggers:\n  - demo\n---\n# {skill_name}\n",
+        encoding='utf-8',
+    )
+
+
+@pytest.mark.asyncio
+class TestSearchSkillsPagination:
+    async def test_next_page_id_is_unique_across_sources(self, tmp_path, monkeypatch):
+        global_dir = tmp_path / 'global'
+        user_dir = tmp_path / 'user'
+        _write_skill(global_dir, 'alpha')
+        _write_skill(global_dir, 'shared')
+        _write_skill(user_dir, 'shared')
+
+        monkeypatch.setattr(skills_router, 'GLOBAL_SKILLS_DIR', global_dir)
+        monkeypatch.setattr(skills_router, 'USER_SKILLS_DIR', user_dir)
+
+        first_page = await skills_router.search_skills(limit=2)
+
+        assert [skill.name for skill in first_page.items] == ['alpha', 'shared']
+        assert first_page.next_page_id == 'global:shared'
+
+        second_page = await skills_router.search_skills(
+            page_id=first_page.next_page_id, limit=2
+        )
+
+        assert [skill.name for skill in second_page.items] == ['shared']
+        assert [skill.source for skill in second_page.items] == ['user']
+        assert second_page.next_page_id is None
+
+    async def test_legacy_name_only_page_id_still_advances(self, tmp_path, monkeypatch):
+        global_dir = tmp_path / 'global'
+        user_dir = tmp_path / 'user'
+        _write_skill(global_dir, 'alpha')
+        _write_skill(global_dir, 'shared')
+        _write_skill(user_dir, 'beta')
+
+        monkeypatch.setattr(skills_router, 'GLOBAL_SKILLS_DIR', global_dir)
+        monkeypatch.setattr(skills_router, 'USER_SKILLS_DIR', user_dir)
+
+        page = await skills_router.search_skills(page_id='shared', limit=2)
+
+        assert [skill.name for skill in page.items] == ['beta']
+        assert [skill.source for skill in page.items] == ['user']

--- a/tests/unit/app_server/test_skills_router.py
+++ b/tests/unit/app_server/test_skills_router.py
@@ -9,7 +9,7 @@ def _write_skill(directory: Path, name: str, *, frontmatter_name: str | None = N
     skill_name = frontmatter_name or name
     directory.mkdir(parents=True, exist_ok=True)
     (directory / f'{name}.md').write_text(
-        f"---\nname: {skill_name}\ntype: knowledge\ntriggers:\n  - demo\n---\n# {skill_name}\n",
+        f'---\nname: {skill_name}\ntype: knowledge\ntriggers:\n  - demo\n---\n# {skill_name}\n',
         encoding='utf-8',
     )
 

--- a/tests/unit/server/routes/test_skills_api.py
+++ b/tests/unit/server/routes/test_skills_api.py
@@ -217,7 +217,7 @@ async def test_skills_search_pagination(test_client, tmp_path):
         assert len(data['items']) == 2
         assert data['items'][0]['name'] == 'skill_a'
         assert data['items'][1]['name'] == 'skill_b'
-        assert data['next_page_id'] == 'skill_b'
+        assert data['next_page_id'] == 'global:skill_b'
 
         # Second page using next_page_id
         response = test_client.get(


### PR DESCRIPTION
## Summary
- make `skills/search` pagination cursors unique across global and user skills
- keep backward compatibility for legacy name-only `page_id` values
- add unit coverage for duplicate skill names across sources

## Testing
- env -u http_proxy -u https_proxy -u all_proxy -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY uv run python -m pytest -q tests/unit/app_server/test_skills_router.py
- python3 -m py_compile openhands/app_server/user/skills_router.py tests/unit/app_server/test_skills_router.py