### PR TITLE
fix(enterprise): migrate Git provider models to SQLAlchemy 2.0 [11/13]

### DIFF
--- a/enterprise/storage/github_app_installation.py
+++ b/enterprise/storage/github_app_installation.py
@@ -1,20 +1,24 @@
-from sqlalchemy import Column, DateTime, Integer, String, text
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, text
+from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
 
 
-class GithubAppInstallation(Base):  # type: ignore
+class GithubAppInstallation(Base):
     """
     Represents a Github App Installation with associated token.
     """
 
     __tablename__ = 'github_app_installations'
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    installation_id = Column(String, nullable=False)
-    encrypted_token = Column(String, nullable=False)
-    created_at = Column(
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    installation_id: Mapped[str] = mapped_column(String, nullable=False)
+    encrypted_token: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=text('CURRENT_TIMESTAMP'), nullable=False
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         server_default=text('CURRENT_TIMESTAMP'),
         onupdate=text('CURRENT_TIMESTAMP'),

--- a/enterprise/storage/gitlab_webhook.py
+++ b/enterprise/storage/gitlab_webhook.py
@@ -1,16 +1,16 @@
 import sys
+from datetime import datetime
 from enum import IntEnum
+from typing import Any
 
 from sqlalchemy import (
     ARRAY,
-    Boolean,
-    Column,
     DateTime,
-    Integer,
     String,
     Text,
     text,
 )
+from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
 
 
@@ -21,23 +21,26 @@ class WebhookStatus(IntEnum):
     INVALID = 3  # Unexpected error occur when checking (keycloak connection, etc)
 
 
-class GitlabWebhook(Base):  # type: ignore
+class GitlabWebhook(Base):
     """
     Represents a Gitlab webhook configuration for a repository or group.
     """
 
     __tablename__ = 'gitlab_webhook'
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    group_id = Column(String, nullable=True)
-    project_id = Column(String, nullable=True)
-    user_id = Column(String, nullable=False)
-    webhook_exists = Column(Boolean, nullable=False)
-    webhook_url = Column(String, nullable=True)
-    webhook_secret = Column(String, nullable=True)
-    webhook_uuid = Column(String, nullable=True)
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    group_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    project_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    user_id: Mapped[str] = mapped_column(String, nullable=False)
+    webhook_exists: Mapped[bool] = mapped_column(nullable=False)
+    webhook_url: Mapped[str | None] = mapped_column(String, nullable=True)
+    webhook_secret: Mapped[str | None] = mapped_column(String, nullable=True)
+    webhook_uuid: Mapped[str | None] = mapped_column(String, nullable=True)
     # Use Text for tests (SQLite compatibility) and ARRAY for production (PostgreSQL)
-    scopes = Column(Text if 'pytest' in sys.modules else ARRAY(Text), nullable=True)
-    last_synced = Column(
+    scopes: Mapped[Any] = mapped_column(
+        Text if 'pytest' in sys.modules else ARRAY(Text), nullable=True
+    )
+    last_synced: Mapped[datetime | None] = mapped_column(
         DateTime,
         server_default=text('CURRENT_TIMESTAMP'),
         onupdate=text('CURRENT_TIMESTAMP'),


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

This is part of an incremental migration to SQLAlchemy 2.0's `mapped_column()` pattern with `Mapped[T]` type annotations to enable proper type checking in the enterprise storage models.

## Summary

- Migrate `github_app_installation.py` to use `mapped_column()` with `Mapped[T]` type hints
- Migrate `gitlab_webhook.py` to use `mapped_column()` with `Mapped[T]` type hints

This fixes **9 [var-annotated] mypy errors**.

## Issue Number

N/A - Part of SQLAlchemy 2.0 type checking migration initiative

## How to Test

```bash
cd enterprise
poetry run python -c "from storage.github_app_installation import GithubAppInstallation; from storage.gitlab_webhook import GitlabWebhook; print('Models imported successfully')"
```

## Video/Screenshots

N/A - Type checking improvement

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Dependencies**: Foundation PR #13846 has been merged to main ✅

This is PR **11 of 13** in the SQLAlchemy 2.0 migration series.

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:d35fc5c-nikolaik   --name openhands-app-d35fc5c   docker.openhands.dev/openhands/openhands:d35fc5c
```