### PR TITLE
feat: Auto-forward LMNR_* environment variables to agent-server

### DIFF
--- a/openhands/app_server/sandbox/sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/sandbox_spec_service.py
@@ -71,7 +71,7 @@ def get_agent_server_image() -> str:
 
 # Prefixes for environment variables that should be auto-forwarded to agent-server
 # These are typically configuration variables that affect the agent's behavior
-AUTO_FORWARD_PREFIXES = ('LLM_',)
+AUTO_FORWARD_PREFIXES = ('LLM_', 'LMNR_')
 
 
 def get_agent_server_env() -> dict[str, str]:
@@ -80,9 +80,10 @@ def get_agent_server_env() -> dict[str, str]:
     This function combines two sources of environment variables:
 
     1. **Auto-forwarded variables**: Environment variables with certain prefixes
-       (e.g., LLM_*) are automatically forwarded to the agent-server container.
+       (e.g., LLM_*, LMNR_*) are automatically forwarded to the agent-server container.
        This ensures that LLM configuration like timeouts and retry settings
-       work correctly in the two-container V1 architecture.
+       work correctly in the two-container V1 architecture, as well as
+       Laminar monitoring/analytics configuration.
 
     2. **Explicit overrides via OH_AGENT_SERVER_ENV**: A JSON string that allows
        setting arbitrary environment variables in the agent-server container.
@@ -90,11 +91,17 @@ def get_agent_server_env() -> dict[str, str]:
 
     Auto-forwarded prefixes:
         - LLM_* : LLM configuration (timeout, retries, model settings, etc.)
+        - LMNR_* : Laminar monitoring/analytics configuration
 
     Usage:
         # Auto-forwarding (no action needed):
         export LLM_TIMEOUT=3600
         export LLM_NUM_RETRIES=10
+        # These will automatically be available in the agent-server
+
+        # Auto-forwarding for Laminar:
+        export LMNR_PROJECT_API_KEY=your-api-key
+        export LMNR_BASE_URL=https://app.lmnr.ai
         # These will automatically be available in the agent-server
 
         # Explicit override via JSON:

--- a/tests/unit/app_server/test_agent_server_env_override.py
+++ b/tests/unit/app_server/test_agent_server_env_override.py
@@ -295,6 +295,68 @@ class TestLLMAutoForwarding:
             assert 'Llm_Timeout' not in result
 
 
+class TestLMNRAutoForwarding:
+    """Test cases for automatic forwarding of LMNR_* environment variables."""
+
+    def test_auto_forward_prefixes_contains_lmnr(self):
+        """Test that LMNR_ is in the auto-forward prefixes."""
+        assert 'LMNR_' in AUTO_FORWARD_PREFIXES
+
+    def test_lmnr_project_api_key_auto_forwarded(self):
+        """Test that LMNR_PROJECT_API_KEY is automatically forwarded."""
+        env_vars = {
+            'LMNR_PROJECT_API_KEY': 'sk-test-key-12345',
+            'OTHER_VAR': 'should_not_be_included',
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            result = get_agent_server_env()
+            assert 'LMNR_PROJECT_API_KEY' in result
+            assert result['LMNR_PROJECT_API_KEY'] == 'sk-test-key-12345'
+            assert 'OTHER_VAR' not in result
+
+    def test_lmnr_base_url_auto_forwarded(self):
+        """Test that LMNR_BASE_URL is automatically forwarded."""
+        env_vars = {
+            'LMNR_BASE_URL': 'https://app.lmnr.ai',
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            result = get_agent_server_env()
+            assert 'LMNR_BASE_URL' in result
+            assert result['LMNR_BASE_URL'] == 'https://app.lmnr.ai'
+
+    def test_multiple_lmnr_vars_auto_forwarded(self):
+        """Test that multiple LMNR_* variables are automatically forwarded."""
+        env_vars = {
+            'LMNR_PROJECT_API_KEY': 'sk-test-key-12345',
+            'LMNR_BASE_URL': 'https://app.lmnr.ai',
+            'LMNR_VERBOSITY': 'debug',
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            result = get_agent_server_env()
+            assert result['LMNR_PROJECT_API_KEY'] == 'sk-test-key-12345'
+            assert result['LMNR_BASE_URL'] == 'https://app.lmnr.ai'
+            assert result['LMNR_VERBOSITY'] == 'debug'
+
+    def test_lmnr_prefix_is_case_sensitive(self):
+        """Test that LMNR_ prefix matching is case-sensitive."""
+        env_vars = {
+            'LMNR_PROJECT_API_KEY': 'sk-test-key',  # Should be included
+            'lmnr_project_api_key': 'lowercase',  # Should NOT be included
+            'Lmnr_Project_Api_Key': 'mixed',  # Should NOT be included
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            result = get_agent_server_env()
+            assert 'LMNR_PROJECT_API_KEY' in result
+            assert result['LMNR_PROJECT_API_KEY'] == 'sk-test-key'
+            # Lowercase variants should not be included
+            assert 'lmnr_project_api_key' not in result
+            assert 'Lmnr_Project_Api_Key' not in result
+
+
 class TestDockerSandboxSpecEnvironmentOverride:
     """Test environment variable override integration in Docker sandbox specs."""
 


### PR DESCRIPTION
## Summary

Add `LMNR_` prefix to `AUTO_FORWARD_PREFIXES` so that Laminar monitoring/analytics configuration is automatically forwarded to agent-server sandbox environments.

## Changes

### `openhands/app_server/sandbox/sandbox_spec_service.py`
- Add `'LMNR_'` to `AUTO_FORWARD_PREFIXES` tuple
- Update docstring to document LMNR_* usage
- Add example showing how to auto-forward Laminar variables

### `tests/unit/app_server/test_agent_server_env_override.py`
- Add `TestLMNRAutoForwarding` test class with tests for:
  - LMNR_* prefix inclusion check
  - LMNR_PROJECT_API_KEY auto-forwarding
  - LMNR_BASE_URL auto-forwarding
  - Multiple LMNR_* vars
  - Case sensitivity

## Why

Currently, the Helm charts set `LMNR_PROJECT_API_KEY` and `LMNR_BASE_URL` as environment variables on the openhands/automation containers, but these are not automatically forwarded to agent-server runtimes (sandboxes).

By adding `LMNR_` to the auto-forward prefixes, any `LMNR_*` environment variables set on the main container will automatically be available in sandbox environments.

## Usage

After this change, setting these environment variables will automatically forward them to sandboxes:

```bash
export LMNR_PROJECT_API_KEY=your-api-key
export LMNR_BASE_URL=https://app.lmnr.ai
```

This complements the Helm chart changes in https://github.com/All-Hands-AI/OpenHands-Cloud/pull/561

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b4c94769-cfe5-4ff7-8670-d945284f2d9a)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-298235c   docker.openhands.dev/openhands/openhands:298235c
```