### PR TITLE
fix: correct SQLAlchemy type annotations in DbSessionInjector

### DIFF
--- a/frontend/__tests__/routes/llm-settings.test.tsx
+++ b/frontend/__tests__/routes/llm-settings.test.tsx
@@ -258,7 +258,7 @@ describe("LlmSettingsScreen", () => {
   it("keeps Advanced visible but hides All in SaaS mode for the default LLM route schema", async () => {
     vi.spyOn(
       organizationService,
-      "getOrganizationAgentSettings",
+      "getOrganizationSettings",
     ).mockResolvedValue(
       buildSettings({
         agent_settings: {

--- a/openhands/app_server/services/db_session_injector.py
+++ b/openhands/app_server/services/db_session_injector.py
@@ -24,7 +24,7 @@ DB_SESSION_ATTR = 'db_session'
 DB_SESSION_KEEP_OPEN_ATTR = 'db_session_keep_open'
 
 
-class DbSessionInjector(BaseModel, Injector[async_sessionmaker]):
+class DbSessionInjector(BaseModel, Injector[AsyncSession]):
     persistence_dir: Path
     host: str | None = None
     port: int | None = None
@@ -166,6 +166,7 @@ class DbSessionInjector(BaseModel, Injector[async_sessionmaker]):
         if self.gcp_db_instance:  # GCP environments
             async_engine = await self._create_async_gcp_engine()
         else:
+            url: str | URL
             if self.host:
                 try:
                     import asyncpg  # noqa: F401
@@ -199,6 +200,7 @@ class DbSessionInjector(BaseModel, Injector[async_sessionmaker]):
                     poolclass=NullPool,
                     pool_pre_ping=True,
                 )
+        assert async_engine is not None  # Always assigned in either branch above
         self._async_engine = async_engine
         return async_engine
 
@@ -209,6 +211,7 @@ class DbSessionInjector(BaseModel, Injector[async_sessionmaker]):
         if self.gcp_db_instance:  # GCP environments
             engine = self._create_gcp_engine()
         else:
+            url: str | URL
             if self.host:
                 try:
                     import pg8000  # noqa: F401
@@ -234,6 +237,7 @@ class DbSessionInjector(BaseModel, Injector[async_sessionmaker]):
                 pool_recycle=self.pool_recycle,
                 pool_pre_ping=True,
             )
+        assert engine is not None  # Always assigned in either branch above
         self._engine = engine
         return engine
 


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

1. **SQLAlchemy Type Fixes**: Preparation for enabling SQLAlchemy type checking in enterprise mypy configuration. When `sqlalchemy>=2.0` is added to mypy's additional dependencies, several type errors are detected in `DbSessionInjector`.

2. **Frontend Lint Fix**: A typo in `llm-settings.test.tsx` was introduced on main that causes the frontend lint CI to fail. This is currently blocking CI for this PR and other PRs targeting main.

## Summary

### Backend Changes (SQLAlchemy types)
- Change `Injector` type parameter from `async_sessionmaker` to `AsyncSession` to match what `inject()` actually yields
- Add explicit `str | URL` type annotation for `url` variables to handle both PostgreSQL (URL object) and SQLite (string) connection strings  
- Add assertions after engine creation to help mypy understand that engine variables are always assigned

### Frontend Changes (Lint fix)
- Fix typo in `llm-settings.test.tsx`: `getOrganizationAgentSettings` → `getOrganizationSettings`
- This was a pre-existing bug on main that was blocking frontend lint CI

## Issue Number

N/A - Part of SQLAlchemy type checking enablement effort + CI fix

## How to Test

### Backend
After adding `sqlalchemy>=2.0` to the enterprise mypy config's additional dependencies:

```bash
cd enterprise
poetry run pre-commit run --all-files --config ./dev_config/python/.pre-commit-config.yaml
```

The following 6 type errors should be resolved:
- `db_session_injector.py:186` - `str` vs `URL` type mismatch
- `db_session_injector.py:203` - `AsyncEngine | None` vs `AsyncEngine` return type
- `db_session_injector.py:229` - `str` vs `URL` type mismatch
- `db_session_injector.py:238` - `Engine | None` vs `Engine` return type
- `db_session_injector.py:275` - `inject` override incompatibility
- `config.py:481` - Return type mismatch (fixed by changing type parameter)

### Frontend
```bash
cd frontend
npm run typecheck
```

Should pass without errors.

## Video/Screenshots

N/A - Type annotation and test fixes only

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR is part of a series to enable full SQLAlchemy type checking. The dev config change that enables SQLAlchemy type stubs will be merged in a separate PR after all type fixes are in place.

The change from `Injector[async_sessionmaker]` to `Injector[AsyncSession]` is a type-only change that better reflects what the `inject()` method actually yields. The runtime behavior is unchanged.

The frontend fix corrects a typo that was introduced on main and is blocking CI for multiple PRs.

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-71ebed6   docker.openhands.dev/openhands/openhands:71ebed6
```