### PR TITLE
Fix get_latest_token to return str instead of SecretStr

### DIFF
--- a/openhands/app_server/user/auth_user_context.py
+++ b/openhands/app_server/user/auth_user_context.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Any, AsyncGenerator
 
 from fastapi import Request
-from pydantic import PrivateAttr
+from pydantic import PrivateAttr, SecretStr
 
 from openhands.app_server.errors import AuthError
 from openhands.app_server.services.injector import InjectorState
@@ -96,6 +96,8 @@ class AuthUserContext(UserContext):
         provider_handler = await self.get_provider_handler()
         service = provider_handler.get_service(provider_type)
         token = await service.get_latest_token()
+        if isinstance(token, SecretStr):
+            return token.get_secret_value()
         return token
 
     async def get_secrets(self) -> dict[str, SecretSource]:


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

The `AuthUserContext.get_latest_token()` method declared `str | None` as its return type but was actually returning `SecretStr | None` from the underlying service's `get_latest_token()` method. 

This caused a bug in `live_status_app_conversation_service.py` at line 873 where the returned value was wrapped in `SecretStr(static_token)`. When `static_token` was already a `SecretStr`, this created a nested `SecretStr` containing the string representation of a `SecretStr` object (something like `SecretStr('**********')`) instead of the actual secret value.

## Summary

- Added `SecretStr` import from pydantic
- Updated `get_latest_token()` to check if the token is a `SecretStr` and call `.get_secret_value()` to return the plain string, matching the declared return type

## How to Test

The fix ensures the method honors its type contract. You can verify by:
1. Checking that `get_latest_token()` returns a plain `str` (not `SecretStr`) when a token exists
2. The existing tests in `enterprise/tests/unit/integrations/test_resolver_context.py` verify this behavior pattern

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is a defensive fix that handles the type mismatch between the `UserContext` interface (which declares `str | None`) and the service implementations (which return `SecretStr | None`).

_This PR was created by an AI assistant (OpenHands)._

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4a10ff52-9f77-4371-af20-ab7dd5aca08a)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:6cbd58b-nikolaik   --name openhands-app-6cbd58b   docker.openhands.dev/openhands/openhands:6cbd58b
```