### PR TITLE
feat(enterprise): Add GitLab event forwarding to automation service

### DIFF
--- a/enterprise/server/routes/integration/gitlab.py
+++ b/enterprise/server/routes/integration/gitlab.py
@@ -2,7 +2,15 @@ import asyncio
 import hashlib
 import json
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    Header,
+    HTTPException,
+    Request,
+    status,
+)
 from fastapi.responses import JSONResponse
 from integrations.gitlab.gitlab_manager import GitlabManager
 from integrations.gitlab.gitlab_service import SaaSGitLabService
@@ -15,12 +23,15 @@ from integrations.models import Message, SourceType
 from integrations.types import GitLabResourceType
 from integrations.utils import GITLAB_WEBHOOK_URL, IS_LOCAL_DEPLOYMENT
 from pydantic import BaseModel
+from server.auth.constants import AUTOMATION_EVENT_FORWARDING_ENABLED
 from server.auth.token_manager import TokenManager
+from server.services.automation_event_service import AutomationEventService
 from storage.gitlab_webhook import GitlabWebhook
 from storage.gitlab_webhook_store import GitlabWebhookStore
 
 from openhands.core.logger import openhands_logger as logger
 from openhands.integrations.gitlab.gitlab_service import GitLabServiceImpl
+from openhands.integrations.provider import ProviderType
 from openhands.server.shared import sio
 from openhands.server.user_auth import get_user_id
 
@@ -29,6 +40,7 @@ webhook_store = GitlabWebhookStore()
 
 token_manager = TokenManager()
 gitlab_manager = GitlabManager(token_manager)
+automation_event_service = AutomationEventService(token_manager)
 
 
 # Request/Response models
@@ -82,6 +94,7 @@ async def verify_gitlab_signature(
 @gitlab_integration_router.post('/gitlab/events')
 async def gitlab_events(
     request: Request,
+    background_tasks: BackgroundTasks,
     x_gitlab_token: str = Header(None),
     x_openhands_webhook_id: str = Header(None),
     x_openhands_user_id: str = Header(None),
@@ -112,6 +125,16 @@ async def gitlab_events(
                 content={'message': 'Duplicate GitLab event ignored.'},
             )
 
+        # Forward to automation service (fire-and-forget background task)
+        if AUTOMATION_EVENT_FORWARDING_ENABLED:
+            background_tasks.add_task(
+                automation_event_service.forward_event,
+                provider=ProviderType.GITLAB,
+                payload=payload_data,
+                installation_id=x_openhands_webhook_id,
+            )
+
+        # Existing resolver bot processing
         message = Message(
             source=SourceType.GITLAB,
             message={

--- a/enterprise/server/services/automation_event_service.py
+++ b/enterprise/server/services/automation_event_service.py
@@ -163,7 +163,8 @@ class AutomationEventService:
         org_id = await self._resolve_git_org(provider, git_org_name)
 
         # Fallback for personal repos (owner_type indicates individual user)
-        if not org_id and owner_type == 'User':
+        # GitHub uses 'User', GitLab uses 'user'
+        if not org_id and owner_type and owner_type.lower() == 'user':
             org_id = await self._resolve_personal_org(provider, owner_id)
             if org_id:
                 logger.info(
@@ -205,6 +206,18 @@ class AutomationEventService:
             repo = payload.get('repository', {})
             owner = repo.get('owner', {})
             return owner.get('login'), owner.get('type'), owner.get('id')
+
+        if provider == ProviderType.GITLAB:
+            # GitLab uses 'project' instead of 'repository'
+            # path_with_namespace is like "org-name/repo-name" or "user-name/repo-name"
+            project = payload.get('project', {})
+            path_with_namespace = project.get('path_with_namespace', '')
+            git_org = path_with_namespace.split('/')[0] if path_with_namespace else None
+            namespace = project.get('namespace', {})
+            # GitLab uses 'group' for organizations and 'user' for personal projects
+            owner_type = namespace.get('kind')
+            owner_id = namespace.get('id')
+            return git_org, owner_type, owner_id
 
         logger.warning(f'Unsupported provider ({provider.value})')
         return None, None, None

--- a/enterprise/tests/unit/server/services/test_automation_event_service.py
+++ b/enterprise/tests/unit/server/services/test_automation_event_service.py
@@ -826,3 +826,249 @@ class TestCacheHelpers:
             service = create_service(mock_token_manager)
             # Should not raise
             await service._set_cached_value('test-key', 'test-value', 3600)
+
+
+# =============================================================================
+# GitLab-specific tests
+# =============================================================================
+
+
+@pytest.fixture
+def gitlab_group_payload():
+    """Create a sample GitLab webhook payload for a group-owned project."""
+    return {
+        'object_kind': 'issue',
+        'event_type': 'issue',
+        'project': {
+            'id': 123456,
+            'path_with_namespace': 'test-org/test-repo',
+            'visibility': 'public',
+            'namespace': {
+                'id': 789,
+                'kind': 'group',
+                'name': 'test-org',
+            },
+        },
+        'user': {
+            'id': 12345,
+            'username': 'testuser',
+        },
+        'object_attributes': {
+            'id': 1,
+            'iid': 1,
+            'title': 'Test Issue',
+        },
+    }
+
+
+@pytest.fixture
+def gitlab_user_payload():
+    """Create a sample GitLab webhook payload for a user-owned project."""
+    return {
+        'object_kind': 'issue',
+        'event_type': 'issue',
+        'project': {
+            'id': 654321,
+            'path_with_namespace': 'testuser/personal-repo',
+            'visibility': 'private',
+            'namespace': {
+                'id': 12345,
+                'kind': 'user',
+                'name': 'testuser',
+            },
+        },
+        'user': {
+            'id': 12345,
+            'username': 'testuser',
+        },
+        'object_attributes': {
+            'id': 2,
+            'iid': 1,
+            'title': 'Personal Issue',
+        },
+    }
+
+
+class TestExtractOwnerInfoGitLab:
+    """Tests for _extract_owner_info method with GitLab payloads."""
+
+    def test_extract_gitlab_group_owner(self, mock_token_manager, gitlab_group_payload):
+        """
+        GIVEN: GitLab payload for a group-owned project
+        WHEN: _extract_owner_info is called
+        THEN: Returns correct git_org, owner_type, owner_id
+        """
+        with patch('server.services.automation_event_service.sio'):
+            service = create_service(mock_token_manager)
+            git_org, owner_type, owner_id = service._extract_owner_info(
+                ProviderType.GITLAB, gitlab_group_payload
+            )
+
+            assert git_org == 'test-org'
+            assert owner_type == 'group'
+            assert owner_id == 789
+
+    def test_extract_gitlab_user_owner(self, mock_token_manager, gitlab_user_payload):
+        """
+        GIVEN: GitLab payload for a user-owned project
+        WHEN: _extract_owner_info is called
+        THEN: Returns correct git_org, owner_type, owner_id
+        """
+        with patch('server.services.automation_event_service.sio'):
+            service = create_service(mock_token_manager)
+            git_org, owner_type, owner_id = service._extract_owner_info(
+                ProviderType.GITLAB, gitlab_user_payload
+            )
+
+            assert git_org == 'testuser'
+            assert owner_type == 'user'
+            assert owner_id == 12345
+
+    def test_extract_gitlab_missing_project(self, mock_token_manager):
+        """
+        GIVEN: GitLab payload without project data
+        WHEN: _extract_owner_info is called
+        THEN: Returns None values
+        """
+        payload = {'object_kind': 'issue'}
+
+        with patch('server.services.automation_event_service.sio'):
+            service = create_service(mock_token_manager)
+            git_org, owner_type, owner_id = service._extract_owner_info(
+                ProviderType.GITLAB, payload
+            )
+
+            assert git_org is None
+            assert owner_type is None
+            assert owner_id is None
+
+
+class TestResolveOrgContextGitLab:
+    """Tests for _resolve_org_context method with GitLab payloads."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_gitlab_group_org(
+        self, mock_token_manager, mock_org_git_claim, gitlab_group_payload
+    ):
+        """
+        GIVEN: GitLab payload for a group project with claimed org
+        WHEN: _resolve_org_context is called
+        THEN: Returns correct OrgContext with org_id
+        """
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)  # Cache miss
+        mock_redis.setex = AsyncMock()
+
+        with patch(
+            'server.services.automation_event_service.resolve_org_for_repo',
+            new_callable=AsyncMock,
+            return_value=mock_org_git_claim.org_id,
+        ), patch('server.services.automation_event_service.sio') as mock_sio:
+            mock_sio.manager.redis = mock_redis
+
+            service = create_service(mock_token_manager)
+            result = await service._resolve_org_context(
+                ProviderType.GITLAB, gitlab_group_payload
+            )
+
+            assert result is not None
+            assert result.org_id == mock_org_git_claim.org_id
+            assert result.git_org == 'test-org'
+
+    @pytest.mark.asyncio
+    async def test_resolve_gitlab_user_personal_org_fallback(
+        self, mock_token_manager, mock_org_git_claim, gitlab_user_payload
+    ):
+        """
+        GIVEN: GitLab payload for a user project (not claimed via OrgGitClaim)
+        WHEN: _resolve_org_context is called
+        THEN: Falls back to personal org resolution
+        """
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)  # Cache miss
+        mock_redis.setex = AsyncMock()
+
+        with patch(
+            'server.services.automation_event_service.resolve_org_for_repo',
+            new_callable=AsyncMock,
+            return_value=None,  # No OrgGitClaim for user
+        ), patch('server.services.automation_event_service.sio') as mock_sio:
+            mock_sio.manager.redis = mock_redis
+
+            service = create_service(mock_token_manager)
+            # Mock _resolve_personal_org to return a personal org
+            service._resolve_personal_org = AsyncMock(
+                return_value=mock_org_git_claim.org_id
+            )
+
+            result = await service._resolve_org_context(
+                ProviderType.GITLAB, gitlab_user_payload
+            )
+
+            assert result is not None
+            assert result.org_id == mock_org_git_claim.org_id
+            assert result.git_org == 'testuser'
+            # Verify personal org fallback was called with GitLab user ID
+            service._resolve_personal_org.assert_called_once_with(
+                ProviderType.GITLAB, 12345
+            )
+
+    @pytest.mark.asyncio
+    async def test_resolve_gitlab_no_org_found(
+        self, mock_token_manager, gitlab_group_payload
+    ):
+        """
+        GIVEN: GitLab payload for a project with no org claim and no personal org
+        WHEN: _resolve_org_context is called
+        THEN: Returns None
+        """
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.setex = AsyncMock()
+
+        with patch(
+            'server.services.automation_event_service.resolve_org_for_repo',
+            new_callable=AsyncMock,
+            return_value=None,
+        ), patch('server.services.automation_event_service.sio') as mock_sio:
+            mock_sio.manager.redis = mock_redis
+
+            service = create_service(mock_token_manager)
+            result = await service._resolve_org_context(
+                ProviderType.GITLAB, gitlab_group_payload
+            )
+
+            # Group owner doesn't fall back to personal org
+            assert result is None
+
+
+class TestResolveGitOrgGitLab:
+    """Tests for _resolve_git_org method with GitLab provider."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_gitlab_org_includes_provider_in_cache_key(
+        self, mock_token_manager, mock_org_git_claim
+    ):
+        """
+        GIVEN: GitLab provider with an org name
+        WHEN: _resolve_git_org is called
+        THEN: Cache key includes the gitlab provider name
+        """
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.setex = AsyncMock()
+
+        with patch(
+            'server.services.automation_event_service.resolve_org_for_repo',
+            new_callable=AsyncMock,
+            return_value=mock_org_git_claim.org_id,
+        ), patch('server.services.automation_event_service.sio') as mock_sio:
+            mock_sio.manager.redis = mock_redis
+
+            service = create_service(mock_token_manager)
+            await service._resolve_git_org(ProviderType.GITLAB, 'Test-Org')
+
+            # Verify cache key includes provider and normalized org name
+            get_call_args = mock_redis.get.call_args[0][0]
+            assert 'gitlab' in get_call_args
+            assert 'test-org' in get_call_args  # Lowercase normalized

--- a/enterprise/tests/unit/test_gitlab_resolver.py
+++ b/enterprise/tests/unit/test_gitlab_resolver.py
@@ -8,8 +8,15 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import BackgroundTasks
 from fastapi.responses import JSONResponse
 from server.routes.integration.gitlab import gitlab_events
+
+
+@pytest.fixture
+def mock_background_tasks():
+    """Create a mock BackgroundTasks."""
+    return MagicMock(spec=BackgroundTasks)
 
 
 @pytest.mark.asyncio
@@ -17,7 +24,7 @@ from server.routes.integration.gitlab import gitlab_events
 @patch('server.routes.integration.gitlab.gitlab_manager')
 @patch('server.routes.integration.gitlab.sio')
 async def test_gitlab_events_deduplication_with_object_id(
-    mock_sio, mock_gitlab_manager, mock_verify_signature
+    mock_sio, mock_gitlab_manager, mock_verify_signature, mock_background_tasks
 ):
     """Test that duplicate GitLab events are deduplicated using object_attributes.id."""
     # Setup mocks
@@ -47,6 +54,7 @@ async def test_gitlab_events_deduplication_with_object_id(
     # Call the endpoint
     response = await gitlab_events(
         request=mock_request,
+        background_tasks=mock_background_tasks,
         x_gitlab_token='test_token',
         x_openhands_webhook_id='test_webhook_id',
         x_openhands_user_id='test_user_id',
@@ -70,6 +78,7 @@ async def test_gitlab_events_deduplication_with_object_id(
     # Call the endpoint again with the same payload
     response = await gitlab_events(
         request=mock_request,
+        background_tasks=mock_background_tasks,
         x_gitlab_token='test_token',
         x_openhands_webhook_id='test_webhook_id',
         x_openhands_user_id='test_user_id',
@@ -92,7 +101,7 @@ async def test_gitlab_events_deduplication_with_object_id(
 @patch('server.routes.integration.gitlab.gitlab_manager')
 @patch('server.routes.integration.gitlab.sio')
 async def test_gitlab_events_deduplication_without_object_id(
-    mock_sio, mock_gitlab_manager, mock_verify_signature
+    mock_sio, mock_gitlab_manager, mock_verify_signature, mock_background_tasks
 ):
     """Test that GitLab events without object_attributes.id are deduplicated using hash of payload."""
     # Setup mocks
@@ -127,6 +136,7 @@ async def test_gitlab_events_deduplication_without_object_id(
     # Call the endpoint
     response = await gitlab_events(
         request=mock_request,
+        background_tasks=mock_background_tasks,
         x_gitlab_token='test_token',
         x_openhands_webhook_id='test_webhook_id',
         x_openhands_user_id='test_user_id',
@@ -150,6 +160,7 @@ async def test_gitlab_events_deduplication_without_object_id(
     # Call the endpoint again with the same payload
     response = await gitlab_events(
         request=mock_request,
+        background_tasks=mock_background_tasks,
         x_gitlab_token='test_token',
         x_openhands_webhook_id='test_webhook_id',
         x_openhands_user_id='test_user_id',
@@ -172,7 +183,7 @@ async def test_gitlab_events_deduplication_without_object_id(
 @patch('server.routes.integration.gitlab.gitlab_manager')
 @patch('server.routes.integration.gitlab.sio')
 async def test_gitlab_events_different_payloads_not_deduplicated(
-    mock_sio, mock_gitlab_manager, mock_verify_signature
+    mock_sio, mock_gitlab_manager, mock_verify_signature, mock_background_tasks
 ):
     """Test that different GitLab events are not deduplicated."""
     # Setup mocks
@@ -196,6 +207,7 @@ async def test_gitlab_events_different_payloads_not_deduplicated(
     # Call the endpoint with first payload
     response1 = await gitlab_events(
         request=mock_request1,
+        background_tasks=mock_background_tasks,
         x_gitlab_token='test_token',
         x_openhands_webhook_id='test_webhook_id',
         x_openhands_user_id='test_user_id',
@@ -223,6 +235,7 @@ async def test_gitlab_events_different_payloads_not_deduplicated(
     # Call the endpoint with second payload
     response2 = await gitlab_events(
         request=mock_request2,
+        background_tasks=mock_background_tasks,
         x_gitlab_token='test_token',
         x_openhands_webhook_id='test_webhook_id',
         x_openhands_user_id='test_user_id',
@@ -242,7 +255,7 @@ async def test_gitlab_events_different_payloads_not_deduplicated(
 @patch('server.routes.integration.gitlab.gitlab_manager')
 @patch('server.routes.integration.gitlab.sio')
 async def test_gitlab_events_multiple_identical_payloads_deduplicated(
-    mock_sio, mock_gitlab_manager, mock_verify_signature
+    mock_sio, mock_gitlab_manager, mock_verify_signature, mock_background_tasks
 ):
     """Test that multiple identical GitLab events are properly deduplicated."""
     # Setup mocks
@@ -273,6 +286,7 @@ async def test_gitlab_events_multiple_identical_payloads_deduplicated(
     # Call the endpoint first time
     response1 = await gitlab_events(
         request=mock_request,
+        background_tasks=mock_background_tasks,
         x_gitlab_token='test_token',
         x_openhands_webhook_id='test_webhook_id',
         x_openhands_user_id='test_user_id',
@@ -298,6 +312,7 @@ async def test_gitlab_events_multiple_identical_payloads_deduplicated(
     # Call the endpoint second time with the same payload
     response2 = await gitlab_events(
         request=mock_request,
+        background_tasks=mock_background_tasks,
         x_gitlab_token='test_token',
         x_openhands_webhook_id='test_webhook_id',
         x_openhands_user_id='test_user_id',
@@ -321,6 +336,7 @@ async def test_gitlab_events_multiple_identical_payloads_deduplicated(
     # Call the endpoint third time with the same payload
     response3 = await gitlab_events(
         request=mock_request,
+        background_tasks=mock_background_tasks,
         x_gitlab_token='test_token',
         x_openhands_webhook_id='test_webhook_id',
         x_openhands_user_id='test_user_id',


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

To support automation triggers for GitLab repositories, similar to the existing GitHub implementation. This allows users to create automations that trigger on GitLab webhook events (issues, merge requests, comments, etc.).

## Summary

- Add GitLab support to `_extract_owner_info()` in `AutomationEventService` to handle GitLab's payload structure (`project/namespace` vs GitHub's `repository/owner`)
- Handle lowercase `'user'` owner_type for GitLab personal org fallback (GitLab uses `'user'` while GitHub uses `'User'`)
- Add event forwarding to GitLab route handler using `BackgroundTasks`
- Add comprehensive unit tests for GitLab event forwarding

## Issue Number

N/A - Internal enhancement

## How to Test

1. Run the unit tests:
   ```bash
   cd /workspace/project/OpenHands
   PYTHONPATH=".:$PYTHONPATH" poetry run --project=enterprise pytest -v enterprise/tests/unit/server/services/test_automation_event_service.py -k "GitLab"
   ```

2. For end-to-end testing:
   - Set `AUTOMATION_EVENT_FORWARDING_ENABLED=true`
   - Configure `AUTOMATION_SERVICE_URL` and `AUTOMATION_WEBHOOK_SECRET`
   - Trigger a GitLab webhook event (e.g., create an issue or comment)
   - Verify the event is forwarded to the automation service with the correct `openhands_org_id`

## Video/Screenshots

N/A - Backend changes only

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- This implementation reuses the existing `OrgGitClaim` infrastructure for org resolution, so no database changes are required
- GitLab org claims work the same way as GitHub - organizations/groups are claimed via `OrgGitClaimStore`
- The forwarded payload includes `openhands_org_id` in the same format as GitHub events:
  ```json
  {
    "organization": {
      "git_org": "org-name",
      "openhands_org_id": "uuid-string"
    },
    "payload": { ... }
  }
  ```

---

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7c3ea496-668e-4e25-9fa1-23d7e5d262f6)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-9314052   docker.openhands.dev/openhands/openhands:9314052
```