### PR TITLE
Update Suggestions Service API to use new V1 endpoint with pagination

### DIFF
--- a/frontend/src/api/suggestions-service/suggestions-service.api.ts
+++ b/frontend/src/api/suggestions-service/suggestions-service.api.ts
@@ -1,9 +1,31 @@
 import { SuggestedTask } from "#/utils/types";
 import { openHands } from "../open-hands-axios";
 
+interface SuggestedTaskPage {
+  items: SuggestedTask[];
+  next_page_id: string | null;
+}
+
 export class SuggestionsService {
-  static async getSuggestedTasks(): Promise<SuggestedTask[]> {
-    const { data } = await openHands.get("/api/user/suggested-tasks");
-    return data;
+  /**
+   * Get suggested tasks for the user with pagination.
+   *
+   * @param pageId - Optional cursor for the next page (from previous response's next_page_id)
+   * @param limit - Max number of results per page (default: 30, max: 100)
+   */
+  static async getSuggestedTasks(
+    pageId?: string,
+    limit: number = 30,
+  ): Promise<SuggestedTask[]> {
+    const { data } = await openHands.get<SuggestedTaskPage>(
+      "/api/v1/git/suggested-tasks/search",
+      {
+        params: {
+          page_id: pageId ?? undefined,
+          limit,
+        },
+      },
+    );
+    return data.items;
   }
 }

--- a/frontend/src/hooks/query/use-suggested-tasks.ts
+++ b/frontend/src/hooks/query/use-suggested-tasks.ts
@@ -8,7 +8,7 @@ export const useSuggestedTasks = () => {
 
   return useQuery({
     queryKey: ["tasks"],
-    queryFn: SuggestionsService.getSuggestedTasks,
+    queryFn: () => SuggestionsService.getSuggestedTasks(),
     select: groupSuggestedTasks,
     enabled: shouldShowUserFeatures,
   });

--- a/frontend/src/mocks/task-suggestions-handlers.ts
+++ b/frontend/src/mocks/task-suggestions-handlers.ts
@@ -80,6 +80,25 @@ const TASKS_2: SuggestedTask[] = [
 export const MOCK_TASKS = [...TASKS_1, ...TASKS_2];
 
 export const TASK_SUGGESTIONS_HANDLERS = [
+  // New V1 endpoint with pagination
+  http.get("/api/v1/git/suggested-tasks/search", async ({ request }) => {
+    const url = new URL(request.url);
+    const limit = url.searchParams.get("limit");
+    const pageId = url.searchParams.get("page_id");
+
+    // Simple pagination: return all items if no pagination params, otherwise apply limit
+    let tasks = [...MOCK_TASKS];
+    if (pageId || limit) {
+      const limitNum = limit ? parseInt(limit, 10) : 30;
+      tasks = tasks.slice(0, limitNum);
+    }
+
+    return HttpResponse.json({
+      items: tasks,
+      next_page_id: null, // No pagination in mock data
+    });
+  }),
+  // Deprecated V0 endpoint (keep for backward compatibility)
   http.get("/api/user/suggested-tasks", async () =>
     HttpResponse.json(MOCK_TASKS),
   ),


### PR DESCRIPTION
## Why

The Suggestions Service API was using the deprecated endpoint `GET /api/user/suggested-tasks` which should be replaced with the new V1 endpoint `GET /api/v1/git/suggested-tasks/search`.

## Summary

- Replace deprecated `GET /api/user/suggested-tasks` with `GET /api/v1/git/suggested-tasks/search`
- Add pagination parameters (`page_id`, `limit`) to support cursor-based pagination
- Update response handling to extract `items` from the paginated `SuggestedTaskPage` response

## Screenshots
<img width="627" height="594" alt="image" src="https://github.com/user-attachments/assets/ff6351cd-22ed-4ebc-8fdf-f7d151bf7c38" />
<img width="1027" height="478" alt="image" src="https://github.com/user-attachments/assets/40f7eb7c-8537-42ed-8e20-417d76c0f735" />

## How to Test

1. Run the frontend
2. Verify that suggested tasks are still loading correctly
3. The new endpoint supports pagination with cursor-based navigation
4. Also tests SAAS Local

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This change aligns with the new V1 API design which uses cursor-based pagination via `page_id` and `limit` parameters, consistent with other endpoints in the git router (like `/api/v1/git/installations/search`, `/api/v1/git/repositories/search`, etc.).

---
*This pull request was created by an AI assistant (OpenHands) on behalf of the user.*

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:0fb9071-nikolaik   --name openhands-app-0fb9071   docker.openhands.dev/openhands/openhands:0fb9071
```