### PR TITLE
docs: add missing components to openhands-ui README

### DIFF
--- a/openhands-ui/README.md
+++ b/openhands-ui/README.md
@@ -38,21 +38,27 @@ function App() {
 
 ## Components
 
-| Component         | Description                               |
-| ----------------- | ----------------------------------------- |
-| `Button`          | Interactive button with multiple variants |
-| `Checkbox`        | Checkbox input with label support         |
-| `Chip`            | Display tags or labels                    |
-| `Divider`         | Visual separator                          |
-| `Icon`            | Icon wrapper component                    |
-| `Input`           | Text input field                          |
-| `InteractiveChip` | Clickable chip component                  |
-| `RadioGroup`      | Radio button group                        |
-| `RadioOption`     | Individual radio option                   |
-| `Scrollable`      | Scrollable container                      |
-| `Toggle`          | Toggle switch                             |
-| `Tooltip`         | Tooltip overlay                           |
-| `Typography`      | Text components (H1-H6, Text, Code)       |
+| Component         | Description                                              |
+| ----------------- | -------------------------------------------------------- |
+| `Accordion`       | Collapsible content sections with single or multi-expand |
+| `Button`          | Interactive button with multiple variants                |
+| `Checkbox`        | Checkbox input with label support                        |
+| `Chip`            | Display tags or labels                                   |
+| `Dialog`          | Modal overlay with focus trap and dismiss support        |
+| `Divider`         | Visual separator                                         |
+| `Icon`            | Icon wrapper component                                   |
+| `Input`           | Text input field                                         |
+| `InteractiveChip` | Clickable chip component                                 |
+| `RadioGroup`      | Radio button group                                       |
+| `RadioOption`     | Individual radio option                                  |
+| `Scrollable`      | Scrollable container                                     |
+| `Select`          | Dropdown select input with search and custom options     |
+| `Spinner`         | Loading indicator with determinate and indeterminate modes |
+| `Tabs`            | Tabbed navigation with overflow scrolling                |
+| `Toast`           | Temporary notification messages                          |
+| `Toggle`          | Toggle switch                                            |
+| `Tooltip`         | Tooltip overlay                                          |
+| `Typography`      | Text components (H1-H6, Text, Code)                     |
 
 ## Development
 


### PR DESCRIPTION
- [x] A human has tested these changes.
---
## Why
Currently, several newly built components in the `openhands-ui` package are missing from the README's Components table. This makes it difficult for developers to know the full suite of available UI components they can use.
## Summary
- Added missing component entries (including `Accordion`, `Dialog`, `Select`, `Spinner`, `Tabs`, and `Toast`) to the Components table in the `openhands-ui` README.
## Issue Number
<!-- Leave blank if you don't have an issue number -->
## How to Test
This is a purely markdown change. You can test by reviewing the rendered `openhands-ui/README.md` file in this Pull Request to ensure the table renders correctly.
## Video/Screenshots
*Not applicable (markdown-only change).*
## Type
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore
## Notes
None