### PR TITLE
fix(app_server): clamp negative event callback page ids

### DIFF
--- a/openhands/app_server/event_callback/sql_event_callback_service.py
+++ b/openhands/app_server/event_callback/sql_event_callback_service.py
@@ -148,7 +148,7 @@ class SQLEventCallbackService(EventCallbackService):
         if page_id is not None:
             # Parse page_id to get offset or cursor
             try:
-                offset = int(page_id)
+                offset = max(int(page_id), 0)
                 stmt = stmt.offset(offset)
             except ValueError:
                 # If page_id is not a valid integer, start from beginning

--- a/tests/unit/app_server/test_sql_event_callback_service.py
+++ b/tests/unit/app_server/test_sql_event_callback_service.py
@@ -267,6 +267,29 @@ class TestSQLEventCallbackService:
         assert len(next_result.items) == 2
         assert next_result.next_page_id is None
 
+    async def test_search_callbacks_with_negative_page_id(
+        self,
+        service: SQLEventCallbackService,
+        sample_processor: EventCallbackProcessor,
+    ):
+        """Test negative page_id falls back to the first page."""
+        for _ in range(3):
+            callback_request = CreateEventCallbackRequest(
+                conversation_id=uuid4(),
+                processor=sample_processor,
+                event_kind='ActionEvent',
+            )
+            await service.create_event_callback(callback_request)
+
+        first_page = await service.search_event_callbacks(limit=2)
+        negative_page = await service.search_event_callbacks(page_id='-1', limit=2)
+
+        assert len(negative_page.items) == 2
+        assert [item.id for item in negative_page.items] == [
+            item.id for item in first_page.items
+        ]
+        assert negative_page.next_page_id == first_page.next_page_id
+
     async def test_search_callbacks_with_null_filters(
         self,
         service: SQLEventCallbackService,


### PR DESCRIPTION
## Summary
- clamp negative `page_id` values to the first page in `SQLEventCallbackService`
- keep malformed non-integer cursors on the existing fallback-to-first-page path
- add a regression test showing `-1` returns the same first page as no cursor

## Testing
- `git diff --check`
- `python3 -m py_compile openhands/app_server/event_callback/sql_event_callback_service.py tests/unit/app_server/test_sql_event_callback_service.py`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY uv run python -m pytest -q tests/unit/app_server/test_sql_event_callback_service.py -k negative_page_id`