### PR TITLE
fix: don't persist Gemini model-specific endpoint as base_url

### DIFF
--- a/openhands/app_server/utils/llm.py
+++ b/openhands/app_server/utils/llm.py
@@ -179,6 +179,13 @@ def get_provider_api_base(model: str) -> str | None:
     try:
         api_base = litellm.get_api_base(model, {})
         if api_base:
+            # For gemini/<model>, litellm returns the fully-resolved request URL
+            # (e.g. ``.../v1beta/models/gemini-xxx:generateContent``) instead of a
+            # reusable base. Persisting that as ``base_url`` makes the subsequent
+            # request append the model path a second time and 404. Treat it as no
+            # base_url so litellm falls back to its own default. See issue #14028.
+            if api_base.endswith((':generateContent', ':streamGenerateContent')):
+                return None
             return api_base
     except Exception:
         pass

--- a/tests/unit/utils/test_llm_utils.py
+++ b/tests/unit/utils/test_llm_utils.py
@@ -145,11 +145,18 @@ class TestGetProviderApiBase:
             == 'https://api.anthropic.com'
         )
 
-    def test_gemini_model_returns_google_api_base(self):
-        """Test that Gemini models return a Google API base URL."""
-        api_base = get_provider_api_base('gemini/gemini-pro')
-        assert api_base is not None
-        assert 'generativelanguage.googleapis.com' in api_base
+    def test_gemini_model_returns_none_not_model_specific_endpoint(self):
+        """Regression for #14028.
+
+        ``litellm.get_api_base`` returns the fully-resolved request URL for
+        ``gemini/<model>`` (e.g. ``.../models/gemini-pro:generateContent``),
+        not a reusable base. Persisting that as ``base_url`` caused the
+        subsequent request to append the model path a second time and 404.
+        We now treat it as no base_url and let litellm fall back to its own
+        default.
+        """
+        assert get_provider_api_base('gemini/gemini-pro') is None
+        assert get_provider_api_base('gemini/gemini-2.5-pro') is None
 
     def test_mistral_model_returns_mistral_api_base(self):
         """Test that Mistral models return the Mistral API base URL."""


### PR DESCRIPTION
Fixes #14028.

## Problem

Selecting any `gemini/` model → every message fails with `litellm.NotFoundError: GeminiException` / HTTP 404 against a URL that has the model path appended twice:

```
.../models/gemini-pro:generateContent/models/gemini-pro:generateContent
```

## Root cause

`litellm.get_api_base()` does not return a uniform shape across providers. For most (OpenAI → `https://api.openai.com`, Mistral → `https://api.mistral.ai/v1`) it returns a proper base URL. For `gemini/<model>` it returns the **fully-resolved request URL**:

```
https://generativelanguage.googleapis.com/v1beta/models/gemini-xxx:generateContent
```

`get_provider_api_base()` was trusting this uniformly and handing the result back as a `base_url`. `resolve_llm_base_url()` persisted it, litellm then appended `/models/{name}:generateContent` a second time at request time → 404.

## Fix

When the URL litellm gives us already ends in `:generateContent` or `:streamGenerateContent`, it isn't a base URL — return `None` and let litellm use its own default (which is what works today when `base_url` is unset). All other providers keep their existing behavior.

## Tests

The previous `test_gemini_model_returns_google_api_base` only asserted that the buggy full URL was returned, which is exactly what kept this bug invisible. Replaced it with an explicit regression test (`test_gemini_model_returns_none_not_model_specific_endpoint`) that pins the corrected behavior.

Full suite:

```
$ pytest tests/unit/utils/test_llm_utils.py -v
... 13 passed
```

## Scope

Intentionally minimal — only touches the Gemini code path in `get_provider_api_base`. No behavior change for OpenAI / Mistral / Anthropic / other providers, and no change to how users who explicitly set a `base_url` are handled (that still short-circuits at the top of `resolve_llm_base_url`).