### PR TITLE
fix: fallback to LLM_BASE_URL for openhands_provider_base_url

### DIFF
--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -105,8 +105,11 @@ def get_default_permitted_cors_origins() -> list[str]:
 
 
 def get_openhands_provider_base_url() -> str | None:
-    """Return the base URL for the OpenHands provider, if configured."""
-    return os.getenv('OPENHANDS_PROVIDER_BASE_URL') or None
+    """Return the base URL for the OpenHands provider, if configured.
+
+    Falls back to LLM_BASE_URL for backward compatibility.
+    """
+    return os.getenv('OPENHANDS_PROVIDER_BASE_URL') or os.getenv('LLM_BASE_URL') or None
 
 
 def _get_default_lifespan():


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

When creating new conversations via /new command, the LLM base_url was not being set correctly because the code looked for OPENHANDS_PROVIDER_BASE_URL env var, but many deployments use the traditional LLM_BASE_URL instead.

This caused conversations to fail with 'Incorrect API key' errors when using litellm_proxy/* models, because without the base_url, requests went to the wrong endpoint.

## Summary

The fix looks more like a workaround, I don't know what the intended design is. But it feels wrong to have the base url come from two different variables.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

1. Create new Openhands conversation (this creates a new sandbox)
2. Say Hi to LLM: no problem
3. Issue the /new command: same sandbox, blank conversation
4. Say Hi to LLM: API key error


## Video/Screenshots

<img width="558" height="275" alt="imagen" src="https://github.com/user-attachments/assets/1aec4763-ffc9-4769-87b4-858cb5c53e42" />

<img width="495" height="931" alt="imagen" src="https://github.com/user-attachments/assets/16bfda70-b2e5-42f8-b0f9-36b7837ecba3" />

<img width="549" height="928" alt="imagen" src="https://github.com/user-attachments/assets/52a7477b-bfd7-41a1-965f-cd6ab91d7d4d" />


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->
