### PR TITLE
Remove dead frontend exports

### DIFF
--- a/frontend/src/mocks/settings-handlers.ts
+++ b/frontend/src/mocks/settings-handlers.ts
@@ -106,10 +106,6 @@ export const SETTINGS_HANDLERS = [
     }),
   ),
 
-  http.get("/api/options/agents", async () =>
-    HttpResponse.json(["CodeActAgent", "CoActAgent"]),
-  ),
-
   http.get("/api/options/security-analyzers", async () =>
     HttpResponse.json(["llm", "none"]),
   ),


### PR DESCRIPTION
## Why

The frontend contains exports that are only used in test files but not in the actual application code. These should be removed to keep the codebase clean.

## Summary

- Remove `formatTimestamp`, `getExtension`, `removeApiKey` from `src/utils/utils.ts` (only used in tests)
- Delete `src/utils/is-number.ts` (entire file was dead code - only contained `isNumber` function)
- Clean up related tests in `__tests__/utils/utils.test.ts`
- Delete `__tests__/utils/is-number.test.ts`

## Issue Number

N/A - Found during code review

## How to Test

Run `npm run lint` in the frontend directory to verify no TypeScript errors:
```bash
cd frontend && npm run lint
```

The linter should pass successfully.

## Type

- [x] Refactor
- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Docs / chore

## Notes

These 4 exports (`formatTimestamp`, `getExtension`, `removeApiKey`, `isNumber`) were identified as dead code - they are exported and tested but never imported in the actual application source code. After verification, they are only used in test files.