### PR TITLE
feat(keycloak): register plugin-directory OIDC client in allhands realm

### DIFF
--- a/enterprise/allhands-realm-github-provider.json.tmpl
+++ b/enterprise/allhands-realm-github-provider.json.tmpl
@@ -772,6 +772,64 @@
       ]
     },
     {
+      "id": "e3d1cc5d-6a71-4c9b-9e0a-5b1e1a7a2c11",
+      "clientId": "plugin-directory",
+      "name": "client_plugin_directory",
+      "description": "",
+      "rootUrl": "$PLUGIN_DIRECTORY_HOST",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "$PLUGIN_DIRECTORY_CLIENT_SECRET",
+      "redirectUris": [
+        "$PLUGIN_DIRECTORY_HOST/auth/callback"
+      ],
+      "webOrigins": [
+        "$PLUGIN_DIRECTORY_HOST"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "frontchannel.logout.session.required": "true",
+        "post.logout.redirect.uris": "+",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "display.on.consent.screen": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
       "id": "8f11a72d-34bb-4708-8658-9f34737212b1",
       "clientId": "realm-management",
       "name": "${client_realm-management}",


### PR DESCRIPTION
## Summary
- Adds a Keycloak client entry for `plugin-directory` in the allhands realm template.
- The plugin-directory Helm chart already wires `OIDC_ISSUER_URL` / `OIDC_CLIENT_ID=plugin-directory` / `OIDC_CLIENT_SECRET` through to the SSR client, and `keycloak-config-script.yaml` already envsubsts `$PLUGIN_DIRECTORY_HOST` and `$PLUGIN_DIRECTORY_CLIENT_SECRET` — but the realm template didn't contain the client definition itself, so logins failed.
- Redirect URI uses `$PLUGIN_DIRECTORY_HOST/auth/callback`, matching the path the plugin-directory SSR builds via `new URL('/auth/callback', process.env.APP_URL)`.

## Test plan
- [ ] CI `ghcr_build_enterprise` builds a tagged image
- [ ] Deploy the image via OpenHands-Cloud charts with `plugin-directory.enabled=true`
- [ ] Confirm keycloak admin API lists `plugin-directory` as a client in the `allhands` realm
- [ ] Confirm browsing to `/plugins` redirects through keycloak and lands back on `/plugins` authenticated

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:178f4f8-nikolaik   --name openhands-app-178f4f8   docker.openhands.dev/openhands/openhands:178f4f8
```