### PR TITLE
fix(integrations): return True on error in Azure DevOps is_pr_open

### DIFF
--- a/openhands/app_server/integrations/azure_devops/service/prs.py
+++ b/openhands/app_server/integrations/azure_devops/service/prs.py
@@ -309,9 +309,11 @@ class AzureDevOpsPRsMixin(AzureDevOpsMixinBase):
             return status == 'active'
         except Exception as e:
             logger.warning(
-                f'Failed to check PR status for {repository}#{pr_number}: {e}'
+                f'Could not determine Azure DevOps PR status for {repository}#{pr_number}: {e}. '
+                f'Including conversation to be safe.'
             )
-            return False
+            # If we can't determine the PR status, include the conversation to be safe
+            return True
 
     async def add_pr_reaction(
         self, repository: str, pr_number: int, reaction_type: str = ':thumbsup:'

--- a/tests/unit/test_azure_devops.py
+++ b/tests/unit/test_azure_devops.py
@@ -125,3 +125,70 @@ async def test_azure_devops_get_repository_details():
         assert repo.id == 'repo1'
         assert repo.full_name == 'myorg/Project1/Repo1'
         assert repo.git_provider == ProviderType.AZURE_DEVOPS
+
+
+def _make_pr_service() -> AzureDevOpsService:
+    return AzureDevOpsService(
+        user_id='test_user',
+        token=None,
+        base_domain='myorg',
+    )
+
+
+@pytest.mark.asyncio
+async def test_is_pr_open_returns_true_for_active():
+    svc = _make_pr_service()
+
+    with patch.object(
+        svc, 'get_pr_details', new=AsyncMock(return_value={'status': 'active'})
+    ):
+        assert await svc.is_pr_open('myorg/Project1/Repo1', 1) is True
+
+
+@pytest.mark.asyncio
+async def test_is_pr_open_returns_false_for_completed():
+    svc = _make_pr_service()
+
+    with patch.object(
+        svc, 'get_pr_details', new=AsyncMock(return_value={'status': 'completed'})
+    ):
+        assert await svc.is_pr_open('myorg/Project1/Repo1', 1) is False
+
+
+@pytest.mark.asyncio
+async def test_is_pr_open_returns_false_for_abandoned():
+    svc = _make_pr_service()
+
+    with patch.object(
+        svc, 'get_pr_details', new=AsyncMock(return_value={'status': 'abandoned'})
+    ):
+        assert await svc.is_pr_open('myorg/Project1/Repo1', 1) is False
+
+
+@pytest.mark.asyncio
+async def test_is_pr_open_returns_true_on_exception():
+    """On transient API failure, fall back to True so the conversation is still
+    included — matching the behaviour of the GitHub / GitLab / Bitbucket /
+    Bitbucket Data Center siblings ('Including conversation to be safe')."""
+    svc = _make_pr_service()
+
+    with patch.object(
+        svc,
+        'get_pr_details',
+        new=AsyncMock(side_effect=Exception('network error')),
+    ):
+        result = await svc.is_pr_open('myorg/Project1/Repo1', 999)
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_is_pr_open_missing_status_field_returns_false():
+    """If the API response omits the status field, .get('status', '') yields ''
+    which is not 'active' — consistent with treating unknown-shape responses
+    from get_pr_details as non-open (whereas an exception falls through to the
+    safer True default)."""
+    svc = _make_pr_service()
+
+    with patch.object(svc, 'get_pr_details', new=AsyncMock(return_value={})):
+        assert await svc.is_pr_open('myorg/Project1/Repo1', 1) is False


### PR DESCRIPTION
```
## Summary

- `is_pr_open` in `openhands/integrations/azure_devops/service/prs.py` returned `False` on any exception from the Azure DevOps API, silently treating transient failures as "PR is closed/merged" and excluding the conversation — the opposite of the documented safer default used by every other provider
- All four sibling implementations (GitHub, GitLab, Bitbucket Cloud, Bitbucket Data Center) return `True` on the same exception path with the rationale `"Including conversation to be safe."`; the Bitbucket DC test suite explicitly pins this with `test_is_pr_open_returns_true_on_exception` and docstring *"Current implementation catches all exceptions and returns True."*
- Align the Azure DevOps exception branch with the sibling implementations: return `True`, log the same `"Could not determine ... Including conversation to be safe."` warning, and add the matching rationale comment
- Add four tests in `tests/unit/test_azure_devops.py` covering `active` / `completed` / `abandoned` status mapping, exception → `True` fallback, and the missing-status-field edge case

## Related Issues

N/A — code review. The inconsistency was introduced when Azure DevOps integration landed (commit `3504ca775`, PR #11243); no upstream PR currently addresses it (verified via `search/issues?q=is_pr_open+is:pr` → 0 hits).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added — four new `test_is_pr_open_*` cases in `tests/unit/test_azure_devops.py` matching the existing Bitbucket DC test layout (`active`, `completed`, `abandoned`, exception, missing-status)
- [x] Syntax-checked both modified files with `python3 -m py_compile` — no errors
- [ ] `pytest tests/unit/test_azure_devops.py` — not run locally because the OpenHands project virtualenv / poetry dependency graph is not installed in this environment; the tests follow the exact pattern already used by `tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_prs.py` which the project CI executes

## Checklist

- [x] Code follows project style guidelines (mirrors the four sibling `is_pr_open` implementations)
- [x] Self-review completed
- [x] Changes are documented (if applicable)
```