### PR TITLE
Filter out ConversationStateUpdateEvent from shared-events endpoints

### DIFF
--- a/enterprise/server/sharing/shared_event_router.py
+++ b/enterprise/server/sharing/shared_event_router.py
@@ -1,4 +1,12 @@
-"""Shared Event router for OpenHands Server."""
+"""Shared Event router for OpenHands Server.
+
+All endpoints in this router are unauthenticated — shared conversations are
+public.  To avoid returning internal system state that the viewer does not
+need, ``ConversationStateUpdateEvent`` instances are filtered out before the
+response is sent.  The shared-conversation frontend only renders messages,
+actions, observations, errors, and hook-execution events; state snapshots
+are consumed exclusively by the authenticated WebSocket path.
+"""
 
 from datetime import datetime
 from typing import Annotated
@@ -13,7 +21,13 @@ from server.sharing.shared_event_service import (
 from openhands.agent_server.models import EventPage, EventSortOrder
 from openhands.app_server.event_callback.event_callback_models import EventKind
 from openhands.sdk import Event
+from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.utils.environment import StorageProvider, get_storage_provider
+
+
+def _is_viewable(event: Event) -> bool:
+    """Return True if *event* should be included in public shared responses."""
+    return not isinstance(event, ConversationStateUpdateEvent)
 
 
 def get_shared_event_service_injector() -> SharedEventServiceInjector:
@@ -88,7 +102,7 @@ async def search_shared_events(
     shared_event_service: SharedEventService = shared_event_service_dependency,
 ) -> EventPage:
     """Search / List events for a shared conversation."""
-    return await shared_event_service.search_shared_events(
+    page = await shared_event_service.search_shared_events(
         conversation_id=UUID(conversation_id),
         kind__eq=kind__eq,
         timestamp__gte=timestamp__gte,
@@ -96,6 +110,10 @@ async def search_shared_events(
         sort_order=sort_order,
         page_id=page_id,
         limit=limit,
+    )
+    return EventPage(
+        items=[e for e in page.items if _is_viewable(e)],
+        next_page_id=page.next_page_id,
     )
 
 
@@ -147,7 +165,7 @@ async def batch_get_shared_events(
     events = await shared_event_service.batch_get_shared_events(
         UUID(conversation_id), event_ids
     )
-    return events
+    return [e if e is not None and _is_viewable(e) else None for e in events]
 
 
 @router.get('/{conversation_id}/{event_id}')
@@ -157,6 +175,9 @@ async def get_shared_event(
     shared_event_service: SharedEventService = shared_event_service_dependency,
 ) -> Event | None:
     """Get a single event from a shared conversation by conversation_id and event_id."""
-    return await shared_event_service.get_shared_event(
+    event = await shared_event_service.get_shared_event(
         UUID(conversation_id), UUID(event_id)
     )
+    if event is not None and not _is_viewable(event):
+        return None
+    return event

--- a/enterprise/tests/unit/test_sharing/test_shared_event_filtering.py
+++ b/enterprise/tests/unit/test_sharing/test_shared_event_filtering.py
@@ -8,7 +8,7 @@ actions, observations, errors, and hook-execution events.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
@@ -24,7 +24,6 @@ from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.sdk.event.llm_convertible import MessageEvent
 from openhands.sdk.llm import Message, TextContent
 
-
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
 # ---------------------------------------------------------------------------
@@ -37,7 +36,9 @@ def _make_message_event() -> MessageEvent:
     )
 
 
-def _make_state_event(key: str = 'full_state', value: dict | str = 'idle') -> ConversationStateUpdateEvent:
+def _make_state_event(
+    key: str = 'full_state', value: dict | str = 'idle'
+) -> ConversationStateUpdateEvent:
     return ConversationStateUpdateEvent(key=key, value=value)
 
 
@@ -81,7 +82,10 @@ class TestSearchSharedEvents:
         )
 
         assert len(result.items) == 2
-        assert all(not isinstance(e, ConversationStateUpdateEvent) for e in result.items)
+        assert all(
+            not isinstance(e, ConversationStateUpdateEvent)
+            for e in result.items
+        )
 
     @pytest.mark.asyncio
     async def test_preserves_next_page_id(self):

--- a/enterprise/tests/unit/test_sharing/test_shared_event_filtering.py
+++ b/enterprise/tests/unit/test_sharing/test_shared_event_filtering.py
@@ -83,8 +83,7 @@ class TestSearchSharedEvents:
 
         assert len(result.items) == 2
         assert all(
-            not isinstance(e, ConversationStateUpdateEvent)
-            for e in result.items
+            not isinstance(e, ConversationStateUpdateEvent) for e in result.items
         )
 
     @pytest.mark.asyncio

--- a/enterprise/tests/unit/test_sharing/test_shared_event_filtering.py
+++ b/enterprise/tests/unit/test_sharing/test_shared_event_filtering.py
@@ -1,0 +1,187 @@
+"""Tests for ConversationStateUpdateEvent filtering in shared_event_router.
+
+The shared-events endpoints are unauthenticated, so internal system state
+(ConversationStateUpdateEvent) must not be returned.  The frontend shared-
+conversation viewer never renders these events — it only uses messages,
+actions, observations, errors, and hook-execution events.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from server.sharing.shared_event_router import (
+    _is_viewable,
+    batch_get_shared_events,
+    get_shared_event,
+    search_shared_events,
+)
+
+from openhands.agent_server.models import EventPage
+from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
+from openhands.sdk.event.llm_convertible import MessageEvent
+from openhands.sdk.llm import Message, TextContent
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_message_event() -> MessageEvent:
+    return MessageEvent(
+        source='user',
+        llm_message=Message(role='user', content=[TextContent(text='Hello')]),
+    )
+
+
+def _make_state_event(key: str = 'full_state', value: dict | str = 'idle') -> ConversationStateUpdateEvent:
+    return ConversationStateUpdateEvent(key=key, value=value)
+
+
+# ---------------------------------------------------------------------------
+# _is_viewable
+# ---------------------------------------------------------------------------
+
+
+class TestIsViewable:
+    def test_message_event_is_viewable(self):
+        assert _is_viewable(_make_message_event()) is True
+
+    def test_full_state_event_is_not_viewable(self):
+        assert _is_viewable(_make_state_event('full_state', {'agent': {}})) is False
+
+    def test_execution_status_event_is_not_viewable(self):
+        assert _is_viewable(_make_state_event('execution_status', 'running')) is False
+
+    def test_stats_event_is_not_viewable(self):
+        assert _is_viewable(_make_state_event('stats', {})) is False
+
+
+# ---------------------------------------------------------------------------
+# search_shared_events
+# ---------------------------------------------------------------------------
+
+
+class TestSearchSharedEvents:
+    @pytest.mark.asyncio
+    async def test_filters_out_state_events(self):
+        msg = _make_message_event()
+        state = _make_state_event()
+        mock_service = AsyncMock()
+        mock_service.search_shared_events.return_value = EventPage(
+            items=[msg, state, msg], next_page_id=None
+        )
+
+        result = await search_shared_events(
+            conversation_id=uuid4().hex,
+            shared_event_service=mock_service,
+        )
+
+        assert len(result.items) == 2
+        assert all(not isinstance(e, ConversationStateUpdateEvent) for e in result.items)
+
+    @pytest.mark.asyncio
+    async def test_preserves_next_page_id(self):
+        mock_service = AsyncMock()
+        mock_service.search_shared_events.return_value = EventPage(
+            items=[_make_state_event()], next_page_id='abc'
+        )
+
+        result = await search_shared_events(
+            conversation_id=uuid4().hex,
+            shared_event_service=mock_service,
+        )
+
+        assert result.next_page_id == 'abc'
+        assert result.items == []
+
+    @pytest.mark.asyncio
+    async def test_empty_page_unchanged(self):
+        mock_service = AsyncMock()
+        mock_service.search_shared_events.return_value = EventPage(
+            items=[], next_page_id=None
+        )
+
+        result = await search_shared_events(
+            conversation_id=uuid4().hex,
+            shared_event_service=mock_service,
+        )
+
+        assert result.items == []
+        assert result.next_page_id is None
+
+
+# ---------------------------------------------------------------------------
+# batch_get_shared_events
+# ---------------------------------------------------------------------------
+
+
+class TestBatchGetSharedEvents:
+    @pytest.mark.asyncio
+    async def test_replaces_state_events_with_none(self):
+        msg = _make_message_event()
+        state = _make_state_event()
+        mock_service = AsyncMock()
+        mock_service.batch_get_shared_events.return_value = [msg, state, None]
+
+        result = await batch_get_shared_events(
+            conversation_id=uuid4().hex,
+            id=[uuid4().hex, uuid4().hex, uuid4().hex],
+            shared_event_service=mock_service,
+        )
+
+        assert len(result) == 3
+        assert result[0] is msg
+        assert result[1] is None  # state event replaced with None
+        assert result[2] is None  # originally None stays None
+
+
+# ---------------------------------------------------------------------------
+# get_shared_event
+# ---------------------------------------------------------------------------
+
+
+class TestGetSharedEvent:
+    @pytest.mark.asyncio
+    async def test_returns_message_event(self):
+        msg = _make_message_event()
+        mock_service = AsyncMock()
+        mock_service.get_shared_event.return_value = msg
+
+        result = await get_shared_event(
+            conversation_id=uuid4().hex,
+            event_id=uuid4().hex,
+            shared_event_service=mock_service,
+        )
+
+        assert result is msg
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_state_event(self):
+        state = _make_state_event()
+        mock_service = AsyncMock()
+        mock_service.get_shared_event.return_value = state
+
+        result = await get_shared_event(
+            conversation_id=uuid4().hex,
+            event_id=uuid4().hex,
+            shared_event_service=mock_service,
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_not_found(self):
+        mock_service = AsyncMock()
+        mock_service.get_shared_event.return_value = None
+
+        result = await get_shared_event(
+            conversation_id=uuid4().hex,
+            event_id=uuid4().hex,
+            shared_event_service=mock_service,
+        )
+
+        assert result is None


### PR DESCRIPTION
## Description

The shared-events API (`/api/shared-events/search`, `/api/shared-events`, `/api/shared-events/{id}/{id}`) returns events for publicly shared conversations. Currently these endpoints return **all** event types, including `ConversationStateUpdateEvent` instances that carry internal system state (agent configuration, execution status, stats snapshots).

The shared-conversation frontend viewer never renders these events — `shouldRenderEvent()` explicitly returns `false` for `ConversationStateUpdateEvent`. They are only consumed by the authenticated WebSocket path for live conversations.

This PR filters them out server-side so the public endpoints only return the event types the viewer actually uses: messages, actions, observations, errors, and hook-execution events.

## Changes

**`enterprise/server/sharing/shared_event_router.py`**
- Added `_is_viewable()` helper that returns `False` for `ConversationStateUpdateEvent`
- `search_shared_events` — filters page items before returning
- `batch_get_shared_events` — replaces non-viewable events with `None` (preserving positional semantics)
- `get_shared_event` — returns `None` if the requested event is a state event

**`enterprise/tests/unit/test_sharing/test_shared_event_filtering.py`** (new)
- 11 tests covering `_is_viewable`, and all three endpoint functions with mocked services

## Testing

All 74 sharing tests pass (63 existing + 11 new), pre-commit checks pass.

---

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/17ab6988-699f-40ba-9be5-27966bf33ee8)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:0c1c743-nikolaik   --name openhands-app-0c1c743   docker.openhands.dev/openhands/openhands:0c1c743
```