### PR TITLE
Update getUser() to use V1 API endpoint /api/v1/users/git-info

### DIFF
--- a/frontend/src/api/user-service/user-service.api.ts
+++ b/frontend/src/api/user-service/user-service.api.ts
@@ -11,20 +11,8 @@ class UserService {
    * @returns Git user information
    */
   static async getUser(): Promise<GitUser> {
-    const response = await openHands.get<GitUser>("/api/user/info");
-
-    const { data } = response;
-
-    const user: GitUser = {
-      id: data.id,
-      login: data.login,
-      avatar_url: data.avatar_url,
-      company: data.company,
-      name: data.name,
-      email: data.email,
-    };
-
-    return user;
+    const { data } = await openHands.get<GitUser>("/api/v1/users/git-info");
+    return data;
   }
 
   /**


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

The `getUser()` method was using the deprecated `/api/user/info` endpoint from the legacy V0 API. The V1 endpoint `/api/v1/users/git-info` provides the same functionality with a cleaner response format.

## Summary

- Updated `UserService.getUser()` to call `/api/v1/users/git-info` instead of `/api/user/info`
- Simplified response handling since the new endpoint returns `GitUser` directly without requiring manual field mapping

## Screenshots
<img width="155" height="157" alt="image" src="https://github.com/user-attachments/assets/be273e6b-f094-48a1-baeb-5175190bc7be" />
<img width="658" height="203" alt="image" src="https://github.com/user-attachments/assets/593654d0-b3a8-45ec-8288-ebc94ff6a403" />


## How to Test

1. Run the frontend application
2. Verify that user information is correctly loaded in the UI
3. Check browser console for any API errors related to user info fetching

## Video/Screenshots

N/A

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The `getGitOrganizations()` method was intentionally left unchanged as it uses `/api/user/git-organizations` which is part of the enterprise UI and is not deprecated.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:03bce8d-nikolaik   --name openhands-app-03bce8d   docker.openhands.dev/openhands/openhands:03bce8d
```