### PR TITLE
fix: register GitlabV1CallbackProcessor for deserialization

### DIFF
--- a/enterprise/saas_server.py
+++ b/enterprise/saas_server.py
@@ -106,7 +106,14 @@ if GITHUB_APP_CLIENT_ID:
 
 # Add GitLab integration router only if GITLAB_APP_CLIENT_ID is set
 if GITLAB_APP_CLIENT_ID:
+    # Make sure that the callback processor is loaded here so we don't get an error when deserializing
+    from integrations.gitlab.gitlab_v1_callback_processor import (  # noqa: E402
+        GitlabV1CallbackProcessor,
+    )
     from server.routes.integration.gitlab import gitlab_integration_router  # noqa: E402
+
+    # Bludgeon mypy into not deleting my import
+    logger.debug(f'Loaded {GitlabV1CallbackProcessor.__name__}')
 
     base_app.include_router(gitlab_integration_router)
 


### PR DESCRIPTION
## Summary

Import `GitlabV1CallbackProcessor` at app startup to ensure it's registered as a known subclass of `EventCallbackProcessor` before webhook events try to deserialize callbacks from the database.

This follows the same pattern already used for `GithubV1CallbackProcessor`.

## Problem

When using the V1 GitLab resolver (`ENABLE_V1_GITLAB_RESOLVER=true`), the callback is registered when a conversation starts, but fails to execute when webhook events are received:

```
ValidationError: Unknown kind 'GitlabV1CallbackProcessor' for EventCallbackProcessor;
Expected one of: ['SlackV1CallbackProcessor', 'LoggingCallbackProcessor', 'SetTitleCallbackProcessor']
```

## Solution

Import `GitlabV1CallbackProcessor` in `saas_server.py` when the GitLab integration is enabled, following the same pattern as `GithubV1CallbackProcessor`.

Fixes #14107

---
_This PR was created by an AI assistant (OpenHands) on behalf of @aivong-openhands._
