### PR TITLE
feat(enterprise): add migration 110 for agent_kind column in conversation_metadata

### DIFF
--- a/enterprise/migrations/versions/109_add_agent_kind_to_conversation_metadata.py
+++ b/enterprise/migrations/versions/109_add_agent_kind_to_conversation_metadata.py
@@ -1,0 +1,31 @@
+"""Add agent_kind column to conversation_metadata table.
+
+Stores the agent type ('llm' or 'acp') for each conversation so the
+correct agent-server endpoint can be used when routing requests.
+
+Revision ID: 109
+Revises: 108
+Create Date: 2026-04-28
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '109'
+down_revision: Union[str, None] = '108'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'conversation_metadata',
+        sa.Column('agent_kind', sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('conversation_metadata', 'agent_kind')

--- a/enterprise/migrations/versions/110_add_agent_kind_to_conversation_metadata.py
+++ b/enterprise/migrations/versions/110_add_agent_kind_to_conversation_metadata.py
@@ -3,8 +3,8 @@
 Stores the agent type ('llm' or 'acp') for each conversation so the
 correct agent-server endpoint can be used when routing requests.
 
-Revision ID: 109
-Revises: 108
+Revision ID: 110
+Revises: 109
 Create Date: 2026-04-28
 """
 
@@ -14,8 +14,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = '109'
-down_revision: Union[str, None] = '108'
+revision: str = '110'
+down_revision: Union[str, None] = '109'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary

- Missed from #14004: the app-server Alembic migration (009) added `agent_kind` to `conversation_metadata` but the corresponding SaaS enterprise migration was not included before merge.
- Adds enterprise migration `110` (chaining from `109`), bumped from 109 to avoid conflict with `109_add_llm_profiles_to_user.py` which merged concurrently.

## Test plan

- [ ] Migration applies cleanly on top of 109
- [ ] `agent_kind` column present in `conversation_metadata` after upgrade
- [ ] Downgrade removes the column

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-c315d3c   docker.openhands.dev/openhands/openhands:c315d3c
```