### PR TITLE
Fix V1 resumed conversation status sync

### DIFF
--- a/frontend/src/components/features/controls/agent-status.tsx
+++ b/frontend/src/components/features/controls/agent-status.tsx
@@ -32,7 +32,7 @@ export function AgentStatus({
 }: AgentStatusProps) {
   const { t } = useTranslation();
   const { setShouldShownAgentLoading } = useConversationStore();
-  const { curAgentState } = useAgentState();
+  const { curAgentState, executionStatus } = useAgentState();
   const webSocketStatus = useUnifiedWebSocketStatus();
   const { data: conversation } = useActiveConversation();
   const { taskStatus } = useTaskPolling();
@@ -48,7 +48,7 @@ export function AgentStatus({
 
   const statusCode = getStatusCode(
     webSocketStatus,
-    conversation?.execution_status || null,
+    executionStatus ?? null,
     conversation?.sandbox_status || null,
     taskStatus,
     subConversationTaskStatus,

--- a/frontend/src/hooks/mutation/conversation-mutation-utils.test.ts
+++ b/frontend/src/hooks/mutation/conversation-mutation-utils.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import { updateConversationSandboxStatusInCache } from "./conversation-mutation-utils";
+import { V1ExecutionStatus } from "#/types/v1/core/base/common";
+import { V1AppConversation } from "#/api/conversation-service/v1-conversation-service.types";
+
+const createConversation = (): V1AppConversation => ({
+  id: "conversation-1",
+  created_by_user_id: null,
+  sandbox_id: "sandbox-1",
+  selected_repository: null,
+  selected_branch: null,
+  git_provider: null,
+  title: "Test conversation",
+  trigger: null,
+  pr_number: [],
+  llm_model: null,
+  metrics: null,
+  created_at: "2026-04-16T00:00:00Z",
+  updated_at: "2026-04-16T00:00:00Z",
+  sandbox_status: "RUNNING",
+  execution_status: V1ExecutionStatus.FINISHED,
+  conversation_url: "http://localhost:3000/api/conversations/conversation-1",
+  session_api_key: "session-key",
+  sub_conversation_ids: [],
+});
+
+describe("updateConversationSandboxStatusInCache", () => {
+  it("updates the active conversation sandbox_status field", () => {
+    const queryClient = new QueryClient();
+    const conversation = createConversation();
+
+    queryClient.setQueryData(
+      ["user", "conversation", conversation.id],
+      conversation,
+    );
+
+    updateConversationSandboxStatusInCache(
+      queryClient,
+      conversation.id,
+      "PAUSED",
+    );
+
+    expect(
+      queryClient.getQueryData<V1AppConversation | null>([
+        "user",
+        "conversation",
+        conversation.id,
+      ]),
+    ).toMatchObject({
+      sandbox_status: "PAUSED",
+      execution_status: null,
+    });
+  });
+
+  it("does not create a legacy status field on the active conversation cache", () => {
+    const queryClient = new QueryClient();
+    const conversation = createConversation();
+
+    queryClient.setQueryData(
+      ["user", "conversation", conversation.id],
+      conversation,
+    );
+
+    updateConversationSandboxStatusInCache(
+      queryClient,
+      conversation.id,
+      "STARTING",
+    );
+
+    const cachedConversation = queryClient.getQueryData<
+      V1AppConversation & { status?: string }
+    >(["user", "conversation", conversation.id]);
+
+    expect(cachedConversation?.status).toBeUndefined();
+    expect(cachedConversation?.sandbox_status).toBe("STARTING");
+  });
+});

--- a/frontend/src/hooks/mutation/conversation-mutation-utils.ts
+++ b/frontend/src/hooks/mutation/conversation-mutation-utils.ts
@@ -1,6 +1,8 @@
 import { QueryClient } from "@tanstack/react-query";
 import V1ConversationService from "#/api/conversation-service/v1-conversation-service.api";
+import { V1AppConversation } from "#/api/conversation-service/v1-conversation-service.types";
 import { SandboxService } from "#/api/sandbox-service/sandbox-service.api";
+import { V1SandboxStatus } from "#/api/sandbox-service/sandbox-service.types";
 
 /**
  * Fetches a V1 conversation's sandbox_id and conversation_url
@@ -93,20 +95,20 @@ export const resumeV1Conversation = async (conversationId: string) => {
 export const updateConversationSandboxStatusInCache = (
   queryClient: QueryClient,
   conversationId: string,
-  sandbox_status: string,
+  sandbox_status: V1SandboxStatus,
 ): void => {
   // Update the individual conversation cache
-  queryClient.setQueryData<{ status: string }>(
+  queryClient.setQueryData<V1AppConversation | null>(
     ["user", "conversation", conversationId],
     (oldData) => {
       if (!oldData) return oldData;
-      let status = sandbox_status;
-      if (status === "PAUSED") {
-        status = "STOPPED";
-      } else if (status === "MISSING") {
-        status = "ARCHIVED";
-      }
-      return { ...oldData, status };
+
+      return {
+        ...oldData,
+        sandbox_status,
+        execution_status:
+          sandbox_status === "RUNNING" ? oldData.execution_status : null,
+      };
     },
   );
 

--- a/frontend/src/hooks/use-agent-state.test.tsx
+++ b/frontend/src/hooks/use-agent-state.test.tsx
@@ -1,0 +1,61 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAgentState } from "./use-agent-state";
+import { useActiveConversation } from "./query/use-active-conversation";
+import { useV1ConversationStateStore } from "#/stores/v1-conversation-state-store";
+import { AgentState } from "#/types/agent-state";
+import { V1ExecutionStatus } from "#/types/v1/core/base/common";
+
+vi.mock("./query/use-active-conversation", () => ({
+  useActiveConversation: vi.fn(),
+}));
+
+describe("useAgentState", () => {
+  const mockUseActiveConversation = vi.mocked(useActiveConversation);
+
+  beforeEach(() => {
+    act(() => {
+      useV1ConversationStateStore.getState().reset();
+    });
+
+    mockUseActiveConversation.mockReturnValue({
+      data: null,
+    } as ReturnType<typeof useActiveConversation>);
+  });
+
+  it("prefers live websocket execution status over cached conversation status", () => {
+    mockUseActiveConversation.mockReturnValue({
+      data: {
+        execution_status: V1ExecutionStatus.FINISHED,
+      },
+    } as ReturnType<typeof useActiveConversation>);
+
+    act(() => {
+      useV1ConversationStateStore
+        .getState()
+        .setExecutionStatus(V1ExecutionStatus.RUNNING);
+    });
+
+    const { result } = renderHook(() => useAgentState());
+
+    expect(result.current.executionStatus).toBe(V1ExecutionStatus.RUNNING);
+    expect(result.current.curAgentState).toBe(AgentState.RUNNING);
+  });
+
+  it("falls back to cached conversation execution status when live state is empty", () => {
+    mockUseActiveConversation.mockReturnValue({
+      data: {
+        execution_status: V1ExecutionStatus.WAITING_FOR_CONFIRMATION,
+      },
+    } as ReturnType<typeof useActiveConversation>);
+
+    const { result } = renderHook(() => useAgentState());
+
+    expect(result.current.executionStatus).toBe(
+      V1ExecutionStatus.WAITING_FOR_CONFIRMATION,
+    );
+    expect(result.current.curAgentState).toBe(
+      AgentState.AWAITING_USER_CONFIRMATION,
+    );
+  });
+});

--- a/frontend/src/hooks/use-agent-state.ts
+++ b/frontend/src/hooks/use-agent-state.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useV1ConversationStateStore } from "#/stores/v1-conversation-state-store";
 import { AgentState } from "#/types/agent-state";
 import { V1ExecutionStatus } from "#/types/v1/core/base/common";
@@ -31,20 +32,28 @@ function mapV1StatusToV0State(status: V1ExecutionStatus | null): AgentState {
   }
 }
 
+export interface UseAgentStateResult {
+  curAgentState: AgentState;
+  executionStatus?: V1ExecutionStatus | null;
+}
+
 /**
  * Unified hook that returns the current agent state
  * - For V0 conversations: Returns state from useAgentStore
  * - For V1 conversations: Returns mapped state from useV1ConversationStateStore
  */
-export function useAgentState() {
-  const v1Status = useV1ConversationStateStore(
+export function useAgentState(): UseAgentStateResult {
+  const liveExecutionStatus = useV1ConversationStateStore(
     (state) => state.execution_status,
   );
+  const fallbackExecutionStatus =
+    useActiveConversation().data?.execution_status ?? null;
 
+  const executionStatus = liveExecutionStatus ?? fallbackExecutionStatus;
   const curAgentState = useMemo(
-    () => mapV1StatusToV0State(v1Status),
-    [v1Status],
+    () => mapV1StatusToV0State(executionStatus),
+    [executionStatus],
   );
 
-  return { curAgentState };
+  return { curAgentState, executionStatus };
 }

--- a/frontend/src/routes/conversation.tsx
+++ b/frontend/src/routes/conversation.tsx
@@ -6,6 +6,7 @@ import { useConversationId } from "#/hooks/use-conversation-id";
 import { useCommandStore } from "#/stores/command-store";
 import { useConversationStore } from "#/stores/conversation-store";
 import { useAgentStore } from "#/stores/agent-store";
+import { useV1ConversationStateStore } from "#/stores/v1-conversation-state-store";
 import { AgentState } from "#/types/agent-state";
 
 import { EventHandler } from "../wrapper/event-handler";
@@ -39,6 +40,9 @@ function AppContent() {
   const { resetConversationState } = useConversationStore();
   const navigate = useNavigate();
   const clearTerminal = useCommandStore((state) => state.clearTerminal);
+  const resetV1ConversationState = useV1ConversationStateStore(
+    (state) => state.reset,
+  );
   const setCurrentAgentState = useAgentStore(
     (state) => state.setCurrentAgentState,
   );
@@ -50,6 +54,7 @@ function AppContent() {
   React.useEffect(() => {
     clearTerminal();
     resetConversationState();
+    resetV1ConversationState();
     setCurrentAgentState(AgentState.LOADING);
     removeErrorMessage();
     clearEvents();
@@ -57,6 +62,7 @@ function AppContent() {
     conversationId,
     clearTerminal,
     resetConversationState,
+    resetV1ConversationState,
     setCurrentAgentState,
     removeErrorMessage,
     clearEvents,


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Resuming a closed V1 conversation could leave the frontend showing stale status data. In practice this made resumed conversations look finished even while the agent was actively running, and sometimes required extra browser refreshes before the UI recovered.

## Summary

- update the V1 conversation cache helper to write `sandbox_status` and clear stale cached `execution_status` when a sandbox is no longer running
- prefer live/store execution state over stale conversation-query data when deriving agent status for the resume UI
- reset V1 execution state on conversation change/resume and add regression tests for cache updates and agent-state precedence

## Issue Number

Closes #13923

## How to Test

1. In `frontend/`, run `vitest run src/hooks/use-agent-state.test.tsx src/hooks/mutation/conversation-mutation-utils.test.ts`
2. In `frontend/`, run `npm run typecheck:staged`
3. In the app UI, start a V1 conversation, let it run, close it, then resume it and confirm the status indicator follows the live agent state instead of showing stale "finished" state

## Video/Screenshots

Not included.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Targeted frontend validation passed locally for the added regression tests and staged typecheck.
- `AGENTS.md` contains an uncommitted local memory note and is intentionally excluded from this PR.
- This PR description was generated by an AI assistant (OpenHands) on behalf of the user.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:0653112-nikolaik   --name openhands-app-0653112   docker.openhands.dev/openhands/openhands:0653112
```