### PR TITLE
fix(app_server): clamp negative preset sandbox page ids

### DIFF
--- a/openhands/app_server/sandbox/preset_sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/preset_sandbox_spec_service.py
@@ -23,7 +23,7 @@ class PresetSandboxSpecService(SandboxSpecService):
         start_idx = 0
         if page_id:
             try:
-                start_idx = int(page_id)
+                start_idx = max(0, int(page_id))
             except ValueError:
                 start_idx = 0
 

--- a/tests/unit/app_server/test_preset_sandbox_spec_service.py
+++ b/tests/unit/app_server/test_preset_sandbox_spec_service.py
@@ -1,0 +1,39 @@
+"""Tests for PresetSandboxSpecService."""
+
+import pytest
+
+from openhands.app_server.sandbox.preset_sandbox_spec_service import (
+    PresetSandboxSpecService,
+)
+from openhands.app_server.sandbox.sandbox_spec_models import SandboxSpecInfo
+
+
+@pytest.fixture
+def service() -> PresetSandboxSpecService:
+    return PresetSandboxSpecService(
+        specs=[
+            SandboxSpecInfo(id='spec-1', command=['/bin/sh']),
+            SandboxSpecInfo(id='spec-2', command=['/bin/sh']),
+            SandboxSpecInfo(id='spec-3', command=['/bin/sh']),
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_sandbox_specs_invalid_page_id_starts_from_beginning(
+    service: PresetSandboxSpecService,
+):
+    page = await service.search_sandbox_specs(page_id='invalid', limit=2)
+
+    assert [spec.id for spec in page.items] == ['spec-1', 'spec-2']
+    assert page.next_page_id == '2'
+
+
+@pytest.mark.asyncio
+async def test_search_sandbox_specs_negative_page_id_starts_from_beginning(
+    service: PresetSandboxSpecService,
+):
+    page = await service.search_sandbox_specs(page_id='-1', limit=2)
+
+    assert [spec.id for spec in page.items] == ['spec-1', 'spec-2']
+    assert page.next_page_id == '2'


### PR DESCRIPTION
## Summary
- clamp negative preset sandbox-spec page ids back to the first page
- keep invalid cursor handling aligned with existing name-only invalid-page behavior
- add a focused unit test file covering invalid and negative page ids

## Testing
- python3 -m py_compile openhands/app_server/sandbox/preset_sandbox_spec_service.py tests/unit/app_server/test_preset_sandbox_spec_service.py
- uv run python -m pytest -q tests/unit/app_server/test_preset_sandbox_spec_service.py