### PR TITLE
Support pagination for branch search

### DIFF
--- a/openhands/app_server/git/git_router.py
+++ b/openhands/app_server/git/git_router.py
@@ -242,19 +242,11 @@ async def search_branches(
         page = decoded_page_id
 
     if query:
-        if page != 1:
-            # TODO(#13883): Support pagination for branch search after refactoring.
-            # The search_branches method does not support paging in the same way as
-            # get_branches - those should be merged into a single paginated method
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail='Pagination not yet supported for branch search queries. Use empty query to list all branches with pagination.',
-            )
-        # Get search results - we'll handle pagination ourselves
         branches: list[Branch] = await client.search_branches(
             selected_provider=provider,
             repository=repository,
             query=query,
+            page=page,
             per_page=limit + 1,
         )
     else:

--- a/openhands/integrations/azure_devops/service/branches.py
+++ b/openhands/integrations/azure_devops/service/branches.py
@@ -135,7 +135,7 @@ class AzureDevOpsBranchesMixin(AzureDevOpsMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
     ) -> list[Branch]:
         """Search for branches within a repository."""
         # Parse repository string: organization/project/repo
@@ -162,6 +162,8 @@ class AzureDevOpsBranchesMixin(AzureDevOpsMixinBase):
 
             # Filter branches by query
             filtered_branches = []
+            start = max((page - 1) * per_page, 0)
+            end = start + per_page
             for branch_data in branches_data:
                 # Extract branch name from the ref (e.g., "refs/heads/main" -> "main")
                 name = branch_data.get('name', '').replace('refs/heads/', '')
@@ -186,10 +188,7 @@ class AzureDevOpsBranchesMixin(AzureDevOpsMixinBase):
                     )
                     filtered_branches.append(branch)
 
-                    if len(filtered_branches) >= per_page:
-                        break
-
-            return filtered_branches
+            return filtered_branches[start:end]
         except Exception:
             # Return empty list on error instead of None
             return []

--- a/openhands/integrations/bitbucket/service/branches.py
+++ b/openhands/integrations/bitbucket/service/branches.py
@@ -84,7 +84,7 @@ class BitBucketBranchesMixin(BitBucketMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
     ) -> list[Branch]:
         """Search branches by name using Bitbucket API with `q` param."""
         parts = repository.split('/')
@@ -98,6 +98,7 @@ class BitBucketBranchesMixin(BitBucketMixinBase):
         # Bitbucket filtering: name ~ "query"
         params = {
             'pagelen': per_page,
+            'page': page,
             'q': f'name~"{query}"',
             'sort': '-target.date',
         }

--- a/openhands/integrations/bitbucket_data_center/service/branches.py
+++ b/openhands/integrations/bitbucket_data_center/service/branches.py
@@ -69,14 +69,16 @@ class BitbucketDCBranchesMixin(BitbucketDCMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
     ) -> list[Branch]:
         """Search branches by name using Bitbucket data center API with `q` param."""
         owner, repo = self._extract_owner_and_repo(repository)
 
         url = f'{self._repo_api_base(owner, repo)}/branches'
+        start = max((page - 1) * per_page, 0)
         params = {
             'limit': per_page,
+            'start': start,
             'filterText': query,
             'orderBy': 'MODIFICATION',
         }

--- a/openhands/integrations/forgejo/service/branches.py
+++ b/openhands/integrations/forgejo/service/branches.py
@@ -65,10 +65,12 @@ class ForgejoBranchesMixin(ForgejoMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
     ) -> list[Branch]:  # type: ignore[override]
         all_branches = await self.get_branches(repository)
         lowered = query.lower()
+        start = max((page - 1) * per_page, 0)
+        end = start + per_page
         return [branch for branch in all_branches if lowered in branch.name.lower()][
-            :per_page
+            start:end
         ]

--- a/openhands/integrations/github/queries.py
+++ b/openhands/integrations/github/queries.py
@@ -129,14 +129,19 @@ query ($threadId: ID!, $page: Int = 50, $after: String) {
 # - query: partial branch name provided by the user
 # - first: pagination size (clamped by caller to GitHub limits)
 search_branches_graphql_query = """
-    query SearchBranches($owner: String!, $name: String!, $query: String!, $perPage: Int!) {
+    query SearchBranches($owner: String!, $name: String!, $query: String!, $perPage: Int!, $after: String) {
         repository(owner: $owner, name: $name) {
             refs(
                 refPrefix: "refs/heads/",
                 query: $query,
                 first: $perPage,
+                after: $after,
                 orderBy: { field: ALPHABETICAL, direction: ASC }
             ) {
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
                 nodes {
                     name
                     target {

--- a/openhands/integrations/github/service/branches_prs.py
+++ b/openhands/integrations/github/service/branches_prs.py
@@ -100,7 +100,7 @@ class GitHubBranchesMixin(GitHubMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
     ) -> list[Branch]:
         """Search branches by name using GitHub GraphQL with a partial query."""
         # Require a non-empty query
@@ -121,12 +121,25 @@ class GitHubBranchesMixin(GitHubMixinBase):
             'name': name,
             'query': query or '',
             'perPage': per_page,
+            'after': None,
         }
 
         try:
-            result = await self.execute_graphql_query(
-                search_branches_graphql_query, variables
-            )
+            result = {}
+            target_page = max(page, 1)
+            current_page = 0
+            for _ in range(target_page):
+                result = await self.execute_graphql_query(
+                    search_branches_graphql_query, variables.copy()
+                )
+                current_page += 1
+                refs = result.get('data', {}).get('repository', {}).get('refs')
+                page_info = refs.get('pageInfo', {}) if refs else {}
+                variables['after'] = page_info.get('endCursor')
+                if current_page < target_page and not page_info.get('hasNextPage'):
+                    return []
+                if current_page == target_page:
+                    break
         except Exception as e:
             logger.warning(f'Failed to search for branches: {e}')
             # Fallback to empty result on any GraphQL error

--- a/openhands/integrations/gitlab/service/branches.py
+++ b/openhands/integrations/gitlab/service/branches.py
@@ -85,13 +85,13 @@ class GitLabBranchesMixin(GitLabMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
     ) -> list[Branch]:
         """Search branches using GitLab API which supports `search` param."""
         encoded_name = repository.replace('/', '%2F')
         url = f'{self.BASE_URL}/projects/{encoded_name}/repository/branches'
 
-        params = {'per_page': str(per_page), 'search': query}
+        params = {'per_page': str(per_page), 'page': str(page), 'search': query}
         response, _ = await self._make_request(url, params)
 
         branches: list[Branch] = []

--- a/openhands/integrations/provider.py
+++ b/openhands/integrations/provider.py
@@ -326,13 +326,14 @@ class ProviderHandler:
         selected_provider: ProviderType | None,
         repository: str,
         query: str,
+        page: int = 1,
         per_page: int = 30,
     ) -> list[Branch]:
         """Search for branches within a repository using the appropriate provider service."""
         if selected_provider:
             service = self.get_service(selected_provider)
             try:
-                return await service.search_branches(repository, query, per_page)
+                return await service.search_branches(repository, query, page, per_page)
             except Exception as e:
                 logger.warning(
                     f'Error searching branches from selected provider {selected_provider}: {e}'
@@ -343,7 +344,7 @@ class ProviderHandler:
         try:
             repo_details = await self.verify_repo_provider(repository)
             service = self.get_service(repo_details.git_provider)
-            return await service.search_branches(repository, query, per_page)
+            return await service.search_branches(repository, query, page, per_page)
         except Exception as e:
             logger.warning(f'Error searching branches for {repository}: {e}')
             return []

--- a/openhands/integrations/service_types.py
+++ b/openhands/integrations/service_types.py
@@ -300,7 +300,7 @@ class GitService(Protocol):
         """Get branches for a repository with pagination"""
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
     ) -> list[Branch]:
         """Search for branches within a repository"""
 

--- a/tests/unit/app_server/test_git_router.py
+++ b/tests/unit/app_server/test_git_router.py
@@ -772,7 +772,50 @@ class TestSearchBranches:
         assert call_kwargs.get('selected_provider') == ProviderType.GITHUB
         assert call_kwargs.get('repository') == 'user/repo'
         assert call_kwargs.get('query') == 'feature'
+        assert call_kwargs.get('page') == 1
         assert call_kwargs.get('per_page') == 11  # limit + 1
+
+    @pytest.mark.asyncio
+    @patch('openhands.app_server.git.git_router.ProviderHandler')
+    async def test_returns_second_page_for_branch_search(self, mock_handler_cls):
+        """Test that branch search accepts a page_id and passes the page through."""
+        # Arrange
+        mock_handler = MagicMock()
+        mock_handler.search_branches = AsyncMock(
+            return_value=[
+                Branch(name='feature-c', commit_sha='ghi789', protected=False),
+                Branch(name='feature-d', commit_sha='jkl012', protected=False),
+                Branch(name='feature-e', commit_sha='mno345', protected=False),
+            ]
+        )
+        mock_handler_cls.return_value = mock_handler
+
+        mock_context = _make_mock_user_context(
+            provider_tokens={
+                ProviderType.GITHUB: ProviderToken(user_id='user-123', token='token')
+            },
+            user_id='user-123',
+        )
+
+        # Act
+        result = await search_branches(
+            provider=ProviderType.GITHUB,
+            repository='user/repo',
+            query='feature',
+            page_id=encode_page_id(2),
+            limit=2,
+            user_context=mock_context,
+        )
+
+        # Assert
+        assert len(result.items) == 2
+        assert result.items[0].name == 'feature-c'
+        assert result.items[1].name == 'feature-d'
+        assert result.next_page_id == encode_page_id(3)
+
+        call_kwargs = mock_handler.search_branches.call_args.kwargs
+        assert call_kwargs.get('page') == 2
+        assert call_kwargs.get('per_page') == 3  # limit + 1
 
     def test_returns_401_when_no_provider_tokens(self, test_client):
         """Test that 401 is returned when no provider tokens."""

--- a/tests/unit/integrations/bitbucket/test_bitbucket_branches.py
+++ b/tests/unit/integrations/bitbucket/test_bitbucket_branches.py
@@ -71,6 +71,7 @@ async def test_search_branches_bitbucket_filters_by_name_contains():
         params = args[1]
         assert 'refs/branches' in url
         assert params['pagelen'] == 15
+        assert params['page'] == 1
         assert params['q'] == 'name~"bugfix"'
         assert params['sort'] == '-target.date'
 

--- a/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_branches.py
+++ b/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_branches.py
@@ -116,6 +116,7 @@ async def test_search_branches_uses_filter_text():
     call_url, call_params = mock_req.call_args[0]
     assert 'filterText' in call_params
     assert call_params['filterText'] == 'my-thing'
+    assert call_params['start'] == 0
     assert 'q' not in call_params
     assert len(branches) == 1
     assert branches[0].name == 'feature/my-thing'

--- a/tests/unit/integrations/github/test_github_branches.py
+++ b/tests/unit/integrations/github/test_github_branches.py
@@ -91,6 +91,7 @@ async def test_search_branches_github_success_and_variables():
         'data': {
             'repository': {
                 'refs': {
+                    'pageInfo': {'hasNextPage': False, 'endCursor': None},
                     'nodes': [
                         {
                             'name': 'feature/bar',
@@ -109,7 +110,7 @@ async def test_search_branches_github_success_and_variables():
                             },
                             'branchProtectionRule': None,
                         },
-                    ]
+                    ],
                 }
             }
         }
@@ -127,6 +128,7 @@ async def test_search_branches_github_success_and_variables():
         assert variables['name'] == 'bar'
         assert variables['query'] == 'fe'
         assert 1 <= variables['perPage'] <= 100
+        assert variables['after'] is None
 
         assert len(branches) == 2
         b0, b1 = branches
@@ -140,6 +142,55 @@ async def test_search_branches_github_success_and_variables():
         assert b1.commit_sha == ''
         assert b1.last_push_date is None
         assert b1.protected is False
+
+
+@pytest.mark.asyncio
+async def test_search_branches_github_uses_cursor_for_requested_page():
+    service = GitHubService(token=SecretStr('t'))
+
+    first_page = {
+        'data': {
+            'repository': {
+                'refs': {
+                    'pageInfo': {'hasNextPage': True, 'endCursor': 'cursor-1'},
+                    'nodes': [
+                        {
+                            'name': 'feature/a',
+                            'target': {'__typename': 'Commit', 'oid': 'aaa111'},
+                        }
+                    ],
+                }
+            }
+        }
+    }
+    second_page = {
+        'data': {
+            'repository': {
+                'refs': {
+                    'pageInfo': {'hasNextPage': False, 'endCursor': None},
+                    'nodes': [
+                        {
+                            'name': 'feature/b',
+                            'target': {'__typename': 'Commit', 'oid': 'bbb222'},
+                        }
+                    ],
+                }
+            }
+        }
+    }
+
+    exec_mock = AsyncMock(side_effect=[first_page, second_page])
+    with patch.object(service, 'execute_graphql_query', exec_mock) as mock_exec:
+        branches = await service.search_branches(
+            'foo/bar', query='feature', page=2, per_page=1
+        )
+
+    assert [branch.name for branch in branches] == ['feature/b']
+    assert mock_exec.call_count == 2
+    first_call_vars = mock_exec.call_args_list[0].args[1]
+    second_call_vars = mock_exec.call_args_list[1].args[1]
+    assert first_call_vars['after'] is None
+    assert second_call_vars['after'] == 'cursor-1'
 
 
 @pytest.mark.asyncio

--- a/tests/unit/integrations/gitlab/test_gitlab_branches.py
+++ b/tests/unit/integrations/gitlab/test_gitlab_branches.py
@@ -102,6 +102,7 @@ async def test_search_branches_gitlab_uses_search_param():
         params = args[1]
         assert 'repository/branches' in url
         assert params['per_page'] == '50'
+        assert params['page'] == '1'
         assert params['search'] == 'feat'
 
         assert len(branches) == 2


### PR DESCRIPTION
## Summary
- allow `/git/branches/search` to accept `page_id` when a search query is provided
- add page-aware branch search across GitHub, GitLab, Bitbucket, Bitbucket Data Center, Forgejo, and Azure DevOps providers
- add router and provider unit coverage for paginated branch search

Fixes OpenHands/enterprise#22

## Tests
- `uv run pytest tests/unit/app_server/test_git_router.py::TestSearchBranches tests/unit/integrations/github/test_github_branches.py tests/unit/integrations/gitlab/test_gitlab_branches.py tests/unit/integrations/bitbucket/test_bitbucket_branches.py tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_branches.py -q`
- `uv run ruff check --config dev_config/python/ruff.toml openhands/app_server/git/git_router.py openhands/integrations/provider.py openhands/integrations/service_types.py openhands/integrations/github/queries.py openhands/integrations/github/service/branches_prs.py openhands/integrations/gitlab/service/branches.py openhands/integrations/bitbucket/service/branches.py openhands/integrations/bitbucket_data_center/service/branches.py openhands/integrations/forgejo/service/branches.py openhands/integrations/azure_devops/service/branches.py tests/unit/app_server/test_git_router.py tests/unit/integrations/github/test_github_branches.py tests/unit/integrations/gitlab/test_gitlab_branches.py tests/unit/integrations/bitbucket/test_bitbucket_branches.py tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_branches.py`
- `uv run ruff format --check --config dev_config/python/ruff.toml openhands/app_server/git/git_router.py openhands/integrations/provider.py openhands/integrations/service_types.py openhands/integrations/github/queries.py openhands/integrations/github/service/branches_prs.py openhands/integrations/gitlab/service/branches.py openhands/integrations/bitbucket/service/branches.py openhands/integrations/bitbucket_data_center/service/branches.py openhands/integrations/forgejo/service/branches.py openhands/integrations/azure_devops/service/branches.py tests/unit/app_server/test_git_router.py tests/unit/integrations/github/test_github_branches.py tests/unit/integrations/gitlab/test_gitlab_branches.py tests/unit/integrations/bitbucket/test_bitbucket_branches.py tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_branches.py`
- `uv run mypy --config-file dev_config/python/mypy.ini openhands/app_server/git/git_router.py openhands/integrations/provider.py openhands/integrations/service_types.py openhands/integrations/github/service/branches_prs.py openhands/integrations/gitlab/service/branches.py openhands/integrations/bitbucket/service/branches.py openhands/integrations/bitbucket_data_center/service/branches.py openhands/integrations/forgejo/service/branches.py openhands/integrations/azure_devops/service/branches.py`
