### PR TITLE
fix(integrations): guard Bitbucket get_user against null links/avatar

### DIFF
--- a/openhands/app_server/integrations/bitbucket/service/base.py
+++ b/openhands/app_server/integrations/bitbucket/service/base.py
@@ -189,10 +189,20 @@ class BitBucketMixinBase(BaseGitService, HTTPClient):
                 exc_info=True,
             )
 
+        # Bitbucket's /user response can carry `"links": null` or `"avatar": null`
+        # (suspended accounts, deleted avatar, custom proxies modifying the shape);
+        # the `(x or {})` idiom mirrors the defensive pattern used by the sibling
+        # GitHub / GitLab / Forgejo / Bitbucket Data Center `get_user` implementations.
+        links = data.get('links') or {}
+        avatar_link = links.get('avatar') if isinstance(links, dict) else None
+        avatar_url = (
+            avatar_link.get('href') or '' if isinstance(avatar_link, dict) else ''
+        )
+
         return User(
             id=account_id,
             login=data.get('username', ''),
-            avatar_url=data.get('links', {}).get('avatar', {}).get('href', ''),
+            avatar_url=avatar_url,
             name=data.get('display_name'),
             email=email,
         )

--- a/tests/unit/integrations/bitbucket/test_bitbucket.py
+++ b/tests/unit/integrations/bitbucket/test_bitbucket.py
@@ -522,3 +522,66 @@ async def test_get_user_handles_user_emails_api_failure():
         assert user.email is None
         assert user.login == 'testuser'
         assert user.name == 'Test User'
+
+
+@pytest.mark.parametrize(
+    'links_value',
+    [
+        None,
+        {},
+        {'avatar': None},
+        {'avatar': {}},
+        {'avatar': {'href': None}},
+    ],
+    ids=[
+        'links_is_null',
+        'links_missing_avatar_key',
+        'avatar_is_null',
+        'avatar_missing_href_key',
+        'avatar_href_is_null',
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_user_handles_null_avatar_fields(links_value):
+    """get_user must not crash when Bitbucket returns a null or missing nested
+    avatar field — matches the defensive pattern used by the sibling GitHub /
+    GitLab / Forgejo / Bitbucket Data Center get_user implementations."""
+    service = BitBucketService(token=SecretStr('test-token'))
+
+    mock_user_response = {
+        'account_id': '123',
+        'username': 'testuser',
+        'display_name': 'Test User',
+        'links': links_value,
+    }
+
+    with (
+        patch.object(service, '_make_request', return_value=(mock_user_response, {})),
+        patch.object(service, 'get_user_emails', return_value=[]),
+    ):
+        user = await service.get_user()
+
+    assert user.avatar_url == ''
+    assert user.login == 'testuser'
+    assert user.name == 'Test User'
+
+
+@pytest.mark.asyncio
+async def test_get_user_returns_avatar_url_on_happy_path():
+    """get_user returns the nested links.avatar.href string on a well-formed response."""
+    service = BitBucketService(token=SecretStr('test-token'))
+
+    mock_user_response = {
+        'account_id': '123',
+        'username': 'testuser',
+        'display_name': 'Test User',
+        'links': {'avatar': {'href': 'https://example.com/avatar.jpg'}},
+    }
+
+    with (
+        patch.object(service, '_make_request', return_value=(mock_user_response, {})),
+        patch.object(service, 'get_user_emails', return_value=[]),
+    ):
+        user = await service.get_user()
+
+    assert user.avatar_url == 'https://example.com/avatar.jpg'


### PR DESCRIPTION
```
## Summary

- `BitBucketMixinBase.get_user` resolved the avatar URL with `data.get('links', {}).get('avatar', {}).get('href', '')`; the `{}` defaults only trigger when the key is missing — when Bitbucket returns `"links": null` (suspended accounts, custom proxies) or `"avatar": null` (users with no avatar image, self-hosted Bitbucket configs that strip the avatar endpoint), each chained `.get` returns `None` and the next call crashes with `AttributeError: 'NoneType' object has no attribute 'get'`
- Extract `links`/`avatar` with `or {}` and `isinstance` guards so a `None` or non-dict value at any level resolves to `avatar_url=''` instead of crashing the caller
- The fix mirrors the defensive pattern already used by the sibling `get_user` implementations in `github/service/base.py`, `gitlab/service/base.py` (which has an explicit comment `"In some self-hosted GitLab instances, the avatar_url field may be returned as None."`), `forgejo/service/base.py`, and `bitbucket_data_center/service/base.py` — Bitbucket Cloud was the only outlier
- Add six tests in `tests/unit/integrations/bitbucket/test_bitbucket.py` pinning the behaviour: a parametrised `test_get_user_handles_null_avatar_fields` with five null-shape cases (`links is null`, `links missing avatar key`, `avatar is null`, `avatar missing href key`, `avatar href is null`) plus `test_get_user_returns_avatar_url_on_happy_path` for the well-formed response

## Related Issues

N/A — code review. The `get_user` function has been in this shape since the BitBucket mixin refactor (`21f3ef540`, 2025-10-28) and was last touched by `a9ede7339` (2026-02-05, PR #12719 *"resolve missing email and display name for user identity tracking"*) which hardened the email branch with `try/except` but left the avatar line untouched. No open upstream PR addresses this specific path (verified via `search/issues?q=bitbucket+avatar+is:pr` — 3 historical closed PRs touched the mixin, none fix the null-avatar case).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added — `test_get_user_handles_null_avatar_fields` (5 parametrised cases) and `test_get_user_returns_avatar_url_on_happy_path` in `tests/unit/integrations/bitbucket/test_bitbucket.py`
- [x] Manually verified the fix logic against 8 input shapes (5 null / missing, 1 happy, 1 entirely-absent `links` key, 1 defensive `links=[]` non-dict case) — all produce the expected `avatar_url` without raising
- [x] Syntax-checked both modified files with `python3 -m py_compile` — no errors
- [ ] `pytest tests/unit/integrations/bitbucket/test_bitbucket.py` — not run locally because the OpenHands project virtualenv / poetry dependency graph is not installed in this environment; the new tests follow the exact `with patch.object(service, '_make_request', return_value=...)` pattern already used by `test_get_user_falls_back_to_user_emails` and `test_get_user_handles_user_emails_api_failure` in the same file

## Checklist

- [x] Code follows project style guidelines (matches the defensive pattern used by every sibling `get_user` in `integrations/`)
- [x] Self-review completed
- [x] Changes are documented (if applicable)
```