### PR TITLE
fix(enterprise): migrate StoredVerifiedModel to SQLAlchemy 2.0 mapped_column

### DIFF
--- a/enterprise/server/verified_models/verified_model_service.py
+++ b/enterprise/server/verified_models/verified_model_service.py
@@ -1,17 +1,15 @@
 """Store for managing verified LLM models in the database."""
 
 from dataclasses import dataclass
+from datetime import datetime
 
 from server.verified_models.verified_model_models import (
     VerifiedModel,
     VerifiedModelPage,
 )
 from sqlalchemy import (
-    Boolean,
-    Column,
     DateTime,
     Identity,
-    Integer,
     String,
     UniqueConstraint,
     and_,
@@ -20,13 +18,14 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
 
 from openhands.app_server.config import depends_db_session
 from openhands.core.logger import openhands_logger as logger
 
 
-class StoredVerifiedModel(Base):  # type: ignore
+class StoredVerifiedModel(Base):
     """A verified LLM model available in the model selector.
 
     The composite unique constraint on (model_name, provider) allows the same
@@ -39,14 +38,16 @@ class StoredVerifiedModel(Base):  # type: ignore
         UniqueConstraint('model_name', 'provider', name='uq_verified_model_provider'),
     )
 
-    id = Column(Integer, Identity(), primary_key=True)
-    model_name = Column(String(255), nullable=False)
-    provider = Column(String(100), nullable=False, index=True)
-    is_enabled = Column(
-        Boolean, nullable=False, default=True, server_default=text('true')
+    id: Mapped[int] = mapped_column(Identity(), primary_key=True)
+    model_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    provider: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    is_enabled: Mapped[bool] = mapped_column(
+        nullable=False, default=True, server_default=text('true')
     )
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    updated_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
     )
 


### PR DESCRIPTION
## Description
Migrate `StoredVerifiedModel` in `enterprise/server/verified_models/verified_model_service.py` to use SQLAlchemy 2.0 `mapped_column()` with `Mapped[T]` type annotations.

## Changes
- Convert `Column()` to `mapped_column()` with `Mapped[T]` type annotations
- Remove `# type: ignore` comment (no longer needed with proper typing)
- Add `datetime` import for `Mapped[datetime]` type hints
- Remove unused `Boolean`, `Column`, `Integer` imports

## Impact
- Fixes ~6 mypy `[var-annotated]` errors
- Improves type safety for `StoredVerifiedModel` model
- Follows the SQLAlchemy 2.0 migration pattern established in PRs #13846-#13859

## Testing
- Pre-commit hooks pass (ruff, ruff-format, mypy)
- CI will validate enterprise unit tests

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/47a7e87e-75c7-4c8b-ba83-c321957b9a8f)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-46ccdc7   docker.openhands.dev/openhands/openhands:46ccdc7
```