### PR TITLE
fix(app): deliver pending messages queued during startup

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1366,23 +1366,28 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             agent_server_url: URL of the agent server
             session_api_key: API key for authenticating with agent server
         """
-        # Convert UUIDs to strings for the pending message service
-        # The frontend uses task-{uuid.hex} format (no hyphens), matching OpenHandsUUID serialization
-        task_id_str = f'task-{task_id.hex}'
+        # Support both task id encodings seen in clients:
+        # - task-{uuid.hex}
+        # - task-{uuid-with-hyphens}
+        task_id_candidates = [f'task-{task_id.hex}', f'task-{task_id}']
         # conversation_id uses standard format (with hyphens) for agent server API compatibility
         conversation_id_str = str(conversation_id)
 
-        _logger.info(f'task_id={task_id_str} conversation_id={conversation_id_str}')
-
-        # First, update any messages that were queued with the task_id
-        updated_count = await self.pending_message_service.update_conversation_id(
-            old_conversation_id=task_id_str,
-            new_conversation_id=conversation_id_str,
+        _logger.info(
+            f'task_ids={task_id_candidates} conversation_id={conversation_id_str}'
         )
-        _logger.info(f'updated_count={updated_count} ')
+
+        # First, update any messages that were queued with the task id used by the client.
+        updated_count = 0
+        for task_id_str in task_id_candidates:
+            updated_count += await self.pending_message_service.update_conversation_id(
+                old_conversation_id=task_id_str,
+                new_conversation_id=conversation_id_str,
+            )
+
         if updated_count > 0:
             _logger.info(
-                f'Updated {updated_count} pending messages from task_id={task_id_str} '
+                f'Updated {updated_count} pending messages from task_ids={task_id_candidates} '
                 f'to conversation_id={conversation_id_str}'
             )
 

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -2484,6 +2484,50 @@ class TestPluginHandling:
         assert result.plugins[1].repo_path == 'plugins/logging'
         assert result.plugins[2].source == '/local/path/to/plugin'
 
+    @pytest.mark.asyncio
+    async def test_process_pending_messages_updates_hyphenated_task_id(self):
+        """Pending messages queued under task-{uuid} are delivered after READY."""
+        task_id = uuid4()
+        conversation_id = uuid4()
+
+        self.service.pending_message_service.update_conversation_id = AsyncMock(
+            side_effect=[0, 1]
+        )
+        pending_message = Mock()
+        pending_message.id = 'msg-1'
+        pending_message.role = 'user'
+        pending_message.content = [TextContent(text='run this once ready')]
+        self.service.pending_message_service.get_pending_messages = AsyncMock(
+            return_value=[pending_message]
+        )
+        self.service.pending_message_service.delete_messages_for_conversation = (
+            AsyncMock(return_value=1)
+        )
+        self.mock_httpx_client.post = AsyncMock(return_value=Mock())
+
+        await self.service._process_pending_messages(
+            task_id=task_id,
+            conversation_id=conversation_id,
+            agent_server_url='http://agent-server:8000',
+            session_api_key='session-key',
+        )
+
+        self.service.pending_message_service.update_conversation_id.assert_any_call(
+            old_conversation_id=f'task-{task_id.hex}',
+            new_conversation_id=str(conversation_id),
+        )
+        self.service.pending_message_service.update_conversation_id.assert_any_call(
+            old_conversation_id=f'task-{task_id}',
+            new_conversation_id=str(conversation_id),
+        )
+        self.service.pending_message_service.get_pending_messages.assert_awaited_once_with(
+            str(conversation_id)
+        )
+        self.mock_httpx_client.post.assert_awaited_once()
+        self.service.pending_message_service.delete_messages_for_conversation.assert_awaited_once_with(
+            str(conversation_id)
+        )
+
 
 class TestPluginSpecModel:
     """Test cases for the PluginSpec model."""

--- a/tests/unit/app_server/test_pending_message_service.py
+++ b/tests/unit/app_server/test_pending_message_service.py
@@ -286,6 +286,26 @@ class TestSQLPendingMessageService:
         assert updated_count == 0
 
     @pytest.mark.asyncio
+    async def test_update_conversation_id_accepts_hyphenated_task_id(
+        self,
+        service: SQLPendingMessageService,
+        sample_content: list[TextContent],
+    ):
+        """Pending messages can be stored under task-{uuid-with-hyphens}."""
+        old_conversation_id = f'task-{uuid4()}'
+        new_conversation_id = str(uuid4())
+
+        await service.add_message(old_conversation_id, sample_content)
+
+        updated_count = await service.update_conversation_id(
+            old_conversation_id, new_conversation_id
+        )
+
+        assert updated_count == 1
+        assert await service.count_pending_messages(old_conversation_id) == 0
+        assert await service.count_pending_messages(new_conversation_id) == 1
+
+    @pytest.mark.asyncio
     async def test_messages_are_isolated_between_conversations(
         self,
         service: SQLPendingMessageService,


### PR DESCRIPTION
## Summary
- accept both task id encodings when migrating queued pending messages to the real conversation id
- add regression coverage for hyphenated task ids in pending message storage and delivery

## Testing
- uv run pytest tests/unit/app_server/test_pending_message_service.py tests/unit/app_server/test_live_status_app_conversation_service.py -q -k "pending_message or process_pending_messages_updates_hyphenated_task_id"
- uv run pytest tests/unit/app_server/test_pending_message_service.py tests/unit/app_server/test_pending_message_router.py tests/unit/app_server/test_live_status_app_conversation_service.py -q

Fixes #13716