### PR TITLE
Add more endpoints as deprecated (microagent repository endpoints)

### DIFF
--- a/openhands/server/routes/git.py
+++ b/openhands/server/routes/git.py
@@ -308,6 +308,7 @@ def _extract_repo_name(repository_name: str) -> str:
 @app.get(
     '/repository/{repository_name:path}/microagents',
     response_model=list[MicroagentResponse],
+    deprecated=True,
 )
 async def get_repository_microagents(
     repository_name: str,
@@ -316,6 +317,10 @@ async def get_repository_microagents(
     user_id: str | None = Depends(get_user_id),
 ) -> list[MicroagentResponse] | JSONResponse:
     """Scan the microagents directory of a repository and return the list of microagents.
+
+    .. deprecated::
+        This endpoint is deprecated. The microagents UI has already been removed
+        and is not supported in V1.
 
     The microagents directory location depends on the git provider and actual repository name:
     - If git provider is not GitLab and actual repository name is ".openhands": scans "microagents" folder
@@ -371,6 +376,7 @@ async def get_repository_microagents(
 @app.get(
     '/repository/{repository_name:path}/microagents/content',
     response_model=MicroagentContentResponse,
+    deprecated=True,
 )
 async def get_repository_microagent_content(
     repository_name: str,
@@ -382,6 +388,10 @@ async def get_repository_microagent_content(
     user_id: str | None = Depends(get_user_id),
 ) -> MicroagentContentResponse | JSONResponse:
     """Fetch the content of a specific microagent file from a repository.
+
+    .. deprecated::
+        This endpoint is deprecated. The microagents UI has already been removed
+        and is not supported in V1.
 
     Args:
         repository_name: Repository name in the format 'owner/repo' or 'domain/owner/repo'


### PR DESCRIPTION
## Summary of PR

Mark the following endpoints as deprecated:

- GET /api/user/repository/{repository_name}/microagents
- GET /api/user/repository/{repository_name}/microagents/content

The microagents UI has already been removed and is not supported in V1.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Release Notes

- [ ] Include this change in the Release Notes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:ca4e213-nikolaik   --name openhands-app-ca4e213   docker.openhands.dev/openhands/openhands:ca4e213
```