### PR TITLE
fix(backend): persist keycloak email on invitation acceptance

### DIFF
--- a/enterprise/server/services/org_invitation_service.py
+++ b/enterprise/server/services/org_invitation_service.py
@@ -319,15 +319,16 @@ class OrgInvitationService:
         if not user_email:
             token_manager = TokenManager()
             user_info = await token_manager.get_user_info_from_user_id(str(user_id))
-            user_email = user_info.get('email') if user_info else None
-            if user_email and user_info is not None:
-                await UserStore.backfill_user_email(
-                    str(user_id),
-                    {
-                        'email': user_email,
-                        'email_verified': user_info.get('emailVerified', False),
-                    },
-                )
+            if user_info:
+                user_email = user_info.get('email')
+                if user_email:
+                    await UserStore.backfill_user_email(
+                        str(user_id),
+                        {
+                            'email': user_email,
+                            'email_verified': user_info.get('emailVerified', False),
+                        },
+                    )
 
         if not user_email:
             raise EmailMismatchError('Your account does not have an email address')

--- a/enterprise/server/services/org_invitation_service.py
+++ b/enterprise/server/services/org_invitation_service.py
@@ -313,11 +313,21 @@ class OrgInvitationService:
             raise InvitationInvalidError('User not found')
 
         user_email = user.email
-        # Fallback: fetch email from Keycloak if not in database (for existing users)
+        # Fallback: fetch email from Keycloak if not in database (for existing users).
+        # When found, persist it back to User.email so the members list shows it
+        # without requiring the user to log out and log back in.
         if not user_email:
             token_manager = TokenManager()
             user_info = await token_manager.get_user_info_from_user_id(str(user_id))
             user_email = user_info.get('email') if user_info else None
+            if user_email and user_info is not None:
+                await UserStore.backfill_user_email(
+                    str(user_id),
+                    {
+                        'email': user_email,
+                        'email_verified': user_info.get('emailVerified', False),
+                    },
+                )
 
         if not user_email:
             raise EmailMismatchError('Your account does not have an email address')

--- a/enterprise/tests/unit/test_org_invitation_service.py
+++ b/enterprise/tests/unit/test_org_invitation_service.py
@@ -136,6 +136,10 @@ class TestAcceptInvitationEmailValidation:
                 'server.services.org_invitation_service.OrgInvitationStore.update_invitation_status',
                 new_callable=AsyncMock,
             ) as mock_update_status,
+            patch(
+                'server.services.org_invitation_service.UserStore.backfill_user_email',
+                new_callable=AsyncMock,
+            ),
         ):
             mock_get_invitation.return_value = mock_invitation
             mock_is_expired.return_value = False
@@ -161,6 +165,98 @@ class TestAcceptInvitationEmailValidation:
             # Assert
             mock_token_manager.get_user_info_from_user_id.assert_called_once_with(
                 str(user_id)
+            )
+
+    @pytest.mark.asyncio
+    async def test_accept_invitation_user_no_email_keycloak_fallback_persists_email(
+        self, mock_invitation
+    ):
+        """When User.email is NULL and Keycloak returns an email, the email is
+        persisted back to the User record (normalized to snake_case) so the
+        members list shows it without requiring the user to log out and back in.
+        """
+        # Arrange
+        user_id = UUID('87654321-4321-8765-4321-876543218765')
+        token = 'inv-test-token-12345'
+
+        mock_user = MagicMock()
+        mock_user.id = user_id
+        mock_user.email = None
+
+        # Keycloak admin API returns camelCase `emailVerified`.
+        mock_keycloak_user_info = {
+            'email': 'alice@example.com',
+            'emailVerified': True,
+        }
+
+        mock_org = MagicMock()
+        mock_org.agent_settings = {'llm': {'model': 'test-model'}}
+
+        with (
+            patch(
+                'server.services.org_invitation_service.OrgInvitationStore.get_invitation_by_token',
+                new_callable=AsyncMock,
+            ) as mock_get_invitation,
+            patch(
+                'server.services.org_invitation_service.OrgInvitationStore.is_token_expired'
+            ) as mock_is_expired,
+            patch(
+                'server.services.org_invitation_service.UserStore.get_user_by_id',
+                new_callable=AsyncMock,
+            ) as mock_get_user,
+            patch(
+                'server.services.org_invitation_service.TokenManager'
+            ) as mock_token_manager_class,
+            patch(
+                'server.services.org_invitation_service.OrgMemberStore.get_org_member',
+                new_callable=AsyncMock,
+            ) as mock_get_member,
+            patch(
+                'server.services.org_invitation_service.OrgService.create_litellm_integration',
+                new_callable=AsyncMock,
+            ) as mock_create_litellm,
+            patch(
+                'server.services.org_invitation_service.OrgStore.get_org_by_id',
+                new_callable=AsyncMock,
+            ) as mock_get_org,
+            patch(
+                'server.services.org_invitation_service.OrgMemberStore.add_user_to_org',
+                new_callable=AsyncMock,
+            ),
+            patch(
+                'server.services.org_invitation_service.OrgInvitationStore.update_invitation_status',
+                new_callable=AsyncMock,
+            ) as mock_update_status,
+            patch(
+                'server.services.org_invitation_service.UserStore.backfill_user_email',
+                new_callable=AsyncMock,
+            ) as mock_backfill,
+        ):
+            mock_get_invitation.return_value = mock_invitation
+            mock_is_expired.return_value = False
+            mock_get_user.return_value = mock_user
+
+            mock_token_manager = MagicMock()
+            mock_token_manager.get_user_info_from_user_id = AsyncMock(
+                return_value=mock_keycloak_user_info
+            )
+            mock_token_manager_class.return_value = mock_token_manager
+
+            mock_get_member.return_value = None
+            mock_settings = MagicMock()
+            mock_settings.llm_api_key = SecretStr('test-key')
+            mock_create_litellm.return_value = mock_settings
+            mock_get_org.return_value = mock_org
+            mock_update_status.return_value = mock_invitation
+
+            # Act
+            await OrgInvitationService.accept_invitation(token, user_id)
+
+            # Assert — persisted with snake_case `email_verified` derived from
+            # Keycloak's camelCase `emailVerified`.
+            mock_backfill.assert_awaited_once_with(
+                str(user_id),
+                {'email': 'alice@example.com', 'email_verified': True},
             )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

Some members appeared in the organization members list with a blank email cell because their `User.email` was NULL in the database. Previously, the only code path that healed a NULL email was the login-time backfill in `auth.py:210`, which required the affected user to log out and log back in before their email would appear.

`OrgInvitationService.accept_invitation` already calls the Keycloak admin API as a fallback when `User.email` is NULL — but only to validate the invitation. This PR persists that resolved value back to the database via the existing `UserStore.backfill_user_email` helper, so the common admin workflow of "remove member, then re-invite" repairs the missing email without the user needing to re-authenticate.

## Summary

<!-- 1-3 bullets describing what changed. -->
- `enterprise/server/services/org_invitation_service.py` — inside the existing Keycloak fallback block in `accept_invitation`, call `UserStore.backfill_user_email` with a payload normalized from Keycloak's camelCase (`emailVerified`) to snake_case (`email_verified`). The persist happens before the email-mismatch check: Keycloak's value is the user's real address regardless of whether this particular invitation is accepted, and the existing `if user.email is None` guard inside `backfill_user_email` keeps the write idempotent and safe against the login-time backfill running concurrently.
- `enterprise/tests/unit/test_org_invitation_service.py` — one new focused test asserting the persist happens with the correctly-normalized payload. The existing `test_accept_invitation_user_no_email_keycloak_fallback_matches` was updated to patch `UserStore.backfill_user_email` so it does not reach real DB code through the new call site; no new assertions added there.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Run the SaaS application.
2. Update the database by clearing the email field for a specific user.
3. Invite the user to an organization.
4. Navigate to the organization’s members page. The user’s email should be correctly populated and displayed in the email column.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-08cd291   docker.openhands.dev/openhands/openhands:08cd291
```