### PR TITLE
fix(app_server): surface skill loader upstream failures

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_router.py
+++ b/openhands/app_server/app_conversation/app_conversation_router.py
@@ -624,6 +624,7 @@ async def get_conversation_skills(
                 ctx.conversation.selected_repository,
                 project_dir,
                 ctx.agent_server_url,
+                raise_on_error=True,
             )
 
         logger.info(
@@ -665,6 +666,26 @@ async def get_conversation_skills(
             content={'skills': [s.model_dump() for s in skills_response]},
         )
 
+    except httpx.HTTPStatusError as e:
+        logger.warning(
+            f'Agent-server returned {e.response.status_code} when loading skills '
+            f'for conversation {conversation_id}: {e.response.text}'
+        )
+        return JSONResponse(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            content={
+                'error': f'Agent-server returned status {e.response.status_code} when loading skills'
+            },
+        )
+    except httpx.RequestError as e:
+        logger.warning(
+            f'Failed to reach agent-server when loading skills '
+            f'for conversation {conversation_id}: {e}'
+        )
+        return JSONResponse(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            content={'error': 'Failed to reach agent-server when loading skills'},
+        )
     except Exception as e:
         logger.error(f'Error getting skills for conversation {conversation_id}: {e}')
         return JSONResponse(

--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -24,6 +24,7 @@ from openhands.app_server.app_conversation.app_conversation_service import (
 from openhands.app_server.app_conversation.skill_loader import (
     build_org_config,
     build_sandbox_config,
+    fetch_skills_from_agent_server,
     load_skills_from_agent_server,
 )
 from openhands.app_server.sandbox.sandbox_models import SandboxInfo
@@ -99,6 +100,7 @@ class AppConversationServiceBase(AppConversationService, ABC):
         selected_repository: str | None,
         project_dir: str,
         agent_server_url: str,
+        raise_on_error: bool = False,
     ) -> list[Skill]:
         """Load skills from all sources via the agent-server.
 
@@ -133,7 +135,13 @@ class AppConversationServiceBase(AppConversationService, ABC):
             sandbox_config = build_sandbox_config(sandbox)
 
             # Single API call to agent-server for ALL skills
-            all_skills = await load_skills_from_agent_server(
+            loader = (
+                fetch_skills_from_agent_server
+                if raise_on_error
+                else load_skills_from_agent_server
+            )
+
+            all_skills = await loader(
                 agent_server_url=agent_server_url,
                 session_api_key=sandbox.session_api_key,
                 project_dir=project_dir,
@@ -153,6 +161,8 @@ class AppConversationServiceBase(AppConversationService, ABC):
             return all_skills
 
         except Exception as e:
+            if raise_on_error:
+                raise
             _logger.warning(f'Failed to load skills: {e}', exc_info=True)
             # Return empty list on failure - skills will be loaded again later if needed
             return []

--- a/openhands/app_server/app_conversation/skill_loader.py
+++ b/openhands/app_server/app_conversation/skill_loader.py
@@ -273,6 +273,44 @@ async def load_skills_from_agent_server(
     load_project: bool = True,
     load_org: bool = True,
 ) -> list[Skill]:
+    """Load all skills from the agent-server, returning an empty list on error."""
+    try:
+        return await fetch_skills_from_agent_server(
+            agent_server_url=agent_server_url,
+            session_api_key=session_api_key,
+            project_dir=project_dir,
+            org_config=org_config,
+            sandbox_config=sandbox_config,
+            load_public=load_public,
+            load_user=load_user,
+            load_project=load_project,
+            load_org=load_org,
+        )
+    except httpx.HTTPStatusError as e:
+        _logger.warning(
+            f'Agent-server returned error status {e.response.status_code}: '
+            f'{e.response.text}'
+        )
+        return []
+    except httpx.RequestError as e:
+        _logger.warning(f'Failed to connect to agent-server: {e}')
+        return []
+    except Exception as e:
+        _logger.warning(f'Failed to load skills from agent-server: {e}')
+        return []
+
+
+async def fetch_skills_from_agent_server(
+    agent_server_url: str,
+    session_api_key: str | None,
+    project_dir: str,
+    org_config: OrgConfig | None = None,
+    sandbox_config: SandboxConfig | None = None,
+    load_public: bool = True,
+    load_user: bool = True,
+    load_project: bool = True,
+    load_org: bool = True,
+) -> list[Skill]:
     """Load all skills from the agent-server.
 
     This function makes a single API call to the agent-server's /api/skills
@@ -291,72 +329,57 @@ async def load_skills_from_agent_server(
 
     Returns:
         List of Skill objects merged from all sources.
-        Returns empty list on error.
     """
-    try:
-        # Build request payload
-        payload = {
-            'load_public': load_public,
-            'load_user': load_user,
-            'load_project': load_project,
-            'load_org': load_org,
-            'project_dir': project_dir,
-            'org_config': org_config.model_dump() if org_config else None,
-            'sandbox_config': sandbox_config.model_dump() if sandbox_config else None,
-        }
+    # Build request payload
+    payload = {
+        'load_public': load_public,
+        'load_user': load_user,
+        'load_project': load_project,
+        'load_org': load_org,
+        'project_dir': project_dir,
+        'org_config': org_config.model_dump() if org_config else None,
+        'sandbox_config': sandbox_config.model_dump() if sandbox_config else None,
+    }
 
-        # Build headers
-        headers = {'Content-Type': 'application/json'}
-        if session_api_key:
-            headers['X-Session-API-Key'] = session_api_key
+    # Build headers
+    headers = {'Content-Type': 'application/json'}
+    if session_api_key:
+        headers['X-Session-API-Key'] = session_api_key
 
-        # Make API request
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                f'{agent_server_url}/api/skills',
-                json=payload,
-                headers=headers,
-                timeout=60.0,
+    # Make API request
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f'{agent_server_url}/api/skills',
+            json=payload,
+            headers=headers,
+            timeout=60.0,
+        )
+        response.raise_for_status()
+
+        data = response.json()
+
+    # Convert response to Skill objects
+    skills: list[Skill] = []
+    for skill_data_dict in data.get('skills', []):
+        try:
+            skill_info = SkillInfo.model_validate(skill_data_dict)
+            skill = _convert_skill_info_to_skill(skill_info)
+            skills.append(skill)
+        except Exception as e:
+            skill_name = (
+                skill_data_dict.get('name', 'unknown')
+                if isinstance(skill_data_dict, dict)
+                else 'unknown'
             )
-            response.raise_for_status()
+            _logger.warning(f'Failed to convert skill {skill_name}: {e}')
 
-            data = response.json()
+    sources = data.get('sources', {})
+    _logger.info(
+        f'Loaded {len(skills)} skills from agent-server: '
+        f'sources={sources}, names={[s.name for s in skills]}'
+    )
 
-        # Convert response to Skill objects
-        skills: list[Skill] = []
-        for skill_data_dict in data.get('skills', []):
-            try:
-                skill_info = SkillInfo.model_validate(skill_data_dict)
-                skill = _convert_skill_info_to_skill(skill_info)
-                skills.append(skill)
-            except Exception as e:
-                skill_name = (
-                    skill_data_dict.get('name', 'unknown')
-                    if isinstance(skill_data_dict, dict)
-                    else 'unknown'
-                )
-                _logger.warning(f'Failed to convert skill {skill_name}: {e}')
-
-        sources = data.get('sources', {})
-        _logger.info(
-            f'Loaded {len(skills)} skills from agent-server: '
-            f'sources={sources}, names={[s.name for s in skills]}'
-        )
-
-        return skills
-
-    except httpx.HTTPStatusError as e:
-        _logger.warning(
-            f'Agent-server returned error status {e.response.status_code}: '
-            f'{e.response.text}'
-        )
-        return []
-    except httpx.RequestError as e:
-        _logger.warning(f'Failed to connect to agent-server: {e}')
-        return []
-    except Exception as e:
-        _logger.warning(f'Failed to load skills from agent-server: {e}')
-        return []
+    return skills
 
 
 def _convert_skill_info_to_skill(skill_info: SkillInfo) -> Skill:

--- a/tests/unit/app_server/test_app_conversation_service_base.py
+++ b/tests/unit/app_server/test_app_conversation_service_base.py
@@ -10,6 +10,7 @@ from types import MethodType
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 from uuid import uuid4
 
+import httpx
 import pytest
 
 from openhands.app_server.app_conversation.app_conversation_models import AgentType
@@ -1197,3 +1198,35 @@ class TestLoadAndMergeAllSkills:
 
             # Assert
             assert result == []
+
+    @pytest.mark.asyncio
+    @patch(
+        'openhands.app_server.app_conversation.app_conversation_service_base.fetch_skills_from_agent_server'
+    )
+    async def test_propagates_exception_when_requested(self, mock_fetch_skills):
+        """Test explicit query paths can surface agent-server failures."""
+        mock_user_context = Mock(spec=UserContext)
+        with patch.object(AppConversationServiceBase, '__abstractmethods__', set()):
+            service = AppConversationServiceBase(
+                init_git_in_empty_workspace=True, user_context=mock_user_context
+            )
+
+            from openhands.app_server.sandbox.sandbox_models import ExposedUrl
+
+            sandbox = Mock(spec=SandboxInfo)
+            exposed_url = ExposedUrl(
+                name='AGENT_SERVER', url='http://localhost:8000', port=8000
+            )
+            sandbox.exposed_urls = [exposed_url]
+            sandbox.session_api_key = 'test-key'
+
+            mock_fetch_skills.side_effect = httpx.RequestError('Network error')
+
+            with pytest.raises(httpx.RequestError):
+                await service.load_and_merge_all_skills(
+                    sandbox,
+                    'owner/repo',
+                    '/workspace/repo',
+                    'http://localhost:8000',
+                    raise_on_error=True,
+                )

--- a/tests/unit/app_server/test_app_conversation_skills_endpoint.py
+++ b/tests/unit/app_server/test_app_conversation_skills_endpoint.py
@@ -7,6 +7,7 @@ following TDD best practices with AAA structure.
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
+import httpx
 import pytest
 from fastapi import status
 
@@ -36,6 +37,7 @@ def _make_service_mock(
     conversation_return: AppConversation | None = None,
     skills_return: list[Skill] | None = None,
     raise_on_load: bool = False,
+    load_exception: Exception | None = None,
 ):
     """Create a mock service that passes the isinstance check and returns the desired values."""
 
@@ -47,6 +49,8 @@ def _make_service_mock(
     service.get_app_conversation = AsyncMock(return_value=conversation_return)
 
     async def _load_skills(*_args, **_kwargs):
+        if load_exception is not None:
+            raise load_exception
         if raise_on_load:
             raise Exception('Skill loading failed')
         return skills_return or []
@@ -429,6 +433,121 @@ class TestGetConversationSkills:
         data = json.loads(content)
         assert 'error' in data
         assert 'Error getting skills' in data['error']
+
+    async def test_get_skills_returns_502_when_agent_server_unreachable(self):
+        """Test endpoint returns 502 for skill-loader connectivity failures."""
+        conversation_id = uuid4()
+        sandbox_id = str(uuid4())
+
+        mock_conversation = AppConversation(
+            id=conversation_id,
+            created_by_user_id='test-user',
+            sandbox_id=sandbox_id,
+            sandbox_status=SandboxStatus.RUNNING,
+        )
+
+        mock_sandbox = SandboxInfo(
+            id=sandbox_id,
+            created_by_user_id='test-user',
+            status=SandboxStatus.RUNNING,
+            sandbox_spec_id=str(uuid4()),
+            session_api_key='test-api-key',
+            exposed_urls=[
+                ExposedUrl(name=AGENT_SERVER, url='http://localhost:8000', port=8000)
+            ],
+        )
+
+        mock_sandbox_spec = SandboxSpecInfo(
+            id=str(uuid4()), command=None, working_dir='/workspace'
+        )
+
+        request = httpx.Request('POST', 'http://localhost:8000/api/skills')
+        mock_user_context = MagicMock(spec=UserContext)
+        mock_app_conversation_service = _make_service_mock(
+            user_context=mock_user_context,
+            conversation_return=mock_conversation,
+            load_exception=httpx.RequestError('Connection failed', request=request),
+        )
+
+        mock_sandbox_service = MagicMock()
+        mock_sandbox_service.get_sandbox = AsyncMock(return_value=mock_sandbox)
+
+        mock_sandbox_spec_service = MagicMock()
+        mock_sandbox_spec_service.get_sandbox_spec = AsyncMock(
+            return_value=mock_sandbox_spec
+        )
+
+        response = await get_conversation_skills(
+            conversation_id=conversation_id,
+            app_conversation_service=mock_app_conversation_service,
+            sandbox_service=mock_sandbox_service,
+            sandbox_spec_service=mock_sandbox_spec_service,
+        )
+
+        assert response.status_code == status.HTTP_502_BAD_GATEWAY
+        data = __import__('json').loads(response.body.decode('utf-8'))
+        assert 'error' in data
+
+    async def test_get_skills_returns_502_when_agent_server_returns_error(self):
+        """Test endpoint returns 502 for skill-loader HTTP failures."""
+        conversation_id = uuid4()
+        sandbox_id = str(uuid4())
+
+        mock_conversation = AppConversation(
+            id=conversation_id,
+            created_by_user_id='test-user',
+            sandbox_id=sandbox_id,
+            sandbox_status=SandboxStatus.RUNNING,
+        )
+
+        mock_sandbox = SandboxInfo(
+            id=sandbox_id,
+            created_by_user_id='test-user',
+            status=SandboxStatus.RUNNING,
+            sandbox_spec_id=str(uuid4()),
+            session_api_key='test-api-key',
+            exposed_urls=[
+                ExposedUrl(name=AGENT_SERVER, url='http://localhost:8000', port=8000)
+            ],
+        )
+
+        mock_sandbox_spec = SandboxSpecInfo(
+            id=str(uuid4()), command=None, working_dir='/workspace'
+        )
+
+        request = httpx.Request('POST', 'http://localhost:8000/api/skills')
+        response = httpx.Response(
+            status_code=503,
+            request=request,
+            text='Service Unavailable',
+        )
+        mock_user_context = MagicMock(spec=UserContext)
+        mock_app_conversation_service = _make_service_mock(
+            user_context=mock_user_context,
+            conversation_return=mock_conversation,
+            load_exception=httpx.HTTPStatusError(
+                'Server error', request=request, response=response
+            ),
+        )
+
+        mock_sandbox_service = MagicMock()
+        mock_sandbox_service.get_sandbox = AsyncMock(return_value=mock_sandbox)
+
+        mock_sandbox_spec_service = MagicMock()
+        mock_sandbox_spec_service.get_sandbox_spec = AsyncMock(
+            return_value=mock_sandbox_spec
+        )
+
+        response = await get_conversation_skills(
+            conversation_id=conversation_id,
+            app_conversation_service=mock_app_conversation_service,
+            sandbox_service=mock_sandbox_service,
+            sandbox_spec_service=mock_sandbox_spec_service,
+        )
+
+        assert response.status_code == status.HTTP_502_BAD_GATEWAY
+        data = __import__('json').loads(response.body.decode('utf-8'))
+        assert 'error' in data
 
     async def test_get_skills_returns_empty_list_when_no_skills_loaded(self):
         """Test endpoint returns empty skills list when no skills are found.

--- a/tests/unit/app_server/test_skill_loader.py
+++ b/tests/unit/app_server/test_skill_loader.py
@@ -22,6 +22,7 @@ from openhands.app_server.app_conversation.skill_loader import (
     _is_gitlab_repository,
     build_org_config,
     build_sandbox_config,
+    fetch_skills_from_agent_server,
     load_skills_from_agent_server,
 )
 from openhands.app_server.sandbox.sandbox_models import (
@@ -354,6 +355,38 @@ class TestLoadSkillsFromAgentServer:
 
     @pytest.mark.asyncio
     @patch('httpx.AsyncClient')
+    async def test_fetches_skills_successfully(self, mock_client_class):
+        """Test the raising variant successfully loads skills."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'skills': [
+                {
+                    'name': 'skill1',
+                    'content': 'Content 1',
+                    'triggers': ['keyword1'],
+                }
+            ],
+            'sources': {'public': 1},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_class.return_value = mock_client
+
+        result = await fetch_skills_from_agent_server(
+            agent_server_url='http://localhost:8000',
+            session_api_key='test-key',
+            project_dir='/workspace/project',
+        )
+
+        assert len(result) == 1
+        assert result[0].name == 'skill1'
+
+    @pytest.mark.asyncio
+    @patch('httpx.AsyncClient')
     async def test_loads_skills_successfully(self, mock_client_class):
         """Test successfully loading skills from agent-server."""
         # Arrange
@@ -436,6 +469,31 @@ class TestLoadSkillsFromAgentServer:
 
     @pytest.mark.asyncio
     @patch('httpx.AsyncClient')
+    async def test_fetch_raises_http_status_error(self, mock_client_class):
+        """Test the raising variant preserves HTTP status errors."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = 'Internal Server Error'
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.post = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                'Server error', request=MagicMock(), response=mock_response
+            )
+        )
+        mock_client_class.return_value = mock_client
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await fetch_skills_from_agent_server(
+                agent_server_url='http://localhost:8000',
+                session_api_key='test-key',
+                project_dir='/workspace',
+            )
+
+    @pytest.mark.asyncio
+    @patch('httpx.AsyncClient')
     async def test_handles_request_error(self, mock_client_class):
         """Test handling request error (connection failure)."""
         # Arrange
@@ -456,6 +514,25 @@ class TestLoadSkillsFromAgentServer:
 
         # Assert
         assert result == []
+
+    @pytest.mark.asyncio
+    @patch('httpx.AsyncClient')
+    async def test_fetch_raises_request_error(self, mock_client_class):
+        """Test the raising variant preserves request errors."""
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.post = AsyncMock(
+            side_effect=httpx.RequestError('Connection failed')
+        )
+        mock_client_class.return_value = mock_client
+
+        with pytest.raises(httpx.RequestError):
+            await fetch_skills_from_agent_server(
+                agent_server_url='http://localhost:8000',
+                session_api_key='test-key',
+                project_dir='/workspace',
+            )
 
 
 # ===== Tests for Organization Skills Functions (Still Existing) =====


### PR DESCRIPTION
## Summary
- add a raising skill-loader path for explicit query surfaces
- let the conversation skills endpoint surface agent-server request/status failures as 502 instead of silently returning an empty skills list
- cover the new raising path and 502 endpoint behavior with unit tests

## Testing
- /Users/ming/code/OpenHands/.venv/bin/pytest -q tests/unit/app_server/test_skill_loader.py
- /Users/ming/code/OpenHands/.venv/bin/pytest -q tests/unit/app_server/test_app_conversation_service_base.py -k "load_and_merge_all_skills or propagates_exception_when_requested"
- /Users/ming/code/OpenHands/.venv/bin/pytest -q tests/unit/app_server/test_app_conversation_skills_endpoint.py