### PR TITLE
feat(github): add optional Laminar observability for @openhands resolver

### DIFF
--- a/enterprise/integrations/github/github_manager.py
+++ b/enterprise/integrations/github/github_manager.py
@@ -1,6 +1,7 @@
 from types import MappingProxyType
 
 from github import Auth, Github, GithubIntegration
+from lmnr import Laminar
 from integrations.github.data_collector import GitHubDataCollector
 from integrations.github.github_solvability import summarize_issue_solvability
 from integrations.github.github_view import (
@@ -22,6 +23,8 @@ from integrations.utils import (
     CONVERSATION_URL,
     ENABLE_SOLVABILITY_ANALYSIS,
     HOST_URL,
+    LAMINAR_ENABLED,
+    LAMINAR_PROJECT_API_KEY,
     OPENHANDS_RESOLVER_TEMPLATES_DIR,
     get_session_expired_message,
     get_user_not_found_message,
@@ -329,6 +332,16 @@ class GithubManager(Manager[GithubViewType]):
             GithubCallbackProcessor,
         )
 
+        # Initialize Laminar if enabled
+        laminar_span_context = None
+        if LAMINAR_ENABLED:
+            try:
+                Laminar.initialize(project_api_key=LAMINAR_PROJECT_API_KEY)
+                laminar_span_context = Laminar.get_laminar_span_context()
+                logger.info('[Github] Laminar initialized for observability')
+            except Exception as e:
+                logger.warning(f'[Github] Failed to initialize Laminar: {e}')
+
         try:
             msg_info: str = ''
 
@@ -389,12 +402,42 @@ class GithubManager(Manager[GithubViewType]):
                     github_view.user_info.keycloak_user_id, self.token_manager
                 )
 
-                await github_view.create_new_conversation(
-                    self.jinja_env,
-                    secret_store.provider_tokens,
-                    convo_metadata,
-                    saas_user_auth,
-                )
+                # Set up Laminar tracing if enabled
+                if LAMINAR_ENABLED and laminar_span_context:
+                    try:
+                        with Laminar.start_as_current_span(
+                            name='github-resolver',
+                            parent_span_context=laminar_span_context,
+                        ):
+                            Laminar.set_trace_metadata({
+                                'source': 'github',
+                                'repo': github_view.full_repo_name,
+                                'issue_number': str(github_view.issue_number),
+                                'username': user_info.username,
+                                'conversation_id': github_view.conversation_id,
+                            })
+                            await github_view.create_new_conversation(
+                                self.jinja_env,
+                                secret_store.provider_tokens,
+                                convo_metadata,
+                                saas_user_auth,
+                            )
+                    except Exception as e:
+                        logger.warning(f'[Github] Laminar span error: {e}')
+                        # Fall back to non-Laminar execution
+                        await github_view.create_new_conversation(
+                            self.jinja_env,
+                            secret_store.provider_tokens,
+                            convo_metadata,
+                            saas_user_auth,
+                        )
+                else:
+                    await github_view.create_new_conversation(
+                        self.jinja_env,
+                        secret_store.provider_tokens,
+                        convo_metadata,
+                        saas_user_auth,
+                    )
 
                 conversation_id = github_view.conversation_id
 
@@ -458,3 +501,10 @@ class GithubManager(Manager[GithubViewType]):
             await self.data_collector.save_data(github_view)
         except Exception:
             logger.warning('[Github]: Error saving interaction data', exc_info=True)
+
+        # Flush Laminar traces if enabled
+        if LAMINAR_ENABLED:
+            try:
+                Laminar.flush()
+            except Exception as e:
+                logger.warning(f'[Github] Error flushing Laminar traces: {e}')

--- a/enterprise/integrations/utils.py
+++ b/enterprise/integrations/utils.py
@@ -98,6 +98,10 @@ ENABLE_V1_SLACK_RESOLVER = (
     os.getenv('ENABLE_V1_SLACK_RESOLVER', 'false').lower() == 'true'
 )
 
+# Laminar observability settings
+LAMINAR_ENABLED = os.environ.get('LMNR_PROJECT_API_KEY', '') != ''
+LAMINAR_PROJECT_API_KEY = os.environ.get('LMNR_PROJECT_API_KEY', '')
+
 # Toggle for V1 GitLab resolver feature
 ENABLE_V1_GITLAB_RESOLVER = (
     os.getenv('ENABLE_V1_GITLAB_RESOLVER', 'false').lower() == 'true'


### PR DESCRIPTION
## Summary

This PR adds optional Laminar tracing to the GitHub integration, allowing users to observe and analyze how the `@openhands` bot processes GitHub issues and PRs.

## Changes

### 1. Configuration (`enterprise/integrations/utils.py`)
- Added `LAMINAR_ENABLED` and `LAMINAR_PROJECT_API_KEY` config flags
- Uses the same `LMNR_PROJECT_API_KEY` environment variable as the PR review bot in `OpenHands/extensions`

### 2. Tracing Implementation (`enterprise/integrations/github/github_manager.py`)
- Initialize Laminar in `start_job()` when `LMNR_PROJECT_API_KEY` is set
- Create a `github-resolver` span with metadata:
  - `source`: always "github"
  - `repo`: repository name (e.g., "owner/repo")
  - `issue_number`: the GitHub issue/PR number
  - `username`: the GitHub username who triggered the job
  - `conversation_id`: the OpenHands conversation ID
- Flush traces at end of job execution
- All Laminar operations are wrapped in try/except to prevent failures from affecting core functionality

## How It Works

When `LMNR_PROJECT_API_KEY` environment variable is set:
1. Laminar is initialized with the API key
2. A span is created around the conversation creation
3. Metadata is set on the span for filtering/dashboards
4. Traces are flushed at the end

When not set: existing behavior is unchanged.

## Consistency with PR Review Bot

This implementation is consistent with the [PR review bot in OpenHands/extensions](https://github.com/OpenHands/extensions/blob/main/plugins/pr-review/scripts/agent_script.py):
- Uses same `LMNR_PROJECT_API_KEY` env var
- Uses same Laminar API (`start_as_current_span`, `set_trace_metadata`, `flush`)
- Wraps operations in try/except for fault tolerance

## Testing

The integration can be tested by:
1. Setting `LMNR_PROJECT_API_KEY` in the environment
2. Triggering `@openhands` on a GitHub issue or PR
3. Viewing traces in the Laminar dashboard

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:678b5c7-nikolaik   --name openhands-app-678b5c7   docker.openhands.dev/openhands/openhands:678b5c7
```