### PR TITLE
fix(chat): allow attachment-only submission

### DIFF
--- a/frontend/src/components/features/chat/custom-chat-input.tsx
+++ b/frontend/src/components/features/chat/custom-chat-input.tsx
@@ -39,9 +39,13 @@ export function CustomChatInput({
   const {
     submittedMessage,
     clearAllFiles,
+    images,
+    files,
     setShouldHideSuggestions,
     setSubmittedMessage,
   } = useConversationStore();
+
+  const hasAttachments = images.length > 0 || files.length > 0;
 
   // Disable input when conversation is stopped
   const isConversationStopped = sandboxStatus === "MISSING";
@@ -95,6 +99,7 @@ export function CustomChatInput({
     fileInputRef as React.RefObject<HTMLInputElement | null>,
     smartResize,
     onSubmit,
+    hasAttachments,
     resetManualResize,
   );
 
@@ -104,6 +109,7 @@ export function CustomChatInput({
       smartResize,
       increaseHeightForEmptyContent,
       checkIsContentEmpty,
+      hasAttachments,
       clearEmptyContentHandler,
       onFocus,
       onBlur,

--- a/frontend/src/hooks/chat/use-chat-input-events.ts
+++ b/frontend/src/hooks/chat/use-chat-input-events.ts
@@ -13,6 +13,7 @@ export const useChatInputEvents = (
   smartResize: () => void,
   increaseHeightForEmptyContent: () => void,
   checkIsContentEmpty: () => boolean,
+  hasAttachments: boolean,
   clearEmptyContentHandler: () => void,
   onFocus?: () => void,
   onBlur?: () => void,
@@ -74,7 +75,7 @@ export const useChatInputEvents = (
         return;
       }
 
-      if (checkIsContentEmpty()) {
+      if (checkIsContentEmpty() && !hasAttachments) {
         e.preventDefault();
         increaseHeightForEmptyContent();
         return;
@@ -86,7 +87,7 @@ export const useChatInputEvents = (
         handleSubmit();
       }
     },
-    [checkIsContentEmpty, increaseHeightForEmptyContent],
+    [checkIsContentEmpty, hasAttachments, increaseHeightForEmptyContent],
   );
 
   // Handle blur events to ensure placeholder shows when empty

--- a/frontend/src/hooks/chat/use-chat-submission.ts
+++ b/frontend/src/hooks/chat/use-chat-submission.ts
@@ -12,6 +12,7 @@ export const useChatSubmission = (
   fileInputRef: React.RefObject<HTMLInputElement | null>,
   smartResize: () => void,
   onSubmit: (message: string) => void,
+  hasAttachments: boolean,
   resetManualResize?: () => void,
 ) => {
   // Send button click handler
@@ -19,7 +20,7 @@ export const useChatSubmission = (
     const message = chatInputRef.current?.innerText || "";
     const trimmedMessage = message.trim();
 
-    if (!trimmedMessage) {
+    if (!trimmedMessage && !hasAttachments) {
       return;
     }
 
@@ -34,7 +35,14 @@ export const useChatSubmission = (
 
     // Reset manual resize state for next message
     resetManualResize?.();
-  }, [chatInputRef, fileInputRef, smartResize, onSubmit, resetManualResize]);
+  }, [
+    chatInputRef,
+    fileInputRef,
+    smartResize,
+    onSubmit,
+    hasAttachments,
+    resetManualResize,
+  ]);
 
   // Handle stop button click
   const handleStop = useCallback((onStop?: () => void) => {


### PR DESCRIPTION
## Summary
- allow chat submission to proceed when the message text is empty but attachments are present
- stop Enter-key handling from blocking attachment-only sends in the same case
- reuse the existing attachment state from the conversation store instead of adding new state

Closes #14047

## Verification
- not run locally because the frontend test/build dependencies are not installed in this sandboxed environment