### PR TITLE
fix(llm): skip Gemini full endpoint URL as base_url to prevent doubled path 404

### DIFF
--- a/openhands/utils/llm.py
+++ b/openhands/utils/llm.py
@@ -182,6 +182,12 @@ def get_provider_api_base(model: str) -> str | None:
     try:
         api_base = litellm.get_api_base(model, {})
         if api_base:
+            # Gemini returns a full model-specific endpoint URL (e.g.
+            # ".../models/gemini-xxx:generateContent"). Storing that as base_url
+            # causes litellm to append the model path a second time, producing a
+            # doubled URL and a 404. Let litellm resolve the Gemini URL itself.
+            if ':generateContent' in api_base or ':streamGenerateContent' in api_base:
+                return None
             return api_base
     except Exception:
         pass

--- a/tests/unit/utils/test_llm_utils.py
+++ b/tests/unit/utils/test_llm_utils.py
@@ -108,11 +108,20 @@ class TestGetProviderApiBase:
             == 'https://api.anthropic.com'
         )
 
-    def test_gemini_model_returns_google_api_base(self):
-        """Test that Gemini models return a Google API base URL."""
-        api_base = get_provider_api_base('gemini/gemini-pro')
-        assert api_base is not None
-        assert 'generativelanguage.googleapis.com' in api_base
+    def test_gemini_model_returns_none_not_model_specific_endpoint(self):
+        """Regression for #14028.
+
+        litellm.get_api_base returns the fully-resolved request URL for
+        gemini/<model> (e.g. .../models/gemini-pro:generateContent), not a
+        reusable base. Persisting that as base_url caused the subsequent
+        request to append the model path a second time and 404. We now
+        return None so litellm falls back to its own default.
+        """
+        assert get_provider_api_base('gemini/gemini-pro') is None
+        assert get_provider_api_base('gemini/gemini-3.1-pro-preview') is None
+        assert get_provider_api_base('gemini/gemini-3-flash-preview') is None
+        assert get_provider_api_base('gemini/gemini-2.5-pro') is None
+        assert get_provider_api_base('gemini/gemini-2.5-flash') is None
 
     def test_mistral_model_returns_mistral_api_base(self):
         """Test that Mistral models return the Mistral API base URL."""


### PR DESCRIPTION
Fixes #14028
Fixes #13645

## What

`litellm.get_api_base()` returns a full endpoint URL for Gemini models:
```
https://generativelanguage.googleapis.com/v1beta/models/gemini-xxx:generateContent
```
This gets stored as `base_url`. litellm appends the model path again on the actual call → doubled URL → 404.

## Fix

In `openhands/utils/llm.py`, return `None` when the URL already contains `:generateContent` or `:streamGenerateContent`, letting litellm build the correct URL itself.

## Test

Updated `test_gemini_model_returns_none_not_model_specific_endpoint` to cover 5 Gemini models across generations (legacy `gemini-pro`, latest pro/flash, 2.5 pro/flash). All assert `get_provider_api_base()` returns `None`.