### PR TITLE
Reduce GitHub resolver comment noise by editing acknowledgement comment

### DIFF
--- a/enterprise/integrations/github/github_comment_utils.py
+++ b/enterprise/integrations/github/github_comment_utils.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any, Iterator
+from uuid import UUID
+
+from integrations.utils import CONVERSATION_URL
+
+_ACK_MARKER_TEMPLATE = '<!-- openhands-ack:{} -->'
+
+
+def build_ack_marker(conversation_id: UUID | str) -> str:
+    """Build a reusable GitHub acknowledgement marker for a resolver conversation."""
+    return _ACK_MARKER_TEMPLATE.format(conversation_id)
+
+
+def append_ack_marker(message: str, conversation_id: UUID | str) -> str:
+    """Append the acknowledgement marker to a message body if it is not already present."""
+    marker = build_ack_marker(conversation_id)
+    if marker in message:
+        return message
+
+    if message.endswith('\n'):
+        return f'{message}{marker}'
+
+    return f'{message}\n\n{marker}'
+
+
+def ensure_conversation_link(message: str, conversation_id: UUID | str) -> str:
+    """Ensure the conversation link is included in the message body."""
+    link_fragment = f'conversations/{conversation_id}'
+    if link_fragment in message:
+        return message
+
+    conversation_link = CONVERSATION_URL.format(conversation_id)
+    return f'{message.rstrip()}\n\nTrack progress [here]({conversation_link})'
+
+
+def build_final_resolver_comment(summary: str, conversation_id: UUID | str) -> str:
+    """Build the final resolver comment with link and acknowledgement marker."""
+    summary_with_link = ensure_conversation_link(summary.strip(), conversation_id)
+    return append_ack_marker(summary_with_link, conversation_id)
+
+
+def iter_recent_paginated_items(
+    paginated_list: Any, max_items: int | None = None
+) -> Iterator[Any]:
+    """Iterate over a GitHub paginated list from newest to oldest.
+
+    This assumes the underlying pages are ordered oldest-first, and it iterates
+    pages in reverse, yielding each page's items in reverse order.
+    """
+    page_count = getattr(paginated_list, 'totalCount', None)
+    if page_count is None:
+        raise ValueError('Paginated list does not expose totalCount')
+
+    yielded = 0
+    for page_index in range(page_count - 1, -1, -1):
+        page = paginated_list.get_page(page_index)
+        for item in reversed(page):
+            yield item
+            yielded += 1
+            if max_items is not None and yielded >= max_items:
+                return

--- a/enterprise/integrations/github/github_manager.py
+++ b/enterprise/integrations/github/github_manager.py
@@ -2,6 +2,7 @@ from types import MappingProxyType
 
 from github import Auth, Github, GithubIntegration
 from integrations.github.data_collector import GitHubDataCollector
+from integrations.github.github_comment_utils import append_ack_marker
 from integrations.github.github_solvability import summarize_issue_solvability
 from integrations.github.github_view import (
     GithubFactory,
@@ -406,6 +407,8 @@ class GithubManager(Manager[GithubViewType]):
                     msg_info = f'{base_msg}\n\n{solvability_summary}'
                 else:
                     msg_info = base_msg
+
+                msg_info = append_ack_marker(msg_info, conversation_id)
 
             except MissingSettingsError as e:
                 logger.warning(

--- a/enterprise/integrations/github/github_v1_callback_processor.py
+++ b/enterprise/integrations/github/github_v1_callback_processor.py
@@ -78,7 +78,7 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
                 f'[GitHub V1] Posting summary {conversation_id}',
                 extra={'summary': summary},
             )
-            await self._post_summary_to_github(summary, conversation_id)
+            await self._post_final_summary_to_github(summary, conversation_id)
 
             return EventCallbackResult(
                 status=EventCallbackResultStatus.SUCCESS,
@@ -132,10 +132,25 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
         token_data = github_integration.get_access_token(installation_id)
         return token_data.token
 
-    async def _post_summary_to_github(
-        self, summary: str, conversation_id: UUID
+    async def _post_summary_to_github(self, comment_body: str) -> None:
+        """Post an error comment to GitHub (used by handle_callback_error)."""
+        await self._post_comment_to_github(comment_body, conversation_id=None)
+
+    async def _post_final_summary_to_github(
+        self,
+        summary: str,
+        conversation_id: UUID,
     ) -> None:
-        """Post a summary comment to the configured GitHub issue."""
+        """Post the final resolver summary to GitHub."""
+        comment_body = build_final_resolver_comment(summary, conversation_id)
+        await self._post_comment_to_github(comment_body, conversation_id=conversation_id)
+
+    async def _post_comment_to_github(
+        self,
+        comment_body: str,
+        conversation_id: UUID | None,
+    ) -> None:
+        """Post a comment to the configured GitHub issue."""
         installation_token = self._get_installation_access_token()
 
         if not installation_token:
@@ -143,7 +158,6 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
 
         full_repo_name = self.github_view_data['full_repo_name']
         issue_number = self.github_view_data['issue_number']
-        comment_body = build_final_resolver_comment(summary, conversation_id)
 
         try:
             with Github(auth=Auth.Token(installation_token)) as github_client:
@@ -151,8 +165,9 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
 
                 if self.inline_pr_comment:
                     pr = repo.get_pull(issue_number)
-                    if self._edit_existing_review_ack_comment(pr, comment_body, conversation_id):
-                        return
+                    if conversation_id is not None:
+                        if self._edit_existing_review_ack_comment(pr, comment_body, conversation_id):
+                            return
 
                     pr.create_review_comment_reply(
                         comment_id=self.github_view_data.get('comment_id', ''),
@@ -161,8 +176,9 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
                     return
 
                 issue = repo.get_issue(number=issue_number)
-                if self._edit_existing_issue_ack_comment(issue, comment_body, conversation_id):
-                    return
+                if conversation_id is not None:
+                    if self._edit_existing_issue_ack_comment(issue, comment_body, conversation_id):
+                        return
 
                 issue.create_comment(comment_body)
         except GithubException as e:

--- a/enterprise/integrations/github/github_v1_callback_processor.py
+++ b/enterprise/integrations/github/github_v1_callback_processor.py
@@ -4,6 +4,11 @@ from uuid import UUID
 
 import httpx
 from github import Auth, Github, GithubException, GithubIntegration
+from integrations.github.github_comment_utils import (
+    build_ack_marker,
+    build_final_resolver_comment,
+    iter_recent_paginated_items,
+)
 from integrations.utils import get_summary_instruction
 from integrations.v1_utils import handle_callback_error
 from pydantic import Field
@@ -73,7 +78,7 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
                 f'[GitHub V1] Posting summary {conversation_id}',
                 extra={'summary': summary},
             )
-            await self._post_summary_to_github(summary)
+            await self._post_summary_to_github(summary, conversation_id)
 
             return EventCallbackResult(
                 status=EventCallbackResultStatus.SUCCESS,
@@ -127,7 +132,9 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
         token_data = github_integration.get_access_token(installation_id)
         return token_data.token
 
-    async def _post_summary_to_github(self, summary: str) -> None:
+    async def _post_summary_to_github(
+        self, summary: str, conversation_id: UUID
+    ) -> None:
         """Post a summary comment to the configured GitHub issue."""
         installation_token = self._get_installation_access_token()
 
@@ -136,31 +143,82 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
 
         full_repo_name = self.github_view_data['full_repo_name']
         issue_number = self.github_view_data['issue_number']
+        comment_body = build_final_resolver_comment(summary, conversation_id)
 
         try:
-            if self.inline_pr_comment:
-                with Github(auth=Auth.Token(installation_token)) as github_client:
-                    repo = github_client.get_repo(full_repo_name)
-                    pr = repo.get_pull(issue_number)
-                    pr.create_review_comment_reply(
-                        comment_id=self.github_view_data.get('comment_id', ''),
-                        body=summary,
-                    )
-                return
-
             with Github(auth=Auth.Token(installation_token)) as github_client:
                 repo = github_client.get_repo(full_repo_name)
+
+                if self.inline_pr_comment:
+                    pr = repo.get_pull(issue_number)
+                    if self._edit_existing_review_ack_comment(pr, comment_body, conversation_id):
+                        return
+
+                    pr.create_review_comment_reply(
+                        comment_id=self.github_view_data.get('comment_id', ''),
+                        body=comment_body,
+                    )
+                    return
+
                 issue = repo.get_issue(number=issue_number)
-                issue.create_comment(summary)
+                if self._edit_existing_issue_ack_comment(issue, comment_body, conversation_id):
+                    return
+
+                issue.create_comment(comment_body)
         except GithubException as e:
-            if e.status == 410:
+            if e.status in {403, 404, 410, 422, 423, 429}:
                 _logger.info(
-                    '[GitHub V1] Issue/PR %s#%s was deleted, skipping summary post',
+                    '[GitHub V1] Skipping summary post due to non-fatal GitHub error %s on %s#%s',
+                    e.status,
                     full_repo_name,
                     issue_number,
                 )
             else:
                 raise
+
+    def _edit_existing_issue_ack_comment(
+        self, issue: Any, comment_body: str, conversation_id: UUID
+    ) -> bool:
+        marker = build_ack_marker(conversation_id)
+        comments = issue.get_comments()
+
+        for comment in iter_recent_paginated_items(comments, max_items=200):
+            if marker in getattr(comment, 'body', ''):
+                try:
+                    comment.edit(comment_body)
+                    return True
+                except GithubException as e:
+                    if e.status in {403, 404, 410, 422, 423, 429}:
+                        _logger.info(
+                            '[GitHub V1] Failed to edit existing ack comment due to non-fatal GitHub error %s',
+                            e.status,
+                        )
+                        return False
+                    raise
+
+        return False
+
+    def _edit_existing_review_ack_comment(
+        self, pr: Any, comment_body: str, conversation_id: UUID
+    ) -> bool:
+        marker = build_ack_marker(conversation_id)
+        review_comments = pr.get_review_comments()
+
+        for comment in iter_recent_paginated_items(review_comments, max_items=200):
+            if marker in getattr(comment, 'body', ''):
+                try:
+                    comment.edit(comment_body)
+                    return True
+                except GithubException as e:
+                    if e.status in {403, 404, 410, 422, 423, 429}:
+                        _logger.info(
+                            '[GitHub V1] Failed to edit existing ack-review comment due to non-fatal GitHub error %s',
+                            e.status,
+                        )
+                        return False
+                    raise
+
+        return False
 
     # -------------------------------------------------------------------------
     # Agent / sandbox helpers

--- a/enterprise/integrations/github/github_v1_callback_processor.py
+++ b/enterprise/integrations/github/github_v1_callback_processor.py
@@ -143,7 +143,9 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
     ) -> None:
         """Post the final resolver summary to GitHub."""
         comment_body = build_final_resolver_comment(summary, conversation_id)
-        await self._post_comment_to_github(comment_body, conversation_id=conversation_id)
+        await self._post_comment_to_github(
+            comment_body, conversation_id=conversation_id
+        )
 
     async def _post_comment_to_github(
         self,
@@ -166,7 +168,9 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
                 if self.inline_pr_comment:
                     pr = repo.get_pull(issue_number)
                     if conversation_id is not None:
-                        if self._edit_existing_review_ack_comment(pr, comment_body, conversation_id):
+                        if self._edit_existing_review_ack_comment(
+                            pr, comment_body, conversation_id
+                        ):
                             return
 
                     pr.create_review_comment_reply(
@@ -177,7 +181,9 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
 
                 issue = repo.get_issue(number=issue_number)
                 if conversation_id is not None:
-                    if self._edit_existing_issue_ack_comment(issue, comment_body, conversation_id):
+                    if self._edit_existing_issue_ack_comment(
+                        issue, comment_body, conversation_id
+                    ):
                         return
 
                 issue.create_comment(comment_body)

--- a/enterprise/tests/unit/integrations/github/test_github_comment_utils.py
+++ b/enterprise/tests/unit/integrations/github/test_github_comment_utils.py
@@ -1,12 +1,9 @@
-from uuid import UUID, uuid4
-
-import pytest
+from uuid import uuid4
 
 from integrations.github.github_comment_utils import (
     append_ack_marker,
     build_ack_marker,
     build_final_resolver_comment,
-    ensure_conversation_link,
     iter_recent_paginated_items,
 )
 

--- a/enterprise/tests/unit/integrations/github/test_github_comment_utils.py
+++ b/enterprise/tests/unit/integrations/github/test_github_comment_utils.py
@@ -1,0 +1,59 @@
+from uuid import UUID, uuid4
+
+import pytest
+
+from integrations.github.github_comment_utils import (
+    append_ack_marker,
+    build_ack_marker,
+    build_final_resolver_comment,
+    ensure_conversation_link,
+    iter_recent_paginated_items,
+)
+
+
+class FakePaginatedList:
+    def __init__(self, pages):
+        self.pages = pages
+        self.totalCount = len(pages)
+
+    def get_page(self, index):
+        return self.pages[index]
+
+
+def test_append_ack_marker_is_idempotent():
+    conversation_id = uuid4()
+    message = "I'm on it!"
+    first = append_ack_marker(message, conversation_id)
+    second = append_ack_marker(first, conversation_id)
+
+    assert first == second
+    assert first.count(build_ack_marker(conversation_id)) == 1
+
+
+def test_build_final_resolver_comment_preserves_conversation_link_and_marker():
+    conversation_id = uuid4()
+    summary = 'Resolved the issue.'
+
+    final_comment = build_final_resolver_comment(summary, conversation_id)
+
+    assert f'conversations/{conversation_id}' in final_comment
+    assert build_ack_marker(conversation_id) in final_comment
+    assert final_comment.startswith(summary)
+
+
+def test_iter_recent_paginated_items_yields_newest_first():
+    pages = [[1, 2], [3, 4], [5, 6]]
+    paginated = FakePaginatedList(pages)
+
+    items = list(iter_recent_paginated_items(paginated))
+
+    assert items == [6, 5, 4, 3, 2, 1]
+
+
+def test_iter_recent_paginated_items_traverses_older_pages_when_needed():
+    pages = [['a'], ['b'], ['c']]
+    paginated = FakePaginatedList(pages)
+
+    items = list(iter_recent_paginated_items(paginated, max_items=2))
+
+    assert items == ['c', 'b']

--- a/enterprise/tests/unit/integrations/github/test_github_v1_callback_processor.py
+++ b/enterprise/tests/unit/integrations/github/test_github_v1_callback_processor.py
@@ -285,7 +285,12 @@ class TestGithubV1CallbackProcessor:
         mock_github.assert_called_once_with(auth=mock_token_auth_instance)
         mock_github_client.get_repo.assert_called_once_with('test-owner/test-repo')
         mock_repo.get_issue.assert_called_once_with(number=42)
-        mock_issue.create_comment.assert_called_once_with('Test summary from agent')
+        mock_issue.create_comment.assert_called_once()
+        created_comment_body = mock_issue.create_comment.call_args.args[0]
+        assert created_comment_body.startswith('Test summary from agent')
+        assert 'Track progress [here]' in created_comment_body
+        assert str(conversation_id) in created_comment_body
+        assert '<!-- openhands-ack:' in created_comment_body
 
         mock_httpx_client.post.assert_called_once()
         url_arg, kwargs = mock_httpx_client.post.call_args
@@ -357,9 +362,13 @@ class TestGithubV1CallbackProcessor:
         assert result.status == EventCallbackResultStatus.SUCCESS
 
         mock_repo.get_pull.assert_called_once_with(42)
-        mock_pr.create_review_comment_reply.assert_called_once_with(
-            comment_id='comment_123', body='Test summary from agent'
-        )
+        mock_pr.create_review_comment_reply.assert_called_once()
+        reply_kwargs = mock_pr.create_review_comment_reply.call_args.kwargs
+        assert reply_kwargs['comment_id'] == 'comment_123'
+        assert reply_kwargs['body'].startswith('Test summary from agent')
+        assert 'Track progress [here]' in reply_kwargs['body']
+        assert str(conversation_id) in reply_kwargs['body']
+        assert '<!-- openhands-ack:' in reply_kwargs['body']
 
     @patch(
         'integrations.github.github_v1_callback_processor.GITHUB_APP_CLIENT_ID',

--- a/enterprise/tests/unit/integrations/github/test_github_v1_callback_processor.py
+++ b/enterprise/tests/unit/integrations/github/test_github_v1_callback_processor.py
@@ -16,6 +16,7 @@ from uuid import uuid4
 import httpx
 import pytest
 from github import GithubException
+from integrations.github.github_comment_utils import build_ack_marker
 from integrations.github.github_v1_callback_processor import (
     GithubV1CallbackProcessor,
 )
@@ -359,6 +360,214 @@ class TestGithubV1CallbackProcessor:
         mock_pr.create_review_comment_reply.assert_called_once_with(
             comment_id='comment_123', body='Test summary from agent'
         )
+
+    @patch(
+        'integrations.github.github_v1_callback_processor.GITHUB_APP_CLIENT_ID',
+        'test_client_id',
+    )
+    @patch(
+        'integrations.github.github_v1_callback_processor.GITHUB_APP_PRIVATE_KEY',
+        'test_private_key',
+    )
+    @patch('openhands.app_server.config.get_app_conversation_info_service')
+    @patch('openhands.app_server.config.get_sandbox_service')
+    @patch('openhands.app_server.config.get_httpx_client')
+    @patch('integrations.github.github_v1_callback_processor.get_summary_instruction')
+    @patch('integrations.github.github_v1_callback_processor.GithubIntegration')
+    @patch('integrations.github.github_v1_callback_processor.Github')
+    async def test_successful_callback_edits_existing_ack_comment_if_present(
+        self,
+        mock_github,
+        mock_github_integration,
+        mock_get_summary_instruction,
+        mock_get_httpx_client,
+        mock_get_sandbox_service,
+        mock_get_app_conversation_info_service,
+        github_callback_processor,
+        conversation_state_update_event,
+        event_callback,
+        mock_app_conversation_info,
+        mock_sandbox_info,
+    ):
+        conversation_id = uuid4()
+
+        await _setup_happy_path_services(
+            mock_get_app_conversation_info_service,
+            mock_get_sandbox_service,
+            mock_get_httpx_client,
+            mock_app_conversation_info,
+            mock_sandbox_info,
+        )
+
+        mock_get_summary_instruction.return_value = 'Please provide a summary'
+
+        mock_token_data = MagicMock()
+        mock_token_data.token = 'test_access_token'
+        mock_integration_instance = MagicMock()
+        mock_integration_instance.get_access_token.return_value = mock_token_data
+        mock_github_integration.return_value = mock_integration_instance
+
+        mock_github_client = MagicMock()
+        mock_repo = MagicMock()
+        mock_issue = MagicMock()
+        mock_comment = MagicMock()
+        mock_comment.body = f"I'm on it! {build_ack_marker(conversation_id)}"
+        mock_issue.get_comments.return_value = MagicMock(
+            totalCount=1,
+            get_page=MagicMock(return_value=[mock_comment]),
+        )
+        mock_repo.get_issue.return_value = mock_issue
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github.return_value.__enter__.return_value = mock_github_client
+
+        result = await github_callback_processor(
+            conversation_id=conversation_id,
+            callback=event_callback,
+            event=conversation_state_update_event,
+        )
+
+        assert result is not None
+        assert result.status == EventCallbackResultStatus.SUCCESS
+        mock_comment.edit.assert_called_once()
+        mock_issue.create_comment.assert_not_called()
+
+    @patch(
+        'integrations.github.github_v1_callback_processor.GITHUB_APP_CLIENT_ID',
+        'test_client_id',
+    )
+    @patch(
+        'integrations.github.github_v1_callback_processor.GITHUB_APP_PRIVATE_KEY',
+        'test_private_key',
+    )
+    @patch('openhands.app_server.config.get_app_conversation_info_service')
+    @patch('openhands.app_server.config.get_sandbox_service')
+    @patch('openhands.app_server.config.get_httpx_client')
+    @patch('integrations.github.github_v1_callback_processor.get_summary_instruction')
+    @patch('integrations.github.github_v1_callback_processor.GithubIntegration')
+    @patch('integrations.github.github_v1_callback_processor.Github')
+    async def test_successful_callback_falls_back_to_create_comment_when_ack_comment_missing(
+        self,
+        mock_github,
+        mock_github_integration,
+        mock_get_summary_instruction,
+        mock_get_httpx_client,
+        mock_get_sandbox_service,
+        mock_get_app_conversation_info_service,
+        github_callback_processor,
+        conversation_state_update_event,
+        event_callback,
+        mock_app_conversation_info,
+        mock_sandbox_info,
+    ):
+        conversation_id = uuid4()
+
+        await _setup_happy_path_services(
+            mock_get_app_conversation_info_service,
+            mock_get_sandbox_service,
+            mock_get_httpx_client,
+            mock_app_conversation_info,
+            mock_sandbox_info,
+        )
+
+        mock_get_summary_instruction.return_value = 'Please provide a summary'
+
+        mock_token_data = MagicMock()
+        mock_token_data.token = 'test_access_token'
+        mock_integration_instance = MagicMock()
+        mock_integration_instance.get_access_token.return_value = mock_token_data
+        mock_github_integration.return_value = mock_integration_instance
+
+        mock_github_client = MagicMock()
+        mock_repo = MagicMock()
+        mock_issue = MagicMock()
+        mock_issue.get_comments.return_value = MagicMock(
+            totalCount=1,
+            get_page=MagicMock(return_value=[MagicMock(body='no marker here')]),
+        )
+        mock_repo.get_issue.return_value = mock_issue
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github.return_value.__enter__.return_value = mock_github_client
+
+        result = await github_callback_processor(
+            conversation_id=conversation_id,
+            callback=event_callback,
+            event=conversation_state_update_event,
+        )
+
+        assert result is not None
+        assert result.status == EventCallbackResultStatus.SUCCESS
+        mock_issue.create_comment.assert_called_once()
+
+    @patch(
+        'integrations.github.github_v1_callback_processor.GITHUB_APP_CLIENT_ID',
+        'test_client_id',
+    )
+    @patch(
+        'integrations.github.github_v1_callback_processor.GITHUB_APP_PRIVATE_KEY',
+        'test_private_key',
+    )
+    @patch('openhands.app_server.config.get_app_conversation_info_service')
+    @patch('openhands.app_server.config.get_sandbox_service')
+    @patch('openhands.app_server.config.get_httpx_client')
+    @patch('integrations.github.github_v1_callback_processor.get_summary_instruction')
+    @patch('integrations.github.github_v1_callback_processor.GithubIntegration')
+    @patch('integrations.github.github_v1_callback_processor.Github')
+    async def test_post_summary_to_github_ignores_nonfatal_github_status_errors(
+        self,
+        mock_github,
+        mock_github_integration,
+        mock_get_summary_instruction,
+        mock_get_httpx_client,
+        mock_get_sandbox_service,
+        mock_get_app_conversation_info_service,
+        github_callback_processor,
+        conversation_state_update_event,
+        event_callback,
+        mock_app_conversation_info,
+        mock_sandbox_info,
+    ):
+        conversation_id = uuid4()
+
+        await _setup_happy_path_services(
+            mock_get_app_conversation_info_service,
+            mock_get_sandbox_service,
+            mock_get_httpx_client,
+            mock_app_conversation_info,
+            mock_sandbox_info,
+        )
+
+        mock_get_summary_instruction.return_value = 'Please provide a summary'
+
+        mock_token_data = MagicMock()
+        mock_token_data.token = 'test_access_token'
+        mock_integration_instance = MagicMock()
+        mock_integration_instance.get_access_token.return_value = mock_token_data
+        mock_github_integration.return_value = mock_integration_instance
+
+        mock_github_client = MagicMock()
+        mock_repo = MagicMock()
+        mock_issue = MagicMock()
+        mock_issue.get_comments.return_value = MagicMock(
+            totalCount=1,
+            get_page=MagicMock(return_value=[MagicMock(body='no marker here')]),
+        )
+        mock_issue.create_comment.side_effect = GithubException(
+            status=403,
+            data={'message': 'Forbidden'},
+            headers={},
+        )
+        mock_repo.get_issue.return_value = mock_issue
+        mock_github_client.get_repo.return_value = mock_repo
+        mock_github.return_value.__enter__.return_value = mock_github_client
+
+        result = await github_callback_processor(
+            conversation_id=conversation_id,
+            callback=event_callback,
+            event=conversation_state_update_event,
+        )
+
+        assert result is not None
+        assert result.status == EventCallbackResultStatus.SUCCESS
 
     # ------------------------------------------------------------------ #
     # Error paths


### PR DESCRIPTION
## Summary

This PR reduces GitHub resolver comment noise by editing the original acknowledgement comment with the final resolver summary when the run completes.

Today a single resolver run can leave two visible comments:

1. the initial `I'm on it! ...` acknowledgement
2. a separate final result/summary comment

This PR keeps the immediate acknowledgement, but replaces it in place with the final result when possible.

Closes #13737.

## What changed

- Adds a hidden resolver acknowledgement marker to the initial GitHub comment.
- On completion, the callback processor looks for that marker in recent comments.
- If found, the original acknowledgement comment is edited with the final summary.
- If not found, the existing fallback behavior remains: create a new summary comment.
- The final summary preserves the OpenHands conversation link.

## Why

This addresses #13737 by reducing duplicate visible resolver comments while preserving the existing user feedback loop.

Users still get immediate confirmation that the resolver started, and the thread ends with one clear final visible resolver comment.

## Implementation notes

The implementation intentionally avoids new persistence or schema changes.

Instead of storing the acknowledgement comment ID in a database, the initial comment includes a hidden HTML correlation token containing the conversation ID. The callback processor uses that token to correlate the final summary with the original acknowledgement comment.

To avoid unnecessary API usage on long-lived threads, the lookup scans recent comments first and stops after a bounded number of comments.

## Fallback behavior

If the original acknowledgement comment cannot be found or edited, the callback processor falls back to the current behavior and creates a new summary comment.

GitHub posting failures that happen after the resolver has already completed are treated as a best-effort side effect for non-writable/deleted/locked/rate-limited threads. Unexpected errors still raise.

## What this does not change

This PR does not:

- remove the initial acknowledgement
- change resolver triggering behavior
- add a new external service
- add a database migration
- change GitHub workflow permissions
- change branch or PR creation logic

## AI assistance note

This PR was prepared with AI assistance and reviewed before submission.

- Scope: GitHub resolver comment flow only
- Files touched: GitHub integration comment helpers and callback posting path
- External services added: none
- Persistence changes: none
- Workflow permission changes: none
- Fallback behavior: preserves existing create-comment behavior if edit-in-place correlation fails
