### PR TITLE
fix(settings): auto-prefix LM Studio custom models with openai/

### DIFF
--- a/openhands/app_server/settings/settings_router.py
+++ b/openhands/app_server/settings/settings_router.py
@@ -30,7 +30,11 @@ from openhands.storage.data_models.secrets import Secrets
 from openhands.storage.data_models.settings import Settings
 from openhands.storage.secrets.secrets_store import SecretsStore
 from openhands.storage.settings.settings_store import SettingsStore
-from openhands.utils.llm import get_provider_api_base, is_openhands_model
+from openhands.utils.llm import (
+    ensure_llm_provider_prefix,
+    get_provider_api_base,
+    is_openhands_model,
+)
 
 LITE_LLM_API_URL = os.environ.get(
     'LITE_LLM_API_URL', 'https://llm-proxy.app.all-hands.dev'
@@ -49,6 +53,9 @@ def _post_merge_llm_fixups(settings: Settings) -> None:
 
     When the merged LLM base_url is empty-string, treat it as cleared.
     When it is None, try to auto-detect the provider default.
+    When the user supplied a custom base_url (e.g. LM Studio) without a
+    recognised LiteLLM provider prefix on the model, prepend ``openai/`` so
+    LiteLLM can route the OpenAI-compatible request.
     """
     llm = settings.agent_settings.llm
 
@@ -66,6 +73,8 @@ def _post_merge_llm_fixups(settings: Settings) -> None:
                 logger.error(
                     f'Failed to get api_base from litellm for model {llm.model}: {e}'
                 )
+    elif llm.base_url and llm.model:
+        llm.model = ensure_llm_provider_prefix(llm.model, llm.base_url)
 
 
 # NOTE: We use response_model=None for endpoints that return JSONResponse directly.

--- a/openhands/utils/llm.py
+++ b/openhands/utils/llm.py
@@ -92,6 +92,47 @@ class ModelsResponse(BaseModel):
     default_model: str
 
 
+def _is_known_litellm_provider(prefix: str) -> bool:
+    """Return True if ``prefix`` is a provider LiteLLM recognises."""
+    try:
+        return prefix in litellm.provider_list
+    except Exception:
+        return False
+
+
+def ensure_llm_provider_prefix(model: str, base_url: str | None) -> str:
+    """Ensure a custom OpenAI-compatible model carries a LiteLLM provider prefix.
+
+    When users point OpenHands at a custom OpenAI-compatible endpoint (e.g.
+    LM Studio, llama.cpp, vLLM), they often paste the raw model identifier
+    served by that endpoint — e.g. ``qwen/qwen3-coder-30b-a3b-instruct`` from
+    LM Studio. LiteLLM splits on ``/`` to find the provider and raises
+    ``BadRequestError: LLM Provider NOT provided`` when the first segment
+    isn't in its provider list.
+
+    When ``base_url`` is set and the model either has no prefix or its prefix
+    isn't a known LiteLLM provider, we prepend ``openai/`` so LiteLLM routes
+    the request through its OpenAI-compatible path. The model identifier that
+    reaches the endpoint is preserved because LiteLLM strips the ``openai/``
+    prefix before sending.
+
+    Args:
+        model: The raw model identifier provided by the user.
+        base_url: The custom endpoint URL, if any.
+
+    Returns:
+        The model string, prefixed with ``openai/`` when necessary.
+    """
+    if not model or not base_url:
+        return model
+
+    prefix = model.split('/', 1)[0]
+    if '/' in model and _is_known_litellm_provider(prefix):
+        return model
+
+    return f'openai/{model}'
+
+
 def is_openhands_model(model: str | None) -> bool:
     """Check if the model uses the OpenHands provider.
 

--- a/tests/unit/utils/test_llm_utils.py
+++ b/tests/unit/utils/test_llm_utils.py
@@ -4,6 +4,7 @@ from openhands.utils import llm as llm_utils
 from openhands.utils.llm import (
     _assign_provider,
     _derive_verified_models,
+    ensure_llm_provider_prefix,
     get_provider_api_base,
     is_openhands_model,
 )
@@ -127,3 +128,63 @@ class TestGetProviderApiBase:
         # May return None or an API base depending on litellm behavior
         # The function should not raise an exception
         assert result is None or isinstance(result, str)
+
+
+class TestEnsureLlmProviderPrefix:
+    """Tests for ensure_llm_provider_prefix (issue #13948)."""
+
+    def test_lm_studio_slash_model_gets_openai_prefix(self):
+        """LM Studio model IDs with ``/`` must not crash litellm."""
+        assert (
+            ensure_llm_provider_prefix(
+                'qwen/qwen3.5-35b-a3b', 'http://172.27.139.1:1234/v1'
+            )
+            == 'openai/qwen/qwen3.5-35b-a3b'
+        )
+
+    def test_bare_model_with_base_url_gets_openai_prefix(self):
+        assert (
+            ensure_llm_provider_prefix('my-model', 'http://localhost:8080')
+            == 'openai/my-model'
+        )
+
+    def test_known_provider_prefix_left_alone(self):
+        assert (
+            ensure_llm_provider_prefix(
+                'anthropic/claude-3-opus', 'https://api.anthropic.com'
+            )
+            == 'anthropic/claude-3-opus'
+        )
+        assert (
+            ensure_llm_provider_prefix(
+                'lm_studio/qwen/qwen3', 'http://localhost:1234/v1'
+            )
+            == 'lm_studio/qwen/qwen3'
+        )
+        assert (
+            ensure_llm_provider_prefix(
+                'litellm_proxy/claude-opus-4-5', 'https://llm-proxy.app.all-hands.dev'
+            )
+            == 'litellm_proxy/claude-opus-4-5'
+        )
+        assert (
+            ensure_llm_provider_prefix('openai/gpt-4', 'https://api.openai.com/v1')
+            == 'openai/gpt-4'
+        )
+
+    def test_openai_prefix_preserved_even_with_slashy_model(self):
+        """Docs recommend ``openai/qwen/...``; preserve that shape."""
+        assert (
+            ensure_llm_provider_prefix(
+                'openai/qwen/qwen3-coder-30b-a3b-instruct',
+                'http://host.docker.internal:1234/v1',
+            )
+            == 'openai/qwen/qwen3-coder-30b-a3b-instruct'
+        )
+
+    def test_no_base_url_leaves_model_alone(self):
+        assert ensure_llm_provider_prefix('qwen/qwen3.5', None) == 'qwen/qwen3.5'
+        assert ensure_llm_provider_prefix('qwen/qwen3.5', '') == 'qwen/qwen3.5'
+
+    def test_empty_model_returned_unchanged(self):
+        assert ensure_llm_provider_prefix('', 'http://foo') == ''


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

LM Studio exposes model IDs that contain a ``/`` (for example ``qwen/qwen3-coder-30b-a3b-instruct``). When a user pastes that identifier into the ``Custom Model`` field together with the LM Studio base URL (``http://host.docker.internal:1234/v1`` or similar), LiteLLM splits the model string on ``/`` to infer the provider, sees ``qwen`` — which isn't in its provider list — and raises:

```
litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model=qwen/qwen3.5-35b-a3b
```

See issue OpenHands/software-agent-sdk#4247 for the full reproduction (screenshots + the LM Studio quickstart the user followed).

## Summary

- Added ``ensure_llm_provider_prefix(model, base_url)`` in ``openhands/utils/llm.py``. When the user supplies a custom ``base_url`` and the model's first ``/`` segment isn't a LiteLLM-recognised provider (``litellm.provider_list``), the helper prepends ``openai/`` so LiteLLM routes the request through its OpenAI-compatible path. LiteLLM strips that prefix before the outbound call, so the endpoint still receives the original model ID (LM Studio, llama.cpp, vLLM, etc. all accept this).
- Wired it into ``_post_merge_llm_fixups`` in ``openhands/app_server/settings/settings_router.py`` — only on the branch where the user set ``base_url`` explicitly, so auto-detected base URLs for well-known providers are left untouched.
- Added 6 unit tests in ``tests/unit/utils/test_llm_utils.py`` covering: the LM Studio slash-in-model case, bare models, already-known prefixes (``anthropic/``, ``openai/``, ``lm_studio/``, ``litellm_proxy/``), the docs-recommended ``openai/qwen/...`` shape, no-base-url, and empty-model.

## Issue Number

Fixes OpenHands/software-agent-sdk#4247

## How to Test

1. Run LM Studio locally and serve a model whose ID contains a slash (e.g. ``qwen/qwen3-coder-30b-a3b-instruct``).
2. Start OpenHands (``make run``).
3. In the LLM settings, switch to the advanced view and enter:
   - Custom Model: ``qwen/qwen3-coder-30b-a3b-instruct`` (no ``openai/`` prefix, matching what LM Studio shows)
   - Base URL: ``http://host.docker.internal:1234/v1``
   - API Key: ``local-llm``
4. Save and start a conversation. Before the fix this errored with ``LLM Provider NOT provided``; after the fix it connects and the stored model becomes ``openai/qwen/qwen3-coder-30b-a3b-instruct``.

Automated:

```
poetry run pytest tests/unit/utils/test_llm_utils.py
```

All 19 tests pass (6 new). ``ruff check`` and ``ruff format`` are clean.

## Video/Screenshots

N/A — backend-only change. The reproduction screenshots from the filer are on issue OpenHands/software-agent-sdk#4247.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The fix only transforms the model when ``base_url`` is explicitly set by the user; models whose ``base_url`` is auto-detected from a known provider (OpenAI, Anthropic, Mistral, etc.) are untouched, so there is no regression for existing configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)