### PR TITLE
fix: strip unsupported params for OpenRouter Xiaomi models

### DIFF
--- a/openhands/llm/async_llm.py
+++ b/openhands/llm/async_llm.py
@@ -76,6 +76,8 @@ class AsyncLLM(LLM):
             ):
                 kwargs['reasoning_effort'] = self.config.reasoning_effort
 
+            self._strip_openrouter_xiaomi_unsupported_params(kwargs)
+
             # ensure we work with a list of messages
             messages = messages if isinstance(messages, list) else [messages]
 

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -60,6 +60,13 @@ LLM_RETRY_EXCEPTIONS: tuple[type[Exception], ...] = (
     LLMNoResponseError,
 )
 
+OPENROUTER_XIAOMI_UNSUPPORTED_PARAMS: tuple[str, ...] = (
+    'reasoning_effort',
+    'native_tool_calling',
+    'extended_thinking_budget',
+    'thinking',
+)
+
 
 class LLM(RetryMixin, DebugMixin):
     """The LLM class represents a Language Model instance.
@@ -218,6 +225,8 @@ class LLM(RetryMixin, DebugMixin):
         if self.config.completion_kwargs is not None:
             kwargs.update(self.config.completion_kwargs)
 
+        self._strip_openrouter_xiaomi_unsupported_params(kwargs)
+
         self._completion = partial(
             litellm_completion,
             model=self.config.model,
@@ -335,6 +344,8 @@ class LLM(RetryMixin, DebugMixin):
             # if we're not using litellm proxy, remove the extra_body
             if 'litellm_proxy' not in self.config.model:
                 kwargs.pop('extra_body', None)
+
+            self._strip_openrouter_xiaomi_unsupported_params(kwargs)
 
             # Record start time for latency measurement
             start_time = time.time()
@@ -830,6 +841,17 @@ class LLM(RetryMixin, DebugMixin):
 
     def __repr__(self) -> str:
         return str(self)
+
+    def _is_openrouter_xiaomi_model(self) -> bool:
+        return self.config.model.strip().lower().startswith('openrouter/xiaomi/')
+
+    def _strip_openrouter_xiaomi_unsupported_params(
+        self, request_kwargs: dict[str, Any]
+    ) -> None:
+        if not self._is_openrouter_xiaomi_model():
+            return
+        for param in OPENROUTER_XIAOMI_UNSUPPORTED_PARAMS:
+            request_kwargs.pop(param, None)
 
     def format_messages_for_llm(self, messages: Message | list[Message]) -> list[dict]:
         if isinstance(messages, Message):

--- a/openhands/llm/streaming_llm.py
+++ b/openhands/llm/streaming_llm.py
@@ -78,6 +78,8 @@ class StreamingLLM(AsyncLLM):
             ):
                 kwargs['reasoning_effort'] = self.config.reasoning_effort
 
+            self._strip_openrouter_xiaomi_unsupported_params(kwargs)
+
             self.log_prompt(messages)
 
             try:

--- a/tests/unit/llm/test_llm.py
+++ b/tests/unit/llm/test_llm.py
@@ -1434,6 +1434,33 @@ def test_non_gemini_uses_reasoning_effort(mock_completion):
     llm.completion(messages=sample_messages)
 
 
+@patch('openhands.llm.llm.litellm_completion')
+def test_openrouter_xiaomi_drops_incompatible_request_params(mock_completion):
+    mock_completion.return_value = {'choices': [{'message': {'content': 'ok'}}]}
+    config = LLMConfig(
+        model='openrouter/xiaomi/mimo-v2-pro',
+        api_key='k',
+        reasoning_effort='high',
+        completion_kwargs={
+            'native_tool_calling': True,
+            'extended_thinking_budget': 1024,
+            'thinking': {'budget_tokens': 2048},
+        },
+    )
+    llm = LLM(config, service_id='svc')
+    llm.completion(
+        messages=[{'role': 'user', 'content': 'hi'}],
+        reasoning_effort='low',
+        native_tool_calling=True,
+        extended_thinking_budget=256,
+    )
+    call_kwargs = mock_completion.call_args[1]
+    assert 'reasoning_effort' not in call_kwargs
+    assert 'native_tool_calling' not in call_kwargs
+    assert 'extended_thinking_budget' not in call_kwargs
+    assert 'thinking' not in call_kwargs
+
+
 @patch('openhands.llm.async_llm.litellm_acompletion')
 @pytest.mark.asyncio
 async def test_async_reasoning_effort_passthrough(mock_acompletion):
@@ -1450,6 +1477,29 @@ async def test_async_reasoning_effort_passthrough(mock_acompletion):
     # Async path does not pop temperature/top_p (parity with main)
     assert call_kwargs.get('temperature') == 0.7
     assert call_kwargs.get('top_p') == 0.9
+
+
+@patch('openhands.llm.async_llm.litellm_acompletion')
+@pytest.mark.asyncio
+async def test_async_openrouter_xiaomi_drops_incompatible_request_params(
+    mock_acompletion,
+):
+    mock_acompletion.return_value = {'choices': [{'message': {'content': 'ok'}}]}
+    config = LLMConfig(
+        model='openrouter/xiaomi/mimo-v2-pro',
+        api_key='k',
+        reasoning_effort='high',
+    )
+    llm = AsyncLLM(config, service_id='svc')
+    await llm.async_completion(
+        messages=[{'role': 'user', 'content': 'hi'}],
+        native_tool_calling=True,
+        extended_thinking_budget=256,
+    )
+    call_kwargs = mock_acompletion.call_args[1]
+    assert 'reasoning_effort' not in call_kwargs
+    assert 'native_tool_calling' not in call_kwargs
+    assert 'extended_thinking_budget' not in call_kwargs
 
 
 @patch('openhands.llm.streaming_llm.AsyncLLM._call_acompletion')
@@ -1475,6 +1525,35 @@ async def test_streaming_reasoning_effort_passthrough(mock_call):
     assert call_kwargs.get('reasoning_effort') == 'low'
     assert call_kwargs.get('temperature') == 0.7
     assert call_kwargs.get('top_p') == 0.9
+
+
+@patch('openhands.llm.streaming_llm.AsyncLLM._call_acompletion')
+@pytest.mark.asyncio
+async def test_streaming_openrouter_xiaomi_drops_incompatible_request_params(mock_call):
+    async def fake_stream(*args, **kwargs):
+        class Dummy:
+            async def __aiter__(self):
+                yield {'choices': [{'delta': {'content': 'x'}}]}
+
+        return Dummy()
+
+    mock_call.side_effect = fake_stream
+    config = LLMConfig(
+        model='openrouter/xiaomi/mimo-v2-pro',
+        api_key='k',
+        reasoning_effort='high',
+    )
+    sllm = StreamingLLM(config, service_id='svc')
+    async for _ in sllm.async_streaming_completion(
+        messages=[{'role': 'user', 'content': 'hi'}],
+        native_tool_calling=True,
+        extended_thinking_budget=256,
+    ):
+        break
+    call_kwargs = mock_call.call_args[1]
+    assert 'reasoning_effort' not in call_kwargs
+    assert 'native_tool_calling' not in call_kwargs
+    assert 'extended_thinking_budget' not in call_kwargs
 
 
 @patch('openhands.llm.async_llm.litellm_acompletion')


### PR DESCRIPTION
### summary of PR

- Fix Xiaomi OpenRouter 400 by removing unsupported LiteLLM params.
- Apply fix in sync, async, and streaming LLM paths.
- Add unit tests for Xiaomi request sanitization.

### Change Type
[x] Bug fix

### Fixes

Resolves #13563