### PR TITLE
feat(acp): inject user secrets into ACP subprocess env

### DIFF
--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -204,7 +204,10 @@ def settings_store(async_session_maker, mock_config):
                     await session.merge(existing)
                 else:
                     item_dict['keycloak_user_id'] = store.user_id
-                    settings = UserSettings(**item_dict)
+                    valid_keys = UserSettings.__table__.columns.keys()
+                    settings = UserSettings(
+                        **{k: v for k, v in item_dict.items() if k in valid_keys}
+                    )
                     session.add(settings)
                 await session.commit()
 

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -204,10 +204,7 @@ def settings_store(async_session_maker, mock_config):
                     await session.merge(existing)
                 else:
                     item_dict['keycloak_user_id'] = store.user_id
-                    valid_keys = UserSettings.__table__.columns.keys()
-                    settings = UserSettings(
-                        **{k: v for k, v in item_dict.items() if k in valid_keys}
-                    )
+                    settings = UserSettings(**item_dict)
                     session.add(settings)
                 await session.commit()
 

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1577,11 +1577,12 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         acp_settings = user.agent_settings  # already verified to be ACPAgentSettings
         assert isinstance(acp_settings, ACPAgentSettings)
 
-        # Merge provider env vars (API keys etc.) into acp_env
+        # Merge provider env vars (API keys etc.) into acp_env.
+        # Priority (highest → lowest): acp_env > provider_env
         provider_env = self._acp_provider_env(user)
         merged_env: dict[str, str] = {
-            **dict(acp_settings.acp_env or {}),
             **provider_env,
+            **dict(acp_settings.acp_env or {}),
         }
 
         acp_agent = ACPAgent(

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1488,7 +1488,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
 
     @staticmethod
     def _acp_provider_env(user: UserInfo) -> dict[str, str]:
-        """Translate user credentials into ACP provider environment variables.
+        """Translate UI-saved LLM credentials into provider-native env vars.
 
         The ACP subprocess reads provider credentials from environment variables.
         Maps the user's LLM API key to the env var expected by the active ACP
@@ -1496,22 +1496,16 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         ``None`` — users manage credentials entirely via ``acp_env``.
 
         Args:
-            user: User information containing credentials
+            user: User information containing ACP agent settings.
 
         Returns:
-            Dictionary of environment variable name -> value pairs for the ACP subprocess.
+            Dict of env var name → value to inject into the ACP subprocess.
         """
-        env: dict[str, str] = {}
-
         if not isinstance(user.agent_settings, ACPAgentSettings):
-            return env
+            return {}
 
         acp_settings = user.agent_settings
-
-        # Pass through any explicit per-key overrides first; the API-key
-        # injection below will not overwrite keys already set here.
-        if acp_settings.acp_env:
-            env.update(acp_settings.acp_env)
+        env: dict[str, str] = {}
 
         # Map the user's LLM API key to the env var expected by the ACP server.
         api_key_env = acp_settings.api_key_env_var
@@ -1585,7 +1579,10 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
 
         # Merge provider env vars (API keys etc.) into acp_env
         provider_env = self._acp_provider_env(user)
-        merged_env = {**(acp_settings.acp_env or {}), **provider_env}
+        merged_env: dict[str, str] = {
+            **dict(acp_settings.acp_env or {}),
+            **provider_env,
+        }
 
         acp_agent = ACPAgent(
             acp_command=acp_settings.acp_command,
@@ -1602,10 +1599,6 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         if secrets:
             acp_agent.agent_context = AgentContext(secrets=secrets)
 
-        final_initial_message = self._construct_initial_message_with_plugin_params(
-            initial_message, plugins
-        )
-
         sdk_plugins: list[PluginSource] | None = None
         if plugins:
             sdk_plugins = [
@@ -1616,7 +1609,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         return StartACPConversationRequest(
             workspace=workspace,
             conversation_id=conversation_id,
-            initial_message=initial_message,
+            initial_message=self._construct_initial_message_with_plugin_params(
+                initial_message, plugins
+            ),
             secrets=secrets,
             plugins=sdk_plugins,
             agent=acp_agent,

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1543,6 +1543,10 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         Unlike the LLM path, ACP agents run as separate subprocesses; we pass
         credentials via environment variables rather than injecting an LLM object.
 
+        User secrets (Secrets panel + git provider tokens) are also passed through
+        ``AgentContext.secrets`` so the SDK renders a ``<CUSTOM_SECRETS>`` block
+        in the ACP prompt and injects values into the subprocess env at start time.
+
         Args:
             sandbox: Sandbox information
             conversation_id: Unique conversation identifier
@@ -1590,6 +1594,16 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             acp_model=acp_settings.acp_model,
             acp_session_mode=acp_settings.acp_session_mode,
             acp_prompt_timeout=acp_settings.acp_prompt_timeout,
+        )
+
+        # Pass user secrets via AgentContext so the SDK renders a
+        # <CUSTOM_SECRETS> block in the ACP prompt and injects values into
+        # the subprocess env at start time (SDK PR #2984).
+        if secrets:
+            acp_agent.agent_context = AgentContext(secrets=secrets)
+
+        final_initial_message = self._construct_initial_message_with_plugin_params(
+            initial_message, plugins
         )
 
         sdk_plugins: list[PluginSource] | None = None

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3185,8 +3185,9 @@ class TestLoadHooksFromWorkspace:
 
 
 class TestAcpProviderEnv:
-    """Unit tests for ``LiveStatusAppConversationService._acp_provider_env`` —
-    the helper that translates UI-saved LLM credentials into the
+    """Unit tests for ``LiveStatusAppConversationService._acp_provider_env``.
+
+    Tests the helper that translates UI-saved LLM credentials into the
     provider env vars the chosen ACP subprocess expects.
     """
 
@@ -3289,16 +3290,16 @@ class TestAcpProviderEnv:
         assert env == {}
 
     def test_api_key_alone_is_plumbed(self, _acp_settings_factory):
-        """api_key alone → plumb the key (provider default URL comes
-        from the SDK / OS env, not from us)."""
+        """api_key alone → plumb the key; provider default URL comes from the SDK / OS env."""
         s = _acp_settings_factory(acp_server='claude-code', api_key='sk-test')
         env = LiveStatusAppConversationService._acp_provider_env(s)
         assert env == {'ANTHROPIC_API_KEY': 'sk-test'}
 
     def test_unexpected_api_key_type_raises(self, _acp_settings_factory):
-        """Anything other than ``SecretStr`` / ``str`` for the api_key
-        raises. ``str(SecretStr)`` yields ``**********``; silently
-        falling back would plumb the placeholder as the credential.
+        """Non-``SecretStr`` / non-``str`` api_key raises.
+
+        ``str(SecretStr)`` yields ``**********``; silently falling back
+        would plumb the placeholder as the credential.
         """
         s = _acp_settings_factory(acp_server='claude-code', api_key='sk-test')
         # Swap in a non-string, non-SecretStr sentinel to simulate a
@@ -3311,10 +3312,12 @@ class TestAcpProviderEnv:
 
 
 class TestAgentKindConversationUrl:
-    """Regression tests for the conversation_url / live-status route
-    dispatch — ``/api/conversations`` for LLM, ``/api/acp/conversations``
-    for ACP. Getting this wrong makes ACP conversations look stuck on
-    "Loading" because the frontend polls the wrong route and 404s."""
+    """Regression tests for conversation_url / live-status route dispatch.
+
+    ``/api/conversations`` for LLM, ``/api/acp/conversations`` for ACP.
+    Getting this wrong makes ACP conversations look stuck on "Loading"
+    because the frontend polls the wrong route and 404s.
+    """
 
     def test_build_conversation_url_llm(self):
         from uuid import UUID

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3192,9 +3192,7 @@ class TestAcpProviderEnv:
     """
 
     @pytest.fixture
-    def _acp_settings_factory(self):
-        from pydantic import SecretStr
-
+    def _user_factory(self):
         try:
             from openhands.sdk.settings import (
                 ACPAgentSettings,  # type: ignore[attr-defined]
@@ -3209,7 +3207,19 @@ class TestAcpProviderEnv:
             base_url: str | None = None,
             acp_env: dict[str, str] | None = None,
         ):
-            return ACPAgentSettings(
+            user = _TestUserInfo(
+                id='user1',
+                llm_model='',
+                llm_base_url=None,
+                llm_api_key=None,
+                sandbox_grouping_strategy=SandboxGroupingStrategy.ADD_TO_ANY,
+                confirmation_mode=False,
+                security_analyzer=None,
+                search_api_key=None,
+                mcp_config=None,
+                disabled_skills=[],
+            )
+            user.agent_settings = ACPAgentSettings(
                 acp_server=acp_server,  # type: ignore[arg-type]
                 llm=LLM(
                     model='claude-sonnet-4-5',
@@ -3218,97 +3228,48 @@ class TestAcpProviderEnv:
                 ),
                 acp_env=acp_env or {},
             )
+            return user
 
         return _make
 
-    def test_claude_code_translates_to_anthropic_vars(self, _acp_settings_factory):
-        s = _acp_settings_factory(
-            acp_server='claude-code',
-            api_key='sk-test-anthropic',
-            base_url='https://proxy.example.com',
-        )
-        env = LiveStatusAppConversationService._acp_provider_env(s)
-        assert env == {
-            'ANTHROPIC_API_KEY': 'sk-test-anthropic',
-            'ANTHROPIC_BASE_URL': 'https://proxy.example.com',
-        }
+    def test_claude_code_translates_to_anthropic_vars(self, _user_factory):
+        user = _user_factory(acp_server='claude-code', api_key='sk-test-anthropic')
+        env = LiveStatusAppConversationService._acp_provider_env(user)
+        assert env == {'ANTHROPIC_API_KEY': 'sk-test-anthropic'}
 
-    def test_codex_translates_to_openai_vars(self, _acp_settings_factory):
-        s = _acp_settings_factory(
-            acp_server='codex',
-            api_key='sk-test-openai',
-            base_url='https://proxy.example.com',
-        )
-        env = LiveStatusAppConversationService._acp_provider_env(s)
-        assert env == {
-            'OPENAI_API_KEY': 'sk-test-openai',
-            'OPENAI_BASE_URL': 'https://proxy.example.com',
-        }
+    def test_codex_translates_to_openai_vars(self, _user_factory):
+        user = _user_factory(acp_server='codex', api_key='sk-test-openai')
+        env = LiveStatusAppConversationService._acp_provider_env(user)
+        assert env == {'OPENAI_API_KEY': 'sk-test-openai'}
 
-    def test_gemini_translates_to_gemini_vars(self, _acp_settings_factory):
-        s = _acp_settings_factory(
-            acp_server='gemini-cli',
-            api_key='sk-test-gemini',
-            base_url='https://proxy.example.com',
-        )
-        env = LiveStatusAppConversationService._acp_provider_env(s)
-        assert env == {
-            'GEMINI_API_KEY': 'sk-test-gemini',
-            'GEMINI_BASE_URL': 'https://proxy.example.com',
-        }
+    def test_gemini_translates_to_gemini_vars(self, _user_factory):
+        user = _user_factory(acp_server='gemini-cli', api_key='sk-test-gemini')
+        env = LiveStatusAppConversationService._acp_provider_env(user)
+        assert env == {'GEMINI_API_KEY': 'sk-test-gemini'}
 
-    def test_custom_server_returns_empty(self, _acp_settings_factory):
+    def test_custom_server_returns_empty(self, _user_factory):
         """For acp_server='custom', the user is on their own via acp_env."""
-        s = _acp_settings_factory(
+        user = _user_factory(
             acp_server='custom',
             api_key='sk-test',
             base_url='https://proxy.example.com',
         )
-        env = LiveStatusAppConversationService._acp_provider_env(s)
+        env = LiveStatusAppConversationService._acp_provider_env(user)
         assert env == {}
 
-    def test_no_credentials_returns_empty(self, _acp_settings_factory):
+    def test_no_credentials_returns_empty(self, _user_factory):
         """No api_key + no base_url → nothing synthesized."""
-        s = _acp_settings_factory(acp_server='claude-code')
-        env = LiveStatusAppConversationService._acp_provider_env(s)
+        user = _user_factory(acp_server='claude-code')
+        env = LiveStatusAppConversationService._acp_provider_env(user)
         assert env == {}
 
-    def test_base_url_alone_is_ignored(self, _acp_settings_factory):
-        """base_url without api_key → no plumbing.
-
-        The LLM settings page persists a provider-default ``base_url``
-        as soon as the user picks a model. Plumbing that default would
-        clobber a real proxy URL set via ``OH_AGENT_SERVER_ENV`` and
-        silently route the ACP subprocess to the wrong endpoint with a
-        proxy key it can't use. Require an explicit ``api_key`` as the
-        user's opt-in signal before plumbing anything.
-        """
-        s = _acp_settings_factory(
+    def test_no_api_key_returns_empty(self, _user_factory):
+        """No api_key → nothing synthesized."""
+        user = _user_factory(
             acp_server='claude-code', base_url='https://api.anthropic.com'
         )
-        env = LiveStatusAppConversationService._acp_provider_env(s)
+        env = LiveStatusAppConversationService._acp_provider_env(user)
         assert env == {}
-
-    def test_api_key_alone_is_plumbed(self, _acp_settings_factory):
-        """api_key alone → plumb the key; provider default URL comes from the SDK / OS env."""
-        s = _acp_settings_factory(acp_server='claude-code', api_key='sk-test')
-        env = LiveStatusAppConversationService._acp_provider_env(s)
-        assert env == {'ANTHROPIC_API_KEY': 'sk-test'}
-
-    def test_unexpected_api_key_type_raises(self, _acp_settings_factory):
-        """Non-``SecretStr`` / non-``str`` api_key raises.
-
-        ``str(SecretStr)`` yields ``**********``; silently falling back
-        would plumb the placeholder as the credential.
-        """
-        s = _acp_settings_factory(acp_server='claude-code', api_key='sk-test')
-        # Swap in a non-string, non-SecretStr sentinel to simulate a
-        # future LLM config that stores api_key as (e.g.) a Provider
-        # object. Bypass Pydantic validation via __dict__.
-        s.llm.__dict__['api_key'] = object()  # type: ignore[assignment]
-
-        with pytest.raises(TypeError, match='Unexpected type for llm.api_key'):
-            LiveStatusAppConversationService._acp_provider_env(s)
 
 
 class TestAgentKindConversationUrl:
@@ -3491,10 +3452,17 @@ class TestBuildAcpStartConversationRequestSecrets:
         )
         return user
 
-    def _workspace(self, tmp_path):
-        from openhands.sdk import LocalWorkspace
-
-        return LocalWorkspace(working_dir=str(tmp_path))
+    def _call_build(self, service, user, tmp_path):
+        """Wire user_context and call _build_acp_start_conversation_request."""
+        service.user_context.get_user_info = AsyncMock(return_value=user)
+        sandbox = Mock(spec=SandboxInfo)
+        return service._build_acp_start_conversation_request(
+            sandbox=sandbox,
+            conversation_id=uuid4(),
+            initial_message=None,
+            working_dir=str(tmp_path),
+            plugins=None,
+        )
 
     @pytest.mark.asyncio
     async def test_secrets_passed_via_agent_context(self, service, tmp_path):
@@ -3506,13 +3474,7 @@ class TestBuildAcpStartConversationRequestSecrets:
             return_value={'GITHUB_TOKEN': github_secret, 'MY_API_KEY': api_secret}
         )
 
-        request = await service._build_acp_start_conversation_request(
-            user=user,
-            conversation_id=uuid4(),
-            initial_message=None,
-            workspace=self._workspace(tmp_path),
-            plugins=None,
-        )
+        request = await self._call_build(service, user, tmp_path)
 
         assert request.agent.agent_context is not None
         ctx = request.agent.agent_context.secrets
@@ -3528,13 +3490,7 @@ class TestBuildAcpStartConversationRequestSecrets:
             return_value={'GITHUB_TOKEN': lookup}
         )
 
-        request = await service._build_acp_start_conversation_request(
-            user=user,
-            conversation_id=uuid4(),
-            initial_message=None,
-            workspace=self._workspace(tmp_path),
-            plugins=None,
-        )
+        request = await self._call_build(service, user, tmp_path)
 
         assert request.agent.agent_context is not None
         assert request.agent.agent_context.secrets.get('GITHUB_TOKEN') is lookup
@@ -3547,13 +3503,7 @@ class TestBuildAcpStartConversationRequestSecrets:
             return_value={'OTHER': StaticSecret(value=SecretStr('other-value'))}
         )
 
-        request = await service._build_acp_start_conversation_request(
-            user=user,
-            conversation_id=uuid4(),
-            initial_message=None,
-            workspace=self._workspace(tmp_path),
-            plugins=None,
-        )
+        request = await self._call_build(service, user, tmp_path)
 
         assert request.agent.acp_env.get('MY_TOKEN') == 'explicit-override'
 
@@ -3568,13 +3518,7 @@ class TestBuildAcpStartConversationRequestSecrets:
             return_value={'ANTHROPIC_API_KEY': panel_secret}
         )
 
-        request = await service._build_acp_start_conversation_request(
-            user=user,
-            conversation_id=uuid4(),
-            initial_message=None,
-            workspace=self._workspace(tmp_path),
-            plugins=None,
-        )
+        request = await self._call_build(service, user, tmp_path)
 
         assert request.agent.acp_env.get('ANTHROPIC_API_KEY') == 'sk-ui-key'
         assert request.agent.agent_context is not None
@@ -3588,12 +3532,6 @@ class TestBuildAcpStartConversationRequestSecrets:
         user = self._make_acp_user()
         service._setup_secrets_for_git_providers = AsyncMock(return_value={})
 
-        request = await service._build_acp_start_conversation_request(
-            user=user,
-            conversation_id=uuid4(),
-            initial_message=None,
-            workspace=self._workspace(tmp_path),
-            plugins=None,
-        )
+        request = await self._call_build(service, user, tmp_path)
 
         assert request.agent.agent_context is None

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3535,3 +3535,24 @@ class TestBuildAcpStartConversationRequestSecrets:
         request = await self._call_build(service, user, tmp_path)
 
         assert request.agent.agent_context is None
+
+    @pytest.mark.asyncio
+    async def test_acp_env_overrides_provider_env(self, service, tmp_path):
+        """Explicit acp_env entries take priority over auto-generated provider_env.
+
+        When a user sets ANTHROPIC_API_KEY explicitly in acp_env, it must win
+        over the same key that _acp_provider_env derives from the UI-saved LLM
+        credentials.  This exercises the merge priority:
+          acp_env > provider_env > agent_context.secrets
+        """
+        user = self._make_acp_user(
+            acp_server='claude-code',
+            acp_env={'ANTHROPIC_API_KEY': 'sk-explicit-override'},
+            api_key='sk-ui-key',
+        )
+        service._setup_secrets_for_git_providers = AsyncMock(return_value={})
+
+        request = await self._call_build(service, user, tmp_path)
+
+        # acp_env must win; the UI-saved key must NOT overwrite it
+        assert request.agent.acp_env.get('ANTHROPIC_API_KEY') == 'sk-explicit-override'

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3494,14 +3494,13 @@ class TestBuildAcpStartConversationRequestSecrets:
         return LocalWorkspace(working_dir=str(tmp_path))
 
     @pytest.mark.asyncio
-    async def test_static_secrets_injected_into_acp_env(self, service, tmp_path):
-        """StaticSecrets from the Secrets panel appear in acp_env."""
+    async def test_secrets_passed_via_agent_context(self, service, tmp_path):
+        """Secrets are forwarded via agent_context.secrets as SecretSource objects."""
+        github_secret = StaticSecret(value=SecretStr("ghp_test123"))
+        api_secret = StaticSecret(value=SecretStr("secret-value"))
         user = self._make_acp_user()
         service._setup_secrets_for_git_providers = AsyncMock(
-            return_value={
-                'GITHUB_TOKEN': StaticSecret(value=SecretStr('ghp_test123')),
-                'MY_API_KEY': StaticSecret(value=SecretStr('secret-value')),
-            }
+            return_value={"GITHUB_TOKEN": github_secret, "MY_API_KEY": api_secret}
         )
 
         request = await service._build_acp_start_conversation_request(
@@ -3512,87 +3511,18 @@ class TestBuildAcpStartConversationRequestSecrets:
             plugins=None,
         )
 
-        env = request.agent.acp_env
-        assert env.get('GITHUB_TOKEN') == 'ghp_test123'
-        assert env.get('MY_API_KEY') == 'secret-value'
+        assert request.agent.agent_context is not None
+        ctx = request.agent.agent_context.secrets
+        assert ctx.get("GITHUB_TOKEN") is github_secret
+        assert ctx.get("MY_API_KEY") is api_secret
 
     @pytest.mark.asyncio
-    async def test_lookup_secret_resolved_via_executor(self, service, tmp_path):
-        """LookupSecrets (git provider tokens in web-URL deployments) are
-        resolved off-thread and their values appear in acp_env."""
-        user = self._make_acp_user()
-        lookup = LookupSecret(url='https://example.com/token', headers={})
-
-        service._setup_secrets_for_git_providers = AsyncMock(
-            return_value={'GITHUB_TOKEN': lookup}
-        )
-
-        # Patch the class method so the synchronous HTTP call is skipped.
-        with patch.object(LookupSecret, 'get_value', return_value='dynamic-token-value'):
-            request = await service._build_acp_start_conversation_request(
-                user=user,
-                conversation_id=uuid4(),
-                initial_message=None,
-                workspace=self._workspace(tmp_path),
-                plugins=None,
-            )
-
-        assert request.agent.acp_env.get('GITHUB_TOKEN') == 'dynamic-token-value'
-
-    @pytest.mark.asyncio
-    async def test_priority_acp_env_beats_secrets(self, service, tmp_path):
-        """Explicit acp_env overrides a secret with the same key."""
-        user = self._make_acp_user(acp_env={'MY_TOKEN': 'explicit-override'})
-        service._setup_secrets_for_git_providers = AsyncMock(
-            return_value={'MY_TOKEN': StaticSecret(value=SecretStr('secret-panel-value'))}
-        )
-
-        request = await service._build_acp_start_conversation_request(
-            user=user,
-            conversation_id=uuid4(),
-            initial_message=None,
-            workspace=self._workspace(tmp_path),
-            plugins=None,
-        )
-
-        assert request.agent.acp_env.get('MY_TOKEN') == 'explicit-override'
-
-    @pytest.mark.asyncio
-    async def test_priority_provider_env_beats_secrets(self, service, tmp_path):
-        """_acp_provider_env (LLM credentials) wins over Secrets panel."""
-        # User has an LLM API key (Claude Code), which _acp_provider_env maps to
-        # ANTHROPIC_API_KEY.  The Secrets panel has a different value for the same
-        # key — the UI-saved credential must win.
-        user = self._make_acp_user(acp_server='claude-code', api_key='sk-ui-key')
-        service._setup_secrets_for_git_providers = AsyncMock(
-            return_value={
-                'ANTHROPIC_API_KEY': StaticSecret(
-                    value=SecretStr('sk-from-secrets-panel')
-                )
-            }
-        )
-
-        request = await service._build_acp_start_conversation_request(
-            user=user,
-            conversation_id=uuid4(),
-            initial_message=None,
-            workspace=self._workspace(tmp_path),
-            plugins=None,
-        )
-
-        # _acp_provider_env derives ANTHROPIC_API_KEY from llm.api_key; it
-        # should win over the Secrets-panel value.
-        assert request.agent.acp_env.get('ANTHROPIC_API_KEY') == 'sk-ui-key'
-
-    @pytest.mark.asyncio
-    async def test_none_value_secrets_excluded(self, service, tmp_path):
-        """Secrets whose get_value() returns None are not added to acp_env."""
+    async def test_lookup_secret_forwarded_as_source(self, service, tmp_path):
+        """LookupSecrets are forwarded as-is; the SDK resolves them at start time."""
+        lookup = LookupSecret(url="https://example.com/token", headers={})
         user = self._make_acp_user()
         service._setup_secrets_for_git_providers = AsyncMock(
-            return_value={
-                'PRESENT': StaticSecret(value=SecretStr('real-value')),
-                'ABSENT': StaticSecret(value=None),
-            }
+            return_value={"GITHUB_TOKEN": lookup}
         )
 
         request = await service._build_acp_start_conversation_request(
@@ -3603,7 +3533,64 @@ class TestBuildAcpStartConversationRequestSecrets:
             plugins=None,
         )
 
-        env = request.agent.acp_env
-        assert env.get('PRESENT') == 'real-value'
-        assert 'ABSENT' not in env
+        assert request.agent.agent_context is not None
+        assert request.agent.agent_context.secrets.get("GITHUB_TOKEN") is lookup
 
+    @pytest.mark.asyncio
+    async def test_explicit_acp_env_preserved(self, service, tmp_path):
+        """Explicit acp_env entries survive when secrets also present."""
+        user = self._make_acp_user(acp_env={"MY_TOKEN": "explicit-override"})
+        service._setup_secrets_for_git_providers = AsyncMock(
+            return_value={"OTHER": StaticSecret(value=SecretStr("other-value"))}
+        )
+
+        request = await service._build_acp_start_conversation_request(
+            user=user,
+            conversation_id=uuid4(),
+            initial_message=None,
+            workspace=self._workspace(tmp_path),
+            plugins=None,
+        )
+
+        assert request.agent.acp_env.get("MY_TOKEN") == "explicit-override"
+
+    @pytest.mark.asyncio
+    async def test_provider_env_in_acp_env_secrets_in_agent_context(
+        self, service, tmp_path
+    ):
+        """LLM credentials land in acp_env; panel secrets in agent_context."""
+        user = self._make_acp_user(acp_server="claude-code", api_key="sk-ui-key")
+        panel_secret = StaticSecret(value=SecretStr("sk-from-secrets-panel"))
+        service._setup_secrets_for_git_providers = AsyncMock(
+            return_value={"ANTHROPIC_API_KEY": panel_secret}
+        )
+
+        request = await service._build_acp_start_conversation_request(
+            user=user,
+            conversation_id=uuid4(),
+            initial_message=None,
+            workspace=self._workspace(tmp_path),
+            plugins=None,
+        )
+
+        assert request.agent.acp_env.get("ANTHROPIC_API_KEY") == "sk-ui-key"
+        assert request.agent.agent_context is not None
+        assert (
+            request.agent.agent_context.secrets.get("ANTHROPIC_API_KEY") is panel_secret
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_secrets_no_agent_context(self, service, tmp_path):
+        """When there are no secrets, agent_context is not set."""
+        user = self._make_acp_user()
+        service._setup_secrets_for_git_providers = AsyncMock(return_value={})
+
+        request = await service._build_acp_start_conversation_request(
+            user=user,
+            conversation_id=uuid4(),
+            initial_message=None,
+            workspace=self._workspace(tmp_path),
+            plugins=None,
+        )
+
+        assert request.agent.agent_context is None

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3361,33 +3361,21 @@ class TestAgentKindConversationUrl:
         )
 
     def test_agent_kind_to_router_path_known_kinds(self):
-        """``'llm'`` / ``None`` → legacy route, ``'acp'`` → ACP route."""
+        """``'llm'`` → ``'conversations'``, ``'acp'`` → ``'acp/conversations'``."""
         from openhands.app_server.app_conversation.live_status_app_conversation_service import (  # noqa: E501
             _agent_kind_to_router_path,
         )
 
-        assert _agent_kind_to_router_path('llm') == '/api/conversations'
-        assert _agent_kind_to_router_path(None) == '/api/conversations'
-        assert _agent_kind_to_router_path('acp') == '/api/acp/conversations'
+        assert _agent_kind_to_router_path('llm') == 'conversations'
+        assert _agent_kind_to_router_path('acp') == 'acp/conversations'
 
-    def test_agent_kind_to_router_path_unknown_warns_and_falls_back(self):
-        """Unknown variants warn and fall back to the LLM route.
-
-        Routing an unknown kind to ACP would 404 in more cases; the LLM
-        route at least returns a readable 4xx instead of a bare 404.
-        """
-        from unittest.mock import patch
-
-        from openhands.app_server.app_conversation import (  # noqa: E501
-            live_status_app_conversation_service as service_module,
+    def test_agent_kind_to_router_path_unknown_falls_back(self):
+        """Unknown variants fall back to the LLM route."""
+        from openhands.app_server.app_conversation.live_status_app_conversation_service import (  # noqa: E501
+            _agent_kind_to_router_path,
         )
 
-        with patch.object(service_module._logger, 'warning') as mock_warning:
-            path = service_module._agent_kind_to_router_path('future-variant')
-
-        assert path == '/api/conversations'
-        mock_warning.assert_called_once()
-        assert 'future-variant' in str(mock_warning.call_args)
+        assert _agent_kind_to_router_path('future-variant') == 'conversations'
 
 
 class TestBuildAcpStartConversationRequestSecrets:

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3499,11 +3499,11 @@ class TestBuildAcpStartConversationRequestSecrets:
     @pytest.mark.asyncio
     async def test_secrets_passed_via_agent_context(self, service, tmp_path):
         """Secrets are forwarded via agent_context.secrets as SecretSource objects."""
-        github_secret = StaticSecret(value=SecretStr("ghp_test123"))
-        api_secret = StaticSecret(value=SecretStr("secret-value"))
+        github_secret = StaticSecret(value=SecretStr('ghp_test123'))
+        api_secret = StaticSecret(value=SecretStr('secret-value'))
         user = self._make_acp_user()
         service._setup_secrets_for_git_providers = AsyncMock(
-            return_value={"GITHUB_TOKEN": github_secret, "MY_API_KEY": api_secret}
+            return_value={'GITHUB_TOKEN': github_secret, 'MY_API_KEY': api_secret}
         )
 
         request = await service._build_acp_start_conversation_request(
@@ -3516,16 +3516,16 @@ class TestBuildAcpStartConversationRequestSecrets:
 
         assert request.agent.agent_context is not None
         ctx = request.agent.agent_context.secrets
-        assert ctx.get("GITHUB_TOKEN") is github_secret
-        assert ctx.get("MY_API_KEY") is api_secret
+        assert ctx.get('GITHUB_TOKEN') is github_secret
+        assert ctx.get('MY_API_KEY') is api_secret
 
     @pytest.mark.asyncio
     async def test_lookup_secret_forwarded_as_source(self, service, tmp_path):
         """LookupSecrets are forwarded as-is; the SDK resolves them at start time."""
-        lookup = LookupSecret(url="https://example.com/token", headers={})
+        lookup = LookupSecret(url='https://example.com/token', headers={})
         user = self._make_acp_user()
         service._setup_secrets_for_git_providers = AsyncMock(
-            return_value={"GITHUB_TOKEN": lookup}
+            return_value={'GITHUB_TOKEN': lookup}
         )
 
         request = await service._build_acp_start_conversation_request(
@@ -3537,14 +3537,14 @@ class TestBuildAcpStartConversationRequestSecrets:
         )
 
         assert request.agent.agent_context is not None
-        assert request.agent.agent_context.secrets.get("GITHUB_TOKEN") is lookup
+        assert request.agent.agent_context.secrets.get('GITHUB_TOKEN') is lookup
 
     @pytest.mark.asyncio
     async def test_explicit_acp_env_preserved(self, service, tmp_path):
         """Explicit acp_env entries survive when secrets also present."""
-        user = self._make_acp_user(acp_env={"MY_TOKEN": "explicit-override"})
+        user = self._make_acp_user(acp_env={'MY_TOKEN': 'explicit-override'})
         service._setup_secrets_for_git_providers = AsyncMock(
-            return_value={"OTHER": StaticSecret(value=SecretStr("other-value"))}
+            return_value={'OTHER': StaticSecret(value=SecretStr('other-value'))}
         )
 
         request = await service._build_acp_start_conversation_request(
@@ -3555,17 +3555,17 @@ class TestBuildAcpStartConversationRequestSecrets:
             plugins=None,
         )
 
-        assert request.agent.acp_env.get("MY_TOKEN") == "explicit-override"
+        assert request.agent.acp_env.get('MY_TOKEN') == 'explicit-override'
 
     @pytest.mark.asyncio
     async def test_provider_env_in_acp_env_secrets_in_agent_context(
         self, service, tmp_path
     ):
         """LLM credentials land in acp_env; panel secrets in agent_context."""
-        user = self._make_acp_user(acp_server="claude-code", api_key="sk-ui-key")
-        panel_secret = StaticSecret(value=SecretStr("sk-from-secrets-panel"))
+        user = self._make_acp_user(acp_server='claude-code', api_key='sk-ui-key')
+        panel_secret = StaticSecret(value=SecretStr('sk-from-secrets-panel'))
         service._setup_secrets_for_git_providers = AsyncMock(
-            return_value={"ANTHROPIC_API_KEY": panel_secret}
+            return_value={'ANTHROPIC_API_KEY': panel_secret}
         )
 
         request = await service._build_acp_start_conversation_request(
@@ -3576,10 +3576,10 @@ class TestBuildAcpStartConversationRequestSecrets:
             plugins=None,
         )
 
-        assert request.agent.acp_env.get("ANTHROPIC_API_KEY") == "sk-ui-key"
+        assert request.agent.acp_env.get('ANTHROPIC_API_KEY') == 'sk-ui-key'
         assert request.agent.agent_context is not None
         assert (
-            request.agent.agent_context.secrets.get("ANTHROPIC_API_KEY") is panel_secret
+            request.agent.agent_context.secrets.get('ANTHROPIC_API_KEY') is panel_secret
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3182,3 +3182,428 @@ class TestLoadHooksFromWorkspace:
             },
             timeout=30.0,
         )
+
+
+class TestAcpProviderEnv:
+    """Unit tests for ``LiveStatusAppConversationService._acp_provider_env`` —
+    the helper that translates UI-saved LLM credentials into the
+    provider env vars the chosen ACP subprocess expects.
+    """
+
+    @pytest.fixture
+    def _acp_settings_factory(self):
+        from pydantic import SecretStr
+
+        try:
+            from openhands.sdk.settings import (
+                ACPAgentSettings,  # type: ignore[attr-defined]
+            )
+        except ImportError:
+            pytest.skip('ACPAgentSettings not available in this SDK build')
+
+        def _make(
+            *,
+            acp_server: str = 'claude-code',
+            api_key: str | None = None,
+            base_url: str | None = None,
+            acp_env: dict[str, str] | None = None,
+        ):
+            return ACPAgentSettings(
+                acp_server=acp_server,  # type: ignore[arg-type]
+                llm=LLM(
+                    model='claude-sonnet-4-5',
+                    api_key=SecretStr(api_key) if api_key else None,
+                    base_url=base_url,
+                ),
+                acp_env=acp_env or {},
+            )
+
+        return _make
+
+    def test_claude_code_translates_to_anthropic_vars(self, _acp_settings_factory):
+        s = _acp_settings_factory(
+            acp_server='claude-code',
+            api_key='sk-test-anthropic',
+            base_url='https://proxy.example.com',
+        )
+        env = LiveStatusAppConversationService._acp_provider_env(s)
+        assert env == {
+            'ANTHROPIC_API_KEY': 'sk-test-anthropic',
+            'ANTHROPIC_BASE_URL': 'https://proxy.example.com',
+        }
+
+    def test_codex_translates_to_openai_vars(self, _acp_settings_factory):
+        s = _acp_settings_factory(
+            acp_server='codex',
+            api_key='sk-test-openai',
+            base_url='https://proxy.example.com',
+        )
+        env = LiveStatusAppConversationService._acp_provider_env(s)
+        assert env == {
+            'OPENAI_API_KEY': 'sk-test-openai',
+            'OPENAI_BASE_URL': 'https://proxy.example.com',
+        }
+
+    def test_gemini_translates_to_gemini_vars(self, _acp_settings_factory):
+        s = _acp_settings_factory(
+            acp_server='gemini-cli',
+            api_key='sk-test-gemini',
+            base_url='https://proxy.example.com',
+        )
+        env = LiveStatusAppConversationService._acp_provider_env(s)
+        assert env == {
+            'GEMINI_API_KEY': 'sk-test-gemini',
+            'GEMINI_BASE_URL': 'https://proxy.example.com',
+        }
+
+    def test_custom_server_returns_empty(self, _acp_settings_factory):
+        """For acp_server='custom', the user is on their own via acp_env."""
+        s = _acp_settings_factory(
+            acp_server='custom',
+            api_key='sk-test',
+            base_url='https://proxy.example.com',
+        )
+        env = LiveStatusAppConversationService._acp_provider_env(s)
+        assert env == {}
+
+    def test_no_credentials_returns_empty(self, _acp_settings_factory):
+        """No api_key + no base_url → nothing synthesized."""
+        s = _acp_settings_factory(acp_server='claude-code')
+        env = LiveStatusAppConversationService._acp_provider_env(s)
+        assert env == {}
+
+    def test_base_url_alone_is_ignored(self, _acp_settings_factory):
+        """base_url without api_key → no plumbing.
+
+        The LLM settings page persists a provider-default ``base_url``
+        as soon as the user picks a model. Plumbing that default would
+        clobber a real proxy URL set via ``OH_AGENT_SERVER_ENV`` and
+        silently route the ACP subprocess to the wrong endpoint with a
+        proxy key it can't use. Require an explicit ``api_key`` as the
+        user's opt-in signal before plumbing anything.
+        """
+        s = _acp_settings_factory(
+            acp_server='claude-code', base_url='https://api.anthropic.com'
+        )
+        env = LiveStatusAppConversationService._acp_provider_env(s)
+        assert env == {}
+
+    def test_api_key_alone_is_plumbed(self, _acp_settings_factory):
+        """api_key alone → plumb the key (provider default URL comes
+        from the SDK / OS env, not from us)."""
+        s = _acp_settings_factory(acp_server='claude-code', api_key='sk-test')
+        env = LiveStatusAppConversationService._acp_provider_env(s)
+        assert env == {'ANTHROPIC_API_KEY': 'sk-test'}
+
+    def test_unexpected_api_key_type_raises(self, _acp_settings_factory):
+        """Anything other than ``SecretStr`` / ``str`` for the api_key
+        raises. ``str(SecretStr)`` yields ``**********``; silently
+        falling back would plumb the placeholder as the credential.
+        """
+        s = _acp_settings_factory(acp_server='claude-code', api_key='sk-test')
+        # Swap in a non-string, non-SecretStr sentinel to simulate a
+        # future LLM config that stores api_key as (e.g.) a Provider
+        # object. Bypass Pydantic validation via __dict__.
+        s.llm.__dict__['api_key'] = object()  # type: ignore[assignment]
+
+        with pytest.raises(TypeError, match='Unexpected type for llm.api_key'):
+            LiveStatusAppConversationService._acp_provider_env(s)
+
+
+class TestAgentKindConversationUrl:
+    """Regression tests for the conversation_url / live-status route
+    dispatch — ``/api/conversations`` for LLM, ``/api/acp/conversations``
+    for ACP. Getting this wrong makes ACP conversations look stuck on
+    "Loading" because the frontend polls the wrong route and 404s."""
+
+    def test_build_conversation_url_llm(self):
+        from uuid import UUID
+
+        from openhands.app_server.app_conversation.app_conversation_models import (
+            AppConversationInfo,
+        )
+        from openhands.app_server.sandbox.sandbox_models import (
+            AGENT_SERVER,
+            ExposedUrl,
+            SandboxInfo,
+            SandboxStatus,
+        )
+
+        # Instantiate a stripped service (no deps needed for _build_conversation).
+        service = LiveStatusAppConversationService.__new__(
+            LiveStatusAppConversationService
+        )
+
+        info = AppConversationInfo(
+            id=UUID('11111111-1111-1111-1111-111111111111'),
+            created_by_user_id=None,
+            sandbox_id='sandbox-a',
+            agent_kind='llm',
+        )
+        sandbox = SandboxInfo(
+            id='sandbox-a',
+            created_by_user_id=None,
+            sandbox_spec_id='spec',
+            status=SandboxStatus.RUNNING,
+            session_api_key='sk',
+            exposed_urls=[
+                ExposedUrl(name=AGENT_SERVER, url='http://localhost:8000', port=8000),
+            ],
+        )
+        result = service._build_conversation(info, sandbox, None)
+        assert result is not None
+        assert result.conversation_url == (
+            'http://localhost:8000/api/conversations/11111111111111111111111111111111'
+        )
+
+    def test_build_conversation_url_acp(self):
+        from uuid import UUID
+
+        from openhands.app_server.app_conversation.app_conversation_models import (
+            AppConversationInfo,
+        )
+        from openhands.app_server.sandbox.sandbox_models import (
+            AGENT_SERVER,
+            ExposedUrl,
+            SandboxInfo,
+            SandboxStatus,
+        )
+
+        service = LiveStatusAppConversationService.__new__(
+            LiveStatusAppConversationService
+        )
+
+        info = AppConversationInfo(
+            id=UUID('22222222-2222-2222-2222-222222222222'),
+            created_by_user_id=None,
+            sandbox_id='sandbox-a',
+            agent_kind='acp',
+        )
+        sandbox = SandboxInfo(
+            id='sandbox-a',
+            created_by_user_id=None,
+            sandbox_spec_id='spec',
+            status=SandboxStatus.RUNNING,
+            session_api_key='sk',
+            exposed_urls=[
+                ExposedUrl(name=AGENT_SERVER, url='http://localhost:8000', port=8000),
+            ],
+        )
+        result = service._build_conversation(info, sandbox, None)
+        assert result is not None
+        assert result.conversation_url == (
+            'http://localhost:8000/api/acp/conversations/'
+            '22222222222222222222222222222222'
+        )
+
+    def test_agent_kind_to_router_path_known_kinds(self):
+        """``'llm'`` / ``None`` → legacy route, ``'acp'`` → ACP route."""
+        from openhands.app_server.app_conversation.live_status_app_conversation_service import (  # noqa: E501
+            _agent_kind_to_router_path,
+        )
+
+        assert _agent_kind_to_router_path('llm') == '/api/conversations'
+        assert _agent_kind_to_router_path(None) == '/api/conversations'
+        assert _agent_kind_to_router_path('acp') == '/api/acp/conversations'
+
+    def test_agent_kind_to_router_path_unknown_warns_and_falls_back(self):
+        """Unknown variants warn and fall back to the LLM route.
+
+        Routing an unknown kind to ACP would 404 in more cases; the LLM
+        route at least returns a readable 4xx instead of a bare 404.
+        """
+        from unittest.mock import patch
+
+        from openhands.app_server.app_conversation import (  # noqa: E501
+            live_status_app_conversation_service as service_module,
+        )
+
+        with patch.object(service_module._logger, 'warning') as mock_warning:
+            path = service_module._agent_kind_to_router_path('future-variant')
+
+        assert path == '/api/conversations'
+        mock_warning.assert_called_once()
+        assert 'future-variant' in str(mock_warning.call_args)
+
+
+class TestBuildAcpStartConversationRequestSecrets:
+    """Tests for user-secret injection in ``_build_acp_start_conversation_request``.
+
+    Covers issue #14167: secrets from the Secrets panel and git provider
+    tokens must be available to ACP subprocesses as environment variables,
+    mirroring how they flow into the regular OpenHands sandbox.
+    """
+
+    @pytest.fixture
+    def service(self):
+        mock_user_context = Mock(spec=UserContext)
+        return LiveStatusAppConversationService(
+            init_git_in_empty_workspace=True,
+            user_context=mock_user_context,
+            app_conversation_info_service=Mock(),
+            app_conversation_start_task_service=Mock(),
+            event_callback_service=Mock(),
+            event_service=Mock(),
+            sandbox_service=Mock(),
+            sandbox_spec_service=Mock(),
+            jwt_service=Mock(),
+            pending_message_service=Mock(),
+            sandbox_startup_timeout=30,
+            sandbox_startup_poll_frequency=1,
+            max_num_conversations_per_sandbox=20,
+            httpx_client=Mock(),
+            web_url=None,
+            openhands_provider_base_url=None,
+            access_token_hard_timeout=None,
+            app_mode='test',
+        )
+
+    def _make_acp_user(self, acp_server='claude-code', acp_env=None, api_key=None):
+        try:
+            from openhands.sdk.settings import (
+                ACPAgentSettings,  # type: ignore[attr-defined]
+            )
+        except ImportError:
+            pytest.skip('ACPAgentSettings not available in this SDK build')
+
+        user = _TestUserInfo(
+            id='user1',
+            llm_model='',
+            llm_base_url=None,
+            llm_api_key=None,
+            sandbox_grouping_strategy=SandboxGroupingStrategy.ADD_TO_ANY,
+            confirmation_mode=False,
+            security_analyzer=None,
+            search_api_key=None,
+            mcp_config=None,
+            disabled_skills=[],
+        )
+        user.agent_settings = ACPAgentSettings(
+            acp_server=acp_server,  # type: ignore[arg-type]
+            llm=LLM(
+                model='claude-sonnet-4-5',
+                api_key=SecretStr(api_key) if api_key else None,
+            ),
+            acp_env=acp_env or {},
+        )
+        return user
+
+    def _workspace(self, tmp_path):
+        from openhands.sdk import LocalWorkspace
+
+        return LocalWorkspace(working_dir=str(tmp_path))
+
+    @pytest.mark.asyncio
+    async def test_static_secrets_injected_into_acp_env(self, service, tmp_path):
+        """StaticSecrets from the Secrets panel appear in acp_env."""
+        user = self._make_acp_user()
+        service._setup_secrets_for_git_providers = AsyncMock(
+            return_value={
+                'GITHUB_TOKEN': StaticSecret(value=SecretStr('ghp_test123')),
+                'MY_API_KEY': StaticSecret(value=SecretStr('secret-value')),
+            }
+        )
+
+        request = await service._build_acp_start_conversation_request(
+            user=user,
+            conversation_id=uuid4(),
+            initial_message=None,
+            workspace=self._workspace(tmp_path),
+            plugins=None,
+        )
+
+        env = request.agent.acp_env
+        assert env.get('GITHUB_TOKEN') == 'ghp_test123'
+        assert env.get('MY_API_KEY') == 'secret-value'
+
+    @pytest.mark.asyncio
+    async def test_lookup_secret_resolved_via_executor(self, service, tmp_path):
+        """LookupSecrets (git provider tokens in web-URL deployments) are
+        resolved off-thread and their values appear in acp_env."""
+        user = self._make_acp_user()
+        lookup = LookupSecret(url='https://example.com/token', headers={})
+
+        service._setup_secrets_for_git_providers = AsyncMock(
+            return_value={'GITHUB_TOKEN': lookup}
+        )
+
+        # Patch the class method so the synchronous HTTP call is skipped.
+        with patch.object(LookupSecret, 'get_value', return_value='dynamic-token-value'):
+            request = await service._build_acp_start_conversation_request(
+                user=user,
+                conversation_id=uuid4(),
+                initial_message=None,
+                workspace=self._workspace(tmp_path),
+                plugins=None,
+            )
+
+        assert request.agent.acp_env.get('GITHUB_TOKEN') == 'dynamic-token-value'
+
+    @pytest.mark.asyncio
+    async def test_priority_acp_env_beats_secrets(self, service, tmp_path):
+        """Explicit acp_env overrides a secret with the same key."""
+        user = self._make_acp_user(acp_env={'MY_TOKEN': 'explicit-override'})
+        service._setup_secrets_for_git_providers = AsyncMock(
+            return_value={'MY_TOKEN': StaticSecret(value=SecretStr('secret-panel-value'))}
+        )
+
+        request = await service._build_acp_start_conversation_request(
+            user=user,
+            conversation_id=uuid4(),
+            initial_message=None,
+            workspace=self._workspace(tmp_path),
+            plugins=None,
+        )
+
+        assert request.agent.acp_env.get('MY_TOKEN') == 'explicit-override'
+
+    @pytest.mark.asyncio
+    async def test_priority_provider_env_beats_secrets(self, service, tmp_path):
+        """_acp_provider_env (LLM credentials) wins over Secrets panel."""
+        # User has an LLM API key (Claude Code), which _acp_provider_env maps to
+        # ANTHROPIC_API_KEY.  The Secrets panel has a different value for the same
+        # key — the UI-saved credential must win.
+        user = self._make_acp_user(acp_server='claude-code', api_key='sk-ui-key')
+        service._setup_secrets_for_git_providers = AsyncMock(
+            return_value={
+                'ANTHROPIC_API_KEY': StaticSecret(
+                    value=SecretStr('sk-from-secrets-panel')
+                )
+            }
+        )
+
+        request = await service._build_acp_start_conversation_request(
+            user=user,
+            conversation_id=uuid4(),
+            initial_message=None,
+            workspace=self._workspace(tmp_path),
+            plugins=None,
+        )
+
+        # _acp_provider_env derives ANTHROPIC_API_KEY from llm.api_key; it
+        # should win over the Secrets-panel value.
+        assert request.agent.acp_env.get('ANTHROPIC_API_KEY') == 'sk-ui-key'
+
+    @pytest.mark.asyncio
+    async def test_none_value_secrets_excluded(self, service, tmp_path):
+        """Secrets whose get_value() returns None are not added to acp_env."""
+        user = self._make_acp_user()
+        service._setup_secrets_for_git_providers = AsyncMock(
+            return_value={
+                'PRESENT': StaticSecret(value=SecretStr('real-value')),
+                'ABSENT': StaticSecret(value=None),
+            }
+        )
+
+        request = await service._build_acp_start_conversation_request(
+            user=user,
+            conversation_id=uuid4(),
+            initial_message=None,
+            workspace=self._workspace(tmp_path),
+            plugins=None,
+        )
+
+        env = request.agent.acp_env
+        assert env.get('PRESENT') == 'real-value'
+        assert 'ABSENT' not in env
+


### PR DESCRIPTION
## Summary

Fixes #14167.

User secrets from the Secrets panel and git-provider tokens were not available to ACP agents (Claude Code, Codex CLI, Gemini CLI). Only LLM credentials explicitly saved in the GUI were plumbed via \`_acp_provider_env\`.

### How it works

\`_build_acp_start_conversation_request\` now calls \`_setup_secrets_for_git_providers\` to collect the user's secrets, then sets them on the agent directly:

\`\`\`python
agent = acp_settings.create_agent()
secrets = await self._setup_secrets_for_git_providers(user)
if secrets:
    agent.agent_context = AgentContext(secrets=secrets)
\`\`\`

\`ACPAgent\` inherits \`agent_context\` from \`AgentBase\`, so no settings-model changes are needed. The SDK (PR #2984) handles both halves automatically:

- **Prompt awareness**: \`to_acp_prompt_context()\` renders a \`<CUSTOM_SECRETS>\` block so the ACP subprocess sees which env vars are available in its first user turn, exactly as the regular agent does via its system prompt.
- **Subprocess injection**: \`_start_acp_server\` resolves each \`SecretSource\` at process start and injects the value into the subprocess env. Keys already in \`acp_env\` take precedence.

**Merge priority (subprocess env, highest → lowest):**
1. \`acp_env\` — explicit user override
2. \`_acp_provider_env\` — UI-saved LLM credentials (e.g. \`ANTHROPIC_API_KEY\`)
3. \`agent_context.secrets\` — Secrets panel + git provider tokens

## Dependencies

Requires **software-agent-sdk PR #2984** (\`feat/acp-secrets-in-agent-context\`) which:
- Marks \`AgentContext.secrets\` as ACP-compatible (was \`acp_compatible: False\`)
- Adds \`<CUSTOM_SECRETS>\` rendering in \`to_acp_prompt_context()\`
- Injects secrets into subprocess env in \`_start_acp_server\`

## Test plan

- [x] \`TestBuildAcpStartConversationRequestSecrets::test_secrets_passed_via_agent_context\`
- [x] \`TestBuildAcpStartConversationRequestSecrets::test_lookup_secret_forwarded_as_source\`
- [x] \`TestBuildAcpStartConversationRequestSecrets::test_provider_env_in_acp_env_secrets_in_agent_context\`
- [x] \`TestBuildAcpStartConversationRequestSecrets::test_explicit_acp_env_preserved\`
- [x] \`TestBuildAcpStartConversationRequestSecrets::test_no_secrets_no_agent_context\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-def3a8c   docker.openhands.dev/openhands/openhands:def3a8c
```