### PR TITLE
fix: paginate through backend pages when filtering shared events

### DIFF
--- a/enterprise/server/sharing/shared_event_router.py
+++ b/enterprise/server/sharing/shared_event_router.py
@@ -13,15 +13,15 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from openhands.agent_server.models import EventPage, EventSortOrder
+from openhands.sdk import Event
+from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from server.sharing.shared_event_service import (
     SharedEventService,
     SharedEventServiceInjector,
 )
 
-from openhands.agent_server.models import EventPage, EventSortOrder
 from openhands.app_server.event_callback.event_callback_models import EventKind
-from openhands.sdk import Event
-from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.utils.environment import StorageProvider, get_storage_provider
 
 
@@ -62,42 +62,42 @@ def get_shared_event_service_injector() -> SharedEventServiceInjector:
         return GoogleCloudSharedEventServiceInjector()
 
 
-router = APIRouter(prefix="/api/shared-events", tags=["Sharing"])
+router = APIRouter(prefix='/api/shared-events', tags=['Sharing'])
 shared_event_service_dependency = Depends(get_shared_event_service_injector().depends)
 
 
 # Read methods
 
 
-@router.get("/search")
+@router.get('/search')
 async def search_shared_events(
     conversation_id: Annotated[
         str,
-        Query(title="Conversation ID to search events for"),
+        Query(title='Conversation ID to search events for'),
     ],
     kind__eq: Annotated[
         EventKind | None,
-        Query(title="Optional filter by event kind"),
+        Query(title='Optional filter by event kind'),
     ] = None,
     timestamp__gte: Annotated[
         datetime | None,
-        Query(title="Optional filter by timestamp greater than or equal to"),
+        Query(title='Optional filter by timestamp greater than or equal to'),
     ] = None,
     timestamp__lt: Annotated[
         datetime | None,
-        Query(title="Optional filter by timestamp less than"),
+        Query(title='Optional filter by timestamp less than'),
     ] = None,
     sort_order: Annotated[
         EventSortOrder,
-        Query(title="Sort order for results"),
+        Query(title='Sort order for results'),
     ] = EventSortOrder.TIMESTAMP,
     page_id: Annotated[
         str | None,
-        Query(title="Optional next_page_id from the previously returned page"),
+        Query(title='Optional next_page_id from the previously returned page'),
     ] = None,
     limit: Annotated[
         int,
-        Query(title="The max number of results in the page", gt=0, le=100),
+        Query(title='The max number of results in the page', gt=0, le=100),
     ] = 100,
     shared_event_service: SharedEventService = shared_event_service_dependency,
 ) -> EventPage:
@@ -134,23 +134,23 @@ async def search_shared_events(
     )
 
 
-@router.get("/count")
+@router.get('/count')
 async def count_shared_events(
     conversation_id: Annotated[
         str,
-        Query(title="Conversation ID to count events for"),
+        Query(title='Conversation ID to count events for'),
     ],
     kind__eq: Annotated[
         EventKind | None,
-        Query(title="Optional filter by event kind"),
+        Query(title='Optional filter by event kind'),
     ] = None,
     timestamp__gte: Annotated[
         datetime | None,
-        Query(title="Optional filter by timestamp greater than or equal to"),
+        Query(title='Optional filter by timestamp greater than or equal to'),
     ] = None,
     timestamp__lt: Annotated[
         datetime | None,
-        Query(title="Optional filter by timestamp less than"),
+        Query(title='Optional filter by timestamp less than'),
     ] = None,
     shared_event_service: SharedEventService = shared_event_service_dependency,
 ) -> int:
@@ -163,11 +163,11 @@ async def count_shared_events(
     )
 
 
-@router.get("")
+@router.get('')
 async def batch_get_shared_events(
     conversation_id: Annotated[
         str,
-        Query(title="Conversation ID to get events for"),
+        Query(title='Conversation ID to get events for'),
     ],
     id: Annotated[list[str], Query()],
     shared_event_service: SharedEventService = shared_event_service_dependency,
@@ -176,7 +176,7 @@ async def batch_get_shared_events(
     if len(id) > 100:
         raise HTTPException(
             status_code=400,
-            detail=f"Cannot request more than 100 events at once, got {len(id)}",
+            detail=f'Cannot request more than 100 events at once, got {len(id)}',
         )
     event_ids = [UUID(id_) for id_ in id]
     events = await shared_event_service.batch_get_shared_events(
@@ -185,7 +185,7 @@ async def batch_get_shared_events(
     return [e if e is not None and _is_viewable(e) else None for e in events]
 
 
-@router.get("/{conversation_id}/{event_id}")
+@router.get('/{conversation_id}/{event_id}')
 async def get_shared_event(
     conversation_id: str,
     event_id: str,

--- a/enterprise/server/sharing/shared_event_router.py
+++ b/enterprise/server/sharing/shared_event_router.py
@@ -13,16 +13,16 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from server.sharing.shared_event_service import (
+    SharedEventService,
+    SharedEventServiceInjector,
+)
+
 from openhands.agent_server.models import EventPage, EventSortOrder
 from openhands.app_server.event_callback.event_callback_models import EventKind
 from openhands.sdk import Event
 from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.utils.environment import StorageProvider, get_storage_provider
-
-from server.sharing.shared_event_service import (
-    SharedEventService,
-    SharedEventServiceInjector,
-)
 
 
 def _is_viewable(event: Event) -> bool:

--- a/enterprise/server/sharing/shared_event_router.py
+++ b/enterprise/server/sharing/shared_event_router.py
@@ -62,78 +62,95 @@ def get_shared_event_service_injector() -> SharedEventServiceInjector:
         return GoogleCloudSharedEventServiceInjector()
 
 
-router = APIRouter(prefix='/api/shared-events', tags=['Sharing'])
+router = APIRouter(prefix="/api/shared-events", tags=["Sharing"])
 shared_event_service_dependency = Depends(get_shared_event_service_injector().depends)
 
 
 # Read methods
 
 
-@router.get('/search')
+@router.get("/search")
 async def search_shared_events(
     conversation_id: Annotated[
         str,
-        Query(title='Conversation ID to search events for'),
+        Query(title="Conversation ID to search events for"),
     ],
     kind__eq: Annotated[
         EventKind | None,
-        Query(title='Optional filter by event kind'),
+        Query(title="Optional filter by event kind"),
     ] = None,
     timestamp__gte: Annotated[
         datetime | None,
-        Query(title='Optional filter by timestamp greater than or equal to'),
+        Query(title="Optional filter by timestamp greater than or equal to"),
     ] = None,
     timestamp__lt: Annotated[
         datetime | None,
-        Query(title='Optional filter by timestamp less than'),
+        Query(title="Optional filter by timestamp less than"),
     ] = None,
     sort_order: Annotated[
         EventSortOrder,
-        Query(title='Sort order for results'),
+        Query(title="Sort order for results"),
     ] = EventSortOrder.TIMESTAMP,
     page_id: Annotated[
         str | None,
-        Query(title='Optional next_page_id from the previously returned page'),
+        Query(title="Optional next_page_id from the previously returned page"),
     ] = None,
     limit: Annotated[
         int,
-        Query(title='The max number of results in the page', gt=0, le=100),
+        Query(title="The max number of results in the page", gt=0, le=100),
     ] = 100,
     shared_event_service: SharedEventService = shared_event_service_dependency,
 ) -> EventPage:
-    """Search / List events for a shared conversation."""
-    page = await shared_event_service.search_shared_events(
-        conversation_id=UUID(conversation_id),
-        kind__eq=kind__eq,
-        timestamp__gte=timestamp__gte,
-        timestamp__lt=timestamp__lt,
-        sort_order=sort_order,
-        page_id=page_id,
-        limit=limit,
-    )
+    """Search / List events for a shared conversation.
+
+    Because non-viewable events (e.g. ``ConversationStateUpdateEvent``) are
+    filtered out after fetching, a single backend page may yield fewer items
+    than *limit*.  This method transparently fetches additional backend pages
+    until the requested *limit* is reached or there are no more results.
+    """
+    conv_id = UUID(conversation_id)
+    viewable: list[Event] = []
+    cursor = page_id
+
+    while len(viewable) < limit:
+        remaining = limit - len(viewable)
+        page = await shared_event_service.search_shared_events(
+            conversation_id=conv_id,
+            kind__eq=kind__eq,
+            timestamp__gte=timestamp__gte,
+            timestamp__lt=timestamp__lt,
+            sort_order=sort_order,
+            page_id=cursor,
+            limit=remaining,
+        )
+        viewable.extend(e for e in page.items if _is_viewable(e))
+        cursor = page.next_page_id
+        if cursor is None:
+            break
+
     return EventPage(
-        items=[e for e in page.items if _is_viewable(e)],
-        next_page_id=page.next_page_id,
+        items=viewable[:limit],
+        next_page_id=cursor,
     )
 
 
-@router.get('/count')
+@router.get("/count")
 async def count_shared_events(
     conversation_id: Annotated[
         str,
-        Query(title='Conversation ID to count events for'),
+        Query(title="Conversation ID to count events for"),
     ],
     kind__eq: Annotated[
         EventKind | None,
-        Query(title='Optional filter by event kind'),
+        Query(title="Optional filter by event kind"),
     ] = None,
     timestamp__gte: Annotated[
         datetime | None,
-        Query(title='Optional filter by timestamp greater than or equal to'),
+        Query(title="Optional filter by timestamp greater than or equal to"),
     ] = None,
     timestamp__lt: Annotated[
         datetime | None,
-        Query(title='Optional filter by timestamp less than'),
+        Query(title="Optional filter by timestamp less than"),
     ] = None,
     shared_event_service: SharedEventService = shared_event_service_dependency,
 ) -> int:
@@ -146,11 +163,11 @@ async def count_shared_events(
     )
 
 
-@router.get('')
+@router.get("")
 async def batch_get_shared_events(
     conversation_id: Annotated[
         str,
-        Query(title='Conversation ID to get events for'),
+        Query(title="Conversation ID to get events for"),
     ],
     id: Annotated[list[str], Query()],
     shared_event_service: SharedEventService = shared_event_service_dependency,
@@ -159,7 +176,7 @@ async def batch_get_shared_events(
     if len(id) > 100:
         raise HTTPException(
             status_code=400,
-            detail=f'Cannot request more than 100 events at once, got {len(id)}',
+            detail=f"Cannot request more than 100 events at once, got {len(id)}",
         )
     event_ids = [UUID(id_) for id_ in id]
     events = await shared_event_service.batch_get_shared_events(
@@ -168,7 +185,7 @@ async def batch_get_shared_events(
     return [e if e is not None and _is_viewable(e) else None for e in events]
 
 
-@router.get('/{conversation_id}/{event_id}')
+@router.get("/{conversation_id}/{event_id}")
 async def get_shared_event(
     conversation_id: str,
     event_id: str,

--- a/enterprise/server/sharing/shared_event_router.py
+++ b/enterprise/server/sharing/shared_event_router.py
@@ -14,15 +14,15 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from openhands.agent_server.models import EventPage, EventSortOrder
+from openhands.app_server.event_callback.event_callback_models import EventKind
 from openhands.sdk import Event
 from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
+from openhands.utils.environment import StorageProvider, get_storage_provider
+
 from server.sharing.shared_event_service import (
     SharedEventService,
     SharedEventServiceInjector,
 )
-
-from openhands.app_server.event_callback.event_callback_models import EventKind
-from openhands.utils.environment import StorageProvider, get_storage_provider
 
 
 def _is_viewable(event: Event) -> bool:

--- a/enterprise/tests/unit/test_sharing/test_shared_event_filtering.py
+++ b/enterprise/tests/unit/test_sharing/test_shared_event_filtering.py
@@ -12,17 +12,17 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
-from openhands.agent_server.models import EventPage
-from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
-from openhands.sdk.event.llm_convertible import MessageEvent
-from openhands.sdk.llm import Message, TextContent
-
 from server.sharing.shared_event_router import (
     _is_viewable,
     batch_get_shared_events,
     get_shared_event,
     search_shared_events,
 )
+
+from openhands.agent_server.models import EventPage
+from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
+from openhands.sdk.event.llm_convertible import MessageEvent
+from openhands.sdk.llm import Message, TextContent
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers

--- a/enterprise/tests/unit/test_sharing/test_shared_event_filtering.py
+++ b/enterprise/tests/unit/test_sharing/test_shared_event_filtering.py
@@ -31,13 +31,13 @@ from openhands.sdk.llm import Message, TextContent
 
 def _make_message_event() -> MessageEvent:
     return MessageEvent(
-        source='user',
-        llm_message=Message(role='user', content=[TextContent(text='Hello')]),
+        source="user",
+        llm_message=Message(role="user", content=[TextContent(text="Hello")]),
     )
 
 
 def _make_state_event(
-    key: str = 'full_state', value: dict | str = 'idle'
+    key: str = "full_state", value: dict | str = "idle"
 ) -> ConversationStateUpdateEvent:
     return ConversationStateUpdateEvent(key=key, value=value)
 
@@ -52,13 +52,13 @@ class TestIsViewable:
         assert _is_viewable(_make_message_event()) is True
 
     def test_full_state_event_is_not_viewable(self):
-        assert _is_viewable(_make_state_event('full_state', {'agent': {}})) is False
+        assert _is_viewable(_make_state_event("full_state", {"agent": {}})) is False
 
     def test_execution_status_event_is_not_viewable(self):
-        assert _is_viewable(_make_state_event('execution_status', 'running')) is False
+        assert _is_viewable(_make_state_event("execution_status", "running")) is False
 
     def test_stats_event_is_not_viewable(self):
-        assert _is_viewable(_make_state_event('stats', {})) is False
+        assert _is_viewable(_make_state_event("stats", {})) is False
 
 
 # ---------------------------------------------------------------------------
@@ -87,21 +87,6 @@ class TestSearchSharedEvents:
         )
 
     @pytest.mark.asyncio
-    async def test_preserves_next_page_id(self):
-        mock_service = AsyncMock()
-        mock_service.search_shared_events.return_value = EventPage(
-            items=[_make_state_event()], next_page_id='abc'
-        )
-
-        result = await search_shared_events(
-            conversation_id=uuid4().hex,
-            shared_event_service=mock_service,
-        )
-
-        assert result.next_page_id == 'abc'
-        assert result.items == []
-
-    @pytest.mark.asyncio
     async def test_empty_page_unchanged(self):
         mock_service = AsyncMock()
         mock_service.search_shared_events.return_value = EventPage(
@@ -115,6 +100,115 @@ class TestSearchSharedEvents:
 
         assert result.items == []
         assert result.next_page_id is None
+
+    @pytest.mark.asyncio
+    async def test_fetches_additional_pages_when_filtering_reduces_count(self):
+        """Fetch next page when first page has only state events."""
+        msg = _make_message_event()
+        state = _make_state_event()
+        mock_service = AsyncMock()
+        mock_service.search_shared_events.side_effect = [
+            # Page 1: only state events — all filtered out
+            EventPage(items=[state, state, state], next_page_id="page2"),
+            # Page 2: all viewable
+            EventPage(items=[msg, msg, msg], next_page_id=None),
+        ]
+
+        result = await search_shared_events(
+            conversation_id=uuid4().hex,
+            limit=3,
+            shared_event_service=mock_service,
+        )
+
+        assert len(result.items) == 3
+        assert result.next_page_id is None
+        assert mock_service.search_shared_events.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_multiple_pages_until_limit_reached(self):
+        """Keep fetching mixed pages until limit viewable events accumulated."""
+        msg = _make_message_event()
+        state = _make_state_event()
+        mock_service = AsyncMock()
+        mock_service.search_shared_events.side_effect = [
+            EventPage(items=[msg, state], next_page_id="p2"),
+            EventPage(items=[state, msg], next_page_id="p3"),
+            EventPage(items=[msg], next_page_id="p4"),
+        ]
+
+        result = await search_shared_events(
+            conversation_id=uuid4().hex,
+            limit=3,
+            shared_event_service=mock_service,
+        )
+
+        assert len(result.items) == 3
+        assert result.next_page_id == "p4"
+        assert mock_service.search_shared_events.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_stops_when_no_more_pages(self):
+        """Return partial results when no more backend pages are available."""
+        msg = _make_message_event()
+        state = _make_state_event()
+        mock_service = AsyncMock()
+        mock_service.search_shared_events.side_effect = [
+            EventPage(items=[msg, state], next_page_id="p2"),
+            EventPage(items=[state], next_page_id=None),
+        ]
+
+        result = await search_shared_events(
+            conversation_id=uuid4().hex,
+            limit=5,
+            shared_event_service=mock_service,
+        )
+
+        assert len(result.items) == 1
+        assert result.next_page_id is None
+
+    @pytest.mark.asyncio
+    async def test_passes_remaining_as_limit_to_backend(self):
+        """Pass remaining needed count as limit to each backend call."""
+        msg = _make_message_event()
+        state = _make_state_event()
+        conv_id = uuid4().hex
+        mock_service = AsyncMock()
+        mock_service.search_shared_events.side_effect = [
+            # First call: limit=3, returns 1 viewable
+            EventPage(items=[msg, state, state], next_page_id="p2"),
+            # Second call: limit should be 2 (remaining)
+            EventPage(items=[msg, msg], next_page_id=None),
+        ]
+
+        await search_shared_events(
+            conversation_id=conv_id,
+            limit=3,
+            shared_event_service=mock_service,
+        )
+
+        calls = mock_service.search_shared_events.call_args_list
+        assert calls[0].kwargs["limit"] == 3
+        assert calls[1].kwargs["limit"] == 2
+
+    @pytest.mark.asyncio
+    async def test_preserves_next_page_id_when_all_filtered(self):
+        """Continue fetching when all events on a page are filtered out."""
+        msg = _make_message_event()
+        state = _make_state_event()
+        mock_service = AsyncMock()
+        mock_service.search_shared_events.side_effect = [
+            EventPage(items=[state], next_page_id="p2"),
+            EventPage(items=[msg], next_page_id="p3"),
+        ]
+
+        result = await search_shared_events(
+            conversation_id=uuid4().hex,
+            limit=1,
+            shared_event_service=mock_service,
+        )
+
+        assert len(result.items) == 1
+        assert result.next_page_id == "p3"
 
 
 # ---------------------------------------------------------------------------

--- a/enterprise/tests/unit/test_sharing/test_shared_event_filtering.py
+++ b/enterprise/tests/unit/test_sharing/test_shared_event_filtering.py
@@ -16,6 +16,7 @@ from openhands.agent_server.models import EventPage
 from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.sdk.event.llm_convertible import MessageEvent
 from openhands.sdk.llm import Message, TextContent
+
 from server.sharing.shared_event_router import (
     _is_viewable,
     batch_get_shared_events,

--- a/enterprise/tests/unit/test_sharing/test_shared_event_filtering.py
+++ b/enterprise/tests/unit/test_sharing/test_shared_event_filtering.py
@@ -12,17 +12,16 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+from openhands.agent_server.models import EventPage
+from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
+from openhands.sdk.event.llm_convertible import MessageEvent
+from openhands.sdk.llm import Message, TextContent
 from server.sharing.shared_event_router import (
     _is_viewable,
     batch_get_shared_events,
     get_shared_event,
     search_shared_events,
 )
-
-from openhands.agent_server.models import EventPage
-from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
-from openhands.sdk.event.llm_convertible import MessageEvent
-from openhands.sdk.llm import Message, TextContent
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
@@ -31,13 +30,13 @@ from openhands.sdk.llm import Message, TextContent
 
 def _make_message_event() -> MessageEvent:
     return MessageEvent(
-        source="user",
-        llm_message=Message(role="user", content=[TextContent(text="Hello")]),
+        source='user',
+        llm_message=Message(role='user', content=[TextContent(text='Hello')]),
     )
 
 
 def _make_state_event(
-    key: str = "full_state", value: dict | str = "idle"
+    key: str = 'full_state', value: dict | str = 'idle'
 ) -> ConversationStateUpdateEvent:
     return ConversationStateUpdateEvent(key=key, value=value)
 
@@ -52,13 +51,13 @@ class TestIsViewable:
         assert _is_viewable(_make_message_event()) is True
 
     def test_full_state_event_is_not_viewable(self):
-        assert _is_viewable(_make_state_event("full_state", {"agent": {}})) is False
+        assert _is_viewable(_make_state_event('full_state', {'agent': {}})) is False
 
     def test_execution_status_event_is_not_viewable(self):
-        assert _is_viewable(_make_state_event("execution_status", "running")) is False
+        assert _is_viewable(_make_state_event('execution_status', 'running')) is False
 
     def test_stats_event_is_not_viewable(self):
-        assert _is_viewable(_make_state_event("stats", {})) is False
+        assert _is_viewable(_make_state_event('stats', {})) is False
 
 
 # ---------------------------------------------------------------------------
@@ -109,7 +108,7 @@ class TestSearchSharedEvents:
         mock_service = AsyncMock()
         mock_service.search_shared_events.side_effect = [
             # Page 1: only state events — all filtered out
-            EventPage(items=[state, state, state], next_page_id="page2"),
+            EventPage(items=[state, state, state], next_page_id='page2'),
             # Page 2: all viewable
             EventPage(items=[msg, msg, msg], next_page_id=None),
         ]
@@ -131,9 +130,9 @@ class TestSearchSharedEvents:
         state = _make_state_event()
         mock_service = AsyncMock()
         mock_service.search_shared_events.side_effect = [
-            EventPage(items=[msg, state], next_page_id="p2"),
-            EventPage(items=[state, msg], next_page_id="p3"),
-            EventPage(items=[msg], next_page_id="p4"),
+            EventPage(items=[msg, state], next_page_id='p2'),
+            EventPage(items=[state, msg], next_page_id='p3'),
+            EventPage(items=[msg], next_page_id='p4'),
         ]
 
         result = await search_shared_events(
@@ -143,7 +142,7 @@ class TestSearchSharedEvents:
         )
 
         assert len(result.items) == 3
-        assert result.next_page_id == "p4"
+        assert result.next_page_id == 'p4'
         assert mock_service.search_shared_events.call_count == 3
 
     @pytest.mark.asyncio
@@ -153,7 +152,7 @@ class TestSearchSharedEvents:
         state = _make_state_event()
         mock_service = AsyncMock()
         mock_service.search_shared_events.side_effect = [
-            EventPage(items=[msg, state], next_page_id="p2"),
+            EventPage(items=[msg, state], next_page_id='p2'),
             EventPage(items=[state], next_page_id=None),
         ]
 
@@ -175,7 +174,7 @@ class TestSearchSharedEvents:
         mock_service = AsyncMock()
         mock_service.search_shared_events.side_effect = [
             # First call: limit=3, returns 1 viewable
-            EventPage(items=[msg, state, state], next_page_id="p2"),
+            EventPage(items=[msg, state, state], next_page_id='p2'),
             # Second call: limit should be 2 (remaining)
             EventPage(items=[msg, msg], next_page_id=None),
         ]
@@ -187,8 +186,8 @@ class TestSearchSharedEvents:
         )
 
         calls = mock_service.search_shared_events.call_args_list
-        assert calls[0].kwargs["limit"] == 3
-        assert calls[1].kwargs["limit"] == 2
+        assert calls[0].kwargs['limit'] == 3
+        assert calls[1].kwargs['limit'] == 2
 
     @pytest.mark.asyncio
     async def test_preserves_next_page_id_when_all_filtered(self):
@@ -197,8 +196,8 @@ class TestSearchSharedEvents:
         state = _make_state_event()
         mock_service = AsyncMock()
         mock_service.search_shared_events.side_effect = [
-            EventPage(items=[state], next_page_id="p2"),
-            EventPage(items=[msg], next_page_id="p3"),
+            EventPage(items=[state], next_page_id='p2'),
+            EventPage(items=[msg], next_page_id='p3'),
         ]
 
         result = await search_shared_events(
@@ -208,7 +207,7 @@ class TestSearchSharedEvents:
         )
 
         assert len(result.items) == 1
-        assert result.next_page_id == "p3"
+        assert result.next_page_id == 'p3'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

PR #13888 introduced filtering of `ConversationStateUpdateEvent` from the `/api/shared-events/search` endpoint. However, the filtering is applied *after* fetching a page from the backend, which means the returned page can contain fewer items than the requested `limit` — or even zero items with a valid `next_page_id`. This breaks pagination for clients that rely on receiving `limit` items per page.

## Summary

- The `search_shared_events` endpoint now loops over backend pages until the requested `limit` of viewable events is collected or no more pages exist.
- Each iteration requests only the remaining needed count (`limit - len(collected)`) to avoid overshooting the limit and losing events at page boundaries.
- Added five new test cases covering multi-page fetching, early termination, remaining-limit passthrough, and the previously broken "all-filtered" scenario. Removed the now-obsolete `test_preserves_next_page_id` test that asserted the old (buggy) behavior.

## Issue Number

Follow-up to #13888

## How to Test

Run the enterprise unit tests for the sharing module:

```bash
cd enterprise
PYTHONPATH=".:$PYTHONPATH" poetry run pytest tests/unit/test_sharing/test_shared_event_filtering.py -v --confcutdir=tests/unit/test_sharing
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

_This PR was created by an AI assistant (OpenHands) on behalf of Xingyao Wang._


@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4a8212ae-f923-4538-92e3-8746050f6fdd)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:b5e033f-nikolaik   --name openhands-app-b5e033f   docker.openhands.dev/openhands/openhands:b5e033f
```