### PR TITLE
Refresh git settings after provider updates

### DIFF
--- a/frontend/__tests__/hooks/mutation/use-add-git-providers.test.tsx
+++ b/frontend/__tests__/hooks/mutation/use-add-git-providers.test.tsx
@@ -1,0 +1,75 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SecretsService } from "#/api/secrets-service";
+import { useAddGitProviders } from "#/hooks/mutation/use-add-git-providers";
+import { Provider, ProviderToken } from "#/types/settings";
+
+const mockTrackGitProviderConnected = vi.fn();
+
+vi.mock("#/hooks/use-tracking", () => ({
+  useTracking: () => ({
+    trackGitProviderConnected: mockTrackGitProviderConnected,
+  }),
+}));
+
+vi.mock("#/context/use-selected-organization", () => ({
+  useSelectedOrganizationId: () => ({ organizationId: "org-1" }),
+}));
+
+const buildProviders = (
+  overrides: Partial<Record<Provider, ProviderToken>> = {},
+): Record<Provider, ProviderToken> => ({
+  github: { token: "", host: null },
+  gitlab: { token: "", host: null },
+  bitbucket: { token: "", host: null },
+  bitbucket_data_center: { token: "", host: null },
+  azure_devops: { token: "", host: null },
+  forgejo: { token: "", host: null },
+  enterprise_sso: { token: "", host: null },
+  ...overrides,
+});
+
+describe("useAddGitProviders", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockTrackGitProviderConnected.mockReset();
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+  });
+
+  it("invalidates personal settings queries after saving providers", async () => {
+    vi.spyOn(SecretsService, "addGitProvider").mockResolvedValue(true);
+
+    const personalSettingsQueryKey = ["settings", "personal", "org-1"] as const;
+    queryClient.setQueryData(personalSettingsQueryKey, {
+      provider_tokens_set: {},
+    });
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useAddGitProviders(), { wrapper });
+
+    await result.current.mutateAsync({
+      providers: buildProviders({
+        github: { token: "ghp_test_123", host: null },
+      }),
+    });
+
+    expect(invalidateSpy).toHaveBeenCalled();
+    expect(queryClient.getQueryState(personalSettingsQueryKey)?.isInvalidated).toBe(
+      true,
+    );
+  });
+});

--- a/frontend/src/hooks/mutation/use-add-git-providers.ts
+++ b/frontend/src/hooks/mutation/use-add-git-providers.ts
@@ -28,7 +28,7 @@ export const useAddGitProviders = () => {
       }
 
       await queryClient.invalidateQueries({
-        queryKey: ["settings", organizationId],
+        queryKey: ["settings", "personal", organizationId],
       });
     },
     meta: {


### PR DESCRIPTION
human: I have QAed this locally and can verify that the problem existed before, and is fixed after.

<img width="711" height="237" alt="Screenshot 2026-04-18 at 6 59 48 AM" src="https://github.com/user-attachments/assets/843df47b-e74c-415d-b5bf-97d65240d285" />

## Summary
- invalidate the actual personal settings query after saving git provider credentials
- add a regression test that proves the cached settings entry becomes invalidated
- exercise the git settings screen path with the existing route tests

## Testing
- cd frontend && npm run test -- __tests__/hooks/mutation/use-add-git-providers.test.tsx __tests__/routes/git-settings.test.tsx
- cd frontend && npm run lint:fix && npm run build

Fixes #13964.

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:73d0490-nikolaik   --name openhands-app-73d0490   docker.openhands.dev/openhands/openhands:73d0490
```