### PR TITLE
add: support for config.toml for docker #11927

### DIFF
--- a/openhands/app_server/README.md
+++ b/openhands/app_server/README.md
@@ -17,3 +17,38 @@ The app server is organized into several key modules:
 - **user/**: User management and authentication
 - **services/**: Core services like JWT authentication
 - **utils/**: Utility functions for common operations
+
+## Docker TOML Configuration
+
+When running the app server in Docker, configuration can be provided through a
+TOML file instead of only environment variables.
+
+Resolution order:
+
+1. Path from `OH_CONFIG_FILE` (or `OPENHANDS_CONFIG_FILE`)
+2. `docker.toml` in the current working directory
+3. `config.toml` in the current working directory
+4. `/app/docker.toml`
+5. `/app/config.toml`
+
+The app server supports both sections:
+
+- `[app_server]` and `[app_server.sandbox]` (V1 format)
+- `[sandbox]` (legacy-compatible format)
+
+Environment variables still take precedence over TOML values.
+
+Example:
+
+```toml
+[app_server]
+web_url = "https://openhands.example.com"
+permitted_cors_origins = ["https://frontend.example.com"]
+
+[app_server.sandbox]
+use_host_network = false
+volumes = "/host/workspace:/workspace:rw"
+
+# Legacy compatibility for exposing additional sandbox ports
+runtime_extra_build_args = ["-p 80:80", "--publish=8080:8080"]
+```

--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -1,10 +1,12 @@
 """Configuration for the OpenHands App Server."""
 
+import logging
 import os
 from pathlib import Path
 from typing import AsyncContextManager
 
 import httpx
+import tomllib
 from fastapi import Depends, Request
 from pydantic import Field, SecretStr
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -61,6 +63,129 @@ from openhands.app_server.web_client.web_client_config_injector import (
 from openhands.sdk.utils.models import OpenHandsModel
 from openhands.server.types import AppMode
 from openhands.utils.environment import StorageProvider, get_storage_provider
+
+_logger = logging.getLogger(__name__)
+
+
+def _env_var_is_set(name: str) -> bool:
+    value = os.getenv(name)
+    return value is not None and value != ''
+
+
+def _env_has_prefix(prefix: str) -> bool:
+    return any(key.startswith(prefix) and _env_var_is_set(key) for key in os.environ)
+
+
+def _resolve_app_server_toml_path() -> Path | None:
+    """Resolve app-server TOML config path.
+
+    Resolution order:
+    1. `OH_CONFIG_FILE` or `OPENHANDS_CONFIG_FILE` when set.
+    2. `docker.toml` in current working directory.
+    3. `config.toml` in current working directory.
+    4. `/app/docker.toml`.
+    5. `/app/config.toml`.
+    """
+    explicit_path = os.getenv('OH_CONFIG_FILE') or os.getenv('OPENHANDS_CONFIG_FILE')
+    if explicit_path:
+        resolved = Path(explicit_path).expanduser()
+        if resolved.is_file():
+            return resolved
+        _logger.warning('Configured app server TOML file was not found: %s', resolved)
+        return None
+
+    candidates = [
+        Path.cwd() / 'docker.toml',
+        Path.cwd() / 'config.toml',
+        Path('/app/docker.toml'),
+        Path('/app/config.toml'),
+    ]
+    seen: set[Path] = set()
+    for candidate in candidates:
+        candidate = candidate.expanduser()
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _load_app_server_toml() -> dict | None:
+    path = _resolve_app_server_toml_path()
+    if path is None:
+        return None
+    try:
+        with path.open('rb') as file_handle:
+            config = tomllib.load(file_handle)
+        _logger.info('Loaded app-server TOML configuration from %s', path)
+        return config
+    except tomllib.TOMLDecodeError as e:
+        _logger.warning('Failed to parse app-server TOML file %s: %s', path, e)
+    except OSError as e:
+        _logger.warning('Failed to read app-server TOML file %s: %s', path, e)
+    return None
+
+
+def _parse_mounts(mounts_spec: str):
+    """Parse legacy volume mount string into docker sandbox mounts."""
+    from openhands.app_server.sandbox.docker_sandbox_service import VolumeMount
+
+    mounts = []
+    for mount_spec in mounts_spec.split(','):
+        mount_spec = mount_spec.strip()
+        if not mount_spec:
+            continue
+        parts = mount_spec.split(':')
+        if len(parts) < 2:
+            _logger.warning('Skipping invalid mount spec %r in TOML config', mount_spec)
+            continue
+
+        host_path = parts[0].strip()
+        container_path = parts[1].strip()
+        mode = parts[2].strip() if len(parts) > 2 and parts[2].strip() else 'rw'
+        mounts.append(
+            VolumeMount(
+                host_path=host_path,
+                container_path=container_path,
+                mode=mode,
+            )
+        )
+    return mounts
+
+
+def _extract_container_ports_from_publish_args(args: list[str]) -> list[int]:
+    """Extract container ports from docker publish args (e.g. `-p 8080:8080`)."""
+    ports: list[int] = []
+    i = 0
+    while i < len(args):
+        arg = args[i].strip()
+        publish_spec: str | None = None
+
+        if arg in ('-p', '--publish') and i + 1 < len(args):
+            publish_spec = args[i + 1].strip()
+            i += 1
+        elif arg.startswith('-p '):
+            publish_spec = arg[3:].strip()
+        elif arg.startswith('--publish '):
+            publish_spec = arg[len('--publish ') :].strip()
+        elif arg.startswith('--publish='):
+            publish_spec = arg[len('--publish=') :].strip()
+
+        if publish_spec:
+            # Support publish specs like:
+            # - 8080
+            # - 8080:8080
+            # - 127.0.0.1:8080:8080/tcp
+            container_part = publish_spec.split(':')[-1].split('/')[0].strip()
+            if container_part.isdigit():
+                port = int(container_part)
+                if port not in ports:
+                    ports.append(port)
+
+        i += 1
+
+    return ports
 
 
 def get_default_persistence_dir() -> Path:
@@ -161,6 +286,127 @@ class AppServerConfig(OpenHandsModel):
     web_client: WebClientConfigInjector = Field(
         default_factory=DefaultWebClientConfigInjector
     )
+
+
+def _apply_toml_overrides(config: AppServerConfig) -> None:
+    """Apply TOML configuration overrides to app server config.
+
+    TOML values are treated as defaults and are only applied when no environment
+    variable override is present.
+    """
+    toml_config = _load_app_server_toml()
+    if not toml_config or not isinstance(toml_config, dict):
+        return
+
+    app_server_section = toml_config.get('app_server')
+    if isinstance(app_server_section, dict):
+        if (
+            not _env_var_is_set('OH_WEB_URL')
+            and not _env_var_is_set('WEB_HOST')
+            and isinstance(app_server_section.get('web_url'), str)
+        ):
+            config.web_url = app_server_section['web_url']
+
+        if (
+            not _env_has_prefix('OH_PERMITTED_CORS_ORIGINS_')
+            and not _env_var_is_set('PERMITTED_CORS_ORIGINS')
+            and isinstance(app_server_section.get('permitted_cors_origins'), list)
+        ):
+            configured_origins = [
+                item
+                for item in app_server_section['permitted_cors_origins']
+                if isinstance(item, str)
+            ]
+            if configured_origins:
+                config.permitted_cors_origins = configured_origins
+
+    # Support both the V1 section ([app_server.sandbox]) and legacy section ([sandbox]).
+    sandbox_section = None
+    if isinstance(app_server_section, dict) and isinstance(
+        app_server_section.get('sandbox'), dict
+    ):
+        sandbox_section = app_server_section['sandbox']
+    elif isinstance(toml_config.get('sandbox'), dict):
+        sandbox_section = toml_config['sandbox']
+
+    if sandbox_section is None:
+        return
+
+    from openhands.app_server.sandbox.docker_sandbox_service import (
+        DockerSandboxServiceInjector,
+        ExposedPort,
+    )
+
+    if not isinstance(config.sandbox, DockerSandboxServiceInjector):
+        return
+
+    if (
+        not _env_var_is_set('AGENT_SERVER_USE_HOST_NETWORK')
+        and not _env_var_is_set('OH_SANDBOX_USE_HOST_NETWORK')
+        and isinstance(sandbox_section.get('use_host_network'), bool)
+    ):
+        config.sandbox.use_host_network = sandbox_section['use_host_network']
+
+    if (
+        not _env_var_is_set('SANDBOX_HOST_PORT')
+        and not _env_var_is_set('OH_SANDBOX_HOST_PORT')
+        and isinstance(sandbox_section.get('host_port'), int)
+    ):
+        config.sandbox.host_port = sandbox_section['host_port']
+
+    if (
+        not _env_var_is_set('SANDBOX_CONTAINER_URL_PATTERN')
+        and not _env_var_is_set('OH_SANDBOX_CONTAINER_URL_PATTERN')
+        and isinstance(sandbox_section.get('container_url_pattern'), str)
+    ):
+        config.sandbox.container_url_pattern = sandbox_section['container_url_pattern']
+
+    if (
+        not _env_var_is_set('SANDBOX_STARTUP_GRACE_SECONDS')
+        and not _env_var_is_set('OH_SANDBOX_STARTUP_GRACE_SECONDS')
+        and isinstance(sandbox_section.get('startup_grace_seconds'), int)
+    ):
+        config.sandbox.startup_grace_seconds = sandbox_section['startup_grace_seconds']
+
+    if not _env_var_is_set('SANDBOX_VOLUMES') and not _env_has_prefix(
+        'OH_SANDBOX_MOUNTS_'
+    ):
+        volumes = sandbox_section.get('volumes')
+        if isinstance(volumes, str):
+            parsed_mounts = _parse_mounts(volumes)
+            if parsed_mounts:
+                config.sandbox.mounts = parsed_mounts
+
+    # Compatibility path: support legacy runtime_extra_build_args publish flags
+    # by turning them into additional exposed container ports in V1 docker sandboxes.
+    if not _env_has_prefix('OH_SANDBOX_EXPOSED_PORTS_') and isinstance(
+        sandbox_section.get('runtime_extra_build_args'), list
+    ):
+        parsed_args = [
+            arg
+            for arg in sandbox_section['runtime_extra_build_args']
+            if isinstance(arg, str)
+        ]
+        custom_ports = _extract_container_ports_from_publish_args(parsed_args)
+        if custom_ports:
+            existing_ports = {
+                exposed_port.container_port
+                for exposed_port in config.sandbox.exposed_ports
+            }
+            extra_ports = [
+                ExposedPort(
+                    name=f'CUSTOM_{port}',
+                    description='Custom sandbox port from TOML runtime_extra_build_args',
+                    container_port=port,
+                )
+                for port in custom_ports
+                if port not in existing_ports
+            ]
+            if extra_ports:
+                config.sandbox.exposed_ports = [
+                    *config.sandbox.exposed_ports,
+                    *extra_ports,
+                ]
 
 
 def config_from_env() -> AppServerConfig:
@@ -266,27 +512,7 @@ def config_from_env() -> AppServerConfig:
             # This is set by the CLI's --mount-cwd flag
             sandbox_volumes = os.getenv('SANDBOX_VOLUMES')
             if sandbox_volumes:
-                from openhands.app_server.sandbox.docker_sandbox_service import (
-                    VolumeMount,
-                )
-
-                mounts = []
-                for mount_spec in sandbox_volumes.split(','):
-                    mount_spec = mount_spec.strip()
-                    if not mount_spec:
-                        continue
-                    parts = mount_spec.split(':')
-                    if len(parts) >= 2:
-                        host_path = parts[0]
-                        container_path = parts[1]
-                        mode = parts[2] if len(parts) > 2 else 'rw'
-                        mounts.append(
-                            VolumeMount(
-                                host_path=host_path,
-                                container_path=container_path,
-                                mode=mode,
-                            )
-                        )
+                mounts = _parse_mounts(sandbox_volumes)
                 if mounts:
                     docker_sandbox_kwargs['mounts'] = mounts
             config.sandbox = DockerSandboxServiceInjector(**docker_sandbox_kwargs)
@@ -328,6 +554,8 @@ def config_from_env() -> AppServerConfig:
 
     if config.jwt is None:
         config.jwt = JwtServiceInjector(persistence_dir=config.persistence_dir)
+
+    _apply_toml_overrides(config)
 
     return config
 

--- a/tests/unit/app_server/test_config_toml_loading.py
+++ b/tests/unit/app_server/test_config_toml_loading.py
@@ -1,0 +1,161 @@
+"""Tests for app-server TOML config loading in Docker deployments."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_global_config():
+    """Reset the global config before and after each test."""
+    import openhands.app_server.config as config_module
+
+    original_config = config_module._global_config
+    config_module._global_config = None
+    yield
+    config_module._global_config = original_config
+
+
+def _base_env() -> dict[str, str]:
+    """Get a base environment with essential process variables preserved."""
+    env = {}
+    for key in ['PATH', 'HOME', 'PYTHONPATH', 'VIRTUAL_ENV', 'TMPDIR', 'TMP', 'TEMP']:
+        if key in os.environ:
+            env[key] = os.environ[key]
+    return env
+
+
+def _write_toml(path: Path, content: str) -> None:
+    path.write_text(content.strip() + '\n', encoding='utf-8')
+
+
+def test_config_from_env_reads_explicit_toml_file(tmp_path: Path):
+    """`OH_CONFIG_FILE` should load TOML sandbox overrides for docker mode."""
+    config_file = tmp_path / 'docker.toml'
+    _write_toml(
+        config_file,
+        """
+        [sandbox]
+        use_host_network = true
+        volumes = "/tmp/from-toml:/workspace:rw,/tmp/readonly:/workspace/readonly:ro"
+        runtime_extra_build_args = ["-p 80:80", "--publish=8080:8080"]
+        """,
+    )
+
+    env = _base_env()
+    env['OH_CONFIG_FILE'] = str(config_file)
+
+    with patch.dict(os.environ, env, clear=True):
+        from openhands.app_server.config import config_from_env
+        from openhands.app_server.sandbox.docker_sandbox_service import (
+            DockerSandboxServiceInjector,
+        )
+
+        config = config_from_env()
+
+    assert isinstance(config.sandbox, DockerSandboxServiceInjector)
+    assert config.sandbox.use_host_network is True
+
+    mounts_by_target = {
+        mount.container_path: (mount.host_path, mount.mode)
+        for mount in config.sandbox.mounts
+    }
+    assert mounts_by_target['/workspace'] == ('/tmp/from-toml', 'rw')
+    assert mounts_by_target['/workspace/readonly'] == ('/tmp/readonly', 'ro')
+
+    custom_ports = {
+        exposed_port.container_port
+        for exposed_port in config.sandbox.exposed_ports
+        if exposed_port.name.startswith('CUSTOM_')
+    }
+    assert custom_ports == {80, 8080}
+
+
+def test_environment_overrides_toml_sandbox_values(tmp_path: Path):
+    """Environment variables should take precedence over TOML defaults."""
+    config_file = tmp_path / 'docker.toml'
+    _write_toml(
+        config_file,
+        """
+        [sandbox]
+        use_host_network = false
+        volumes = "/tmp/from-toml:/workspace:rw"
+        """,
+    )
+
+    env = _base_env()
+    env['OH_CONFIG_FILE'] = str(config_file)
+    env['AGENT_SERVER_USE_HOST_NETWORK'] = 'true'
+    env['SANDBOX_VOLUMES'] = '/tmp/from-env:/workspace:ro'
+
+    with patch.dict(os.environ, env, clear=True):
+        from openhands.app_server.config import config_from_env
+
+        config = config_from_env()
+
+    assert config.sandbox is not None
+    assert config.sandbox.use_host_network is True
+    assert len(config.sandbox.mounts) == 1
+    assert config.sandbox.mounts[0].host_path == '/tmp/from-env'
+    assert config.sandbox.mounts[0].container_path == '/workspace'
+    assert config.sandbox.mounts[0].mode == 'ro'
+
+
+def test_docker_toml_is_preferred_over_config_toml(tmp_path: Path, monkeypatch):
+    """Default resolution should prefer docker.toml before config.toml."""
+    _write_toml(
+        tmp_path / 'docker.toml',
+        """
+        [sandbox]
+        use_host_network = true
+        """,
+    )
+    _write_toml(
+        tmp_path / 'config.toml',
+        """
+        [sandbox]
+        use_host_network = false
+        """,
+    )
+
+    monkeypatch.chdir(tmp_path)
+    env = _base_env()
+
+    with patch.dict(os.environ, env, clear=True):
+        from openhands.app_server.config import config_from_env
+
+        config = config_from_env()
+
+    assert config.sandbox is not None
+    assert config.sandbox.use_host_network is True
+
+
+def test_app_server_section_overrides_supported(tmp_path: Path):
+    """Support [app_server] and [app_server.sandbox] TOML sections."""
+    config_file = tmp_path / 'docker.toml'
+    _write_toml(
+        config_file,
+        """
+        [app_server]
+        web_url = "https://openhands.example"
+        permitted_cors_origins = ["https://frontend.example"]
+
+        [app_server.sandbox]
+        use_host_network = true
+        """,
+    )
+
+    env = _base_env()
+    env['OH_CONFIG_FILE'] = str(config_file)
+
+    with patch.dict(os.environ, env, clear=True):
+        from openhands.app_server.config import config_from_env
+
+        config = config_from_env()
+
+    assert config.web_url == 'https://openhands.example'
+    assert config.permitted_cors_origins == ['https://frontend.example']
+    assert config.sandbox is not None
+    assert config.sandbox.use_host_network is True


### PR DESCRIPTION
# Why
Docker users were mounting config.toml (or docker.toml) but sandbox behavior in app-server Docker mode was effectively environment-variable driven, which made configuration confusing and caused expected TOML sandbox settings not to apply. This addresses the confusion and behavior reported in issue #5957.

# Summary
* Added TOML config discovery/loading for app-server Docker deployments, with explicit file support and clear fallback order.
* Applied TOML sandbox overrides for Docker sandbox injector settings while preserving environment variables as highest precedence.
* Added legacy compatibility for runtime_extra_build_args publish flags so Docker-style port publish entries can map to exposed sandbox ports in V1.
* Added unit tests for TOML loading/precedence and documented Docker TOML usage in app-server README.

# Issue Number
Close #5957 

# How to test:
1. Automated checks:
* uv run pytest [test_config_toml_loading.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) tests/unit/app_server/test_docker_sandbox_service.py::TestDockerSandboxServiceInjectorFromEnv
* uv run --group dev pre-commit run --config [.pre-commit-config.yaml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) --files [config.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) [test_config_toml_loading.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
2. Manual verification:
* Create a docker.toml with sandbox settings (for example use_host_network and runtime_extra_build_args publish entries).
* Run the app-server Docker container with the file mounted and set OH_CONFIG_FILE to that mounted path.
* Start a sandbox and verify configured sandbox behavior is applied.
* Set equivalent env vars and verify env values override TOML values.

If you cannot run manual validation in your environment, leave the human-tested checkbox unchecked and rely on the automated checks above.

# Video/Screenshots
N/A (backend/config behavior change)

# Type
[x] fix bug

# Notes:
* This change is backward-compatible for existing env-based deployments.
* TOML support covers both app_server.sandbox and legacy sandbox sections.