### PR TITLE
fix(enterprise): migrate simple storage models to SQLAlchemy 2.0 [1/13]

### DIFF
--- a/enterprise/storage/billing_session.py
+++ b/enterprise/storage/billing_session.py
@@ -1,22 +1,28 @@
 from datetime import UTC, datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING
+from uuid import UUID
 
-from sqlalchemy import DECIMAL, Column, DateTime, Enum, ForeignKey, String
-from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import relationship
+from sqlalchemy import DECIMAL, DateTime, Enum, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from storage.base import Base
 
+if TYPE_CHECKING:
+    from storage.org import Org
 
-class BillingSession(Base):  # type: ignore
+
+class BillingSession(Base):
     """
     Represents a Stripe billing session for credit purchases.
     Tracks the status of payment transactions and associated user information.
     """
 
     __tablename__ = 'billing_sessions'
-    id = Column(String, primary_key=True)
-    user_id = Column(String, nullable=False)
-    org_id = Column(UUID(as_uuid=True), ForeignKey('org.id'), nullable=True)
-    status = Column(
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    user_id: Mapped[str] = mapped_column(String, nullable=False)
+    org_id: Mapped[UUID | None] = mapped_column(ForeignKey('org.id'), nullable=True)
+    status: Mapped[str] = mapped_column(
         Enum(
             'in_progress',
             'completed',
@@ -26,16 +32,16 @@ class BillingSession(Base):  # type: ignore
         ),
         default='in_progress',
     )
-    price = Column(DECIMAL(19, 4), nullable=False)
-    price_code = Column(String, nullable=False)
-    created_at = Column(
+    price: Mapped[Decimal] = mapped_column(DECIMAL(19, 4), nullable=False)
+    price_code: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
-        default=lambda: datetime.now(UTC),  # type: ignore[attr-defined]
+        default=lambda: datetime.now(UTC),
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
-        default=lambda: datetime.now(UTC),  # type: ignore[attr-defined]
+        default=lambda: datetime.now(UTC),
     )
 
     # Relationships
-    org = relationship('Org', back_populates='billing_sessions')
+    org: Mapped['Org | None'] = relationship('Org', back_populates='billing_sessions')

--- a/enterprise/storage/feedback.py
+++ b/enterprise/storage/feedback.py
@@ -1,29 +1,34 @@
-from sqlalchemy import JSON, Column, DateTime, Enum, Integer, String, Text
-from sqlalchemy.sql import func
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, Enum, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
 
 
-class Feedback(Base):  # type: ignore
+class Feedback(Base):
     __tablename__ = 'feedback'
 
-    id = Column(String, primary_key=True)
-    version = Column(String, nullable=False)
-    email = Column(String, nullable=False)
-    polarity = Column(
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    version: Mapped[str] = mapped_column(String, nullable=False)
+    email: Mapped[str] = mapped_column(String, nullable=False)
+    polarity: Mapped[str] = mapped_column(
         Enum('positive', 'negative', name='polarity_enum'), nullable=False
     )
-    permissions = Column(
+    permissions: Mapped[str] = mapped_column(
         Enum('public', 'private', name='permissions_enum'), nullable=False
     )
-    trajectory = Column(JSON, nullable=True)
+    trajectory: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
 
 
-class ConversationFeedback(Base):  # type: ignore
+class ConversationFeedback(Base):
     __tablename__ = 'conversation_feedback'
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    conversation_id = Column(String, nullable=False, index=True)
-    event_id = Column(Integer, nullable=True)
-    rating = Column(Integer, nullable=False)
-    reason = Column(Text, nullable=True)
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    conversation_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    event_id: Mapped[int | None] = mapped_column(nullable=True)
+    rating: Mapped[int] = mapped_column(nullable=False)
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        nullable=False, server_default=func.now()
+    )

--- a/enterprise/storage/subscription_access.py
+++ b/enterprise/storage/subscription_access.py
@@ -1,10 +1,12 @@
 from datetime import UTC, datetime
+from decimal import Decimal
 
-from sqlalchemy import DECIMAL, Column, DateTime, Enum, Integer, String
+from sqlalchemy import DECIMAL, DateTime, Enum, String
+from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
 
 
-class SubscriptionAccess(Base):  # type: ignore
+class SubscriptionAccess(Base):
     """
     Represents a user's subscription access record.
     Tracks subscription status, duration, payment information, and cancellation status.
@@ -12,8 +14,8 @@ class SubscriptionAccess(Base):  # type: ignore
 
     __tablename__ = 'subscription_access'
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    status = Column(
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    status: Mapped[str] = mapped_column(
         Enum(
             'ACTIVE',
             'DISABLED',
@@ -22,22 +24,30 @@ class SubscriptionAccess(Base):  # type: ignore
         nullable=False,
         index=True,
     )
-    user_id = Column(String, nullable=False, index=True)
-    start_at = Column(DateTime(timezone=True), nullable=True)
-    end_at = Column(DateTime(timezone=True), nullable=True)
-    amount_paid = Column(DECIMAL(19, 4), nullable=True)
-    stripe_invoice_payment_id = Column(String, nullable=False)
-    cancelled_at = Column(DateTime(timezone=True), nullable=True)
-    stripe_subscription_id = Column(String, nullable=True, index=True)
-    created_at = Column(
+    user_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    start_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    end_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    amount_paid: Mapped[Decimal | None] = mapped_column(DECIMAL(19, 4), nullable=True)
+    stripe_invoice_payment_id: Mapped[str] = mapped_column(String, nullable=False)
+    cancelled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    stripe_subscription_id: Mapped[str | None] = mapped_column(
+        String, nullable=True, index=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=lambda: datetime.now(UTC),  # type: ignore[attr-defined]
+        default=lambda: datetime.now(UTC),
         nullable=False,
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=lambda: datetime.now(UTC),  # type: ignore[attr-defined]
-        onupdate=lambda: datetime.now(UTC),  # type: ignore[attr-defined]
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
         nullable=False,
     )
 


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

This is part of an incremental migration to SQLAlchemy 2.0's `mapped_column()` pattern with `Mapped[T]` type annotations to enable proper type checking in the enterprise storage models.

## Summary

- Migrate `feedback.py` (Feedback, ConversationFeedback) to use `mapped_column()` with `Mapped[T]` type hints
- Migrate `billing_session.py` (BillingSession) to use `mapped_column()` with `Mapped[T]` type hints
- Migrate `subscription_access.py` (SubscriptionAccess) to use `mapped_column()` with `Mapped[T]` type hints

This fixes **6 [var-annotated] mypy errors**.

## Issue Number

N/A - Part of SQLAlchemy 2.0 type checking migration initiative

## How to Test

```bash
cd enterprise
poetry run python -c "from storage.feedback import Feedback, ConversationFeedback; from storage.billing_session import BillingSession; from storage.subscription_access import SubscriptionAccess; print('Models imported successfully')"
```

Run unit tests:
```bash
cd enterprise
PYTHONPATH=".:$PYTHONPATH" poetry run pytest tests/unit/storage/ -v
```

## SQLAlchemy 2.0 Type Annotation Pattern

This PR uses `Mapped[T | None]` for optional fields (with `| None` **inside** `Mapped[]`).

**Why this pattern?** SQLAlchemy 2.0 requires the type annotation to be wrapped in `Mapped[]` for the ORM to recognize it. Placing `| None` outside (e.g., `Mapped[T] | None`) causes a runtime error:

```python
# ✅ CORRECT - Works in SQLAlchemy 2.0
field: Mapped[str | None] = mapped_column(nullable=True)
org: Mapped['Org | None'] = relationship(...)

# ❌ INCORRECT - Fails with "Type annotation can't be correctly interpreted"
field: Mapped[str] | None = mapped_column(nullable=True)
org: Mapped['Org'] | None = relationship(...)  # Runtime error!
```

**Source**: [SQLAlchemy 2.0 Declarative Tables Documentation](https://docs.sqlalchemy.org/en/20/orm/declarative_tables.html) states:
> "any type that is combined with `Optional[]` or `| None` will consider this to indicate the column is nullable"

All official examples place `| None` inside `Mapped[]`.

## Video/Screenshots

N/A - Type checking improvement

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Dependencies**: Foundation PR #13846 has been merged to main ✅

**PR Series** (13 total):
1. **This PR**: Simple storage models (feedback, billing_session, subscription_access)
2. Device code model
3. Telemetry models
4. Org models
5. Conversation callback model
6. User models
7. Auth models
8. Slack integration models
9. Jira integration models
10. Linear integration models
11. Git provider models
12. Org-related models
13. Storage models

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*