### PR TITLE
fix(backend): repair org-defaults LLM save flow and sync managed keys to members

### DIFF
--- a/enterprise/server/routes/org_models.py
+++ b/enterprise/server/routes/org_models.py
@@ -7,12 +7,15 @@ from pydantic import (
     SecretStr,
     StringConstraints,
     field_validator,
+    model_validator,
 )
+from server.constants import LITE_LLM_API_URL
 from storage.org import Org
 from storage.org_member import OrgMember
 from storage.role import Role
 
 from openhands.sdk.settings import AgentSettings, ConversationSettings
+from openhands.utils.llm import MASKED_API_KEY, resolve_llm_base_url
 
 
 class OrgCreationError(Exception):
@@ -208,7 +211,13 @@ class OrgPage(BaseModel):
 
 
 class OrgUpdate(BaseModel):
-    """Request model for updating an organization."""
+    """Request model for updating an organization.
+
+    ``agent_settings`` and ``conversation_settings`` match the wire format
+    the frontend already uses for ``OrgLLMSettingsUpdate``; they're
+    applied to the org row as partial/diff patches via ``deep_merge`` in
+    ``OrgStore.update_org``.
+    """
 
     name: Annotated[
         str | None,
@@ -227,8 +236,8 @@ class OrgUpdate(BaseModel):
     enable_solvability_analysis: bool | None = None
     v1_enabled: bool | None = None
     search_api_key: str | None = None
-    agent_settings_diff: dict[str, Any] | None = None
-    conversation_settings_diff: dict[str, Any] | None = None
+    agent_settings: dict[str, Any] | None = None
+    conversation_settings: dict[str, Any] | None = None
 
 
 class OrgLLMSettingsResponse(BaseModel):
@@ -255,11 +264,22 @@ class OrgLLMSettingsResponse(BaseModel):
 
     @classmethod
     def from_org(cls, org: Org) -> 'OrgLLMSettingsResponse':
-        """Create response from Org entity."""
+        """Create response from Org entity.
+
+        Denormalizes the SDK's ``litellm_proxy/`` prefix back to
+        ``openhands/`` so the frontend's basic-view provider/model dropdowns
+        can be populated, and nulls ``api_key`` so neither the raw secret
+        nor the ``MASKED_API_KEY`` marker leaks in the response.
+        ``base_url`` is returned exactly as stored so ``org.agent_settings``,
+        ``org_member.agent_settings_diff`` and this response always carry
+        the same value.
+        """
+        agent_settings = AgentSettings.model_validate(
+            dict(org.agent_settings) if org.agent_settings else {}
+        )
+        cls._denormalize_llm_for_response(agent_settings)
         return cls(
-            agent_settings=AgentSettings.model_validate(
-                dict(org.agent_settings) if org.agent_settings else {}
-            ),
+            agent_settings=agent_settings,
             conversation_settings=ConversationSettings.model_validate(
                 dict(org.conversation_settings) if org.conversation_settings else {}
             ),
@@ -267,13 +287,54 @@ class OrgLLMSettingsResponse(BaseModel):
             search_api_key=cls._mask_key(org.search_api_key),
         )
 
+    @staticmethod
+    def _denormalize_llm_for_response(agent_settings: AgentSettings) -> None:
+        """Rewrite ``agent_settings.llm`` in-place for UI consumption.
+
+        * ``litellm_proxy/X`` → ``openhands/X`` so the basic-view provider
+          dropdown matches (the SDK's ``AgentSettings`` validator
+          normalizes the other direction on load).
+        * ``base_url`` is returned **as stored** so the three sync targets
+          (``org.agent_settings.llm.base_url``,
+          ``org_member.agent_settings_diff.llm.base_url``, and the GET
+          response) always agree. The frontend is responsible for
+          recognizing the managed LiteLLM proxy URL / provider-default URL
+          as "basic mode" — see ``KNOWN_PROVIDER_DEFAULT_BASE_URLS`` in
+          ``frontend/src/routes/llm-settings.tsx``.
+        * ``api_key`` is nulled so neither the raw secret nor the
+          ``MASKED_API_KEY`` marker leaks in the response — the frontend
+          reads ``llm_api_key_set`` to know whether a key exists.
+
+        Pydantic v2 field assignment bypasses ``field_validator`` /
+        ``model_validator`` by default (``validate_assignment`` is off on
+        the SDK's ``LLM`` model), so the rename survives without being
+        re-normalized back to ``litellm_proxy/``.
+        """
+        llm = agent_settings.llm
+        if llm.model and llm.model.startswith('litellm_proxy/'):
+            llm.model = f'openhands/{llm.model.removeprefix("litellm_proxy/")}'
+        llm.api_key = None
+
 
 class OrgMemberLLMSettings(BaseModel):
-    """Shared LLM settings that may be propagated to organization members."""
+    """Shared LLM settings that may be propagated to organization members.
+
+    ``llm_api_key`` is typed as ``SecretStr`` so the raw value never ends up
+    in logs or ``model_dump(mode='json')`` output by accident — the
+    column-backed ``OrgMember.llm_api_key`` setter accepts ``SecretStr``
+    directly and unwraps via ``get_secret_value()``.
+
+    ``has_custom_llm_api_key`` propagates through
+    ``update_all_members_llm_settings_async`` so an org-defaults save can
+    reset every member's "I have a personal BYOR key" flag in one pass —
+    managed-mode switches rely on this to stop load-time fallthrough from
+    returning stale custom markers.
+    """
 
     agent_settings_diff: dict[str, Any] | None = None
     conversation_settings_diff: dict[str, Any] | None = None
-    llm_api_key: str | None = None
+    llm_api_key: SecretStr | None = None
+    has_custom_llm_api_key: bool | None = None
 
     def has_updates(self) -> bool:
         """Check if any field is set (not None)."""
@@ -283,12 +344,96 @@ class OrgMemberLLMSettings(BaseModel):
 
 
 class OrgLLMSettingsUpdate(BaseModel):
-    """Request model for updating organization LLM settings."""
+    """Request model for updating organization LLM settings.
 
-    agent_settings_diff: dict[str, Any] | None = None
-    conversation_settings_diff: dict[str, Any] | None = None
+    ``agent_settings`` and ``conversation_settings`` are applied to the org
+    as partial/diff patches via ``deep_merge`` and are also propagated to
+    each member's stored diff so stale member overrides don't mask the new
+    org defaults.
+    """
+
+    agent_settings: dict[str, Any] | None = None
+    conversation_settings: dict[str, Any] | None = None
     search_api_key: str | None = None
     llm_api_key: str | None = None
+
+    @model_validator(mode='after')
+    def _normalize_agent_settings(self) -> 'OrgLLMSettingsUpdate':
+        """Normalize ``agent_settings`` so post-save stored state stays
+        consistent between the org row, every member row, and the encrypted
+        ``_llm_api_key`` column.
+
+        Two jobs:
+
+        * **Lift ``llm.api_key`` and mask it in the JSON.** The frontend
+          posts the raw key nested inside ``agent_settings``. Leaving it
+          nested would push a raw secret into the ``org.agent_settings``
+          JSON column while ``org._llm_api_key`` (the encrypted column read
+          by ``_get_effective_llm_api_key`` at load time) stays stale. We
+          move the raw value up to ``self.llm_api_key`` (for the encrypted
+          column) and leave a universal ``MASKED_API_KEY`` marker in the
+          JSON. That marker then propagates through ``deep_merge`` into
+          ``org.agent_settings.llm.api_key`` and through
+          ``get_member_updates`` into every member's
+          ``agent_settings_diff.llm.api_key`` — matching the convention
+          ``SaasSettingsStore.store`` already follows via
+          ``model_dump(mode='json')``.
+
+        * **Fill ``llm.base_url`` for OpenHands / managed models.** The
+          basic-view payload sends ``base_url: null`` when the user picks
+          the OpenHands provider. ``deep_merge`` treats ``None`` as "delete
+          this key," which would leave ``org.agent_settings.llm`` without a
+          ``base_url`` (and the frontend then can't tell which provider is
+          configured — see the empty basic-view dropdowns). Substitute the
+          managed LiteLLM proxy URL so the stored state is complete and
+          self-describing.
+        """
+        if self.agent_settings is None:
+            return self
+        llm = self.agent_settings.get('llm')
+        if not isinstance(llm, dict):
+            return self
+
+        if 'api_key' in llm:
+            nested_key = llm.pop('api_key')
+            # Don't re-lift the masked placeholder — the frontend echoes
+            # it back when the user saves without editing the api_key
+            # field. Treating it as a raw key would encrypt ``**********``
+            # into the column and nuke the real key.
+            if (
+                self.llm_api_key is None
+                and nested_key is not None
+                and nested_key != MASKED_API_KEY
+            ):
+                self.llm_api_key = nested_key
+            if nested_key is not None:
+                # Keep the JSON in sync with the encrypted column — both
+                # ``org.agent_settings.llm.api_key`` and every member's
+                # ``agent_settings_diff.llm.api_key`` will carry this marker
+                # after ``deep_merge`` / propagation. An empty string still
+                # gets the marker: the rotation step that runs after the
+                # store update will write a freshly generated managed key
+                # into the column, so "masked" in the JSON still reflects
+                # reality by end of transaction.
+                llm['api_key'] = MASKED_API_KEY
+
+        # Auto-fill ``base_url`` when the wire payload sends ``null``
+        # (basic-view pattern). ``resolve_llm_base_url`` is shared with
+        # ``_post_merge_llm_fixups`` in the personal-settings router so
+        # both save paths agree on "this provider uses this base URL."
+        resolved_base_url = resolve_llm_base_url(
+            model=llm.get('model'),
+            base_url=llm.get('base_url'),
+            managed_proxy_url=LITE_LLM_API_URL,
+        )
+        if resolved_base_url is not None:
+            llm['base_url'] = resolved_base_url
+
+        if not llm:
+            self.agent_settings.pop('llm', None)
+        if not self.agent_settings:
+            self.agent_settings = None
+        return self
 
     def has_updates(self) -> bool:
         """Check if any field is set (not None)."""
@@ -304,8 +449,20 @@ class OrgLLMSettingsUpdate(BaseModel):
             org.llm_api_key = self.llm_api_key or None
 
     def get_member_updates(self) -> OrgMemberLLMSettings | None:
-        """Get updates that need to be propagated to org members."""
-        member_settings = OrgMemberLLMSettings(llm_api_key=self.llm_api_key)
+        """Get updates that need to be propagated to org members.
+
+        An empty ``llm_api_key`` means the org‑wide custom key is being cleared
+        (e.g. owner switching to a managed/OpenHands provider). It must not
+        land in member rows — ``OrgMember.llm_api_key``'s setter has no
+        ``if raw else None`` guard because the column is ``nullable=False``,
+        so an empty string would become an encrypted empty blob rather than a
+        cleared value. Coerce ``""`` to ``None`` so member rows are untouched.
+        """
+        member_settings = OrgMemberLLMSettings(
+            agent_settings_diff=self.agent_settings,
+            conversation_settings_diff=self.conversation_settings,
+            llm_api_key=self.llm_api_key or None,
+        )
         return member_settings if member_settings.has_updates() else None
 
 

--- a/enterprise/server/services/org_llm_settings_service.py
+++ b/enterprise/server/services/org_llm_settings_service.py
@@ -198,6 +198,20 @@ class OrgLLMSettingsService:
         )
         acting_member = result.scalars().first()
         if acting_member is None:
+            # Shouldn't happen — the caller already resolved the user's
+            # current org via ``get_current_org_by_user_id`` before calling
+            # us, so the ``OrgMember`` row must exist. If it's missing
+            # anyway, the org-wide managed-key propagation skips the
+            # ``llm_api_key`` write (``effective_managed_key`` returns
+            # ``None``) and members keep whatever was in their columns.
+            # Log loudly so this data-consistency issue surfaces instead of
+            # silently leaving stale keys on member rows.
+            logger.error(
+                'Acting member row not found during managed LLM key '
+                'rotation; skipping managed-key propagation. Members may '
+                'retain stale keys until they save personal settings.',
+                extra={'user_id': user_id, 'org_id': str(updated_org.id)},
+            )
             return None
 
         existing_key = acting_member.llm_api_key

--- a/enterprise/server/services/org_llm_settings_service.py
+++ b/enterprise/server/services/org_llm_settings_service.py
@@ -6,20 +6,30 @@ Uses dependency injection for db_session and user_context.
 
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass
 from typing import AsyncGenerator
 
 from fastapi import Request
+from pydantic import SecretStr
+from server.constants import LITE_LLM_API_URL
 from server.routes.org_models import (
     OrgLLMSettingsResponse,
     OrgLLMSettingsUpdate,
+    OrgMemberLLMSettings,
     OrgNotFoundError,
 )
+from sqlalchemy import select
+from storage.lite_llm_manager import LiteLlmManager, get_openhands_cloud_key_alias
+from storage.org import Org
 from storage.org_llm_settings_store import OrgLLMSettingsStore
+from storage.org_member import OrgMember
+from storage.org_member_store import OrgMemberStore
 
 from openhands.app_server.services.injector import Injector, InjectorState
 from openhands.app_server.user.user_context import UserContext
 from openhands.core.logger import openhands_logger as logger
+from openhands.utils.llm import is_openhands_model
 
 
 @dataclass
@@ -105,12 +115,135 @@ class OrgLLMSettingsService:
         if not updated_org:
             raise OrgNotFoundError(str(org.id))
 
+        # Build the member-propagation payload from the update diff, then
+        # let the managed-key rotation merge in a freshly generated /
+        # reused managed key (OpenHands / LiteLLM proxy case). A single
+        # ``update_all_members_llm_settings_async`` call at the end writes
+        # the ``agent_settings_diff``, ``llm_api_key``, and a
+        # ``has_custom_llm_api_key=False`` reset to every member row in one
+        # pass. The flag reset is load-bearing: org-defaults saves are an
+        # org-wide "use the org default" signal, so any lingering
+        # "I have a personal BYOR key" marker on a member row would make
+        # ``_get_effective_llm_api_key`` return the wrong key at read time.
+        member_updates = update_data.get_member_updates()
+
+        effective_managed_key = await self._maybe_rotate_managed_llm_key_for_user(
+            updated_org=updated_org,
+            user_id=user_id,
+        )
+        if effective_managed_key is not None:
+            if member_updates is None:
+                member_updates = OrgMemberLLMSettings()
+            member_updates.llm_api_key = SecretStr(effective_managed_key)
+
+        if member_updates is not None:
+            member_updates.has_custom_llm_api_key = False
+            await OrgMemberStore.update_all_members_llm_settings_async(
+                self.store.db_session,
+                org.id,
+                member_updates,
+            )
+            logger.info(
+                'Propagated org LLM settings to members',
+                extra={'user_id': user_id, 'org_id': str(org.id)},
+            )
+
         logger.info(
             'Organization LLM settings updated successfully',
             extra={'user_id': user_id, 'org_id': str(org.id)},
         )
 
         return OrgLLMSettingsResponse.from_org(updated_org)
+
+    async def _maybe_rotate_managed_llm_key_for_user(
+        self,
+        updated_org: Org,
+        user_id: str,
+    ) -> str | None:
+        """Return the managed LLM key every member row should carry, or
+        ``None`` if the org isn't in managed mode.
+
+        When the updated org defaults target a managed LLM (OpenHands
+        provider or the LiteLLM proxy base URL), this reuses the acting
+        user's (any admin or owner with ``EDIT_LLM_SETTINGS``) current
+        managed key if ``verify_existing_key`` confirms it's still valid,
+        otherwise generates a fresh one. The returned key is what every
+        member's ``_llm_api_key`` column should hold — the caller bundles
+        it into the single ``update_all_members_llm_settings_async`` call
+        alongside the ``agent_settings_diff`` and a
+        ``has_custom_llm_api_key=False`` reset so one DB pass covers all
+        three. Detection matches ``SaasSettingsStore.store`` so the two
+        save paths agree on when managed mode is in play; propagation
+        semantics differ because org-defaults saves are intentionally an
+        org-wide operation.
+        """
+        llm = (updated_org.agent_settings or {}).get('llm') or {}
+        llm_model = llm.get('model')
+        llm_base_url = llm.get('base_url')
+        normalized_llm_base_url = llm_base_url.rstrip('/') if llm_base_url else None
+        normalized_managed_base_url = LITE_LLM_API_URL.rstrip('/')
+        openhands_type = is_openhands_model(llm_model)
+        uses_managed_llm_key = (
+            normalized_llm_base_url == normalized_managed_base_url
+            or (normalized_llm_base_url is None and openhands_type)
+        )
+        if not uses_managed_llm_key:
+            return None
+
+        result = await self.store.db_session.execute(
+            select(OrgMember).where(
+                OrgMember.org_id == updated_org.id,
+                OrgMember.user_id == uuid.UUID(user_id),
+            )
+        )
+        acting_member = result.scalars().first()
+        if acting_member is None:
+            return None
+
+        existing_key = acting_member.llm_api_key
+        existing_key_raw = existing_key.get_secret_value() if existing_key else None
+        if existing_key_raw and await LiteLlmManager.verify_existing_key(
+            existing_key_raw,
+            user_id,
+            str(updated_org.id),
+            openhands_type=openhands_type,
+        ):
+            # Reuse the acting user's still-valid managed key — no need to
+            # burn a LiteLLM key rotation on a no-op save.
+            effective_key = existing_key_raw
+            rotated = False
+        else:
+            if openhands_type:
+                effective_key = await LiteLlmManager.generate_key(
+                    user_id,
+                    str(updated_org.id),
+                    None,
+                    {'type': 'openhands'},
+                )
+            else:
+                key_alias = get_openhands_cloud_key_alias(user_id, str(updated_org.id))
+                await LiteLlmManager.delete_key_by_alias(key_alias=key_alias)
+                effective_key = await LiteLlmManager.generate_key(
+                    user_id,
+                    str(updated_org.id),
+                    key_alias,
+                    None,
+                )
+            rotated = True
+
+        # The caller merges ``effective_key`` into ``member_updates`` and
+        # issues a single ``update_all_members_llm_settings_async`` call
+        # that writes the key column AND resets ``has_custom_llm_api_key``
+        # on every member — including this acting row — so we don't touch
+        # the row directly here.
+
+        if rotated:
+            logger.info(
+                'Generated managed LLM key for acting user on org-defaults save',
+                extra={'user_id': user_id, 'org_id': str(updated_org.id)},
+            )
+
+        return effective_key
 
 
 class OrgLLMSettingsServiceInjector(Injector[OrgLLMSettingsService]):

--- a/enterprise/storage/org_llm_settings_store.py
+++ b/enterprise/storage/org_llm_settings_store.py
@@ -68,15 +68,15 @@ class OrgLLMSettingsStore:
             return None
 
         update_data.apply_to_org(org)
-        if update_data.agent_settings_diff:
+        if update_data.agent_settings:
             org.agent_settings = deep_merge(
                 org.agent_settings,
-                update_data.agent_settings_diff,
+                update_data.agent_settings,
             )
-        if update_data.conversation_settings_diff:
+        if update_data.conversation_settings:
             org.conversation_settings = deep_merge(
                 org.conversation_settings,
-                update_data.conversation_settings_diff,
+                update_data.conversation_settings,
             )
 
         # flush instead of commit - DbSessionInjector auto-commits at request end

--- a/enterprise/storage/org_service.py
+++ b/enterprise/storage/org_service.py
@@ -549,8 +549,8 @@ class OrgService:
             return existing_org
 
         restricted_fields = {
-            'agent_settings_diff',
-            'conversation_settings_diff',
+            'agent_settings',
+            'conversation_settings',
             'search_api_key',
             'sandbox_api_key',
         }

--- a/enterprise/storage/org_store.py
+++ b/enterprise/storage/org_store.py
@@ -133,7 +133,7 @@ class OrgStore:
                 org.id,
                 {
                     'org_version': ORG_SETTINGS_VERSION,
-                    'agent_settings_diff': {
+                    'agent_settings': {
                         'llm': {
                             'model': get_default_litellm_model(),
                             'base_url': LITE_LLM_API_URL,
@@ -226,8 +226,11 @@ class OrgStore:
             if 'id' in kwargs:
                 kwargs.pop('id')
 
-            agent_settings_diff = kwargs.pop('agent_settings_diff', None)
-            conversation_settings_diff = kwargs.pop('conversation_settings_diff', None)
+            # Pop the diff-style kwargs before the setattr loop — otherwise
+            # ``hasattr(org, 'agent_settings')`` is True and the loop would
+            # *overwrite* the JSON column instead of deep-merging into it.
+            agent_settings_diff = kwargs.pop('agent_settings', None)
+            conversation_settings_diff = kwargs.pop('conversation_settings', None)
             for key, value in kwargs.items():
                 if hasattr(org, key):
                     setattr(org, key, value)
@@ -464,15 +467,15 @@ class OrgStore:
                 return None
 
             llm_settings.apply_to_org(org)
-            if llm_settings.agent_settings_diff is not None:
+            if llm_settings.agent_settings is not None:
                 org.agent_settings = deep_merge(
                     org.agent_settings,
-                    llm_settings.agent_settings_diff,
+                    llm_settings.agent_settings,
                 )
-            if llm_settings.conversation_settings_diff is not None:
+            if llm_settings.conversation_settings is not None:
                 org.conversation_settings = deep_merge(
                     org.conversation_settings,
-                    llm_settings.conversation_settings_diff,
+                    llm_settings.conversation_settings,
                 )
 
             # Propagate relevant settings to all org members

--- a/enterprise/tests/unit/server/services/test_org_llm_settings_service.py
+++ b/enterprise/tests/unit/server/services/test_org_llm_settings_service.py
@@ -8,13 +8,19 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import SecretStr
+from server.constants import LITE_LLM_API_URL
 from server.routes.org_models import (
+    MASKED_API_KEY,
     OrgLLMSettingsResponse,
     OrgLLMSettingsUpdate,
     OrgNotFoundError,
 )
+from server.services import org_llm_settings_service as service_module
 from server.services.org_llm_settings_service import OrgLLMSettingsService
 from storage.org import Org
+from storage.org_member import OrgMember
+from storage.org_member_store import OrgMemberStore
 
 
 @pytest.fixture
@@ -126,7 +132,7 @@ async def test_get_org_llm_settings_org_not_found(
 
 @pytest.mark.asyncio
 async def test_update_org_llm_settings_success(
-    user_id, mock_org, mock_store, mock_user_context
+    user_id, mock_org, mock_store, mock_user_context, monkeypatch
 ):
     """
     GIVEN: A user with a current organization
@@ -149,17 +155,21 @@ async def test_update_org_llm_settings_success(
     updated_org.search_api_key = None
 
     update_data = OrgLLMSettingsUpdate(
-        agent_settings_diff={
+        agent_settings={
             'llm': {'model': 'new-model'},
         },
-        conversation_settings_diff={
+        conversation_settings={
             'confirmation_mode': False,
             'max_iterations': 100,
         },
     )
 
+    mock_store.db_session = MagicMock()
     mock_store.get_current_org_by_user_id = AsyncMock(return_value=mock_org)
     mock_store.update_org_llm_settings = AsyncMock(return_value=updated_org)
+    monkeypatch.setattr(
+        OrgMemberStore, 'update_all_members_llm_settings_async', AsyncMock()
+    )
     service = OrgLLMSettingsService(store=mock_store, user_context=mock_user_context)
 
     # Act
@@ -211,9 +221,7 @@ async def test_update_org_llm_settings_org_not_found(
     THEN: OrgNotFoundError is raised
     """
     # Arrange
-    update_data = OrgLLMSettingsUpdate(
-        agent_settings_diff={'llm': {'model': 'new-model'}}
-    )
+    update_data = OrgLLMSettingsUpdate(agent_settings={'llm': {'model': 'new-model'}})
 
     mock_store.get_current_org_by_user_id = AsyncMock(return_value=None)
     service = OrgLLMSettingsService(store=mock_store, user_context=mock_user_context)
@@ -223,3 +231,583 @@ async def test_update_org_llm_settings_org_not_found(
         await service.update_org_llm_settings(update_data)
 
     assert 'No current organization' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_update_org_llm_settings_accepts_wire_payload_and_propagates(
+    mock_org, mock_store, mock_user_context, monkeypatch
+):
+    """
+    GIVEN: The exact wire payload the frontend posts to /api/organizations/llm
+           ({"agent_settings": {...}}) and an org with members carrying stale
+           agent_settings_diff overrides
+    WHEN:  update_org_llm_settings is called
+    THEN:  1) the org is actually updated (was a silent no-op before the
+             field-name fix because the payload keys didn't match the model),
+           2) OrgMemberStore.update_all_members_llm_settings_async is invoked
+             so members' stale diffs are overwritten by the new org defaults
+    """
+    # Arrange
+    updated_org = MagicMock(spec=Org)
+    updated_org.id = mock_org.id
+    updated_org.agent_settings = {
+        'schema_version': 1,
+        'agent': 'CodeActAgent',
+        'llm': {
+            'model': 'claude-3',
+            'base_url': 'https://llm-proxy.staging.all-hands.dev',
+        },
+    }
+    updated_org.conversation_settings = {}
+    updated_org.llm_api_key = None
+    updated_org.search_api_key = None
+
+    update_data = OrgLLMSettingsUpdate.model_validate(
+        {
+            'agent_settings': {
+                'llm': {'base_url': 'https://llm-proxy.staging.all-hands.dev'},
+            },
+        }
+    )
+
+    mock_store.db_session = MagicMock()
+    mock_store.get_current_org_by_user_id = AsyncMock(return_value=mock_org)
+    mock_store.update_org_llm_settings = AsyncMock(return_value=updated_org)
+
+    propagation_mock = AsyncMock()
+    monkeypatch.setattr(
+        OrgMemberStore,
+        'update_all_members_llm_settings_async',
+        propagation_mock,
+    )
+
+    service = OrgLLMSettingsService(store=mock_store, user_context=mock_user_context)
+
+    # Act
+    await service.update_org_llm_settings(update_data)
+
+    # Assert
+    mock_store.update_org_llm_settings.assert_awaited_once_with(
+        org_id=mock_org.id,
+        update_data=update_data,
+    )
+    propagation_mock.assert_awaited_once()
+    call_args = propagation_mock.await_args
+    assert call_args.args[0] is mock_store.db_session
+    assert call_args.args[1] == mock_org.id
+    member_settings = call_args.args[2]
+    assert member_settings.agent_settings_diff == {
+        'llm': {'base_url': 'https://llm-proxy.staging.all-hands.dev'},
+    }
+    assert member_settings.conversation_settings_diff is None
+    assert member_settings.llm_api_key is None
+
+
+@pytest.mark.asyncio
+async def test_update_org_llm_settings_does_not_propagate_when_only_org_fields(
+    mock_org, mock_store, mock_user_context, monkeypatch
+):
+    """
+    GIVEN: An update that only touches org-scoped fields (search_api_key),
+           with nothing that should land on members
+    WHEN:  update_org_llm_settings is called
+    THEN:  member propagation is not invoked, guarding against regressions
+           that would needlessly rewrite every member's row
+    """
+    # Arrange
+    updated_org = MagicMock(spec=Org)
+    updated_org.id = mock_org.id
+    updated_org.agent_settings = mock_org.agent_settings
+    updated_org.conversation_settings = {}
+    updated_org.llm_api_key = None
+    updated_org.search_api_key = None
+
+    update_data = OrgLLMSettingsUpdate(search_api_key='new-search-key')
+
+    mock_store.db_session = MagicMock()
+    mock_store.get_current_org_by_user_id = AsyncMock(return_value=mock_org)
+    mock_store.update_org_llm_settings = AsyncMock(return_value=updated_org)
+
+    propagation_mock = AsyncMock()
+    monkeypatch.setattr(
+        OrgMemberStore,
+        'update_all_members_llm_settings_async',
+        propagation_mock,
+    )
+
+    service = OrgLLMSettingsService(store=mock_store, user_context=mock_user_context)
+
+    # Act
+    await service.update_org_llm_settings(update_data)
+
+    # Assert
+    propagation_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_org_llm_settings_lifts_nested_api_key_for_column_sync(
+    mock_org, mock_store, mock_user_context, monkeypatch
+):
+    """
+    GIVEN: The frontend posts the api_key nested inside agent_settings.llm
+    WHEN:  update_org_llm_settings is called
+    THEN:  the raw key is routed through the top-level llm_api_key field,
+           so every member's encrypted _llm_api_key column is updated via
+           the propagation call. Without this, members' encrypted columns
+           stay stale and _get_effective_llm_api_key returns the old key
+           when they refetch settings.
+    """
+    # Arrange
+    updated_org = MagicMock(spec=Org)
+    updated_org.id = mock_org.id
+    updated_org.agent_settings = {
+        'schema_version': 1,
+        'agent': 'CodeActAgent',
+        'llm': {'model': 'claude-3', 'base_url': 'https://example.com'},
+    }
+    updated_org.conversation_settings = {}
+    updated_org.llm_api_key = None
+    updated_org.search_api_key = None
+
+    update_data = OrgLLMSettingsUpdate.model_validate(
+        {
+            'agent_settings': {
+                'llm': {
+                    'api_key': 'sk-new-raw-key',
+                    'base_url': 'https://example.com',
+                },
+            },
+        }
+    )
+
+    # The validator must move the raw key out of agent_settings and into the
+    # top-level field the rest of the pipeline actually wires to the column,
+    # AND leave a masked marker in the JSON so ``org.agent_settings.llm``
+    # and member ``agent_settings_diff.llm`` stay consistent with the
+    # encrypted column.
+    assert update_data.llm_api_key == 'sk-new-raw-key'
+    assert update_data.agent_settings == {
+        'llm': {'api_key': MASKED_API_KEY, 'base_url': 'https://example.com'},
+    }
+
+    mock_store.db_session = MagicMock()
+    mock_store.get_current_org_by_user_id = AsyncMock(return_value=mock_org)
+    mock_store.update_org_llm_settings = AsyncMock(return_value=updated_org)
+
+    propagation_mock = AsyncMock()
+    monkeypatch.setattr(
+        OrgMemberStore,
+        'update_all_members_llm_settings_async',
+        propagation_mock,
+    )
+
+    service = OrgLLMSettingsService(store=mock_store, user_context=mock_user_context)
+
+    # Act
+    await service.update_org_llm_settings(update_data)
+
+    # Assert
+    propagation_mock.assert_awaited_once()
+    member_settings = propagation_mock.await_args.args[2]
+    assert isinstance(member_settings.llm_api_key, SecretStr)
+    assert member_settings.llm_api_key.get_secret_value() == 'sk-new-raw-key'
+    assert member_settings.agent_settings_diff == {
+        'llm': {'api_key': MASKED_API_KEY, 'base_url': 'https://example.com'},
+    }
+    # org-defaults saves are org-wide: always reset members' personal
+    # BYOR flag so load-time fallthrough won't return a stale custom key.
+    assert member_settings.has_custom_llm_api_key is False
+
+
+def test_get_member_updates_treats_empty_llm_api_key_as_none():
+    """
+    GIVEN: The frontend posts an empty api_key to signal "switch to the
+           managed/OpenHands provider" (clear the org-wide custom key)
+    WHEN:  get_member_updates builds the payload for member propagation
+    THEN:  llm_api_key is coerced to None — because OrgMember.llm_api_key's
+           setter has no ``if raw else None`` guard (the column is
+           ``nullable=False``), an empty string would be encrypted into an
+           empty blob on every member rather than cleared. agent_settings_diff
+           still carries the model diff so the org default actually lands on
+           members.
+    """
+    # Arrange
+    update = OrgLLMSettingsUpdate(
+        agent_settings={'llm': {'model': 'openhands/x'}}, llm_api_key=''
+    )
+
+    # Act
+    member_updates = update.get_member_updates()
+
+    # Assert — llm_api_key is coerced to None, and the agent_settings_diff
+    # carries both the model diff AND the auto-filled LiteLLM proxy URL so
+    # the stored state is self-describing.
+    assert member_updates is not None
+    assert member_updates.llm_api_key is None
+    assert member_updates.agent_settings_diff == {
+        'llm': {'model': 'openhands/x', 'base_url': LITE_LLM_API_URL},
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_org_llm_settings_generates_managed_key_for_openhands(
+    user_id, mock_org, mock_store, mock_user_context, monkeypatch
+):
+    """
+    GIVEN: An admin or owner saves org-defaults with the OpenHands provider
+           in basic view (payload: model="openhands/...", api_key="",
+           base_url=None), and their OrgMember row still holds the custom key
+           from a prior *All*-tab save
+    WHEN:  update_org_llm_settings runs
+    THEN:  a managed LiteLLM key is generated for the acting user, their
+           has_custom_llm_api_key flag is cleared, and a single propagation
+           call writes the generated key + agent_settings_diff to every
+           member row in one DB pass — so the whole org shares one managed
+           key column value without doubling the row-write churn.
+    """
+    # Arrange
+    updated_org = MagicMock(spec=Org)
+    updated_org.id = mock_org.id
+    updated_org.agent_settings = {
+        'schema_version': 1,
+        'agent': 'CodeActAgent',
+        'llm': {'model': 'openhands/claude-3'},
+    }
+    updated_org.conversation_settings = {}
+    updated_org.llm_api_key = None
+    updated_org.search_api_key = None
+
+    update_data = OrgLLMSettingsUpdate.model_validate(
+        {
+            'agent_settings': {
+                'llm': {
+                    'model': 'openhands/claude-3',
+                    'api_key': '',
+                    'base_url': None,
+                },
+            },
+        }
+    )
+
+    # The acting user's member row — carries the stale custom key from the
+    # prior *All*-tab save.
+    acting_member = MagicMock(spec=OrgMember)
+    acting_member.llm_api_key = SecretStr('old-custom-key')
+    acting_member.has_custom_llm_api_key = True
+
+    scalars_result = MagicMock()
+    scalars_result.first.return_value = acting_member
+    execute_result = MagicMock()
+    execute_result.scalars.return_value = scalars_result
+
+    db_session = MagicMock()
+    db_session.execute = AsyncMock(return_value=execute_result)
+
+    mock_store.db_session = db_session
+    mock_store.get_current_org_by_user_id = AsyncMock(return_value=mock_org)
+    mock_store.update_org_llm_settings = AsyncMock(return_value=updated_org)
+
+    propagation_mock = AsyncMock()
+    monkeypatch.setattr(
+        OrgMemberStore,
+        'update_all_members_llm_settings_async',
+        propagation_mock,
+    )
+    monkeypatch.setattr(
+        service_module.LiteLlmManager,
+        'verify_existing_key',
+        AsyncMock(return_value=False),
+    )
+    generate_key_mock = AsyncMock(return_value='litellm-new-key')
+    monkeypatch.setattr(
+        service_module.LiteLlmManager, 'generate_key', generate_key_mock
+    )
+
+    service = OrgLLMSettingsService(store=mock_store, user_context=mock_user_context)
+
+    # Act
+    await service.update_org_llm_settings(update_data)
+
+    # Assert — key was generated with openhands metadata.
+    generate_key_mock.assert_awaited_once()
+    assert generate_key_mock.await_args.args[0] == user_id
+    assert generate_key_mock.await_args.args[1] == str(mock_org.id)
+    assert generate_key_mock.await_args.args[2] is None
+    assert generate_key_mock.await_args.args[3] == {'type': 'openhands'}
+
+    # Assert — a single propagation call writes the diff, the generated
+    # key, AND the has_custom_llm_api_key=False reset to every member row
+    # (including the acting user's own row) in one DB pass.
+    propagation_mock.assert_awaited_once()
+    member_settings = propagation_mock.await_args.args[2]
+    assert isinstance(member_settings.llm_api_key, SecretStr)
+    assert member_settings.llm_api_key.get_secret_value() == 'litellm-new-key'
+    assert member_settings.has_custom_llm_api_key is False
+    assert member_settings.agent_settings_diff == {
+        'llm': {
+            'model': 'openhands/claude-3',
+            'api_key': MASKED_API_KEY,
+            'base_url': LITE_LLM_API_URL,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_org_llm_settings_does_not_generate_key_for_non_managed_model(
+    mock_org, mock_store, mock_user_context, monkeypatch
+):
+    """
+    GIVEN: The owner saves org-defaults with a BYOR model (non-OpenHands,
+           non-proxy base_url)
+    WHEN:  update_org_llm_settings runs
+    THEN:  no LiteLLM key is generated — the managed-key path is reserved for
+           the OpenHands provider / managed-proxy case, mirroring the personal
+           save flow's detection logic.
+    """
+    # Arrange
+    updated_org = MagicMock(spec=Org)
+    updated_org.id = mock_org.id
+    updated_org.agent_settings = {
+        'schema_version': 1,
+        'agent': 'CodeActAgent',
+        'llm': {
+            'model': 'anthropic/claude-3',
+            'base_url': 'https://example.com',
+        },
+    }
+    updated_org.conversation_settings = {}
+    updated_org.llm_api_key = None
+    updated_org.search_api_key = None
+
+    update_data = OrgLLMSettingsUpdate.model_validate(
+        {
+            'agent_settings': {
+                'llm': {
+                    'model': 'anthropic/claude-3',
+                    'base_url': 'https://example.com',
+                    'api_key': 'custom',
+                },
+            },
+        }
+    )
+
+    mock_store.db_session = MagicMock()
+    mock_store.get_current_org_by_user_id = AsyncMock(return_value=mock_org)
+    mock_store.update_org_llm_settings = AsyncMock(return_value=updated_org)
+
+    monkeypatch.setattr(
+        OrgMemberStore,
+        'update_all_members_llm_settings_async',
+        AsyncMock(),
+    )
+    generate_key_mock = AsyncMock(return_value='should-not-be-called')
+    monkeypatch.setattr(
+        service_module.LiteLlmManager, 'generate_key', generate_key_mock
+    )
+    monkeypatch.setattr(
+        service_module.LiteLlmManager,
+        'verify_existing_key',
+        AsyncMock(return_value=True),
+    )
+
+    service = OrgLLMSettingsService(store=mock_store, user_context=mock_user_context)
+
+    # Act
+    await service.update_org_llm_settings(update_data)
+
+    # Assert
+    generate_key_mock.assert_not_awaited()
+
+
+def test_normalize_agent_settings_masks_api_key_in_json_on_empty_and_real_keys():
+    """
+    GIVEN: Wire payloads that either carry a real raw api_key (BYOR save) or
+           an empty string api_key (managed/OpenHands switch)
+    WHEN:  OrgLLMSettingsUpdate's model validator runs
+    THEN:  both shapes lift the raw value to ``llm_api_key`` for encrypted
+           column sync AND leave the universal ``MASKED_API_KEY`` marker in
+           ``agent_settings.llm.api_key``, so the three storage locations
+           (``org._llm_api_key``, ``org.agent_settings.llm.api_key``,
+           ``org_member.agent_settings_diff.llm.api_key``) stay in sync once
+           the update is applied + propagated.
+    """
+    # Arrange + Act
+    real_key = OrgLLMSettingsUpdate.model_validate(
+        {'agent_settings': {'llm': {'model': 'anthropic/x', 'api_key': 'sk-raw'}}}
+    )
+    empty_key = OrgLLMSettingsUpdate.model_validate(
+        {
+            'agent_settings': {
+                'llm': {'model': 'openhands/x', 'api_key': '', 'base_url': None},
+            },
+        }
+    )
+
+    # Assert — masked in JSON in both cases; lifted raw value on top-level.
+    assert real_key.llm_api_key == 'sk-raw'
+    assert real_key.agent_settings is not None
+    assert real_key.agent_settings['llm']['api_key'] == MASKED_API_KEY
+    assert empty_key.llm_api_key == ''
+    assert empty_key.agent_settings is not None
+    assert empty_key.agent_settings['llm']['api_key'] == MASKED_API_KEY
+
+
+def test_normalize_agent_settings_fills_base_url_for_all_providers():
+    """
+    GIVEN: Wire payloads from the basic view that send ``base_url: null`` for
+           various providers (OpenHands managed + BYOR providers like OpenAI
+           and Anthropic)
+    WHEN:  OrgLLMSettingsUpdate's model validator runs
+    THEN:  ``base_url`` is populated for every recognised provider —
+           ``LITE_LLM_API_URL`` for OpenHands/managed models and the
+           litellm-derived default URL for non-managed providers (via
+           ``get_provider_api_base``). Mirrors the ``_post_merge_llm_fixups``
+           behavior the personal-save flow already performs, so
+           ``org.agent_settings.llm`` and every member's
+           ``agent_settings_diff.llm`` carry a usable, self-describing
+           base URL.
+    """
+    # Arrange + Act — covers: OpenHands explicit null, OpenHands missing,
+    # BYOR provider explicit null (base_url auto-filled to provider default).
+    openhands_null = OrgLLMSettingsUpdate.model_validate(
+        {
+            'agent_settings': {
+                'llm': {'model': 'openhands/claude-3', 'base_url': None},
+            },
+        }
+    )
+    openhands_missing = OrgLLMSettingsUpdate.model_validate(
+        {'agent_settings': {'llm': {'model': 'openhands/claude-3'}}}
+    )
+    anthropic_null = OrgLLMSettingsUpdate.model_validate(
+        {
+            'agent_settings': {
+                'llm': {'model': 'anthropic/claude-3-opus-20240229', 'base_url': None},
+            },
+        }
+    )
+
+    # Assert — OpenHands gets the proxy URL; non-OpenHands provider gets the
+    # provider default that ``litellm.get_api_base`` reports.
+    assert openhands_null.agent_settings is not None
+    assert openhands_null.agent_settings['llm']['base_url'] == LITE_LLM_API_URL
+    assert openhands_missing.agent_settings is not None
+    assert openhands_missing.agent_settings['llm']['base_url'] == LITE_LLM_API_URL
+    assert anthropic_null.agent_settings is not None
+    # get_provider_api_base('anthropic/claude-3-opus-20240229') returns the
+    # Anthropic public API. Be lenient about the exact suffix litellm returns
+    # across versions — only require that it got filled with Anthropic's host.
+    anthropic_base = anthropic_null.agent_settings['llm']['base_url']
+    assert isinstance(anthropic_base, str)
+    assert 'anthropic.com' in anthropic_base
+
+
+def test_from_org_denormalizes_litellm_proxy_prefix_and_returns_base_url_as_stored():
+    """
+    GIVEN: An org whose stored ``agent_settings.llm.model`` is in the SDK's
+           normalized ``litellm_proxy/`` form with ``base_url`` equal to the
+           managed proxy URL (the state produced by
+           ``_normalize_agent_settings`` on save)
+    WHEN:  OrgLLMSettingsResponse.from_org serializes for the frontend
+    THEN:  the response shows ``openhands/X`` so the basic-view provider
+           dropdown matches, returns ``base_url`` exactly as stored so the
+           three sync targets (``org.agent_settings.llm.base_url``,
+           ``org_member.agent_settings_diff.llm.base_url``, and this
+           response) agree, and nulls ``api_key`` so neither the raw secret
+           nor the ``MASKED_API_KEY`` marker leaks in the response.
+    """
+    # Arrange
+    org = MagicMock(spec=Org)
+    org.agent_settings = {
+        'schema_version': 1,
+        'agent': 'CodeActAgent',
+        'llm': {
+            'model': 'litellm_proxy/minimax-m2.5',
+            'base_url': LITE_LLM_API_URL,
+            'api_key': MASKED_API_KEY,
+        },
+    }
+    org.conversation_settings = {}
+    org.llm_api_key = None
+    org.search_api_key = None
+
+    # Act
+    response = OrgLLMSettingsResponse.from_org(org)
+
+    # Assert
+    assert response.agent_settings.llm.model == 'openhands/minimax-m2.5'
+    assert response.agent_settings.llm.base_url == LITE_LLM_API_URL
+    assert response.agent_settings.llm.api_key is None
+
+
+def test_from_org_returns_provider_default_base_url_as_stored_for_non_managed_models():
+    """
+    GIVEN: An org saved with a BYOR provider whose stored ``base_url`` equals
+           that provider's canonical base URL (what ``_normalize_agent_settings``
+           auto-filled on save via ``get_provider_api_base``)
+    WHEN:  OrgLLMSettingsResponse.from_org serializes for the frontend
+    THEN:  ``base_url`` is passed through unchanged — the response must
+           reflect stored state so a future drift that re-introduces
+           clearing fails this test. The frontend
+           (``KNOWN_PROVIDER_DEFAULT_BASE_URLS``) is responsible for
+           recognizing provider defaults as "basic mode."
+    """
+    # Arrange — look up the canonical anthropic base URL the same way the
+    # validator does so the test stays in sync with whatever litellm reports.
+    from openhands.utils.llm import get_provider_api_base as _provider_base
+
+    anthropic_default = _provider_base('anthropic/claude-3-opus-20240229')
+    assert anthropic_default is not None
+
+    org = MagicMock(spec=Org)
+    org.agent_settings = {
+        'schema_version': 1,
+        'agent': 'CodeActAgent',
+        'llm': {
+            'model': 'anthropic/claude-3-opus-20240229',
+            'base_url': anthropic_default,
+        },
+    }
+    org.conversation_settings = {}
+    org.llm_api_key = None
+    org.search_api_key = None
+
+    # Act
+    response = OrgLLMSettingsResponse.from_org(org)
+
+    # Assert — model is unchanged (no litellm_proxy/ prefix), base_url is
+    # returned as stored so stored state and response agree.
+    assert response.agent_settings.llm.model == 'anthropic/claude-3-opus-20240229'
+    assert response.agent_settings.llm.base_url == anthropic_default
+
+
+def test_from_org_keeps_custom_base_url_that_is_not_provider_default():
+    """
+    GIVEN: An org saved with a BYOR provider and a genuinely custom base URL
+           (e.g. a company-run proxy) that does NOT match the provider default
+    WHEN:  OrgLLMSettingsResponse.from_org serializes for the frontend
+    THEN:  ``base_url`` is preserved so the "advanced" view can display it —
+           we only clear values we're certain match a canonical default.
+    """
+    # Arrange
+    org = MagicMock(spec=Org)
+    org.agent_settings = {
+        'schema_version': 1,
+        'agent': 'CodeActAgent',
+        'llm': {
+            'model': 'anthropic/claude-3-opus-20240229',
+            'base_url': 'https://company-proxy.internal/anthropic',
+        },
+    }
+    org.conversation_settings = {}
+    org.llm_api_key = None
+    org.search_api_key = None
+
+    # Act
+    response = OrgLLMSettingsResponse.from_org(org)
+
+    # Assert
+    assert (
+        response.agent_settings.llm.base_url
+        == 'https://company-proxy.internal/anthropic'
+    )

--- a/enterprise/tests/unit/storage/test_org_llm_settings_store.py
+++ b/enterprise/tests/unit/storage/test_org_llm_settings_store.py
@@ -105,11 +105,11 @@ async def test_update_org_llm_settings_success(async_session_maker):
         org_id = org.id
 
         update_data = OrgLLMSettingsUpdate(
-            agent_settings_diff={
+            agent_settings={
                 'llm': {'model': 'new-model'},
                 'agent': 'CodeActAgent',
             },
-            conversation_settings_diff={
+            conversation_settings={
                 'confirmation_mode': True,
             },
         )
@@ -134,9 +134,7 @@ async def test_update_org_llm_settings_org_not_found(async_session_maker):
     """
     # Arrange
     non_existent_org_id = uuid.uuid4()
-    update_data = OrgLLMSettingsUpdate(
-        agent_settings_diff={'llm': {'model': 'new-model'}}
-    )
+    update_data = OrgLLMSettingsUpdate(agent_settings={'llm': {'model': 'new-model'}})
 
     # Act
     async with async_session_maker() as session:
@@ -166,7 +164,7 @@ async def test_update_org_llm_settings_updates_org_defaults_only(async_session_m
         result = await store.update_org_llm_settings(
             org.id,
             OrgLLMSettingsUpdate(
-                agent_settings_diff={'llm': {'model': 'new-model'}},
+                agent_settings={'llm': {'model': 'new-model'}},
                 llm_api_key='new-api-key',
                 search_api_key='search-key',
             ),

--- a/enterprise/tests/unit/test_org_member_store.py
+++ b/enterprise/tests/unit/test_org_member_store.py
@@ -1227,15 +1227,15 @@ def test_org_llm_settings_update_apply_to_org_updates_secret_fields():
 
 def test_org_llm_settings_update_get_member_updates_includes_llm_api_key():
     """
-    GIVEN: OrgLLMSettingsUpdate with llm_api_key set
+    GIVEN: OrgLLMSettingsUpdate with agent_settings and llm_api_key set
     WHEN: get_member_updates() is called
-    THEN: Returns OrgMemberLLMSettings with llm_api_key included
+    THEN: Returns OrgMemberLLMSettings including both the diff and llm_api_key
     """
     from server.routes.org_models import OrgLLMSettingsUpdate
 
     # Arrange
     settings = OrgLLMSettingsUpdate(
-        agent_settings_diff={'llm': {'model': 'claude-3'}},
+        agent_settings={'llm': {'model': 'claude-3'}},
         llm_api_key='new-member-key',
     )
 
@@ -1244,8 +1244,8 @@ def test_org_llm_settings_update_get_member_updates_includes_llm_api_key():
 
     # Assert
     assert member_updates is not None
-    assert member_updates.llm_api_key == 'new-member-key'
-    assert member_updates.agent_settings_diff is None
+    assert member_updates.llm_api_key.get_secret_value() == 'new-member-key'
+    assert member_updates.agent_settings_diff == {'llm': {'model': 'claude-3'}}
 
 
 def test_org_llm_settings_update_get_member_updates_only_llm_api_key():
@@ -1264,7 +1264,7 @@ def test_org_llm_settings_update_get_member_updates_only_llm_api_key():
 
     # Assert
     assert member_updates is not None
-    assert member_updates.llm_api_key == 'member-key-only'
+    assert member_updates.llm_api_key.get_secret_value() == 'member-key-only'
     assert member_updates.agent_settings_diff is None
 
 

--- a/enterprise/tests/unit/test_org_service.py
+++ b/enterprise/tests/unit/test_org_service.py
@@ -1200,7 +1200,7 @@ async def test_update_org_with_permissions_success_llm_fields_admin(
     from server.routes.org_models import OrgUpdate
 
     update_data = OrgUpdate(
-        agent_settings_diff={
+        agent_settings={
             'llm': {
                 'model': 'claude-opus-4-5-20251101',
                 'base_url': 'https://api.anthropic.com',
@@ -1266,10 +1266,10 @@ async def test_update_org_with_permissions_success_llm_fields_owner(
     from server.routes.org_models import OrgUpdate
 
     update_data = OrgUpdate(
-        agent_settings_diff={
+        agent_settings={
             'llm': {'model': 'claude-opus-4-5-20251101'},
         },
-        conversation_settings_diff={
+        conversation_settings={
             'security_analyzer': 'llm',
         },
     )
@@ -1333,7 +1333,7 @@ async def test_update_org_with_permissions_success_mixed_fields_admin(
 
     update_data = OrgUpdate(
         contact_name='Jane Doe',
-        agent_settings_diff={'llm': {'model': 'claude-opus-4-5-20251101'}},
+        agent_settings={'llm': {'model': 'claude-opus-4-5-20251101'}},
         conversation_expiration=30,
     )
 
@@ -1537,7 +1537,7 @@ async def test_update_org_with_permissions_llm_fields_insufficient_permission(
     from server.routes.org_models import OrgUpdate
 
     update_data = OrgUpdate(
-        agent_settings_diff={'llm': {'model': 'claude-opus-4-5-20251101'}}
+        agent_settings={'llm': {'model': 'claude-opus-4-5-20251101'}}
     )
 
     with (
@@ -1781,11 +1781,11 @@ async def test_update_org_with_permissions_only_llm_fields(
     from server.routes.org_models import OrgUpdate
 
     update_data = OrgUpdate(
-        agent_settings_diff={
+        agent_settings={
             'llm': {'model': 'claude-opus-4-5-20251101'},
             'agent': 'agent-mode',
         },
-        conversation_settings_diff={
+        conversation_settings={
             'security_analyzer': 'llm',
         },
     )

--- a/enterprise/tests/unit/test_org_store.py
+++ b/enterprise/tests/unit/test_org_store.py
@@ -114,7 +114,7 @@ async def test_update_org(async_session_maker, mock_litellm_api):
             org_id=org_id,
             kwargs={
                 'name': 'updated-org',
-                'agent_settings_diff': {'agent': 'PlannerAgent'},
+                'agent_settings': {'agent': 'PlannerAgent'},
             },
         )
 
@@ -1053,7 +1053,7 @@ async def test_update_org_llm_settings_async_with_llm_api_key():
     )
 
     llm_settings = OrgLLMSettingsUpdate(
-        agent_settings_diff={'llm': {'model': 'new-model'}},
+        agent_settings={'llm': {'model': 'new-model'}},
         llm_api_key='new-member-api-key',
     )
 
@@ -1087,8 +1087,8 @@ async def test_update_org_llm_settings_async_with_llm_api_key():
         mock_member_update.assert_called_once()
         call_args = mock_member_update.call_args
         member_settings = call_args[0][2]  # Third positional arg is member_settings
-        assert member_settings.llm_api_key == 'new-member-api-key'
-        assert member_settings.agent_settings_diff is None
+        assert member_settings.llm_api_key.get_secret_value() == 'new-member-api-key'
+        assert member_settings.agent_settings_diff == {'llm': {'model': 'new-model'}}
 
 
 @pytest.mark.asyncio
@@ -1102,9 +1102,7 @@ async def test_update_org_llm_settings_async_org_not_found():
 
     # Arrange
     non_existent_org_id = uuid.uuid4()
-    llm_settings = OrgLLMSettingsUpdate(
-        agent_settings_diff={'llm': {'model': 'new-model'}}
-    )
+    llm_settings = OrgLLMSettingsUpdate(agent_settings={'llm': {'model': 'new-model'}})
 
     # Mock the async session to return None for org
     mock_session = AsyncMock()

--- a/openhands/app_server/settings/settings_router.py
+++ b/openhands/app_server/settings/settings_router.py
@@ -30,7 +30,11 @@ from openhands.storage.data_models.secrets import Secrets
 from openhands.storage.data_models.settings import Settings
 from openhands.storage.secrets.secrets_store import SecretsStore
 from openhands.storage.settings.settings_store import SettingsStore
-from openhands.utils.llm import get_provider_api_base, is_openhands_model
+from openhands.utils.llm import (
+    get_provider_api_base,
+    is_openhands_model,
+    resolve_llm_base_url,
+)
 
 LITE_LLM_API_URL = os.environ.get(
     'LITE_LLM_API_URL', 'https://llm-proxy.app.all-hands.dev'
@@ -47,25 +51,16 @@ router = APIRouter(
 def _post_merge_llm_fixups(settings: Settings) -> None:
     """Apply LLM-specific fixups after merging settings.
 
-    When the merged LLM base_url is empty-string, treat it as cleared.
-    When it is None, try to auto-detect the provider default.
+    Delegates the empty-string → cleared and provider-default inference
+    rules to :func:`openhands.utils.llm.resolve_llm_base_url` so the
+    personal-save and enterprise org-defaults paths stay in lockstep.
     """
     llm = settings.agent_settings.llm
-
-    if llm.base_url == '':
-        llm.base_url = None
-    elif llm.base_url is None and llm.model:
-        if is_openhands_model(llm.model):
-            llm.base_url = LITE_LLM_API_URL
-        else:
-            try:
-                api_base = get_provider_api_base(llm.model)
-                if api_base:
-                    llm.base_url = api_base
-            except Exception as e:
-                logger.error(
-                    f'Failed to get api_base from litellm for model {llm.model}: {e}'
-                )
+    llm.base_url = resolve_llm_base_url(
+        model=llm.model,
+        base_url=llm.base_url,
+        managed_proxy_url=LITE_LLM_API_URL,
+    )
 
 
 # NOTE: We use response_model=None for endpoints that return JSONResponse directly.

--- a/openhands/utils/llm.py
+++ b/openhands/utils/llm.py
@@ -111,6 +111,59 @@ def is_openhands_model(model: str | None) -> bool:
     )
 
 
+# Canonical masked placeholder for LLM API keys. Matches pydantic's
+# ``SecretStr`` default representation so request/response payloads that pass
+# through ``model_dump(mode='json')`` stay consistent with payloads that the
+# enterprise org-settings validator constructs by hand. Importers should treat
+# this as the single source of truth for "a key exists but its value is
+# intentionally hidden."
+MASKED_API_KEY = '**********'
+
+
+def resolve_llm_base_url(
+    model: str | None,
+    base_url: str | None,
+    *,
+    managed_proxy_url: str,
+) -> str | None:
+    """Resolve the ``base_url`` to persist for an LLM configuration.
+
+    Single source of truth for two code paths that otherwise duplicated the
+    same logic:
+
+    * ``openhands/app_server/settings/settings_router._post_merge_llm_fixups``
+      (personal-settings save path).
+    * ``enterprise/server/routes/org_models.OrgLLMSettingsUpdate._normalize_agent_settings``
+      (org-defaults save path).
+
+    Semantics:
+
+    * ``base_url == ''`` → ``None`` (explicit "clear" signal from the UI;
+      don't auto-infer on top of it).
+    * ``base_url`` non-empty → returned unchanged.
+    * ``base_url is None`` + known OpenHands / managed model → ``managed_proxy_url``.
+    * ``base_url is None`` + known BYOR provider → default from
+      :func:`get_provider_api_base`.
+    * Any other combination → ``None``.
+
+    Exceptions from ``litellm`` are logged and swallowed so a flaky provider
+    lookup can never break a settings save.
+    """
+    if base_url == '':
+        return None
+    if base_url is not None:
+        return base_url
+    if not model:
+        return None
+    if is_openhands_model(model):
+        return managed_proxy_url
+    try:
+        return get_provider_api_base(model)
+    except Exception as e:
+        logger.error(f'Failed to get api_base from litellm for model {model}: {e}')
+        return None
+
+
 def get_provider_api_base(model: str) -> str | None:
     """Get the API base URL for a model using litellm.
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

POST /api/organizations/llm silently dropped its payload due to a wire/model field-name mismatch, never generated a managed LiteLLM key on OpenHands switches, and left stale custom keys on member rows. Response and stored state also diverged for `model`, `base_url`, and `api_key`.

## Summary

<!-- 1-3 bullets describing what changed. -->
Fixes a compound defect in SaaS-mode org-defaults settings save (`POST /api/organizations/llm`):

- **Payload silently dropped.** Backend `OrgLLMSettingsUpdate` expected `agent_settings_diff` but the frontend sent `agent_settings` → pydantic discarded the keys and `has_updates()` returned `False`, short-circuiting the service.
- **No managed LiteLLM key generated** when an admin/owner flipped to the OpenHands provider in basic view — the rotation logic that `SaasSettingsStore.store` runs for personal saves had no equivalent on the org path.
- **Stale custom keys persisted** across members after a managed-mode switch, because (a) the empty-string `api_key` signal didn't propagate correctly and (b) `has_custom_llm_api_key` was never reset.
- **`GET /api/organizations/llm` response diverged from stored state** for `model` (leaking the SDK's `litellm_proxy/` internal prefix) and `api_key` (not being nulled), leaving the basic-view UI dropdowns empty after refetch.

### Changes

#### Save path (`enterprise/server/routes/org_models.py`, `enterprise/server/services/org_llm_settings_service.py`)

- Rename `OrgLLMSettingsUpdate.{agent,conversation}_settings_diff` → `{agent,conversation}_settings` to match the frontend wire format.
- New `_normalize_agent_settings` model validator:
  - Lifts nested `agent_settings.llm.api_key` to the top-level `llm_api_key` field for the encrypted column, leaves `MASKED_API_KEY` in the JSON so stored state and propagated member diffs stay in sync.
  - Skips re-lifting the masked placeholder when the frontend echoes it back (prevents accidentally encrypting `**********` into the column on a no-op save).
  - Auto-fills `base_url` via the new shared `resolve_llm_base_url` helper — `LITE_LLM_API_URL` for OpenHands / managed models, `get_provider_api_base(model)` for BYOR providers, pass-through otherwise.
- New `_maybe_rotate_managed_llm_key_for_user` returns the managed key every member row should carry:
  - Reuses the acting user's current managed key if `verify_existing_key` confirms it's still valid; otherwise generates fresh via `LiteLlmManager.generate_key` (`openhands/` models get `{'type': 'openhands'}` metadata; managed-proxy URL models use `get_openhands_cloud_key_alias` + `delete_key_by_alias`).
  - Only admins and owners reach this path (`EDIT_LLM_SETTINGS` permission is enforced on the route).
- Service now makes a **single** `update_all_members_llm_settings_async` call at the end that writes the `agent_settings_diff`, the `llm_api_key`, and a `has_custom_llm_api_key=False` reset to every member row in one DB pass — org-defaults saves are org-wide, so any lingering personal BYOR marker would make `_get_effective_llm_api_key` return the wrong key at read time.

#### Read path (`OrgLLMSettingsResponse.from_org`)

- Denormalises `litellm_proxy/X` → `openhands/X` so the basic-view provider dropdown matches the OSS `/api/v1/settings` response shape.
- Nulls `api_key` so neither the raw secret nor the masked marker leaks.
- Returns `base_url` exactly as stored — frontend is responsible for recognising managed/provider defaults as "basic mode" via `KNOWN_PROVIDER_DEFAULT_BASE_URLS`.

#### Shared OSS helpers (`openhands/utils/llm.py`, `openhands/app_server/settings/settings_router.py`)

- New `MASKED_API_KEY = '**********'` — canonical placeholder matching pydantic's `SecretStr` default.
- New `resolve_llm_base_url(model, base_url, *, managed_proxy_url)` — empty-string → cleared, non-empty → pass-through, `None` + known model → inferred default.
- `_post_merge_llm_fixups` in the personal-save router now delegates to `resolve_llm_base_url`, killing ~20 lines of duplicated inference logic.

#### Cross-cutting

- `OrgMemberLLMSettings.llm_api_key` typed as `SecretStr | None` — pydantic auto-wraps `str` inputs; `OrgMember.llm_api_key`'s setter already handles both.
- `OrgMemberLLMSettings.has_custom_llm_api_key: bool | None = None` added; flows through the existing `setattr` tail in `update_all_members_llm_settings_async`.
- `OrgUpdate.{agent,conversation}_settings_diff` renamed to match (verified via frontend grep that no UI code sends these fields). Updated `OrgStore.update_org`, `OrgService.restricted_fields`, and `_validate_org_version`'s internal self-call.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

N/A.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Run the SaaS application.
2. Access an organization that includes both an owner/admin and a member.
3. Have the owner update the LLM settings, ensuring that these changes are propagated to all members within the organization.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.
-->

**Video 1:** Set up a custom LLM configuration.

https://github.com/user-attachments/assets/dfc8d1f1-d943-44a3-86af-7327cf0ad453

**Video 2:** Select the OpenHands provider.

https://github.com/user-attachments/assets/404af1a5-32be-48ca-b550-4640b1966797

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

N/A.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:24ba1b2-nikolaik   --name openhands-app-24ba1b2   docker.openhands.dev/openhands/openhands:24ba1b2
```