### PR TITLE
fix(enterprise): migrate telemetry models to SQLAlchemy 2.0 [3/13]

### DIFF
--- a/enterprise/storage/telemetry_identity.py
+++ b/enterprise/storage/telemetry_identity.py
@@ -5,13 +5,14 @@ for the OpenHands Enterprise Telemetry Service.
 """
 
 from datetime import UTC, datetime
-from typing import Optional
+from typing import Any
 
-from sqlalchemy import CheckConstraint, Column, DateTime, Integer, String
+from sqlalchemy import CheckConstraint, DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
 
 
-class TelemetryIdentity(Base):  # type: ignore
+class TelemetryIdentity(Base):
     """Stores persistent identity information for telemetry.
 
     This table is designed to contain exactly one row (enforced by database constraint)
@@ -25,15 +26,15 @@ class TelemetryIdentity(Base):  # type: ignore
     __tablename__ = 'telemetry_replicated_identity'
     __table_args__ = (CheckConstraint('id = 1', name='single_identity_row'),)
 
-    id = Column(Integer, primary_key=True, default=1)
-    customer_id = Column(String(255), nullable=True)
-    instance_id = Column(String(255), nullable=True)
-    created_at = Column(
+    id: Mapped[int] = mapped_column(primary_key=True, default=1)
+    customer_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    instance_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(UTC),
         nullable=False,
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(UTC),
         onupdate=lambda: datetime.now(UTC),
@@ -42,9 +43,9 @@ class TelemetryIdentity(Base):  # type: ignore
 
     def __init__(
         self,
-        customer_id: Optional[str] = None,
-        instance_id: Optional[str] = None,
-        **kwargs,
+        customer_id: str | None = None,
+        instance_id: str | None = None,
+        **kwargs: Any,
     ):
         """Initialize telemetry identity.
 
@@ -69,8 +70,8 @@ class TelemetryIdentity(Base):  # type: ignore
 
     def set_customer_info(
         self,
-        customer_id: Optional[str] = None,
-        instance_id: Optional[str] = None,
+        customer_id: str | None = None,
+        instance_id: str | None = None,
     ) -> None:
         """Update customer and instance identification information.
 

--- a/enterprise/storage/telemetry_metrics.py
+++ b/enterprise/storage/telemetry_metrics.py
@@ -6,13 +6,14 @@ and retry logic for the OpenHands Enterprise Telemetry Service.
 
 import uuid
 from datetime import UTC, datetime
-from typing import Any, Dict, Optional
+from typing import Any
 
-from sqlalchemy import JSON, Column, DateTime, Integer, String, Text
+from sqlalchemy import JSON, DateTime, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
 
 
-class TelemetryMetrics(Base):  # type: ignore
+class TelemetryMetrics(Base):
     """Stores collected telemetry metrics with upload tracking.
 
     Each record represents a single metrics collection event with associated
@@ -21,23 +22,27 @@ class TelemetryMetrics(Base):  # type: ignore
 
     __tablename__ = 'telemetry_metrics'
 
-    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
-    collected_at = Column(
+    id: Mapped[str] = mapped_column(
+        String, primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    collected_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(UTC),
         index=True,
     )
-    metrics_data = Column(JSON, nullable=False)
-    uploaded_at = Column(DateTime(timezone=True), nullable=True, index=True)
-    upload_attempts = Column(Integer, nullable=False, default=0)
-    last_upload_error = Column(Text, nullable=True)
-    created_at = Column(
+    metrics_data: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    uploaded_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
+    upload_attempts: Mapped[int] = mapped_column(nullable=False, default=0)
+    last_upload_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(UTC),
         nullable=False,
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(UTC),
         onupdate=lambda: datetime.now(UTC),
@@ -46,9 +51,9 @@ class TelemetryMetrics(Base):  # type: ignore
 
     def __init__(
         self,
-        metrics_data: Dict[str, Any],
-        collected_at: Optional[datetime] = None,
-        **kwargs,
+        metrics_data: dict[str, Any],
+        collected_at: datetime | None = None,
+        **kwargs: Any,
     ):
         """Initialize a new telemetry metrics record.
 


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

This is part of an incremental migration to SQLAlchemy 2.0's `mapped_column()` pattern with `Mapped[T]` type annotations to enable proper type checking in the enterprise storage models.

## Summary

- Migrate `telemetry_metrics.py` (TelemetryMetrics) to use `mapped_column()` with `Mapped[T]` type hints
- Add explicit `JSON` type for `metrics_data` field (required for `dict[str, Any]` mapping)

This fixes **[var-annotated] mypy errors**.

## Issue Number

N/A - Part of SQLAlchemy 2.0 type checking migration initiative

## How to Test

```bash
cd enterprise
poetry run python -c "from storage.telemetry_metrics import TelemetryMetrics; print('Model imported successfully')"
```

## SQLAlchemy 2.0 Type Annotation Pattern

This PR uses `Mapped[T | None]` for optional fields (with `| None` **inside** `Mapped[]`).

**Why this pattern?** SQLAlchemy 2.0 requires the type annotation to be wrapped in `Mapped[]` for the ORM to recognize it. Placing `| None` outside (e.g., `Mapped[T] | None`) causes a runtime error:

```python
# ✅ CORRECT - Works in SQLAlchemy 2.0
field: Mapped[str | None] = mapped_column(nullable=True)

# ❌ INCORRECT - Fails with "Type annotation can't be correctly interpreted"
field: Mapped[str] | None = mapped_column(nullable=True)
```

**JSON Type for Dict Fields**: For `Mapped[dict[str, Any]]` fields, SQLAlchemy cannot infer the database type automatically. You must explicitly use `mapped_column(JSON, ...)`:

```python
# ✅ CORRECT - Explicit JSON type
metrics_data: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)

# ❌ INCORRECT - Fails with "Could not locate SQLAlchemy Core type"
metrics_data: Mapped[dict[str, Any]] = mapped_column(nullable=False)
```

**Source**: [SQLAlchemy 2.0 Declarative Tables Documentation](https://docs.sqlalchemy.org/en/20/orm/declarative_tables.html)

## Video/Screenshots

N/A - Type checking improvement

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Dependencies**: Foundation PR #13846 has been merged to main ✅

This is PR **3 of 13** in the SQLAlchemy 2.0 migration series.

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:bc42d9f-nikolaik   --name openhands-app-bc42d9f   docker.openhands.dev/openhands/openhands:bc42d9f
```