### PR TITLE
fix: resolve SQLAlchemy mypy type errors in core OpenHands files

### DIFF
--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -26,6 +26,7 @@ from uuid import UUID
 
 from fastapi import Request
 from sqlalchemy import (
+    ColumnElement,
     DateTime,
     Select,
     String,
@@ -241,7 +242,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
         sandbox_id__eq: str | None = None,
     ) -> Select:
         # Apply the same filters as search_app_conversations
-        conditions = []
+        conditions: list[ColumnElement[bool]] = []
         if title__contains is not None:
             conditions.append(
                 StoredConversationMetadata.title.like(f'%{title__contains}%')
@@ -539,9 +540,9 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             accumulated_token_usage=token_usage,
         )
 
-        # Get timestamps
-        created_at = self._fix_timezone(stored.created_at)
-        updated_at = self._fix_timezone(stored.last_updated_at)
+        # Get timestamps with UTC fallback for missing values
+        created_at = self._fix_timezone(stored.created_at) or utc_now()
+        updated_at = self._fix_timezone(stored.last_updated_at) or utc_now()
 
         return AppConversationInfo(
             id=UUID(stored.conversation_id),
@@ -569,10 +570,12 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             updated_at=updated_at,
         )
 
-    def _fix_timezone(self, value: datetime) -> datetime:
-        """Sqlite does not stpre timezones - and since we can't update the existing models
+    def _fix_timezone(self, value: datetime | None) -> datetime | None:
+        """Sqlite does not store timezones - and since we can't update the existing models
         we assume UTC if the timezone is missing.
         """
+        if value is None:
+            return None
         if not value.tzinfo:
             value = value.replace(tzinfo=UTC)
         return value
@@ -595,7 +598,8 @@ class SQLAppConversationInfoService(AppConversationInfoService):
         # Execute the secure delete query
         result = await self.db_session.execute(delete_query)
 
-        return result.rowcount > 0
+        # CursorResult from DML statements has rowcount
+        return result.rowcount > 0  # type: ignore[attr-defined]
 
 
 class SQLAppConversationInfoServiceInjector(AppConversationInfoServiceInjector):

--- a/openhands/app_server/app_conversation/sql_app_conversation_start_task_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_start_task_service.py
@@ -267,7 +267,8 @@ class SQLAppConversationStartTaskService(AppConversationStartTaskService):
         result = await self.session.execute(delete_query)
 
         # Return True if any rows were affected
-        return result.rowcount > 0
+        # CursorResult from DML statements has rowcount
+        return result.rowcount > 0  # type: ignore[attr-defined]
 
 
 class SQLAppConversationStartTaskServiceInjector(

--- a/openhands/app_server/services/db_session_injector.py
+++ b/openhands/app_server/services/db_session_injector.py
@@ -24,7 +24,7 @@ DB_SESSION_ATTR = 'db_session'
 DB_SESSION_KEEP_OPEN_ATTR = 'db_session_keep_open'
 
 
-class DbSessionInjector(BaseModel, Injector[async_sessionmaker]):
+class DbSessionInjector(BaseModel, Injector[AsyncSession]):
     persistence_dir: Path
     host: str | None = None
     port: int | None = None
@@ -174,7 +174,7 @@ class DbSessionInjector(BaseModel, Injector[async_sessionmaker]):
                         "PostgreSQL driver 'asyncpg' is required for async connections but is not installed."
                     ) from e
                 password = self.password.get_secret_value() if self.password else None
-                url = URL.create(
+                url: str | URL = URL.create(
                     'postgresql+asyncpg',
                     username=self.user or '',
                     password=password,
@@ -182,10 +182,6 @@ class DbSessionInjector(BaseModel, Injector[async_sessionmaker]):
                     port=self.port,
                     database=self.name,
                 )
-            else:
-                url = f'sqlite+aiosqlite:///{str(self.persistence_dir)}/openhands.db'
-
-            if self.host:
                 async_engine = create_async_engine(
                     url,
                     pool_size=self.pool_size,
@@ -194,8 +190,11 @@ class DbSessionInjector(BaseModel, Injector[async_sessionmaker]):
                     pool_pre_ping=True,
                 )
             else:
+                sqlite_url = (
+                    f'sqlite+aiosqlite:///{str(self.persistence_dir)}/openhands.db'
+                )
                 async_engine = create_async_engine(
-                    url,
+                    sqlite_url,
                     poolclass=NullPool,
                     pool_pre_ping=True,
                 )
@@ -217,7 +216,7 @@ class DbSessionInjector(BaseModel, Injector[async_sessionmaker]):
                         "PostgreSQL driver 'pg8000' is required for sync connections but is not installed."
                     ) from e
                 password = self.password.get_secret_value() if self.password else None
-                url = URL.create(
+                url: str | URL = URL.create(
                     'postgresql+pg8000',
                     username=self.user or '',
                     password=password,
@@ -225,15 +224,22 @@ class DbSessionInjector(BaseModel, Injector[async_sessionmaker]):
                     port=self.port,
                     database=self.name,
                 )
+                engine = create_engine(
+                    url,
+                    pool_size=self.pool_size,
+                    max_overflow=self.max_overflow,
+                    pool_recycle=self.pool_recycle,
+                    pool_pre_ping=True,
+                )
             else:
-                url = f'sqlite:///{self.persistence_dir}/openhands.db'
-            engine = create_engine(
-                url,
-                pool_size=self.pool_size,
-                max_overflow=self.max_overflow,
-                pool_recycle=self.pool_recycle,
-                pool_pre_ping=True,
-            )
+                sqlite_url = f'sqlite:///{self.persistence_dir}/openhands.db'
+                engine = create_engine(
+                    sqlite_url,
+                    pool_size=self.pool_size,
+                    max_overflow=self.max_overflow,
+                    pool_recycle=self.pool_recycle,
+                    pool_pre_ping=True,
+                )
         self._engine = engine
         return engine
 

--- a/openhands/app_server/services/injector.py
+++ b/openhands/app_server/services/injector.py
@@ -1,5 +1,6 @@
 import contextlib
 from abc import ABC, abstractmethod
+from contextlib import AbstractAsyncContextManager
 from typing import AsyncGenerator, Generic, TypeAlias, TypeVar
 
 from fastapi import Request
@@ -20,11 +21,17 @@ class Injector(Generic[T], ABC):
         reuse by other injectors, as injection operations may be nested."""
         yield None  # type: ignore
 
+    def context(
+        self, state: InjectorState, request: Request | None = None
+    ) -> AbstractAsyncContextManager[T]:
+        """Context function suitable for use in async with clauses"""
+        return self._context(state, request)
+
     @contextlib.asynccontextmanager
-    async def context(
+    async def _context(
         self, state: InjectorState, request: Request | None = None
     ) -> AsyncGenerator[T, None]:
-        """Context function suitable for use in async with clauses"""
+        """Internal context manager implementation."""
         async for result in self.inject(state, request):
             yield result
 

--- a/openhands/events/event.py
+++ b/openhands/events/event.py
@@ -106,7 +106,7 @@ class Event:
         return None
 
     @tool_call_metadata.setter
-    def tool_call_metadata(self, value: ToolCallMetadata) -> None:
+    def tool_call_metadata(self, value: ToolCallMetadata | None) -> None:
         self._tool_call_metadata = value
 
     # optional field, the id of the response from the LLM


### PR DESCRIPTION
## Description

This PR fixes SQLAlchemy-related mypy type errors in core OpenHands files to prepare for migration from `sqlalchemy-stubs` to native SQLAlchemy 2.0 type hints.

## Changes

### `openhands/events/event.py`
- Fix `tool_call_metadata` setter to accept `ToolCallMetadata | None` instead of just `ToolCallMetadata`

### `openhands/app_server/services/db_session_injector.py`
- Add explicit `str | URL` type annotations for database connection URL variables
- Fix `DbSessionInjector` type parameter from `Injector[async_sessionmaker]` to `Injector[AsyncSession]`

### `openhands/app_server/services/injector.py`
- Refactor `context()` method to return `AbstractAsyncContextManager[T]` instead of decorated async generator
- Add internal `_context()` method as the actual async context manager implementation

### `openhands/app_server/app_conversation/sql_app_conversation_info_service.py`
- Add `ColumnElement` import for proper type annotation
- Add `list[ColumnElement[bool]]` type annotation for filter conditions list
- Fix `_fix_timezone()` to handle `datetime | None` input and return type
- Add `or utc_now()` fallback for timestamps to ensure non-None values
- Add `type: ignore[attr-defined]` comment for `CursorResult.rowcount` access

### `openhands/app_server/app_conversation/sql_app_conversation_start_task_service.py`
- Add `type: ignore[attr-defined]` comment for `CursorResult.rowcount` access

## Context

This is **PR 1** in a series of PRs to fix mypy type errors that appear when using `sqlalchemy>=2.0` as a mypy dependency instead of the deprecated `sqlalchemy-stubs`. The full migration plan includes:

1. **This PR**: Core OpenHands type fixes (6 files)
2. PR 2: Enterprise SQLAlchemy type fixes (~10 files)
3. PR 3: Enterprise business logic type fixes (~8 files)
4. PR 4: Update dev config to use `sqlalchemy>=2.0`

## Testing

- Ran `pre-commit run --all-files --config ./dev_config/python/.pre-commit-config.yaml` - ✅ Passed
- Verified enterprise mypy with `sqlalchemy>=2.0` dependency shows reduction from 48 to 32 errors

---

*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/47a7e87e-75c7-4c8b-ba83-c321957b9a8f)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-e3fb52a   docker.openhands.dev/openhands/openhands:e3fb52a
```