### PR TITLE
fix(slack): update initial resolver ack with final result

### DIFF
--- a/enterprise/integrations/slack/slack_manager.py
+++ b/enterprise/integrations/slack/slack_manager.py
@@ -512,7 +512,7 @@ class SlackManager(Manager[SlackViewInterface]):
         message: str | dict[str, Any],
         slack_view: SlackMessageView,
         ephemeral: bool = False,
-    ):
+    ) -> dict[str, Any] | None:
         """Send a message to Slack.
 
         Args:
@@ -525,14 +525,14 @@ class SlackManager(Manager[SlackViewInterface]):
         """
         client = AsyncWebClient(token=slack_view.bot_access_token)
         if ephemeral and isinstance(message, str):
-            await client.chat_postEphemeral(
+            return await client.chat_postEphemeral(
                 channel=slack_view.channel_id,
                 markdown_text=message,
                 user=slack_view.slack_user_id,
                 thread_ts=slack_view.thread_ts,
             )
         elif ephemeral and isinstance(message, dict):
-            await client.chat_postEphemeral(
+            return await client.chat_postEphemeral(
                 channel=slack_view.channel_id,
                 user=slack_view.slack_user_id,
                 thread_ts=slack_view.thread_ts,
@@ -540,7 +540,7 @@ class SlackManager(Manager[SlackViewInterface]):
                 blocks=message['blocks'],
             )
         else:
-            await client.chat_postMessage(
+            return await client.chat_postMessage(
                 channel=slack_view.channel_id,
                 markdown_text=message,
                 thread_ts=slack_view.message_ts,
@@ -730,7 +730,15 @@ class SlackManager(Manager[SlackViewInterface]):
             except StartingConvoException as e:
                 msg_info = str(e)
 
-            await self.send_message(msg_info, slack_view)
+            response = await self.send_message(msg_info, slack_view)
+            if (
+                slack_view.v1_enabled
+                and isinstance(slack_view, SlackNewConversationView)
+                and response
+            ):
+                ack_message_ts = response.get('ts')
+                if ack_message_ts:
+                    slack_view.set_ack_message_ts_for_v1_callback(ack_message_ts)
 
         except Exception:
             logger.exception('[Slack]: Error starting job')

--- a/enterprise/integrations/slack/slack_v1_callback_processor.py
+++ b/enterprise/integrations/slack/slack_v1_callback_processor.py
@@ -2,7 +2,7 @@ import logging
 from uuid import UUID
 
 import httpx
-from integrations.utils import get_summary_instruction
+from integrations.utils import CONVERSATION_URL, get_summary_instruction
 from integrations.v1_utils import handle_callback_error
 from pydantic import Field
 from slack_sdk import WebClient
@@ -56,7 +56,7 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
 
         try:
             summary = await self._request_summary(conversation_id)
-            await self._post_summary_to_slack(summary)
+            await self._post_summary_to_slack(summary, conversation_id)
 
             return EventCallbackResult(
                 status=EventCallbackResultStatus.SUCCESS,
@@ -72,7 +72,9 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
                 service_name='Slack',
                 service_logger=_logger,
                 can_post_error=True,  # Slack always attempts to post errors
-                post_error_func=self._post_summary_to_slack,
+                post_error_func=lambda message: self._post_summary_to_slack(
+                    message, conversation_id
+                ),
             )
 
             return EventCallbackResult(
@@ -96,8 +98,12 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
 
         return bot_access_token
 
-    async def _post_summary_to_slack(self, summary: str) -> None:
-        """Post a summary message to the configured Slack channel."""
+    def _build_final_slack_message(self, summary: str, conversation_id: UUID) -> str:
+        conversation_link = CONVERSATION_URL.format(str(conversation_id))
+        return f'{summary}\n\n[OpenHands conversation]({conversation_link})'
+
+    async def _post_summary_to_slack(self, summary: str, conversation_id: UUID) -> None:
+        """Post or update the final Slack message."""
         bot_access_token = await self._get_bot_access_token()
         if not bot_access_token:
             raise RuntimeError('Missing Slack bot access token')
@@ -106,18 +112,28 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
         thread_ts = self.slack_view_data.get('thread_ts') or self.slack_view_data.get(
             'message_ts'
         )
+        ack_message_ts = self.slack_view_data.get('ack_message_ts')
+        final_message = self._build_final_slack_message(summary, conversation_id)
 
         client = WebClient(token=bot_access_token)
 
         try:
-            # Post the summary as a threaded reply
-            response = client.chat_postMessage(
-                channel=channel_id,
-                text=summary,
-                thread_ts=thread_ts,
-                unfurl_links=False,
-                unfurl_media=False,
-            )
+            if ack_message_ts:
+                response = client.chat_update(
+                    channel=channel_id,
+                    ts=ack_message_ts,
+                    text=final_message,
+                    unfurl_links=False,
+                    unfurl_media=False,
+                )
+            else:
+                response = client.chat_postMessage(
+                    channel=channel_id,
+                    text=final_message,
+                    thread_ts=thread_ts,
+                    unfurl_links=False,
+                    unfurl_media=False,
+                )
 
             if not response['ok']:
                 raise RuntimeError(
@@ -125,7 +141,7 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
                 )
 
             _logger.info(
-                '[Slack V1] Successfully posted summary to channel %s', channel_id
+                '[Slack V1] Successfully posted final message to channel %s', channel_id
             )
 
         except Exception as e:

--- a/enterprise/integrations/slack/slack_v1_callback_processor.py
+++ b/enterprise/integrations/slack/slack_v1_callback_processor.py
@@ -103,7 +103,6 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
         return f'{summary}\n\n[OpenHands conversation]({conversation_link})'
 
     async def _post_summary_to_slack(self, summary: str, conversation_id: UUID) -> None:
-        """Post or update the final Slack message."""
         bot_access_token = await self._get_bot_access_token()
         if not bot_access_token:
             raise RuntimeError('Missing Slack bot access token')

--- a/enterprise/integrations/slack/slack_view.py
+++ b/enterprise/integrations/slack/slack_view.py
@@ -200,7 +200,6 @@ class SlackNewConversationView(SlackViewInterface):
         return self.slack_v1_callback_processor
 
     def set_ack_message_ts_for_v1_callback(self, ack_message_ts: str) -> None:
-        """Persist acknowledgement message ts for final in-place Slack update."""
         if self.slack_v1_callback_processor is None:
             return
         self.slack_v1_callback_processor.slack_view_data['ack_message_ts'] = ack_message_ts

--- a/enterprise/integrations/slack/slack_view.py
+++ b/enterprise/integrations/slack/slack_view.py
@@ -1,5 +1,5 @@
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from uuid import UUID, uuid4
 
 from integrations.models import Message
@@ -79,6 +79,9 @@ class SlackNewConversationView(SlackViewInterface):
     conversation_id: str
     team_id: str
     v1_enabled: bool
+    slack_v1_callback_processor: SlackV1CallbackProcessor | None = field(
+        default=None, init=False
+    )
 
     def _get_initial_prompt(self, text: str, blocks: list[dict]):
         bot_id = self._get_bot_id(blocks)
@@ -185,7 +188,7 @@ class SlackNewConversationView(SlackViewInterface):
 
     def _create_slack_v1_callback_processor(self) -> SlackV1CallbackProcessor:
         """Create a SlackV1CallbackProcessor for V1 conversation handling."""
-        return SlackV1CallbackProcessor(
+        self.slack_v1_callback_processor = SlackV1CallbackProcessor(
             slack_view_data={
                 'channel_id': self.channel_id,
                 'message_ts': self.message_ts,
@@ -194,6 +197,13 @@ class SlackNewConversationView(SlackViewInterface):
                 'slack_user_id': self.slack_user_id,
             }
         )
+        return self.slack_v1_callback_processor
+
+    def set_ack_message_ts_for_v1_callback(self, ack_message_ts: str) -> None:
+        """Persist acknowledgement message ts for final in-place Slack update."""
+        if self.slack_v1_callback_processor is None:
+            return
+        self.slack_v1_callback_processor.slack_view_data['ack_message_ts'] = ack_message_ts
 
     async def create_or_update_conversation(self, jinja: Environment) -> str:
         """Only creates a new conversation"""

--- a/enterprise/tests/unit/integrations/slack/test_slack_v1_callback_processor.py
+++ b/enterprise/tests/unit/integrations/slack/test_slack_v1_callback_processor.py
@@ -15,6 +15,7 @@ import pytest
 from integrations.slack.slack_v1_callback_processor import (
     SlackV1CallbackProcessor,
 )
+from integrations.utils import CONVERSATION_URL
 
 from openhands.app_server.app_conversation.app_conversation_models import (
     AppConversationInfo,
@@ -257,11 +258,55 @@ class TestSlackV1CallbackProcessor:
         # Verify Slack posting
         mock_slack_client.chat_postMessage.assert_called_once_with(
             channel='C1234567890',
-            text='Test summary from agent',
+            text=f'Test summary from agent\n\n[OpenHands conversation]({CONVERSATION_URL.format(str(conversation_id))})',
             thread_ts='1234567890.123456',
             unfurl_links=False,
             unfurl_media=False,
         )
+
+    @patch('storage.slack_team_store.SlackTeamStore.get_instance')
+    @patch('integrations.slack.slack_v1_callback_processor.WebClient')
+    @patch.object(SlackV1CallbackProcessor, '_request_summary')
+    async def test_updates_ack_message_when_ack_ts_available(
+        self,
+        mock_request_summary,
+        mock_web_client,
+        mock_slack_team_store,
+        finish_event,
+        event_callback,
+    ):
+        conversation_id = uuid4()
+        processor = SlackV1CallbackProcessor(
+            slack_view_data={
+                'channel_id': 'C1234567890',
+                'message_ts': '1234567890.123456',
+                'team_id': 'T1234567890',
+                'ack_message_ts': '1234567890.654321',
+            }
+        )
+
+        mock_store = MagicMock()
+        mock_store.get_team_bot_token = AsyncMock(return_value='xoxb-test-token')
+        mock_slack_team_store.return_value = mock_store
+
+        mock_request_summary.return_value = 'Updated final answer'
+
+        mock_slack_client = MagicMock()
+        mock_slack_client.chat_update.return_value = {'ok': True}
+        mock_web_client.return_value = mock_slack_client
+
+        result = await processor(conversation_id, event_callback, finish_event)
+
+        assert result is not None
+        assert result.status == EventCallbackResultStatus.SUCCESS
+        mock_slack_client.chat_update.assert_called_once_with(
+            channel='C1234567890',
+            ts='1234567890.654321',
+            text=f'Updated final answer\n\n[OpenHands conversation]({CONVERSATION_URL.format(str(conversation_id))})',
+            unfurl_links=False,
+            unfurl_media=False,
+        )
+        mock_slack_client.chat_postMessage.assert_not_called()
 
     # -------------------------------------------------------------------------
     # Error handling tests (parameterized)


### PR DESCRIPTION
### summary of PR

- Slack resolver now updates the initial ack message with the final result.
- Falls back to posting a final threaded message if update timestamp is unavailable.
- Final visible message keeps the OpenHands conversation link.
- Added tests for update and fallback paths.

### change Type
[x] Bug fix

### Fixes
Resolves #13736