### PR TITLE
fix: correct GLOBAL_SKILLS_DIR path for skills settings page

### DIFF
--- a/openhands/app_server/user/skills_router.py
+++ b/openhands/app_server/user/skills_router.py
@@ -12,7 +12,8 @@ from openhands.core.logger import openhands_logger as logger
 
 router = APIRouter(prefix='/skills', tags=['Skills'], dependencies=get_dependencies())
 
-GLOBAL_SKILLS_DIR = Path(os.path.dirname(openhands.__file__)) / 'skills'
+# skills/ is at the repo root, one level above the openhands package
+GLOBAL_SKILLS_DIR = Path(os.path.dirname(os.path.dirname(openhands.__file__))) / 'skills'
 USER_SKILLS_DIR = Path.home() / '.openhands' / 'microagents'
 
 

--- a/openhands/app_server/user/skills_router.py
+++ b/openhands/app_server/user/skills_router.py
@@ -13,7 +13,9 @@ from openhands.core.logger import openhands_logger as logger
 router = APIRouter(prefix='/skills', tags=['Skills'], dependencies=get_dependencies())
 
 # skills/ is at the repo root, one level above the openhands package
-GLOBAL_SKILLS_DIR = Path(os.path.dirname(os.path.dirname(openhands.__file__))) / 'skills'
+GLOBAL_SKILLS_DIR = (
+    Path(os.path.dirname(os.path.dirname(openhands.__file__))) / 'skills'
+)
 USER_SKILLS_DIR = Path.home() / '.openhands' / 'microagents'
 
 

--- a/openhands/app_server/user/skills_router.py
+++ b/openhands/app_server/user/skills_router.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import Annotated
 
@@ -12,10 +11,8 @@ from openhands.core.logger import openhands_logger as logger
 
 router = APIRouter(prefix='/skills', tags=['Skills'], dependencies=get_dependencies())
 
-# skills/ is at the repo root, one level above the openhands package
-GLOBAL_SKILLS_DIR = (
-    Path(os.path.dirname(os.path.dirname(openhands.__file__))) / 'skills'
-)
+# skills/ is at the repo root, two levels above the openhands package __file__
+GLOBAL_SKILLS_DIR = Path(openhands.__file__).parent.parent / 'skills'
 USER_SKILLS_DIR = Path.home() / '.openhands' / 'microagents'
 
 

--- a/tests/unit/server/routes/test_skills_api.py
+++ b/tests/unit/server/routes/test_skills_api.py
@@ -232,3 +232,37 @@ async def test_skills_search_pagination(test_client, tmp_path):
         assert len(data['items']) == 1
         assert data['items'][0]['name'] == 'skill_c'
         assert data['next_page_id'] is None
+
+
+def test_global_skills_dir_points_to_repo_root():
+    """Test that GLOBAL_SKILLS_DIR points to the correct location.
+
+    This test validates that GLOBAL_SKILLS_DIR is correctly configured to point
+    to the skills/ directory at the repo root. This prevents regressions like the
+    one introduced in fb98faf4a where an incorrect path caused no skills to load.
+    """
+    from openhands.app_server.user.skills_router import GLOBAL_SKILLS_DIR
+
+    # The directory should exist
+    assert GLOBAL_SKILLS_DIR.exists(), (
+        f'GLOBAL_SKILLS_DIR does not exist: {GLOBAL_SKILLS_DIR}'
+    )
+
+    # It should be named 'skills'
+    assert GLOBAL_SKILLS_DIR.name == 'skills', (
+        f"Expected directory name 'skills', got '{GLOBAL_SKILLS_DIR.name}'"
+    )
+
+    # It should contain at least one .md file (skill definition)
+    md_files = list(GLOBAL_SKILLS_DIR.glob('*.md'))
+    assert len(md_files) > 0, (
+        f'GLOBAL_SKILLS_DIR contains no .md files: {GLOBAL_SKILLS_DIR}'
+    )
+
+    # Verify it's at repo root by checking for known skill files
+    # (github.md is a core skill that should always exist)
+    expected_skill = GLOBAL_SKILLS_DIR / 'github.md'
+    assert expected_skill.exists(), (
+        f'Expected skill file not found: {expected_skill}. '
+        f'GLOBAL_SKILLS_DIR may be pointing to wrong location.'
+    )


### PR DESCRIPTION
- [X] A human has tested these changes.

---

## Why

The `/settings/skills` page shows "No skills available" because `GLOBAL_SKILLS_DIR` was pointing to the wrong directory after the refactor in #14106.

## Summary

- Fix `GLOBAL_SKILLS_DIR` path to correctly point to the repo root's `skills/` directory instead of `openhands/skills/`

## Issue Number

Regression introduced in fb98faf4a (#14106)

## How to Test

1. Run the OpenHands app
2. Navigate to `/settings/skills`
3. Verify that skills are now displayed instead of "No skills available"

Alternatively, verify the path programmatically:
```python
import os
from pathlib import Path
import openhands

# Fixed path (goes up TWO levels)
p = Path(os.path.dirname(os.path.dirname(openhands.__file__))) / 'skills'
print(f'Path: {p}')
print(f'Exists: {p.exists()}')  # Should be True
print(f'Skills: {list(p.glob("*.md"))[:5]}')  # Should show skill files
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The original code in `openhands.memory.memory` used `os.path.dirname` twice to go up two levels from `openhands/__file__`, correctly pointing to the repo root's `skills/` directory. When the dependency was removed in #14106, the replacement code only went up one level, incorrectly pointing to `openhands/skills/` which doesn't exist.

_This PR was created by an AI agent (OpenHands) on behalf of a user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3efded55-7afe-4ffd-80c5-d2a0d973f8f0)


Fixes [APP-1463](https://linear.app/all-hands-ai/issue/APP-1463/skills-page-is-empty-now)

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-196c6df   docker.openhands.dev/openhands/openhands:196c6df
```