### PR TITLE
Remove unused searchEventsV0 method from EventService

### DIFF
--- a/frontend/src/api/event-service/event-service.api.ts
+++ b/frontend/src/api/event-service/event-service.api.ts
@@ -74,16 +74,5 @@ class EventService {
 
     return data.items;
   }
-
-  // V0 conversations — Legacy REST endpoint
-  static async searchEventsV0(conversationId: string, limit = 100) {
-    const { data } = await openHands.get<{
-      events: OpenHandsEvent[];
-    }>(`/api/conversations/${conversationId}/events`, {
-      params: { limit },
-    });
-
-    return data.events;
-  }
 }
 export default EventService;


### PR DESCRIPTION
## Why

The `searchEventsV0` method in `EventService` was defined but never actually invoked in any production code. This is dead code that can be removed to clean up the codebase.

## Summary

- Removed the unused `searchEventsV0` method from `EventService` class in `frontend/src/api/event-service/event-service.api.ts`
- The method was intended for legacy V0 conversations but was never called

## How to Test

No testing needed - this is a simple code removal that doesn't change any functionality. The existing tests in `use-conversation-history.test.tsx` continue to pass as they only test `searchEventsV1`.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:f9b7257-nikolaik   --name openhands-app-f9b7257   docker.openhands.dev/openhands/openhands:f9b7257
```