### PR TITLE
APP-1238 Fix concurrent GET /api/v1/web-client/config calls

### DIFF
--- a/frontend/__tests__/utils/permission-guard.test.ts
+++ b/frontend/__tests__/utils/permission-guard.test.ts
@@ -38,6 +38,7 @@ vi.mock("#/query-client-config", () => ({
   queryClient: {
     getQueryData: vi.fn(() => mockConfig),
     setQueryData: vi.fn(),
+    fetchQuery: vi.fn(() => Promise.resolve(mockConfig)),
   },
 }));
 

--- a/frontend/src/components/providers/posthog-wrapper.tsx
+++ b/frontend/src/components/providers/posthog-wrapper.tsx
@@ -1,9 +1,14 @@
 import React from "react";
 import { PostHogProvider } from "posthog-js/react";
+import { queryClient } from "#/query-client-config";
 import OptionService from "#/api/option-service/option-service.api";
+import { QUERY_KEYS } from "#/hooks/query/query-keys";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
 
 const POSTHOG_BOOTSTRAP_KEY = "posthog_bootstrap";
+
+const CONFIG_STALE_TIME = 1000 * 60 * 5; // 5 minutes
+const CONFIG_GC_TIME = 1000 * 60 * 15; // 15 minutes
 
 function getBootstrapIds() {
   // Try to extract from URL hash (e.g. #distinct_id=abc&session_id=xyz)
@@ -47,7 +52,13 @@ export function PostHogWrapper({ children }: { children: React.ReactNode }) {
   React.useEffect(() => {
     (async () => {
       try {
-        const config = await OptionService.getConfig();
+        // Use fetchQuery for automatic caching and deduplication
+        const config = await queryClient.fetchQuery({
+          queryKey: QUERY_KEYS.WEB_CLIENT_CONFIG,
+          queryFn: OptionService.getConfig,
+          staleTime: CONFIG_STALE_TIME,
+          gcTime: CONFIG_GC_TIME,
+        });
         setPosthogClientKey(config.posthog_client_key);
       } catch {
         displayErrorToast("Error fetching PostHog client key");

--- a/frontend/src/components/providers/posthog-wrapper.tsx
+++ b/frontend/src/components/providers/posthog-wrapper.tsx
@@ -2,13 +2,10 @@ import React from "react";
 import { PostHogProvider } from "posthog-js/react";
 import { queryClient } from "#/query-client-config";
 import OptionService from "#/api/option-service/option-service.api";
-import { QUERY_KEYS } from "#/hooks/query/query-keys";
+import { QUERY_KEYS, CONFIG_CACHE_OPTIONS } from "#/hooks/query/query-keys";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
 
 const POSTHOG_BOOTSTRAP_KEY = "posthog_bootstrap";
-
-const CONFIG_STALE_TIME = 1000 * 60 * 5; // 5 minutes
-const CONFIG_GC_TIME = 1000 * 60 * 15; // 15 minutes
 
 function getBootstrapIds() {
   // Try to extract from URL hash (e.g. #distinct_id=abc&session_id=xyz)
@@ -56,8 +53,7 @@ export function PostHogWrapper({ children }: { children: React.ReactNode }) {
         const config = await queryClient.fetchQuery({
           queryKey: QUERY_KEYS.WEB_CLIENT_CONFIG,
           queryFn: OptionService.getConfig,
-          staleTime: CONFIG_STALE_TIME,
-          gcTime: CONFIG_GC_TIME,
+          ...CONFIG_CACHE_OPTIONS,
         });
         setPosthogClientKey(config.posthog_client_key);
       } catch {

--- a/frontend/src/hooks/query/query-keys.ts
+++ b/frontend/src/hooks/query/query-keys.ts
@@ -1,0 +1,11 @@
+/**
+ * Centralized query keys for TanStack Query.
+ * Using constants ensures type safety and prevents typos.
+ */
+
+export const QUERY_KEYS = {
+  /** Web client configuration from the server */
+  WEB_CLIENT_CONFIG: ["web-client-config"] as const,
+} as const;
+
+export type QueryKeys = (typeof QUERY_KEYS)[keyof typeof QUERY_KEYS];

--- a/frontend/src/hooks/query/query-keys.ts
+++ b/frontend/src/hooks/query/query-keys.ts
@@ -1,11 +1,17 @@
 /**
- * Centralized query keys for TanStack Query.
+ * Centralized query keys and cache configuration for TanStack Query.
  * Using constants ensures type safety and prevents typos.
  */
 
 export const QUERY_KEYS = {
   /** Web client configuration from the server */
   WEB_CLIENT_CONFIG: ["web-client-config"] as const,
+} as const;
+
+/** Cache configuration shared across all config-related queries */
+export const CONFIG_CACHE_OPTIONS = {
+  staleTime: 1000 * 60 * 5, // 5 minutes
+  gcTime: 1000 * 60 * 15, // 15 minutes
 } as const;
 
 export type QueryKeys = (typeof QUERY_KEYS)[keyof typeof QUERY_KEYS];

--- a/frontend/src/hooks/query/use-config.ts
+++ b/frontend/src/hooks/query/use-config.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import OptionService from "#/api/option-service/option-service.api";
 import { useIsOnIntermediatePage } from "#/hooks/use-is-on-intermediate-page";
+import { QUERY_KEYS } from "./query-keys";
 
 interface UseConfigOptions {
   enabled?: boolean;
@@ -10,7 +11,7 @@ export const useConfig = (options?: UseConfigOptions) => {
   const isOnIntermediatePage = useIsOnIntermediatePage();
 
   return useQuery({
-    queryKey: ["web-client-config"],
+    queryKey: QUERY_KEYS.WEB_CLIENT_CONFIG,
     queryFn: OptionService.getConfig,
     staleTime: 1000 * 60 * 5, // 5 minutes
     gcTime: 1000 * 60 * 15, // 15 minutes,

--- a/frontend/src/hooks/query/use-config.ts
+++ b/frontend/src/hooks/query/use-config.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import OptionService from "#/api/option-service/option-service.api";
 import { useIsOnIntermediatePage } from "#/hooks/use-is-on-intermediate-page";
-import { QUERY_KEYS } from "./query-keys";
+import { QUERY_KEYS, CONFIG_CACHE_OPTIONS } from "./query-keys";
 
 interface UseConfigOptions {
   enabled?: boolean;
@@ -13,8 +13,7 @@ export const useConfig = (options?: UseConfigOptions) => {
   return useQuery({
     queryKey: QUERY_KEYS.WEB_CLIENT_CONFIG,
     queryFn: OptionService.getConfig,
-    staleTime: 1000 * 60 * 5, // 5 minutes
-    gcTime: 1000 * 60 * 15, // 15 minutes,
+    ...CONFIG_CACHE_OPTIONS,
     enabled: options?.enabled ?? !isOnIntermediatePage,
   });
 };

--- a/frontend/src/routes/billing.tsx
+++ b/frontend/src/routes/billing.tsx
@@ -16,13 +16,23 @@ import { isBillingHidden } from "#/utils/org/billing-visibility";
 import { queryClient } from "#/query-client-config";
 import OptionService from "#/api/option-service/option-service.api";
 import { WebClientConfig } from "#/api/option-service/option.types";
+import { QUERY_KEYS } from "#/hooks/query/query-keys";
 import { getFirstAvailablePath } from "#/utils/settings-utils";
 
+const CONFIG_STALE_TIME = 1000 * 60 * 5; // 5 minutes
+const CONFIG_GC_TIME = 1000 * 60 * 15; // 15 minutes
+
 export const clientLoader = async () => {
-  let config = queryClient.getQueryData<WebClientConfig>(["web-client-config"]);
+  let config = queryClient.getQueryData<WebClientConfig>(
+    QUERY_KEYS.WEB_CLIENT_CONFIG,
+  );
   if (!config) {
-    config = await OptionService.getConfig();
-    queryClient.setQueryData<WebClientConfig>(["web-client-config"], config);
+    config = await queryClient.fetchQuery<WebClientConfig>({
+      queryKey: QUERY_KEYS.WEB_CLIENT_CONFIG,
+      queryFn: OptionService.getConfig,
+      staleTime: CONFIG_STALE_TIME,
+      gcTime: CONFIG_GC_TIME,
+    });
   }
 
   const isSaas = config?.app_mode === "saas";

--- a/frontend/src/routes/billing.tsx
+++ b/frontend/src/routes/billing.tsx
@@ -20,16 +20,11 @@ import { QUERY_KEYS, CONFIG_CACHE_OPTIONS } from "#/hooks/query/query-keys";
 import { getFirstAvailablePath } from "#/utils/settings-utils";
 
 export const clientLoader = async () => {
-  let config = queryClient.getQueryData<WebClientConfig>(
-    QUERY_KEYS.WEB_CLIENT_CONFIG,
-  );
-  if (!config) {
-    config = await queryClient.fetchQuery<WebClientConfig>({
-      queryKey: QUERY_KEYS.WEB_CLIENT_CONFIG,
-      queryFn: OptionService.getConfig,
-      ...CONFIG_CACHE_OPTIONS,
-    });
-  }
+  const config = await queryClient.fetchQuery<WebClientConfig>({
+    queryKey: QUERY_KEYS.WEB_CLIENT_CONFIG,
+    queryFn: OptionService.getConfig,
+    ...CONFIG_CACHE_OPTIONS,
+  });
 
   const isSaas = config?.app_mode === "saas";
   const featureFlags = config?.feature_flags;

--- a/frontend/src/routes/billing.tsx
+++ b/frontend/src/routes/billing.tsx
@@ -16,11 +16,8 @@ import { isBillingHidden } from "#/utils/org/billing-visibility";
 import { queryClient } from "#/query-client-config";
 import OptionService from "#/api/option-service/option-service.api";
 import { WebClientConfig } from "#/api/option-service/option.types";
-import { QUERY_KEYS } from "#/hooks/query/query-keys";
+import { QUERY_KEYS, CONFIG_CACHE_OPTIONS } from "#/hooks/query/query-keys";
 import { getFirstAvailablePath } from "#/utils/settings-utils";
-
-const CONFIG_STALE_TIME = 1000 * 60 * 5; // 5 minutes
-const CONFIG_GC_TIME = 1000 * 60 * 15; // 15 minutes
 
 export const clientLoader = async () => {
   let config = queryClient.getQueryData<WebClientConfig>(
@@ -30,8 +27,7 @@ export const clientLoader = async () => {
     config = await queryClient.fetchQuery<WebClientConfig>({
       queryKey: QUERY_KEYS.WEB_CLIENT_CONFIG,
       queryFn: OptionService.getConfig,
-      staleTime: CONFIG_STALE_TIME,
-      gcTime: CONFIG_GC_TIME,
+      ...CONFIG_CACHE_OPTIONS,
     });
   }
 

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -6,6 +6,7 @@ import OptionService from "#/api/option-service/option-service.api";
 import { queryClient } from "#/query-client-config";
 import { SettingsLayout } from "#/components/features/settings";
 import { WebClientConfig } from "#/api/option-service/option.types";
+import { QUERY_KEYS } from "#/hooks/query/query-keys";
 import { Organization } from "#/types/org";
 import { Typography } from "#/ui/typography";
 import { useSettingsNavItems } from "#/hooks/use-settings-nav-items";
@@ -31,15 +32,24 @@ const SAAS_ONLY_PATHS = [
   "/settings/org",
 ];
 
+const CONFIG_STALE_TIME = 1000 * 60 * 5; // 5 minutes
+const CONFIG_GC_TIME = 1000 * 60 * 15; // 15 minutes
+
 export const clientLoader = async ({ request }: Route.ClientLoaderArgs) => {
   const url = new URL(request.url);
   const { pathname } = url;
 
   // Step 1: Get config first (needed for all checks, no user data required)
-  let config = queryClient.getQueryData<WebClientConfig>(["web-client-config"]);
+  let config = queryClient.getQueryData<WebClientConfig>(
+    QUERY_KEYS.WEB_CLIENT_CONFIG,
+  );
   if (!config) {
-    config = await OptionService.getConfig();
-    queryClient.setQueryData<WebClientConfig>(["web-client-config"], config);
+    config = await queryClient.fetchQuery<WebClientConfig>({
+      queryKey: QUERY_KEYS.WEB_CLIENT_CONFIG,
+      queryFn: OptionService.getConfig,
+      staleTime: CONFIG_STALE_TIME,
+      gcTime: CONFIG_GC_TIME,
+    });
   }
 
   const isSaas = config?.app_mode === "saas";

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -6,7 +6,7 @@ import OptionService from "#/api/option-service/option-service.api";
 import { queryClient } from "#/query-client-config";
 import { SettingsLayout } from "#/components/features/settings";
 import { WebClientConfig } from "#/api/option-service/option.types";
-import { QUERY_KEYS } from "#/hooks/query/query-keys";
+import { QUERY_KEYS, CONFIG_CACHE_OPTIONS } from "#/hooks/query/query-keys";
 import { Organization } from "#/types/org";
 import { Typography } from "#/ui/typography";
 import { useSettingsNavItems } from "#/hooks/use-settings-nav-items";
@@ -32,9 +32,6 @@ const SAAS_ONLY_PATHS = [
   "/settings/org",
 ];
 
-const CONFIG_STALE_TIME = 1000 * 60 * 5; // 5 minutes
-const CONFIG_GC_TIME = 1000 * 60 * 15; // 15 minutes
-
 export const clientLoader = async ({ request }: Route.ClientLoaderArgs) => {
   const url = new URL(request.url);
   const { pathname } = url;
@@ -47,8 +44,7 @@ export const clientLoader = async ({ request }: Route.ClientLoaderArgs) => {
     config = await queryClient.fetchQuery<WebClientConfig>({
       queryKey: QUERY_KEYS.WEB_CLIENT_CONFIG,
       queryFn: OptionService.getConfig,
-      staleTime: CONFIG_STALE_TIME,
-      gcTime: CONFIG_GC_TIME,
+      ...CONFIG_CACHE_OPTIONS,
     });
   }
 

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -37,16 +37,11 @@ export const clientLoader = async ({ request }: Route.ClientLoaderArgs) => {
   const { pathname } = url;
 
   // Step 1: Get config first (needed for all checks, no user data required)
-  let config = queryClient.getQueryData<WebClientConfig>(
-    QUERY_KEYS.WEB_CLIENT_CONFIG,
-  );
-  if (!config) {
-    config = await queryClient.fetchQuery<WebClientConfig>({
-      queryKey: QUERY_KEYS.WEB_CLIENT_CONFIG,
-      queryFn: OptionService.getConfig,
-      ...CONFIG_CACHE_OPTIONS,
-    });
-  }
+  const config = await queryClient.fetchQuery<WebClientConfig>({
+    queryKey: QUERY_KEYS.WEB_CLIENT_CONFIG,
+    queryFn: OptionService.getConfig,
+    ...CONFIG_CACHE_OPTIONS,
+  });
 
   const isSaas = config?.app_mode === "saas";
   const featureFlags = config?.feature_flags;

--- a/frontend/src/utils/org/permission-guard.ts
+++ b/frontend/src/utils/org/permission-guard.ts
@@ -2,13 +2,10 @@ import { redirect } from "react-router";
 import { queryClient } from "#/query-client-config";
 import OptionService from "#/api/option-service/option-service.api";
 import { WebClientConfig } from "#/api/option-service/option.types";
-import { QUERY_KEYS } from "#/hooks/query/query-keys";
+import { QUERY_KEYS, CONFIG_CACHE_OPTIONS } from "#/hooks/query/query-keys";
 import { getFirstAvailablePath } from "#/utils/settings-utils";
 import { getActiveOrganizationUser } from "./permission-checks";
 import { PermissionKey, rolePermissions } from "./permissions";
-
-const CONFIG_STALE_TIME = 1000 * 60 * 5; // 5 minutes
-const CONFIG_GC_TIME = 1000 * 60 * 15; // 15 minutes
 
 /**
  * Helper to get config, using fetchQuery for automatic caching and deduplication.
@@ -18,8 +15,7 @@ async function getConfig(): Promise<WebClientConfig | undefined> {
   return queryClient.fetchQuery({
     queryKey: QUERY_KEYS.WEB_CLIENT_CONFIG,
     queryFn: OptionService.getConfig,
-    staleTime: CONFIG_STALE_TIME,
-    gcTime: CONFIG_GC_TIME,
+    ...CONFIG_CACHE_OPTIONS,
   });
 }
 

--- a/frontend/src/utils/org/permission-guard.ts
+++ b/frontend/src/utils/org/permission-guard.ts
@@ -1,21 +1,26 @@
 import { redirect } from "react-router";
+import { queryClient } from "#/query-client-config";
 import OptionService from "#/api/option-service/option-service.api";
 import { WebClientConfig } from "#/api/option-service/option.types";
-import { queryClient } from "#/query-client-config";
+import { QUERY_KEYS } from "#/hooks/query/query-keys";
 import { getFirstAvailablePath } from "#/utils/settings-utils";
 import { getActiveOrganizationUser } from "./permission-checks";
 import { PermissionKey, rolePermissions } from "./permissions";
 
+const CONFIG_STALE_TIME = 1000 * 60 * 5; // 5 minutes
+const CONFIG_GC_TIME = 1000 * 60 * 15; // 15 minutes
+
 /**
- * Helper to get config, using cache or fetching if needed.
+ * Helper to get config, using fetchQuery for automatic caching and deduplication.
+ * Uses the shared query key from QUERY_KEYS to ensure consistency across the app.
  */
 async function getConfig(): Promise<WebClientConfig | undefined> {
-  let config = queryClient.getQueryData<WebClientConfig>(["web-client-config"]);
-  if (!config) {
-    config = await OptionService.getConfig();
-    queryClient.setQueryData<WebClientConfig>(["web-client-config"], config);
-  }
-  return config;
+  return queryClient.fetchQuery({
+    queryKey: QUERY_KEYS.WEB_CLIENT_CONFIG,
+    queryFn: OptionService.getConfig,
+    staleTime: CONFIG_STALE_TIME,
+    gcTime: CONFIG_GC_TIME,
+  });
 }
 
 /**


### PR DESCRIPTION
## Why

Multiple concurrent calls to `GET /api/v1/web-client/config` were being made on app load. The root cause was `PostHogWrapper` calling `OptionService.getConfig()` directly, bypassing TanStack Query's cache entirely. Additionally, different places were using slightly different query keys.

## Summary

- Create centralized `QUERY_KEYS` constant for web-client-config to ensure consistent query keys across the app
- Update `PostHogWrapper` to use `queryClient.fetchQuery()` instead of direct API call, enabling automatic caching and deduplication
- Update `permission-guard`, `billing`, and `settings` loaders to use `fetchQuery` with the shared query key
- This ensures only ONE HTTP request fires even with multiple concurrent callers (TanStack Query automatically deduplicates)

## How to Test

1. Open browser DevTools Network tab
2. Load the app
3. Verify only ONE `GET /api/v1/web-client/config` request is made (not multiple concurrent calls)

<img width="743" height="476" alt="image" src="https://github.com/user-attachments/assets/31848a79-cb3e-4c87-a2c8-bb1cd04dca11" />

## Type

- [x] Bug fix

## Notes

Uses `queryClient.fetchQuery()` which provides automatic request deduplication - if the same query is already in-flight, it returns the same promise instead of making duplicate requests.

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:3f4a4c2-nikolaik   --name openhands-app-3f4a4c2   docker.openhands.dev/openhands/openhands:3f4a4c2
```