### PR TITLE
fix(secrets): return 404 for missing custom secret

### DIFF
--- a/openhands/app_server/secrets/secrets_router.py
+++ b/openhands/app_server/secrets/secrets_router.py
@@ -290,37 +290,42 @@ async def update_custom_secret(
         500: Error updating secret
     """
     existing_secrets = await secrets_store.load()
-    if existing_secrets:
-        # Check if the secret to update exists
-        if secret_id not in existing_secrets.custom_secrets:
-            return HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f'Secret with ID {secret_id} not found',
-            )
-
-        secret_name = incoming_secret.name
-        secret_description = incoming_secret.description
-
-        custom_secrets = dict(existing_secrets.custom_secrets)
-        existing_secret = custom_secrets.pop(secret_id)
-
-        if secret_name != secret_id and secret_name in custom_secrets:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f'Secret {secret_name} already exists',
-            )
-
-        custom_secrets[secret_name] = CustomSecret(
-            secret=existing_secret.secret,
-            description=secret_description or '',
+    if not existing_secrets:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f'Secret with ID {secret_id} not found',
         )
 
-        updated_secrets = Secrets(
-            custom_secrets=custom_secrets,  # type: ignore[arg-type]
-            provider_tokens=existing_secrets.provider_tokens,
+    # Check if the secret to update exists
+    if secret_id not in existing_secrets.custom_secrets:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f'Secret with ID {secret_id} not found',
         )
 
-        await secrets_store.store(updated_secrets)
+    secret_name = incoming_secret.name
+    secret_description = incoming_secret.description
+
+    custom_secrets = dict(existing_secrets.custom_secrets)
+    existing_secret = custom_secrets.pop(secret_id)
+
+    if secret_name != secret_id and secret_name in custom_secrets:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f'Secret {secret_name} already exists',
+        )
+
+    custom_secrets[secret_name] = CustomSecret(
+        secret=existing_secret.secret,
+        description=secret_description or '',
+    )
+
+    updated_secrets = Secrets(
+        custom_secrets=custom_secrets,  # type: ignore[arg-type]
+        provider_tokens=existing_secrets.provider_tokens,
+    )
+
+    await secrets_store.store(updated_secrets)
 
     return EditResponse(
         message='Secret updated successfully',

--- a/tests/unit/app_server/test_secrets_api.py
+++ b/tests/unit/app_server/test_secrets_api.py
@@ -282,6 +282,31 @@ async def test_update_existing_custom_secret(test_client, file_secrets_store):
 
 
 @pytest.mark.asyncio
+async def test_update_nonexistent_custom_secret(test_client, file_secrets_store):
+    """Test updating a custom secret that doesn't exist."""
+    custom_secrets = {'API_KEY': CustomSecret(secret=SecretStr('old-api-key'))}
+    await file_secrets_store.store(Secrets(custom_secrets=custom_secrets))
+
+    response = test_client.put(
+        '/secrets/MISSING_KEY',
+        json={'name': 'MISSING_KEY', 'description': None},
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_custom_secret_with_empty_store(test_client, file_secrets_store):
+    """Test updating a custom secret when the store is empty."""
+    response = test_client.put(
+        '/secrets/MISSING_KEY',
+        json={'name': 'MISSING_KEY', 'description': None},
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_add_multiple_custom_secrets(test_client, file_secrets_store):
     """Test adding multiple custom secrets at once."""
     # Create initial settings with one custom secret


### PR DESCRIPTION
`update_custom_secret` was returning an `HTTPException` object when the secret ID was missing, which FastAPI could serialize as a 200 response. This raises 404 for missing secrets, including an empty store, and keeps the existing conflict check intact. Verified with `./.venv/bin/pytest tests/unit/app_server/test_secrets_api.py -q` and `./.venv/bin/ruff check openhands/app_server/secrets/secrets_router.py tests/unit/app_server/test_secrets_api.py`. Fixes #14204.
