### PR TITLE
fix: surface unverified bare LLM names in the provider dropdowns

### DIFF
--- a/openhands/utils/llm.py
+++ b/openhands/utils/llm.py
@@ -230,8 +230,10 @@ def _assign_provider(model: str) -> str:
     """Prefix a bare model name with its canonical provider.
 
     Models that already contain a ``/`` provider separator are returned
-    unchanged. Only well-known bare names (OpenAI, Anthropic, Mistral)
-    are prefixed.
+    unchanged. Bare names are first checked against the SDK's verified
+    sets (cheap, no network), then fall back to LiteLLM's own routing
+    tables so that unverified names like ``claude-opus-4-7`` or
+    ``gemini-2.0-flash`` still reach the provider-keyed dropdown.
     """
     if '/' in model:
         return model
@@ -244,7 +246,12 @@ def _assign_provider(model: str) -> str:
         return f'anthropic/{model}'
     if model in _BARE_MISTRAL_MODELS:
         return f'mistral/{model}'
-    return model
+
+    try:
+        _, provider, _, _ = get_llm_provider(model)
+    except Exception:
+        return model
+    return f'{provider}/{model}' if provider else model
 
 
 def _derive_verified_models(openhands_models: list[str]) -> list[str]:

--- a/tests/unit/utils/test_llm_utils.py
+++ b/tests/unit/utils/test_llm_utils.py
@@ -60,15 +60,52 @@ class TestAssignProvider:
             _assign_provider('mistral-large-latest') == 'mistral/mistral-large-latest'
         )
 
-    def test_prefixed_and_unknown_models_remain_unchanged(self, monkeypatch):
-        """Test that only known bare models are rewritten."""
+    def test_prefixed_models_remain_unchanged(self, monkeypatch):
+        """Test that already-prefixed models are returned untouched."""
         monkeypatch.setattr(llm_utils, '_BARE_OPENAI_MODELS', {'gpt-5.2'})
         monkeypatch.setattr(llm_utils, '_BARE_ANTHROPIC_MODELS', set())
         monkeypatch.setattr(llm_utils, '_BARE_MISTRAL_MODELS', set())
 
         assert _assign_provider('openai/gpt-5.2') == 'openai/gpt-5.2'
-        assert _assign_provider('cohere.command-r-v1:0') == 'cohere.command-r-v1:0'
-        assert _assign_provider('custom-model') == 'custom-model'
+
+    def test_unresolvable_bare_models_remain_unchanged(self, monkeypatch):
+        """Bare names LiteLLM cannot resolve fall through unchanged."""
+        monkeypatch.setattr(llm_utils, '_BARE_OPENAI_MODELS', set())
+        monkeypatch.setattr(llm_utils, '_BARE_ANTHROPIC_MODELS', set())
+        monkeypatch.setattr(llm_utils, '_BARE_MISTRAL_MODELS', set())
+
+        assert _assign_provider('totally-made-up-model-xyz') == (
+            'totally-made-up-model-xyz'
+        )
+
+    def test_unverified_bare_models_use_litellm_fallback(self, monkeypatch):
+        """Unverified bare names reach the dropdown via LiteLLM's routing."""
+        monkeypatch.setattr(llm_utils, '_BARE_OPENAI_MODELS', set())
+        monkeypatch.setattr(llm_utils, '_BARE_ANTHROPIC_MODELS', set())
+        monkeypatch.setattr(llm_utils, '_BARE_MISTRAL_MODELS', set())
+
+        # gemini-* lives bare in litellm.model_cost; LiteLLM routes it to
+        # vertex_ai. Without the fallback the frontend's provider filter
+        # drops it entirely.
+        assert _assign_provider('gemini-2.0-flash') == 'vertex_ai/gemini-2.0-flash'
+        # cohere.<model>:<rev> is the Bedrock-style ID for Cohere models;
+        # LiteLLM resolves it to bedrock.
+        assert (
+            _assign_provider('cohere.command-r-v1:0') == 'bedrock/cohere.command-r-v1:0'
+        )
+
+    def test_litellm_fallback_exception_is_swallowed(self, monkeypatch):
+        """A raising get_llm_provider must not break the model list build."""
+        monkeypatch.setattr(llm_utils, '_BARE_OPENAI_MODELS', set())
+        monkeypatch.setattr(llm_utils, '_BARE_ANTHROPIC_MODELS', set())
+        monkeypatch.setattr(llm_utils, '_BARE_MISTRAL_MODELS', set())
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError('litellm exploded')
+
+        monkeypatch.setattr(llm_utils, 'get_llm_provider', _boom)
+
+        assert _assign_provider('whatever') == 'whatever'
 
 
 class TestDeriveVerifiedModels:


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why

When a user opened the Anthropic provider dropdown in the LLM picker, only the SDK's curated *verified* models appeared (e.g. `claude-opus-4-6`). 

Other Anthropic models were silently dropped, even though they exist in `litellm.model_cost`. The same bug affected Vertex AI / Gemini, Cohere, and others: every provider whose models LiteLLM stores as bare names (no `provider/` prefix) lost its non-verified tail in the UI.

Root cause is `_assign_provider()` in `openhands/utils/llm.py`. 

It only knew how to prefix bare names already present in the SDK's three hardcoded sets (`_BARE_OPENAI_MODELS`, `_BARE_ANTHROPIC_MODELS`, `_BARE_MISTRAL_MODELS`). Anything else stayed bare, then `_get_all_models_with_verified()` assigned `provider=None`, then `?provider__eq=anthropic` (and friends) filtered it out.

## Summary

- Adds a `litellm.get_llm_provider()` fallback to `_assign_provider()` so any bare name LiteLLM can route reaches the correct provider's dropdown.

## Issue Number

## How to Test

Today, no unverified models appear for Anthropic:
<img width="694" height="359" alt="image" src="https://github.com/user-attachments/assets/b77127c9-e1b2-451c-b008-35f173a798da" />

After this change, other models appear beneath verified models:
<img width="694" height="359" alt="image" src="https://github.com/user-attachments/assets/a0c248ea-33b1-4c23-9de7-37c33e5fc957" />


## Video/Screenshots

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The fallback is in-process — `litellm.get_llm_provider` is a string-routing function over LiteLLM's static `provider_list` and `model_list_set`, ~3.4µs per call, no network. Exceptions are swallowed so unresolvable names pass through unchanged.
- Does *not* change which models are tagged "Verified" in the UI — that remains the SDK's `VERIFIED_MODELS` dict via `_get_verified_models()`. Newly surfaced names appear under "Others".

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-521b35f   docker.openhands.dev/openhands/openhands:521b35f
```