### PR TITLE
fix: migrate core SQLAlchemy models to SQLAlchemy 2.0 mapped_column

### DIFF
--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -26,17 +26,14 @@ from uuid import UUID
 
 from fastapi import Request
 from sqlalchemy import (
-    Boolean,
-    Column,
     DateTime,
-    Float,
-    Integer,
     Select,
     String,
     func,
     select,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
 
 from openhands.agent_server.utils import utc_now
 from openhands.app_server.app_conversation.app_conversation_info_service import (
@@ -63,45 +60,58 @@ from openhands.storage.data_models.conversation_metadata import ConversationTrig
 logger = logging.getLogger(__name__)
 
 
-class StoredConversationMetadata(Base):  # type: ignore
+class StoredConversationMetadata(Base):
     __tablename__ = 'conversation_metadata'
-    conversation_id = Column(
+
+    conversation_id: Mapped[str] = mapped_column(
         String, primary_key=True, default=lambda: str(uuid.uuid4())
     )
-    selected_repository = Column(String, nullable=True)
-    selected_branch = Column(String, nullable=True)
-    git_provider = Column(
+    selected_repository: Mapped[str | None] = mapped_column(String, nullable=True)
+    selected_branch: Mapped[str | None] = mapped_column(String, nullable=True)
+    git_provider: Mapped[str | None] = mapped_column(
         String, nullable=True
     )  # The git provider (GitHub, GitLab, etc.)
-    title = Column(String, nullable=True)
-    last_updated_at = Column(DateTime(timezone=True), default=utc_now)  # type: ignore[attr-defined]
-    created_at = Column(DateTime(timezone=True), default=utc_now)  # type: ignore[attr-defined]
+    title: Mapped[str | None] = mapped_column(String, nullable=True)
+    last_updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), default=utc_now
+    )
+    created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), default=utc_now
+    )
 
-    trigger = Column(String, nullable=True)
-    pr_number = Column(create_json_type_decorator(list[int]))
+    trigger: Mapped[str | None] = mapped_column(String, nullable=True)
+    pr_number: Mapped[list[int] | None] = mapped_column(
+        create_json_type_decorator(list[int])
+    )
 
     # Cost and token metrics
-    accumulated_cost = Column(Float, default=0.0)
-    prompt_tokens = Column(Integer, default=0)
-    completion_tokens = Column(Integer, default=0)
-    total_tokens = Column(Integer, default=0)
-    max_budget_per_task = Column(Float, nullable=True)
-    cache_read_tokens = Column(Integer, default=0)
-    cache_write_tokens = Column(Integer, default=0)
-    reasoning_tokens = Column(Integer, default=0)
-    context_window = Column(Integer, default=0)
-    per_turn_token = Column(Integer, default=0)
+    accumulated_cost: Mapped[float | None] = mapped_column(default=0.0)
+    prompt_tokens: Mapped[int | None] = mapped_column(default=0)
+    completion_tokens: Mapped[int | None] = mapped_column(default=0)
+    total_tokens: Mapped[int | None] = mapped_column(default=0)
+    max_budget_per_task: Mapped[float | None] = mapped_column(nullable=True)
+    cache_read_tokens: Mapped[int | None] = mapped_column(default=0)
+    cache_write_tokens: Mapped[int | None] = mapped_column(default=0)
+    reasoning_tokens: Mapped[int | None] = mapped_column(default=0)
+    context_window: Mapped[int | None] = mapped_column(default=0)
+    per_turn_token: Mapped[int | None] = mapped_column(default=0)
 
     # LLM model used for the conversation
-    llm_model = Column(String, nullable=True)
+    llm_model: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    conversation_version = Column(String, nullable=False, default='V0', index=True)
-    sandbox_id = Column(String, nullable=True, index=True)
-    parent_conversation_id = Column(String, nullable=True, index=True)
-    public = Column(Boolean, nullable=True, index=True)
+    conversation_version: Mapped[str] = mapped_column(
+        String, nullable=False, default='V0', index=True
+    )
+    sandbox_id: Mapped[str | None] = mapped_column(String, nullable=True, index=True)
+    parent_conversation_id: Mapped[str | None] = mapped_column(
+        String, nullable=True, index=True
+    )
+    public: Mapped[bool | None] = mapped_column(nullable=True, index=True)
 
     # Tags for conversation metadata (e.g., automation context, skills used)
-    tags = Column(create_json_type_decorator(dict[str, str]), nullable=True)
+    tags: Mapped[dict[str, str] | None] = mapped_column(
+        create_json_type_decorator(dict[str, str]), nullable=True
+    )
 
 
 @dataclass

--- a/openhands/app_server/app_conversation/sql_app_conversation_start_task_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_start_task_service.py
@@ -23,9 +23,9 @@ from typing import AsyncGenerator
 from uuid import UUID
 
 from fastapi import Request
-from sqlalchemy import UUID as SQLUUID
-from sqlalchemy import Column, Enum, String, func, select
+from sqlalchemy import Enum, String, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
 
 from openhands.agent_server.models import utc_now
 from openhands.app_server.app_conversation.app_conversation_models import (
@@ -50,18 +50,27 @@ from openhands.app_server.utils.sql_utils import (
 logger = logging.getLogger(__name__)
 
 
-class StoredAppConversationStartTask(Base):  # type: ignore
+class StoredAppConversationStartTask(Base):
     __tablename__ = 'app_conversation_start_task'
-    id = Column(SQLUUID, primary_key=True)
-    created_by_user_id = Column(String, index=True)
-    status = Column(Enum(AppConversationStartTaskStatus), nullable=True)
-    detail = Column(String, nullable=True)
-    app_conversation_id = Column(SQLUUID, nullable=True)
-    sandbox_id = Column(String, nullable=True)
-    agent_server_url = Column(String, nullable=True)
-    request = Column(create_json_type_decorator(AppConversationStartRequest))
-    created_at = Column(UtcDateTime, server_default=func.now(), index=True)
-    updated_at = Column(UtcDateTime, onupdate=func.now(), index=True)
+
+    id: Mapped[UUID] = mapped_column(primary_key=True)
+    created_by_user_id: Mapped[str] = mapped_column(String, index=True)
+    status: Mapped[AppConversationStartTaskStatus | None] = mapped_column(
+        Enum(AppConversationStartTaskStatus), nullable=True
+    )
+    detail: Mapped[str | None] = mapped_column(String, nullable=True)
+    app_conversation_id: Mapped[UUID | None] = mapped_column(nullable=True)
+    sandbox_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    agent_server_url: Mapped[str | None] = mapped_column(String, nullable=True)
+    request: Mapped[AppConversationStartRequest] = mapped_column(
+        create_json_type_decorator(AppConversationStartRequest)
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        UtcDateTime, server_default=func.now(), index=True
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        UtcDateTime, onupdate=func.now(), index=True
+    )
 
 
 @dataclass

--- a/openhands/app_server/event_callback/sql_event_callback_service.py
+++ b/openhands/app_server/event_callback/sql_event_callback_service.py
@@ -6,13 +6,14 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from typing import AsyncGenerator
 from uuid import UUID, uuid4
 
 from fastapi import Request
-from sqlalchemy import UUID as SQLUUID
-from sqlalchemy import Column, Enum, String, and_, func, or_, select
+from sqlalchemy import Enum, String, and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
 
 from openhands.agent_server.utils import utc_now
 from openhands.app_server.event_callback.event_callback_models import (
@@ -44,28 +45,40 @@ _logger = logging.getLogger(__name__)
 # TODO: Add user level filtering to this class
 
 
-class StoredEventCallback(Base):  # type: ignore
+class StoredEventCallback(Base):
     __tablename__ = 'event_callback'
-    id = Column(SQLUUID, primary_key=True)
-    conversation_id = Column(SQLUUID, nullable=True)
-    status = Column(
+
+    id: Mapped[UUID] = mapped_column(primary_key=True)
+    conversation_id: Mapped[UUID | None] = mapped_column(nullable=True)
+    status: Mapped[EventCallbackStatus] = mapped_column(
         Enum(EventCallbackStatus), nullable=False, default=EventCallbackStatus.ACTIVE
     )
-    processor = Column(create_json_type_decorator(EventCallbackProcessor))
-    event_kind = Column(String, nullable=True)
-    created_at = Column(UtcDateTime, server_default=func.now(), index=True)
-    updated_at = Column(UtcDateTime, server_default=func.now(), index=True)
+    processor: Mapped[EventCallbackProcessor] = mapped_column(
+        create_json_type_decorator(EventCallbackProcessor)
+    )
+    event_kind: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        UtcDateTime, server_default=func.now(), index=True
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        UtcDateTime, server_default=func.now(), index=True
+    )
 
 
-class StoredEventCallbackResult(Base):  # type: ignore
+class StoredEventCallbackResult(Base):
     __tablename__ = 'event_callback_result'
-    id = Column(SQLUUID, primary_key=True, default=uuid4)
-    status = Column(Enum(EventCallbackResultStatus), nullable=True)
-    event_callback_id = Column(SQLUUID, index=True)
-    event_id = Column(String, index=True)
-    conversation_id = Column(SQLUUID, index=True)
-    detail = Column(String, nullable=True)
-    created_at = Column(UtcDateTime, server_default=func.now(), index=True)
+
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    status: Mapped[EventCallbackResultStatus | None] = mapped_column(
+        Enum(EventCallbackResultStatus), nullable=True
+    )
+    event_callback_id: Mapped[UUID] = mapped_column(index=True)
+    event_id: Mapped[str] = mapped_column(String, index=True)
+    conversation_id: Mapped[UUID] = mapped_column(index=True)
+    detail: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        UtcDateTime, server_default=func.now(), index=True
+    )
 
 
 @dataclass

--- a/openhands/app_server/pending_messages/pending_message_service.py
+++ b/openhands/app_server/pending_messages/pending_message_service.py
@@ -2,12 +2,14 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import AsyncGenerator
+from datetime import datetime
+from typing import Any, AsyncGenerator
 
 from fastapi import Request
 from pydantic import TypeAdapter
-from sqlalchemy import JSON, Column, String, func, select
+from sqlalchemy import JSON, String, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
 
 from openhands.agent_server.models import ImageContent, TextContent
 from openhands.app_server.pending_messages.pending_message_models import (
@@ -22,15 +24,18 @@ from openhands.sdk.utils.models import DiscriminatedUnionMixin
 _content_type_adapter = TypeAdapter(list[TextContent | ImageContent])
 
 
-class StoredPendingMessage(Base):  # type: ignore
+class StoredPendingMessage(Base):
     """SQLAlchemy model for pending messages."""
 
     __tablename__ = 'pending_messages'
-    id = Column(String, primary_key=True)
-    conversation_id = Column(String, nullable=False, index=True)
-    role = Column(String(20), nullable=False, default='user')
-    content = Column(JSON, nullable=False)
-    created_at = Column(UtcDateTime, server_default=func.now(), index=True)
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    conversation_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    role: Mapped[str] = mapped_column(String(20), nullable=False, default='user')
+    content: Mapped[list[Any]] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        UtcDateTime, server_default=func.now(), index=True
+    )
 
 
 class PendingMessageService(ABC):

--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -3,6 +3,7 @@ import hashlib
 import logging
 import os
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, AsyncGenerator, Union
 from urllib.parse import urlparse
 from uuid import UUID
@@ -11,8 +12,9 @@ import base62
 import httpx
 from fastapi import Request
 from pydantic import Field
-from sqlalchemy import Column, String, func, select
+from sqlalchemy import String, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
 
 from openhands.agent_server.models import ConversationInfo, EventPage
 from openhands.agent_server.utils import utc_now
@@ -71,7 +73,7 @@ def _hash_session_api_key(session_api_key: str) -> str:
     return hashlib.sha256(session_api_key.encode()).hexdigest()
 
 
-class StoredRemoteSandbox(Base):  # type: ignore
+class StoredRemoteSandbox(Base):
     """Local storage for remote sandbox info.
 
     The remote runtime API does not return some variables we need, and does not
@@ -80,11 +82,20 @@ class StoredRemoteSandbox(Base):  # type: ignore
     run historicallly."""
 
     __tablename__ = 'v1_remote_sandbox'
-    id = Column(String, primary_key=True)
-    created_by_user_id = Column(String, nullable=True, index=True)
-    sandbox_spec_id = Column(String, index=True)  # shadows runtime['image']
-    session_api_key_hash = Column(String, nullable=True, index=True)
-    created_at = Column(UtcDateTime, server_default=func.now(), index=True)
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    created_by_user_id: Mapped[str | None] = mapped_column(
+        String, nullable=True, index=True
+    )
+    sandbox_spec_id: Mapped[str] = mapped_column(
+        String, index=True
+    )  # shadows runtime['image']
+    session_api_key_hash: Mapped[str | None] = mapped_column(
+        String, nullable=True, index=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        UtcDateTime, server_default=func.now(), index=True
+    )
 
 
 @dataclass


### PR DESCRIPTION
## Description
Migrate core OpenHands SQLAlchemy models to use SQLAlchemy 2.0 `mapped_column()` with `Mapped[T]` type annotations.

## Models Migrated
- `StoredPendingMessage` (`pending_message_service.py`) - 5 columns
- `StoredRemoteSandbox` (`remote_sandbox_service.py`) - 5 columns  
- `StoredEventCallback`, `StoredEventCallbackResult` (`sql_event_callback_service.py`) - 14 columns
- `StoredAppConversationStartTask` (`sql_app_conversation_start_task_service.py`) - 10 columns
- `StoredConversationMetadata` (`sql_app_conversation_info_service.py`) - 25 columns

## Changes
- Convert `Column()` to `mapped_column()` with `Mapped[T]` type annotations
- Remove `# type: ignore` comments (no longer needed with proper typing)
- Add `datetime` import for `Mapped[datetime]` type hints
- Remove unused `Column`, `Boolean`, `Float`, `Integer` imports
- Remove unused `UUID as SQLUUID` import (Python's `uuid.UUID` used directly with `Mapped[UUID]`)

## Impact
- Fixes ~59 mypy `[var-annotated]` errors across 5 files
- Improves type safety for all core SQLAlchemy models
- Follows the SQLAlchemy 2.0 migration pattern established in PRs #13846-#13859

## Testing
- Pre-commit hooks pass (ruff, ruff-format, mypy)
- CI will validate unit tests

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-52a1cef   docker.openhands.dev/openhands/openhands:52a1cef
```