### PR TITLE
refactor: consolidate loading spinners into single reusable component

### DIFF
--- a/frontend/__tests__/components/shared/spinner.test.tsx
+++ b/frontend/__tests__/components/shared/spinner.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Spinner } from "#/components/shared/spinner";
+
+describe("Spinner", () => {
+  it("should render with default size (md)", () => {
+    render(<Spinner />);
+    const spinner = screen.getByTestId("spinner");
+    expect(spinner).toBeInTheDocument();
+    expect(spinner).toHaveClass("h-6", "w-6");
+  });
+
+  it("should render with sm size", () => {
+    render(<Spinner size="sm" />);
+    const spinner = screen.getByTestId("spinner");
+    expect(spinner).toHaveClass("h-4", "w-4");
+  });
+
+  it("should render with lg size", () => {
+    render(<Spinner size="lg" />);
+    const spinner = screen.getByTestId("spinner");
+    expect(spinner).toHaveClass("h-8", "w-8");
+  });
+
+  it("should render with xl size", () => {
+    render(<Spinner size="xl" />);
+    const spinner = screen.getByTestId("spinner");
+    expect(spinner).toHaveClass("h-16", "w-16");
+  });
+
+  it("should render with a label", () => {
+    render(<Spinner label="Loading data..." />);
+    expect(screen.getByText("Loading data...")).toBeInTheDocument();
+  });
+
+  it("should apply custom className to the spinner element", () => {
+    render(<Spinner className="text-white" />);
+    const spinner = screen.getByTestId("spinner");
+    expect(spinner).toHaveClass("text-white");
+  });
+
+  it("should apply custom labelClassName to the label", () => {
+    render(<Spinner label="Loading" labelClassName="text-2xl" />);
+    const label = screen.getByText("Loading");
+    expect(label).toHaveClass("text-2xl");
+  });
+
+  it("should have role=status for accessibility", () => {
+    render(<Spinner />);
+    const spinner = screen.getByRole("status");
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it("should use label as aria-label when provided", () => {
+    render(<Spinner label="Loading items" />);
+    const spinner = screen.getByRole("status");
+    expect(spinner).toHaveAttribute("aria-label", "Loading items");
+  });
+
+  it("should default aria-label to Loading when no label provided", () => {
+    render(<Spinner />);
+    const spinner = screen.getByRole("status");
+    expect(spinner).toHaveAttribute("aria-label", "Loading");
+  });
+});

--- a/frontend/src/components/features/chat/microagent/loading-microagent-body.tsx
+++ b/frontend/src/components/features/chat/microagent/loading-microagent-body.tsx
@@ -1,7 +1,7 @@
-import { Spinner } from "@heroui/react";
 import { useTranslation } from "react-i18next";
 import { ModalBody } from "#/components/shared/modals/modal-body";
 import { Typography } from "#/ui/typography";
+import { Spinner } from "#/components/shared/spinner";
 
 export function LoadingMicroagentBody() {
   const { t } = useTranslation();

--- a/frontend/src/components/features/controls/agent-loading.tsx
+++ b/frontend/src/components/features/controls/agent-loading.tsx
@@ -1,9 +1,9 @@
-import { LoaderCircle } from "lucide-react";
+import { Spinner } from "#/components/shared/spinner";
 
 export function AgentLoading() {
   return (
     <div data-testid="agent-loading-spinner">
-      <LoaderCircle className="animate-spin w-4 h-4" color="white" />
+      <Spinner size="sm" className="text-white" />
     </div>
   );
 }

--- a/frontend/src/components/features/conversation-panel/skills-loading-state.tsx
+++ b/frontend/src/components/features/conversation-panel/skills-loading-state.tsx
@@ -1,7 +1,9 @@
+import { Spinner } from "#/components/shared/spinner";
+
 export function SkillsLoadingState() {
   return (
     <div className="flex justify-center items-center py-8">
-      <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary" />
+      <Spinner size="lg" />
     </div>
   );
 }

--- a/frontend/src/components/features/conversation/conversation-loading.tsx
+++ b/frontend/src/components/features/conversation/conversation-loading.tsx
@@ -1,7 +1,7 @@
-import { LoaderCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
 import { cn } from "#/utils/utils";
+import { Spinner } from "#/components/shared/spinner";
 
 type ConversationLoadingProps = {
   className?: string;
@@ -17,10 +17,12 @@ export function ConversationLoading({ className }: ConversationLoadingProps) {
         className,
       )}
     >
-      <LoaderCircle className="animate-spin w-16 h-16" color="white" />
-      <span className="text-2xl font-normal leading-5 text-white p-4">
-        {t(I18nKey.HOME$LOADING)}
-      </span>
+      <Spinner
+        size="xl"
+        label={t(I18nKey.HOME$LOADING)}
+        className="text-white"
+        labelClassName="text-2xl font-normal leading-5 text-white p-4"
+      />
     </div>
   );
 }

--- a/frontend/src/components/features/home/repository-selection/branch-loading-state.tsx
+++ b/frontend/src/components/features/home/repository-selection/branch-loading-state.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
-import { Spinner } from "@heroui/react";
 import { cn } from "#/utils/utils";
+import { Spinner } from "#/components/shared/spinner";
 
 interface BranchLoadingStateProps {
   wrapperClassName?: string;

--- a/frontend/src/components/features/home/repository-selection/repository-loading-state.tsx
+++ b/frontend/src/components/features/home/repository-selection/repository-loading-state.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
-import { Spinner } from "@heroui/react";
 import { cn } from "#/utils/utils";
+import { Spinner } from "#/components/shared/spinner";
 
 export interface RepositoryLoadingStateProps {
   wrapperClassName?: string;

--- a/frontend/src/components/features/home/shared/loading-spinner.tsx
+++ b/frontend/src/components/features/home/shared/loading-spinner.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { cn } from "#/utils/utils";
+import { Spinner } from "#/components/shared/spinner";
 
 interface LoadingSpinnerProps {
   hasSelection: boolean;
@@ -12,15 +12,13 @@ export function LoadingSpinner({
 }: LoadingSpinnerProps) {
   return (
     <div
+      data-testid={testId}
       className={cn(
         "absolute top-1/2 transform -translate-y-1/2",
         hasSelection ? "right-11" : "right-6",
       )}
     >
-      <div
-        className="animate-spin h-4 w-4 border-2 border-blue-500 border-t-transparent rounded-full"
-        data-testid={testId}
-      />
+      <Spinner size="sm" className="text-blue-500" />
     </div>
   );
 }

--- a/frontend/src/components/shared/spinner.tsx
+++ b/frontend/src/components/shared/spinner.tsx
@@ -1,0 +1,48 @@
+import { cn } from "#/utils/utils";
+
+type SpinnerSize = "sm" | "md" | "lg" | "xl";
+
+interface SpinnerProps {
+  size?: SpinnerSize;
+  label?: string;
+  className?: string;
+  labelClassName?: string;
+}
+
+const SIZE_CLASSES: Record<SpinnerSize, string> = {
+  sm: "h-4 w-4 border-2",
+  md: "h-6 w-6 border-2",
+  lg: "h-8 w-8 border-3",
+  xl: "h-16 w-16 border-4",
+};
+
+export function Spinner({
+  size = "md",
+  label,
+  className,
+  labelClassName,
+}: SpinnerProps) {
+  const spinner = (
+    <div
+      data-testid="spinner"
+      role="status"
+      aria-label={label ?? "Loading"}
+      className={cn(
+        "animate-spin rounded-full border-current border-t-transparent",
+        SIZE_CLASSES[size],
+        className,
+      )}
+    />
+  );
+
+  if (label) {
+    return (
+      <div className="flex flex-col items-center gap-2">
+        {spinner}
+        <span className={cn("text-sm", labelClassName)}>{label}</span>
+      </div>
+    );
+  }
+
+  return spinner;
+}


### PR DESCRIPTION
## Summary

Fixes #12550

Creates a unified `Spinner` component in `src/components/shared/spinner.tsx` that replaces multiple inconsistent spinner implementations across the frontend codebase.

The new `Spinner` component supports:
- **Configurable sizes**: `sm` (16px), `md` (24px), `lg` (32px), `xl` (64px)
- **Optional label text** with customizable styling
- **Accessible by default**: `role="status"` and `aria-label`
- **Consistent styling**: `animate-spin` border-based spinner using `currentColor`

### Components migrated

| Component | Before | After |
|-----------|--------|-------|
| `AgentLoading` | Lucide `LoaderCircle` icon | `Spinner size="sm"` |
| `ConversationLoading` | Lucide `LoaderCircle` icon | `Spinner size="xl"` with label |
| `LoadingMicroagentBody` | HeroUI `Spinner` | Shared `Spinner size="lg"` |
| `BranchLoadingState` | HeroUI `Spinner` | Shared `Spinner size="sm"` |
| `RepositoryLoadingState` | HeroUI `Spinner` | Shared `Spinner size="sm"` |
| `SkillsLoadingState` | Inline CSS spinner | `Spinner size="lg"` |
| Home `LoadingSpinner` | Inline CSS spinner | `Spinner size="sm"` in positioning wrapper |

### What is NOT changed
- `shared/loader.tsx` — fundamentally different animation (dot pulse, not a spinner)
- `shared/loading-spinner.tsx` — complex two-ring SVG spinner used in 10+ places, different visual design
- `ui/dropdown/loading-spinner.tsx` and `diff-viewer/loading-spinner.tsx` — not listed in the issue scope

## Test plan
- [x] Added 10 unit tests for the new `Spinner` component covering all sizes, label rendering, custom classes, and accessibility attributes
- [x] All frontend lint checks pass (eslint, typecheck, prettier, translation completeness)
- [x] Pre-existing test failures confirmed unrelated (zustand localStorage mock issue)