### PR TITLE
feat: pass WEB_HOST to agent context in V1 conversations

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1251,11 +1251,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         # --- web host context -----------------------------------------------
         # Add WEB_HOST to agent context if available
         if self.web_url:
-            web_host_context = (
-                '[BEGIN context from [web_host]]\n'
-                f'The web application is hosted at: {self.web_url}\n'
-                '[END Context]'
-            )
+            web_host_context = f'<HOST>\n{self.web_url}\n</HOST>'
             if effective_suffix:
                 effective_suffix = f'{effective_suffix}\n\n{web_host_context}'
             else:

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1248,6 +1248,19 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             else:
                 effective_suffix = PLANNING_AGENT_INSTRUCTION
 
+        # --- web host context -----------------------------------------------
+        # Add WEB_HOST to agent context if available
+        if self.web_url:
+            web_host_context = (
+                '[BEGIN context from [web_host]]\n'
+                f'The web application is hosted at: {self.web_url}\n'
+                '[END Context]'
+            )
+            if effective_suffix:
+                effective_suffix = f'{effective_suffix}\n\n{web_host_context}'
+            else:
+                effective_suffix = web_host_context
+
         # --- tools ----------------------------------------------------------
         if agent_type == AgentType.PLAN:
             plan_path = None

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -1093,8 +1093,13 @@ class TestLiveStatusAppConversationService:
         assert result.agent.llm.model == 'gpt-4'
         # Secrets are injected via agent_context
         assert result.agent.agent_context.secrets == mock_secrets
-        # System message suffix is passed through
-        assert result.agent.agent_context.system_message_suffix == 'Test suffix'
+        # System message suffix includes the original suffix and web host context
+        assert 'Test suffix' in result.agent.agent_context.system_message_suffix
+        assert '<HOST>' in result.agent.agent_context.system_message_suffix
+        assert (
+            'https://test.example.com'
+            in result.agent.agent_context.system_message_suffix
+        )
         # Workspace points to the repo subdirectory
         assert result.workspace.working_dir == '/test/dir/repo'
 


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

When creating V1 conversations, the agent needs to know the web application URL where it's hosted. This information is useful for the agent to provide context-aware responses and to reference the correct URLs when needed.

## Summary

- Added web host context to the agent's system message suffix when creating V1 conversations
- Uses the existing `self.web_url` field (which is populated from the `WEB_HOST` environment variable)
- The agent will now see the web host information in its system prompt when `WEB_HOST` is set

## How to Test

1. Set the `WEB_HOST` environment variable (e.g., `WEB_HOST=app.all-hands.dev`)
2. Start a V1 conversation
3. Verify that the agent's system message includes the web host context:
```
[BEGIN context from [web_host]]
The web application is hosted at: https://app.all-hands.dev
[END Context]
```

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This change only affects V1 conversations. The web host information is added via `self.web_url` which is already populated from `WEB_HOST` in the `LiveStatusAppConversationServiceInjector`.

Related to [ALL-5652](https://linear.app/all-hands-ai/issue/ALL-5652/ensure-agent-uses-correct-automation-api-host-for-featurestaging)


---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-282abc6   docker.openhands.dev/openhands/openhands:282abc6
```