### PR TITLE
fix(settings): align MCP settings layout with other settings pages

### DIFF
--- a/frontend/src/routes/mcp-settings.tsx
+++ b/frontend/src/routes/mcp-settings.tsx
@@ -157,7 +157,7 @@ function MCPSettingsScreen() {
   }
 
   return (
-    <div className="h-full max-w-[1000px] mx-auto flex flex-col px-6 gap-6 pb-8">
+    <div className="h-full flex flex-col gap-6 pb-8">
       <div className="flex justify-between items-center">
         <div>
           <Typography.H2 className="mb-2">


### PR DESCRIPTION
Fixes #13982

## Problem
The MCP settings page had `max-w-[1000px] mx-auto px-6` on its outer container, which caused the content to be centered with extra padding rather than left-aligned. This made the MCP settings visually inconsistent with other settings pages (e.g., Secrets, Git settings) that start content from the left edge.

## Solution
Removed `max-w-[1000px]`, `mx-auto`, and `px-6` from the list view wrapper in `mcp-settings.tsx`. The content now aligns to the left, consistent with the rest of the settings pages which use the same layout provided by `SettingsLayout`.

## Testing
- Verified the MCP settings list view now starts from the left edge, matching `secrets-settings` and other settings pages.
- No functional behavior was changed; only the layout class was adjusted.