### PR TITLE
fix(enterprise): Apply deployment LLM proxy URL override in /api/v1/users/me

### DIFF
--- a/enterprise/server/routes/users_v1.py
+++ b/enterprise/server/routes/users_v1.py
@@ -12,7 +12,10 @@ from fastapi.responses import JSONResponse
 from server.auth.saas_user_auth import SaasUserAuth
 from server.models.user_models import SaasUserInfo
 
-from openhands.app_server.config import depends_user_context
+from openhands.app_server.config import (
+    depends_user_context,
+    resolve_provider_llm_base_url,
+)
 from openhands.app_server.sandbox.session_auth import validate_session_key_ownership
 from openhands.app_server.user.auth_user_context import AuthUserContext
 from openhands.app_server.user.user_context import UserContext
@@ -42,8 +45,9 @@ def _inject_sdk_compat_fields(
     """
     agent_settings = content.get('agent_settings') or {}
     llm = agent_settings.get('llm') or {}
-    content['llm_model'] = llm.get('model')
-    content['llm_base_url'] = llm.get('base_url')
+    model = llm.get('model')
+    content['llm_model'] = model
+    content['llm_base_url'] = resolve_provider_llm_base_url(model, llm.get('base_url'))
     if include_api_key:
         content['llm_api_key'] = llm.get('api_key')
     content['mcp_config'] = agent_settings.get('mcp_config')

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -890,24 +890,13 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             or user.agent_settings.llm.model
             or LLM.model_fields['model'].default
         )
-        base_url = user.agent_settings.llm.base_url
-        if model and (
-            model.startswith('openhands/') or model.startswith('litellm_proxy/')
-        ):
-            # The SDK auto-fills base_url with the default public proxy for
-            # openhands/ models.  We need to distinguish "user explicitly set a
-            # custom URL" from "SDK auto-filled the default".
-            #
-            # Priority: user-explicit URL > deployment provider URL > SDK default
-            _SDK_DEFAULT_PROXY = 'https://llm-proxy.app.all-hands.dev/'
-            user_set_custom = base_url and base_url.rstrip(
-                '/'
-            ) != _SDK_DEFAULT_PROXY.rstrip('/')
-            if user_set_custom:
-                pass  # keep user's explicit base_url
-            elif self.openhands_provider_base_url:
-                base_url = self.openhands_provider_base_url
-            # else: keep the SDK default
+        from openhands.app_server.config import resolve_provider_llm_base_url
+
+        base_url = resolve_provider_llm_base_url(
+            model,
+            user.agent_settings.llm.base_url,
+            provider_base_url=self.openhands_provider_base_url,
+        )
 
         return LLM(
             model=model,

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -52,7 +52,10 @@ from openhands.app_server.app_conversation.hook_loader import (
 from openhands.app_server.app_conversation.sql_app_conversation_info_service import (
     SQLAppConversationInfoService,
 )
-from openhands.app_server.config import get_event_callback_service
+from openhands.app_server.config import (
+    get_event_callback_service,
+    resolve_provider_llm_base_url,
+)
 from openhands.app_server.errors import SandboxError
 from openhands.app_server.event.event_service import EventService
 from openhands.app_server.event_callback.event_callback_models import EventCallback
@@ -890,7 +893,6 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             or user.agent_settings.llm.model
             or LLM.model_fields['model'].default
         )
-        from openhands.app_server.config import resolve_provider_llm_base_url
 
         base_url = resolve_provider_llm_base_url(
             model,

--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -112,6 +112,50 @@ def get_openhands_provider_base_url() -> str | None:
     return os.getenv('OPENHANDS_PROVIDER_BASE_URL') or os.getenv('LLM_BASE_URL') or None
 
 
+# The SDK auto-fills this URL as the default for openhands/ and litellm_proxy/
+# models.  Deployments (e.g. staging) may use a different LLM proxy, configured
+# via OPENHANDS_PROVIDER_BASE_URL.
+_SDK_DEFAULT_PROXY = 'https://llm-proxy.app.all-hands.dev/'
+
+
+def resolve_provider_llm_base_url(
+    model: str | None,
+    base_url: str | None,
+    provider_base_url: str | None = None,
+) -> str | None:
+    """Apply deployment-specific LLM proxy override when needed.
+
+    When the model uses ``openhands/`` or ``litellm_proxy/`` prefix and the
+    stored ``base_url`` is the SDK default, replace it with the deployment's
+    provider URL.
+
+    Priority: user-explicit URL > deployment provider URL > SDK default.
+
+    Args:
+        model: LLM model name (e.g. ``litellm_proxy/gpt-4``).
+        base_url: The base URL from user/org settings.
+        provider_base_url: Deployment provider URL.  Falls back to
+            ``get_openhands_provider_base_url()`` when *None*.
+    """
+    if not model or not (
+        model.startswith('openhands/') or model.startswith('litellm_proxy/')
+    ):
+        return base_url
+
+    user_set_custom = base_url and base_url.rstrip('/') != _SDK_DEFAULT_PROXY.rstrip(
+        '/'
+    )
+    if user_set_custom:
+        return base_url
+
+    if provider_base_url is None:
+        provider_base_url = get_openhands_provider_base_url()
+    if provider_base_url:
+        return provider_base_url
+
+    return base_url
+
+
 def _get_default_lifespan():
     # Check legacy parameters for saas mode. If we are in SAAS mode do not apply
     # OpenHands alembic migrations

--- a/tests/unit/app_server/test_resolve_provider_llm_base_url.py
+++ b/tests/unit/app_server/test_resolve_provider_llm_base_url.py
@@ -1,0 +1,193 @@
+"""Tests for resolve_provider_llm_base_url in openhands.app_server.config."""
+
+from openhands.app_server.config import (
+    _SDK_DEFAULT_PROXY,
+    resolve_provider_llm_base_url,
+)
+
+SDK_DEFAULT = _SDK_DEFAULT_PROXY  # 'https://llm-proxy.app.all-hands.dev/'
+STAGING_URL = 'https://llm-proxy.staging.all-hands.dev/'
+CUSTOM_URL = 'https://my-own-proxy.example.com/v1'
+
+
+class TestOpenHandsPrefixWithProviderUrl:
+    """openhands/ prefix + SDK default URL + provider URL set → returns provider URL."""
+
+    def test_openhands_prefix_replaces_sdk_default(self):
+        result = resolve_provider_llm_base_url(
+            model='openhands/gpt-4',
+            base_url=SDK_DEFAULT,
+            provider_base_url=STAGING_URL,
+        )
+        assert result == STAGING_URL
+
+    def test_openhands_prefix_sdk_default_no_trailing_slash(self):
+        result = resolve_provider_llm_base_url(
+            model='openhands/gpt-4',
+            base_url=SDK_DEFAULT.rstrip('/'),
+            provider_base_url=STAGING_URL,
+        )
+        assert result == STAGING_URL
+
+
+class TestOpenHandsPrefixWithCustomUrl:
+    """openhands/ prefix + custom URL (not SDK default) → returns custom URL."""
+
+    def test_custom_url_preserved(self):
+        result = resolve_provider_llm_base_url(
+            model='openhands/gpt-4',
+            base_url=CUSTOM_URL,
+            provider_base_url=STAGING_URL,
+        )
+        assert result == CUSTOM_URL
+
+    def test_custom_url_preserved_no_provider(self):
+        result = resolve_provider_llm_base_url(
+            model='openhands/gpt-4',
+            base_url=CUSTOM_URL,
+            provider_base_url=None,
+        )
+        assert result == CUSTOM_URL
+
+
+class TestOpenHandsPrefixNoProviderUrl:
+    """openhands/ prefix + SDK default URL + no provider URL → returns SDK default."""
+
+    def test_sdk_default_returned_when_no_provider(self):
+        result = resolve_provider_llm_base_url(
+            model='openhands/gpt-4',
+            base_url=SDK_DEFAULT,
+            provider_base_url='',  # empty string = falsy
+        )
+        assert result == SDK_DEFAULT
+
+    def test_sdk_default_returned_when_provider_none_and_env_unset(self, monkeypatch):
+        monkeypatch.delenv('OPENHANDS_PROVIDER_BASE_URL', raising=False)
+        monkeypatch.delenv('LLM_BASE_URL', raising=False)
+        result = resolve_provider_llm_base_url(
+            model='openhands/gpt-4',
+            base_url=SDK_DEFAULT,
+            # provider_base_url defaults to None → falls back to env lookup
+        )
+        assert result == SDK_DEFAULT
+
+
+class TestNonMatchingModelPrefix:
+    """Model without openhands/ or litellm_proxy/ prefix → returns base_url unchanged."""
+
+    def test_plain_model_returns_base_url(self):
+        result = resolve_provider_llm_base_url(
+            model='gpt-4',
+            base_url='https://api.openai.com/v1',
+            provider_base_url=STAGING_URL,
+        )
+        assert result == 'https://api.openai.com/v1'
+
+    def test_anthropic_model_returns_base_url(self):
+        result = resolve_provider_llm_base_url(
+            model='anthropic/claude-3-opus',
+            base_url='https://api.anthropic.com',
+            provider_base_url=STAGING_URL,
+        )
+        assert result == 'https://api.anthropic.com'
+
+    def test_none_base_url_passthrough(self):
+        result = resolve_provider_llm_base_url(
+            model='gpt-4',
+            base_url=None,
+            provider_base_url=STAGING_URL,
+        )
+        assert result is None
+
+
+class TestLitellmProxyPrefix:
+    """litellm_proxy/ prefix behaves identically to openhands/ prefix."""
+
+    def test_replaces_sdk_default(self):
+        result = resolve_provider_llm_base_url(
+            model='litellm_proxy/gpt-4',
+            base_url=SDK_DEFAULT,
+            provider_base_url=STAGING_URL,
+        )
+        assert result == STAGING_URL
+
+    def test_custom_url_preserved(self):
+        result = resolve_provider_llm_base_url(
+            model='litellm_proxy/gpt-4',
+            base_url=CUSTOM_URL,
+            provider_base_url=STAGING_URL,
+        )
+        assert result == CUSTOM_URL
+
+    def test_sdk_default_returned_when_no_provider(self):
+        result = resolve_provider_llm_base_url(
+            model='litellm_proxy/gpt-4',
+            base_url=SDK_DEFAULT,
+            provider_base_url='',
+        )
+        assert result == SDK_DEFAULT
+
+
+class TestEdgeCases:
+    """Edge cases: None values, empty strings, trailing slash normalization."""
+
+    def test_none_model_returns_base_url(self):
+        result = resolve_provider_llm_base_url(
+            model=None,
+            base_url=SDK_DEFAULT,
+            provider_base_url=STAGING_URL,
+        )
+        assert result == SDK_DEFAULT
+
+    def test_empty_model_returns_base_url(self):
+        result = resolve_provider_llm_base_url(
+            model='',
+            base_url=SDK_DEFAULT,
+            provider_base_url=STAGING_URL,
+        )
+        assert result == SDK_DEFAULT
+
+    def test_none_base_url_with_openhands_model_and_provider(self):
+        result = resolve_provider_llm_base_url(
+            model='openhands/gpt-4',
+            base_url=None,
+            provider_base_url=STAGING_URL,
+        )
+        assert result == STAGING_URL
+
+    def test_none_base_url_with_openhands_model_no_provider(self, monkeypatch):
+        monkeypatch.delenv('OPENHANDS_PROVIDER_BASE_URL', raising=False)
+        monkeypatch.delenv('LLM_BASE_URL', raising=False)
+        result = resolve_provider_llm_base_url(
+            model='openhands/gpt-4',
+            base_url=None,
+        )
+        assert result is None
+
+    def test_trailing_slash_normalization(self):
+        """SDK default with and without trailing slash should both be detected."""
+        for url in [SDK_DEFAULT, SDK_DEFAULT.rstrip('/')]:
+            result = resolve_provider_llm_base_url(
+                model='openhands/gpt-4',
+                base_url=url,
+                provider_base_url=STAGING_URL,
+            )
+            assert result == STAGING_URL, f'Failed for base_url={url!r}'
+
+    def test_env_fallback_when_provider_base_url_is_none(self, monkeypatch):
+        monkeypatch.setenv('OPENHANDS_PROVIDER_BASE_URL', STAGING_URL)
+        result = resolve_provider_llm_base_url(
+            model='openhands/gpt-4',
+            base_url=SDK_DEFAULT,
+            # provider_base_url defaults to None → env lookup
+        )
+        assert result == STAGING_URL
+
+    def test_llm_base_url_env_fallback(self, monkeypatch):
+        monkeypatch.delenv('OPENHANDS_PROVIDER_BASE_URL', raising=False)
+        monkeypatch.setenv('LLM_BASE_URL', STAGING_URL)
+        result = resolve_provider_llm_base_url(
+            model='openhands/gpt-4',
+            base_url=SDK_DEFAULT,
+        )
+        assert result == STAGING_URL


### PR DESCRIPTION
## Problem

Automation-triggered conversations on non-production deployments (e.g. staging) fail immediately with:

```
litellm.AuthenticationError: Litellm_proxyException - Authentication Error, Invalid proxy server token passed.
Unable to find token in cache or `LiteLLM_VerificationTokenTable`
```

The agent starts but immediately errors out and the conversation is archived without executing.

## Root Cause

When the SDK runs inside an automation sandbox, it calls `GET /api/v1/users/me?expose_secrets=true` to retrieve the user's LLM configuration (model, api_key, base_url). The `_inject_sdk_compat_fields()` function returned the raw `llm_base_url` from the user's stored settings without applying the deployment-specific override.

On staging, the user's settings contain the SDK default proxy URL (`https://llm-proxy.app.all-hands.dev/` — production), but the staging deployment uses `https://llm-proxy.staging.all-hands.dev/`. This caused the SDK to send a staging-generated LLM API key to the production LiteLLM proxy, which doesn't recognize it.

The v1 conversation path (`live_status_app_conversation_service._get_llm()`) already had this override logic — it detects the SDK default URL and replaces it with the deployment's `OPENHANDS_PROVIDER_BASE_URL`. But the `/api/v1/users/me` endpoint (used by SDK callers like automations) was missing this logic.

**Path comparison:**

| Path | Base URL Override | Result |
|------|------------------|--------|
| V1 conversation (web UI) | `_get_llm()` detects SDK default, replaces with deployment URL | ✅ Works |
| Automation SDK (`get_llm()` → `/api/v1/users/me`) | `_inject_sdk_compat_fields()` returned raw settings | ❌ Wrong URL → AuthenticationError |

## Fix

Extracted `resolve_provider_llm_base_url()` into `openhands/app_server/config.py` — a shared utility that both `_inject_sdk_compat_fields()` (enterprise route) and `_configure_llm()` (conversation service) now use. When the model uses `litellm_proxy/` or `openhands/` prefix and the base URL is the SDK default, it replaces it with `OPENHANDS_PROVIDER_BASE_URL` (if configured).

This is a minimal, targeted fix — only the `/api/v1/users/me` response is affected, and only for the flat SDK compatibility fields (`llm_base_url`). Custom user-set URLs are preserved.

## Test Coverage

19 unit tests added for `resolve_provider_llm_base_url()` covering all critical scenarios:
- `openhands/` prefix + SDK default URL + provider URL → returns provider URL
- `openhands/` prefix + custom URL (not SDK default) → preserves custom URL  
- `openhands/` prefix + SDK default URL + no provider → returns SDK default
- Non-matching model prefix → returns `base_url` unchanged
- `litellm_proxy/` prefix (same behavior as `openhands/`)
- Edge cases: `None`/empty values, trailing slash normalization, env var fallbacks (`OPENHANDS_PROVIDER_BASE_URL`, `LLM_BASE_URL`)

## Evidence

This fix addresses the same URL resolution logic that `_configure_llm()` (V1 conversation path) already performs successfully in production. The refactoring extracts that proven logic into a shared function and applies it to the `/api/v1/users/me` endpoint as well.

**Unit test verification:**
```
$ poetry run pytest tests/unit/app_server/test_resolve_provider_llm_base_url.py -v
19 passed
```

**Staging e2e verification** requires deploying to a feature environment (`ohpr-*`) with its own Keycloak — the isolated auth means production API keys don't work. E2e testing should be performed by a maintainer with staging access after deployment.

_This PR was created by an AI assistant (OpenHands)._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/48dae754-e2e1-4ad0-9d79-576c2ddfafb5)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:a9de05e-nikolaik   --name openhands-app-a9de05e   docker.openhands.dev/openhands/openhands:a9de05e
```