### PR TITLE
fix(enterprise): register GitlabV1CallbackProcessor at startup

### DIFF
--- a/enterprise/saas_server.py
+++ b/enterprise/saas_server.py
@@ -106,7 +106,17 @@ if GITHUB_APP_CLIENT_ID:
 
 # Add GitLab integration router only if GITLAB_APP_CLIENT_ID is set
 if GITLAB_APP_CLIENT_ID:
+    # Make sure that the callback processor is loaded here so we don't get an
+    # error when deserializing EventCallback rows from the database — the
+    # class otherwise only gets imported lazily inside gitlab_view and stays
+    # invisible to DiscriminatedUnionMixin.get_known_concrete_subclasses().
+    from integrations.gitlab.gitlab_v1_callback_processor import (  # noqa: E402
+        GitlabV1CallbackProcessor,
+    )
     from server.routes.integration.gitlab import gitlab_integration_router  # noqa: E402
+
+    # Bludgeon mypy into not deleting my import
+    logger.debug(f'Loaded {GitlabV1CallbackProcessor.__name__}')
 
     base_app.include_router(gitlab_integration_router)
 


### PR DESCRIPTION
Fixes #14107.

## Bug

With \`ENABLE_V1_GITLAB_RESOLVER=true\`, V1 summary comments never reach the MR/issue. The webhook router fails to hydrate the stored callback with:

\`\`\`
ValidationError: 1 validation error for EventCallback
processor
  Value error, Unknown kind 'GitlabV1CallbackProcessor' for
  openhands.app_server.event_callback.event_callback_models.EventCallbackProcessor;
  Expected one of: ['SlackV1CallbackProcessor', 'LoggingCallbackProcessor', 'SetTitleCallbackProcessor']
\`\`\`

and the error is silently swallowed as "Task exception was never retrieved".

## Root cause

\`DiscriminatedUnionMixin.get_known_concrete_subclasses()\` only returns subclasses whose defining module has already been imported at the point deserialization runs. \`GitlabV1CallbackProcessor\` lives in \`enterprise/integrations/gitlab/gitlab_v1_callback_processor.py\` and is referenced **only** from a lazy inline import inside \`gitlab_view._create_gitlab_v1_callback_processor\`. Webhook deserialization never touches that code path, so the subclass never gets registered.

The GitHub branch of \`saas_server.py\` already handles this: under \`if GITHUB_APP_CLIENT_ID:\` it eagerly imports \`GithubV1CallbackProcessor\` with an explicit comment ("Make sure that the callback processor is loaded here so we don't get an error when deserializing"). The GitLab branch missed the same treatment.

## Fix

Mirror the GitHub pattern in the \`if GITLAB_APP_CLIENT_ID:\` block — eagerly import \`GitlabV1CallbackProcessor\` at startup and log its name so mypy/dead-code analyzers don't drop the import.

## Test plan

- With \`GITLAB_APP_CLIENT_ID\` set: startup logs \`Loaded GitlabV1CallbackProcessor\`; webhook events that previously 404'd on deserialization now hydrate successfully, and the V1 summary comment reaches the MR.
- With \`GITLAB_APP_CLIENT_ID\` unset: unchanged behavior (the entire block is skipped).
- No public API change; no impact on GitHub / Slack / Jira paths.