### PR TITLE
fix: add ColumnElement type annotation for SQLAlchemy filter conditions

### DIFF
--- a/enterprise/server/utils/saas_app_conversation_info_injector.py
+++ b/enterprise/server/utils/saas_app_conversation_info_injector.py
@@ -5,7 +5,7 @@ from typing import AsyncGenerator
 from uuid import UUID
 
 from fastapi import Request
-from sqlalchemy import func, select
+from sqlalchemy import ColumnElement, func, select
 from storage.stored_conversation_metadata import StoredConversationMetadata
 from storage.stored_conversation_metadata_saas import StoredConversationMetadataSaas
 from storage.user import User
@@ -242,7 +242,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
     ):
         """Apply filters to query that includes SAAS metadata."""
         # Apply the same filters as the base class
-        conditions = []
+        conditions: list[ColumnElement[bool]] = []
         if title__contains is not None:
             conditions.append(
                 StoredConversationMetadata.title.like(f'%{title__contains}%')

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -26,6 +26,7 @@ from uuid import UUID
 
 from fastapi import Request
 from sqlalchemy import (
+    ColumnElement,
     DateTime,
     Select,
     String,
@@ -241,7 +242,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
         sandbox_id__eq: str | None = None,
     ) -> Select:
         # Apply the same filters as search_app_conversations
-        conditions = []
+        conditions: list[ColumnElement[bool]] = []
         if title__contains is not None:
             conditions.append(
                 StoredConversationMetadata.title.like(f'%{title__contains}%')


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Preparation for enabling SQLAlchemy type checking in enterprise mypy configuration. When `sqlalchemy>=2.0` is added to mypy's additional dependencies, mypy infers the wrong type for filter condition lists.

The `conditions` list contains various SQLAlchemy expressions that all inherit from `ColumnElement`, but mypy was inferring a more specific `BinaryExpression` type from the first append, causing type errors on subsequent appends.

## Summary

- Add explicit `list[ColumnElement[bool]]` type annotation to filter condition lists in `sql_app_conversation_info_service.py`
- Add the same type annotation to `saas_app_conversation_info_injector.py`
- Import `ColumnElement` from sqlalchemy in both files

## Issue Number

N/A - Part of SQLAlchemy type checking enablement effort

## How to Test

After adding `sqlalchemy>=2.0` to the enterprise mypy config's additional dependencies:

```bash
cd enterprise
poetry run pre-commit run --all-files --config ./dev_config/python/.pre-commit-config.yaml
```

The 10 `BinaryExpression` vs `ColumnElement` type errors should be resolved.

## Video/Screenshots

N/A - Type annotation changes only

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR is part of a series to enable full SQLAlchemy type checking. The dev config change that enables SQLAlchemy type stubs will be merged in a separate PR after all type fixes are in place.

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/39a7c6d6-c5c8-4a1e-bb09-ef37718b4fa8)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-056092d   docker.openhands.dev/openhands/openhands:056092d
```