### PR TITLE
fix: correct wrong variable in max_size validation error message in condensers

### DIFF
--- a/openhands/memory/condenser/impl/amortized_forgetting_condenser.py
+++ b/openhands/memory/condenser/impl/amortized_forgetting_condenser.py
@@ -30,7 +30,7 @@ class AmortizedForgettingCondenser(RollingCondenser):
         if keep_first < 0:
             raise ValueError(f'keep_first ({keep_first}) cannot be negative')
         if max_size < 1:
-            raise ValueError(f'max_size ({keep_first}) cannot be non-positive')
+            raise ValueError(f'max_size ({max_size}) cannot be non-positive')
 
         self.max_size = max_size
         self.keep_first = keep_first

--- a/openhands/memory/condenser/impl/llm_attention_condenser.py
+++ b/openhands/memory/condenser/impl/llm_attention_condenser.py
@@ -36,7 +36,7 @@ class LLMAttentionCondenser(RollingCondenser):
         if keep_first < 0:
             raise ValueError(f'keep_first ({keep_first}) cannot be negative')
         if max_size < 1:
-            raise ValueError(f'max_size ({keep_first}) cannot be non-positive')
+            raise ValueError(f'max_size ({max_size}) cannot be non-positive')
 
         self.max_size = max_size
         self.keep_first = keep_first


### PR DESCRIPTION
## Bug Description

In `AmortizedForgettingCondenser.__init__` and `LLMAttentionCondenser.__init__`, the validation check for `max_size < 1` raises a `ValueError` that incorrectly displays the `keep_first` variable instead of `max_size`:

```python
# Bug: shows keep_first value instead of max_size
raise ValueError(f'max_size ({keep_first}) cannot be non-positive')
```

This means when a user passes an invalid `max_size` (e.g., `max_size=0`), the error message would display the unrelated `keep_first` value, making it confusing to debug.

## Fix

Changed `keep_first` to `max_size` in the f-string so the error message displays the correct value:

```python
raise ValueError(f'max_size ({max_size}) cannot be non-positive')
```

This is consistent with `LLMSummarizingCondenser` and `StructuredSummaryCondenser`, which already use the correct variable in the same validation check.

## Files Changed

- `openhands/memory/condenser/impl/amortized_forgetting_condenser.py`
- `openhands/memory/condenser/impl/llm_attention_condenser.py`