### PR TITLE
feat(backend): route Slack resolver conversations to claimed org workspaces

### DIFF
--- a/enterprise/integrations/slack/slack_view.py
+++ b/enterprise/integrations/slack/slack_view.py
@@ -39,7 +39,7 @@ from openhands.core.logger import openhands_logger as logger
 from openhands.core.schema.agent import AgentState
 from openhands.events.action import MessageAction
 from openhands.events.serialization.event import event_to_dict
-from openhands.integrations.provider import ProviderHandler, ProviderType
+from openhands.integrations.provider import ProviderHandler
 from openhands.sdk import TextContent
 from openhands.server.services.conversation_service import (
     setup_init_conversation_settings,
@@ -301,11 +301,7 @@ class SlackNewConversationView(SlackViewInterface):
         slack_callback_processor = self._create_slack_v1_callback_processor()
 
         # Use git provider resolved in create_or_update_conversation
-        git_provider = (
-            ProviderType(self._resolved_git_provider.value)
-            if self._resolved_git_provider
-            else None
-        )
+        git_provider = self._resolved_git_provider
 
         # Get the app conversation service and start the conversation
         injector_state = InjectorState()

--- a/enterprise/tests/unit/test_slack_view.py
+++ b/enterprise/tests/unit/test_slack_view.py
@@ -96,17 +96,20 @@ class TestSlackV0ConversationRouting:
     @patch('integrations.slack.slack_view.resolve_org_for_repo', new_callable=AsyncMock)
     @patch('integrations.slack.slack_view.ProviderHandler')
     @patch(
-        'integrations.slack.slack_view.create_new_conversation', new_callable=AsyncMock
+        'integrations.slack.slack_view.SaasConversationStore.get_resolver_instance',
+        new_callable=AsyncMock,
     )
+    @patch('integrations.slack.slack_view.start_conversation', new_callable=AsyncMock)
     async def test_v0_passes_resolver_org_id(
         self,
-        mock_create_convo,
+        mock_start_convo,
+        mock_get_resolver_instance,
         mock_provider_handler_cls,
         mock_resolve_org,
         mock_v1_enabled,
         slack_view,
     ):
-        """V0 path should pass resolver_org_id to create_new_conversation."""
+        """V0 path should pass resolver_org_id to SaasConversationStore.get_resolver_instance."""
         # Arrange
         mock_repo = MagicMock()
         mock_repo.git_provider = ProviderType.GITHUB
@@ -115,7 +118,10 @@ class TestSlackV0ConversationRouting:
         mock_provider_handler_cls.return_value = mock_handler
 
         mock_resolve_org.return_value = CLAIMING_ORG_ID
-        mock_create_convo.return_value = MagicMock(conversation_id='test-conv-id')
+        mock_store = MagicMock()
+        mock_store.save_metadata = AsyncMock()
+        mock_get_resolver_instance.return_value = mock_store
+        mock_start_convo.return_value = MagicMock(conversation_id='test-conv-id')
 
         mock_jinja = MagicMock()
 
@@ -137,10 +143,13 @@ class TestSlackV0ConversationRouting:
             full_repo_name='OpenHands/foo',
             keycloak_user_id=KEYCLOAK_USER_ID,
         )
-        mock_create_convo.assert_called_once()
-        call_kwargs = mock_create_convo.call_args[1]
-        assert call_kwargs['resolver_org_id'] == CLAIMING_ORG_ID
-        assert call_kwargs['git_provider'] == ProviderType.GITHUB
+        mock_get_resolver_instance.assert_called_once()
+        call_args = mock_get_resolver_instance.call_args
+        assert call_args[0][1] == KEYCLOAK_USER_ID  # user_id
+        assert call_args[0][2] == CLAIMING_ORG_ID  # resolver_org_id
+        mock_store.save_metadata.assert_called_once()
+        saved_metadata = mock_store.save_metadata.call_args[0][0]
+        assert saved_metadata.git_provider == ProviderType.GITHUB
 
     @pytest.mark.asyncio
     @patch(
@@ -151,11 +160,14 @@ class TestSlackV0ConversationRouting:
     @patch('integrations.slack.slack_view.resolve_org_for_repo', new_callable=AsyncMock)
     @patch('integrations.slack.slack_view.ProviderHandler')
     @patch(
-        'integrations.slack.slack_view.create_new_conversation', new_callable=AsyncMock
+        'integrations.slack.slack_view.SaasConversationStore.get_resolver_instance',
+        new_callable=AsyncMock,
     )
+    @patch('integrations.slack.slack_view.start_conversation', new_callable=AsyncMock)
     async def test_v0_passes_none_when_no_claim(
         self,
-        mock_create_convo,
+        mock_start_convo,
+        mock_get_resolver_instance,
         mock_provider_handler_cls,
         mock_resolve_org,
         mock_v1_enabled,
@@ -170,7 +182,10 @@ class TestSlackV0ConversationRouting:
         mock_provider_handler_cls.return_value = mock_handler
 
         mock_resolve_org.return_value = None
-        mock_create_convo.return_value = MagicMock(conversation_id='test-conv-id')
+        mock_store = MagicMock()
+        mock_store.save_metadata = AsyncMock()
+        mock_get_resolver_instance.return_value = mock_store
+        mock_start_convo.return_value = MagicMock(conversation_id='test-conv-id')
 
         mock_jinja = MagicMock()
 
@@ -187,8 +202,8 @@ class TestSlackV0ConversationRouting:
             await slack_view.create_or_update_conversation(mock_jinja)
 
         # Assert
-        call_kwargs = mock_create_convo.call_args[1]
-        assert call_kwargs['resolver_org_id'] is None
+        call_args = mock_get_resolver_instance.call_args
+        assert call_args[0][2] is None  # resolver_org_id is None
 
 
 class TestSlackV1ConversationRouting:
@@ -267,18 +282,24 @@ class TestSlackNoRepoRouting:
     )
     @patch('integrations.slack.slack_view.resolve_org_for_repo', new_callable=AsyncMock)
     @patch(
-        'integrations.slack.slack_view.create_new_conversation', new_callable=AsyncMock
+        'integrations.slack.slack_view.SaasConversationStore.get_resolver_instance',
+        new_callable=AsyncMock,
     )
+    @patch('integrations.slack.slack_view.start_conversation', new_callable=AsyncMock)
     async def test_no_repo_skips_org_resolution(
         self,
-        mock_create_convo,
+        mock_start_convo,
+        mock_get_resolver_instance,
         mock_resolve_org,
         mock_v1_enabled,
         slack_view_no_repo,
     ):
         """When selected_repo is None, org resolution should be skipped."""
         # Arrange
-        mock_create_convo.return_value = MagicMock(conversation_id='test-conv-id')
+        mock_store = MagicMock()
+        mock_store.save_metadata = AsyncMock()
+        mock_get_resolver_instance.return_value = mock_store
+        mock_start_convo.return_value = MagicMock(conversation_id='test-conv-id')
         mock_jinja = MagicMock()
 
         # Act
@@ -298,9 +319,10 @@ class TestSlackNoRepoRouting:
 
         # Assert
         mock_resolve_org.assert_not_called()
-        call_kwargs = mock_create_convo.call_args[1]
-        assert call_kwargs['resolver_org_id'] is None
-        assert call_kwargs['git_provider'] is None
+        call_args = mock_get_resolver_instance.call_args
+        assert call_args[0][2] is None  # resolver_org_id is None
+        saved_metadata = mock_store.save_metadata.call_args[0][0]
+        assert saved_metadata.git_provider is None
 
 
 async def aiter_empty():


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

<!-- Summarize what the PR does -->

When a Slack resolver request includes a selected repository, the system now checks whether the repository's Git organization is claimed by an OpenHands organization and whether the requesting user is a member of that organization. If both conditions are met, the conversation is
created in that organization's workspace; otherwise it falls back to the user's personal workspace.

### Summary

- Add Git org claim-based routing for Slack resolver conversations
- When a Slack user starts a conversation with a selected repo, the system resolves whether the repo's Git organization is claimed and routes the conversation to the claiming org's workspace (if the user is a member) or the user's personal workspace
- Introduce shared resolve_org_for_repo utility and thread resolver_org_id through both V0 (legacy) and V1 conversation creation paths

## Demo Screenshots/Videos

<!-- AI/LLM AGENTS: This section is intended for a human author to add screenshots or videos demonstrating the PR in action (optional). While many pull requests may be generated by AI/LLM agents, we are fine with this as long as a human author has reviewed and tested the changes to ensure accuracy and functionality. -->

## Change Type

<!-- Choose the types that apply to your PR -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves #(issue)

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:0f51e08-nikolaik   --name openhands-app-0f51e08   docker.openhands.dev/openhands/openhands:0f51e08
```