### PR TITLE
Disable Slack repo selector after submission

### DIFF
--- a/enterprise/integrations/slack/slack_manager.py
+++ b/enterprise/integrations/slack/slack_manager.py
@@ -57,6 +57,9 @@ SLACK_USER_MSG_KEY_PREFIX = 'slack_user_msg'
 # Expiration time for stored user messages (5 minutes)
 # Arbitrary timeout based on typical user attention span; may be tuned based on feedback
 SLACK_USER_MSG_EXPIRATION = 300
+# Key prefix for deduplicating repository selection form submissions
+SLACK_FORM_INTERACTION_KEY_PREFIX = 'slack_form_interaction'
+SLACK_FORM_INTERACTION_EXPIRATION = 300
 
 
 class SlackManager(Manager[SlackViewInterface]):
@@ -323,6 +326,124 @@ class SlackManager(Manager[SlackViewInterface]):
             for repo in repos[:100]
         ]
 
+    def _build_repo_selection_submitted_message(
+        self, selected_repository: str | None
+    ) -> dict[str, Any]:
+        """Build a non-interactive repo selection message after submission."""
+        status_text = (
+            ':white_check_mark: Continuing without a repository. Starting OpenHands...'
+            if selected_repository is None
+            else f':white_check_mark: Selected repository `{selected_repository}`. Starting OpenHands...'
+        )
+
+        return {
+            'text': 'Repository selection submitted.',
+            'blocks': [
+                {
+                    'type': 'header',
+                    'text': {
+                        'type': 'plain_text',
+                        'text': 'Choose a repository',
+                        'emoji': True,
+                    },
+                },
+                {
+                    'type': 'section',
+                    'text': {
+                        'type': 'mrkdwn',
+                        'text': 'Select a repository or continue without one:',
+                    },
+                },
+                {
+                    'type': 'section',
+                    'text': {
+                        'type': 'mrkdwn',
+                        'text': status_text,
+                    },
+                },
+            ],
+        }
+
+    async def _disable_repo_selection_controls(
+        self, slack_payload: dict[str, Any], selected_repository: str | None
+    ) -> None:
+        """Replace the interactive repo selector with a submitted status message."""
+        selector_message_ts = slack_payload.get('container', {}).get('message_ts')
+        if not selector_message_ts:
+            logger.warning(
+                'slack_disable_repo_selection_missing_message_ts',
+                extra={'payload_keys': list(slack_payload.keys())},
+            )
+            return
+
+        slack_view = await SlackMessageView.from_payload(
+            slack_payload, self._get_slack_team_store()
+        )
+        if not slack_view:
+            logger.warning(
+                'slack_disable_repo_selection_missing_view',
+                extra={'payload_keys': list(slack_payload.keys())},
+            )
+            return
+
+        updated_message = self._build_repo_selection_submitted_message(
+            selected_repository
+        )
+
+        try:
+            client = AsyncWebClient(token=slack_view.bot_access_token)
+            await client.chat_update(
+                channel=slack_view.channel_id,
+                ts=selector_message_ts,
+                text=updated_message['text'],
+                blocks=updated_message['blocks'],
+            )
+        except Exception as e:
+            logger.warning(
+                'slack_disable_repo_selection_failed',
+                extra={
+                    'error': str(e),
+                    'channel_id': slack_view.channel_id,
+                    'message_ts': selector_message_ts,
+                    'selected_repository': selected_repository,
+                },
+            )
+
+    async def _claim_form_interaction(
+        self, message_ts: str, thread_ts: str | None
+    ) -> bool:
+        """Claim a repo selection form submission, ignoring duplicates."""
+        interaction_key = (
+            f'{SLACK_FORM_INTERACTION_KEY_PREFIX}:{message_ts}:{thread_ts}'
+        )
+
+        try:
+            created = await sio.manager.redis.set(
+                interaction_key,
+                1,
+                nx=True,
+                ex=SLACK_FORM_INTERACTION_EXPIRATION,
+            )
+        except Exception as e:
+            logger.warning(
+                'slack_form_interaction_claim_failed',
+                extra={
+                    'error': str(e),
+                    'message_ts': message_ts,
+                    'thread_ts': thread_ts,
+                },
+            )
+            return True
+
+        if not created:
+            logger.info(
+                'slack_form_interaction_duplicate',
+                extra={'message_ts': message_ts, 'thread_ts': thread_ts},
+            )
+            return False
+
+        return True
+
     async def search_repos_for_slack(
         self, user_auth: UserAuth, query: str, per_page: int = 20
     ) -> list[dict[str, Any]]:
@@ -444,6 +565,11 @@ class SlackManager(Manager[SlackViewInterface]):
 
         # Convert "-" (No Repository) to None
         selected_repository = None if selected_value == '-' else selected_value
+
+        if not await self._claim_form_interaction(message_ts, thread_ts):
+            return
+
+        await self._disable_repo_selection_controls(slack_payload, selected_repository)
 
         # Retrieve the original user message from Redis
         try:

--- a/enterprise/tests/unit/test_slack_integration.py
+++ b/enterprise/tests/unit/test_slack_integration.py
@@ -4,6 +4,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import BackgroundTasks
 from integrations.slack.slack_manager import (
+    SLACK_FORM_INTERACTION_EXPIRATION,
+    SLACK_FORM_INTERACTION_KEY_PREFIX,
     SLACK_USER_MSG_EXPIRATION,
     SLACK_USER_MSG_KEY_PREFIX,
     SlackManager,
@@ -206,6 +208,7 @@ class TestRepoVerificationHandling:
         mock_sio.manager.redis = mock_redis
         stored_msg = json.dumps({'text': 'Hello, help me with code', 'user': 'U123'})
         mock_redis.get = AsyncMock(return_value=stored_msg)
+        mock_redis.set = AsyncMock(return_value=True)
 
         # Simulate button click payload (what Slack sends when button is clicked)
         button_payload = {
@@ -218,15 +221,30 @@ class TestRepoVerificationHandling:
                 }
             ],
             'user': {'id': 'U123'},
-            'container': {'channel_id': 'C123'},
+            'container': {'channel_id': 'C123', 'message_ts': 'selector.123'},
             'team': {'id': 'T123'},
         }
 
         # Mock receive_message to capture what's passed to it
-        with patch.object(
-            slack_manager, 'receive_message', new_callable=AsyncMock
-        ) as mock_receive:
+        with (
+            patch.object(
+                slack_manager, 'receive_message', new_callable=AsyncMock
+            ) as mock_receive,
+            patch.object(
+                slack_manager,
+                '_disable_repo_selection_controls',
+                new_callable=AsyncMock,
+            ) as mock_disable_controls,
+        ):
             await slack_manager.receive_form_interaction(button_payload)
+
+            mock_redis.set.assert_awaited_once_with(
+                f'{SLACK_FORM_INTERACTION_KEY_PREFIX}:1234567890.123456:None',
+                1,
+                nx=True,
+                ex=SLACK_FORM_INTERACTION_EXPIRATION,
+            )
+            mock_disable_controls.assert_awaited_once_with(button_payload, None)
 
             # Verify receive_message was called
             mock_receive.assert_called_once()
@@ -236,6 +254,49 @@ class TestRepoVerificationHandling:
             assert call_args.message['selected_repo'] is None
             assert call_args.message['message_ts'] == '1234567890.123456'
             assert call_args.message['thread_ts'] is None
+
+    @pytest.mark.asyncio
+    @patch('integrations.slack.slack_manager.sio')
+    async def test_duplicate_form_interaction_is_ignored(
+        self,
+        mock_sio,
+        slack_manager,
+    ):
+        """Test that duplicate repo selection interactions do not start twice."""
+        mock_redis = AsyncMock()
+        mock_sio.manager.redis = mock_redis
+        mock_redis.set = AsyncMock(return_value=False)
+        mock_redis.get = AsyncMock()
+
+        button_payload = {
+            'type': 'block_actions',
+            'actions': [
+                {
+                    'action_id': 'no_repository:1234567890.123456:None',
+                    'type': 'button',
+                    'value': '-',
+                }
+            ],
+            'user': {'id': 'U123'},
+            'container': {'channel_id': 'C123', 'message_ts': 'selector.123'},
+            'team': {'id': 'T123'},
+        }
+
+        with (
+            patch.object(
+                slack_manager,
+                '_disable_repo_selection_controls',
+                new_callable=AsyncMock,
+            ) as mock_disable_controls,
+            patch.object(
+                slack_manager, 'receive_message', new_callable=AsyncMock
+            ) as mock_receive_message,
+        ):
+            await slack_manager.receive_form_interaction(button_payload)
+
+        mock_disable_controls.assert_not_awaited()
+        mock_receive_message.assert_not_called()
+        mock_redis.get.assert_not_called()
 
     @patch('integrations.slack.slack_manager.sio')
     @patch('integrations.slack.slack_manager.ProviderHandler')
@@ -314,6 +375,18 @@ class TestBuildRepoOptions:
         assert len(options) == 2
         assert options[0]['value'] == 'owner/repo1'
         assert options[1]['value'] == 'owner/repo2'
+
+    def test_build_repo_selection_submitted_message_removes_controls(
+        self, slack_manager
+    ):
+        """Test submitted repo selection message no longer includes interactive controls."""
+        message = slack_manager._build_repo_selection_submitted_message(None)
+
+        assert message['text'] == 'Repository selection submitted.'
+        assert all(block['type'] != 'actions' for block in message['blocks'])
+        assert (
+            'Continuing without a repository' in message['blocks'][-1]['text']['text']
+        )
 
     def test_build_options_empty_repos(self, slack_manager):
         """Test building options with empty repo list returns empty list.


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Slack's repository chooser remained interactive after selecting **No Repository**, so users could click it multiple times and start duplicate OpenHands jobs.

## Summary

- replace the interactive Slack repo chooser message with a non-interactive status message as soon as a selection is submitted
- dedupe repo-selection form submissions with a Redis `SET NX` guard keyed by the original Slack message/thread timestamps
- add unit coverage for the submission-state message and duplicate-interaction handling

## Issue Number

N/A

## How to Test

- `cd enterprise && PYTHONPATH=".:/workspace/project/OpenHands:$PYTHONPATH" poetry run pytest tests/unit/test_slack_integration.py -q`
- `cd enterprise && poetry run pre-commit run --files integrations/slack/slack_manager.py tests/unit/test_slack_integration.py --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml`
- In Slack, trigger the repo chooser, click **No Repository** once, and verify the controls are replaced by a submitted state and a second interaction does not start another job.

## Video/Screenshots

N/A

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- This PR was created by an AI assistant (OpenHands) on behalf of the user.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:7e14d69-nikolaik   --name openhands-app-7e14d69   docker.openhands.dev/openhands/openhands:7e14d69
```