### PR TITLE
feat(github): add optional Laminar observability to the GitHub resolver 

### DIFF
--- a/enterprise/integrations/github/github_manager.py
+++ b/enterprise/integrations/github/github_manager.py
@@ -395,6 +395,13 @@ class GithubManager(Manager[GithubViewType]):
                 )
 
                 # Set up Laminar tracing if enabled (laminar_span_context is None if disabled)
+                create_conversation_coro = github_view.create_new_conversation(
+                    self.jinja_env,
+                    secret_store.provider_tokens,
+                    convo_metadata,
+                    saas_user_auth,
+                )
+
                 if laminar_span_context:
                     try:
                         with Laminar.start_as_current_span(
@@ -408,28 +415,13 @@ class GithubManager(Manager[GithubViewType]):
                                 'username': user_info.username,
                                 'conversation_id': github_view.conversation_id,
                             })
-                            await github_view.create_new_conversation(
-                                self.jinja_env,
-                                secret_store.provider_tokens,
-                                convo_metadata,
-                                saas_user_auth,
-                            )
+                            await create_conversation_coro
                     except Exception as e:
-                        logger.warning(f'[Github] Laminar span error: {e}')
-                        # Fall back to non-Laminar execution
-                        await github_view.create_new_conversation(
-                            self.jinja_env,
-                            secret_store.provider_tokens,
-                            convo_metadata,
-                            saas_user_auth,
-                        )
+                        logger.warning(f'[Github] Laminar tracing error: {e}')
+                        # Fall back to non-Laminar execution if span creation failed
+                        await create_conversation_coro
                 else:
-                    await github_view.create_new_conversation(
-                        self.jinja_env,
-                        secret_store.provider_tokens,
-                        convo_metadata,
-                        saas_user_auth,
-                    )
+                    await create_conversation_coro
 
                 conversation_id = github_view.conversation_id
 

--- a/enterprise/integrations/github/github_manager.py
+++ b/enterprise/integrations/github/github_manager.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from types import MappingProxyType
 
 from github import Auth, Github, GithubIntegration
@@ -394,34 +395,35 @@ class GithubManager(Manager[GithubViewType]):
                     github_view.user_info.keycloak_user_id, self.token_manager
                 )
 
-                # Set up Laminar tracing if enabled (laminar_span_context is None if disabled)
-                create_conversation_coro = github_view.create_new_conversation(
-                    self.jinja_env,
-                    secret_store.provider_tokens,
-                    convo_metadata,
-                    saas_user_auth,
-                )
-
+                # Try to set up Laminar span before conversation creation
+                # Note: Only catch Laminar setup errors; conversation errors should propagate
+                span_context = nullcontext()
                 if laminar_span_context:
                     try:
-                        with Laminar.start_as_current_span(
+                        span = Laminar.start_as_current_span(
                             name='github-resolver',
                             parent_span_context=laminar_span_context,
-                        ):
-                            Laminar.set_trace_metadata({
-                                'source': 'github',
-                                'repo': github_view.full_repo_name,
-                                'issue_number': str(github_view.issue_number),
-                                'username': user_info.username,
-                                'conversation_id': github_view.conversation_id,
-                            })
-                            await create_conversation_coro
+                        )
+                        Laminar.set_trace_metadata({
+                            'source': 'github',
+                            'repo': github_view.full_repo_name,
+                            'issue_number': str(github_view.issue_number),
+                            'username': user_info.username,
+                            'conversation_id': github_view.conversation_id,
+                        })
+                        span_context = span
                     except Exception as e:
-                        logger.warning(f'[Github] Laminar tracing error: {e}')
-                        # Fall back to non-Laminar execution if span creation failed
-                        await create_conversation_coro
-                else:
-                    await create_conversation_coro
+                        # Log Laminar setup failure but continue without tracing
+                        logger.warning(f'[Github] Laminar span setup error: {e}')
+
+                # Create conversation (with span if enabled)
+                with span_context:
+                    await github_view.create_new_conversation(
+                        self.jinja_env,
+                        secret_store.provider_tokens,
+                        convo_metadata,
+                        saas_user_auth,
+                    )
 
                 conversation_id = github_view.conversation_id
 

--- a/enterprise/integrations/github/github_manager.py
+++ b/enterprise/integrations/github/github_manager.py
@@ -1,6 +1,7 @@
 from types import MappingProxyType
 
 from github import Auth, Github, GithubIntegration
+from lmnr import Laminar
 from integrations.github.data_collector import GitHubDataCollector
 from integrations.github.github_solvability import summarize_issue_solvability
 from integrations.github.github_view import (
@@ -22,6 +23,8 @@ from integrations.utils import (
     CONVERSATION_URL,
     ENABLE_SOLVABILITY_ANALYSIS,
     HOST_URL,
+    LAMINAR_ENABLED,
+    LAMINAR_PROJECT_API_KEY,
     OPENHANDS_RESOLVER_TEMPLATES_DIR,
     get_session_expired_message,
     get_user_not_found_message,
@@ -329,6 +332,16 @@ class GithubManager(Manager[GithubViewType]):
             GithubCallbackProcessor,
         )
 
+        # Initialize Laminar if enabled
+        laminar_span_context = None
+        if LAMINAR_ENABLED:
+            try:
+                Laminar.initialize(project_api_key=LAMINAR_PROJECT_API_KEY)
+                laminar_span_context = Laminar.get_laminar_span_context()
+                logger.info('[Github] Laminar initialized for observability')
+            except Exception as e:
+                logger.warning(f'[Github] Failed to initialize Laminar: {e}')
+
         try:
             msg_info: str = ''
 
@@ -389,12 +402,42 @@ class GithubManager(Manager[GithubViewType]):
                     github_view.user_info.keycloak_user_id, self.token_manager
                 )
 
-                await github_view.create_new_conversation(
-                    self.jinja_env,
-                    secret_store.provider_tokens,
-                    convo_metadata,
-                    saas_user_auth,
-                )
+                # Set up Laminar tracing if enabled
+                if LAMINAR_ENABLED and laminar_span_context:
+                    try:
+                        with Laminar.start_as_current_span(
+                            name='github-resolver',
+                            parent_span_context=laminar_span_context,
+                        ):
+                            Laminar.set_trace_metadata({
+                                'source': 'github',
+                                'repo': github_view.full_repo_name,
+                                'issue_number': str(github_view.issue_number),
+                                'username': user_info.username,
+                                'conversation_id': github_view.conversation_id,
+                            })
+                            await github_view.create_new_conversation(
+                                self.jinja_env,
+                                secret_store.provider_tokens,
+                                convo_metadata,
+                                saas_user_auth,
+                            )
+                    except Exception as e:
+                        logger.warning(f'[Github] Laminar span error: {e}')
+                        # Fall back to non-Laminar execution
+                        await github_view.create_new_conversation(
+                            self.jinja_env,
+                            secret_store.provider_tokens,
+                            convo_metadata,
+                            saas_user_auth,
+                        )
+                else:
+                    await github_view.create_new_conversation(
+                        self.jinja_env,
+                        secret_store.provider_tokens,
+                        convo_metadata,
+                        saas_user_auth,
+                    )
 
                 conversation_id = github_view.conversation_id
 
@@ -458,3 +501,10 @@ class GithubManager(Manager[GithubViewType]):
             await self.data_collector.save_data(github_view)
         except Exception:
             logger.warning('[Github]: Error saving interaction data', exc_info=True)
+
+        # Flush Laminar traces if enabled
+        if LAMINAR_ENABLED:
+            try:
+                Laminar.flush()
+            except Exception as e:
+                logger.warning(f'[Github] Error flushing Laminar traces: {e}')

--- a/enterprise/integrations/github/github_manager.py
+++ b/enterprise/integrations/github/github_manager.py
@@ -23,8 +23,6 @@ from integrations.utils import (
     CONVERSATION_URL,
     ENABLE_SOLVABILITY_ANALYSIS,
     HOST_URL,
-    LAMINAR_ENABLED,
-    LAMINAR_PROJECT_API_KEY,
     OPENHANDS_RESOLVER_TEMPLATES_DIR,
     get_session_expired_message,
     get_user_not_found_message,
@@ -40,6 +38,7 @@ from server.utils.conversation_callback_utils import register_callback_processor
 from openhands.core.logger import openhands_logger as logger
 from openhands.integrations.provider import ProviderToken, ProviderType
 from openhands.integrations.service_types import AuthenticationError
+from openhands.sdk.observability import init_laminar_for_external
 from openhands.server.types import (
     LLMAuthenticationError,
     MissingSettingsError,
@@ -332,15 +331,8 @@ class GithubManager(Manager[GithubViewType]):
             GithubCallbackProcessor,
         )
 
-        # Initialize Laminar if enabled
-        laminar_span_context = None
-        if LAMINAR_ENABLED:
-            try:
-                Laminar.initialize(project_api_key=LAMINAR_PROJECT_API_KEY)
-                laminar_span_context = Laminar.get_laminar_span_context()
-                logger.info('[Github] Laminar initialized for observability')
-            except Exception as e:
-                logger.warning(f'[Github] Failed to initialize Laminar: {e}')
+        # Initialize Laminar for external caller (webhook) and get parent span context
+        laminar_span_context = init_laminar_for_external()
 
         try:
             msg_info: str = ''
@@ -402,8 +394,8 @@ class GithubManager(Manager[GithubViewType]):
                     github_view.user_info.keycloak_user_id, self.token_manager
                 )
 
-                # Set up Laminar tracing if enabled
-                if LAMINAR_ENABLED and laminar_span_context:
+                # Set up Laminar tracing if enabled (laminar_span_context is None if disabled)
+                if laminar_span_context:
                     try:
                         with Laminar.start_as_current_span(
                             name='github-resolver',
@@ -502,8 +494,8 @@ class GithubManager(Manager[GithubViewType]):
         except Exception:
             logger.warning('[Github]: Error saving interaction data', exc_info=True)
 
-        # Flush Laminar traces if enabled
-        if LAMINAR_ENABLED:
+        # Flush Laminar traces if enabled (laminar_span_context is None if disabled)
+        if laminar_span_context:
             try:
                 Laminar.flush()
             except Exception as e:

--- a/enterprise/integrations/github/github_manager.py
+++ b/enterprise/integrations/github/github_manager.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import nullcontext
 from types import MappingProxyType
 
@@ -39,13 +40,42 @@ from server.utils.conversation_callback_utils import register_callback_processor
 from openhands.core.logger import openhands_logger as logger
 from openhands.integrations.provider import ProviderToken, ProviderType
 from openhands.integrations.service_types import AuthenticationError
-from openhands.sdk.observability import init_laminar_for_external
 from openhands.server.types import (
     LLMAuthenticationError,
     MissingSettingsError,
     SessionExpiredError,
 )
 from openhands.storage.data_models.secrets import Secrets
+
+
+def _should_enable_laminar_observability() -> bool:
+    observability_env_vars = (
+        'LMNR_PROJECT_API_KEY',
+        'OTEL_ENDPOINT',
+        'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT',
+        'OTEL_EXPORTER_OTLP_ENDPOINT',
+    )
+    return (
+        any(os.getenv(key) for key in observability_env_vars)
+        or Laminar.is_initialized()
+    )
+
+
+def init_laminar_for_external():
+    """Compatibility wrapper for the SDK helper until it is released in openhands-sdk."""
+    try:
+        from openhands.sdk.observability import (
+            init_laminar_for_external as sdk_init_laminar_for_external,
+        )
+    except ImportError:
+        from openhands.sdk.observability import maybe_init_laminar
+
+        maybe_init_laminar()
+        if _should_enable_laminar_observability():
+            return Laminar.get_laminar_span_context()
+        return None
+
+    return sdk_init_laminar_for_external()
 
 
 class GithubManager(Manager[GithubViewType]):

--- a/enterprise/integrations/github/github_manager.py
+++ b/enterprise/integrations/github/github_manager.py
@@ -2,7 +2,6 @@ from contextlib import nullcontext
 from types import MappingProxyType
 
 from github import Auth, Github, GithubIntegration
-from lmnr import Laminar
 from integrations.github.data_collector import GitHubDataCollector
 from integrations.github.github_solvability import summarize_issue_solvability
 from integrations.github.github_view import (
@@ -30,6 +29,7 @@ from integrations.utils import (
 )
 from integrations.v1_utils import get_saas_user_auth
 from jinja2 import Environment, FileSystemLoader
+from lmnr import Laminar
 from pydantic import SecretStr
 from server.auth.auth_error import ExpiredError
 from server.auth.constants import GITHUB_APP_CLIENT_ID, GITHUB_APP_PRIVATE_KEY
@@ -404,13 +404,15 @@ class GithubManager(Manager[GithubViewType]):
                             name='github-resolver',
                             parent_span_context=laminar_span_context,
                         )
-                        Laminar.set_trace_metadata({
-                            'source': 'github',
-                            'repo': github_view.full_repo_name,
-                            'issue_number': str(github_view.issue_number),
-                            'username': user_info.username,
-                            'conversation_id': github_view.conversation_id,
-                        })
+                        Laminar.set_trace_metadata(
+                            {
+                                'source': 'github',
+                                'repo': github_view.full_repo_name,
+                                'issue_number': str(github_view.issue_number),
+                                'username': user_info.username,
+                                'conversation_id': github_view.conversation_id,
+                            }
+                        )
                         span_context = span
                     except Exception as e:
                         # Log Laminar setup failure but continue without tracing

--- a/enterprise/integrations/utils.py
+++ b/enterprise/integrations/utils.py
@@ -98,10 +98,6 @@ ENABLE_V1_SLACK_RESOLVER = (
     os.getenv('ENABLE_V1_SLACK_RESOLVER', 'false').lower() == 'true'
 )
 
-# Laminar observability settings
-LAMINAR_ENABLED = os.environ.get('LMNR_PROJECT_API_KEY', '') != ''
-LAMINAR_PROJECT_API_KEY = os.environ.get('LMNR_PROJECT_API_KEY', '')
-
 # Toggle for V1 GitLab resolver feature
 ENABLE_V1_GITLAB_RESOLVER = (
     os.getenv('ENABLE_V1_GITLAB_RESOLVER', 'false').lower() == 'true'

--- a/enterprise/integrations/utils.py
+++ b/enterprise/integrations/utils.py
@@ -98,6 +98,10 @@ ENABLE_V1_SLACK_RESOLVER = (
     os.getenv('ENABLE_V1_SLACK_RESOLVER', 'false').lower() == 'true'
 )
 
+# Laminar observability settings
+LAMINAR_ENABLED = os.environ.get('LMNR_PROJECT_API_KEY', '') != ''
+LAMINAR_PROJECT_API_KEY = os.environ.get('LMNR_PROJECT_API_KEY', '')
+
 # Toggle for V1 GitLab resolver feature
 ENABLE_V1_GITLAB_RESOLVER = (
     os.getenv('ENABLE_V1_GITLAB_RESOLVER', 'false').lower() == 'true'

--- a/enterprise/tests/unit/integrations/github/test_github_manager.py
+++ b/enterprise/tests/unit/integrations/github/test_github_manager.py
@@ -614,125 +614,37 @@ class TestGetUserNotFoundMessageIntegration:
 class TestLaminarObservability:
     """Test cases for Laminar observability integration."""
 
-    @pytest.fixture
-    def mock_token_manager(self):
-        """Create a mock token manager."""
-        token_manager = MagicMock()
-        token_manager.get_idp_token_from_idp_user_id = AsyncMock(return_value='fake-token')
-        return token_manager
-
-    @pytest.fixture
-    def mock_data_collector(self):
-        """Create a mock data collector."""
-        data_collector = MagicMock()
-        data_collector.process_payload = AsyncMock()
-        data_collector.save_data = AsyncMock()
-        return data_collector
-
-    @pytest.fixture
-    def mock_github_view(self):
-        """Create a mock GitHub view."""
-        view = MagicMock()
-        view.user_info = MagicMock()
-        view.user_info.user_id = '123'
-        view.user_info.username = 'testuser'
-        view.user_info.keycloak_user_id = 'keycloak-123'
-        view.full_repo_name = 'test-owner/test-repo'
-        view.issue_number = 42
-        view.conversation_id = None
-        view.initialize_new_conversation = AsyncMock(
-            return_value={'conversation_id': 'new-convo-123'}
-        )
-        view.create_new_conversation = AsyncMock(return_value=None)
-        view.v1_enabled = False
-        return view
-
-    @patch('integrations.github.github_manager.Auth')
-    @patch('integrations.github.github_manager.GithubIntegration')
-    @patch('integrations.github.github_manager.Github')
-    @patch('integrations.github.github_manager.Laminar')
-    def test_laminar_tracing_enabled_when_api_key_set(
-        self,
-        mock_laminar,
-        mock_github_class,
-        mock_github_integration,
-        mock_auth,
-        mock_token_manager,
-        mock_data_collector,
-        mock_github_view,
-    ):
-        """Test that Laminar tracing is enabled when LMNR_PROJECT_API_KEY is set."""
-        # Set up mock span context
-        mock_laminar_span = MagicMock()
-        mock_laminar_span.__enter__ = MagicMock(return_value=None)
-        mock_laminar_span.__exit__ = MagicMock(return_value=False)
-        mock_laminar.start_as_current_span.return_value = mock_laminar_span
-
-        # Import after patching
-        from openhands.sdk.observability import init_laminar_for_external
-
-        # Test: init_laminar_for_external returns span context when enabled
-        # This test verifies the pattern - actual SDK behavior tested elsewhere
-        assert mock_laminar is not None
-
-    @patch('integrations.github.github_manager.Auth')
-    @patch('integrations.github.github_manager.GithubIntegration')
-    @patch('integrations.github.github_manager.Github')
-    def test_metadata_set_correctly(
-        self,
-        mock_github_class,
-        mock_github_integration,
-        mock_auth,
-        mock_token_manager,
-        mock_data_collector,
-        mock_github_view,
-    ):
-        """Test that Laminar metadata is set correctly when tracing is enabled."""
-        # Verify metadata keys are correctly defined
-        expected_metadata_keys = {
-            'source',
-            'repo',
-            'issue_number',
-            'username',
-            'conversation_id',
-        }
-        # This tests the metadata structure we expect to set
-        assert expected_metadata_keys == {
-            'source',
-            'repo',
-            'issue_number',
-            'username',
-            'conversation_id',
-        }
-
-    @patch('integrations.github.github_manager.Auth')
-    @patch('integrations.github.github_manager.GithubIntegration')
-    @patch('integrations.github.github_manager.Github')
-    @patch('integrations.github.github_manager.Laminar')
-    def test_laminar_operations_wrapped_in_try_except(
-        self,
-        mock_laminar,
-        mock_github_class,
-        mock_github_integration,
-        mock_auth,
-        mock_token_manager,
-        mock_data_collector,
-        mock_github_view,
-    ):
-        """Test that Laminar operations are wrapped in try/except for fault tolerance."""
-        # Set up mock to raise exception
-        mock_laminar_span = MagicMock()
-        mock_laminar_span.__enter__ = MagicMock(side_effect=Exception('Laminar error'))
-        mock_laminar_span.__exit__ = MagicMock(return_value=False)
-        mock_laminar.start_as_current_span.return_value = mock_laminar_span
-
-        # Verify the code has try/except wrapping - this is a structural test
-        import inspect
+    def test_laminar_span_metadata_structure(self):
+        """Test that Laminar metadata keys are correctly defined in source code."""
         from integrations.github.github_manager import GithubManager
 
+        import inspect
+
         source = inspect.getsource(GithubManager.start_job)
-        # Verify try/except is present in the method
-        assert 'try:' in source
-        assert 'except Exception' in source
-        # Verify fallback behavior exists
-        assert 'create_new_conversation' in source
+
+        # Verify metadata keys are present in the source code
+        assert "'source': 'github'" in source
+        assert "'repo': " in source
+        assert "'issue_number': " in source
+        assert "'username': " in source
+        assert "'conversation_id': " in source
+
+    def test_laminar_error_handling_isolation(self):
+        """Verify that Laminar errors are handled separately from conversation errors.
+
+        This test verifies the code structure ensures that:
+        1. Laminar setup errors are caught in their own try/except block
+        2. The conversation is created regardless of Laminar setup failures
+        """
+        from integrations.github.github_manager import GithubManager
+
+        import inspect
+
+        source = inspect.getsource(GithubManager.start_job)
+
+        # Verify error handling structure
+        # The Laminar setup should be in its own try/except, not wrapping conversation creation
+        assert 'span_context = nullcontext()' in source
+        assert '[Github] Laminar span setup error' in source
+        # Ensure conversation creation is NOT inside the Laminar try/except
+        assert source.count('try:') >= 2  # Multiple try blocks exist

--- a/enterprise/tests/unit/integrations/github/test_github_manager.py
+++ b/enterprise/tests/unit/integrations/github/test_github_manager.py
@@ -5,9 +5,21 @@ Covers:
 - User not found scenario when a GitHub user hasn't created an OpenHands account
 - Sign-up message posting to GitHub issues/PRs
 - All supported trigger types: labeled issues, issue comments, PR comments, inline PR comments
+- Laminar observability integration
 """
 
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
+
+# Mock the lmnr (Laminar) module before importing github_manager
+mock_laminar = MagicMock()
+mock_laminar.Laminar = MagicMock()
+sys.modules['lmnr'] = mock_laminar
+
+# Mock the SDK observability module before importing github_manager
+mock_observability = MagicMock()
+mock_observability.init_laminar_for_external = MagicMock(return_value=None)
+sys.modules['openhands.sdk.observability'] = mock_observability
 
 import pytest
 from integrations.github.github_manager import GithubManager
@@ -597,3 +609,130 @@ class TestGetUserNotFoundMessageIntegration:
         message = get_user_not_found_message('testuser')
         assert 'it looks like' in message.lower()
         assert "haven't created an openhands account" in message.lower()
+
+
+class TestLaminarObservability:
+    """Test cases for Laminar observability integration."""
+
+    @pytest.fixture
+    def mock_token_manager(self):
+        """Create a mock token manager."""
+        token_manager = MagicMock()
+        token_manager.get_idp_token_from_idp_user_id = AsyncMock(return_value='fake-token')
+        return token_manager
+
+    @pytest.fixture
+    def mock_data_collector(self):
+        """Create a mock data collector."""
+        data_collector = MagicMock()
+        data_collector.process_payload = AsyncMock()
+        data_collector.save_data = AsyncMock()
+        return data_collector
+
+    @pytest.fixture
+    def mock_github_view(self):
+        """Create a mock GitHub view."""
+        view = MagicMock()
+        view.user_info = MagicMock()
+        view.user_info.user_id = '123'
+        view.user_info.username = 'testuser'
+        view.user_info.keycloak_user_id = 'keycloak-123'
+        view.full_repo_name = 'test-owner/test-repo'
+        view.issue_number = 42
+        view.conversation_id = None
+        view.initialize_new_conversation = AsyncMock(
+            return_value={'conversation_id': 'new-convo-123'}
+        )
+        view.create_new_conversation = AsyncMock(return_value=None)
+        view.v1_enabled = False
+        return view
+
+    @patch('integrations.github.github_manager.Auth')
+    @patch('integrations.github.github_manager.GithubIntegration')
+    @patch('integrations.github.github_manager.Github')
+    @patch('integrations.github.github_manager.Laminar')
+    def test_laminar_tracing_enabled_when_api_key_set(
+        self,
+        mock_laminar,
+        mock_github_class,
+        mock_github_integration,
+        mock_auth,
+        mock_token_manager,
+        mock_data_collector,
+        mock_github_view,
+    ):
+        """Test that Laminar tracing is enabled when LMNR_PROJECT_API_KEY is set."""
+        # Set up mock span context
+        mock_laminar_span = MagicMock()
+        mock_laminar_span.__enter__ = MagicMock(return_value=None)
+        mock_laminar_span.__exit__ = MagicMock(return_value=False)
+        mock_laminar.start_as_current_span.return_value = mock_laminar_span
+
+        # Import after patching
+        from openhands.sdk.observability import init_laminar_for_external
+
+        # Test: init_laminar_for_external returns span context when enabled
+        # This test verifies the pattern - actual SDK behavior tested elsewhere
+        assert mock_laminar is not None
+
+    @patch('integrations.github.github_manager.Auth')
+    @patch('integrations.github.github_manager.GithubIntegration')
+    @patch('integrations.github.github_manager.Github')
+    def test_metadata_set_correctly(
+        self,
+        mock_github_class,
+        mock_github_integration,
+        mock_auth,
+        mock_token_manager,
+        mock_data_collector,
+        mock_github_view,
+    ):
+        """Test that Laminar metadata is set correctly when tracing is enabled."""
+        # Verify metadata keys are correctly defined
+        expected_metadata_keys = {
+            'source',
+            'repo',
+            'issue_number',
+            'username',
+            'conversation_id',
+        }
+        # This tests the metadata structure we expect to set
+        assert expected_metadata_keys == {
+            'source',
+            'repo',
+            'issue_number',
+            'username',
+            'conversation_id',
+        }
+
+    @patch('integrations.github.github_manager.Auth')
+    @patch('integrations.github.github_manager.GithubIntegration')
+    @patch('integrations.github.github_manager.Github')
+    @patch('integrations.github.github_manager.Laminar')
+    def test_laminar_operations_wrapped_in_try_except(
+        self,
+        mock_laminar,
+        mock_github_class,
+        mock_github_integration,
+        mock_auth,
+        mock_token_manager,
+        mock_data_collector,
+        mock_github_view,
+    ):
+        """Test that Laminar operations are wrapped in try/except for fault tolerance."""
+        # Set up mock to raise exception
+        mock_laminar_span = MagicMock()
+        mock_laminar_span.__enter__ = MagicMock(side_effect=Exception('Laminar error'))
+        mock_laminar_span.__exit__ = MagicMock(return_value=False)
+        mock_laminar.start_as_current_span.return_value = mock_laminar_span
+
+        # Verify the code has try/except wrapping - this is a structural test
+        import inspect
+        from integrations.github.github_manager import GithubManager
+
+        source = inspect.getsource(GithubManager.start_job)
+        # Verify try/except is present in the method
+        assert 'try:' in source
+        assert 'except Exception' in source
+        # Verify fallback behavior exists
+        assert 'create_new_conversation' in source

--- a/enterprise/tests/unit/integrations/github/test_github_manager.py
+++ b/enterprise/tests/unit/integrations/github/test_github_manager.py
@@ -600,23 +600,78 @@ class TestGetUserNotFoundMessageIntegration:
         assert "haven't created an openhands account" in message.lower()
 
 
+def test_init_laminar_for_external_falls_back_to_maybe_init_laminar(monkeypatch):
+    """Test the local compatibility wrapper when the SDK helper is unavailable."""
+    from integrations.github import github_manager
+
+    mock_observability = type(sys)('openhands.sdk.observability')
+    mock_observability.maybe_init_laminar = MagicMock()
+    monkeypatch.setitem(sys.modules, 'openhands.sdk.observability', mock_observability)
+
+    mock_laminar = MagicMock()
+    mock_laminar.is_initialized.return_value = True
+    mock_laminar.get_laminar_span_context.return_value = 'span-context'
+    monkeypatch.setattr(github_manager, 'Laminar', mock_laminar)
+
+    assert github_manager.init_laminar_for_external() == 'span-context'
+    mock_observability.maybe_init_laminar.assert_called_once()
+
+
 class TestLaminarObservability:
     """Test cases for Laminar observability integration."""
 
     @pytest.fixture(autouse=True)
-    def mock_laminar_and_observability(self, monkeypatch):
-        """Mock Laminar and SDK observability modules for all tests in this class."""
-        from unittest.mock import MagicMock
+    def mock_github_manager_dependencies(self, monkeypatch):
+        """Patch GithubManager dependencies so Laminar behavior can be tested in isolation."""
+        from integrations.github import github_manager
 
         mock_laminar = MagicMock()
-        mock_laminar.Laminar = MagicMock()
-        monkeypatch.setitem(sys.modules, 'lmnr', mock_laminar)
-
-        mock_observability = MagicMock()
-        mock_observability.init_laminar_for_external = MagicMock(return_value=None)
-        monkeypatch.setitem(
-            sys.modules, 'openhands.sdk.observability', mock_observability
+        mock_laminar.is_initialized.return_value = False
+        mock_laminar.get_laminar_span_context.return_value = None
+        monkeypatch.setattr(github_manager, 'Laminar', mock_laminar)
+        monkeypatch.setattr(github_manager, 'Auth', MagicMock())
+        monkeypatch.setattr(github_manager, 'GithubIntegration', MagicMock())
+        monkeypatch.setattr(
+            github_manager,
+            'get_saas_user_auth',
+            AsyncMock(return_value=MagicMock()),
         )
+        monkeypatch.setattr(github_manager, 'register_callback_processor', MagicMock())
+        monkeypatch.setattr(github_manager, 'ENABLE_SOLVABILITY_ANALYSIS', False)
+
+        mock_init_laminar_for_external = MagicMock(return_value=None)
+        monkeypatch.setattr(
+            github_manager,
+            'init_laminar_for_external',
+            mock_init_laminar_for_external,
+        )
+
+        mock_callback_module = type(sys)(
+            'server.conversation_callback_processor.github_callback_processor'
+        )
+        mock_callback_module.GithubCallbackProcessor = MagicMock(
+            return_value=MagicMock()
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            'server.conversation_callback_processor.github_callback_processor',
+            mock_callback_module,
+        )
+
+        return {
+            'github_manager': github_manager,
+            'laminar': mock_laminar,
+            'init_laminar_for_external': mock_init_laminar_for_external,
+        }
+
+    @pytest.fixture
+    def manager(self, mock_token_manager, mock_data_collector):
+        """Create a GithubManager with outbound messaging mocked."""
+        from integrations.github import github_manager
+
+        manager = github_manager.GithubManager(mock_token_manager, mock_data_collector)
+        manager.send_message = AsyncMock()
+        return manager
 
     @pytest.fixture
     def mock_token_manager(self):
@@ -668,41 +723,35 @@ class TestLaminarObservability:
 
     @pytest.mark.asyncio
     async def test_laminar_span_created_with_metadata_when_enabled(
-        self, mock_token_manager, mock_data_collector, mock_github_view, monkeypatch
+        self,
+        manager,
+        mock_github_view,
+        mock_github_manager_dependencies,
     ):
         """Test that Laminar span is created with correct metadata when Laminar is enabled."""
-        from lmnr import Laminar
-
-        # Set up Laminar mock to return a span context
         mock_span = MagicMock()
         mock_span.__enter__ = MagicMock(return_value=mock_span)
         mock_span.__exit__ = MagicMock(return_value=False)
         mock_span_context = MagicMock()
-        mock_span_context.__enter__ = MagicMock(return_value=mock_span)
-        mock_span_context.__exit__ = MagicMock(return_value=False)
-        Laminar.start_as_current_span.return_value = mock_span
 
-        # Set up init_laminar_for_external to return a span context (enabled)
-        from openhands.sdk.observability import init_laminar_for_external
+        mock_github_manager_dependencies[
+            'laminar'
+        ].start_as_current_span.return_value = mock_span
+        mock_github_manager_dependencies[
+            'init_laminar_for_external'
+        ].return_value = mock_span_context
 
-        monkeypatch.setattr(
-            init_laminar_for_external, 'return_value', mock_span_context
-        )
-
-        from integrations.github import github_manager
-
-        # Call start_job
-        manager = github_manager.GithubManager(mock_token_manager, mock_data_collector)
         await manager.start_job(mock_github_view)
 
-        # Verify Laminar.start_as_current_span was called with correct name
-        Laminar.start_as_current_span.assert_called_once()
-        call_kwargs = Laminar.start_as_current_span.call_args.kwargs
-        assert call_kwargs['name'] == 'github-resolver'
-        assert call_kwargs['parent_span_context'] == mock_span_context
-
-        # Verify trace metadata was set
-        Laminar.set_trace_metadata.assert_called_once_with(
+        mock_github_manager_dependencies[
+            'laminar'
+        ].start_as_current_span.assert_called_once_with(
+            name='github-resolver',
+            parent_span_context=mock_span_context,
+        )
+        mock_github_manager_dependencies[
+            'laminar'
+        ].set_trace_metadata.assert_called_once_with(
             {
                 'source': 'github',
                 'repo': 'test-owner/test-repo',
@@ -711,102 +760,80 @@ class TestLaminarObservability:
                 'conversation_id': 'conv-123',
             }
         )
-
-        # Verify conversation was created
         mock_github_view.create_new_conversation.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_conversation_created_when_laminar_disabled(
-        self, mock_token_manager, mock_data_collector, mock_github_view, monkeypatch
+        self,
+        manager,
+        mock_github_view,
+        mock_github_manager_dependencies,
     ):
-        """Test that conversation is created when Laminar is disabled (returns None)."""
-        from lmnr import Laminar
+        """Test that conversation is created when Laminar is disabled."""
+        mock_github_manager_dependencies[
+            'init_laminar_for_external'
+        ].return_value = None
 
-        from openhands.sdk.observability import init_laminar_for_external
-
-        # Ensure init_laminar_for_external returns None (disabled)
-        monkeypatch.setattr(init_laminar_for_external, 'return_value', None)
-
-        from integrations.github import github_manager
-
-        # Call start_job
-        manager = github_manager.GithubManager(mock_token_manager, mock_data_collector)
         await manager.start_job(mock_github_view)
 
-        # Verify Laminar.start_as_current_span was NOT called
-        Laminar.start_as_current_span.assert_not_called()
-
-        # Verify conversation was still created
+        mock_github_manager_dependencies[
+            'laminar'
+        ].start_as_current_span.assert_not_called()
         mock_github_view.create_new_conversation.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_conversation_created_when_laminar_span_setup_fails(
-        self, mock_token_manager, mock_data_collector, mock_github_view, monkeypatch
+        self,
+        manager,
+        mock_github_view,
+        mock_github_manager_dependencies,
     ):
         """Test that conversation is created even when Laminar span setup fails."""
-        from lmnr import Laminar
+        mock_github_manager_dependencies[
+            'init_laminar_for_external'
+        ].return_value = MagicMock()
+        mock_github_manager_dependencies[
+            'laminar'
+        ].start_as_current_span.side_effect = RuntimeError('Laminar unavailable')
 
-        from openhands.sdk.observability import init_laminar_for_external
-
-        # Set up init_laminar_for_external to return a span context (enabled)
-        mock_span_context = MagicMock()
-        monkeypatch.setattr(
-            init_laminar_for_external, 'return_value', mock_span_context
-        )
-
-        # Make Laminar.start_as_current_span raise an exception
-        Laminar.start_as_current_span.side_effect = RuntimeError('Laminar unavailable')
-
-        from integrations.github import github_manager
-
-        # Call start_job - should NOT raise
-        manager = github_manager.GithubManager(mock_token_manager, mock_data_collector)
         await manager.start_job(mock_github_view)
 
-        # Verify conversation was still created despite Laminar failure
         mock_github_view.create_new_conversation.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_laminar_flush_called_when_enabled(
-        self, mock_token_manager, mock_data_collector, mock_github_view, monkeypatch
+        self,
+        manager,
+        mock_github_view,
+        mock_github_manager_dependencies,
     ):
         """Test that Laminar.flush() is called when Laminar is enabled."""
-        from lmnr import Laminar
+        mock_span = MagicMock()
+        mock_span.__enter__ = MagicMock(return_value=mock_span)
+        mock_span.__exit__ = MagicMock(return_value=False)
+        mock_github_manager_dependencies[
+            'laminar'
+        ].start_as_current_span.return_value = mock_span
+        mock_github_manager_dependencies[
+            'init_laminar_for_external'
+        ].return_value = MagicMock()
 
-        from openhands.sdk.observability import init_laminar_for_external
-
-        # Set up init_laminar_for_external to return a span context (enabled)
-        mock_span_context = MagicMock()
-        monkeypatch.setattr(
-            init_laminar_for_external, 'return_value', mock_span_context
-        )
-
-        from integrations.github import github_manager
-
-        # Call start_job
-        manager = github_manager.GithubManager(mock_token_manager, mock_data_collector)
         await manager.start_job(mock_github_view)
 
-        # Verify Laminar.flush was called
-        Laminar.flush.assert_called_once()
+        mock_github_manager_dependencies['laminar'].flush.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_laminar_flush_not_called_when_disabled(
-        self, mock_token_manager, mock_data_collector, mock_github_view, monkeypatch
+        self,
+        manager,
+        mock_github_view,
+        mock_github_manager_dependencies,
     ):
         """Test that Laminar.flush() is NOT called when Laminar is disabled."""
-        from lmnr import Laminar
+        mock_github_manager_dependencies[
+            'init_laminar_for_external'
+        ].return_value = None
 
-        from openhands.sdk.observability import init_laminar_for_external
-
-        # Ensure init_laminar_for_external returns None (disabled)
-        monkeypatch.setattr(init_laminar_for_external, 'return_value', None)
-
-        from integrations.github import github_manager
-
-        # Call start_job
-        manager = github_manager.GithubManager(mock_token_manager, mock_data_collector)
         await manager.start_job(mock_github_view)
 
-        # Verify Laminar.flush was NOT called
-        Laminar.flush.assert_not_called()
+        mock_github_manager_dependencies['laminar'].flush.assert_not_called()

--- a/enterprise/tests/unit/integrations/github/test_github_manager.py
+++ b/enterprise/tests/unit/integrations/github/test_github_manager.py
@@ -687,7 +687,6 @@ class TestLaminarObservability:
             init_laminar_for_external, 'return_value', mock_span_context
         )
 
-        # Reload the module to pick up the new mock
         from integrations.github import github_manager
 
         # Call start_job

--- a/enterprise/tests/unit/integrations/github/test_github_manager.py
+++ b/enterprise/tests/unit/integrations/github/test_github_manager.py
@@ -1,5 +1,4 @@
-"""
-Tests for the GithubManager class.
+"""Tests for the GithubManager class.
 
 Covers:
 - User not found scenario when a GitHub user hasn't created an OpenHands account
@@ -8,18 +7,8 @@ Covers:
 - Laminar observability integration
 """
 
-import sys
 from unittest.mock import AsyncMock, MagicMock, patch
-
-# Mock the lmnr (Laminar) module before importing github_manager
-mock_laminar = MagicMock()
-mock_laminar.Laminar = MagicMock()
-sys.modules['lmnr'] = mock_laminar
-
-# Mock the SDK observability module before importing github_manager
-mock_observability = MagicMock()
-mock_observability.init_laminar_for_external = MagicMock(return_value=None)
-sys.modules['openhands.sdk.observability'] = mock_observability
+import sys
 
 import pytest
 from integrations.github.github_manager import GithubManager
@@ -614,37 +603,90 @@ class TestGetUserNotFoundMessageIntegration:
 class TestLaminarObservability:
     """Test cases for Laminar observability integration."""
 
-    def test_laminar_span_metadata_structure(self):
-        """Test that Laminar metadata keys are correctly defined in source code."""
-        from integrations.github.github_manager import GithubManager
+    @pytest.fixture(autouse=True)
+    def mock_laminar_and_observability(self, monkeypatch):
+        """Mock Laminar and SDK observability modules for all tests in this class."""
+        from unittest.mock import MagicMock
 
-        import inspect
+        mock_laminar = MagicMock()
+        mock_laminar.Laminar = MagicMock()
+        monkeypatch.setitem(sys.modules, 'lmnr', mock_laminar)
 
-        source = inspect.getsource(GithubManager.start_job)
+        mock_observability = MagicMock()
+        mock_observability.init_laminar_for_external = MagicMock(return_value=None)
+        monkeypatch.setitem(sys.modules, 'openhands.sdk.observability', mock_observability)
 
-        # Verify metadata keys are present in the source code
-        assert "'source': 'github'" in source
-        assert "'repo': " in source
-        assert "'issue_number': " in source
-        assert "'username': " in source
-        assert "'conversation_id': " in source
+    @pytest.fixture
+    def mock_token_manager(self):
+        """Create a mock token manager."""
+        token_manager = MagicMock()
+        return token_manager
 
-    def test_laminar_error_handling_isolation(self):
-        """Verify that Laminar errors are handled separately from conversation errors.
+    @pytest.fixture
+    def mock_data_collector(self):
+        """Create a mock data collector."""
+        data_collector = MagicMock()
+        return data_collector
 
-        This test verifies the code structure ensures that:
-        1. Laminar setup errors are caught in their own try/except block
-        2. The conversation is created regardless of Laminar setup failures
+    @pytest.mark.asyncio
+    async def test_laminar_initialized_when_api_key_set(self):
+        """Test that Laminar is initialized when LMNR_PROJECT_API_KEY is set."""
+        from openhands.sdk.observability import init_laminar_for_external
+        from lmnr import Laminar
+
+        # Reset the mock to clear previous call counts
+        init_laminar_for_external.reset_mock()
+        init_laminar_for_external.return_value = MagicMock()
+
+        # Verify the function exists and is callable
+        assert callable(init_laminar_for_external)
+        init_laminar_for_external()
+        init_laminar_for_external.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_conversation_created_when_laminar_fails(self):
+        """Test that conversation is created even when Laminar span setup fails.
+
+        This verifies that:
+        1. Laminar errors during span setup are caught
+        2. Conversation creation still happens
+        3. Errors are logged without blocking the main flow
         """
+        from lmnr import Laminar
+
+        # Make Laminar span setup fail
+        Laminar.start_as_current_span.side_effect = RuntimeError('Laminar unavailable')
+
+        # Verify Laminar exception doesn't prevent the code from running
+        # by checking that the mock was set up correctly
+        assert Laminar.start_as_current_span is not None
+
+    def test_laminar_span_name_is_github_resolver(self):
+        """Test that the Laminar span is created with the correct name."""
         from integrations.github.github_manager import GithubManager
 
         import inspect
 
         source = inspect.getsource(GithubManager.start_job)
 
-        # Verify error handling structure
-        # The Laminar setup should be in its own try/except, not wrapping conversation creation
-        assert 'span_context = nullcontext()' in source
-        assert '[Github] Laminar span setup error' in source
-        # Ensure conversation creation is NOT inside the Laminar try/except
-        assert source.count('try:') >= 2  # Multiple try blocks exist
+        # Verify the span name matches what we expect
+        assert "name='github-resolver'" in source
+
+    def test_laminar_metadata_includes_required_fields(self):
+        """Test that Laminar metadata includes all required fields."""
+        from integrations.github.github_manager import GithubManager
+
+        import inspect
+
+        source = inspect.getsource(GithubManager.start_job)
+
+        # Verify all required metadata keys are present
+        expected_keys = [
+            "'source': 'github'",
+            "'repo':",
+            "'issue_number':",
+            "'username':",
+            "'conversation_id':",
+        ]
+        for key in expected_keys:
+            assert key in source

--- a/enterprise/tests/unit/integrations/github/test_github_manager.py
+++ b/enterprise/tests/unit/integrations/github/test_github_manager.py
@@ -620,73 +620,192 @@ class TestLaminarObservability:
     def mock_token_manager(self):
         """Create a mock token manager."""
         token_manager = MagicMock()
+        token_manager.get_idp_token_from_idp_user_id = AsyncMock(
+            return_value='test-token'
+        )
+        token_manager.load_org_token = AsyncMock(return_value='installation-token')
         return token_manager
 
     @pytest.fixture
     def mock_data_collector(self):
         """Create a mock data collector."""
         data_collector = MagicMock()
+        data_collector.save_data = AsyncMock()
         return data_collector
 
+    @pytest.fixture
+    def mock_user_info(self):
+        """Create a mock UserInfo object."""
+        user_info = MagicMock()
+        user_info.user_id = '123'
+        user_info.username = 'testuser'
+        user_info.keycloak_user_id = 'kc-123'
+        return user_info
+
+    @pytest.fixture
+    def mock_github_view(self, mock_user_info):
+        """Create a mock GithubViewType object."""
+        from integrations.github.github_view import GithubIssue
+
+        github_view = MagicMock(spec=GithubIssue)
+        github_view.user_info = mock_user_info
+        github_view.full_repo_name = 'test-owner/test-repo'
+        github_view.issue_number = 42
+        github_view.conversation_id = 'conv-123'
+        github_view.installation_id = 12345
+        github_view.v1_enabled = False
+
+        github_view.initialize_new_conversation = AsyncMock(
+            return_value=MagicMock(
+                conversation_id='conv-123',
+                selected_repository='test-owner/test-repo',
+            )
+        )
+        github_view.create_new_conversation = AsyncMock()
+        return github_view
+
     @pytest.mark.asyncio
-    async def test_laminar_initialized_when_api_key_set(self):
-        """Test that Laminar is initialized when LMNR_PROJECT_API_KEY is set."""
+    async def test_laminar_span_created_with_metadata_when_enabled(
+        self, mock_token_manager, mock_data_collector, mock_github_view, monkeypatch
+    ):
+        """Test that Laminar span is created with correct metadata when Laminar is enabled."""
+        from lmnr import Laminar
+
+        # Set up Laminar mock to return a span context
+        mock_span = MagicMock()
+        mock_span.__enter__ = MagicMock(return_value=mock_span)
+        mock_span.__exit__ = MagicMock(return_value=False)
+        mock_span_context = MagicMock()
+        mock_span_context.__enter__ = MagicMock(return_value=mock_span)
+        mock_span_context.__exit__ = MagicMock(return_value=False)
+        Laminar.start_as_current_span.return_value = mock_span
+
+        # Set up init_laminar_for_external to return a span context (enabled)
         from openhands.sdk.observability import init_laminar_for_external
-        from lmnr import Laminar
 
-        # Reset the mock to clear previous call counts
-        init_laminar_for_external.reset_mock()
-        init_laminar_for_external.return_value = MagicMock()
+        monkeypatch.setattr(
+            init_laminar_for_external, 'return_value', mock_span_context
+        )
 
-        # Verify the function exists and is callable
-        assert callable(init_laminar_for_external)
-        init_laminar_for_external()
-        init_laminar_for_external.assert_called_once()
+        # Reload the module to pick up the new mock
+        from integrations.github import github_manager
+
+        # Call start_job
+        manager = github_manager.GithubManager(
+            mock_token_manager, mock_data_collector
+        )
+        await manager.start_job(mock_github_view)
+
+        # Verify Laminar.start_as_current_span was called with correct name
+        Laminar.start_as_current_span.assert_called_once()
+        call_kwargs = Laminar.start_as_current_span.call_args.kwargs
+        assert call_kwargs['name'] == 'github-resolver'
+        assert call_kwargs['parent_span_context'] == mock_span_context
+
+        # Verify trace metadata was set
+        Laminar.set_trace_metadata.assert_called_once_with({
+            'source': 'github',
+            'repo': 'test-owner/test-repo',
+            'issue_number': '42',
+            'username': 'testuser',
+            'conversation_id': 'conv-123',
+        })
+
+        # Verify conversation was created
+        mock_github_view.create_new_conversation.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_conversation_created_when_laminar_fails(self):
-        """Test that conversation is created even when Laminar span setup fails.
-
-        This verifies that:
-        1. Laminar errors during span setup are caught
-        2. Conversation creation still happens
-        3. Errors are logged without blocking the main flow
-        """
+    async def test_conversation_created_when_laminar_disabled(
+        self, mock_token_manager, mock_data_collector, mock_github_view, monkeypatch
+    ):
+        """Test that conversation is created when Laminar is disabled (returns None)."""
         from lmnr import Laminar
+        from openhands.sdk.observability import init_laminar_for_external
 
-        # Make Laminar span setup fail
+        # Ensure init_laminar_for_external returns None (disabled)
+        monkeypatch.setattr(init_laminar_for_external, 'return_value', None)
+
+        from integrations.github import github_manager
+
+        # Call start_job
+        manager = github_manager.GithubManager(
+            mock_token_manager, mock_data_collector
+        )
+        await manager.start_job(mock_github_view)
+
+        # Verify Laminar.start_as_current_span was NOT called
+        Laminar.start_as_current_span.assert_not_called()
+
+        # Verify conversation was still created
+        mock_github_view.create_new_conversation.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_conversation_created_when_laminar_span_setup_fails(
+        self, mock_token_manager, mock_data_collector, mock_github_view, monkeypatch
+    ):
+        """Test that conversation is created even when Laminar span setup fails."""
+        from lmnr import Laminar
+        from openhands.sdk.observability import init_laminar_for_external
+
+        # Set up init_laminar_for_external to return a span context (enabled)
+        mock_span_context = MagicMock()
+        monkeypatch.setattr(init_laminar_for_external, 'return_value', mock_span_context)
+
+        # Make Laminar.start_as_current_span raise an exception
         Laminar.start_as_current_span.side_effect = RuntimeError('Laminar unavailable')
 
-        # Verify Laminar exception doesn't prevent the code from running
-        # by checking that the mock was set up correctly
-        assert Laminar.start_as_current_span is not None
+        from integrations.github import github_manager
 
-    def test_laminar_span_name_is_github_resolver(self):
-        """Test that the Laminar span is created with the correct name."""
-        from integrations.github.github_manager import GithubManager
+        # Call start_job - should NOT raise
+        manager = github_manager.GithubManager(
+            mock_token_manager, mock_data_collector
+        )
+        await manager.start_job(mock_github_view)
 
-        import inspect
+        # Verify conversation was still created despite Laminar failure
+        mock_github_view.create_new_conversation.assert_called_once()
 
-        source = inspect.getsource(GithubManager.start_job)
+    @pytest.mark.asyncio
+    async def test_laminar_flush_called_when_enabled(
+        self, mock_token_manager, mock_data_collector, mock_github_view, monkeypatch
+    ):
+        """Test that Laminar.flush() is called when Laminar is enabled."""
+        from lmnr import Laminar
+        from openhands.sdk.observability import init_laminar_for_external
 
-        # Verify the span name matches what we expect
-        assert "name='github-resolver'" in source
+        # Set up init_laminar_for_external to return a span context (enabled)
+        mock_span_context = MagicMock()
+        monkeypatch.setattr(init_laminar_for_external, 'return_value', mock_span_context)
 
-    def test_laminar_metadata_includes_required_fields(self):
-        """Test that Laminar metadata includes all required fields."""
-        from integrations.github.github_manager import GithubManager
+        from integrations.github import github_manager
 
-        import inspect
+        # Call start_job
+        manager = github_manager.GithubManager(
+            mock_token_manager, mock_data_collector
+        )
+        await manager.start_job(mock_github_view)
 
-        source = inspect.getsource(GithubManager.start_job)
+        # Verify Laminar.flush was called
+        Laminar.flush.assert_called_once()
 
-        # Verify all required metadata keys are present
-        expected_keys = [
-            "'source': 'github'",
-            "'repo':",
-            "'issue_number':",
-            "'username':",
-            "'conversation_id':",
-        ]
-        for key in expected_keys:
-            assert key in source
+    @pytest.mark.asyncio
+    async def test_laminar_flush_not_called_when_disabled(
+        self, mock_token_manager, mock_data_collector, mock_github_view, monkeypatch
+    ):
+        """Test that Laminar.flush() is NOT called when Laminar is disabled."""
+        from lmnr import Laminar
+        from openhands.sdk.observability import init_laminar_for_external
+
+        # Ensure init_laminar_for_external returns None (disabled)
+        monkeypatch.setattr(init_laminar_for_external, 'return_value', None)
+
+        from integrations.github import github_manager
+
+        # Call start_job
+        manager = github_manager.GithubManager(
+            mock_token_manager, mock_data_collector
+        )
+        await manager.start_job(mock_github_view)
+
+        # Verify Laminar.flush was NOT called
+        Laminar.flush.assert_not_called()

--- a/enterprise/tests/unit/integrations/github/test_github_manager.py
+++ b/enterprise/tests/unit/integrations/github/test_github_manager.py
@@ -7,8 +7,8 @@ Covers:
 - Laminar observability integration
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
 import sys
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from integrations.github.github_manager import GithubManager
@@ -614,7 +614,9 @@ class TestLaminarObservability:
 
         mock_observability = MagicMock()
         mock_observability.init_laminar_for_external = MagicMock(return_value=None)
-        monkeypatch.setitem(sys.modules, 'openhands.sdk.observability', mock_observability)
+        monkeypatch.setitem(
+            sys.modules, 'openhands.sdk.observability', mock_observability
+        )
 
     @pytest.fixture
     def mock_token_manager(self):
@@ -690,9 +692,7 @@ class TestLaminarObservability:
         from integrations.github import github_manager
 
         # Call start_job
-        manager = github_manager.GithubManager(
-            mock_token_manager, mock_data_collector
-        )
+        manager = github_manager.GithubManager(mock_token_manager, mock_data_collector)
         await manager.start_job(mock_github_view)
 
         # Verify Laminar.start_as_current_span was called with correct name
@@ -702,13 +702,15 @@ class TestLaminarObservability:
         assert call_kwargs['parent_span_context'] == mock_span_context
 
         # Verify trace metadata was set
-        Laminar.set_trace_metadata.assert_called_once_with({
-            'source': 'github',
-            'repo': 'test-owner/test-repo',
-            'issue_number': '42',
-            'username': 'testuser',
-            'conversation_id': 'conv-123',
-        })
+        Laminar.set_trace_metadata.assert_called_once_with(
+            {
+                'source': 'github',
+                'repo': 'test-owner/test-repo',
+                'issue_number': '42',
+                'username': 'testuser',
+                'conversation_id': 'conv-123',
+            }
+        )
 
         # Verify conversation was created
         mock_github_view.create_new_conversation.assert_called_once()
@@ -719,6 +721,7 @@ class TestLaminarObservability:
     ):
         """Test that conversation is created when Laminar is disabled (returns None)."""
         from lmnr import Laminar
+
         from openhands.sdk.observability import init_laminar_for_external
 
         # Ensure init_laminar_for_external returns None (disabled)
@@ -727,9 +730,7 @@ class TestLaminarObservability:
         from integrations.github import github_manager
 
         # Call start_job
-        manager = github_manager.GithubManager(
-            mock_token_manager, mock_data_collector
-        )
+        manager = github_manager.GithubManager(mock_token_manager, mock_data_collector)
         await manager.start_job(mock_github_view)
 
         # Verify Laminar.start_as_current_span was NOT called
@@ -744,11 +745,14 @@ class TestLaminarObservability:
     ):
         """Test that conversation is created even when Laminar span setup fails."""
         from lmnr import Laminar
+
         from openhands.sdk.observability import init_laminar_for_external
 
         # Set up init_laminar_for_external to return a span context (enabled)
         mock_span_context = MagicMock()
-        monkeypatch.setattr(init_laminar_for_external, 'return_value', mock_span_context)
+        monkeypatch.setattr(
+            init_laminar_for_external, 'return_value', mock_span_context
+        )
 
         # Make Laminar.start_as_current_span raise an exception
         Laminar.start_as_current_span.side_effect = RuntimeError('Laminar unavailable')
@@ -756,9 +760,7 @@ class TestLaminarObservability:
         from integrations.github import github_manager
 
         # Call start_job - should NOT raise
-        manager = github_manager.GithubManager(
-            mock_token_manager, mock_data_collector
-        )
+        manager = github_manager.GithubManager(mock_token_manager, mock_data_collector)
         await manager.start_job(mock_github_view)
 
         # Verify conversation was still created despite Laminar failure
@@ -770,18 +772,19 @@ class TestLaminarObservability:
     ):
         """Test that Laminar.flush() is called when Laminar is enabled."""
         from lmnr import Laminar
+
         from openhands.sdk.observability import init_laminar_for_external
 
         # Set up init_laminar_for_external to return a span context (enabled)
         mock_span_context = MagicMock()
-        monkeypatch.setattr(init_laminar_for_external, 'return_value', mock_span_context)
+        monkeypatch.setattr(
+            init_laminar_for_external, 'return_value', mock_span_context
+        )
 
         from integrations.github import github_manager
 
         # Call start_job
-        manager = github_manager.GithubManager(
-            mock_token_manager, mock_data_collector
-        )
+        manager = github_manager.GithubManager(mock_token_manager, mock_data_collector)
         await manager.start_job(mock_github_view)
 
         # Verify Laminar.flush was called
@@ -793,6 +796,7 @@ class TestLaminarObservability:
     ):
         """Test that Laminar.flush() is NOT called when Laminar is disabled."""
         from lmnr import Laminar
+
         from openhands.sdk.observability import init_laminar_for_external
 
         # Ensure init_laminar_for_external returns None (disabled)
@@ -801,9 +805,7 @@ class TestLaminarObservability:
         from integrations.github import github_manager
 
         # Call start_job
-        manager = github_manager.GithubManager(
-            mock_token_manager, mock_data_collector
-        )
+        manager = github_manager.GithubManager(mock_token_manager, mock_data_collector)
         await manager.start_job(mock_github_view)
 
         # Verify Laminar.flush was NOT called


### PR DESCRIPTION
## Summary

Add optional Laminar observability to the GitHub resolver using the SDK's new `init_laminar_for_external()` helper.

## Changes

This PR uses the SDK's `init_laminar_for_external()` helper (PR: https://github.com/OpenHands/software-agent-sdk/pull/2820) to:

1. Initialize Laminar if `LMNR_PROJECT_API_KEY` env var is set
2. Register `LaminarLiteLLMCallback` for automatic LLM tracing
3. Capture parent span context from the webhook trigger
4. Create a `github-resolver` span with metadata:
   - `source`: "github"
   - `repo`: repository name
   - `issue_number`: GitHub issue/PR number
   - `username`: GitHub username
   - `conversation_id`: OpenHands conversation ID

## Benefits over original approach (PR #13842)

- Uses SDK's `maybe_init_laminar()` which registers the LLM callback (was missing)
- Removes duplicate constants from `utils.py`
- Simpler conditional checks using `laminar_span_context` directly
- Consistent with SDK patterns for future integrations (Slack, GitLab)

## Testing

1. Set `LMNR_PROJECT_API_KEY` in environment
2. Trigger `@openhands` on a GitHub issue
3. View traces in Laminar dashboard

## Notes

- Depends on SDK PR https://github.com/OpenHands/software-agent-sdk/pull/2820
- All Laminar operations wrapped in try/except for fault tolerance

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:df5c6b6-nikolaik   --name openhands-app-df5c6b6   docker.openhands.dev/openhands/openhands:df5c6b6
```