### PR TITLE
feat(skills): add .NET SDK installation guide for sandbox

### DIFF
--- a/skills/dotnet.md
+++ b/skills/dotnet.md
@@ -1,0 +1,108 @@
+---
+name: dotnet
+type: knowledge
+version: 1.0.0
+agent: CodeActAgent
+triggers:
+- dotnet
+- .NET
+- csproj
+- nuget
+- dotnet-sdk
+- dotnet-install
+---
+
+# .NET SDK Installation Guide for Linux
+
+The .NET SDK is not pre-installed in the OpenHands sandbox. When working on a C#/.NET
+project (you'll typically see `*.csproj`, `*.sln`, `*.fsproj`, or `global.json` files),
+install the SDK yourself before building or running tests.
+
+Do **not** rely on a project-provided `install.sh`; those scripts usually assume
+elevated privileges and a particular apt repo layout and will frequently fail in the
+sandbox. Use one of the two approaches below instead.
+
+## Preferred: install into the user home with `dotnet-install.sh`
+
+This is the most reliable approach in the sandbox because it does not require `sudo`
+and does not touch system directories. It is the method recommended by Microsoft for
+non-root installs.
+
+1. Check whether the project pins a specific SDK version in `global.json`. If it does,
+   install that exact version. Otherwise install the latest LTS (`--channel LTS`) or
+   a specific channel (e.g. `--channel 10.0`, `--channel 9.0`, `--channel 8.0`).
+
+2. Download and run the official install script:
+
+   ```bash
+   # Install latest LTS (currently .NET 10) into ~/.dotnet
+   curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+   chmod +x /tmp/dotnet-install.sh
+   /tmp/dotnet-install.sh --channel LTS --install-dir "$HOME/.dotnet"
+   ```
+
+   To pin a specific channel or version:
+
+   ```bash
+   # Specific channel (major.minor)
+   /tmp/dotnet-install.sh --channel 10.0 --install-dir "$HOME/.dotnet"
+
+   # Exact version from global.json
+   /tmp/dotnet-install.sh --version 10.0.100 --install-dir "$HOME/.dotnet"
+   ```
+
+3. Put `dotnet` on `PATH` for the current shell and future shells:
+
+   ```bash
+   export DOTNET_ROOT="$HOME/.dotnet"
+   export PATH="$DOTNET_ROOT:$PATH"
+   echo 'export DOTNET_ROOT="$HOME/.dotnet"' >> ~/.bashrc
+   echo 'export PATH="$DOTNET_ROOT:$PATH"' >> ~/.bashrc
+   ```
+
+4. Suppress the first-run telemetry prompt so it doesn't interfere with non-interactive
+   commands:
+
+   ```bash
+   export DOTNET_CLI_TELEMETRY_OPTOUT=1
+   export DOTNET_NOLOGO=1
+   ```
+
+5. Verify the installation:
+
+   ```bash
+   dotnet --info
+   dotnet --list-sdks
+   ```
+
+## Alternative: install via apt (requires sudo)
+
+The sandbox's `openhands` user has passwordless sudo, so the Microsoft apt package
+feed also works. Use this only if you specifically need the system-wide install
+location (`/usr/share/dotnet`):
+
+```bash
+# Ubuntu 24.04 / 22.04 — adjust the version in the URL for other distros
+source /etc/os-release
+wget -q "https://packages.microsoft.com/config/${ID}/${VERSION_ID}/packages-microsoft-prod.deb" -O /tmp/packages-microsoft-prod.deb
+sudo dpkg -i /tmp/packages-microsoft-prod.deb
+sudo apt-get update
+sudo apt-get install -y dotnet-sdk-10.0
+```
+
+If `packages-microsoft-prod.deb` is not available for the detected distro (e.g.
+Debian unstable), fall back to the `dotnet-install.sh` method above.
+
+## Building and testing a project
+
+Once the SDK is on `PATH`:
+
+```bash
+dotnet restore
+dotnet build --no-restore
+dotnet test --no-build --logger "console;verbosity=normal"
+```
+
+If `dotnet restore` is slow or fails due to network restrictions, check whether the
+project has a `NuGet.config` that points at a private feed; you may need credentials
+from the user before the restore can succeed.


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Issue #14008 reports that agents working on C#/.NET projects in the OpenHands Cloud sandbox can't build or test the code because the .NET SDK is not pre-installed. When the agent falls back to running a project-provided `install.sh`, the script typically assumes root / apt paths that don't exist in the sandbox and fails with "insufficient permissions" — so the agent gives up without verifying its changes.

The sandbox's `openhands` user does have passwordless sudo, and Microsoft ships a `dotnet-install.sh` that installs into `$HOME/.dotnet` without any privileges at all. The agent just doesn't know that's the right path, because there's no skill/microagent guiding it (unlike Swift, pdflatex, Docker, etc.).

## Summary

- Add `skills/dotnet.md`, a keyword-triggered knowledge skill (triggers: `dotnet`, `.NET`, `csproj`, `nuget`, `dotnet-sdk`, `dotnet-install`) modeled after the existing `skills/swift-linux.md`.
- Tells the agent to prefer Microsoft's `dotnet-install.sh` into `$HOME/.dotnet` (no sudo, avoids the exact failure mode in the bug report) with examples for `--channel LTS`, `--channel 10.0`, and pinned `--version` from `global.json`.
- Documents the `packages-microsoft-prod.deb` apt alternative for when a system-wide install is required, plus `PATH`/`DOTNET_ROOT`, telemetry opt-out, and the standard `restore`/`build`/`test` flow.

## Issue Number

Fixes #14008

## How to Test

1. `poetry run pytest tests/unit/microagent/ -q` — existing 26 microagent tests still pass.
2. Load the file through the microagent parser to confirm it registers as a `KnowledgeMicroagent` with the declared triggers:

   ```bash
   poetry run python -c "
   from openhands.microagent import BaseMicroagent, MicroagentType
   from pathlib import Path
   ma = BaseMicroagent.load(Path('skills/dotnet.md'))
   assert ma.type == MicroagentType.KNOWLEDGE
   print(ma.name, ma.triggers)
   "
   ```

3. In a conversation, mention `dotnet` or `.NET`; the skill content should be injected and the agent should install the SDK via `dotnet-install.sh` instead of invoking the project's `install.sh`.

## Video/Screenshots

N/A — skill content only, no UI changes.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- No changes to the runtime Dockerfile: keeping the SDK out of the base image avoids bloating every user's container for a language most won't use, matching the pattern used for Swift and PDFLaTeX.
- This PR was created by an AI assistant (OpenHands) on behalf of the user.