### PR TITLE
fix(app_server): ignore invalid event search page ids

### DIFF
--- a/openhands/app_server/event/event_service_base.py
+++ b/openhands/app_server/event/event_service_base.py
@@ -110,7 +110,11 @@ class EventServiceBase(EventService, ABC):
         start_offset = 0
         next_page_id = None
         if page_id:
-            start_offset = int(page_id)
+            try:
+                start_offset = int(page_id)
+            except ValueError:
+                # Invalid cursors fall back to the first page, matching other V1 services.
+                start_offset = 0
             items = items[start_offset:]
         if len(items) > limit:
             next_page_id = str(start_offset + limit)

--- a/tests/unit/app_server/test_filesystem_event_service.py
+++ b/tests/unit/app_server/test_filesystem_event_service.py
@@ -231,6 +231,23 @@ class TestFilesystemEventServiceSearchEvents:
         assert page_count == expected_pages
 
     @pytest.mark.asyncio
+    async def test_search_events_invalid_page_id_starts_from_beginning(
+        self, service: FilesystemEventService
+    ):
+        """Test that invalid page_id values fall back to the first page."""
+        conversation_id = uuid4()
+
+        for _ in range(4):
+            await service.save_event(conversation_id, create_token_event())
+
+        result = await service.search_events(
+            conversation_id, page_id='invalid', limit=2
+        )
+
+        assert len(result.items) == 2
+        assert result.next_page_id == '2'
+
+    @pytest.mark.asyncio
     async def test_search_events_pagination_with_filters(
         self, service: FilesystemEventService
     ):


### PR DESCRIPTION
## Summary
- make V1 event search pagination ignore invalid `page_id` values instead of raising during `int(page_id)` conversion
- align the behavior with the other V1 pagination services that fall back to the first page on malformed cursors
- add regression coverage in `test_filesystem_event_service.py`

## Testing
- env -u http_proxy -u https_proxy -u all_proxy -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY uv run python -m pytest -q tests/unit/app_server/test_filesystem_event_service.py -k invalid_page_id
- env -u http_proxy -u https_proxy -u all_proxy -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY uv run python -m pytest -q tests/unit/app_server/test_filesystem_event_service.py
- python3 -m py_compile openhands/app_server/event/event_service_base.py tests/unit/app_server/test_filesystem_event_service.py