### PR TITLE
fix: handle nullable datetime in _fix_timezone methods

### DIFF
--- a/enterprise/server/sharing/sql_shared_conversation_info_service.py
+++ b/enterprise/server/sharing/sql_shared_conversation_info_service.py
@@ -152,6 +152,9 @@ class SQLSharedConversationInfoService(SharedConversationInfoService):
         we assume UTC if the timezone is missing. Returns current UTC time if value is None.
         """
         if value is None:
+            # Fallback for legacy data: use current time to match model defaults.
+            # The DB columns have default=utc_now, so None only occurs in legacy records.
+            # Using utc_now() keeps the API model non-nullable and matches new record behavior.
             return utc_now()
         if not value.tzinfo:
             value = value.replace(tzinfo=UTC)

--- a/enterprise/server/sharing/sql_shared_conversation_info_service.py
+++ b/enterprise/server/sharing/sql_shared_conversation_info_service.py
@@ -26,6 +26,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from storage.stored_conversation_metadata_saas import StoredConversationMetadataSaas
 
+from openhands.agent_server.utils import utc_now
 from openhands.app_server.app_conversation.sql_app_conversation_info_service import (
     StoredConversationMetadata,
 )
@@ -146,9 +147,12 @@ class SQLSharedConversationInfoService(SharedConversationInfoService):
             updated_at=updated_at,
         )
 
-    def _fix_timezone(self, value: datetime) -> datetime:
+    def _fix_timezone(self, value: datetime | None) -> datetime:
         """Sqlite does not store timezones - and since we can't update the existing models
-        we assume UTC if the timezone is missing."""
+        we assume UTC if the timezone is missing. Returns current UTC time if value is None.
+        """
+        if value is None:
+            return utc_now()
         if not value.tzinfo:
             value = value.replace(tzinfo=UTC)
         return value

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -569,10 +569,12 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             updated_at=updated_at,
         )
 
-    def _fix_timezone(self, value: datetime) -> datetime:
-        """Sqlite does not stpre timezones - and since we can't update the existing models
-        we assume UTC if the timezone is missing.
+    def _fix_timezone(self, value: datetime | None) -> datetime:
+        """Sqlite does not store timezones - and since we can't update the existing models
+        we assume UTC if the timezone is missing. Returns current UTC time if value is None.
         """
+        if value is None:
+            return utc_now()
         if not value.tzinfo:
             value = value.replace(tzinfo=UTC)
         return value

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -574,6 +574,9 @@ class SQLAppConversationInfoService(AppConversationInfoService):
         we assume UTC if the timezone is missing. Returns current UTC time if value is None.
         """
         if value is None:
+            # Fallback for legacy data: use current time to match model defaults.
+            # The DB columns have default=utc_now, so None only occurs in legacy records.
+            # Using utc_now() keeps the API model non-nullable and matches new record behavior.
             return utc_now()
         if not value.tzinfo:
             value = value.replace(tzinfo=UTC)

--- a/tests/unit/app_server/test_sql_app_conversation_info_service.py
+++ b/tests/unit/app_server/test_sql_app_conversation_info_service.py
@@ -1241,3 +1241,32 @@ class TestSandboxIdFilter:
             sandbox_id__eq='sandbox_time_test', created_at__gte=cutoff
         )
         assert count == 2
+
+
+class TestFixTimezone:
+    """Test suite for the _fix_timezone helper method."""
+
+    def test_fix_timezone_with_none(self, service: SQLAppConversationInfoService):
+        """Test that None values return current UTC time."""
+        from openhands.agent_server.utils import utc_now
+
+        result = service._fix_timezone(None)
+        assert result.tzinfo == timezone.utc
+        # Verify it's close to current time (within 1 second)
+        assert abs((utc_now() - result).total_seconds()) < 1
+
+    def test_fix_timezone_with_naive_datetime(
+        self, service: SQLAppConversationInfoService
+    ):
+        """Test that naive datetime gets UTC timezone added."""
+        naive_dt = datetime(2024, 1, 1, 12, 0, 0)
+        result = service._fix_timezone(naive_dt)
+        assert result == datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_fix_timezone_with_aware_datetime(
+        self, service: SQLAppConversationInfoService
+    ):
+        """Test that aware datetime is returned unchanged."""
+        aware_dt = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        result = service._fix_timezone(aware_dt)
+        assert result == aware_dt


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Preparation for enabling SQLAlchemy type checking in enterprise mypy configuration. When `sqlalchemy>=2.0` is added to mypy's additional dependencies, type errors occur because `_fix_timezone` accepts `datetime` but is called with `datetime | None` values.

The stored models define `created_at` and `last_updated_at` as `Mapped[datetime | None]`, but `_fix_timezone` expected non-nullable datetime values.

## Summary

- Update `_fix_timezone` in `sql_app_conversation_info_service.py` to accept `datetime | None` parameter
- Update `_fix_timezone` in `sql_shared_conversation_info_service.py` with the same change
- Return current UTC time as a fallback when value is `None`
- Add `utc_now` import to `sql_shared_conversation_info_service.py`

## Issue Number

N/A - Part of SQLAlchemy type checking enablement effort

## How to Test

After adding `sqlalchemy>=2.0` to the enterprise mypy config's additional dependencies:

```bash
cd enterprise
poetry run pre-commit run --all-files --config ./dev_config/python/.pre-commit-config.yaml
```

The 4 `datetime | None` vs `datetime` type errors related to `_fix_timezone` should be resolved.

## Video/Screenshots

N/A - Type annotation changes only

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR is part of a series to enable full SQLAlchemy type checking. The dev config change that enables SQLAlchemy type stubs will be merged in a separate PR after all type fixes are in place.

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-aba35a1   docker.openhands.dev/openhands/openhands:aba35a1
```