### PR TITLE
fix: use Jira Wiki Markup instead of Markdown in Jira integrations

### DIFF
--- a/enterprise/integrations/jira/jira_manager.py
+++ b/enterprise/integrations/jira/jira_manager.py
@@ -305,14 +305,14 @@ class JiraManager(Manager[JiraViewInterface]):
                 '[Jira] Missing settings error',
                 extra={'issue_key': view.payload.issue_key, 'error': str(e)},
             )
-            msg_info = f'Please re-login into [OpenHands Cloud]({HOST_URL}) before starting a job.'
+            msg_info = f'Please re-login into [OpenHands Cloud|{HOST_URL}] before starting a job.'
 
         except LLMAuthenticationError as e:
             logger.warning(
                 '[Jira] LLM authentication error',
                 extra={'issue_key': view.payload.issue_key, 'error': str(e)},
             )
-            msg_info = f'Please set a valid LLM API key in [OpenHands Cloud]({HOST_URL}) before starting a job.'
+            msg_info = f'Please set a valid LLM API key in [OpenHands Cloud|{HOST_URL}] before starting a job.'
 
         except SessionExpiredError as e:
             logger.warning(

--- a/enterprise/integrations/jira_dc/jira_dc_manager.py
+++ b/enterprise/integrations/jira_dc/jira_dc_manager.py
@@ -396,11 +396,11 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
 
         except MissingSettingsError as e:
             logger.warning(f'[Jira DC] Missing settings error: {str(e)}')
-            msg_info = f'Please re-login into [OpenHands Cloud]({HOST_URL}) before starting a job.'
+            msg_info = f'Please re-login into [OpenHands Cloud|{HOST_URL}] before starting a job.'
 
         except LLMAuthenticationError as e:
             logger.warning(f'[Jira DC] LLM authentication error: {str(e)}')
-            msg_info = f'Please set a valid LLM API key in [OpenHands Cloud]({HOST_URL}) before starting a job.'
+            msg_info = f'Please set a valid LLM API key in [OpenHands Cloud|{HOST_URL}] before starting a job.'
 
         except SessionExpiredError as e:
             logger.warning(f'[Jira DC] Session expired: {str(e)}')

--- a/enterprise/integrations/utils.py
+++ b/enterprise/integrations/utils.py
@@ -62,7 +62,7 @@ def get_session_expired_message(username: str | None = None) -> str:
     """
     if username:
         return f'@{username} your session has expired. Please login again at [OpenHands Cloud]({HOST_URL}) and try again.'
-    return f'Your session has expired. Please login again at [OpenHands Cloud]({HOST_URL}) and try again.'
+    return f'Your session has expired. Please login again at [OpenHands Cloud|{HOST_URL}] and try again.'
 
 
 def get_user_not_found_message(username: str | None = None) -> str:
@@ -81,7 +81,7 @@ def get_user_not_found_message(username: str | None = None) -> str:
     """
     if username:
         return f"@{username} it looks like you haven't created an OpenHands account yet. Please sign up at [OpenHands Cloud]({HOST_URL}) and try again."
-    return f"It looks like you haven't created an OpenHands account yet. Please sign up at [OpenHands Cloud]({HOST_URL}) and try again."
+    return f"It looks like you haven't created an OpenHands account yet. Please sign up at [OpenHands Cloud|{HOST_URL}] and try again."
 
 
 # Toggle for solvability report feature


### PR DESCRIPTION
## Summary

Fixes #13878

Jira's REST API v2 expects [Jira Wiki Markup](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all), not Markdown. Links formatted as `[text](url)` display as raw text in Jira comments instead of rendering as clickable links.

## Changes

Convert link syntax from Markdown `[text](url)` to Jira Wiki Markup `[text|url]` in:

- **`enterprise/integrations/jira/jira_manager.py`**: Login and API key error messages (lines 308, 315)
- **`enterprise/integrations/jira_dc/jira_dc_manager.py`**: Same error messages for DC variant (lines 399, 403)
- **`enterprise/integrations/utils.py`**: Shared messages in the `username=None` code path (Jira/Jira DC), while leaving the `username` path unchanged for GitHub/GitLab/Slack which support Markdown

## Not changed

- `v1_utils.py` and `get_summary_for_agent_state()` in `utils.py` are shared across all providers — changing link format there would break GitHub/GitLab/Slack. These should be addressed separately with provider-aware formatting.
- Linear, GitHub, GitLab, Slack managers — these platforms support Markdown natively.