### PR TITLE
fix(app_server): normalize web client feature flags

### DIFF
--- a/openhands/app_server/web_client/default_web_client_config_injector.py
+++ b/openhands/app_server/web_client/default_web_client_config_injector.py
@@ -26,6 +26,11 @@ def _get_recaptcha_site_key() -> str | None:
 _OSS_POSTHOG_KEY = 'phc_3ESMmY9SgqEAGBB6sMGK5ayYHkeUuknH2vP6FmWH9RA'
 
 
+def _is_enabled_env(name: str) -> bool:
+    """Return True only when an env var is explicitly set to true."""
+    return os.getenv(name, 'false').strip().lower() == 'true'
+
+
 def _get_posthog_client_key() -> str:
     """Get PostHog client key from environment variable.
 
@@ -121,16 +126,16 @@ def _get_feature_flags() -> WebClientFeatureFlags:
     only if the corresponding env var is exactly 'true', otherwise False.
     """
     return WebClientFeatureFlags(
-        enable_billing=os.getenv('ENABLE_BILLING', 'false') == 'true',
-        hide_llm_settings=os.getenv('HIDE_LLM_SETTINGS', 'false') == 'true',
-        enable_jira=os.getenv('ENABLE_JIRA', 'false') == 'true',
-        enable_jira_dc=os.getenv('ENABLE_JIRA_DC', 'false') == 'true',
-        enable_linear=os.getenv('ENABLE_LINEAR', 'false') == 'true',
-        hide_users_page=os.getenv('HIDE_USERS_PAGE', 'false') == 'true',
-        hide_billing_page=os.getenv('HIDE_BILLING_PAGE', 'false') == 'true',
-        hide_integrations_page=os.getenv('HIDE_INTEGRATIONS_PAGE', 'false') == 'true',
-        enable_acp=os.getenv('ENABLE_ACP', 'false') == 'true',
-        enable_onboarding=os.getenv('OH_ENABLE_ONBOARDING', 'false') == 'true',
+        enable_billing=_is_enabled_env('ENABLE_BILLING'),
+        hide_llm_settings=_is_enabled_env('HIDE_LLM_SETTINGS'),
+        enable_jira=_is_enabled_env('ENABLE_JIRA'),
+        enable_jira_dc=_is_enabled_env('ENABLE_JIRA_DC'),
+        enable_linear=_is_enabled_env('ENABLE_LINEAR'),
+        hide_users_page=_is_enabled_env('HIDE_USERS_PAGE'),
+        hide_billing_page=_is_enabled_env('HIDE_BILLING_PAGE'),
+        hide_integrations_page=_is_enabled_env('HIDE_INTEGRATIONS_PAGE'),
+        enable_acp=_is_enabled_env('ENABLE_ACP'),
+        enable_onboarding=_is_enabled_env('OH_ENABLE_ONBOARDING'),
     )
 
 

--- a/tests/unit/app_server/test_default_web_client_config_injector.py
+++ b/tests/unit/app_server/test_default_web_client_config_injector.py
@@ -216,6 +216,27 @@ class TestGetFeatureFlags:
             result = _get_feature_flags()
             assert result.enable_linear is True
 
+    def test_feature_flags_strip_whitespace_and_ignore_case(self):
+        """Whitespace and case differences should not disable explicit true flags."""
+        from openhands.app_server.web_client.default_web_client_config_injector import (
+            _get_feature_flags,
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                'ENABLE_BILLING': ' True ',
+                'HIDE_LLM_SETTINGS': ' TRUE ',
+                'ENABLE_JIRA': ' false ',
+                'ENABLE_LINEAR': ' TrUe ',
+            },
+        ):
+            result = _get_feature_flags()
+            assert result.enable_billing is True
+            assert result.hide_llm_settings is True
+            assert result.enable_jira is False
+            assert result.enable_linear is True
+
     def test_multiple_flags_can_be_set(self):
         """Multiple feature flags can be enabled simultaneously."""
         from openhands.app_server.web_client.default_web_client_config_injector import (


### PR DESCRIPTION
## Summary
- normalize web client feature-flag env vars with `strip().lower()`
- keep the existing explicit-true semantics while accepting whitespace-padded and case-variant `true` values
- add a regression test covering mixed-case and whitespace-padded flags

## Testing
- `git diff --check -- openhands/app_server/web_client/default_web_client_config_injector.py tests/unit/app_server/test_default_web_client_config_injector.py`
- `python3 -m py_compile openhands/app_server/web_client/default_web_client_config_injector.py tests/unit/app_server/test_default_web_client_config_injector.py`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY uv run python -m pytest -q tests/unit/app_server/test_default_web_client_config_injector.py -k "feature_flags_strip_whitespace_and_ignore_case or enable_billing_true_when_env_var_true or multiple_flags_can_be_set"`