### PR TITLE
fix: handle nullable arguments in enterprise code

### DIFF
--- a/enterprise/integrations/github/data_collector.py
+++ b/enterprise/integrations/github/data_collector.py
@@ -429,6 +429,11 @@ class GitHubDataCollector:
         - Num openhands review comments
         """
         pr_number = openhands_pr.pr_number
+        if openhands_pr.installation_id is None:
+            logger.warning(
+                f'Skipping PR {openhands_pr.repo_name}#{pr_number}: missing installation_id'
+            )
+            return
         installation_id = int(openhands_pr.installation_id)
         repo_id = openhands_pr.repo_id
 

--- a/enterprise/integrations/stripe_service.py
+++ b/enterprise/integrations/stripe_service.py
@@ -59,11 +59,11 @@ async def find_or_create_customer_by_user_id(user_id: str) -> dict | None:
         extra={'user_id': user_id, 'org_id': str(org.id)},
     )
 
-    # Create the customer in stripe
-    customer = await stripe.Customer.create_async(
-        email=org.contact_email or '',
-        metadata={'org_id': str(org.id)},
-    )
+    # Create the customer in stripe (only include email if available)
+    create_params: dict = {'metadata': {'org_id': str(org.id)}}
+    if org.contact_email:
+        create_params['email'] = org.contact_email
+    customer = await stripe.Customer.create_async(**create_params)
 
     # Save the stripe customer in the local db
     async with a_session_maker() as session:
@@ -108,11 +108,14 @@ async def migrate_customer(session, user_id: str, org: Org):
     if stripe_customer is None:
         return
     stripe_customer.org_id = org.id
-    customer = await stripe.Customer.modify_async(
-        id=stripe_customer.stripe_customer_id,
-        email=org.contact_email or '',
-        metadata={'user_id': '', 'org_id': str(org.id)},
-    )
+    # Only include email if available to avoid sending empty strings to Stripe
+    modify_params: dict = {
+        'id': stripe_customer.stripe_customer_id,
+        'metadata': {'user_id': '', 'org_id': str(org.id)},
+    }
+    if org.contact_email:
+        modify_params['email'] = org.contact_email
+    customer = await stripe.Customer.modify_async(**modify_params)
 
     logger.info(
         'migrated_customer',

--- a/enterprise/integrations/stripe_service.py
+++ b/enterprise/integrations/stripe_service.py
@@ -61,7 +61,7 @@ async def find_or_create_customer_by_user_id(user_id: str) -> dict | None:
 
     # Create the customer in stripe
     customer = await stripe.Customer.create_async(
-        email=org.contact_email,
+        email=org.contact_email or '',
         metadata={'org_id': str(org.id)},
     )
 
@@ -110,7 +110,7 @@ async def migrate_customer(session, user_id: str, org: Org):
     stripe_customer.org_id = org.id
     customer = await stripe.Customer.modify_async(
         id=stripe_customer.stripe_customer_id,
-        email=org.contact_email,
+        email=org.contact_email or '',
         metadata={'user_id': '', 'org_id': str(org.id)},
     )
 

--- a/enterprise/server/routes/oauth_device.py
+++ b/enterprise/server/routes/oauth_device.py
@@ -180,6 +180,18 @@ async def device_token(device_code: str = Form(...)):
             )
 
         if device_code_entry.status == 'authorized':
+            # Verify user_id is set (should always be true for authorized status)
+            if not device_code_entry.keycloak_user_id:
+                logger.error(
+                    'Authorized device code missing user_id',
+                    extra={'user_code': device_code_entry.user_code},
+                )
+                return _oauth_error(
+                    status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    'server_error',
+                    'User identification missing',
+                )
+
             # Retrieve the specific API key for this device using the user_code
             api_key_store = ApiKeyStore.get_instance()
             device_key_name = f'{API_KEY_NAME} ({device_code_entry.user_code})'

--- a/enterprise/storage/saas_conversation_store.py
+++ b/enterprise/storage/saas_conversation_store.py
@@ -4,10 +4,13 @@ import dataclasses
 import logging
 from dataclasses import dataclass
 from datetime import UTC
+from typing import TYPE_CHECKING, Callable, ContextManager
 from uuid import UUID
 
-from sqlalchemy.orm import sessionmaker
 from storage.database import session_maker
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 from storage.stored_conversation_metadata import StoredConversationMetadata
 from storage.stored_conversation_metadata_saas import StoredConversationMetadataSaas
 from storage.user_store import UserStore
@@ -31,14 +34,14 @@ logger = logging.getLogger(__name__)
 @dataclass
 class SaasConversationStore(ConversationStore):
     user_id: str
-    session_maker: sessionmaker
+    session_maker: Callable[..., ContextManager[Session]]
     org_id: UUID | None = None  # will be fetched automatically
 
     def __init__(
         self,
         user_id: str,
-        org_id: UUID,
-        session_maker: sessionmaker,
+        org_id: UUID | None,
+        session_maker: Callable[..., ContextManager[Session]],
         resolver_org_id: UUID | None = None,
     ):
         self.user_id = user_id

--- a/enterprise/storage/saas_conversation_store.py
+++ b/enterprise/storage/saas_conversation_store.py
@@ -34,14 +34,14 @@ logger = logging.getLogger(__name__)
 @dataclass
 class SaasConversationStore(ConversationStore):
     user_id: str
-    session_maker: Callable[..., ContextManager[Session]]
+    session_maker: Callable[[], ContextManager[Session]]
     org_id: UUID | None = None  # will be fetched automatically
 
     def __init__(
         self,
         user_id: str,
         org_id: UUID | None,
-        session_maker: Callable[..., ContextManager[Session]],
+        session_maker: Callable[[], ContextManager[Session]],
         resolver_org_id: UUID | None = None,
     ):
         self.user_id = user_id


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Preparation for enabling SQLAlchemy type checking in enterprise mypy configuration. When `sqlalchemy>=2.0` is added to mypy's additional dependencies, several type errors are detected where nullable values are passed to functions expecting non-null arguments.

## Summary

### 1. stripe_service.py - Empty string fallback for nullable email
- `org.contact_email` is `str | None` but Stripe's `create_async`/`modify_async` expect `str`
- Use `org.contact_email or ''` as fallback since Stripe allows empty string for email

### 2. saas_conversation_store.py - Fix type annotations
- Update `org_id` parameter to accept `UUID | None` (matches the dataclass field)
- Change `session_maker` type from `sessionmaker` to `Callable[..., ContextManager[Session]]`
  - The actual `session_maker` from `database.py` is a wrapper function, not a `sessionmaker` instance
  - This accurately reflects how it's used: `with self.session_maker() as session`

### 3. oauth_device.py - Guard for nullable user_id
- `device_code_entry.keycloak_user_id` is `str | None` but `retrieve_api_key_by_name` expects `str`
- Add guard to verify user_id is set before proceeding (returns error if missing)

### 4. data_collector.py - Guard for nullable installation_id
- `openhands_pr.installation_id` is `str | None` but `int()` expects non-None
- Add guard to skip PRs with missing installation_id with a warning log

## Files Changed

- `enterprise/integrations/stripe_service.py` - Use empty string fallback for nullable email
- `enterprise/storage/saas_conversation_store.py` - Fix org_id and session_maker types
- `enterprise/server/routes/oauth_device.py` - Add guard for nullable user_id
- `enterprise/integrations/github/data_collector.py` - Add guard for nullable installation_id

## Issue Number

N/A - Part of SQLAlchemy type checking enablement effort

## How to Test

After adding `sqlalchemy>=2.0` to the enterprise mypy config's additional dependencies:

```bash
cd enterprise
poetry run pre-commit run --all-files --config ./dev_config/python/.pre-commit-config.yaml
```

The following type errors should be resolved:
- `stripe_service.py:64` - Argument "email" has incompatible type "str | None"; expected "str"
- `stripe_service.py:113` - Argument "email" has incompatible type "str | None"; expected "str"
- `saas_conversation_store.py:256` - Argument 2 has incompatible type "UUID | None"; expected "UUID"
- `saas_conversation_store.py:256` - Argument 3 has incompatible type "Callable"; expected "sessionmaker"
- `saas_conversation_store.py:272` - Argument 2 has incompatible type "UUID | None"; expected "UUID"
- `saas_conversation_store.py:272` - Argument 3 has incompatible type "Callable"; expected "sessionmaker"
- `oauth_device.py:187` - Argument 1 has incompatible type "str | None"; expected "str"
- `data_collector.py:432` - Argument 1 to "int" has incompatible type "str | None"

## Video/Screenshots

N/A - Type annotation and guard fixes only

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR is part of a series to enable full SQLAlchemy type checking. The dev config change that enables SQLAlchemy type stubs will be merged in a separate PR after all type fixes are in place.

The guards added in oauth_device.py and data_collector.py improve runtime safety in addition to fixing type errors - they handle edge cases that could previously have caused runtime exceptions.

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-900ad46   docker.openhands.dev/openhands/openhands:900ad46
```