### PR TITLE
feat: add `notifications` scope to GitHub OAuth defaultScope

### DIFF
--- a/enterprise/allhands-realm-github-provider.json.tmpl
+++ b/enterprise/allhands-realm-github-provider.json.tmpl
@@ -1729,7 +1729,7 @@
         "syncMode": "IMPORT",
         "clientSecret": "$GITHUB_APP_CLIENT_SECRET",
         "caseSensitiveOriginalUsername": "false",
-        "defaultScope": "openid email profile",
+        "defaultScope": "openid email profile notifications",
         "baseUrl": "$GITHUB_BASE_URL"
       }
     },


### PR DESCRIPTION
## Summary

Add the `notifications` scope to the GitHub identity provider's `defaultScope` in the Keycloak realm configuration template.

## Problem

Currently, the GitHub OAuth token obtained through Keycloak has `defaultScope: "openid email profile"`. The resulting token has **no GitHub-specific OAuth scopes**, which means agents cannot access the GitHub Notifications API (`GET /notifications`, `DELETE /notifications/threads/{id}`). The API returns `403 Resource not accessible by integration`.

## Fix

Add `notifications` to the `defaultScope` for the GitHub identity provider in `enterprise/allhands-realm-github-provider.json.tmpl`:

```diff
- "defaultScope": "openid email profile",
+ "defaultScope": "openid email profile notifications",
```

## What this enables

After this change, **newly authenticated users** (or users who re-authenticate) will have their GitHub OAuth tokens include the `notifications` scope, allowing agents to:
- List notifications (`GET /notifications`)
- Mark notifications as read (`PATCH /notifications/threads/{id}`)
- Mark notifications as done (`DELETE /notifications/threads/{id}`)

## Note

- This only affects newly issued tokens. Existing users would need to re-authenticate (or wait for token refresh) to get the updated scope.
- The `notifications` scope is read/write for notifications only — it does not grant any additional repository access.
- Reference: [GitHub OAuth Scopes](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes)

---
_This PR was created by an AI assistant (OpenHands) on behalf of @xingyaoww._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9b226bbc-0ff4-4b49-853f-050529ecec10)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:1f7335f-nikolaik   --name openhands-app-1f7335f   docker.openhands.dev/openhands/openhands:1f7335f
```