### PR TITLE
fix: deliver pending messages in self-hosted installs without session_api_key

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -388,13 +388,12 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             yield task
 
             # Process any pending messages queued while waiting for conversation
-            if sandbox.session_api_key:
-                await self._process_pending_messages(
-                    task_id=task.id,
-                    conversation_id=info.id,
-                    agent_server_url=agent_server_url,
-                    session_api_key=sandbox.session_api_key,
-                )
+            await self._process_pending_messages(
+                task_id=task.id,
+                conversation_id=info.id,
+                agent_server_url=agent_server_url,
+                session_api_key=sandbox.session_api_key,
+            )
 
         except Exception as exc:
             _logger.exception('Error starting conversation', stack_info=True)
@@ -1353,7 +1352,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         task_id: UUID,
         conversation_id: UUID,
         agent_server_url: str,
-        session_api_key: str,
+        session_api_key: str | None = None,
     ) -> None:
         """Process pending messages queued before conversation was ready.
 
@@ -1364,7 +1363,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             task_id: The start task ID (may have been used as conversation_id initially)
             conversation_id: The real conversation ID
             agent_server_url: URL of the agent server
-            session_api_key: API key for authenticating with agent server
+            session_api_key: Optional API key for authenticating with agent server.
+                When None (e.g. local/self-hosted installations), the request is
+                sent without authentication headers.
         """
         # Convert UUIDs to strings for the pending message service
         # The frontend uses task-{uuid.hex} format (no hyphens), matching OpenHandsUUID serialization
@@ -1405,6 +1406,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 # Serialize content objects to JSON-compatible dicts
                 content_json = [item.model_dump() for item in msg.content]
                 # Use the events endpoint which handles message sending
+                headers = {}
+                if session_api_key:
+                    headers['X-Session-API-Key'] = session_api_key
                 response = await self.httpx_client.post(
                     f'{agent_server_url}/api/conversations/{conversation_id_str}/events',
                     json={
@@ -1412,7 +1416,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                         'content': content_json,
                         'run': True,
                     },
-                    headers={'X-Session-API-Key': session_api_key},
+                    headers=headers,
                     timeout=30.0,
                 )
                 response.raise_for_status()

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -131,6 +131,13 @@ class TestLiveStatusAppConversationService:
         self.mock_event_service = Mock()
         self.mock_httpx_client = Mock()
         self.mock_pending_message_service = Mock()
+        # Async methods on the pending message service must be AsyncMock so they
+        # can be awaited inside _process_pending_messages (which now runs unconditionally).
+        self.mock_pending_message_service.update_conversation_id = AsyncMock(return_value=0)
+        self.mock_pending_message_service.get_pending_messages = AsyncMock(return_value=[])
+        self.mock_pending_message_service.delete_messages_for_conversation = AsyncMock(
+            return_value=0
+        )
 
         # Create service instance
         self.service = LiveStatusAppConversationService(
@@ -2111,6 +2118,13 @@ class TestPluginHandling:
         self.mock_event_service = Mock()
         self.mock_httpx_client = Mock()
         self.mock_pending_message_service = Mock()
+        # Async methods on the pending message service must be AsyncMock so they
+        # can be awaited inside _process_pending_messages (which now runs unconditionally).
+        self.mock_pending_message_service.update_conversation_id = AsyncMock(return_value=0)
+        self.mock_pending_message_service.get_pending_messages = AsyncMock(return_value=[])
+        self.mock_pending_message_service.delete_messages_for_conversation = AsyncMock(
+            return_value=0
+        )
 
         # Create service instance
         self.service = LiveStatusAppConversationService(
@@ -2773,6 +2787,13 @@ class TestLoadHooksFromWorkspace:
         self.mock_event_service = Mock()
         self.mock_httpx_client = AsyncMock()
         self.mock_pending_message_service = Mock()
+        # Async methods on the pending message service must be AsyncMock so they
+        # can be awaited inside _process_pending_messages (which now runs unconditionally).
+        self.mock_pending_message_service.update_conversation_id = AsyncMock(return_value=0)
+        self.mock_pending_message_service.get_pending_messages = AsyncMock(return_value=[])
+        self.mock_pending_message_service.delete_messages_for_conversation = AsyncMock(
+            return_value=0
+        )
 
         # Create service instance
         self.service = LiveStatusAppConversationService(

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -133,8 +133,12 @@ class TestLiveStatusAppConversationService:
         self.mock_pending_message_service = Mock()
         # Async methods on the pending message service must be AsyncMock so they
         # can be awaited inside _process_pending_messages (which now runs unconditionally).
-        self.mock_pending_message_service.update_conversation_id = AsyncMock(return_value=0)
-        self.mock_pending_message_service.get_pending_messages = AsyncMock(return_value=[])
+        self.mock_pending_message_service.update_conversation_id = AsyncMock(
+            return_value=0
+        )
+        self.mock_pending_message_service.get_pending_messages = AsyncMock(
+            return_value=[]
+        )
         self.mock_pending_message_service.delete_messages_for_conversation = AsyncMock(
             return_value=0
         )
@@ -2120,8 +2124,12 @@ class TestPluginHandling:
         self.mock_pending_message_service = Mock()
         # Async methods on the pending message service must be AsyncMock so they
         # can be awaited inside _process_pending_messages (which now runs unconditionally).
-        self.mock_pending_message_service.update_conversation_id = AsyncMock(return_value=0)
-        self.mock_pending_message_service.get_pending_messages = AsyncMock(return_value=[])
+        self.mock_pending_message_service.update_conversation_id = AsyncMock(
+            return_value=0
+        )
+        self.mock_pending_message_service.get_pending_messages = AsyncMock(
+            return_value=[]
+        )
         self.mock_pending_message_service.delete_messages_for_conversation = AsyncMock(
             return_value=0
         )
@@ -2789,8 +2797,12 @@ class TestLoadHooksFromWorkspace:
         self.mock_pending_message_service = Mock()
         # Async methods on the pending message service must be AsyncMock so they
         # can be awaited inside _process_pending_messages (which now runs unconditionally).
-        self.mock_pending_message_service.update_conversation_id = AsyncMock(return_value=0)
-        self.mock_pending_message_service.get_pending_messages = AsyncMock(return_value=[])
+        self.mock_pending_message_service.update_conversation_id = AsyncMock(
+            return_value=0
+        )
+        self.mock_pending_message_service.get_pending_messages = AsyncMock(
+            return_value=[]
+        )
         self.mock_pending_message_service.delete_messages_for_conversation = AsyncMock(
             return_value=0
         )


### PR DESCRIPTION
## Summary

Fixes #13716 — pending messages queued during conversation startup are silently dropped in self-hosted / local installations that have no `session_api_key`.

**Root cause**: `_process_pending_messages` was wrapped in `if sandbox.session_api_key:`, so the entire delivery step was skipped for users who run OpenHands without cloud authentication.

**Changes**:
- Remove the `if sandbox.session_api_key:` guard so `_process_pending_messages` is always called once the conversation reaches the READY state.
- Change `session_api_key: str` to `session_api_key: str | None = None` in the method signature.
- Only attach the `X-Session-API-Key` request header when the key is present; fall back to an empty headers dict for unauthenticated installations.
- Fix test fixtures in `test_live_status_app_conversation_service.py`: the three async methods on the pending-message service mock (`update_conversation_id`, `get_pending_messages`, `delete_messages_for_conversation`) are now `AsyncMock` instances so they can be awaited through the now-unconditional call path.

## Test plan

- [x] Unit test `test_start_app_conversation_default_title_uses_first_five_characters` exercises the full `_start_app_conversation` generator, which now always reaches the `_process_pending_messages` call — the updated `AsyncMock` fixtures make the test pass without error.
- [ ] Manual: start OpenHands locally (no `session_api_key`), send a message while the conversation is still starting, confirm the message is delivered once the agent is ready.