### PR TITLE
feat(microagent): add dependency_repos frontmatter field for multi-repo support

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import os
 import shlex
@@ -12,6 +13,7 @@ if TYPE_CHECKING:
     import httpx
 
 import base62
+import frontmatter
 
 from openhands.app_server.app_conversation.app_conversation_models import (
     AgentType,
@@ -278,6 +280,9 @@ class AppConversationServiceBase(AppConversationService, ABC):
             agent_server_url,
         )
 
+        # Clone dependency repos declared in microagent frontmatter
+        await self._clone_dependency_repos(workspace, project_dir)
+
     async def _configure_git_user_settings(
         self,
         workspace: AsyncRemoteWorkspace,
@@ -380,6 +385,74 @@ class AppConversationServiceBase(AppConversationService, ABC):
         result = await workspace.execute_command(checkout_command, git_dir)
         if result.exit_code:
             _logger.warning(f'Git checkout failed: {result.stderr}')
+
+    async def _clone_dependency_repos(
+        self,
+        workspace: AsyncRemoteWorkspace,
+        project_dir: str,
+    ) -> None:
+        """Read microagent frontmatter and clone any dependency_repos."""
+        microagents_dir = project_dir + '/.openhands/microagents'
+
+        # List .md files in the microagents directory
+        result = await workspace.execute_command(
+            f'find {shlex.quote(microagents_dir)} -name "*.md" 2>/dev/null',
+            workspace.working_dir,
+        )
+        if result.exit_code or not result.stdout.strip():
+            return
+
+        # Parse frontmatter from each file to collect dependency_repos
+        dep_repos: list[str] = []
+        seen: set[str] = set()
+        for md_path in result.stdout.strip().split('\n'):
+            md_path = md_path.strip()
+            if not md_path:
+                continue
+            cat_result = await workspace.execute_command(
+                f'cat {shlex.quote(md_path)}', workspace.working_dir
+            )
+            if cat_result.exit_code or not cat_result.stdout:
+                continue
+            try:
+                loaded = frontmatter.load(io.StringIO(cat_result.stdout))
+                metadata: dict = loaded.metadata or {}
+                for repo in metadata.get('dependency_repos', []):
+                    if repo not in seen:
+                        seen.add(repo)
+                        dep_repos.append(repo)
+            except Exception:
+                continue
+
+        if not dep_repos:
+            return
+
+        _logger.info(f'Cloning dependency repos: {dep_repos}')
+        for repo in dep_repos:
+            dir_name = repo.split('/')[-1]
+            # Skip if already exists
+            check = await workspace.execute_command(
+                f'test -d {shlex.quote(dir_name)}', workspace.working_dir
+            )
+            if check.exit_code == 0:
+                _logger.info(f'Dependency repo {repo} already exists, skipping')
+                continue
+            try:
+                remote_url = await self.user_context.get_authenticated_git_url(repo)
+                if not remote_url:
+                    _logger.warning(f'Could not get URL for dependency repo {repo}')
+                    continue
+                clone_result = await workspace.execute_command(
+                    f'git clone {shlex.quote(remote_url)} {shlex.quote(dir_name)}',
+                    workspace.working_dir,
+                    120,
+                )
+                if clone_result.exit_code:
+                    _logger.warning(f'Failed to clone dependency repo {repo}: {clone_result.stderr}')
+                else:
+                    _logger.info(f'Cloned dependency repo: {repo}')
+            except Exception as e:
+                _logger.warning(f'Error cloning dependency repo {repo}: {e}')
 
     async def maybe_run_setup_script(
         self,

--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -448,7 +448,9 @@ class AppConversationServiceBase(AppConversationService, ABC):
                     120,
                 )
                 if clone_result.exit_code:
-                    _logger.warning(f'Failed to clone dependency repo {repo}: {clone_result.stderr}')
+                    _logger.warning(
+                        f'Failed to clone dependency repo {repo}: {clone_result.stderr}'
+                    )
                 else:
                     _logger.info(f'Cloned dependency repo: {repo}')
             except Exception as e:

--- a/openhands/core/setup.py
+++ b/openhands/core/setup.py
@@ -30,8 +30,8 @@ from openhands.integrations.provider import (
 )
 from openhands.llm.llm_registry import LLMRegistry
 from openhands.memory.memory import Memory
-from openhands.microagent.microagent import BaseMicroagent
 from openhands.microagent import collect_dependency_repos
+from openhands.microagent.microagent import BaseMicroagent
 from openhands.runtime import get_runtime_cls
 from openhands.runtime.base import Runtime
 from openhands.server.services.conversation_stats import ConversationStats

--- a/openhands/core/setup.py
+++ b/openhands/core/setup.py
@@ -31,6 +31,7 @@ from openhands.integrations.provider import (
 from openhands.llm.llm_registry import LLMRegistry
 from openhands.memory.memory import Memory
 from openhands.microagent.microagent import BaseMicroagent
+from openhands.microagent import collect_dependency_repos
 from openhands.runtime import get_runtime_cls
 from openhands.runtime.base import Runtime
 from openhands.server.services.conversation_stats import ConversationStats
@@ -223,6 +224,19 @@ def create_memory(
             selected_repository
         )
         memory.load_user_workspace_microagents(microagents)
+
+        # Clone dependency repos declared in microagent frontmatter
+        dep_repos = collect_dependency_repos(microagents)
+        if dep_repos:
+            logger.info(f'Cloning dependency repos: {dep_repos}')
+            cloned = call_async_from_sync(
+                runtime.clone_dependency_repos,
+                GENERAL_TIMEOUT,
+                dep_repos,
+                None,
+            )
+            if cloned:
+                logger.info(f'Cloned dependency repos: {cloned}')
 
         if selected_repository and repo_directory:
             memory.set_repository_info(selected_repository, repo_directory)

--- a/openhands/microagent/__init__.py
+++ b/openhands/microagent/__init__.py
@@ -6,11 +6,25 @@ from .microagent import (
 )
 from .types import MicroagentMetadata, MicroagentType
 
+
+def collect_dependency_repos(microagents: list[BaseMicroagent]) -> list[str]:
+    """Collect unique dependency_repos from all microagents."""
+    seen: set[str] = set()
+    repos: list[str] = []
+    for agent in microagents:
+        for repo in agent.metadata.dependency_repos:
+            if repo not in seen:
+                seen.add(repo)
+                repos.append(repo)
+    return repos
+
+
 __all__ = [
     'BaseMicroagent',
     'KnowledgeMicroagent',
     'RepoMicroagent',
     'MicroagentMetadata',
     'MicroagentType',
+    'collect_dependency_repos',
     'load_microagents_from_dir',
 ]

--- a/openhands/microagent/types.py
+++ b/openhands/microagent/types.py
@@ -35,7 +35,9 @@ class MicroagentMetadata(BaseModel):
     mcp_tools: MCPConfig | None = (
         None  # optional, for microagents that provide additional MCP tools
     )
-    dependency_repos: list[str] = []  # optional, repos to clone at startup (e.g. "org/repo")
+    dependency_repos: list[
+        str
+    ] = []  # optional, repos to clone at startup (e.g. "org/repo")
 
 
 class MicroagentResponse(BaseModel):

--- a/openhands/microagent/types.py
+++ b/openhands/microagent/types.py
@@ -35,6 +35,7 @@ class MicroagentMetadata(BaseModel):
     mcp_tools: MCPConfig | None = (
         None  # optional, for microagents that provide additional MCP tools
     )
+    dependency_repos: list[str] = []  # optional, repos to clone at startup (e.g. "org/repo")
 
 
 class MicroagentResponse(BaseModel):

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -565,6 +565,48 @@ class Runtime(FileEditRuntimeMixin):
 
         return dir_name
 
+    async def clone_dependency_repos(
+        self,
+        dependency_repos: list[str],
+        git_provider_tokens: PROVIDER_TOKEN_TYPE | None,
+    ) -> list[str]:
+        """Clone dependency repos declared in microagent frontmatter.
+
+        Returns list of directory names that were successfully cloned.
+        """
+        cloned: list[str] = []
+        for repo in dependency_repos:
+            dir_name = repo.split('/')[-1]
+            repo_path = self.workspace_root / dir_name
+
+            # Skip if already cloned (e.g. it's the main repo)
+            check = CmdRunAction(command=f'test -d {shlex.quote(str(repo_path))}')
+            obs = await call_sync_from_async(self.run_action, check)
+            if isinstance(obs, CmdOutputObservation) and obs.exit_code == 0:
+                self.log('info', f'Dependency repo {repo} already exists, skipping')
+                cloned.append(dir_name)
+                continue
+
+            try:
+                remote_url = await self.provider_handler.get_authenticated_git_url(repo)
+                if not remote_url:
+                    self.log('warning', f'Could not get URL for dependency repo {repo}')
+                    continue
+
+                clone_action = CmdRunAction(
+                    command=f'git clone {shlex.quote(remote_url)} {shlex.quote(str(repo_path))}'
+                )
+                obs = await call_sync_from_async(self.run_action, clone_action)
+                if isinstance(obs, CmdOutputObservation) and obs.exit_code == 0:
+                    self.log('info', f'Cloned dependency repo: {repo}')
+                    cloned.append(dir_name)
+                else:
+                    self.log('warning', f'Failed to clone dependency repo {repo}')
+            except Exception as e:
+                self.log('warning', f'Error cloning dependency repo {repo}: {e}')
+
+        return cloned
+
     def maybe_run_setup_script(self):
         """Run .openhands/setup.sh if it exists in the workspace or repository."""
         setup_script = '.openhands/setup.sh'

--- a/tests/unit/microagent/test_microagent_utils.py
+++ b/tests/unit/microagent/test_microagent_utils.py
@@ -545,3 +545,69 @@ def test_load_both_cursorrules_and_agents_md(temp_dir_with_both_cursorrules_and_
     agents_agent = repo_agents['agents']
     assert isinstance(agents_agent, RepoMicroagent)
     assert 'Install deps: `poetry install`' in agents_agent.content
+
+
+def test_dependency_repos_in_frontmatter(tmp_path):
+    """Test that dependency_repos are parsed from frontmatter."""
+    md_content = """---
+name: my-agent
+dependency_repos:
+  - OpenHands/OpenHands
+  - OpenHands/software-agent-sdk
+---
+# My Agent
+Some content here.
+"""
+    md_file = tmp_path / 'my-agent.md'
+    md_file.write_text(md_content)
+
+    agent = BaseMicroagent.load(md_file, tmp_path)
+    assert agent.metadata.dependency_repos == [
+        'OpenHands/OpenHands',
+        'OpenHands/software-agent-sdk',
+    ]
+
+
+def test_dependency_repos_empty_by_default(tmp_path):
+    """Test that dependency_repos defaults to empty list."""
+    md_content = """---
+name: simple-agent
+---
+# Simple Agent
+No dependency repos.
+"""
+    md_file = tmp_path / 'simple.md'
+    md_file.write_text(md_content)
+
+    agent = BaseMicroagent.load(md_file, tmp_path)
+    assert agent.metadata.dependency_repos == []
+
+
+def test_collect_dependency_repos():
+    """Test collecting unique dependency repos from multiple microagents."""
+    from openhands.microagent import collect_dependency_repos
+
+    agents = [
+        RepoMicroagent(
+            name='a',
+            content='',
+            metadata=MicroagentMetadata(
+                name='a',
+                dependency_repos=['org/repo1', 'org/repo2'],
+            ),
+            source='a.md',
+            type=MicroagentType.REPO_KNOWLEDGE,
+        ),
+        RepoMicroagent(
+            name='b',
+            content='',
+            metadata=MicroagentMetadata(
+                name='b',
+                dependency_repos=['org/repo2', 'org/repo3'],
+            ),
+            source='b.md',
+            type=MicroagentType.REPO_KNOWLEDGE,
+        ),
+    ]
+    result = collect_dependency_repos(agents)
+    assert result == ['org/repo1', 'org/repo2', 'org/repo3']


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

Currently, OpenHands only supports working with a single repository per conversation. Many real-world projects span multiple repos (e.g. frontend + backend, app + SDK). Users have no way to declare these dependencies, forcing them to manually ask the agent to clone additional repos each time.

## Summary

- Add `dependency_repos` frontmatter field to microagent metadata, allowing repos to declare additional repositories that should be cloned at conversation start
- Implement auto-cloning of dependency repos in both V0 (local runtime) and V1 (Docker sandbox) code paths
- Add unit tests for frontmatter parsing, default behavior, and deduplication across multiple microagents

## Issue Number

Resolves OpenHands/software-agent-sdk#4242

## Testing

1. Create a repo with `.openhands/microagents/deps.md`:

```yaml
---
name: test-dependency
dependency_repos:
  - sjathin/sjathin-temp-1
  - sjathin/sjathin-temp-2
---
# Test Dependency Repos
```

2. Start a conversation with that repo selected
3. The dependency repo should be automatically cloned into the workspace alongside the main repo
4. Ask the agent "list the directories in the workspace" to confirm both repos are present

## Video/Screenshots

Tested with 3 small repos (sjathin-temp-main declaring dependencies on sjathin-temp-1 and sjathin-temp-2). All three appeared in the workspace after conversation start:

<img width="989" height="922" alt="Screenshot 2026-04-12 at 00 31 53" src="https://github.com/user-attachments/assets/74cc0e4b-26f0-4124-b1f3-ebefe24b495f" />


## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Dependency repo cloning is best-effort: failures are logged as warnings and don't block conversation start
- Each clone has a 120s timeout matching the main repo clone timeout
- If a dependency repo has the same directory name as the main repo, it's skipped