### PR TITLE
fix: convert Markdown to Jira Wiki Markup in comment output

### DIFF
--- a/enterprise/integrations/jira/jira_manager.py
+++ b/enterprise/integrations/jira/jira_manager.py
@@ -33,6 +33,7 @@ from integrations.utils import (
     OPENHANDS_RESOLVER_TEMPLATES_DIR,
     get_oh_labels,
     get_session_expired_message,
+    markdown_to_jira_markup,
 )
 from jinja2 import Environment, FileSystemLoader
 from server.auth.saas_user_auth import get_user_auth_from_keycloak_id
@@ -359,7 +360,7 @@ class JiraManager(Manager[JiraViewInterface]):
         url = (
             f'{JIRA_CLOUD_API_URL}/{jira_cloud_id}/rest/api/2/issue/{issue_key}/comment'
         )
-        data = {'body': message}
+        data = {'body': markdown_to_jira_markup(message)}
         async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
             response = await client.post(
                 url, auth=(svc_acc_email, svc_acc_api_key), json=data

--- a/enterprise/integrations/jira_dc/jira_dc_manager.py
+++ b/enterprise/integrations/jira_dc/jira_dc_manager.py
@@ -20,6 +20,7 @@ from integrations.utils import (
     OPENHANDS_RESOLVER_TEMPLATES_DIR,
     filter_potential_repos_by_user_msg,
     get_session_expired_message,
+    markdown_to_jira_markup,
 )
 from jinja2 import Environment, FileSystemLoader
 from server.auth.saas_user_auth import get_user_auth_from_keycloak_id
@@ -468,7 +469,7 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
         """
         url = f'{base_api_url}/rest/api/2/issue/{issue_key}/comment'
         headers = {'Authorization': f'Bearer {svc_acc_api_key}'}
-        data = {'body': message}
+        data = {'body': markdown_to_jira_markup(message)}
         async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
             response = await client.post(url, headers=headers, json=data)
             response.raise_for_status()

--- a/enterprise/tests/unit/integrations/jira/test_jira_manager.py
+++ b/enterprise/tests/unit/integrations/jira/test_jira_manager.py
@@ -284,6 +284,143 @@ class TestSendMessage:
             assert result == {'id': 'comment_id'}
             mock_response.raise_for_status.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_send_message_converts_markdown_links_to_jira(self, jira_manager):
+        """Test that send_message converts Markdown links to Jira wiki markup.
+
+        Jira REST API v2 expects Jira Wiki Markup, not Markdown. Links like
+        [text](url) must be converted to [text|url] format.
+        See: https://github.com/All-Hands-AI/OpenHands/issues/13878
+        """
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'comment_id'}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch('httpx.AsyncClient') as mock_client:
+            mock_post = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.post = mock_post
+
+            await jira_manager.send_message(
+                'Please re-login into [OpenHands Cloud](https://app.all-hands.dev) before starting a job.',
+                'PROJ-123',
+                'cloud-123',
+                'service@test.com',
+                'api_key',
+            )
+
+            # Verify the body was converted from Markdown to Jira wiki markup
+            call_kwargs = mock_post.call_args
+            posted_data = call_kwargs.kwargs.get('json') or call_kwargs[1].get('json')
+            assert posted_data['body'] == (
+                'Please re-login into [OpenHands Cloud|https://app.all-hands.dev]'
+                ' before starting a job.'
+            )
+
+    @pytest.mark.asyncio
+    async def test_send_message_converts_markdown_bold_to_jira(self, jira_manager):
+        """Test that send_message converts Markdown bold (**text**) to Jira bold (*text*)."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'comment_id'}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch('httpx.AsyncClient') as mock_client:
+            mock_post = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.post = mock_post
+
+            await jira_manager.send_message(
+                'OpenHands encountered an error: **LLM budget exceeded**.',
+                'PROJ-123',
+                'cloud-123',
+                'service@test.com',
+                'api_key',
+            )
+
+            call_kwargs = mock_post.call_args
+            posted_data = call_kwargs.kwargs.get('json') or call_kwargs[1].get('json')
+            assert posted_data['body'] == (
+                'OpenHands encountered an error: *LLM budget exceeded*.'
+            )
+
+    @pytest.mark.asyncio
+    async def test_send_message_converts_error_with_link_to_jira(self, jira_manager):
+        """Test conversion of error messages containing both bold and links."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'comment_id'}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch('httpx.AsyncClient') as mock_client:
+            mock_post = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.post = mock_post
+
+            await jira_manager.send_message(
+                'OpenHands encountered an error: **timeout**\n\n'
+                '[See the conversation](https://app.all-hands.dev/c/123) for more information.',
+                'PROJ-123',
+                'cloud-123',
+                'service@test.com',
+                'api_key',
+            )
+
+            call_kwargs = mock_post.call_args
+            posted_data = call_kwargs.kwargs.get('json') or call_kwargs[1].get('json')
+            assert '*timeout*' in posted_data['body']
+            assert '[See the conversation|https://app.all-hands.dev/c/123]' in posted_data['body']
+            # Should NOT contain Markdown syntax
+            assert '**' not in posted_data['body']
+            assert '](https://' not in posted_data['body']
+
+    @pytest.mark.asyncio
+    async def test_send_message_plain_text_unchanged(self, jira_manager):
+        """Test that plain text messages pass through without corruption."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'comment_id'}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch('httpx.AsyncClient') as mock_client:
+            mock_post = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.post = mock_post
+
+            await jira_manager.send_message(
+                'Simple plain text message with no formatting.',
+                'PROJ-123',
+                'cloud-123',
+                'service@test.com',
+                'api_key',
+            )
+
+            call_kwargs = mock_post.call_args
+            posted_data = call_kwargs.kwargs.get('json') or call_kwargs[1].get('json')
+            assert posted_data['body'] == 'Simple plain text message with no formatting.'
+
+    @pytest.mark.asyncio
+    async def test_send_message_preserves_existing_jira_markup(self, jira_manager):
+        """Test that messages already in Jira wiki markup are not corrupted.
+
+        Some code paths (e.g., jira_view.py) already produce Jira-formatted
+        messages. The conversion should not break these.
+        """
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'comment_id'}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch('httpx.AsyncClient') as mock_client:
+            mock_post = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.post = mock_post
+
+            # This is already in Jira wiki markup format (from jira_view.py)
+            await jira_manager.send_message(
+                "I'm on it! John can [track my progress here|https://app.all-hands.dev/c/123].",
+                'PROJ-123',
+                'cloud-123',
+                'service@test.com',
+                'api_key',
+            )
+
+            call_kwargs = mock_post.call_args
+            posted_data = call_kwargs.kwargs.get('json') or call_kwargs[1].get('json')
+            # The pipe-based link should survive conversion
+            assert '[track my progress here|https://app.all-hands.dev/c/123]' in posted_data['body']
+
 
 class TestSendErrorFromPayload:
     """Test error comment sending from payload."""

--- a/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_manager.py
+++ b/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_manager.py
@@ -950,6 +950,129 @@ class TestSendMessage:
             assert result == {'id': 'comment_id'}
             mock_response.raise_for_status.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_send_message_converts_markdown_links_to_jira(self, jira_dc_manager):
+        """Test that send_message converts Markdown links to Jira wiki markup.
+
+        Jira DC REST API v2 expects Jira Wiki Markup, not Markdown.
+        See: https://github.com/All-Hands-AI/OpenHands/issues/13878
+        """
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'comment_id'}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch('httpx.AsyncClient') as mock_client:
+            mock_post = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.post = mock_post
+
+            await jira_dc_manager.send_message(
+                'Please re-login into [OpenHands Cloud](https://app.all-hands.dev) before starting a job.',
+                'PROJ-123',
+                'https://jira.company.com',
+                'bearer_token',
+            )
+
+            call_kwargs = mock_post.call_args
+            posted_data = call_kwargs.kwargs.get('json') or call_kwargs[1].get('json')
+            assert posted_data['body'] == (
+                'Please re-login into [OpenHands Cloud|https://app.all-hands.dev]'
+                ' before starting a job.'
+            )
+
+    @pytest.mark.asyncio
+    async def test_send_message_converts_markdown_bold_to_jira(self, jira_dc_manager):
+        """Test that send_message converts Markdown bold (**text**) to Jira bold (*text*)."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'comment_id'}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch('httpx.AsyncClient') as mock_client:
+            mock_post = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.post = mock_post
+
+            await jira_dc_manager.send_message(
+                'OpenHands encountered an error: **LLM budget exceeded**.',
+                'PROJ-123',
+                'https://jira.company.com',
+                'bearer_token',
+            )
+
+            call_kwargs = mock_post.call_args
+            posted_data = call_kwargs.kwargs.get('json') or call_kwargs[1].get('json')
+            assert posted_data['body'] == (
+                'OpenHands encountered an error: *LLM budget exceeded*.'
+            )
+
+    @pytest.mark.asyncio
+    async def test_send_message_converts_error_with_link_to_jira(self, jira_dc_manager):
+        """Test conversion of error messages containing both bold and links."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'comment_id'}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch('httpx.AsyncClient') as mock_client:
+            mock_post = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.post = mock_post
+
+            await jira_dc_manager.send_message(
+                'OpenHands encountered an error: **timeout**\n\n'
+                '[See the conversation](https://app.all-hands.dev/c/123) for more information.',
+                'PROJ-123',
+                'https://jira.company.com',
+                'bearer_token',
+            )
+
+            call_kwargs = mock_post.call_args
+            posted_data = call_kwargs.kwargs.get('json') or call_kwargs[1].get('json')
+            assert '*timeout*' in posted_data['body']
+            assert '[See the conversation|https://app.all-hands.dev/c/123]' in posted_data['body']
+            assert '**' not in posted_data['body']
+            assert '](https://' not in posted_data['body']
+
+    @pytest.mark.asyncio
+    async def test_send_message_plain_text_unchanged(self, jira_dc_manager):
+        """Test that plain text messages pass through without corruption."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'comment_id'}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch('httpx.AsyncClient') as mock_client:
+            mock_post = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.post = mock_post
+
+            await jira_dc_manager.send_message(
+                'Simple plain text message with no formatting.',
+                'PROJ-123',
+                'https://jira.company.com',
+                'bearer_token',
+            )
+
+            call_kwargs = mock_post.call_args
+            posted_data = call_kwargs.kwargs.get('json') or call_kwargs[1].get('json')
+            assert posted_data['body'] == 'Simple plain text message with no formatting.'
+
+    @pytest.mark.asyncio
+    async def test_send_message_preserves_existing_jira_markup(self, jira_dc_manager):
+        """Test that messages already in Jira wiki markup are not corrupted."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'id': 'comment_id'}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch('httpx.AsyncClient') as mock_client:
+            mock_post = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.post = mock_post
+
+            await jira_dc_manager.send_message(
+                "I'm on it! John can [track my progress here|https://app.all-hands.dev/c/123].",
+                'PROJ-123',
+                'https://jira.company.com',
+                'bearer_token',
+            )
+
+            call_kwargs = mock_post.call_args
+            posted_data = call_kwargs.kwargs.get('json') or call_kwargs[1].get('json')
+            assert '[track my progress here|https://app.all-hands.dev/c/123]' in posted_data['body']
+
 
 class TestSendErrorComment:
     """Test error comment sending."""

--- a/enterprise/tests/unit/test_utils.py
+++ b/enterprise/tests/unit/test_utils.py
@@ -69,6 +69,82 @@ def test_markdown_to_jira_markup():
         ), f'Failed for {repr(markdown)}: got {repr(result)}, expected {repr(expected)}'
 
 
+def test_markdown_to_jira_markup_real_jira_messages():
+    """Test conversion of actual messages sent by Jira integrations.
+
+    These are real message patterns from jira_manager.py, jira_dc_manager.py,
+    utils.py, and v1_utils.py that previously displayed as raw Markdown in Jira.
+    See: https://github.com/All-Hands-AI/OpenHands/issues/13878
+    """
+    test_cases = [
+        # MissingSettingsError messages (jira_manager.py:308, jira_dc_manager.py:399)
+        (
+            'Please re-login into [OpenHands Cloud](https://app.all-hands.dev) before starting a job.',
+            'Please re-login into [OpenHands Cloud|https://app.all-hands.dev] before starting a job.',
+        ),
+        # LLMAuthenticationError messages (jira_manager.py:315, jira_dc_manager.py:403)
+        (
+            'Please set a valid LLM API key in [OpenHands Cloud](https://app.all-hands.dev) before starting a job.',
+            'Please set a valid LLM API key in [OpenHands Cloud|https://app.all-hands.dev] before starting a job.',
+        ),
+        # Session expired messages (utils.py:64-65)
+        (
+            'Your session has expired. Please login again at [OpenHands Cloud](https://app.all-hands.dev) and try again.',
+            'Your session has expired. Please login again at [OpenHands Cloud|https://app.all-hands.dev] and try again.',
+        ),
+        # Unknown error messages (utils.py:210)
+        (
+            'OpenHands encountered an unknown error. [See the conversation](https://app.all-hands.dev/c/abc123) for more information, or try again',
+            'OpenHands encountered an unknown error. [See the conversation|https://app.all-hands.dev/c/abc123] for more information, or try again',
+        ),
+        # Error with reason (utils.py:247)
+        (
+            'OpenHands encountered an error: **LLM budget has been exceeded**.\n\n[See the conversation](https://app.all-hands.dev/c/abc123) for more information.',
+            'OpenHands encountered an error: *LLM budget has been exceeded*.\n\n[See the conversation|https://app.all-hands.dev/c/abc123] for more information.',
+        ),
+        # Waiting for input (utils.py:258)
+        (
+            'OpenHands is waiting for your input. [Continue the conversation](https://app.all-hands.dev/c/abc123) to provide additional instructions.',
+            'OpenHands is waiting for your input. [Continue the conversation|https://app.all-hands.dev/c/abc123] to provide additional instructions.',
+        ),
+        # V1 error callback (v1_utils.py:73-75)
+        (
+            'OpenHands encountered an error: **Connection timeout**\n\n[See the conversation](https://app.all-hands.dev/c/abc123) for more information.',
+            'OpenHands encountered an error: *Connection timeout*\n\n[See the conversation|https://app.all-hands.dev/c/abc123] for more information.',
+        ),
+    ]
+
+    for markdown, expected in test_cases:
+        result = markdown_to_jira_markup(markdown)
+        assert (
+            result == expected
+        ), f'Failed for {repr(markdown)}: got {repr(result)}, expected {repr(expected)}'
+
+
+def test_markdown_to_jira_markup_edge_cases():
+    """Test edge cases for the markdown-to-Jira conversion."""
+    # Empty / None input
+    assert markdown_to_jira_markup('') == ''
+    assert markdown_to_jira_markup(None) == ''
+
+    # Plain text without any Markdown should pass through unchanged
+    assert markdown_to_jira_markup('Hello world') == 'Hello world'
+
+    # Already-correct Jira wiki markup links should not be double-converted
+    result = markdown_to_jira_markup(
+        "I'm on it! John can [track my progress here|https://app.all-hands.dev/c/123]."
+    )
+    assert '[track my progress here|https://app.all-hands.dev/c/123]' in result
+
+    # User not found message (utils.py:83-84)
+    result = markdown_to_jira_markup(
+        "It looks like you haven't created an OpenHands account yet. "
+        "Please sign up at [OpenHands Cloud](https://app.all-hands.dev) and try again."
+    )
+    assert '[OpenHands Cloud|https://app.all-hands.dev]' in result
+    assert '](https://' not in result
+
+
 def test_infer_repo_from_message():
     test_cases = [
         # Single GitHub URLs


### PR DESCRIPTION
## Summary

- Apply the existing but unused `markdown_to_jira_markup()` converter in `JiraManager.send_message()` and `JiraDcManager.send_message()` so all comments posted to Jira are properly formatted
- Previously, Markdown links (`[text](url)`) and bold (`**text**`) were sent as-is to the Jira REST API v2, which expects Jira Wiki Markup (`[text|url]` and `*text*`), causing links to display as raw text
- Add comprehensive tests covering real message patterns from the codebase (error messages, session expired, conversation links) for both Jira Cloud and Jira DC managers

## Details

The fix is applied at the `send_message()` level in both managers rather than at each individual call site. This ensures **all** messages going to Jira get converted, including:
- `MissingSettingsError` login messages
- `LLMAuthenticationError` API key messages
- Session expired messages from `get_session_expired_message()`
- Error/conversation link messages from callback processors
- Messages already in Jira wiki markup (e.g., from `jira_view.py`) pass through safely

The `markdown_to_jira_markup()` function already existed in `enterprise/integrations/utils.py` (and was already used in the callback processors) but was not applied to the main comment-sending path.

Fixes #13878

## Test plan

- [x] Add tests verifying Markdown links are converted to Jira `[text|url]` format in `JiraManager.send_message()`
- [x] Add tests verifying Markdown bold is converted to Jira `*text*` format
- [x] Add tests verifying mixed formatting (bold + links) is converted correctly
- [x] Add tests verifying plain text passes through unchanged
- [x] Add tests verifying existing Jira wiki markup is not corrupted
- [x] Mirror all tests for `JiraDcManager.send_message()`
- [x] Add tests for real message patterns from the codebase (error, session expired, conversation links)
- [x] Add edge case tests (empty input, None, already-correct markup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)