### PR TITLE
feat(frontend): add X-Org-Id header to API requests for per-tab org context

### DIFF
--- a/frontend/__tests__/api/open-hands-axios.test.ts
+++ b/frontend/__tests__/api/open-hands-axios.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "#/mocks/node";
+import { openHands } from "#/api/open-hands-axios";
+import { useSelectedOrganizationStore } from "#/stores/selected-organization-store";
+
+describe("openHands axios instance", () => {
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("should attach X-Org-Id header when an organization is selected", async () => {
+    // Arrange
+    let capturedOrgHeader: string | null = null;
+    server.use(
+      http.get("*/api/test-endpoint", ({ request }) => {
+        capturedOrgHeader = request.headers.get("X-Org-Id");
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    useSelectedOrganizationStore.setState({ organizationId: "org-abc-123" });
+
+    // Act
+    await openHands.get("/api/test-endpoint");
+
+    // Assert
+    expect(capturedOrgHeader).toBe("org-abc-123");
+  });
+
+  it("should not attach X-Org-Id header when no organization is selected", async () => {
+    // Arrange
+    let capturedOrgHeader: string | null = "should-be-replaced";
+    server.use(
+      http.get("*/api/test-endpoint", ({ request }) => {
+        capturedOrgHeader = request.headers.get("X-Org-Id");
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    // Act
+    await openHands.get("/api/test-endpoint");
+
+    // Assert
+    expect(capturedOrgHeader).toBeNull();
+  });
+});

--- a/frontend/__tests__/stores/selected-organization-store.test.ts
+++ b/frontend/__tests__/stores/selected-organization-store.test.ts
@@ -1,8 +1,12 @@
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { useSelectedOrganizationStore } from "#/stores/selected-organization-store";
 
 describe("useSelectedOrganizationStore", () => {
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
   it("should have null as initial organizationId", () => {
     const { result } = renderHook(() => useSelectedOrganizationStore());
     expect(result.current.organizationId).toBeNull();
@@ -47,5 +51,29 @@ describe("useSelectedOrganizationStore", () => {
     });
 
     expect(result2.current.organizationId).toBe("shared-organization");
+  });
+
+  it("should persist organizationId to sessionStorage when set", () => {
+    const { result } = renderHook(() => useSelectedOrganizationStore());
+
+    act(() => {
+      result.current.setOrganizationId("org-456");
+    });
+
+    expect(sessionStorage.getItem("selectedOrgId")).toBe("org-456");
+  });
+
+  it("should remove organizationId from sessionStorage when set to null", () => {
+    const { result } = renderHook(() => useSelectedOrganizationStore());
+
+    act(() => {
+      result.current.setOrganizationId("org-789");
+    });
+
+    act(() => {
+      result.current.setOrganizationId(null);
+    });
+
+    expect(sessionStorage.getItem("selectedOrgId")).toBeNull();
   });
 });

--- a/frontend/src/api/open-hands-axios.ts
+++ b/frontend/src/api/open-hands-axios.ts
@@ -1,7 +1,19 @@
 import axios, { AxiosError, AxiosResponse } from "axios";
+import { getSelectedOrganizationIdFromStore } from "#/stores/selected-organization-store";
 
 export const openHands = axios.create({
   baseURL: `${window.location.protocol}//${import.meta.env.VITE_BACKEND_BASE_URL || window?.location.host}`,
+});
+
+// Attach the selected organization ID to every request so the backend
+// can resolve org context per-request instead of relying on a shared
+// server-side current_org_id.
+openHands.interceptors.request.use((config) => {
+  const orgId = getSelectedOrganizationIdFromStore();
+  if (orgId) {
+    config.headers.set("X-Org-Id", orgId);
+  }
+  return config;
 });
 
 // Helper function to check if a response contains an email verification error

--- a/frontend/src/stores/selected-organization-store.ts
+++ b/frontend/src/stores/selected-organization-store.ts
@@ -1,6 +1,8 @@
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 
+const SESSION_STORAGE_KEY = "selectedOrgId";
+
 interface SelectedOrganizationState {
   organizationId: string | null;
 }
@@ -13,14 +15,21 @@ type SelectedOrganizationStore = SelectedOrganizationState &
   SelectedOrganizationActions;
 
 const initialState: SelectedOrganizationState = {
-  organizationId: null,
+  organizationId: sessionStorage.getItem(SESSION_STORAGE_KEY),
 };
 
 export const useSelectedOrganizationStore = create<SelectedOrganizationStore>()(
   devtools(
     (set) => ({
       ...initialState,
-      setOrganizationId: (organizationId) => set({ organizationId }),
+      setOrganizationId: (organizationId) => {
+        if (organizationId) {
+          sessionStorage.setItem(SESSION_STORAGE_KEY, organizationId);
+        } else {
+          sessionStorage.removeItem(SESSION_STORAGE_KEY);
+        }
+        set({ organizationId });
+      },
     }),
     { name: "SelectedOrganizationStore" },
   ),


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

**Description:**

Many API endpoints rely on an organization ID. Currently, the server stores a current_org_id, which is implicitly used by endpoints that do not accept an explicit org_id parameter. This shared state causes incorrect behavior when users open multiple browser tabs with different organizations selected or make parallel API calls requiring different org contexts.

**Acceptance Criteria:**
- Every API request from the frontend includes an X-Org-Id header with the currently selected organization ID.
- Each browser tab maintains its own independent organization context.
- The selected organization persists across page refreshes within the same tab.
- Opening a new tab falls back to the backend's current_org_id.

Scope: Frontend only. Backend changes to consume the header will be handled separately.

## Summary

<!-- 1-3 bullets describing what changed. -->

Add a request interceptor to the shared axios instance that attaches an X-Org-Id header from the Zustand store on every outgoing request. This allows the backend to resolve organization context per-request instead of relying on a shared server-side current_org_id.

Persist the selected organization ID in sessionStorage so it survives page refreshes while remaining isolated per tab, enabling users to work with different organizations in different browser tabs simultaneously.

- Add an axios request interceptor that attaches `X-Org-Id` header to all API requests made through the shared `openHands` instance, sourced from the selected organization Zustand store.
- Persist selected organization ID in `sessionStorage` (per-tab) so it survives page refreshes while keeping different tabs independent.
- No changes needed to individual API service files or the auto-select hook — the interceptor handles all requests centrally, and the store initialization from `sessionStorage` integrates naturally with existing selection logic.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

Run the SaaS application locally, then open it in two separate browser tabs. In each tab, switch to a different organization to simulate multiple contexts.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/5a92a6d3-e3ef-4317-8e7a-f374915945fd

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

N/A.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:49ec2ee-nikolaik   --name openhands-app-49ec2ee   docker.openhands.dev/openhands/openhands:49ec2ee
```