### PR TITLE
feat: add /api/me endpoint for user info with role and permissions

### DIFF
--- a/enterprise/server/routes/auth.py
+++ b/enterprise/server/routes/auth.py
@@ -52,10 +52,10 @@ from openhands.server.user_auth import get_access_token
 from openhands.server.user_auth.user_auth import get_user_auth
 
 with warnings.catch_warnings():
-    warnings.simplefilter('ignore')
+    warnings.simplefilter("ignore")
 
-api_router = APIRouter(prefix='/api')
-oauth_router = APIRouter(prefix='/oauth')
+api_router = APIRouter(prefix="/api")
+oauth_router = APIRouter(prefix="/oauth")
 
 token_manager = TokenManager()
 
@@ -70,9 +70,9 @@ def set_response_cookie(
 ):
     # Create a signed JWT token
     cookie_data = {
-        'access_token': keycloak_access_token,
-        'refresh_token': keycloak_refresh_token,
-        'accepted_tos': accepted_tos,
+        "access_token": keycloak_access_token,
+        "refresh_token": keycloak_refresh_token,
+        "accepted_tos": accepted_tos,
     }
     signed_token = sign_token(cookie_data, config.jwt_secret.get_secret_value())  # type: ignore
 
@@ -80,7 +80,7 @@ def set_response_cookie(
     domain = get_cookie_domain()
     if domain:
         response.set_cookie(
-            key='keycloak_auth',
+            key="keycloak_auth",
             value=signed_token,
             domain=domain,
             httponly=True,
@@ -89,7 +89,7 @@ def set_response_cookie(
         )
     else:
         response.set_cookie(
-            key='keycloak_auth',
+            key="keycloak_auth",
             value=signed_token,
             httponly=True,
             secure=secure,
@@ -105,22 +105,22 @@ def _extract_oauth_state(state: str | None) -> tuple[str, str | None, str | None
         Tokens may be None.
     """
     if not state:
-        return '', None, None
+        return "", None, None
 
     try:
         # Try to decode as JSON (new format with reCAPTCHA and/or invitation)
         state_data = json.loads(base64.urlsafe_b64decode(state.encode()).decode())
         return (
-            state_data.get('redirect_url', ''),
-            state_data.get('recaptcha_token'),
-            state_data.get('invitation_token'),
+            state_data.get("redirect_url", ""),
+            state_data.get("recaptcha_token"),
+            state_data.get("invitation_token"),
         )
     except Exception:
         # Old format - state is just the redirect URL
         return state, None, None
 
 
-@oauth_router.get('/keycloak/callback')
+@oauth_router.get("/keycloak/callback")
 async def keycloak_callback(
     request: Request,
     code: Optional[str] = None,
@@ -135,19 +135,19 @@ async def keycloak_callback(
     if redirect_url is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail='Missing state in request params',
+            detail="Missing state in request params",
         )
 
     if not code:
         # check if this is a forward from the account linking page
         if (
-            error == 'temporarily_unavailable'
-            and error_description == 'authentication_expired'
+            error == "temporarily_unavailable"
+            and error_description == "authentication_expired"
         ):
             return RedirectResponse(redirect_url, status_code=302)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail='Missing code in request params',
+            detail="Missing code in request params",
         )
 
     web_url = get_web_url(request)
@@ -160,34 +160,34 @@ async def keycloak_callback(
     if not keycloak_access_token or not keycloak_refresh_token:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail='Problem retrieving Keycloak tokens',
+            detail="Problem retrieving Keycloak tokens",
         )
 
     user_info = await token_manager.get_user_info(keycloak_access_token)
-    logger.debug(f'user_info: {user_info}')
+    logger.debug(f"user_info: {user_info}")
     if ROLE_CHECK_ENABLED and user_info.roles is None:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail='Missing required role'
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing required role"
         )
 
     authorization = await user_authorizer.authorize_user(user_info)
     if not authorization.success:
         # For duplicate_email errors, clean up the newly created Keycloak user
         # (only if they're not already in our UserStore, i.e., they're a new user)
-        if authorization.error_detail == 'duplicate_email':
+        if authorization.error_detail == "duplicate_email":
             try:
                 existing_user = await UserStore.get_user_by_id(user_info.sub)
                 if not existing_user:
                     # New user created during OAuth should be deleted from Keycloak
                     await token_manager.delete_keycloak_user(user_info.sub)
                     logger.info(
-                        f'Deleted orphaned Keycloak user {user_info.sub} '
-                        'after duplicate_email rejection'
+                        f"Deleted orphaned Keycloak user {user_info.sub} "
+                        "after duplicate_email rejection"
                     )
             except Exception as e:
                 # Log but don't fail - user should still get 401 response
                 logger.warning(
-                    f'Failed to clean up orphaned Keycloak user {user_info.sub}: {e}'
+                    f"Failed to clean up orphaned Keycloak user {user_info.sub}: {e}"
                 )
         # Return unauthorized
         raise HTTPException(
@@ -207,39 +207,39 @@ async def keycloak_callback(
         await UserStore.backfill_user_email(user_id, user_info_dict)
 
     if not user:
-        logger.error(f'Failed to authenticate user {user_info.email}')
+        logger.error(f"Failed to authenticate user {user_info.email}")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f'Failed to authenticate user {user_info.email}',
+            detail=f"Failed to authenticate user {user_info.email}",
         )
 
-    logger.info(f'Logging in user {str(user.id)} in org {user.current_org_id}')
+    logger.info(f"Logging in user {str(user.id)} in org {user.current_org_id}")
 
     # reCAPTCHA verification with Account Defender
     if RECAPTCHA_SITE_KEY:
         if not recaptcha_token:
             logger.warning(
-                'recaptcha_token_missing',
+                "recaptcha_token_missing",
                 extra={
-                    'user_id': user_id,
-                    'email': email,
+                    "user_id": user_id,
+                    "email": email,
                 },
             )
-            error_url = f'{web_url}/login?recaptcha_blocked=true'
+            error_url = f"{web_url}/login?recaptcha_blocked=true"
             return RedirectResponse(error_url, status_code=302)
 
-        user_ip = request.client.host if request.client else 'unknown'
-        user_agent = request.headers.get('User-Agent', '')
+        user_ip = request.client.host if request.client else "unknown"
+        user_agent = request.headers.get("User-Agent", "")
 
         # Handle X-Forwarded-For for proxied requests
-        forwarded_for = request.headers.get('X-Forwarded-For')
+        forwarded_for = request.headers.get("X-Forwarded-For")
         if forwarded_for:
-            user_ip = forwarded_for.split(',')[0].strip()
+            user_ip = forwarded_for.split(",")[0].strip()
 
         try:
             result = recaptcha_service.create_assessment(
                 token=recaptcha_token,
-                action='LOGIN',
+                action="LOGIN",
                 user_ip=user_ip,
                 user_agent=user_agent,
                 email=email,
@@ -248,19 +248,19 @@ async def keycloak_callback(
 
             if not result.allowed:
                 logger.warning(
-                    'recaptcha_blocked_at_callback',
+                    "recaptcha_blocked_at_callback",
                     extra={
-                        'user_ip': user_ip,
-                        'score': result.score,
-                        'user_id': user_id,
+                        "user_ip": user_ip,
+                        "score": result.score,
+                        "user_id": user_id,
                     },
                 )
                 # Redirect to home with error parameter
-                error_url = f'{web_url}/login?recaptcha_blocked=true'
+                error_url = f"{web_url}/login?recaptcha_blocked=true"
                 return RedirectResponse(error_url, status_code=302)
 
         except Exception as e:
-            logger.exception(f'reCAPTCHA verification error at callback: {e}')
+            logger.exception(f"reCAPTCHA verification error at callback: {e}")
             # Fail open - continue with login if reCAPTCHA service unavailable
 
     # Check email verification status
@@ -278,7 +278,7 @@ async def keycloak_callback(
         try:
             await check_rate_limit_by_user_id(
                 request=request,
-                key_prefix='auth_verify_email',
+                key_prefix="auth_verify_email",
                 user_id=user_id,
                 user_rate_limit_seconds=60,
                 ip_rate_limit_seconds=120,
@@ -289,21 +289,21 @@ async def keycloak_callback(
                 # Rate limited - still redirect to verification page but don't send email
                 rate_limited = True
                 logger.info(
-                    f'Rate limited verification email for user {user_id} during auth flow'
+                    f"Rate limited verification email for user {user_id} during auth flow"
                 )
             else:
                 raise
 
         verification_redirect_url = (
-            f'{web_url}/login?email_verification_required=true&user_id={user_id}'
+            f"{web_url}/login?email_verification_required=true&user_id={user_id}"
         )
         if rate_limited:
-            verification_redirect_url = f'{verification_redirect_url}&rate_limited=true'
+            verification_redirect_url = f"{verification_redirect_url}&rate_limited=true"
 
         # Preserve invitation token so it can be included in OAuth state after verification
         if invitation_token:
             verification_redirect_url = (
-                f'{verification_redirect_url}&invitation_token={invitation_token}'
+                f"{verification_redirect_url}&invitation_token={invitation_token}"
             )
         response = RedirectResponse(verification_redirect_url, status_code=302)
         return response
@@ -311,10 +311,10 @@ async def keycloak_callback(
     # default to github IDP for now.
     # TODO: remove default once Keycloak is updated universally with the new attribute.
     idp: str = user_info.identity_provider or ProviderType.GITHUB.value
-    logger.info(f'Full IDP is {idp}')
-    idp_type = 'oidc'
-    if ':' in idp:
-        idp, idp_type = idp.rsplit(':', 1)
+    logger.info(f"Full IDP is {idp}")
+    idp_type = "oidc"
+    if ":" in idp:
+        idp, idp_type = idp.rsplit(":", 1)
         idp_type = idp_type.lower()
 
     await token_manager.store_idp_tokens(
@@ -323,62 +323,62 @@ async def keycloak_callback(
 
     valid_offline_token = (
         await token_manager.validate_offline_token(user_id=user_info.sub)
-        if idp_type != 'saml'
+        if idp_type != "saml"
         else True
     )
 
     logger.debug(
-        f'keycloakAccessToken: {keycloak_access_token}, keycloakUserId: {user_id}'
+        f"keycloakAccessToken: {keycloak_access_token}, keycloakUserId: {user_id}"
     )
 
     # adding in posthog tracking
 
     # If this is a feature environment, add "FEATURE_" prefix to user_id for PostHog
-    posthog_user_id = f'FEATURE_{user_id}' if IS_FEATURE_ENV else user_id
+    posthog_user_id = f"FEATURE_{user_id}" if IS_FEATURE_ENV else user_id
 
     try:
         posthog.set(
             distinct_id=posthog_user_id,
             properties={
-                'user_id': posthog_user_id,
-                'original_user_id': user_id,
-                'is_feature_env': IS_FEATURE_ENV,
+                "user_id": posthog_user_id,
+                "original_user_id": user_id,
+                "is_feature_env": IS_FEATURE_ENV,
             },
         )
     except Exception as e:
         logger.error(
-            'auth:posthog_set:failed',
+            "auth:posthog_set:failed",
             extra={
-                'user_id': user_id,
-                'error': str(e),
+                "user_id": user_id,
+                "error": str(e),
             },
         )
         # Continue execution as this is not critical
 
     logger.info(
-        'user_logged_in',
+        "user_logged_in",
         extra={
-            'idp': idp,
-            'idp_type': idp_type,
-            'posthog_user_id': posthog_user_id,
-            'is_feature_env': IS_FEATURE_ENV,
+            "idp": idp,
+            "idp_type": idp_type,
+            "posthog_user_id": posthog_user_id,
+            "is_feature_env": IS_FEATURE_ENV,
         },
     )
 
     if not valid_offline_token:
         param_str = urlencode(
             {
-                'client_id': KEYCLOAK_CLIENT_ID,
-                'response_type': 'code',
-                'kc_idp_hint': idp,
-                'redirect_uri': f'{web_url}/oauth/keycloak/offline/callback',
-                'scope': 'openid email profile offline_access',
-                'state': state,
+                "client_id": KEYCLOAK_CLIENT_ID,
+                "response_type": "code",
+                "kc_idp_hint": idp,
+                "redirect_uri": f"{web_url}/oauth/keycloak/offline/callback",
+                "scope": "openid email profile offline_access",
+                "state": state,
             }
         )
         redirect_url = (
-            f'{KEYCLOAK_SERVER_URL_EXT}/realms/{KEYCLOAK_REALM_NAME}/protocol/openid-connect/auth'
-            f'?{param_str}'
+            f"{KEYCLOAK_SERVER_URL_EXT}/realms/{KEYCLOAK_REALM_NAME}/protocol/openid-connect/auth"
+            f"?{param_str}"
         )
 
     has_accepted_tos = user.accepted_tos is not None
@@ -387,10 +387,10 @@ async def keycloak_callback(
     if invitation_token:
         try:
             logger.info(
-                'Processing invitation token during auth callback',
+                "Processing invitation token during auth callback",
                 extra={
-                    'user_id': user_id,
-                    'invitation_token_prefix': invitation_token[:10] + '...',
+                    "user_id": user_id,
+                    "invitation_token_prefix": invitation_token[:10] + "...",
                 },
             )
 
@@ -398,72 +398,72 @@ async def keycloak_callback(
                 invitation_token, parse_uuid(user_id)
             )
             logger.info(
-                'Invitation accepted during auth callback',
-                extra={'user_id': user_id},
+                "Invitation accepted during auth callback",
+                extra={"user_id": user_id},
             )
 
         except InvitationExpiredError:
             logger.warning(
-                'Invitation expired during auth callback',
-                extra={'user_id': user_id},
+                "Invitation expired during auth callback",
+                extra={"user_id": user_id},
             )
             # Add query param to redirect URL
-            if '?' in redirect_url:
-                redirect_url = f'{redirect_url}&invitation_expired=true'
+            if "?" in redirect_url:
+                redirect_url = f"{redirect_url}&invitation_expired=true"
             else:
-                redirect_url = f'{redirect_url}?invitation_expired=true'
+                redirect_url = f"{redirect_url}?invitation_expired=true"
 
         except InvitationInvalidError as e:
             logger.warning(
-                'Invalid invitation during auth callback',
-                extra={'user_id': user_id, 'error': str(e)},
+                "Invalid invitation during auth callback",
+                extra={"user_id": user_id, "error": str(e)},
             )
-            if '?' in redirect_url:
-                redirect_url = f'{redirect_url}&invitation_invalid=true'
+            if "?" in redirect_url:
+                redirect_url = f"{redirect_url}&invitation_invalid=true"
             else:
-                redirect_url = f'{redirect_url}?invitation_invalid=true'
+                redirect_url = f"{redirect_url}?invitation_invalid=true"
 
         except UserAlreadyMemberError:
             logger.info(
-                'User already member during invitation acceptance',
-                extra={'user_id': user_id},
+                "User already member during invitation acceptance",
+                extra={"user_id": user_id},
             )
-            if '?' in redirect_url:
-                redirect_url = f'{redirect_url}&already_member=true'
+            if "?" in redirect_url:
+                redirect_url = f"{redirect_url}&already_member=true"
             else:
-                redirect_url = f'{redirect_url}?already_member=true'
+                redirect_url = f"{redirect_url}?already_member=true"
 
         except EmailMismatchError as e:
             logger.warning(
-                'Email mismatch during auth callback invitation acceptance',
-                extra={'user_id': user_id, 'error': str(e)},
+                "Email mismatch during auth callback invitation acceptance",
+                extra={"user_id": user_id, "error": str(e)},
             )
-            if '?' in redirect_url:
-                redirect_url = f'{redirect_url}&email_mismatch=true'
+            if "?" in redirect_url:
+                redirect_url = f"{redirect_url}&email_mismatch=true"
             else:
-                redirect_url = f'{redirect_url}?email_mismatch=true'
+                redirect_url = f"{redirect_url}?email_mismatch=true"
 
         except Exception as e:
             logger.exception(
-                'Unexpected error processing invitation during auth callback',
-                extra={'user_id': user_id, 'error': str(e)},
+                "Unexpected error processing invitation during auth callback",
+                extra={"user_id": user_id, "error": str(e)},
             )
             # Don't fail the login if invitation processing fails
-            if '?' in redirect_url:
-                redirect_url = f'{redirect_url}&invitation_error=true'
+            if "?" in redirect_url:
+                redirect_url = f"{redirect_url}&invitation_error=true"
             else:
-                redirect_url = f'{redirect_url}?invitation_error=true'
+                redirect_url = f"{redirect_url}?invitation_error=true"
 
     # If the user hasn't accepted the TOS, redirect to the TOS page
     if not has_accepted_tos:
-        encoded_redirect_url = quote(redirect_url, safe='')
-        tos_redirect_url = f'{web_url}/accept-tos?redirect_url={encoded_redirect_url}'
+        encoded_redirect_url = quote(redirect_url, safe="")
+        tos_redirect_url = f"{web_url}/accept-tos?redirect_url={encoded_redirect_url}"
         if invitation_token:
-            tos_redirect_url = f'{tos_redirect_url}&invitation_success=true'
+            tos_redirect_url = f"{tos_redirect_url}&invitation_success=true"
         response = RedirectResponse(tos_redirect_url, status_code=302)
     else:
         if invitation_token:
-            redirect_url = f'{redirect_url}&invitation_success=true'
+            redirect_url = f"{redirect_url}&invitation_success=true"
         response = RedirectResponse(redirect_url, status_code=302)
 
     set_response_cookie(
@@ -471,7 +471,7 @@ async def keycloak_callback(
         response=response,
         keycloak_access_token=keycloak_access_token,
         keycloak_refresh_token=keycloak_refresh_token,
-        secure=True if redirect_url.startswith('https') else False,
+        secure=True if redirect_url.startswith("https") else False,
         accepted_tos=has_accepted_tos,
     )
 
@@ -482,17 +482,17 @@ async def keycloak_callback(
     return response
 
 
-@oauth_router.get('/keycloak/offline/callback')
+@oauth_router.get("/keycloak/offline/callback")
 async def keycloak_offline_callback(code: str, state: str, request: Request):
     if not code:
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
-            content={'error': 'Missing code in request params'},
+            content={"error": "Missing code in request params"},
         )
 
     web_url = get_web_url(request)
     redirect_uri = web_url + request.url.path
-    logger.debug(f'code: {code}, redirect_uri: {redirect_uri}')
+    logger.debug(f"code: {code}, redirect_uri: {redirect_uri}")
 
     (
         keycloak_access_token,
@@ -501,11 +501,11 @@ async def keycloak_offline_callback(code: str, state: str, request: Request):
     if not keycloak_access_token or not keycloak_refresh_token:
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
-            content={'error': 'Problem retrieving Keycloak tokens'},
+            content={"error": "Problem retrieving Keycloak tokens"},
         )
 
     user_info = await token_manager.get_user_info(keycloak_access_token)
-    logger.debug(f'user_info: {user_info}')
+    logger.debug(f"user_info: {user_info}")
     # sub is a required field in KeycloakUserInfo, validation happens in get_user_info
 
     await token_manager.store_offline_token(
@@ -516,32 +516,32 @@ async def keycloak_offline_callback(code: str, state: str, request: Request):
     return RedirectResponse(redirect_url if redirect_url else web_url, status_code=302)
 
 
-@oauth_router.get('/github/callback')
+@oauth_router.get("/github/callback")
 async def github_dummy_callback(request: Request):
     """Callback for GitHub that just forwards the user to the app base URL."""
     web_url = get_web_url(request)
     return RedirectResponse(web_url, status_code=302)
 
 
-@api_router.post('/authenticate')
+@api_router.post("/authenticate")
 async def authenticate(request: Request):
     try:
         await get_access_token(request)
         return JSONResponse(
-            status_code=status.HTTP_200_OK, content={'message': 'User authenticated'}
+            status_code=status.HTTP_200_OK, content={"message": "User authenticated"}
         )
     except Exception:
         # For any error during authentication, clear the auth cookie and return 401
         response = JSONResponse(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            content={'error': 'User is not authenticated'},
+            content={"error": "User is not authenticated"},
         )
 
         # Delete the auth cookie if it exists
-        keycloak_auth_cookie = request.cookies.get('keycloak_auth')
+        keycloak_auth_cookie = request.cookies.get("keycloak_auth")
         if keycloak_auth_cookie:
             response.delete_cookie(
-                key='keycloak_auth',
+                key="keycloak_auth",
                 domain=get_cookie_domain(),
                 samesite=get_cookie_samesite(),
             )
@@ -549,7 +549,7 @@ async def authenticate(request: Request):
         return response
 
 
-@api_router.post('/accept_tos')
+@api_router.post("/accept_tos")
 async def accept_tos(request: Request):
     user_auth = cast(SaasUserAuth, await get_user_auth(request))
     access_token = await user_auth.get_access_token()
@@ -558,17 +558,17 @@ async def accept_tos(request: Request):
 
     if not access_token or not refresh_token or not user_id:
         logger.warning(
-            f'accept_tos: One or more is None: access_token {access_token}, refresh_token {refresh_token}, user_id {user_id}'
+            f"accept_tos: One or more is None: access_token {access_token}, refresh_token {refresh_token}, user_id {user_id}"
         )
         return JSONResponse(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            content={'error': 'User is not authenticated'},
+            content={"error": "User is not authenticated"},
         )
 
     # Get redirect URL from request body
     body = await request.json()
     web_url = get_web_url(request)
-    redirect_url = body.get('redirect_url', str(web_url))
+    redirect_url = body.get("redirect_url", str(web_url))
 
     # Update user settings with TOS acceptance
     accepted_tos: datetime = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -579,18 +579,18 @@ async def accept_tos(request: Request):
         user = result.scalar_one_or_none()
         if not user:
             await session.rollback()
-            logger.error('User for {user_id} not found.')
+            logger.error("User for {user_id} not found.")
             return JSONResponse(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                content={'error': 'User does not exist'},
+                content={"error": "User does not exist"},
             )
         user.accepted_tos = accepted_tos
         await session.commit()
 
-        logger.info(f'User {user_id} accepted TOS')
+        logger.info(f"User {user_id} accepted TOS")
 
     response = JSONResponse(
-        status_code=status.HTTP_200_OK, content={'redirect_url': redirect_url}
+        status_code=status.HTTP_200_OK, content={"redirect_url": redirect_url}
     )
 
     set_response_cookie(
@@ -604,17 +604,17 @@ async def accept_tos(request: Request):
     return response
 
 
-@api_router.post('/logout')
+@api_router.post("/logout")
 async def logout(request: Request):
     # Always create the response object first to ensure we can return it even if errors occur
     response = JSONResponse(
         status_code=status.HTTP_200_OK,
-        content={'message': 'User logged out'},
+        content={"message": "User logged out"},
     )
 
     # Always delete the cookie regardless of what happens
     response.delete_cookie(
-        key='keycloak_auth',
+        key="keycloak_auth",
         domain=get_cookie_domain(),
         samesite=get_cookie_samesite(),
     )
@@ -627,26 +627,88 @@ async def logout(request: Request):
             await token_manager.logout(refresh_token)
     except Exception as e:
         # Log any errors but don't fail the request
-        logger.debug(f'Error during logout: {str(e)}')
+        logger.debug(f"Error during logout: {str(e)}")
         # We still want to clear the cookie and return success
 
     return response
 
 
-@api_router.get('/refresh-tokens', response_model=TokenResponse)
+@api_router.get("/me")
+async def get_current_user(request: Request):
+    """Get current authenticated user information including org role and permissions."""
+    try:
+        user_auth = await SaasUserAuth.get_instance(request)
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not authenticated",
+        )
+
+    user_id = await user_auth.get_user_id()
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not authenticated",
+        )
+
+    email = await user_auth.get_user_email()
+
+    # Get user and their current org
+    user = await UserStore.get_user_by_id(user_id)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+
+    from server.auth.authorization import get_role_permissions, get_user_org_role
+    from storage.org_store import OrgStore
+
+    # Get the current org
+    org = await OrgStore.get_org_by_id(user.current_org_id)
+    if not org:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organization not found",
+        )
+
+    # Get user's role in the current org
+    role = await get_user_org_role(user_id, user.current_org_id)
+    role_name = role.name if role else None
+
+    # Get permissions for the role
+    permissions: list[str] = []
+    if role_name:
+        role_permissions = get_role_permissions(role_name)
+        permissions = [p.value for p in role_permissions]
+
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content={
+            "user_id": user_id,
+            "email": email,
+            "org_id": str(user.current_org_id),
+            "org_name": org.name,
+            "role": role_name,
+            "permissions": permissions,
+        },
+    )
+
+
+@api_router.get("/refresh-tokens", response_model=TokenResponse)
 async def refresh_tokens(
     request: Request,
     provider: ProviderType,
     sid: str,
-    x_session_api_key: Annotated[str | None, Header(alias='X-Session-API-Key')],
+    x_session_api_key: Annotated[str | None, Header(alias="X-Session-API-Key")],
 ) -> TokenResponse:
     """Return the latest token for a given provider."""
     user_id = _get_user_id(sid)
     session_api_key = await _get_session_api_key(user_id, sid)
     if session_api_key != x_session_api_key:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Forbidden')
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
 
-    logger.info(f'Refreshing token for conversation {sid}')
+    logger.info(f"Refreshing token for conversation {sid}")
     provider_handler = ProviderHandler(
         create_provider_tokens_object([provider]), external_auth_id=user_id
     )

--- a/enterprise/server/routes/auth.py
+++ b/enterprise/server/routes/auth.py
@@ -52,10 +52,10 @@ from openhands.server.user_auth import get_access_token
 from openhands.server.user_auth.user_auth import get_user_auth
 
 with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
+    warnings.simplefilter('ignore')
 
-api_router = APIRouter(prefix="/api")
-oauth_router = APIRouter(prefix="/oauth")
+api_router = APIRouter(prefix='/api')
+oauth_router = APIRouter(prefix='/oauth')
 
 token_manager = TokenManager()
 
@@ -70,9 +70,9 @@ def set_response_cookie(
 ):
     # Create a signed JWT token
     cookie_data = {
-        "access_token": keycloak_access_token,
-        "refresh_token": keycloak_refresh_token,
-        "accepted_tos": accepted_tos,
+        'access_token': keycloak_access_token,
+        'refresh_token': keycloak_refresh_token,
+        'accepted_tos': accepted_tos,
     }
     signed_token = sign_token(cookie_data, config.jwt_secret.get_secret_value())  # type: ignore
 
@@ -80,7 +80,7 @@ def set_response_cookie(
     domain = get_cookie_domain()
     if domain:
         response.set_cookie(
-            key="keycloak_auth",
+            key='keycloak_auth',
             value=signed_token,
             domain=domain,
             httponly=True,
@@ -89,7 +89,7 @@ def set_response_cookie(
         )
     else:
         response.set_cookie(
-            key="keycloak_auth",
+            key='keycloak_auth',
             value=signed_token,
             httponly=True,
             secure=secure,
@@ -105,22 +105,22 @@ def _extract_oauth_state(state: str | None) -> tuple[str, str | None, str | None
         Tokens may be None.
     """
     if not state:
-        return "", None, None
+        return '', None, None
 
     try:
         # Try to decode as JSON (new format with reCAPTCHA and/or invitation)
         state_data = json.loads(base64.urlsafe_b64decode(state.encode()).decode())
         return (
-            state_data.get("redirect_url", ""),
-            state_data.get("recaptcha_token"),
-            state_data.get("invitation_token"),
+            state_data.get('redirect_url', ''),
+            state_data.get('recaptcha_token'),
+            state_data.get('invitation_token'),
         )
     except Exception:
         # Old format - state is just the redirect URL
         return state, None, None
 
 
-@oauth_router.get("/keycloak/callback")
+@oauth_router.get('/keycloak/callback')
 async def keycloak_callback(
     request: Request,
     code: Optional[str] = None,
@@ -135,19 +135,19 @@ async def keycloak_callback(
     if redirect_url is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Missing state in request params",
+            detail='Missing state in request params',
         )
 
     if not code:
         # check if this is a forward from the account linking page
         if (
-            error == "temporarily_unavailable"
-            and error_description == "authentication_expired"
+            error == 'temporarily_unavailable'
+            and error_description == 'authentication_expired'
         ):
             return RedirectResponse(redirect_url, status_code=302)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Missing code in request params",
+            detail='Missing code in request params',
         )
 
     web_url = get_web_url(request)
@@ -160,34 +160,34 @@ async def keycloak_callback(
     if not keycloak_access_token or not keycloak_refresh_token:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Problem retrieving Keycloak tokens",
+            detail='Problem retrieving Keycloak tokens',
         )
 
     user_info = await token_manager.get_user_info(keycloak_access_token)
-    logger.debug(f"user_info: {user_info}")
+    logger.debug(f'user_info: {user_info}')
     if ROLE_CHECK_ENABLED and user_info.roles is None:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing required role"
+            status_code=status.HTTP_401_UNAUTHORIZED, detail='Missing required role'
         )
 
     authorization = await user_authorizer.authorize_user(user_info)
     if not authorization.success:
         # For duplicate_email errors, clean up the newly created Keycloak user
         # (only if they're not already in our UserStore, i.e., they're a new user)
-        if authorization.error_detail == "duplicate_email":
+        if authorization.error_detail == 'duplicate_email':
             try:
                 existing_user = await UserStore.get_user_by_id(user_info.sub)
                 if not existing_user:
                     # New user created during OAuth should be deleted from Keycloak
                     await token_manager.delete_keycloak_user(user_info.sub)
                     logger.info(
-                        f"Deleted orphaned Keycloak user {user_info.sub} "
-                        "after duplicate_email rejection"
+                        f'Deleted orphaned Keycloak user {user_info.sub} '
+                        'after duplicate_email rejection'
                     )
             except Exception as e:
                 # Log but don't fail - user should still get 401 response
                 logger.warning(
-                    f"Failed to clean up orphaned Keycloak user {user_info.sub}: {e}"
+                    f'Failed to clean up orphaned Keycloak user {user_info.sub}: {e}'
                 )
         # Return unauthorized
         raise HTTPException(
@@ -207,39 +207,39 @@ async def keycloak_callback(
         await UserStore.backfill_user_email(user_id, user_info_dict)
 
     if not user:
-        logger.error(f"Failed to authenticate user {user_info.email}")
+        logger.error(f'Failed to authenticate user {user_info.email}')
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"Failed to authenticate user {user_info.email}",
+            detail=f'Failed to authenticate user {user_info.email}',
         )
 
-    logger.info(f"Logging in user {str(user.id)} in org {user.current_org_id}")
+    logger.info(f'Logging in user {str(user.id)} in org {user.current_org_id}')
 
     # reCAPTCHA verification with Account Defender
     if RECAPTCHA_SITE_KEY:
         if not recaptcha_token:
             logger.warning(
-                "recaptcha_token_missing",
+                'recaptcha_token_missing',
                 extra={
-                    "user_id": user_id,
-                    "email": email,
+                    'user_id': user_id,
+                    'email': email,
                 },
             )
-            error_url = f"{web_url}/login?recaptcha_blocked=true"
+            error_url = f'{web_url}/login?recaptcha_blocked=true'
             return RedirectResponse(error_url, status_code=302)
 
-        user_ip = request.client.host if request.client else "unknown"
-        user_agent = request.headers.get("User-Agent", "")
+        user_ip = request.client.host if request.client else 'unknown'
+        user_agent = request.headers.get('User-Agent', '')
 
         # Handle X-Forwarded-For for proxied requests
-        forwarded_for = request.headers.get("X-Forwarded-For")
+        forwarded_for = request.headers.get('X-Forwarded-For')
         if forwarded_for:
-            user_ip = forwarded_for.split(",")[0].strip()
+            user_ip = forwarded_for.split(',')[0].strip()
 
         try:
             result = recaptcha_service.create_assessment(
                 token=recaptcha_token,
-                action="LOGIN",
+                action='LOGIN',
                 user_ip=user_ip,
                 user_agent=user_agent,
                 email=email,
@@ -248,19 +248,19 @@ async def keycloak_callback(
 
             if not result.allowed:
                 logger.warning(
-                    "recaptcha_blocked_at_callback",
+                    'recaptcha_blocked_at_callback',
                     extra={
-                        "user_ip": user_ip,
-                        "score": result.score,
-                        "user_id": user_id,
+                        'user_ip': user_ip,
+                        'score': result.score,
+                        'user_id': user_id,
                     },
                 )
                 # Redirect to home with error parameter
-                error_url = f"{web_url}/login?recaptcha_blocked=true"
+                error_url = f'{web_url}/login?recaptcha_blocked=true'
                 return RedirectResponse(error_url, status_code=302)
 
         except Exception as e:
-            logger.exception(f"reCAPTCHA verification error at callback: {e}")
+            logger.exception(f'reCAPTCHA verification error at callback: {e}')
             # Fail open - continue with login if reCAPTCHA service unavailable
 
     # Check email verification status
@@ -278,7 +278,7 @@ async def keycloak_callback(
         try:
             await check_rate_limit_by_user_id(
                 request=request,
-                key_prefix="auth_verify_email",
+                key_prefix='auth_verify_email',
                 user_id=user_id,
                 user_rate_limit_seconds=60,
                 ip_rate_limit_seconds=120,
@@ -289,21 +289,21 @@ async def keycloak_callback(
                 # Rate limited - still redirect to verification page but don't send email
                 rate_limited = True
                 logger.info(
-                    f"Rate limited verification email for user {user_id} during auth flow"
+                    f'Rate limited verification email for user {user_id} during auth flow'
                 )
             else:
                 raise
 
         verification_redirect_url = (
-            f"{web_url}/login?email_verification_required=true&user_id={user_id}"
+            f'{web_url}/login?email_verification_required=true&user_id={user_id}'
         )
         if rate_limited:
-            verification_redirect_url = f"{verification_redirect_url}&rate_limited=true"
+            verification_redirect_url = f'{verification_redirect_url}&rate_limited=true'
 
         # Preserve invitation token so it can be included in OAuth state after verification
         if invitation_token:
             verification_redirect_url = (
-                f"{verification_redirect_url}&invitation_token={invitation_token}"
+                f'{verification_redirect_url}&invitation_token={invitation_token}'
             )
         response = RedirectResponse(verification_redirect_url, status_code=302)
         return response
@@ -311,10 +311,10 @@ async def keycloak_callback(
     # default to github IDP for now.
     # TODO: remove default once Keycloak is updated universally with the new attribute.
     idp: str = user_info.identity_provider or ProviderType.GITHUB.value
-    logger.info(f"Full IDP is {idp}")
-    idp_type = "oidc"
-    if ":" in idp:
-        idp, idp_type = idp.rsplit(":", 1)
+    logger.info(f'Full IDP is {idp}')
+    idp_type = 'oidc'
+    if ':' in idp:
+        idp, idp_type = idp.rsplit(':', 1)
         idp_type = idp_type.lower()
 
     await token_manager.store_idp_tokens(
@@ -323,62 +323,62 @@ async def keycloak_callback(
 
     valid_offline_token = (
         await token_manager.validate_offline_token(user_id=user_info.sub)
-        if idp_type != "saml"
+        if idp_type != 'saml'
         else True
     )
 
     logger.debug(
-        f"keycloakAccessToken: {keycloak_access_token}, keycloakUserId: {user_id}"
+        f'keycloakAccessToken: {keycloak_access_token}, keycloakUserId: {user_id}'
     )
 
     # adding in posthog tracking
 
     # If this is a feature environment, add "FEATURE_" prefix to user_id for PostHog
-    posthog_user_id = f"FEATURE_{user_id}" if IS_FEATURE_ENV else user_id
+    posthog_user_id = f'FEATURE_{user_id}' if IS_FEATURE_ENV else user_id
 
     try:
         posthog.set(
             distinct_id=posthog_user_id,
             properties={
-                "user_id": posthog_user_id,
-                "original_user_id": user_id,
-                "is_feature_env": IS_FEATURE_ENV,
+                'user_id': posthog_user_id,
+                'original_user_id': user_id,
+                'is_feature_env': IS_FEATURE_ENV,
             },
         )
     except Exception as e:
         logger.error(
-            "auth:posthog_set:failed",
+            'auth:posthog_set:failed',
             extra={
-                "user_id": user_id,
-                "error": str(e),
+                'user_id': user_id,
+                'error': str(e),
             },
         )
         # Continue execution as this is not critical
 
     logger.info(
-        "user_logged_in",
+        'user_logged_in',
         extra={
-            "idp": idp,
-            "idp_type": idp_type,
-            "posthog_user_id": posthog_user_id,
-            "is_feature_env": IS_FEATURE_ENV,
+            'idp': idp,
+            'idp_type': idp_type,
+            'posthog_user_id': posthog_user_id,
+            'is_feature_env': IS_FEATURE_ENV,
         },
     )
 
     if not valid_offline_token:
         param_str = urlencode(
             {
-                "client_id": KEYCLOAK_CLIENT_ID,
-                "response_type": "code",
-                "kc_idp_hint": idp,
-                "redirect_uri": f"{web_url}/oauth/keycloak/offline/callback",
-                "scope": "openid email profile offline_access",
-                "state": state,
+                'client_id': KEYCLOAK_CLIENT_ID,
+                'response_type': 'code',
+                'kc_idp_hint': idp,
+                'redirect_uri': f'{web_url}/oauth/keycloak/offline/callback',
+                'scope': 'openid email profile offline_access',
+                'state': state,
             }
         )
         redirect_url = (
-            f"{KEYCLOAK_SERVER_URL_EXT}/realms/{KEYCLOAK_REALM_NAME}/protocol/openid-connect/auth"
-            f"?{param_str}"
+            f'{KEYCLOAK_SERVER_URL_EXT}/realms/{KEYCLOAK_REALM_NAME}/protocol/openid-connect/auth'
+            f'?{param_str}'
         )
 
     has_accepted_tos = user.accepted_tos is not None
@@ -387,10 +387,10 @@ async def keycloak_callback(
     if invitation_token:
         try:
             logger.info(
-                "Processing invitation token during auth callback",
+                'Processing invitation token during auth callback',
                 extra={
-                    "user_id": user_id,
-                    "invitation_token_prefix": invitation_token[:10] + "...",
+                    'user_id': user_id,
+                    'invitation_token_prefix': invitation_token[:10] + '...',
                 },
             )
 
@@ -398,72 +398,72 @@ async def keycloak_callback(
                 invitation_token, parse_uuid(user_id)
             )
             logger.info(
-                "Invitation accepted during auth callback",
-                extra={"user_id": user_id},
+                'Invitation accepted during auth callback',
+                extra={'user_id': user_id},
             )
 
         except InvitationExpiredError:
             logger.warning(
-                "Invitation expired during auth callback",
-                extra={"user_id": user_id},
+                'Invitation expired during auth callback',
+                extra={'user_id': user_id},
             )
             # Add query param to redirect URL
-            if "?" in redirect_url:
-                redirect_url = f"{redirect_url}&invitation_expired=true"
+            if '?' in redirect_url:
+                redirect_url = f'{redirect_url}&invitation_expired=true'
             else:
-                redirect_url = f"{redirect_url}?invitation_expired=true"
+                redirect_url = f'{redirect_url}?invitation_expired=true'
 
         except InvitationInvalidError as e:
             logger.warning(
-                "Invalid invitation during auth callback",
-                extra={"user_id": user_id, "error": str(e)},
+                'Invalid invitation during auth callback',
+                extra={'user_id': user_id, 'error': str(e)},
             )
-            if "?" in redirect_url:
-                redirect_url = f"{redirect_url}&invitation_invalid=true"
+            if '?' in redirect_url:
+                redirect_url = f'{redirect_url}&invitation_invalid=true'
             else:
-                redirect_url = f"{redirect_url}?invitation_invalid=true"
+                redirect_url = f'{redirect_url}?invitation_invalid=true'
 
         except UserAlreadyMemberError:
             logger.info(
-                "User already member during invitation acceptance",
-                extra={"user_id": user_id},
+                'User already member during invitation acceptance',
+                extra={'user_id': user_id},
             )
-            if "?" in redirect_url:
-                redirect_url = f"{redirect_url}&already_member=true"
+            if '?' in redirect_url:
+                redirect_url = f'{redirect_url}&already_member=true'
             else:
-                redirect_url = f"{redirect_url}?already_member=true"
+                redirect_url = f'{redirect_url}?already_member=true'
 
         except EmailMismatchError as e:
             logger.warning(
-                "Email mismatch during auth callback invitation acceptance",
-                extra={"user_id": user_id, "error": str(e)},
+                'Email mismatch during auth callback invitation acceptance',
+                extra={'user_id': user_id, 'error': str(e)},
             )
-            if "?" in redirect_url:
-                redirect_url = f"{redirect_url}&email_mismatch=true"
+            if '?' in redirect_url:
+                redirect_url = f'{redirect_url}&email_mismatch=true'
             else:
-                redirect_url = f"{redirect_url}?email_mismatch=true"
+                redirect_url = f'{redirect_url}?email_mismatch=true'
 
         except Exception as e:
             logger.exception(
-                "Unexpected error processing invitation during auth callback",
-                extra={"user_id": user_id, "error": str(e)},
+                'Unexpected error processing invitation during auth callback',
+                extra={'user_id': user_id, 'error': str(e)},
             )
             # Don't fail the login if invitation processing fails
-            if "?" in redirect_url:
-                redirect_url = f"{redirect_url}&invitation_error=true"
+            if '?' in redirect_url:
+                redirect_url = f'{redirect_url}&invitation_error=true'
             else:
-                redirect_url = f"{redirect_url}?invitation_error=true"
+                redirect_url = f'{redirect_url}?invitation_error=true'
 
     # If the user hasn't accepted the TOS, redirect to the TOS page
     if not has_accepted_tos:
-        encoded_redirect_url = quote(redirect_url, safe="")
-        tos_redirect_url = f"{web_url}/accept-tos?redirect_url={encoded_redirect_url}"
+        encoded_redirect_url = quote(redirect_url, safe='')
+        tos_redirect_url = f'{web_url}/accept-tos?redirect_url={encoded_redirect_url}'
         if invitation_token:
-            tos_redirect_url = f"{tos_redirect_url}&invitation_success=true"
+            tos_redirect_url = f'{tos_redirect_url}&invitation_success=true'
         response = RedirectResponse(tos_redirect_url, status_code=302)
     else:
         if invitation_token:
-            redirect_url = f"{redirect_url}&invitation_success=true"
+            redirect_url = f'{redirect_url}&invitation_success=true'
         response = RedirectResponse(redirect_url, status_code=302)
 
     set_response_cookie(
@@ -471,7 +471,7 @@ async def keycloak_callback(
         response=response,
         keycloak_access_token=keycloak_access_token,
         keycloak_refresh_token=keycloak_refresh_token,
-        secure=True if redirect_url.startswith("https") else False,
+        secure=True if redirect_url.startswith('https') else False,
         accepted_tos=has_accepted_tos,
     )
 
@@ -482,17 +482,17 @@ async def keycloak_callback(
     return response
 
 
-@oauth_router.get("/keycloak/offline/callback")
+@oauth_router.get('/keycloak/offline/callback')
 async def keycloak_offline_callback(code: str, state: str, request: Request):
     if not code:
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
-            content={"error": "Missing code in request params"},
+            content={'error': 'Missing code in request params'},
         )
 
     web_url = get_web_url(request)
     redirect_uri = web_url + request.url.path
-    logger.debug(f"code: {code}, redirect_uri: {redirect_uri}")
+    logger.debug(f'code: {code}, redirect_uri: {redirect_uri}')
 
     (
         keycloak_access_token,
@@ -501,11 +501,11 @@ async def keycloak_offline_callback(code: str, state: str, request: Request):
     if not keycloak_access_token or not keycloak_refresh_token:
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
-            content={"error": "Problem retrieving Keycloak tokens"},
+            content={'error': 'Problem retrieving Keycloak tokens'},
         )
 
     user_info = await token_manager.get_user_info(keycloak_access_token)
-    logger.debug(f"user_info: {user_info}")
+    logger.debug(f'user_info: {user_info}')
     # sub is a required field in KeycloakUserInfo, validation happens in get_user_info
 
     await token_manager.store_offline_token(
@@ -516,32 +516,32 @@ async def keycloak_offline_callback(code: str, state: str, request: Request):
     return RedirectResponse(redirect_url if redirect_url else web_url, status_code=302)
 
 
-@oauth_router.get("/github/callback")
+@oauth_router.get('/github/callback')
 async def github_dummy_callback(request: Request):
     """Callback for GitHub that just forwards the user to the app base URL."""
     web_url = get_web_url(request)
     return RedirectResponse(web_url, status_code=302)
 
 
-@api_router.post("/authenticate")
+@api_router.post('/authenticate')
 async def authenticate(request: Request):
     try:
         await get_access_token(request)
         return JSONResponse(
-            status_code=status.HTTP_200_OK, content={"message": "User authenticated"}
+            status_code=status.HTTP_200_OK, content={'message': 'User authenticated'}
         )
     except Exception:
         # For any error during authentication, clear the auth cookie and return 401
         response = JSONResponse(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            content={"error": "User is not authenticated"},
+            content={'error': 'User is not authenticated'},
         )
 
         # Delete the auth cookie if it exists
-        keycloak_auth_cookie = request.cookies.get("keycloak_auth")
+        keycloak_auth_cookie = request.cookies.get('keycloak_auth')
         if keycloak_auth_cookie:
             response.delete_cookie(
-                key="keycloak_auth",
+                key='keycloak_auth',
                 domain=get_cookie_domain(),
                 samesite=get_cookie_samesite(),
             )
@@ -549,7 +549,7 @@ async def authenticate(request: Request):
         return response
 
 
-@api_router.post("/accept_tos")
+@api_router.post('/accept_tos')
 async def accept_tos(request: Request):
     user_auth = cast(SaasUserAuth, await get_user_auth(request))
     access_token = await user_auth.get_access_token()
@@ -558,17 +558,17 @@ async def accept_tos(request: Request):
 
     if not access_token or not refresh_token or not user_id:
         logger.warning(
-            f"accept_tos: One or more is None: access_token {access_token}, refresh_token {refresh_token}, user_id {user_id}"
+            f'accept_tos: One or more is None: access_token {access_token}, refresh_token {refresh_token}, user_id {user_id}'
         )
         return JSONResponse(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            content={"error": "User is not authenticated"},
+            content={'error': 'User is not authenticated'},
         )
 
     # Get redirect URL from request body
     body = await request.json()
     web_url = get_web_url(request)
-    redirect_url = body.get("redirect_url", str(web_url))
+    redirect_url = body.get('redirect_url', str(web_url))
 
     # Update user settings with TOS acceptance
     accepted_tos: datetime = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -579,18 +579,18 @@ async def accept_tos(request: Request):
         user = result.scalar_one_or_none()
         if not user:
             await session.rollback()
-            logger.error("User for {user_id} not found.")
+            logger.error('User for {user_id} not found.')
             return JSONResponse(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                content={"error": "User does not exist"},
+                content={'error': 'User does not exist'},
             )
         user.accepted_tos = accepted_tos
         await session.commit()
 
-        logger.info(f"User {user_id} accepted TOS")
+        logger.info(f'User {user_id} accepted TOS')
 
     response = JSONResponse(
-        status_code=status.HTTP_200_OK, content={"redirect_url": redirect_url}
+        status_code=status.HTTP_200_OK, content={'redirect_url': redirect_url}
     )
 
     set_response_cookie(
@@ -604,17 +604,17 @@ async def accept_tos(request: Request):
     return response
 
 
-@api_router.post("/logout")
+@api_router.post('/logout')
 async def logout(request: Request):
     # Always create the response object first to ensure we can return it even if errors occur
     response = JSONResponse(
         status_code=status.HTTP_200_OK,
-        content={"message": "User logged out"},
+        content={'message': 'User logged out'},
     )
 
     # Always delete the cookie regardless of what happens
     response.delete_cookie(
-        key="keycloak_auth",
+        key='keycloak_auth',
         domain=get_cookie_domain(),
         samesite=get_cookie_samesite(),
     )
@@ -627,13 +627,13 @@ async def logout(request: Request):
             await token_manager.logout(refresh_token)
     except Exception as e:
         # Log any errors but don't fail the request
-        logger.debug(f"Error during logout: {str(e)}")
+        logger.debug(f'Error during logout: {str(e)}')
         # We still want to clear the cookie and return success
 
     return response
 
 
-@api_router.get("/me")
+@api_router.get('/me')
 async def get_current_user(request: Request):
     """Get current authenticated user information including org role and permissions."""
     try:
@@ -641,14 +641,14 @@ async def get_current_user(request: Request):
     except Exception:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="User not authenticated",
+            detail='User not authenticated',
         )
 
     user_id = await user_auth.get_user_id()
     if not user_id:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="User not authenticated",
+            detail='User not authenticated',
         )
 
     email = await user_auth.get_user_email()
@@ -658,7 +658,7 @@ async def get_current_user(request: Request):
     if not user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="User not found",
+            detail='User not found',
         )
 
     from server.auth.authorization import get_role_permissions, get_user_org_role
@@ -669,7 +669,7 @@ async def get_current_user(request: Request):
     if not org:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Organization not found",
+            detail='Organization not found',
         )
 
     # Get user's role in the current org
@@ -685,30 +685,30 @@ async def get_current_user(request: Request):
     return JSONResponse(
         status_code=status.HTTP_200_OK,
         content={
-            "user_id": user_id,
-            "email": email,
-            "org_id": str(user.current_org_id),
-            "org_name": org.name,
-            "role": role_name,
-            "permissions": permissions,
+            'user_id': user_id,
+            'email': email,
+            'org_id': str(user.current_org_id),
+            'org_name': org.name,
+            'role': role_name,
+            'permissions': permissions,
         },
     )
 
 
-@api_router.get("/refresh-tokens", response_model=TokenResponse)
+@api_router.get('/refresh-tokens', response_model=TokenResponse)
 async def refresh_tokens(
     request: Request,
     provider: ProviderType,
     sid: str,
-    x_session_api_key: Annotated[str | None, Header(alias="X-Session-API-Key")],
+    x_session_api_key: Annotated[str | None, Header(alias='X-Session-API-Key')],
 ) -> TokenResponse:
     """Return the latest token for a given provider."""
     user_id = _get_user_id(sid)
     session_api_key = await _get_session_api_key(user_id, sid)
     if session_api_key != x_session_api_key:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Forbidden')
 
-    logger.info(f"Refreshing token for conversation {sid}")
+    logger.info(f'Refreshing token for conversation {sid}')
     provider_handler = ProviderHandler(
         create_provider_tokens_object([provider]), external_auth_id=user_id
     )

--- a/enterprise/tests/unit/test_auth_routes.py
+++ b/enterprise/tests/unit/test_auth_routes.py
@@ -37,10 +37,10 @@ def create_mock_user_authorizer(success: bool = True, error_detail: str | None =
 def mock_request():
     request = MagicMock(spec=Request)
     request.url = MagicMock()
-    request.url.hostname = 'localhost'
-    request.url.netloc = 'localhost:8000'
-    request.url.path = '/oauth/keycloak/callback'
-    request.base_url = 'http://localhost:8000/'
+    request.url.hostname = "localhost"
+    request.url.netloc = "localhost:8000"
+    request.url.path = "/oauth/keycloak/callback"
+    request.base_url = "http://localhost:8000/"
     request.headers = {}
     request.cookies = {}
     return request
@@ -55,17 +55,17 @@ def test_set_response_cookie(mock_response, mock_request):
     """Test setting the auth cookie on a response."""
 
     with (
-        patch('server.routes.auth.config') as mock_config,
-        patch('server.utils.url_utils.get_global_config') as get_global_config,
+        patch("server.routes.auth.config") as mock_config,
+        patch("server.utils.url_utils.get_global_config") as get_global_config,
     ):
-        mock_config.jwt_secret.get_secret_value.return_value = 'test_secret'
-        get_global_config.return_value = MagicMock(web_url='https://example.com')
+        mock_config.jwt_secret.get_secret_value.return_value = "test_secret"
+        get_global_config.return_value = MagicMock(web_url="https://example.com")
 
         set_response_cookie(
             request=mock_request,
             response=mock_response,
-            keycloak_access_token='test_access_token',
-            keycloak_refresh_token='test_refresh_token',
+            keycloak_access_token="test_access_token",
+            keycloak_refresh_token="test_refresh_token",
             secure=True,
             accepted_tos=True,
         )
@@ -73,18 +73,18 @@ def test_set_response_cookie(mock_response, mock_request):
         mock_response.set_cookie.assert_called_once()
         args, kwargs = mock_response.set_cookie.call_args
 
-        assert kwargs['key'] == 'keycloak_auth'
-        assert 'value' in kwargs
-        assert kwargs['httponly'] is True
-        assert kwargs['secure'] is True
-        assert kwargs['samesite'] == 'strict'
-        assert kwargs['domain'] == 'example.com'
+        assert kwargs["key"] == "keycloak_auth"
+        assert "value" in kwargs
+        assert kwargs["httponly"] is True
+        assert kwargs["secure"] is True
+        assert kwargs["samesite"] == "strict"
+        assert kwargs["domain"] == "example.com"
 
         # Verify the JWT token contains the correct data
-        token_data = jwt.decode(kwargs['value'], 'test_secret', algorithms=['HS256'])
-        assert token_data['access_token'] == 'test_access_token'
-        assert token_data['refresh_token'] == 'test_refresh_token'
-        assert token_data['accepted_tos'] is True
+        token_data = jwt.decode(kwargs["value"], "test_secret", algorithms=["HS256"])
+        assert token_data["access_token"] == "test_access_token"
+        assert token_data["refresh_token"] == "test_refresh_token"
+        assert token_data["accepted_tos"] is True
 
 
 @pytest.mark.asyncio
@@ -92,14 +92,14 @@ async def test_keycloak_callback_missing_code(mock_request):
     """Test keycloak_callback with missing code."""
     with pytest.raises(HTTPException) as exc_info:
         await keycloak_callback(
-            code='',
-            state='test_state',
+            code="",
+            state="test_state",
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
 
     assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
-    assert 'Missing code' in exc_info.value.detail
+    assert "Missing code" in exc_info.value.detail
 
 
 @pytest.mark.asyncio
@@ -107,18 +107,18 @@ async def test_keycloak_callback_token_retrieval_failure(mock_request):
     """Test keycloak_callback when token retrieval fails."""
     get_keycloak_tokens_mock = AsyncMock(return_value=(None, None))
     with patch(
-        'server.routes.auth.token_manager.get_keycloak_tokens', get_keycloak_tokens_mock
+        "server.routes.auth.token_manager.get_keycloak_tokens", get_keycloak_tokens_mock
     ):
         with pytest.raises(HTTPException) as exc_info:
             await keycloak_callback(
-                code='test_code',
-                state='test_state',
+                code="test_code",
+                state="test_state",
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
             )
 
         assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
-        assert 'Problem retrieving Keycloak tokens' in exc_info.value.detail
+        assert "Problem retrieving Keycloak tokens" in exc_info.value.detail
         get_keycloak_tokens_mock.assert_called_once()
 
 
@@ -133,17 +133,17 @@ async def test_keycloak_callback_user_not_authorized(
 ):
     """Test keycloak_callback when user authorization fails."""
     with (
-        patch('server.routes.auth.token_manager') as mock_token_manager,
-        patch('server.routes.auth.UserStore') as mock_user_store,
+        patch("server.routes.auth.token_manager") as mock_token_manager,
+        patch("server.routes.auth.UserStore") as mock_user_store,
     ):
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=('test_access_token', 'test_refresh_token')
+            return_value=("test_access_token", "test_refresh_token")
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub='test_user_id',
-                preferred_username='test_user',
-                identity_provider='github',
+                sub="test_user_id",
+                preferred_username="test_user",
+                identity_provider="github",
                 email_verified=True,
             )
         )
@@ -151,8 +151,8 @@ async def test_keycloak_callback_user_not_authorized(
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = 'test_user_id'
-        mock_user.current_org_id = 'test_org_id'
+        mock_user.id = "test_user_id"
+        mock_user.current_org_id = "test_org_id"
         mock_user.accepted_tos = None
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
@@ -162,19 +162,19 @@ async def test_keycloak_callback_user_not_authorized(
 
         # Create mock user authorizer that denies authorization
         mock_authorizer = create_mock_user_authorizer(
-            success=False, error_detail='blocked'
+            success=False, error_detail="blocked"
         )
 
         with pytest.raises(HTTPException) as exc_info:
             await keycloak_callback(
-                code='test_code',
-                state='test_state',
+                code="test_code",
+                state="test_state",
                 request=mock_request,
                 user_authorizer=mock_authorizer,
             )
 
         assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert exc_info.value.detail == 'blocked'
+        assert exc_info.value.detail == "blocked"
 
 
 @pytest.mark.asyncio
@@ -183,16 +183,16 @@ async def test_keycloak_callback_success_with_valid_offline_token(
 ):
     """Test successful keycloak_callback with valid offline token."""
     with (
-        patch('server.routes.auth.token_manager') as mock_token_manager,
-        patch('server.routes.auth.set_response_cookie') as mock_set_cookie,
-        patch('server.routes.auth.UserStore') as mock_user_store,
-        patch('server.routes.auth.posthog') as mock_posthog,
+        patch("server.routes.auth.token_manager") as mock_token_manager,
+        patch("server.routes.auth.set_response_cookie") as mock_set_cookie,
+        patch("server.routes.auth.UserStore") as mock_user_store,
+        patch("server.routes.auth.posthog") as mock_posthog,
     ):
         # Mock user with accepted_tos
         mock_user = MagicMock()
-        mock_user.id = 'test_user_id'
-        mock_user.current_org_id = 'test_org_id'
-        mock_user.accepted_tos = '2025-01-01'
+        mock_user.id = "test_user_id"
+        mock_user.current_org_id = "test_org_id"
+        mock_user.accepted_tos = "2025-01-01"
 
         # Setup UserStore mocks
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
@@ -202,13 +202,13 @@ async def test_keycloak_callback_success_with_valid_offline_token(
         mock_user_store.backfill_user_email = AsyncMock()
 
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=('test_access_token', 'test_refresh_token')
+            return_value=("test_access_token", "test_refresh_token")
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub='test_user_id',
-                preferred_username='test_user',
-                identity_provider='github',
+                sub="test_user_id",
+                preferred_username="test_user",
+                identity_provider="github",
                 email_verified=True,
             )
         )
@@ -216,24 +216,24 @@ async def test_keycloak_callback_success_with_valid_offline_token(
         mock_token_manager.validate_offline_token = AsyncMock(return_value=True)
 
         result = await keycloak_callback(
-            code='test_code',
-            state='test_state',
+            code="test_code",
+            state="test_state",
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
 
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 302
-        assert result.headers['location'] == 'test_state'
+        assert result.headers["location"] == "test_state"
 
         mock_token_manager.store_idp_tokens.assert_called_once_with(
-            ProviderType.GITHUB, 'test_user_id', 'test_access_token'
+            ProviderType.GITHUB, "test_user_id", "test_access_token"
         )
         mock_set_cookie.assert_called_once_with(
             request=mock_request,
             response=result,
-            keycloak_access_token='test_access_token',
-            keycloak_refresh_token='test_refresh_token',
+            keycloak_access_token="test_access_token",
+            keycloak_refresh_token="test_refresh_token",
             secure=False,
             accepted_tos=True,
         )
@@ -249,19 +249,19 @@ async def test_keycloak_callback_email_not_verified(
     mock_verify_email = AsyncMock()
     mock_rate_limit = AsyncMock()
     with (
-        patch('server.routes.auth.token_manager') as mock_token_manager,
-        patch('server.routes.email.verify_email', mock_verify_email),
-        patch('server.routes.auth.check_rate_limit_by_user_id', mock_rate_limit),
-        patch('server.routes.auth.UserStore') as mock_user_store,
+        patch("server.routes.auth.token_manager") as mock_token_manager,
+        patch("server.routes.email.verify_email", mock_verify_email),
+        patch("server.routes.auth.check_rate_limit_by_user_id", mock_rate_limit),
+        patch("server.routes.auth.UserStore") as mock_user_store,
     ):
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=('test_access_token', 'test_refresh_token')
+            return_value=("test_access_token", "test_refresh_token")
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub='test_user_id',
-                preferred_username='test_user',
-                identity_provider='github',
+                sub="test_user_id",
+                preferred_username="test_user",
+                identity_provider="github",
                 email_verified=False,
             )
         )
@@ -269,8 +269,8 @@ async def test_keycloak_callback_email_not_verified(
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = 'test_user_id'
-        mock_user.current_org_id = 'test_org_id'
+        mock_user.id = "test_user_id"
+        mock_user.current_org_id = "test_org_id"
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
         mock_user_store.backfill_contact_name = AsyncMock()
@@ -278,8 +278,8 @@ async def test_keycloak_callback_email_not_verified(
 
         # Act
         result = await keycloak_callback(
-            code='test_code',
-            state='test_state',
+            code="test_code",
+            state="test_state",
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
@@ -287,16 +287,16 @@ async def test_keycloak_callback_email_not_verified(
         # Assert
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 302
-        assert 'email_verification_required=true' in result.headers['location']
-        assert 'user_id=test_user_id' in result.headers['location']
+        assert "email_verification_required=true" in result.headers["location"]
+        assert "user_id=test_user_id" in result.headers["location"]
         mock_verify_email.assert_called_once_with(
-            request=mock_request, user_id='test_user_id', is_auth_flow=True
+            request=mock_request, user_id="test_user_id", is_auth_flow=True
         )
         # Verify rate limit was checked
         mock_rate_limit.assert_called_once_with(
             request=mock_request,
-            key_prefix='auth_verify_email',
-            user_id='test_user_id',
+            key_prefix="auth_verify_email",
+            user_id="test_user_id",
             user_rate_limit_seconds=60,
             ip_rate_limit_seconds=120,
         )
@@ -311,19 +311,19 @@ async def test_keycloak_callback_email_not_verified_missing_field(
     mock_verify_email = AsyncMock()
     mock_rate_limit = AsyncMock()
     with (
-        patch('server.routes.auth.token_manager') as mock_token_manager,
-        patch('server.routes.email.verify_email', mock_verify_email),
-        patch('server.routes.auth.check_rate_limit_by_user_id', mock_rate_limit),
-        patch('server.routes.auth.UserStore') as mock_user_store,
+        patch("server.routes.auth.token_manager") as mock_token_manager,
+        patch("server.routes.email.verify_email", mock_verify_email),
+        patch("server.routes.auth.check_rate_limit_by_user_id", mock_rate_limit),
+        patch("server.routes.auth.UserStore") as mock_user_store,
     ):
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=('test_access_token', 'test_refresh_token')
+            return_value=("test_access_token", "test_refresh_token")
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub='test_user_id',
-                preferred_username='test_user',
-                identity_provider='github',
+                sub="test_user_id",
+                preferred_username="test_user",
+                identity_provider="github",
                 # email_verified field is missing
             )
         )
@@ -331,8 +331,8 @@ async def test_keycloak_callback_email_not_verified_missing_field(
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = 'test_user_id'
-        mock_user.current_org_id = 'test_org_id'
+        mock_user.id = "test_user_id"
+        mock_user.current_org_id = "test_org_id"
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
         mock_user_store.backfill_contact_name = AsyncMock()
@@ -340,8 +340,8 @@ async def test_keycloak_callback_email_not_verified_missing_field(
 
         # Act
         result = await keycloak_callback(
-            code='test_code',
-            state='test_state',
+            code="test_code",
+            state="test_state",
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
@@ -349,10 +349,10 @@ async def test_keycloak_callback_email_not_verified_missing_field(
         # Assert
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 302
-        assert 'email_verification_required=true' in result.headers['location']
-        assert 'user_id=test_user_id' in result.headers['location']
+        assert "email_verification_required=true" in result.headers["location"]
+        assert "user_id=test_user_id" in result.headers["location"]
         mock_verify_email.assert_called_once_with(
-            request=mock_request, user_id='test_user_id', is_auth_flow=True
+            request=mock_request, user_id="test_user_id", is_auth_flow=True
         )
 
 
@@ -372,23 +372,23 @@ async def test_keycloak_callback_email_verification_rate_limited(
     mock_rate_limit = AsyncMock(
         side_effect=HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-            detail='Too many requests. Please wait 1 minute before trying again.',
+            detail="Too many requests. Please wait 1 minute before trying again.",
         )
     )
     with (
-        patch('server.routes.auth.token_manager') as mock_token_manager,
-        patch('server.routes.email.verify_email', mock_verify_email),
-        patch('server.routes.auth.check_rate_limit_by_user_id', mock_rate_limit),
-        patch('server.routes.auth.UserStore') as mock_user_store,
+        patch("server.routes.auth.token_manager") as mock_token_manager,
+        patch("server.routes.email.verify_email", mock_verify_email),
+        patch("server.routes.auth.check_rate_limit_by_user_id", mock_rate_limit),
+        patch("server.routes.auth.UserStore") as mock_user_store,
     ):
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=('test_access_token', 'test_refresh_token')
+            return_value=("test_access_token", "test_refresh_token")
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub='test_user_id',
-                preferred_username='test_user',
-                identity_provider='github',
+                sub="test_user_id",
+                preferred_username="test_user",
+                identity_provider="github",
                 email_verified=False,
             )
         )
@@ -396,8 +396,8 @@ async def test_keycloak_callback_email_verification_rate_limited(
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = 'test_user_id'
-        mock_user.current_org_id = 'test_org_id'
+        mock_user.id = "test_user_id"
+        mock_user.current_org_id = "test_org_id"
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
         mock_user_store.backfill_contact_name = AsyncMock()
@@ -405,8 +405,8 @@ async def test_keycloak_callback_email_verification_rate_limited(
 
         # Act
         result = await keycloak_callback(
-            code='test_code',
-            state='test_state',
+            code="test_code",
+            state="test_state",
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
@@ -414,11 +414,11 @@ async def test_keycloak_callback_email_verification_rate_limited(
         # Assert - should still redirect to verification page but NOT send email
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 302
-        assert 'email_verification_required=true' in result.headers['location']
-        assert 'user_id=test_user_id' in result.headers['location']
+        assert "email_verification_required=true" in result.headers["location"]
+        assert "user_id=test_user_id" in result.headers["location"]
         # When rate limited, the redirect URL should include rate_limited=true
         # so the frontend can show an appropriate message
-        assert 'rate_limited=true' in result.headers['location']
+        assert "rate_limited=true" in result.headers["location"]
         # verify_email should NOT have been called due to rate limit
         mock_verify_email.assert_not_called()
         mock_rate_limit.assert_called_once()
@@ -430,21 +430,21 @@ async def test_keycloak_callback_success_without_offline_token(
 ):
     """Test successful keycloak_callback without valid offline token."""
     with (
-        patch('server.routes.auth.token_manager') as mock_token_manager,
-        patch('server.routes.auth.set_response_cookie') as mock_set_cookie,
+        patch("server.routes.auth.token_manager") as mock_token_manager,
+        patch("server.routes.auth.set_response_cookie") as mock_set_cookie,
         patch(
-            'server.routes.auth.KEYCLOAK_SERVER_URL_EXT', 'https://keycloak.example.com'
+            "server.routes.auth.KEYCLOAK_SERVER_URL_EXT", "https://keycloak.example.com"
         ),
-        patch('server.routes.auth.KEYCLOAK_REALM_NAME', 'test-realm'),
-        patch('server.routes.auth.KEYCLOAK_CLIENT_ID', 'test-client'),
-        patch('server.routes.auth.UserStore') as mock_user_store,
-        patch('server.routes.auth.posthog') as mock_posthog,
+        patch("server.routes.auth.KEYCLOAK_REALM_NAME", "test-realm"),
+        patch("server.routes.auth.KEYCLOAK_CLIENT_ID", "test-client"),
+        patch("server.routes.auth.UserStore") as mock_user_store,
+        patch("server.routes.auth.posthog") as mock_posthog,
     ):
         # Mock user with accepted_tos
         mock_user = MagicMock()
-        mock_user.id = 'test_user_id'
-        mock_user.current_org_id = 'test_org_id'
-        mock_user.accepted_tos = '2025-01-01'
+        mock_user.id = "test_user_id"
+        mock_user.current_org_id = "test_org_id"
+        mock_user.accepted_tos = "2025-01-01"
 
         # Setup UserStore mocks
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
@@ -454,13 +454,13 @@ async def test_keycloak_callback_success_without_offline_token(
         mock_user_store.backfill_user_email = AsyncMock()
 
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=('test_access_token', 'test_refresh_token')
+            return_value=("test_access_token", "test_refresh_token")
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub='test_user_id',
-                preferred_username='test_user',
-                identity_provider='github',
+                sub="test_user_id",
+                preferred_username="test_user",
+                identity_provider="github",
                 email_verified=True,
             )
         )
@@ -469,8 +469,8 @@ async def test_keycloak_callback_success_without_offline_token(
         mock_token_manager.validate_offline_token = AsyncMock(return_value=False)
 
         result = await keycloak_callback(
-            code='test_code',
-            state='test_state',
+            code="test_code",
+            state="test_state",
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
@@ -478,19 +478,19 @@ async def test_keycloak_callback_success_without_offline_token(
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 302
         # In this case, we should be redirected to the Keycloak offline token URL
-        assert 'keycloak.example.com' in result.headers['location']
-        assert 'offline_access' in result.headers['location']
+        assert "keycloak.example.com" in result.headers["location"]
+        assert "offline_access" in result.headers["location"]
 
         mock_token_manager.store_idp_tokens.assert_called_once_with(
-            ProviderType.GITHUB, 'test_user_id', 'test_access_token'
+            ProviderType.GITHUB, "test_user_id", "test_access_token"
         )
         # When redirecting to Keycloak for offline token, redirect_url becomes https://keycloak...
         # so secure=True is expected
         mock_set_cookie.assert_called_once_with(
             request=mock_request,
             response=result,
-            keycloak_access_token='test_access_token',
-            keycloak_refresh_token='test_refresh_token',
+            keycloak_access_token="test_access_token",
+            keycloak_refresh_token="test_refresh_token",
             secure=True,
             accepted_tos=True,
         )
@@ -503,43 +503,43 @@ async def test_keycloak_callback_account_linking_error(mock_request):
     # Test the case where error is 'temporarily_unavailable' and error_description is 'authentication_expired'
     result = await keycloak_callback(
         code=None,
-        state='http://redirect.example.com',
-        error='temporarily_unavailable',
-        error_description='authentication_expired',
+        state="http://redirect.example.com",
+        error="temporarily_unavailable",
+        error_description="authentication_expired",
         request=mock_request,
         user_authorizer=create_mock_user_authorizer(),
     )
 
     assert isinstance(result, RedirectResponse)
     assert result.status_code == 302
-    assert result.headers['location'] == 'http://redirect.example.com'
+    assert result.headers["location"] == "http://redirect.example.com"
 
 
 @pytest.mark.asyncio
 async def test_keycloak_offline_callback_missing_code(mock_request):
     """Test keycloak_offline_callback with missing code."""
-    result = await keycloak_offline_callback('', 'test_state', mock_request)
+    result = await keycloak_offline_callback("", "test_state", mock_request)
 
     assert isinstance(result, JSONResponse)
     assert result.status_code == status.HTTP_400_BAD_REQUEST
-    assert 'error' in result.body.decode()
-    assert 'Missing code' in result.body.decode()
+    assert "error" in result.body.decode()
+    assert "Missing code" in result.body.decode()
 
 
 @pytest.mark.asyncio
 async def test_keycloak_offline_callback_token_retrieval_failure(mock_request):
     """Test keycloak_offline_callback when token retrieval fails."""
-    with patch('server.routes.auth.token_manager') as mock_token_manager:
+    with patch("server.routes.auth.token_manager") as mock_token_manager:
         mock_token_manager.get_keycloak_tokens = AsyncMock(return_value=(None, None))
 
         result = await keycloak_offline_callback(
-            'test_code', 'test_state', mock_request
+            "test_code", "test_state", mock_request
         )
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == status.HTTP_400_BAD_REQUEST
-        assert 'error' in result.body.decode()
-        assert 'Problem retrieving Keycloak tokens' in result.body.decode()
+        assert "error" in result.body.decode()
+        assert "Problem retrieving Keycloak tokens" in result.body.decode()
 
 
 @pytest.mark.asyncio
@@ -547,19 +547,19 @@ async def test_keycloak_offline_callback_missing_user_info(mock_request):
     """Test keycloak_offline_callback when user info is missing required fields."""
     from pydantic import ValidationError
 
-    with patch('server.routes.auth.token_manager') as mock_token_manager:
+    with patch("server.routes.auth.token_manager") as mock_token_manager:
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=('test_access_token', 'test_refresh_token')
+            return_value=("test_access_token", "test_refresh_token")
         )
         # With Pydantic model, missing 'sub' raises ValidationError during get_user_info
         mock_token_manager.get_user_info = AsyncMock(
             side_effect=ValidationError.from_exception_data(
-                'KeycloakUserInfo',
+                "KeycloakUserInfo",
                 [
                     {
-                        'type': 'missing',
-                        'loc': ('sub',),
-                        'input': {'some_field': 'value'},
+                        "type": "missing",
+                        "loc": ("sub",),
+                        "input": {"some_field": "value"},
                     }
                 ],
             )
@@ -567,7 +567,7 @@ async def test_keycloak_offline_callback_missing_user_info(mock_request):
 
         # The endpoint should propagate the error (or handle it gracefully)
         with pytest.raises(ValidationError):
-            await keycloak_offline_callback('test_code', 'test_state', mock_request)
+            await keycloak_offline_callback("test_code", "test_state", mock_request)
 
 
 @pytest.mark.asyncio
@@ -575,55 +575,55 @@ async def test_keycloak_offline_callback_success(
     mock_request, create_keycloak_user_info
 ):
     """Test successful keycloak_offline_callback."""
-    with patch('server.routes.auth.token_manager') as mock_token_manager:
+    with patch("server.routes.auth.token_manager") as mock_token_manager:
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=('test_access_token', 'test_refresh_token')
+            return_value=("test_access_token", "test_refresh_token")
         )
         mock_token_manager.get_user_info = AsyncMock(
-            return_value=create_keycloak_user_info(sub='test_user_id')
+            return_value=create_keycloak_user_info(sub="test_user_id")
         )
         mock_token_manager.store_idp_tokens = AsyncMock()
         mock_token_manager.store_offline_token = AsyncMock()
 
         result = await keycloak_offline_callback(
-            'test_code', 'test_state', mock_request
+            "test_code", "test_state", mock_request
         )
 
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 302
-        assert result.headers['location'] == 'test_state'
+        assert result.headers["location"] == "test_state"
 
         mock_token_manager.store_offline_token.assert_called_once_with(
-            user_id='test_user_id', offline_token='test_refresh_token'
+            user_id="test_user_id", offline_token="test_refresh_token"
         )
 
 
 @pytest.mark.asyncio
 async def test_authenticate_success():
     """Test successful authentication."""
-    with patch('server.routes.auth.get_access_token') as mock_get_token:
-        mock_get_token.return_value = 'test_access_token'
+    with patch("server.routes.auth.get_access_token") as mock_get_token:
+        mock_get_token.return_value = "test_access_token"
 
         result = await authenticate(MagicMock())
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == status.HTTP_200_OK
-        assert 'message' in result.body.decode()
-        assert 'User authenticated' in result.body.decode()
+        assert "message" in result.body.decode()
+        assert "User authenticated" in result.body.decode()
 
 
 @pytest.mark.asyncio
 async def test_authenticate_failure():
     """Test authentication failure."""
-    with patch('server.routes.auth.get_access_token') as mock_get_token:
+    with patch("server.routes.auth.get_access_token") as mock_get_token:
         mock_get_token.side_effect = AuthError()
 
         result = await authenticate(MagicMock())
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == status.HTTP_401_UNAUTHORIZED
-        assert 'error' in result.body.decode()
-        assert 'User is not authenticated' in result.body.decode()
+        assert "error" in result.body.decode()
+        assert "User is not authenticated" in result.body.decode()
 
 
 @pytest.mark.asyncio
@@ -631,21 +631,21 @@ async def test_logout_with_refresh_token():
     """Test logout with refresh token."""
     mock_request = MagicMock()
     mock_request.state.user_auth = SaasUserAuth(
-        refresh_token=SecretStr('test-refresh-token'), user_id='test_user_id'
+        refresh_token=SecretStr("test-refresh-token"), user_id="test_user_id"
     )
 
-    with patch('server.routes.auth.token_manager') as mock_token_manager:
+    with patch("server.routes.auth.token_manager") as mock_token_manager:
         mock_token_manager.logout = AsyncMock()
         result = await logout(mock_request)
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == status.HTTP_200_OK
-        assert 'message' in result.body.decode()
-        assert 'User logged out' in result.body.decode()
+        assert "message" in result.body.decode()
+        assert "User logged out" in result.body.decode()
 
-        mock_token_manager.logout.assert_called_once_with('test-refresh-token')
+        mock_token_manager.logout.assert_called_once_with("test-refresh-token")
         # Cookie should be deleted
-        assert 'set-cookie' in result.headers
+        assert "set-cookie" in result.headers
 
 
 @pytest.mark.asyncio
@@ -654,20 +654,20 @@ async def test_logout_without_refresh_token():
     mock_request = MagicMock(state=MagicMock(user_auth=None))
     # No refresh_token attribute
 
-    with patch('server.routes.auth.token_manager') as mock_token_manager:
+    with patch("server.routes.auth.token_manager") as mock_token_manager:
         with patch(
-            'openhands.server.user_auth.default_user_auth.DefaultUserAuth.get_instance'
+            "openhands.server.user_auth.default_user_auth.DefaultUserAuth.get_instance"
         ) as mock_get_instance:
             mock_get_instance.side_effect = AuthError()
             result = await logout(mock_request)
 
             assert isinstance(result, JSONResponse)
             assert result.status_code == status.HTTP_200_OK
-            assert 'message' in result.body.decode()
-            assert 'User logged out' in result.body.decode()
+            assert "message" in result.body.decode()
+            assert "User logged out" in result.body.decode()
 
             mock_token_manager.logout.assert_not_called()
-            assert 'set-cookie' in result.headers
+            assert "set-cookie" in result.headers
 
 
 @pytest.mark.asyncio
@@ -677,25 +677,25 @@ async def test_keycloak_callback_blocked_email_domain(
     """Test keycloak_callback when user authorization fails (blocked email domain)."""
     # Arrange
     with (
-        patch('server.routes.auth.token_manager') as mock_token_manager,
-        patch('server.routes.auth.UserStore') as mock_user_store,
+        patch("server.routes.auth.token_manager") as mock_token_manager,
+        patch("server.routes.auth.UserStore") as mock_user_store,
     ):
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=('test_access_token', 'test_refresh_token')
+            return_value=("test_access_token", "test_refresh_token")
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub='test_user_id',
-                preferred_username='test_user',
-                email='user@colsch.us',
-                identity_provider='github',
+                sub="test_user_id",
+                preferred_username="test_user",
+                email="user@colsch.us",
+                identity_provider="github",
             )
         )
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = 'test_user_id'
-        mock_user.current_org_id = 'test_org_id'
+        mock_user.id = "test_user_id"
+        mock_user.current_org_id = "test_org_id"
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
         mock_user_store.backfill_contact_name = AsyncMock()
@@ -703,21 +703,21 @@ async def test_keycloak_callback_blocked_email_domain(
 
         # Create mock user authorizer that blocks the user
         mock_authorizer = create_mock_user_authorizer(
-            success=False, error_detail='blocked'
+            success=False, error_detail="blocked"
         )
 
         # Act
         with pytest.raises(HTTPException) as exc_info:
             await keycloak_callback(
-                code='test_code',
-                state='test_state',
+                code="test_code",
+                state="test_state",
                 request=mock_request,
                 user_authorizer=mock_authorizer,
             )
 
         # Assert
         assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert exc_info.value.detail == 'blocked'
+        assert exc_info.value.detail == "blocked"
 
 
 # Note: test_keycloak_callback_allowed_email_domain was simplified as part of
@@ -736,12 +736,12 @@ async def test_keycloak_callback_missing_email(mock_request, create_keycloak_use
     """Test keycloak_callback when user info does not contain email."""
     # Arrange
     with (
-        patch('server.routes.auth.token_manager') as mock_token_manager,
+        patch("server.routes.auth.token_manager") as mock_token_manager,
         patch(
-            'storage.user_authorization_store.UserAuthorizationStore'
+            "storage.user_authorization_store.UserAuthorizationStore"
         ) as mock_user_auth_store,
-        patch('server.routes.auth.a_session_maker') as mock_session_maker,
-        patch('server.routes.auth.UserStore') as mock_user_store,
+        patch("server.routes.auth.a_session_maker") as mock_session_maker,
+        patch("server.routes.auth.UserStore") as mock_user_store,
     ):
         mock_session = MagicMock()
         mock_session_maker.return_value.__enter__.return_value = mock_session
@@ -750,17 +750,17 @@ async def test_keycloak_callback_missing_email(mock_request, create_keycloak_use
         mock_query.filter.return_value = mock_query
 
         mock_user_settings = MagicMock()
-        mock_user_settings.accepted_tos = '2025-01-01'
+        mock_user_settings.accepted_tos = "2025-01-01"
         mock_query.first.return_value = mock_user_settings
 
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=('test_access_token', 'test_refresh_token')
+            return_value=("test_access_token", "test_refresh_token")
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub='test_user_id',
-                preferred_username='test_user',
-                identity_provider='github',
+                sub="test_user_id",
+                preferred_username="test_user",
+                identity_provider="github",
                 email_verified=True,
                 # No email field
             )
@@ -770,9 +770,9 @@ async def test_keycloak_callback_missing_email(mock_request, create_keycloak_use
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = 'test_user_id'
-        mock_user.current_org_id = 'test_org_id'
-        mock_user.accepted_tos = '2025-01-01'
+        mock_user.id = "test_user_id"
+        mock_user.current_org_id = "test_org_id"
+        mock_user.accepted_tos = "2025-01-01"
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
         mock_user_store.backfill_contact_name = AsyncMock()
@@ -780,8 +780,8 @@ async def test_keycloak_callback_missing_email(mock_request, create_keycloak_use
 
         # Act
         result = await keycloak_callback(
-            code='test_code',
-            state='test_state',
+            code="test_code",
+            state="test_state",
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
@@ -803,26 +803,26 @@ async def test_keycloak_callback_duplicate_email_detected(
     failure when a duplicate email is detected.
     """
     with (
-        patch('server.routes.auth.token_manager') as mock_token_manager,
-        patch('server.routes.auth.UserStore') as mock_user_store,
+        patch("server.routes.auth.token_manager") as mock_token_manager,
+        patch("server.routes.auth.UserStore") as mock_user_store,
     ):
         # Arrange
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=('test_access_token', 'test_refresh_token')
+            return_value=("test_access_token", "test_refresh_token")
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub='test_user_id',
-                preferred_username='test_user',
-                email='joe+test@example.com',
-                identity_provider='github',
+                sub="test_user_id",
+                preferred_username="test_user",
+                email="joe+test@example.com",
+                identity_provider="github",
             )
         )
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = 'test_user_id'
-        mock_user.current_org_id = 'test_org_id'
+        mock_user.id = "test_user_id"
+        mock_user.current_org_id = "test_org_id"
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
         mock_user_store.backfill_contact_name = AsyncMock()
@@ -830,20 +830,20 @@ async def test_keycloak_callback_duplicate_email_detected(
 
         # Create mock authorizer that returns duplicate_email error
         mock_authorizer = create_mock_user_authorizer(
-            success=False, error_detail='duplicate_email'
+            success=False, error_detail="duplicate_email"
         )
 
         # Act & Assert - should raise HTTPException with 401
         with pytest.raises(HTTPException) as exc_info:
             await keycloak_callback(
-                code='test_code',
-                state='test_state',
+                code="test_code",
+                state="test_state",
                 request=mock_request,
                 user_authorizer=mock_authorizer,
             )
 
         assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert exc_info.value.detail == 'duplicate_email'
+        assert exc_info.value.detail == "duplicate_email"
 
 
 @pytest.mark.asyncio
@@ -857,19 +857,19 @@ async def test_keycloak_callback_duplicate_email_deletes_new_keycloak_user(
     user should be deleted to prevent orphaned accounts from blocking future sign-ins.
     """
     with (
-        patch('server.routes.auth.token_manager') as mock_token_manager,
-        patch('server.routes.auth.UserStore') as mock_user_store,
+        patch("server.routes.auth.token_manager") as mock_token_manager,
+        patch("server.routes.auth.UserStore") as mock_user_store,
     ):
         # Arrange
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=('test_access_token', 'test_refresh_token')
+            return_value=("test_access_token", "test_refresh_token")
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub='new_user_id',
-                preferred_username='test_user',
-                email='joe+1@example.com',
-                identity_provider='github',
+                sub="new_user_id",
+                preferred_username="test_user",
+                email="joe+1@example.com",
+                identity_provider="github",
             )
         )
         mock_token_manager.delete_keycloak_user = AsyncMock(return_value=True)
@@ -879,22 +879,22 @@ async def test_keycloak_callback_duplicate_email_deletes_new_keycloak_user(
 
         # Create mock authorizer that returns duplicate_email error
         mock_authorizer = create_mock_user_authorizer(
-            success=False, error_detail='duplicate_email'
+            success=False, error_detail="duplicate_email"
         )
 
         # Act & Assert
         with pytest.raises(HTTPException) as exc_info:
             await keycloak_callback(
-                code='test_code',
-                state='test_state',
+                code="test_code",
+                state="test_state",
                 request=mock_request,
                 user_authorizer=mock_authorizer,
             )
 
         assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert exc_info.value.detail == 'duplicate_email'
+        assert exc_info.value.detail == "duplicate_email"
         # Keycloak user should be deleted since user doesn't exist in UserStore
-        mock_token_manager.delete_keycloak_user.assert_called_once_with('new_user_id')
+        mock_token_manager.delete_keycloak_user.assert_called_once_with("new_user_id")
 
 
 @pytest.mark.asyncio
@@ -908,44 +908,44 @@ async def test_keycloak_callback_duplicate_email_preserves_existing_user(
     was disabled), the existing user's Keycloak account should NOT be deleted.
     """
     with (
-        patch('server.routes.auth.token_manager') as mock_token_manager,
-        patch('server.routes.auth.UserStore') as mock_user_store,
+        patch("server.routes.auth.token_manager") as mock_token_manager,
+        patch("server.routes.auth.UserStore") as mock_user_store,
     ):
         # Arrange
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=('test_access_token', 'test_refresh_token')
+            return_value=("test_access_token", "test_refresh_token")
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub='existing_user_id',
-                preferred_username='test_user',
-                email='joe@example.com',
-                identity_provider='github',
+                sub="existing_user_id",
+                preferred_username="test_user",
+                email="joe@example.com",
+                identity_provider="github",
             )
         )
         mock_token_manager.delete_keycloak_user = AsyncMock(return_value=True)
 
         # User EXISTS in UserStore (legitimate existing user)
         mock_existing_user = MagicMock()
-        mock_existing_user.id = 'existing_user_id'
+        mock_existing_user.id = "existing_user_id"
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_existing_user)
 
         # Create mock authorizer that returns duplicate_email error
         mock_authorizer = create_mock_user_authorizer(
-            success=False, error_detail='duplicate_email'
+            success=False, error_detail="duplicate_email"
         )
 
         # Act & Assert
         with pytest.raises(HTTPException) as exc_info:
             await keycloak_callback(
-                code='test_code',
-                state='test_state',
+                code="test_code",
+                state="test_state",
                 request=mock_request,
                 user_authorizer=mock_authorizer,
             )
 
         assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert exc_info.value.detail == 'duplicate_email'
+        assert exc_info.value.detail == "duplicate_email"
         # Keycloak user should NOT be deleted since user exists in UserStore
         mock_token_manager.delete_keycloak_user.assert_not_called()
 
@@ -956,9 +956,9 @@ async def test_keycloak_callback_duplicate_check_exception(
 ):
     """Test keycloak_callback when duplicate check raises exception."""
     with (
-        patch('server.routes.auth.token_manager') as mock_token_manager,
-        patch('server.routes.auth.a_session_maker') as mock_session_maker,
-        patch('server.routes.auth.UserStore') as mock_user_store,
+        patch("server.routes.auth.token_manager") as mock_token_manager,
+        patch("server.routes.auth.a_session_maker") as mock_session_maker,
+        patch("server.routes.auth.UserStore") as mock_user_store,
     ):
         # Arrange
         mock_session = MagicMock()
@@ -967,32 +967,32 @@ async def test_keycloak_callback_duplicate_check_exception(
         mock_session.query.return_value = mock_query
         mock_query.filter.return_value = mock_query
         mock_user_settings = MagicMock()
-        mock_user_settings.accepted_tos = '2025-01-01'
+        mock_user_settings.accepted_tos = "2025-01-01"
         mock_query.first.return_value = mock_user_settings
 
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=('test_access_token', 'test_refresh_token')
+            return_value=("test_access_token", "test_refresh_token")
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub='test_user_id',
-                preferred_username='test_user',
-                email='joe+test@example.com',
-                identity_provider='github',
+                sub="test_user_id",
+                preferred_username="test_user",
+                email="joe+test@example.com",
+                identity_provider="github",
                 email_verified=True,
             )
         )
         mock_token_manager.check_duplicate_base_email = AsyncMock(
-            side_effect=Exception('Check failed')
+            side_effect=Exception("Check failed")
         )
         mock_token_manager.store_idp_tokens = AsyncMock()
         mock_token_manager.validate_offline_token = AsyncMock(return_value=True)
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = 'test_user_id'
-        mock_user.current_org_id = 'test_org_id'
-        mock_user.accepted_tos = '2025-01-01'
+        mock_user.id = "test_user_id"
+        mock_user.current_org_id = "test_org_id"
+        mock_user.accepted_tos = "2025-01-01"
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
         mock_user_store.backfill_contact_name = AsyncMock()
@@ -1000,8 +1000,8 @@ async def test_keycloak_callback_duplicate_check_exception(
 
         # Act
         result = await keycloak_callback(
-            code='test_code',
-            state='test_state',
+            code="test_code",
+            state="test_state",
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
@@ -1022,9 +1022,9 @@ async def test_keycloak_callback_no_duplicate_email(
     This test verifies the normal flow when authorization is successful.
     """
     with (
-        patch('server.routes.auth.token_manager') as mock_token_manager,
-        patch('server.routes.auth.a_session_maker') as mock_session_maker,
-        patch('server.routes.auth.UserStore') as mock_user_store,
+        patch("server.routes.auth.token_manager") as mock_token_manager,
+        patch("server.routes.auth.a_session_maker") as mock_session_maker,
+        patch("server.routes.auth.UserStore") as mock_user_store,
     ):
         # Arrange
         mock_session = MagicMock()
@@ -1033,18 +1033,18 @@ async def test_keycloak_callback_no_duplicate_email(
         mock_session.query.return_value = mock_query
         mock_query.filter.return_value = mock_query
         mock_user_settings = MagicMock()
-        mock_user_settings.accepted_tos = '2025-01-01'
+        mock_user_settings.accepted_tos = "2025-01-01"
         mock_query.first.return_value = mock_user_settings
 
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=('test_access_token', 'test_refresh_token')
+            return_value=("test_access_token", "test_refresh_token")
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub='test_user_id',
-                preferred_username='test_user',
-                email='joe+test@example.com',
-                identity_provider='github',
+                sub="test_user_id",
+                preferred_username="test_user",
+                email="joe+test@example.com",
+                identity_provider="github",
                 email_verified=True,
             )
         )
@@ -1053,9 +1053,9 @@ async def test_keycloak_callback_no_duplicate_email(
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = 'test_user_id'
-        mock_user.current_org_id = 'test_org_id'
-        mock_user.accepted_tos = '2025-01-01'
+        mock_user.id = "test_user_id"
+        mock_user.current_org_id = "test_org_id"
+        mock_user.accepted_tos = "2025-01-01"
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
         mock_user_store.backfill_contact_name = AsyncMock()
@@ -1063,8 +1063,8 @@ async def test_keycloak_callback_no_duplicate_email(
 
         # Act - use successful authorizer (no duplicate detected)
         result = await keycloak_callback(
-            code='test_code',
-            state='test_state',
+            code="test_code",
+            state="test_state",
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(success=True),
         )
@@ -1080,9 +1080,9 @@ async def test_keycloak_callback_no_email_in_user_info(
 ):
     """Test keycloak_callback when email is not in user_info."""
     with (
-        patch('server.routes.auth.token_manager') as mock_token_manager,
-        patch('server.routes.auth.a_session_maker') as mock_session_maker,
-        patch('server.routes.auth.UserStore') as mock_user_store,
+        patch("server.routes.auth.token_manager") as mock_token_manager,
+        patch("server.routes.auth.a_session_maker") as mock_session_maker,
+        patch("server.routes.auth.UserStore") as mock_user_store,
     ):
         # Arrange
         mock_session = MagicMock()
@@ -1091,18 +1091,18 @@ async def test_keycloak_callback_no_email_in_user_info(
         mock_session.query.return_value = mock_query
         mock_query.filter.return_value = mock_query
         mock_user_settings = MagicMock()
-        mock_user_settings.accepted_tos = '2025-01-01'
+        mock_user_settings.accepted_tos = "2025-01-01"
         mock_query.first.return_value = mock_user_settings
 
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=('test_access_token', 'test_refresh_token')
+            return_value=("test_access_token", "test_refresh_token")
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub='test_user_id',
-                preferred_username='test_user',
+                sub="test_user_id",
+                preferred_username="test_user",
                 # No email field
-                identity_provider='github',
+                identity_provider="github",
                 email_verified=True,
             )
         )
@@ -1111,9 +1111,9 @@ async def test_keycloak_callback_no_email_in_user_info(
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = 'test_user_id'
-        mock_user.current_org_id = 'test_org_id'
-        mock_user.accepted_tos = '2025-01-01'
+        mock_user.id = "test_user_id"
+        mock_user.current_org_id = "test_org_id"
+        mock_user.accepted_tos = "2025-01-01"
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
         mock_user_store.backfill_contact_name = AsyncMock()
@@ -1121,8 +1121,8 @@ async def test_keycloak_callback_no_email_in_user_info(
 
         # Act
         result = await keycloak_callback(
-            code='test_code',
-            state='test_state',
+            code="test_code",
+            state="test_state",
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
@@ -1144,8 +1144,8 @@ class TestKeycloakCallbackRecaptcha:
         """Test that login proceeds when reCAPTCHA score is high."""
         # Arrange
         state_data = {
-            'redirect_url': 'https://example.com',
-            'recaptcha_token': 'test-token',
+            "redirect_url": "https://example.com",
+            "recaptcha_token": "test-token",
         }
         encoded_state = base64.urlsafe_b64encode(
             json.dumps(state_data).encode()
@@ -1156,17 +1156,17 @@ class TestKeycloakCallbackRecaptcha:
         mock_assessment_result.score = 0.9
 
         with (
-            patch('server.routes.auth.token_manager') as mock_token_manager,
-            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
-            patch('server.routes.auth.RECAPTCHA_SITE_KEY', 'test-site-key'),
-            patch('server.routes.auth.a_session_maker') as mock_session_maker,
+            patch("server.routes.auth.token_manager") as mock_token_manager,
+            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
+            patch("server.routes.auth.RECAPTCHA_SITE_KEY", "test-site-key"),
+            patch("server.routes.auth.a_session_maker") as mock_session_maker,
             patch(
-                'storage.user_authorization_store.UserAuthorizationStore'
+                "storage.user_authorization_store.UserAuthorizationStore"
             ) as mock_user_auth_store,
-            patch('server.routes.auth.set_response_cookie'),
-            patch('server.routes.auth.posthog'),
-            patch('server.routes.email.verify_email', new_callable=AsyncMock),
-            patch('server.routes.auth.UserStore') as mock_user_store,
+            patch("server.routes.auth.set_response_cookie"),
+            patch("server.routes.auth.posthog"),
+            patch("server.routes.email.verify_email", new_callable=AsyncMock),
+            patch("server.routes.auth.UserStore") as mock_user_store,
         ):
             mock_session = MagicMock()
             mock_session_maker.return_value.__enter__.return_value = mock_session
@@ -1174,18 +1174,18 @@ class TestKeycloakCallbackRecaptcha:
             mock_session.query.return_value = mock_query
             mock_query.filter.return_value = mock_query
             mock_user_settings = MagicMock()
-            mock_user_settings.accepted_tos = '2025-01-01'
+            mock_user_settings.accepted_tos = "2025-01-01"
             mock_query.first.return_value = mock_user_settings
 
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=('test_access_token', 'test_refresh_token')
+                return_value=("test_access_token", "test_refresh_token")
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub='test_user_id',
-                    preferred_username='test_user',
-                    email='user@example.com',
-                    identity_provider='github',
+                    sub="test_user_id",
+                    preferred_username="test_user",
+                    email="user@example.com",
+                    identity_provider="github",
                     email_verified=True,
                 )
             )
@@ -1197,9 +1197,9 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = 'test_user_id'
-            mock_user.current_org_id = 'test_org_id'
-            mock_user.accepted_tos = '2025-01-01'
+            mock_user.id = "test_user_id"
+            mock_user.current_org_id = "test_org_id"
+            mock_user.accepted_tos = "2025-01-01"
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1214,7 +1214,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Act
             result = await keycloak_callback(
-                code='test_code',
+                code="test_code",
                 state=encoded_state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1232,8 +1232,8 @@ class TestKeycloakCallbackRecaptcha:
         """Test that login is blocked and redirected when reCAPTCHA score is low."""
         # Arrange
         state_data = {
-            'redirect_url': 'https://example.com',
-            'recaptcha_token': 'test-token',
+            "redirect_url": "https://example.com",
+            "recaptcha_token": "test-token",
         }
         encoded_state = base64.urlsafe_b64encode(
             json.dumps(state_data).encode()
@@ -1244,22 +1244,22 @@ class TestKeycloakCallbackRecaptcha:
         mock_assessment_result.score = 0.2
 
         with (
-            patch('server.routes.auth.token_manager') as mock_token_manager,
-            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
-            patch('server.routes.auth.RECAPTCHA_SITE_KEY', 'test-site-key'),
+            patch("server.routes.auth.token_manager") as mock_token_manager,
+            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
+            patch("server.routes.auth.RECAPTCHA_SITE_KEY", "test-site-key"),
             patch(
-                'storage.user_authorization_store.UserAuthorizationStore'
+                "storage.user_authorization_store.UserAuthorizationStore"
             ) as mock_user_auth_store,
-            patch('server.routes.auth.UserStore') as mock_user_store,
+            patch("server.routes.auth.UserStore") as mock_user_store,
         ):
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=('test_access_token', 'test_refresh_token')
+                return_value=("test_access_token", "test_refresh_token")
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub='test_user_id',
-                    preferred_username='test_user',
-                    email='user@example.com',
+                    sub="test_user_id",
+                    preferred_username="test_user",
+                    email="user@example.com",
                 )
             )
             mock_token_manager.check_duplicate_base_email = AsyncMock(
@@ -1268,8 +1268,8 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = 'test_user_id'
-            mock_user.current_org_id = 'test_org_id'
+            mock_user.id = "test_user_id"
+            mock_user.current_org_id = "test_org_id"
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1284,7 +1284,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Act
             result = await keycloak_callback(
-                code='test_code',
+                code="test_code",
                 state=encoded_state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1293,7 +1293,7 @@ class TestKeycloakCallbackRecaptcha:
             # Assert
             assert isinstance(result, RedirectResponse)
             assert result.status_code == 302
-            assert 'recaptcha_blocked=true' in result.headers['location']
+            assert "recaptcha_blocked=true" in result.headers["location"]
 
     @pytest.mark.asyncio
     async def test_should_extract_ip_from_x_forwarded_for_header(
@@ -1302,31 +1302,31 @@ class TestKeycloakCallbackRecaptcha:
         """Test that IP is extracted from X-Forwarded-For header when present."""
         # Arrange
         state_data = {
-            'redirect_url': 'https://example.com',
-            'recaptcha_token': 'test-token',
+            "redirect_url": "https://example.com",
+            "recaptcha_token": "test-token",
         }
         encoded_state = base64.urlsafe_b64encode(
             json.dumps(state_data).encode()
         ).decode()
 
-        mock_request.headers = {'X-Forwarded-For': '192.168.1.1, 10.0.0.1'}
+        mock_request.headers = {"X-Forwarded-For": "192.168.1.1, 10.0.0.1"}
         mock_request.client = None
 
         mock_assessment_result = MagicMock()
         mock_assessment_result.allowed = True
 
         with (
-            patch('server.routes.auth.token_manager') as mock_token_manager,
-            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
-            patch('server.routes.auth.RECAPTCHA_SITE_KEY', 'test-site-key'),
+            patch("server.routes.auth.token_manager") as mock_token_manager,
+            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
+            patch("server.routes.auth.RECAPTCHA_SITE_KEY", "test-site-key"),
             patch(
-                'storage.user_authorization_store.UserAuthorizationStore'
+                "storage.user_authorization_store.UserAuthorizationStore"
             ) as mock_user_auth_store,
-            patch('server.routes.auth.a_session_maker') as mock_session_maker,
-            patch('server.routes.auth.set_response_cookie'),
-            patch('server.routes.auth.posthog'),
-            patch('server.routes.email.verify_email', new_callable=AsyncMock),
-            patch('server.routes.auth.UserStore') as mock_user_store,
+            patch("server.routes.auth.a_session_maker") as mock_session_maker,
+            patch("server.routes.auth.set_response_cookie"),
+            patch("server.routes.auth.posthog"),
+            patch("server.routes.email.verify_email", new_callable=AsyncMock),
+            patch("server.routes.auth.UserStore") as mock_user_store,
         ):
             mock_session = MagicMock()
             mock_session_maker.return_value.__enter__.return_value = mock_session
@@ -1334,18 +1334,18 @@ class TestKeycloakCallbackRecaptcha:
             mock_session.query.return_value = mock_query
             mock_query.filter.return_value = mock_query
             mock_user_settings = MagicMock()
-            mock_user_settings.accepted_tos = '2025-01-01'
+            mock_user_settings.accepted_tos = "2025-01-01"
             mock_query.first.return_value = mock_user_settings
 
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=('test_access_token', 'test_refresh_token')
+                return_value=("test_access_token", "test_refresh_token")
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub='test_user_id',
-                    preferred_username='test_user',
-                    email='user@example.com',
-                    identity_provider='github',
+                    sub="test_user_id",
+                    preferred_username="test_user",
+                    email="user@example.com",
+                    identity_provider="github",
                     email_verified=True,
                 )
             )
@@ -1357,9 +1357,9 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = 'test_user_id'
-            mock_user.current_org_id = 'test_org_id'
-            mock_user.accepted_tos = '2025-01-01'
+            mock_user.id = "test_user_id"
+            mock_user.current_org_id = "test_org_id"
+            mock_user.accepted_tos = "2025-01-01"
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1374,7 +1374,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Act
             await keycloak_callback(
-                code='test_code',
+                code="test_code",
                 state=encoded_state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1382,7 +1382,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Assert
             call_args = mock_recaptcha_service.create_assessment.call_args
-            assert call_args[1]['user_ip'] == '192.168.1.1'
+            assert call_args[1]["user_ip"] == "192.168.1.1"
 
     @pytest.mark.asyncio
     async def test_should_use_client_host_when_x_forwarded_for_missing(
@@ -1391,8 +1391,8 @@ class TestKeycloakCallbackRecaptcha:
         """Test that client.host is used when X-Forwarded-For is missing."""
         # Arrange
         state_data = {
-            'redirect_url': 'https://example.com',
-            'recaptcha_token': 'test-token',
+            "redirect_url": "https://example.com",
+            "recaptcha_token": "test-token",
         }
         encoded_state = base64.urlsafe_b64encode(
             json.dumps(state_data).encode()
@@ -1400,23 +1400,23 @@ class TestKeycloakCallbackRecaptcha:
 
         mock_request.headers = {}
         mock_request.client = MagicMock()
-        mock_request.client.host = '192.168.1.2'
+        mock_request.client.host = "192.168.1.2"
 
         mock_assessment_result = MagicMock()
         mock_assessment_result.allowed = True
 
         with (
-            patch('server.routes.auth.token_manager') as mock_token_manager,
-            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
-            patch('server.routes.auth.RECAPTCHA_SITE_KEY', 'test-site-key'),
+            patch("server.routes.auth.token_manager") as mock_token_manager,
+            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
+            patch("server.routes.auth.RECAPTCHA_SITE_KEY", "test-site-key"),
             patch(
-                'storage.user_authorization_store.UserAuthorizationStore'
+                "storage.user_authorization_store.UserAuthorizationStore"
             ) as mock_user_auth_store,
-            patch('server.routes.auth.a_session_maker') as mock_session_maker,
-            patch('server.routes.auth.set_response_cookie'),
-            patch('server.routes.auth.posthog'),
-            patch('server.routes.email.verify_email', new_callable=AsyncMock),
-            patch('server.routes.auth.UserStore') as mock_user_store,
+            patch("server.routes.auth.a_session_maker") as mock_session_maker,
+            patch("server.routes.auth.set_response_cookie"),
+            patch("server.routes.auth.posthog"),
+            patch("server.routes.email.verify_email", new_callable=AsyncMock),
+            patch("server.routes.auth.UserStore") as mock_user_store,
         ):
             mock_session = MagicMock()
             mock_session_maker.return_value.__enter__.return_value = mock_session
@@ -1424,18 +1424,18 @@ class TestKeycloakCallbackRecaptcha:
             mock_session.query.return_value = mock_query
             mock_query.filter.return_value = mock_query
             mock_user_settings = MagicMock()
-            mock_user_settings.accepted_tos = '2025-01-01'
+            mock_user_settings.accepted_tos = "2025-01-01"
             mock_query.first.return_value = mock_user_settings
 
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=('test_access_token', 'test_refresh_token')
+                return_value=("test_access_token", "test_refresh_token")
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub='test_user_id',
-                    preferred_username='test_user',
-                    email='user@example.com',
-                    identity_provider='github',
+                    sub="test_user_id",
+                    preferred_username="test_user",
+                    email="user@example.com",
+                    identity_provider="github",
                     email_verified=True,
                 )
             )
@@ -1447,9 +1447,9 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = 'test_user_id'
-            mock_user.current_org_id = 'test_org_id'
-            mock_user.accepted_tos = '2025-01-01'
+            mock_user.id = "test_user_id"
+            mock_user.current_org_id = "test_org_id"
+            mock_user.accepted_tos = "2025-01-01"
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1464,7 +1464,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Act
             await keycloak_callback(
-                code='test_code',
+                code="test_code",
                 state=encoded_state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1472,7 +1472,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Assert
             call_args = mock_recaptcha_service.create_assessment.call_args
-            assert call_args[1]['user_ip'] == '192.168.1.2'
+            assert call_args[1]["user_ip"] == "192.168.1.2"
 
     @pytest.mark.asyncio
     async def test_should_use_unknown_ip_when_client_is_none(
@@ -1481,8 +1481,8 @@ class TestKeycloakCallbackRecaptcha:
         """Test that 'unknown' IP is used when client is None."""
         # Arrange
         state_data = {
-            'redirect_url': 'https://example.com',
-            'recaptcha_token': 'test-token',
+            "redirect_url": "https://example.com",
+            "recaptcha_token": "test-token",
         }
         encoded_state = base64.urlsafe_b64encode(
             json.dumps(state_data).encode()
@@ -1495,17 +1495,17 @@ class TestKeycloakCallbackRecaptcha:
         mock_assessment_result.allowed = True
 
         with (
-            patch('server.routes.auth.token_manager') as mock_token_manager,
-            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
-            patch('server.routes.auth.RECAPTCHA_SITE_KEY', 'test-site-key'),
+            patch("server.routes.auth.token_manager") as mock_token_manager,
+            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
+            patch("server.routes.auth.RECAPTCHA_SITE_KEY", "test-site-key"),
             patch(
-                'storage.user_authorization_store.UserAuthorizationStore'
+                "storage.user_authorization_store.UserAuthorizationStore"
             ) as mock_user_auth_store,
-            patch('server.routes.auth.a_session_maker') as mock_session_maker,
-            patch('server.routes.auth.set_response_cookie'),
-            patch('server.routes.auth.posthog'),
-            patch('server.routes.email.verify_email', new_callable=AsyncMock),
-            patch('server.routes.auth.UserStore') as mock_user_store,
+            patch("server.routes.auth.a_session_maker") as mock_session_maker,
+            patch("server.routes.auth.set_response_cookie"),
+            patch("server.routes.auth.posthog"),
+            patch("server.routes.email.verify_email", new_callable=AsyncMock),
+            patch("server.routes.auth.UserStore") as mock_user_store,
         ):
             mock_session = MagicMock()
             mock_session_maker.return_value.__enter__.return_value = mock_session
@@ -1513,18 +1513,18 @@ class TestKeycloakCallbackRecaptcha:
             mock_session.query.return_value = mock_query
             mock_query.filter.return_value = mock_query
             mock_user_settings = MagicMock()
-            mock_user_settings.accepted_tos = '2025-01-01'
+            mock_user_settings.accepted_tos = "2025-01-01"
             mock_query.first.return_value = mock_user_settings
 
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=('test_access_token', 'test_refresh_token')
+                return_value=("test_access_token", "test_refresh_token")
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub='test_user_id',
-                    preferred_username='test_user',
-                    email='user@example.com',
-                    identity_provider='github',
+                    sub="test_user_id",
+                    preferred_username="test_user",
+                    email="user@example.com",
+                    identity_provider="github",
                     email_verified=True,
                 )
             )
@@ -1536,9 +1536,9 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = 'test_user_id'
-            mock_user.current_org_id = 'test_org_id'
-            mock_user.accepted_tos = '2025-01-01'
+            mock_user.id = "test_user_id"
+            mock_user.current_org_id = "test_org_id"
+            mock_user.accepted_tos = "2025-01-01"
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1553,7 +1553,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Act
             await keycloak_callback(
-                code='test_code',
+                code="test_code",
                 state=encoded_state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1561,7 +1561,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Assert
             call_args = mock_recaptcha_service.create_assessment.call_args
-            assert call_args[1]['user_ip'] == 'unknown'
+            assert call_args[1]["user_ip"] == "unknown"
 
     @pytest.mark.asyncio
     async def test_should_include_email_in_assessment_when_available(
@@ -1570,8 +1570,8 @@ class TestKeycloakCallbackRecaptcha:
         """Test that email is included in assessment when available."""
         # Arrange
         state_data = {
-            'redirect_url': 'https://example.com',
-            'recaptcha_token': 'test-token',
+            "redirect_url": "https://example.com",
+            "recaptcha_token": "test-token",
         }
         encoded_state = base64.urlsafe_b64encode(
             json.dumps(state_data).encode()
@@ -1581,17 +1581,17 @@ class TestKeycloakCallbackRecaptcha:
         mock_assessment_result.allowed = True
 
         with (
-            patch('server.routes.auth.token_manager') as mock_token_manager,
-            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
-            patch('server.routes.auth.RECAPTCHA_SITE_KEY', 'test-site-key'),
+            patch("server.routes.auth.token_manager") as mock_token_manager,
+            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
+            patch("server.routes.auth.RECAPTCHA_SITE_KEY", "test-site-key"),
             patch(
-                'storage.user_authorization_store.UserAuthorizationStore'
+                "storage.user_authorization_store.UserAuthorizationStore"
             ) as mock_user_auth_store,
-            patch('server.routes.auth.a_session_maker') as mock_session_maker,
-            patch('server.routes.auth.set_response_cookie'),
-            patch('server.routes.auth.posthog'),
-            patch('server.routes.email.verify_email', new_callable=AsyncMock),
-            patch('server.routes.auth.UserStore') as mock_user_store,
+            patch("server.routes.auth.a_session_maker") as mock_session_maker,
+            patch("server.routes.auth.set_response_cookie"),
+            patch("server.routes.auth.posthog"),
+            patch("server.routes.email.verify_email", new_callable=AsyncMock),
+            patch("server.routes.auth.UserStore") as mock_user_store,
         ):
             mock_session = MagicMock()
             mock_session_maker.return_value.__enter__.return_value = mock_session
@@ -1599,18 +1599,18 @@ class TestKeycloakCallbackRecaptcha:
             mock_session.query.return_value = mock_query
             mock_query.filter.return_value = mock_query
             mock_user_settings = MagicMock()
-            mock_user_settings.accepted_tos = '2025-01-01'
+            mock_user_settings.accepted_tos = "2025-01-01"
             mock_query.first.return_value = mock_user_settings
 
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=('test_access_token', 'test_refresh_token')
+                return_value=("test_access_token", "test_refresh_token")
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub='test_user_id',
-                    preferred_username='test_user',
-                    email='user@example.com',
-                    identity_provider='github',
+                    sub="test_user_id",
+                    preferred_username="test_user",
+                    email="user@example.com",
+                    identity_provider="github",
                     email_verified=True,
                 )
             )
@@ -1622,9 +1622,9 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = 'test_user_id'
-            mock_user.current_org_id = 'test_org_id'
-            mock_user.accepted_tos = '2025-01-01'
+            mock_user.id = "test_user_id"
+            mock_user.current_org_id = "test_org_id"
+            mock_user.accepted_tos = "2025-01-01"
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1639,7 +1639,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Act
             await keycloak_callback(
-                code='test_code',
+                code="test_code",
                 state=encoded_state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1647,7 +1647,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Assert
             call_args = mock_recaptcha_service.create_assessment.call_args
-            assert call_args[1]['email'] == 'user@example.com'
+            assert call_args[1]["email"] == "user@example.com"
 
     @pytest.mark.asyncio
     async def test_should_skip_recaptcha_when_site_key_not_configured(
@@ -1656,25 +1656,25 @@ class TestKeycloakCallbackRecaptcha:
         """Test that reCAPTCHA is skipped when RECAPTCHA_SITE_KEY is not configured."""
         # Arrange
         state_data = {
-            'redirect_url': 'https://example.com',
-            'recaptcha_token': 'test-token',
+            "redirect_url": "https://example.com",
+            "recaptcha_token": "test-token",
         }
         encoded_state = base64.urlsafe_b64encode(
             json.dumps(state_data).encode()
         ).decode()
 
         with (
-            patch('server.routes.auth.token_manager') as mock_token_manager,
-            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
-            patch('server.routes.auth.RECAPTCHA_SITE_KEY', ''),
-            patch('server.routes.auth.a_session_maker') as mock_session_maker,
+            patch("server.routes.auth.token_manager") as mock_token_manager,
+            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
+            patch("server.routes.auth.RECAPTCHA_SITE_KEY", ""),
+            patch("server.routes.auth.a_session_maker") as mock_session_maker,
             patch(
-                'storage.user_authorization_store.UserAuthorizationStore'
+                "storage.user_authorization_store.UserAuthorizationStore"
             ) as mock_user_auth_store,
-            patch('server.routes.auth.set_response_cookie'),
-            patch('server.routes.auth.posthog'),
-            patch('server.routes.email.verify_email', new_callable=AsyncMock),
-            patch('server.routes.auth.UserStore') as mock_user_store,
+            patch("server.routes.auth.set_response_cookie"),
+            patch("server.routes.auth.posthog"),
+            patch("server.routes.email.verify_email", new_callable=AsyncMock),
+            patch("server.routes.auth.UserStore") as mock_user_store,
         ):
             mock_session = MagicMock()
             mock_session_maker.return_value.__enter__.return_value = mock_session
@@ -1682,18 +1682,18 @@ class TestKeycloakCallbackRecaptcha:
             mock_session.query.return_value = mock_query
             mock_query.filter.return_value = mock_query
             mock_user_settings = MagicMock()
-            mock_user_settings.accepted_tos = '2025-01-01'
+            mock_user_settings.accepted_tos = "2025-01-01"
             mock_query.first.return_value = mock_user_settings
 
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=('test_access_token', 'test_refresh_token')
+                return_value=("test_access_token", "test_refresh_token")
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub='test_user_id',
-                    preferred_username='test_user',
-                    email='user@example.com',
-                    identity_provider='github',
+                    sub="test_user_id",
+                    preferred_username="test_user",
+                    email="user@example.com",
+                    identity_provider="github",
                     email_verified=True,
                 )
             )
@@ -1705,9 +1705,9 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = 'test_user_id'
-            mock_user.current_org_id = 'test_org_id'
-            mock_user.accepted_tos = '2025-01-01'
+            mock_user.id = "test_user_id"
+            mock_user.current_org_id = "test_org_id"
+            mock_user.accepted_tos = "2025-01-01"
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1717,7 +1717,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Act
             await keycloak_callback(
-                code='test_code',
+                code="test_code",
                 state=encoded_state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1732,20 +1732,20 @@ class TestKeycloakCallbackRecaptcha:
     ):
         """Test that reCAPTCHA is skipped when token is missing from state."""
         # Arrange
-        state = 'https://example.com'  # Old format without token
+        state = "https://example.com"  # Old format without token
 
         with (
-            patch('server.routes.auth.token_manager') as mock_token_manager,
-            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
-            patch('server.routes.auth.RECAPTCHA_SITE_KEY', 'test-site-key'),
-            patch('server.routes.auth.a_session_maker') as mock_session_maker,
+            patch("server.routes.auth.token_manager") as mock_token_manager,
+            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
+            patch("server.routes.auth.RECAPTCHA_SITE_KEY", "test-site-key"),
+            patch("server.routes.auth.a_session_maker") as mock_session_maker,
             patch(
-                'storage.user_authorization_store.UserAuthorizationStore'
+                "storage.user_authorization_store.UserAuthorizationStore"
             ) as mock_user_auth_store,
-            patch('server.routes.auth.set_response_cookie'),
-            patch('server.routes.auth.posthog'),
-            patch('server.routes.email.verify_email', new_callable=AsyncMock),
-            patch('server.routes.auth.UserStore') as mock_user_store,
+            patch("server.routes.auth.set_response_cookie"),
+            patch("server.routes.auth.posthog"),
+            patch("server.routes.email.verify_email", new_callable=AsyncMock),
+            patch("server.routes.auth.UserStore") as mock_user_store,
         ):
             mock_session = MagicMock()
             mock_session_maker.return_value.__enter__.return_value = mock_session
@@ -1753,18 +1753,18 @@ class TestKeycloakCallbackRecaptcha:
             mock_session.query.return_value = mock_query
             mock_query.filter.return_value = mock_query
             mock_user_settings = MagicMock()
-            mock_user_settings.accepted_tos = '2025-01-01'
+            mock_user_settings.accepted_tos = "2025-01-01"
             mock_query.first.return_value = mock_user_settings
 
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=('test_access_token', 'test_refresh_token')
+                return_value=("test_access_token", "test_refresh_token")
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub='test_user_id',
-                    preferred_username='test_user',
-                    email='user@example.com',
-                    identity_provider='github',
+                    sub="test_user_id",
+                    preferred_username="test_user",
+                    email="user@example.com",
+                    identity_provider="github",
                     email_verified=True,
                 )
             )
@@ -1776,9 +1776,9 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = 'test_user_id'
-            mock_user.current_org_id = 'test_org_id'
-            mock_user.accepted_tos = '2025-01-01'
+            mock_user.id = "test_user_id"
+            mock_user.current_org_id = "test_org_id"
+            mock_user.accepted_tos = "2025-01-01"
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1788,7 +1788,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Act
             await keycloak_callback(
-                code='test_code',
+                code="test_code",
                 state=state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1804,25 +1804,25 @@ class TestKeycloakCallbackRecaptcha:
         """Test that login proceeds (fail open) when reCAPTCHA service throws exception."""
         # Arrange
         state_data = {
-            'redirect_url': 'https://example.com',
-            'recaptcha_token': 'test-token',
+            "redirect_url": "https://example.com",
+            "recaptcha_token": "test-token",
         }
         encoded_state = base64.urlsafe_b64encode(
             json.dumps(state_data).encode()
         ).decode()
 
         with (
-            patch('server.routes.auth.token_manager') as mock_token_manager,
-            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
-            patch('server.routes.auth.RECAPTCHA_SITE_KEY', 'test-site-key'),
-            patch('server.routes.auth.a_session_maker') as mock_session_maker,
+            patch("server.routes.auth.token_manager") as mock_token_manager,
+            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
+            patch("server.routes.auth.RECAPTCHA_SITE_KEY", "test-site-key"),
+            patch("server.routes.auth.a_session_maker") as mock_session_maker,
             patch(
-                'storage.user_authorization_store.UserAuthorizationStore'
+                "storage.user_authorization_store.UserAuthorizationStore"
             ) as mock_user_auth_store,
-            patch('server.routes.auth.set_response_cookie'),
-            patch('server.routes.auth.posthog'),
-            patch('server.routes.auth.logger') as mock_logger,
-            patch('server.routes.auth.UserStore') as mock_user_store,
+            patch("server.routes.auth.set_response_cookie"),
+            patch("server.routes.auth.posthog"),
+            patch("server.routes.auth.logger") as mock_logger,
+            patch("server.routes.auth.UserStore") as mock_user_store,
         ):
             mock_session = MagicMock()
             mock_session_maker.return_value.__enter__.return_value = mock_session
@@ -1830,18 +1830,18 @@ class TestKeycloakCallbackRecaptcha:
             mock_session.query.return_value = mock_query
             mock_query.filter.return_value = mock_query
             mock_user_settings = MagicMock()
-            mock_user_settings.accepted_tos = '2025-01-01'
+            mock_user_settings.accepted_tos = "2025-01-01"
             mock_query.first.return_value = mock_user_settings
 
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=('test_access_token', 'test_refresh_token')
+                return_value=("test_access_token", "test_refresh_token")
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub='test_user_id',
-                    preferred_username='test_user',
-                    email='user@example.com',
-                    identity_provider='github',
+                    sub="test_user_id",
+                    preferred_username="test_user",
+                    email="user@example.com",
+                    identity_provider="github",
                     email_verified=True,
                 )
             )
@@ -1853,9 +1853,9 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = 'test_user_id'
-            mock_user.current_org_id = 'test_org_id'
-            mock_user.accepted_tos = '2025-01-01'
+            mock_user.id = "test_user_id"
+            mock_user.current_org_id = "test_org_id"
+            mock_user.accepted_tos = "2025-01-01"
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1864,12 +1864,12 @@ class TestKeycloakCallbackRecaptcha:
             mock_user_auth_store.get_authorization_type = AsyncMock(return_value=None)
 
             mock_recaptcha_service.create_assessment.side_effect = Exception(
-                'Service error'
+                "Service error"
             )
 
             # Act
             result = await keycloak_callback(
-                code='test_code',
+                code="test_code",
                 state=encoded_state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1881,7 +1881,7 @@ class TestKeycloakCallbackRecaptcha:
             recaptcha_error_calls = [
                 call
                 for call in mock_logger.exception.call_args_list
-                if 'reCAPTCHA verification error' in str(call)
+                if "reCAPTCHA verification error" in str(call)
             ]
             assert len(recaptcha_error_calls) > 0
 
@@ -1892,8 +1892,8 @@ class TestKeycloakCallbackRecaptcha:
         """Test that warning is logged when reCAPTCHA blocks user."""
         # Arrange
         state_data = {
-            'redirect_url': 'https://example.com',
-            'recaptcha_token': 'test-token',
+            "redirect_url": "https://example.com",
+            "recaptcha_token": "test-token",
         }
         encoded_state = base64.urlsafe_b64encode(
             json.dumps(state_data).encode()
@@ -1904,24 +1904,24 @@ class TestKeycloakCallbackRecaptcha:
         mock_assessment_result.score = 0.2
 
         with (
-            patch('server.routes.auth.token_manager') as mock_token_manager,
-            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
-            patch('server.routes.auth.RECAPTCHA_SITE_KEY', 'test-site-key'),
+            patch("server.routes.auth.token_manager") as mock_token_manager,
+            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
+            patch("server.routes.auth.RECAPTCHA_SITE_KEY", "test-site-key"),
             patch(
-                'storage.user_authorization_store.UserAuthorizationStore'
+                "storage.user_authorization_store.UserAuthorizationStore"
             ) as mock_user_auth_store,
-            patch('server.routes.auth.logger') as mock_logger,
-            patch('server.routes.email.verify_email', new_callable=AsyncMock),
-            patch('server.routes.auth.UserStore') as mock_user_store,
+            patch("server.routes.auth.logger") as mock_logger,
+            patch("server.routes.email.verify_email", new_callable=AsyncMock),
+            patch("server.routes.auth.UserStore") as mock_user_store,
         ):
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=('test_access_token', 'test_refresh_token')
+                return_value=("test_access_token", "test_refresh_token")
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub='test_user_id',
-                    preferred_username='test_user',
-                    email='user@example.com',
+                    sub="test_user_id",
+                    preferred_username="test_user",
+                    email="user@example.com",
                 )
             )
             mock_token_manager.check_duplicate_base_email = AsyncMock(
@@ -1930,8 +1930,8 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = 'test_user_id'
-            mock_user.current_org_id = 'test_org_id'
+            mock_user.id = "test_user_id"
+            mock_user.current_org_id = "test_org_id"
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1946,7 +1946,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Act
             await keycloak_callback(
-                code='test_code',
+                code="test_code",
                 state=encoded_state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1955,9 +1955,9 @@ class TestKeycloakCallbackRecaptcha:
             # Assert
             mock_logger.warning.assert_called_once()
             call_kwargs = mock_logger.warning.call_args
-            assert call_kwargs[0][0] == 'recaptcha_blocked_at_callback'
-            assert call_kwargs[1]['extra']['score'] == 0.2
-            assert call_kwargs[1]['extra']['user_id'] == 'test_user_id'
+            assert call_kwargs[0][0] == "recaptcha_blocked_at_callback"
+            assert call_kwargs[1]["extra"]["score"] == 0.2
+            assert call_kwargs[1]["extra"]["user_id"] == "test_user_id"
 
 
 @pytest.mark.asyncio
@@ -1966,23 +1966,23 @@ async def test_keycloak_callback_calls_backfill_user_email_for_existing_user(
 ):
     """When an existing user logs in, backfill_user_email should be called."""
     user_info = create_keycloak_user_info(
-        sub='test_user_id',
-        preferred_username='test_user',
-        identity_provider='github',
-        email='test@example.com',
+        sub="test_user_id",
+        preferred_username="test_user",
+        identity_provider="github",
+        email="test@example.com",
         email_verified=True,
     )
 
     with (
-        patch('server.routes.auth.token_manager') as mock_token_manager,
-        patch('server.routes.auth.set_response_cookie'),
-        patch('server.routes.auth.UserStore') as mock_user_store,
-        patch('server.routes.auth.posthog'),
+        patch("server.routes.auth.token_manager") as mock_token_manager,
+        patch("server.routes.auth.set_response_cookie"),
+        patch("server.routes.auth.UserStore") as mock_user_store,
+        patch("server.routes.auth.posthog"),
     ):
         mock_user = MagicMock()
-        mock_user.id = 'test_user_id'
-        mock_user.current_org_id = 'test_org_id'
-        mock_user.accepted_tos = '2025-01-01'
+        mock_user.id = "test_user_id"
+        mock_user.current_org_id = "test_org_id"
+        mock_user.accepted_tos = "2025-01-01"
 
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
@@ -1990,7 +1990,7 @@ async def test_keycloak_callback_calls_backfill_user_email_for_existing_user(
         mock_user_store.backfill_user_email = AsyncMock()
 
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=('test_access_token', 'test_refresh_token')
+            return_value=("test_access_token", "test_refresh_token")
         )
         mock_token_manager.get_user_info = AsyncMock(return_value=user_info)
         mock_token_manager.store_idp_tokens = AsyncMock()
@@ -1998,8 +1998,8 @@ async def test_keycloak_callback_calls_backfill_user_email_for_existing_user(
         mock_token_manager.check_duplicate_base_email = AsyncMock(return_value=False)
 
         result = await keycloak_callback(
-            code='test_code',
-            state='test_state',
+            code="test_code",
+            state="test_state",
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
@@ -2009,7 +2009,7 @@ async def test_keycloak_callback_calls_backfill_user_email_for_existing_user(
 
         # backfill_user_email should have been called with the user_id and user_info dict
         mock_user_store.backfill_user_email.assert_called_once_with(
-            'test_user_id', user_info.model_dump(exclude_none=True)
+            "test_user_id", user_info.model_dump(exclude_none=True)
         )
 
 
@@ -2017,7 +2017,7 @@ async def test_keycloak_callback_calls_backfill_user_email_for_existing_user(
 async def test_accept_tos_stores_timezone_naive_datetime(mock_request):
     """Test that accept_tos stores a timezone-naive datetime for database compatibility."""
     # Arrange
-    test_user_id = '12345678-1234-5678-1234-567812345678'
+    test_user_id = "12345678-1234-5678-1234-567812345678"
 
     mock_user = MagicMock()
     mock_user.id = test_user_id
@@ -2035,19 +2035,19 @@ async def test_accept_tos_stores_timezone_naive_datetime(mock_request):
 
     mock_user_auth = MagicMock(spec=SaasUserAuth)
     mock_user_auth.get_access_token = AsyncMock(
-        return_value=SecretStr('test_access_token')
+        return_value=SecretStr("test_access_token")
     )
-    mock_user_auth.refresh_token = SecretStr('test_refresh_token')
+    mock_user_auth.refresh_token = SecretStr("test_refresh_token")
     mock_user_auth.get_user_id = AsyncMock(return_value=test_user_id)
 
-    mock_request.json = AsyncMock(return_value={'redirect_url': 'http://example.com'})
+    mock_request.json = AsyncMock(return_value={"redirect_url": "http://example.com"})
 
     with (
         patch(
-            'server.routes.auth.get_user_auth', AsyncMock(return_value=mock_user_auth)
+            "server.routes.auth.get_user_auth", AsyncMock(return_value=mock_user_auth)
         ),
-        patch('server.routes.auth.a_session_maker', return_value=mock_session_context),
-        patch('server.routes.auth.set_response_cookie'),
+        patch("server.routes.auth.a_session_maker", return_value=mock_session_context),
+        patch("server.routes.auth.set_response_cookie"),
     ):
         # Act
         result = await accept_tos(mock_request)
@@ -2058,3 +2058,170 @@ async def test_accept_tos_stores_timezone_naive_datetime(mock_request):
         # The datetime assigned to user.accepted_tos must be timezone-naive
         # (compatible with TIMESTAMP WITHOUT TIME ZONE database column)
         assert mock_user.accepted_tos.tzinfo is None
+
+
+class TestGetCurrentUser:
+    """Tests for the /api/me endpoint."""
+
+    @pytest.fixture
+    def mock_request(self):
+        request = MagicMock(spec=Request)
+        request.url = MagicMock()
+        request.url.hostname = "localhost"
+        request.url.netloc = "localhost:8000"
+        request.headers = {}
+        request.cookies = {}
+        return request
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_not_authenticated(self, mock_request):
+        """Test that unauthenticated requests return 401."""
+        from server.auth.auth_error import NoCredentialsError
+        from server.routes.auth import get_current_user
+
+        with patch(
+            "server.routes.auth.SaasUserAuth.get_instance",
+            AsyncMock(side_effect=NoCredentialsError("failed to authenticate")),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(mock_request)
+
+            assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+            assert exc_info.value.detail == "User not authenticated"
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_user_not_found(self, mock_request):
+        """Test that requests for non-existent users return 404."""
+        from server.routes.auth import get_current_user
+
+        mock_user_auth = MagicMock(spec=SaasUserAuth)
+        mock_user_auth.get_user_id = AsyncMock(return_value="test_user_id")
+        mock_user_auth.get_user_email = AsyncMock(return_value="test@example.com")
+
+        with (
+            patch(
+                "server.routes.auth.SaasUserAuth.get_instance",
+                AsyncMock(return_value=mock_user_auth),
+            ),
+            patch("server.routes.auth.UserStore") as mock_user_store,
+        ):
+            mock_user_store.get_user_by_id = AsyncMock(return_value=None)
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(mock_request)
+
+            assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+            assert exc_info.value.detail == "User not found"
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_success(self, mock_request):
+        """Test successful retrieval of current user info."""
+        from uuid import UUID
+
+        from server.auth.authorization import Permission, RoleName
+        from server.routes.auth import get_current_user
+
+        test_user_id = "test_user_id"
+        test_org_id = UUID("12345678-1234-5678-1234-567812345678")
+        test_email = "test@example.com"
+        test_org_name = "Test Organization"
+
+        mock_user_auth = MagicMock(spec=SaasUserAuth)
+        mock_user_auth.get_user_id = AsyncMock(return_value=test_user_id)
+        mock_user_auth.get_user_email = AsyncMock(return_value=test_email)
+
+        mock_user = MagicMock()
+        mock_user.current_org_id = test_org_id
+
+        mock_org = MagicMock()
+        mock_org.name = test_org_name
+
+        mock_role = MagicMock()
+        mock_role.name = RoleName.MEMBER.value
+
+        with (
+            patch(
+                "server.routes.auth.SaasUserAuth.get_instance",
+                AsyncMock(return_value=mock_user_auth),
+            ),
+            patch("server.routes.auth.UserStore") as mock_user_store,
+            patch(
+                "server.auth.authorization.get_user_org_role",
+                AsyncMock(return_value=mock_role),
+            ),
+            patch(
+                "storage.org_store.OrgStore.get_org_by_id",
+                AsyncMock(return_value=mock_org),
+            ),
+        ):
+            mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
+
+            result = await get_current_user(mock_request)
+
+            assert isinstance(result, JSONResponse)
+            assert result.status_code == status.HTTP_200_OK
+
+            # Parse the JSON content
+            import json
+
+            content = json.loads(result.body.decode())
+            assert content["user_id"] == test_user_id
+            assert content["email"] == test_email
+            assert content["org_id"] == str(test_org_id)
+            assert content["org_name"] == test_org_name
+            assert content["role"] == RoleName.MEMBER.value
+            assert Permission.MANAGE_SECRETS.value in content["permissions"]
+            assert Permission.VIEW_LLM_SETTINGS.value in content["permissions"]
+            # Members should not have owner-only permissions
+            assert Permission.DELETE_ORGANIZATION.value not in content["permissions"]
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_no_role(self, mock_request):
+        """Test retrieval when user has no role in org."""
+        from uuid import UUID
+
+        from server.routes.auth import get_current_user
+
+        test_user_id = "test_user_id"
+        test_org_id = UUID("12345678-1234-5678-1234-567812345678")
+        test_email = "test@example.com"
+        test_org_name = "Test Organization"
+
+        mock_user_auth = MagicMock(spec=SaasUserAuth)
+        mock_user_auth.get_user_id = AsyncMock(return_value=test_user_id)
+        mock_user_auth.get_user_email = AsyncMock(return_value=test_email)
+
+        mock_user = MagicMock()
+        mock_user.current_org_id = test_org_id
+
+        mock_org = MagicMock()
+        mock_org.name = test_org_name
+
+        with (
+            patch(
+                "server.routes.auth.SaasUserAuth.get_instance",
+                AsyncMock(return_value=mock_user_auth),
+            ),
+            patch("server.routes.auth.UserStore") as mock_user_store,
+            patch(
+                "server.auth.authorization.get_user_org_role",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "storage.org_store.OrgStore.get_org_by_id",
+                AsyncMock(return_value=mock_org),
+            ),
+        ):
+            mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
+
+            result = await get_current_user(mock_request)
+
+            assert isinstance(result, JSONResponse)
+            assert result.status_code == status.HTTP_200_OK
+
+            import json
+
+            content = json.loads(result.body.decode())
+            assert content["user_id"] == test_user_id
+            assert content["role"] is None
+            assert content["permissions"] == []

--- a/enterprise/tests/unit/test_auth_routes.py
+++ b/enterprise/tests/unit/test_auth_routes.py
@@ -37,10 +37,10 @@ def create_mock_user_authorizer(success: bool = True, error_detail: str | None =
 def mock_request():
     request = MagicMock(spec=Request)
     request.url = MagicMock()
-    request.url.hostname = "localhost"
-    request.url.netloc = "localhost:8000"
-    request.url.path = "/oauth/keycloak/callback"
-    request.base_url = "http://localhost:8000/"
+    request.url.hostname = 'localhost'
+    request.url.netloc = 'localhost:8000'
+    request.url.path = '/oauth/keycloak/callback'
+    request.base_url = 'http://localhost:8000/'
     request.headers = {}
     request.cookies = {}
     return request
@@ -55,17 +55,17 @@ def test_set_response_cookie(mock_response, mock_request):
     """Test setting the auth cookie on a response."""
 
     with (
-        patch("server.routes.auth.config") as mock_config,
-        patch("server.utils.url_utils.get_global_config") as get_global_config,
+        patch('server.routes.auth.config') as mock_config,
+        patch('server.utils.url_utils.get_global_config') as get_global_config,
     ):
-        mock_config.jwt_secret.get_secret_value.return_value = "test_secret"
-        get_global_config.return_value = MagicMock(web_url="https://example.com")
+        mock_config.jwt_secret.get_secret_value.return_value = 'test_secret'
+        get_global_config.return_value = MagicMock(web_url='https://example.com')
 
         set_response_cookie(
             request=mock_request,
             response=mock_response,
-            keycloak_access_token="test_access_token",
-            keycloak_refresh_token="test_refresh_token",
+            keycloak_access_token='test_access_token',
+            keycloak_refresh_token='test_refresh_token',
             secure=True,
             accepted_tos=True,
         )
@@ -73,18 +73,18 @@ def test_set_response_cookie(mock_response, mock_request):
         mock_response.set_cookie.assert_called_once()
         args, kwargs = mock_response.set_cookie.call_args
 
-        assert kwargs["key"] == "keycloak_auth"
-        assert "value" in kwargs
-        assert kwargs["httponly"] is True
-        assert kwargs["secure"] is True
-        assert kwargs["samesite"] == "strict"
-        assert kwargs["domain"] == "example.com"
+        assert kwargs['key'] == 'keycloak_auth'
+        assert 'value' in kwargs
+        assert kwargs['httponly'] is True
+        assert kwargs['secure'] is True
+        assert kwargs['samesite'] == 'strict'
+        assert kwargs['domain'] == 'example.com'
 
         # Verify the JWT token contains the correct data
-        token_data = jwt.decode(kwargs["value"], "test_secret", algorithms=["HS256"])
-        assert token_data["access_token"] == "test_access_token"
-        assert token_data["refresh_token"] == "test_refresh_token"
-        assert token_data["accepted_tos"] is True
+        token_data = jwt.decode(kwargs['value'], 'test_secret', algorithms=['HS256'])
+        assert token_data['access_token'] == 'test_access_token'
+        assert token_data['refresh_token'] == 'test_refresh_token'
+        assert token_data['accepted_tos'] is True
 
 
 @pytest.mark.asyncio
@@ -92,14 +92,14 @@ async def test_keycloak_callback_missing_code(mock_request):
     """Test keycloak_callback with missing code."""
     with pytest.raises(HTTPException) as exc_info:
         await keycloak_callback(
-            code="",
-            state="test_state",
+            code='',
+            state='test_state',
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
 
     assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
-    assert "Missing code" in exc_info.value.detail
+    assert 'Missing code' in exc_info.value.detail
 
 
 @pytest.mark.asyncio
@@ -107,18 +107,18 @@ async def test_keycloak_callback_token_retrieval_failure(mock_request):
     """Test keycloak_callback when token retrieval fails."""
     get_keycloak_tokens_mock = AsyncMock(return_value=(None, None))
     with patch(
-        "server.routes.auth.token_manager.get_keycloak_tokens", get_keycloak_tokens_mock
+        'server.routes.auth.token_manager.get_keycloak_tokens', get_keycloak_tokens_mock
     ):
         with pytest.raises(HTTPException) as exc_info:
             await keycloak_callback(
-                code="test_code",
-                state="test_state",
+                code='test_code',
+                state='test_state',
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
             )
 
         assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
-        assert "Problem retrieving Keycloak tokens" in exc_info.value.detail
+        assert 'Problem retrieving Keycloak tokens' in exc_info.value.detail
         get_keycloak_tokens_mock.assert_called_once()
 
 
@@ -133,17 +133,17 @@ async def test_keycloak_callback_user_not_authorized(
 ):
     """Test keycloak_callback when user authorization fails."""
     with (
-        patch("server.routes.auth.token_manager") as mock_token_manager,
-        patch("server.routes.auth.UserStore") as mock_user_store,
+        patch('server.routes.auth.token_manager') as mock_token_manager,
+        patch('server.routes.auth.UserStore') as mock_user_store,
     ):
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=("test_access_token", "test_refresh_token")
+            return_value=('test_access_token', 'test_refresh_token')
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub="test_user_id",
-                preferred_username="test_user",
-                identity_provider="github",
+                sub='test_user_id',
+                preferred_username='test_user',
+                identity_provider='github',
                 email_verified=True,
             )
         )
@@ -151,8 +151,8 @@ async def test_keycloak_callback_user_not_authorized(
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = "test_user_id"
-        mock_user.current_org_id = "test_org_id"
+        mock_user.id = 'test_user_id'
+        mock_user.current_org_id = 'test_org_id'
         mock_user.accepted_tos = None
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
@@ -162,19 +162,19 @@ async def test_keycloak_callback_user_not_authorized(
 
         # Create mock user authorizer that denies authorization
         mock_authorizer = create_mock_user_authorizer(
-            success=False, error_detail="blocked"
+            success=False, error_detail='blocked'
         )
 
         with pytest.raises(HTTPException) as exc_info:
             await keycloak_callback(
-                code="test_code",
-                state="test_state",
+                code='test_code',
+                state='test_state',
                 request=mock_request,
                 user_authorizer=mock_authorizer,
             )
 
         assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert exc_info.value.detail == "blocked"
+        assert exc_info.value.detail == 'blocked'
 
 
 @pytest.mark.asyncio
@@ -183,16 +183,16 @@ async def test_keycloak_callback_success_with_valid_offline_token(
 ):
     """Test successful keycloak_callback with valid offline token."""
     with (
-        patch("server.routes.auth.token_manager") as mock_token_manager,
-        patch("server.routes.auth.set_response_cookie") as mock_set_cookie,
-        patch("server.routes.auth.UserStore") as mock_user_store,
-        patch("server.routes.auth.posthog") as mock_posthog,
+        patch('server.routes.auth.token_manager') as mock_token_manager,
+        patch('server.routes.auth.set_response_cookie') as mock_set_cookie,
+        patch('server.routes.auth.UserStore') as mock_user_store,
+        patch('server.routes.auth.posthog') as mock_posthog,
     ):
         # Mock user with accepted_tos
         mock_user = MagicMock()
-        mock_user.id = "test_user_id"
-        mock_user.current_org_id = "test_org_id"
-        mock_user.accepted_tos = "2025-01-01"
+        mock_user.id = 'test_user_id'
+        mock_user.current_org_id = 'test_org_id'
+        mock_user.accepted_tos = '2025-01-01'
 
         # Setup UserStore mocks
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
@@ -202,13 +202,13 @@ async def test_keycloak_callback_success_with_valid_offline_token(
         mock_user_store.backfill_user_email = AsyncMock()
 
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=("test_access_token", "test_refresh_token")
+            return_value=('test_access_token', 'test_refresh_token')
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub="test_user_id",
-                preferred_username="test_user",
-                identity_provider="github",
+                sub='test_user_id',
+                preferred_username='test_user',
+                identity_provider='github',
                 email_verified=True,
             )
         )
@@ -216,24 +216,24 @@ async def test_keycloak_callback_success_with_valid_offline_token(
         mock_token_manager.validate_offline_token = AsyncMock(return_value=True)
 
         result = await keycloak_callback(
-            code="test_code",
-            state="test_state",
+            code='test_code',
+            state='test_state',
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
 
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 302
-        assert result.headers["location"] == "test_state"
+        assert result.headers['location'] == 'test_state'
 
         mock_token_manager.store_idp_tokens.assert_called_once_with(
-            ProviderType.GITHUB, "test_user_id", "test_access_token"
+            ProviderType.GITHUB, 'test_user_id', 'test_access_token'
         )
         mock_set_cookie.assert_called_once_with(
             request=mock_request,
             response=result,
-            keycloak_access_token="test_access_token",
-            keycloak_refresh_token="test_refresh_token",
+            keycloak_access_token='test_access_token',
+            keycloak_refresh_token='test_refresh_token',
             secure=False,
             accepted_tos=True,
         )
@@ -249,19 +249,19 @@ async def test_keycloak_callback_email_not_verified(
     mock_verify_email = AsyncMock()
     mock_rate_limit = AsyncMock()
     with (
-        patch("server.routes.auth.token_manager") as mock_token_manager,
-        patch("server.routes.email.verify_email", mock_verify_email),
-        patch("server.routes.auth.check_rate_limit_by_user_id", mock_rate_limit),
-        patch("server.routes.auth.UserStore") as mock_user_store,
+        patch('server.routes.auth.token_manager') as mock_token_manager,
+        patch('server.routes.email.verify_email', mock_verify_email),
+        patch('server.routes.auth.check_rate_limit_by_user_id', mock_rate_limit),
+        patch('server.routes.auth.UserStore') as mock_user_store,
     ):
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=("test_access_token", "test_refresh_token")
+            return_value=('test_access_token', 'test_refresh_token')
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub="test_user_id",
-                preferred_username="test_user",
-                identity_provider="github",
+                sub='test_user_id',
+                preferred_username='test_user',
+                identity_provider='github',
                 email_verified=False,
             )
         )
@@ -269,8 +269,8 @@ async def test_keycloak_callback_email_not_verified(
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = "test_user_id"
-        mock_user.current_org_id = "test_org_id"
+        mock_user.id = 'test_user_id'
+        mock_user.current_org_id = 'test_org_id'
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
         mock_user_store.backfill_contact_name = AsyncMock()
@@ -278,8 +278,8 @@ async def test_keycloak_callback_email_not_verified(
 
         # Act
         result = await keycloak_callback(
-            code="test_code",
-            state="test_state",
+            code='test_code',
+            state='test_state',
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
@@ -287,16 +287,16 @@ async def test_keycloak_callback_email_not_verified(
         # Assert
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 302
-        assert "email_verification_required=true" in result.headers["location"]
-        assert "user_id=test_user_id" in result.headers["location"]
+        assert 'email_verification_required=true' in result.headers['location']
+        assert 'user_id=test_user_id' in result.headers['location']
         mock_verify_email.assert_called_once_with(
-            request=mock_request, user_id="test_user_id", is_auth_flow=True
+            request=mock_request, user_id='test_user_id', is_auth_flow=True
         )
         # Verify rate limit was checked
         mock_rate_limit.assert_called_once_with(
             request=mock_request,
-            key_prefix="auth_verify_email",
-            user_id="test_user_id",
+            key_prefix='auth_verify_email',
+            user_id='test_user_id',
             user_rate_limit_seconds=60,
             ip_rate_limit_seconds=120,
         )
@@ -311,19 +311,19 @@ async def test_keycloak_callback_email_not_verified_missing_field(
     mock_verify_email = AsyncMock()
     mock_rate_limit = AsyncMock()
     with (
-        patch("server.routes.auth.token_manager") as mock_token_manager,
-        patch("server.routes.email.verify_email", mock_verify_email),
-        patch("server.routes.auth.check_rate_limit_by_user_id", mock_rate_limit),
-        patch("server.routes.auth.UserStore") as mock_user_store,
+        patch('server.routes.auth.token_manager') as mock_token_manager,
+        patch('server.routes.email.verify_email', mock_verify_email),
+        patch('server.routes.auth.check_rate_limit_by_user_id', mock_rate_limit),
+        patch('server.routes.auth.UserStore') as mock_user_store,
     ):
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=("test_access_token", "test_refresh_token")
+            return_value=('test_access_token', 'test_refresh_token')
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub="test_user_id",
-                preferred_username="test_user",
-                identity_provider="github",
+                sub='test_user_id',
+                preferred_username='test_user',
+                identity_provider='github',
                 # email_verified field is missing
             )
         )
@@ -331,8 +331,8 @@ async def test_keycloak_callback_email_not_verified_missing_field(
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = "test_user_id"
-        mock_user.current_org_id = "test_org_id"
+        mock_user.id = 'test_user_id'
+        mock_user.current_org_id = 'test_org_id'
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
         mock_user_store.backfill_contact_name = AsyncMock()
@@ -340,8 +340,8 @@ async def test_keycloak_callback_email_not_verified_missing_field(
 
         # Act
         result = await keycloak_callback(
-            code="test_code",
-            state="test_state",
+            code='test_code',
+            state='test_state',
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
@@ -349,10 +349,10 @@ async def test_keycloak_callback_email_not_verified_missing_field(
         # Assert
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 302
-        assert "email_verification_required=true" in result.headers["location"]
-        assert "user_id=test_user_id" in result.headers["location"]
+        assert 'email_verification_required=true' in result.headers['location']
+        assert 'user_id=test_user_id' in result.headers['location']
         mock_verify_email.assert_called_once_with(
-            request=mock_request, user_id="test_user_id", is_auth_flow=True
+            request=mock_request, user_id='test_user_id', is_auth_flow=True
         )
 
 
@@ -372,23 +372,23 @@ async def test_keycloak_callback_email_verification_rate_limited(
     mock_rate_limit = AsyncMock(
         side_effect=HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-            detail="Too many requests. Please wait 1 minute before trying again.",
+            detail='Too many requests. Please wait 1 minute before trying again.',
         )
     )
     with (
-        patch("server.routes.auth.token_manager") as mock_token_manager,
-        patch("server.routes.email.verify_email", mock_verify_email),
-        patch("server.routes.auth.check_rate_limit_by_user_id", mock_rate_limit),
-        patch("server.routes.auth.UserStore") as mock_user_store,
+        patch('server.routes.auth.token_manager') as mock_token_manager,
+        patch('server.routes.email.verify_email', mock_verify_email),
+        patch('server.routes.auth.check_rate_limit_by_user_id', mock_rate_limit),
+        patch('server.routes.auth.UserStore') as mock_user_store,
     ):
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=("test_access_token", "test_refresh_token")
+            return_value=('test_access_token', 'test_refresh_token')
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub="test_user_id",
-                preferred_username="test_user",
-                identity_provider="github",
+                sub='test_user_id',
+                preferred_username='test_user',
+                identity_provider='github',
                 email_verified=False,
             )
         )
@@ -396,8 +396,8 @@ async def test_keycloak_callback_email_verification_rate_limited(
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = "test_user_id"
-        mock_user.current_org_id = "test_org_id"
+        mock_user.id = 'test_user_id'
+        mock_user.current_org_id = 'test_org_id'
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
         mock_user_store.backfill_contact_name = AsyncMock()
@@ -405,8 +405,8 @@ async def test_keycloak_callback_email_verification_rate_limited(
 
         # Act
         result = await keycloak_callback(
-            code="test_code",
-            state="test_state",
+            code='test_code',
+            state='test_state',
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
@@ -414,11 +414,11 @@ async def test_keycloak_callback_email_verification_rate_limited(
         # Assert - should still redirect to verification page but NOT send email
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 302
-        assert "email_verification_required=true" in result.headers["location"]
-        assert "user_id=test_user_id" in result.headers["location"]
+        assert 'email_verification_required=true' in result.headers['location']
+        assert 'user_id=test_user_id' in result.headers['location']
         # When rate limited, the redirect URL should include rate_limited=true
         # so the frontend can show an appropriate message
-        assert "rate_limited=true" in result.headers["location"]
+        assert 'rate_limited=true' in result.headers['location']
         # verify_email should NOT have been called due to rate limit
         mock_verify_email.assert_not_called()
         mock_rate_limit.assert_called_once()
@@ -430,21 +430,21 @@ async def test_keycloak_callback_success_without_offline_token(
 ):
     """Test successful keycloak_callback without valid offline token."""
     with (
-        patch("server.routes.auth.token_manager") as mock_token_manager,
-        patch("server.routes.auth.set_response_cookie") as mock_set_cookie,
+        patch('server.routes.auth.token_manager') as mock_token_manager,
+        patch('server.routes.auth.set_response_cookie') as mock_set_cookie,
         patch(
-            "server.routes.auth.KEYCLOAK_SERVER_URL_EXT", "https://keycloak.example.com"
+            'server.routes.auth.KEYCLOAK_SERVER_URL_EXT', 'https://keycloak.example.com'
         ),
-        patch("server.routes.auth.KEYCLOAK_REALM_NAME", "test-realm"),
-        patch("server.routes.auth.KEYCLOAK_CLIENT_ID", "test-client"),
-        patch("server.routes.auth.UserStore") as mock_user_store,
-        patch("server.routes.auth.posthog") as mock_posthog,
+        patch('server.routes.auth.KEYCLOAK_REALM_NAME', 'test-realm'),
+        patch('server.routes.auth.KEYCLOAK_CLIENT_ID', 'test-client'),
+        patch('server.routes.auth.UserStore') as mock_user_store,
+        patch('server.routes.auth.posthog') as mock_posthog,
     ):
         # Mock user with accepted_tos
         mock_user = MagicMock()
-        mock_user.id = "test_user_id"
-        mock_user.current_org_id = "test_org_id"
-        mock_user.accepted_tos = "2025-01-01"
+        mock_user.id = 'test_user_id'
+        mock_user.current_org_id = 'test_org_id'
+        mock_user.accepted_tos = '2025-01-01'
 
         # Setup UserStore mocks
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
@@ -454,13 +454,13 @@ async def test_keycloak_callback_success_without_offline_token(
         mock_user_store.backfill_user_email = AsyncMock()
 
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=("test_access_token", "test_refresh_token")
+            return_value=('test_access_token', 'test_refresh_token')
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub="test_user_id",
-                preferred_username="test_user",
-                identity_provider="github",
+                sub='test_user_id',
+                preferred_username='test_user',
+                identity_provider='github',
                 email_verified=True,
             )
         )
@@ -469,8 +469,8 @@ async def test_keycloak_callback_success_without_offline_token(
         mock_token_manager.validate_offline_token = AsyncMock(return_value=False)
 
         result = await keycloak_callback(
-            code="test_code",
-            state="test_state",
+            code='test_code',
+            state='test_state',
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
@@ -478,19 +478,19 @@ async def test_keycloak_callback_success_without_offline_token(
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 302
         # In this case, we should be redirected to the Keycloak offline token URL
-        assert "keycloak.example.com" in result.headers["location"]
-        assert "offline_access" in result.headers["location"]
+        assert 'keycloak.example.com' in result.headers['location']
+        assert 'offline_access' in result.headers['location']
 
         mock_token_manager.store_idp_tokens.assert_called_once_with(
-            ProviderType.GITHUB, "test_user_id", "test_access_token"
+            ProviderType.GITHUB, 'test_user_id', 'test_access_token'
         )
         # When redirecting to Keycloak for offline token, redirect_url becomes https://keycloak...
         # so secure=True is expected
         mock_set_cookie.assert_called_once_with(
             request=mock_request,
             response=result,
-            keycloak_access_token="test_access_token",
-            keycloak_refresh_token="test_refresh_token",
+            keycloak_access_token='test_access_token',
+            keycloak_refresh_token='test_refresh_token',
             secure=True,
             accepted_tos=True,
         )
@@ -503,43 +503,43 @@ async def test_keycloak_callback_account_linking_error(mock_request):
     # Test the case where error is 'temporarily_unavailable' and error_description is 'authentication_expired'
     result = await keycloak_callback(
         code=None,
-        state="http://redirect.example.com",
-        error="temporarily_unavailable",
-        error_description="authentication_expired",
+        state='http://redirect.example.com',
+        error='temporarily_unavailable',
+        error_description='authentication_expired',
         request=mock_request,
         user_authorizer=create_mock_user_authorizer(),
     )
 
     assert isinstance(result, RedirectResponse)
     assert result.status_code == 302
-    assert result.headers["location"] == "http://redirect.example.com"
+    assert result.headers['location'] == 'http://redirect.example.com'
 
 
 @pytest.mark.asyncio
 async def test_keycloak_offline_callback_missing_code(mock_request):
     """Test keycloak_offline_callback with missing code."""
-    result = await keycloak_offline_callback("", "test_state", mock_request)
+    result = await keycloak_offline_callback('', 'test_state', mock_request)
 
     assert isinstance(result, JSONResponse)
     assert result.status_code == status.HTTP_400_BAD_REQUEST
-    assert "error" in result.body.decode()
-    assert "Missing code" in result.body.decode()
+    assert 'error' in result.body.decode()
+    assert 'Missing code' in result.body.decode()
 
 
 @pytest.mark.asyncio
 async def test_keycloak_offline_callback_token_retrieval_failure(mock_request):
     """Test keycloak_offline_callback when token retrieval fails."""
-    with patch("server.routes.auth.token_manager") as mock_token_manager:
+    with patch('server.routes.auth.token_manager') as mock_token_manager:
         mock_token_manager.get_keycloak_tokens = AsyncMock(return_value=(None, None))
 
         result = await keycloak_offline_callback(
-            "test_code", "test_state", mock_request
+            'test_code', 'test_state', mock_request
         )
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == status.HTTP_400_BAD_REQUEST
-        assert "error" in result.body.decode()
-        assert "Problem retrieving Keycloak tokens" in result.body.decode()
+        assert 'error' in result.body.decode()
+        assert 'Problem retrieving Keycloak tokens' in result.body.decode()
 
 
 @pytest.mark.asyncio
@@ -547,19 +547,19 @@ async def test_keycloak_offline_callback_missing_user_info(mock_request):
     """Test keycloak_offline_callback when user info is missing required fields."""
     from pydantic import ValidationError
 
-    with patch("server.routes.auth.token_manager") as mock_token_manager:
+    with patch('server.routes.auth.token_manager') as mock_token_manager:
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=("test_access_token", "test_refresh_token")
+            return_value=('test_access_token', 'test_refresh_token')
         )
         # With Pydantic model, missing 'sub' raises ValidationError during get_user_info
         mock_token_manager.get_user_info = AsyncMock(
             side_effect=ValidationError.from_exception_data(
-                "KeycloakUserInfo",
+                'KeycloakUserInfo',
                 [
                     {
-                        "type": "missing",
-                        "loc": ("sub",),
-                        "input": {"some_field": "value"},
+                        'type': 'missing',
+                        'loc': ('sub',),
+                        'input': {'some_field': 'value'},
                     }
                 ],
             )
@@ -567,7 +567,7 @@ async def test_keycloak_offline_callback_missing_user_info(mock_request):
 
         # The endpoint should propagate the error (or handle it gracefully)
         with pytest.raises(ValidationError):
-            await keycloak_offline_callback("test_code", "test_state", mock_request)
+            await keycloak_offline_callback('test_code', 'test_state', mock_request)
 
 
 @pytest.mark.asyncio
@@ -575,55 +575,55 @@ async def test_keycloak_offline_callback_success(
     mock_request, create_keycloak_user_info
 ):
     """Test successful keycloak_offline_callback."""
-    with patch("server.routes.auth.token_manager") as mock_token_manager:
+    with patch('server.routes.auth.token_manager') as mock_token_manager:
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=("test_access_token", "test_refresh_token")
+            return_value=('test_access_token', 'test_refresh_token')
         )
         mock_token_manager.get_user_info = AsyncMock(
-            return_value=create_keycloak_user_info(sub="test_user_id")
+            return_value=create_keycloak_user_info(sub='test_user_id')
         )
         mock_token_manager.store_idp_tokens = AsyncMock()
         mock_token_manager.store_offline_token = AsyncMock()
 
         result = await keycloak_offline_callback(
-            "test_code", "test_state", mock_request
+            'test_code', 'test_state', mock_request
         )
 
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 302
-        assert result.headers["location"] == "test_state"
+        assert result.headers['location'] == 'test_state'
 
         mock_token_manager.store_offline_token.assert_called_once_with(
-            user_id="test_user_id", offline_token="test_refresh_token"
+            user_id='test_user_id', offline_token='test_refresh_token'
         )
 
 
 @pytest.mark.asyncio
 async def test_authenticate_success():
     """Test successful authentication."""
-    with patch("server.routes.auth.get_access_token") as mock_get_token:
-        mock_get_token.return_value = "test_access_token"
+    with patch('server.routes.auth.get_access_token') as mock_get_token:
+        mock_get_token.return_value = 'test_access_token'
 
         result = await authenticate(MagicMock())
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == status.HTTP_200_OK
-        assert "message" in result.body.decode()
-        assert "User authenticated" in result.body.decode()
+        assert 'message' in result.body.decode()
+        assert 'User authenticated' in result.body.decode()
 
 
 @pytest.mark.asyncio
 async def test_authenticate_failure():
     """Test authentication failure."""
-    with patch("server.routes.auth.get_access_token") as mock_get_token:
+    with patch('server.routes.auth.get_access_token') as mock_get_token:
         mock_get_token.side_effect = AuthError()
 
         result = await authenticate(MagicMock())
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == status.HTTP_401_UNAUTHORIZED
-        assert "error" in result.body.decode()
-        assert "User is not authenticated" in result.body.decode()
+        assert 'error' in result.body.decode()
+        assert 'User is not authenticated' in result.body.decode()
 
 
 @pytest.mark.asyncio
@@ -631,21 +631,21 @@ async def test_logout_with_refresh_token():
     """Test logout with refresh token."""
     mock_request = MagicMock()
     mock_request.state.user_auth = SaasUserAuth(
-        refresh_token=SecretStr("test-refresh-token"), user_id="test_user_id"
+        refresh_token=SecretStr('test-refresh-token'), user_id='test_user_id'
     )
 
-    with patch("server.routes.auth.token_manager") as mock_token_manager:
+    with patch('server.routes.auth.token_manager') as mock_token_manager:
         mock_token_manager.logout = AsyncMock()
         result = await logout(mock_request)
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == status.HTTP_200_OK
-        assert "message" in result.body.decode()
-        assert "User logged out" in result.body.decode()
+        assert 'message' in result.body.decode()
+        assert 'User logged out' in result.body.decode()
 
-        mock_token_manager.logout.assert_called_once_with("test-refresh-token")
+        mock_token_manager.logout.assert_called_once_with('test-refresh-token')
         # Cookie should be deleted
-        assert "set-cookie" in result.headers
+        assert 'set-cookie' in result.headers
 
 
 @pytest.mark.asyncio
@@ -654,20 +654,20 @@ async def test_logout_without_refresh_token():
     mock_request = MagicMock(state=MagicMock(user_auth=None))
     # No refresh_token attribute
 
-    with patch("server.routes.auth.token_manager") as mock_token_manager:
+    with patch('server.routes.auth.token_manager') as mock_token_manager:
         with patch(
-            "openhands.server.user_auth.default_user_auth.DefaultUserAuth.get_instance"
+            'openhands.server.user_auth.default_user_auth.DefaultUserAuth.get_instance'
         ) as mock_get_instance:
             mock_get_instance.side_effect = AuthError()
             result = await logout(mock_request)
 
             assert isinstance(result, JSONResponse)
             assert result.status_code == status.HTTP_200_OK
-            assert "message" in result.body.decode()
-            assert "User logged out" in result.body.decode()
+            assert 'message' in result.body.decode()
+            assert 'User logged out' in result.body.decode()
 
             mock_token_manager.logout.assert_not_called()
-            assert "set-cookie" in result.headers
+            assert 'set-cookie' in result.headers
 
 
 @pytest.mark.asyncio
@@ -677,25 +677,25 @@ async def test_keycloak_callback_blocked_email_domain(
     """Test keycloak_callback when user authorization fails (blocked email domain)."""
     # Arrange
     with (
-        patch("server.routes.auth.token_manager") as mock_token_manager,
-        patch("server.routes.auth.UserStore") as mock_user_store,
+        patch('server.routes.auth.token_manager') as mock_token_manager,
+        patch('server.routes.auth.UserStore') as mock_user_store,
     ):
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=("test_access_token", "test_refresh_token")
+            return_value=('test_access_token', 'test_refresh_token')
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub="test_user_id",
-                preferred_username="test_user",
-                email="user@colsch.us",
-                identity_provider="github",
+                sub='test_user_id',
+                preferred_username='test_user',
+                email='user@colsch.us',
+                identity_provider='github',
             )
         )
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = "test_user_id"
-        mock_user.current_org_id = "test_org_id"
+        mock_user.id = 'test_user_id'
+        mock_user.current_org_id = 'test_org_id'
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
         mock_user_store.backfill_contact_name = AsyncMock()
@@ -703,21 +703,21 @@ async def test_keycloak_callback_blocked_email_domain(
 
         # Create mock user authorizer that blocks the user
         mock_authorizer = create_mock_user_authorizer(
-            success=False, error_detail="blocked"
+            success=False, error_detail='blocked'
         )
 
         # Act
         with pytest.raises(HTTPException) as exc_info:
             await keycloak_callback(
-                code="test_code",
-                state="test_state",
+                code='test_code',
+                state='test_state',
                 request=mock_request,
                 user_authorizer=mock_authorizer,
             )
 
         # Assert
         assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert exc_info.value.detail == "blocked"
+        assert exc_info.value.detail == 'blocked'
 
 
 # Note: test_keycloak_callback_allowed_email_domain was simplified as part of
@@ -736,12 +736,12 @@ async def test_keycloak_callback_missing_email(mock_request, create_keycloak_use
     """Test keycloak_callback when user info does not contain email."""
     # Arrange
     with (
-        patch("server.routes.auth.token_manager") as mock_token_manager,
+        patch('server.routes.auth.token_manager') as mock_token_manager,
         patch(
-            "storage.user_authorization_store.UserAuthorizationStore"
+            'storage.user_authorization_store.UserAuthorizationStore'
         ) as mock_user_auth_store,
-        patch("server.routes.auth.a_session_maker") as mock_session_maker,
-        patch("server.routes.auth.UserStore") as mock_user_store,
+        patch('server.routes.auth.a_session_maker') as mock_session_maker,
+        patch('server.routes.auth.UserStore') as mock_user_store,
     ):
         mock_session = MagicMock()
         mock_session_maker.return_value.__enter__.return_value = mock_session
@@ -750,17 +750,17 @@ async def test_keycloak_callback_missing_email(mock_request, create_keycloak_use
         mock_query.filter.return_value = mock_query
 
         mock_user_settings = MagicMock()
-        mock_user_settings.accepted_tos = "2025-01-01"
+        mock_user_settings.accepted_tos = '2025-01-01'
         mock_query.first.return_value = mock_user_settings
 
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=("test_access_token", "test_refresh_token")
+            return_value=('test_access_token', 'test_refresh_token')
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub="test_user_id",
-                preferred_username="test_user",
-                identity_provider="github",
+                sub='test_user_id',
+                preferred_username='test_user',
+                identity_provider='github',
                 email_verified=True,
                 # No email field
             )
@@ -770,9 +770,9 @@ async def test_keycloak_callback_missing_email(mock_request, create_keycloak_use
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = "test_user_id"
-        mock_user.current_org_id = "test_org_id"
-        mock_user.accepted_tos = "2025-01-01"
+        mock_user.id = 'test_user_id'
+        mock_user.current_org_id = 'test_org_id'
+        mock_user.accepted_tos = '2025-01-01'
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
         mock_user_store.backfill_contact_name = AsyncMock()
@@ -780,8 +780,8 @@ async def test_keycloak_callback_missing_email(mock_request, create_keycloak_use
 
         # Act
         result = await keycloak_callback(
-            code="test_code",
-            state="test_state",
+            code='test_code',
+            state='test_state',
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
@@ -803,26 +803,26 @@ async def test_keycloak_callback_duplicate_email_detected(
     failure when a duplicate email is detected.
     """
     with (
-        patch("server.routes.auth.token_manager") as mock_token_manager,
-        patch("server.routes.auth.UserStore") as mock_user_store,
+        patch('server.routes.auth.token_manager') as mock_token_manager,
+        patch('server.routes.auth.UserStore') as mock_user_store,
     ):
         # Arrange
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=("test_access_token", "test_refresh_token")
+            return_value=('test_access_token', 'test_refresh_token')
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub="test_user_id",
-                preferred_username="test_user",
-                email="joe+test@example.com",
-                identity_provider="github",
+                sub='test_user_id',
+                preferred_username='test_user',
+                email='joe+test@example.com',
+                identity_provider='github',
             )
         )
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = "test_user_id"
-        mock_user.current_org_id = "test_org_id"
+        mock_user.id = 'test_user_id'
+        mock_user.current_org_id = 'test_org_id'
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
         mock_user_store.backfill_contact_name = AsyncMock()
@@ -830,20 +830,20 @@ async def test_keycloak_callback_duplicate_email_detected(
 
         # Create mock authorizer that returns duplicate_email error
         mock_authorizer = create_mock_user_authorizer(
-            success=False, error_detail="duplicate_email"
+            success=False, error_detail='duplicate_email'
         )
 
         # Act & Assert - should raise HTTPException with 401
         with pytest.raises(HTTPException) as exc_info:
             await keycloak_callback(
-                code="test_code",
-                state="test_state",
+                code='test_code',
+                state='test_state',
                 request=mock_request,
                 user_authorizer=mock_authorizer,
             )
 
         assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert exc_info.value.detail == "duplicate_email"
+        assert exc_info.value.detail == 'duplicate_email'
 
 
 @pytest.mark.asyncio
@@ -857,19 +857,19 @@ async def test_keycloak_callback_duplicate_email_deletes_new_keycloak_user(
     user should be deleted to prevent orphaned accounts from blocking future sign-ins.
     """
     with (
-        patch("server.routes.auth.token_manager") as mock_token_manager,
-        patch("server.routes.auth.UserStore") as mock_user_store,
+        patch('server.routes.auth.token_manager') as mock_token_manager,
+        patch('server.routes.auth.UserStore') as mock_user_store,
     ):
         # Arrange
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=("test_access_token", "test_refresh_token")
+            return_value=('test_access_token', 'test_refresh_token')
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub="new_user_id",
-                preferred_username="test_user",
-                email="joe+1@example.com",
-                identity_provider="github",
+                sub='new_user_id',
+                preferred_username='test_user',
+                email='joe+1@example.com',
+                identity_provider='github',
             )
         )
         mock_token_manager.delete_keycloak_user = AsyncMock(return_value=True)
@@ -879,22 +879,22 @@ async def test_keycloak_callback_duplicate_email_deletes_new_keycloak_user(
 
         # Create mock authorizer that returns duplicate_email error
         mock_authorizer = create_mock_user_authorizer(
-            success=False, error_detail="duplicate_email"
+            success=False, error_detail='duplicate_email'
         )
 
         # Act & Assert
         with pytest.raises(HTTPException) as exc_info:
             await keycloak_callback(
-                code="test_code",
-                state="test_state",
+                code='test_code',
+                state='test_state',
                 request=mock_request,
                 user_authorizer=mock_authorizer,
             )
 
         assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert exc_info.value.detail == "duplicate_email"
+        assert exc_info.value.detail == 'duplicate_email'
         # Keycloak user should be deleted since user doesn't exist in UserStore
-        mock_token_manager.delete_keycloak_user.assert_called_once_with("new_user_id")
+        mock_token_manager.delete_keycloak_user.assert_called_once_with('new_user_id')
 
 
 @pytest.mark.asyncio
@@ -908,44 +908,44 @@ async def test_keycloak_callback_duplicate_email_preserves_existing_user(
     was disabled), the existing user's Keycloak account should NOT be deleted.
     """
     with (
-        patch("server.routes.auth.token_manager") as mock_token_manager,
-        patch("server.routes.auth.UserStore") as mock_user_store,
+        patch('server.routes.auth.token_manager') as mock_token_manager,
+        patch('server.routes.auth.UserStore') as mock_user_store,
     ):
         # Arrange
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=("test_access_token", "test_refresh_token")
+            return_value=('test_access_token', 'test_refresh_token')
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub="existing_user_id",
-                preferred_username="test_user",
-                email="joe@example.com",
-                identity_provider="github",
+                sub='existing_user_id',
+                preferred_username='test_user',
+                email='joe@example.com',
+                identity_provider='github',
             )
         )
         mock_token_manager.delete_keycloak_user = AsyncMock(return_value=True)
 
         # User EXISTS in UserStore (legitimate existing user)
         mock_existing_user = MagicMock()
-        mock_existing_user.id = "existing_user_id"
+        mock_existing_user.id = 'existing_user_id'
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_existing_user)
 
         # Create mock authorizer that returns duplicate_email error
         mock_authorizer = create_mock_user_authorizer(
-            success=False, error_detail="duplicate_email"
+            success=False, error_detail='duplicate_email'
         )
 
         # Act & Assert
         with pytest.raises(HTTPException) as exc_info:
             await keycloak_callback(
-                code="test_code",
-                state="test_state",
+                code='test_code',
+                state='test_state',
                 request=mock_request,
                 user_authorizer=mock_authorizer,
             )
 
         assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert exc_info.value.detail == "duplicate_email"
+        assert exc_info.value.detail == 'duplicate_email'
         # Keycloak user should NOT be deleted since user exists in UserStore
         mock_token_manager.delete_keycloak_user.assert_not_called()
 
@@ -956,9 +956,9 @@ async def test_keycloak_callback_duplicate_check_exception(
 ):
     """Test keycloak_callback when duplicate check raises exception."""
     with (
-        patch("server.routes.auth.token_manager") as mock_token_manager,
-        patch("server.routes.auth.a_session_maker") as mock_session_maker,
-        patch("server.routes.auth.UserStore") as mock_user_store,
+        patch('server.routes.auth.token_manager') as mock_token_manager,
+        patch('server.routes.auth.a_session_maker') as mock_session_maker,
+        patch('server.routes.auth.UserStore') as mock_user_store,
     ):
         # Arrange
         mock_session = MagicMock()
@@ -967,32 +967,32 @@ async def test_keycloak_callback_duplicate_check_exception(
         mock_session.query.return_value = mock_query
         mock_query.filter.return_value = mock_query
         mock_user_settings = MagicMock()
-        mock_user_settings.accepted_tos = "2025-01-01"
+        mock_user_settings.accepted_tos = '2025-01-01'
         mock_query.first.return_value = mock_user_settings
 
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=("test_access_token", "test_refresh_token")
+            return_value=('test_access_token', 'test_refresh_token')
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub="test_user_id",
-                preferred_username="test_user",
-                email="joe+test@example.com",
-                identity_provider="github",
+                sub='test_user_id',
+                preferred_username='test_user',
+                email='joe+test@example.com',
+                identity_provider='github',
                 email_verified=True,
             )
         )
         mock_token_manager.check_duplicate_base_email = AsyncMock(
-            side_effect=Exception("Check failed")
+            side_effect=Exception('Check failed')
         )
         mock_token_manager.store_idp_tokens = AsyncMock()
         mock_token_manager.validate_offline_token = AsyncMock(return_value=True)
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = "test_user_id"
-        mock_user.current_org_id = "test_org_id"
-        mock_user.accepted_tos = "2025-01-01"
+        mock_user.id = 'test_user_id'
+        mock_user.current_org_id = 'test_org_id'
+        mock_user.accepted_tos = '2025-01-01'
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
         mock_user_store.backfill_contact_name = AsyncMock()
@@ -1000,8 +1000,8 @@ async def test_keycloak_callback_duplicate_check_exception(
 
         # Act
         result = await keycloak_callback(
-            code="test_code",
-            state="test_state",
+            code='test_code',
+            state='test_state',
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
@@ -1022,9 +1022,9 @@ async def test_keycloak_callback_no_duplicate_email(
     This test verifies the normal flow when authorization is successful.
     """
     with (
-        patch("server.routes.auth.token_manager") as mock_token_manager,
-        patch("server.routes.auth.a_session_maker") as mock_session_maker,
-        patch("server.routes.auth.UserStore") as mock_user_store,
+        patch('server.routes.auth.token_manager') as mock_token_manager,
+        patch('server.routes.auth.a_session_maker') as mock_session_maker,
+        patch('server.routes.auth.UserStore') as mock_user_store,
     ):
         # Arrange
         mock_session = MagicMock()
@@ -1033,18 +1033,18 @@ async def test_keycloak_callback_no_duplicate_email(
         mock_session.query.return_value = mock_query
         mock_query.filter.return_value = mock_query
         mock_user_settings = MagicMock()
-        mock_user_settings.accepted_tos = "2025-01-01"
+        mock_user_settings.accepted_tos = '2025-01-01'
         mock_query.first.return_value = mock_user_settings
 
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=("test_access_token", "test_refresh_token")
+            return_value=('test_access_token', 'test_refresh_token')
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub="test_user_id",
-                preferred_username="test_user",
-                email="joe+test@example.com",
-                identity_provider="github",
+                sub='test_user_id',
+                preferred_username='test_user',
+                email='joe+test@example.com',
+                identity_provider='github',
                 email_verified=True,
             )
         )
@@ -1053,9 +1053,9 @@ async def test_keycloak_callback_no_duplicate_email(
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = "test_user_id"
-        mock_user.current_org_id = "test_org_id"
-        mock_user.accepted_tos = "2025-01-01"
+        mock_user.id = 'test_user_id'
+        mock_user.current_org_id = 'test_org_id'
+        mock_user.accepted_tos = '2025-01-01'
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
         mock_user_store.backfill_contact_name = AsyncMock()
@@ -1063,8 +1063,8 @@ async def test_keycloak_callback_no_duplicate_email(
 
         # Act - use successful authorizer (no duplicate detected)
         result = await keycloak_callback(
-            code="test_code",
-            state="test_state",
+            code='test_code',
+            state='test_state',
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(success=True),
         )
@@ -1080,9 +1080,9 @@ async def test_keycloak_callback_no_email_in_user_info(
 ):
     """Test keycloak_callback when email is not in user_info."""
     with (
-        patch("server.routes.auth.token_manager") as mock_token_manager,
-        patch("server.routes.auth.a_session_maker") as mock_session_maker,
-        patch("server.routes.auth.UserStore") as mock_user_store,
+        patch('server.routes.auth.token_manager') as mock_token_manager,
+        patch('server.routes.auth.a_session_maker') as mock_session_maker,
+        patch('server.routes.auth.UserStore') as mock_user_store,
     ):
         # Arrange
         mock_session = MagicMock()
@@ -1091,18 +1091,18 @@ async def test_keycloak_callback_no_email_in_user_info(
         mock_session.query.return_value = mock_query
         mock_query.filter.return_value = mock_query
         mock_user_settings = MagicMock()
-        mock_user_settings.accepted_tos = "2025-01-01"
+        mock_user_settings.accepted_tos = '2025-01-01'
         mock_query.first.return_value = mock_user_settings
 
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=("test_access_token", "test_refresh_token")
+            return_value=('test_access_token', 'test_refresh_token')
         )
         mock_token_manager.get_user_info = AsyncMock(
             return_value=create_keycloak_user_info(
-                sub="test_user_id",
-                preferred_username="test_user",
+                sub='test_user_id',
+                preferred_username='test_user',
                 # No email field
-                identity_provider="github",
+                identity_provider='github',
                 email_verified=True,
             )
         )
@@ -1111,9 +1111,9 @@ async def test_keycloak_callback_no_email_in_user_info(
 
         # Mock the user creation
         mock_user = MagicMock()
-        mock_user.id = "test_user_id"
-        mock_user.current_org_id = "test_org_id"
-        mock_user.accepted_tos = "2025-01-01"
+        mock_user.id = 'test_user_id'
+        mock_user.current_org_id = 'test_org_id'
+        mock_user.accepted_tos = '2025-01-01'
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
         mock_user_store.backfill_contact_name = AsyncMock()
@@ -1121,8 +1121,8 @@ async def test_keycloak_callback_no_email_in_user_info(
 
         # Act
         result = await keycloak_callback(
-            code="test_code",
-            state="test_state",
+            code='test_code',
+            state='test_state',
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
@@ -1144,8 +1144,8 @@ class TestKeycloakCallbackRecaptcha:
         """Test that login proceeds when reCAPTCHA score is high."""
         # Arrange
         state_data = {
-            "redirect_url": "https://example.com",
-            "recaptcha_token": "test-token",
+            'redirect_url': 'https://example.com',
+            'recaptcha_token': 'test-token',
         }
         encoded_state = base64.urlsafe_b64encode(
             json.dumps(state_data).encode()
@@ -1156,17 +1156,17 @@ class TestKeycloakCallbackRecaptcha:
         mock_assessment_result.score = 0.9
 
         with (
-            patch("server.routes.auth.token_manager") as mock_token_manager,
-            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
-            patch("server.routes.auth.RECAPTCHA_SITE_KEY", "test-site-key"),
-            patch("server.routes.auth.a_session_maker") as mock_session_maker,
+            patch('server.routes.auth.token_manager') as mock_token_manager,
+            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
+            patch('server.routes.auth.RECAPTCHA_SITE_KEY', 'test-site-key'),
+            patch('server.routes.auth.a_session_maker') as mock_session_maker,
             patch(
-                "storage.user_authorization_store.UserAuthorizationStore"
+                'storage.user_authorization_store.UserAuthorizationStore'
             ) as mock_user_auth_store,
-            patch("server.routes.auth.set_response_cookie"),
-            patch("server.routes.auth.posthog"),
-            patch("server.routes.email.verify_email", new_callable=AsyncMock),
-            patch("server.routes.auth.UserStore") as mock_user_store,
+            patch('server.routes.auth.set_response_cookie'),
+            patch('server.routes.auth.posthog'),
+            patch('server.routes.email.verify_email', new_callable=AsyncMock),
+            patch('server.routes.auth.UserStore') as mock_user_store,
         ):
             mock_session = MagicMock()
             mock_session_maker.return_value.__enter__.return_value = mock_session
@@ -1174,18 +1174,18 @@ class TestKeycloakCallbackRecaptcha:
             mock_session.query.return_value = mock_query
             mock_query.filter.return_value = mock_query
             mock_user_settings = MagicMock()
-            mock_user_settings.accepted_tos = "2025-01-01"
+            mock_user_settings.accepted_tos = '2025-01-01'
             mock_query.first.return_value = mock_user_settings
 
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=("test_access_token", "test_refresh_token")
+                return_value=('test_access_token', 'test_refresh_token')
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub="test_user_id",
-                    preferred_username="test_user",
-                    email="user@example.com",
-                    identity_provider="github",
+                    sub='test_user_id',
+                    preferred_username='test_user',
+                    email='user@example.com',
+                    identity_provider='github',
                     email_verified=True,
                 )
             )
@@ -1197,9 +1197,9 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = "test_user_id"
-            mock_user.current_org_id = "test_org_id"
-            mock_user.accepted_tos = "2025-01-01"
+            mock_user.id = 'test_user_id'
+            mock_user.current_org_id = 'test_org_id'
+            mock_user.accepted_tos = '2025-01-01'
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1214,7 +1214,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Act
             result = await keycloak_callback(
-                code="test_code",
+                code='test_code',
                 state=encoded_state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1232,8 +1232,8 @@ class TestKeycloakCallbackRecaptcha:
         """Test that login is blocked and redirected when reCAPTCHA score is low."""
         # Arrange
         state_data = {
-            "redirect_url": "https://example.com",
-            "recaptcha_token": "test-token",
+            'redirect_url': 'https://example.com',
+            'recaptcha_token': 'test-token',
         }
         encoded_state = base64.urlsafe_b64encode(
             json.dumps(state_data).encode()
@@ -1244,22 +1244,22 @@ class TestKeycloakCallbackRecaptcha:
         mock_assessment_result.score = 0.2
 
         with (
-            patch("server.routes.auth.token_manager") as mock_token_manager,
-            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
-            patch("server.routes.auth.RECAPTCHA_SITE_KEY", "test-site-key"),
+            patch('server.routes.auth.token_manager') as mock_token_manager,
+            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
+            patch('server.routes.auth.RECAPTCHA_SITE_KEY', 'test-site-key'),
             patch(
-                "storage.user_authorization_store.UserAuthorizationStore"
+                'storage.user_authorization_store.UserAuthorizationStore'
             ) as mock_user_auth_store,
-            patch("server.routes.auth.UserStore") as mock_user_store,
+            patch('server.routes.auth.UserStore') as mock_user_store,
         ):
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=("test_access_token", "test_refresh_token")
+                return_value=('test_access_token', 'test_refresh_token')
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub="test_user_id",
-                    preferred_username="test_user",
-                    email="user@example.com",
+                    sub='test_user_id',
+                    preferred_username='test_user',
+                    email='user@example.com',
                 )
             )
             mock_token_manager.check_duplicate_base_email = AsyncMock(
@@ -1268,8 +1268,8 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = "test_user_id"
-            mock_user.current_org_id = "test_org_id"
+            mock_user.id = 'test_user_id'
+            mock_user.current_org_id = 'test_org_id'
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1284,7 +1284,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Act
             result = await keycloak_callback(
-                code="test_code",
+                code='test_code',
                 state=encoded_state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1293,7 +1293,7 @@ class TestKeycloakCallbackRecaptcha:
             # Assert
             assert isinstance(result, RedirectResponse)
             assert result.status_code == 302
-            assert "recaptcha_blocked=true" in result.headers["location"]
+            assert 'recaptcha_blocked=true' in result.headers['location']
 
     @pytest.mark.asyncio
     async def test_should_extract_ip_from_x_forwarded_for_header(
@@ -1302,31 +1302,31 @@ class TestKeycloakCallbackRecaptcha:
         """Test that IP is extracted from X-Forwarded-For header when present."""
         # Arrange
         state_data = {
-            "redirect_url": "https://example.com",
-            "recaptcha_token": "test-token",
+            'redirect_url': 'https://example.com',
+            'recaptcha_token': 'test-token',
         }
         encoded_state = base64.urlsafe_b64encode(
             json.dumps(state_data).encode()
         ).decode()
 
-        mock_request.headers = {"X-Forwarded-For": "192.168.1.1, 10.0.0.1"}
+        mock_request.headers = {'X-Forwarded-For': '192.168.1.1, 10.0.0.1'}
         mock_request.client = None
 
         mock_assessment_result = MagicMock()
         mock_assessment_result.allowed = True
 
         with (
-            patch("server.routes.auth.token_manager") as mock_token_manager,
-            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
-            patch("server.routes.auth.RECAPTCHA_SITE_KEY", "test-site-key"),
+            patch('server.routes.auth.token_manager') as mock_token_manager,
+            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
+            patch('server.routes.auth.RECAPTCHA_SITE_KEY', 'test-site-key'),
             patch(
-                "storage.user_authorization_store.UserAuthorizationStore"
+                'storage.user_authorization_store.UserAuthorizationStore'
             ) as mock_user_auth_store,
-            patch("server.routes.auth.a_session_maker") as mock_session_maker,
-            patch("server.routes.auth.set_response_cookie"),
-            patch("server.routes.auth.posthog"),
-            patch("server.routes.email.verify_email", new_callable=AsyncMock),
-            patch("server.routes.auth.UserStore") as mock_user_store,
+            patch('server.routes.auth.a_session_maker') as mock_session_maker,
+            patch('server.routes.auth.set_response_cookie'),
+            patch('server.routes.auth.posthog'),
+            patch('server.routes.email.verify_email', new_callable=AsyncMock),
+            patch('server.routes.auth.UserStore') as mock_user_store,
         ):
             mock_session = MagicMock()
             mock_session_maker.return_value.__enter__.return_value = mock_session
@@ -1334,18 +1334,18 @@ class TestKeycloakCallbackRecaptcha:
             mock_session.query.return_value = mock_query
             mock_query.filter.return_value = mock_query
             mock_user_settings = MagicMock()
-            mock_user_settings.accepted_tos = "2025-01-01"
+            mock_user_settings.accepted_tos = '2025-01-01'
             mock_query.first.return_value = mock_user_settings
 
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=("test_access_token", "test_refresh_token")
+                return_value=('test_access_token', 'test_refresh_token')
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub="test_user_id",
-                    preferred_username="test_user",
-                    email="user@example.com",
-                    identity_provider="github",
+                    sub='test_user_id',
+                    preferred_username='test_user',
+                    email='user@example.com',
+                    identity_provider='github',
                     email_verified=True,
                 )
             )
@@ -1357,9 +1357,9 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = "test_user_id"
-            mock_user.current_org_id = "test_org_id"
-            mock_user.accepted_tos = "2025-01-01"
+            mock_user.id = 'test_user_id'
+            mock_user.current_org_id = 'test_org_id'
+            mock_user.accepted_tos = '2025-01-01'
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1374,7 +1374,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Act
             await keycloak_callback(
-                code="test_code",
+                code='test_code',
                 state=encoded_state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1382,7 +1382,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Assert
             call_args = mock_recaptcha_service.create_assessment.call_args
-            assert call_args[1]["user_ip"] == "192.168.1.1"
+            assert call_args[1]['user_ip'] == '192.168.1.1'
 
     @pytest.mark.asyncio
     async def test_should_use_client_host_when_x_forwarded_for_missing(
@@ -1391,8 +1391,8 @@ class TestKeycloakCallbackRecaptcha:
         """Test that client.host is used when X-Forwarded-For is missing."""
         # Arrange
         state_data = {
-            "redirect_url": "https://example.com",
-            "recaptcha_token": "test-token",
+            'redirect_url': 'https://example.com',
+            'recaptcha_token': 'test-token',
         }
         encoded_state = base64.urlsafe_b64encode(
             json.dumps(state_data).encode()
@@ -1400,23 +1400,23 @@ class TestKeycloakCallbackRecaptcha:
 
         mock_request.headers = {}
         mock_request.client = MagicMock()
-        mock_request.client.host = "192.168.1.2"
+        mock_request.client.host = '192.168.1.2'
 
         mock_assessment_result = MagicMock()
         mock_assessment_result.allowed = True
 
         with (
-            patch("server.routes.auth.token_manager") as mock_token_manager,
-            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
-            patch("server.routes.auth.RECAPTCHA_SITE_KEY", "test-site-key"),
+            patch('server.routes.auth.token_manager') as mock_token_manager,
+            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
+            patch('server.routes.auth.RECAPTCHA_SITE_KEY', 'test-site-key'),
             patch(
-                "storage.user_authorization_store.UserAuthorizationStore"
+                'storage.user_authorization_store.UserAuthorizationStore'
             ) as mock_user_auth_store,
-            patch("server.routes.auth.a_session_maker") as mock_session_maker,
-            patch("server.routes.auth.set_response_cookie"),
-            patch("server.routes.auth.posthog"),
-            patch("server.routes.email.verify_email", new_callable=AsyncMock),
-            patch("server.routes.auth.UserStore") as mock_user_store,
+            patch('server.routes.auth.a_session_maker') as mock_session_maker,
+            patch('server.routes.auth.set_response_cookie'),
+            patch('server.routes.auth.posthog'),
+            patch('server.routes.email.verify_email', new_callable=AsyncMock),
+            patch('server.routes.auth.UserStore') as mock_user_store,
         ):
             mock_session = MagicMock()
             mock_session_maker.return_value.__enter__.return_value = mock_session
@@ -1424,18 +1424,18 @@ class TestKeycloakCallbackRecaptcha:
             mock_session.query.return_value = mock_query
             mock_query.filter.return_value = mock_query
             mock_user_settings = MagicMock()
-            mock_user_settings.accepted_tos = "2025-01-01"
+            mock_user_settings.accepted_tos = '2025-01-01'
             mock_query.first.return_value = mock_user_settings
 
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=("test_access_token", "test_refresh_token")
+                return_value=('test_access_token', 'test_refresh_token')
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub="test_user_id",
-                    preferred_username="test_user",
-                    email="user@example.com",
-                    identity_provider="github",
+                    sub='test_user_id',
+                    preferred_username='test_user',
+                    email='user@example.com',
+                    identity_provider='github',
                     email_verified=True,
                 )
             )
@@ -1447,9 +1447,9 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = "test_user_id"
-            mock_user.current_org_id = "test_org_id"
-            mock_user.accepted_tos = "2025-01-01"
+            mock_user.id = 'test_user_id'
+            mock_user.current_org_id = 'test_org_id'
+            mock_user.accepted_tos = '2025-01-01'
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1464,7 +1464,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Act
             await keycloak_callback(
-                code="test_code",
+                code='test_code',
                 state=encoded_state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1472,7 +1472,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Assert
             call_args = mock_recaptcha_service.create_assessment.call_args
-            assert call_args[1]["user_ip"] == "192.168.1.2"
+            assert call_args[1]['user_ip'] == '192.168.1.2'
 
     @pytest.mark.asyncio
     async def test_should_use_unknown_ip_when_client_is_none(
@@ -1481,8 +1481,8 @@ class TestKeycloakCallbackRecaptcha:
         """Test that 'unknown' IP is used when client is None."""
         # Arrange
         state_data = {
-            "redirect_url": "https://example.com",
-            "recaptcha_token": "test-token",
+            'redirect_url': 'https://example.com',
+            'recaptcha_token': 'test-token',
         }
         encoded_state = base64.urlsafe_b64encode(
             json.dumps(state_data).encode()
@@ -1495,17 +1495,17 @@ class TestKeycloakCallbackRecaptcha:
         mock_assessment_result.allowed = True
 
         with (
-            patch("server.routes.auth.token_manager") as mock_token_manager,
-            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
-            patch("server.routes.auth.RECAPTCHA_SITE_KEY", "test-site-key"),
+            patch('server.routes.auth.token_manager') as mock_token_manager,
+            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
+            patch('server.routes.auth.RECAPTCHA_SITE_KEY', 'test-site-key'),
             patch(
-                "storage.user_authorization_store.UserAuthorizationStore"
+                'storage.user_authorization_store.UserAuthorizationStore'
             ) as mock_user_auth_store,
-            patch("server.routes.auth.a_session_maker") as mock_session_maker,
-            patch("server.routes.auth.set_response_cookie"),
-            patch("server.routes.auth.posthog"),
-            patch("server.routes.email.verify_email", new_callable=AsyncMock),
-            patch("server.routes.auth.UserStore") as mock_user_store,
+            patch('server.routes.auth.a_session_maker') as mock_session_maker,
+            patch('server.routes.auth.set_response_cookie'),
+            patch('server.routes.auth.posthog'),
+            patch('server.routes.email.verify_email', new_callable=AsyncMock),
+            patch('server.routes.auth.UserStore') as mock_user_store,
         ):
             mock_session = MagicMock()
             mock_session_maker.return_value.__enter__.return_value = mock_session
@@ -1513,18 +1513,18 @@ class TestKeycloakCallbackRecaptcha:
             mock_session.query.return_value = mock_query
             mock_query.filter.return_value = mock_query
             mock_user_settings = MagicMock()
-            mock_user_settings.accepted_tos = "2025-01-01"
+            mock_user_settings.accepted_tos = '2025-01-01'
             mock_query.first.return_value = mock_user_settings
 
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=("test_access_token", "test_refresh_token")
+                return_value=('test_access_token', 'test_refresh_token')
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub="test_user_id",
-                    preferred_username="test_user",
-                    email="user@example.com",
-                    identity_provider="github",
+                    sub='test_user_id',
+                    preferred_username='test_user',
+                    email='user@example.com',
+                    identity_provider='github',
                     email_verified=True,
                 )
             )
@@ -1536,9 +1536,9 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = "test_user_id"
-            mock_user.current_org_id = "test_org_id"
-            mock_user.accepted_tos = "2025-01-01"
+            mock_user.id = 'test_user_id'
+            mock_user.current_org_id = 'test_org_id'
+            mock_user.accepted_tos = '2025-01-01'
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1553,7 +1553,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Act
             await keycloak_callback(
-                code="test_code",
+                code='test_code',
                 state=encoded_state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1561,7 +1561,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Assert
             call_args = mock_recaptcha_service.create_assessment.call_args
-            assert call_args[1]["user_ip"] == "unknown"
+            assert call_args[1]['user_ip'] == 'unknown'
 
     @pytest.mark.asyncio
     async def test_should_include_email_in_assessment_when_available(
@@ -1570,8 +1570,8 @@ class TestKeycloakCallbackRecaptcha:
         """Test that email is included in assessment when available."""
         # Arrange
         state_data = {
-            "redirect_url": "https://example.com",
-            "recaptcha_token": "test-token",
+            'redirect_url': 'https://example.com',
+            'recaptcha_token': 'test-token',
         }
         encoded_state = base64.urlsafe_b64encode(
             json.dumps(state_data).encode()
@@ -1581,17 +1581,17 @@ class TestKeycloakCallbackRecaptcha:
         mock_assessment_result.allowed = True
 
         with (
-            patch("server.routes.auth.token_manager") as mock_token_manager,
-            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
-            patch("server.routes.auth.RECAPTCHA_SITE_KEY", "test-site-key"),
+            patch('server.routes.auth.token_manager') as mock_token_manager,
+            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
+            patch('server.routes.auth.RECAPTCHA_SITE_KEY', 'test-site-key'),
             patch(
-                "storage.user_authorization_store.UserAuthorizationStore"
+                'storage.user_authorization_store.UserAuthorizationStore'
             ) as mock_user_auth_store,
-            patch("server.routes.auth.a_session_maker") as mock_session_maker,
-            patch("server.routes.auth.set_response_cookie"),
-            patch("server.routes.auth.posthog"),
-            patch("server.routes.email.verify_email", new_callable=AsyncMock),
-            patch("server.routes.auth.UserStore") as mock_user_store,
+            patch('server.routes.auth.a_session_maker') as mock_session_maker,
+            patch('server.routes.auth.set_response_cookie'),
+            patch('server.routes.auth.posthog'),
+            patch('server.routes.email.verify_email', new_callable=AsyncMock),
+            patch('server.routes.auth.UserStore') as mock_user_store,
         ):
             mock_session = MagicMock()
             mock_session_maker.return_value.__enter__.return_value = mock_session
@@ -1599,18 +1599,18 @@ class TestKeycloakCallbackRecaptcha:
             mock_session.query.return_value = mock_query
             mock_query.filter.return_value = mock_query
             mock_user_settings = MagicMock()
-            mock_user_settings.accepted_tos = "2025-01-01"
+            mock_user_settings.accepted_tos = '2025-01-01'
             mock_query.first.return_value = mock_user_settings
 
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=("test_access_token", "test_refresh_token")
+                return_value=('test_access_token', 'test_refresh_token')
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub="test_user_id",
-                    preferred_username="test_user",
-                    email="user@example.com",
-                    identity_provider="github",
+                    sub='test_user_id',
+                    preferred_username='test_user',
+                    email='user@example.com',
+                    identity_provider='github',
                     email_verified=True,
                 )
             )
@@ -1622,9 +1622,9 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = "test_user_id"
-            mock_user.current_org_id = "test_org_id"
-            mock_user.accepted_tos = "2025-01-01"
+            mock_user.id = 'test_user_id'
+            mock_user.current_org_id = 'test_org_id'
+            mock_user.accepted_tos = '2025-01-01'
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1639,7 +1639,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Act
             await keycloak_callback(
-                code="test_code",
+                code='test_code',
                 state=encoded_state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1647,7 +1647,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Assert
             call_args = mock_recaptcha_service.create_assessment.call_args
-            assert call_args[1]["email"] == "user@example.com"
+            assert call_args[1]['email'] == 'user@example.com'
 
     @pytest.mark.asyncio
     async def test_should_skip_recaptcha_when_site_key_not_configured(
@@ -1656,25 +1656,25 @@ class TestKeycloakCallbackRecaptcha:
         """Test that reCAPTCHA is skipped when RECAPTCHA_SITE_KEY is not configured."""
         # Arrange
         state_data = {
-            "redirect_url": "https://example.com",
-            "recaptcha_token": "test-token",
+            'redirect_url': 'https://example.com',
+            'recaptcha_token': 'test-token',
         }
         encoded_state = base64.urlsafe_b64encode(
             json.dumps(state_data).encode()
         ).decode()
 
         with (
-            patch("server.routes.auth.token_manager") as mock_token_manager,
-            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
-            patch("server.routes.auth.RECAPTCHA_SITE_KEY", ""),
-            patch("server.routes.auth.a_session_maker") as mock_session_maker,
+            patch('server.routes.auth.token_manager') as mock_token_manager,
+            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
+            patch('server.routes.auth.RECAPTCHA_SITE_KEY', ''),
+            patch('server.routes.auth.a_session_maker') as mock_session_maker,
             patch(
-                "storage.user_authorization_store.UserAuthorizationStore"
+                'storage.user_authorization_store.UserAuthorizationStore'
             ) as mock_user_auth_store,
-            patch("server.routes.auth.set_response_cookie"),
-            patch("server.routes.auth.posthog"),
-            patch("server.routes.email.verify_email", new_callable=AsyncMock),
-            patch("server.routes.auth.UserStore") as mock_user_store,
+            patch('server.routes.auth.set_response_cookie'),
+            patch('server.routes.auth.posthog'),
+            patch('server.routes.email.verify_email', new_callable=AsyncMock),
+            patch('server.routes.auth.UserStore') as mock_user_store,
         ):
             mock_session = MagicMock()
             mock_session_maker.return_value.__enter__.return_value = mock_session
@@ -1682,18 +1682,18 @@ class TestKeycloakCallbackRecaptcha:
             mock_session.query.return_value = mock_query
             mock_query.filter.return_value = mock_query
             mock_user_settings = MagicMock()
-            mock_user_settings.accepted_tos = "2025-01-01"
+            mock_user_settings.accepted_tos = '2025-01-01'
             mock_query.first.return_value = mock_user_settings
 
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=("test_access_token", "test_refresh_token")
+                return_value=('test_access_token', 'test_refresh_token')
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub="test_user_id",
-                    preferred_username="test_user",
-                    email="user@example.com",
-                    identity_provider="github",
+                    sub='test_user_id',
+                    preferred_username='test_user',
+                    email='user@example.com',
+                    identity_provider='github',
                     email_verified=True,
                 )
             )
@@ -1705,9 +1705,9 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = "test_user_id"
-            mock_user.current_org_id = "test_org_id"
-            mock_user.accepted_tos = "2025-01-01"
+            mock_user.id = 'test_user_id'
+            mock_user.current_org_id = 'test_org_id'
+            mock_user.accepted_tos = '2025-01-01'
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1717,7 +1717,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Act
             await keycloak_callback(
-                code="test_code",
+                code='test_code',
                 state=encoded_state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1732,20 +1732,20 @@ class TestKeycloakCallbackRecaptcha:
     ):
         """Test that reCAPTCHA is skipped when token is missing from state."""
         # Arrange
-        state = "https://example.com"  # Old format without token
+        state = 'https://example.com'  # Old format without token
 
         with (
-            patch("server.routes.auth.token_manager") as mock_token_manager,
-            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
-            patch("server.routes.auth.RECAPTCHA_SITE_KEY", "test-site-key"),
-            patch("server.routes.auth.a_session_maker") as mock_session_maker,
+            patch('server.routes.auth.token_manager') as mock_token_manager,
+            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
+            patch('server.routes.auth.RECAPTCHA_SITE_KEY', 'test-site-key'),
+            patch('server.routes.auth.a_session_maker') as mock_session_maker,
             patch(
-                "storage.user_authorization_store.UserAuthorizationStore"
+                'storage.user_authorization_store.UserAuthorizationStore'
             ) as mock_user_auth_store,
-            patch("server.routes.auth.set_response_cookie"),
-            patch("server.routes.auth.posthog"),
-            patch("server.routes.email.verify_email", new_callable=AsyncMock),
-            patch("server.routes.auth.UserStore") as mock_user_store,
+            patch('server.routes.auth.set_response_cookie'),
+            patch('server.routes.auth.posthog'),
+            patch('server.routes.email.verify_email', new_callable=AsyncMock),
+            patch('server.routes.auth.UserStore') as mock_user_store,
         ):
             mock_session = MagicMock()
             mock_session_maker.return_value.__enter__.return_value = mock_session
@@ -1753,18 +1753,18 @@ class TestKeycloakCallbackRecaptcha:
             mock_session.query.return_value = mock_query
             mock_query.filter.return_value = mock_query
             mock_user_settings = MagicMock()
-            mock_user_settings.accepted_tos = "2025-01-01"
+            mock_user_settings.accepted_tos = '2025-01-01'
             mock_query.first.return_value = mock_user_settings
 
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=("test_access_token", "test_refresh_token")
+                return_value=('test_access_token', 'test_refresh_token')
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub="test_user_id",
-                    preferred_username="test_user",
-                    email="user@example.com",
-                    identity_provider="github",
+                    sub='test_user_id',
+                    preferred_username='test_user',
+                    email='user@example.com',
+                    identity_provider='github',
                     email_verified=True,
                 )
             )
@@ -1776,9 +1776,9 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = "test_user_id"
-            mock_user.current_org_id = "test_org_id"
-            mock_user.accepted_tos = "2025-01-01"
+            mock_user.id = 'test_user_id'
+            mock_user.current_org_id = 'test_org_id'
+            mock_user.accepted_tos = '2025-01-01'
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1788,7 +1788,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Act
             await keycloak_callback(
-                code="test_code",
+                code='test_code',
                 state=state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1804,25 +1804,25 @@ class TestKeycloakCallbackRecaptcha:
         """Test that login proceeds (fail open) when reCAPTCHA service throws exception."""
         # Arrange
         state_data = {
-            "redirect_url": "https://example.com",
-            "recaptcha_token": "test-token",
+            'redirect_url': 'https://example.com',
+            'recaptcha_token': 'test-token',
         }
         encoded_state = base64.urlsafe_b64encode(
             json.dumps(state_data).encode()
         ).decode()
 
         with (
-            patch("server.routes.auth.token_manager") as mock_token_manager,
-            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
-            patch("server.routes.auth.RECAPTCHA_SITE_KEY", "test-site-key"),
-            patch("server.routes.auth.a_session_maker") as mock_session_maker,
+            patch('server.routes.auth.token_manager') as mock_token_manager,
+            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
+            patch('server.routes.auth.RECAPTCHA_SITE_KEY', 'test-site-key'),
+            patch('server.routes.auth.a_session_maker') as mock_session_maker,
             patch(
-                "storage.user_authorization_store.UserAuthorizationStore"
+                'storage.user_authorization_store.UserAuthorizationStore'
             ) as mock_user_auth_store,
-            patch("server.routes.auth.set_response_cookie"),
-            patch("server.routes.auth.posthog"),
-            patch("server.routes.auth.logger") as mock_logger,
-            patch("server.routes.auth.UserStore") as mock_user_store,
+            patch('server.routes.auth.set_response_cookie'),
+            patch('server.routes.auth.posthog'),
+            patch('server.routes.auth.logger') as mock_logger,
+            patch('server.routes.auth.UserStore') as mock_user_store,
         ):
             mock_session = MagicMock()
             mock_session_maker.return_value.__enter__.return_value = mock_session
@@ -1830,18 +1830,18 @@ class TestKeycloakCallbackRecaptcha:
             mock_session.query.return_value = mock_query
             mock_query.filter.return_value = mock_query
             mock_user_settings = MagicMock()
-            mock_user_settings.accepted_tos = "2025-01-01"
+            mock_user_settings.accepted_tos = '2025-01-01'
             mock_query.first.return_value = mock_user_settings
 
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=("test_access_token", "test_refresh_token")
+                return_value=('test_access_token', 'test_refresh_token')
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub="test_user_id",
-                    preferred_username="test_user",
-                    email="user@example.com",
-                    identity_provider="github",
+                    sub='test_user_id',
+                    preferred_username='test_user',
+                    email='user@example.com',
+                    identity_provider='github',
                     email_verified=True,
                 )
             )
@@ -1853,9 +1853,9 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = "test_user_id"
-            mock_user.current_org_id = "test_org_id"
-            mock_user.accepted_tos = "2025-01-01"
+            mock_user.id = 'test_user_id'
+            mock_user.current_org_id = 'test_org_id'
+            mock_user.accepted_tos = '2025-01-01'
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1864,12 +1864,12 @@ class TestKeycloakCallbackRecaptcha:
             mock_user_auth_store.get_authorization_type = AsyncMock(return_value=None)
 
             mock_recaptcha_service.create_assessment.side_effect = Exception(
-                "Service error"
+                'Service error'
             )
 
             # Act
             result = await keycloak_callback(
-                code="test_code",
+                code='test_code',
                 state=encoded_state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1881,7 +1881,7 @@ class TestKeycloakCallbackRecaptcha:
             recaptcha_error_calls = [
                 call
                 for call in mock_logger.exception.call_args_list
-                if "reCAPTCHA verification error" in str(call)
+                if 'reCAPTCHA verification error' in str(call)
             ]
             assert len(recaptcha_error_calls) > 0
 
@@ -1892,8 +1892,8 @@ class TestKeycloakCallbackRecaptcha:
         """Test that warning is logged when reCAPTCHA blocks user."""
         # Arrange
         state_data = {
-            "redirect_url": "https://example.com",
-            "recaptcha_token": "test-token",
+            'redirect_url': 'https://example.com',
+            'recaptcha_token': 'test-token',
         }
         encoded_state = base64.urlsafe_b64encode(
             json.dumps(state_data).encode()
@@ -1904,24 +1904,24 @@ class TestKeycloakCallbackRecaptcha:
         mock_assessment_result.score = 0.2
 
         with (
-            patch("server.routes.auth.token_manager") as mock_token_manager,
-            patch("server.routes.auth.recaptcha_service") as mock_recaptcha_service,
-            patch("server.routes.auth.RECAPTCHA_SITE_KEY", "test-site-key"),
+            patch('server.routes.auth.token_manager') as mock_token_manager,
+            patch('server.routes.auth.recaptcha_service') as mock_recaptcha_service,
+            patch('server.routes.auth.RECAPTCHA_SITE_KEY', 'test-site-key'),
             patch(
-                "storage.user_authorization_store.UserAuthorizationStore"
+                'storage.user_authorization_store.UserAuthorizationStore'
             ) as mock_user_auth_store,
-            patch("server.routes.auth.logger") as mock_logger,
-            patch("server.routes.email.verify_email", new_callable=AsyncMock),
-            patch("server.routes.auth.UserStore") as mock_user_store,
+            patch('server.routes.auth.logger') as mock_logger,
+            patch('server.routes.email.verify_email', new_callable=AsyncMock),
+            patch('server.routes.auth.UserStore') as mock_user_store,
         ):
             mock_token_manager.get_keycloak_tokens = AsyncMock(
-                return_value=("test_access_token", "test_refresh_token")
+                return_value=('test_access_token', 'test_refresh_token')
             )
             mock_token_manager.get_user_info = AsyncMock(
                 return_value=create_keycloak_user_info(
-                    sub="test_user_id",
-                    preferred_username="test_user",
-                    email="user@example.com",
+                    sub='test_user_id',
+                    preferred_username='test_user',
+                    email='user@example.com',
                 )
             )
             mock_token_manager.check_duplicate_base_email = AsyncMock(
@@ -1930,8 +1930,8 @@ class TestKeycloakCallbackRecaptcha:
 
             # Setup UserStore mocks
             mock_user = MagicMock()
-            mock_user.id = "test_user_id"
-            mock_user.current_org_id = "test_org_id"
+            mock_user.id = 'test_user_id'
+            mock_user.current_org_id = 'test_org_id'
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
             mock_user_store.create_user = AsyncMock(return_value=mock_user)
             mock_user_store.backfill_contact_name = AsyncMock()
@@ -1946,7 +1946,7 @@ class TestKeycloakCallbackRecaptcha:
 
             # Act
             await keycloak_callback(
-                code="test_code",
+                code='test_code',
                 state=encoded_state,
                 request=mock_request,
                 user_authorizer=create_mock_user_authorizer(),
@@ -1955,9 +1955,9 @@ class TestKeycloakCallbackRecaptcha:
             # Assert
             mock_logger.warning.assert_called_once()
             call_kwargs = mock_logger.warning.call_args
-            assert call_kwargs[0][0] == "recaptcha_blocked_at_callback"
-            assert call_kwargs[1]["extra"]["score"] == 0.2
-            assert call_kwargs[1]["extra"]["user_id"] == "test_user_id"
+            assert call_kwargs[0][0] == 'recaptcha_blocked_at_callback'
+            assert call_kwargs[1]['extra']['score'] == 0.2
+            assert call_kwargs[1]['extra']['user_id'] == 'test_user_id'
 
 
 @pytest.mark.asyncio
@@ -1966,23 +1966,23 @@ async def test_keycloak_callback_calls_backfill_user_email_for_existing_user(
 ):
     """When an existing user logs in, backfill_user_email should be called."""
     user_info = create_keycloak_user_info(
-        sub="test_user_id",
-        preferred_username="test_user",
-        identity_provider="github",
-        email="test@example.com",
+        sub='test_user_id',
+        preferred_username='test_user',
+        identity_provider='github',
+        email='test@example.com',
         email_verified=True,
     )
 
     with (
-        patch("server.routes.auth.token_manager") as mock_token_manager,
-        patch("server.routes.auth.set_response_cookie"),
-        patch("server.routes.auth.UserStore") as mock_user_store,
-        patch("server.routes.auth.posthog"),
+        patch('server.routes.auth.token_manager') as mock_token_manager,
+        patch('server.routes.auth.set_response_cookie'),
+        patch('server.routes.auth.UserStore') as mock_user_store,
+        patch('server.routes.auth.posthog'),
     ):
         mock_user = MagicMock()
-        mock_user.id = "test_user_id"
-        mock_user.current_org_id = "test_org_id"
-        mock_user.accepted_tos = "2025-01-01"
+        mock_user.id = 'test_user_id'
+        mock_user.current_org_id = 'test_org_id'
+        mock_user.accepted_tos = '2025-01-01'
 
         mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
         mock_user_store.create_user = AsyncMock(return_value=mock_user)
@@ -1990,7 +1990,7 @@ async def test_keycloak_callback_calls_backfill_user_email_for_existing_user(
         mock_user_store.backfill_user_email = AsyncMock()
 
         mock_token_manager.get_keycloak_tokens = AsyncMock(
-            return_value=("test_access_token", "test_refresh_token")
+            return_value=('test_access_token', 'test_refresh_token')
         )
         mock_token_manager.get_user_info = AsyncMock(return_value=user_info)
         mock_token_manager.store_idp_tokens = AsyncMock()
@@ -1998,8 +1998,8 @@ async def test_keycloak_callback_calls_backfill_user_email_for_existing_user(
         mock_token_manager.check_duplicate_base_email = AsyncMock(return_value=False)
 
         result = await keycloak_callback(
-            code="test_code",
-            state="test_state",
+            code='test_code',
+            state='test_state',
             request=mock_request,
             user_authorizer=create_mock_user_authorizer(),
         )
@@ -2009,7 +2009,7 @@ async def test_keycloak_callback_calls_backfill_user_email_for_existing_user(
 
         # backfill_user_email should have been called with the user_id and user_info dict
         mock_user_store.backfill_user_email.assert_called_once_with(
-            "test_user_id", user_info.model_dump(exclude_none=True)
+            'test_user_id', user_info.model_dump(exclude_none=True)
         )
 
 
@@ -2017,7 +2017,7 @@ async def test_keycloak_callback_calls_backfill_user_email_for_existing_user(
 async def test_accept_tos_stores_timezone_naive_datetime(mock_request):
     """Test that accept_tos stores a timezone-naive datetime for database compatibility."""
     # Arrange
-    test_user_id = "12345678-1234-5678-1234-567812345678"
+    test_user_id = '12345678-1234-5678-1234-567812345678'
 
     mock_user = MagicMock()
     mock_user.id = test_user_id
@@ -2035,19 +2035,19 @@ async def test_accept_tos_stores_timezone_naive_datetime(mock_request):
 
     mock_user_auth = MagicMock(spec=SaasUserAuth)
     mock_user_auth.get_access_token = AsyncMock(
-        return_value=SecretStr("test_access_token")
+        return_value=SecretStr('test_access_token')
     )
-    mock_user_auth.refresh_token = SecretStr("test_refresh_token")
+    mock_user_auth.refresh_token = SecretStr('test_refresh_token')
     mock_user_auth.get_user_id = AsyncMock(return_value=test_user_id)
 
-    mock_request.json = AsyncMock(return_value={"redirect_url": "http://example.com"})
+    mock_request.json = AsyncMock(return_value={'redirect_url': 'http://example.com'})
 
     with (
         patch(
-            "server.routes.auth.get_user_auth", AsyncMock(return_value=mock_user_auth)
+            'server.routes.auth.get_user_auth', AsyncMock(return_value=mock_user_auth)
         ),
-        patch("server.routes.auth.a_session_maker", return_value=mock_session_context),
-        patch("server.routes.auth.set_response_cookie"),
+        patch('server.routes.auth.a_session_maker', return_value=mock_session_context),
+        patch('server.routes.auth.set_response_cookie'),
     ):
         # Act
         result = await accept_tos(mock_request)
@@ -2067,8 +2067,8 @@ class TestGetCurrentUser:
     def mock_request(self):
         request = MagicMock(spec=Request)
         request.url = MagicMock()
-        request.url.hostname = "localhost"
-        request.url.netloc = "localhost:8000"
+        request.url.hostname = 'localhost'
+        request.url.netloc = 'localhost:8000'
         request.headers = {}
         request.cookies = {}
         return request
@@ -2080,14 +2080,14 @@ class TestGetCurrentUser:
         from server.routes.auth import get_current_user
 
         with patch(
-            "server.routes.auth.SaasUserAuth.get_instance",
-            AsyncMock(side_effect=NoCredentialsError("failed to authenticate")),
+            'server.routes.auth.SaasUserAuth.get_instance',
+            AsyncMock(side_effect=NoCredentialsError('failed to authenticate')),
         ):
             with pytest.raises(HTTPException) as exc_info:
                 await get_current_user(mock_request)
 
             assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
-            assert exc_info.value.detail == "User not authenticated"
+            assert exc_info.value.detail == 'User not authenticated'
 
     @pytest.mark.asyncio
     async def test_get_current_user_user_not_found(self, mock_request):
@@ -2095,15 +2095,15 @@ class TestGetCurrentUser:
         from server.routes.auth import get_current_user
 
         mock_user_auth = MagicMock(spec=SaasUserAuth)
-        mock_user_auth.get_user_id = AsyncMock(return_value="test_user_id")
-        mock_user_auth.get_user_email = AsyncMock(return_value="test@example.com")
+        mock_user_auth.get_user_id = AsyncMock(return_value='test_user_id')
+        mock_user_auth.get_user_email = AsyncMock(return_value='test@example.com')
 
         with (
             patch(
-                "server.routes.auth.SaasUserAuth.get_instance",
+                'server.routes.auth.SaasUserAuth.get_instance',
                 AsyncMock(return_value=mock_user_auth),
             ),
-            patch("server.routes.auth.UserStore") as mock_user_store,
+            patch('server.routes.auth.UserStore') as mock_user_store,
         ):
             mock_user_store.get_user_by_id = AsyncMock(return_value=None)
 
@@ -2111,7 +2111,7 @@ class TestGetCurrentUser:
                 await get_current_user(mock_request)
 
             assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
-            assert exc_info.value.detail == "User not found"
+            assert exc_info.value.detail == 'User not found'
 
     @pytest.mark.asyncio
     async def test_get_current_user_success(self, mock_request):
@@ -2121,10 +2121,10 @@ class TestGetCurrentUser:
         from server.auth.authorization import Permission, RoleName
         from server.routes.auth import get_current_user
 
-        test_user_id = "test_user_id"
-        test_org_id = UUID("12345678-1234-5678-1234-567812345678")
-        test_email = "test@example.com"
-        test_org_name = "Test Organization"
+        test_user_id = 'test_user_id'
+        test_org_id = UUID('12345678-1234-5678-1234-567812345678')
+        test_email = 'test@example.com'
+        test_org_name = 'Test Organization'
 
         mock_user_auth = MagicMock(spec=SaasUserAuth)
         mock_user_auth.get_user_id = AsyncMock(return_value=test_user_id)
@@ -2141,16 +2141,16 @@ class TestGetCurrentUser:
 
         with (
             patch(
-                "server.routes.auth.SaasUserAuth.get_instance",
+                'server.routes.auth.SaasUserAuth.get_instance',
                 AsyncMock(return_value=mock_user_auth),
             ),
-            patch("server.routes.auth.UserStore") as mock_user_store,
+            patch('server.routes.auth.UserStore') as mock_user_store,
             patch(
-                "server.auth.authorization.get_user_org_role",
+                'server.auth.authorization.get_user_org_role',
                 AsyncMock(return_value=mock_role),
             ),
             patch(
-                "storage.org_store.OrgStore.get_org_by_id",
+                'storage.org_store.OrgStore.get_org_by_id',
                 AsyncMock(return_value=mock_org),
             ),
         ):
@@ -2165,15 +2165,15 @@ class TestGetCurrentUser:
             import json
 
             content = json.loads(result.body.decode())
-            assert content["user_id"] == test_user_id
-            assert content["email"] == test_email
-            assert content["org_id"] == str(test_org_id)
-            assert content["org_name"] == test_org_name
-            assert content["role"] == RoleName.MEMBER.value
-            assert Permission.MANAGE_SECRETS.value in content["permissions"]
-            assert Permission.VIEW_LLM_SETTINGS.value in content["permissions"]
+            assert content['user_id'] == test_user_id
+            assert content['email'] == test_email
+            assert content['org_id'] == str(test_org_id)
+            assert content['org_name'] == test_org_name
+            assert content['role'] == RoleName.MEMBER.value
+            assert Permission.MANAGE_SECRETS.value in content['permissions']
+            assert Permission.VIEW_LLM_SETTINGS.value in content['permissions']
             # Members should not have owner-only permissions
-            assert Permission.DELETE_ORGANIZATION.value not in content["permissions"]
+            assert Permission.DELETE_ORGANIZATION.value not in content['permissions']
 
     @pytest.mark.asyncio
     async def test_get_current_user_no_role(self, mock_request):
@@ -2182,10 +2182,10 @@ class TestGetCurrentUser:
 
         from server.routes.auth import get_current_user
 
-        test_user_id = "test_user_id"
-        test_org_id = UUID("12345678-1234-5678-1234-567812345678")
-        test_email = "test@example.com"
-        test_org_name = "Test Organization"
+        test_user_id = 'test_user_id'
+        test_org_id = UUID('12345678-1234-5678-1234-567812345678')
+        test_email = 'test@example.com'
+        test_org_name = 'Test Organization'
 
         mock_user_auth = MagicMock(spec=SaasUserAuth)
         mock_user_auth.get_user_id = AsyncMock(return_value=test_user_id)
@@ -2199,16 +2199,16 @@ class TestGetCurrentUser:
 
         with (
             patch(
-                "server.routes.auth.SaasUserAuth.get_instance",
+                'server.routes.auth.SaasUserAuth.get_instance',
                 AsyncMock(return_value=mock_user_auth),
             ),
-            patch("server.routes.auth.UserStore") as mock_user_store,
+            patch('server.routes.auth.UserStore') as mock_user_store,
             patch(
-                "server.auth.authorization.get_user_org_role",
+                'server.auth.authorization.get_user_org_role',
                 AsyncMock(return_value=None),
             ),
             patch(
-                "storage.org_store.OrgStore.get_org_by_id",
+                'storage.org_store.OrgStore.get_org_by_id',
                 AsyncMock(return_value=mock_org),
             ),
         ):
@@ -2222,6 +2222,6 @@ class TestGetCurrentUser:
             import json
 
             content = json.loads(result.body.decode())
-            assert content["user_id"] == test_user_id
-            assert content["role"] is None
-            assert content["permissions"] == []
+            assert content['user_id'] == test_user_id
+            assert content['role'] is None
+            assert content['permissions'] == []


### PR DESCRIPTION
Add a new GET endpoint at /api/me that returns authenticated user information including their role and permissions in their current organization.

The endpoint:
- Uses SaasUserAuth to authenticate via API key or cookie
- Returns user_id, email, org_id, org_name, role, and permissions
- Uses authorization.py's get_user_org_role and get_role_permissions
- Returns 401 for unauthenticated requests
- Returns 404 if user or organization not found

Also adds unit tests for the new endpoint covering:
- Unauthenticated access
- User not found scenario
- Successful retrieval with permissions
- User with no role in organization

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:d01c74e-nikolaik   --name openhands-app-d01c74e   docker.openhands.dev/openhands/openhands:d01c74e
```