### PR TITLE
fix(runtime): shrink BashSession tmux pane from 1000x1000 to 256x50

### DIFF
--- a/openhands/runtime/utils/bash.py
+++ b/openhands/runtime/utils/bash.py
@@ -232,8 +232,16 @@ class BashSession:
             session_name=session_name,
             start_directory=self.work_dir,  # This parameter is supported by libtmux
             kill_session=True,
-            x=1000,
-            y=1000,
+            # Tmux emulates a pty the size of the grid. A 1000x1000 grid
+            # (a million cells) makes tmux server burn ~80% of a CPU core
+            # in kernel-mode pty I/O even when the session is detached and
+            # the agent is idle waiting on inference. Keep the pane wide
+            # enough that most tool output doesn't wrap awkwardly (git,
+            # grep, make) while avoiding the oversized grid; capture-pane
+            # still reads the full history via `-pS -`, so a shorter y
+            # doesn't lose any scrollback.
+            x=256,
+            y=50,
         )
 
         # Set history limit to a large number to avoid losing history


### PR DESCRIPTION
Fixes #13894.

## Bug

\`BashSession\` in \`openhands/runtime/utils/bash.py\` creates its tmux session with \`x=1000, y=1000\`. Tmux emulates a pty the size of the grid — a million cells — so the tmux server process sits at state R (running, not sleeping) burning ~80% of a CPU core in kernel mode even when the session is detached and the agent is idle waiting on LLM inference:

\`\`\`
(tmux: server) R ... utime=0 stime=206844 ...
ticks consumed in 1 second (100 = 1 full core): 79
\`\`\`

All \`stime\`, zero \`utime\` — it's churning through pty read/write syscalls for the oversized terminal buffer. Every line of output the child produces gets terminal-emulated across that grid.

## Fix

Shrink to \`x=256, y=50\`. That's:
- **Wide enough** that typical agent-facing tool output (git, grep, make, ripgrep) doesn't wrap awkwardly. 80 cols is too narrow, 160 still trims some \`git log --oneline\` / \`ripgrep\` lines; 256 covers everything I can find in OpenHands' own toolchain without going back to the million-cell regime.
- **Tall enough** to see a meaningful window but no taller — the downstream capture uses \`self.pane.cmd('capture-pane', '-J', '-pS', '-')\`, which reads **from the first line of scrollback** through the current cursor. So shrinking \`y\` doesn't drop any history; only the visible viewport shrinks, and the agent never looks at the viewport directly — it always gets capture-pane output.
- **Scrollback preserved.** \`history-limit\` is set to \`self.HISTORY_LIMIT\` (10000) right after, and the new-pane pattern in the surrounding code is untouched.

## Test plan

- Local: run an OpenHands task that produces terminal output; check tmux server \`stime\` in \`/proc/<pid>/stat\` — goes from ~80 ticks/sec to negligible.
- Capture output: \`pane.cmd('capture-pane', '-J', '-pS', '-')\` still returns the same text for commands whose output fits within 256 columns; wider output wraps the same way it would have at 1000 cols once the terminal hits the right edge.
- No change to public API, no change to history limit, no change to the pane/session creation pattern beyond the grid size and an explanatory comment.