### PR TITLE
docs: fix app_server README to reflect actual module structure

### DIFF
--- a/openhands/app_server/README.md
+++ b/openhands/app_server/README.md
@@ -10,10 +10,18 @@ As of 2025-09-29, much of the code in the OpenHands repository can be regarded a
 
 The app server is organized into several key modules:
 
-- **conversation/**: Manages sandboxed conversations and their lifecycle
+- **app_conversation/**: Manages sandboxed conversations and their lifecycle
+- **app_lifespan/**: Application startup and shutdown lifecycle management
+- **config_api/**: Configuration API endpoints
 - **event/**: Handles event storage, retrieval, and streaming
 - **event_callback/**: Manages webhooks and event callbacks
+- **git/**: Git integration endpoints
+- **pending_messages/**: Server-side message queuing
 - **sandbox/**: Manages sandbox environments for agent execution
-- **user/**: User management and authentication
+- **secrets/**: Secrets management endpoints
 - **services/**: Core services like JWT authentication
+- **settings/**: User and application settings endpoints
+- **status/**: Server status and system stats
+- **user/**: User management and authentication
 - **utils/**: Utility functions for common operations
+- **web_client/**: Web client configuration and routing


### PR DESCRIPTION
  - [x] A human has tested these changes.

  ---

  ## Why

  The `app_server/README.md` Architecture section listed module names that didn't match the actual directory structure. Several modules were missing and one was
   listed under the wrong name (`conversation/` instead of `app_conversation/`).

  ## Summary

  - Replaced outdated module list with the actual directories in `openhands/app_server/`
  - Added 8 missing modules and corrected `conversation/` → `app_conversation/`

  ## Issue Number

  N/A

  ## How to Test

  Open `openhands/app_server/README.md` and verify each listed module matches an actual directory under `openhands/app_server/`.

  ## Video/Screenshots

  N/A — documentation-only change.

  ## Type

  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Breaking change
  - [x] Docs / chore

  ## Notes

  Documentation-only change, no code affected.