### PR TITLE
security: fix critical default-off confirmation mode and plaintext secret serialization

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -352,7 +352,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
 
             # Start conversation...
             body_json = start_conversation_request.model_dump(
-                mode='json', context={'expose_secrets': True}
+                mode='json', context={'expose_secrets': False}
             )
             # Log hook_config to verify it's being passed
             hook_config_in_request = body_json.get('hook_config')

--- a/openhands/core/config/security_config.py
+++ b/openhands/core/config/security_config.py
@@ -16,7 +16,7 @@ class SecurityConfig(BaseModel):
         security_analyzer: The security analyzer to use.
     """
 
-    confirmation_mode: bool = Field(default=False)
+    confirmation_mode: bool = Field(default=True)
     security_analyzer: str | None = Field(default=None)
 
     model_config = ConfigDict(extra='forbid')


### PR DESCRIPTION
## Summary

Fixes two critical security findings from the 2026-04-28 security audit of the OpenHands repository.

### Changes

1. **Default confirmation mode ON** (`openhands/core/config/security_config.py`)
   - Changed `SecurityConfig.confirmation_mode` default from `False` to `True`.
   - Previously, confirmation mode defaulted to OFF, causing the `NeverConfirm` policy to be selected and allowing agent actions to execute without user approval.

2. **Stop serializing secrets in plaintext to sandbox HTTP** (`openhands/app_server/app_conversation/live_status_app_conversation_service.py`)
   - Changed `expose_secrets` context from `True` to `False` when serializing `StartConversationRequest` sent to the sandbox agent server over HTTP.
   - Previously, secrets (API keys, tokens) were serialized in plaintext and transmitted over HTTP to the sandbox.

### Test Results

- `tests/unit/core/config/test_config.py` — **38 passed**
- `tests/unit/app_server/test_live_status_app_conversation_service.py` — **123 passed**
- `tests/unit/app_server/test_app_conversation_service_base.py` — **42 passed**

All existing tests pass; no test logic was modified.