### PR TITLE
fix: correct SQLAlchemy Result and Table type annotations

### DIFF
--- a/enterprise/storage/gitlab_webhook_store.py
+++ b/enterprise/storage/gitlab_webhook_store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from integrations.types import GitLabResourceType
-from sqlalchemy import and_, asc, select, text, update
+from sqlalchemy import and_, asc, delete, select, text, update
 from sqlalchemy.dialects.postgresql import insert
 from storage.database import a_session_maker
 from storage.gitlab_webhook import GitlabWebhook
@@ -123,11 +123,11 @@ class GitlabWebhookStore:
             async with session.begin():
                 # Create query based on the identifier provided
                 if resource_type == GitLabResourceType.PROJECT:
-                    query = GitlabWebhook.__table__.delete().where(
+                    query = delete(GitlabWebhook).where(
                         GitlabWebhook.project_id == resource_id
                     )
                 else:  # has_group_id must be True based on validation
-                    query = GitlabWebhook.__table__.delete().where(
+                    query = delete(GitlabWebhook).where(
                         GitlabWebhook.group_id == resource_id
                     )
 

--- a/frontend/__tests__/routes/llm-settings.test.tsx
+++ b/frontend/__tests__/routes/llm-settings.test.tsx
@@ -258,7 +258,7 @@ describe("LlmSettingsScreen", () => {
   it("keeps Advanced visible but hides All in SaaS mode for the default LLM route schema", async () => {
     vi.spyOn(
       organizationService,
-      "getOrganizationAgentSettings",
+      "getOrganizationSettings",
     ).mockResolvedValue(
       buildSettings({
         agent_settings: {

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -21,7 +21,7 @@ import logging
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import AsyncGenerator
+from typing import AsyncGenerator, cast
 from uuid import UUID
 
 from fastapi import Request
@@ -33,6 +33,7 @@ from sqlalchemy import (
     func,
     select,
 )
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -599,7 +600,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
         )
 
         # Execute the secure delete query
-        result = await self.db_session.execute(delete_query)
+        result = cast(CursorResult, await self.db_session.execute(delete_query))
 
         return result.rowcount > 0
 

--- a/openhands/app_server/app_conversation/sql_app_conversation_start_task_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_start_task_service.py
@@ -19,11 +19,12 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import AsyncGenerator
+from typing import AsyncGenerator, cast
 from uuid import UUID
 
 from fastapi import Request
 from sqlalchemy import Enum, String, func, select
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -264,7 +265,7 @@ class SQLAppConversationStartTaskService(AppConversationStartTaskService):
                 StoredAppConversationStartTask.created_by_user_id == self.user_id
             )
 
-        result = await self.session.execute(delete_query)
+        result = cast(CursorResult, await self.session.execute(delete_query))
 
         # Return True if any rows were affected
         return result.rowcount > 0


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

1. **SQLAlchemy Type Fixes**: Preparation for enabling SQLAlchemy type checking in enterprise mypy configuration. When `sqlalchemy>=2.0` is added to mypy's additional dependencies, several type errors are detected related to `Result.rowcount` and `Table.delete()`.

2. **Frontend Lint Fix**: A typo in `llm-settings.test.tsx` was introduced on main that causes the frontend lint CI to fail. This is currently blocking CI for this PR and other PRs targeting main.

## Summary

### Backend Changes (SQLAlchemy types)

#### Fix 1: CursorResult cast for DML operations
- `session.execute()` returns `Result[Any]` according to mypy, but DML statements (DELETE, INSERT, UPDATE) actually return `CursorResult` which has the `rowcount` attribute
- Use `cast(CursorResult, ...)` to properly type the result and access `rowcount`

#### Fix 2: Use delete() function instead of Table.__table__.delete()
- `GitlabWebhook.__table__` returns `FromClause` which doesn't have a `delete()` method according to SQLAlchemy 2.0 type stubs
- Use the `delete(GitlabWebhook).where()` pattern which is properly typed

### Frontend Changes (Lint fix)
- Fix typo in `llm-settings.test.tsx`: `getOrganizationAgentSettings` → `getOrganizationSettings`
- This was a pre-existing bug on main that was blocking frontend lint CI

## Files Changed

- `openhands/app_server/app_conversation/sql_app_conversation_start_task_service.py` - Add CursorResult cast
- `openhands/app_server/app_conversation/sql_app_conversation_info_service.py` - Add CursorResult cast  
- `enterprise/storage/gitlab_webhook_store.py` - Use delete() function
- `frontend/__tests__/routes/llm-settings.test.tsx` - Fix method name typo

## Issue Number

N/A - Part of SQLAlchemy type checking enablement effort + CI fix

## How to Test

### Backend
After adding `sqlalchemy>=2.0` to the enterprise mypy config's additional dependencies:

```bash
cd enterprise
poetry run pre-commit run --all-files --config ./dev_config/python/.pre-commit-config.yaml
```

The following 4 type errors should be resolved:
- `sql_app_conversation_start_task_service.py:270` - "Result[Any]" has no attribute "rowcount"
- `sql_app_conversation_info_service.py:604` - "Result[Any]" has no attribute "rowcount"
- `gitlab_webhook_store.py:126` - "FromClause" has no attribute "delete"
- `gitlab_webhook_store.py:130` - "FromClause" has no attribute "delete"

### Frontend
```bash
cd frontend
npm run typecheck
```

Should pass without errors.

## Video/Screenshots

N/A - Type annotation and test fixes only

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR is part of a series to enable full SQLAlchemy type checking. The dev config change that enables SQLAlchemy type stubs will be merged in a separate PR after all type fixes are in place.

The `cast()` approach is preferred over `# type: ignore` as it:
1. Is more explicit about the type conversion
2. Documents that we know the actual runtime type differs from the static type
3. Doesn't hide potential real type errors

The runtime behavior is unchanged - these are purely type annotation fixes.

The frontend fix corrects a typo that was introduced on main and is blocking CI for multiple PRs.

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-2c192a2   docker.openhands.dev/openhands/openhands:2c192a2
```