### PR TITLE
fix(frontend): add scrolling support to user avatar popup

### DIFF
--- a/frontend/src/components/features/context-menu/context-menu-container.tsx
+++ b/frontend/src/components/features/context-menu/context-menu-container.tsx
@@ -25,11 +25,13 @@ export function ContextMenuContainer({
         // Base styling - same for ALL modes (SaaS, OSS, mobile, desktop)
         "absolute rounded-[12px] p-[25px]",
         "bg-[#050505] border border-[#242424]",
-        "text-white overflow-hidden z-[9999]",
+        "text-white overflow-y-auto z-[9999]",
         "context-menu-box-shadow",
         // Positioning
         "right-0 md:right-auto md:left-full md:bottom-0",
         "w-fit",
+        // Constrain height to viewport with some padding
+        "max-h-[calc(100vh-2rem)]",
         className,
       )}
     >


### PR DESCRIPTION
- Change overflow-hidden to overflow-y-auto to enable vertical scrolling
- Add max-h-[calc(100vh-2rem)] to constrain height to viewport

This fixes the issue where items in the User Avatar popup would be inaccessible when they extended beyond the visible screen area.

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:e7e2b9f-nikolaik   --name openhands-app-e7e2b9f   docker.openhands.dev/openhands/openhands:e7e2b9f
```