### PR TITLE
fix(runtime): prevent agent from killing sandbox server on port 8000

### DIFF
--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -183,11 +183,13 @@ class ActionExecutor:
         user_id: int,
         enable_browser: bool,
         browsergym_eval_env: str | None,
+        server_port: int | None = None,
     ) -> None:
         self.plugins_to_load = plugins_to_load
         self._initial_cwd = work_dir
         self.username = username
         self.user_id = user_id
+        self.server_port = server_port
         _updated_user_id = init_user_and_working_directory(
             username=username, user_id=self.user_id, initial_cwd=work_dir
         )
@@ -291,6 +293,7 @@ class ActionExecutor:
                     os.environ.get('NO_CHANGE_TIMEOUT_SECONDS', 10)
                 ),
                 max_memory_mb=self.max_memory_gb * 1024 if self.max_memory_gb else None,
+                server_port=self.server_port,
             )
             bash_session.initialize()
             return bash_session
@@ -712,6 +715,7 @@ if __name__ == '__main__':
             user_id=args.user_id,
             enable_browser=args.enable_browser,
             browsergym_eval_env=args.browsergym_eval_env,
+            server_port=args.port,
         )
         await client.ainit()
         logger.info('ActionExecutor initialized.')

--- a/openhands/runtime/utils/bash.py
+++ b/openhands/runtime/utils/bash.py
@@ -193,18 +193,35 @@ class BashSession:
     HISTORY_LIMIT = 10_000
     PS1 = CmdOutputMetadata.to_ps1_prompt()
 
+    # Patterns that indicate a command may kill processes on a specific port.
+    # These are checked against the lowercased command string.
+    _PORT_KILL_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+        # fuser -k <port>/tcp or fuser --kill <port>
+        (re.compile(r'fuser\s+.*-k'), 'fuser -k'),
+        # kill with lsof port lookup: kill $(lsof -t -i:<port>)
+        (re.compile(r'kill\s.*lsof\s.*-i\s*:'), 'kill via lsof'),
+        # lsof piped to kill: lsof -i:<port> | ... kill
+        (re.compile(r'lsof\s.*-i\s*:.*\|\s*.*kill'), 'lsof piped to kill'),
+        # lsof piped to xargs kill
+        (re.compile(r'lsof\s.*-i\s*:.*\|\s*xargs\s+kill'), 'lsof piped to xargs kill'),
+        # ss or netstat piped to kill
+        (re.compile(r'(ss|netstat)\s.*\|\s*.*kill'), 'ss/netstat piped to kill'),
+    ]
+
     def __init__(
         self,
         work_dir: str,
         username: str | None = None,
         no_change_timeout_seconds: int = 30,
         max_memory_mb: int | None = None,
+        server_port: int | None = None,
     ):
         self.NO_CHANGE_TIMEOUT_SECONDS = no_change_timeout_seconds
         self.work_dir = work_dir
         self.username = username
         self._initialized = False
         self.max_memory_mb = max_memory_mb
+        self.server_port = server_port
 
     def initialize(self) -> None:
         self.server = libtmux.Server()
@@ -250,6 +267,13 @@ class BashSession:
         self.pane = self.window.active_pane
         logger.debug(f'pane: {self.pane}; history_limit: {self.session.history_limit}')
         _initial_window.kill()
+
+        # Export the sandbox server port so agents are aware of it
+        if self.server_port is not None and self.pane:
+            self.pane.send_keys(
+                f'export OPENHANDS_SANDBOX_PORT={self.server_port}'
+            )
+            time.sleep(0.05)
 
         # Configure bash to use simple PS1 and disable PS2
         if self.pane:
@@ -302,6 +326,32 @@ class BashSession:
         # Special keys are of the form C-<key>
         _command = command.strip()
         return _command.startswith('C-') and len(_command) == 3
+
+    def _is_command_dangerous_for_server(self, command: str) -> str | None:
+        """Check if the command would kill processes on the sandbox server port.
+
+        Returns an error message if dangerous, None otherwise.
+        """
+        if self.server_port is None:
+            return None
+
+        cmd_lower = command.lower()
+        port_str = str(self.server_port)
+
+        # Check if the command references the server port AND matches a kill pattern
+        if port_str not in cmd_lower:
+            return None
+
+        for pattern, description in self._PORT_KILL_PATTERNS:
+            if pattern.search(cmd_lower):
+                return (
+                    f'ERROR: Cannot execute this command because it would kill '
+                    f'the OpenHands sandbox server process on port {self.server_port}. '
+                    f'The sandbox runtime uses port {self.server_port} — killing it will crash your session. '
+                    f'Please use a different port for your application '
+                    f'(e.g., 3000, 5000, 8080, or any other available port).'
+                )
+        return None
 
     def _clear_screen(self) -> None:
         """Clear the tmux pane screen and history."""
@@ -541,6 +591,11 @@ class BashSession:
                     f'Provided commands:\n{"\n".join(f"({i + 1}) {cmd}" for i, cmd in enumerate(splited_commands))}'
                 )
             )
+
+        # Check if the command would kill the sandbox server process
+        dangerous_msg = self._is_command_dangerous_for_server(command)
+        if dangerous_msg:
+            return ErrorObservation(content=dangerous_msg)
 
         # Get initial state before sending command
         initial_pane_output = self._get_pane_content()

--- a/tests/unit/runtime/utils/test_bash_port_protection.py
+++ b/tests/unit/runtime/utils/test_bash_port_protection.py
@@ -1,0 +1,114 @@
+"""Tests for BashSession port protection against self-termination.
+
+See: https://github.com/OpenHands/OpenHands/issues/13927
+"""
+
+import pytest
+
+from openhands.runtime.utils.bash import BashSession
+
+
+@pytest.fixture
+def bash_session_with_port():
+    """Create a BashSession instance without initializing tmux, for unit testing."""
+    session = BashSession(
+        work_dir='/tmp',
+        server_port=8000,
+    )
+    return session
+
+
+@pytest.fixture
+def bash_session_without_port():
+    """Create a BashSession instance without a server port."""
+    session = BashSession(
+        work_dir='/tmp',
+    )
+    return session
+
+
+class TestPortProtection:
+    """Test _is_command_dangerous_for_server detects port-killing commands."""
+
+    def test_fuser_kill_detected(self, bash_session_with_port):
+        assert bash_session_with_port._is_command_dangerous_for_server(
+            'fuser -k 8000/tcp'
+        ) is not None
+
+    def test_fuser_kill_flag_variants(self, bash_session_with_port):
+        assert bash_session_with_port._is_command_dangerous_for_server(
+            'fuser --kill 8000/tcp'
+        ) is not None
+        assert bash_session_with_port._is_command_dangerous_for_server(
+            'fuser -k -n tcp 8000'
+        ) is not None
+
+    def test_kill_via_lsof(self, bash_session_with_port):
+        assert bash_session_with_port._is_command_dangerous_for_server(
+            'kill $(lsof -t -i:8000)'
+        ) is not None
+        assert bash_session_with_port._is_command_dangerous_for_server(
+            'kill -9 $(lsof -t -i:8000)'
+        ) is not None
+
+    def test_lsof_piped_to_kill(self, bash_session_with_port):
+        assert bash_session_with_port._is_command_dangerous_for_server(
+            'lsof -i:8000 | awk \'{print $2}\' | xargs kill'
+        ) is not None
+
+    def test_lsof_piped_to_xargs_kill(self, bash_session_with_port):
+        assert bash_session_with_port._is_command_dangerous_for_server(
+            'lsof -t -i:8000 | xargs kill -9'
+        ) is not None
+
+    def test_safe_commands_not_blocked(self, bash_session_with_port):
+        """Commands that don't kill processes on the server port should pass."""
+        assert bash_session_with_port._is_command_dangerous_for_server(
+            'ls -la'
+        ) is None
+        assert bash_session_with_port._is_command_dangerous_for_server(
+            'python -m http.server 8080'
+        ) is None
+        assert bash_session_with_port._is_command_dangerous_for_server(
+            'lsof -i:8000'
+        ) is None  # Just listing, not killing
+        assert bash_session_with_port._is_command_dangerous_for_server(
+            'fuser 8000/tcp'
+        ) is None  # No -k flag
+
+    def test_different_port_not_blocked(self, bash_session_with_port):
+        """Commands targeting a different port should not be blocked."""
+        assert bash_session_with_port._is_command_dangerous_for_server(
+            'fuser -k 3000/tcp'
+        ) is None
+        assert bash_session_with_port._is_command_dangerous_for_server(
+            'kill $(lsof -t -i:3000)'
+        ) is None
+
+    def test_no_server_port_allows_all(self, bash_session_without_port):
+        """When no server port is set, all commands are allowed."""
+        assert bash_session_without_port._is_command_dangerous_for_server(
+            'fuser -k 8000/tcp'
+        ) is None
+
+    def test_error_message_contains_port(self, bash_session_with_port):
+        msg = bash_session_with_port._is_command_dangerous_for_server(
+            'fuser -k 8000/tcp'
+        )
+        assert '8000' in msg
+        assert 'different port' in msg
+
+    def test_kill_all_port_variant(self, bash_session_with_port):
+        """Test kill with lsof using different syntax."""
+        # Both backtick and $() variants should be caught
+        assert bash_session_with_port._is_command_dangerous_for_server(
+            'kill -9 `lsof -t -i:8000`'
+        ) is not None
+        assert bash_session_with_port._is_command_dangerous_for_server(
+            'kill -9 $(lsof -t -i:8000)'
+        ) is not None
+
+    def test_ss_piped_to_kill(self, bash_session_with_port):
+        assert bash_session_with_port._is_command_dangerous_for_server(
+            "ss -tlnp | grep 8000 | awk '{print $6}' | xargs kill"
+        ) is not None


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

When an AI agent tries to deploy a local web app, it may check for an available port and decide to free port 8000 by terminating the process using it (e.g., `fuser -k 8000/tcp` or `kill $(lsof -t -i:8000)`). The problem is that port 8000 is used by the OpenHands action execution server running inside the sandbox — so the agent kills its own runtime, causing the entire session to crash.

## Summary

- Add a pre-execution safety check in `BashSession.execute()` that detects commands which would kill processes on the sandbox server port and returns an error with guidance to use a different port
- Pass the server port from `ActionExecutor` through to `BashSession` so it knows which port to protect
- Export `OPENHANDS_SANDBOX_PORT` environment variable in the bash session so agents can proactively avoid the port
- Add 11 unit tests covering various port-killing command patterns (fuser, lsof, kill, ss/netstat pipes) and safe command passthrough

## Issue Number

Closes #13927

## How to Test

1. Run the unit tests:
   ```bash
   poetry run pytest tests/unit/runtime/utils/test_bash_port_protection.py -v
   ```
2. All 11 tests should pass, verifying:
   - Commands like `fuser -k 8000/tcp` and `kill $(lsof -t -i:8000)` are blocked when targeting the server port
   - Safe commands (e.g., `ls`, `lsof -i:8000` without kill) are not blocked
   - Commands targeting other ports are not blocked
   - When no server port is configured, all commands are allowed

3. To test end-to-end: start OpenHands, ask the agent to "create and run a web server on port 8000" — it should now get an error message suggesting an alternative port instead of crashing the session.

## Video/Screenshots

N/A — backend-only change with unit tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The detection uses regex patterns matching common port-killing idioms (`fuser -k`, `kill` via `lsof`, pipe chains to `kill`). This is intentionally conservative — it only blocks commands that both reference the server port number AND match a kill pattern.
- The `OPENHANDS_SANDBOX_PORT` env var provides a secondary defense: well-behaved agents can read it to avoid the port entirely.
- This is in the legacy V0 `action_execution_server.py` / `bash.py` codepath, which is still actively used. The V1 agent server (via the Software Agent SDK) would need a similar protection.