### PR TITLE
Remove unused startConversation method and dead code

### DIFF
--- a/frontend/src/api/conversation-service/conversation-service.api.ts
+++ b/frontend/src/api/conversation-service/conversation-service.api.ts
@@ -6,7 +6,6 @@ import {
   Conversation,
 } from "../open-hands.types";
 import { openHands } from "../open-hands-axios";
-import { Provider } from "#/types/settings";
 import { V1AppConversation } from "./v1-conversation-service.types";
 
 class ConversationService {
@@ -74,18 +73,6 @@ class ConversationService {
   ): Promise<Conversation | null> {
     const { data } = await openHands.get<Conversation | null>(
       `/api/conversations/${conversationId}`,
-    );
-
-    return data;
-  }
-
-  static async startConversation(
-    conversationId: string,
-    providers?: Provider[],
-  ): Promise<Conversation | null> {
-    const { data } = await openHands.post<Conversation | null>(
-      `/api/conversations/${conversationId}/start`,
-      providers ? { providers_set: providers } : {},
     );
 
     return data;

--- a/frontend/src/hooks/mutation/conversation-mutation-utils.ts
+++ b/frontend/src/hooks/mutation/conversation-mutation-utils.ts
@@ -1,5 +1,4 @@
 import { QueryClient } from "@tanstack/react-query";
-import { Provider } from "#/types/settings";
 import ConversationService from "#/api/conversation-service/conversation-service.api";
 import V1ConversationService from "#/api/conversation-service/v1-conversation-service.api";
 import { SandboxService } from "#/api/sandbox-service/sandbox-service.api";
@@ -91,14 +90,6 @@ export const resumeV1Conversation = async (conversationId: string) => {
     sessionApiKey,
   );
 };
-
-/**
- * Starts a V0 conversation using the legacy API
- */
-export const startV0Conversation = async (
-  conversationId: string,
-  providers?: Provider[],
-) => ConversationService.startConversation(conversationId, providers);
 
 /**
  * Optimistically updates the conversation status in the cache


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

The `startConversation()` method in `ConversationService` and its wrapper `startV0Conversation()` were V0 legacy API methods that are no longer being called anywhere in the UI. All conversation starting/resuming now goes through the V1 API path.

## Summary

- Removed `startConversation()` method from `ConversationService` (conversation-service.api.ts)
- Removed `startV0Conversation()` wrapper function from conversation-mutation-utils.ts
- Removed unused `Provider` import from both files

## Issue Number

N/A - cleanup

## How to Test

1. Build the frontend: `cd frontend && npm install && npm run build`
2. Run linting: `npm run lint:fix`
3. The removal doesn't affect any functionality as the V0 start API was not being used

## Video/Screenshots

N/A - code cleanup only

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is a straightforward cleanup of dead code. The V1 conversation API (`V1ConversationService.resumeConversation()`) is what's currently being used for starting/resuming conversations.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:2a1faeb-nikolaik   --name openhands-app-2a1faeb   docker.openhands.dev/openhands/openhands:2a1faeb
```