### PR TITLE
fix: correct logger format args and -0 slice bug

### DIFF
--- a/openhands/app_server/event_callback/set_title_callback_processor.py
+++ b/openhands/app_server/event_callback/set_title_callback_processor.py
@@ -68,6 +68,7 @@ async def _poll_for_title(
             # Transient agent-server failures are acceptable; retry later.
             _logger.warning(
                 'Title poll failed for conversation %s: %s',
+                url,
                 exc,
             )
         else:

--- a/openhands/memory/condenser/impl/recent_events_condenser.py
+++ b/openhands/memory/condenser/impl/recent_events_condenser.py
@@ -18,7 +18,7 @@ class RecentEventsCondenser(Condenser):
         """Keep only the most recent events (up to `max_events`)."""
         head = view[: self.keep_first]
         tail_length = max(0, self.max_events - len(head))
-        tail = view[-tail_length:]
+        tail = view[-tail_length:] if tail_length > 0 else []
         return View(events=head + tail)
 
     @classmethod


### PR DESCRIPTION
## Summary

This PR fixes two small but impactful bugs:

### Bug 1 — Missing format argument in `logger.warning` (`set_title_callback_processor.py`)

The log call has two `%s` placeholders but only passes one argument (`exc`), which causes a `TypeError` at runtime whenever the `except` branch is hit:

```python
# Before (broken)
_logger.warning(
    'Title poll failed for conversation %s: %s',
    exc,
)

# After (fixed) — supply `url` as the first positional arg
_logger.warning(
    'Title poll failed for conversation %s: %s',
    url,
    exc,
)
```

### Bug 2 — `-0` slice returns full list instead of empty (`recent_events_condenser.py`)

When `keep_first >= max_events`, `tail_length` becomes `0`. In Python `view[-0:]` is equivalent to `view[0:]`, which returns the **entire** list rather than an empty list. This silently defeats the `max_events` cap:

```python
# Before (broken)
tail = view[-tail_length:]

# After (fixed)
tail = view[-tail_length:] if tail_length > 0 else []
```

## Test plan

- [x] Verified the logger call now matches the number of format placeholders
- [x] Verified that `RecentEventsCondenser` with `keep_first >= max_events` returns only `head` (empty tail)
- [x] Existing tests continue to pass