### PR TITLE
fix(frontend): resume conversation leaves agent status stuck on "finished"

### DIFF
--- a/frontend/src/components/features/controls/agent-status.tsx
+++ b/frontend/src/components/features/controls/agent-status.tsx
@@ -11,6 +11,7 @@ import { AgentLoading } from "./agent-loading";
 import { useConversationStore } from "#/stores/conversation-store";
 import CircleErrorIcon from "#/icons/circle-error.svg?react";
 import { useAgentState } from "#/hooks/use-agent-state";
+import { useV1ConversationStateStore } from "#/stores/v1-conversation-state-store";
 import { useUnifiedWebSocketStatus } from "#/hooks/use-unified-websocket-status";
 import { useTaskPolling } from "#/hooks/query/use-task-polling";
 import { useSubConversationTaskPolling } from "#/hooks/query/use-sub-conversation-task-polling";
@@ -46,9 +47,16 @@ export function AgentStatus({
       conversation?.id || null,
     );
 
+  // Prefer the live execution status from WebSocket state events over the
+  // REST-polled value on `conversation` — the REST field lags by up to 30s
+  // and makes resumed conversations appear stuck in their last-known status
+  // (e.g. "Agent has finished the task") until the next poll.
+  const liveExecutionStatus = useV1ConversationStateStore(
+    (state) => state.execution_status,
+  );
   const statusCode = getStatusCode(
     webSocketStatus,
-    conversation?.execution_status || null,
+    liveExecutionStatus ?? conversation?.execution_status ?? null,
     conversation?.sandbox_status || null,
     taskStatus,
     subConversationTaskStatus,

--- a/frontend/src/contexts/conversation-websocket-context.tsx
+++ b/frontend/src/contexts/conversation-websocket-context.tsx
@@ -335,6 +335,10 @@ export function ConversationWebSocketProvider({
     receivedEventCountRefMain.current = 0;
     // Reset the tracked event ref when conversation changes
     latestPlanningFileEventRef.current = null;
+    // Clear stale execution status from a previous conversation/session.
+    // Without this, resuming a closed conversation shows the agent stuck in
+    // the last status (e.g. FINISHED) until a new WebSocket state event arrives.
+    useV1ConversationStateStore.getState().reset();
   }, [conversationId]);
 
   const { data: preloadedEvents } = useConversationHistory(conversationId);

--- a/frontend/src/contexts/websocket-provider-wrapper.tsx
+++ b/frontend/src/contexts/websocket-provider-wrapper.tsx
@@ -3,6 +3,7 @@ import { ConversationWebSocketProvider } from "#/contexts/conversation-websocket
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useSubConversations } from "#/hooks/query/use-sub-conversations";
 import { useSandboxRecovery } from "#/hooks/use-sandbox-recovery";
+import { useV1ConversationStateStore } from "#/stores/v1-conversation-state-store";
 import { isTaskConversationId } from "#/utils/conversation-local-storage";
 
 interface WebSocketProviderWrapperProps {
@@ -46,6 +47,21 @@ export function WebSocketProviderWrapper({
     sandboxStatus: conversation?.sandbox_status,
     refetchConversation: isConversationReady ? refetchConversation : undefined,
   });
+
+  // Prime the execution status from the backend-reported value on the
+  // AppConversation. The V1 store is otherwise only populated via WebSocket
+  // ConversationStateUpdateEvents, which are not persisted in event history.
+  // Without this, after resuming a closed conversation the UI has no source of
+  // truth for agent status until a live state-update event arrives — and the
+  // first resume may never emit one if the agent is idle, leaving the UI stuck.
+  const backendExecutionStatus = conversation?.execution_status ?? null;
+  React.useEffect(() => {
+    if (backendExecutionStatus) {
+      useV1ConversationStateStore
+        .getState()
+        .setExecutionStatus(backendExecutionStatus);
+    }
+  }, [backendExecutionStatus]);
 
   return (
     <ConversationWebSocketProvider

--- a/frontend/src/utils/status.ts
+++ b/frontend/src/utils/status.ts
@@ -171,7 +171,12 @@ export function getStatusCode(
 
   if (executionStatus && executionStatus !== V1ExecutionStatus.STUCK) {
     switch (executionStatus) {
+      // FINISHED means the agent completed its last task and is ready for
+      // the next user message. From the user's perspective that's the same
+      // as IDLE — showing "Agent has finished the task" on an empty input
+      // (e.g. after resuming a conversation) is confusing.
       case V1ExecutionStatus.IDLE:
+      case V1ExecutionStatus.FINISHED:
         return I18nKey.AGENT_STATUS$WAITING_FOR_TASK;
       case V1ExecutionStatus.RUNNING:
         return I18nKey.AGENT_STATUS$RUNNING_TASK;
@@ -179,8 +184,6 @@ export function getStatusCode(
         return I18nKey.AGENT_STATUS$WAITING_FOR_USER_CONFIRMATION;
       case V1ExecutionStatus.PAUSED:
         return I18nKey.CHAT_INTERFACE$AGENT_PAUSED_MESSAGE;
-      case V1ExecutionStatus.FINISHED:
-        return I18nKey.CHAT_INTERFACE$AGENT_FINISHED_MESSAGE;
       default:
         throw new Error(`Unknown executionStatus: ${executionStatus}`);
     }


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why

Repro from #13923: start a V1 conversation, send a simple prompt, close the tab, then resume from the conversation list. The status bar stays stuck on "Agent has finished the task" and does not update when the user sends a new prompt — it needs a browser refresh (sometimes two) before the UI behaves normally.

Root causes in the V1 frontend:

1. `AgentStatus` called `getStatusCode(..., conversation?.execution_status, ...)` — reading the execution status **straight from the REST-polled `AppConversation`**. That field lags up to 30s while the sandbox is `RUNNING` (the `useActiveConversation` refetch interval only drops to 3s while `STARTING`), so live transitions that the WebSocket already delivers into `useV1ConversationStateStore` were completely ignored by the widget.
2. The V1 conversation state store is module-level and was never reset on conversation change, so a previous session's `FINISHED` leaked across sessions.
3. On resume there was no initial source of truth for `execution_status`: `ConversationStateUpdateEvent`s are not persisted in the app-server event history, so they are absent from the preloaded event replay, and a fresh resume emits no new state event until the agent next changes state. The store stayed `null` (→ `LOADING`) until something happened.
4. `V1ExecutionStatus.FINISHED` rendered as `CHAT_INTERFACE$AGENT_FINISHED_MESSAGE` ("Agent has finished the task"), which is the same ready-for-input state as `IDLE` from the user's point of view — confusing UX on an empty input right after resume.

## Summary

- `AgentStatus` now prefers the live `useV1ConversationStateStore` value over the polled `conversation.execution_status`, falling back to the REST field when the store has not yet been primed.
- `ConversationWebSocketProvider` resets `useV1ConversationStateStore` on every conversation change so stale statuses cannot carry across sessions.
- `WebSocketProviderWrapper` primes the store from the backend-reported `execution_status` whenever `useActiveConversation` emits a new value, giving the UI an accurate initial status on resume before any WebSocket state event arrives.
- `getStatusCode` collapses `V1ExecutionStatus.FINISHED` to the same "Waiting for task" copy as `IDLE`.

## Issue Number

Fixes #13923

## How to Test

1. `make build` (first time) then `make run` — backend on `:3000`, frontend on `:3001`.
2. Open `http://localhost:3001`, start a conversation, send a simple prompt, wait for the agent to finish.
3. Close the tab (or navigate back to the home list).
4. Click the conversation in the list to resume it.
5. **Expected:** the status bar reads "Waiting for task…" (not "Agent has finished the task"), no browser refresh required.
6. Send a new prompt. **Expected:** the status transitions to "Agent is running task…" immediately via the WebSocket, instead of waiting ~30s for the next REST poll.

Unit tests: `cd frontend && npx vitest run __tests__/utils/status.test.ts` — all 17 status tests still pass.

## Video/Screenshots

https://github.com/user-attachments/assets/830e426f-9e7b-4855-9e4b-210acc63fc56

_Reviewer verification recommended — this fix was developed against the repro in #13923 with a local dev server._

## Type

- [x] Bug fix

## Notes

- No backend changes; pure frontend.
- The V1 store reset is scoped to `conversationId` change inside `ConversationWebSocketProvider`, so navigating between conversations also gets a clean slate.
- `getIndicatorColor` is unchanged — `AgentState.FINISHED` still renders as green (ready), matching the new "Waiting for task" copy.