### PR TITLE
Remove unused OpenHandsConfig from RepositoryStore and UserRepositoryMapStore

### DIFF
--- a/enterprise/integrations/store_repo_utils.py
+++ b/enterprise/integrations/store_repo_utils.py
@@ -4,7 +4,6 @@ from storage.user_repo_map import UserRepositoryMap
 from storage.user_repo_map_store import UserRepositoryMapStore
 
 from openhands.app_server.integrations.service_types import Repository
-from openhands.core.config.openhands_config import OpenHandsConfig
 from openhands.core.logger import openhands_logger as logger
 
 
@@ -36,16 +35,13 @@ async def store_repositories_in_db(repos: list[Repository], user_id: str) -> Non
 
         user_repos.append(user_repo_map)
 
-    # Get config instance
-    config = OpenHandsConfig()
-
     try:
         # Store repositories in the repos table
-        repo_store = RepositoryStore.get_instance(config)
+        repo_store = RepositoryStore.get_instance()
         await repo_store.store_projects(stored_repos)
 
         # Store user-repository mappings in the user-repos table
-        user_repo_store = UserRepositoryMapStore.get_instance(config)
+        user_repo_store = UserRepositoryMapStore.get_instance()
         await user_repo_store.store_user_repo_mappings(user_repos)
 
         logger.info(f'Saved repos for user {user_id}')

--- a/enterprise/storage/repository_store.py
+++ b/enterprise/storage/repository_store.py
@@ -1,18 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 from sqlalchemy import select
 from storage.database import a_session_maker
 from storage.stored_repository import StoredRepository
 
-from openhands.core.config.openhands_config import OpenHandsConfig
 
-
-@dataclass
 class RepositoryStore:
-    config: OpenHandsConfig
-
     async def store_projects(self, repositories: list[StoredRepository]) -> None:
         """
         Store repositories in database (async version)
@@ -50,6 +43,6 @@ class RepositoryStore:
             await session.commit()
 
     @classmethod
-    def get_instance(cls, config: OpenHandsConfig) -> RepositoryStore:
-        """Get an instance of the UserRepositoryStore."""
-        return RepositoryStore(config)
+    def get_instance(cls) -> RepositoryStore:
+        """Get an instance of the RepositoryStore."""
+        return RepositoryStore()

--- a/enterprise/storage/user_repo_map_store.py
+++ b/enterprise/storage/user_repo_map_store.py
@@ -1,19 +1,12 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 import sqlalchemy
 from sqlalchemy import select
 from storage.database import a_session_maker
 from storage.user_repo_map import UserRepositoryMap
 
-from openhands.core.config.openhands_config import OpenHandsConfig
 
-
-@dataclass
 class UserRepositoryMapStore:
-    config: OpenHandsConfig
-
     async def store_user_repo_mappings(self, mappings: list[UserRepositoryMap]) -> None:
         """
         Store user-repository mappings in database (async version)
@@ -60,6 +53,6 @@ class UserRepositoryMapStore:
             await session.commit()
 
     @classmethod
-    def get_instance(cls, config: OpenHandsConfig) -> UserRepositoryMapStore:
+    def get_instance(cls) -> UserRepositoryMapStore:
         """Get an instance of the UserRepositoryMapStore."""
-        return UserRepositoryMapStore(config)
+        return UserRepositoryMapStore()

--- a/enterprise/tests/unit/test_repository_store.py
+++ b/enterprise/tests/unit/test_repository_store.py
@@ -8,7 +8,7 @@ from storage.stored_repository import StoredRepository
 
 @pytest.fixture
 def repository_store():
-    return RepositoryStore(config=None)
+    return RepositoryStore()
 
 
 @pytest.mark.asyncio

--- a/enterprise/tests/unit/test_user_repo_map_store.py
+++ b/enterprise/tests/unit/test_user_repo_map_store.py
@@ -9,7 +9,7 @@ from storage.user_repo_map_store import UserRepositoryMapStore
 
 @pytest.fixture
 def user_repo_map_store():
-    return UserRepositoryMapStore(config=None)
+    return UserRepositoryMapStore()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

The `config: OpenHandsConfig` field on `RepositoryStore` and `UserRepositoryMapStore` is never referenced by any method (`self.config` does not appear anywhere in either class). The field, import, and `@dataclass` decorator are dead code. In `store_repo_utils.py`, an `OpenHandsConfig()` was being instantiated solely to satisfy the `get_instance(config)` signature, adding unnecessary overhead.

## Summary

- Removed `config: OpenHandsConfig` field and `@dataclass` decorator from `RepositoryStore` and `UserRepositoryMapStore`
- Removed `config` parameter from `get_instance()` class methods on both classes
- Removed unused `OpenHandsConfig` import and instantiation from `store_repo_utils.py`
- Updated test fixtures to use `RepositoryStore()` / `UserRepositoryMapStore()` without `config=None`

## How to Test

Run the existing unit tests:

```bash
cd enterprise
python -m pytest tests/unit/test_repository_store.py tests/unit/test_user_repo_map_store.py -v
```

All 9 tests pass.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

_This PR was created by an AI agent (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-736315b   docker.openhands.dev/openhands/openhands:736315b
```