### PR TITLE
Update Linear integration to use V1 conversations

### DIFF
--- a/enterprise/integrations/linear/linear_manager.py
+++ b/enterprise/integrations/linear/linear_manager.py
@@ -8,7 +8,6 @@ from integrations.linear.linear_types import LinearViewInterface
 from integrations.linear.linear_view import (
     LinearExistingConversationView,
     LinearFactory,
-    LinearNewConversationView,
 )
 from integrations.manager import Manager
 from integrations.models import JobContext, Message
@@ -21,7 +20,6 @@ from integrations.utils import (
 from jinja2 import Environment, FileSystemLoader
 from server.auth.saas_user_auth import get_user_auth_from_keycloak_id
 from server.auth.token_manager import TokenManager
-from server.utils.conversation_callback_utils import register_callback_processor
 from storage.linear_integration_store import LinearIntegrationStore
 from storage.linear_user import LinearUser
 from storage.linear_workspace import LinearWorkspace
@@ -285,12 +283,18 @@ class LinearManager(Manager[LinearViewInterface]):
             return
 
         try:
+            # Decrypt the API key for the V1 callback processor
+            decrypted_api_key = self.token_manager.decrypt_text(
+                workspace.svc_acc_api_key
+            )
+
             # Create Linear view
             linear_view = await LinearFactory.create_linear_view_from_payload(
                 job_context,
                 saas_user_auth,
                 linear_user,
                 workspace,
+                decrypted_api_key=decrypted_api_key,
             )
         except Exception as e:
             logger.error(
@@ -344,12 +348,11 @@ class LinearManager(Manager[LinearViewInterface]):
             return False
 
     async def start_job(self, linear_view: LinearViewInterface) -> None:
-        """Start a Linear job/conversation."""
-        # Import here to prevent circular import
-        from server.conversation_callback_processor.linear_callback_processor import (
-            LinearCallbackProcessor,
-        )
+        """Start a Linear job/conversation.
 
+        For new conversations, the V1 callback processor is registered automatically
+        by passing it to AppConversationStartRequest.processors in the view.
+        """
         try:
             user_info: LinearUser = linear_view.linear_user
             logger.info(
@@ -357,7 +360,7 @@ class LinearManager(Manager[LinearViewInterface]):
                 f'issue {linear_view.job_context.issue_key}',
             )
 
-            # Create conversation
+            # Create conversation (V1 callback processor is registered in the view)
             conversation_id = await linear_view.create_or_update_conversation(
                 self.jinja_env
             )
@@ -365,21 +368,6 @@ class LinearManager(Manager[LinearViewInterface]):
             logger.info(
                 f'[Linear] Created/Updated conversation {conversation_id} for issue {linear_view.job_context.issue_key}'
             )
-
-            if isinstance(linear_view, LinearNewConversationView):
-                # Register callback processor for updates
-                processor = LinearCallbackProcessor(
-                    issue_id=linear_view.job_context.issue_id,
-                    issue_key=linear_view.job_context.issue_key,
-                    workspace_name=linear_view.linear_workspace.name,
-                )
-
-                # Register the callback processor
-                register_callback_processor(conversation_id, processor)
-
-                logger.info(
-                    f'[Linear] Created callback processor for conversation {conversation_id}'
-                )
 
             # Send initial response
             msg_info = linear_view.get_response_msg()

--- a/enterprise/integrations/linear/linear_v1_callback_processor.py
+++ b/enterprise/integrations/linear/linear_v1_callback_processor.py
@@ -1,0 +1,248 @@
+import logging
+from uuid import UUID
+
+import httpx
+from integrations.utils import get_summary_instruction
+from pydantic import Field
+
+from openhands.agent_server.models import AskAgentRequest, AskAgentResponse
+from openhands.app_server.event_callback.event_callback_models import (
+    EventCallback,
+    EventCallbackProcessor,
+)
+from openhands.app_server.event_callback.event_callback_result_models import (
+    EventCallbackResult,
+    EventCallbackResultStatus,
+)
+from openhands.app_server.event_callback.util import (
+    ensure_conversation_found,
+    ensure_running_sandbox,
+    get_agent_server_url_from_sandbox,
+)
+from openhands.sdk import Event
+from openhands.sdk.event import ConversationStateUpdateEvent
+from openhands.utils.http_session import httpx_verify_option
+
+_logger = logging.getLogger(__name__)
+
+LINEAR_API_URL = 'https://api.linear.app/graphql'
+
+
+class LinearV1CallbackProcessor(EventCallbackProcessor):
+    """Callback processor for Linear V1 integrations."""
+
+    should_request_summary: bool = Field(default=True)
+    decrypted_api_key: str
+    issue_id: str
+    issue_key: str
+    workspace_name: str
+
+    async def __call__(
+        self,
+        conversation_id: UUID,
+        callback: EventCallback,
+        event: Event,
+    ) -> EventCallbackResult | None:
+        """Process events for Linear V1 integration."""
+        # Only handle ConversationStateUpdateEvent for execution_status
+        if not isinstance(event, ConversationStateUpdateEvent):
+            return None
+
+        if event.key != 'execution_status':
+            return None
+
+        _logger.info('[Linear] Callback agent state was %s', event)
+
+        # Only request summary when execution has finished successfully
+        if event.value != 'finished':
+            return None
+
+        _logger.info('[Linear] Should request summary: %s', self.should_request_summary)
+
+        if not self.should_request_summary:
+            return None
+
+        self.should_request_summary = False
+
+        try:
+            _logger.info(f'[Linear] Requesting summary {conversation_id}')
+            summary = await self._request_summary(conversation_id)
+            _logger.info(
+                f'[Linear] Posting summary {conversation_id}',
+                extra={'summary': summary},
+            )
+            await self._post_summary_to_linear(summary)
+
+            return EventCallbackResult(
+                status=EventCallbackResultStatus.SUCCESS,
+                event_callback_id=callback.id,
+                event_id=event.id,
+                conversation_id=conversation_id,
+                detail=summary,
+            )
+        except Exception as e:
+            _logger.exception(f'[Linear] Failed to post summary: {e}', stack_info=True)
+            return EventCallbackResult(
+                status=EventCallbackResultStatus.ERROR,
+                event_callback_id=callback.id,
+                event_id=event.id,
+                conversation_id=conversation_id,
+                detail=str(e),
+            )
+
+    async def _request_summary(self, conversation_id: UUID) -> str:
+        """Ask the agent to produce a summary of its work and return the agent response."""
+        # Import services within the method to avoid circular imports
+        from openhands.app_server.config import (
+            get_app_conversation_info_service,
+            get_httpx_client,
+            get_sandbox_service,
+        )
+        from openhands.app_server.services.injector import InjectorState
+        from openhands.app_server.user.specifiy_user_context import (
+            ADMIN,
+            USER_CONTEXT_ATTR,
+        )
+
+        # Create injector state for dependency injection
+        state = InjectorState()
+        setattr(state, USER_CONTEXT_ATTR, ADMIN)
+
+        async with (
+            get_app_conversation_info_service(state) as app_conversation_info_service,
+            get_sandbox_service(state) as sandbox_service,
+            get_httpx_client(state) as httpx_client,
+        ):
+            # 1. Conversation lookup
+            app_conversation_info = ensure_conversation_found(
+                await app_conversation_info_service.get_app_conversation_info(
+                    conversation_id
+                ),
+                conversation_id,
+            )
+
+            # 2. Sandbox lookup + validation
+            sandbox = ensure_running_sandbox(
+                await sandbox_service.get_sandbox(app_conversation_info.sandbox_id),
+                app_conversation_info.sandbox_id,
+            )
+
+            assert (
+                sandbox.session_api_key is not None
+            ), f'No session API key for sandbox: {sandbox.id}'
+
+            # 3. URL + instruction
+            agent_server_url = get_agent_server_url_from_sandbox(sandbox)
+
+            # Prepare message based on agent state
+            message_content = get_summary_instruction()
+
+            # Ask the agent and return the response text
+            return await self._ask_question(
+                httpx_client=httpx_client,
+                agent_server_url=agent_server_url,
+                conversation_id=conversation_id,
+                session_api_key=sandbox.session_api_key,
+                message_content=message_content,
+            )
+
+    async def _ask_question(
+        self,
+        httpx_client: httpx.AsyncClient,
+        agent_server_url: str,
+        conversation_id: UUID,
+        session_api_key: str,
+        message_content: str,
+    ) -> str:
+        """Send a message to the agent server via the V1 API and return response text."""
+        send_message_request = AskAgentRequest(question=message_content)
+
+        url = (
+            f"{agent_server_url.rstrip('/')}"
+            f"/api/conversations/{conversation_id}/ask_agent"
+        )
+        headers = {'X-Session-API-Key': session_api_key}
+        payload = send_message_request.model_dump()
+
+        try:
+            response = await httpx_client.post(
+                url,
+                json=payload,
+                headers=headers,
+                timeout=30.0,
+            )
+            response.raise_for_status()
+
+            agent_response = AskAgentResponse.model_validate(response.json())
+            return agent_response.response
+
+        except httpx.HTTPStatusError as e:
+            error_detail = f'HTTP {e.response.status_code} error'
+            try:
+                error_body = e.response.text
+                if error_body:
+                    error_detail += f': {error_body}'
+            except Exception:
+                pass
+
+            _logger.exception(
+                '[Linear] HTTP error sending message to %s: %s. '
+                'Request payload: %s. Response headers: %s',
+                url,
+                error_detail,
+                payload,
+                dict(e.response.headers),
+                stack_info=True,
+            )
+            raise Exception(f'Failed to send message to agent server: {error_detail}')
+
+        except httpx.TimeoutException:
+            error_detail = f'Request timeout after 30 seconds to {url}'
+            _logger.exception(
+                '[Linear] Timeout error: %s. Request payload: %s',
+                error_detail,
+                payload,
+                stack_info=True,
+            )
+            raise Exception(f'Failed to send message to agent server: {error_detail}')
+
+    async def _post_summary_to_linear(self, summary: str):
+        """Post the summary back to the Linear issue."""
+        if not all(
+            [
+                self.decrypted_api_key,
+                self.issue_id,
+                self.issue_key,
+            ]
+        ):
+            _logger.warning('[Linear] Missing required data for posting summary')
+            return
+
+        message = f'OpenHands resolved this issue:\n\n{summary}'
+
+        # Use Linear GraphQL API to create a comment
+        query = """
+            mutation CommentCreate($input: CommentCreateInput!) {
+              commentCreate(input: $input) {
+                success
+                comment {
+                  id
+                }
+              }
+            }
+        """
+        variables = {'input': {'issueId': self.issue_id, 'body': message}}
+
+        async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
+            response = await client.post(
+                LINEAR_API_URL,
+                headers={'Authorization': self.decrypted_api_key},
+                json={'query': query, 'variables': variables},
+            )
+            response.raise_for_status()
+
+            result = response.json()
+            if result.get('errors'):
+                raise Exception(f"Linear API error: {result['errors']}")
+
+            _logger.info(f'[Linear] Posted summary to {self.issue_key}')

--- a/enterprise/integrations/linear/linear_view.py
+++ b/enterprise/integrations/linear/linear_view.py
@@ -1,46 +1,66 @@
-from dataclasses import dataclass
-from uuid import uuid4
+"""Linear view implementations and factory.
+
+Views are responsible for:
+- Holding the webhook payload and auth context
+- Creating conversations with the selected repository
+"""
+
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
 
 from integrations.linear.linear_types import LinearViewInterface, StartingConvoException
+from integrations.linear.linear_v1_callback_processor import LinearV1CallbackProcessor
 from integrations.models import JobContext
+from integrations.resolver_context import ResolverUserContext
 from integrations.resolver_org_router import resolve_org_for_repo
-from integrations.utils import CONVERSATION_URL, get_final_agent_observation
+from integrations.utils import CONVERSATION_URL
 from jinja2 import Environment
-from server.config import get_config
 from storage.linear_conversation import LinearConversation
 from storage.linear_integration_store import LinearIntegrationStore
 from storage.linear_user import LinearUser
 from storage.linear_workspace import LinearWorkspace
-from storage.saas_conversation_store import SaasConversationStore
 
-from openhands.core.logger import openhands_logger as logger
-from openhands.core.schema.agent import AgentState
-from openhands.events.action import MessageAction
-from openhands.events.serialization.event import event_to_dict
-from openhands.integrations.provider import ProviderHandler
-from openhands.server.services.conversation_service import (
-    setup_init_conversation_settings,
-    start_conversation,
+from openhands.agent_server.models import SendMessageRequest
+from openhands.app_server.app_conversation.app_conversation_models import (
+    AppConversationStartRequest,
+    AppConversationStartTaskStatus,
 )
-from openhands.server.shared import ConversationStoreImpl, config, conversation_manager
+from openhands.app_server.config import get_app_conversation_service
+from openhands.app_server.services.injector import InjectorState
+from openhands.app_server.user.specifiy_user_context import USER_CONTEXT_ATTR
+from openhands.core.logger import openhands_logger as logger
+from openhands.integrations.provider import ProviderHandler
+from openhands.integrations.service_types import ProviderType
+from openhands.sdk import TextContent
 from openhands.server.user_auth.user_auth import UserAuth
 from openhands.storage.data_models.conversation_metadata import (
     ConversationMetadata,
     ConversationTrigger,
 )
-from openhands.utils.conversation_summary import get_default_conversation_title
 
 integration_store = LinearIntegrationStore.get_instance()
 
 
 @dataclass
 class LinearNewConversationView(LinearViewInterface):
+    """View for creating a new Linear conversation.
+
+    This view holds the job context directly and creates V1 conversations
+    using the app conversation service.
+    """
+
     job_context: JobContext
     saas_user_auth: UserAuth
     linear_user: LinearUser
     linear_workspace: LinearWorkspace
     selected_repo: str | None
     conversation_id: str
+
+    # Decrypted API key (set by manager)
+    _decrypted_api_key: str = field(default='', repr=False)
+
+    # Resolved org ID for V1 conversations
+    resolved_org_id: UUID | None = None
 
     async def _get_instructions(self, jinja_env: Environment) -> tuple[str, str]:
         """Instructions passed when conversation is first initialized"""
@@ -60,99 +80,155 @@ class LinearNewConversationView(LinearViewInterface):
         return instructions, user_msg
 
     async def create_or_update_conversation(self, jinja_env: Environment) -> str:
-        """Create a new Linear conversation"""
+        """Create a new Linear conversation using V1 system."""
 
         if not self.selected_repo:
             raise StartingConvoException('No repository selected for this conversation')
 
+        # Store Linear conversation mapping first
+        linear_conversation = LinearConversation(
+            conversation_id=self.conversation_id,
+            issue_id=self.job_context.issue_id,
+            issue_key=self.job_context.issue_key,
+            linear_user_id=self.linear_user.id,
+        )
+        await integration_store.create_conversation(linear_conversation)
+
+        # Create V1 conversation
+        conversation_metadata = await self._create_v1_metadata()
+        await self._create_v1_conversation(jinja_env, conversation_metadata)
+        return self.conversation_id
+
+    async def _create_v1_metadata(self) -> ConversationMetadata:
+        """Create conversation metadata for V1 conversations.
+
+        The LinearConversation mapping is saved to the integration store (above), but
+        V1 conversation metadata is managed by the app conversation system, not
+        the legacy conversation store.
+        """
+        logger.info('[Linear]: Creating V1 metadata')
+
+        # Generate a conversation ID for V1
+        self.conversation_id = uuid4().hex
+        self.resolved_org_id = await self._get_resolved_org_id()
+
+        return ConversationMetadata(
+            conversation_id=self.conversation_id,
+            selected_repository=self.selected_repo,
+        )
+
+    async def _create_v1_conversation(
+        self,
+        jinja_env: Environment,
+        conversation_metadata: ConversationMetadata,
+    ):
+        """Create conversation using the new V1 app conversation system."""
+        logger.info('[Linear]: Creating V1 conversation')
+
+        initial_user_text = await self._get_v1_initial_user_message(jinja_env)
+
+        # Create the initial message request
+        initial_message = SendMessageRequest(
+            role='user', content=[TextContent(text=initial_user_text)]
+        )
+
+        # Create the Linear V1 callback processor
+        linear_callback_processor = self._create_linear_v1_callback_processor()
+
+        injector_state = InjectorState()
+
+        # Resolve git provider for the repository
+        git_provider = await self._resolve_git_provider()
+
+        # Create the V1 conversation start request
+        start_request = AppConversationStartRequest(
+            conversation_id=UUID(conversation_metadata.conversation_id),
+            system_message_suffix=None,
+            initial_message=initial_message,
+            selected_repository=self.selected_repo,
+            selected_branch=None,
+            git_provider=git_provider,
+            title=f'Linear Issue {self.job_context.issue_key}: {self.job_context.issue_title or "Unknown"}',
+            trigger=ConversationTrigger.LINEAR,
+            processors=[linear_callback_processor],
+        )
+
+        # Set up the Linear user context for the V1 system
+        linear_user_context = ResolverUserContext(
+            saas_user_auth=self.saas_user_auth,
+            resolver_org_id=self.resolved_org_id,
+        )
+        setattr(injector_state, USER_CONTEXT_ATTR, linear_user_context)
+
+        async with get_app_conversation_service(
+            injector_state
+        ) as app_conversation_service:
+            async for task in app_conversation_service.start_app_conversation(
+                start_request
+            ):
+                if task.status == AppConversationStartTaskStatus.ERROR:
+                    logger.error(f'Failed to start V1 conversation: {task.detail}')
+                    raise RuntimeError(
+                        f'Failed to start V1 conversation: {task.detail}'
+                    )
+
+    async def _get_v1_initial_user_message(self, jinja_env: Environment) -> str:
+        """Build the initial user message for V1 conversations."""
+        user_msg_template = jinja_env.get_template('linear_new_conversation.j2')
+        user_msg = user_msg_template.render(
+            issue_key=self.job_context.issue_key,
+            issue_title=self.job_context.issue_title,
+            issue_description=self.job_context.issue_description,
+            user_message=self.job_context.user_msg or '',
+        )
+
+        return user_msg
+
+    def _create_linear_v1_callback_processor(self):
+        """Create a V1 callback processor for Linear integration."""
+        return LinearV1CallbackProcessor(
+            decrypted_api_key=self._decrypted_api_key,
+            issue_id=self.job_context.issue_id,
+            issue_key=self.job_context.issue_key,
+            workspace_name=self.linear_workspace.name,
+        )
+
+    async def _resolve_git_provider(self) -> ProviderType | None:
+        """Resolve the git provider for the repository."""
         provider_tokens = await self.saas_user_auth.get_provider_tokens()
-        user_secrets = await self.saas_user_auth.get_secrets()
-        instructions, user_msg = await self._get_instructions(jinja_env)
+        if not provider_tokens or not self.selected_repo:
+            return None
 
         try:
-            user_id = self.linear_user.keycloak_user_id
-
-            # Resolve git provider from repository
-            resolved_git_provider = None
-            if provider_tokens:
-                try:
-                    provider_handler = ProviderHandler(provider_tokens)
-                    repository = await provider_handler.verify_repo_provider(
-                        self.selected_repo
-                    )
-                    resolved_git_provider = repository.git_provider
-                except Exception as e:
-                    logger.warning(
-                        f'[Linear] Failed to resolve git provider for {self.selected_repo}: {e}'
-                    )
-
-            # Resolve target org based on claimed git organizations
-            resolved_org_id = None
-            if resolved_git_provider and self.selected_repo:
-                try:
-                    resolved_org_id = await resolve_org_for_repo(
-                        provider=resolved_git_provider.value,
-                        full_repo_name=self.selected_repo,
-                        keycloak_user_id=user_id,
-                    )
-                except Exception as e:
-                    logger.warning(
-                        f'[Linear] Failed to resolve org for {self.selected_repo}: {e}'
-                    )
-
-            # Create the conversation store with resolver org routing
-            # (bypasses initialize_conversation to avoid threading enterprise-only
-            # resolver_org_id through the generic OSS interface)
-            store = await SaasConversationStore.get_resolver_instance(
-                get_config(),
-                user_id,
-                resolved_org_id,
-            )
-
-            conversation_id = uuid4().hex
-            conversation_metadata = ConversationMetadata(
-                trigger=ConversationTrigger.LINEAR,
-                conversation_id=conversation_id,
-                title=get_default_conversation_title(conversation_id),
-                user_id=user_id,
-                selected_repository=self.selected_repo,
-                selected_branch=None,
-                git_provider=resolved_git_provider,
-            )
-            await store.save_metadata(conversation_metadata)
-
-            await start_conversation(
-                user_id=user_id,
-                git_provider_tokens=provider_tokens,
-                custom_secrets=user_secrets.custom_secrets if user_secrets else None,
-                initial_user_msg=user_msg,
-                image_urls=None,
-                replay_json=None,
-                conversation_id=conversation_id,
-                conversation_metadata=conversation_metadata,
-                conversation_instructions=instructions,
-            )
-
-            self.conversation_id = conversation_id
-
-            logger.info(f'[Linear] Created conversation {self.conversation_id}')
-
-            # Store Linear conversation mapping
-            linear_conversation = LinearConversation(
-                conversation_id=self.conversation_id,
-                issue_id=self.job_context.issue_id,
-                issue_key=self.job_context.issue_key,
-                linear_user_id=self.linear_user.id,
-            )
-
-            await integration_store.create_conversation(linear_conversation)
-
-            return self.conversation_id
+            provider_handler = ProviderHandler(provider_tokens)
+            repository = await provider_handler.verify_repo_provider(self.selected_repo)
+            return repository.git_provider
         except Exception as e:
-            logger.error(
-                f'[Linear] Failed to create conversation: {str(e)}', exc_info=True
+            logger.warning(
+                f'[Linear] Failed to resolve git provider for {self.selected_repo}: {e}'
             )
-            raise StartingConvoException(f'Failed to create conversation: {str(e)}')
+            return None
+
+    async def _get_resolved_org_id(self) -> UUID | None:
+        """Resolve the org ID for V1 conversations."""
+        provider_tokens = await self.saas_user_auth.get_provider_tokens()
+        if not provider_tokens or not self.selected_repo:
+            return None
+
+        try:
+            provider_handler = ProviderHandler(provider_tokens)
+            repository = await provider_handler.verify_repo_provider(self.selected_repo)
+            resolved_org_id = await resolve_org_for_repo(
+                provider=repository.git_provider.value,
+                full_repo_name=self.selected_repo,
+                keycloak_user_id=self.linear_user.keycloak_user_id,
+            )
+            return resolved_org_id
+        except Exception as e:
+            logger.warning(
+                f'[Linear] Failed to resolve org for {self.selected_repo}: {e}'
+            )
+            return None
 
     def get_response_msg(self) -> str:
         """Get the response message to send back to Linear"""
@@ -162,6 +238,12 @@ class LinearNewConversationView(LinearViewInterface):
 
 @dataclass
 class LinearExistingConversationView(LinearViewInterface):
+    """View for updating an existing Linear conversation.
+
+    This view handles follow-up messages to existing conversations
+    using the V1 app conversation system.
+    """
+
     job_context: JobContext
     saas_user_auth: UserAuth
     linear_user: LinearUser
@@ -183,61 +265,94 @@ class LinearExistingConversationView(LinearViewInterface):
         return '', user_msg
 
     async def create_or_update_conversation(self, jinja_env: Environment) -> str:
-        """Update an existing Linear conversation"""
-
-        user_id = self.linear_user.keycloak_user_id
+        """Update an existing Linear conversation using V1 system."""
+        logger.info(f'[Linear] Updating existing conversation {self.conversation_id}')
 
         try:
-            conversation_store = await ConversationStoreImpl.get_instance(
-                config, user_id
-            )
-
-            try:
-                await conversation_store.get_metadata(self.conversation_id)
-            except FileNotFoundError:
-                raise StartingConvoException('Conversation no longer exists.')
-
-            provider_tokens = await self.saas_user_auth.get_provider_tokens()
-            if provider_tokens is None:
-                raise ValueError('Could not load provider tokens')
-            providers_set = list(provider_tokens.keys())
-
-            conversation_init_data = await setup_init_conversation_settings(
-                user_id, self.conversation_id, providers_set
-            )
-
-            # Either join ongoing conversation, or restart the conversation
-            agent_loop_info = await conversation_manager.maybe_start_agent_loop(
-                self.conversation_id, conversation_init_data, user_id
-            )
-
-            if agent_loop_info.event_store is None:
-                raise StartingConvoException('Event store not available')
-
-            final_agent_observation = get_final_agent_observation(
-                agent_loop_info.event_store
-            )
-            agent_state = (
-                None
-                if len(final_agent_observation) == 0
-                else final_agent_observation[0].agent_state
-            )
-
-            if not agent_state or agent_state == AgentState.LOADING:
-                raise StartingConvoException('Conversation is still starting')
-
+            sandbox = await self._get_running_sandbox()
             _, user_msg = await self._get_instructions(jinja_env)
-            user_message_event = MessageAction(content=user_msg)
-            await conversation_manager.send_event_to_conversation(
-                self.conversation_id, event_to_dict(user_message_event)
-            )
-
+            await self._send_followup_message(sandbox, user_msg)
             return self.conversation_id
+
+        except StartingConvoException:
+            raise
         except Exception as e:
             logger.error(
-                f'[Linear] Failed to create conversation: {str(e)}', exc_info=True
+                f'[Linear] Failed to update conversation: {str(e)}', exc_info=True
             )
-            raise StartingConvoException(f'Failed to create conversation: {str(e)}')
+            raise StartingConvoException(f'Failed to update conversation: {str(e)}')
+
+    async def _get_running_sandbox(self):
+        """Get the running sandbox for the conversation."""
+        from openhands.app_server.config import (
+            get_app_conversation_info_service,
+            get_sandbox_service,
+        )
+        from openhands.app_server.user.specifiy_user_context import ADMIN
+
+        # Set up admin context for V1 API calls
+        injector_state = InjectorState()
+        setattr(injector_state, USER_CONTEXT_ATTR, ADMIN)
+
+        async with get_app_conversation_info_service(
+            injector_state
+        ) as app_conversation_info_service:
+            # Check if conversation exists
+            conversation_info = (
+                await app_conversation_info_service.get_app_conversation_info(
+                    UUID(self.conversation_id)
+                )
+            )
+            if not conversation_info:
+                raise StartingConvoException('Conversation no longer exists.')
+
+            async with get_sandbox_service(injector_state) as sandbox_service:
+                # Check sandbox is running
+                sandbox = await sandbox_service.get_sandbox(
+                    conversation_info.sandbox_id
+                )
+                if not sandbox or sandbox.status != 'running':
+                    raise StartingConvoException(
+                        'Conversation sandbox is not available.'
+                    )
+                return sandbox  # type: ignore[unreachable]
+
+    async def _send_followup_message(self, sandbox, message: str):
+        """Send a follow-up message to an existing conversation via V1 API."""
+        import httpx
+
+        from openhands.app_server.event_callback.util import (
+            get_agent_server_url_from_sandbox,
+        )
+        from openhands.utils.http_session import httpx_verify_option
+
+        if not sandbox.session_api_key:
+            raise StartingConvoException('No session API key for sandbox')
+
+        agent_server_url = get_agent_server_url_from_sandbox(sandbox)
+        url = (
+            f"{agent_server_url.rstrip('/')}"
+            f"/api/conversations/{self.conversation_id}/send-message"
+        )
+        headers = {'X-Session-API-Key': sandbox.session_api_key}
+
+        # Create the message request
+        message_request = SendMessageRequest(
+            role='user', content=[TextContent(text=message)]
+        )
+
+        async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
+            response = await client.post(
+                url,
+                json=message_request.model_dump(),
+                headers=headers,
+                timeout=30.0,
+            )
+            response.raise_for_status()
+
+        logger.info(
+            f'[Linear] Sent follow-up message to conversation {self.conversation_id}'
+        )
 
     def get_response_msg(self) -> str:
         """Get the response message to send back to Linear"""
@@ -246,7 +361,12 @@ class LinearExistingConversationView(LinearViewInterface):
 
 
 class LinearFactory:
-    """Factory for creating Linear views based on message content"""
+    """Factory for creating Linear views based on message content.
+
+    The factory is responsible for:
+    - Creating the appropriate view type (new or existing conversation)
+    - Looking up existing conversations for the issue
+    """
 
     @staticmethod
     async def create_linear_view_from_payload(
@@ -254,9 +374,20 @@ class LinearFactory:
         saas_user_auth: UserAuth,
         linear_user: LinearUser,
         linear_workspace: LinearWorkspace,
+        decrypted_api_key: str = '',
     ) -> LinearViewInterface:
-        """Create appropriate Linear view based on the message and user state"""
+        """Create appropriate Linear view based on the message and user state.
 
+        Args:
+            job_context: The job context with issue details
+            saas_user_auth: OpenHands user authentication
+            linear_user: The Linear user
+            linear_workspace: The Linear workspace
+            decrypted_api_key: Decrypted service account API key
+
+        Returns:
+            A LinearViewInterface for the appropriate conversation type
+        """
         if not linear_user or not saas_user_auth or not linear_workspace:
             raise StartingConvoException(
                 'User not authenticated with Linear integration'
@@ -285,4 +416,5 @@ class LinearFactory:
             linear_workspace=linear_workspace,
             selected_repo=None,  # Will be set later after repo inference
             conversation_id='',  # Will be set when conversation is created
+            _decrypted_api_key=decrypted_api_key,
         )

--- a/enterprise/tests/unit/integrations/linear/conftest.py
+++ b/enterprise/tests/unit/integrations/linear/conftest.py
@@ -152,7 +152,7 @@ def mock_jinja_env():
 def linear_conversation():
     """Sample Linear conversation for testing"""
     return LinearConversation(
-        conversation_id='conv-123',
+        conversation_id='12345678123456781234567812345678',  # Valid UUID hex string
         issue_id='test_issue_id',
         issue_key='TEST-123',
         linear_user_id='linear-user-123',
@@ -170,7 +170,7 @@ def new_conversation_view(
         linear_user=sample_linear_user,
         linear_workspace=sample_linear_workspace,
         selected_repo='test/repo1',
-        conversation_id='conv-123',
+        conversation_id='12345678123456781234567812345678',  # Valid UUID hex string
     )
 
 
@@ -185,7 +185,7 @@ def existing_conversation_view(
         linear_user=sample_linear_user,
         linear_workspace=sample_linear_workspace,
         selected_repo='test/repo1',
-        conversation_id='conv-123',
+        conversation_id='12345678123456781234567812345678',  # Valid UUID hex string
     )
 
 

--- a/enterprise/tests/unit/integrations/linear/test_linear_manager.py
+++ b/enterprise/tests/unit/integrations/linear/test_linear_manager.py
@@ -738,17 +738,11 @@ class TestStartJob:
         linear_manager.send_message = AsyncMock()
         linear_manager.token_manager.decrypt_text.return_value = 'decrypted_key'
 
-        with patch(
-            'integrations.linear.linear_manager.register_callback_processor'
-        ) as mock_register:
-            with patch(
-                'server.conversation_callback_processor.linear_callback_processor.LinearCallbackProcessor'
-            ):
-                await linear_manager.start_job(mock_view)
+        # V1 callback processor is registered in the view, not the manager
+        await linear_manager.start_job(mock_view)
 
-                mock_view.create_or_update_conversation.assert_called_once()
-                mock_register.assert_called_once()
-                linear_manager.send_message.assert_called_once()
+        mock_view.create_or_update_conversation.assert_called_once()
+        linear_manager.send_message.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_start_job_success_existing_conversation(
@@ -768,15 +762,10 @@ class TestStartJob:
         linear_manager.send_message = AsyncMock()
         linear_manager.token_manager.decrypt_text.return_value = 'decrypted_key'
 
-        with patch(
-            'integrations.linear.linear_manager.register_callback_processor'
-        ) as mock_register:
-            await linear_manager.start_job(mock_view)
+        await linear_manager.start_job(mock_view)
 
-            mock_view.create_or_update_conversation.assert_called_once()
-            # Should not register callback for existing conversation
-            mock_register.assert_not_called()
-            linear_manager.send_message.assert_called_once()
+        mock_view.create_or_update_conversation.assert_called_once()
+        linear_manager.send_message.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_start_job_missing_settings_error(
@@ -901,9 +890,8 @@ class TestStartJob:
         linear_manager.send_message = AsyncMock(side_effect=Exception('Send failed'))
         linear_manager.token_manager.decrypt_text.return_value = 'decrypted_key'
 
-        with patch('integrations.linear.linear_manager.register_callback_processor'):
-            # Should not raise exception even if send_message fails
-            await linear_manager.start_job(mock_view)
+        # Should not raise exception even if send_message fails
+        await linear_manager.start_job(mock_view)
 
 
 class TestQueryApi:

--- a/enterprise/tests/unit/integrations/linear/test_linear_v1_callback_processor.py
+++ b/enterprise/tests/unit/integrations/linear/test_linear_v1_callback_processor.py
@@ -1,0 +1,388 @@
+"""Tests for LinearV1CallbackProcessor.
+
+This module tests the V1 callback processor that handles Linear integration
+callbacks when conversations complete.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+from integrations.linear.linear_v1_callback_processor import (
+    LINEAR_API_URL,
+    LinearV1CallbackProcessor,
+)
+
+from openhands.app_server.event_callback.event_callback_models import EventCallback
+from openhands.app_server.event_callback.event_callback_result_models import (
+    EventCallbackResultStatus,
+)
+from openhands.sdk.event import ConversationStateUpdateEvent
+
+
+@pytest.fixture
+def callback_processor():
+    """Create a LinearV1CallbackProcessor for testing."""
+    return LinearV1CallbackProcessor(
+        decrypted_api_key='test_api_key',
+        issue_id='issue-123',
+        issue_key='TEST-123',
+        workspace_name='test-workspace',
+    )
+
+
+@pytest.fixture
+def mock_event_callback():
+    """Create a mock EventCallback."""
+    callback = MagicMock(spec=EventCallback)
+    callback.id = UUID('12345678-1234-5678-1234-567812345678')
+    callback.conversation_id = UUID('87654321-4321-8765-4321-876543218765')
+    return callback
+
+
+@pytest.fixture
+def finished_event():
+    """Create a ConversationStateUpdateEvent for finished state."""
+    return ConversationStateUpdateEvent(
+        id='event-123',
+        key='execution_status',
+        value='finished',
+    )
+
+
+@pytest.fixture
+def running_event():
+    """Create a ConversationStateUpdateEvent for running state."""
+    return ConversationStateUpdateEvent(
+        id='event-456',
+        key='execution_status',
+        value='running',
+    )
+
+
+class TestLinearV1CallbackProcessor:
+    """Tests for LinearV1CallbackProcessor."""
+
+    @pytest.mark.asyncio
+    async def test_ignores_non_conversation_state_events(
+        self, callback_processor, mock_event_callback
+    ):
+        """Test that non-ConversationStateUpdateEvent events are ignored."""
+        # Use a different event type (mock)
+        other_event = MagicMock()
+        other_event.__class__ = object  # Not ConversationStateUpdateEvent
+
+        result = await callback_processor(
+            conversation_id=uuid4(),
+            callback=mock_event_callback,
+            event=other_event,
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_ignores_non_execution_status_keys(
+        self, callback_processor, mock_event_callback
+    ):
+        """Test that events with keys other than 'execution_status' are ignored."""
+        event = ConversationStateUpdateEvent(
+            id='event-123',
+            key='agent_status',  # Different key
+            value='finished',
+        )
+
+        result = await callback_processor(
+            conversation_id=uuid4(),
+            callback=mock_event_callback,
+            event=event,
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_ignores_non_finished_status(
+        self, callback_processor, mock_event_callback, running_event
+    ):
+        """Test that non-finished execution statuses are ignored."""
+        result = await callback_processor(
+            conversation_id=uuid4(),
+            callback=mock_event_callback,
+            event=running_event,
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_only_requests_summary_once(
+        self, callback_processor, mock_event_callback, finished_event
+    ):
+        """Test that summary is only requested once (should_request_summary flag)."""
+        callback_processor.should_request_summary = False
+
+        result = await callback_processor(
+            conversation_id=uuid4(),
+            callback=mock_event_callback,
+            event=finished_event,
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    @patch.object(LinearV1CallbackProcessor, '_request_summary')
+    @patch.object(LinearV1CallbackProcessor, '_post_summary_to_linear')
+    async def test_successful_summary_flow(
+        self,
+        mock_post_summary,
+        mock_request_summary,
+        callback_processor,
+        mock_event_callback,
+        finished_event,
+    ):
+        """Test successful summary request and posting flow."""
+        conversation_id = uuid4()
+        mock_request_summary.return_value = 'Test summary content'
+        mock_post_summary.return_value = None
+
+        result = await callback_processor(
+            conversation_id=conversation_id,
+            callback=mock_event_callback,
+            event=finished_event,
+        )
+
+        assert result is not None
+        assert result.status == EventCallbackResultStatus.SUCCESS
+        assert result.detail == 'Test summary content'
+        assert callback_processor.should_request_summary is False
+        mock_request_summary.assert_called_once_with(conversation_id)
+        mock_post_summary.assert_called_once_with('Test summary content')
+
+    @pytest.mark.asyncio
+    @patch.object(LinearV1CallbackProcessor, '_request_summary')
+    async def test_error_handling_on_summary_request_failure(
+        self,
+        mock_request_summary,
+        callback_processor,
+        mock_event_callback,
+        finished_event,
+    ):
+        """Test error handling when summary request fails."""
+        conversation_id = uuid4()
+        mock_request_summary.side_effect = Exception('Agent server unavailable')
+
+        result = await callback_processor(
+            conversation_id=conversation_id,
+            callback=mock_event_callback,
+            event=finished_event,
+        )
+
+        assert result is not None
+        assert result.status == EventCallbackResultStatus.ERROR
+        assert 'Agent server unavailable' in result.detail
+
+    @pytest.mark.asyncio
+    @patch.object(LinearV1CallbackProcessor, '_request_summary')
+    @patch.object(LinearV1CallbackProcessor, '_post_summary_to_linear')
+    async def test_error_handling_on_post_failure(
+        self,
+        mock_post_summary,
+        mock_request_summary,
+        callback_processor,
+        mock_event_callback,
+        finished_event,
+    ):
+        """Test error handling when posting to Linear fails."""
+        conversation_id = uuid4()
+        mock_request_summary.return_value = 'Test summary'
+        mock_post_summary.side_effect = Exception('Linear API error')
+
+        result = await callback_processor(
+            conversation_id=conversation_id,
+            callback=mock_event_callback,
+            event=finished_event,
+        )
+
+        assert result is not None
+        assert result.status == EventCallbackResultStatus.ERROR
+        assert 'Linear API error' in result.detail
+
+
+class TestPostSummaryToLinear:
+    """Tests for _post_summary_to_linear method."""
+
+    @pytest.mark.asyncio
+    async def test_skips_when_missing_api_key(self, callback_processor):
+        """Test that posting is skipped when API key is missing."""
+        callback_processor.decrypted_api_key = ''
+
+        # Should not raise, just log and return
+        await callback_processor._post_summary_to_linear('Test summary')
+
+    @pytest.mark.asyncio
+    async def test_skips_when_missing_issue_id(self, callback_processor):
+        """Test that posting is skipped when issue ID is missing."""
+        callback_processor.issue_id = ''
+
+        # Should not raise, just log and return
+        await callback_processor._post_summary_to_linear('Test summary')
+
+    @pytest.mark.asyncio
+    async def test_skips_when_missing_issue_key(self, callback_processor):
+        """Test that posting is skipped when issue key is missing."""
+        callback_processor.issue_key = ''
+
+        # Should not raise, just log and return
+        await callback_processor._post_summary_to_linear('Test summary')
+
+    @pytest.mark.asyncio
+    @patch('httpx.AsyncClient')
+    async def test_posts_comment_with_correct_format(
+        self, mock_async_client, callback_processor
+    ):
+        """Test that comment is posted with correct format (GraphQL mutation)."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            'data': {'commentCreate': {'success': True, 'comment': {'id': 'comment-123'}}}
+        }
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.post = AsyncMock(return_value=mock_response)
+        mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+        await callback_processor._post_summary_to_linear('Test summary content')
+
+        # Verify the post was called
+        mock_client_instance.post.assert_called_once()
+        call_args = mock_client_instance.post.call_args
+
+        # Check URL is Linear GraphQL API
+        assert call_args[0][0] == LINEAR_API_URL
+
+        # Check headers contain Authorization
+        assert call_args[1]['headers'] == {'Authorization': 'test_api_key'}
+
+        # Check that body contains the GraphQL mutation
+        json_body = call_args[1]['json']
+        assert 'query' in json_body
+        assert 'commentCreate' in json_body['query']
+        assert 'variables' in json_body
+        assert json_body['variables']['input']['issueId'] == 'issue-123'
+        assert 'OpenHands resolved this issue' in json_body['variables']['input']['body']
+        assert 'Test summary content' in json_body['variables']['input']['body']
+
+    @pytest.mark.asyncio
+    @patch('httpx.AsyncClient')
+    async def test_raises_on_http_error(self, mock_async_client, callback_processor):
+        """Test that HTTP errors are propagated."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            'Bad Request',
+            request=MagicMock(),
+            response=MagicMock(status_code=400),
+        )
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.post = AsyncMock(return_value=mock_response)
+        mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await callback_processor._post_summary_to_linear('Test summary')
+
+    @pytest.mark.asyncio
+    @patch('httpx.AsyncClient')
+    async def test_raises_on_graphql_error(self, mock_async_client, callback_processor):
+        """Test that GraphQL errors are handled and raised."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            'errors': [{'message': 'Issue not found'}]
+        }
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.post = AsyncMock(return_value=mock_response)
+        mock_async_client.return_value.__aenter__.return_value = mock_client_instance
+
+        with pytest.raises(Exception, match='Linear API error'):
+            await callback_processor._post_summary_to_linear('Test summary')
+
+
+class TestAskQuestion:
+    """Tests for _ask_question method."""
+
+    @pytest.mark.asyncio
+    async def test_sends_request_with_correct_payload(self, callback_processor):
+        """Test that ask_question sends correct request to agent server."""
+        mock_httpx_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'response': 'Agent response text'}
+        mock_response.raise_for_status = MagicMock()
+        mock_httpx_client.post = AsyncMock(return_value=mock_response)
+
+        conversation_id = uuid4()
+        agent_server_url = 'http://localhost:8000'
+        session_api_key = 'test_session_key'
+        message_content = 'Please summarize your work'
+
+        result = await callback_processor._ask_question(
+            httpx_client=mock_httpx_client,
+            agent_server_url=agent_server_url,
+            conversation_id=conversation_id,
+            session_api_key=session_api_key,
+            message_content=message_content,
+        )
+
+        assert result == 'Agent response text'
+
+        # Verify request
+        mock_httpx_client.post.assert_called_once()
+        call_args = mock_httpx_client.post.call_args
+
+        expected_url = (
+            f'{agent_server_url}/api/conversations/{conversation_id}/ask_agent'
+        )
+        assert call_args[0][0] == expected_url
+        assert call_args[1]['headers'] == {'X-Session-API-Key': session_api_key}
+        assert call_args[1]['json'] == {'question': message_content}
+        assert call_args[1]['timeout'] == 30.0
+
+    @pytest.mark.asyncio
+    async def test_handles_http_error(self, callback_processor):
+        """Test that HTTP errors are handled and wrapped."""
+        mock_httpx_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = 'Internal Server Error'
+        mock_response.headers = {}
+        mock_error = httpx.HTTPStatusError(
+            'Server Error',
+            request=MagicMock(),
+            response=mock_response,
+        )
+        mock_httpx_client.post = AsyncMock(side_effect=mock_error)
+
+        with pytest.raises(Exception, match='Failed to send message to agent server'):
+            await callback_processor._ask_question(
+                httpx_client=mock_httpx_client,
+                agent_server_url='http://localhost:8000',
+                conversation_id=uuid4(),
+                session_api_key='test_key',
+                message_content='test message',
+            )
+
+    @pytest.mark.asyncio
+    async def test_handles_timeout(self, callback_processor):
+        """Test that timeout errors are handled and wrapped."""
+        mock_httpx_client = AsyncMock()
+        mock_httpx_client.post = AsyncMock(
+            side_effect=httpx.TimeoutException('Timeout')
+        )
+
+        with pytest.raises(Exception, match='Failed to send message to agent server'):
+            await callback_processor._ask_question(
+                httpx_client=mock_httpx_client,
+                agent_server_url='http://localhost:8000',
+                conversation_id=uuid4(),
+                session_api_key='test_key',
+                message_content='test message',
+            )

--- a/enterprise/tests/unit/integrations/linear/test_linear_v1_callback_processor.py
+++ b/enterprise/tests/unit/integrations/linear/test_linear_v1_callback_processor.py
@@ -243,7 +243,9 @@ class TestPostSummaryToLinear:
         mock_response = MagicMock()
         mock_response.raise_for_status = MagicMock()
         mock_response.json.return_value = {
-            'data': {'commentCreate': {'success': True, 'comment': {'id': 'comment-123'}}}
+            'data': {
+                'commentCreate': {'success': True, 'comment': {'id': 'comment-123'}}
+            }
         }
 
         mock_client_instance = AsyncMock()
@@ -268,7 +270,9 @@ class TestPostSummaryToLinear:
         assert 'commentCreate' in json_body['query']
         assert 'variables' in json_body
         assert json_body['variables']['input']['issueId'] == 'issue-123'
-        assert 'OpenHands resolved this issue' in json_body['variables']['input']['body']
+        assert (
+            'OpenHands resolved this issue' in json_body['variables']['input']['body']
+        )
         assert 'Test summary content' in json_body['variables']['input']['body']
 
     @pytest.mark.asyncio
@@ -295,9 +299,7 @@ class TestPostSummaryToLinear:
         """Test that GraphQL errors are handled and raised."""
         mock_response = MagicMock()
         mock_response.raise_for_status = MagicMock()
-        mock_response.json.return_value = {
-            'errors': [{'message': 'Issue not found'}]
-        }
+        mock_response.json.return_value = {'errors': [{'message': 'Issue not found'}]}
 
         mock_client_instance = AsyncMock()
         mock_client_instance.post = AsyncMock(return_value=mock_response)

--- a/enterprise/tests/unit/integrations/linear/test_linear_view.py
+++ b/enterprise/tests/unit/integrations/linear/test_linear_view.py
@@ -12,7 +12,9 @@ from integrations.linear.linear_view import (
     LinearNewConversationView,
 )
 
-from openhands.core.schema.agent import AgentState
+from openhands.app_server.app_conversation.app_conversation_models import (
+    AppConversationStartTaskStatus,
+)
 
 
 class TestLinearNewConversationView:
@@ -29,32 +31,41 @@ class TestLinearNewConversationView:
         assert 'Test Issue' in user_msg
         assert 'Fix this bug @openhands' in user_msg
 
-    @patch(
-        'integrations.linear.linear_view.SaasConversationStore.get_resolver_instance',
-        new_callable=AsyncMock,
-    )
-    @patch('integrations.linear.linear_view.start_conversation', new_callable=AsyncMock)
     @patch('integrations.linear.linear_view.integration_store')
+    @patch('integrations.linear.linear_view.get_app_conversation_service')
     async def test_create_or_update_conversation_success(
         self,
+        mock_get_app_conversation_service,
         mock_integration_store,
-        mock_start_convo,
-        mock_get_resolver_instance,
         new_conversation_view,
         mock_jinja_env,
     ):
-        """Test successful conversation creation"""
-        mock_store = MagicMock()
-        mock_store.save_metadata = AsyncMock()
-        mock_get_resolver_instance.return_value = mock_store
+        """Test successful conversation creation using V1 system"""
         mock_integration_store.create_conversation = AsyncMock()
+
+        # Mock the app conversation service
+        mock_service = AsyncMock()
+
+        # Create a mock task that indicates success (WORKING is a valid status)
+        mock_task = MagicMock()
+        mock_task.status = AppConversationStartTaskStatus.WORKING
+
+        async def mock_start_app_conversation(*args, **kwargs):
+            yield mock_task
+
+        mock_service.start_app_conversation = mock_start_app_conversation
+
+        # Set up the async context manager
+        mock_context = AsyncMock()
+        mock_context.__aenter__.return_value = mock_service
+        mock_context.__aexit__.return_value = None
+        mock_get_app_conversation_service.return_value = mock_context
 
         result = await new_conversation_view.create_or_update_conversation(
             mock_jinja_env
         )
 
         assert result is not None
-        mock_start_convo.assert_called_once()
         mock_integration_store.create_conversation.assert_called_once()
 
     async def test_create_or_update_conversation_no_repo(
@@ -66,27 +77,38 @@ class TestLinearNewConversationView:
         with pytest.raises(StartingConvoException, match='No repository selected'):
             await new_conversation_view.create_or_update_conversation(mock_jinja_env)
 
-    @patch(
-        'integrations.linear.linear_view.SaasConversationStore.get_resolver_instance',
-        new_callable=AsyncMock,
-    )
-    @patch('integrations.linear.linear_view.start_conversation', new_callable=AsyncMock)
+    @patch('integrations.linear.linear_view.integration_store')
+    @patch('integrations.linear.linear_view.get_app_conversation_service')
     async def test_create_or_update_conversation_failure(
         self,
-        mock_start_convo,
-        mock_get_resolver_instance,
+        mock_get_app_conversation_service,
+        mock_integration_store,
         new_conversation_view,
         mock_jinja_env,
     ):
         """Test conversation creation failure"""
-        mock_store = MagicMock()
-        mock_store.save_metadata = AsyncMock()
-        mock_get_resolver_instance.return_value = mock_store
-        mock_start_convo.side_effect = Exception('Creation failed')
+        mock_integration_store.create_conversation = AsyncMock()
 
-        with pytest.raises(
-            StartingConvoException, match='Failed to create conversation'
-        ):
+        # Mock the app conversation service to return an error
+        mock_service = AsyncMock()
+
+        # Create a mock task that indicates error
+        mock_task = MagicMock()
+        mock_task.status = AppConversationStartTaskStatus.ERROR
+        mock_task.detail = 'Creation failed'
+
+        async def mock_start_app_conversation(*args, **kwargs):
+            yield mock_task
+
+        mock_service.start_app_conversation = mock_start_app_conversation
+
+        # Set up the async context manager
+        mock_context = AsyncMock()
+        mock_context.__aenter__.return_value = mock_service
+        mock_context.__aexit__.return_value = None
+        mock_get_app_conversation_service.return_value = mock_context
+
+        with pytest.raises(RuntimeError, match='Failed to start V1 conversation'):
             await new_conversation_view.create_or_update_conversation(mock_jinja_env)
 
     def test_get_response_msg(self, new_conversation_view):
@@ -96,7 +118,17 @@ class TestLinearNewConversationView:
         assert "I'm on it!" in response
         assert 'Test User' in response
         assert 'track my progress here' in response
-        assert 'conv-123' in response
+        assert '12345678123456781234567812345678' in response
+
+    def test_create_linear_v1_callback_processor(self, new_conversation_view):
+        """Test that V1 callback processor is created correctly"""
+        new_conversation_view._decrypted_api_key = 'test_api_key'
+        processor = new_conversation_view._create_linear_v1_callback_processor()
+
+        assert processor.decrypted_api_key == 'test_api_key'
+        assert processor.issue_id == 'test_issue_id'
+        assert processor.issue_key == 'TEST-123'
+        assert processor.workspace_name == 'test-workspace'
 
 
 class TestLinearExistingConversationView:
@@ -113,53 +145,42 @@ class TestLinearExistingConversationView:
         assert 'Test Issue' in user_msg
         assert 'Fix this bug @openhands' in user_msg
 
-    @patch('integrations.linear.linear_view.ConversationStoreImpl.get_instance')
-    @patch('integrations.linear.linear_view.setup_init_conversation_settings')
-    @patch('integrations.linear.linear_view.conversation_manager')
-    @patch('integrations.linear.linear_view.get_final_agent_observation')
+    @patch.object(LinearExistingConversationView, '_get_running_sandbox')
+    @patch.object(LinearExistingConversationView, '_send_followup_message')
     async def test_create_or_update_conversation_success(
         self,
-        mock_get_observation,
-        mock_conversation_manager,
-        mock_setup_init,
-        mock_store_impl,
+        mock_send_followup,
+        mock_get_running_sandbox,
         existing_conversation_view,
         mock_jinja_env,
-        mock_conversation_store,
-        mock_conversation_init_data,
-        mock_agent_loop_info,
     ):
-        """Test successful existing conversation update"""
-        # Setup mocks
-        mock_store_impl.return_value = mock_conversation_store
-        mock_setup_init.return_value = mock_conversation_init_data
-        mock_conversation_manager.maybe_start_agent_loop = AsyncMock(
-            return_value=mock_agent_loop_info
-        )
-        mock_conversation_manager.send_event_to_conversation = AsyncMock()
+        """Test successful existing conversation update using V1 system"""
+        # Mock the sandbox
+        mock_sandbox = MagicMock()
+        mock_sandbox.status = 'running'
+        mock_sandbox.session_api_key = 'test_session_key'
+        mock_get_running_sandbox.return_value = mock_sandbox
 
-        # Mock agent observation with RUNNING state
-        mock_observation = MagicMock()
-        mock_observation.agent_state = AgentState.RUNNING
-        mock_get_observation.return_value = [mock_observation]
+        mock_send_followup.return_value = None
 
         result = await existing_conversation_view.create_or_update_conversation(
             mock_jinja_env
         )
 
-        assert result == 'conv-123'
-        mock_conversation_manager.send_event_to_conversation.assert_called_once()
+        assert result == '12345678123456781234567812345678'
+        mock_send_followup.assert_called_once()
 
-    @patch('integrations.linear.linear_view.ConversationStoreImpl.get_instance')
-    async def test_create_or_update_conversation_no_metadata(
-        self, mock_store_impl, existing_conversation_view, mock_jinja_env
+    @patch.object(LinearExistingConversationView, '_get_running_sandbox')
+    async def test_create_or_update_conversation_no_conversation(
+        self,
+        mock_get_running_sandbox,
+        existing_conversation_view,
+        mock_jinja_env,
     ):
-        """Test conversation update with no metadata"""
-        mock_store = AsyncMock()
-        mock_store.get_metadata.side_effect = FileNotFoundError(
-            'No such file or directory'
+        """Test conversation update when conversation no longer exists"""
+        mock_get_running_sandbox.side_effect = StartingConvoException(
+            'Conversation no longer exists.'
         )
-        mock_store_impl.return_value = mock_store
 
         with pytest.raises(
             StartingConvoException, match='Conversation no longer exists'
@@ -168,50 +189,37 @@ class TestLinearExistingConversationView:
                 mock_jinja_env
             )
 
-    @patch('integrations.linear.linear_view.ConversationStoreImpl.get_instance')
-    @patch('integrations.linear.linear_view.setup_init_conversation_settings')
-    @patch('integrations.linear.linear_view.conversation_manager')
-    @patch('integrations.linear.linear_view.get_final_agent_observation')
-    async def test_create_or_update_conversation_loading_state(
+    @patch.object(LinearExistingConversationView, '_get_running_sandbox')
+    async def test_create_or_update_conversation_sandbox_not_running(
         self,
-        mock_get_observation,
-        mock_conversation_manager,
-        mock_setup_init,
-        mock_store_impl,
+        mock_get_running_sandbox,
         existing_conversation_view,
         mock_jinja_env,
-        mock_conversation_store,
-        mock_conversation_init_data,
-        mock_agent_loop_info,
     ):
-        """Test conversation update with loading state"""
-        mock_store_impl.return_value = mock_conversation_store
-        mock_setup_init.return_value = mock_conversation_init_data
-        mock_conversation_manager.maybe_start_agent_loop = AsyncMock(
-            return_value=mock_agent_loop_info
+        """Test conversation update when sandbox is not running"""
+        mock_get_running_sandbox.side_effect = StartingConvoException(
+            'Conversation sandbox is not available.'
         )
 
-        # Mock agent observation with LOADING state
-        mock_observation = MagicMock()
-        mock_observation.agent_state = AgentState.LOADING
-        mock_get_observation.return_value = [mock_observation]
-
         with pytest.raises(
-            StartingConvoException, match='Conversation is still starting'
+            StartingConvoException, match='Conversation sandbox is not available'
         ):
             await existing_conversation_view.create_or_update_conversation(
                 mock_jinja_env
             )
 
-    @patch('integrations.linear.linear_view.ConversationStoreImpl.get_instance')
+    @patch.object(LinearExistingConversationView, '_get_running_sandbox')
     async def test_create_or_update_conversation_failure(
-        self, mock_store_impl, existing_conversation_view, mock_jinja_env
+        self,
+        mock_get_running_sandbox,
+        existing_conversation_view,
+        mock_jinja_env,
     ):
         """Test conversation update failure"""
-        mock_store_impl.side_effect = Exception('Store error')
+        mock_get_running_sandbox.side_effect = Exception('Service error')
 
         with pytest.raises(
-            StartingConvoException, match='Failed to create conversation'
+            StartingConvoException, match='Failed to update conversation'
         ):
             await existing_conversation_view.create_or_update_conversation(
                 mock_jinja_env
@@ -224,7 +232,7 @@ class TestLinearExistingConversationView:
         assert "I'm on it!" in response
         assert 'Test User' in response
         assert 'continue tracking my progress here' in response
-        assert 'conv-123' in response
+        assert '12345678123456781234567812345678' in response
 
 
 class TestLinearFactory:
@@ -253,7 +261,7 @@ class TestLinearFactory:
         )
 
         assert isinstance(view, LinearExistingConversationView)
-        assert view.conversation_id == 'conv-123'
+        assert view.conversation_id == '12345678123456781234567812345678'
 
     @patch('integrations.linear.linear_view.integration_store')
     async def test_create_linear_view_from_payload_new_conversation(
@@ -276,6 +284,29 @@ class TestLinearFactory:
 
         assert isinstance(view, LinearNewConversationView)
         assert view.conversation_id == ''
+
+    @patch('integrations.linear.linear_view.integration_store')
+    async def test_create_linear_view_from_payload_with_api_key(
+        self,
+        mock_store,
+        sample_job_context,
+        sample_user_auth,
+        sample_linear_user,
+        sample_linear_workspace,
+    ):
+        """Test factory creates view with decrypted API key"""
+        mock_store.get_user_conversations_by_issue_id = AsyncMock(return_value=None)
+
+        view = await LinearFactory.create_linear_view_from_payload(
+            sample_job_context,
+            sample_user_auth,
+            sample_linear_user,
+            sample_linear_workspace,
+            decrypted_api_key='test_api_key',
+        )
+
+        assert isinstance(view, LinearNewConversationView)
+        assert view._decrypted_api_key == 'test_api_key'
 
     async def test_create_linear_view_from_payload_no_user(
         self, sample_job_context, sample_user_auth, sample_linear_workspace
@@ -317,139 +348,44 @@ class TestLinearFactory:
 class TestLinearViewEdgeCases:
     """Tests for edge cases and error scenarios"""
 
-    @patch(
-        'integrations.linear.linear_view.SaasConversationStore.get_resolver_instance',
-        new_callable=AsyncMock,
-    )
-    @patch('integrations.linear.linear_view.start_conversation', new_callable=AsyncMock)
-    @patch('integrations.linear.linear_view.integration_store')
-    async def test_conversation_creation_with_no_user_secrets(
-        self,
-        mock_integration_store,
-        mock_start_convo,
-        mock_get_resolver_instance,
-        new_conversation_view,
-        mock_jinja_env,
-    ):
-        """Test conversation creation when user has no secrets"""
-        new_conversation_view.saas_user_auth.get_secrets = AsyncMock(return_value=None)
-        mock_store = MagicMock()
-        mock_store.save_metadata = AsyncMock()
-        mock_get_resolver_instance.return_value = mock_store
-        mock_integration_store.create_conversation = AsyncMock()
-
-        result = await new_conversation_view.create_or_update_conversation(
-            mock_jinja_env
-        )
-
-        assert result is not None
-        # Verify start_conversation was called with custom_secrets=None
-        call_kwargs = mock_start_convo.call_args[1]
-        assert call_kwargs['custom_secrets'] is None
-
-    @patch(
-        'integrations.linear.linear_view.SaasConversationStore.get_resolver_instance',
-        new_callable=AsyncMock,
-    )
-    @patch('integrations.linear.linear_view.start_conversation', new_callable=AsyncMock)
-    @patch('integrations.linear.linear_view.integration_store')
-    async def test_conversation_creation_store_failure(
-        self,
-        mock_integration_store,
-        mock_start_convo,
-        mock_get_resolver_instance,
-        new_conversation_view,
-        mock_jinja_env,
-    ):
-        """Test conversation creation when store creation fails"""
-        mock_store = MagicMock()
-        mock_store.save_metadata = AsyncMock()
-        mock_get_resolver_instance.return_value = mock_store
-        mock_integration_store.create_conversation = AsyncMock(
-            side_effect=Exception('Store error')
-        )
-
-        with pytest.raises(
-            StartingConvoException, match='Failed to create conversation'
-        ):
-            await new_conversation_view.create_or_update_conversation(mock_jinja_env)
-
-    @patch('integrations.linear.linear_view.ConversationStoreImpl.get_instance')
-    @patch('integrations.linear.linear_view.setup_init_conversation_settings')
-    @patch('integrations.linear.linear_view.conversation_manager')
-    @patch('integrations.linear.linear_view.get_final_agent_observation')
-    async def test_existing_conversation_empty_observations(
-        self,
-        mock_get_observation,
-        mock_conversation_manager,
-        mock_setup_init,
-        mock_store_impl,
-        existing_conversation_view,
-        mock_jinja_env,
-        mock_conversation_store,
-        mock_conversation_init_data,
-        mock_agent_loop_info,
-    ):
-        """Test existing conversation with empty observations"""
-        mock_store_impl.return_value = mock_conversation_store
-        mock_setup_init.return_value = mock_conversation_init_data
-        mock_conversation_manager.maybe_start_agent_loop = AsyncMock(
-            return_value=mock_agent_loop_info
-        )
-        mock_get_observation.return_value = []  # Empty observations
-
-        with pytest.raises(
-            StartingConvoException, match='Conversation is still starting'
-        ):
-            await existing_conversation_view.create_or_update_conversation(
-                mock_jinja_env
-            )
-
     def test_new_conversation_view_attributes(self, new_conversation_view):
         """Test new conversation view attribute access"""
         assert new_conversation_view.job_context.issue_key == 'TEST-123'
         assert new_conversation_view.selected_repo == 'test/repo1'
-        assert new_conversation_view.conversation_id == 'conv-123'
+        assert (
+            new_conversation_view.conversation_id == '12345678123456781234567812345678'
+        )
 
     def test_existing_conversation_view_attributes(self, existing_conversation_view):
         """Test existing conversation view attribute access"""
         assert existing_conversation_view.job_context.issue_key == 'TEST-123'
         assert existing_conversation_view.selected_repo == 'test/repo1'
-        assert existing_conversation_view.conversation_id == 'conv-123'
+        assert (
+            existing_conversation_view.conversation_id
+            == '12345678123456781234567812345678'
+        )
 
-    @patch('integrations.linear.linear_view.ConversationStoreImpl.get_instance')
-    @patch('integrations.linear.linear_view.setup_init_conversation_settings')
-    @patch('integrations.linear.linear_view.conversation_manager')
-    @patch('integrations.linear.linear_view.get_final_agent_observation')
+    @patch.object(LinearExistingConversationView, '_get_running_sandbox')
+    @patch.object(LinearExistingConversationView, '_send_followup_message')
     async def test_existing_conversation_message_send_failure(
         self,
-        mock_get_observation,
-        mock_conversation_manager,
-        mock_setup_init,
-        mock_store_impl,
+        mock_send_followup,
+        mock_get_running_sandbox,
         existing_conversation_view,
         mock_jinja_env,
-        mock_conversation_store,
-        mock_conversation_init_data,
-        mock_agent_loop_info,
     ):
         """Test existing conversation when message sending fails"""
-        mock_store_impl.return_value = mock_conversation_store
-        mock_setup_init.return_value = mock_conversation_init_data
-        mock_conversation_manager.maybe_start_agent_loop.return_value = (
-            mock_agent_loop_info
-        )
-        mock_conversation_manager.send_event_to_conversation = AsyncMock(
-            side_effect=Exception('Send error')
-        )
+        # Mock the sandbox
+        mock_sandbox = MagicMock()
+        mock_sandbox.status = 'running'
+        mock_sandbox.session_api_key = 'test_session_key'
+        mock_get_running_sandbox.return_value = mock_sandbox
 
-        # Mock agent observation with RUNNING state
-        mock_observation = MagicMock()
-        mock_observation.agent_state = AgentState.RUNNING
-        mock_get_observation.return_value = [mock_observation]
+        # Mock the followup message to fail
+        mock_send_followup.side_effect = Exception('Send error')
 
         with pytest.raises(
-            StartingConvoException, match='Failed to create conversation'
+            StartingConvoException, match='Failed to update conversation'
         ):
             await existing_conversation_view.create_or_update_conversation(
                 mock_jinja_env

--- a/enterprise/tests/unit/test_linear_view.py
+++ b/enterprise/tests/unit/test_linear_view.py
@@ -139,7 +139,9 @@ class TestLinearV1OrgRouting:
         mock_get_app_convo_svc.side_effect = mock_context_manager
 
         mock_jinja = MagicMock()
-        mock_jinja.get_template = MagicMock(return_value=MagicMock(render=MagicMock(return_value='test')))
+        mock_jinja.get_template = MagicMock(
+            return_value=MagicMock(render=MagicMock(return_value='test'))
+        )
 
         # Act
         await linear_view.create_or_update_conversation(mock_jinja)
@@ -188,7 +190,9 @@ class TestLinearV1OrgRouting:
         mock_get_app_convo_svc.side_effect = mock_context_manager
 
         mock_jinja = MagicMock()
-        mock_jinja.get_template = MagicMock(return_value=MagicMock(render=MagicMock(return_value='test')))
+        mock_jinja.get_template = MagicMock(
+            return_value=MagicMock(render=MagicMock(return_value='test'))
+        )
 
         # Act
         await linear_view.create_or_update_conversation(mock_jinja)
@@ -225,7 +229,9 @@ class TestLinearV1OrgRouting:
         mock_get_app_convo_svc.side_effect = mock_context_manager
 
         mock_jinja = MagicMock()
-        mock_jinja.get_template = MagicMock(return_value=MagicMock(render=MagicMock(return_value='test')))
+        mock_jinja.get_template = MagicMock(
+            return_value=MagicMock(render=MagicMock(return_value='test'))
+        )
 
         # Act
         await linear_view.create_or_update_conversation(mock_jinja)
@@ -269,7 +275,9 @@ class TestLinearV1OrgRouting:
         mock_get_app_convo_svc.side_effect = mock_context_manager
 
         mock_jinja = MagicMock()
-        mock_jinja.get_template = MagicMock(return_value=MagicMock(render=MagicMock(return_value='test')))
+        mock_jinja.get_template = MagicMock(
+            return_value=MagicMock(render=MagicMock(return_value='test'))
+        )
 
         # Act
         await linear_view.create_or_update_conversation(mock_jinja)
@@ -314,7 +322,9 @@ class TestLinearV1OrgRouting:
         mock_get_app_convo_svc.side_effect = mock_context_manager
 
         mock_jinja = MagicMock()
-        mock_jinja.get_template = MagicMock(return_value=MagicMock(render=MagicMock(return_value='test')))
+        mock_jinja.get_template = MagicMock(
+            return_value=MagicMock(render=MagicMock(return_value='test'))
+        )
 
         # Act
         await linear_view.create_or_update_conversation(mock_jinja)

--- a/enterprise/tests/unit/test_linear_view.py
+++ b/enterprise/tests/unit/test_linear_view.py
@@ -1,9 +1,10 @@
 """Tests for Linear resolver org routing logic.
 
 Tests that the LinearNewConversationView correctly resolves the target
-organization and passes resolver_org_id through the V0 conversation path.
+organization and passes resolver_org_id through the V1 conversation path.
 """
 
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
@@ -15,7 +16,6 @@ from storage.linear_workspace import LinearWorkspace
 
 from openhands.integrations.service_types import ProviderType
 from openhands.server.user_auth.user_auth import UserAuth
-from openhands.storage.data_models.conversation_metadata import ConversationTrigger
 
 CLAIMING_ORG_ID = UUID('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
 KEYCLOAK_USER_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
@@ -83,32 +83,44 @@ def linear_view(job_context, mock_user_auth, mock_linear_user, mock_linear_works
     )
 
 
-class TestLinearV0OrgRouting:
-    """Test V0 conversation routing logic for Linear resolver."""
+def create_mock_app_conversation_service():
+    """Create a mock app conversation service that yields MagicMock tasks."""
+    mock_service = MagicMock()
+
+    async def mock_generator(request):
+        # Create mock tasks that pass the status checks in the code
+        mock_task = MagicMock()
+        mock_task.status = MagicMock()
+        # Ensure the status check in the code passes
+        # (status != ERROR)
+        mock_task.status.__eq__ = lambda self, other: False
+        yield mock_task
+
+    mock_service.start_app_conversation = mock_generator
+    return mock_service
+
+
+class TestLinearV1OrgRouting:
+    """Test V1 conversation routing logic for Linear resolver."""
 
     @pytest.mark.asyncio
     @patch(
         'integrations.linear.linear_view.resolve_org_for_repo', new_callable=AsyncMock
     )
     @patch('integrations.linear.linear_view.ProviderHandler')
-    @patch(
-        'integrations.linear.linear_view.SaasConversationStore.get_resolver_instance',
-        new_callable=AsyncMock,
-    )
-    @patch('integrations.linear.linear_view.start_conversation', new_callable=AsyncMock)
+    @patch('integrations.linear.linear_view.get_app_conversation_service')
     @patch(
         'integrations.linear.linear_view.integration_store',
     )
-    async def test_v0_passes_resolver_org_id_to_get_resolver_instance(
+    async def test_v1_passes_resolver_org_id_to_user_context(
         self,
         mock_integration_store,
-        mock_start_convo,
-        mock_get_resolver_instance,
+        mock_get_app_convo_svc,
         mock_provider_handler_cls,
         mock_resolve_org,
         linear_view,
     ):
-        """V0 path should resolve org and pass resolver_org_id to get_resolver_instance."""
+        """V1 path should resolve org and set resolver_org_id in user context."""
         # Arrange
         mock_repo = MagicMock()
         mock_repo.git_provider = ProviderType.GITHUB
@@ -117,21 +129,20 @@ class TestLinearV0OrgRouting:
         mock_provider_handler_cls.return_value = mock_handler
 
         mock_resolve_org.return_value = CLAIMING_ORG_ID
-        mock_store = MagicMock()
-        mock_store.save_metadata = AsyncMock()
-        mock_get_resolver_instance.return_value = mock_store
         mock_integration_store.create_conversation = AsyncMock()
 
+        # Create mock app conversation service
+        @asynccontextmanager
+        async def mock_context_manager(injector_state):
+            yield create_mock_app_conversation_service()
+
+        mock_get_app_convo_svc.side_effect = mock_context_manager
+
         mock_jinja = MagicMock()
+        mock_jinja.get_template = MagicMock(return_value=MagicMock(render=MagicMock(return_value='test')))
 
         # Act
-        with patch.object(
-            linear_view,
-            '_get_instructions',
-            new_callable=AsyncMock,
-            return_value=('instructions', 'user_msg'),
-        ):
-            await linear_view.create_or_update_conversation(mock_jinja)
+        await linear_view.create_or_update_conversation(mock_jinja)
 
         # Assert
         mock_resolve_org.assert_called_once_with(
@@ -139,31 +150,21 @@ class TestLinearV0OrgRouting:
             full_repo_name='OpenHands/foo',
             keycloak_user_id=KEYCLOAK_USER_ID,
         )
-        call_args = mock_get_resolver_instance.call_args
-        assert call_args[0][1] == KEYCLOAK_USER_ID
-        assert call_args[0][2] == CLAIMING_ORG_ID
-        saved_metadata = mock_store.save_metadata.call_args[0][0]
-        assert saved_metadata.trigger == ConversationTrigger.LINEAR
-        assert saved_metadata.git_provider == ProviderType.GITHUB
+        assert linear_view.resolved_org_id == CLAIMING_ORG_ID
 
     @pytest.mark.asyncio
     @patch(
         'integrations.linear.linear_view.resolve_org_for_repo', new_callable=AsyncMock
     )
     @patch('integrations.linear.linear_view.ProviderHandler')
-    @patch(
-        'integrations.linear.linear_view.SaasConversationStore.get_resolver_instance',
-        new_callable=AsyncMock,
-    )
-    @patch('integrations.linear.linear_view.start_conversation', new_callable=AsyncMock)
+    @patch('integrations.linear.linear_view.get_app_conversation_service')
     @patch(
         'integrations.linear.linear_view.integration_store',
     )
-    async def test_v0_passes_none_when_no_claim(
+    async def test_v1_passes_none_when_no_claim(
         self,
         mock_integration_store,
-        mock_start_convo,
-        mock_get_resolver_instance,
+        mock_get_app_convo_svc,
         mock_provider_handler_cls,
         mock_resolve_org,
         linear_view,
@@ -177,43 +178,36 @@ class TestLinearV0OrgRouting:
         mock_provider_handler_cls.return_value = mock_handler
 
         mock_resolve_org.return_value = None
-        mock_store = MagicMock()
-        mock_store.save_metadata = AsyncMock()
-        mock_get_resolver_instance.return_value = mock_store
         mock_integration_store.create_conversation = AsyncMock()
 
+        # Create mock app conversation service
+        @asynccontextmanager
+        async def mock_context_manager(injector_state):
+            yield create_mock_app_conversation_service()
+
+        mock_get_app_convo_svc.side_effect = mock_context_manager
+
         mock_jinja = MagicMock()
+        mock_jinja.get_template = MagicMock(return_value=MagicMock(render=MagicMock(return_value='test')))
 
         # Act
-        with patch.object(
-            linear_view,
-            '_get_instructions',
-            new_callable=AsyncMock,
-            return_value=('instructions', 'user_msg'),
-        ):
-            await linear_view.create_or_update_conversation(mock_jinja)
+        await linear_view.create_or_update_conversation(mock_jinja)
 
         # Assert
-        call_args = mock_get_resolver_instance.call_args
-        assert call_args[0][2] is None
+        assert linear_view.resolved_org_id is None
 
     @pytest.mark.asyncio
     @patch(
         'integrations.linear.linear_view.resolve_org_for_repo', new_callable=AsyncMock
     )
-    @patch(
-        'integrations.linear.linear_view.SaasConversationStore.get_resolver_instance',
-        new_callable=AsyncMock,
-    )
-    @patch('integrations.linear.linear_view.start_conversation', new_callable=AsyncMock)
+    @patch('integrations.linear.linear_view.get_app_conversation_service')
     @patch(
         'integrations.linear.linear_view.integration_store',
     )
     async def test_no_provider_tokens_skips_org_resolution(
         self,
         mock_integration_store,
-        mock_start_convo,
-        mock_get_resolver_instance,
+        mock_get_app_convo_svc,
         mock_resolve_org,
         linear_view,
         mock_user_auth,
@@ -221,47 +215,38 @@ class TestLinearV0OrgRouting:
         """When provider tokens are None, org resolution should be skipped."""
         # Arrange
         mock_user_auth.get_provider_tokens = AsyncMock(return_value=None)
-        mock_store = MagicMock()
-        mock_store.save_metadata = AsyncMock()
-        mock_get_resolver_instance.return_value = mock_store
         mock_integration_store.create_conversation = AsyncMock()
 
+        # Create mock app conversation service
+        @asynccontextmanager
+        async def mock_context_manager(injector_state):
+            yield create_mock_app_conversation_service()
+
+        mock_get_app_convo_svc.side_effect = mock_context_manager
+
         mock_jinja = MagicMock()
+        mock_jinja.get_template = MagicMock(return_value=MagicMock(render=MagicMock(return_value='test')))
 
         # Act
-        with patch.object(
-            linear_view,
-            '_get_instructions',
-            new_callable=AsyncMock,
-            return_value=('instructions', 'user_msg'),
-        ):
-            await linear_view.create_or_update_conversation(mock_jinja)
+        await linear_view.create_or_update_conversation(mock_jinja)
 
         # Assert
         mock_resolve_org.assert_not_called()
-        call_args = mock_get_resolver_instance.call_args
-        assert call_args[0][2] is None
-        saved_metadata = mock_store.save_metadata.call_args[0][0]
-        assert saved_metadata.git_provider is None
+        assert linear_view.resolved_org_id is None
 
     @pytest.mark.asyncio
     @patch(
         'integrations.linear.linear_view.resolve_org_for_repo', new_callable=AsyncMock
     )
     @patch('integrations.linear.linear_view.ProviderHandler')
-    @patch(
-        'integrations.linear.linear_view.SaasConversationStore.get_resolver_instance',
-        new_callable=AsyncMock,
-    )
-    @patch('integrations.linear.linear_view.start_conversation', new_callable=AsyncMock)
+    @patch('integrations.linear.linear_view.get_app_conversation_service')
     @patch(
         'integrations.linear.linear_view.integration_store',
     )
     async def test_verify_repo_provider_failure_falls_back_to_personal_workspace(
         self,
         mock_integration_store,
-        mock_start_convo,
-        mock_get_resolver_instance,
+        mock_get_app_convo_svc,
         mock_provider_handler_cls,
         mock_resolve_org,
         linear_view,
@@ -274,45 +259,38 @@ class TestLinearV0OrgRouting:
         )
         mock_provider_handler_cls.return_value = mock_handler
 
-        mock_store = MagicMock()
-        mock_store.save_metadata = AsyncMock()
-        mock_get_resolver_instance.return_value = mock_store
         mock_integration_store.create_conversation = AsyncMock()
 
+        # Create mock app conversation service
+        @asynccontextmanager
+        async def mock_context_manager(injector_state):
+            yield create_mock_app_conversation_service()
+
+        mock_get_app_convo_svc.side_effect = mock_context_manager
+
         mock_jinja = MagicMock()
+        mock_jinja.get_template = MagicMock(return_value=MagicMock(render=MagicMock(return_value='test')))
 
         # Act
-        with patch.object(
-            linear_view,
-            '_get_instructions',
-            new_callable=AsyncMock,
-            return_value=('instructions', 'user_msg'),
-        ):
-            await linear_view.create_or_update_conversation(mock_jinja)
+        await linear_view.create_or_update_conversation(mock_jinja)
 
         # Assert - org resolution should be skipped, conversation created in personal workspace
         mock_resolve_org.assert_not_called()
-        call_args = mock_get_resolver_instance.call_args
-        assert call_args[0][2] is None
+        assert linear_view.resolved_org_id is None
 
     @pytest.mark.asyncio
     @patch(
         'integrations.linear.linear_view.resolve_org_for_repo', new_callable=AsyncMock
     )
     @patch('integrations.linear.linear_view.ProviderHandler')
-    @patch(
-        'integrations.linear.linear_view.SaasConversationStore.get_resolver_instance',
-        new_callable=AsyncMock,
-    )
-    @patch('integrations.linear.linear_view.start_conversation', new_callable=AsyncMock)
+    @patch('integrations.linear.linear_view.get_app_conversation_service')
     @patch(
         'integrations.linear.linear_view.integration_store',
     )
     async def test_resolve_org_failure_falls_back_to_personal_workspace(
         self,
         mock_integration_store,
-        mock_start_convo,
-        mock_get_resolver_instance,
+        mock_get_app_convo_svc,
         mock_provider_handler_cls,
         mock_resolve_org,
         linear_view,
@@ -326,22 +304,20 @@ class TestLinearV0OrgRouting:
         mock_provider_handler_cls.return_value = mock_handler
 
         mock_resolve_org.side_effect = Exception('Database connection failed')
-        mock_store = MagicMock()
-        mock_store.save_metadata = AsyncMock()
-        mock_get_resolver_instance.return_value = mock_store
         mock_integration_store.create_conversation = AsyncMock()
 
+        # Create mock app conversation service
+        @asynccontextmanager
+        async def mock_context_manager(injector_state):
+            yield create_mock_app_conversation_service()
+
+        mock_get_app_convo_svc.side_effect = mock_context_manager
+
         mock_jinja = MagicMock()
+        mock_jinja.get_template = MagicMock(return_value=MagicMock(render=MagicMock(return_value='test')))
 
         # Act
-        with patch.object(
-            linear_view,
-            '_get_instructions',
-            new_callable=AsyncMock,
-            return_value=('instructions', 'user_msg'),
-        ):
-            await linear_view.create_or_update_conversation(mock_jinja)
+        await linear_view.create_or_update_conversation(mock_jinja)
 
         # Assert - conversation should be created with resolver_org_id=None
-        call_args = mock_get_resolver_instance.call_args
-        assert call_args[0][2] is None
+        assert linear_view.resolved_org_id is None


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

The Linear integration currently uses the legacy conversation API. Following the pattern established in PR #13909 for Jira, this PR updates the Linear integration to use the V1 conversations API for consistency and to leverage the improved event-based callback system.

## Summary

- Create `LinearV1CallbackProcessor` that inherits from `EventCallbackProcessor` to handle `ConversationStateUpdateEvent` and post summaries to Linear issues
- Update `LinearNewConversationView` to use `AppConversationStartRequest` and `ConversationMetadata` for V1 conversations
- Update `LinearExistingConversationView` to use `_get_running_sandbox()` and `_send_followup_message()` methods
- Update `LinearManager` to pass decrypted API key to factory
- Add comprehensive tests for the V1 callback processor

## Issue Number

Related to #13909

## How to Test

1. Run the Linear tests:
   ```bash
   cd enterprise
   PYTHONPATH=".:$PYTHONPATH" poetry run pytest tests/unit/integrations/linear/ -v
   ```
   All 86 tests should pass.

2. Run pre-commit hooks to verify code quality:
   ```bash
   poetry run pre-commit run --all-files --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml
   ```

## Video/Screenshots

N/A - Backend changes only

## Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR follows the same pattern as the Jira V1 integration (#13909):
- Uses `EventCallbackProcessor` instead of the legacy `ConversationCallbackProcessor`
- Uses `AppConversationStartRequest` to start V1 conversations
- The callback processor handles `ConversationStateUpdateEvent` to post summaries when conversations complete

_This pull request was created by an AI assistant (OpenHands) on behalf of the user._

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/714a9e09-f11e-4115-9d83-20dd4f1062f3)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:aa02a05-nikolaik   --name openhands-app-aa02a05   docker.openhands.dev/openhands/openhands:aa02a05
```