### PR TITLE
fix: invalidate sandbox and VS Code URL caches on conversation resume

### DIFF
--- a/frontend/__tests__/hooks/mutation/use-unified-resume-conversation-sandbox.test.tsx
+++ b/frontend/__tests__/hooks/mutation/use-unified-resume-conversation-sandbox.test.tsx
@@ -85,10 +85,12 @@ describe("useUnifiedResumeConversationSandbox", () => {
     // Verify sandbox queries were invalidated
     const invalidateCalls = invalidateSpy.mock.calls.map((call) => call[0]);
     const sandboxInvalidation = invalidateCalls.find(
-      (call) => JSON.stringify(call?.queryKey) === JSON.stringify(["sandboxes"]),
+      (call) => call?.queryKey?.[0] === "sandboxes",
     );
     const vscodeInvalidation = invalidateCalls.find(
-      (call) => JSON.stringify(call?.queryKey) === JSON.stringify(["unified", "vscode_url"]),
+      (call) =>
+        call?.queryKey?.[0] === "unified" &&
+        call?.queryKey?.[1] === "vscode_url",
     );
 
     expect(sandboxInvalidation).toBeDefined();

--- a/frontend/__tests__/hooks/mutation/use-unified-resume-conversation-sandbox.test.tsx
+++ b/frontend/__tests__/hooks/mutation/use-unified-resume-conversation-sandbox.test.tsx
@@ -1,0 +1,97 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import React from "react";
+import { SandboxService } from "#/api/sandbox-service/sandbox-service.api";
+import V1ConversationService from "#/api/conversation-service/v1-conversation-service.api";
+import { useUnifiedResumeConversationSandbox } from "#/hooks/mutation/use-unified-start-conversation";
+
+// Mock the error message store
+vi.mock("#/stores/error-message-store", () => ({
+  useErrorMessageStore: (selector: (state: { removeErrorMessage: () => void }) => unknown) =>
+    selector({ removeErrorMessage: vi.fn() }),
+}));
+
+describe("useUnifiedResumeConversationSandbox", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    vi.restoreAllMocks();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+
+  it("invalidates sandbox and vscode_url queries on settled", async () => {
+    // Mock the API calls in the mutation chain
+    vi.spyOn(V1ConversationService, "batchGetAppConversations").mockResolvedValue([
+      {
+        id: "test-conv-id",
+        created_by_user_id: null,
+        sandbox_id: "test-sandbox-id",
+        conversation_url: "http://localhost:3000",
+        session_api_key: "test-key",
+        selected_repository: null,
+        selected_branch: null,
+        git_provider: null,
+        title: "Test",
+        public: false,
+        sandbox_status: "RUNNING",
+        execution_status: null,
+        trigger: null,
+        pr_number: [],
+        llm_model: null,
+        metrics: null,
+        sub_conversation_ids: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    ]);
+    vi.spyOn(SandboxService, "resumeSandbox").mockResolvedValue({ success: true });
+
+    // Pre-populate query cache with stale sandbox data
+    queryClient.setQueryData(["sandboxes", "batch", ["test-sandbox-id"]], [
+      {
+        sandbox_id: "test-sandbox-id",
+        exposed_urls: [{ name: "VSCODE", url: "https://old-runtime.example.com" }],
+      },
+    ]);
+    queryClient.setQueryData(["unified", "vscode_url", "test-conv-id"], {
+      url: "https://old-runtime.example.com",
+      error: null,
+    });
+
+    // Spy on invalidateQueries
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useUnifiedResumeConversationSandbox(), { wrapper });
+
+    // Trigger the mutation
+    result.current.mutate({ conversationId: "test-conv-id" });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess || result.current.isError).toBe(true);
+    });
+
+    // Verify sandbox queries were invalidated
+    const invalidateCalls = invalidateSpy.mock.calls.map((call) => call[0]);
+    const sandboxInvalidation = invalidateCalls.find(
+      (call) => JSON.stringify(call?.queryKey) === JSON.stringify(["sandboxes"]),
+    );
+    const vscodeInvalidation = invalidateCalls.find(
+      (call) => JSON.stringify(call?.queryKey) === JSON.stringify(["unified", "vscode_url"]),
+    );
+
+    expect(sandboxInvalidation).toBeDefined();
+    expect(vscodeInvalidation).toBeDefined();
+  });
+});

--- a/frontend/__tests__/hooks/mutation/use-v1-resume-conversation.test.tsx
+++ b/frontend/__tests__/hooks/mutation/use-v1-resume-conversation.test.tsx
@@ -1,0 +1,92 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import React from "react";
+import V1ConversationService from "#/api/conversation-service/v1-conversation-service.api";
+import { useV1ResumeConversation } from "#/hooks/mutation/use-v1-resume-conversation";
+
+describe("useV1ResumeConversation", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    vi.restoreAllMocks();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+
+  it("invalidates sandbox and vscode_url queries on settled", async () => {
+    // Mock the API calls in the mutation chain
+    vi.spyOn(V1ConversationService, "batchGetAppConversations").mockResolvedValue([
+      {
+        id: "test-conv-id",
+        created_by_user_id: null,
+        sandbox_id: "test-sandbox-id",
+        conversation_url: "http://localhost:3000",
+        session_api_key: "test-key",
+        selected_repository: null,
+        selected_branch: null,
+        git_provider: null,
+        title: "Test",
+        public: false,
+        sandbox_status: "RUNNING",
+        execution_status: null,
+        trigger: null,
+        pr_number: [],
+        llm_model: null,
+        metrics: null,
+        sub_conversation_ids: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    ]);
+    vi.spyOn(V1ConversationService, "resumeConversation").mockResolvedValue({
+      success: true,
+    });
+
+    // Pre-populate query cache with stale sandbox data
+    queryClient.setQueryData(["sandboxes", "batch", ["test-sandbox-id"]], [
+      {
+        sandbox_id: "test-sandbox-id",
+        exposed_urls: [{ name: "VSCODE", url: "https://old-runtime.example.com" }],
+      },
+    ]);
+    queryClient.setQueryData(["unified", "vscode_url", "test-conv-id"], {
+      url: "https://old-runtime.example.com",
+      error: null,
+    });
+
+    // Spy on invalidateQueries
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useV1ResumeConversation(), { wrapper });
+
+    // Trigger the mutation
+    result.current.mutate({ conversationId: "test-conv-id" });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess || result.current.isError).toBe(true);
+    });
+
+    // Verify sandbox queries were invalidated
+    const invalidateCalls = invalidateSpy.mock.calls.map((call) => call[0]);
+    const sandboxInvalidation = invalidateCalls.find(
+      (call) => JSON.stringify(call?.queryKey) === JSON.stringify(["sandboxes"]),
+    );
+    const vscodeInvalidation = invalidateCalls.find(
+      (call) => JSON.stringify(call?.queryKey) === JSON.stringify(["unified", "vscode_url"]),
+    );
+
+    expect(sandboxInvalidation).toBeDefined();
+    expect(vscodeInvalidation).toBeDefined();
+  });
+});

--- a/frontend/__tests__/hooks/mutation/use-v1-resume-conversation.test.tsx
+++ b/frontend/__tests__/hooks/mutation/use-v1-resume-conversation.test.tsx
@@ -80,10 +80,12 @@ describe("useV1ResumeConversation", () => {
     // Verify sandbox queries were invalidated
     const invalidateCalls = invalidateSpy.mock.calls.map((call) => call[0]);
     const sandboxInvalidation = invalidateCalls.find(
-      (call) => JSON.stringify(call?.queryKey) === JSON.stringify(["sandboxes"]),
+      (call) => call?.queryKey?.[0] === "sandboxes",
     );
     const vscodeInvalidation = invalidateCalls.find(
-      (call) => JSON.stringify(call?.queryKey) === JSON.stringify(["unified", "vscode_url"]),
+      (call) =>
+        call?.queryKey?.[0] === "unified" &&
+        call?.queryKey?.[1] === "vscode_url",
     );
 
     expect(sandboxInvalidation).toBeDefined();

--- a/frontend/src/hooks/mutation/conversation-mutation-utils.ts
+++ b/frontend/src/hooks/mutation/conversation-mutation-utils.ts
@@ -147,4 +147,8 @@ export const invalidateConversationQueries = (
   queryClient.invalidateQueries({
     queryKey: ["v1-batch-get-app-conversations"],
   });
+  // Invalidate sandbox data so new runtime URLs are picked up after resume
+  queryClient.invalidateQueries({ queryKey: ["sandboxes"] });
+  // Invalidate VS Code URL cache so it refetches with the new sandbox data
+  queryClient.invalidateQueries({ queryKey: ["unified", "vscode_url"] });
 };

--- a/frontend/src/hooks/mutation/conversation-mutation-utils.ts
+++ b/frontend/src/hooks/mutation/conversation-mutation-utils.ts
@@ -147,8 +147,8 @@ export const invalidateConversationQueries = (
   queryClient.invalidateQueries({
     queryKey: ["v1-batch-get-app-conversations"],
   });
-  // Invalidate sandbox data so new runtime URLs are picked up after resume
+  // Invalidate sandbox and VS Code URL caches to pick up new runtime URLs after resume
+  // Uses partial key matching to invalidate all sandbox-related queries (batch, individual, etc.)
   queryClient.invalidateQueries({ queryKey: ["sandboxes"] });
-  // Invalidate VS Code URL cache so it refetches with the new sandbox data
   queryClient.invalidateQueries({ queryKey: ["unified", "vscode_url"] });
 };

--- a/frontend/src/hooks/mutation/use-v1-resume-conversation.ts
+++ b/frontend/src/hooks/mutation/use-v1-resume-conversation.ts
@@ -35,6 +35,10 @@ export const useV1ResumeConversation = () => {
       queryClient.invalidateQueries({
         queryKey: ["v1-batch-get-app-conversations"],
       });
+      // Invalidate sandbox data so new runtime URLs are picked up after resume
+      queryClient.invalidateQueries({ queryKey: ["sandboxes"] });
+      // Invalidate VS Code URL cache so it refetches with the new sandbox data
+      queryClient.invalidateQueries({ queryKey: ["unified", "vscode_url"] });
     },
   });
 };


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

When a conversation is resumed after its runtime was auto-paused, a **new runtime** is provisioned but the VS Code tab still loads the URL from the **old runtime**, resulting in a "Bad Gateway" error. This happens because the TanStack Query cache for sandbox data and VS Code URLs is not invalidated when the resume mutation settles.

## Summary

- Invalidate `["sandboxes"]` and `["unified", "vscode_url"]` query caches in both `invalidateConversationQueries` (used by `useUnifiedResumeConversationSandbox`) and `useV1ResumeConversation`'s `onSettled` callback
- Added tests for both resume hooks verifying sandbox and VS Code URL cache invalidation

## Issue Number

Fixes #13987

## How to Test

1. Start a conversation, open the VS Code tab (should work)
2. Wait for the runtime to idle out and get paused
3. Resume the conversation
4. The VS Code tab should load the new runtime's URL instead of showing "Bad Gateway"

Alternatively, run the new unit tests:
```bash
cd frontend && npx vitest run __tests__/hooks/mutation/use-unified-resume-conversation-sandbox.test.tsx __tests__/hooks/mutation/use-v1-resume-conversation.test.tsx
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The fix invalidates all sandbox-related caches (using the partial key `["sandboxes"]`) rather than specific sandbox IDs, since the mutation doesn't have direct access to the sandbox ID. TanStack Query's partial key matching ensures all sandbox batch queries are invalidated. This also fixes the same stale-URL issue for worker/active host URLs, which depend on the same sandbox data.


@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9a5d0557-49fb-43b4-8d03-0a5ed8e952d1)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:ed1cbc1-nikolaik   --name openhands-app-ed1cbc1   docker.openhands.dev/openhands/openhands:ed1cbc1
```