### PR TITLE
fix(backend): restore git-organizations endpoint for git conversation routing

### DIFF
--- a/enterprise/server/models/user_models.py
+++ b/enterprise/server/models/user_models.py
@@ -1,6 +1,9 @@
 """SAAS-specific user models that extend OSS UserInfo with organization fields."""
 
+from pydantic import BaseModel
+
 from openhands.app_server.user.user_models import UserInfo
+from openhands.integrations.service_types import ProviderType
 
 
 class SaasUserInfo(UserInfo):
@@ -14,3 +17,10 @@ class SaasUserInfo(UserInfo):
     org_name: str | None = None
     role: str | None = None
     permissions: list[str] | None = None
+
+
+class GitOrganizationsResponse(BaseModel):
+    """Response model for the Git organizations the user belongs to on their active provider."""
+
+    provider: ProviderType
+    organizations: list[str]

--- a/enterprise/server/routes/users_v1.py
+++ b/enterprise/server/routes/users_v1.py
@@ -5,12 +5,13 @@ user endpoints with organization context (org_id, org_name, role, permissions).
 """
 
 import logging
-from typing import Any
+from types import MappingProxyType
+from typing import Any, cast
 
 from fastapi import APIRouter, FastAPI, Header, HTTPException, Query, status
 from fastapi.responses import JSONResponse
 from server.auth.saas_user_auth import SaasUserAuth
-from server.models.user_models import SaasUserInfo
+from server.models.user_models import GitOrganizationsResponse, SaasUserInfo
 
 from openhands.app_server.config import (
     depends_user_context,
@@ -20,6 +21,8 @@ from openhands.app_server.sandbox.session_auth import validate_session_key_owner
 from openhands.app_server.user.auth_user_context import AuthUserContext
 from openhands.app_server.user.user_context import UserContext
 from openhands.app_server.utils.dependencies import get_dependencies
+from openhands.integrations.provider import ProviderHandler
+from openhands.integrations.service_types import ProviderType
 
 _logger = logging.getLogger(__name__)
 
@@ -98,6 +101,45 @@ async def get_current_user_saas(
     content = user_info.model_dump(mode='json')
     _inject_sdk_compat_fields(content, include_api_key=False)
     return JSONResponse(content=content)  # type: ignore[return-value]
+
+
+@saas_users_v1_router.get('/git-organizations')
+async def get_current_user_git_organizations(
+    user_context: UserContext = user_dependency,
+) -> GitOrganizationsResponse:
+    """Return the Git organizations, groups, or workspaces the user belongs to
+    on their active provider.
+
+    In SAAS mode users sign in with one provider at a time, so the response
+    reflects that single provider.
+    """
+    provider_tokens = await user_context.get_provider_tokens()
+    if not provider_tokens:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail='Git provider token required.',
+        )
+
+    user_id = await user_context.get_user_id()
+    client = ProviderHandler(
+        provider_tokens=MappingProxyType(provider_tokens),  # type: ignore[arg-type]
+        external_auth_id=user_id,
+    )
+
+    provider = cast(ProviderType, next(iter(provider_tokens)))
+    if provider == ProviderType.GITHUB:
+        orgs = await client.get_github_organizations()
+    elif provider == ProviderType.GITLAB:
+        orgs = await client.get_gitlab_groups()
+    elif provider == ProviderType.BITBUCKET:
+        orgs = await client.get_bitbucket_workspaces()
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Provider {provider.value} doesn't support git organizations",
+        )
+
+    return GitOrganizationsResponse(provider=provider, organizations=orgs)
 
 
 async def _get_org_info_from_context(user_context: UserContext) -> dict | None:

--- a/enterprise/tests/unit/test_user_git_organizations.py
+++ b/enterprise/tests/unit/test_user_git_organizations.py
@@ -1,0 +1,110 @@
+"""Tests for the GET /api/v1/users/git-organizations SAAS endpoint.
+
+This endpoint returns the Git organizations / groups / workspaces the user
+belongs to on their active provider. In SAAS mode users sign in with one
+provider at a time.
+"""
+
+from types import MappingProxyType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, status
+from pydantic import SecretStr
+
+from openhands.app_server.user.user_context import UserContext
+from openhands.integrations.provider import ProviderToken
+from openhands.integrations.service_types import ProviderType
+
+
+def _make_user_context(provider_tokens, user_id: str = 'user-1') -> UserContext:
+    """Build a mock UserContext with the given provider tokens."""
+    context = MagicMock(spec=UserContext)
+    context.get_provider_tokens = AsyncMock(return_value=provider_tokens)
+    context.get_user_id = AsyncMock(return_value=user_id)
+    return context
+
+
+@pytest.mark.asyncio
+async def test_raises_401_when_no_provider_tokens():
+    """Without provider tokens the endpoint refuses the request."""
+    # Arrange
+    from server.routes.users_v1 import get_current_user_git_organizations
+
+    user_context = _make_user_context(provider_tokens=None)
+
+    # Act
+    with pytest.raises(HTTPException) as excinfo:
+        await get_current_user_git_organizations(user_context=user_context)
+
+    # Assert
+    assert excinfo.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_raises_400_when_provider_unsupported():
+    """An active provider with no organizations concept surfaces a 400."""
+    # Arrange
+    from server.routes.users_v1 import get_current_user_git_organizations
+
+    user_context = _make_user_context(
+        provider_tokens=MappingProxyType(
+            {ProviderType.AZURE_DEVOPS: ProviderToken(token=SecretStr('az-token'))}
+        )
+    )
+
+    # Act
+    with pytest.raises(HTTPException) as excinfo:
+        await get_current_user_git_organizations(user_context=user_context)
+
+    # Assert
+    assert excinfo.value.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'provider, service_method, service_return',
+    [
+        (
+            ProviderType.GITHUB,
+            'get_organizations_from_installations',
+            ['All-Hands-AI', 'OpenHands'],
+        ),
+        (
+            ProviderType.GITLAB,
+            'get_user_groups',
+            ['my-team', 'open-source'],
+        ),
+        (
+            ProviderType.BITBUCKET,
+            'get_installations',
+            ['my-workspace'],
+        ),
+    ],
+    ids=['github', 'gitlab', 'bitbucket'],
+)
+async def test_returns_organizations_for_supported_provider(
+    provider, service_method, service_return
+):
+    """Each supported provider routes to its service method and is returned in the response."""
+    # Arrange
+    from server.routes.users_v1 import get_current_user_git_organizations
+
+    user_context = _make_user_context(
+        provider_tokens=MappingProxyType(
+            {provider: ProviderToken(token=SecretStr('token'))}
+        )
+    )
+
+    with patch(
+        'openhands.integrations.provider.ProviderHandler.get_service'
+    ) as mock_get_service:
+        mock_service = mock_get_service.return_value
+        setattr(mock_service, service_method, AsyncMock(return_value=service_return))
+
+        # Act
+        result = await get_current_user_git_organizations(user_context=user_context)
+
+    # Assert
+    assert result.provider == provider
+    assert result.organizations == service_return

--- a/frontend/src/api/user-service/user-service.api.ts
+++ b/frontend/src/api/user-service/user-service.api.ts
@@ -21,7 +21,7 @@ class UserService {
    */
   static async getGitOrganizations(): Promise<UserGitOrganizationsResponse> {
     const { data } = await openHands.get<UserGitOrganizationsResponse>(
-      "/api/user/git-organizations",
+      "/api/v1/users/git-organizations",
     );
     return data;
   }

--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -88,7 +88,7 @@ def get_default_web_url() -> str | None:
     web_host = os.getenv('WEB_HOST')
     if not web_host:
         return None
-    return f'http://{web_host}'
+    return f'https://{web_host}'
 
 
 def get_default_permitted_cors_origins() -> list[str]:

--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -88,7 +88,7 @@ def get_default_web_url() -> str | None:
     web_host = os.getenv('WEB_HOST')
     if not web_host:
         return None
-    return f'https://{web_host}'
+    return f'http://{web_host}'
 
 
 def get_default_permitted_cors_origins() -> list[str]:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

#13952 cleaned up deprecated V0 FastAPI endpoints and assumed each had a V1 replacement. `/api/user/git-organizations` was **not** marked `deprecated=True` and had no V1 equivalent — it was removed alongside its genuinely-deprecated siblings. As a consequence:

- `frontend/src/api/user-service/user-service.api.ts` 404s on every call.
- The Git Conversation Routing UI (`frontend/src/components/features/org/git-conversation-routing.tsx`) can't list the user's Git orgs, so "claim" / "disconnect" actions for `/api/organizations/{org_id}/git-claims` are unusable.

The provider methods (`ProviderHandler.get_github_organizations()`, `get_gitlab_groups()`, `get_bitbucket_workspaces()`) were left intact in `openhands/integrations/provider.py`, so the fix is a thin SAAS router wrapper following the V1 migration direction the PR was otherwise applying.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Reintroduce the `git-organizations` endpoint removed in #13952 as a SAAS-only V1 route at `GET /api/v1/users/git-organizations`, restoring the Git Conversation Routing feature.
- Update the frontend `UserService.getGitOrganizations()` to call the V1 path; response shape is unchanged.
- Add unit tests covering 401 (no provider tokens), 400 (unsupported provider), and the happy path for GitHub / GitLab / Bitbucket.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

N/A.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Run the SaaS code.
2. Create a new organization.
3. Navigate to the organization page, where the list of Git organizations should be displayed.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="756" alt="app-1338" src="https://github.com/user-attachments/assets/d691272d-4d53-49c0-a785-b7f1ea4c42b6" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

N/A.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:68c7aa2-nikolaik   --name openhands-app-68c7aa2   docker.openhands.dev/openhands/openhands:68c7aa2
```