### PR TITLE
PLTF-139: Add Analytics redirect URI to Keycloak allhands client

### DIFF
--- a/enterprise/allhands-realm-github-provider.json.tmpl
+++ b/enterprise/allhands-realm-github-provider.json.tmpl
@@ -724,12 +724,14 @@
         "https://$WEB_HOST/oauth/device/keycloak-callback",
         "https://$WEB_HOST/api/email/verified",
         "/realms/$KEYCLOAK_REALM_NAME/$KEYCLOAK_CLIENT_ID/*",
-        "https://laminar.$WEB_HOST/api/auth/callback/keycloak"
+        "https://laminar.$WEB_HOST/api/auth/callback/keycloak",
+        "https://analytics.$WEB_HOST/api/auth/callback/keycloak"
       ],
       "webOrigins": [
         "https://$WEB_HOST",
         "https://$AUTH_WEB_HOST",
-        "https://laminar.$WEB_HOST"
+        "https://laminar.$WEB_HOST",
+        "https://analytics.$WEB_HOST"
       ],
       "notBefore": 0,
       "bearerOnly": false,


### PR DESCRIPTION
## Summary

We had previously added a redirect for laminar here https://github.com/OpenHands/OpenHands/pull/13666. But for replicated OHE installs, we want to expose laminar via analytics.BASE_DOMAIN.

This PR enables Keycloak authentication for the Analytics frontend by adding:
- **Redirect URI**: `https://analytics.$WEB_HOST/api/auth/callback/keycloak`
- **Web origin (CORS)**: `https://analytics.$WEB_HOST`

## Context
Analytics uses NextAuth.js for authentication with a Keycloak provider. When the Keycloak realm is created, the `allhands` client needs to allow redirects to Analytics auth callback endpoint.

Without this configuration, users see an `invalid_redirect_uri` error when attempting to log in via Keycloak.

## Testing
- Tested on Replicated install `replicated-01.aws.aivong.platform-team.all-hands.dev`
- Manually added the redirect URI to Keycloak to verify the fix
- This change codifies the configuration in the realm template

## Notes
- For existing deployments, the redirect URI will need to be added manually or the realm recreated
- New deployments will automatically include this configuration

---

_This PR was created by an AI assistant (OpenHands) on behalf of @aivong._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-b1b2efa   docker.openhands.dev/openhands/openhands:b1b2efa
```