### PR TITLE
fix: normalize legacy MCP config in migration 108

### DIFF
--- a/enterprise/migrations/versions/108_add_agent_settings_to_enterprise_settings.py
+++ b/enterprise/migrations/versions/108_add_agent_settings_to_enterprise_settings.py
@@ -49,6 +49,133 @@ def _strip_none_and_empty(value: Any) -> Any:
     return value
 
 
+def _next_server_name(existing: Mapping[str, Any], base_name: str) -> str:
+    if base_name not in existing:
+        return base_name
+
+    suffix = 1
+    while f'{base_name}_{suffix}' in existing:
+        suffix += 1
+    return f'{base_name}_{suffix}'
+
+
+def _normalize_mcp_config(value: Any) -> Any:
+    if not isinstance(value, Mapping):
+        return value
+
+    raw_mcp_servers = value.get('mcpServers')
+    if isinstance(raw_mcp_servers, Mapping):
+        mcp_servers = dict(raw_mcp_servers)
+        return {'mcpServers': mcp_servers} if mcp_servers else None
+
+    if not any(
+        key in value for key in ('sse_servers', 'stdio_servers', 'shttp_servers')
+    ):
+        return value
+
+    servers: dict[str, dict[str, Any]] = {}
+
+    for entry in value.get('sse_servers', []) or []:
+        if isinstance(entry, str):
+            entry = {'url': entry}
+        if not isinstance(entry, Mapping) or not isinstance(entry.get('url'), str):
+            continue
+
+        server: dict[str, Any] = {'url': entry['url'], 'transport': 'sse'}
+        if entry.get('api_key') is not None:
+            server['auth'] = entry.get('api_key')
+        servers[_next_server_name(servers, 'sse')] = server
+
+    for entry in value.get('shttp_servers', []) or []:
+        if isinstance(entry, str):
+            entry = {'url': entry}
+        if not isinstance(entry, Mapping) or not isinstance(entry.get('url'), str):
+            continue
+
+        server = {'url': entry['url']}
+        if entry.get('api_key') is not None:
+            server['auth'] = entry.get('api_key')
+        if entry.get('timeout') is not None:
+            server['timeout'] = entry.get('timeout')
+        servers[_next_server_name(servers, 'shttp')] = server
+
+    for entry in value.get('stdio_servers', []) or []:
+        if not isinstance(entry, Mapping) or not isinstance(entry.get('command'), str):
+            continue
+
+        server = {'command': entry['command']}
+        if entry.get('args') is not None:
+            server['args'] = entry.get('args')
+        if entry.get('env') is not None:
+            server['env'] = entry.get('env')
+        base_name = entry.get('name') if isinstance(entry.get('name'), str) else 'stdio'
+        servers[_next_server_name(servers, base_name)] = server
+
+    return {'mcpServers': servers} if servers else None
+
+
+def _legacy_api_key(auth_value: Any) -> str | None:
+    if isinstance(auth_value, str) and auth_value != 'oauth':
+        return auth_value
+    return None
+
+
+def _to_legacy_mcp_config(value: Any) -> Any:
+    if not isinstance(value, Mapping):
+        return value
+
+    raw_mcp_servers = value.get('mcpServers')
+    if not isinstance(raw_mcp_servers, Mapping):
+        return value
+
+    legacy: dict[str, list[Any]] = {
+        'sse_servers': [],
+        'stdio_servers': [],
+        'shttp_servers': [],
+    }
+
+    for server_name, server_config in raw_mcp_servers.items():
+        if not isinstance(server_config, Mapping):
+            continue
+
+        url = server_config.get('url')
+        if isinstance(url, str):
+            entry: dict[str, Any] = {'url': url}
+            api_key = _legacy_api_key(server_config.get('auth'))
+            if api_key is not None:
+                entry['api_key'] = api_key
+            if server_config.get('transport') == 'sse':
+                legacy['sse_servers'].append(entry)
+            else:
+                if server_config.get('timeout') is not None:
+                    entry['timeout'] = server_config.get('timeout')
+                legacy['shttp_servers'].append(entry)
+            continue
+
+        command = server_config.get('command')
+        if not isinstance(command, str):
+            continue
+
+        entry = {'name': server_name, 'command': command}
+        if server_config.get('args') is not None:
+            entry['args'] = server_config.get('args')
+        if server_config.get('env') is not None:
+            entry['env'] = server_config.get('env')
+        legacy['stdio_servers'].append(entry)
+
+    return legacy
+
+
+def _normalize_nested_mcp_config(settings: Mapping[str, Any] | None) -> dict[str, Any]:
+    normalized = dict(settings or {})
+    mcp_config = _normalize_mcp_config(normalized.get('mcp_config'))
+    if mcp_config is None:
+        normalized.pop('mcp_config', None)
+    else:
+        normalized['mcp_config'] = mcp_config
+    return normalized
+
+
 def _build_user_agent_settings(row: Mapping[str, Any]) -> dict[str, Any]:
     generated = _strip_none_and_empty(
         {
@@ -62,10 +189,14 @@ def _build_user_agent_settings(row: Mapping[str, Any]) -> dict[str, Any]:
                 'enabled': row['enable_default_condenser'],
                 'max_size': row['condenser_max_size'],
             },
-            'mcp_config': row['mcp_config'],
+            'mcp_config': _normalize_mcp_config(row['mcp_config']),
         }
     )
-    return _deep_merge(generated, row.get('agent_settings') or {})
+    merged = _deep_merge(
+        generated,
+        _normalize_nested_mcp_config(row.get('agent_settings')),
+    )
+    return _normalize_nested_mcp_config(merged)
 
 
 def _build_user_conversation_settings(row: Mapping[str, Any]) -> dict[str, Any]:
@@ -87,10 +218,14 @@ def _build_org_member_agent_settings_diff(row: Mapping[str, Any]) -> dict[str, A
                 'model': row['llm_model'],
                 'base_url': row['llm_base_url'],
             },
-            'mcp_config': row['mcp_config'],
+            'mcp_config': _normalize_mcp_config(row['mcp_config']),
         }
     )
-    return _deep_merge(generated, row.get('agent_settings_diff') or {})
+    merged = _deep_merge(
+        generated,
+        _normalize_nested_mcp_config(row.get('agent_settings_diff')),
+    )
+    return _normalize_nested_mcp_config(merged)
 
 
 def _build_org_member_conversation_settings_diff(
@@ -113,10 +248,14 @@ def _build_org_agent_settings(row: Mapping[str, Any]) -> dict[str, Any]:
                 'enabled': row['enable_default_condenser'],
                 'max_size': row['condenser_max_size'],
             },
-            'mcp_config': row['mcp_config'],
+            'mcp_config': _normalize_mcp_config(row['mcp_config']),
         }
     )
-    return _deep_merge(generated, row.get('agent_settings') or {})
+    merged = _deep_merge(
+        generated,
+        _normalize_nested_mcp_config(row.get('agent_settings')),
+    )
+    return _normalize_nested_mcp_config(merged)
 
 
 def _build_org_conversation_settings(row: Mapping[str, Any]) -> dict[str, Any]:
@@ -172,7 +311,9 @@ def _legacy_org_member_values(row: Mapping[str, Any]) -> dict[str, Any]:
         'max_iterations': _get_nested_value(
             conversation_settings_diff, 'max_iterations'
         ),
-        'mcp_config': _get_nested_value(agent_settings_diff, 'mcp_config'),
+        'mcp_config': _to_legacy_mcp_config(
+            _get_nested_value(agent_settings_diff, 'mcp_config')
+        ),
     }
 
 
@@ -196,7 +337,9 @@ def _legacy_org_values(row: Mapping[str, Any]) -> dict[str, Any]:
         'enable_default_condenser': (
             True if condenser_enabled is None else condenser_enabled
         ),
-        'mcp_config': _get_nested_value(agent_settings, 'mcp_config'),
+        'mcp_config': _to_legacy_mcp_config(
+            _get_nested_value(agent_settings, 'mcp_config')
+        ),
         'condenser_max_size': _get_nested_value(
             agent_settings, 'condenser', 'max_size'
         ),

--- a/enterprise/migrations/versions/108_add_agent_settings_to_enterprise_settings.py
+++ b/enterprise/migrations/versions/108_add_agent_settings_to_enterprise_settings.py
@@ -13,8 +13,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "108"
-down_revision: Union[str, None] = "107"
+revision: str = '108'
+down_revision: Union[str, None] = '107'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -54,68 +54,68 @@ def _next_server_name(existing: Mapping[str, Any], base_name: str) -> str:
         return base_name
 
     suffix = 1
-    while f"{base_name}_{suffix}" in existing:
+    while f'{base_name}_{suffix}' in existing:
         suffix += 1
-    return f"{base_name}_{suffix}"
+    return f'{base_name}_{suffix}'
 
 
 def _normalize_mcp_config(value: Any) -> Any:
     if not isinstance(value, Mapping):
         return value
 
-    raw_mcp_servers = value.get("mcpServers")
+    raw_mcp_servers = value.get('mcpServers')
     if isinstance(raw_mcp_servers, Mapping):
         mcp_servers = dict(raw_mcp_servers)
-        return {"mcpServers": mcp_servers} if mcp_servers else None
+        return {'mcpServers': mcp_servers} if mcp_servers else None
 
     if not any(
-        key in value for key in ("sse_servers", "stdio_servers", "shttp_servers")
+        key in value for key in ('sse_servers', 'stdio_servers', 'shttp_servers')
     ):
         return value
 
     servers: dict[str, dict[str, Any]] = {}
 
-    for entry in value.get("sse_servers", []) or []:
+    for entry in value.get('sse_servers', []) or []:
         if isinstance(entry, str):
-            entry = {"url": entry}
-        if not isinstance(entry, Mapping) or not isinstance(entry.get("url"), str):
+            entry = {'url': entry}
+        if not isinstance(entry, Mapping) or not isinstance(entry.get('url'), str):
             continue
 
-        server: dict[str, Any] = {"url": entry["url"], "transport": "sse"}
-        if entry.get("api_key") is not None:
-            server["auth"] = entry.get("api_key")
-        servers[_next_server_name(servers, "sse")] = server
+        server: dict[str, Any] = {'url': entry['url'], 'transport': 'sse'}
+        if entry.get('api_key') is not None:
+            server['auth'] = entry.get('api_key')
+        servers[_next_server_name(servers, 'sse')] = server
 
-    for entry in value.get("shttp_servers", []) or []:
+    for entry in value.get('shttp_servers', []) or []:
         if isinstance(entry, str):
-            entry = {"url": entry}
-        if not isinstance(entry, Mapping) or not isinstance(entry.get("url"), str):
+            entry = {'url': entry}
+        if not isinstance(entry, Mapping) or not isinstance(entry.get('url'), str):
             continue
 
-        server = {"url": entry["url"]}
-        if entry.get("api_key") is not None:
-            server["auth"] = entry.get("api_key")
-        if entry.get("timeout") is not None:
-            server["timeout"] = entry.get("timeout")
-        servers[_next_server_name(servers, "shttp")] = server
+        server = {'url': entry['url']}
+        if entry.get('api_key') is not None:
+            server['auth'] = entry.get('api_key')
+        if entry.get('timeout') is not None:
+            server['timeout'] = entry.get('timeout')
+        servers[_next_server_name(servers, 'shttp')] = server
 
-    for entry in value.get("stdio_servers", []) or []:
-        if not isinstance(entry, Mapping) or not isinstance(entry.get("command"), str):
+    for entry in value.get('stdio_servers', []) or []:
+        if not isinstance(entry, Mapping) or not isinstance(entry.get('command'), str):
             continue
 
-        server = {"command": entry["command"]}
-        if entry.get("args") is not None:
-            server["args"] = entry.get("args")
-        if entry.get("env") is not None:
-            server["env"] = entry.get("env")
-        base_name = entry.get("name") if isinstance(entry.get("name"), str) else "stdio"
+        server = {'command': entry['command']}
+        if entry.get('args') is not None:
+            server['args'] = entry.get('args')
+        if entry.get('env') is not None:
+            server['env'] = entry.get('env')
+        base_name = entry.get('name') if isinstance(entry.get('name'), str) else 'stdio'
         servers[_next_server_name(servers, base_name)] = server
 
-    return {"mcpServers": servers} if servers else None
+    return {'mcpServers': servers} if servers else None
 
 
 def _legacy_api_key(auth_value: Any) -> str | None:
-    if isinstance(auth_value, str) and auth_value != "oauth":
+    if isinstance(auth_value, str) and auth_value != 'oauth':
         return auth_value
     return None
 
@@ -124,77 +124,77 @@ def _to_legacy_mcp_config(value: Any) -> Any:
     if not isinstance(value, Mapping):
         return value
 
-    raw_mcp_servers = value.get("mcpServers")
+    raw_mcp_servers = value.get('mcpServers')
     if not isinstance(raw_mcp_servers, Mapping):
         return value
 
     legacy: dict[str, list[Any]] = {
-        "sse_servers": [],
-        "stdio_servers": [],
-        "shttp_servers": [],
+        'sse_servers': [],
+        'stdio_servers': [],
+        'shttp_servers': [],
     }
 
     for server_name, server_config in raw_mcp_servers.items():
         if not isinstance(server_config, Mapping):
             continue
 
-        url = server_config.get("url")
+        url = server_config.get('url')
         if isinstance(url, str):
-            entry: dict[str, Any] = {"url": url}
-            api_key = _legacy_api_key(server_config.get("auth"))
+            entry: dict[str, Any] = {'url': url}
+            api_key = _legacy_api_key(server_config.get('auth'))
             if api_key is not None:
-                entry["api_key"] = api_key
-            if server_config.get("transport") == "sse":
-                legacy["sse_servers"].append(entry)
+                entry['api_key'] = api_key
+            if server_config.get('transport') == 'sse':
+                legacy['sse_servers'].append(entry)
             else:
-                if server_config.get("timeout") is not None:
-                    entry["timeout"] = server_config.get("timeout")
-                legacy["shttp_servers"].append(entry)
+                if server_config.get('timeout') is not None:
+                    entry['timeout'] = server_config.get('timeout')
+                legacy['shttp_servers'].append(entry)
             continue
 
-        command = server_config.get("command")
+        command = server_config.get('command')
         if not isinstance(command, str):
             continue
 
-        entry = {"name": server_name, "command": command}
-        if server_config.get("args") is not None:
-            entry["args"] = server_config.get("args")
-        if server_config.get("env") is not None:
-            entry["env"] = server_config.get("env")
-        legacy["stdio_servers"].append(entry)
+        entry = {'name': server_name, 'command': command}
+        if server_config.get('args') is not None:
+            entry['args'] = server_config.get('args')
+        if server_config.get('env') is not None:
+            entry['env'] = server_config.get('env')
+        legacy['stdio_servers'].append(entry)
 
     return legacy
 
 
 def _normalize_nested_mcp_config(settings: Mapping[str, Any] | None) -> dict[str, Any]:
     normalized = dict(settings or {})
-    mcp_config = _normalize_mcp_config(normalized.get("mcp_config"))
+    mcp_config = _normalize_mcp_config(normalized.get('mcp_config'))
     if mcp_config is None:
-        normalized.pop("mcp_config", None)
+        normalized.pop('mcp_config', None)
     else:
-        normalized["mcp_config"] = mcp_config
+        normalized['mcp_config'] = mcp_config
     return normalized
 
 
 def _build_user_agent_settings(row: Mapping[str, Any]) -> dict[str, Any]:
     generated = _strip_none_and_empty(
         {
-            "schema_version": 1,
-            "agent": row["agent"],
-            "llm": {
-                "model": row["llm_model"],
-                "base_url": row["llm_base_url"],
+            'schema_version': 1,
+            'agent': row['agent'],
+            'llm': {
+                'model': row['llm_model'],
+                'base_url': row['llm_base_url'],
             },
-            "condenser": {
-                "enabled": row["enable_default_condenser"],
-                "max_size": row["condenser_max_size"],
+            'condenser': {
+                'enabled': row['enable_default_condenser'],
+                'max_size': row['condenser_max_size'],
             },
-            "mcp_config": _normalize_mcp_config(row["mcp_config"]),
+            'mcp_config': _normalize_mcp_config(row['mcp_config']),
         }
     )
     merged = _deep_merge(
         generated,
-        _normalize_nested_mcp_config(row.get("agent_settings")),
+        _normalize_nested_mcp_config(row.get('agent_settings')),
     )
     return _normalize_nested_mcp_config(merged)
 
@@ -202,28 +202,28 @@ def _build_user_agent_settings(row: Mapping[str, Any]) -> dict[str, Any]:
 def _build_user_conversation_settings(row: Mapping[str, Any]) -> dict[str, Any]:
     generated = _strip_none_and_empty(
         {
-            "max_iterations": row["max_iterations"],
-            "confirmation_mode": row["confirmation_mode"],
-            "security_analyzer": row["security_analyzer"],
+            'max_iterations': row['max_iterations'],
+            'confirmation_mode': row['confirmation_mode'],
+            'security_analyzer': row['security_analyzer'],
         }
     )
-    return _deep_merge(generated, row.get("conversation_settings") or {})
+    return _deep_merge(generated, row.get('conversation_settings') or {})
 
 
 def _build_org_member_agent_settings_diff(row: Mapping[str, Any]) -> dict[str, Any]:
     generated = _strip_none_and_empty(
         {
-            "schema_version": 1,
-            "llm": {
-                "model": row["llm_model"],
-                "base_url": row["llm_base_url"],
+            'schema_version': 1,
+            'llm': {
+                'model': row['llm_model'],
+                'base_url': row['llm_base_url'],
             },
-            "mcp_config": _normalize_mcp_config(row["mcp_config"]),
+            'mcp_config': _normalize_mcp_config(row['mcp_config']),
         }
     )
     merged = _deep_merge(
         generated,
-        _normalize_nested_mcp_config(row.get("agent_settings_diff")),
+        _normalize_nested_mcp_config(row.get('agent_settings_diff')),
     )
     return _normalize_nested_mcp_config(merged)
 
@@ -231,29 +231,29 @@ def _build_org_member_agent_settings_diff(row: Mapping[str, Any]) -> dict[str, A
 def _build_org_member_conversation_settings_diff(
     row: Mapping[str, Any],
 ) -> dict[str, Any]:
-    generated = _strip_none_and_empty({"max_iterations": row["max_iterations"]})
-    return _deep_merge(generated, row.get("conversation_settings_diff") or {})
+    generated = _strip_none_and_empty({'max_iterations': row['max_iterations']})
+    return _deep_merge(generated, row.get('conversation_settings_diff') or {})
 
 
 def _build_org_agent_settings(row: Mapping[str, Any]) -> dict[str, Any]:
     generated = _strip_none_and_empty(
         {
-            "schema_version": 1,
-            "agent": row["agent"],
-            "llm": {
-                "model": row["default_llm_model"],
-                "base_url": row["default_llm_base_url"],
+            'schema_version': 1,
+            'agent': row['agent'],
+            'llm': {
+                'model': row['default_llm_model'],
+                'base_url': row['default_llm_base_url'],
             },
-            "condenser": {
-                "enabled": row["enable_default_condenser"],
-                "max_size": row["condenser_max_size"],
+            'condenser': {
+                'enabled': row['enable_default_condenser'],
+                'max_size': row['condenser_max_size'],
             },
-            "mcp_config": _normalize_mcp_config(row["mcp_config"]),
+            'mcp_config': _normalize_mcp_config(row['mcp_config']),
         }
     )
     merged = _deep_merge(
         generated,
-        _normalize_nested_mcp_config(row.get("agent_settings")),
+        _normalize_nested_mcp_config(row.get('agent_settings')),
     )
     return _normalize_nested_mcp_config(merged)
 
@@ -261,12 +261,12 @@ def _build_org_agent_settings(row: Mapping[str, Any]) -> dict[str, Any]:
 def _build_org_conversation_settings(row: Mapping[str, Any]) -> dict[str, Any]:
     generated = _strip_none_and_empty(
         {
-            "max_iterations": row["default_max_iterations"],
-            "confirmation_mode": row["confirmation_mode"],
-            "security_analyzer": row["security_analyzer"],
+            'max_iterations': row['default_max_iterations'],
+            'confirmation_mode': row['confirmation_mode'],
+            'security_analyzer': row['security_analyzer'],
         }
     )
-    return _deep_merge(generated, row.get("conversation_settings") or {})
+    return _deep_merge(generated, row.get('conversation_settings') or {})
 
 
 def _get_nested_value(data: Mapping[str, Any] | None, *path: str) -> Any:
@@ -279,128 +279,128 @@ def _get_nested_value(data: Mapping[str, Any] | None, *path: str) -> Any:
 
 
 def _legacy_user_settings_values(row: Mapping[str, Any]) -> dict[str, Any]:
-    agent_settings = row.get("agent_settings") or {}
-    conversation_settings = row.get("conversation_settings") or {}
-    condenser_enabled = _get_nested_value(agent_settings, "condenser", "enabled")
+    agent_settings = row.get('agent_settings') or {}
+    conversation_settings = row.get('conversation_settings') or {}
+    condenser_enabled = _get_nested_value(agent_settings, 'condenser', 'enabled')
     return {
-        "agent": _get_nested_value(agent_settings, "agent"),
-        "max_iterations": _get_nested_value(conversation_settings, "max_iterations"),
-        "security_analyzer": _get_nested_value(
-            conversation_settings, "security_analyzer"
+        'agent': _get_nested_value(agent_settings, 'agent'),
+        'max_iterations': _get_nested_value(conversation_settings, 'max_iterations'),
+        'security_analyzer': _get_nested_value(
+            conversation_settings, 'security_analyzer'
         ),
-        "confirmation_mode": _get_nested_value(
-            conversation_settings, "confirmation_mode"
+        'confirmation_mode': _get_nested_value(
+            conversation_settings, 'confirmation_mode'
         ),
-        "llm_model": _get_nested_value(agent_settings, "llm", "model"),
-        "llm_base_url": _get_nested_value(agent_settings, "llm", "base_url"),
-        "enable_default_condenser": (
+        'llm_model': _get_nested_value(agent_settings, 'llm', 'model'),
+        'llm_base_url': _get_nested_value(agent_settings, 'llm', 'base_url'),
+        'enable_default_condenser': (
             True if condenser_enabled is None else condenser_enabled
         ),
-        "condenser_max_size": _get_nested_value(
-            agent_settings, "condenser", "max_size"
+        'condenser_max_size': _get_nested_value(
+            agent_settings, 'condenser', 'max_size'
         ),
     }
 
 
 def _legacy_org_member_values(row: Mapping[str, Any]) -> dict[str, Any]:
-    agent_settings_diff = row.get("agent_settings_diff") or {}
-    conversation_settings_diff = row.get("conversation_settings_diff") or {}
+    agent_settings_diff = row.get('agent_settings_diff') or {}
+    conversation_settings_diff = row.get('conversation_settings_diff') or {}
     return {
-        "llm_model": _get_nested_value(agent_settings_diff, "llm", "model"),
-        "llm_base_url": _get_nested_value(agent_settings_diff, "llm", "base_url"),
-        "max_iterations": _get_nested_value(
-            conversation_settings_diff, "max_iterations"
+        'llm_model': _get_nested_value(agent_settings_diff, 'llm', 'model'),
+        'llm_base_url': _get_nested_value(agent_settings_diff, 'llm', 'base_url'),
+        'max_iterations': _get_nested_value(
+            conversation_settings_diff, 'max_iterations'
         ),
-        "mcp_config": _to_legacy_mcp_config(
-            _get_nested_value(agent_settings_diff, "mcp_config")
+        'mcp_config': _to_legacy_mcp_config(
+            _get_nested_value(agent_settings_diff, 'mcp_config')
         ),
     }
 
 
 def _legacy_org_values(row: Mapping[str, Any]) -> dict[str, Any]:
-    agent_settings = row.get("agent_settings") or {}
-    conversation_settings = row.get("conversation_settings") or {}
-    condenser_enabled = _get_nested_value(agent_settings, "condenser", "enabled")
+    agent_settings = row.get('agent_settings') or {}
+    conversation_settings = row.get('conversation_settings') or {}
+    condenser_enabled = _get_nested_value(agent_settings, 'condenser', 'enabled')
     return {
-        "agent": _get_nested_value(agent_settings, "agent"),
-        "default_max_iterations": _get_nested_value(
-            conversation_settings, "max_iterations"
+        'agent': _get_nested_value(agent_settings, 'agent'),
+        'default_max_iterations': _get_nested_value(
+            conversation_settings, 'max_iterations'
         ),
-        "security_analyzer": _get_nested_value(
-            conversation_settings, "security_analyzer"
+        'security_analyzer': _get_nested_value(
+            conversation_settings, 'security_analyzer'
         ),
-        "confirmation_mode": _get_nested_value(
-            conversation_settings, "confirmation_mode"
+        'confirmation_mode': _get_nested_value(
+            conversation_settings, 'confirmation_mode'
         ),
-        "default_llm_model": _get_nested_value(agent_settings, "llm", "model"),
-        "default_llm_base_url": _get_nested_value(agent_settings, "llm", "base_url"),
-        "enable_default_condenser": (
+        'default_llm_model': _get_nested_value(agent_settings, 'llm', 'model'),
+        'default_llm_base_url': _get_nested_value(agent_settings, 'llm', 'base_url'),
+        'enable_default_condenser': (
             True if condenser_enabled is None else condenser_enabled
         ),
-        "mcp_config": _to_legacy_mcp_config(
-            _get_nested_value(agent_settings, "mcp_config")
+        'mcp_config': _to_legacy_mcp_config(
+            _get_nested_value(agent_settings, 'mcp_config')
         ),
-        "condenser_max_size": _get_nested_value(
-            agent_settings, "condenser", "max_size"
+        'condenser_max_size': _get_nested_value(
+            agent_settings, 'condenser', 'max_size'
         ),
     }
 
 
 def upgrade() -> None:
     op.add_column(
-        "user_settings",
+        'user_settings',
         sa.Column(
-            "agent_settings", sa.JSON(), nullable=False, server_default=_EMPTY_JSON
+            'agent_settings', sa.JSON(), nullable=False, server_default=_EMPTY_JSON
         ),
     )
     op.add_column(
-        "user_settings",
+        'user_settings',
         sa.Column(
-            "conversation_settings",
+            'conversation_settings',
             sa.JSON(),
             nullable=False,
             server_default=_EMPTY_JSON,
         ),
     )
     op.add_column(
-        "org_member",
+        'org_member',
         sa.Column(
-            "agent_settings_diff",
+            'agent_settings_diff',
             sa.JSON(),
             nullable=False,
             server_default=_EMPTY_JSON,
         ),
     )
     op.add_column(
-        "org_member",
+        'org_member',
         sa.Column(
-            "conversation_settings_diff",
+            'conversation_settings_diff',
             sa.JSON(),
             nullable=False,
             server_default=_EMPTY_JSON,
         ),
     )
     op.add_column(
-        "org",
+        'org',
         sa.Column(
-            "agent_settings", sa.JSON(), nullable=False, server_default=_EMPTY_JSON
+            'agent_settings', sa.JSON(), nullable=False, server_default=_EMPTY_JSON
         ),
     )
     op.add_column(
-        "org",
+        'org',
         sa.Column(
-            "conversation_settings",
+            'conversation_settings',
             sa.JSON(),
             nullable=False,
             server_default=_EMPTY_JSON,
         ),
     )
 
-    op.add_column("org", sa.Column("_llm_api_key", sa.String(), nullable=True))
+    op.add_column('org', sa.Column('_llm_api_key', sa.String(), nullable=True))
     op.add_column(
-        "org_member",
+        'org_member',
         sa.Column(
-            "has_custom_llm_api_key",
+            'has_custom_llm_api_key',
             sa.Boolean(),
             nullable=False,
             server_default=sa.false(),
@@ -410,19 +410,19 @@ def upgrade() -> None:
     bind = op.get_bind()
 
     user_settings_table = sa.table(
-        "user_settings",
-        sa.column("id", sa.Integer()),
-        sa.column("agent", sa.String()),
-        sa.column("max_iterations", sa.Integer()),
-        sa.column("security_analyzer", sa.String()),
-        sa.column("confirmation_mode", sa.Boolean()),
-        sa.column("llm_model", sa.String()),
-        sa.column("llm_base_url", sa.String()),
-        sa.column("enable_default_condenser", sa.Boolean()),
-        sa.column("condenser_max_size", sa.Integer()),
-        sa.column("mcp_config", sa.JSON()),
-        sa.column("agent_settings", sa.JSON()),
-        sa.column("conversation_settings", sa.JSON()),
+        'user_settings',
+        sa.column('id', sa.Integer()),
+        sa.column('agent', sa.String()),
+        sa.column('max_iterations', sa.Integer()),
+        sa.column('security_analyzer', sa.String()),
+        sa.column('confirmation_mode', sa.Boolean()),
+        sa.column('llm_model', sa.String()),
+        sa.column('llm_base_url', sa.String()),
+        sa.column('enable_default_condenser', sa.Boolean()),
+        sa.column('condenser_max_size', sa.Integer()),
+        sa.column('mcp_config', sa.JSON()),
+        sa.column('agent_settings', sa.JSON()),
+        sa.column('conversation_settings', sa.JSON()),
     )
     user_settings_rows = bind.execute(
         sa.select(
@@ -443,7 +443,7 @@ def upgrade() -> None:
     for row in user_settings_rows:
         bind.execute(
             user_settings_table.update()
-            .where(user_settings_table.c.id == row["id"])
+            .where(user_settings_table.c.id == row['id'])
             .values(
                 agent_settings=_build_user_agent_settings(row),
                 conversation_settings=_build_user_conversation_settings(row),
@@ -451,15 +451,15 @@ def upgrade() -> None:
         )
 
     org_member_table = sa.table(
-        "org_member",
-        sa.column("org_id", sa.Uuid()),
-        sa.column("user_id", sa.Uuid()),
-        sa.column("max_iterations", sa.Integer()),
-        sa.column("llm_model", sa.String()),
-        sa.column("llm_base_url", sa.String()),
-        sa.column("mcp_config", sa.JSON()),
-        sa.column("agent_settings_diff", sa.JSON()),
-        sa.column("conversation_settings_diff", sa.JSON()),
+        'org_member',
+        sa.column('org_id', sa.Uuid()),
+        sa.column('user_id', sa.Uuid()),
+        sa.column('max_iterations', sa.Integer()),
+        sa.column('llm_model', sa.String()),
+        sa.column('llm_base_url', sa.String()),
+        sa.column('mcp_config', sa.JSON()),
+        sa.column('agent_settings_diff', sa.JSON()),
+        sa.column('conversation_settings_diff', sa.JSON()),
     )
     org_member_rows = bind.execute(
         sa.select(
@@ -476,8 +476,8 @@ def upgrade() -> None:
     for row in org_member_rows:
         bind.execute(
             org_member_table.update()
-            .where(org_member_table.c.org_id == row["org_id"])
-            .where(org_member_table.c.user_id == row["user_id"])
+            .where(org_member_table.c.org_id == row['org_id'])
+            .where(org_member_table.c.user_id == row['user_id'])
             .values(
                 agent_settings_diff=_build_org_member_agent_settings_diff(row),
                 conversation_settings_diff=_build_org_member_conversation_settings_diff(
@@ -487,19 +487,19 @@ def upgrade() -> None:
         )
 
     org_table = sa.table(
-        "org",
-        sa.column("id", sa.Uuid()),
-        sa.column("agent", sa.String()),
-        sa.column("default_max_iterations", sa.Integer()),
-        sa.column("security_analyzer", sa.String()),
-        sa.column("confirmation_mode", sa.Boolean()),
-        sa.column("default_llm_model", sa.String()),
-        sa.column("default_llm_base_url", sa.String()),
-        sa.column("enable_default_condenser", sa.Boolean()),
-        sa.column("mcp_config", sa.JSON()),
-        sa.column("condenser_max_size", sa.Integer()),
-        sa.column("agent_settings", sa.JSON()),
-        sa.column("conversation_settings", sa.JSON()),
+        'org',
+        sa.column('id', sa.Uuid()),
+        sa.column('agent', sa.String()),
+        sa.column('default_max_iterations', sa.Integer()),
+        sa.column('security_analyzer', sa.String()),
+        sa.column('confirmation_mode', sa.Boolean()),
+        sa.column('default_llm_model', sa.String()),
+        sa.column('default_llm_base_url', sa.String()),
+        sa.column('enable_default_condenser', sa.Boolean()),
+        sa.column('mcp_config', sa.JSON()),
+        sa.column('condenser_max_size', sa.Integer()),
+        sa.column('agent_settings', sa.JSON()),
+        sa.column('conversation_settings', sa.JSON()),
     )
     org_rows = bind.execute(
         sa.select(
@@ -520,111 +520,111 @@ def upgrade() -> None:
     for row in org_rows:
         bind.execute(
             org_table.update()
-            .where(org_table.c.id == row["id"])
+            .where(org_table.c.id == row['id'])
             .values(
                 agent_settings=_build_org_agent_settings(row),
                 conversation_settings=_build_org_conversation_settings(row),
             )
         )
 
-    op.alter_column("user_settings", "agent_settings", server_default=None)
-    op.alter_column("user_settings", "conversation_settings", server_default=None)
-    op.alter_column("org_member", "agent_settings_diff", server_default=None)
-    op.alter_column("org_member", "conversation_settings_diff", server_default=None)
-    op.alter_column("org", "agent_settings", server_default=None)
-    op.alter_column("org", "conversation_settings", server_default=None)
-    op.alter_column("org_member", "has_custom_llm_api_key", server_default=None)
-    op.drop_column("user_settings", "agent")
-    op.drop_column("user_settings", "max_iterations")
-    op.drop_column("user_settings", "security_analyzer")
-    op.drop_column("user_settings", "confirmation_mode")
-    op.drop_column("user_settings", "llm_model")
-    op.drop_column("user_settings", "llm_base_url")
-    op.drop_column("user_settings", "enable_default_condenser")
-    op.drop_column("user_settings", "condenser_max_size")
-    op.drop_column("org_member", "max_iterations")
-    op.drop_column("org_member", "llm_model")
-    op.drop_column("org_member", "llm_base_url")
-    op.drop_column("org_member", "mcp_config")
-    op.drop_column("org", "agent")
-    op.drop_column("org", "default_max_iterations")
-    op.drop_column("org", "security_analyzer")
-    op.drop_column("org", "confirmation_mode")
-    op.drop_column("org", "default_llm_model")
-    op.drop_column("org", "default_llm_base_url")
-    op.drop_column("org", "enable_default_condenser")
-    op.drop_column("org", "mcp_config")
-    op.drop_column("org", "condenser_max_size")
+    op.alter_column('user_settings', 'agent_settings', server_default=None)
+    op.alter_column('user_settings', 'conversation_settings', server_default=None)
+    op.alter_column('org_member', 'agent_settings_diff', server_default=None)
+    op.alter_column('org_member', 'conversation_settings_diff', server_default=None)
+    op.alter_column('org', 'agent_settings', server_default=None)
+    op.alter_column('org', 'conversation_settings', server_default=None)
+    op.alter_column('org_member', 'has_custom_llm_api_key', server_default=None)
+    op.drop_column('user_settings', 'agent')
+    op.drop_column('user_settings', 'max_iterations')
+    op.drop_column('user_settings', 'security_analyzer')
+    op.drop_column('user_settings', 'confirmation_mode')
+    op.drop_column('user_settings', 'llm_model')
+    op.drop_column('user_settings', 'llm_base_url')
+    op.drop_column('user_settings', 'enable_default_condenser')
+    op.drop_column('user_settings', 'condenser_max_size')
+    op.drop_column('org_member', 'max_iterations')
+    op.drop_column('org_member', 'llm_model')
+    op.drop_column('org_member', 'llm_base_url')
+    op.drop_column('org_member', 'mcp_config')
+    op.drop_column('org', 'agent')
+    op.drop_column('org', 'default_max_iterations')
+    op.drop_column('org', 'security_analyzer')
+    op.drop_column('org', 'confirmation_mode')
+    op.drop_column('org', 'default_llm_model')
+    op.drop_column('org', 'default_llm_base_url')
+    op.drop_column('org', 'enable_default_condenser')
+    op.drop_column('org', 'mcp_config')
+    op.drop_column('org', 'condenser_max_size')
 
 
 def downgrade() -> None:
-    op.add_column("user_settings", sa.Column("agent", sa.String(), nullable=True))
+    op.add_column('user_settings', sa.Column('agent', sa.String(), nullable=True))
     op.add_column(
-        "user_settings", sa.Column("max_iterations", sa.Integer(), nullable=True)
+        'user_settings', sa.Column('max_iterations', sa.Integer(), nullable=True)
     )
     op.add_column(
-        "user_settings", sa.Column("security_analyzer", sa.String(), nullable=True)
+        'user_settings', sa.Column('security_analyzer', sa.String(), nullable=True)
     )
     op.add_column(
-        "user_settings", sa.Column("confirmation_mode", sa.Boolean(), nullable=True)
+        'user_settings', sa.Column('confirmation_mode', sa.Boolean(), nullable=True)
     )
-    op.add_column("user_settings", sa.Column("llm_model", sa.String(), nullable=True))
+    op.add_column('user_settings', sa.Column('llm_model', sa.String(), nullable=True))
     op.add_column(
-        "user_settings", sa.Column("llm_base_url", sa.String(), nullable=True)
+        'user_settings', sa.Column('llm_base_url', sa.String(), nullable=True)
     )
     op.add_column(
-        "user_settings",
+        'user_settings',
         sa.Column(
-            "enable_default_condenser",
+            'enable_default_condenser',
             sa.Boolean(),
             nullable=False,
             server_default=sa.true(),
         ),
     )
     op.add_column(
-        "user_settings", sa.Column("condenser_max_size", sa.Integer(), nullable=True)
+        'user_settings', sa.Column('condenser_max_size', sa.Integer(), nullable=True)
     )
-    op.add_column("org_member", sa.Column("llm_base_url", sa.String(), nullable=True))
-    op.add_column("org_member", sa.Column("llm_model", sa.String(), nullable=True))
+    op.add_column('org_member', sa.Column('llm_base_url', sa.String(), nullable=True))
+    op.add_column('org_member', sa.Column('llm_model', sa.String(), nullable=True))
     op.add_column(
-        "org_member", sa.Column("max_iterations", sa.Integer(), nullable=True)
+        'org_member', sa.Column('max_iterations', sa.Integer(), nullable=True)
     )
-    op.add_column("org_member", sa.Column("mcp_config", sa.JSON(), nullable=True))
-    op.add_column("org", sa.Column("agent", sa.String(), nullable=True))
+    op.add_column('org_member', sa.Column('mcp_config', sa.JSON(), nullable=True))
+    op.add_column('org', sa.Column('agent', sa.String(), nullable=True))
     op.add_column(
-        "org", sa.Column("default_max_iterations", sa.Integer(), nullable=True)
+        'org', sa.Column('default_max_iterations', sa.Integer(), nullable=True)
     )
-    op.add_column("org", sa.Column("security_analyzer", sa.String(), nullable=True))
-    op.add_column("org", sa.Column("confirmation_mode", sa.Boolean(), nullable=True))
-    op.add_column("org", sa.Column("default_llm_model", sa.String(), nullable=True))
-    op.add_column("org", sa.Column("default_llm_base_url", sa.String(), nullable=True))
+    op.add_column('org', sa.Column('security_analyzer', sa.String(), nullable=True))
+    op.add_column('org', sa.Column('confirmation_mode', sa.Boolean(), nullable=True))
+    op.add_column('org', sa.Column('default_llm_model', sa.String(), nullable=True))
+    op.add_column('org', sa.Column('default_llm_base_url', sa.String(), nullable=True))
     op.add_column(
-        "org",
+        'org',
         sa.Column(
-            "enable_default_condenser",
+            'enable_default_condenser',
             sa.Boolean(),
             nullable=False,
             server_default=sa.true(),
         ),
     )
-    op.add_column("org", sa.Column("mcp_config", sa.JSON(), nullable=True))
-    op.add_column("org", sa.Column("condenser_max_size", sa.Integer(), nullable=True))
+    op.add_column('org', sa.Column('mcp_config', sa.JSON(), nullable=True))
+    op.add_column('org', sa.Column('condenser_max_size', sa.Integer(), nullable=True))
 
     bind = op.get_bind()
 
     user_settings_table = sa.table(
-        "user_settings",
-        sa.column("id", sa.Integer()),
-        sa.column("agent_settings", sa.JSON()),
-        sa.column("conversation_settings", sa.JSON()),
-        sa.column("agent", sa.String()),
-        sa.column("max_iterations", sa.Integer()),
-        sa.column("security_analyzer", sa.String()),
-        sa.column("confirmation_mode", sa.Boolean()),
-        sa.column("llm_model", sa.String()),
-        sa.column("llm_base_url", sa.String()),
-        sa.column("enable_default_condenser", sa.Boolean()),
-        sa.column("condenser_max_size", sa.Integer()),
+        'user_settings',
+        sa.column('id', sa.Integer()),
+        sa.column('agent_settings', sa.JSON()),
+        sa.column('conversation_settings', sa.JSON()),
+        sa.column('agent', sa.String()),
+        sa.column('max_iterations', sa.Integer()),
+        sa.column('security_analyzer', sa.String()),
+        sa.column('confirmation_mode', sa.Boolean()),
+        sa.column('llm_model', sa.String()),
+        sa.column('llm_base_url', sa.String()),
+        sa.column('enable_default_condenser', sa.Boolean()),
+        sa.column('condenser_max_size', sa.Integer()),
     )
     user_settings_rows = bind.execute(
         sa.select(
@@ -636,20 +636,20 @@ def downgrade() -> None:
     for row in user_settings_rows:
         bind.execute(
             user_settings_table.update()
-            .where(user_settings_table.c.id == row["id"])
+            .where(user_settings_table.c.id == row['id'])
             .values(**_legacy_user_settings_values(row))
         )
 
     org_member_table = sa.table(
-        "org_member",
-        sa.column("org_id", sa.Uuid()),
-        sa.column("user_id", sa.Uuid()),
-        sa.column("agent_settings_diff", sa.JSON()),
-        sa.column("conversation_settings_diff", sa.JSON()),
-        sa.column("llm_model", sa.String()),
-        sa.column("llm_base_url", sa.String()),
-        sa.column("max_iterations", sa.Integer()),
-        sa.column("mcp_config", sa.JSON()),
+        'org_member',
+        sa.column('org_id', sa.Uuid()),
+        sa.column('user_id', sa.Uuid()),
+        sa.column('agent_settings_diff', sa.JSON()),
+        sa.column('conversation_settings_diff', sa.JSON()),
+        sa.column('llm_model', sa.String()),
+        sa.column('llm_base_url', sa.String()),
+        sa.column('max_iterations', sa.Integer()),
+        sa.column('mcp_config', sa.JSON()),
     )
     org_member_rows = bind.execute(
         sa.select(
@@ -662,25 +662,25 @@ def downgrade() -> None:
     for row in org_member_rows:
         bind.execute(
             org_member_table.update()
-            .where(org_member_table.c.org_id == row["org_id"])
-            .where(org_member_table.c.user_id == row["user_id"])
+            .where(org_member_table.c.org_id == row['org_id'])
+            .where(org_member_table.c.user_id == row['user_id'])
             .values(**_legacy_org_member_values(row))
         )
 
     org_table = sa.table(
-        "org",
-        sa.column("id", sa.Uuid()),
-        sa.column("agent_settings", sa.JSON()),
-        sa.column("conversation_settings", sa.JSON()),
-        sa.column("agent", sa.String()),
-        sa.column("default_max_iterations", sa.Integer()),
-        sa.column("security_analyzer", sa.String()),
-        sa.column("confirmation_mode", sa.Boolean()),
-        sa.column("default_llm_model", sa.String()),
-        sa.column("default_llm_base_url", sa.String()),
-        sa.column("enable_default_condenser", sa.Boolean()),
-        sa.column("mcp_config", sa.JSON()),
-        sa.column("condenser_max_size", sa.Integer()),
+        'org',
+        sa.column('id', sa.Uuid()),
+        sa.column('agent_settings', sa.JSON()),
+        sa.column('conversation_settings', sa.JSON()),
+        sa.column('agent', sa.String()),
+        sa.column('default_max_iterations', sa.Integer()),
+        sa.column('security_analyzer', sa.String()),
+        sa.column('confirmation_mode', sa.Boolean()),
+        sa.column('default_llm_model', sa.String()),
+        sa.column('default_llm_base_url', sa.String()),
+        sa.column('enable_default_condenser', sa.Boolean()),
+        sa.column('mcp_config', sa.JSON()),
+        sa.column('condenser_max_size', sa.Integer()),
     )
     org_rows = bind.execute(
         sa.select(
@@ -692,15 +692,15 @@ def downgrade() -> None:
     for row in org_rows:
         bind.execute(
             org_table.update()
-            .where(org_table.c.id == row["id"])
+            .where(org_table.c.id == row['id'])
             .values(**_legacy_org_values(row))
         )
 
-    op.drop_column("org", "agent_settings")
-    op.drop_column("org", "conversation_settings")
-    op.drop_column("org", "_llm_api_key")
-    op.drop_column("org_member", "agent_settings_diff")
-    op.drop_column("org_member", "conversation_settings_diff")
-    op.drop_column("org_member", "has_custom_llm_api_key")
-    op.drop_column("user_settings", "agent_settings")
-    op.drop_column("user_settings", "conversation_settings")
+    op.drop_column('org', 'agent_settings')
+    op.drop_column('org', 'conversation_settings')
+    op.drop_column('org', '_llm_api_key')
+    op.drop_column('org_member', 'agent_settings_diff')
+    op.drop_column('org_member', 'conversation_settings_diff')
+    op.drop_column('org_member', 'has_custom_llm_api_key')
+    op.drop_column('user_settings', 'agent_settings')
+    op.drop_column('user_settings', 'conversation_settings')

--- a/enterprise/migrations/versions/108_add_agent_settings_to_enterprise_settings.py
+++ b/enterprise/migrations/versions/108_add_agent_settings_to_enterprise_settings.py
@@ -13,8 +13,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = '108'
-down_revision: Union[str, None] = '107'
+revision: str = "108"
+down_revision: Union[str, None] = "107"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -54,68 +54,68 @@ def _next_server_name(existing: Mapping[str, Any], base_name: str) -> str:
         return base_name
 
     suffix = 1
-    while f'{base_name}_{suffix}' in existing:
+    while f"{base_name}_{suffix}" in existing:
         suffix += 1
-    return f'{base_name}_{suffix}'
+    return f"{base_name}_{suffix}"
 
 
 def _normalize_mcp_config(value: Any) -> Any:
     if not isinstance(value, Mapping):
         return value
 
-    raw_mcp_servers = value.get('mcpServers')
+    raw_mcp_servers = value.get("mcpServers")
     if isinstance(raw_mcp_servers, Mapping):
         mcp_servers = dict(raw_mcp_servers)
-        return {'mcpServers': mcp_servers} if mcp_servers else None
+        return {"mcpServers": mcp_servers} if mcp_servers else None
 
     if not any(
-        key in value for key in ('sse_servers', 'stdio_servers', 'shttp_servers')
+        key in value for key in ("sse_servers", "stdio_servers", "shttp_servers")
     ):
         return value
 
     servers: dict[str, dict[str, Any]] = {}
 
-    for entry in value.get('sse_servers', []) or []:
+    for entry in value.get("sse_servers", []) or []:
         if isinstance(entry, str):
-            entry = {'url': entry}
-        if not isinstance(entry, Mapping) or not isinstance(entry.get('url'), str):
+            entry = {"url": entry}
+        if not isinstance(entry, Mapping) or not isinstance(entry.get("url"), str):
             continue
 
-        server: dict[str, Any] = {'url': entry['url'], 'transport': 'sse'}
-        if entry.get('api_key') is not None:
-            server['auth'] = entry.get('api_key')
-        servers[_next_server_name(servers, 'sse')] = server
+        server: dict[str, Any] = {"url": entry["url"], "transport": "sse"}
+        if entry.get("api_key") is not None:
+            server["auth"] = entry.get("api_key")
+        servers[_next_server_name(servers, "sse")] = server
 
-    for entry in value.get('shttp_servers', []) or []:
+    for entry in value.get("shttp_servers", []) or []:
         if isinstance(entry, str):
-            entry = {'url': entry}
-        if not isinstance(entry, Mapping) or not isinstance(entry.get('url'), str):
+            entry = {"url": entry}
+        if not isinstance(entry, Mapping) or not isinstance(entry.get("url"), str):
             continue
 
-        server = {'url': entry['url']}
-        if entry.get('api_key') is not None:
-            server['auth'] = entry.get('api_key')
-        if entry.get('timeout') is not None:
-            server['timeout'] = entry.get('timeout')
-        servers[_next_server_name(servers, 'shttp')] = server
+        server = {"url": entry["url"]}
+        if entry.get("api_key") is not None:
+            server["auth"] = entry.get("api_key")
+        if entry.get("timeout") is not None:
+            server["timeout"] = entry.get("timeout")
+        servers[_next_server_name(servers, "shttp")] = server
 
-    for entry in value.get('stdio_servers', []) or []:
-        if not isinstance(entry, Mapping) or not isinstance(entry.get('command'), str):
+    for entry in value.get("stdio_servers", []) or []:
+        if not isinstance(entry, Mapping) or not isinstance(entry.get("command"), str):
             continue
 
-        server = {'command': entry['command']}
-        if entry.get('args') is not None:
-            server['args'] = entry.get('args')
-        if entry.get('env') is not None:
-            server['env'] = entry.get('env')
-        base_name = entry.get('name') if isinstance(entry.get('name'), str) else 'stdio'
+        server = {"command": entry["command"]}
+        if entry.get("args") is not None:
+            server["args"] = entry.get("args")
+        if entry.get("env") is not None:
+            server["env"] = entry.get("env")
+        base_name = entry.get("name") if isinstance(entry.get("name"), str) else "stdio"
         servers[_next_server_name(servers, base_name)] = server
 
-    return {'mcpServers': servers} if servers else None
+    return {"mcpServers": servers} if servers else None
 
 
 def _legacy_api_key(auth_value: Any) -> str | None:
-    if isinstance(auth_value, str) and auth_value != 'oauth':
+    if isinstance(auth_value, str) and auth_value != "oauth":
         return auth_value
     return None
 
@@ -124,77 +124,77 @@ def _to_legacy_mcp_config(value: Any) -> Any:
     if not isinstance(value, Mapping):
         return value
 
-    raw_mcp_servers = value.get('mcpServers')
+    raw_mcp_servers = value.get("mcpServers")
     if not isinstance(raw_mcp_servers, Mapping):
         return value
 
     legacy: dict[str, list[Any]] = {
-        'sse_servers': [],
-        'stdio_servers': [],
-        'shttp_servers': [],
+        "sse_servers": [],
+        "stdio_servers": [],
+        "shttp_servers": [],
     }
 
     for server_name, server_config in raw_mcp_servers.items():
         if not isinstance(server_config, Mapping):
             continue
 
-        url = server_config.get('url')
+        url = server_config.get("url")
         if isinstance(url, str):
-            entry: dict[str, Any] = {'url': url}
-            api_key = _legacy_api_key(server_config.get('auth'))
+            entry: dict[str, Any] = {"url": url}
+            api_key = _legacy_api_key(server_config.get("auth"))
             if api_key is not None:
-                entry['api_key'] = api_key
-            if server_config.get('transport') == 'sse':
-                legacy['sse_servers'].append(entry)
+                entry["api_key"] = api_key
+            if server_config.get("transport") == "sse":
+                legacy["sse_servers"].append(entry)
             else:
-                if server_config.get('timeout') is not None:
-                    entry['timeout'] = server_config.get('timeout')
-                legacy['shttp_servers'].append(entry)
+                if server_config.get("timeout") is not None:
+                    entry["timeout"] = server_config.get("timeout")
+                legacy["shttp_servers"].append(entry)
             continue
 
-        command = server_config.get('command')
+        command = server_config.get("command")
         if not isinstance(command, str):
             continue
 
-        entry = {'name': server_name, 'command': command}
-        if server_config.get('args') is not None:
-            entry['args'] = server_config.get('args')
-        if server_config.get('env') is not None:
-            entry['env'] = server_config.get('env')
-        legacy['stdio_servers'].append(entry)
+        entry = {"name": server_name, "command": command}
+        if server_config.get("args") is not None:
+            entry["args"] = server_config.get("args")
+        if server_config.get("env") is not None:
+            entry["env"] = server_config.get("env")
+        legacy["stdio_servers"].append(entry)
 
     return legacy
 
 
 def _normalize_nested_mcp_config(settings: Mapping[str, Any] | None) -> dict[str, Any]:
     normalized = dict(settings or {})
-    mcp_config = _normalize_mcp_config(normalized.get('mcp_config'))
+    mcp_config = _normalize_mcp_config(normalized.get("mcp_config"))
     if mcp_config is None:
-        normalized.pop('mcp_config', None)
+        normalized.pop("mcp_config", None)
     else:
-        normalized['mcp_config'] = mcp_config
+        normalized["mcp_config"] = mcp_config
     return normalized
 
 
 def _build_user_agent_settings(row: Mapping[str, Any]) -> dict[str, Any]:
     generated = _strip_none_and_empty(
         {
-            'schema_version': 1,
-            'agent': row['agent'],
-            'llm': {
-                'model': row['llm_model'],
-                'base_url': row['llm_base_url'],
+            "schema_version": 1,
+            "agent": row["agent"],
+            "llm": {
+                "model": row["llm_model"],
+                "base_url": row["llm_base_url"],
             },
-            'condenser': {
-                'enabled': row['enable_default_condenser'],
-                'max_size': row['condenser_max_size'],
+            "condenser": {
+                "enabled": row["enable_default_condenser"],
+                "max_size": row["condenser_max_size"],
             },
-            'mcp_config': _normalize_mcp_config(row['mcp_config']),
+            "mcp_config": _normalize_mcp_config(row["mcp_config"]),
         }
     )
     merged = _deep_merge(
         generated,
-        _normalize_nested_mcp_config(row.get('agent_settings')),
+        _normalize_nested_mcp_config(row.get("agent_settings")),
     )
     return _normalize_nested_mcp_config(merged)
 
@@ -202,28 +202,28 @@ def _build_user_agent_settings(row: Mapping[str, Any]) -> dict[str, Any]:
 def _build_user_conversation_settings(row: Mapping[str, Any]) -> dict[str, Any]:
     generated = _strip_none_and_empty(
         {
-            'max_iterations': row['max_iterations'],
-            'confirmation_mode': row['confirmation_mode'],
-            'security_analyzer': row['security_analyzer'],
+            "max_iterations": row["max_iterations"],
+            "confirmation_mode": row["confirmation_mode"],
+            "security_analyzer": row["security_analyzer"],
         }
     )
-    return _deep_merge(generated, row.get('conversation_settings') or {})
+    return _deep_merge(generated, row.get("conversation_settings") or {})
 
 
 def _build_org_member_agent_settings_diff(row: Mapping[str, Any]) -> dict[str, Any]:
     generated = _strip_none_and_empty(
         {
-            'schema_version': 1,
-            'llm': {
-                'model': row['llm_model'],
-                'base_url': row['llm_base_url'],
+            "schema_version": 1,
+            "llm": {
+                "model": row["llm_model"],
+                "base_url": row["llm_base_url"],
             },
-            'mcp_config': _normalize_mcp_config(row['mcp_config']),
+            "mcp_config": _normalize_mcp_config(row["mcp_config"]),
         }
     )
     merged = _deep_merge(
         generated,
-        _normalize_nested_mcp_config(row.get('agent_settings_diff')),
+        _normalize_nested_mcp_config(row.get("agent_settings_diff")),
     )
     return _normalize_nested_mcp_config(merged)
 
@@ -231,29 +231,29 @@ def _build_org_member_agent_settings_diff(row: Mapping[str, Any]) -> dict[str, A
 def _build_org_member_conversation_settings_diff(
     row: Mapping[str, Any],
 ) -> dict[str, Any]:
-    generated = _strip_none_and_empty({'max_iterations': row['max_iterations']})
-    return _deep_merge(generated, row.get('conversation_settings_diff') or {})
+    generated = _strip_none_and_empty({"max_iterations": row["max_iterations"]})
+    return _deep_merge(generated, row.get("conversation_settings_diff") or {})
 
 
 def _build_org_agent_settings(row: Mapping[str, Any]) -> dict[str, Any]:
     generated = _strip_none_and_empty(
         {
-            'schema_version': 1,
-            'agent': row['agent'],
-            'llm': {
-                'model': row['default_llm_model'],
-                'base_url': row['default_llm_base_url'],
+            "schema_version": 1,
+            "agent": row["agent"],
+            "llm": {
+                "model": row["default_llm_model"],
+                "base_url": row["default_llm_base_url"],
             },
-            'condenser': {
-                'enabled': row['enable_default_condenser'],
-                'max_size': row['condenser_max_size'],
+            "condenser": {
+                "enabled": row["enable_default_condenser"],
+                "max_size": row["condenser_max_size"],
             },
-            'mcp_config': _normalize_mcp_config(row['mcp_config']),
+            "mcp_config": _normalize_mcp_config(row["mcp_config"]),
         }
     )
     merged = _deep_merge(
         generated,
-        _normalize_nested_mcp_config(row.get('agent_settings')),
+        _normalize_nested_mcp_config(row.get("agent_settings")),
     )
     return _normalize_nested_mcp_config(merged)
 
@@ -261,12 +261,12 @@ def _build_org_agent_settings(row: Mapping[str, Any]) -> dict[str, Any]:
 def _build_org_conversation_settings(row: Mapping[str, Any]) -> dict[str, Any]:
     generated = _strip_none_and_empty(
         {
-            'max_iterations': row['default_max_iterations'],
-            'confirmation_mode': row['confirmation_mode'],
-            'security_analyzer': row['security_analyzer'],
+            "max_iterations": row["default_max_iterations"],
+            "confirmation_mode": row["confirmation_mode"],
+            "security_analyzer": row["security_analyzer"],
         }
     )
-    return _deep_merge(generated, row.get('conversation_settings') or {})
+    return _deep_merge(generated, row.get("conversation_settings") or {})
 
 
 def _get_nested_value(data: Mapping[str, Any] | None, *path: str) -> Any:
@@ -279,128 +279,128 @@ def _get_nested_value(data: Mapping[str, Any] | None, *path: str) -> Any:
 
 
 def _legacy_user_settings_values(row: Mapping[str, Any]) -> dict[str, Any]:
-    agent_settings = row.get('agent_settings') or {}
-    conversation_settings = row.get('conversation_settings') or {}
-    condenser_enabled = _get_nested_value(agent_settings, 'condenser', 'enabled')
+    agent_settings = row.get("agent_settings") or {}
+    conversation_settings = row.get("conversation_settings") or {}
+    condenser_enabled = _get_nested_value(agent_settings, "condenser", "enabled")
     return {
-        'agent': _get_nested_value(agent_settings, 'agent'),
-        'max_iterations': _get_nested_value(conversation_settings, 'max_iterations'),
-        'security_analyzer': _get_nested_value(
-            conversation_settings, 'security_analyzer'
+        "agent": _get_nested_value(agent_settings, "agent"),
+        "max_iterations": _get_nested_value(conversation_settings, "max_iterations"),
+        "security_analyzer": _get_nested_value(
+            conversation_settings, "security_analyzer"
         ),
-        'confirmation_mode': _get_nested_value(
-            conversation_settings, 'confirmation_mode'
+        "confirmation_mode": _get_nested_value(
+            conversation_settings, "confirmation_mode"
         ),
-        'llm_model': _get_nested_value(agent_settings, 'llm', 'model'),
-        'llm_base_url': _get_nested_value(agent_settings, 'llm', 'base_url'),
-        'enable_default_condenser': (
+        "llm_model": _get_nested_value(agent_settings, "llm", "model"),
+        "llm_base_url": _get_nested_value(agent_settings, "llm", "base_url"),
+        "enable_default_condenser": (
             True if condenser_enabled is None else condenser_enabled
         ),
-        'condenser_max_size': _get_nested_value(
-            agent_settings, 'condenser', 'max_size'
+        "condenser_max_size": _get_nested_value(
+            agent_settings, "condenser", "max_size"
         ),
     }
 
 
 def _legacy_org_member_values(row: Mapping[str, Any]) -> dict[str, Any]:
-    agent_settings_diff = row.get('agent_settings_diff') or {}
-    conversation_settings_diff = row.get('conversation_settings_diff') or {}
+    agent_settings_diff = row.get("agent_settings_diff") or {}
+    conversation_settings_diff = row.get("conversation_settings_diff") or {}
     return {
-        'llm_model': _get_nested_value(agent_settings_diff, 'llm', 'model'),
-        'llm_base_url': _get_nested_value(agent_settings_diff, 'llm', 'base_url'),
-        'max_iterations': _get_nested_value(
-            conversation_settings_diff, 'max_iterations'
+        "llm_model": _get_nested_value(agent_settings_diff, "llm", "model"),
+        "llm_base_url": _get_nested_value(agent_settings_diff, "llm", "base_url"),
+        "max_iterations": _get_nested_value(
+            conversation_settings_diff, "max_iterations"
         ),
-        'mcp_config': _to_legacy_mcp_config(
-            _get_nested_value(agent_settings_diff, 'mcp_config')
+        "mcp_config": _to_legacy_mcp_config(
+            _get_nested_value(agent_settings_diff, "mcp_config")
         ),
     }
 
 
 def _legacy_org_values(row: Mapping[str, Any]) -> dict[str, Any]:
-    agent_settings = row.get('agent_settings') or {}
-    conversation_settings = row.get('conversation_settings') or {}
-    condenser_enabled = _get_nested_value(agent_settings, 'condenser', 'enabled')
+    agent_settings = row.get("agent_settings") or {}
+    conversation_settings = row.get("conversation_settings") or {}
+    condenser_enabled = _get_nested_value(agent_settings, "condenser", "enabled")
     return {
-        'agent': _get_nested_value(agent_settings, 'agent'),
-        'default_max_iterations': _get_nested_value(
-            conversation_settings, 'max_iterations'
+        "agent": _get_nested_value(agent_settings, "agent"),
+        "default_max_iterations": _get_nested_value(
+            conversation_settings, "max_iterations"
         ),
-        'security_analyzer': _get_nested_value(
-            conversation_settings, 'security_analyzer'
+        "security_analyzer": _get_nested_value(
+            conversation_settings, "security_analyzer"
         ),
-        'confirmation_mode': _get_nested_value(
-            conversation_settings, 'confirmation_mode'
+        "confirmation_mode": _get_nested_value(
+            conversation_settings, "confirmation_mode"
         ),
-        'default_llm_model': _get_nested_value(agent_settings, 'llm', 'model'),
-        'default_llm_base_url': _get_nested_value(agent_settings, 'llm', 'base_url'),
-        'enable_default_condenser': (
+        "default_llm_model": _get_nested_value(agent_settings, "llm", "model"),
+        "default_llm_base_url": _get_nested_value(agent_settings, "llm", "base_url"),
+        "enable_default_condenser": (
             True if condenser_enabled is None else condenser_enabled
         ),
-        'mcp_config': _to_legacy_mcp_config(
-            _get_nested_value(agent_settings, 'mcp_config')
+        "mcp_config": _to_legacy_mcp_config(
+            _get_nested_value(agent_settings, "mcp_config")
         ),
-        'condenser_max_size': _get_nested_value(
-            agent_settings, 'condenser', 'max_size'
+        "condenser_max_size": _get_nested_value(
+            agent_settings, "condenser", "max_size"
         ),
     }
 
 
 def upgrade() -> None:
     op.add_column(
-        'user_settings',
+        "user_settings",
         sa.Column(
-            'agent_settings', sa.JSON(), nullable=False, server_default=_EMPTY_JSON
+            "agent_settings", sa.JSON(), nullable=False, server_default=_EMPTY_JSON
         ),
     )
     op.add_column(
-        'user_settings',
+        "user_settings",
         sa.Column(
-            'conversation_settings',
+            "conversation_settings",
             sa.JSON(),
             nullable=False,
             server_default=_EMPTY_JSON,
         ),
     )
     op.add_column(
-        'org_member',
+        "org_member",
         sa.Column(
-            'agent_settings_diff',
+            "agent_settings_diff",
             sa.JSON(),
             nullable=False,
             server_default=_EMPTY_JSON,
         ),
     )
     op.add_column(
-        'org_member',
+        "org_member",
         sa.Column(
-            'conversation_settings_diff',
+            "conversation_settings_diff",
             sa.JSON(),
             nullable=False,
             server_default=_EMPTY_JSON,
         ),
     )
     op.add_column(
-        'org',
+        "org",
         sa.Column(
-            'agent_settings', sa.JSON(), nullable=False, server_default=_EMPTY_JSON
+            "agent_settings", sa.JSON(), nullable=False, server_default=_EMPTY_JSON
         ),
     )
     op.add_column(
-        'org',
+        "org",
         sa.Column(
-            'conversation_settings',
+            "conversation_settings",
             sa.JSON(),
             nullable=False,
             server_default=_EMPTY_JSON,
         ),
     )
 
-    op.add_column('org', sa.Column('_llm_api_key', sa.String(), nullable=True))
+    op.add_column("org", sa.Column("_llm_api_key", sa.String(), nullable=True))
     op.add_column(
-        'org_member',
+        "org_member",
         sa.Column(
-            'has_custom_llm_api_key',
+            "has_custom_llm_api_key",
             sa.Boolean(),
             nullable=False,
             server_default=sa.false(),
@@ -410,19 +410,19 @@ def upgrade() -> None:
     bind = op.get_bind()
 
     user_settings_table = sa.table(
-        'user_settings',
-        sa.column('id', sa.Integer()),
-        sa.column('agent', sa.String()),
-        sa.column('max_iterations', sa.Integer()),
-        sa.column('security_analyzer', sa.String()),
-        sa.column('confirmation_mode', sa.Boolean()),
-        sa.column('llm_model', sa.String()),
-        sa.column('llm_base_url', sa.String()),
-        sa.column('enable_default_condenser', sa.Boolean()),
-        sa.column('condenser_max_size', sa.Integer()),
-        sa.column('mcp_config', sa.JSON()),
-        sa.column('agent_settings', sa.JSON()),
-        sa.column('conversation_settings', sa.JSON()),
+        "user_settings",
+        sa.column("id", sa.Integer()),
+        sa.column("agent", sa.String()),
+        sa.column("max_iterations", sa.Integer()),
+        sa.column("security_analyzer", sa.String()),
+        sa.column("confirmation_mode", sa.Boolean()),
+        sa.column("llm_model", sa.String()),
+        sa.column("llm_base_url", sa.String()),
+        sa.column("enable_default_condenser", sa.Boolean()),
+        sa.column("condenser_max_size", sa.Integer()),
+        sa.column("mcp_config", sa.JSON()),
+        sa.column("agent_settings", sa.JSON()),
+        sa.column("conversation_settings", sa.JSON()),
     )
     user_settings_rows = bind.execute(
         sa.select(
@@ -443,7 +443,7 @@ def upgrade() -> None:
     for row in user_settings_rows:
         bind.execute(
             user_settings_table.update()
-            .where(user_settings_table.c.id == row['id'])
+            .where(user_settings_table.c.id == row["id"])
             .values(
                 agent_settings=_build_user_agent_settings(row),
                 conversation_settings=_build_user_conversation_settings(row),
@@ -451,15 +451,15 @@ def upgrade() -> None:
         )
 
     org_member_table = sa.table(
-        'org_member',
-        sa.column('org_id', sa.Uuid()),
-        sa.column('user_id', sa.Uuid()),
-        sa.column('max_iterations', sa.Integer()),
-        sa.column('llm_model', sa.String()),
-        sa.column('llm_base_url', sa.String()),
-        sa.column('mcp_config', sa.JSON()),
-        sa.column('agent_settings_diff', sa.JSON()),
-        sa.column('conversation_settings_diff', sa.JSON()),
+        "org_member",
+        sa.column("org_id", sa.Uuid()),
+        sa.column("user_id", sa.Uuid()),
+        sa.column("max_iterations", sa.Integer()),
+        sa.column("llm_model", sa.String()),
+        sa.column("llm_base_url", sa.String()),
+        sa.column("mcp_config", sa.JSON()),
+        sa.column("agent_settings_diff", sa.JSON()),
+        sa.column("conversation_settings_diff", sa.JSON()),
     )
     org_member_rows = bind.execute(
         sa.select(
@@ -476,8 +476,8 @@ def upgrade() -> None:
     for row in org_member_rows:
         bind.execute(
             org_member_table.update()
-            .where(org_member_table.c.org_id == row['org_id'])
-            .where(org_member_table.c.user_id == row['user_id'])
+            .where(org_member_table.c.org_id == row["org_id"])
+            .where(org_member_table.c.user_id == row["user_id"])
             .values(
                 agent_settings_diff=_build_org_member_agent_settings_diff(row),
                 conversation_settings_diff=_build_org_member_conversation_settings_diff(
@@ -487,19 +487,19 @@ def upgrade() -> None:
         )
 
     org_table = sa.table(
-        'org',
-        sa.column('id', sa.Uuid()),
-        sa.column('agent', sa.String()),
-        sa.column('default_max_iterations', sa.Integer()),
-        sa.column('security_analyzer', sa.String()),
-        sa.column('confirmation_mode', sa.Boolean()),
-        sa.column('default_llm_model', sa.String()),
-        sa.column('default_llm_base_url', sa.String()),
-        sa.column('enable_default_condenser', sa.Boolean()),
-        sa.column('mcp_config', sa.JSON()),
-        sa.column('condenser_max_size', sa.Integer()),
-        sa.column('agent_settings', sa.JSON()),
-        sa.column('conversation_settings', sa.JSON()),
+        "org",
+        sa.column("id", sa.Uuid()),
+        sa.column("agent", sa.String()),
+        sa.column("default_max_iterations", sa.Integer()),
+        sa.column("security_analyzer", sa.String()),
+        sa.column("confirmation_mode", sa.Boolean()),
+        sa.column("default_llm_model", sa.String()),
+        sa.column("default_llm_base_url", sa.String()),
+        sa.column("enable_default_condenser", sa.Boolean()),
+        sa.column("mcp_config", sa.JSON()),
+        sa.column("condenser_max_size", sa.Integer()),
+        sa.column("agent_settings", sa.JSON()),
+        sa.column("conversation_settings", sa.JSON()),
     )
     org_rows = bind.execute(
         sa.select(
@@ -520,111 +520,111 @@ def upgrade() -> None:
     for row in org_rows:
         bind.execute(
             org_table.update()
-            .where(org_table.c.id == row['id'])
+            .where(org_table.c.id == row["id"])
             .values(
                 agent_settings=_build_org_agent_settings(row),
                 conversation_settings=_build_org_conversation_settings(row),
             )
         )
 
-    op.alter_column('user_settings', 'agent_settings', server_default=None)
-    op.alter_column('user_settings', 'conversation_settings', server_default=None)
-    op.alter_column('org_member', 'agent_settings_diff', server_default=None)
-    op.alter_column('org_member', 'conversation_settings_diff', server_default=None)
-    op.alter_column('org', 'agent_settings', server_default=None)
-    op.alter_column('org', 'conversation_settings', server_default=None)
-    op.alter_column('org_member', 'has_custom_llm_api_key', server_default=None)
-    op.drop_column('user_settings', 'agent')
-    op.drop_column('user_settings', 'max_iterations')
-    op.drop_column('user_settings', 'security_analyzer')
-    op.drop_column('user_settings', 'confirmation_mode')
-    op.drop_column('user_settings', 'llm_model')
-    op.drop_column('user_settings', 'llm_base_url')
-    op.drop_column('user_settings', 'enable_default_condenser')
-    op.drop_column('user_settings', 'condenser_max_size')
-    op.drop_column('org_member', 'max_iterations')
-    op.drop_column('org_member', 'llm_model')
-    op.drop_column('org_member', 'llm_base_url')
-    op.drop_column('org_member', 'mcp_config')
-    op.drop_column('org', 'agent')
-    op.drop_column('org', 'default_max_iterations')
-    op.drop_column('org', 'security_analyzer')
-    op.drop_column('org', 'confirmation_mode')
-    op.drop_column('org', 'default_llm_model')
-    op.drop_column('org', 'default_llm_base_url')
-    op.drop_column('org', 'enable_default_condenser')
-    op.drop_column('org', 'mcp_config')
-    op.drop_column('org', 'condenser_max_size')
+    op.alter_column("user_settings", "agent_settings", server_default=None)
+    op.alter_column("user_settings", "conversation_settings", server_default=None)
+    op.alter_column("org_member", "agent_settings_diff", server_default=None)
+    op.alter_column("org_member", "conversation_settings_diff", server_default=None)
+    op.alter_column("org", "agent_settings", server_default=None)
+    op.alter_column("org", "conversation_settings", server_default=None)
+    op.alter_column("org_member", "has_custom_llm_api_key", server_default=None)
+    op.drop_column("user_settings", "agent")
+    op.drop_column("user_settings", "max_iterations")
+    op.drop_column("user_settings", "security_analyzer")
+    op.drop_column("user_settings", "confirmation_mode")
+    op.drop_column("user_settings", "llm_model")
+    op.drop_column("user_settings", "llm_base_url")
+    op.drop_column("user_settings", "enable_default_condenser")
+    op.drop_column("user_settings", "condenser_max_size")
+    op.drop_column("org_member", "max_iterations")
+    op.drop_column("org_member", "llm_model")
+    op.drop_column("org_member", "llm_base_url")
+    op.drop_column("org_member", "mcp_config")
+    op.drop_column("org", "agent")
+    op.drop_column("org", "default_max_iterations")
+    op.drop_column("org", "security_analyzer")
+    op.drop_column("org", "confirmation_mode")
+    op.drop_column("org", "default_llm_model")
+    op.drop_column("org", "default_llm_base_url")
+    op.drop_column("org", "enable_default_condenser")
+    op.drop_column("org", "mcp_config")
+    op.drop_column("org", "condenser_max_size")
 
 
 def downgrade() -> None:
-    op.add_column('user_settings', sa.Column('agent', sa.String(), nullable=True))
+    op.add_column("user_settings", sa.Column("agent", sa.String(), nullable=True))
     op.add_column(
-        'user_settings', sa.Column('max_iterations', sa.Integer(), nullable=True)
+        "user_settings", sa.Column("max_iterations", sa.Integer(), nullable=True)
     )
     op.add_column(
-        'user_settings', sa.Column('security_analyzer', sa.String(), nullable=True)
+        "user_settings", sa.Column("security_analyzer", sa.String(), nullable=True)
     )
     op.add_column(
-        'user_settings', sa.Column('confirmation_mode', sa.Boolean(), nullable=True)
+        "user_settings", sa.Column("confirmation_mode", sa.Boolean(), nullable=True)
     )
-    op.add_column('user_settings', sa.Column('llm_model', sa.String(), nullable=True))
+    op.add_column("user_settings", sa.Column("llm_model", sa.String(), nullable=True))
     op.add_column(
-        'user_settings', sa.Column('llm_base_url', sa.String(), nullable=True)
+        "user_settings", sa.Column("llm_base_url", sa.String(), nullable=True)
     )
     op.add_column(
-        'user_settings',
+        "user_settings",
         sa.Column(
-            'enable_default_condenser',
+            "enable_default_condenser",
             sa.Boolean(),
             nullable=False,
             server_default=sa.true(),
         ),
     )
     op.add_column(
-        'user_settings', sa.Column('condenser_max_size', sa.Integer(), nullable=True)
+        "user_settings", sa.Column("condenser_max_size", sa.Integer(), nullable=True)
     )
-    op.add_column('org_member', sa.Column('llm_base_url', sa.String(), nullable=True))
-    op.add_column('org_member', sa.Column('llm_model', sa.String(), nullable=True))
+    op.add_column("org_member", sa.Column("llm_base_url", sa.String(), nullable=True))
+    op.add_column("org_member", sa.Column("llm_model", sa.String(), nullable=True))
     op.add_column(
-        'org_member', sa.Column('max_iterations', sa.Integer(), nullable=True)
+        "org_member", sa.Column("max_iterations", sa.Integer(), nullable=True)
     )
-    op.add_column('org_member', sa.Column('mcp_config', sa.JSON(), nullable=True))
-    op.add_column('org', sa.Column('agent', sa.String(), nullable=True))
+    op.add_column("org_member", sa.Column("mcp_config", sa.JSON(), nullable=True))
+    op.add_column("org", sa.Column("agent", sa.String(), nullable=True))
     op.add_column(
-        'org', sa.Column('default_max_iterations', sa.Integer(), nullable=True)
+        "org", sa.Column("default_max_iterations", sa.Integer(), nullable=True)
     )
-    op.add_column('org', sa.Column('security_analyzer', sa.String(), nullable=True))
-    op.add_column('org', sa.Column('confirmation_mode', sa.Boolean(), nullable=True))
-    op.add_column('org', sa.Column('default_llm_model', sa.String(), nullable=True))
-    op.add_column('org', sa.Column('default_llm_base_url', sa.String(), nullable=True))
+    op.add_column("org", sa.Column("security_analyzer", sa.String(), nullable=True))
+    op.add_column("org", sa.Column("confirmation_mode", sa.Boolean(), nullable=True))
+    op.add_column("org", sa.Column("default_llm_model", sa.String(), nullable=True))
+    op.add_column("org", sa.Column("default_llm_base_url", sa.String(), nullable=True))
     op.add_column(
-        'org',
+        "org",
         sa.Column(
-            'enable_default_condenser',
+            "enable_default_condenser",
             sa.Boolean(),
             nullable=False,
             server_default=sa.true(),
         ),
     )
-    op.add_column('org', sa.Column('mcp_config', sa.JSON(), nullable=True))
-    op.add_column('org', sa.Column('condenser_max_size', sa.Integer(), nullable=True))
+    op.add_column("org", sa.Column("mcp_config", sa.JSON(), nullable=True))
+    op.add_column("org", sa.Column("condenser_max_size", sa.Integer(), nullable=True))
 
     bind = op.get_bind()
 
     user_settings_table = sa.table(
-        'user_settings',
-        sa.column('id', sa.Integer()),
-        sa.column('agent_settings', sa.JSON()),
-        sa.column('conversation_settings', sa.JSON()),
-        sa.column('agent', sa.String()),
-        sa.column('max_iterations', sa.Integer()),
-        sa.column('security_analyzer', sa.String()),
-        sa.column('confirmation_mode', sa.Boolean()),
-        sa.column('llm_model', sa.String()),
-        sa.column('llm_base_url', sa.String()),
-        sa.column('enable_default_condenser', sa.Boolean()),
-        sa.column('condenser_max_size', sa.Integer()),
+        "user_settings",
+        sa.column("id", sa.Integer()),
+        sa.column("agent_settings", sa.JSON()),
+        sa.column("conversation_settings", sa.JSON()),
+        sa.column("agent", sa.String()),
+        sa.column("max_iterations", sa.Integer()),
+        sa.column("security_analyzer", sa.String()),
+        sa.column("confirmation_mode", sa.Boolean()),
+        sa.column("llm_model", sa.String()),
+        sa.column("llm_base_url", sa.String()),
+        sa.column("enable_default_condenser", sa.Boolean()),
+        sa.column("condenser_max_size", sa.Integer()),
     )
     user_settings_rows = bind.execute(
         sa.select(
@@ -636,20 +636,20 @@ def downgrade() -> None:
     for row in user_settings_rows:
         bind.execute(
             user_settings_table.update()
-            .where(user_settings_table.c.id == row['id'])
+            .where(user_settings_table.c.id == row["id"])
             .values(**_legacy_user_settings_values(row))
         )
 
     org_member_table = sa.table(
-        'org_member',
-        sa.column('org_id', sa.Uuid()),
-        sa.column('user_id', sa.Uuid()),
-        sa.column('agent_settings_diff', sa.JSON()),
-        sa.column('conversation_settings_diff', sa.JSON()),
-        sa.column('llm_model', sa.String()),
-        sa.column('llm_base_url', sa.String()),
-        sa.column('max_iterations', sa.Integer()),
-        sa.column('mcp_config', sa.JSON()),
+        "org_member",
+        sa.column("org_id", sa.Uuid()),
+        sa.column("user_id", sa.Uuid()),
+        sa.column("agent_settings_diff", sa.JSON()),
+        sa.column("conversation_settings_diff", sa.JSON()),
+        sa.column("llm_model", sa.String()),
+        sa.column("llm_base_url", sa.String()),
+        sa.column("max_iterations", sa.Integer()),
+        sa.column("mcp_config", sa.JSON()),
     )
     org_member_rows = bind.execute(
         sa.select(
@@ -662,25 +662,25 @@ def downgrade() -> None:
     for row in org_member_rows:
         bind.execute(
             org_member_table.update()
-            .where(org_member_table.c.org_id == row['org_id'])
-            .where(org_member_table.c.user_id == row['user_id'])
+            .where(org_member_table.c.org_id == row["org_id"])
+            .where(org_member_table.c.user_id == row["user_id"])
             .values(**_legacy_org_member_values(row))
         )
 
     org_table = sa.table(
-        'org',
-        sa.column('id', sa.Uuid()),
-        sa.column('agent_settings', sa.JSON()),
-        sa.column('conversation_settings', sa.JSON()),
-        sa.column('agent', sa.String()),
-        sa.column('default_max_iterations', sa.Integer()),
-        sa.column('security_analyzer', sa.String()),
-        sa.column('confirmation_mode', sa.Boolean()),
-        sa.column('default_llm_model', sa.String()),
-        sa.column('default_llm_base_url', sa.String()),
-        sa.column('enable_default_condenser', sa.Boolean()),
-        sa.column('mcp_config', sa.JSON()),
-        sa.column('condenser_max_size', sa.Integer()),
+        "org",
+        sa.column("id", sa.Uuid()),
+        sa.column("agent_settings", sa.JSON()),
+        sa.column("conversation_settings", sa.JSON()),
+        sa.column("agent", sa.String()),
+        sa.column("default_max_iterations", sa.Integer()),
+        sa.column("security_analyzer", sa.String()),
+        sa.column("confirmation_mode", sa.Boolean()),
+        sa.column("default_llm_model", sa.String()),
+        sa.column("default_llm_base_url", sa.String()),
+        sa.column("enable_default_condenser", sa.Boolean()),
+        sa.column("mcp_config", sa.JSON()),
+        sa.column("condenser_max_size", sa.Integer()),
     )
     org_rows = bind.execute(
         sa.select(
@@ -692,15 +692,15 @@ def downgrade() -> None:
     for row in org_rows:
         bind.execute(
             org_table.update()
-            .where(org_table.c.id == row['id'])
+            .where(org_table.c.id == row["id"])
             .values(**_legacy_org_values(row))
         )
 
-    op.drop_column('org', 'agent_settings')
-    op.drop_column('org', 'conversation_settings')
-    op.drop_column('org', '_llm_api_key')
-    op.drop_column('org_member', 'agent_settings_diff')
-    op.drop_column('org_member', 'conversation_settings_diff')
-    op.drop_column('org_member', 'has_custom_llm_api_key')
-    op.drop_column('user_settings', 'agent_settings')
-    op.drop_column('user_settings', 'conversation_settings')
+    op.drop_column("org", "agent_settings")
+    op.drop_column("org", "conversation_settings")
+    op.drop_column("org", "_llm_api_key")
+    op.drop_column("org_member", "agent_settings_diff")
+    op.drop_column("org_member", "conversation_settings_diff")
+    op.drop_column("org_member", "has_custom_llm_api_key")
+    op.drop_column("user_settings", "agent_settings")
+    op.drop_column("user_settings", "conversation_settings")

--- a/enterprise/tests/unit/test_migration_108_add_agent_settings.py
+++ b/enterprise/tests/unit/test_migration_108_add_agent_settings.py
@@ -50,6 +50,43 @@ def test_user_settings_are_split_into_agent_and_conversation_buckets():
     }
 
 
+def test_user_settings_normalize_legacy_mcp_config():
+    row = {
+        'agent': 'CodeActAgent',
+        'max_iterations': 42,
+        'security_analyzer': 'llm',
+        'confirmation_mode': True,
+        'llm_model': 'anthropic/claude-sonnet-4-5-20250929',
+        'llm_base_url': 'https://api.example.com',
+        'enable_default_condenser': False,
+        'condenser_max_size': 128,
+        'mcp_config': {
+            'sse_servers': [],
+            'stdio_servers': [],
+            'shttp_servers': [
+                {'url': 'https://mcp.example.com', 'api_key': None, 'timeout': 60}
+            ],
+        },
+        'agent_settings': {},
+        'conversation_settings': {},
+    }
+
+    assert migration_108._build_user_agent_settings(row) == {
+        'schema_version': 1,
+        'agent': 'CodeActAgent',
+        'llm': {
+            'model': 'anthropic/claude-sonnet-4-5-20250929',
+            'base_url': 'https://api.example.com',
+        },
+        'condenser': {'enabled': False, 'max_size': 128},
+        'mcp_config': {
+            'mcpServers': {
+                'shttp': {'url': 'https://mcp.example.com', 'timeout': 60}
+            }
+        },
+    }
+
+
 def test_org_member_diffs_use_nested_llm_and_conversation_settings():
     row = {
         'max_iterations': 50,
@@ -74,6 +111,36 @@ def test_org_member_diffs_use_nested_llm_and_conversation_settings():
         'mcp_config': {'mcpServers': {'admin': {'url': 'https://mcp.example.com'}}},
     }
     assert conversation_settings_diff == {'max_iterations': 50}
+
+
+def test_org_member_diffs_normalize_legacy_mcp_config():
+    row = {
+        'max_iterations': 50,
+        'llm_model': 'openhands/claude-3',
+        'llm_base_url': 'https://proxy.example.com',
+        'mcp_config': {
+            'sse_servers': [],
+            'stdio_servers': [],
+            'shttp_servers': [
+                {'url': 'https://mcp.deepwiki.com/mcp', 'api_key': None, 'timeout': 60}
+            ],
+        },
+        'agent_settings_diff': {},
+        'conversation_settings_diff': {},
+    }
+
+    assert migration_108._build_org_member_agent_settings_diff(row) == {
+        'schema_version': 1,
+        'llm': {
+            'model': 'openhands/claude-3',
+            'base_url': 'https://proxy.example.com',
+        },
+        'mcp_config': {
+            'mcpServers': {
+                'shttp': {'url': 'https://mcp.deepwiki.com/mcp', 'timeout': 60}
+            }
+        },
+    }
 
 
 def test_org_settings_are_split_into_agent_and_conversation_buckets():
@@ -138,6 +205,44 @@ def test_downgrade_extracts_legacy_values_from_nested_settings():
         'llm_base_url': 'https://api.example.com',
         'enable_default_condenser': False,
         'condenser_max_size': 128,
+    }
+
+
+def test_downgrade_restores_legacy_mcp_config_from_sdk_settings():
+    row = {
+        'agent_settings_diff': {
+            'schema_version': 1,
+            'mcp_config': {
+                'mcpServers': {
+                    'sse': {'url': 'https://mcp.example.com', 'transport': 'sse'},
+                    'shttp': {
+                        'url': 'https://mcp.deepwiki.com/mcp',
+                        'timeout': 60,
+                    },
+                    'deepwiki-stdio': {
+                        'command': 'npx',
+                        'args': ['-y', 'deepwiki-mcp'],
+                        'env': {'A': 'B'},
+                    },
+                }
+            },
+        },
+        'conversation_settings_diff': {},
+    }
+
+    assert migration_108._legacy_org_member_values(row)['mcp_config'] == {
+        'sse_servers': [{'url': 'https://mcp.example.com'}],
+        'stdio_servers': [
+            {
+                'name': 'deepwiki-stdio',
+                'command': 'npx',
+                'args': ['-y', 'deepwiki-mcp'],
+                'env': {'A': 'B'},
+            }
+        ],
+        'shttp_servers': [
+            {'url': 'https://mcp.deepwiki.com/mcp', 'timeout': 60}
+        ],
     }
 
 

--- a/enterprise/tests/unit/test_migration_108_add_agent_settings.py
+++ b/enterprise/tests/unit/test_migration_108_add_agent_settings.py
@@ -5,11 +5,11 @@ from storage.user_settings import UserSettings
 
 MIGRATION_PATH = (
     Path(__file__).resolve().parents[2]
-    / 'migrations'
-    / 'versions'
-    / '108_add_agent_settings_to_enterprise_settings.py'
+    / "migrations"
+    / "versions"
+    / "108_add_agent_settings_to_enterprise_settings.py"
 )
-spec = spec_from_file_location('migration_108', MIGRATION_PATH)
+spec = spec_from_file_location("migration_108", MIGRATION_PATH)
 assert spec is not None and spec.loader is not None
 migration_108 = module_from_spec(spec)
 spec.loader.exec_module(migration_108)
@@ -17,84 +17,82 @@ spec.loader.exec_module(migration_108)
 
 def test_user_settings_are_split_into_agent_and_conversation_buckets():
     row = {
-        'agent': 'CodeActAgent',
-        'max_iterations': 42,
-        'security_analyzer': 'llm',
-        'confirmation_mode': True,
-        'llm_model': 'anthropic/claude-sonnet-4-5-20250929',
-        'llm_base_url': 'https://api.example.com',
-        'enable_default_condenser': False,
-        'condenser_max_size': 128,
-        'mcp_config': {'mcpServers': {'admin': {'url': 'https://mcp.example.com'}}},
-        'agent_settings': {},
-        'conversation_settings': {},
+        "agent": "CodeActAgent",
+        "max_iterations": 42,
+        "security_analyzer": "llm",
+        "confirmation_mode": True,
+        "llm_model": "anthropic/claude-sonnet-4-5-20250929",
+        "llm_base_url": "https://api.example.com",
+        "enable_default_condenser": False,
+        "condenser_max_size": 128,
+        "mcp_config": {"mcpServers": {"admin": {"url": "https://mcp.example.com"}}},
+        "agent_settings": {},
+        "conversation_settings": {},
     }
 
     agent_settings = migration_108._build_user_agent_settings(row)
     conversation_settings = migration_108._build_user_conversation_settings(row)
 
     assert agent_settings == {
-        'schema_version': 1,
-        'agent': 'CodeActAgent',
-        'llm': {
-            'model': 'anthropic/claude-sonnet-4-5-20250929',
-            'base_url': 'https://api.example.com',
+        "schema_version": 1,
+        "agent": "CodeActAgent",
+        "llm": {
+            "model": "anthropic/claude-sonnet-4-5-20250929",
+            "base_url": "https://api.example.com",
         },
-        'condenser': {'enabled': False, 'max_size': 128},
-        'mcp_config': {'mcpServers': {'admin': {'url': 'https://mcp.example.com'}}},
+        "condenser": {"enabled": False, "max_size": 128},
+        "mcp_config": {"mcpServers": {"admin": {"url": "https://mcp.example.com"}}},
     }
     assert conversation_settings == {
-        'max_iterations': 42,
-        'confirmation_mode': True,
-        'security_analyzer': 'llm',
+        "max_iterations": 42,
+        "confirmation_mode": True,
+        "security_analyzer": "llm",
     }
 
 
 def test_user_settings_normalize_legacy_mcp_config():
     row = {
-        'agent': 'CodeActAgent',
-        'max_iterations': 42,
-        'security_analyzer': 'llm',
-        'confirmation_mode': True,
-        'llm_model': 'anthropic/claude-sonnet-4-5-20250929',
-        'llm_base_url': 'https://api.example.com',
-        'enable_default_condenser': False,
-        'condenser_max_size': 128,
-        'mcp_config': {
-            'sse_servers': [],
-            'stdio_servers': [],
-            'shttp_servers': [
-                {'url': 'https://mcp.example.com', 'api_key': None, 'timeout': 60}
+        "agent": "CodeActAgent",
+        "max_iterations": 42,
+        "security_analyzer": "llm",
+        "confirmation_mode": True,
+        "llm_model": "anthropic/claude-sonnet-4-5-20250929",
+        "llm_base_url": "https://api.example.com",
+        "enable_default_condenser": False,
+        "condenser_max_size": 128,
+        "mcp_config": {
+            "sse_servers": [],
+            "stdio_servers": [],
+            "shttp_servers": [
+                {"url": "https://mcp.example.com", "api_key": None, "timeout": 60}
             ],
         },
-        'agent_settings': {},
-        'conversation_settings': {},
+        "agent_settings": {},
+        "conversation_settings": {},
     }
 
     assert migration_108._build_user_agent_settings(row) == {
-        'schema_version': 1,
-        'agent': 'CodeActAgent',
-        'llm': {
-            'model': 'anthropic/claude-sonnet-4-5-20250929',
-            'base_url': 'https://api.example.com',
+        "schema_version": 1,
+        "agent": "CodeActAgent",
+        "llm": {
+            "model": "anthropic/claude-sonnet-4-5-20250929",
+            "base_url": "https://api.example.com",
         },
-        'condenser': {'enabled': False, 'max_size': 128},
-        'mcp_config': {
-            'mcpServers': {
-                'shttp': {'url': 'https://mcp.example.com', 'timeout': 60}
-            }
+        "condenser": {"enabled": False, "max_size": 128},
+        "mcp_config": {
+            "mcpServers": {"shttp": {"url": "https://mcp.example.com", "timeout": 60}}
         },
     }
 
 
 def test_org_member_diffs_use_nested_llm_and_conversation_settings():
     row = {
-        'max_iterations': 50,
-        'llm_model': 'openhands/claude-3',
-        'llm_base_url': 'https://proxy.example.com',
-        'mcp_config': {'mcpServers': {'admin': {'url': 'https://mcp.example.com'}}},
-        'agent_settings_diff': {},
-        'conversation_settings_diff': {},
+        "max_iterations": 50,
+        "llm_model": "openhands/claude-3",
+        "llm_base_url": "https://proxy.example.com",
+        "mcp_config": {"mcpServers": {"admin": {"url": "https://mcp.example.com"}}},
+        "agent_settings_diff": {},
+        "conversation_settings_diff": {},
     }
 
     agent_settings_diff = migration_108._build_org_member_agent_settings_diff(row)
@@ -103,41 +101,41 @@ def test_org_member_diffs_use_nested_llm_and_conversation_settings():
     )
 
     assert agent_settings_diff == {
-        'schema_version': 1,
-        'llm': {
-            'model': 'openhands/claude-3',
-            'base_url': 'https://proxy.example.com',
+        "schema_version": 1,
+        "llm": {
+            "model": "openhands/claude-3",
+            "base_url": "https://proxy.example.com",
         },
-        'mcp_config': {'mcpServers': {'admin': {'url': 'https://mcp.example.com'}}},
+        "mcp_config": {"mcpServers": {"admin": {"url": "https://mcp.example.com"}}},
     }
-    assert conversation_settings_diff == {'max_iterations': 50}
+    assert conversation_settings_diff == {"max_iterations": 50}
 
 
 def test_org_member_diffs_normalize_legacy_mcp_config():
     row = {
-        'max_iterations': 50,
-        'llm_model': 'openhands/claude-3',
-        'llm_base_url': 'https://proxy.example.com',
-        'mcp_config': {
-            'sse_servers': [],
-            'stdio_servers': [],
-            'shttp_servers': [
-                {'url': 'https://mcp.deepwiki.com/mcp', 'api_key': None, 'timeout': 60}
+        "max_iterations": 50,
+        "llm_model": "openhands/claude-3",
+        "llm_base_url": "https://proxy.example.com",
+        "mcp_config": {
+            "sse_servers": [],
+            "stdio_servers": [],
+            "shttp_servers": [
+                {"url": "https://mcp.deepwiki.com/mcp", "api_key": None, "timeout": 60}
             ],
         },
-        'agent_settings_diff': {},
-        'conversation_settings_diff': {},
+        "agent_settings_diff": {},
+        "conversation_settings_diff": {},
     }
 
     assert migration_108._build_org_member_agent_settings_diff(row) == {
-        'schema_version': 1,
-        'llm': {
-            'model': 'openhands/claude-3',
-            'base_url': 'https://proxy.example.com',
+        "schema_version": 1,
+        "llm": {
+            "model": "openhands/claude-3",
+            "base_url": "https://proxy.example.com",
         },
-        'mcp_config': {
-            'mcpServers': {
-                'shttp': {'url': 'https://mcp.deepwiki.com/mcp', 'timeout': 60}
+        "mcp_config": {
+            "mcpServers": {
+                "shttp": {"url": "https://mcp.deepwiki.com/mcp", "timeout": 60}
             }
         },
     }
@@ -145,120 +143,118 @@ def test_org_member_diffs_normalize_legacy_mcp_config():
 
 def test_org_settings_are_split_into_agent_and_conversation_buckets():
     row = {
-        'agent': 'CodeActAgent',
-        'default_max_iterations': 99,
-        'security_analyzer': 'auto',
-        'confirmation_mode': False,
-        'default_llm_model': 'anthropic/claude-3-7-sonnet',
-        'default_llm_base_url': 'https://api.example.com',
-        'enable_default_condenser': True,
-        'condenser_max_size': 256,
-        'mcp_config': {'mcpServers': {'org': {'url': 'https://org-mcp.example.com'}}},
-        'agent_settings': {},
-        'conversation_settings': {},
+        "agent": "CodeActAgent",
+        "default_max_iterations": 99,
+        "security_analyzer": "auto",
+        "confirmation_mode": False,
+        "default_llm_model": "anthropic/claude-3-7-sonnet",
+        "default_llm_base_url": "https://api.example.com",
+        "enable_default_condenser": True,
+        "condenser_max_size": 256,
+        "mcp_config": {"mcpServers": {"org": {"url": "https://org-mcp.example.com"}}},
+        "agent_settings": {},
+        "conversation_settings": {},
     }
 
     agent_settings = migration_108._build_org_agent_settings(row)
     conversation_settings = migration_108._build_org_conversation_settings(row)
 
     assert agent_settings == {
-        'schema_version': 1,
-        'agent': 'CodeActAgent',
-        'llm': {
-            'model': 'anthropic/claude-3-7-sonnet',
-            'base_url': 'https://api.example.com',
+        "schema_version": 1,
+        "agent": "CodeActAgent",
+        "llm": {
+            "model": "anthropic/claude-3-7-sonnet",
+            "base_url": "https://api.example.com",
         },
-        'condenser': {'enabled': True, 'max_size': 256},
-        'mcp_config': {'mcpServers': {'org': {'url': 'https://org-mcp.example.com'}}},
+        "condenser": {"enabled": True, "max_size": 256},
+        "mcp_config": {"mcpServers": {"org": {"url": "https://org-mcp.example.com"}}},
     }
     assert conversation_settings == {
-        'max_iterations': 99,
-        'confirmation_mode': False,
-        'security_analyzer': 'auto',
+        "max_iterations": 99,
+        "confirmation_mode": False,
+        "security_analyzer": "auto",
     }
 
 
 def test_downgrade_extracts_legacy_values_from_nested_settings():
     row = {
-        'agent_settings': {
-            'schema_version': 1,
-            'agent': 'CodeActAgent',
-            'llm': {
-                'model': 'anthropic/claude-sonnet-4-5-20250929',
-                'base_url': 'https://api.example.com',
+        "agent_settings": {
+            "schema_version": 1,
+            "agent": "CodeActAgent",
+            "llm": {
+                "model": "anthropic/claude-sonnet-4-5-20250929",
+                "base_url": "https://api.example.com",
             },
-            'condenser': {'enabled': False, 'max_size': 128},
+            "condenser": {"enabled": False, "max_size": 128},
         },
-        'conversation_settings': {
-            'max_iterations': 42,
-            'confirmation_mode': True,
-            'security_analyzer': 'llm',
+        "conversation_settings": {
+            "max_iterations": 42,
+            "confirmation_mode": True,
+            "security_analyzer": "llm",
         },
     }
 
     assert migration_108._legacy_user_settings_values(row) == {
-        'agent': 'CodeActAgent',
-        'max_iterations': 42,
-        'security_analyzer': 'llm',
-        'confirmation_mode': True,
-        'llm_model': 'anthropic/claude-sonnet-4-5-20250929',
-        'llm_base_url': 'https://api.example.com',
-        'enable_default_condenser': False,
-        'condenser_max_size': 128,
+        "agent": "CodeActAgent",
+        "max_iterations": 42,
+        "security_analyzer": "llm",
+        "confirmation_mode": True,
+        "llm_model": "anthropic/claude-sonnet-4-5-20250929",
+        "llm_base_url": "https://api.example.com",
+        "enable_default_condenser": False,
+        "condenser_max_size": 128,
     }
 
 
 def test_downgrade_restores_legacy_mcp_config_from_sdk_settings():
     row = {
-        'agent_settings_diff': {
-            'schema_version': 1,
-            'mcp_config': {
-                'mcpServers': {
-                    'sse': {'url': 'https://mcp.example.com', 'transport': 'sse'},
-                    'shttp': {
-                        'url': 'https://mcp.deepwiki.com/mcp',
-                        'timeout': 60,
+        "agent_settings_diff": {
+            "schema_version": 1,
+            "mcp_config": {
+                "mcpServers": {
+                    "sse": {"url": "https://mcp.example.com", "transport": "sse"},
+                    "shttp": {
+                        "url": "https://mcp.deepwiki.com/mcp",
+                        "timeout": 60,
                     },
-                    'deepwiki-stdio': {
-                        'command': 'npx',
-                        'args': ['-y', 'deepwiki-mcp'],
-                        'env': {'A': 'B'},
+                    "deepwiki-stdio": {
+                        "command": "npx",
+                        "args": ["-y", "deepwiki-mcp"],
+                        "env": {"A": "B"},
                     },
                 }
             },
         },
-        'conversation_settings_diff': {},
+        "conversation_settings_diff": {},
     }
 
-    assert migration_108._legacy_org_member_values(row)['mcp_config'] == {
-        'sse_servers': [{'url': 'https://mcp.example.com'}],
-        'stdio_servers': [
+    assert migration_108._legacy_org_member_values(row)["mcp_config"] == {
+        "sse_servers": [{"url": "https://mcp.example.com"}],
+        "stdio_servers": [
             {
-                'name': 'deepwiki-stdio',
-                'command': 'npx',
-                'args': ['-y', 'deepwiki-mcp'],
-                'env': {'A': 'B'},
+                "name": "deepwiki-stdio",
+                "command": "npx",
+                "args": ["-y", "deepwiki-mcp"],
+                "env": {"A": "B"},
             }
         ],
-        'shttp_servers': [
-            {'url': 'https://mcp.deepwiki.com/mcp', 'timeout': 60}
-        ],
+        "shttp_servers": [{"url": "https://mcp.deepwiki.com/mcp", "timeout": 60}],
     }
 
 
 def test_migrated_payload_loads_via_user_settings_to_settings():
     row = {
-        'agent': 'CodeActAgent',
-        'max_iterations': 42,
-        'security_analyzer': 'llm',
-        'confirmation_mode': True,
-        'llm_model': 'anthropic/claude-sonnet-4-5-20250929',
-        'llm_base_url': 'https://api.example.com',
-        'enable_default_condenser': False,
-        'condenser_max_size': 128,
-        'mcp_config': {'mcpServers': {'admin': {'url': 'https://mcp.example.com'}}},
-        'agent_settings': {},
-        'conversation_settings': {},
+        "agent": "CodeActAgent",
+        "max_iterations": 42,
+        "security_analyzer": "llm",
+        "confirmation_mode": True,
+        "llm_model": "anthropic/claude-sonnet-4-5-20250929",
+        "llm_base_url": "https://api.example.com",
+        "enable_default_condenser": False,
+        "condenser_max_size": 128,
+        "mcp_config": {"mcpServers": {"admin": {"url": "https://mcp.example.com"}}},
+        "agent_settings": {},
+        "conversation_settings": {},
     }
 
     user_settings = UserSettings(
@@ -268,16 +264,16 @@ def test_migrated_payload_loads_via_user_settings_to_settings():
 
     settings = user_settings.to_settings()
 
-    assert settings.agent_settings.agent == 'CodeActAgent'
-    assert settings.agent_settings.llm.model == 'anthropic/claude-sonnet-4-5-20250929'
-    assert settings.agent_settings.llm.base_url == 'https://api.example.com'
+    assert settings.agent_settings.agent == "CodeActAgent"
+    assert settings.agent_settings.llm.model == "anthropic/claude-sonnet-4-5-20250929"
+    assert settings.agent_settings.llm.base_url == "https://api.example.com"
     assert settings.agent_settings.condenser.enabled is False
     assert settings.agent_settings.condenser.max_size == 128
     assert settings.agent_settings.mcp_config is not None
     assert (
-        settings.agent_settings.mcp_config.mcpServers['admin'].url
-        == 'https://mcp.example.com'
+        settings.agent_settings.mcp_config.mcpServers["admin"].url
+        == "https://mcp.example.com"
     )
     assert settings.conversation_settings.max_iterations == 42
     assert settings.conversation_settings.confirmation_mode is True
-    assert settings.conversation_settings.security_analyzer == 'llm'
+    assert settings.conversation_settings.security_analyzer == "llm"

--- a/enterprise/tests/unit/test_migration_108_add_agent_settings.py
+++ b/enterprise/tests/unit/test_migration_108_add_agent_settings.py
@@ -5,11 +5,11 @@ from storage.user_settings import UserSettings
 
 MIGRATION_PATH = (
     Path(__file__).resolve().parents[2]
-    / "migrations"
-    / "versions"
-    / "108_add_agent_settings_to_enterprise_settings.py"
+    / 'migrations'
+    / 'versions'
+    / '108_add_agent_settings_to_enterprise_settings.py'
 )
-spec = spec_from_file_location("migration_108", MIGRATION_PATH)
+spec = spec_from_file_location('migration_108', MIGRATION_PATH)
 assert spec is not None and spec.loader is not None
 migration_108 = module_from_spec(spec)
 spec.loader.exec_module(migration_108)
@@ -17,82 +17,82 @@ spec.loader.exec_module(migration_108)
 
 def test_user_settings_are_split_into_agent_and_conversation_buckets():
     row = {
-        "agent": "CodeActAgent",
-        "max_iterations": 42,
-        "security_analyzer": "llm",
-        "confirmation_mode": True,
-        "llm_model": "anthropic/claude-sonnet-4-5-20250929",
-        "llm_base_url": "https://api.example.com",
-        "enable_default_condenser": False,
-        "condenser_max_size": 128,
-        "mcp_config": {"mcpServers": {"admin": {"url": "https://mcp.example.com"}}},
-        "agent_settings": {},
-        "conversation_settings": {},
+        'agent': 'CodeActAgent',
+        'max_iterations': 42,
+        'security_analyzer': 'llm',
+        'confirmation_mode': True,
+        'llm_model': 'anthropic/claude-sonnet-4-5-20250929',
+        'llm_base_url': 'https://api.example.com',
+        'enable_default_condenser': False,
+        'condenser_max_size': 128,
+        'mcp_config': {'mcpServers': {'admin': {'url': 'https://mcp.example.com'}}},
+        'agent_settings': {},
+        'conversation_settings': {},
     }
 
     agent_settings = migration_108._build_user_agent_settings(row)
     conversation_settings = migration_108._build_user_conversation_settings(row)
 
     assert agent_settings == {
-        "schema_version": 1,
-        "agent": "CodeActAgent",
-        "llm": {
-            "model": "anthropic/claude-sonnet-4-5-20250929",
-            "base_url": "https://api.example.com",
+        'schema_version': 1,
+        'agent': 'CodeActAgent',
+        'llm': {
+            'model': 'anthropic/claude-sonnet-4-5-20250929',
+            'base_url': 'https://api.example.com',
         },
-        "condenser": {"enabled": False, "max_size": 128},
-        "mcp_config": {"mcpServers": {"admin": {"url": "https://mcp.example.com"}}},
+        'condenser': {'enabled': False, 'max_size': 128},
+        'mcp_config': {'mcpServers': {'admin': {'url': 'https://mcp.example.com'}}},
     }
     assert conversation_settings == {
-        "max_iterations": 42,
-        "confirmation_mode": True,
-        "security_analyzer": "llm",
+        'max_iterations': 42,
+        'confirmation_mode': True,
+        'security_analyzer': 'llm',
     }
 
 
 def test_user_settings_normalize_legacy_mcp_config():
     row = {
-        "agent": "CodeActAgent",
-        "max_iterations": 42,
-        "security_analyzer": "llm",
-        "confirmation_mode": True,
-        "llm_model": "anthropic/claude-sonnet-4-5-20250929",
-        "llm_base_url": "https://api.example.com",
-        "enable_default_condenser": False,
-        "condenser_max_size": 128,
-        "mcp_config": {
-            "sse_servers": [],
-            "stdio_servers": [],
-            "shttp_servers": [
-                {"url": "https://mcp.example.com", "api_key": None, "timeout": 60}
+        'agent': 'CodeActAgent',
+        'max_iterations': 42,
+        'security_analyzer': 'llm',
+        'confirmation_mode': True,
+        'llm_model': 'anthropic/claude-sonnet-4-5-20250929',
+        'llm_base_url': 'https://api.example.com',
+        'enable_default_condenser': False,
+        'condenser_max_size': 128,
+        'mcp_config': {
+            'sse_servers': [],
+            'stdio_servers': [],
+            'shttp_servers': [
+                {'url': 'https://mcp.example.com', 'api_key': None, 'timeout': 60}
             ],
         },
-        "agent_settings": {},
-        "conversation_settings": {},
+        'agent_settings': {},
+        'conversation_settings': {},
     }
 
     assert migration_108._build_user_agent_settings(row) == {
-        "schema_version": 1,
-        "agent": "CodeActAgent",
-        "llm": {
-            "model": "anthropic/claude-sonnet-4-5-20250929",
-            "base_url": "https://api.example.com",
+        'schema_version': 1,
+        'agent': 'CodeActAgent',
+        'llm': {
+            'model': 'anthropic/claude-sonnet-4-5-20250929',
+            'base_url': 'https://api.example.com',
         },
-        "condenser": {"enabled": False, "max_size": 128},
-        "mcp_config": {
-            "mcpServers": {"shttp": {"url": "https://mcp.example.com", "timeout": 60}}
+        'condenser': {'enabled': False, 'max_size': 128},
+        'mcp_config': {
+            'mcpServers': {'shttp': {'url': 'https://mcp.example.com', 'timeout': 60}}
         },
     }
 
 
 def test_org_member_diffs_use_nested_llm_and_conversation_settings():
     row = {
-        "max_iterations": 50,
-        "llm_model": "openhands/claude-3",
-        "llm_base_url": "https://proxy.example.com",
-        "mcp_config": {"mcpServers": {"admin": {"url": "https://mcp.example.com"}}},
-        "agent_settings_diff": {},
-        "conversation_settings_diff": {},
+        'max_iterations': 50,
+        'llm_model': 'openhands/claude-3',
+        'llm_base_url': 'https://proxy.example.com',
+        'mcp_config': {'mcpServers': {'admin': {'url': 'https://mcp.example.com'}}},
+        'agent_settings_diff': {},
+        'conversation_settings_diff': {},
     }
 
     agent_settings_diff = migration_108._build_org_member_agent_settings_diff(row)
@@ -101,41 +101,41 @@ def test_org_member_diffs_use_nested_llm_and_conversation_settings():
     )
 
     assert agent_settings_diff == {
-        "schema_version": 1,
-        "llm": {
-            "model": "openhands/claude-3",
-            "base_url": "https://proxy.example.com",
+        'schema_version': 1,
+        'llm': {
+            'model': 'openhands/claude-3',
+            'base_url': 'https://proxy.example.com',
         },
-        "mcp_config": {"mcpServers": {"admin": {"url": "https://mcp.example.com"}}},
+        'mcp_config': {'mcpServers': {'admin': {'url': 'https://mcp.example.com'}}},
     }
-    assert conversation_settings_diff == {"max_iterations": 50}
+    assert conversation_settings_diff == {'max_iterations': 50}
 
 
 def test_org_member_diffs_normalize_legacy_mcp_config():
     row = {
-        "max_iterations": 50,
-        "llm_model": "openhands/claude-3",
-        "llm_base_url": "https://proxy.example.com",
-        "mcp_config": {
-            "sse_servers": [],
-            "stdio_servers": [],
-            "shttp_servers": [
-                {"url": "https://mcp.deepwiki.com/mcp", "api_key": None, "timeout": 60}
+        'max_iterations': 50,
+        'llm_model': 'openhands/claude-3',
+        'llm_base_url': 'https://proxy.example.com',
+        'mcp_config': {
+            'sse_servers': [],
+            'stdio_servers': [],
+            'shttp_servers': [
+                {'url': 'https://mcp.deepwiki.com/mcp', 'api_key': None, 'timeout': 60}
             ],
         },
-        "agent_settings_diff": {},
-        "conversation_settings_diff": {},
+        'agent_settings_diff': {},
+        'conversation_settings_diff': {},
     }
 
     assert migration_108._build_org_member_agent_settings_diff(row) == {
-        "schema_version": 1,
-        "llm": {
-            "model": "openhands/claude-3",
-            "base_url": "https://proxy.example.com",
+        'schema_version': 1,
+        'llm': {
+            'model': 'openhands/claude-3',
+            'base_url': 'https://proxy.example.com',
         },
-        "mcp_config": {
-            "mcpServers": {
-                "shttp": {"url": "https://mcp.deepwiki.com/mcp", "timeout": 60}
+        'mcp_config': {
+            'mcpServers': {
+                'shttp': {'url': 'https://mcp.deepwiki.com/mcp', 'timeout': 60}
             }
         },
     }
@@ -143,118 +143,118 @@ def test_org_member_diffs_normalize_legacy_mcp_config():
 
 def test_org_settings_are_split_into_agent_and_conversation_buckets():
     row = {
-        "agent": "CodeActAgent",
-        "default_max_iterations": 99,
-        "security_analyzer": "auto",
-        "confirmation_mode": False,
-        "default_llm_model": "anthropic/claude-3-7-sonnet",
-        "default_llm_base_url": "https://api.example.com",
-        "enable_default_condenser": True,
-        "condenser_max_size": 256,
-        "mcp_config": {"mcpServers": {"org": {"url": "https://org-mcp.example.com"}}},
-        "agent_settings": {},
-        "conversation_settings": {},
+        'agent': 'CodeActAgent',
+        'default_max_iterations': 99,
+        'security_analyzer': 'auto',
+        'confirmation_mode': False,
+        'default_llm_model': 'anthropic/claude-3-7-sonnet',
+        'default_llm_base_url': 'https://api.example.com',
+        'enable_default_condenser': True,
+        'condenser_max_size': 256,
+        'mcp_config': {'mcpServers': {'org': {'url': 'https://org-mcp.example.com'}}},
+        'agent_settings': {},
+        'conversation_settings': {},
     }
 
     agent_settings = migration_108._build_org_agent_settings(row)
     conversation_settings = migration_108._build_org_conversation_settings(row)
 
     assert agent_settings == {
-        "schema_version": 1,
-        "agent": "CodeActAgent",
-        "llm": {
-            "model": "anthropic/claude-3-7-sonnet",
-            "base_url": "https://api.example.com",
+        'schema_version': 1,
+        'agent': 'CodeActAgent',
+        'llm': {
+            'model': 'anthropic/claude-3-7-sonnet',
+            'base_url': 'https://api.example.com',
         },
-        "condenser": {"enabled": True, "max_size": 256},
-        "mcp_config": {"mcpServers": {"org": {"url": "https://org-mcp.example.com"}}},
+        'condenser': {'enabled': True, 'max_size': 256},
+        'mcp_config': {'mcpServers': {'org': {'url': 'https://org-mcp.example.com'}}},
     }
     assert conversation_settings == {
-        "max_iterations": 99,
-        "confirmation_mode": False,
-        "security_analyzer": "auto",
+        'max_iterations': 99,
+        'confirmation_mode': False,
+        'security_analyzer': 'auto',
     }
 
 
 def test_downgrade_extracts_legacy_values_from_nested_settings():
     row = {
-        "agent_settings": {
-            "schema_version": 1,
-            "agent": "CodeActAgent",
-            "llm": {
-                "model": "anthropic/claude-sonnet-4-5-20250929",
-                "base_url": "https://api.example.com",
+        'agent_settings': {
+            'schema_version': 1,
+            'agent': 'CodeActAgent',
+            'llm': {
+                'model': 'anthropic/claude-sonnet-4-5-20250929',
+                'base_url': 'https://api.example.com',
             },
-            "condenser": {"enabled": False, "max_size": 128},
+            'condenser': {'enabled': False, 'max_size': 128},
         },
-        "conversation_settings": {
-            "max_iterations": 42,
-            "confirmation_mode": True,
-            "security_analyzer": "llm",
+        'conversation_settings': {
+            'max_iterations': 42,
+            'confirmation_mode': True,
+            'security_analyzer': 'llm',
         },
     }
 
     assert migration_108._legacy_user_settings_values(row) == {
-        "agent": "CodeActAgent",
-        "max_iterations": 42,
-        "security_analyzer": "llm",
-        "confirmation_mode": True,
-        "llm_model": "anthropic/claude-sonnet-4-5-20250929",
-        "llm_base_url": "https://api.example.com",
-        "enable_default_condenser": False,
-        "condenser_max_size": 128,
+        'agent': 'CodeActAgent',
+        'max_iterations': 42,
+        'security_analyzer': 'llm',
+        'confirmation_mode': True,
+        'llm_model': 'anthropic/claude-sonnet-4-5-20250929',
+        'llm_base_url': 'https://api.example.com',
+        'enable_default_condenser': False,
+        'condenser_max_size': 128,
     }
 
 
 def test_downgrade_restores_legacy_mcp_config_from_sdk_settings():
     row = {
-        "agent_settings_diff": {
-            "schema_version": 1,
-            "mcp_config": {
-                "mcpServers": {
-                    "sse": {"url": "https://mcp.example.com", "transport": "sse"},
-                    "shttp": {
-                        "url": "https://mcp.deepwiki.com/mcp",
-                        "timeout": 60,
+        'agent_settings_diff': {
+            'schema_version': 1,
+            'mcp_config': {
+                'mcpServers': {
+                    'sse': {'url': 'https://mcp.example.com', 'transport': 'sse'},
+                    'shttp': {
+                        'url': 'https://mcp.deepwiki.com/mcp',
+                        'timeout': 60,
                     },
-                    "deepwiki-stdio": {
-                        "command": "npx",
-                        "args": ["-y", "deepwiki-mcp"],
-                        "env": {"A": "B"},
+                    'deepwiki-stdio': {
+                        'command': 'npx',
+                        'args': ['-y', 'deepwiki-mcp'],
+                        'env': {'A': 'B'},
                     },
                 }
             },
         },
-        "conversation_settings_diff": {},
+        'conversation_settings_diff': {},
     }
 
-    assert migration_108._legacy_org_member_values(row)["mcp_config"] == {
-        "sse_servers": [{"url": "https://mcp.example.com"}],
-        "stdio_servers": [
+    assert migration_108._legacy_org_member_values(row)['mcp_config'] == {
+        'sse_servers': [{'url': 'https://mcp.example.com'}],
+        'stdio_servers': [
             {
-                "name": "deepwiki-stdio",
-                "command": "npx",
-                "args": ["-y", "deepwiki-mcp"],
-                "env": {"A": "B"},
+                'name': 'deepwiki-stdio',
+                'command': 'npx',
+                'args': ['-y', 'deepwiki-mcp'],
+                'env': {'A': 'B'},
             }
         ],
-        "shttp_servers": [{"url": "https://mcp.deepwiki.com/mcp", "timeout": 60}],
+        'shttp_servers': [{'url': 'https://mcp.deepwiki.com/mcp', 'timeout': 60}],
     }
 
 
 def test_migrated_payload_loads_via_user_settings_to_settings():
     row = {
-        "agent": "CodeActAgent",
-        "max_iterations": 42,
-        "security_analyzer": "llm",
-        "confirmation_mode": True,
-        "llm_model": "anthropic/claude-sonnet-4-5-20250929",
-        "llm_base_url": "https://api.example.com",
-        "enable_default_condenser": False,
-        "condenser_max_size": 128,
-        "mcp_config": {"mcpServers": {"admin": {"url": "https://mcp.example.com"}}},
-        "agent_settings": {},
-        "conversation_settings": {},
+        'agent': 'CodeActAgent',
+        'max_iterations': 42,
+        'security_analyzer': 'llm',
+        'confirmation_mode': True,
+        'llm_model': 'anthropic/claude-sonnet-4-5-20250929',
+        'llm_base_url': 'https://api.example.com',
+        'enable_default_condenser': False,
+        'condenser_max_size': 128,
+        'mcp_config': {'mcpServers': {'admin': {'url': 'https://mcp.example.com'}}},
+        'agent_settings': {},
+        'conversation_settings': {},
     }
 
     user_settings = UserSettings(
@@ -264,16 +264,16 @@ def test_migrated_payload_loads_via_user_settings_to_settings():
 
     settings = user_settings.to_settings()
 
-    assert settings.agent_settings.agent == "CodeActAgent"
-    assert settings.agent_settings.llm.model == "anthropic/claude-sonnet-4-5-20250929"
-    assert settings.agent_settings.llm.base_url == "https://api.example.com"
+    assert settings.agent_settings.agent == 'CodeActAgent'
+    assert settings.agent_settings.llm.model == 'anthropic/claude-sonnet-4-5-20250929'
+    assert settings.agent_settings.llm.base_url == 'https://api.example.com'
     assert settings.agent_settings.condenser.enabled is False
     assert settings.agent_settings.condenser.max_size == 128
     assert settings.agent_settings.mcp_config is not None
     assert (
-        settings.agent_settings.mcp_config.mcpServers["admin"].url
-        == "https://mcp.example.com"
+        settings.agent_settings.mcp_config.mcpServers['admin'].url
+        == 'https://mcp.example.com'
     )
     assert settings.conversation_settings.max_iterations == 42
     assert settings.conversation_settings.confirmation_mode is True
-    assert settings.conversation_settings.security_analyzer == "llm"
+    assert settings.conversation_settings.security_analyzer == 'llm'

--- a/frontend/__tests__/routes/llm-settings.test.tsx
+++ b/frontend/__tests__/routes/llm-settings.test.tsx
@@ -258,7 +258,7 @@ describe("LlmSettingsScreen", () => {
   it("keeps Advanced visible but hides All in SaaS mode for the default LLM route schema", async () => {
     vi.spyOn(
       organizationService,
-      "getOrganizationAgentSettings",
+      "getOrganizationSettings",
     ).mockResolvedValue(
       buildSettings({
         agent_settings: {


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

After the 1.22.2 -> 1.23.0 upgrade flow, MCP settings can still exist in the DB but remain stored in the legacy list-based shape (`sse_servers` / `stdio_servers` / `shttp_servers`). Migration 108 was preserving the data, but not normalizing that legacy shape into the SDK `mcpServers` structure expected downstream, so migrated MCP settings could appear to disappear.

## Summary

- normalize legacy `mcp_config` into SDK `mcpServers` shape during migration 108
- preserve downgrade behavior by converting SDK MCP config back to the legacy shape for org/org_member rows
- add regression tests for legacy upgrade normalization and downgrade restoration

## Issue Number

N/A

## How to Test

- `PYTHONPATH="enterprise:.:$PYTHONPATH" poetry run pytest enterprise/tests/unit/test_migration_108_add_agent_settings.py --noconftest`
- `poetry run pre-commit run --files enterprise/migrations/versions/108_add_agent_settings_to_enterprise_settings.py enterprise/tests/unit/test_migration_108_add_agent_settings.py --config ./dev_config/python/.pre-commit-config.yaml`

## Video/Screenshots

Not applicable.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- This PR targets `saas-rel-1.23.0`.
- This PR was created by an AI assistant (OpenHands) on behalf of the user.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7049e6f9-1b45-434a-b266-cf8a2f497ed4)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-73dcee5   docker.openhands.dev/openhands/openhands:73dcee5
```