### PR TITLE
feat(runtime): configurable timeout for Docker runtime image builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,8 +266,42 @@ containers/runtime/Dockerfile
 containers/runtime/project.tar.gz
 containers/runtime/code
 **/node_modules/
+**/node_modules._old*/
 
 # test results
 test-results
 .sessions
 .eval_sessions
+
+# Root-level scratch / Windows experiment files (optional; keep repo clean)
+/*.zip
+/backend-err.txt
+/backend-out.txt
+/rebuild_log.txt
+/build_check.txt
+/env_check_result.txt
+/frontend-build.log
+/docker_update_monitor.log
+/docker_update_monitor.ps1
+/docker-api-fix.py
+/docker-daemon-setup.ps1
+/simple-docker-upgrade.ps1
+/upgrade-docker-desktop.ps1
+/complete-fix.ps1
+/fix_windows_compat.py
+/fcntl_compat.py
+/container-runtime-setup.sh
+/wsl-docker-setup.sh
+/condenser_config_source.txt
+/query
+/tmp_*.py
+/test_fixes.py
+/test_condenser.py
+/.tmp_*.py
+/WINDOWS_COMPATIBILITY_FIXES.md
+
+# Docker Desktop legacy install path (local only)
+/docker-legacy/
+
+# Root uvicorn log dumps
+/uvicorn_backend*.log

--- a/.gitignore
+++ b/.gitignore
@@ -243,6 +243,13 @@ ralph/
 /debug
 cache
 
+# OpenHands local workspace: JWT, encryption keys, SQLite, settings, and
+# exported conversation JSON. Never commit — treat like ~/.openhands on your machine.
+.openhands/
+
+# Local debug console output (may contain sensitive paths or tokens).
+.debug_console_plus/
+
 # configuration
 config.toml
 config.toml_

--- a/openhands/runtime/builder/base.py
+++ b/openhands/runtime/builder/base.py
@@ -16,6 +16,7 @@ class RuntimeBuilder(abc.ABC):
         tags: list[str],
         platform: str | None = None,
         extra_build_args: list[str] | None = None,
+        timeout: int = 600,
     ) -> str:
         """Build the runtime image.
 

--- a/openhands/runtime/builder/base.py
+++ b/openhands/runtime/builder/base.py
@@ -16,6 +16,7 @@ class RuntimeBuilder(abc.ABC):
         tags: list[str],
         platform: str | None = None,
         extra_build_args: list[str] | None = None,
+        use_local_cache: bool = False,
         timeout: int = 600,
     ) -> str:
         """Build the runtime image.
@@ -25,6 +26,7 @@ class RuntimeBuilder(abc.ABC):
             tags (list[str]): The tags to apply to the runtime image (e.g., ["repo:my-repo", "sha:my-sha"]).
             platform (str, optional): The target platform for the build. Defaults to None.
             extra_build_args (list[str], optional): Additional build arguments to pass to the builder. Defaults to None.
+            use_local_cache (bool, optional): For local Docker builds, whether to use local cache. Ignored by remote builders. Defaults to False.
 
         Returns:
             str: The name:tag of the runtime image after build (e.g., "repo:sha").

--- a/openhands/runtime/builder/docker.py
+++ b/openhands/runtime/builder/docker.py
@@ -65,6 +65,7 @@ class DockerRuntimeBuilder(RuntimeBuilder):
         platform: str | None = None,
         extra_build_args: list[str] | None = None,
         use_local_cache: bool = False,
+        timeout: int = 600,
     ) -> str:
         """Builds a Docker image using BuildKit and handles the build logs appropriately.
 
@@ -194,10 +195,18 @@ class DockerRuntimeBuilder(RuntimeBuilder):
                 for line in iter(process.stdout.readline, ''):
                     line = line.strip()
                     if line:
-                        output_lines.append(line)  # Store all output lines
+                        output_lines.append(line)
                         self._output_logs(line)
 
-            return_code = process.wait()
+            try:
+                return_code = process.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                process.terminate()
+                try:
+                    return_code = process.wait(timeout=30)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    return_code = process.wait()
 
             if return_code != 0:
                 # Use the collected output for error reporting

--- a/openhands/runtime/builder/remote.py
+++ b/openhands/runtime/builder/remote.py
@@ -38,6 +38,7 @@ class RemoteRuntimeBuilder(RuntimeBuilder):
         tags: list[str],
         platform: str | None = None,
         extra_build_args: list[str] | None = None,
+        use_local_cache: bool = False,
         timeout: int = 600,
     ) -> str:
         """Builds a Docker image using the Runtime API's /build endpoint."""
@@ -73,7 +74,14 @@ class RemoteRuntimeBuilder(RuntimeBuilder):
             if e.response.status_code == 429:
                 logger.warning('Build was rate limited. Retrying in 30 seconds.')
                 time.sleep(30)
-                return self.build(path, tags, platform)
+                return self.build(
+                    path,
+                    tags,
+                    platform,
+                    extra_build_args,
+                    use_local_cache,
+                    timeout,
+                )
             else:
                 raise e
 

--- a/openhands/runtime/builder/remote.py
+++ b/openhands/runtime/builder/remote.py
@@ -38,6 +38,7 @@ class RemoteRuntimeBuilder(RuntimeBuilder):
         tags: list[str],
         platform: str | None = None,
         extra_build_args: list[str] | None = None,
+        timeout: int = 600,
     ) -> str:
         """Builds a Docker image using the Runtime API's /build endpoint."""
         # Create a tar archive of the build context

--- a/openhands/runtime/utils/runtime_build.py
+++ b/openhands/runtime/utils/runtime_build.py
@@ -186,6 +186,8 @@ def build_runtime_image_in_folder(
     platform: str | None = None,
     extra_build_args: list[str] | None = None,
     enable_browser: bool = True,
+    build_from: BuildFromImageType = BuildFromImageType.SCRATCH,
+    timeout: int = 600,
 ) -> str:
     runtime_image_repo, _ = get_runtime_image_repo_and_tag(base_image)
     lock_tag = (
@@ -221,6 +223,7 @@ def build_runtime_image_in_folder(
                 versioned_tag,
                 platform,
                 extra_build_args=extra_build_args,
+                timeout=timeout,
             )
         return hash_image_name
 
@@ -263,6 +266,7 @@ def build_runtime_image_in_folder(
             ),
             platform=platform,
             extra_build_args=extra_build_args,
+            timeout=timeout,
         )
 
     return hash_image_name
@@ -378,6 +382,7 @@ def _build_sandbox_image(
     versioned_tag: str | None,
     platform: str | None = None,
     extra_build_args: list[str] | None = None,
+    timeout: int = 600,
 ) -> str:
     """Build and tag the sandbox image. The image will be tagged with all tags that do not yet exist."""
     names = [
@@ -393,6 +398,7 @@ def _build_sandbox_image(
         tags=names,
         platform=platform,
         extra_build_args=extra_build_args,
+        timeout=timeout,
     )
     if not image_name:
         raise AgentRuntimeBuildError(f'Build failed for image {names}')

--- a/tests/unit/runtime/builder/test_runtime_build.py
+++ b/tests/unit/runtime/builder/test_runtime_build.py
@@ -344,6 +344,8 @@ def test_build_runtime_image_from_scratch():
             ],
             platform=None,
             extra_build_args=None,
+            use_local_cache=False,
+            timeout=600,
         )
         assert (
             image_name
@@ -439,6 +441,8 @@ def test_build_runtime_image_exact_hash_not_exist_and_lock_exist():
             ],
             platform=None,
             extra_build_args=None,
+            use_local_cache=False,
+            timeout=600,
         )
         mock_prep_build_folder.assert_called_once_with(
             ANY,
@@ -499,6 +503,8 @@ def test_build_runtime_image_exact_hash_not_exist_and_lock_not_exist_and_version
             ],
             platform=None,
             extra_build_args=None,
+            use_local_cache=False,
+            timeout=600,
         )
         mock_prep_build_folder.assert_called_once_with(
             ANY,


### PR DESCRIPTION
<!-- If you are still working on the PR, please mark it as draft. Maintainers will review PRs marked ready for review, which leads to lost time if your PR is actually not ready yet. Keep the PR marked as draft until it is finally ready for review -->

## Summary of PR

### Runtime: configurable Docker image build timeout

Adds a configurable `timeout` (default 600s) to runtime image build paths: `RuntimeBuilder.build()`, Docker builder (`process.wait(timeout=...)` with terminate/kill on expiry), remote builder signature, and `runtime_build` helpers (`build_runtime_image_in_folder`, `_build_sandbox_image`). Prevents hung Docker builds from blocking indefinitely.

### Gitignore: local workspace and scratch files

- Ignore **`.openhands/`** (JWT, keys, SQLite, settings, exported conversation JSON) and **`.debug_console_plus/`** (local debug plugin output).
- Root-level scratch patterns for optional local experiment files (see `.gitignore` tail): e.g. zip/logs/scripts at repo root, `**/node_modules._old*/`, `docker-legacy/`, uvicorn logs.

**Note:** A previous branch revision had a large unrelated “local dev / bind-mount patch” commit; that snapshot is preserved on fork branch `cursor/runtime-image-build-with-local-chore` if needed. This PR branch was rewritten to **runtime + `.gitignore` only** for review.

## Demo Screenshots/Videos

<!-- N/A — backend/runtime + gitignore -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [x] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [ ] I have read and reviewed the code and I understand what the code is doing.
- [ ] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

Resolves #(issue)

## Release Notes

- [ ] Include this change in the Release Notes.
