### PR TITLE
fix(enterprise): migrate Linear models to SQLAlchemy 2.0 [10/13]

### DIFF
--- a/enterprise/storage/linear_conversation.py
+++ b/enterprise/storage/linear_conversation.py
@@ -1,21 +1,25 @@
-from sqlalchemy import Column, DateTime, Integer, String, text
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, text
+from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
 
 
-class LinearConversation(Base):  # type: ignore
+class LinearConversation(Base):
     __tablename__ = 'linear_conversations'
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    conversation_id = Column(String, nullable=False, index=True)
-    issue_id = Column(String, nullable=False, index=True)
-    issue_key = Column(String, nullable=False, index=True)
-    parent_id = Column(String, nullable=True)
-    linear_user_id = Column(Integer, nullable=False, index=True)
-    created_at = Column(
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    conversation_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    issue_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    issue_key: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    parent_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    linear_user_id: Mapped[int] = mapped_column(nullable=False, index=True)
+    created_at: Mapped[datetime] = mapped_column(
         DateTime,
         server_default=text('CURRENT_TIMESTAMP'),
         nullable=False,
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         server_default=text('CURRENT_TIMESTAMP'),
         onupdate=text('CURRENT_TIMESTAMP'),

--- a/enterprise/storage/linear_user.py
+++ b/enterprise/storage/linear_user.py
@@ -1,20 +1,24 @@
-from sqlalchemy import Column, DateTime, Integer, String, text
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, text
+from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
 
 
-class LinearUser(Base):  # type: ignore
+class LinearUser(Base):
     __tablename__ = 'linear_users'
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    keycloak_user_id = Column(String, nullable=False, index=True)
-    linear_user_id = Column(String, nullable=False, index=True)
-    linear_workspace_id = Column(Integer, nullable=False, index=True)
-    status = Column(String, nullable=False)
-    created_at = Column(
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    keycloak_user_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    linear_user_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    linear_workspace_id: Mapped[int] = mapped_column(nullable=False, index=True)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
         DateTime,
         server_default=text('CURRENT_TIMESTAMP'),
         nullable=False,
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         server_default=text('CURRENT_TIMESTAMP'),
         onupdate=text('CURRENT_TIMESTAMP'),

--- a/enterprise/storage/linear_workspace.py
+++ b/enterprise/storage/linear_workspace.py
@@ -1,23 +1,27 @@
-from sqlalchemy import Column, DateTime, Integer, String, text
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, text
+from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
 
 
-class LinearWorkspace(Base):  # type: ignore
+class LinearWorkspace(Base):
     __tablename__ = 'linear_workspaces'
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    name = Column(String, nullable=False)
-    linear_org_id = Column(String, nullable=False)
-    admin_user_id = Column(String, nullable=False)
-    webhook_secret = Column(String, nullable=False)
-    svc_acc_email = Column(String, nullable=False)
-    svc_acc_api_key = Column(String, nullable=False)
-    status = Column(String, nullable=False)
-    created_at = Column(
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    linear_org_id: Mapped[str] = mapped_column(String, nullable=False)
+    admin_user_id: Mapped[str] = mapped_column(String, nullable=False)
+    webhook_secret: Mapped[str] = mapped_column(String, nullable=False)
+    svc_acc_email: Mapped[str] = mapped_column(String, nullable=False)
+    svc_acc_api_key: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
         DateTime,
         server_default=text('CURRENT_TIMESTAMP'),
         nullable=False,
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         server_default=text('CURRENT_TIMESTAMP'),
         onupdate=text('CURRENT_TIMESTAMP'),


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

This is part of an incremental migration to SQLAlchemy 2.0's `mapped_column()` pattern with `Mapped[T]` type annotations to enable proper type checking in the enterprise storage models.

## Summary

- Migrate `linear_conversation.py` to use `mapped_column()` with `Mapped[T]` type hints
- Migrate `linear_user.py` to use `mapped_column()` with `Mapped[T]` type hints
- Migrate `linear_workspace.py` to use `mapped_column()` with `Mapped[T]` type hints

This fixes **14 [var-annotated] mypy errors**.

## Issue Number

N/A - Part of SQLAlchemy 2.0 type checking migration initiative

## How to Test

```bash
cd enterprise
poetry run python -c "from storage.linear_conversation import LinearConversation; from storage.linear_user import LinearUser; print('Models imported successfully')"
```

## Video/Screenshots

N/A - Type checking improvement

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Dependencies**: Foundation PR #13846 has been merged to main ✅

This is PR **10 of 13** in the SQLAlchemy 2.0 migration series.

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:e7bedaa-nikolaik   --name openhands-app-e7bedaa   docker.openhands.dev/openhands/openhands:e7bedaa
```