### PR TITLE
docs: add note about updating enterprise poetry lockfile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,7 @@ Each integration follows a consistent pattern with service classes, storage mode
 - Database changes require careful migration planning in `enterprise/migrations/`
 - Always test changes in both OpenHands and enterprise contexts
 - Use the enterprise-specific Makefile commands for development
+- When the `openhands-ai` package (root project) version has been updated, run `poetry lock` in the `enterprise/` folder to update the version in the enterprise poetry lockfile.
 
 **Enterprise Testing Best Practices:**
 


### PR DESCRIPTION
This PR adds a note in the `AGENTS.md` Enterprise Directory section that when the `openhands-ai` package (root project) version has been updated, one must run `poetry lock` in the `enterprise/` folder to update the version in the enterprise poetry lockfile.

Resolves an action item requested in PR #13704.

@aivong-openhands can click here to [continue refining the PR](https://app.all-hands.dev/conversations/24630640-a50b-4782-a82f-09ac6cbf30c2)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:631e4ef-nikolaik   --name openhands-app-631e4ef   docker.openhands.dev/openhands/openhands:631e4ef
```