### PR TITLE
fix: update deprecated FastMCP API usage in mcp_patch.py

### DIFF
--- a/enterprise/server/routes/mcp_patch.py
+++ b/enterprise/server/routes/mcp_patch.py
@@ -1,7 +1,8 @@
 import os
 
-from fastmcp import Client, FastMCP
+from fastmcp import Client
 from fastmcp.client.transports import NpxStdioTransport
+from fastmcp.server import create_proxy
 
 from openhands.app_server.mcp.mcp_router import mcp_server
 from openhands.core.logger import openhands_logger as logger
@@ -24,9 +25,9 @@ def patch_mcp_server():
                 package='tavily-mcp@0.2.1', env_vars={'TAVILY_API_KEY': TAVILY_API_KEY}
             )
         )
-        proxy_server = FastMCP.as_proxy(proxy_client)
+        proxy_server = create_proxy(proxy_client)
 
-        mcp_server.mount(prefix='tavily', server=proxy_server)
+        mcp_server.mount(namespace='tavily', server=proxy_server)
         logger.info('Tavily search integration initialized successfully')
     else:
         logger.warning('Tavily API key not found, skipping search integration')


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

The enterprise MCP patch file is using deprecated FastMCP APIs that produce deprecation warnings at startup:
```
FastMCPDeprecationWarning: FastMCP.as_proxy() is deprecated. Use create_proxy() from fastmcp.server instead
FastMCPDeprecationWarning: The 'prefix' parameter is deprecated, use 'namespace' instead
```

## Summary

- Replace `FastMCP.as_proxy()` with `create_proxy()` from `fastmcp.server`
- Replace `prefix='tavily'` with `namespace='tavily'` in `mcp_server.mount()`

## Issue Number

N/A - fixing deprecation warnings

## How to Test

Start the enterprise server with `ENABLE_MCP_SEARCH_ENGINE=true` and `TAVILY_API_KEY` set. Verify that the deprecation warnings no longer appear in the logs.

## Video/Screenshots

N/A

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f8ca5c07-1a14-41d8-ab55-92e98aa9985b)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-3a20f59   docker.openhands.dev/openhands/openhands:3a20f59
```