### PR TITLE
fix(app_server): strip .git from plugin display names

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_models.py
+++ b/openhands/app_server/app_conversation/app_conversation_models.py
@@ -47,10 +47,11 @@ class PluginSpec(PluginSource):
 
         Examples:
             - 'github:owner/repo' -> 'repo'
-            - 'https://github.com/owner/repo.git' -> 'repo.git'
+            - 'https://github.com/owner/repo.git' -> 'repo'
             - '/local/path' -> 'path'
         """
-        return self.source.split('/')[-1] if '/' in self.source else self.source
+        display_name = self.source.split('/')[-1] if '/' in self.source else self.source
+        return display_name.removesuffix('.git')
 
     def format_params_as_text(self, indent: str = '') -> str | None:
         """Format parameters as a readable text block for display.

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3028,7 +3028,7 @@ class TestPluginSpecModel:
         )
 
         plugin = PluginSpec(source='https://github.com/owner/repo.git')
-        assert plugin.display_name == 'repo.git'
+        assert plugin.display_name == 'repo'
 
     def test_plugin_spec_display_name_local_path(self):
         """Test display_name extracts directory name from local path."""


### PR DESCRIPTION
## Summary
- trim the trailing `.git` suffix from `PluginSpec.display_name` when the source is a Git URL
- keep the existing display-name behavior for GitHub shorthand sources and local paths
- update the plugin display-name regression test to cover the cleaned label

## Testing
- env -u http_proxy -u https_proxy -u all_proxy -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY uv run python -m pytest -q tests/unit/app_server/test_live_status_app_conversation_service.py -k "plugin_spec_display_name_git_url or plugin_spec_display_name_github_format or plugin_spec_display_name_local_path or plugin_spec_display_name_no_slash"
- python3 -m py_compile openhands/app_server/app_conversation/app_conversation_models.py tests/unit/app_server/test_live_status_app_conversation_service.py