### PR TITLE
fix(enterprise): migrate device_code model to SQLAlchemy 2.0 [2/13]

### DIFF
--- a/enterprise/storage/device_code.py
+++ b/enterprise/storage/device_code.py
@@ -3,7 +3,8 @@
 from datetime import datetime, timezone
 from enum import Enum
 
-from sqlalchemy import Column, DateTime, Integer, String
+from sqlalchemy import DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
 
 
@@ -25,21 +26,33 @@ class DeviceCode(Base):
 
     __tablename__ = 'device_codes'
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    device_code = Column(String(128), unique=True, nullable=False, index=True)
-    user_code = Column(String(16), unique=True, nullable=False, index=True)
-    status = Column(String(32), nullable=False, default=DeviceCodeStatus.PENDING.value)
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    device_code: Mapped[str] = mapped_column(
+        String(128), unique=True, nullable=False, index=True
+    )
+    user_code: Mapped[str] = mapped_column(
+        String(16), unique=True, nullable=False, index=True
+    )
+    status: Mapped[str] = mapped_column(
+        String(32), nullable=False, default=DeviceCodeStatus.PENDING.value
+    )
 
     # Keycloak user ID who authorized the device (set during verification)
-    keycloak_user_id = Column(String(255), nullable=True)
+    keycloak_user_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # Timestamps
-    expires_at = Column(DateTime(timezone=True), nullable=False)
-    authorized_at = Column(DateTime(timezone=True), nullable=True)
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    authorized_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Rate limiting fields for RFC 8628 section 3.5 compliance
-    last_poll_time = Column(DateTime(timezone=True), nullable=True)
-    current_interval = Column(Integer, nullable=False, default=5)
+    last_poll_time: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    current_interval: Mapped[int] = mapped_column(nullable=False, default=5)
 
     def __repr__(self) -> str:
         return f"<DeviceCode(user_code='{self.user_code}', status='{self.status}')>"


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

This is part of an incremental migration to SQLAlchemy 2.0's `mapped_column()` pattern with `Mapped[T]` type annotations to enable proper type checking in the enterprise storage models.

## Summary

- Migrate `device_code.py` to use `mapped_column()` with `Mapped[T]` type hints

This fixes **3 [var-annotated] mypy errors**.

## Issue Number

N/A - Part of SQLAlchemy 2.0 type checking migration initiative

## How to Test

```bash
cd enterprise
poetry run python -c "from storage.device_code import DeviceCode; print('Model imported successfully')"
```

## SQLAlchemy 2.0 Type Annotation Pattern

This PR uses `Mapped[T | None]` for optional fields (with `| None` **inside** `Mapped[]`).

**Why this pattern?** SQLAlchemy 2.0 requires the type annotation to be wrapped in `Mapped[]` for the ORM to recognize it. Placing `| None` outside (e.g., `Mapped[T] | None`) causes a runtime error:

```python
# ✅ CORRECT - Works in SQLAlchemy 2.0
field: Mapped[str | None] = mapped_column(nullable=True)

# ❌ INCORRECT - Fails with "Type annotation can't be correctly interpreted"
field: Mapped[str] | None = mapped_column(nullable=True)
```

**Source**: [SQLAlchemy 2.0 Declarative Tables Documentation](https://docs.sqlalchemy.org/en/20/orm/declarative_tables.html) states:
> "any type that is combined with `Optional[]` or `| None` will consider this to indicate the column is nullable"

All official examples place `| None` inside `Mapped[]`.

## Video/Screenshots

N/A - Type checking improvement

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Dependencies**: Foundation PR #13846 has been merged to main ✅

This is PR **2 of 13** in the SQLAlchemy 2.0 migration series.

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:212dcc7-nikolaik   --name openhands-app-212dcc7   docker.openhands.dev/openhands/openhands:212dcc7
```