### PR TITLE
feat(app-server): route ACP agents to the ACP conversation endpoint

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_models.py
+++ b/openhands/app_server/app_conversation/app_conversation_models.py
@@ -84,6 +84,15 @@ class AppConversationInfo(BaseModel):
     pr_number: list[int] = Field(default_factory=list)
     llm_model: str | None = None
 
+    # Discriminator for the agent variant that owns this conversation.
+    # Defaults to ``"llm"`` so rows persisted before the ACP variant
+    # shipped round-trip unchanged. Populated from the ``agent_kind`` on
+    # ``AgentSettings`` at conversation-start time. Downstream consumers
+    # (URL builder, live-status poller) branch on this to hit the right
+    # agent-server route — ``/api/conversations`` for ``"llm"``,
+    # ``/api/acp/conversations`` for ``"acp"``.
+    agent_kind: str = 'llm'
+
     metrics: MetricsSnapshot | None = None
 
     parent_conversation_id: OpenHandsUUID | None = None

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -15,8 +15,10 @@ from fastapi import Request
 from pydantic import Field, SecretStr, TypeAdapter
 
 from openhands.agent_server.models import (
+    ACPConversationInfo,
     ConversationInfo,
     SendMessageRequest,
+    StartACPConversationRequest,
     StartConversationRequest,
     TextContent,
 )
@@ -52,10 +54,7 @@ from openhands.app_server.app_conversation.hook_loader import (
 from openhands.app_server.app_conversation.sql_app_conversation_info_service import (
     SQLAppConversationInfoService,
 )
-from openhands.app_server.config import (
-    get_event_callback_service,
-    resolve_provider_llm_base_url,
-)
+from openhands.app_server.config import get_event_callback_service
 from openhands.app_server.errors import SandboxError
 from openhands.app_server.event.event_service import EventService
 from openhands.app_server.event_callback.event_callback_models import EventCallback
@@ -90,10 +89,27 @@ from openhands.app_server.utils.llm_metadata import (
 from openhands.integrations.provider import PROVIDER_TOKEN_TYPE, ProviderType
 from openhands.integrations.service_types import SuggestedTask
 from openhands.sdk import Agent, AgentContext, LocalWorkspace
+from openhands.sdk.agent.acp_agent import ACPAgent
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.llm import LLM
 from openhands.sdk.plugin import PluginSource
 from openhands.sdk.secret import LookupSecret, StaticSecret
+
+# ``ACPAgentSettings`` is new in the discriminated-union rework. Pre-commit
+# mypy pins ``openhands-sdk==1.17.0`` (without this symbol); the editable
+# install exposes it. Remove the ignore once the SDK ships.
+try:
+    from openhands.sdk.settings import ACPAgentSettings  # type: ignore[attr-defined]
+except ImportError:
+    # Fallback for SDK 1.17.0: ACP paths will never be taken since
+    # ACPAgentSettings won't exist. We define a private sentinel class so
+    # isinstance() checks compile.
+    class _ACPAgentSettingsStub:
+        """Placeholder that will never match any runtime instance."""
+
+        pass
+
+    ACPAgentSettings = _ACPAgentSettingsStub  # type: ignore[misc, assignment]
 from openhands.sdk.utils.paging import page_iterator
 from openhands.sdk.workspace.remote.async_remote_workspace import AsyncRemoteWorkspace
 from openhands.server.types import AppMode
@@ -317,15 +333,25 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             task.agent_server_url = agent_server_url
             yield task
 
-            # Start conversation...
+            # Start conversation — ACP-backed requests go to the ACP
+            # router (``/api/acp/conversations``) which accepts the
+            # ``ACPEnabledAgent`` union; the legacy Agent-only
+            # endpoint stays at ``/api/conversations``.
+            is_acp_request = isinstance(
+                start_conversation_request, StartACPConversationRequest
+            )
+            conversation_path = (
+                '/api/acp/conversations' if is_acp_request else '/api/conversations'
+            )
             body_json = start_conversation_request.model_dump(
                 mode='json', context={'expose_secrets': True}
             )
-            # Log hook_config to verify it's being passed
             hook_config_in_request = body_json.get('hook_config')
             _logger.debug(
-                f'Sending StartConversationRequest with hook_config: '
-                f'{hook_config_in_request}'
+                'Sending %s to %s with hook_config: %s',
+                type(start_conversation_request).__name__,
+                conversation_path,
+                hook_config_in_request,
             )
             headers = (
                 {'X-Session-API-Key': sandbox.session_api_key}
@@ -333,23 +359,40 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 else {}
             )
             response = await self.httpx_client.post(
-                f'{agent_server_url}/api/conversations',
+                f'{agent_server_url}{conversation_path}',
                 json=body_json,
                 headers=headers,
                 timeout=self.sandbox_startup_timeout,
             )
 
             response.raise_for_status()
-            info = ConversationInfo.model_validate(response.json())
+            info: ConversationInfo | ACPConversationInfo
+            if is_acp_request:
+                info = ACPConversationInfo.model_validate(response.json())
+            else:
+                info = ConversationInfo.model_validate(response.json())
 
-            # Store info...
+            # Store info. For ACP agents the ``agent.llm`` field is a
+            # dummy sentinel; prefer ``acp_model`` (the real provider
+            # model) so the conversation list shows a meaningful name.
             user_id = await self.user_context.get_user_id()
+            agent_obj = start_conversation_request.agent
+            if isinstance(agent_obj, ACPAgent):
+                display_model = agent_obj.acp_model or agent_obj.llm.model
+                agent_kind = 'acp'
+            else:
+                display_model = agent_obj.llm.model
+                agent_kind = 'llm'
             app_conversation_info = AppConversationInfo(
                 id=info.id,
                 title=f'Conversation {info.id.hex[:5]}',
                 sandbox_id=sandbox.id,
                 created_by_user_id=user_id,
-                llm_model=start_conversation_request.agent.llm.model,
+                llm_model=display_model,
+                # Discriminator used downstream (URL builder, live-status
+                # poller) to pick ``/api/conversations`` vs
+                # ``/api/acp/conversations``.
+                agent_kind=agent_kind,
                 # Git parameters
                 selected_repository=request.selected_repository,
                 selected_branch=request.selected_branch,
@@ -409,6 +452,15 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             app_conversation_infos
         )
 
+        # Map each conversation id to its ACP-vs-LLM discriminator so
+        # ``_get_live_conversation_info`` knows which agent-server route
+        # to call (``/api/conversations`` vs ``/api/acp/conversations``).
+        conversation_kind_by_id: dict[str, str] = {
+            info.id.hex: info.agent_kind
+            for info in app_conversation_infos
+            if info is not None
+        }
+
         # Get referenced sandboxes in a single batch operation...
         sandboxes = await self.sandbox_service.batch_get_sandboxes(
             list(sandbox_id_to_conversation_ids)
@@ -418,7 +470,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         # Gather the running conversations
         tasks = [
             self._get_live_conversation_info(
-                sandbox, sandbox_id_to_conversation_ids.get(sandbox.id)
+                sandbox,
+                sandbox_id_to_conversation_ids.get(sandbox.id),
+                conversation_kind_by_id,
             )
             for sandbox in sandboxes
             if sandbox and sandbox.status == SandboxStatus.RUNNING
@@ -454,41 +508,59 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         self,
         sandbox: SandboxInfo,
         conversation_ids: list[str],
+        conversation_kind_by_id: dict[str, str] | None = None,
     ) -> list[ConversationInfo]:
-        """Get agent status for multiple conversations from the Agent Server."""
-        try:
-            # Build the URL with query parameters
-            agent_server_url = self._get_agent_server_url(sandbox)
-            url = f'{agent_server_url.rstrip("/")}/api/conversations'
-            params = {'ids': conversation_ids}
+        """Get agent status for multiple conversations from the Agent Server.
 
-            # Set up headers
-            headers = {}
-            if sandbox.session_api_key:
-                headers['X-Session-API-Key'] = sandbox.session_api_key
-
-            response = await self.httpx_client.get(url, params=params, headers=headers)
-            response.raise_for_status()
-
-            data = response.json()
-            conversation_info = _conversation_info_type_adapter.validate_python(data)
-            conversation_info = [c for c in conversation_info if c]
-            return conversation_info
-        except httpx.HTTPStatusError:
-            # The runtime API stops idle sandboxes all the time and they return a 404 or a 503.
-            # This is normal and should not be considered an error.
-            _logger.warning(
-                f'Error getting conversation status from sandbox {sandbox.id}',
-                exc_info=True,
-            )
+        The agent-server exposes two routers — ``/api/conversations`` for
+        the LLM agent and ``/api/acp/conversations`` for the ACP variant.
+        A single sandbox can host a mix, so split the id list by
+        ``agent_kind`` and hit each router independently. Missing from
+        the map → treated as ``"llm"`` (back-compat for legacy rows).
+        """
+        if not conversation_ids:
             return []
-        except Exception:
-            # Not getting a status is not a fatal error - we just mark the conversation as stopped
-            _logger.exception(
-                f'Error getting conversation status from sandbox {sandbox.id}',
-                stack_info=True,
-            )
-            return []
+        kind_map = conversation_kind_by_id or {}
+        llm_ids = [c for c in conversation_ids if kind_map.get(c, 'llm') != 'acp']
+        acp_ids = [c for c in conversation_ids if kind_map.get(c, 'llm') == 'acp']
+
+        agent_server_url = self._get_agent_server_url(sandbox).rstrip('/')
+        headers: dict[str, str] = {}
+        if sandbox.session_api_key:
+            headers['X-Session-API-Key'] = sandbox.session_api_key
+
+        async def _fetch(path: str, ids: list[str]) -> list[ConversationInfo]:
+            if not ids:
+                return []
+            try:
+                response = await self.httpx_client.get(
+                    f'{agent_server_url}{path}',
+                    params={'ids': ids},
+                    headers=headers,
+                )
+                response.raise_for_status()
+                data = response.json()
+                infos = _conversation_info_type_adapter.validate_python(data)
+                return [c for c in infos if c]
+            except httpx.HTTPStatusError:
+                # Runtime API stops idle sandboxes all the time; normal.
+                _logger.warning(
+                    f'Error getting conversation status from sandbox {sandbox.id} '
+                    f'at {path}',
+                    exc_info=True,
+                )
+                return []
+            except Exception:
+                _logger.exception(
+                    f'Error getting conversation status from sandbox {sandbox.id} '
+                    f'at {path}',
+                    stack_info=True,
+                )
+                return []
+
+        llm_infos = await _fetch('/api/conversations', llm_ids)
+        acp_infos = await _fetch('/api/acp/conversations', acp_ids)
+        return llm_infos + acp_infos
 
     def _build_conversation(
         self,
@@ -514,7 +586,17 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 None,
             )
             if conversation_url:
-                conversation_url += f'/api/conversations/{app_conversation_info.id.hex}'
+                # ACP conversations live at ``/api/acp/conversations/{id}``;
+                # the legacy ``/api/conversations/{id}`` route 404s for them
+                # because it only accepts the LLM-agent variant. The frontend
+                # polls ``conversation_url`` for live status, so pointing it
+                # at the wrong route makes ACP conversations look stuck.
+                path = (
+                    '/api/acp/conversations'
+                    if app_conversation_info.agent_kind == 'acp'
+                    else '/api/conversations'
+                )
+                conversation_url += f'{path}/{app_conversation_info.id.hex}'
             session_api_key = sandbox.session_api_key
 
         return AppConversation(
@@ -893,12 +975,24 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             or user.agent_settings.llm.model
             or LLM.model_fields['model'].default
         )
-
-        base_url = resolve_provider_llm_base_url(
-            model,
-            user.agent_settings.llm.base_url,
-            provider_base_url=self.openhands_provider_base_url,
-        )
+        base_url = user.agent_settings.llm.base_url
+        if model and (
+            model.startswith('openhands/') or model.startswith('litellm_proxy/')
+        ):
+            # The SDK auto-fills base_url with the default public proxy for
+            # openhands/ models.  We need to distinguish "user explicitly set a
+            # custom URL" from "SDK auto-filled the default".
+            #
+            # Priority: user-explicit URL > deployment provider URL > SDK default
+            _SDK_DEFAULT_PROXY = 'https://llm-proxy.app.all-hands.dev/'
+            user_set_custom = base_url and base_url.rstrip(
+                '/'
+            ) != _SDK_DEFAULT_PROXY.rstrip('/')
+            if user_set_custom:
+                pass  # keep user's explicit base_url
+            elif self.openhands_provider_base_url:
+                base_url = self.openhands_provider_base_url
+            # else: keep the SDK default
 
         return LLM(
             model=model,
@@ -1216,20 +1310,38 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         remote_workspace: AsyncRemoteWorkspace | None = None,
         selected_repository: str | None = None,
         plugins: list[PluginSpec] | None = None,
-    ) -> StartConversationRequest:
-        """Build a complete StartConversationRequest for a user.
+    ) -> StartConversationRequest | StartACPConversationRequest:
+        """Build a conversation-start request for the user.
 
-        Resolves LLM, MCP, tools, secrets and agent context, then
-        builds the ``Agent`` via ``AgentSettings.create_agent()``.
-        Server-only overrides (system prompts, LLM tracing metadata,
-        skills, hooks) are applied to the agent after creation.
-        Finally delegates to ``ConversationSettings.create_request()``.
+        ``user.agent_settings`` is a discriminated union — either
+        ``LLMAgentSettings`` (standard Agent) or ``ACPAgentSettings``
+        (ACP-delegating ACPAgent). This method dispatches on the
+        variant and returns the matching request type:
+
+        - ``StartConversationRequest`` (LLM agent) — server-only
+          overrides (system prompts, LLM tracing metadata, skills,
+          hooks) are applied to the agent after ``create_agent()``.
+        - ``StartACPConversationRequest`` (ACP agent) — those
+          server-only overrides are **not** applied: the ACP
+          subprocess owns its own system prompt, tools, and agent
+          context, so hooks/skills/MCP do not apply.
         """
         user = await self.user_context.get_user_info()
 
         project_dir = get_project_dir(working_dir, selected_repository)
         workspace = LocalWorkspace(working_dir=project_dir)
 
+        # Dispatch on the discriminated-union variant.
+        if isinstance(user.agent_settings, ACPAgentSettings):
+            return await self._build_acp_start_conversation_request(
+                user=user,
+                conversation_id=conversation_id,
+                initial_message=initial_message,
+                workspace=workspace,
+                plugins=plugins,
+            )
+
+        # --- LLM-agent path (default) --------------------------------------
         # --- secrets --------------------------------------------------------
         secrets = await self._setup_secrets_for_git_providers(user)
 
@@ -1257,7 +1369,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         else:
             tools = get_default_tools(enable_browser=True)
 
-        # --- build AgentSettings and create agent ---------------------------
+        # --- build LLMAgentSettings and create agent ------------------------
         from fastmcp.mcp_config import MCPConfig
 
         configured_agent_settings = user.agent_settings.model_copy(
@@ -1338,6 +1450,132 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         # Pass agent explicitly — it has server-only overrides (system
         # prompts, LLM metadata, skills) applied after create_agent().
         return conv_settings.create_request(StartConversationRequest, agent=agent)
+
+    @staticmethod
+    def _acp_provider_env(settings: ACPAgentSettings) -> dict[str, str]:
+        """Translate UI-saved LLM credentials into the provider env vars
+        the chosen ACP subprocess expects.
+
+        Each ACP server reads auth + gateway config from environment
+        variables in its native provider's namespace:
+
+        - ``claude-code`` → ``ANTHROPIC_API_KEY`` / ``ANTHROPIC_BASE_URL``
+        - ``codex``       → ``OPENAI_API_KEY``   / ``OPENAI_BASE_URL``
+        - ``gemini-cli``  → ``GEMINI_API_KEY``   / ``GEMINI_BASE_URL``
+
+        ``custom`` receives nothing synthesized — the user is on their
+        own via ``acp_env``.
+
+        Gated on ``llm.api_key``: the base URL alone is NOT a user
+        signal. The LLM settings page persists a provider-default
+        ``base_url`` (e.g. ``https://api.anthropic.com`` for Anthropic
+        models) as soon as the user picks a model, even if they never
+        touched the field. Plumbing that default would clobber any
+        proxy URL coming from ``OH_AGENT_SERVER_ENV`` / the OS env and
+        silently send the ACP subprocess to the wrong endpoint with a
+        proxy key it can't use.
+
+        An explicit ``api_key`` in the UI IS a user signal: the user
+        typed it, so they're declaring "authenticate the ACP subprocess
+        with this and the accompanying base URL". Only then do we
+        synthesize env vars; otherwise we leave the ACP subprocess to
+        inherit from the OS env (where ``OH_AGENT_SERVER_ENV`` lives).
+
+        Callers should ``setdefault`` the resulting keys into a
+        user-supplied ``acp_env`` so explicit ``acp_env`` overrides win.
+        """
+        llm = settings.llm
+        api_key: str | None = None
+        if llm.api_key is not None:
+            raw = llm.api_key
+            api_key = (
+                raw.get_secret_value() if hasattr(raw, 'get_secret_value') else str(raw)
+            )
+
+        # Without an explicit api_key the user hasn't opted in — don't
+        # synthesize anything, don't touch base_url. See class docstring.
+        if not api_key:
+            return {}
+
+        base_url = llm.base_url or None
+        env: dict[str, str] = {}
+        if settings.acp_server == 'claude-code':
+            env['ANTHROPIC_API_KEY'] = api_key
+            if base_url:
+                env['ANTHROPIC_BASE_URL'] = base_url
+        elif settings.acp_server == 'codex':
+            env['OPENAI_API_KEY'] = api_key
+            if base_url:
+                env['OPENAI_BASE_URL'] = base_url
+        elif settings.acp_server == 'gemini-cli':
+            env['GEMINI_API_KEY'] = api_key
+            if base_url:
+                env['GEMINI_BASE_URL'] = base_url
+        # 'custom' → nothing: the user already set acp_command + acp_env.
+        return env
+
+    async def _build_acp_start_conversation_request(
+        self,
+        user: UserInfo,
+        conversation_id: UUID,
+        initial_message: SendMessageRequest | None,
+        workspace: LocalWorkspace,
+        plugins: list[PluginSpec] | None,
+    ) -> StartACPConversationRequest:
+        """Build a ``StartACPConversationRequest`` from ACP agent settings.
+
+        The ACP subprocess owns its own system prompt, tools, context,
+        and MCP, so all the LLM-agent-path customization (skills
+        loading, system-prompt overrides, LLM tracing metadata,
+        hook-config discovery in the workspace) is deliberately
+        skipped here.
+
+        Credentials set in the GUI's LLM section (``llm.api_key`` /
+        ``llm.base_url``) are translated into the provider-specific env
+        vars the ACP subprocess expects and merged into ``acp_env``.
+        User-supplied ``acp_env`` entries take precedence so power
+        users can still override.
+        """
+        acp_settings = user.agent_settings
+        assert isinstance(acp_settings, ACPAgentSettings)
+
+        # Merge UI-saved credentials into acp_env. User-supplied entries
+        # win (they come second).
+        derived_env = self._acp_provider_env(acp_settings)
+        if derived_env:
+            merged_env = {**derived_env, **dict(acp_settings.acp_env)}
+            acp_settings = acp_settings.model_copy(update={'acp_env': merged_env})
+
+        agent = acp_settings.create_agent()
+
+        final_initial_message = self._construct_initial_message_with_plugin_params(
+            initial_message, plugins
+        )
+        sdk_plugins: list[PluginSource] | None = None
+        if plugins:
+            sdk_plugins = [
+                PluginSource(
+                    source=p.source,
+                    ref=p.ref,
+                    repo_path=p.repo_path,
+                )
+                for p in plugins
+            ]
+
+        conv_settings = user.conversation_settings.model_copy(
+            update={
+                'agent_settings': acp_settings,
+                'workspace': workspace,
+                'conversation_id': conversation_id,
+                'initial_message': final_initial_message,
+                'plugins': sdk_plugins,
+                # ACP agents do not support hook_config — the subprocess
+                # manages its own tool lifecycle. Leave unset.
+                'hook_config': None,
+            }
+        )
+
+        return conv_settings.create_request(StartACPConversationRequest, agent=agent)
 
     async def _process_pending_messages(
         self,

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -95,6 +95,10 @@ class StoredConversationMetadata(Base):  # type: ignore
     # LLM model used for the conversation
     llm_model = Column(String, nullable=True)
 
+    # Agent-variant discriminator ("llm" or "acp"). Nullable so existing
+    # rows stay valid post-migration; readers coerce null → "llm".
+    agent_kind = Column(String, nullable=True)
+
     conversation_version = Column(String, nullable=False, default='V0', index=True)
     sandbox_id = Column(String, nullable=True, index=True)
     parent_conversation_id = Column(String, nullable=True, index=True)
@@ -358,6 +362,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             context_window=usage.context_window,
             per_turn_token=usage.per_turn_token,
             llm_model=info.llm_model,
+            agent_kind=info.agent_kind,
             conversation_version='V1',
             sandbox_id=info.sandbox_id,
             parent_conversation_id=(
@@ -546,6 +551,9 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             trigger=ConversationTrigger(stored.trigger) if stored.trigger else None,
             pr_number=stored.pr_number,
             llm_model=stored.llm_model,
+            # Coerce legacy NULL → "llm" so rows written before the ACP
+            # variant shipped validate correctly.
+            agent_kind=stored.agent_kind or 'llm',
             metrics=metrics,
             parent_conversation_id=(
                 UUID(stored.parent_conversation_id)

--- a/openhands/app_server/app_lifespan/alembic/versions/009.py
+++ b/openhands/app_server/app_lifespan/alembic/versions/009.py
@@ -1,0 +1,39 @@
+"""Add agent_kind column to conversation_metadata table
+
+Revision ID: 009
+Revises: 008
+Create Date: 2026-04-17 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '009'
+down_revision: Union[str, None] = '008'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add agent_kind column discriminating between LLM and ACP agents.
+
+    Populated at conversation-start time from ``AgentSettings.agent_kind``.
+    Downstream consumers (conversation-URL builder, live-status poller)
+    branch on this to hit the right agent-server route —
+    ``/api/conversations`` for ``"llm"``, ``/api/acp/conversations`` for
+    ``"acp"``. The column is nullable for backwards compatibility with
+    existing rows; readers coerce NULL → ``"llm"``.
+    """
+    op.add_column(
+        'conversation_metadata',
+        sa.Column('agent_kind', sa.String, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop the agent_kind column."""
+    op.drop_column('conversation_metadata', 'agent_kind')

--- a/openhands/app_server/sandbox/process_sandbox_service.py
+++ b/openhands/app_server/sandbox/process_sandbox_service.py
@@ -134,22 +134,35 @@ class ProcessSandboxService(SandboxService):
         )
 
         try:
-            # Start the process
+            # Redirect stdout/stderr to a log file instead of ``PIPE``.
+            # With ``PIPE`` and no drain loop the subprocess deadlocks
+            # as soon as it fills the 64 KB OS pipe buffer — which
+            # happens quickly for chatty startups (SDK banner + debug
+            # logs + request traces). A file handle lets the child
+            # write freely and keeps the output around for post-mortem.
+            import os as _os
+            log_path = _os.path.join(working_dir, '.openhands-agent-server.log')
+            log_handle = open(log_path, 'a', buffering=1)
             process = subprocess.Popen(
                 cmd,
                 env=env,
                 cwd=working_dir,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                stdout=log_handle,
+                stderr=log_handle,
             )
 
             # Wait a moment for the process to start
             await asyncio.sleep(1)
 
-            # Check if process is still running
+            # Check if process is still running; if it exited, surface the
+            # log file path so the operator can investigate. (We can't use
+            # ``communicate()`` any more — stdout/stderr are redirected to
+            # the log file above.)
             if process.poll() is not None:
-                stdout, stderr = process.communicate()
-                raise SandboxError(f'Agent process failed to start: {stderr.decode()}')
+                raise SandboxError(
+                    f'Agent process failed to start (exit code {process.returncode}). '
+                    f'See {log_path} for details.'
+                )
 
             return process
 

--- a/openhands/app_server/settings/settings_router.py
+++ b/openhands/app_server/settings/settings_router.py
@@ -15,7 +15,24 @@ from openhands.integrations.provider import (
     PROVIDER_TOKEN_TYPE,
     ProviderType,
 )
-from openhands.sdk.settings import AgentSettings, ConversationSettings
+
+# ``export_agent_settings_schema`` is new in the discriminated-union rework.
+# Pre-commit mypy pins ``openhands-sdk==1.17.0``; the editable install
+# exposes it. Remove the ignore once the SDK ships.
+from openhands.sdk.settings import ConversationSettings
+
+try:
+    from openhands.sdk.settings import (  # type: ignore[attr-defined]
+        export_agent_settings_schema,
+    )
+except ImportError:
+    # Fallback for SDK 1.17.0: export only AgentSettings schema (no ACP).
+    from openhands.sdk.settings import AgentSettings
+
+    def export_agent_settings_schema():  # type: ignore[misc]
+        return AgentSettings.export_schema()
+
+
 from openhands.server.routes.secrets import invalidate_legacy_secrets_store
 from openhands.server.settings import (
     GETSettingsModel,
@@ -239,8 +256,14 @@ async def store_settings(
 
 @router.get('/agent-schema')
 async def load_settings_schema() -> dict[str, Any]:
-    """Load the schema for settings"""
-    return AgentSettings.export_schema().model_dump(mode='json')
+    """Load the schema for settings.
+
+    ``AgentSettings`` is a discriminated union over ``LLMAgentSettings``
+    and ``ACPAgentSettings``; the combined schema tags sections with a
+    ``variant`` field so the frontend can show LLM-only or ACP-only
+    sections based on the active ``agent_kind`` value.
+    """
+    return export_agent_settings_schema().model_dump(mode='json')
 
 
 @router.get('/conversation-schema')

--- a/openhands/storage/data_models/settings.py
+++ b/openhands/storage/data_models/settings.py
@@ -16,7 +16,41 @@ from pydantic import (
 
 from openhands.core.config.llm_config import LLMConfig
 from openhands.core.config.utils import load_openhands_config
-from openhands.sdk.settings import AgentSettings, ConversationSettings
+
+# The LLM/ACP variant types, ``AgentSettingsConfig`` union alias, and the
+# validate/default helpers are new in the discriminated-union rework.
+# Pre-commit mypy pins ``openhands-sdk==1.17.0`` (without these symbols);
+# the editable install exposes them. Remove the ignore once the SDK ships.
+#
+# Note: ``AgentSettings`` is retained as a deprecated v1.17-compat class
+# alias for ``LLMAgentSettings``. ``AgentSettingsConfig`` is the union
+# type for fields that may hold either variant — use that in new code.
+from openhands.sdk.settings import ConversationSettings
+
+try:
+    from openhands.sdk.settings import (  # type: ignore[attr-defined]
+        ACPAgentSettings,
+        AgentSettingsConfig,
+        LLMAgentSettings,
+        default_agent_settings,
+        validate_agent_settings,
+    )
+except ImportError:
+    # Fallback for SDK 1.17.0 which doesn't have the new discriminated union
+    # types. SDK 1.17.0 uses ``AgentSettings`` instead of ``LLMAgentSettings``.
+    from openhands.sdk.settings import AgentSettings
+
+    LLMAgentSettings = AgentSettings  # type: ignore[misc, assignment]
+    ACPAgentSettings = AgentSettings  # type: ignore[misc, assignment]
+    AgentSettingsConfig = AgentSettings  # type: ignore[misc, assignment]
+
+    def default_agent_settings() -> AgentSettings:  # type: ignore[misc]
+        return AgentSettings()
+
+    def validate_agent_settings(data: dict) -> AgentSettings:  # type: ignore[misc]
+        return AgentSettings.model_validate(data)
+
+
 from openhands.storage.data_models.secrets import Secrets
 from openhands.utils.jsonpatch_compat import deep_merge
 
@@ -121,7 +155,7 @@ class Settings(BaseModel):
     git_user_name: str | None = None
     git_user_email: str | None = None
     v1_enabled: bool = True
-    agent_settings: AgentSettings = Field(default_factory=AgentSettings)
+    agent_settings: AgentSettingsConfig = Field(default_factory=default_agent_settings)
     conversation_settings: ConversationSettings = Field(
         default_factory=ConversationSettings
     )
@@ -174,9 +208,10 @@ class Settings(BaseModel):
                     merged['mcp_config'] = mcp_config
 
                 # Use object.__setattr__ to avoid validate_assignment
-                # side-effects on other fields.
+                # side-effects on other fields. ``AgentSettings`` is a
+                # discriminated union, so go through the type adapter.
                 object.__setattr__(
-                    self, 'agent_settings', AgentSettings.model_validate(merged)
+                    self, 'agent_settings', validate_agent_settings(merged)
                 )
 
         if 'conversation_settings' in payload:
@@ -223,7 +258,9 @@ class Settings(BaseModel):
 
     @field_serializer('agent_settings')
     def agent_settings_serializer(
-        self, agent_settings: AgentSettings, info: SerializationInfo
+        self,
+        agent_settings: LLMAgentSettings | ACPAgentSettings,
+        info: SerializationInfo,
     ) -> dict[str, Any]:
         context = info.context or {}
         if context.get('expose_secrets', False):
@@ -240,10 +277,12 @@ class Settings(BaseModel):
             return data
 
         # --- Agent settings: coerce SecretStr leaves to plain strings ---
+        # ``AgentSettings`` is a discriminated union; accept either
+        # concrete variant.
         agent_settings = data.get('agent_settings')
         if isinstance(agent_settings, dict):
             data['agent_settings'] = _coerce_dict_secrets(agent_settings)
-        elif isinstance(agent_settings, AgentSettings):
+        elif isinstance(agent_settings, (LLMAgentSettings, ACPAgentSettings)):
             data['agent_settings'] = agent_settings.model_dump(
                 mode='json', context={'expose_secrets': True}
             )
@@ -312,7 +351,10 @@ class Settings(BaseModel):
             remote_runtime_resource_factor=app_config.sandbox.remote_runtime_resource_factor,
             search_api_key=app_config.search_api_key,
             max_budget_per_task=app_config.max_budget_per_task,
-            agent_settings=AgentSettings(**agent_settings_dict),
+            # ``from_config`` only loads LLM-agent fields, so build the LLM
+            # variant directly. To configure an ACP agent, use the GUI or
+            # API to set ``agent_kind='acp'``.
+            agent_settings=LLMAgentSettings(**agent_settings_dict),
             conversation_settings=ConversationSettings.model_validate(
                 {
                     'confirmation_mode': bool(app_config.security.confirmation_mode),
@@ -323,9 +365,19 @@ class Settings(BaseModel):
         )
 
     def merge_with_config_settings(self) -> 'Settings':
-        """Merge config.toml MCP settings with stored SDK agent_settings."""
+        """Merge config.toml MCP settings with stored SDK agent_settings.
+
+        MCP config only lives on ``LLMAgentSettings`` — the ACP
+        subprocess manages its own MCP via the ACP server, so when
+        ``agent_kind='acp'`` there's nothing to merge and we skip.
+        """
+        if not isinstance(self.agent_settings, LLMAgentSettings):
+            return self
+
         config_settings = Settings.from_config()
         if not config_settings:
+            return self
+        if not isinstance(config_settings.agent_settings, LLMAgentSettings):
             return self
 
         merged_mcp = _merge_sdk_mcp_configs(
@@ -338,7 +390,7 @@ class Settings(BaseModel):
         self.agent_settings.mcp_config = merged_mcp
         return self
 
-    def to_agent_settings(self) -> AgentSettings:
+    def to_agent_settings(self) -> LLMAgentSettings | ACPAgentSettings:
         return self.agent_settings
 
     def get_agent_settings_display(self) -> dict[str, Any]:

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -39,7 +39,12 @@ from openhands.integrations.service_types import SuggestedTask, TaskType
 from openhands.sdk import Agent, Event
 from openhands.sdk.llm import LLM
 from openhands.sdk.secret import LookupSecret, StaticSecret
-from openhands.sdk.settings import AgentSettings, ConversationSettings
+from openhands.sdk.settings import ConversationSettings
+
+try:
+    from openhands.sdk.settings import LLMAgentSettings as AgentSettings
+except ImportError:
+    from openhands.sdk.settings import AgentSettings
 from openhands.sdk.workspace.remote.async_remote_workspace import AsyncRemoteWorkspace
 from openhands.server.types import AppMode
 from openhands.storage.data_models.conversation_metadata import ConversationTrigger
@@ -3024,4 +3029,200 @@ class TestLoadHooksFromWorkspace:
                 'X-Session-API-Key': 'test-key',
             },
             timeout=30.0,
+        )
+
+
+class TestAcpProviderEnv:
+    """Unit tests for ``LiveStatusAppConversationService._acp_provider_env`` —
+    the helper that translates UI-saved LLM credentials into the
+    provider env vars the chosen ACP subprocess expects.
+    """
+
+    @pytest.fixture
+    def _acp_settings_factory(self):
+        from pydantic import SecretStr
+
+        try:
+            from openhands.sdk.settings import ACPAgentSettings  # type: ignore[attr-defined]
+        except ImportError:
+            pytest.skip('ACPAgentSettings not available in this SDK build')
+
+        def _make(
+            *,
+            acp_server: str = 'claude-code',
+            api_key: str | None = None,
+            base_url: str | None = None,
+            acp_env: dict[str, str] | None = None,
+        ):
+            return ACPAgentSettings(
+                acp_server=acp_server,  # type: ignore[arg-type]
+                llm=LLM(
+                    model='claude-sonnet-4-5',
+                    api_key=SecretStr(api_key) if api_key else None,
+                    base_url=base_url,
+                ),
+                acp_env=acp_env or {},
+            )
+
+        return _make
+
+    def test_claude_code_translates_to_anthropic_vars(self, _acp_settings_factory):
+        s = _acp_settings_factory(
+            acp_server='claude-code',
+            api_key='sk-test-anthropic',
+            base_url='https://proxy.example.com',
+        )
+        env = LiveStatusAppConversationService._acp_provider_env(s)
+        assert env == {
+            'ANTHROPIC_API_KEY': 'sk-test-anthropic',
+            'ANTHROPIC_BASE_URL': 'https://proxy.example.com',
+        }
+
+    def test_codex_translates_to_openai_vars(self, _acp_settings_factory):
+        s = _acp_settings_factory(
+            acp_server='codex',
+            api_key='sk-test-openai',
+            base_url='https://proxy.example.com',
+        )
+        env = LiveStatusAppConversationService._acp_provider_env(s)
+        assert env == {
+            'OPENAI_API_KEY': 'sk-test-openai',
+            'OPENAI_BASE_URL': 'https://proxy.example.com',
+        }
+
+    def test_gemini_translates_to_gemini_vars(self, _acp_settings_factory):
+        s = _acp_settings_factory(
+            acp_server='gemini-cli',
+            api_key='sk-test-gemini',
+            base_url='https://proxy.example.com',
+        )
+        env = LiveStatusAppConversationService._acp_provider_env(s)
+        assert env == {
+            'GEMINI_API_KEY': 'sk-test-gemini',
+            'GEMINI_BASE_URL': 'https://proxy.example.com',
+        }
+
+    def test_custom_server_returns_empty(self, _acp_settings_factory):
+        """For acp_server='custom', the user is on their own via acp_env."""
+        s = _acp_settings_factory(
+            acp_server='custom',
+            api_key='sk-test',
+            base_url='https://proxy.example.com',
+        )
+        env = LiveStatusAppConversationService._acp_provider_env(s)
+        assert env == {}
+
+    def test_no_credentials_returns_empty(self, _acp_settings_factory):
+        """No api_key + no base_url → nothing synthesized."""
+        s = _acp_settings_factory(acp_server='claude-code')
+        env = LiveStatusAppConversationService._acp_provider_env(s)
+        assert env == {}
+
+    def test_base_url_alone_is_ignored(self, _acp_settings_factory):
+        """base_url without api_key → no plumbing.
+
+        The LLM settings page persists a provider-default ``base_url``
+        as soon as the user picks a model. Plumbing that default would
+        clobber a real proxy URL set via ``OH_AGENT_SERVER_ENV`` and
+        silently route the ACP subprocess to the wrong endpoint with a
+        proxy key it can't use. Require an explicit ``api_key`` as the
+        user's opt-in signal before plumbing anything.
+        """
+        s = _acp_settings_factory(
+            acp_server='claude-code', base_url='https://api.anthropic.com'
+        )
+        env = LiveStatusAppConversationService._acp_provider_env(s)
+        assert env == {}
+
+    def test_api_key_alone_is_plumbed(self, _acp_settings_factory):
+        """api_key alone → plumb the key (provider default URL comes
+        from the SDK / OS env, not from us)."""
+        s = _acp_settings_factory(acp_server='claude-code', api_key='sk-test')
+        env = LiveStatusAppConversationService._acp_provider_env(s)
+        assert env == {'ANTHROPIC_API_KEY': 'sk-test'}
+
+
+class TestAgentKindConversationUrl:
+    """Regression tests for the conversation_url / live-status route
+    dispatch — ``/api/conversations`` for LLM, ``/api/acp/conversations``
+    for ACP. Getting this wrong makes ACP conversations look stuck on
+    "Loading" because the frontend polls the wrong route and 404s."""
+
+    def test_build_conversation_url_llm(self):
+        from uuid import UUID
+        from openhands.app_server.app_conversation.app_conversation_models import (
+            AppConversationInfo,
+        )
+        from openhands.app_server.sandbox.sandbox_models import (
+            AGENT_SERVER,
+            ExposedUrl,
+            SandboxInfo,
+            SandboxStatus,
+        )
+
+        # Instantiate a stripped service (no deps needed for _build_conversation).
+        service = LiveStatusAppConversationService.__new__(
+            LiveStatusAppConversationService
+        )
+
+        info = AppConversationInfo(
+            id=UUID('11111111-1111-1111-1111-111111111111'),
+            created_by_user_id=None,
+            sandbox_id='sandbox-a',
+            agent_kind='llm',
+        )
+        sandbox = SandboxInfo(
+            id='sandbox-a',
+            created_by_user_id=None,
+            sandbox_spec_id='spec',
+            status=SandboxStatus.RUNNING,
+            session_api_key='sk',
+            exposed_urls=[
+                ExposedUrl(name=AGENT_SERVER, url='http://localhost:8000', port=8000),
+            ],
+        )
+        result = service._build_conversation(info, sandbox, None)
+        assert result is not None
+        assert result.conversation_url == (
+            'http://localhost:8000/api/conversations/'
+            '11111111111111111111111111111111'
+        )
+
+    def test_build_conversation_url_acp(self):
+        from uuid import UUID
+        from openhands.app_server.app_conversation.app_conversation_models import (
+            AppConversationInfo,
+        )
+        from openhands.app_server.sandbox.sandbox_models import (
+            AGENT_SERVER,
+            ExposedUrl,
+            SandboxInfo,
+            SandboxStatus,
+        )
+
+        service = LiveStatusAppConversationService.__new__(
+            LiveStatusAppConversationService
+        )
+
+        info = AppConversationInfo(
+            id=UUID('22222222-2222-2222-2222-222222222222'),
+            created_by_user_id=None,
+            sandbox_id='sandbox-a',
+            agent_kind='acp',
+        )
+        sandbox = SandboxInfo(
+            id='sandbox-a',
+            created_by_user_id=None,
+            sandbox_spec_id='spec',
+            status=SandboxStatus.RUNNING,
+            session_api_key='sk',
+            exposed_urls=[
+                ExposedUrl(name=AGENT_SERVER, url='http://localhost:8000', port=8000),
+            ],
+        )
+        result = service._build_conversation(info, sandbox, None)
+        assert result is not None
+        assert result.conversation_url == (
+            'http://localhost:8000/api/acp/conversations/'
+            '22222222222222222222222222222222'
         )

--- a/tests/unit/app_server/test_sandbox_secrets_router.py
+++ b/tests/unit/app_server/test_sandbox_secrets_router.py
@@ -36,7 +36,11 @@ from openhands.integrations.provider import ProviderHandler, ProviderToken
 from openhands.integrations.service_types import ProviderType
 from openhands.sdk.llm import LLM
 from openhands.sdk.secret import StaticSecret
-from openhands.sdk.settings import AgentSettings
+
+try:
+    from openhands.sdk.settings import LLMAgentSettings as AgentSettings
+except ImportError:
+    from openhands.sdk.settings import AgentSettings
 
 SANDBOX_ID = 'sb-test-123'
 USER_ID = 'test-user-id'

--- a/tests/unit/app_server/test_settings_api.py
+++ b/tests/unit/app_server/test_settings_api.py
@@ -10,10 +10,14 @@ from openhands.integrations.provider import ProviderToken, ProviderType
 from openhands.integrations.service_types import UserGitInfo
 from openhands.sdk.llm import LLM
 from openhands.sdk.settings import (
-    AgentSettings,
     ConversationSettings,
     VerificationSettings,
 )
+
+try:
+    from openhands.sdk.settings import LLMAgentSettings as AgentSettings
+except ImportError:
+    from openhands.sdk.settings import AgentSettings
 from openhands.server.app import app
 from openhands.server.user_auth.user_auth import UserAuth
 from openhands.storage.data_models.secrets import Secrets

--- a/tests/unit/core/config/test_mcp_settings_merge.py
+++ b/tests/unit/core/config/test_mcp_settings_merge.py
@@ -11,7 +11,11 @@ from openhands.core.config.mcp_config import (
     StdioMCPServer,
 )
 from openhands.sdk.llm import LLM
-from openhands.sdk.settings import AgentSettings
+
+try:
+    from openhands.sdk.settings import LLMAgentSettings as AgentSettings
+except ImportError:
+    from openhands.sdk.settings import AgentSettings
 from openhands.storage.data_models.settings import Settings
 
 

--- a/tests/unit/mcp/test_mcp_integration.py
+++ b/tests/unit/mcp/test_mcp_integration.py
@@ -6,7 +6,11 @@ import pytest
 
 from openhands.core.config.mcp_config import MCPConfig, RemoteMCPServer
 from openhands.sdk.llm import LLM
-from openhands.sdk.settings import AgentSettings
+
+try:
+    from openhands.sdk.settings import LLMAgentSettings as AgentSettings
+except ImportError:
+    from openhands.sdk.settings import AgentSettings
 from openhands.server.user_auth.default_user_auth import DefaultUserAuth
 from openhands.storage.data_models.settings import Settings
 from openhands.storage.settings.file_settings_store import FileSettingsStore

--- a/tests/unit/server/routes/test_settings_store_functions.py
+++ b/tests/unit/server/routes/test_settings_store_functions.py
@@ -13,9 +13,13 @@ from openhands.integrations.service_types import ProviderType
 from openhands.sdk.llm import LLM
 from openhands.sdk.settings import (
     AGENT_SETTINGS_SCHEMA_VERSION,
-    AgentSettings,
     ConversationSettings,
 )
+
+try:
+    from openhands.sdk.settings import LLMAgentSettings as AgentSettings
+except ImportError:
+    from openhands.sdk.settings import AgentSettings
 from openhands.server.routes.secrets import (
     app as secrets_router,
 )

--- a/tests/unit/storage/data_models/test_settings.py
+++ b/tests/unit/storage/data_models/test_settings.py
@@ -11,9 +11,13 @@ from openhands.core.config.security_config import SecurityConfig
 from openhands.sdk.llm import LLM
 from openhands.sdk.settings import (
     AGENT_SETTINGS_SCHEMA_VERSION,
-    AgentSettings,
     ConversationSettings,
 )
+
+try:
+    from openhands.sdk.settings import LLMAgentSettings as AgentSettings
+except ImportError:
+    from openhands.sdk.settings import AgentSettings
 from openhands.sdk.settings.model import CondenserSettings, VerificationSettings
 from openhands.storage.data_models.settings import Settings
 

--- a/tests/unit/storage/settings/test_file_settings_store.py
+++ b/tests/unit/storage/settings/test_file_settings_store.py
@@ -6,7 +6,12 @@ from pydantic import SecretStr
 
 from openhands.core.config.openhands_config import OpenHandsConfig
 from openhands.sdk.llm import LLM
-from openhands.sdk.settings import AgentSettings, ConversationSettings
+from openhands.sdk.settings import ConversationSettings
+
+try:
+    from openhands.sdk.settings import LLMAgentSettings as AgentSettings
+except ImportError:
+    from openhands.sdk.settings import AgentSettings
 from openhands.storage.data_models.settings import Settings
 from openhands.storage.files import FileStore
 from openhands.storage.settings.file_settings_store import FileSettingsStore


### PR DESCRIPTION
## Summary

Integration layer for ACP-in-GUI, building on the discriminated-union `AgentSettings` merged as OpenHands/software-agent-sdk#2861. **This is the backend half of #13983**; the settings UX stays in #13983 to keep this one small and reviewable.

When `AgentSettings` is an `ACPAgentSettings` the app server now:

- Persists `agent_kind='acp'` on `AppConversationInfo` (new column via Alembic `009`; existing rows coerce `NULL → 'llm'`).
- POSTs conversation-start to `/api/acp/conversations` on the agent-server, skipping LLM-only concerns (skills, hooks, server overrides).
- Plumbs UI-saved credentials from `llm.api_key` / `llm.base_url` into the subprocess env as provider-native vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY` + `*_BASE_URL`), **gated on `api_key` being set** so a provider-default `base_url` alone never clobbers an explicit `OH_AGENT_SERVER_ENV` passthrough.
- Branches `conversation_url` and live-status polling to the right router so clients don't 404 on `/api/conversations/{id}` for ACP conversations.

Also redirects the agent-server subprocess stdout/stderr to `{working_dir}/.openhands-agent-server.log` — the previous `PIPE` approach deadlocked once the 64 KB kernel buffer filled without a drain loop.

## Test plan

- [x] New `TestAcpProviderEnv` covers all three provider shapes + empty + api-key-alone + base-url-alone-ignored.
- [x] New `TestAgentKindConversationUrl` asserts both URL shapes (`/api/conversations/{id}` for LLM, `/api/acp/conversations/{id}` for ACP).
- [x] Existing suite still green.
- [ ] End-to-end: spin a local GUI, configure an ACP agent, verify conversation starts, live-status polls the right route, and credentials reach the subprocess.

## Related

- Builds on OpenHands/software-agent-sdk#2861 (merged).
- Split out of #13983 — the settings UX (frontend) follows in that PR after this lands.
- Frontend live tool-call rendering is separate (#13994).

🤖 Generated with [Claude Code](https://claude.com/claude-code)