### PR TITLE
Fix: Use container StartedAt for Docker sandbox status grace period calculation

### DIFF
--- a/openhands/app_server/sandbox/docker_sandbox_service.py
+++ b/openhands/app_server/sandbox/docker_sandbox_service.py
@@ -255,8 +255,8 @@ class DockerSandboxService(SandboxService):
             except Exception as exc:
                 # Get the started_at from the docker container info and fallback to sandbox created_at
                 try:
-                    state = container.attrs.get('State')
-                    started_at = datetime.fromisoformat(state.get('StartedAt'))
+                    state = container.attrs['State']
+                    started_at = datetime.fromisoformat(state['StartedAt'])
                 except Exception:
                     _logger.debug('Error getting container start time')
                     started_at = sandbox_info.created_at

--- a/openhands/app_server/sandbox/docker_sandbox_service.py
+++ b/openhands/app_server/sandbox/docker_sandbox_service.py
@@ -257,7 +257,8 @@ class DockerSandboxService(SandboxService):
                 try:
                     state = container.attrs.get('State')
                     started_at = datetime.fromisoformat(state.get('StartedAt'))
-                except (KeyError, ValueError, AttributeError):
+                except Exception:
+                    _logger.debug('Error getting container start time')
                     started_at = sandbox_info.created_at
 
                 # If the server has exceeded the startup grace period, it's an error

--- a/openhands/app_server/sandbox/docker_sandbox_service.py
+++ b/openhands/app_server/sandbox/docker_sandbox_service.py
@@ -253,8 +253,15 @@ class DockerSandboxService(SandboxService):
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
+                # Get the started_at from the docker container info and fallback to sandbox created_at
+                try:
+                    state = container.attrs.get('State')
+                    started_at = datetime.fromisoformat(state.get('StartedAt'))
+                except (KeyError, ValueError, AttributeError):
+                    started_at = sandbox_info.created_at
+
                 # If the server has exceeded the startup grace period, it's an error
-                if sandbox_info.created_at < utc_now() - timedelta(
+                if started_at < utc_now() - timedelta(
                     seconds=self.startup_grace_seconds
                 ):
                     _logger.info(

--- a/tests/unit/app_server/test_docker_sandbox_service.py
+++ b/tests/unit/app_server/test_docker_sandbox_service.py
@@ -9,7 +9,7 @@ This module tests the Docker sandbox service implementation, focusing on:
 - Edge cases with malformed container data
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -1670,17 +1670,20 @@ class TestDockerSandboxServiceHostNetwork:
         mock_utc_now.return_value = now
 
         # Container started 4 seconds ago (within 15s grace period)
-        container_started_within_grace_period = datetime(2024, 1, 15, 11, 59, 56, tzinfo=timezone.utc)
+        container_started_within_grace_period = datetime(
+            2024, 1, 15, 11, 59, 56, tzinfo=timezone.utc
+        )
         # Sandbox was created 5 days ago (way outside grace period)
         sandbox_created_long_ago = datetime(2024, 1, 10, 10, 0, 0, tzinfo=timezone.utc)
 
         container.attrs = {
             'Created': '2024-01-15T10:30:00.000000000Z',
-            'State': {
-                'StartedAt': container_started_within_grace_period.isoformat()
-            },
+            'State': {'StartedAt': container_started_within_grace_period.isoformat()},
             'Config': {
-                'Env': ['OH_SESSION_API_KEYS_0=session_key_123', 'OTHER_VAR=other_value'],
+                'Env': [
+                    'OH_SESSION_API_KEYS_0=session_key_123',
+                    'OTHER_VAR=other_value',
+                ],
                 'WorkingDir': '/workspace',
             },
             'NetworkSettings': {

--- a/tests/unit/app_server/test_docker_sandbox_service.py
+++ b/tests/unit/app_server/test_docker_sandbox_service.py
@@ -9,7 +9,7 @@ This module tests the Docker sandbox service implementation, focusing on:
 - Edge cases with malformed container data
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -1649,3 +1649,57 @@ class TestDockerSandboxServiceHostNetwork:
 
         # Verify no warning was logged about port collision
         mock_logger.warning.assert_not_called()
+
+    @patch('openhands.app_server.sandbox.docker_sandbox_service.utc_now')
+    async def test_container_to_checked_sandbox_info_uses_container_started_at(
+        self, mock_utc_now, service
+    ):
+        """Test that health check uses container's StartedAt for grace period calculation instead of sandbox created_at.
+
+        This tests the fix for the bug where resuming a stopped container incorrectly
+        marked the sandbox as ERROR instead of STARTING because it was using
+        sandbox_info.created_at (when the sandbox record was created) instead of
+        the actual container start time.
+        """
+        # Setup - create a fresh container with State that includes StartedAt
+        container = MagicMock()
+        container.name = 'oh-test-abc123'
+        container.status = 'running'
+        container.image.tags = ['spec456']
+        now = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        mock_utc_now.return_value = now
+
+        # Container started 4 seconds ago (within 15s grace period)
+        container_started_within_grace_period = datetime(2024, 1, 15, 11, 59, 56, tzinfo=timezone.utc)
+        # Sandbox was created 5 days ago (way outside grace period)
+        sandbox_created_long_ago = datetime(2024, 1, 10, 10, 0, 0, tzinfo=timezone.utc)
+
+        container.attrs = {
+            'Created': '2024-01-15T10:30:00.000000000Z',
+            'State': {
+                'StartedAt': container_started_within_grace_period.isoformat()
+            },
+            'Config': {
+                'Env': ['OH_SESSION_API_KEYS_0=session_key_123', 'OTHER_VAR=other_value'],
+                'WorkingDir': '/workspace',
+            },
+            'NetworkSettings': {
+                'Ports': {
+                    '8000/tcp': [{'HostPort': '12345'}],
+                    '8001/tcp': [{'HostPort': '12346'}],
+                }
+            },
+        }
+
+        # Create a sandbox_info with old created_at (simulates old sandbox record)
+        sandbox_info = await service._container_to_sandbox_info(container)
+        sandbox_info.created_at = sandbox_created_long_ago
+
+        # Health check fails but container was started recently (within 15s grace period)
+        service.httpx_client.get.side_effect = httpx.HTTPError('Health check failed')
+
+        result = await service._container_to_checked_sandbox_info(container)
+
+        # Verify - should be STARTING because container started within grace period
+        assert result is not None
+        assert result.status == SandboxStatus.STARTING


### PR DESCRIPTION
## Why

When resuming a stopped Docker container via the resume endpoint, the initial calls to the service incorrectly marked the sandbox status as "ERROR" rather than "STARTING". This happened because the code was using `sandbox_info.created_at` (when the sandbox record was initially created in the database) instead of the actual container start time to calculate the startup grace period.

## Summary

- Use container's `State.StartedAt` for the startup grace period calculation instead of `sandbox_info.created_at`
- Falls back to `sandbox_info.created_at` if `StartedAt` is not available
- Added `AttributeError` handling for cases where `State` is `None`
- Added unit test `test_container_to_checked_sandbox_info_uses_container_started_at` to verify the fix

## Video/Screenshots

https://github.com/user-attachments/assets/7c55cc43-fc82-4ffd-afd0-53ba515bd972

## How to Test

Run the unit tests:
```bash
pytest tests/unit/app_server/test_docker_sandbox_service.py -v
```

The test `test_container_to_checked_sandbox_info_uses_container_started_at` verifies that when a container was started recently (within the 15s grace period) but the sandbox record was created a long time ago, the status should be STARTING (not ERROR) because the container's actual start time is used.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2300473a-0101-4110-96dd-583a6f9ae786)

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:2af124e-nikolaik   --name openhands-app-2af124e   docker.openhands.dev/openhands/openhands:2af124e
```