### PR TITLE
fix(frontend): allow attachment-only chat submits

### DIFF
--- a/frontend/__tests__/components/interactive-chat-box.test.tsx
+++ b/frontend/__tests__/components/interactive-chat-box.test.tsx
@@ -1,6 +1,14 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { MemoryRouter } from "react-router";
 import { InteractiveChatBox } from "#/components/features/chat/interactive-chat-box";
 import { renderWithProviders } from "../../test-utils";
@@ -57,7 +65,8 @@ describe("InteractiveChatBox", () => {
 
   const mockStores = (agentState: AgentState = AgentState.INIT) => {
     vi.mocked(useAgentState).mockReturnValue({
-      curAgentState: agentState, isArchived: false,
+      curAgentState: agentState,
+      isArchived: false,
     });
 
     useConversationStore.setState({
@@ -199,6 +208,27 @@ describe("InteractiveChatBox", () => {
     await user.click(submitButton);
 
     expect(onSubmitMock).toHaveBeenCalledWith("Hello, world!", [], []);
+  });
+
+  it("should submit attachments when the text input is empty", async () => {
+    const user = userEvent.setup();
+    const image = new File(["image-content"], "screenshot.png", {
+      type: "image/png",
+    });
+
+    mockStores(AgentState.AWAITING_USER_INPUT);
+    useConversationStore.setState({ images: [image], files: [] });
+
+    renderInteractiveChatBox({
+      onSubmit: onSubmitMock,
+    });
+
+    const submitButton = screen.getByTestId("submit-button");
+    expect(submitButton).not.toBeDisabled();
+
+    await user.click(submitButton);
+
+    expect(onSubmitMock).toHaveBeenCalledWith("", [image], []);
   });
 
   it("should disable the submit button when awaiting user confirmation", async () => {

--- a/frontend/src/components/features/chat/custom-chat-input.tsx
+++ b/frontend/src/components/features/chat/custom-chat-input.tsx
@@ -38,10 +38,14 @@ export function CustomChatInput({
 }: CustomChatInputProps) {
   const {
     submittedMessage,
+    images,
+    files,
     clearAllFiles,
     setShouldHideSuggestions,
     setSubmittedMessage,
   } = useConversationStore();
+
+  const hasAttachments = images.length > 0 || files.length > 0;
 
   // Disable input when conversation is stopped
   const isConversationStopped = sandboxStatus === "MISSING";
@@ -96,6 +100,7 @@ export function CustomChatInput({
     smartResize,
     onSubmit,
     resetManualResize,
+    hasAttachments,
   );
 
   const { handleInput, handlePaste, handleKeyDown, handleBlur, handleFocus } =
@@ -107,6 +112,7 @@ export function CustomChatInput({
       clearEmptyContentHandler,
       onFocus,
       onBlur,
+      hasAttachments,
     );
 
   const {

--- a/frontend/src/hooks/chat/use-chat-input-events.ts
+++ b/frontend/src/hooks/chat/use-chat-input-events.ts
@@ -16,6 +16,7 @@ export const useChatInputEvents = (
   clearEmptyContentHandler: () => void,
   onFocus?: () => void,
   onBlur?: () => void,
+  hasAttachments = false,
 ) => {
   // Handle input events
   const handleInput = useCallback(() => {
@@ -74,7 +75,7 @@ export const useChatInputEvents = (
         return;
       }
 
-      if (checkIsContentEmpty()) {
+      if (checkIsContentEmpty() && !hasAttachments) {
         e.preventDefault();
         increaseHeightForEmptyContent();
         return;
@@ -86,7 +87,7 @@ export const useChatInputEvents = (
         handleSubmit();
       }
     },
-    [checkIsContentEmpty, increaseHeightForEmptyContent],
+    [checkIsContentEmpty, increaseHeightForEmptyContent, hasAttachments],
   );
 
   // Handle blur events to ensure placeholder shows when empty

--- a/frontend/src/hooks/chat/use-chat-submission.ts
+++ b/frontend/src/hooks/chat/use-chat-submission.ts
@@ -13,13 +13,14 @@ export const useChatSubmission = (
   smartResize: () => void,
   onSubmit: (message: string) => void,
   resetManualResize?: () => void,
+  hasAttachments = false,
 ) => {
   // Send button click handler
   const handleSubmit = useCallback(() => {
     const message = chatInputRef.current?.innerText || "";
     const trimmedMessage = message.trim();
 
-    if (!trimmedMessage) {
+    if (!trimmedMessage && !hasAttachments) {
       return;
     }
 
@@ -34,7 +35,14 @@ export const useChatSubmission = (
 
     // Reset manual resize state for next message
     resetManualResize?.();
-  }, [chatInputRef, fileInputRef, smartResize, onSubmit, resetManualResize]);
+  }, [
+    chatInputRef,
+    fileInputRef,
+    smartResize,
+    onSubmit,
+    resetManualResize,
+    hasAttachments,
+  ]);
 
   // Handle stop button click
   const handleStop = useCallback((onStop?: () => void) => {


### PR DESCRIPTION
## Summary
- allow chat submissions when the input text is empty but attachments are already queued
- let Enter submit attachment-only messages instead of treating the empty text field as an invalid submission
- add regression coverage for submitting an attached image without text

Fixes #14047.

## Tests
- `npm_config_prefix= ./node_modules/.bin/vitest run __tests__/components/interactive-chat-box.test.tsx`
