### PR TITLE
fix(enterprise): migrate Slack models to SQLAlchemy 2.0 [8/13]

### DIFF
--- a/enterprise/storage/slack_conversation.py
+++ b/enterprise/storage/slack_conversation.py
@@ -1,18 +1,26 @@
-from sqlalchemy import Boolean, Column, ForeignKey, Identity, Integer, String
-from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import relationship
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, Identity, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from storage.base import Base
 
+if TYPE_CHECKING:
+    from storage.org import Org
 
-class SlackConversation(Base):  # type: ignore
+
+class SlackConversation(Base):
     __tablename__ = 'slack_conversation'
-    id = Column(Integer, Identity(), primary_key=True)
-    conversation_id = Column(String, nullable=False, index=True)
-    channel_id = Column(String, nullable=False)
-    keycloak_user_id = Column(String, nullable=False)
-    org_id = Column(UUID(as_uuid=True), ForeignKey('org.id'), nullable=True)
-    parent_id = Column(String, nullable=True, index=True)
-    v1_enabled = Column(Boolean, nullable=True)
+
+    id: Mapped[int] = mapped_column(Identity(), primary_key=True)
+    conversation_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    channel_id: Mapped[str] = mapped_column(String, nullable=False)
+    keycloak_user_id: Mapped[str] = mapped_column(String, nullable=False)
+    org_id: Mapped[UUID | None] = mapped_column(ForeignKey('org.id'), nullable=True)
+    parent_id: Mapped[str | None] = mapped_column(String, nullable=True, index=True)
+    v1_enabled: Mapped[bool | None] = mapped_column(nullable=True)
 
     # Relationships
-    org = relationship('Org', back_populates='slack_conversations')
+    org: Mapped['Org | None'] = relationship(
+        'Org', back_populates='slack_conversations'
+    )

--- a/enterprise/storage/slack_team.py
+++ b/enterprise/storage/slack_team.py
@@ -1,13 +1,19 @@
-from sqlalchemy import Column, DateTime, Identity, Integer, String, text
+from datetime import datetime
+
+from sqlalchemy import DateTime, Identity, String, text
+from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
 
 
-class SlackTeam(Base):  # type: ignore
+class SlackTeam(Base):
     __tablename__ = 'slack_teams'
-    id = Column(Integer, Identity(), primary_key=True)
-    team_id = Column(String, nullable=False, index=True, unique=True)
-    bot_access_token = Column(String, nullable=False)
-    created_at = Column(
+
+    id: Mapped[int] = mapped_column(Identity(), primary_key=True)
+    team_id: Mapped[str] = mapped_column(
+        String, nullable=False, index=True, unique=True
+    )
+    bot_access_token: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
         DateTime,
         server_default=text('CURRENT_TIMESTAMP'),
         nullable=False,

--- a/enterprise/storage/slack_user.py
+++ b/enterprise/storage/slack_user.py
@@ -1,21 +1,28 @@
-from sqlalchemy import Column, DateTime, ForeignKey, Identity, Integer, String, text
-from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import relationship
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, Identity, String, text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from storage.base import Base
 
+if TYPE_CHECKING:
+    from storage.org import Org
 
-class SlackUser(Base):  # type: ignore
+
+class SlackUser(Base):
     __tablename__ = 'slack_users'
-    id = Column(Integer, Identity(), primary_key=True)
-    keycloak_user_id = Column(String, nullable=False, index=True)
-    org_id = Column(UUID(as_uuid=True), ForeignKey('org.id'), nullable=True)
-    slack_user_id = Column(String, nullable=False, index=True)
-    slack_display_name = Column(String, nullable=False)
-    created_at = Column(
+
+    id: Mapped[int] = mapped_column(Identity(), primary_key=True)
+    keycloak_user_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    org_id: Mapped[UUID | None] = mapped_column(ForeignKey('org.id'), nullable=True)
+    slack_user_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    slack_display_name: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
         DateTime,
         server_default=text('CURRENT_TIMESTAMP'),
         nullable=False,
     )
 
     # Relationships
-    org = relationship('Org', back_populates='slack_users')
+    org: Mapped['Org | None'] = relationship('Org', back_populates='slack_users')


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

This is part of an incremental migration to SQLAlchemy 2.0's `mapped_column()` pattern with `Mapped[T]` type annotations to enable proper type checking in the enterprise storage models.

## Summary

- Migrate `slack_conversation.py` to use `mapped_column()` with `Mapped[T]` type hints
- Migrate `slack_team.py` to use `mapped_column()` with `Mapped[T]` type hints
- Migrate `slack_user.py` to use `mapped_column()` with `Mapped[T]` type hints

This fixes **17 [var-annotated] mypy errors**.

## Issue Number

N/A - Part of SQLAlchemy 2.0 type checking migration initiative

## How to Test

```bash
cd enterprise
poetry run python -c "from storage.slack_conversation import SlackConversation; from storage.slack_team import SlackTeam; from storage.slack_user import SlackUser; print('Models imported successfully')"
```

## Video/Screenshots

N/A - Type checking improvement

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Dependencies**: Foundation PR #13846 has been merged to main ✅

This is PR **8 of 13** in the SQLAlchemy 2.0 migration series.

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-79c376f   docker.openhands.dev/openhands/openhands:79c376f
```