### PR TITLE
fix(enterprise): accept pydantic models in EncryptedJSON.process_bind_param

### DIFF
--- a/enterprise/storage/encrypt_utils.py
+++ b/enterprise/storage/encrypt_utils.py
@@ -5,7 +5,7 @@ from base64 import b64decode, b64encode
 from typing import Any
 
 from cryptography.fernet import Fernet, InvalidToken
-from pydantic import SecretStr
+from pydantic import BaseModel, SecretStr
 from server.config import get_config
 from sqlalchemy import String, TypeDecorator
 from sqlalchemy.engine.interfaces import Dialect
@@ -144,7 +144,13 @@ def model_to_kwargs(model_instance):
 class EncryptedJSON(TypeDecorator[dict[str, Any]]):
     """JSON column whose serialized payload is encrypted at rest.
 
-    Use for JSON dicts that may contain secrets (e.g. nested ``api_key``
+    Accepts either a plain ``dict`` or a pydantic ``BaseModel``. Pydantic
+    models are dumped via ``model_dump(mode='json', context={'expose_secrets': True})``
+    so nested ``SecretStr`` values keep their real payload — the column
+    itself is the encryption boundary, so masking on the way in would
+    corrupt round-trips.
+
+    Use for JSON payloads that may contain secrets (e.g. nested ``api_key``
     fields) where the existing ``_<field>`` String + property pattern is
     awkward — this keeps the column accessible as a normal ORM attribute
     while encrypting the entire JSON blob via the same JWE service used
@@ -155,10 +161,12 @@ class EncryptedJSON(TypeDecorator[dict[str, Any]]):
     cache_ok = True
 
     def process_bind_param(
-        self, value: dict[str, Any] | None, dialect: Dialect
+        self, value: BaseModel | dict[str, Any] | None, dialect: Dialect
     ) -> str | None:
         if value is None:
             return None
+        if isinstance(value, BaseModel):
+            value = value.model_dump(mode='json', context={'expose_secrets': True})
         return encrypt_value(json.dumps(value))
 
     def process_result_value(

--- a/enterprise/tests/unit/test_user_store.py
+++ b/enterprise/tests/unit/test_user_store.py
@@ -73,6 +73,66 @@ def test_get_kwargs_from_settings():
     assert 'llm_api_key' not in kwargs
 
 
+@pytest.mark.asyncio
+async def test_create_user_with_llm_profiles_does_not_crash_and_preserves_secrets(
+    async_session_maker,
+):
+    """Regression: User creation must not crash on a populated ``llm_profiles``.
+
+    ``UserStore.get_kwargs_from_settings`` hands ``settings.llm_profiles``
+    (an ``LLMProfiles`` pydantic model) straight to ``User(**kwargs)``.
+    Before ``EncryptedJSON`` accepted pydantic models, ``json.dumps`` in
+    ``process_bind_param`` raised
+    ``TypeError: Object of type LLMProfiles is not JSON serializable``,
+    crashing keycloak_callback → create_user for every new login —
+    default ``Settings`` already carries an empty ``LLMProfiles()`` via
+    ``default_factory``, so the path was hit even for users who never
+    saved a profile.
+
+    Also locks in that nested ``SecretStr`` api_keys keep their plaintext
+    through the column: the column itself is the encryption boundary, so
+    masking on the way in would corrupt round-trips.
+    """
+    from openhands.sdk.llm import LLM
+
+    user_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+
+    settings = Settings(language='en')
+    settings.llm_profiles.save(
+        'work',
+        LLM(
+            model='anthropic/claude-sonnet-4-5-20250929',
+            base_url='https://api.anthropic.com/v1',
+            api_key=SecretStr('work-secret-key'),
+        ),
+    )
+    settings.llm_profiles.active = 'work'
+
+    kwargs = UserStore.get_kwargs_from_settings(settings)
+    assert 'llm_profiles' in kwargs
+    # Caller hands the pydantic model straight to User; the column
+    # converts it on bind, so the kwarg is still the model here.
+    assert kwargs['llm_profiles'] is settings.llm_profiles
+
+    async with async_session_maker() as session:
+        session.add(Org(id=org_id, name='test-org'))
+        session.add(User(id=user_id, current_org_id=org_id, **kwargs))
+        # Would raise TypeError before the EncryptedJSON BaseModel branch.
+        await session.commit()
+
+    async with async_session_maker() as session:
+        user = (
+            await session.execute(select(User).where(User.id == user_id))
+        ).scalar_one()
+
+    assert user.llm_profiles is not None
+    assert user.llm_profiles['active'] == 'work'
+    # SecretStr would serialize as '**********' without
+    # context={'expose_secrets': True}; assert the real value survived.
+    assert user.llm_profiles['profiles']['work']['api_key'] == 'work-secret-key'
+
+
 # --- Tests for create_default_settings ---
 
 


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why

`server/routes/auth.py` `keycloak_callback` -> `UserStore.create_user` crashes on every new login with:

```
TypeError: Object of type LLMProfiles is not JSON serializable
  File "storage/encrypt_utils.py", line 162, in process_bind_param
    return encrypt_value(json.dumps(value))
```

`UserStore.get_kwargs_from_settings` does `getattr(settings, 'llm_profiles')` and hands the resulting `LLMProfiles` pydantic model straight to `User(**kwargs)`. The `EncryptedJSON` `TypeDecorator` only handled `dict`, so `json.dumps(LLMProfiles(...))` blew up. `Settings.llm_profiles` has `default_factory=LLMProfiles`, so this fires for every new user — not only ones who already saved a profile.

Introduced in #14146 ("feat(settings): add saved LLM profiles (BE)").

## Summary

- `EncryptedJSON.process_bind_param` now accepts `BaseModel | dict | None` and dumps pydantic instances via `model_dump(mode='json', context={'expose_secrets': True})` before `json.dumps`. Other encrypted-JSON columns added later get the same robustness for free.
- `expose_secrets=True` matches `saas_settings_store.store()` and is required because `LLMProfiles._profiles_serializer` forwards the context to nested `LLM` dumps; without it, `SecretStr` api_keys serialize as `'**********'` and the masked literal would be encrypted into the column.
- Adds a regression test in `test_user_store.py` that builds `Settings` with a populated `LLMProfiles` containing a `SecretStr` api_key, persists via `User(**kwargs)`, and asserts both no `TypeError` and a clean round-trip of the plaintext secret. Without this patch the test fails with the exact production `TypeError`.

## Alternative considered

Special-casing `llm_profiles` inside `UserStore.get_kwargs_from_settings` (as in #14190). Same crash goes away, but: the same shape mismatch repeats in `OrgStore`/`OrgMemberStore` `get_kwargs_from_settings` and the loose `setattr(user, key, value)` loop in `saas_settings_store.store()`, and any future encrypted-JSON column reproduces the bug. Fixing it at the column is one place, narrow surface, symmetric with `process_result_value` already returning `dict`.

## Issue Number

Supersedes #14190.

## How to Test

```
cd enterprise
poetry run pytest \
  tests/unit/test_user_store.py::test_create_user_with_llm_profiles_does_not_crash_and_preserves_secrets \
  tests/unit/test_user_store.py::test_get_kwargs_from_settings \
  tests/unit/test_saas_settings_store.py -k llm_profiles
```

Manual: log in via keycloak as a brand-new user — `create_user` no longer crashes.

## Type

- [x] Bug fix

## Notes

- No schema changes; the column type is unchanged at rest.
- `process_result_value` is unchanged: callers still read `dict`. If a follow-up wants symmetric pydantic-typed reads, that can be done with a generic `EncryptedPydantic[T]` decorator without touching this fix.