### PR TITLE
Fix LLMProfiles serialization in user creation

### DIFF
--- a/enterprise/storage/user_store.py
+++ b/enterprise/storage/user_store.py
@@ -969,11 +969,15 @@ class UserStore:
 
     @staticmethod
     def get_kwargs_from_settings(settings: 'Settings'):
-        kwargs = {
-            normalized: getattr(settings, normalized)
-            for c in User.__table__.columns
-            if (normalized := c.name.lstrip('_')) and hasattr(settings, normalized)
-        }
+        kwargs = {}
+        for c in User.__table__.columns:
+            normalized = c.name.lstrip('_')
+            if normalized and hasattr(settings, normalized):
+                value = getattr(settings, normalized)
+                # LLMProfiles must be serialized to dict for EncryptedJSON storage
+                if normalized == 'llm_profiles' and value is not None:
+                    value = value.model_dump(mode='json')
+                kwargs[normalized] = value
         return kwargs
 
     @staticmethod


### PR DESCRIPTION
The get_kwargs_from_settings method was passing LLMProfiles objects directly to User model, which SQLAlchemy's EncryptedJSON column couldn't serialize with json.dumps().

Fix: Explicitly serialize LLMProfiles to dict using model_dump(mode='json') before passing to User model.

Fixes: TypeError: Object of type LLMProfiles is not JSON serializable

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-982db9c   docker.openhands.dev/openhands/openhands:982db9c
```