### PR TITLE
Update frontend to use V1 settings endpoints

### DIFF
--- a/frontend/src/api/settings-service/settings-service.api.ts
+++ b/frontend/src/api/settings-service/settings-service.api.ts
@@ -9,7 +9,7 @@ class SettingsService {
    * Get the settings from the server or use the default settings if not found
    */
   static async getSettings(): Promise<Settings> {
-    const { data } = await openHands.get<Settings>("/api/settings");
+    const { data } = await openHands.get<Settings>("/api/v1/settings");
     return data;
   }
 
@@ -18,7 +18,7 @@ class SettingsService {
    * @param settings - the settings to save
    */
   static async saveSettings(settings: Partial<Settings>): Promise<boolean> {
-    const data = await openHands.post("/api/settings", settings);
+    const data = await openHands.post("/api/v1/settings", settings);
     return data.status === 200;
   }
 }

--- a/frontend/src/mocks/settings-handlers.ts
+++ b/frontend/src/mocks/settings-handlers.ts
@@ -145,7 +145,7 @@ export const SETTINGS_HANDLERS = [
     return HttpResponse.json(config);
   }),
 
-  http.get("/api/settings", async () => {
+  http.get("/api/v1/settings", async () => {
     await delay();
     const { settings } = MOCK_USER_PREFERENCES;
 
@@ -154,7 +154,7 @@ export const SETTINGS_HANDLERS = [
     return HttpResponse.json(settings);
   }),
 
-  http.post("/api/settings", async ({ request }) => {
+  http.post("/api/v1/settings", async ({ request }) => {
     await delay();
     const body = await request.json();
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

The V0 settings endpoints (/api/settings) are deprecated and scheduled for removal. The frontend was still using these legacy endpoints instead of the new V1 endpoints.

## Summary

- Changed GET /api/settings to GET /api/v1/settings
- Changed POST /api/settings to POST /api/v1/settings
- Updated mock handlers to use V1 endpoints for tests

## Issue Number

N/A

## How to Test

1. Build the frontend: `cd frontend && npm install && npm run build`
2. Run settings-related tests: `npm run test -- --run __tests__/routes/settings.test.tsx`
3. Verify settings load and save correctly in the app

## Video/Screenshots

N/A

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The V0 and V1 endpoints share the same implementation, so inputs/outputs are identical. This is a safe migration.

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/21742eb9-cbba-4b5b-93b2-30c0bd6e431b)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:4af7a35-nikolaik   --name openhands-app-4af7a35   docker.openhands.dev/openhands/openhands:4af7a35
```