### PR TITLE
fix(frontend): allow send when only attachments are present

### DIFF
--- a/frontend/src/hooks/chat/use-chat-submission.ts
+++ b/frontend/src/hooks/chat/use-chat-submission.ts
@@ -3,6 +3,7 @@ import {
   clearTextContent,
   clearFileInput,
 } from "#/components/features/chat/utils/chat-input.utils";
+import { useConversationStore } from "#/stores/conversation-store";
 
 /**
  * Hook for handling chat message submission
@@ -19,7 +20,10 @@ export const useChatSubmission = (
     const message = chatInputRef.current?.innerText || "";
     const trimmedMessage = message.trim();
 
-    if (!trimmedMessage) {
+    // Attachment-only submissions are valid; only bail out when there
+    // is nothing at all to send.
+    const { images, files } = useConversationStore.getState();
+    if (!trimmedMessage && images.length === 0 && files.length === 0) {
       return;
     }
 


### PR DESCRIPTION
Fixes #14047.

In a V1 conversation, attaching an image or file (drag-and-drop, paste, or paperclip) but leaving the text input empty made the send button — and Enter-key submission — silently do nothing: no toast, no error, the attachment just sat there.

Root cause: `handleSubmit` in `frontend/src/hooks/chat/use-chat-submission.ts` short-circuits on empty trimmed text without considering the attachments that `interactive-chat-box` parks in the conversation store and forwards to `onSubmit(message, images, files)`.

Fix: pull the pending `images`/`files` lists from `useConversationStore` and bail out only when **all three** (text, images, files) are empty. `interactive-chat-box` already passes the attachment arrays through and calls `clearAllFiles()` after submit, so no further plumbing is needed and the trimmed-text early-return still covers the truly empty case.

## To verify
- Attach only an image via paperclip → click send → message sends, attachment clears.
- Attach only a file via drag-and-drop → press Enter → sends.
- Empty text + no attachments → send button still does nothing.
- Text + attachment → unchanged behavior.

I couldn't easily spin up the V1 dev stack locally to run this end-to-end, so the steps above are the ones I'd appreciate a reviewer smoke-testing. The change is behind the same call path that's already used when both text and attachments are present, so regressions beyond that should be unlikely.