### PR TITLE
fix(app_server): trim aws s3 secure env flag

### DIFF
--- a/openhands/app_server/event/aws_event_service.py
+++ b/openhands/app_server/event/aws_event_service.py
@@ -81,7 +81,7 @@ def _get_default_aws_endpoint_url() -> str | None:
     endpoint_url = os.getenv('AWS_S3_ENDPOINT')
     if not endpoint_url:
         return None
-    secure = os.getenv('AWS_S3_SECURE', 'true').lower() == 'true'
+    secure = os.getenv('AWS_S3_SECURE', 'true').strip().lower() == 'true'
     if secure:
         if not endpoint_url.startswith('https://'):
             endpoint_url = 'https://' + endpoint_url.removeprefix('http://')

--- a/tests/unit/app_server/test_aws_event_service.py
+++ b/tests/unit/app_server/test_aws_event_service.py
@@ -289,6 +289,16 @@ class TestGetDefaultAwsEndpointUrl:
         result = aws_event_service._get_default_aws_endpoint_url()
         assert result == 'http://minio.example.com:9000'
 
+    def test_endpoint_with_whitespace_false_uses_http(self, monkeypatch):
+        """Test whitespace-padded false still selects insecure http."""
+        monkeypatch.setenv('AWS_S3_ENDPOINT', 'minio.example.com:9000')
+        monkeypatch.setenv('AWS_S3_SECURE', ' false ')
+
+        importlib.reload(aws_event_service)
+
+        result = aws_event_service._get_default_aws_endpoint_url()
+        assert result == 'http://minio.example.com:9000'
+
     def test_secure_default_is_true(self, monkeypatch):
         """Test that secure defaults to true when not set."""
         monkeypatch.setenv('AWS_S3_ENDPOINT', 'minio.example.com:9000')


### PR DESCRIPTION
## Summary
- trim `AWS_S3_SECURE` before boolean parsing in the AWS event-service endpoint helper
- preserve existing true/false behavior while accepting whitespace-padded env values
- add a focused regression test for the whitespace false case

## Testing
- python3 -m py_compile openhands/app_server/event/aws_event_service.py tests/unit/app_server/test_aws_event_service.py
- uv run python -m pytest -q tests/unit/app_server/test_aws_event_service.py -k whitespace_false