### PR TITLE
fix(enterprise): migrate conversation_callback model to SQLAlchemy 2.0 [5/13]

### DIFF
--- a/enterprise/storage/conversation_callback.py
+++ b/enterprise/storage/conversation_callback.py
@@ -8,11 +8,11 @@ if TYPE_CHECKING:
 from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import Enum
-from typing import Type
 
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text, text
+from sqlalchemy import DateTime, ForeignKey, String, Text, text
 from sqlalchemy import Enum as SQLEnum
+from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
 
 from openhands.utils.import_utils import get_impl
@@ -57,31 +57,31 @@ class CallbackStatus(Enum):
     ERROR = 'ERROR'
 
 
-class ConversationCallback(Base):  # type: ignore
+class ConversationCallback(Base):
     """
     Model for storing conversation callbacks that process conversation events.
     """
 
     __tablename__ = 'conversation_callbacks'
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    conversation_id = Column(
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    conversation_id: Mapped[str] = mapped_column(
         String,
         ForeignKey('conversation_metadata.conversation_id'),
         nullable=False,
         index=True,
     )
-    status = Column(
+    status: Mapped[CallbackStatus] = mapped_column(
         SQLEnum(CallbackStatus), nullable=False, default=CallbackStatus.ACTIVE
     )
-    processor_type = Column(String, nullable=False)
-    processor_json = Column(Text, nullable=False)
-    created_at = Column(
+    processor_type: Mapped[str] = mapped_column(String, nullable=False)
+    processor_json: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
         DateTime,
         server_default=text('CURRENT_TIMESTAMP'),
         nullable=False,
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         server_default=text('CURRENT_TIMESTAMP'),
         onupdate=datetime.now,
@@ -96,10 +96,10 @@ class ConversationCallback(Base):  # type: ignore
             ConversationCallbackProcessor: The processor instance
         """
         # Import the processor class dynamically
-        processor_type: Type[ConversationCallbackProcessor] = get_impl(
+        processor_class: type[ConversationCallbackProcessor] = get_impl(
             ConversationCallbackProcessor, self.processor_type
         )
-        processor = processor_type.model_validate_json(self.processor_json)
+        processor = processor_class.model_validate_json(self.processor_json)
         return processor
 
     def set_processor(self, processor: ConversationCallbackProcessor) -> None:


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

This is part of an incremental migration to SQLAlchemy 2.0's `mapped_column()` pattern with `Mapped[T]` type annotations to enable proper type checking in the enterprise storage models.

## Summary

- Migrate `conversation_callback.py` to use `mapped_column()` with `Mapped[T]` type hints

This fixes **5 [var-annotated] mypy errors**.

## Issue Number

N/A - Part of SQLAlchemy 2.0 type checking migration initiative

## How to Test

```bash
cd enterprise
poetry run python -c "from storage.conversation_callback import ConversationCallback; print('Model imported successfully')"
```

## Video/Screenshots

N/A - Type checking improvement

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Dependencies**: Foundation PR #13846 has been merged to main ✅

This is PR **5 of 13** in the SQLAlchemy 2.0 migration series.

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:92d92dc-nikolaik   --name openhands-app-92d92dc   docker.openhands.dev/openhands/openhands:92d92dc
```