### PR TITLE
feat(enterprise): Build ARM64 image for enterprise, use native runners for all images

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
       - "saas-rel-*"
+      - "jl/enterprise-arm64-build"
     tags:
       - "*"
   pull_request:
@@ -33,45 +34,44 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       base_image: ${{ steps.define-base-images.outputs.base_image }}
-      platforms: ${{ steps.define-base-images.outputs.platforms }}
+      architectures: ${{ steps.define-base-images.outputs.architectures }}
     steps:
       - name: Define base images
         shell: bash
         id: define-base-images
         run: |
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            platforms="linux/amd64"
-            json=$(jq -n -c --arg platforms "$platforms" '[
-                { image: "nikolaik/python-nodejs:python3.12-nodejs22-slim", tag: "nikolaik", platforms: $platforms }
+            architectures='["amd64"]'
+            json=$(jq -n -c '[
+                { image: "nikolaik/python-nodejs:python3.12-nodejs22-slim", tag: "nikolaik" }
               ]')
           else
-            platforms="linux/amd64,linux/arm64"
-            json=$(jq -n -c --arg platforms "$platforms" '[
-                { image: "nikolaik/python-nodejs:python3.12-nodejs22-slim", tag: "nikolaik", platforms: $platforms },
-                { image: "ubuntu:24.04", tag: "ubuntu", platforms: $platforms }
+            architectures='["amd64", "arm64"]'
+            json=$(jq -n -c '[
+                { image: "nikolaik/python-nodejs:python3.12-nodejs22-slim", tag: "nikolaik" },
+                { image: "ubuntu:24.04", tag: "ubuntu" }
               ]')
           fi
           echo "base_image=$json" >> "$GITHUB_OUTPUT"
-          echo "platforms=$platforms" >> "$GITHUB_OUTPUT"
+          echo "architectures=$architectures" >> "$GITHUB_OUTPUT"
 
-  # Builds the OpenHands Docker images
+  # Builds the OpenHands Docker images (one per architecture, natively)
   ghcr_build_app:
-    name: Build App Image
-    runs-on: ubuntu-22.04
+    name: Build App Image (${{ matrix.arch }})
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-22.04' }}
     if: "!(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/ext-v'))"
     needs: define-matrix
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        arch: ${{ fromJson(needs.define-matrix.outputs.architectures) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.7.0
-        with:
-          image: tonistiigi/binfmt:latest
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -87,12 +87,51 @@ jobs:
       - name: Build and push app image
         if: "!github.event.pull_request.head.repo.fork"
         run: |
-          ./containers/build.sh -i openhands -o ${{ env.REPO_OWNER }} --push -p ${{ needs.define-matrix.outputs.platforms }}
+          ./containers/build.sh -i openhands -o ${{ env.REPO_OWNER }} --push --arch ${{ matrix.arch }}
 
-  # Builds the runtime Docker images
-  ghcr_build_runtime:
-    name: Build Runtime Image
+  # Merges per-architecture app images into a multi-arch manifest
+  ghcr_build_app_merge:
+    name: Merge App Multi-Arch Manifest
     runs-on: ubuntu-22.04
+    needs: [define-matrix, ghcr_build_app]
+    if: github.event.pull_request.head.repo.fork != true
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Lowercase Repository Owner
+        run: |
+          echo REPO_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+      - name: Merge multi-arch manifest
+        run: |
+          ARCHS='${{ join(fromJson(needs.define-matrix.outputs.architectures), ' ') }}'
+          TAGS=$(./containers/build.sh -i openhands -o ${{ env.REPO_OWNER }} --tags-only)
+          while IFS= read -r tag; do
+            [[ -z "$tag" ]] && continue
+            sources=""
+            for arch in $ARCHS; do
+              sources+=" ${tag}-${arch}"
+            done
+            echo "Creating manifest for $tag from:$sources"
+            docker buildx imagetools create -t "$tag" $sources
+          done <<< "$TAGS"
+
+  # Builds the runtime Docker images (one per architecture x base_image, natively)
+  ghcr_build_runtime:
+    name: Build Runtime Image (${{ matrix.base_image.tag }}, ${{ matrix.arch }})
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-22.04' }}
     if: "!(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/ext-v'))"
     permissions:
       contents: read
@@ -101,15 +140,12 @@ jobs:
     strategy:
       matrix:
         base_image: ${{ fromJson(needs.define-matrix.outputs.base_image) }}
+        arch: ${{ fromJson(needs.define-matrix.outputs.architectures) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.7.0
-        with:
-          image: tonistiigi/binfmt:latest
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -140,8 +176,7 @@ jobs:
         if: github.event.pull_request.head.repo.fork != true
         shell: bash
         run: |
-
-          ./containers/build.sh -i runtime -o ${{ env.REPO_OWNER }} -t ${{ matrix.base_image.tag }} --dry -p ${{ matrix.base_image.platforms }}
+          ./containers/build.sh -i runtime -o ${{ env.REPO_OWNER }} -t ${{ matrix.base_image.tag }} --arch ${{ matrix.arch }} --dry
 
           DOCKER_BUILD_JSON=$(jq -c . < docker-build-dry.json)
           echo "DOCKER_TAGS=$(echo "$DOCKER_BUILD_JSON" | jq -r '.tags | join(",")')" >> $GITHUB_ENV
@@ -154,9 +189,8 @@ jobs:
           push: true
           tags: ${{ env.DOCKER_TAGS }}
           platforms: ${{ env.DOCKER_PLATFORM }}
-          # Caching directives to boost performance
-          cache-from: type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/runtime:buildcache-${{ matrix.base_image.tag }}
-          cache-to: type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/runtime:buildcache-${{ matrix.base_image.tag }},mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/runtime:buildcache-${{ matrix.base_image.tag }}-${{ matrix.arch }}
+          cache-to: type=registry,ref=ghcr.io/${{ env.REPO_OWNER }}/runtime:buildcache-${{ matrix.base_image.tag }}-${{ matrix.arch }},mode=max
           build-args: ${{ env.DOCKER_BUILD_ARGS }}
           context: containers/runtime
           provenance: false
@@ -171,18 +205,74 @@ jobs:
         if: github.event.pull_request.head.repo.fork
         uses: actions/upload-artifact@v6
         with:
-          name: runtime-src-${{ matrix.base_image.tag }}
+          name: runtime-src-${{ matrix.base_image.tag }}-${{ matrix.arch }}
           path: containers/runtime
 
-  ghcr_build_enterprise:
-    name: Push Enterprise Image
+  # Merges per-architecture runtime images into multi-arch manifests
+  ghcr_build_runtime_merge:
+    name: Merge Runtime Multi-Arch Manifest (${{ matrix.base_image.tag }})
     runs-on: ubuntu-22.04
+    needs: [define-matrix, ghcr_build_runtime]
+    if: github.event.pull_request.head.repo.fork != true
     permissions:
       contents: read
       packages: write
-    needs: [define-matrix, ghcr_build_app]
+    strategy:
+      matrix:
+        base_image: ${{ fromJson(needs.define-matrix.outputs.base_image) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Lowercase Repository Owner
+        run: |
+          echo REPO_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+      - name: Install poetry via pipx
+        run: pipx install poetry
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: poetry
+      - name: Install Python dependencies using Poetry
+        run: make install-python-dependencies POETRY_GROUP=main INSTALL_PLAYWRIGHT=0
+      - name: Create source distribution and Dockerfile
+        run: poetry run python3 -m openhands.runtime.utils.runtime_build --base_image ${{ matrix.base_image.image }} --build_folder containers/runtime --force_rebuild
+      - name: Merge multi-arch manifest
+        run: |
+          ARCHS='${{ join(fromJson(needs.define-matrix.outputs.architectures), ' ') }}'
+          TAGS=$(./containers/build.sh -i runtime -o ${{ env.REPO_OWNER }} -t ${{ matrix.base_image.tag }} --tags-only)
+          while IFS= read -r tag; do
+            [[ -z "$tag" ]] && continue
+            sources=""
+            for arch in $ARCHS; do
+              sources+=" ${tag}-${arch}"
+            done
+            echo "Creating manifest for $tag from:$sources"
+            docker buildx imagetools create -t "$tag" $sources
+          done <<< "$TAGS"
+
+  ghcr_build_enterprise:
+    name: Push Enterprise Image (${{ matrix.arch }})
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-22.04' }}
+    permissions:
+      contents: read
+      packages: write
+    needs: [define-matrix, ghcr_build_app_merge]
     # Do not build enterprise in forks
     if: github.event.pull_request.head.repo.fork != true
+    strategy:
+      matrix:
+        arch: ${{ fromJson(needs.define-matrix.outputs.architectures) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -219,7 +309,7 @@ jobs:
           flavor: |
             latest=auto
             prefix=
-            suffix=
+            suffix=-${{ matrix.arch }}
         env:
           DOCKER_METADATA_PR_HEAD_SHA: true
       - name: Determine app image tag
@@ -238,11 +328,71 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             OPENHANDS_VERSION=${{ env.OPENHANDS_DOCKER_TAG }}
-          platforms: linux/amd64
+          platforms: linux/${{ matrix.arch }}
           # Add build provenance
           provenance: true
           # Add build attestations for better security
           sbom: true
+
+  # Merges per-architecture enterprise images into a multi-arch manifest
+  ghcr_build_enterprise_merge:
+    name: Merge Enterprise Multi-Arch Manifest
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    needs: [define-matrix, ghcr_build_enterprise]
+    if: github.event.pull_request.head.repo.fork != true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/openhands/enterprise-server
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=sha,format=long
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=match,pattern=cloud-\d+\.\d+\.\d+
+          flavor: |
+            latest=auto
+            prefix=
+            suffix=
+        env:
+          DOCKER_METADATA_PR_HEAD_SHA: true
+
+      - name: Merge multi-arch manifest
+        run: |
+          ARCHS='${{ join(fromJson(needs.define-matrix.outputs.architectures), ' ') }}'
+          TAGS="${{ steps.meta.outputs.tags }}"
+          while IFS= read -r tag; do
+            [[ -z "$tag" ]] && continue
+            sources=""
+            for arch in $ARCHS; do
+              sources+=" ${tag}-${arch}"
+            done
+            echo "Creating manifest for $tag from:$sources"
+            docker buildx imagetools create -t "$tag" $sources
+          done <<< "$TAGS"
 
   # "All Runtime Tests Passed" is a required job for PRs to merge
   # We can remove this once the config changes
@@ -256,7 +406,7 @@ jobs:
   update_pr_description:
     name: Update PR Description
     if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'
-    needs: [ghcr_build_runtime]
+    needs: [ghcr_build_runtime_merge]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -40,13 +40,12 @@ jobs:
         shell: bash
         id: define-base-images
         run: |
+          architectures='["amd64", "arm64"]'
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            architectures='["amd64"]'
             json=$(jq -n -c '[
                 { image: "nikolaik/python-nodejs:python3.12-nodejs22-slim", tag: "nikolaik" }
               ]')
           else
-            architectures='["amd64", "arm64"]'
             json=$(jq -n -c '[
                 { image: "nikolaik/python-nodejs:python3.12-nodejs22-slim", tag: "nikolaik" },
                 { image: "ubuntu:24.04", tag: "ubuntu" }

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -60,6 +60,9 @@ jobs:
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-22.04' }}
     if: "!(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/ext-v'))"
     needs: define-matrix
+    outputs:
+      # All arch variants produce the same base tags, so any entry works
+      base_tags: ${{ steps.build.outputs.base_tags }}
     permissions:
       contents: read
       packages: write
@@ -84,9 +87,17 @@ jobs:
         run: |
           echo REPO_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
       - name: Build and push app image
+        id: build
         if: "!github.event.pull_request.head.repo.fork"
         run: |
           ./containers/build.sh -i openhands -o ${{ env.REPO_OWNER }} --push --arch ${{ matrix.arch }}
+
+          # Output base tags (without arch suffix) for the merge job
+          ./containers/build.sh -i openhands -o ${{ env.REPO_OWNER }} --arch ${{ matrix.arch }} --dry
+          BASE_TAGS=$(jq -r '.base_tags | join("\n")' docker-build-dry.json)
+          echo "base_tags<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$BASE_TAGS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
   # Merges per-architecture app images into a multi-arch manifest
   ghcr_build_app_merge:
@@ -95,13 +106,8 @@ jobs:
     needs: [define-matrix, ghcr_build_app]
     if: github.event.pull_request.head.repo.fork != true
     permissions:
-      contents: read
       packages: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -110,13 +116,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Lowercase Repository Owner
-        run: |
-          echo REPO_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
       - name: Merge multi-arch manifest
         run: |
           ARCHS='${{ join(fromJson(needs.define-matrix.outputs.architectures), ' ') }}'
-          TAGS=$(./containers/build.sh -i openhands -o ${{ env.REPO_OWNER }} --tags-only)
+          TAGS="${{ needs.ghcr_build_app.outputs.base_tags }}"
           while IFS= read -r tag; do
             [[ -z "$tag" ]] && continue
             sources=""
@@ -136,6 +139,12 @@ jobs:
       contents: read
       packages: write
     needs: define-matrix
+    outputs:
+      # Keyed by base_image tag so the merge job can access per-variant tags.
+      # Matrix outputs from different entries with the same key overwrite each other,
+      # but all arch variants of the same base_image produce identical base tags.
+      base_tags_nikolaik: ${{ steps.params.outputs.base_tags_nikolaik }}
+      base_tags_ubuntu: ${{ steps.params.outputs.base_tags_ubuntu }}
     strategy:
       matrix:
         base_image: ${{ fromJson(needs.define-matrix.outputs.base_image) }}
@@ -172,6 +181,7 @@ jobs:
         run: |
           echo SHORT_SHA=$(git rev-parse --short "$RELEVANT_SHA") >> $GITHUB_ENV
       - name: Determine docker build params
+        id: params
         if: github.event.pull_request.head.repo.fork != true
         shell: bash
         run: |
@@ -181,6 +191,12 @@ jobs:
           echo "DOCKER_TAGS=$(echo "$DOCKER_BUILD_JSON" | jq -r '.tags | join(",")')" >> $GITHUB_ENV
           echo "DOCKER_PLATFORM=$(echo "$DOCKER_BUILD_JSON" | jq -r '.platform')" >> $GITHUB_ENV
           echo "DOCKER_BUILD_ARGS=$(echo "$DOCKER_BUILD_JSON" | jq -r '.build_args | join(",")')" >> $GITHUB_ENV
+
+          # Output base tags (without arch suffix) keyed by base_image tag for the merge job
+          BASE_TAGS=$(echo "$DOCKER_BUILD_JSON" | jq -r '.base_tags | join("\n")')
+          echo "base_tags_${{ matrix.base_image.tag }}<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$BASE_TAGS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Build and push runtime image ${{ matrix.base_image.image }}
         if: github.event.pull_request.head.repo.fork != true
         uses: docker/build-push-action@v6
@@ -209,21 +225,13 @@ jobs:
 
   # Merges per-architecture runtime images into multi-arch manifests
   ghcr_build_runtime_merge:
-    name: Merge Runtime Multi-Arch Manifest (${{ matrix.base_image.tag }})
+    name: Merge Runtime Multi-Arch Manifest
     runs-on: ubuntu-22.04
     needs: [define-matrix, ghcr_build_runtime]
     if: github.event.pull_request.head.repo.fork != true
     permissions:
-      contents: read
       packages: write
-    strategy:
-      matrix:
-        base_image: ${{ fromJson(needs.define-matrix.outputs.base_image) }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -232,33 +240,24 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Lowercase Repository Owner
-        run: |
-          echo REPO_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
-      - name: Install poetry via pipx
-        run: pipx install poetry
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: poetry
-      - name: Install Python dependencies using Poetry
-        run: make install-python-dependencies POETRY_GROUP=main INSTALL_PLAYWRIGHT=0
-      - name: Create source distribution and Dockerfile
-        run: poetry run python3 -m openhands.runtime.utils.runtime_build --base_image ${{ matrix.base_image.image }} --build_folder containers/runtime --force_rebuild
-      - name: Merge multi-arch manifest
+      - name: Merge multi-arch manifests
         run: |
           ARCHS='${{ join(fromJson(needs.define-matrix.outputs.architectures), ' ') }}'
-          TAGS=$(./containers/build.sh -i runtime -o ${{ env.REPO_OWNER }} -t ${{ matrix.base_image.tag }} --tags-only)
-          while IFS= read -r tag; do
-            [[ -z "$tag" ]] && continue
-            sources=""
-            for arch in $ARCHS; do
-              sources+=" ${tag}-${arch}"
-            done
-            echo "Creating manifest for $tag from:$sources"
-            docker buildx imagetools create -t "$tag" $sources
-          done <<< "$TAGS"
+
+          # Merge all runtime base_image variants
+          for variant_tags in \
+            "${{ needs.ghcr_build_runtime.outputs.base_tags_nikolaik }}" \
+            "${{ needs.ghcr_build_runtime.outputs.base_tags_ubuntu }}"; do
+            while IFS= read -r tag; do
+              [[ -z "$tag" ]] && continue
+              sources=""
+              for arch in $ARCHS; do
+                sources+=" ${tag}-${arch}"
+              done
+              echo "Creating manifest for $tag from:$sources"
+              docker buildx imagetools create -t "$tag" $sources
+            done <<< "$variant_tags"
+          done
 
   ghcr_build_enterprise:
     name: Push Enterprise Image (${{ matrix.arch }})
@@ -269,6 +268,9 @@ jobs:
     needs: [define-matrix, ghcr_build_app_merge]
     # Do not build enterprise in forks
     if: github.event.pull_request.head.repo.fork != true
+    outputs:
+      # Tags without arch suffix, for the merge job
+      base_tags: ${{ steps.meta_base.outputs.tags }}
     strategy:
       matrix:
         arch: ${{ fromJson(needs.define-matrix.outputs.architectures) }}
@@ -311,6 +313,29 @@ jobs:
             suffix=-${{ matrix.arch }}
         env:
           DOCKER_METADATA_PR_HEAD_SHA: true
+
+      # Also compute base tags (no arch suffix) for the merge job output
+      - name: Extract base metadata for merge
+        id: meta_base
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/openhands/enterprise-server
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=sha,format=long
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=match,pattern=cloud-\d+\.\d+\.\d+
+          flavor: |
+            latest=auto
+            prefix=
+            suffix=
+        env:
+          DOCKER_METADATA_PR_HEAD_SHA: true
+
       - name: Determine app image tag
         shell: bash
         run: |
@@ -338,16 +363,10 @@ jobs:
     name: Merge Enterprise Multi-Arch Manifest
     runs-on: ubuntu-22.04
     permissions:
-      contents: read
       packages: write
     needs: [define-matrix, ghcr_build_enterprise]
     if: github.event.pull_request.head.repo.fork != true
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -358,31 +377,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/openhands/enterprise-server
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha
-            type=sha,format=long
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=match,pattern=cloud-\d+\.\d+\.\d+
-          flavor: |
-            latest=auto
-            prefix=
-            suffix=
-        env:
-          DOCKER_METADATA_PR_HEAD_SHA: true
-
       - name: Merge multi-arch manifest
         run: |
           ARCHS='${{ join(fromJson(needs.define-matrix.outputs.architectures), ' ') }}'
-          TAGS="${{ steps.meta.outputs.tags }}"
+          TAGS="${{ needs.ghcr_build_enterprise.outputs.base_tags }}"
           while IFS= read -r tag; do
             [[ -z "$tag" ]] && continue
             sources=""

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
       - "saas-rel-*"
-      - "jl/enterprise-arm64-build"
+      - "jl/native-arm64-builds"
     tags:
       - "*"
   pull_request:

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -10,7 +10,6 @@ on:
     branches:
       - main
       - "saas-rel-*"
-      - "jl/native-arm64-builds"
     tags:
       - "*"
   pull_request:

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -123,6 +123,10 @@ jobs:
             [[ -z "$tag" ]] && continue
             sources=""
             for arch in $ARCHS; do
+              if ! docker buildx imagetools inspect "${tag}-${arch}" > /dev/null 2>&1; then
+                echo "::error::Missing image ${tag}-${arch}"
+                exit 1
+              fi
               sources+=" ${tag}-${arch}"
             done
             echo "Creating manifest for $tag from:$sources"
@@ -251,6 +255,10 @@ jobs:
               [[ -z "$tag" ]] && continue
               sources=""
               for arch in $ARCHS; do
+                if ! docker buildx imagetools inspect "${tag}-${arch}" > /dev/null 2>&1; then
+                  echo "::error::Missing image ${tag}-${arch}"
+                  exit 1
+                fi
                 sources+=" ${tag}-${arch}"
               done
               echo "Creating manifest for $tag from:$sources"
@@ -384,6 +392,10 @@ jobs:
             [[ -z "$tag" ]] && continue
             sources=""
             for arch in $ARCHS; do
+              if ! docker buildx imagetools inspect "${tag}-${arch}" > /dev/null 2>&1; then
+                echo "::error::Missing image ${tag}-${arch}"
+                exit 1
+              fi
               sources+=" ${tag}-${arch}"
             done
             echo "Creating manifest for $tag from:$sources"

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -48,7 +48,14 @@ if [[ -z "$image_name" ]]; then
     usage
 fi
 
-echo "Building: $image_name"
+# When --tags-only is set, redirect informational output to stderr so only tags go to stdout
+if [[ $tags_only -eq 1 ]]; then
+  log() { echo "$@" >&2; }
+else
+  log() { echo "$@"; }
+fi
+
+log "Building: $image_name"
 tags=()
 
 OPENHANDS_BUILD_VERSION="dev"
@@ -84,7 +91,7 @@ if [[ -n $tag_suffix ]]; then
   done
 fi
 
-echo "Tags (before arch suffix): ${tags[@]}"
+log "Tags (before arch suffix): ${tags[@]}"
 
 if [[ "$image_name" == "openhands" ]]; then
   dir="./containers/app"
@@ -131,9 +138,9 @@ fi
 
 DOCKER_REPOSITORY="$DOCKER_REGISTRY/$DOCKER_ORG/$DOCKER_IMAGE"
 DOCKER_REPOSITORY=${DOCKER_REPOSITORY,,} # lowercase
-echo "Repo: $DOCKER_REPOSITORY"
-echo "Base dir: $DOCKER_BASE_DIR"
-echo "Tags: ${tags[@]}"
+log "Repo: $DOCKER_REPOSITORY"
+log "Base dir: $DOCKER_BASE_DIR"
+log "Tags: ${tags[@]}"
 
 args=""
 full_tags=()

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -10,11 +10,10 @@ tag_suffix=""
 dry_run=0
 platform_override=""
 arch_suffix=""
-tags_only=0
 
 # Function to display usage information
 usage() {
-    echo "Usage: $0 -i <image_name> [-o <org_name>] [--push] [--load] [-t <tag_suffix>] [-p <platform>] [--dry] [--arch <arch>] [--tags-only]"
+    echo "Usage: $0 -i <image_name> [-o <org_name>] [--push] [--load] [-t <tag_suffix>] [-p <platform>] [--dry] [--arch <arch>]"
     echo "  -i: Image name (required)"
     echo "  -o: Organization name"
     echo "  --push: Push the image"
@@ -23,7 +22,6 @@ usage() {
     echo "  -p: Platform(s) to build for (e.g. linux/amd64 or linux/amd64,linux/arm64)"
     echo "  --dry: Don't build, only create build-args.json"
     echo "  --arch: Architecture suffix (e.g. amd64 or arm64). Appends -<arch> to tags and forces single-platform build"
-    echo "  --tags-only: Print final (non-arch-suffixed) fully-qualified tags and exit"
     exit 1
 }
 
@@ -38,7 +36,6 @@ while [[ $# -gt 0 ]]; do
         -p) platform_override="$2"; shift 2 ;;
         --dry) dry_run=1; shift ;;
         --arch) arch_suffix="$2"; shift 2 ;;
-        --tags-only) tags_only=1; shift ;;
         *) usage ;;
     esac
 done
@@ -48,14 +45,7 @@ if [[ -z "$image_name" ]]; then
     usage
 fi
 
-# When --tags-only is set, redirect informational output to stderr so only tags go to stdout
-if [[ $tags_only -eq 1 ]]; then
-  log() { echo "$@" >&2; }
-else
-  log() { echo "$@"; }
-fi
-
-log "Building: $image_name"
+echo "Building: $image_name"
 tags=()
 
 OPENHANDS_BUILD_VERSION="dev"
@@ -91,7 +81,7 @@ if [[ -n $tag_suffix ]]; then
   done
 fi
 
-log "Tags (before arch suffix): ${tags[@]}"
+echo "Tags (before arch suffix): ${tags[@]}"
 
 if [[ "$image_name" == "openhands" ]]; then
   dir="./containers/app"
@@ -138,9 +128,9 @@ fi
 
 DOCKER_REPOSITORY="$DOCKER_REGISTRY/$DOCKER_ORG/$DOCKER_IMAGE"
 DOCKER_REPOSITORY=${DOCKER_REPOSITORY,,} # lowercase
-log "Repo: $DOCKER_REPOSITORY"
-log "Base dir: $DOCKER_BASE_DIR"
-log "Tags: ${tags[@]}"
+echo "Repo: $DOCKER_REPOSITORY"
+echo "Base dir: $DOCKER_BASE_DIR"
+echo "Tags: ${tags[@]}"
 
 args=""
 full_tags=()
@@ -148,18 +138,6 @@ for tag in "${tags[@]}"; do
   args+=" -t $DOCKER_REPOSITORY:$tag"
   full_tags+=("$DOCKER_REPOSITORY:$tag")
 done
-
-# --tags-only: print final fully-qualified tags (without arch suffix) and exit
-if [[ $tags_only -eq 1 ]]; then
-  for ftag in "${full_tags[@]}"; do
-    if [[ -n "$arch_suffix" ]]; then
-      echo "${ftag%-${arch_suffix}}"
-    else
-      echo "$ftag"
-    fi
-  done
-  exit 0
-fi
 
 if [[ $push -eq 1 ]]; then
   args+=" --push"
@@ -184,13 +162,24 @@ else
 fi
 if [[ $dry_run -eq 1 ]]; then
   echo "Dry Run is enabled. Writing build config to docker-build-dry.json"
+  # Compute base tags (arch suffix stripped) for use by merge jobs
+  base_tags=()
+  for ftag in "${full_tags[@]}"; do
+    if [[ -n "$arch_suffix" ]]; then
+      base_tags+=("${ftag%-${arch_suffix}}")
+    else
+      base_tags+=("$ftag")
+    fi
+  done
   jq -n \
     --argjson tags "$(printf '%s\n' "${full_tags[@]}" | jq -R . | jq -s .)" \
+    --argjson base_tags "$(printf '%s\n' "${base_tags[@]}" | jq -R . | jq -s .)" \
     --arg platform "$platform" \
     --arg openhands_build_version "$OPENHANDS_BUILD_VERSION" \
     --arg dockerfile "$dir/Dockerfile" \
     '{
       tags: $tags,
+      base_tags: $base_tags,
       platform: $platform,
       build_args: [
         "OPENHANDS_BUILD_VERSION=" + $openhands_build_version

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -9,10 +9,12 @@ load=0
 tag_suffix=""
 dry_run=0
 platform_override=""
+arch_suffix=""
+tags_only=0
 
 # Function to display usage information
 usage() {
-    echo "Usage: $0 -i <image_name> [-o <org_name>] [--push] [--load] [-t <tag_suffix>] [-p <platform>] [--dry]"
+    echo "Usage: $0 -i <image_name> [-o <org_name>] [--push] [--load] [-t <tag_suffix>] [-p <platform>] [--dry] [--arch <arch>] [--tags-only]"
     echo "  -i: Image name (required)"
     echo "  -o: Organization name"
     echo "  --push: Push the image"
@@ -20,6 +22,8 @@ usage() {
     echo "  -t: Tag suffix"
     echo "  -p: Platform(s) to build for (e.g. linux/amd64 or linux/amd64,linux/arm64)"
     echo "  --dry: Don't build, only create build-args.json"
+    echo "  --arch: Architecture suffix (e.g. amd64 or arm64). Appends -<arch> to tags and forces single-platform build"
+    echo "  --tags-only: Print final (non-arch-suffixed) fully-qualified tags and exit"
     exit 1
 }
 
@@ -33,6 +37,8 @@ while [[ $# -gt 0 ]]; do
         -t) tag_suffix="$2"; shift 2 ;;
         -p) platform_override="$2"; shift 2 ;;
         --dry) dry_run=1; shift ;;
+        --arch) arch_suffix="$2"; shift 2 ;;
+        --tags-only) tags_only=1; shift ;;
         *) usage ;;
     esac
 done
@@ -78,7 +84,7 @@ if [[ -n $tag_suffix ]]; then
   done
 fi
 
-echo "Tags: ${tags[@]}"
+echo "Tags (before arch suffix): ${tags[@]}"
 
 if [[ "$image_name" == "openhands" ]]; then
   dir="./containers/app"
@@ -113,10 +119,21 @@ if [[ -n "$DOCKER_IMAGE_TAG" ]]; then
   tags+=("$DOCKER_IMAGE_TAG")
 fi
 
+# Apply architecture suffix for split-arch builds (after all tags are collected)
+if [[ -n "$arch_suffix" ]]; then
+  cache_tag+="-${arch_suffix}"
+  for i in "${!tags[@]}"; do
+    tags[$i]="${tags[$i]}-${arch_suffix}"
+  done
+  # Force single-platform build for this architecture
+  platform_override="linux/${arch_suffix}"
+fi
+
 DOCKER_REPOSITORY="$DOCKER_REGISTRY/$DOCKER_ORG/$DOCKER_IMAGE"
 DOCKER_REPOSITORY=${DOCKER_REPOSITORY,,} # lowercase
 echo "Repo: $DOCKER_REPOSITORY"
 echo "Base dir: $DOCKER_BASE_DIR"
+echo "Tags: ${tags[@]}"
 
 args=""
 full_tags=()
@@ -125,6 +142,17 @@ for tag in "${tags[@]}"; do
   full_tags+=("$DOCKER_REPOSITORY:$tag")
 done
 
+# --tags-only: print final fully-qualified tags (without arch suffix) and exit
+if [[ $tags_only -eq 1 ]]; then
+  for ftag in "${full_tags[@]}"; do
+    if [[ -n "$arch_suffix" ]]; then
+      echo "${ftag%-${arch_suffix}}"
+    else
+      echo "$ftag"
+    fi
+  done
+  exit 0
+fi
 
 if [[ $push -eq 1 ]]; then
   args+=" --push"
@@ -174,7 +202,7 @@ docker buildx build \
   $args \
   --build-arg OPENHANDS_BUILD_VERSION="$OPENHANDS_BUILD_VERSION" \
   --cache-from=type=registry,ref=$DOCKER_REPOSITORY:$cache_tag \
-  --cache-from=type=registry,ref=$DOCKER_REPOSITORY:$cache_tag_base-main \
+  --cache-from=type=registry,ref=$DOCKER_REPOSITORY:${cache_tag_base}-main${arch_suffix:+-${arch_suffix}} \
   --platform $platform \
   --provenance=false \
   -f "$dir/Dockerfile" \

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -8,18 +8,16 @@ push=0
 load=0
 tag_suffix=""
 dry_run=0
-platform_override=""
 arch_suffix=""
 
 # Function to display usage information
 usage() {
-    echo "Usage: $0 -i <image_name> [-o <org_name>] [--push] [--load] [-t <tag_suffix>] [-p <platform>] [--dry] [--arch <arch>]"
+    echo "Usage: $0 -i <image_name> [-o <org_name>] [--push] [--load] [-t <tag_suffix>] [--dry] [--arch <arch>]"
     echo "  -i: Image name (required)"
     echo "  -o: Organization name"
     echo "  --push: Push the image"
     echo "  --load: Load the image"
     echo "  -t: Tag suffix"
-    echo "  -p: Platform(s) to build for (e.g. linux/amd64 or linux/amd64,linux/arm64)"
     echo "  --dry: Don't build, only create build-args.json"
     echo "  --arch: Architecture suffix (e.g. amd64 or arm64). Appends -<arch> to tags and forces single-platform build"
     exit 1
@@ -33,7 +31,6 @@ while [[ $# -gt 0 ]]; do
         --push) push=1; shift ;;
         --load) load=1; shift ;;
         -t) tag_suffix="$2"; shift 2 ;;
-        -p) platform_override="$2"; shift 2 ;;
         --dry) dry_run=1; shift ;;
         --arch) arch_suffix="$2"; shift 2 ;;
         *) usage ;;
@@ -123,7 +120,7 @@ if [[ -n "$arch_suffix" ]]; then
     tags[$i]="${tags[$i]}-${arch_suffix}"
   done
   # Force single-platform build for this architecture
-  platform_override="linux/${arch_suffix}"
+  arch_platform="linux/${arch_suffix}"
 fi
 
 DOCKER_REPOSITORY="$DOCKER_REGISTRY/$DOCKER_ORG/$DOCKER_IMAGE"
@@ -151,8 +148,8 @@ fi
 echo "Args: $args"
 
 # Determine the platform(s) to build for
-if [[ -n "$platform_override" ]]; then
-  platform="$platform_override"
+if [[ -n "$arch_platform" ]]; then
+  platform="$arch_platform"
 elif [[ $load -eq 1 ]]; then
   # When loading, build only for the current platform
   platform=$(docker version -f '{{.Server.Os}}/{{.Server.Arch}}')


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

I'd like to be able to run the enterprise image in a self-hosted K8S cluster on my mac, without using emulation, but we only publish AMD64 images today.

For the other images that we publish, ARM64 Docker images are built via QEMU emulation on x86 runners, which is slower than native ARM64 runners.

This PR updates the Github actions pipeline to build ARM64 images for all the images that we publish. It now builds both architectures separately on native runners, then merges the results and publishes a multi-arch manifest.

## Summary

  - Replace QEMU emulation with native ARM64 runners using a split-build-then-merge pattern
  - Add ARM64 support to the enterprise image (previously amd64-only)
  - Build both architectures on PRs (native builds are fast enough at ~4 min total)
 
## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

CI has been run end-to-end on this branch. To verify the multi-arch manifests:
```
docker buildx imagetools inspect ghcr.io/openhands/openhands:
```
Should show both `linux/amd64` and `linux/arm64` platforms. 


To verify native ARM64 execution on an Apple Silicon Mac:
```
docker run --rm ghcr.io/openhands/openhands: python3 -c "import platform; print(platform.machine())"
```
Should print `aarch64` (not `x86_64` under Rosetta/QEMU).

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:3f9b5cc-nikolaik   --name openhands-app-3f9b5cc   docker.openhands.dev/openhands/openhands:3f9b5cc
```