### PR TITLE
feat: Auto-generate OPENHANDS_API_KEY as system secret for all users

### DIFF
--- a/enterprise/server/auth/saas_user_auth.py
+++ b/enterprise/server/auth/saas_user_auth.py
@@ -165,7 +165,7 @@ class SaasUserAuth(UserAuth):
         user_secrets = await secrets_store.load()
 
         # Inject OPENHANDS_API_KEY (system-level, lazily generated)
-        openhands_api_key = await self.get_openhands_api_key()
+        openhands_api_key = await self._get_openhands_api_key()
         if openhands_api_key:
             custom_secrets = dict(user_secrets.custom_secrets) if user_secrets else {}
             custom_secrets['OPENHANDS_API_KEY'] = CustomSecret(
@@ -269,7 +269,7 @@ class SaasUserAuth(UserAuth):
             )
         return mcp_api_key
 
-    async def get_openhands_api_key(self) -> str:
+    async def _get_openhands_api_key(self) -> str:
         """Get or create the user's OPENHANDS_API_KEY (system-level, non-deletable).
 
         This key is automatically generated on first access and stored as a system

--- a/enterprise/server/auth/saas_user_auth.py
+++ b/enterprise/server/auth/saas_user_auth.py
@@ -37,6 +37,7 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fi
 
 from openhands.app_server.integrations.provider import (
     PROVIDER_TOKEN_TYPE,
+    CustomSecret,
     ProviderToken,
     ProviderType,
 )
@@ -162,6 +163,20 @@ class SaasUserAuth(UserAuth):
             return user_secrets
         secrets_store = await self.get_secrets_store()
         user_secrets = await secrets_store.load()
+
+        # Inject OPENHANDS_API_KEY (system-level, lazily generated)
+        openhands_api_key = await self.get_openhands_api_key()
+        if openhands_api_key:
+            custom_secrets = dict(user_secrets.custom_secrets) if user_secrets else {}
+            custom_secrets['OPENHANDS_API_KEY'] = CustomSecret(
+                secret=SecretStr(openhands_api_key),
+                description='OpenHands Cloud API Key for automations and integrations (system-managed)',
+            )
+            user_secrets = Secrets(
+                custom_secrets=custom_secrets,
+                provider_tokens=user_secrets.provider_tokens if user_secrets else {},
+            )
+
         self._secrets = user_secrets
         return user_secrets
 
@@ -253,6 +268,25 @@ class SaasUserAuth(UserAuth):
                 self.user_id, 'MCP_API_KEY', None
             )
         return mcp_api_key
+
+    async def get_openhands_api_key(self) -> str:
+        """Get or create the user's OPENHANDS_API_KEY (system-level, non-deletable).
+
+        This key is automatically generated on first access and stored as a system
+        key that users cannot delete or modify. It is used for automations and
+        integrations.
+        """
+        user = await UserStore.get_user_by_id(self.user_id)
+        if user is None:
+            raise ValueError(f'User not found: {self.user_id}')
+
+        api_key_store = ApiKeyStore.get_instance()
+        openhands_api_key = await api_key_store.get_or_create_system_api_key(
+            user_id=self.user_id,
+            org_id=user.current_org_id,
+            name='OPENHANDS_API_KEY',
+        )
+        return openhands_api_key
 
     async def get_org_info(self) -> dict | None:
         """Get organization info for the current user.

--- a/enterprise/server/auth/saas_user_auth.py
+++ b/enterprise/server/auth/saas_user_auth.py
@@ -279,6 +279,8 @@ class SaasUserAuth(UserAuth):
         user = await UserStore.get_user_by_id(self.user_id)
         if user is None:
             raise ValueError(f'User not found: {self.user_id}')
+        if user.current_org_id is None:
+            raise ValueError(f'User {self.user_id} has no current organization')
 
         api_key_store = ApiKeyStore.get_instance()
         openhands_api_key = await api_key_store.get_or_create_system_api_key(

--- a/enterprise/tests/unit/test_saas_user_auth.py
+++ b/enterprise/tests/unit/test_saas_user_auth.py
@@ -910,3 +910,229 @@ async def test_saas_user_auth_from_signed_token_domain_blocking_inactive(mock_co
         mock_user_auth_store.get_authorization_type.assert_called_once_with(
             'user@colsch.us', None
         )
+
+
+# =============================================================================
+# Tests for OPENHANDS_API_KEY injection
+# =============================================================================
+
+
+class TestOpenHandsApiKey:
+    """Tests for OPENHANDS_API_KEY system secret generation and injection."""
+
+    @pytest.mark.asyncio
+    async def test_get_openhands_api_key_creates_system_key(self):
+        """Test that _get_openhands_api_key creates a system key via ApiKeyStore."""
+        user_id = 'test_user_id'
+        org_id = uuid.uuid4()
+        expected_api_key = 'sk-oh-test-key-12345'
+
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.current_org_id = org_id
+
+        user_auth = SaasUserAuth(
+            user_id=user_id,
+            refresh_token=SecretStr('refresh_token'),
+        )
+
+        with (
+            patch('server.auth.saas_user_auth.UserStore') as mock_user_store,
+            patch('server.auth.saas_user_auth.ApiKeyStore') as mock_api_key_store_cls,
+        ):
+            mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
+
+            mock_api_key_store = MagicMock()
+            mock_api_key_store.get_or_create_system_api_key = AsyncMock(
+                return_value=expected_api_key
+            )
+            mock_api_key_store_cls.get_instance.return_value = mock_api_key_store
+
+            # Act
+            result = await user_auth._get_openhands_api_key()
+
+            # Assert
+            assert result == expected_api_key
+            mock_user_store.get_user_by_id.assert_called_once_with(user_id)
+            mock_api_key_store.get_or_create_system_api_key.assert_called_once_with(
+                user_id=user_id,
+                org_id=org_id,
+                name='OPENHANDS_API_KEY',
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_openhands_api_key_raises_for_missing_user(self):
+        """Test that _get_openhands_api_key raises ValueError if user not found."""
+        user_id = 'nonexistent_user'
+
+        user_auth = SaasUserAuth(
+            user_id=user_id,
+            refresh_token=SecretStr('refresh_token'),
+        )
+
+        with patch('server.auth.saas_user_auth.UserStore') as mock_user_store:
+            mock_user_store.get_user_by_id = AsyncMock(return_value=None)
+
+            # Act & Assert
+            with pytest.raises(ValueError, match=f'User not found: {user_id}'):
+                await user_auth._get_openhands_api_key()
+
+    @pytest.mark.asyncio
+    async def test_get_secrets_includes_openhands_api_key(self):
+        """Test that get_secrets injects OPENHANDS_API_KEY into custom_secrets."""
+        user_id = 'test_user_id'
+        org_id = uuid.uuid4()
+        expected_api_key = 'sk-oh-test-key-12345'
+
+        # Create mock user
+        mock_user = MagicMock()
+        mock_user.current_org_id = org_id
+
+        # Create mock secrets from store (without OPENHANDS_API_KEY)
+        mock_stored_secrets = Secrets(
+            custom_secrets={
+                'MY_SECRET': {
+                    'secret': 'my-secret-value',
+                    'description': 'My custom secret',
+                }
+            }
+        )
+
+        user_auth = SaasUserAuth(
+            user_id=user_id,
+            refresh_token=SecretStr('refresh_token'),
+        )
+
+        with (
+            patch('server.auth.saas_user_auth.UserStore') as mock_user_store,
+            patch('server.auth.saas_user_auth.ApiKeyStore') as mock_api_key_store_cls,
+            patch(
+                'server.auth.saas_user_auth.SaasSecretsStore'
+            ) as mock_secrets_store_cls,
+            patch('server.auth.saas_user_auth.get_config') as mock_get_config,
+        ):
+            mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
+
+            mock_api_key_store = MagicMock()
+            mock_api_key_store.get_or_create_system_api_key = AsyncMock(
+                return_value=expected_api_key
+            )
+            mock_api_key_store_cls.get_instance.return_value = mock_api_key_store
+
+            mock_secrets_store = MagicMock()
+            mock_secrets_store.load = AsyncMock(return_value=mock_stored_secrets)
+            mock_secrets_store_cls.return_value = mock_secrets_store
+
+            mock_get_config.return_value = MagicMock()
+
+            # Act
+            result = await user_auth.get_secrets()
+
+            # Assert
+            assert result is not None
+            assert 'OPENHANDS_API_KEY' in result.custom_secrets
+            assert (
+                result.custom_secrets['OPENHANDS_API_KEY'].secret.get_secret_value()
+                == expected_api_key
+            )
+            assert (
+                'system-managed'
+                in result.custom_secrets['OPENHANDS_API_KEY'].description
+            )
+            # Original secret should still be present
+            assert 'MY_SECRET' in result.custom_secrets
+
+    @pytest.mark.asyncio
+    async def test_get_secrets_caches_result(self):
+        """Test that get_secrets caches the result and doesn't call store again."""
+        user_id = 'test_user_id'
+        org_id = uuid.uuid4()
+        expected_api_key = 'sk-oh-test-key-12345'
+
+        mock_user = MagicMock()
+        mock_user.current_org_id = org_id
+
+        mock_stored_secrets = Secrets()
+
+        user_auth = SaasUserAuth(
+            user_id=user_id,
+            refresh_token=SecretStr('refresh_token'),
+        )
+
+        with (
+            patch('server.auth.saas_user_auth.UserStore') as mock_user_store,
+            patch('server.auth.saas_user_auth.ApiKeyStore') as mock_api_key_store_cls,
+            patch(
+                'server.auth.saas_user_auth.SaasSecretsStore'
+            ) as mock_secrets_store_cls,
+            patch('server.auth.saas_user_auth.get_config') as mock_get_config,
+        ):
+            mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
+
+            mock_api_key_store = MagicMock()
+            mock_api_key_store.get_or_create_system_api_key = AsyncMock(
+                return_value=expected_api_key
+            )
+            mock_api_key_store_cls.get_instance.return_value = mock_api_key_store
+
+            mock_secrets_store = MagicMock()
+            mock_secrets_store.load = AsyncMock(return_value=mock_stored_secrets)
+            mock_secrets_store_cls.return_value = mock_secrets_store
+
+            mock_get_config.return_value = MagicMock()
+
+            # Act - call get_secrets twice
+            result1 = await user_auth.get_secrets()
+            result2 = await user_auth.get_secrets()
+
+            # Assert - store.load should only be called once (caching)
+            assert result1 is result2
+            mock_secrets_store.load.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_secrets_handles_empty_stored_secrets(self):
+        """Test that get_secrets works when store returns empty Secrets."""
+        user_id = 'test_user_id'
+        org_id = uuid.uuid4()
+        expected_api_key = 'sk-oh-test-key-12345'
+
+        mock_user = MagicMock()
+        mock_user.current_org_id = org_id
+
+        # Empty secrets from store
+        mock_stored_secrets = Secrets()
+
+        user_auth = SaasUserAuth(
+            user_id=user_id,
+            refresh_token=SecretStr('refresh_token'),
+        )
+
+        with (
+            patch('server.auth.saas_user_auth.UserStore') as mock_user_store,
+            patch('server.auth.saas_user_auth.ApiKeyStore') as mock_api_key_store_cls,
+            patch(
+                'server.auth.saas_user_auth.SaasSecretsStore'
+            ) as mock_secrets_store_cls,
+            patch('server.auth.saas_user_auth.get_config') as mock_get_config,
+        ):
+            mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
+
+            mock_api_key_store = MagicMock()
+            mock_api_key_store.get_or_create_system_api_key = AsyncMock(
+                return_value=expected_api_key
+            )
+            mock_api_key_store_cls.get_instance.return_value = mock_api_key_store
+
+            mock_secrets_store = MagicMock()
+            mock_secrets_store.load = AsyncMock(return_value=mock_stored_secrets)
+            mock_secrets_store_cls.return_value = mock_secrets_store
+
+            mock_get_config.return_value = MagicMock()
+
+            # Act
+            result = await user_auth.get_secrets()
+
+            # Assert - should have only OPENHANDS_API_KEY
+            assert result is not None
+            assert 'OPENHANDS_API_KEY' in result.custom_secrets
+            assert len(result.custom_secrets) == 1

--- a/enterprise/tests/unit/test_saas_user_auth.py
+++ b/enterprise/tests/unit/test_saas_user_auth.py
@@ -978,6 +978,27 @@ class TestOpenHandsApiKey:
                 await user_auth._get_openhands_api_key()
 
     @pytest.mark.asyncio
+    async def test_get_openhands_api_key_raises_for_user_without_org(self):
+        """Test that _get_openhands_api_key raises ValueError if user has no org."""
+        user_id = 'test_user_id'
+
+        # Create mock user with no current organization
+        mock_user = MagicMock()
+        mock_user.current_org_id = None
+
+        user_auth = SaasUserAuth(
+            user_id=user_id,
+            refresh_token=SecretStr('refresh_token'),
+        )
+
+        with patch('server.auth.saas_user_auth.UserStore') as mock_user_store:
+            mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
+
+            # Act & Assert
+            with pytest.raises(ValueError, match='has no current organization'):
+                await user_auth._get_openhands_api_key()
+
+    @pytest.mark.asyncio
     async def test_get_secrets_includes_openhands_api_key(self):
         """Test that get_secrets injects OPENHANDS_API_KEY into custom_secrets."""
         user_id = 'test_user_id'

--- a/openhands/app_server/secrets/secrets_router.py
+++ b/openhands/app_server/secrets/secrets_router.py
@@ -189,6 +189,8 @@ async def search_custom_secrets(
     Retrieves the names and descriptions of custom secrets for the authenticated user.
     Results are paginated and can be filtered by name.
 
+    In SaaS mode, includes the system-generated OPENHANDS_API_KEY which cannot be deleted.
+
     Returns:
         CustomSecretPage: Paginated list of custom secrets (without values)
     """

--- a/openhands/app_server/user/auth_user_context.py
+++ b/openhands/app_server/user/auth_user_context.py
@@ -103,7 +103,7 @@ class AuthUserContext(UserContext):
     async def get_secrets(self) -> dict[str, SecretSource]:
         results: dict[str, SecretSource] = {}
 
-        # Include custom secrets
+        # Include custom secrets (includes OPENHANDS_API_KEY in SaaS mode)
         secrets = await self.user_auth.get_secrets()
         if secrets:
             for name, custom_secret in secrets.custom_secrets.items():


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Currently, users need to manually set the `OPENHANDS_API_KEY` secret in their settings. This adds friction to the onboarding experience and causes confusion. Users should have this key automatically available.

## Summary

- Add `get_openhands_api_key()` method to `SaasUserAuth` that lazily creates a system-level API key using existing `get_or_create_system_api_key()` infrastructure
- Inject `OPENHANDS_API_KEY` into the `Secrets` model returned by `get_secrets()` so it's automatically available to all downstream consumers (sandbox, secrets listing, etc.)
- System key is stored as `__SYSTEM__:OPENHANDS_API_KEY` which is hidden from user API key list and cannot be deleted by users

## Issue Number

Resolves [APP-1478](https://linear.app/all-hands-ai/issue/APP-1478/automatically-add-openhands-api-key-as-a-secret-to-every-users)

## How to Test

1. Login to OpenHands Cloud
2. Go to Settings > Secrets and verify `OPENHANDS_API_KEY` appears in the list with description "(system-managed)"
3. Start a conversation and verify the secret is available in the sandbox environment
4. Try to delete `OPENHANDS_API_KEY` - it should appear in the list but cannot be deleted (since it's not a user-created custom secret)

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Uses lazy generation: key is only created on first access, not during account creation
- Key never expires (system keys don't have expiration)
- Key is tied to user's current organization
- No database migrations required - uses existing `api_keys` table infrastructure

---

*This PR was created by an AI agent (OpenHands) on behalf of a user.*

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fa3371e6-b8c7-4e7d-8d09-9333590ccfcc)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-10960ca   docker.openhands.dev/openhands/openhands:10960ca
```