### PR TITLE
fix(frontend): context window metric stuck at 0% when multiple LLM usages are tracked 

### DIFF
--- a/frontend/__tests__/utils/conversation-metrics.test.ts
+++ b/frontend/__tests__/utils/conversation-metrics.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "vitest";
+import { getCombinedMetrics } from "#/utils/conversation-metrics";
+import type { V1RuntimeConversationInfo } from "#/api/conversation-service/v1-conversation-service.types";
+
+const buildInfo = (
+  usageToMetrics: Record<string, unknown>,
+): V1RuntimeConversationInfo =>
+  ({
+    stats: { usage_to_metrics: usageToMetrics },
+  }) as unknown as V1RuntimeConversationInfo;
+
+describe("getCombinedMetrics", () => {
+  test("returns empty snapshot when stats are missing", () => {
+    const result = getCombinedMetrics({} as V1RuntimeConversationInfo);
+    expect(result).toEqual({
+      accumulated_cost: 0,
+      max_budget_per_task: null,
+      accumulated_token_usage: null,
+    });
+  });
+
+  test("does not let a zeroed condenser clobber the agent's per_turn_token and context_window", () => {
+    const info = buildInfo({
+      agent: {
+        accumulated_cost: 0.18,
+        max_budget_per_task: null,
+        accumulated_token_usage: {
+          prompt_tokens: 90503,
+          completion_tokens: 1228,
+          cache_read_tokens: 71414,
+          cache_write_tokens: 18744,
+          context_window: 200000,
+          per_turn_token: 18877,
+        },
+      },
+      condenser: {
+        accumulated_cost: 0,
+        max_budget_per_task: null,
+        accumulated_token_usage: {
+          prompt_tokens: 0,
+          completion_tokens: 0,
+          cache_read_tokens: 0,
+          cache_write_tokens: 0,
+          context_window: 0,
+          per_turn_token: 0,
+        },
+      },
+    });
+
+    const result = getCombinedMetrics(info);
+
+    expect(result.accumulated_cost).toBeCloseTo(0.18);
+    expect(result.accumulated_token_usage).toEqual({
+      prompt_tokens: 90503,
+      completion_tokens: 1228,
+      cache_read_tokens: 71414,
+      cache_write_tokens: 18744,
+      context_window: 200000,
+      per_turn_token: 18877,
+    });
+  });
+
+  test("sums token counts and takes max of context_window and per_turn_token across entries", () => {
+    const info = buildInfo({
+      a: {
+        accumulated_cost: 1,
+        max_budget_per_task: 10,
+        accumulated_token_usage: {
+          prompt_tokens: 100,
+          completion_tokens: 10,
+          cache_read_tokens: 5,
+          cache_write_tokens: 2,
+          context_window: 100000,
+          per_turn_token: 50,
+        },
+      },
+      b: {
+        accumulated_cost: 2,
+        max_budget_per_task: null,
+        accumulated_token_usage: {
+          prompt_tokens: 200,
+          completion_tokens: 20,
+          cache_read_tokens: 7,
+          cache_write_tokens: 3,
+          context_window: 200000,
+          per_turn_token: 75,
+        },
+      },
+    });
+
+    const result = getCombinedMetrics(info);
+
+    expect(result.accumulated_cost).toBe(3);
+    expect(result.max_budget_per_task).toBe(10);
+    expect(result.accumulated_token_usage).toEqual({
+      prompt_tokens: 300,
+      completion_tokens: 30,
+      cache_read_tokens: 12,
+      cache_write_tokens: 5,
+      context_window: 200000,
+      per_turn_token: 75,
+    });
+  });
+});

--- a/frontend/src/utils/conversation-metrics.ts
+++ b/frontend/src/utils/conversation-metrics.ts
@@ -57,7 +57,10 @@ export function getCombinedMetrics(
             combinedTokenUsage.context_window,
             metrics.accumulated_token_usage.context_window,
           ),
-          per_turn_token: metrics.accumulated_token_usage.per_turn_token, // Use the latest per_turn_token
+          per_turn_token: Math.max(
+            combinedTokenUsage.per_turn_token,
+            metrics.accumulated_token_usage.per_turn_token,
+          ),
         };
       }
     }


### PR DESCRIPTION
- [x] A human has tested these changes.

## Summary

The "Context Window" progress bar in the conversation metrics modal always displayed 0% even when tokens were clearly being consumed. 

Moreover, added tests for the conversations-metric: they were missing.

## Root Cause
 
V1 conversations report metrics per LLM usage_id in stats.usage_to_metrics — typically an agent entry and a condenser entry. The condenser entry stays at all-zero until condensation actually runs.                                   

In frontend/src/utils/conversation-metrics.ts, getCombinedMetrics merged entries by iterating Object.values(...), and for per_turn_token it unconditionally took the last iterated value:                                              
- per_turn_token: metrics.accumulated_token_usage.per_turn_token, // Use the latest per_turn_token                                                                                                                                       
                      
Since insertion order puts condenser after agent, the real per_turn_token (e.g. 18877) was clobbered by the condenser's 0, making the numerator zero → 0 / 200000 = 0%.

## Fix                                                                                                                                                                                                                                    
                  
Take the max across usage entries for per_turn_token, matching the existing behavior for context_window.

## Video/Screenshots

note: are two different convos. One in the cloud (in prod) and one locally. It was difficult to reproduce the bug locally because of caching

before 
<img width="396" height="472" alt="Screenshot 2026-04-15 at 17 02 58" src="https://github.com/user-attachments/assets/71850e29-fa4b-430b-9096-c07b0cf70b72" />

after
<img width="396" height="472" alt="Screenshot 2026-04-15 at 16 57 21" src="https://github.com/user-attachments/assets/2d712e64-617f-40b4-9a54-00cd086e278f" />


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No backend / SDK change needed — the SDK already emits context_window correctly from max_input_tokens. This was purely a frontend aggregation bug.
