### PR TITLE
fix(enterprise): migrate org models to SQLAlchemy 2.0 [4/13]

### DIFF
--- a/enterprise/storage/maintenance_task.py
+++ b/enterprise/storage/maintenance_task.py
@@ -68,7 +68,7 @@ class MaintenanceTask(Base):
     )
     processor_type: Mapped[str] = mapped_column(String, nullable=False)
     processor_json: Mapped[str] = mapped_column(Text, nullable=False)
-    delay: Mapped[int | None] = mapped_column(server_default='0')
+    delay: Mapped[int] = mapped_column(server_default='0')
     started_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     info: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/enterprise/storage/maintenance_task.py
+++ b/enterprise/storage/maintenance_task.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import Enum
-from typing import Type
+from typing import Any, Type
 
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import Column, DateTime, Integer, String, Text, text
+from sqlalchemy import DateTime, String, Text, text
 from sqlalchemy import Enum as SQLEnum
 from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
 
 from openhands.utils.import_utils import get_impl
@@ -52,30 +53,28 @@ class MaintenanceTaskStatus(Enum):
     ERROR = 'ERROR'
 
 
-class MaintenanceTask(Base):  # type: ignore
+class MaintenanceTask(Base):
     """
     Model for storing maintenance tasks that perform background operations.
     """
 
     __tablename__ = 'maintenance_tasks'
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    status = Column(
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    status: Mapped[MaintenanceTaskStatus] = mapped_column(
         SQLEnum(MaintenanceTaskStatus),
         nullable=False,
         default=MaintenanceTaskStatus.INACTIVE,
     )
-    processor_type = Column(String, nullable=False)
-    processor_json = Column(Text, nullable=False)
-    delay = Column(Integer, server_default='0')
-    started_at = Column(DateTime, nullable=True)
-    info = Column(JSON, nullable=True)
-    created_at = Column(
-        DateTime,
-        server_default=text('CURRENT_TIMESTAMP'),
-        nullable=False,
+    processor_type: Mapped[str] = mapped_column(String, nullable=False)
+    processor_json: Mapped[str] = mapped_column(Text, nullable=False)
+    delay: Mapped[int | None] = mapped_column(server_default='0')
+    started_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    info: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=text('CURRENT_TIMESTAMP'), nullable=False
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         server_default=text('CURRENT_TIMESTAMP'),
         onupdate=datetime.now,

--- a/enterprise/storage/openhands_pr.py
+++ b/enterprise/storage/openhands_pr.py
@@ -1,67 +1,57 @@
+from datetime import datetime
+
 from integrations.types import PRStatus
-from sqlalchemy import (
-    Boolean,
-    Column,
-    DateTime,
-    Enum,
-    Identity,
-    Integer,
-    String,
-    text,
-)
+from sqlalchemy import DateTime, Enum, Identity, String, text
+from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
 
 
-class OpenhandsPR(Base):  # type: ignore
+class OpenhandsPR(Base):
     """
     Represents a pull request created by OpenHands.
     """
 
     __tablename__ = 'openhands_prs'
-    id = Column(Integer, Identity(), primary_key=True)
-    repo_id = Column(String, nullable=False, index=True)
-    repo_name = Column(String, nullable=False)
-    pr_number = Column(Integer, nullable=False, index=True)
-    status = Column(
-        Enum(PRStatus),
-        nullable=False,
-        index=True,
-    )
-    provider = Column(String, nullable=False)
-    installation_id = Column(String, nullable=True)
-    private = Column(Boolean, nullable=True)
 
-    # PR metrics columns (optional fields as all providers may not include this information, and will require post processing to enrich)
-    num_reviewers = Column(Integer, nullable=True)
-    num_commits = Column(Integer, nullable=True)
-    num_review_comments = Column(Integer, nullable=True)
-    num_general_comments = Column(Integer, nullable=True)
-    num_changed_files = Column(Integer, nullable=True)
-    num_additions = Column(Integer, nullable=True)
-    num_deletions = Column(Integer, nullable=True)
-    merged = Column(Boolean, nullable=True)
+    id: Mapped[int] = mapped_column(Identity(), primary_key=True)
+    repo_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    repo_name: Mapped[str] = mapped_column(String, nullable=False)
+    pr_number: Mapped[int] = mapped_column(nullable=False, index=True)
+    status: Mapped[PRStatus] = mapped_column(Enum(PRStatus), nullable=False, index=True)
+    provider: Mapped[str] = mapped_column(String, nullable=False)
+    installation_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    private: Mapped[bool | None] = mapped_column(nullable=True)
+
+    # PR metrics columns (optional fields as all providers may not include this
+    # information, and will require post processing to enrich)
+    num_reviewers: Mapped[int | None] = mapped_column(nullable=True)
+    num_commits: Mapped[int | None] = mapped_column(nullable=True)
+    num_review_comments: Mapped[int | None] = mapped_column(nullable=True)
+    num_general_comments: Mapped[int | None] = mapped_column(nullable=True)
+    num_changed_files: Mapped[int | None] = mapped_column(nullable=True)
+    num_additions: Mapped[int | None] = mapped_column(nullable=True)
+    num_deletions: Mapped[int | None] = mapped_column(nullable=True)
+    merged: Mapped[bool | None] = mapped_column(nullable=True)
 
     # Fields that will definitely require post processing to enrich
-    openhands_helped_author = Column(Boolean, nullable=True)
-    num_openhands_commits = Column(Integer, nullable=True)
-    num_openhands_review_comments = Column(Integer, nullable=True)
-    num_openhands_general_comments = Column(Integer, nullable=True)
+    openhands_helped_author: Mapped[bool | None] = mapped_column(nullable=True)
+    num_openhands_commits: Mapped[int | None] = mapped_column(nullable=True)
+    num_openhands_review_comments: Mapped[int | None] = mapped_column(nullable=True)
+    num_openhands_general_comments: Mapped[int | None] = mapped_column(nullable=True)
 
     # Attributes to track progress on enrichment
-    processed = Column(Boolean, nullable=False, server_default=text('FALSE'))
-    process_attempts = Column(
-        Integer, nullable=False, server_default=text('0')
+    processed: Mapped[bool] = mapped_column(
+        nullable=False, server_default=text('FALSE')
+    )
+    process_attempts: Mapped[int] = mapped_column(
+        nullable=False, server_default=text('0')
     )  # Max attempts in case we hit rate limits or information is no longer accessible
-    updated_at = Column(
-        DateTime,
-        server_default=text('CURRENT_TIMESTAMP'),
-        nullable=False,
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=text('CURRENT_TIMESTAMP'), nullable=False
     )  # To buffer between attempts
-    closed_at = Column(
-        DateTime,
-        nullable=False,
+    closed_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False
     )  # Timestamp when the PR was closed
-    created_at = Column(
-        DateTime,
-        nullable=False,
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False
     )  # Timestamp when the PR was created

--- a/enterprise/storage/org.py
+++ b/enterprise/storage/org.py
@@ -2,64 +2,106 @@
 SQLAlchemy model for Organization.
 """
 
-from uuid import uuid4
+from typing import TYPE_CHECKING, Any
+from uuid import UUID, uuid4
 
 from pydantic import SecretStr
 from server.constants import DEFAULT_BILLING_MARGIN
-from sqlalchemy import JSON, UUID, Boolean, Column, Float, Integer, String
-from sqlalchemy.orm import relationship
+from sqlalchemy import JSON, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from storage.base import Base
 from storage.encrypt_utils import decrypt_value, encrypt_value
 
+if TYPE_CHECKING:
+    from storage.api_key import ApiKey
+    from storage.billing_session import BillingSession
+    from storage.org_git_claim import OrgGitClaim
+    from storage.org_invitation import OrgInvitation
+    from storage.org_member import OrgMember
+    from storage.slack_conversation import SlackConversation
+    from storage.slack_user import SlackUser
+    from storage.stored_conversation_metadata_saas import StoredConversationMetadataSaas
+    from storage.stored_custom_secrets import StoredCustomSecrets
+    from storage.stripe_customer import StripeCustomer
+    from storage.user import User
 
-class Org(Base):  # type: ignore
+
+class Org(Base):
     """Organization model."""
 
     __tablename__ = 'org'
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
-    name = Column(String, nullable=False, unique=True)
-    contact_name = Column(String, nullable=True)
-    contact_email = Column(String, nullable=True)
-    remote_runtime_resource_factor = Column(Integer, nullable=True)
-    billing_margin = Column(Float, nullable=True, default=DEFAULT_BILLING_MARGIN)
-    enable_proactive_conversation_starters = Column(
-        Boolean, nullable=False, default=True
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    name: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    contact_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    contact_email: Mapped[str | None] = mapped_column(String, nullable=True)
+    remote_runtime_resource_factor: Mapped[int | None] = mapped_column(nullable=True)
+    billing_margin: Mapped[float | None] = mapped_column(
+        nullable=True, default=DEFAULT_BILLING_MARGIN
     )
-    sandbox_base_container_image = Column(String, nullable=True)
-    sandbox_runtime_container_image = Column(String, nullable=True)
-    org_version = Column(Integer, nullable=False, default=0)
-    agent_settings = Column(JSON, nullable=False, default=dict)
-    conversation_settings = Column(JSON, nullable=False, default=dict)
+    enable_proactive_conversation_starters: Mapped[bool] = mapped_column(
+        nullable=False, default=True
+    )
+    sandbox_base_container_image: Mapped[str | None] = mapped_column(
+        String, nullable=True
+    )
+    sandbox_runtime_container_image: Mapped[str | None] = mapped_column(
+        String, nullable=True
+    )
+    org_version: Mapped[int] = mapped_column(nullable=False, default=0)
+    agent_settings: Mapped[dict[str, Any]] = mapped_column(
+        JSON, nullable=False, default=dict
+    )
+    conversation_settings: Mapped[dict[str, Any]] = mapped_column(
+        JSON, nullable=False, default=dict
+    )
     # encrypted column, don't set directly, set without the underscore
-    _llm_api_key = Column(String, nullable=True)
+    _llm_api_key: Mapped[str | None] = mapped_column(String, nullable=True)
     # encrypted column, don't set directly, set without the underscore
-    _search_api_key = Column(String, nullable=True)
+    _search_api_key: Mapped[str | None] = mapped_column(String, nullable=True)
     # encrypted column, don't set directly, set without the underscore
-    _sandbox_api_key = Column(String, nullable=True)
-    max_budget_per_task = Column(Float, nullable=True)
-    enable_solvability_analysis = Column(Boolean, nullable=True, default=False)
-    v1_enabled = Column(Boolean, nullable=True)
-    conversation_expiration = Column(Integer, nullable=True)
-    byor_export_enabled = Column(Boolean, nullable=False, default=False)
-    sandbox_grouping_strategy = Column(String, nullable=True)
+    _sandbox_api_key: Mapped[str | None] = mapped_column(String, nullable=True)
+    max_budget_per_task: Mapped[float | None] = mapped_column(nullable=True)
+    enable_solvability_analysis: Mapped[bool | None] = mapped_column(
+        nullable=True, default=False
+    )
+    v1_enabled: Mapped[bool | None] = mapped_column(nullable=True)
+    conversation_expiration: Mapped[int | None] = mapped_column(nullable=True)
+    byor_export_enabled: Mapped[bool] = mapped_column(nullable=False, default=False)
+    sandbox_grouping_strategy: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # Relationships
-    org_members = relationship('OrgMember', back_populates='org')
-    current_users = relationship('User', back_populates='current_org')
-    invitations = relationship(
+    org_members: Mapped[list['OrgMember']] = relationship(
+        'OrgMember', back_populates='org'
+    )
+    current_users: Mapped[list['User']] = relationship(
+        'User', back_populates='current_org'
+    )
+    invitations: Mapped[list['OrgInvitation']] = relationship(
         'OrgInvitation', back_populates='org', passive_deletes=True
     )
-    billing_sessions = relationship('BillingSession', back_populates='org')
-    stored_conversation_metadata_saas = relationship(
-        'StoredConversationMetadataSaas', back_populates='org'
+    billing_sessions: Mapped[list['BillingSession']] = relationship(
+        'BillingSession', back_populates='org'
     )
-    user_secrets = relationship('StoredCustomSecrets', back_populates='org')
-    api_keys = relationship('ApiKey', back_populates='org')
-    slack_conversations = relationship('SlackConversation', back_populates='org')
-    slack_users = relationship('SlackUser', back_populates='org')
-    stripe_customers = relationship('StripeCustomer', back_populates='org')
-    git_claims = relationship('OrgGitClaim', back_populates='org')
+    stored_conversation_metadata_saas: Mapped[
+        list['StoredConversationMetadataSaas']
+    ] = relationship('StoredConversationMetadataSaas', back_populates='org')
+    user_secrets: Mapped[list['StoredCustomSecrets']] = relationship(
+        'StoredCustomSecrets', back_populates='org'
+    )
+    api_keys: Mapped[list['ApiKey']] = relationship('ApiKey', back_populates='org')
+    slack_conversations: Mapped[list['SlackConversation']] = relationship(
+        'SlackConversation', back_populates='org'
+    )
+    slack_users: Mapped[list['SlackUser']] = relationship(
+        'SlackUser', back_populates='org'
+    )
+    stripe_customers: Mapped[list['StripeCustomer']] = relationship(
+        'StripeCustomer', back_populates='org'
+    )
+    git_claims: Mapped[list['OrgGitClaim']] = relationship(
+        'OrgGitClaim', back_populates='org'
+    )
 
     def __init__(self, **kwargs):
         # Serialize Pydantic model objects to dicts for JSON columns.

--- a/enterprise/storage/org_member.py
+++ b/enterprise/storage/org_member.py
@@ -2,32 +2,44 @@
 SQLAlchemy model for Organization-Member relationship.
 """
 
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
 from pydantic import SecretStr
-from sqlalchemy import JSON, UUID, Boolean, Column, ForeignKey, Integer, String
-from sqlalchemy.orm import relationship
+from sqlalchemy import JSON, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from storage.base import Base
 from storage.encrypt_utils import decrypt_value, encrypt_value
 
+if TYPE_CHECKING:
+    from storage.org import Org
+    from storage.role import Role
+    from storage.user import User
 
-class OrgMember(Base):  # type: ignore
+
+class OrgMember(Base):
     """Junction table for organization-member relationships with roles."""
 
     __tablename__ = 'org_member'
 
-    org_id = Column(UUID(as_uuid=True), ForeignKey('org.id'), primary_key=True)
-    user_id = Column(UUID(as_uuid=True), ForeignKey('user.id'), primary_key=True)
-    role_id = Column(Integer, ForeignKey('role.id'), nullable=False)
-    _llm_api_key = Column(String, nullable=False)
-    _llm_api_key_for_byor = Column(String, nullable=True)
-    has_custom_llm_api_key = Column(Boolean, nullable=False, default=False)
-    agent_settings_diff = Column(JSON, nullable=False, default=dict)
-    conversation_settings_diff = Column(JSON, nullable=False, default=dict)
-    status = Column(String, nullable=True)
+    org_id: Mapped[UUID] = mapped_column(ForeignKey('org.id'), primary_key=True)
+    user_id: Mapped[UUID] = mapped_column(ForeignKey('user.id'), primary_key=True)
+    role_id: Mapped[int] = mapped_column(ForeignKey('role.id'), nullable=False)
+    _llm_api_key: Mapped[str] = mapped_column(String, nullable=False)
+    _llm_api_key_for_byor: Mapped[str | None] = mapped_column(String, nullable=True)
+    has_custom_llm_api_key: Mapped[bool] = mapped_column(nullable=False, default=False)
+    agent_settings_diff: Mapped[dict[str, Any]] = mapped_column(
+        JSON, nullable=False, default=dict
+    )
+    conversation_settings_diff: Mapped[dict[str, Any]] = mapped_column(
+        JSON, nullable=False, default=dict
+    )
+    status: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # Relationships
-    org = relationship('Org', back_populates='org_members')
-    user = relationship('User', back_populates='org_members')
-    role = relationship('Role', back_populates='org_members')
+    org: Mapped['Org'] = relationship('Org', back_populates='org_members')
+    user: Mapped['User'] = relationship('User', back_populates='org_members')
+    role: Mapped['Role'] = relationship('Role', back_populates='org_members')
 
     def __init__(self, **kwargs):
         # Handle known SQLAlchemy columns directly


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

This is part of an incremental migration to SQLAlchemy 2.0's `mapped_column()` pattern with `Mapped[T]` type annotations to enable proper type checking in the enterprise storage models.

## Summary

- Migrate `org.py` (Org) to use `mapped_column()` with `Mapped[T]` type hints
- Migrate `org_member.py` (OrgMember) to use `mapped_column()` with `Mapped[T]` type hints
- Migrate `openhands_pr.py` (OpenhandsPR) to use `mapped_column()` with `Mapped[T]` type hints
- Migrate `maintenance_task.py` (MaintenanceTask) to use `mapped_column()` with `Mapped[T]` type hints
- Add explicit `JSON` type for `dict[str, Any]` fields (agent_settings, conversation_settings, agent_settings_diff, conversation_settings_diff, info)

This fixes **[var-annotated] mypy errors**.

## Issue Number

N/A - Part of SQLAlchemy 2.0 type checking migration initiative

## How to Test

```bash
cd enterprise
poetry run python -c "from storage.org import Org; from storage.org_member import OrgMember; from storage.openhands_pr import OpenhandsPR; from storage.maintenance_task import MaintenanceTask; print('Models imported successfully')"
```

## SQLAlchemy 2.0 Type Annotation Pattern

This PR uses `Mapped[T | None]` for optional fields (with `| None` **inside** `Mapped[]`).

**Why this pattern?** SQLAlchemy 2.0 requires the type annotation to be wrapped in `Mapped[]` for the ORM to recognize it.

```python
# ✅ CORRECT - Works in SQLAlchemy 2.0
field: Mapped[str | None] = mapped_column(nullable=True)

# ❌ INCORRECT - Fails with "Type annotation can't be correctly interpreted"
field: Mapped[str] | None = mapped_column(nullable=True)
```

**JSON Type for Dict Fields**: For `Mapped[dict[str, Any]]` fields, SQLAlchemy cannot infer the database type automatically:

```python
# ✅ CORRECT - Explicit JSON type
agent_settings: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)

# ❌ INCORRECT - Fails with "Could not locate SQLAlchemy Core type"
agent_settings: Mapped[dict[str, Any]] = mapped_column(nullable=False, default=dict)
```

**Source**: [SQLAlchemy 2.0 Declarative Tables Documentation](https://docs.sqlalchemy.org/en/20/orm/declarative_tables.html)

## Video/Screenshots

N/A - Type checking improvement

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Dependencies**: Foundation PR #13846 has been merged to main ✅

This is PR **4 of 13** in the SQLAlchemy 2.0 migration series.

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-31ee5a3   docker.openhands.dev/openhands/openhands:31ee5a3
```