### PR TITLE
fix(git): prioritize exact repository matches in search

### DIFF
--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -4,7 +4,7 @@ import os
 from collections.abc import Mapping
 from types import MappingProxyType
 from typing import Any, Coroutine, Literal, cast, overload
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 import httpx
 from pydantic import (
@@ -362,26 +362,36 @@ class ProviderHandler:
     ) -> list[Repository]:
         if selected_provider:
             service = self.get_service(selected_provider)
+            exact_match = await self._get_exact_repository_match(
+                selected_provider, query, service
+            )
             public = self._is_repository_url(query, selected_provider)
             user_repos = await service.search_repositories(
                 query, per_page, sort, order, public, app_mode
             )
+            if exact_match:
+                user_repos = [exact_match, *user_repos]
             return self._deduplicate_repositories(user_repos)
 
         all_repos: list[Repository] = []
         for provider in self.provider_tokens:
             try:
                 service = self.get_service(provider)
+                exact_match = await self._get_exact_repository_match(
+                    provider, query, service
+                )
                 public = self._is_repository_url(query, provider)
                 service_repos = await service.search_repositories(
                     query, per_page, sort, order, public, app_mode
                 )
+                if exact_match:
+                    service_repos = [exact_match, *service_repos]
                 all_repos.extend(service_repos)
             except Exception as e:
                 logger.warning(f'Error searching repos from {provider}: {e}')
                 continue
 
-        return all_repos
+        return self._deduplicate_repositories(all_repos)
 
     def _is_repository_url(self, query: str, provider: ProviderType) -> bool:
         """Check if the query is a repository URL."""
@@ -395,14 +405,76 @@ class ProviderHandler:
         )
 
     def _deduplicate_repositories(self, repos: list[Repository]) -> list[Repository]:
-        """Remove duplicate repositories based on full_name."""
-        seen = set()
-        unique_repos = []
+        """Remove duplicate repositories from the same provider."""
+        seen: set[tuple[ProviderType, str]] = set()
+        unique_repos: list[Repository] = []
         for repo in repos:
-            if repo.full_name not in seen:
-                seen.add(repo.id)
+            repository_key = (repo.git_provider, repo.full_name)
+            if repository_key not in seen:
+                seen.add(repository_key)
                 unique_repos.append(repo)
         return unique_repos
+
+    async def _get_exact_repository_match(
+        self,
+        provider: ProviderType,
+        query: str,
+        service: GitService,
+    ) -> Repository | None:
+        """Try an exact repository lookup for owner/repo-style identifiers."""
+        normalized_query = self._normalize_repository_query(query, provider)
+        if normalized_query is None:
+            return None
+
+        try:
+            return await service.get_repository_details_from_repo_name(normalized_query)
+        except Exception as e:
+            logger.debug(
+                'Exact repository lookup failed for %s on %s: %s',
+                normalized_query,
+                provider.value,
+                e,
+            )
+            return None
+
+    def _normalize_repository_query(
+        self, query: str, provider: ProviderType
+    ) -> str | None:
+        """Normalize exact repository identifiers from URLs or owner/repo strings."""
+        normalized_query = query.strip()
+        if not normalized_query:
+            return None
+
+        if normalized_query.startswith(('http://', 'https://')):
+            parsed_url = urlparse(normalized_query)
+            path_segments = [segment for segment in parsed_url.path.split('/') if segment]
+            if provider in (
+                ProviderType.GITHUB,
+                ProviderType.FORGEJO,
+                ProviderType.BITBUCKET,
+            ):
+                if len(path_segments) < 2:
+                    return None
+                normalized_query = '/'.join(path_segments[:2])
+            elif provider == ProviderType.AZURE_DEVOPS:
+                if len(path_segments) < 3:
+                    return None
+                normalized_query = '/'.join(path_segments[:3])
+            else:
+                return None
+        elif any(char in normalized_query for char in (' ', '?', '#')):
+            return None
+
+        normalized_query = normalized_query.strip('/').removesuffix('.git')
+        if not normalized_query:
+            return None
+
+        path_segments = [segment for segment in normalized_query.split('/') if segment]
+        minimum_segments = 3 if provider == ProviderType.AZURE_DEVOPS else 2
+        if len(path_segments) < minimum_segments:
+            return None
+
+        return '/'.join(path_segments)
 
     async def set_event_stream_secrets(
         self,

--- a/tests/unit/integrations/test_provider_immutability.py
+++ b/tests/unit/integrations/test_provider_immutability.py
@@ -10,6 +10,8 @@ from openhands.integrations.provider import (
     ProviderToken,
     ProviderType,
 )
+from openhands.integrations.service_types import Repository
+from openhands.server.types import AppMode
 from openhands.storage.data_models.secrets import Secrets
 from openhands.storage.data_models.settings import Settings
 
@@ -396,3 +398,94 @@ async def test_get_gitlab_groups_delegates_to_service():
 
         assert result == ['group-a', 'group-b']
         mock_get_service.assert_called_once_with(ProviderType.GITLAB)
+
+
+@pytest.mark.asyncio
+async def test_search_repositories_prioritizes_exact_repository_match():
+    """Test that exact owner/repo matches are returned first and de-duplicated."""
+    tokens = MappingProxyType(
+        {ProviderType.GITHUB: ProviderToken(token=SecretStr('gh-token'))}
+    )
+    handler = ProviderHandler(provider_tokens=tokens)
+
+    exact_repo = Repository(
+        id='1',
+        full_name='OpenHands/OpenHands',
+        git_provider=ProviderType.GITHUB,
+        is_public=True,
+    )
+    duplicate_search_repo = Repository(
+        id='999',
+        full_name='OpenHands/OpenHands',
+        git_provider=ProviderType.GITHUB,
+        is_public=True,
+    )
+    related_repo = Repository(
+        id='2',
+        full_name='OpenHands/OpenHands-CLI',
+        git_provider=ProviderType.GITHUB,
+        is_public=True,
+    )
+
+    with patch.object(handler, 'get_service') as mock_get_service:
+        mock_service = mock_get_service.return_value
+        mock_service.get_repository_details_from_repo_name = AsyncMock(
+            return_value=exact_repo
+        )
+        mock_service.search_repositories = AsyncMock(
+            return_value=[duplicate_search_repo, related_repo]
+        )
+
+        repositories = await handler.search_repositories(
+            selected_provider=ProviderType.GITHUB,
+            query='OpenHands/OpenHands',
+            per_page=10,
+            sort='stars',
+            order='desc',
+            app_mode=AppMode.SAAS,
+        )
+
+        mock_service.get_repository_details_from_repo_name.assert_called_once_with(
+            'OpenHands/OpenHands'
+        )
+        assert [repo.full_name for repo in repositories] == [
+            'OpenHands/OpenHands',
+            'OpenHands/OpenHands-CLI',
+        ]
+
+
+@pytest.mark.asyncio
+async def test_search_repositories_normalizes_repository_urls_for_exact_lookup():
+    """Test that repository URLs are normalized before exact lookup."""
+    tokens = MappingProxyType(
+        {ProviderType.GITHUB: ProviderToken(token=SecretStr('gh-token'))}
+    )
+    handler = ProviderHandler(provider_tokens=tokens)
+
+    exact_repo = Repository(
+        id='1',
+        full_name='OpenHands/OpenHands',
+        git_provider=ProviderType.GITHUB,
+        is_public=True,
+    )
+
+    with patch.object(handler, 'get_service') as mock_get_service:
+        mock_service = mock_get_service.return_value
+        mock_service.get_repository_details_from_repo_name = AsyncMock(
+            return_value=exact_repo
+        )
+        mock_service.search_repositories = AsyncMock(return_value=[])
+
+        repositories = await handler.search_repositories(
+            selected_provider=ProviderType.GITHUB,
+            query='https://github.com/OpenHands/OpenHands.git/tree/main',
+            per_page=10,
+            sort='stars',
+            order='desc',
+            app_mode=AppMode.SAAS,
+        )
+
+        mock_service.get_repository_details_from_repo_name.assert_called_once_with(
+            'OpenHands/OpenHands'
+        )
+        assert [repo.full_name for repo in repositories] == ['OpenHands/OpenHands']


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

The repo picker currently relies on provider search results even when the user enters an exact `owner/repo` identifier or pastes a repository URL. On GitHub this can miss accessible repos when broader prefix-based search results rank ahead of the exact match, and duplicate repo entries from multiple search passes make the result list noisier.

## Summary

- prioritize exact repository lookups for `owner/repo` identifiers and repository URLs before falling back to provider search
- normalize URL-style inputs like `https://github.com/org/repo.git/tree/main` into exact repository names for the lookup path
- fix repository deduplication so duplicates are removed per provider and add regression tests for both exact-match and URL flows

## Issue Number

Closes #13769

## How to Test

1. `uv sync --group dev --group test`
2. `uv run pytest tests/unit/integrations/test_provider_immutability.py tests/unit/app_server/test_git_router.py -q`
3. In the OpenHands repo picker, type an exact repo like `OpenHands/OpenHands` or paste a repository URL like `https://github.com/OpenHands/OpenHands.git/tree/main` and verify the exact repo appears in the results.

## Video/Screenshots

Not included. This change was validated with automated regression tests and backend search-path coverage.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Changelog message: Repo picker search now prioritizes exact repository identifiers and pasted repository URLs before broader provider search results.