### PR TITLE
refactor(settings): rename LLMAgentSettings → OpenHandsAgentSettings (SDK 1.19.0)

### DIFF
--- a/openhands/app_server/settings/settings_models.py
+++ b/openhands/app_server/settings/settings_models.py
@@ -35,7 +35,7 @@ from openhands.utils.jsonpatch_compat import deep_merge
 from openhands.utils.sdk_settings_compat import (
     ACPAgentSettings,
     AgentSettingsConfig,
-    LLMAgentSettings,
+    OpenHandsAgentSettings,
     default_agent_settings,
     validate_agent_settings,
 )
@@ -287,7 +287,7 @@ class Settings(BaseModel):
     @field_serializer('agent_settings')
     def agent_settings_serializer(
         self,
-        agent_settings: LLMAgentSettings | ACPAgentSettings,
+        agent_settings: OpenHandsAgentSettings | ACPAgentSettings,
         info: SerializationInfo,
     ) -> dict[str, Any]:
         context = info.context or {}
@@ -326,7 +326,7 @@ class Settings(BaseModel):
         agent_settings = data.get('agent_settings')
         if isinstance(agent_settings, dict):
             data['agent_settings'] = _coerce_dict_secrets(agent_settings)
-        elif isinstance(agent_settings, (LLMAgentSettings, ACPAgentSettings)):
+        elif isinstance(agent_settings, (OpenHandsAgentSettings, ACPAgentSettings)):
             data['agent_settings'] = agent_settings.model_dump(
                 mode='json', context={'expose_secrets': True}
             )
@@ -396,7 +396,7 @@ class Settings(BaseModel):
             search_api_key=app_config.search_api_key,
             max_budget_per_task=app_config.max_budget_per_task,
             # Always LLM for config-file-sourced settings
-            agent_settings=LLMAgentSettings(**agent_settings_dict),
+            agent_settings=OpenHandsAgentSettings(**agent_settings_dict),
             conversation_settings=ConversationSettings.model_validate(
                 {
                     'confirmation_mode': bool(app_config.security.confirmation_mode),
@@ -408,7 +408,7 @@ class Settings(BaseModel):
 
     def merge_with_config_settings(self) -> 'Settings':
         """Merge config.toml MCP settings with stored SDK agent_settings."""
-        if not isinstance(self.agent_settings, LLMAgentSettings):
+        if not isinstance(self.agent_settings, OpenHandsAgentSettings):
             return self
         config_settings = Settings.from_config()
         if not config_settings:
@@ -424,7 +424,7 @@ class Settings(BaseModel):
         self.agent_settings.mcp_config = merged_mcp
         return self
 
-    def to_agent_settings(self) -> LLMAgentSettings | ACPAgentSettings:
+    def to_agent_settings(self) -> OpenHandsAgentSettings | ACPAgentSettings:
         return self.agent_settings
 
     def get_agent_settings_display(self) -> dict[str, Any]:

--- a/openhands/app_server/settings/settings_router.py
+++ b/openhands/app_server/settings/settings_router.py
@@ -47,7 +47,7 @@ from openhands.utils.llm import (
     resolve_llm_base_url,
 )
 from openhands.utils.sdk_settings_compat import (
-    LLMAgentSettings,
+    OpenHandsAgentSettings,
     export_agent_settings_schema,
 )
 
@@ -70,7 +70,7 @@ def _post_merge_llm_fixups(settings: Settings) -> None:
     rules to :func:`openhands.utils.llm.resolve_llm_base_url` so the
     personal-save and enterprise org-defaults paths stay in lockstep.
     """
-    if not isinstance(settings.agent_settings, LLMAgentSettings):
+    if not isinstance(settings.agent_settings, OpenHandsAgentSettings):
         return
     llm = settings.agent_settings.llm
     llm.base_url = resolve_llm_base_url(

--- a/openhands/utils/sdk_settings_compat.py
+++ b/openhands/utils/sdk_settings_compat.py
@@ -12,9 +12,11 @@ try:
     )
 
     try:
-        from openhands.sdk.settings import OpenHandsAgentSettings  # type: ignore[attr-defined]
+        from openhands.sdk.settings import (  # type: ignore[attr-defined]
+            OpenHandsAgentSettings,
+        )
     except ImportError:
-        from openhands.sdk.settings import (  # type: ignore[attr-defined, misc, assignment]
+        from openhands.sdk.settings import (  # type: ignore[attr-defined, misc, assignment, no-redef]
             LLMAgentSettings as OpenHandsAgentSettings,
         )
 

--- a/openhands/utils/sdk_settings_compat.py
+++ b/openhands/utils/sdk_settings_compat.py
@@ -6,17 +6,25 @@ try:
     from openhands.sdk.settings import (  # type: ignore[attr-defined]
         ACPAgentSettings,
         AgentSettingsConfig,
-        LLMAgentSettings,
         default_agent_settings,
         export_agent_settings_schema,
         validate_agent_settings,
     )
 
+    try:
+        from openhands.sdk.settings import OpenHandsAgentSettings  # type: ignore[attr-defined]
+    except ImportError:
+        from openhands.sdk.settings import (  # type: ignore[attr-defined, misc, assignment]
+            LLMAgentSettings as OpenHandsAgentSettings,
+        )
+
+    LLMAgentSettings = OpenHandsAgentSettings
     _HAS_DISCRIMINATED_UNION = True
 except ImportError:
     _HAS_DISCRIMINATED_UNION = False
     from openhands.sdk.settings import AgentSettings
 
+    OpenHandsAgentSettings = AgentSettings  # type: ignore[misc, assignment]
     LLMAgentSettings = AgentSettings  # type: ignore[misc, assignment]
 
     class _ACPAgentSettingsStub:
@@ -46,6 +54,7 @@ __all__ = [
     'ACPAgentSettings',
     'AgentSettingsConfig',
     'LLMAgentSettings',
+    'OpenHandsAgentSettings',
     '_HAS_DISCRIMINATED_UNION',
     'default_agent_settings',
     'export_agent_settings_schema',

--- a/tests/unit/utils/test_sdk_settings_compat.py
+++ b/tests/unit/utils/test_sdk_settings_compat.py
@@ -7,6 +7,7 @@ from openhands.utils.sdk_settings_compat import (
     ACPAgentSettings,
     AgentSettingsConfig,
     LLMAgentSettings,
+    OpenHandsAgentSettings,
     default_agent_settings,
     export_agent_settings_schema,
     validate_agent_settings,
@@ -53,6 +54,18 @@ def test_llm_agent_settings_is_usable():
     """LLMAgentSettings should be constructable."""
     settings = LLMAgentSettings()
     assert settings is not None
+    assert isinstance(settings, OpenHandsAgentSettings)
+
+
+def test_openhands_agent_settings_is_usable():
+    """OpenHandsAgentSettings is the canonical local name for the LLM agent."""
+    settings = OpenHandsAgentSettings()
+    assert settings is not None
+    assert settings.agent_kind == 'llm'
+
+
+def test_llm_agent_settings_is_silent_alias_for_openhands():
+    assert LLMAgentSettings is OpenHandsAgentSettings
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

Adds a small OpenHands-side compatibility layer for the SDK rename from `LLMAgentSettings` to `OpenHandsAgentSettings`, without pulling in unrelated ACP UI or conversation-routing work.

OpenHands is still pinned to `openhands-sdk==1.19.0`, so this PR does not start writing `agent_kind: "openhands"`. The standard built-in agent continues to use the SDK-compatible runtime/persisted discriminator `agent_kind: "llm"`; `OpenHandsAgentSettings` is only the local/canonical class name exposed by the shim.

## Changes

- `sdk_settings_compat.py` now exports `OpenHandsAgentSettings`.
- When the installed SDK already provides `OpenHandsAgentSettings`, the shim imports it directly.
- With the current SDK pin, the shim falls back to `LLMAgentSettings as OpenHandsAgentSettings` and keeps `LLMAgentSettings = OpenHandsAgentSettings` as a silent local alias.
- Settings model/router call sites use `OpenHandsAgentSettings` naming through the shim.
- Shim tests cover `OpenHandsAgentSettings`, the legacy alias, and existing discriminated-union behavior.

## Compatibility strategy

- Existing production settings/conversations using `"llm"` continue unchanged.
- No deprecation warnings are emitted inside OpenHands for the local alias or when loading persisted settings.
- Deprecation warnings remain the SDK's responsibility for public SDK deprecated API access paths.
- ACP agents have not been used in production, so this PR deliberately avoids adding broad ACP data migration logic.

## Test plan

- [x] `uv run pytest tests/unit/utils/test_sdk_settings_compat.py tests/unit/app_server/test_settings_api.py -q`
- [x] Verified PR diff is one commit touching only four files.
- [ ] `uv run ruff check ...` reports pre-existing docstring style violations in touched files; no new lint-specific code path was added.


---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-46d84ba   docker.openhands.dev/openhands/openhands:46d84ba
```