### PR TITLE
chore(ci): rename ALLHANDS_BOT_GITHUB_PAT to PAT_TOKEN

### DIFF
--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -35,7 +35,7 @@ jobs:
               if: steps.check-fork.outputs.is_fork == 'false'
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
-                  token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  token: ${{ secrets.PAT_TOKEN }}
 
             - name: Remove .pr/ directory
               id: remove

--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -44,5 +44,5 @@ jobs:
                   llm-base-url: https://llm-proxy.app.all-hands.dev
                   review-style: roasted
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  github-token: ${{ secrets.PAT_TOKEN }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}


### PR DESCRIPTION
## Summary
- Rename `ALLHANDS_BOT_GITHUB_PAT` → `PAT_TOKEN` in `pr-review-by-openhands.yml` and `pr-artifacts.yml`
- Completes the org-wide rename started in `software-agent-sdk` (commit aa829596)
- Both secret names point to the same underlying token — this unifies naming ahead of the credential rotation planned in OpenHands/evaluation#428

## Prerequisite
`PAT_TOKEN` already exists in this repo's secrets — `openhands-resolver.yml` uses it.

## Test plan
- [ ] After merge, trigger a PR review and verify it still posts comments
- [ ] After merge, approve a PR with `.pr/` directory and verify cleanup still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:f378abb-nikolaik   --name openhands-app-f378abb   docker.openhands.dev/openhands/openhands:f378abb
```