### PR TITLE
fix(integrations): guard Bitbucket _parse_repository against null nested fields

### DIFF
--- a/openhands/app_server/integrations/bitbucket/service/base.py
+++ b/openhands/app_server/integrations/bitbucket/service/base.py
@@ -211,7 +211,18 @@ class BitBucketMixinBase(BaseGitService, HTTPClient):
         """
         repo_id = repo.get('uuid', '')
 
-        workspace_slug = repo.get('workspace', {}).get('slug', '')
+        # Bitbucket's repository endpoint can return `"workspace": null` or
+        # `"mainbranch": null` for empty / uninitialized repos (the downstream
+        # checks in `_get_cursorrules_url` and `_get_microagents_directory_url`
+        # already handle `main_branch is None` by raising ResourceNotFoundError,
+        # so callers expect None here rather than an AttributeError crash).
+        # The `or {}` idiom mirrors the defensive pattern used by the sibling
+        # `get_user` avatar extraction in this file and by every other
+        # provider's repository parser.
+        workspace = repo.get('workspace') or {}
+        workspace_slug = (
+            workspace.get('slug', '') if isinstance(workspace, dict) else ''
+        )
         repo_slug = repo.get('slug', '')
         full_name = (
             f'{workspace_slug}/{repo_slug}' if workspace_slug and repo_slug else ''
@@ -219,7 +230,8 @@ class BitBucketMixinBase(BaseGitService, HTTPClient):
 
         is_public = not repo.get('is_private', True)
         owner_type = OwnerType.ORGANIZATION
-        main_branch = repo.get('mainbranch', {}).get('name')
+        mainbranch = repo.get('mainbranch') or {}
+        main_branch = mainbranch.get('name') if isinstance(mainbranch, dict) else None
 
         return Repository(
             id=repo_id,

--- a/tests/unit/integrations/bitbucket/test_bitbucket_repos.py
+++ b/tests/unit/integrations/bitbucket/test_bitbucket_repos.py
@@ -136,3 +136,84 @@ async def test_search_repositories_url_parsing_insufficient_path_segments(
         # Should return empty list for insufficient path segments and not call API
         assert len(repositories) == 0
         mock_get_repo.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    'raw_repo, expected_full_name, expected_main_branch',
+    [
+        pytest.param(
+            {
+                'uuid': '{abc}',
+                'slug': 'empty-repo',
+                'workspace': None,
+                'mainbranch': None,
+                'is_private': True,
+            },
+            '',
+            None,
+            id='workspace_and_mainbranch_both_null',
+        ),
+        pytest.param(
+            {
+                'uuid': '{abc}',
+                'slug': 'empty-repo',
+                'workspace': {'slug': 'ws'},
+                'mainbranch': None,
+                'is_private': True,
+            },
+            'ws/empty-repo',
+            None,
+            id='mainbranch_null_only',
+        ),
+        pytest.param(
+            {
+                'uuid': '{abc}',
+                'slug': 'repo',
+                'workspace': None,
+                'mainbranch': {'name': 'main'},
+                'is_private': True,
+            },
+            '',
+            'main',
+            id='workspace_null_only',
+        ),
+        pytest.param(
+            {
+                'uuid': '{abc}',
+                'slug': 'repo',
+                'workspace': {'slug': 'ws'},
+                'mainbranch': {'name': 'main'},
+                'is_private': False,
+            },
+            'ws/repo',
+            'main',
+            id='happy_path',
+        ),
+        pytest.param(
+            {
+                'uuid': '{abc}',
+                'slug': 'repo',
+                'workspace': [],
+                'mainbranch': 'not-a-dict',
+                'is_private': True,
+            },
+            '',
+            None,
+            id='workspace_and_mainbranch_non_dict_types',
+        ),
+    ],
+)
+def test_parse_repository_handles_null_nested_fields(
+    bitbucket_service, raw_repo, expected_full_name, expected_main_branch
+):
+    """_parse_repository must not crash when Bitbucket returns null (or a
+    non-dict) for `workspace` / `mainbranch`; downstream callers
+    (`_get_cursorrules_url`, `_get_microagents_directory_url`) already expect
+    `main_branch is None` on empty repos and raise `ResourceNotFoundError`
+    themselves, so this extraction should degrade gracefully rather than
+    crashing with AttributeError."""
+    repository = bitbucket_service._parse_repository(raw_repo)
+
+    assert repository.full_name == expected_full_name
+    assert repository.main_branch == expected_main_branch
+    assert repository.id == '{abc}'


### PR DESCRIPTION
```
## Summary

- `BitBucketMixinBase._parse_repository` read `workspace.slug` and `mainbranch.name` with `repo.get(key, {}).get(...)`; the `{}` default only triggers when the key is missing, so any Bitbucket `/repositories/<slug>` response with `"workspace": null` or `"mainbranch": null` (empty / uninitialized repos) crashes with `AttributeError: 'NoneType' object has no attribute 'get'`
- The downstream callers `_get_cursorrules_url` (line 244) and `_get_microagents_directory_url` (line 257) already expect `main_branch is None` for empty repos and raise `ResourceNotFoundError("Main branch not found for repository ... This repository may be empty or have no default branch configured.")` in that case, so the intent is clearly that extraction should degrade gracefully rather than crash
- Extract `workspace` / `mainbranch` with `or {}` and `isinstance` guards so a `None` or non-dict value at any level resolves to the empty-string / `None` defaults the callers already handle; mirrors the defensive pattern this file's own `get_user` uses for avatar extraction and every other provider's repository parser
- Add a parametrised `test_parse_repository_handles_null_nested_fields` in `tests/unit/integrations/bitbucket/test_bitbucket_repos.py` pinning five shapes: both-null, mainbranch-null only, workspace-null only, happy path, and non-dict values (list / string) at either level

## Related Issues

N/A — code review. The function was introduced in `21f3ef540` (2025-08-31, *"refactor: Apply GitHub mixins pattern to BitBucket service"*, PR #10728) and the anti-pattern has been untouched since. No upstream PR addresses this path (verified via `search/issues?q=mainbranch+bitbucket+is:pr` → 0 hits).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added — parametrised `test_parse_repository_handles_null_nested_fields` with 5 shapes in `tests/unit/integrations/bitbucket/test_bitbucket_repos.py`
- [x] Manually verified fix logic against 7 input shapes (5 null / non-dict, 1 happy, 1 with all-None leaf values, 1 with both nested keys absent) — all produce expected `full_name` / `main_branch` without raising
- [x] `ruff check --config dev_config/python/ruff.toml` — passed
- [x] `ruff format --config dev_config/python/ruff.toml --check` — passed
- [x] `pre-commit run --config dev_config/python/.pre-commit-config.yaml --files ...` — all 9 hooks pass locally (trim whitespace / end-of-files / debug statements / AppMode.OSS / ruff / ruff-format / mypy)

## Checklist

- [x] Code follows project style guidelines (matches the defensive pattern used by `get_user` in the same file and by every sibling repository parser)
- [x] Self-review completed
- [x] Changes are documented (if applicable)
```