### PR TITLE
fix: add return type annotation for ConversationMetadata conversion (SQLAlchemy typing PR7)

### DIFF
--- a/enterprise/storage/saas_conversation_store.py
+++ b/enterprise/storage/saas_conversation_store.py
@@ -68,7 +68,9 @@ class SaasConversationStore(ConversationStore):
 
         return query
 
-    def _to_external_model(self, conversation_metadata: StoredConversationMetadata):
+    def _to_external_model(
+        self, conversation_metadata: StoredConversationMetadata
+    ) -> ConversationMetadata:
         kwargs = {
             c.name: getattr(conversation_metadata, c.name)
             for c in StoredConversationMetadata.__table__.columns
@@ -219,7 +221,7 @@ class SaasConversationStore(ConversationStore):
 
         def _search():
             with self.session_maker() as session:
-                conversations = (
+                stored_conversations = (
                     session.query(StoredConversationMetadata)
                     .join(
                         StoredConversationMetadataSaas,
@@ -236,13 +238,16 @@ class SaasConversationStore(ConversationStore):
                     .limit(limit + 1)
                     .all()
                 )
-                conversations = [self._to_external_model(c) for c in conversations]
+                conversations = [
+                    self._to_external_model(c) for c in stored_conversations
+                ]
                 current_page_size = len(conversations)
                 next_page_id = offset_to_page_id(
                     offset + limit, current_page_size > limit
                 )
-                conversations = conversations[:limit]
-                return ConversationMetadataResultSet(conversations, next_page_id)
+                return ConversationMetadataResultSet(
+                    conversations[:limit], next_page_id
+                )
 
         return await call_sync_from_async(_search)
 


### PR DESCRIPTION
## Description
This PR fixes the final type error found when adding `sqlalchemy>=2.0` to mypy's type checking dependencies. This completes the SQLAlchemy type checking migration.

## Changes

### saas_conversation_store.py

**Error:** `Argument 1 to "ConversationMetadataResultSet" has incompatible type "list[StoredConversationMetadata]"; expected "list[ConversationMetadata]"`

**Root Cause:** The `_to_external_model()` method was missing a return type annotation, so mypy couldn't infer that it converts `StoredConversationMetadata` to `ConversationMetadata`. Additionally, the variable `conversations` was reused for both types, causing type confusion.

**Fix:**
1. Added return type annotation `-> ConversationMetadata` to `_to_external_model()`
2. Renamed the query result variable from `conversations` to `stored_conversations` to distinguish the ORM model list from the converted Pydantic model list

## Testing
This change doesn't affect runtime behavior - it only improves type safety:
- The `_to_external_model()` method already returned `ConversationMetadata`
- The variable rename is a pure refactoring with no logic changes

To verify: Add `sqlalchemy>=2.0` to mypy dependencies in `enterprise/dev_config/python/.pre-commit-config.yaml` and run `make lint`.

## Related PRs
This is the final PR in a series fixing SQLAlchemy type errors:
- PR1: #14072 - Filter expression types
- PR2: #14073 - Nullable datetime handling
- PR3: #14075 - DbSessionInjector types
- PR4: #14076 - Result and Table types (merged)
- PR5: #14078 - Nullable argument types (merged)
- PR6: #14079 - Return types and unreachable code (merged)
- **PR7: This PR** - ConversationMetadata conversion type

After this PR is merged, the dev config PR (fix-missing-sqlalchemy-type-stub) can be merged to enable SQLAlchemy type checking.

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-b0006b8   docker.openhands.dev/openhands/openhands:b0006b8
```