### PR TITLE
fix(enterprise): enable SQLAlchemy 2.0 type checking foundation

### DIFF
--- a/enterprise/dev_config/python/.pre-commit-config.yaml
+++ b/enterprise/dev_config/python/.pre-commit-config.yaml
@@ -50,6 +50,7 @@ repos:
           - ./
           - stripe==11.5.0
           - pygithub==2.6.1
+          - sqlalchemy>=2.0
         # Use -p (package) to avoid dual module name conflict when using MYPYPATH
         # MYPYPATH=enterprise allows resolving bare imports like "from integrations.xxx"
         # Note: tests package excluded to avoid conflict with core openhands tests

--- a/enterprise/dev_config/python/.pre-commit-config.yaml
+++ b/enterprise/dev_config/python/.pre-commit-config.yaml
@@ -50,7 +50,6 @@ repos:
           - ./
           - stripe==11.5.0
           - pygithub==2.6.1
-          - sqlalchemy>=2.0
         # Use -p (package) to avoid dual module name conflict when using MYPYPATH
         # MYPYPATH=enterprise allows resolving bare imports like "from integrations.xxx"
         # Note: tests package excluded to avoid conflict with core openhands tests

--- a/enterprise/storage/base.py
+++ b/enterprise/storage/base.py
@@ -1,7 +1,18 @@
 """
 Unified SQLAlchemy declarative base for all models.
+
+Uses SQLAlchemy 2.0 DeclarativeBase for proper type inference with Mapped types.
+This is backward compatible with existing Column() definitions while enabling
+gradual migration to mapped_column() with Mapped[T] type annotations.
 """
 
-from openhands.app_server.utils.sql_utils import Base
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """Base class for all SQLAlchemy models in the enterprise package."""
+
+    pass
+
 
 __all__ = ['Base']

--- a/enterprise/storage/base.py
+++ b/enterprise/storage/base.py
@@ -1,18 +1,15 @@
 """
 Unified SQLAlchemy declarative base for all models.
 
-Uses SQLAlchemy 2.0 DeclarativeBase for proper type inference with Mapped types.
-This is backward compatible with existing Column() definitions while enabling
-gradual migration to mapped_column() with Mapped[T] type annotations.
+Re-exports the core Base to ensure enterprise and core models share the same
+metadata registry. This allows foreign key relationships between enterprise
+models (e.g., ConversationCallback) and core models (e.g., StoredConversationMetadata).
+
+The core Base now uses SQLAlchemy 2.0 DeclarativeBase for proper type inference
+with Mapped types, while remaining backward compatible with existing Column()
+definitions.
 """
 
-from sqlalchemy.orm import DeclarativeBase
-
-
-class Base(DeclarativeBase):
-    """Base class for all SQLAlchemy models in the enterprise package."""
-
-    pass
-
+from openhands.app_server.utils.sql_utils import Base
 
 __all__ = ['Base']

--- a/openhands/app_server/utils/sql_utils.py
+++ b/openhands/app_server/utils/sql_utils.py
@@ -4,9 +4,21 @@ from typing import TypeVar
 
 from pydantic import SecretStr, TypeAdapter
 from sqlalchemy import JSON, DateTime, String, TypeDecorator
-from sqlalchemy.orm import declarative_base
+from sqlalchemy.orm import DeclarativeBase
 
-Base = declarative_base()
+
+class Base(DeclarativeBase):
+    """
+    Base class for all SQLAlchemy models.
+
+    Uses SQLAlchemy 2.0 DeclarativeBase for proper type inference with Mapped types.
+    This is backward compatible with existing Column() definitions while enabling
+    gradual migration to mapped_column() with Mapped[T] type annotations.
+    """
+
+    pass
+
+
 T = TypeVar('T', bound=Enum)
 
 


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

The enterprise storage models currently use SQLAlchemy's legacy `Column()` pattern which does not provide proper type inference for mypy. This PR is the **foundation** for an incremental migration to SQLAlchemy 2.0's `mapped_column()` pattern with `Mapped[T]` type annotations.

## Summary

- Update `openhands/app_server/utils/sql_utils.py` to use `DeclarativeBase` class instead of `declarative_base()` function for proper `Mapped[T]` type support
- Enterprise `storage/base.py` continues to re-export from core (ensuring shared metadata registry)

**Why update core instead of enterprise-only?**
- Enterprise models have foreign key relationships to core models (e.g., `ConversationCallback` → `conversation_metadata`)
- SQLAlchemy requires FK-related tables to share the same metadata registry
- By updating the core `Base`, both core and enterprise models share the same `Base.metadata`, preserving FK resolution

**Important**: This change is **backward compatible** - existing models using `Column()` will continue to work unchanged. Subsequent PRs will incrementally migrate individual model files to use `mapped_column()` with `Mapped[T]` type annotations.

## Evidence

**Test 1: Model imports and metadata registration (40 tables - including core)**
```bash
$ cd enterprise && poetry run python -c "from storage.api_key import ApiKey; from storage.conversation_callback import ConversationCallback; from storage.base import Base; print(f'Tables: {len(Base.metadata.tables)}'); assert 'api_keys' in Base.metadata.tables; assert 'conversation_metadata' in Base.metadata.tables; assert 'conversation_callbacks' in Base.metadata.tables"
Tables: 40
```

**Test 2: FK relationships work (conversation_callbacks → conversation_metadata)**
```bash
$ cd enterprise && poetry run pytest tests/unit/server/auth/test_saas_user_auth_org_info.py -v
# 8 passed - tests use Base.metadata.create_all() which requires FK resolution
```

**Test 3: Storage unit tests pass**
```bash
$ cd enterprise && poetry run pytest tests/unit/storage/ -v
# 188 passed, 2 skipped
```

## Issue Number

N/A - Part of SQLAlchemy 2.0 type checking migration initiative

## How to Test

1. Verify existing models still work:
```bash
cd enterprise
poetry run python -c "from storage.base import Base; print(Base)"
poetry run python -c "from storage.api_key import ApiKey; from storage.base import Base; print(len(Base.metadata.tables))"
```

2. Verify FK relationships resolve:
```bash
cd enterprise
poetry run python -c "from storage.conversation_callback import ConversationCallback; from storage.base import Base; assert 'conversation_metadata' in Base.metadata.tables; print('FK relationship OK')"
```

3. Run existing unit tests:
```bash
cd enterprise
PYTHONPATH=".:$PYTHONPATH" poetry run pytest tests/unit/storage/ -v
```

## Video/Screenshots

N/A - Infrastructure change

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is the first PR in a series that will migrate all enterprise storage models to SQLAlchemy 2.0's typed pattern:

1. **This PR (Foundation)** - Base class change in core sql_utils.py
2-14. **Model Migration PRs** [1/13] through [13/13] - Each migrates a logical group of enterprise models
15. **Final PR** - Add `sqlalchemy>=2.0` to pre-commit config to enforce type checking

The `sqlalchemy>=2.0` mypy dependency will be added in a final PR once all models are migrated, ensuring CI passes on every PR in the series.

**Future work**: After enterprise migration is complete, core OpenHands models can also be migrated to `mapped_column()` pattern.

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:6e44e08-nikolaik   --name openhands-app-6e44e08   docker.openhands.dev/openhands/openhands:6e44e08
```