### PR TITLE
fix(slack): use markdown_text parameter for proper Markdown rendering in V1

### DIFF
--- a/enterprise/integrations/slack/slack_v1_callback_processor.py
+++ b/enterprise/integrations/slack/slack_v1_callback_processor.py
@@ -111,9 +111,11 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
 
         try:
             # Post the summary as a threaded reply
+            # Use markdown_text instead of text to properly render standard Markdown
+            # (e.g., **bold**, [link](url)) which is used throughout the codebase
             response = client.chat_postMessage(
                 channel=channel_id,
-                text=summary,
+                markdown_text=summary,
                 thread_ts=thread_ts,
                 unfurl_links=False,
                 unfurl_media=False,

--- a/enterprise/tests/unit/integrations/slack/test_slack_v1_callback_processor.py
+++ b/enterprise/tests/unit/integrations/slack/test_slack_v1_callback_processor.py
@@ -257,7 +257,7 @@ class TestSlackV1CallbackProcessor:
         # Verify Slack posting
         mock_slack_client.chat_postMessage.assert_called_once_with(
             channel='C1234567890',
-            text='Test summary from agent',
+            markdown_text='Test summary from agent',
             thread_ts='1234567890.123456',
             unfurl_links=False,
             unfurl_media=False,
@@ -509,7 +509,7 @@ class TestSlackV1CallbackProcessor:
         # Verify user-friendly message was posted to Slack
         mock_slack_client.chat_postMessage.assert_called_once()
         call_kwargs = mock_slack_client.chat_postMessage.call_args[1]
-        posted_message = call_kwargs.get('text', '')
+        posted_message = call_kwargs.get('markdown_text', '')
         assert 'OpenHands encountered an error' in posted_message
         assert 'LLM budget has been exceeded' in posted_message
         assert 'please re-fill' in posted_message


### PR DESCRIPTION
## Summary

This PR fixes the Markdown formatting issue in V1 Slack callback processor by using the `markdown_text` parameter instead of `text`.

## Problem

The V1 Slack callback processor was sending messages with standard Markdown formatting (`**bold**`, `[link](url)`) using the `text=` parameter, which expects Slack's mrkdwn format (`*bold*`, `<url|text>`). This caused formatting to appear as literal text instead of being rendered properly.

## Solution

Changed `text=summary` to `markdown_text=summary` in `_post_summary_to_slack()` method. The `markdown_text` parameter accepts standard Markdown and Slack converts it appropriately.

## Changes

- `enterprise/integrations/slack/slack_v1_callback_processor.py`: Changed `text=` to `markdown_text=`
- `enterprise/tests/unit/integrations/slack/test_slack_v1_callback_processor.py`: Updated tests to expect `markdown_text` parameter

## References

- Fixes #13868
- [Slack API chat.postMessage documentation](https://docs.slack.dev/reference/methods/chat.postMessage)

---

_This PR was created by an AI assistant (OpenHands) on behalf of the user._
