### PR TITLE
Fix duplicate enterprise migration revision

### DIFF
--- a/enterprise/migrations/versions/108_add_agent_settings_to_enterprise_settings.py
+++ b/enterprise/migrations/versions/108_add_agent_settings_to_enterprise_settings.py
@@ -1,7 +1,7 @@
 """Add agent_settings columns to enterprise settings tables.
 
-Revision ID: 107
-Revises: 106
+Revision ID: 108
+Revises: 107
 Create Date: 2026-03-22 00:00:00.000000
 
 """
@@ -12,8 +12,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = '107'
-down_revision: Union[str, None] = '106'
+revision: str = '108'
+down_revision: Union[str, None] = '107'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

The latest OpenHands deploy picked up commit `b4da0e1c69b317a8b288f5ad83406f16b99061a4` and failed during database migration because enterprise migrations had two files with `revision = '107'`. Alembic reported `Revision 107 is present more than once` / `Multiple head revisions are present for given argument 'head'`, which blocked `migrate-db` and kept the app unready until Helm timed out.

## Summary

- rename the new agent settings enterprise migration from `107_*` to `108_*`
- update that migration's `revision` to `108` and `down_revision` to `107`
- restore a single linear enterprise Alembic head so migrations can advance normally

## Issue Number

N/A

## How to Test

1. Run a migration graph check over `enterprise/migrations/versions` and confirm there are no duplicate revisions.
2. Confirm the single enterprise head is `108`.
3. Rebuild/redeploy the OpenHands image and verify `migrate-db` no longer fails with duplicate-head errors.

I also ran a local AST-based verification script in the sandbox to confirm the enterprise migration graph now has unique revisions and a single head `108`.

I could not run `make install-pre-commit-hooks` in this sandbox because the repo requires `python3.12` and that interpreter is not installed here.

## Video/Screenshots

N/A

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- This PR only changes the migration identifier/ordering; the migration contents are unchanged.
- This PR was created by an AI assistant (OpenHands) on behalf of the user.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:48af328-nikolaik   --name openhands-app-48af328   docker.openhands.dev/openhands/openhands:48af328
```