### PR TITLE
feat: add manage automations permission and broadcast org selection

### DIFF
--- a/enterprise/server/auth/authorization.py
+++ b/enterprise/server/auth/authorization.py
@@ -87,6 +87,9 @@ class Permission(str, Enum):
     # Git organization claims
     MANAGE_ORG_CLAIMS = 'manage_org_claims'
 
+    # Manage Automations
+    MANAGE_AUTOMATIONS = 'manage_automations'
+
 
 class RoleName(str, Enum):
     """Role names used in the system."""
@@ -123,6 +126,8 @@ ROLE_PERMISSIONS: dict[RoleName, frozenset[Permission]] = {
             Permission.DELETE_ORGANIZATION,
             # Git organization claims
             Permission.MANAGE_ORG_CLAIMS,
+            # Manage Automations
+            Permission.MANAGE_AUTOMATIONS,
         ]
     ),
     RoleName.ADMIN: frozenset(
@@ -146,6 +151,8 @@ ROLE_PERMISSIONS: dict[RoleName, frozenset[Permission]] = {
             Permission.EDIT_ORG_SETTINGS,
             # Git organization claims
             Permission.MANAGE_ORG_CLAIMS,
+            # Manage Automations
+            Permission.MANAGE_AUTOMATIONS,
         ]
     ),
     RoleName.MEMBER: frozenset(
@@ -159,6 +166,8 @@ ROLE_PERMISSIONS: dict[RoleName, frozenset[Permission]] = {
             # Settings (View only)
             Permission.VIEW_ORG_SETTINGS,
             Permission.VIEW_LLM_SETTINGS,
+            # Manage Automations
+            Permission.MANAGE_AUTOMATIONS,
         ]
     ),
 }

--- a/enterprise/tests/unit/test_authorization.py
+++ b/enterprise/tests/unit/test_authorization.py
@@ -56,6 +56,7 @@ class TestPermission:
         assert Permission.VIEW_ORG_SETTINGS.value == 'view_org_settings'
         assert Permission.CHANGE_ORGANIZATION_NAME.value == 'change_organization_name'
         assert Permission.DELETE_ORGANIZATION.value == 'delete_organization'
+        assert Permission.MANAGE_AUTOMATIONS.value == 'manage_automations'
 
     def test_permission_from_string(self):
         """
@@ -142,6 +143,7 @@ class TestRolePermissions:
         assert Permission.CHANGE_USER_ROLE_OWNER in owner_perms
         assert Permission.CHANGE_ORGANIZATION_NAME in owner_perms
         assert Permission.DELETE_ORGANIZATION in owner_perms
+        assert Permission.MANAGE_AUTOMATIONS in owner_perms
 
     def test_admin_has_admin_permissions(self):
         """
@@ -159,6 +161,7 @@ class TestRolePermissions:
         assert Permission.INVITE_USER_TO_ORGANIZATION in admin_perms
         assert Permission.CHANGE_USER_ROLE_MEMBER in admin_perms
         assert Permission.CHANGE_USER_ROLE_ADMIN in admin_perms
+        assert Permission.MANAGE_AUTOMATIONS in admin_perms
         # Admin should NOT have owner-only permissions
         assert Permission.CHANGE_USER_ROLE_OWNER not in admin_perms
         assert Permission.CHANGE_ORGANIZATION_NAME not in admin_perms
@@ -177,6 +180,7 @@ class TestRolePermissions:
         assert Permission.MANAGE_INTEGRATIONS in member_perms
         assert Permission.MANAGE_APPLICATION_SETTINGS in member_perms
         assert Permission.MANAGE_API_KEYS in member_perms
+        assert Permission.MANAGE_AUTOMATIONS in member_perms
         assert Permission.VIEW_LLM_SETTINGS in member_perms
         assert Permission.VIEW_ORG_SETTINGS in member_perms
         # Member should NOT have admin/owner permissions

--- a/frontend/src/hooks/mutation/use-switch-organization.ts
+++ b/frontend/src/hooks/mutation/use-switch-organization.ts
@@ -5,6 +5,7 @@ import { organizationService } from "#/api/organization-service/organization-ser
 import { useSelectedOrganizationId } from "#/context/use-selected-organization";
 import { I18nKey } from "#/i18n/declaration";
 import { displaySuccessToast } from "#/utils/custom-toast-handlers";
+import { setSelectedOrg } from "#/utils/local-storage";
 
 export const useSwitchOrganization = () => {
   const { t } = useTranslation();
@@ -33,6 +34,8 @@ export const useSwitchOrganization = () => {
       // Update local state - this triggers automatic refetch for all org-scoped queries
       // since their query keys include organizationId (e.g., ["settings", orgId], ["secrets", orgId])
       setOrganizationId(orgId);
+      // Broadcast org change to other apps (e.g. Automations) via localStorage
+      setSelectedOrg(orgId);
       // Invalidate conversations to fetch data for the new org context
       queryClient.invalidateQueries({ queryKey: ["user", "conversations"] });
       // Remove all individual conversation queries to clear any stale/null data

--- a/frontend/src/hooks/use-auto-select-organization.ts
+++ b/frontend/src/hooks/use-auto-select-organization.ts
@@ -1,6 +1,7 @@
 import React from "react";
 import { useSelectedOrganizationId } from "#/context/use-selected-organization";
 import { useOrganizations } from "#/hooks/query/use-organizations";
+import { setSelectedOrg } from "#/utils/local-storage";
 
 /**
  * Hook that automatically selects an organization when:
@@ -28,6 +29,8 @@ export function useAutoSelectOrganization() {
       // Revalidation is only needed when user explicitly switches organizations
       // to redirect away from admin-only pages they may no longer have access to.
       setOrganizationId(initialOrgId, { skipRevalidation: true });
+      // Broadcast org selection to other apps (e.g. Automations) via localStorage
+      setSelectedOrg(initialOrgId);
     }
   }, [organizationId, organizations, currentOrgId, setOrganizationId]);
 }

--- a/frontend/src/utils/local-storage.ts
+++ b/frontend/src/utils/local-storage.ts
@@ -3,6 +3,7 @@ export const LOCAL_STORAGE_KEYS = {
   LOGIN_METHOD: "openhands_login_method",
   ENTERPRISE_FORM_SAAS: "openhands_enterprise_form_saas",
   ENTERPRISE_FORM_SELF_HOSTED: "openhands_enterprise_form_self_hosted",
+  SELECTED_ORG: "openhands_selected_org",
 };
 
 // Login methods
@@ -37,6 +38,10 @@ export const getLoginMethod = (): LoginMethod | null => {
  */
 export const clearLoginData = (): void => {
   localStorage.removeItem(LOCAL_STORAGE_KEYS.LOGIN_METHOD);
+};
+
+export const setSelectedOrg = (orgId: string): void => {
+  localStorage.setItem(LOCAL_STORAGE_KEYS.SELECTED_ORG, orgId);
 };
 
 // CTA locations that can be dismissed


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

Add a new MANAGE_AUTOMATIONS permission granted to owner, admin, and member roles, and persist the selected organization ID to localStorage so that other apps (e.g. Automations) can stay in sync when the user switches orgs.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Add a new `MANAGE_AUTOMATIONS` permission to the authorization system, granted to all roles (owner, admin, member).
- Persist selected organization ID to `localStorage` (`openhands_selected_org`) when switching orgs or on auto-select, enabling cross-app sync with the Automations app.
- Add `setSelectedOrg` helper in `local-storage.ts`.

### Backend

- **enterprise/server/auth/authorization.py**: Add `MANAGE_AUTOMATIONS` permission enum value and grant it to owner, admin, and member roles.

### Frontend

- **frontend/src/utils/local-storage.ts**: Add `SELECTED_ORG` key and `setSelectedOrg()` helper.
- **frontend/src/hooks/mutation/use-switch-organization.ts**: Call `setSelectedOrg` when user explicitly switches orgs.
- **frontend/src/hooks/use-auto-select-organization.ts**: Call `setSelectedOrg` on initial auto-selection.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

Please run the SaaS code and the automation service to verify the changes.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

N/A.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

N/A.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:528509c-nikolaik   --name openhands-app-528509c   docker.openhands.dev/openhands/openhands:528509c
```