### PR TITLE
docs: fix broken React Router test doc links

### DIFF
--- a/frontend/__tests__/router.md
+++ b/frontend/__tests__/router.md
@@ -217,9 +217,9 @@ expect(screen.getByTestId("settings-screen")).toBeInTheDocument();
 
 ### Codebase Examples
 
-- [settings.test.tsx](__tests__/routes/settings.test.tsx) - `createRoutesStub` with nested routes and loaders
-- [home-screen.test.tsx](__tests__/routes/home-screen.test.tsx) - `createRoutesStub` with navigation testing
-- [chat-interface.test.tsx](__tests__/components/chat/chat-interface.test.tsx) - `MemoryRouter` usage
+- [settings.test.tsx](routes/settings.test.tsx) - `createRoutesStub` with nested routes and loaders
+- [home-screen.test.tsx](routes/home-screen.test.tsx) - `createRoutesStub` with navigation testing
+- [chat-interface.test.tsx](components/chat/chat-interface.test.tsx) - `MemoryRouter` usage
 
 ### Official Documentation
 


### PR DESCRIPTION
This PR fixes three broken relative links in `frontend/__tests__/router.md` so the codebase examples point to the actual test files again. No runtime behavior changes.