### PR TITLE
fix(app_server): clamp negative process sandbox page ids

### DIFF
--- a/openhands/app_server/sandbox/process_sandbox_service.py
+++ b/openhands/app_server/sandbox/process_sandbox_service.py
@@ -247,7 +247,7 @@ class ProcessSandboxService(SandboxService):
         start_idx = 0
         if page_id:
             try:
-                start_idx = int(page_id)
+                start_idx = max(0, int(page_id))
             except ValueError:
                 start_idx = 0
 

--- a/openhands/app_server/sandbox/process_sandbox_service.py
+++ b/openhands/app_server/sandbox/process_sandbox_service.py
@@ -93,11 +93,11 @@ class ProcessSandboxService(SandboxService):
         while port < self.base_port + 10000:  # Try up to 10000 ports
             try:
                 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                    s.bind(('', port))
+                    s.bind(("", port))
                     return port
             except OSError:
                 port += 1
-        raise SandboxError('No available ports found')
+        raise SandboxError("No available ports found")
 
     def _create_sandbox_directory(self, sandbox_id: str) -> str:
         """Create a dedicated directory for the sandbox."""
@@ -114,23 +114,22 @@ class ProcessSandboxService(SandboxService):
         sandbox_spec: SandboxSpecInfo,
     ) -> subprocess.Popen:
         """Start the agent server process."""
-
         # Prepare environment variables
         env = os.environ.copy()
         env.update(sandbox_spec.initial_env)
-        env['SESSION_API_KEY'] = session_api_key
+        env["SESSION_API_KEY"] = session_api_key
 
         # Prepare command arguments
         cmd = [
             self.python_executable,
-            '-m',
+            "-m",
             self.agent_server_module,
-            '--port',
+            "--port",
             str(port),
         ]
 
         _logger.info(
-            f'Starting agent process for sandbox {sandbox_id}: {" ".join(cmd)}'
+            f"Starting agent process for sandbox {sandbox_id}: {' '.join(cmd)}"
         )
 
         try:
@@ -149,12 +148,12 @@ class ProcessSandboxService(SandboxService):
             # Check if process is still running
             if process.poll() is not None:
                 stdout, stderr = process.communicate()
-                raise SandboxError(f'Agent process failed to start: {stderr.decode()}')
+                raise SandboxError(f"Agent process failed to start: {stderr.decode()}")
 
             return process
 
         except Exception as e:
-            raise SandboxError(f'Failed to start agent process: {e}')
+            raise SandboxError(f"Failed to start agent process: {e}")
 
     async def _wait_for_server_ready(self, port: int, timeout: int = 30) -> bool:
         """Wait for the agent server to be ready."""
@@ -162,12 +161,12 @@ class ProcessSandboxService(SandboxService):
         while time.time() - start_time < timeout:
             try:
                 url = replace_localhost_hostname_for_docker(
-                    f'http://localhost:{port}/alive'
+                    f"http://localhost:{port}/alive"
                 )
                 response = await self.httpx_client.get(url, timeout=5.0)
                 if response.status_code == 200:
                     data = response.json()
-                    if data.get('status') == 'ok':
+                    if data.get("status") == "ok":
                         return True
             except Exception:
                 pass
@@ -204,14 +203,14 @@ class ProcessSandboxService(SandboxService):
             # Check if server is actually responding
             try:
                 url = replace_localhost_hostname_for_docker(
-                    f'http://localhost:{process_info.port}{self.health_check_path}'
+                    f"http://localhost:{process_info.port}{self.health_check_path}"
                 )
                 response = await self.httpx_client.get(url, timeout=5.0)
                 if response.status_code == 200:
                     exposed_urls = [
                         ExposedUrl(
                             name=AGENT_SERVER,
-                            url=f'http://localhost:{process_info.port}',
+                            url=f"http://localhost:{process_info.port}",
                             port=process_info.port,
                         ),
                     ]
@@ -298,7 +297,7 @@ class ProcessSandboxService(SandboxService):
                 sandbox_spec_id
             )
             if sandbox_spec_maybe is None:
-                raise ValueError('Sandbox Spec not found')
+                raise ValueError("Sandbox Spec not found")
             sandbox_spec = sandbox_spec_maybe
 
         # Generate unique sandbox ID and session API key
@@ -338,7 +337,7 @@ class ProcessSandboxService(SandboxService):
         if not await self._wait_for_server_ready(port):
             # Clean up if server didn't start properly
             await self.delete_sandbox(sandbox_id)
-            raise SandboxError('Agent Server Failed to start properly')
+            raise SandboxError("Agent Server Failed to start properly")
 
         return await self._process_to_sandbox_info(sandbox_id, process_info)
 
@@ -401,7 +400,7 @@ class ProcessSandboxService(SandboxService):
             return True
 
         except (psutil.NoSuchProcess, psutil.AccessDenied, OSError) as e:
-            _logger.warning(f'Error deleting sandbox {sandbox_id}: {e}')
+            _logger.warning(f"Error deleting sandbox {sandbox_id}: {e}")
             # Still remove from tracking even if cleanup failed
             if sandbox_id in _processes:
                 del _processes[sandbox_id]
@@ -412,22 +411,22 @@ class ProcessSandboxServiceInjector(SandboxServiceInjector):
     """Dependency injector for process sandbox services."""
 
     base_working_dir: str = Field(
-        default='/tmp/openhands-sandboxes',
-        description='Base directory for sandbox working directories',
+        default="/tmp/openhands-sandboxes",
+        description="Base directory for sandbox working directories",
     )
     base_port: int = Field(
-        default=8000, description='Base port number for agent servers'
+        default=8000, description="Base port number for agent servers"
     )
     python_executable: str = Field(
         default=sys.executable,
-        description='Python executable to use for agent processes',
+        description="Python executable to use for agent processes",
     )
     agent_server_module: str = Field(
-        default='openhands.agent_server',
-        description='Python module for the agent server',
+        default="openhands.agent_server",
+        description="Python module for the agent server",
     )
     health_check_path: str = Field(
-        default='/alive', description='Health check endpoint path'
+        default="/alive", description="Health check endpoint path"
     )
 
     async def inject(

--- a/openhands/app_server/sandbox/process_sandbox_service.py
+++ b/openhands/app_server/sandbox/process_sandbox_service.py
@@ -93,11 +93,11 @@ class ProcessSandboxService(SandboxService):
         while port < self.base_port + 10000:  # Try up to 10000 ports
             try:
                 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                    s.bind(("", port))
+                    s.bind(('', port))
                     return port
             except OSError:
                 port += 1
-        raise SandboxError("No available ports found")
+        raise SandboxError('No available ports found')
 
     def _create_sandbox_directory(self, sandbox_id: str) -> str:
         """Create a dedicated directory for the sandbox."""
@@ -117,19 +117,19 @@ class ProcessSandboxService(SandboxService):
         # Prepare environment variables
         env = os.environ.copy()
         env.update(sandbox_spec.initial_env)
-        env["SESSION_API_KEY"] = session_api_key
+        env['SESSION_API_KEY'] = session_api_key
 
         # Prepare command arguments
         cmd = [
             self.python_executable,
-            "-m",
+            '-m',
             self.agent_server_module,
-            "--port",
+            '--port',
             str(port),
         ]
 
         _logger.info(
-            f"Starting agent process for sandbox {sandbox_id}: {' '.join(cmd)}"
+            f'Starting agent process for sandbox {sandbox_id}: {" ".join(cmd)}'
         )
 
         try:
@@ -148,12 +148,12 @@ class ProcessSandboxService(SandboxService):
             # Check if process is still running
             if process.poll() is not None:
                 stdout, stderr = process.communicate()
-                raise SandboxError(f"Agent process failed to start: {stderr.decode()}")
+                raise SandboxError(f'Agent process failed to start: {stderr.decode()}')
 
             return process
 
         except Exception as e:
-            raise SandboxError(f"Failed to start agent process: {e}")
+            raise SandboxError(f'Failed to start agent process: {e}')
 
     async def _wait_for_server_ready(self, port: int, timeout: int = 30) -> bool:
         """Wait for the agent server to be ready."""
@@ -161,12 +161,12 @@ class ProcessSandboxService(SandboxService):
         while time.time() - start_time < timeout:
             try:
                 url = replace_localhost_hostname_for_docker(
-                    f"http://localhost:{port}/alive"
+                    f'http://localhost:{port}/alive'
                 )
                 response = await self.httpx_client.get(url, timeout=5.0)
                 if response.status_code == 200:
                     data = response.json()
-                    if data.get("status") == "ok":
+                    if data.get('status') == 'ok':
                         return True
             except Exception:
                 pass
@@ -203,14 +203,14 @@ class ProcessSandboxService(SandboxService):
             # Check if server is actually responding
             try:
                 url = replace_localhost_hostname_for_docker(
-                    f"http://localhost:{process_info.port}{self.health_check_path}"
+                    f'http://localhost:{process_info.port}{self.health_check_path}'
                 )
                 response = await self.httpx_client.get(url, timeout=5.0)
                 if response.status_code == 200:
                     exposed_urls = [
                         ExposedUrl(
                             name=AGENT_SERVER,
-                            url=f"http://localhost:{process_info.port}",
+                            url=f'http://localhost:{process_info.port}',
                             port=process_info.port,
                         ),
                     ]
@@ -297,7 +297,7 @@ class ProcessSandboxService(SandboxService):
                 sandbox_spec_id
             )
             if sandbox_spec_maybe is None:
-                raise ValueError("Sandbox Spec not found")
+                raise ValueError('Sandbox Spec not found')
             sandbox_spec = sandbox_spec_maybe
 
         # Generate unique sandbox ID and session API key
@@ -337,7 +337,7 @@ class ProcessSandboxService(SandboxService):
         if not await self._wait_for_server_ready(port):
             # Clean up if server didn't start properly
             await self.delete_sandbox(sandbox_id)
-            raise SandboxError("Agent Server Failed to start properly")
+            raise SandboxError('Agent Server Failed to start properly')
 
         return await self._process_to_sandbox_info(sandbox_id, process_info)
 
@@ -400,7 +400,7 @@ class ProcessSandboxService(SandboxService):
             return True
 
         except (psutil.NoSuchProcess, psutil.AccessDenied, OSError) as e:
-            _logger.warning(f"Error deleting sandbox {sandbox_id}: {e}")
+            _logger.warning(f'Error deleting sandbox {sandbox_id}: {e}')
             # Still remove from tracking even if cleanup failed
             if sandbox_id in _processes:
                 del _processes[sandbox_id]
@@ -411,22 +411,22 @@ class ProcessSandboxServiceInjector(SandboxServiceInjector):
     """Dependency injector for process sandbox services."""
 
     base_working_dir: str = Field(
-        default="/tmp/openhands-sandboxes",
-        description="Base directory for sandbox working directories",
+        default='/tmp/openhands-sandboxes',
+        description='Base directory for sandbox working directories',
     )
     base_port: int = Field(
-        default=8000, description="Base port number for agent servers"
+        default=8000, description='Base port number for agent servers'
     )
     python_executable: str = Field(
         default=sys.executable,
-        description="Python executable to use for agent processes",
+        description='Python executable to use for agent processes',
     )
     agent_server_module: str = Field(
-        default="openhands.agent_server",
-        description="Python module for the agent server",
+        default='openhands.agent_server',
+        description='Python module for the agent server',
     )
     health_check_path: str = Field(
-        default="/alive", description="Health check endpoint path"
+        default='/alive', description='Health check endpoint path'
     )
 
     async def inject(

--- a/tests/unit/app_server/test_process_sandbox_service.py
+++ b/tests/unit/app_server/test_process_sandbox_service.py
@@ -22,8 +22,8 @@ class MockSandboxSpec:
     """Mock sandbox specification."""
 
     def __init__(self):
-        self.id = "test-spec"
-        self.initial_env = {"TEST_VAR": "test_value"}
+        self.id = 'test-spec'
+        self.initial_env = {'TEST_VAR': 'test_value'}
         self.plugins = []
 
 
@@ -34,7 +34,7 @@ class MockSandboxSpecService:
         return MockSandboxSpec()
 
     async def get_sandbox_spec(self, spec_id: str):
-        if spec_id == "test-spec":
+        if spec_id == 'test-spec':
             return MockSandboxSpec()
         return None
 
@@ -57,13 +57,13 @@ def temp_dir():
 def process_sandbox_service(mock_httpx_client, temp_dir):
     """Create a ProcessSandboxService instance for testing."""
     return ProcessSandboxService(
-        user_id="test-user-id",
+        user_id='test-user-id',
         sandbox_spec_service=MockSandboxSpecService(),
         base_working_dir=temp_dir,
         base_port=9000,
-        python_executable="python",
-        agent_server_module="openhands.agent_server",
-        health_check_path="/alive",
+        python_executable='python',
+        agent_server_module='openhands.agent_server',
+        health_check_path='/alive',
         httpx_client=mock_httpx_client,
     )
 
@@ -77,12 +77,12 @@ class TestProcessSandboxService:
         assert port >= process_sandbox_service.base_port
         assert port < process_sandbox_service.base_port + 10000
 
-    @patch("os.makedirs")
+    @patch('os.makedirs')
     def test_create_sandbox_directory(self, mock_makedirs, process_sandbox_service):
         """Test creating a sandbox directory."""
-        sandbox_dir = process_sandbox_service._create_sandbox_directory("test-id")
+        sandbox_dir = process_sandbox_service._create_sandbox_directory('test-id')
 
-        expected_dir = os.path.join(process_sandbox_service.base_working_dir, "test-id")
+        expected_dir = os.path.join(process_sandbox_service.base_working_dir, 'test-id')
         assert sandbox_dir == expected_dir
         mock_makedirs.assert_called_once_with(expected_dir, exist_ok=True)
 
@@ -92,7 +92,7 @@ class TestProcessSandboxService:
         # Mock successful response
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {"status": "ok"}
+        mock_response.json.return_value = {'status': 'ok'}
         process_sandbox_service.httpx_client.get.return_value = mock_response
 
         result = await process_sandbox_service._wait_for_server_ready(9000, timeout=1)
@@ -103,13 +103,13 @@ class TestProcessSandboxService:
         """Test waiting for server to be ready - timeout case."""
         # Mock failed response
         process_sandbox_service.httpx_client.get.side_effect = Exception(
-            "Connection failed"
+            'Connection failed'
         )
 
         result = await process_sandbox_service._wait_for_server_ready(9000, timeout=1)
         assert result is False
 
-    @patch("psutil.Process")
+    @patch('psutil.Process')
     def test_get_process_status_running(
         self, mock_process_class, process_sandbox_service
     ):
@@ -122,17 +122,17 @@ class TestProcessSandboxService:
         process_info = ProcessInfo(
             pid=1234,
             port=9000,
-            user_id="test-user-id",
-            working_dir="/tmp/test",
-            session_api_key="test-key",
+            user_id='test-user-id',
+            working_dir='/tmp/test',
+            session_api_key='test-key',
             created_at=datetime.now(),
-            sandbox_spec_id="test-spec",
+            sandbox_spec_id='test-spec',
         )
 
         status = process_sandbox_service._get_process_status(process_info)
         assert status == SandboxStatus.RUNNING
 
-    @patch("psutil.Process")
+    @patch('psutil.Process')
     def test_get_process_status_missing(
         self, mock_process_class, process_sandbox_service
     ):
@@ -144,11 +144,11 @@ class TestProcessSandboxService:
         process_info = ProcessInfo(
             pid=1234,
             port=9000,
-            user_id="test-user-id",
-            working_dir="/tmp/test",
-            session_api_key="test-key",
+            user_id='test-user-id',
+            working_dir='/tmp/test',
+            session_api_key='test-key',
             created_at=datetime.now(),
-            sandbox_spec_id="test-spec",
+            sandbox_spec_id='test-spec',
         )
 
         status = process_sandbox_service._get_process_status(process_info)
@@ -165,7 +165,7 @@ class TestProcessSandboxService:
     @pytest.mark.asyncio
     async def test_search_sandboxes_negative_page_id(self, process_sandbox_service):
         """Test negative page_id falls back to the first page."""
-        sandbox_ids = ["sandbox-1", "sandbox-2", "sandbox-3"]
+        sandbox_ids = ['sandbox-1', 'sandbox-2', 'sandbox-3']
         created_times = [
             datetime(2024, 1, 1, 10, 0, 0),
             datetime(2024, 1, 1, 11, 0, 0),
@@ -176,45 +176,45 @@ class TestProcessSandboxService:
             _processes[sandbox_id] = ProcessInfo(
                 pid=1000,
                 port=9000,
-                user_id="test-user-id",
-                working_dir="/tmp/test",
-                session_api_key="test-key",
+                user_id='test-user-id',
+                working_dir='/tmp/test',
+                session_api_key='test-key',
                 created_at=created_at,
-                sandbox_spec_id="test-spec",
+                sandbox_spec_id='test-spec',
             )
 
         with patch.object(
             process_sandbox_service,
-            "_get_process_status",
+            '_get_process_status',
             return_value=SandboxStatus.RUNNING,
         ):
-            page = await process_sandbox_service.search_sandboxes(page_id="-1", limit=2)
+            page = await process_sandbox_service.search_sandboxes(page_id='-1', limit=2)
 
-        assert [sandbox.id for sandbox in page.items] == ["sandbox-3", "sandbox-2"]
-        assert page.next_page_id == "2"
+        assert [sandbox.id for sandbox in page.items] == ['sandbox-3', 'sandbox-2']
+        assert page.next_page_id == '2'
 
     @pytest.mark.asyncio
     async def test_get_sandbox_not_found(self, process_sandbox_service):
         """Test getting a sandbox that doesn't exist."""
-        result = await process_sandbox_service.get_sandbox("nonexistent")
+        result = await process_sandbox_service.get_sandbox('nonexistent')
         assert result is None
 
     @pytest.mark.asyncio
     async def test_resume_sandbox_not_found(self, process_sandbox_service):
         """Test resuming a sandbox that doesn't exist."""
-        result = await process_sandbox_service.resume_sandbox("nonexistent")
+        result = await process_sandbox_service.resume_sandbox('nonexistent')
         assert result is False
 
     @pytest.mark.asyncio
     async def test_pause_sandbox_not_found(self, process_sandbox_service):
         """Test pausing a sandbox that doesn't exist."""
-        result = await process_sandbox_service.pause_sandbox("nonexistent")
+        result = await process_sandbox_service.pause_sandbox('nonexistent')
         assert result is False
 
     @pytest.mark.asyncio
     async def test_delete_sandbox_not_found(self, process_sandbox_service):
         """Test deleting a sandbox that doesn't exist."""
-        result = await process_sandbox_service.delete_sandbox("nonexistent")
+        result = await process_sandbox_service.delete_sandbox('nonexistent')
         assert result is False
 
     @pytest.mark.asyncio
@@ -223,14 +223,14 @@ class TestProcessSandboxService:
         # Mock subprocess and waiting for server
         with (
             patch.object(
-                process_sandbox_service, "_start_agent_process"
+                process_sandbox_service, '_start_agent_process'
             ) as mock_start_process,
             patch.object(
-                process_sandbox_service, "_wait_for_server_ready", return_value=True
+                process_sandbox_service, '_wait_for_server_ready', return_value=True
             ),
             patch.object(
                 process_sandbox_service,
-                "_get_process_status",
+                '_get_process_status',
                 return_value=SandboxStatus.RUNNING,
             ),
         ):
@@ -245,14 +245,14 @@ class TestProcessSandboxService:
 
             # Execute with custom sandbox_id
             result = await process_sandbox_service.start_sandbox(
-                sandbox_id="custom_sandbox_id"
+                sandbox_id='custom_sandbox_id'
             )
 
             # Verify
             assert result is not None
-            assert result.id == "custom_sandbox_id"
+            assert result.id == 'custom_sandbox_id'
 
-    @patch("psutil.Process")
+    @patch('psutil.Process')
     def test_get_process_status_paused(
         self, mock_process_class, process_sandbox_service
     ):
@@ -265,17 +265,17 @@ class TestProcessSandboxService:
         process_info = ProcessInfo(
             pid=1234,
             port=9000,
-            user_id="test-user-id",
-            working_dir="/tmp/test",
-            session_api_key="test-key",
+            user_id='test-user-id',
+            working_dir='/tmp/test',
+            session_api_key='test-key',
             created_at=datetime.now(),
-            sandbox_spec_id="test-spec",
+            sandbox_spec_id='test-spec',
         )
 
         status = process_sandbox_service._get_process_status(process_info)
         assert status == SandboxStatus.PAUSED
 
-    @patch("psutil.Process")
+    @patch('psutil.Process')
     def test_get_process_status_starting(
         self, mock_process_class, process_sandbox_service
     ):
@@ -288,17 +288,17 @@ class TestProcessSandboxService:
         process_info = ProcessInfo(
             pid=1234,
             port=9000,
-            user_id="test-user-id",
-            working_dir="/tmp/test",
-            session_api_key="test-key",
+            user_id='test-user-id',
+            working_dir='/tmp/test',
+            session_api_key='test-key',
             created_at=datetime.now(),
-            sandbox_spec_id="test-spec",
+            sandbox_spec_id='test-spec',
         )
 
         status = process_sandbox_service._get_process_status(process_info)
         assert status == SandboxStatus.STARTING
 
-    @patch("psutil.Process")
+    @patch('psutil.Process')
     def test_get_process_status_access_denied(
         self, mock_process_class, process_sandbox_service
     ):
@@ -308,11 +308,11 @@ class TestProcessSandboxService:
         process_info = ProcessInfo(
             pid=1234,
             port=9000,
-            user_id="test-user-id",
-            working_dir="/tmp/test",
-            session_api_key="test-key",
+            user_id='test-user-id',
+            working_dir='/tmp/test',
+            session_api_key='test-key',
             created_at=datetime.now(),
-            sandbox_spec_id="test-spec",
+            sandbox_spec_id='test-spec',
         )
 
         status = process_sandbox_service._get_process_status(process_info)
@@ -324,7 +324,7 @@ class TestProcessSandboxService:
         # Mock a process that's running but server is not responding
         with patch.object(
             process_sandbox_service,
-            "_get_process_status",
+            '_get_process_status',
             return_value=SandboxStatus.RUNNING,
         ):
             # Mock httpx client to return error response
@@ -335,15 +335,15 @@ class TestProcessSandboxService:
             process_info = ProcessInfo(
                 pid=1234,
                 port=9000,
-                user_id="test-user-id",
-                working_dir="/tmp/test",
-                session_api_key="test-key",
+                user_id='test-user-id',
+                working_dir='/tmp/test',
+                session_api_key='test-key',
                 created_at=datetime.now(),
-                sandbox_spec_id="test-spec",
+                sandbox_spec_id='test-spec',
             )
 
             sandbox_info = await process_sandbox_service._process_to_sandbox_info(
-                "test-sandbox", process_info
+                'test-sandbox', process_info
             )
 
             assert sandbox_info.status == SandboxStatus.ERROR
@@ -356,26 +356,26 @@ class TestProcessSandboxService:
         # Mock a process that's running but httpx raises exception
         with patch.object(
             process_sandbox_service,
-            "_get_process_status",
+            '_get_process_status',
             return_value=SandboxStatus.RUNNING,
         ):
             # Mock httpx client to raise exception
             process_sandbox_service.httpx_client.get.side_effect = Exception(
-                "Connection failed"
+                'Connection failed'
             )
 
             process_info = ProcessInfo(
                 pid=1234,
                 port=9000,
-                user_id="test-user-id",
-                working_dir="/tmp/test",
-                session_api_key="test-key",
+                user_id='test-user-id',
+                working_dir='/tmp/test',
+                session_api_key='test-key',
                 created_at=datetime.now(),
-                sandbox_spec_id="test-spec",
+                sandbox_spec_id='test-spec',
             )
 
             sandbox_info = await process_sandbox_service._process_to_sandbox_info(
-                "test-sandbox", process_info
+                'test-sandbox', process_info
             )
 
             assert sandbox_info.status == SandboxStatus.ERROR
@@ -390,21 +390,21 @@ class TestProcessSandboxServiceInjector:
         """Test default configuration values."""
         injector = ProcessSandboxServiceInjector()
 
-        assert injector.base_working_dir == "/tmp/openhands-sandboxes"
+        assert injector.base_working_dir == '/tmp/openhands-sandboxes'
         assert injector.base_port == 8000
-        assert injector.health_check_path == "/alive"
-        assert injector.agent_server_module == "openhands.agent_server"
+        assert injector.health_check_path == '/alive'
+        assert injector.agent_server_module == 'openhands.agent_server'
 
     def test_custom_values(self):
         """Test custom configuration values."""
         injector = ProcessSandboxServiceInjector(
-            base_working_dir="/custom/path",
+            base_working_dir='/custom/path',
             base_port=9000,
-            health_check_path="/health",
-            agent_server_module="custom.agent.module",
+            health_check_path='/health',
+            agent_server_module='custom.agent.module',
         )
 
-        assert injector.base_working_dir == "/custom/path"
+        assert injector.base_working_dir == '/custom/path'
         assert injector.base_port == 9000
-        assert injector.health_check_path == "/health"
-        assert injector.agent_server_module == "custom.agent.module"
+        assert injector.health_check_path == '/health'
+        assert injector.agent_server_module == 'custom.agent.module'

--- a/tests/unit/app_server/test_process_sandbox_service.py
+++ b/tests/unit/app_server/test_process_sandbox_service.py
@@ -13,6 +13,7 @@ from openhands.app_server.sandbox.process_sandbox_service import (
     ProcessInfo,
     ProcessSandboxService,
     ProcessSandboxServiceInjector,
+    _processes,
 )
 from openhands.app_server.sandbox.sandbox_models import SandboxStatus
 
@@ -160,6 +161,41 @@ class TestProcessSandboxService:
 
         assert len(result.items) == 0
         assert result.next_page_id is None
+
+    @pytest.mark.asyncio
+    async def test_search_sandboxes_negative_page_id(
+        self, process_sandbox_service
+    ):
+        """Test negative page_id falls back to the first page."""
+        sandbox_ids = ['sandbox-1', 'sandbox-2', 'sandbox-3']
+        created_times = [
+            datetime(2024, 1, 1, 10, 0, 0),
+            datetime(2024, 1, 1, 11, 0, 0),
+            datetime(2024, 1, 1, 12, 0, 0),
+        ]
+
+        for sandbox_id, created_at in zip(sandbox_ids, created_times, strict=False):
+            _processes[sandbox_id] = ProcessInfo(
+                pid=1000,
+                port=9000,
+                user_id='test-user-id',
+                working_dir='/tmp/test',
+                session_api_key='test-key',
+                created_at=created_at,
+                sandbox_spec_id='test-spec',
+            )
+
+        with patch.object(
+            process_sandbox_service,
+            '_get_process_status',
+            return_value=SandboxStatus.RUNNING,
+        ):
+            page = await process_sandbox_service.search_sandboxes(
+                page_id='-1', limit=2
+            )
+
+        assert [sandbox.id for sandbox in page.items] == ['sandbox-3', 'sandbox-2']
+        assert page.next_page_id == '2'
 
     @pytest.mark.asyncio
     async def test_get_sandbox_not_found(self, process_sandbox_service):

--- a/tests/unit/app_server/test_process_sandbox_service.py
+++ b/tests/unit/app_server/test_process_sandbox_service.py
@@ -22,8 +22,8 @@ class MockSandboxSpec:
     """Mock sandbox specification."""
 
     def __init__(self):
-        self.id = 'test-spec'
-        self.initial_env = {'TEST_VAR': 'test_value'}
+        self.id = "test-spec"
+        self.initial_env = {"TEST_VAR": "test_value"}
         self.plugins = []
 
 
@@ -34,7 +34,7 @@ class MockSandboxSpecService:
         return MockSandboxSpec()
 
     async def get_sandbox_spec(self, spec_id: str):
-        if spec_id == 'test-spec':
+        if spec_id == "test-spec":
             return MockSandboxSpec()
         return None
 
@@ -57,13 +57,13 @@ def temp_dir():
 def process_sandbox_service(mock_httpx_client, temp_dir):
     """Create a ProcessSandboxService instance for testing."""
     return ProcessSandboxService(
-        user_id='test-user-id',
+        user_id="test-user-id",
         sandbox_spec_service=MockSandboxSpecService(),
         base_working_dir=temp_dir,
         base_port=9000,
-        python_executable='python',
-        agent_server_module='openhands.agent_server',
-        health_check_path='/alive',
+        python_executable="python",
+        agent_server_module="openhands.agent_server",
+        health_check_path="/alive",
         httpx_client=mock_httpx_client,
     )
 
@@ -77,12 +77,12 @@ class TestProcessSandboxService:
         assert port >= process_sandbox_service.base_port
         assert port < process_sandbox_service.base_port + 10000
 
-    @patch('os.makedirs')
+    @patch("os.makedirs")
     def test_create_sandbox_directory(self, mock_makedirs, process_sandbox_service):
         """Test creating a sandbox directory."""
-        sandbox_dir = process_sandbox_service._create_sandbox_directory('test-id')
+        sandbox_dir = process_sandbox_service._create_sandbox_directory("test-id")
 
-        expected_dir = os.path.join(process_sandbox_service.base_working_dir, 'test-id')
+        expected_dir = os.path.join(process_sandbox_service.base_working_dir, "test-id")
         assert sandbox_dir == expected_dir
         mock_makedirs.assert_called_once_with(expected_dir, exist_ok=True)
 
@@ -92,7 +92,7 @@ class TestProcessSandboxService:
         # Mock successful response
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {'status': 'ok'}
+        mock_response.json.return_value = {"status": "ok"}
         process_sandbox_service.httpx_client.get.return_value = mock_response
 
         result = await process_sandbox_service._wait_for_server_ready(9000, timeout=1)
@@ -103,13 +103,13 @@ class TestProcessSandboxService:
         """Test waiting for server to be ready - timeout case."""
         # Mock failed response
         process_sandbox_service.httpx_client.get.side_effect = Exception(
-            'Connection failed'
+            "Connection failed"
         )
 
         result = await process_sandbox_service._wait_for_server_ready(9000, timeout=1)
         assert result is False
 
-    @patch('psutil.Process')
+    @patch("psutil.Process")
     def test_get_process_status_running(
         self, mock_process_class, process_sandbox_service
     ):
@@ -122,17 +122,17 @@ class TestProcessSandboxService:
         process_info = ProcessInfo(
             pid=1234,
             port=9000,
-            user_id='test-user-id',
-            working_dir='/tmp/test',
-            session_api_key='test-key',
+            user_id="test-user-id",
+            working_dir="/tmp/test",
+            session_api_key="test-key",
             created_at=datetime.now(),
-            sandbox_spec_id='test-spec',
+            sandbox_spec_id="test-spec",
         )
 
         status = process_sandbox_service._get_process_status(process_info)
         assert status == SandboxStatus.RUNNING
 
-    @patch('psutil.Process')
+    @patch("psutil.Process")
     def test_get_process_status_missing(
         self, mock_process_class, process_sandbox_service
     ):
@@ -144,11 +144,11 @@ class TestProcessSandboxService:
         process_info = ProcessInfo(
             pid=1234,
             port=9000,
-            user_id='test-user-id',
-            working_dir='/tmp/test',
-            session_api_key='test-key',
+            user_id="test-user-id",
+            working_dir="/tmp/test",
+            session_api_key="test-key",
             created_at=datetime.now(),
-            sandbox_spec_id='test-spec',
+            sandbox_spec_id="test-spec",
         )
 
         status = process_sandbox_service._get_process_status(process_info)
@@ -163,11 +163,9 @@ class TestProcessSandboxService:
         assert result.next_page_id is None
 
     @pytest.mark.asyncio
-    async def test_search_sandboxes_negative_page_id(
-        self, process_sandbox_service
-    ):
+    async def test_search_sandboxes_negative_page_id(self, process_sandbox_service):
         """Test negative page_id falls back to the first page."""
-        sandbox_ids = ['sandbox-1', 'sandbox-2', 'sandbox-3']
+        sandbox_ids = ["sandbox-1", "sandbox-2", "sandbox-3"]
         created_times = [
             datetime(2024, 1, 1, 10, 0, 0),
             datetime(2024, 1, 1, 11, 0, 0),
@@ -178,47 +176,45 @@ class TestProcessSandboxService:
             _processes[sandbox_id] = ProcessInfo(
                 pid=1000,
                 port=9000,
-                user_id='test-user-id',
-                working_dir='/tmp/test',
-                session_api_key='test-key',
+                user_id="test-user-id",
+                working_dir="/tmp/test",
+                session_api_key="test-key",
                 created_at=created_at,
-                sandbox_spec_id='test-spec',
+                sandbox_spec_id="test-spec",
             )
 
         with patch.object(
             process_sandbox_service,
-            '_get_process_status',
+            "_get_process_status",
             return_value=SandboxStatus.RUNNING,
         ):
-            page = await process_sandbox_service.search_sandboxes(
-                page_id='-1', limit=2
-            )
+            page = await process_sandbox_service.search_sandboxes(page_id="-1", limit=2)
 
-        assert [sandbox.id for sandbox in page.items] == ['sandbox-3', 'sandbox-2']
-        assert page.next_page_id == '2'
+        assert [sandbox.id for sandbox in page.items] == ["sandbox-3", "sandbox-2"]
+        assert page.next_page_id == "2"
 
     @pytest.mark.asyncio
     async def test_get_sandbox_not_found(self, process_sandbox_service):
         """Test getting a sandbox that doesn't exist."""
-        result = await process_sandbox_service.get_sandbox('nonexistent')
+        result = await process_sandbox_service.get_sandbox("nonexistent")
         assert result is None
 
     @pytest.mark.asyncio
     async def test_resume_sandbox_not_found(self, process_sandbox_service):
         """Test resuming a sandbox that doesn't exist."""
-        result = await process_sandbox_service.resume_sandbox('nonexistent')
+        result = await process_sandbox_service.resume_sandbox("nonexistent")
         assert result is False
 
     @pytest.mark.asyncio
     async def test_pause_sandbox_not_found(self, process_sandbox_service):
         """Test pausing a sandbox that doesn't exist."""
-        result = await process_sandbox_service.pause_sandbox('nonexistent')
+        result = await process_sandbox_service.pause_sandbox("nonexistent")
         assert result is False
 
     @pytest.mark.asyncio
     async def test_delete_sandbox_not_found(self, process_sandbox_service):
         """Test deleting a sandbox that doesn't exist."""
-        result = await process_sandbox_service.delete_sandbox('nonexistent')
+        result = await process_sandbox_service.delete_sandbox("nonexistent")
         assert result is False
 
     @pytest.mark.asyncio
@@ -227,14 +223,14 @@ class TestProcessSandboxService:
         # Mock subprocess and waiting for server
         with (
             patch.object(
-                process_sandbox_service, '_start_agent_process'
+                process_sandbox_service, "_start_agent_process"
             ) as mock_start_process,
             patch.object(
-                process_sandbox_service, '_wait_for_server_ready', return_value=True
+                process_sandbox_service, "_wait_for_server_ready", return_value=True
             ),
             patch.object(
                 process_sandbox_service,
-                '_get_process_status',
+                "_get_process_status",
                 return_value=SandboxStatus.RUNNING,
             ),
         ):
@@ -249,14 +245,14 @@ class TestProcessSandboxService:
 
             # Execute with custom sandbox_id
             result = await process_sandbox_service.start_sandbox(
-                sandbox_id='custom_sandbox_id'
+                sandbox_id="custom_sandbox_id"
             )
 
             # Verify
             assert result is not None
-            assert result.id == 'custom_sandbox_id'
+            assert result.id == "custom_sandbox_id"
 
-    @patch('psutil.Process')
+    @patch("psutil.Process")
     def test_get_process_status_paused(
         self, mock_process_class, process_sandbox_service
     ):
@@ -269,17 +265,17 @@ class TestProcessSandboxService:
         process_info = ProcessInfo(
             pid=1234,
             port=9000,
-            user_id='test-user-id',
-            working_dir='/tmp/test',
-            session_api_key='test-key',
+            user_id="test-user-id",
+            working_dir="/tmp/test",
+            session_api_key="test-key",
             created_at=datetime.now(),
-            sandbox_spec_id='test-spec',
+            sandbox_spec_id="test-spec",
         )
 
         status = process_sandbox_service._get_process_status(process_info)
         assert status == SandboxStatus.PAUSED
 
-    @patch('psutil.Process')
+    @patch("psutil.Process")
     def test_get_process_status_starting(
         self, mock_process_class, process_sandbox_service
     ):
@@ -292,17 +288,17 @@ class TestProcessSandboxService:
         process_info = ProcessInfo(
             pid=1234,
             port=9000,
-            user_id='test-user-id',
-            working_dir='/tmp/test',
-            session_api_key='test-key',
+            user_id="test-user-id",
+            working_dir="/tmp/test",
+            session_api_key="test-key",
             created_at=datetime.now(),
-            sandbox_spec_id='test-spec',
+            sandbox_spec_id="test-spec",
         )
 
         status = process_sandbox_service._get_process_status(process_info)
         assert status == SandboxStatus.STARTING
 
-    @patch('psutil.Process')
+    @patch("psutil.Process")
     def test_get_process_status_access_denied(
         self, mock_process_class, process_sandbox_service
     ):
@@ -312,11 +308,11 @@ class TestProcessSandboxService:
         process_info = ProcessInfo(
             pid=1234,
             port=9000,
-            user_id='test-user-id',
-            working_dir='/tmp/test',
-            session_api_key='test-key',
+            user_id="test-user-id",
+            working_dir="/tmp/test",
+            session_api_key="test-key",
             created_at=datetime.now(),
-            sandbox_spec_id='test-spec',
+            sandbox_spec_id="test-spec",
         )
 
         status = process_sandbox_service._get_process_status(process_info)
@@ -328,7 +324,7 @@ class TestProcessSandboxService:
         # Mock a process that's running but server is not responding
         with patch.object(
             process_sandbox_service,
-            '_get_process_status',
+            "_get_process_status",
             return_value=SandboxStatus.RUNNING,
         ):
             # Mock httpx client to return error response
@@ -339,15 +335,15 @@ class TestProcessSandboxService:
             process_info = ProcessInfo(
                 pid=1234,
                 port=9000,
-                user_id='test-user-id',
-                working_dir='/tmp/test',
-                session_api_key='test-key',
+                user_id="test-user-id",
+                working_dir="/tmp/test",
+                session_api_key="test-key",
                 created_at=datetime.now(),
-                sandbox_spec_id='test-spec',
+                sandbox_spec_id="test-spec",
             )
 
             sandbox_info = await process_sandbox_service._process_to_sandbox_info(
-                'test-sandbox', process_info
+                "test-sandbox", process_info
             )
 
             assert sandbox_info.status == SandboxStatus.ERROR
@@ -360,26 +356,26 @@ class TestProcessSandboxService:
         # Mock a process that's running but httpx raises exception
         with patch.object(
             process_sandbox_service,
-            '_get_process_status',
+            "_get_process_status",
             return_value=SandboxStatus.RUNNING,
         ):
             # Mock httpx client to raise exception
             process_sandbox_service.httpx_client.get.side_effect = Exception(
-                'Connection failed'
+                "Connection failed"
             )
 
             process_info = ProcessInfo(
                 pid=1234,
                 port=9000,
-                user_id='test-user-id',
-                working_dir='/tmp/test',
-                session_api_key='test-key',
+                user_id="test-user-id",
+                working_dir="/tmp/test",
+                session_api_key="test-key",
                 created_at=datetime.now(),
-                sandbox_spec_id='test-spec',
+                sandbox_spec_id="test-spec",
             )
 
             sandbox_info = await process_sandbox_service._process_to_sandbox_info(
-                'test-sandbox', process_info
+                "test-sandbox", process_info
             )
 
             assert sandbox_info.status == SandboxStatus.ERROR
@@ -394,21 +390,21 @@ class TestProcessSandboxServiceInjector:
         """Test default configuration values."""
         injector = ProcessSandboxServiceInjector()
 
-        assert injector.base_working_dir == '/tmp/openhands-sandboxes'
+        assert injector.base_working_dir == "/tmp/openhands-sandboxes"
         assert injector.base_port == 8000
-        assert injector.health_check_path == '/alive'
-        assert injector.agent_server_module == 'openhands.agent_server'
+        assert injector.health_check_path == "/alive"
+        assert injector.agent_server_module == "openhands.agent_server"
 
     def test_custom_values(self):
         """Test custom configuration values."""
         injector = ProcessSandboxServiceInjector(
-            base_working_dir='/custom/path',
+            base_working_dir="/custom/path",
             base_port=9000,
-            health_check_path='/health',
-            agent_server_module='custom.agent.module',
+            health_check_path="/health",
+            agent_server_module="custom.agent.module",
         )
 
-        assert injector.base_working_dir == '/custom/path'
+        assert injector.base_working_dir == "/custom/path"
         assert injector.base_port == 9000
-        assert injector.health_check_path == '/health'
-        assert injector.agent_server_module == 'custom.agent.module'
+        assert injector.health_check_path == "/health"
+        assert injector.agent_server_module == "custom.agent.module"


### PR DESCRIPTION
## Summary
- clamp negative process-sandbox page ids back to the first page
- keep invalid cursor handling aligned with the existing invalid-page fallback behavior
- add a focused regression test for negative process sandbox page ids

## Testing
- python3 -m py_compile openhands/app_server/sandbox/process_sandbox_service.py tests/unit/app_server/test_process_sandbox_service.py
- uv run python -m pytest -q tests/unit/app_server/test_process_sandbox_service.py -k negative_page_id