### PR TITLE
Remove dead frontend exports

### DIFF
--- a/frontend/__tests__/utils/is-number.test.ts
+++ b/frontend/__tests__/utils/is-number.test.ts
@@ -1,9 +1,0 @@
-import { test, expect } from "vitest";
-import { isNumber } from "../../src/utils/is-number";
-
-test("isNumber", () => {
-  expect(isNumber(1)).toBe(true);
-  expect(isNumber(0)).toBe(true);
-  expect(isNumber("3")).toBe(true);
-  expect(isNumber("0")).toBe(true);
-});

--- a/frontend/__tests__/utils/utils.test.ts
+++ b/frontend/__tests__/utils/utils.test.ts
@@ -1,9 +1,4 @@
 import { describe, it, expect, vi, test } from "vitest";
-import {
-  formatTimestamp,
-  getExtension,
-  removeApiKey,
-} from "../../src/utils/utils";
 import { getStatusText } from "#/utils/utils";
 import { AgentState } from "#/types/agent-state";
 import { I18nKey } from "#/i18n/declaration";
@@ -21,25 +16,6 @@ const t = (key: string) => {
   };
   return translations[key] || key;
 };
-
-test("removeApiKey", () => {
-  const data = [{ args: { LLM_API_KEY: "key", LANGUAGE: "en" } }];
-  expect(removeApiKey(data)).toEqual([{ args: { LANGUAGE: "en" } }]);
-});
-
-test("getExtension", () => {
-  expect(getExtension("main.go")).toBe("go");
-  expect(getExtension("get-extension.test.ts")).toBe("ts");
-  expect(getExtension("directory")).toBe("");
-});
-
-test("formatTimestamp", () => {
-  const morningDate = new Date("2021-10-10T10:10:10.000").toISOString();
-  expect(formatTimestamp(morningDate)).toBe("10/10/2021, 10:10:10");
-
-  const eveningDate = new Date("2021-10-10T22:10:10.000").toISOString();
-  expect(formatTimestamp(eveningDate)).toBe("10/10/2021, 22:10:10");
-});
 
 describe("getStatusText", () => {
   it("returns STOPPING when pausing", () => {

--- a/frontend/src/utils/is-number.ts
+++ b/frontend/src/utils/is-number.ts
@@ -1,2 +1,0 @@
-export const isNumber = (value: string | number): boolean =>
-  !Number.isNaN(Number(value));

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -146,28 +146,6 @@ export const removeUnwantedKeys = (
     });
 };
 
-export const removeApiKey = (
-  data: EventActionHistory[],
-): EventActionHistory[] =>
-  data.map((item) => {
-    // Create a shallow copy of item
-    const newItem = { ...item };
-
-    // Check if LLM_API_KEY exists and delete it from a new args object
-    if (newItem.args?.LLM_API_KEY) {
-      const newArgs = { ...newItem.args };
-      delete newArgs.LLM_API_KEY;
-      newItem.args = newArgs;
-    }
-
-    return newItem;
-  });
-
-export const getExtension = (code: string) => {
-  if (code.includes(".")) return code.split(".").pop() || "";
-  return "";
-};
-
 /**
  * Get file extension from file name in uppercase format
  * @param fileName The file name to extract extension from
@@ -182,25 +160,6 @@ export const getFileExtension = (fileName: string): string => {
   const extension = fileName.split(".").pop()?.toUpperCase();
   return extension || "FILE";
 };
-
-/**
- * Format a timestamp to a human-readable format
- * @param timestamp The timestamp to format (ISO 8601)
- * @returns The formatted timestamp
- *
- * @example
- * formatTimestamp("2021-10-10T10:10:10.000") // "10/10/2021, 10:10:10"
- * formatTimestamp("2021-10-10T22:10:10.000") // "10/10/2021, 22:10:10"
- */
-export const formatTimestamp = (timestamp: string) =>
-  new Date(timestamp).toLocaleString("en-GB", {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  });
 
 export const shouldUseInstallationRepos = (
   provider: Provider,


### PR DESCRIPTION
## Why

The frontend contains exports that are only used in test files but not in the actual application code. These should be removed to keep the codebase clean.

## Summary

- Remove `formatTimestamp`, `getExtension`, `removeApiKey` from `src/utils/utils.ts` (only used in tests)
- Delete `src/utils/is-number.ts` (entire file was dead code - only contained `isNumber` function)
- Clean up related tests in `__tests__/utils/utils.test.ts`
- Delete `__tests__/utils/is-number.test.ts`

## Issue Number

N/A - Found during code review

## How to Test

Run `npm run lint` in the frontend directory to verify no TypeScript errors:
```bash
cd frontend && npm run lint
```

The linter should pass successfully.

## Type

- [x] Refactor
- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Docs / chore

## Notes

These 4 exports (`formatTimestamp`, `getExtension`, `removeApiKey`, `isNumber`) were identified as dead code - they are exported and tested but never imported in the actual application source code.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:fe2f01f-nikolaik   --name openhands-app-fe2f01f   docker.openhands.dev/openhands/openhands:fe2f01f
```