### PR TITLE
chore(ci): use ALLHANDS_BOT_GITHUB_PAT in resolver workflow

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -131,7 +131,7 @@ jobs:
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
           LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
           LLM_API_VERSION: ${{ inputs.LLM_API_VERSION }}
-          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN || secrets.ALLHANDS_BOT_GITHUB_PAT }}
           PAT_USERNAME: ${{ secrets.PAT_USERNAME }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -185,7 +185,7 @@ jobs:
           fi
 
           echo "MAX_ITERATIONS=${{ inputs.max_iterations || 50 }}" >> $GITHUB_ENV
-          echo "SANDBOX_ENV_GITHUB_TOKEN=${{ secrets.PAT_TOKEN || github.token }}" >> $GITHUB_ENV
+          echo "SANDBOX_ENV_GITHUB_TOKEN=${{ secrets.PAT_TOKEN || secrets.ALLHANDS_BOT_GITHUB_PAT || github.token }}" >> $GITHUB_ENV
           echo "SANDBOX_BASE_CONTAINER_IMAGE=${{ inputs.base_container_image }}" >> $GITHUB_ENV
 
           # Set branch variables
@@ -194,7 +194,7 @@ jobs:
       - name: Comment on issue with start message
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PAT_TOKEN || github.token }}
+          github-token: ${{ secrets.PAT_TOKEN || secrets.ALLHANDS_BOT_GITHUB_PAT || github.token }}
           script: |
             const issueType = process.env.ISSUE_TYPE;
             github.rest.issues.createComment({
@@ -242,7 +242,7 @@ jobs:
 
       - name: Attempt to resolve issue
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN || secrets.ALLHANDS_BOT_GITHUB_PAT || github.token }}
           GITHUB_USERNAME: ${{ secrets.PAT_USERNAME || 'openhands-agent' }}
           GIT_USERNAME: ${{ secrets.PAT_USERNAME || 'openhands-agent' }}
           LLM_MODEL: ${{ secrets.LLM_MODEL || inputs.LLM_MODEL }}
@@ -279,7 +279,7 @@ jobs:
       - name: Create draft PR or push branch
         if: always() # Create PR or branch even if the previous steps fail
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN || secrets.ALLHANDS_BOT_GITHUB_PAT || github.token }}
           GITHUB_USERNAME: ${{ secrets.PAT_USERNAME || 'openhands-agent' }}
           GIT_USERNAME: ${{ secrets.PAT_USERNAME || 'openhands-agent' }}
           LLM_MODEL: ${{ secrets.LLM_MODEL || inputs.LLM_MODEL }}
@@ -311,7 +311,7 @@ jobs:
           AGENT_RESPONDED: ${{ env.AGENT_RESPONDED || 'false' }}
           ISSUE_NUMBER: ${{ env.ISSUE_NUMBER }}
         with:
-          github-token: ${{ secrets.PAT_TOKEN || github.token }}
+          github-token: ${{ secrets.PAT_TOKEN || secrets.ALLHANDS_BOT_GITHUB_PAT || github.token }}
           script: |
             const fs = require('fs');
             const issueNumber = process.env.ISSUE_NUMBER;
@@ -348,7 +348,7 @@ jobs:
           ISSUE_NUMBER: ${{ env.ISSUE_NUMBER }}
           RESOLUTION_SUCCESS: ${{ steps.check_result.outputs.RESOLUTION_SUCCESS }}
         with:
-          github-token: ${{ secrets.PAT_TOKEN || github.token }}
+          github-token: ${{ secrets.PAT_TOKEN || secrets.ALLHANDS_BOT_GITHUB_PAT || github.token }}
           script: |
             const fs = require('fs');
             const path = require('path');
@@ -421,7 +421,7 @@ jobs:
         env:
           ISSUE_NUMBER: ${{ env.ISSUE_NUMBER }}
         with:
-          github-token: ${{ secrets.PAT_TOKEN || github.token }}
+          github-token: ${{ secrets.PAT_TOKEN || secrets.ALLHANDS_BOT_GITHUB_PAT || github.token }}
           script: |
             const issueNumber = process.env.ISSUE_NUMBER;
 

--- a/openhands/resolver/examples/openhands-resolver.yml
+++ b/openhands/resolver/examples/openhands-resolver.yml
@@ -28,7 +28,7 @@ jobs:
       target_branch: ${{ vars.TARGET_BRANCH || 'main' }}
       runner: ${{ vars.TARGET_RUNNER }}
     secrets:
-      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      PAT_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
       PAT_USERNAME: ${{ secrets.PAT_USERNAME }}
       LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
       LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}


### PR DESCRIPTION
## Summary
- Update `openhands-resolver.yml` to use `ALLHANDS_BOT_GITHUB_PAT` org secret
- **No breaking change** for downstream callers — the `workflow_call` secret input stays named `PAT_TOKEN`
- Uses fallback pattern: `secrets.PAT_TOKEN || secrets.ALLHANDS_BOT_GITHUB_PAT || github.token`
  - **workflow_call**: `secrets.PAT_TOKEN` is populated by caller → uses it
  - **direct trigger** (issues/PRs): `secrets.PAT_TOKEN` is empty → falls through to `secrets.ALLHANDS_BOT_GITHUB_PAT` org secret
  - **no PAT at all**: falls through to `github.token`
- Updates downstream template to show callers mapping `ALLHANDS_BOT_GITHUB_PAT`
- Part of OpenHands/evaluation#428

## Test plan
- [ ] Trigger resolver via issue label and verify it picks up `ALLHANDS_BOT_GITHUB_PAT`
- [ ] Verify downstream callers (e.g., `openhands-aci`) still work without changes (they pass `PAT_TOKEN:`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:9e12dea-nikolaik   --name openhands-app-9e12dea   docker.openhands.dev/openhands/openhands:9e12dea
```