### PR TITLE
refactor: move openhands.core.logger to openhands.app_server.utils.logger

### DIFF
--- a/enterprise/integrations/bitbucket/bitbucket_manager.py
+++ b/enterprise/integrations/bitbucket/bitbucket_manager.py
@@ -25,7 +25,7 @@ from storage.bitbucket_webhook_store import BitbucketWebhookStore
 
 from openhands.app_server.integrations.provider import ProviderToken, ProviderType
 from openhands.app_server.secrets.secrets_models import Secrets
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.server.types import (
     LLMAuthenticationError,
     MissingSettingsError,

--- a/enterprise/integrations/bitbucket/bitbucket_service.py
+++ b/enterprise/integrations/bitbucket/bitbucket_service.py
@@ -5,7 +5,7 @@ from openhands.app_server.integrations.bitbucket.bitbucket_service import (
     BitBucketService,
 )
 from openhands.app_server.integrations.service_types import ProviderType
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class SaaSBitBucketService(BitBucketService):

--- a/enterprise/integrations/bitbucket/bitbucket_view.py
+++ b/enterprise/integrations/bitbucket/bitbucket_view.py
@@ -33,7 +33,7 @@ from openhands.app_server.integrations.service_types import Comment
 from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.user.specifiy_user_context import USER_CONTEXT_ATTR
 from openhands.app_server.user_auth.user_auth import UserAuth
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.sdk import TextContent
 
 OH_LABEL, INLINE_OH_LABEL = get_oh_labels(HOST)

--- a/enterprise/integrations/bitbucket_data_center/bitbucket_dc_manager.py
+++ b/enterprise/integrations/bitbucket_data_center/bitbucket_dc_manager.py
@@ -26,7 +26,7 @@ from storage.bitbucket_dc_webhook_store import BitbucketDCWebhookStore
 
 from openhands.app_server.integrations.provider import ProviderToken, ProviderType
 from openhands.app_server.secrets.secrets_models import Secrets
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.server.types import (
     LLMAuthenticationError,
     MissingSettingsError,

--- a/enterprise/integrations/bitbucket_data_center/bitbucket_dc_service.py
+++ b/enterprise/integrations/bitbucket_data_center/bitbucket_dc_service.py
@@ -5,7 +5,7 @@ from openhands.app_server.integrations.bitbucket_data_center.bitbucket_dc_servic
     BitbucketDCService,
 )
 from openhands.app_server.integrations.service_types import ProviderType
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class SaaSBitbucketDCService(BitbucketDCService):

--- a/enterprise/integrations/bitbucket_data_center/bitbucket_dc_view.py
+++ b/enterprise/integrations/bitbucket_data_center/bitbucket_dc_view.py
@@ -33,7 +33,7 @@ from openhands.app_server.integrations.service_types import Comment
 from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.user.specifiy_user_context import USER_CONTEXT_ATTR
 from openhands.app_server.user_auth.user_auth import UserAuth
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.sdk import TextContent
 
 OH_LABEL, INLINE_OH_LABEL = get_oh_labels(HOST)

--- a/enterprise/integrations/github/data_collector.py
+++ b/enterprise/integrations/github/data_collector.py
@@ -23,8 +23,8 @@ from openhands.app_server.conversation_paths import get_conversation_dir
 from openhands.app_server.file_store import get_file_store
 from openhands.app_server.integrations.github.github_service import GithubServiceImpl
 from openhands.app_server.integrations.service_types import ProviderType
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.core.config import load_openhands_config
-from openhands.core.logger import openhands_logger as logger
 
 config = load_openhands_config()
 file_store = get_file_store(config.file_store, config.file_store_path)

--- a/enterprise/integrations/github/github_manager.py
+++ b/enterprise/integrations/github/github_manager.py
@@ -34,7 +34,7 @@ from server.auth.token_manager import TokenManager
 from openhands.app_server.integrations.provider import ProviderToken, ProviderType
 from openhands.app_server.integrations.service_types import AuthenticationError
 from openhands.app_server.secrets.secrets_models import Secrets
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.server.types import (
     LLMAuthenticationError,
     MissingSettingsError,

--- a/enterprise/integrations/github/github_service.py
+++ b/enterprise/integrations/github/github_service.py
@@ -6,7 +6,7 @@ from server.auth.token_manager import TokenManager
 
 from openhands.app_server.integrations.github.github_service import GitHubService
 from openhands.app_server.integrations.service_types import ProviderType, Repository
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.server.types import AppMode
 
 

--- a/enterprise/integrations/github/github_view.py
+++ b/enterprise/integrations/github/github_view.py
@@ -41,7 +41,7 @@ from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.user.specifiy_user_context import USER_CONTEXT_ATTR
 from openhands.app_server.user_auth.user_auth import UserAuth
 from openhands.app_server.utils.async_utils import call_sync_from_async
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.sdk import TextContent
 
 OH_LABEL, INLINE_OH_LABEL = get_oh_labels(HOST)

--- a/enterprise/integrations/gitlab/gitlab_manager.py
+++ b/enterprise/integrations/gitlab/gitlab_manager.py
@@ -28,7 +28,7 @@ from server.auth.token_manager import TokenManager
 from openhands.app_server.integrations.gitlab.gitlab_service import GitLabServiceImpl
 from openhands.app_server.integrations.provider import ProviderToken, ProviderType
 from openhands.app_server.secrets.secrets_models import Secrets
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.server.types import (
     LLMAuthenticationError,
     MissingSettingsError,

--- a/enterprise/integrations/gitlab/gitlab_service.py
+++ b/enterprise/integrations/gitlab/gitlab_service.py
@@ -14,7 +14,7 @@ from openhands.app_server.integrations.service_types import (
     Repository,
     RequestMethod,
 )
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.server.types import AppMode
 
 

--- a/enterprise/integrations/gitlab/gitlab_view.py
+++ b/enterprise/integrations/gitlab/gitlab_view.py
@@ -28,7 +28,7 @@ from openhands.app_server.integrations.service_types import Comment
 from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.user.specifiy_user_context import USER_CONTEXT_ATTR
 from openhands.app_server.user_auth.user_auth import UserAuth
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.sdk import TextContent
 
 OH_LABEL, INLINE_OH_LABEL = get_oh_labels(HOST)

--- a/enterprise/integrations/gitlab/webhook_installation.py
+++ b/enterprise/integrations/gitlab/webhook_installation.py
@@ -14,7 +14,7 @@ from integrations.utils import GITLAB_WEBHOOK_URL
 from storage.gitlab_webhook import GitlabWebhook, WebhookStatus
 from storage.gitlab_webhook_store import GitlabWebhookStore
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 if TYPE_CHECKING:
     from integrations.gitlab.gitlab_service import SaaSGitLabService

--- a/enterprise/integrations/jira/jira_manager.py
+++ b/enterprise/integrations/jira/jira_manager.py
@@ -44,7 +44,7 @@ from storage.jira_workspace import JiraWorkspace
 
 from openhands.app_server.user_auth.user_auth import UserAuth
 from openhands.app_server.utils.http_session import httpx_verify_option
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.server.types import (
     LLMAuthenticationError,
     MissingSettingsError,

--- a/enterprise/integrations/jira/jira_payload.py
+++ b/enterprise/integrations/jira/jira_payload.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from enum import Enum
 from urllib.parse import urlparse
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class JiraEventType(Enum):

--- a/enterprise/integrations/jira/jira_view.py
+++ b/enterprise/integrations/jira/jira_view.py
@@ -43,7 +43,7 @@ from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.user.specifiy_user_context import USER_CONTEXT_ATTR
 from openhands.app_server.user_auth.user_auth import UserAuth
 from openhands.app_server.utils.http_session import httpx_verify_option
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.sdk import TextContent
 
 JIRA_CLOUD_API_URL = 'https://api.atlassian.com/ex/jira'

--- a/enterprise/integrations/jira_dc/jira_dc_manager.py
+++ b/enterprise/integrations/jira_dc/jira_dc_manager.py
@@ -33,7 +33,7 @@ from openhands.app_server.integrations.provider import ProviderHandler
 from openhands.app_server.integrations.service_types import Repository
 from openhands.app_server.user_auth.user_auth import UserAuth
 from openhands.app_server.utils.http_session import httpx_verify_option
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.server.shared import server_config
 from openhands.server.types import (
     LLMAuthenticationError,

--- a/enterprise/integrations/jira_dc/jira_dc_view.py
+++ b/enterprise/integrations/jira_dc/jira_dc_view.py
@@ -34,7 +34,7 @@ from openhands.app_server.integrations.provider import ProviderHandler, Provider
 from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.user.specifiy_user_context import USER_CONTEXT_ATTR
 from openhands.app_server.user_auth.user_auth import UserAuth
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.sdk import TextContent
 
 integration_store = JiraDcIntegrationStore.get_instance()

--- a/enterprise/integrations/resolver_org_router.py
+++ b/enterprise/integrations/resolver_org_router.py
@@ -10,7 +10,7 @@ from uuid import UUID
 from storage.org_git_claim_store import OrgGitClaimStore
 from storage.org_member_store import OrgMemberStore
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 async def resolve_org_for_repo(

--- a/enterprise/integrations/slack/slack_manager.py
+++ b/enterprise/integrations/slack/slack_manager.py
@@ -38,7 +38,7 @@ from openhands.app_server.integrations.service_types import (
     Repository,
 )
 from openhands.app_server.user_auth.user_auth import UserAuth
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.server.shared import config, server_config
 from openhands.server.types import (
     LLMAuthenticationError,

--- a/enterprise/integrations/slack/slack_types.py
+++ b/enterprise/integrations/slack/slack_types.py
@@ -53,7 +53,7 @@ class SlackMessageView:
             SlackMessageView if all required fields are available,
             None if required fields are missing or bot token unavailable.
         """
-        from openhands.core.logger import openhands_logger as logger
+        from openhands.app_server.utils.logger import openhands_logger as logger
 
         team_id = payload.get('team', {}).get('id') or payload.get('team_id')
         channel_id = (

--- a/enterprise/integrations/slack/slack_view.py
+++ b/enterprise/integrations/slack/slack_view.py
@@ -36,7 +36,7 @@ from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.user.specifiy_user_context import USER_CONTEXT_ATTR
 from openhands.app_server.user_auth.user_auth import UserAuth
 from openhands.app_server.utils.async_utils import GENERAL_TIMEOUT
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.sdk import TextContent
 
 # =================================================

--- a/enterprise/integrations/store_repo_utils.py
+++ b/enterprise/integrations/store_repo_utils.py
@@ -4,8 +4,8 @@ from storage.user_repo_map import UserRepositoryMap
 from storage.user_repo_map_store import UserRepositoryMapStore
 
 from openhands.app_server.integrations.service_types import Repository
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.core.config.openhands_config import OpenHandsConfig
-from openhands.core.logger import openhands_logger as logger
 
 
 async def store_repositories_in_db(repos: list[Repository], user_id: str) -> None:

--- a/enterprise/integrations/v1_utils.py
+++ b/enterprise/integrations/v1_utils.py
@@ -8,7 +8,7 @@ from server.auth.saas_user_auth import SaasUserAuth
 from server.auth.token_manager import TokenManager
 
 from openhands.app_server.user_auth.user_auth import UserAuth
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 def is_budget_exceeded_error(error_message: str) -> bool:

--- a/enterprise/server/auth/authorization.py
+++ b/enterprise/server/auth/authorization.py
@@ -41,7 +41,7 @@ from storage.role import Role
 from storage.role_store import RoleStore
 
 from openhands.app_server.user_auth import get_user_auth, get_user_id
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class Permission(str, Enum):

--- a/enterprise/server/auth/github_utils.py
+++ b/enterprise/server/auth/github_utils.py
@@ -3,7 +3,7 @@ from pydantic import SecretStr
 from server.auth.auth_utils import user_verifier
 
 from openhands.app_server.integrations.github.github_types import GitHubUser
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 def is_user_allowed(user_login: str):

--- a/enterprise/server/auth/gitlab_sync.py
+++ b/enterprise/server/auth/gitlab_sync.py
@@ -4,7 +4,7 @@ from pydantic import SecretStr
 from sqlalchemy import select
 
 from openhands.app_server.integrations.service_types import ProviderType
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.server.types import AppMode
 
 

--- a/enterprise/server/auth/recaptcha_service.py
+++ b/enterprise/server/auth/recaptcha_service.py
@@ -11,7 +11,7 @@ from server.auth.constants import (
     SUSPICIOUS_LABELS,
 )
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 @dataclass

--- a/enterprise/server/auth/sheets_client.py
+++ b/enterprise/server/auth/sheets_client.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, Tuple
 import gspread
 from google.auth import default
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class GoogleSheetsClient:

--- a/enterprise/server/email_validation.py
+++ b/enterprise/server/email_validation.py
@@ -5,7 +5,7 @@ Email domain validation utilities for enterprise endpoints.
 from fastapi import Depends, HTTPException, Request, status
 
 from openhands.app_server.user_auth import get_user_auth, get_user_id
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 async def get_admin_user_id(

--- a/enterprise/server/logger.py
+++ b/enterprise/server/logger.py
@@ -8,7 +8,7 @@ from typing import TextIO
 
 from pythonjsonlogger.json import JsonFormatter
 
-from openhands.core.logger import openhands_logger
+from openhands.app_server.utils.logger import openhands_logger
 
 LOG_JSON = os.getenv('LOG_JSON', '1') == '1'
 LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO').upper()

--- a/enterprise/server/middleware.py
+++ b/enterprise/server/middleware.py
@@ -16,7 +16,7 @@ from server.routes.auth import set_response_cookie
 from server.utils.url_utils import get_cookie_domain, get_cookie_samesite
 
 from openhands.app_server.user_auth.user_auth import AuthType, UserAuth, get_user_auth
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.server.shared import config
 
 

--- a/enterprise/server/rate_limit.py
+++ b/enterprise/server/rate_limit.py
@@ -19,7 +19,7 @@ from starlette.applications import Request, Response, Starlette
 from starlette.exceptions import HTTPException
 from storage.redis import get_redis_authed_url
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 def setup_rate_limit_handler(app: Starlette):

--- a/enterprise/server/routes/api_keys.py
+++ b/enterprise/server/routes/api_keys.py
@@ -14,7 +14,7 @@ from storage.user_store import UserStore
 
 from openhands.app_server.user_auth import get_user_auth, get_user_id
 from openhands.app_server.user_auth.user_auth import AuthType
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 # Helper functions for BYOR API key management

--- a/enterprise/server/routes/auth.py
+++ b/enterprise/server/routes/auth.py
@@ -55,7 +55,7 @@ from openhands.app_server.integrations.provider import (
 from openhands.app_server.integrations.service_types import ProviderType, TokenResponse
 from openhands.app_server.user_auth import get_access_token
 from openhands.app_server.user_auth.user_auth import get_user_auth
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.server.shared import config
 
 with warnings.catch_warnings():

--- a/enterprise/server/routes/email.py
+++ b/enterprise/server/routes/email.py
@@ -15,7 +15,7 @@ from storage.user_store import UserStore
 
 from openhands.app_server.user_auth import get_user_id
 from openhands.app_server.user_auth.user_auth import get_user_auth
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 # Email validation regex pattern
 EMAIL_REGEX = re.compile(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$')

--- a/enterprise/server/routes/integration/bitbucket.py
+++ b/enterprise/server/routes/integration/bitbucket.py
@@ -13,7 +13,7 @@ from server.auth.token_manager import TokenManager
 from storage.bitbucket_webhook_store import BitbucketWebhookStore
 from storage.redis import get_redis_client_async
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 bitbucket_integration_router = APIRouter(prefix='/integration')
 

--- a/enterprise/server/routes/integration/bitbucket_dc.py
+++ b/enterprise/server/routes/integration/bitbucket_dc.py
@@ -13,7 +13,7 @@ from server.auth.token_manager import TokenManager
 from storage.bitbucket_dc_webhook_store import BitbucketDCWebhookStore
 from storage.redis import get_redis_client_async
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 bitbucket_dc_integration_router = APIRouter(prefix='/integration')
 

--- a/enterprise/server/routes/integration/github.py
+++ b/enterprise/server/routes/integration/github.py
@@ -16,7 +16,7 @@ from server.auth.token_manager import TokenManager
 from server.services.automation_event_service import AutomationEventService
 
 from openhands.app_server.integrations.provider import ProviderType
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 # Environment variable to disable GitHub webhooks
 GITHUB_WEBHOOKS_ENABLED = os.environ.get('GITHUB_WEBHOOKS_ENABLED', '1') in (

--- a/enterprise/server/routes/integration/gitlab.py
+++ b/enterprise/server/routes/integration/gitlab.py
@@ -22,7 +22,7 @@ from storage.redis import get_redis_client_async
 
 from openhands.app_server.integrations.gitlab.gitlab_service import GitLabServiceImpl
 from openhands.app_server.user_auth import get_user_id
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 gitlab_integration_router = APIRouter(prefix='/integration')
 webhook_store = GitlabWebhookStore()

--- a/enterprise/server/routes/integration/jira.py
+++ b/enterprise/server/routes/integration/jira.py
@@ -21,7 +21,7 @@ from storage.jira_workspace import JiraWorkspace
 from storage.redis import get_redis_client
 
 from openhands.app_server.user_auth.user_auth import get_user_auth
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 # Environment variable to disable Jira webhooks
 JIRA_WEBHOOKS_ENABLED = os.environ.get('JIRA_WEBHOOKS_ENABLED', '0') in (

--- a/enterprise/server/routes/integration/jira_dc.py
+++ b/enterprise/server/routes/integration/jira_dc.py
@@ -29,7 +29,7 @@ from server.constants import WEB_HOST
 from storage.redis import get_redis_client
 
 from openhands.app_server.user_auth.user_auth import get_user_auth
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 # Environment variable to disable Jira DC webhooks
 JIRA_DC_WEBHOOKS_ENABLED = os.environ.get('JIRA_DC_WEBHOOKS_ENABLED', '0') in (

--- a/enterprise/server/routes/mcp_patch.py
+++ b/enterprise/server/routes/mcp_patch.py
@@ -5,7 +5,7 @@ from fastmcp.client.transports import NpxStdioTransport
 from fastmcp.server import create_proxy
 
 from openhands.app_server.mcp.mcp_router import mcp_server
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 ENABLE_MCP_SEARCH_ENGINE = (
     os.getenv('ENABLE_MCP_SEARCH_ENGINE', 'false').lower() == 'true'

--- a/enterprise/server/routes/oauth_device.py
+++ b/enterprise/server/routes/oauth_device.py
@@ -11,7 +11,7 @@ from storage.api_key_store import ApiKeyStore
 from storage.device_code_store import DeviceCodeStore
 
 from openhands.app_server.user_auth import get_user_id
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 # ---------------------------------------------------------------------------
 # Constants

--- a/enterprise/server/routes/org_invitations.py
+++ b/enterprise/server/routes/org_invitations.py
@@ -23,7 +23,7 @@ from storage.org_store import OrgStore
 from storage.role_store import RoleStore
 
 from openhands.app_server.user_auth import get_user_id
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 # Router for invitation operations on an organization (requires org_id)
 invitation_router = APIRouter(prefix='/api/organizations/{org_id}/members')

--- a/enterprise/server/routes/orgs.py
+++ b/enterprise/server/routes/orgs.py
@@ -51,7 +51,7 @@ from storage.org_store import OrgStore
 from storage.user_store import UserStore
 
 from openhands.app_server.user_auth import get_user_id
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 # Initialize API router
 org_router = APIRouter(prefix='/api/organizations', tags=['Orgs'])

--- a/enterprise/server/routes/readiness.py
+++ b/enterprise/server/routes/readiness.py
@@ -3,7 +3,7 @@ from sqlalchemy.sql import text
 from storage.database import a_session_maker
 from storage.redis import get_redis_client
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 readiness_router = APIRouter()
 

--- a/enterprise/server/routes/service.py
+++ b/enterprise/server/routes/service.py
@@ -17,7 +17,7 @@ from storage.api_key_store import ApiKeyStore
 from storage.org_member_store import OrgMemberStore
 from storage.user_store import UserStore
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 # Environment variable for the service API key
 AUTOMATIONS_SERVICE_KEY = os.getenv('AUTOMATIONS_SERVICE_KEY', '').strip()

--- a/enterprise/server/routes/user_app_settings.py
+++ b/enterprise/server/routes/user_app_settings.py
@@ -16,7 +16,7 @@ from server.services.user_app_settings_service import (
     UserAppSettingsServiceInjector,
 )
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 user_app_settings_router = APIRouter(prefix='/api/users')
 

--- a/enterprise/server/services/automation_event_service.py
+++ b/enterprise/server/services/automation_event_service.py
@@ -37,7 +37,7 @@ from server.auth.token_manager import TokenManager
 from storage.redis import get_redis_client_async
 
 from openhands.app_server.integrations.provider import ProviderType
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 # Cache TTL constants
 ORG_CLAIM_CACHE_TTL_SECONDS = 3600  # 1 hour for org claims (rarely change)

--- a/enterprise/server/services/email_service.py
+++ b/enterprise/server/services/email_service.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     RESEND_AVAILABLE = False
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 DEFAULT_FROM_EMAIL = 'OpenHands <no-reply@openhands.dev>'
 DEFAULT_WEB_HOST = 'https://app.all-hands.dev'

--- a/enterprise/server/services/org_app_settings_service.py
+++ b/enterprise/server/services/org_app_settings_service.py
@@ -20,7 +20,7 @@ from storage.org_app_settings_store import OrgAppSettingsStore
 from openhands.app_server.errors import AuthError
 from openhands.app_server.services.injector import Injector, InjectorState
 from openhands.app_server.user.user_context import UserContext
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 @dataclass

--- a/enterprise/server/services/org_invitation_service.py
+++ b/enterprise/server/services/org_invitation_service.py
@@ -21,7 +21,7 @@ from storage.org_store import OrgStore
 from storage.role_store import RoleStore
 from storage.user_store import UserStore
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class OrgInvitationService:

--- a/enterprise/server/services/org_member_financial_service.py
+++ b/enterprise/server/services/org_member_financial_service.py
@@ -10,7 +10,7 @@ from server.routes.org_models import (
 from storage.lite_llm_manager import LiteLlmManager
 from storage.org_member_store import OrgMemberStore
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class OrgMemberFinancialService:

--- a/enterprise/server/services/org_member_service.py
+++ b/enterprise/server/services/org_member_service.py
@@ -21,7 +21,7 @@ from storage.org_member_store import OrgMemberStore
 from storage.role_store import RoleStore
 from storage.user_store import UserStore
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class OrgMemberService:

--- a/enterprise/server/services/user_app_settings_service.py
+++ b/enterprise/server/services/user_app_settings_service.py
@@ -19,7 +19,7 @@ from storage.user_app_settings_store import UserAppSettingsStore
 
 from openhands.app_server.services.injector import Injector, InjectorState
 from openhands.app_server.user.user_context import UserContext
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 @dataclass

--- a/enterprise/server/utils/rate_limit_utils.py
+++ b/enterprise/server/utils/rate_limit_utils.py
@@ -1,7 +1,7 @@
 from fastapi import HTTPException, Request, status
 from storage.redis import get_redis_client_async
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 # Rate limiting constants
 RATE_LIMIT_USER_SECONDS = 120  # 2 minutes per user_id

--- a/enterprise/server/verified_models/verified_model_service.py
+++ b/enterprise/server/verified_models/verified_model_service.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
 
 from openhands.app_server.config import depends_db_session
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class StoredVerifiedModel(Base):

--- a/enterprise/storage/api_key_store.py
+++ b/enterprise/storage/api_key_store.py
@@ -11,7 +11,7 @@ from storage.api_key import ApiKey
 from storage.database import a_session_maker
 from storage.user_store import UserStore
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 @dataclass

--- a/enterprise/storage/auth_token_store.py
+++ b/enterprise/storage/auth_token_store.py
@@ -11,7 +11,7 @@ from storage.auth_tokens import AuthTokens
 from storage.database import a_session_maker
 
 from openhands.app_server.integrations.service_types import ProviderType
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 # Time buffer (in seconds) before actual expiration to consider token expired
 # This ensures tokens are refreshed before they actually expire. The

--- a/enterprise/storage/gitlab_webhook_store.py
+++ b/enterprise/storage/gitlab_webhook_store.py
@@ -8,7 +8,7 @@ from sqlalchemy.dialects.postgresql import insert
 from storage.database import a_session_maker
 from storage.gitlab_webhook import GitlabWebhook
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 @dataclass

--- a/enterprise/storage/jira_dc_integration_store.py
+++ b/enterprise/storage/jira_dc_integration_store.py
@@ -9,7 +9,7 @@ from storage.jira_dc_conversation import JiraDcConversation
 from storage.jira_dc_user import JiraDcUser
 from storage.jira_dc_workspace import JiraDcWorkspace
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 @dataclass

--- a/enterprise/storage/jira_integration_store.py
+++ b/enterprise/storage/jira_integration_store.py
@@ -9,7 +9,7 @@ from storage.jira_conversation import JiraConversation
 from storage.jira_user import JiraUser
 from storage.jira_workspace import JiraWorkspace
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 @dataclass

--- a/enterprise/storage/linear_integration_store.py
+++ b/enterprise/storage/linear_integration_store.py
@@ -9,7 +9,7 @@ from storage.linear_conversation import LinearConversation
 from storage.linear_user import LinearUser
 from storage.linear_workspace import LinearWorkspace
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 @dataclass

--- a/enterprise/storage/offline_token_store.py
+++ b/enterprise/storage/offline_token_store.py
@@ -6,8 +6,8 @@ from sqlalchemy import select
 from storage.database import a_session_maker
 from storage.stored_offline_token import StoredOfflineToken
 
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.core.config.openhands_config import OpenHandsConfig
-from openhands.core.logger import openhands_logger as logger
 
 
 @dataclass

--- a/enterprise/storage/openhands_pr_store.py
+++ b/enterprise/storage/openhands_pr_store.py
@@ -7,7 +7,7 @@ from storage.database import a_session_maker
 from storage.openhands_pr import OpenhandsPR
 
 from openhands.app_server.integrations.service_types import ProviderType
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class OpenhandsPRStore:

--- a/enterprise/storage/org_git_claim_store.py
+++ b/enterprise/storage/org_git_claim_store.py
@@ -10,7 +10,7 @@ from sqlalchemy import and_, select
 from storage.database import a_session_maker
 from storage.org_git_claim import OrgGitClaim
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class OrgGitClaimStore:

--- a/enterprise/storage/org_invitation_store.py
+++ b/enterprise/storage/org_invitation_store.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import joinedload
 from storage.database import a_session_maker
 from storage.org_invitation import OrgInvitation
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 # Invitation token configuration
 INVITATION_TOKEN_PREFIX = 'inv-'

--- a/enterprise/storage/org_service.py
+++ b/enterprise/storage/org_service.py
@@ -25,7 +25,7 @@ from storage.role_store import RoleStore
 from storage.user_store import UserStore
 
 from openhands.app_server.settings.settings_models import Settings
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.sdk.settings import AgentSettings, ConversationSettings
 
 

--- a/enterprise/storage/org_store.py
+++ b/enterprise/storage/org_store.py
@@ -27,7 +27,7 @@ from storage.user_settings import UserSettings
 from openhands.app_server.settings.settings_models import Settings
 from openhands.app_server.utils.jsonpatch_compat import deep_merge
 from openhands.app_server.utils.llm import is_openhands_model
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.sdk.settings import AgentSettings, ConversationSettings
 
 _ORG_SETTINGS_EXCLUDED_FIELDS = {

--- a/enterprise/storage/proactive_conversation_store.py
+++ b/enterprise/storage/proactive_conversation_store.py
@@ -14,7 +14,7 @@ from storage.database import a_session_maker
 from storage.proactive_convos import ProactiveConversation
 
 from openhands.app_server.integrations.service_types import ProviderType
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 @dataclass

--- a/enterprise/storage/saas_secrets_store.py
+++ b/enterprise/storage/saas_secrets_store.py
@@ -12,8 +12,8 @@ from storage.user_store import UserStore
 
 from openhands.app_server.secrets.secrets_models import Secrets
 from openhands.app_server.secrets.secrets_store import SecretsStore
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.core.config.openhands_config import OpenHandsConfig
-from openhands.core.logger import openhands_logger as logger
 
 
 @dataclass

--- a/enterprise/sync/clean_proactive_convo_table.py
+++ b/enterprise/sync/clean_proactive_convo_table.py
@@ -3,7 +3,7 @@ import asyncio  # noqa: I001
 # This must be before the import of storage
 # to set up logging and prevent alembic from
 # running its mouth.
-from openhands.core.logger import openhands_logger
+from openhands.app_server.utils.logger import openhands_logger
 
 from storage.proactive_conversation_store import (
     ProactiveConversationStore,

--- a/enterprise/sync/enrich_user_interaction_data.py
+++ b/enterprise/sync/enrich_user_interaction_data.py
@@ -4,7 +4,7 @@ from integrations.github.data_collector import GitHubDataCollector
 from storage.openhands_pr import OpenhandsPR
 from storage.openhands_pr_store import OpenhandsPRStore
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 PROCESS_AMOUNT = 50
 MAX_RETRIES = 3

--- a/enterprise/sync/install_gitlab_webhooks.py
+++ b/enterprise/sync/install_gitlab_webhooks.py
@@ -16,7 +16,7 @@ from storage.gitlab_webhook import GitlabWebhook, WebhookStatus
 from storage.gitlab_webhook_store import GitlabWebhookStore
 
 from openhands.app_server.integrations.gitlab.gitlab_service import GitLabServiceImpl
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 if TYPE_CHECKING:
     from integrations.gitlab.gitlab_service import SaaSGitLabService

--- a/enterprise/sync/resend_keycloak.py
+++ b/enterprise/sync/resend_keycloak.py
@@ -43,7 +43,7 @@ from tenacity import (
     wait_exponential,
 )
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 # Get Keycloak configuration from environment variables
 KEYCLOAK_SERVER_URL = os.environ.get('KEYCLOAK_SERVER_URL', '')
@@ -52,7 +52,7 @@ KEYCLOAK_CLIENT_ID = os.environ.get('KEYCLOAK_CLIENT_ID', '')
 KEYCLOAK_CLIENT_SECRET = os.environ.get('KEYCLOAK_CLIENT_SECRET', '')
 KEYCLOAK_ADMIN_PASSWORD = os.environ.get('KEYCLOAK_ADMIN_PASSWORD', '')
 
-# Logger is imported from openhands.core.logger
+# Logger is imported from openhands.app_server.utils.logger
 
 # Get configuration from environment variables
 RESEND_API_KEY = os.environ.get('RESEND_API_KEY')

--- a/enterprise/tests/unit/test_import.py
+++ b/enterprise/tests/unit/test_import.py
@@ -1,6 +1,6 @@
 from server.auth.sheets_client import GoogleSheetsClient
 
-from openhands.core.logger import openhands_logger
+from openhands.app_server.utils.logger import openhands_logger
 
 
 def test_import():

--- a/enterprise/tests/unit/test_logger.py
+++ b/enterprise/tests/unit/test_logger.py
@@ -8,7 +8,7 @@ import pytest
 from freezegun import freeze_time
 from server.logger import format_stack, setup_json_logger
 
-from openhands.core.logger import openhands_logger
+from openhands.app_server.utils.logger import openhands_logger
 
 FROZEN_TIMESTAMP = '2024-01-15T10:30:00+00:00'
 # datetime.now().isoformat() doesn't include timezone info

--- a/openhands/app_server/file_store/local.py
+++ b/openhands/app_server/file_store/local.py
@@ -5,7 +5,7 @@ import threading
 from pydantic import model_validator
 
 from openhands.app_server.file_store.files import FileStore
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class LocalFileStore(FileStore):

--- a/openhands/app_server/file_store/memory.py
+++ b/openhands/app_server/file_store/memory.py
@@ -3,7 +3,7 @@ import os
 from pydantic import Field
 
 from openhands.app_server.file_store.files import FileStore
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class InMemoryFileStore(FileStore):

--- a/openhands/app_server/integrations/azure_devops/service/prs.py
+++ b/openhands/app_server/integrations/azure_devops/service/prs.py
@@ -6,7 +6,7 @@ from openhands.app_server.integrations.azure_devops.service.base import (
     AzureDevOpsMixinBase,
 )
 from openhands.app_server.integrations.service_types import Comment, RequestMethod
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class AzureDevOpsPRsMixin(AzureDevOpsMixinBase):

--- a/openhands/app_server/integrations/azure_devops/service/resolver.py
+++ b/openhands/app_server/integrations/azure_devops/service/resolver.py
@@ -4,7 +4,7 @@ from openhands.app_server.integrations.azure_devops.service.base import (
     AzureDevOpsMixinBase,
 )
 from openhands.app_server.integrations.service_types import Comment
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class AzureDevOpsResolverMixin(AzureDevOpsMixinBase):

--- a/openhands/app_server/integrations/azure_devops/service/work_items.py
+++ b/openhands/app_server/integrations/azure_devops/service/work_items.py
@@ -6,7 +6,7 @@ from openhands.app_server.integrations.azure_devops.service.base import (
     AzureDevOpsMixinBase,
 )
 from openhands.app_server.integrations.service_types import Comment, RequestMethod
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class AzureDevOpsWorkItemsMixin(AzureDevOpsMixinBase):

--- a/openhands/app_server/integrations/bitbucket/service/base.py
+++ b/openhands/app_server/integrations/bitbucket/service/base.py
@@ -14,7 +14,7 @@ from openhands.app_server.integrations.service_types import (
     User,
 )
 from openhands.app_server.utils.http_session import httpx_verify_option
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class BitBucketMixinBase(BaseGitService, HTTPClient):

--- a/openhands/app_server/integrations/bitbucket/service/prs.py
+++ b/openhands/app_server/integrations/bitbucket/service/prs.py
@@ -1,6 +1,6 @@
 from openhands.app_server.integrations.bitbucket.service.base import BitBucketMixinBase
 from openhands.app_server.integrations.service_types import RequestMethod
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class BitBucketPRsMixin(BitBucketMixinBase):

--- a/openhands/app_server/integrations/bitbucket_data_center/service/base.py
+++ b/openhands/app_server/integrations/bitbucket_data_center/service/base.py
@@ -15,7 +15,7 @@ from openhands.app_server.integrations.service_types import (
     User,
 )
 from openhands.app_server.utils.http_session import httpx_verify_option
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class BitbucketDCMixinBase(BaseGitService, HTTPClient):

--- a/openhands/app_server/integrations/bitbucket_data_center/service/prs.py
+++ b/openhands/app_server/integrations/bitbucket_data_center/service/prs.py
@@ -4,7 +4,7 @@ from openhands.app_server.integrations.bitbucket_data_center.service.base import
     BitbucketDCMixinBase,
 )
 from openhands.app_server.integrations.service_types import RequestMethod
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class BitbucketDCPRsMixin(BitbucketDCMixinBase):

--- a/openhands/app_server/integrations/forgejo/service/base.py
+++ b/openhands/app_server/integrations/forgejo/service/base.py
@@ -18,7 +18,7 @@ from openhands.app_server.integrations.service_types import (
     User,
 )
 from openhands.app_server.utils.http_session import httpx_verify_option
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class ForgejoMixinBase(BaseGitService, HTTPClient):

--- a/openhands/app_server/integrations/forgejo/service/prs.py
+++ b/openhands/app_server/integrations/forgejo/service/prs.py
@@ -7,7 +7,7 @@ from openhands.app_server.integrations.service_types import (
     RequestMethod,
     UnknownException,
 )
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class ForgejoPRsMixin(ForgejoMixinBase):

--- a/openhands/app_server/integrations/github/service/base.py
+++ b/openhands/app_server/integrations/github/service/base.py
@@ -12,7 +12,7 @@ from openhands.app_server.integrations.service_types import (
     User,
 )
 from openhands.app_server.utils.http_session import httpx_verify_option
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class GitHubMixinBase(BaseGitService, HTTPClient):

--- a/openhands/app_server/integrations/github/service/branches_prs.py
+++ b/openhands/app_server/integrations/github/service/branches_prs.py
@@ -6,7 +6,7 @@ from openhands.app_server.integrations.service_types import (
     Branch,
     PaginatedBranchesResponse,
 )
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class GitHubBranchesMixin(GitHubMixinBase):

--- a/openhands/app_server/integrations/github/service/features.py
+++ b/openhands/app_server/integrations/github/service/features.py
@@ -8,7 +8,7 @@ from openhands.app_server.integrations.service_types import (
     SuggestedTask,
     TaskType,
 )
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class GitHubFeaturesMixin(GitHubMixinBase):

--- a/openhands/app_server/integrations/github/service/prs.py
+++ b/openhands/app_server/integrations/github/service/prs.py
@@ -1,6 +1,6 @@
 from openhands.app_server.integrations.github.service.base import GitHubMixinBase
 from openhands.app_server.integrations.service_types import RequestMethod
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class GitHubPRsMixin(GitHubMixinBase):

--- a/openhands/app_server/integrations/github/service/repos.py
+++ b/openhands/app_server/integrations/github/service/repos.py
@@ -6,7 +6,7 @@ from openhands.app_server.integrations.service_types import (
     ProviderType,
     Repository,
 )
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.server.types import AppMode
 
 

--- a/openhands/app_server/integrations/github/service/resolver.py
+++ b/openhands/app_server/integrations/github/service/resolver.py
@@ -8,7 +8,7 @@ from openhands.app_server.integrations.github.queries import (
 )
 from openhands.app_server.integrations.github.service.base import GitHubMixinBase
 from openhands.app_server.integrations.service_types import Comment
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class GitHubResolverMixin(GitHubMixinBase):

--- a/openhands/app_server/integrations/gitlab/service/prs.py
+++ b/openhands/app_server/integrations/gitlab/service/prs.py
@@ -1,6 +1,6 @@
 from openhands.app_server.integrations.gitlab.service.base import GitLabMixinBase
 from openhands.app_server.integrations.service_types import RequestMethod
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class GitLabPRsMixin(GitLabMixinBase):

--- a/openhands/app_server/integrations/gitlab/service/repos.py
+++ b/openhands/app_server/integrations/gitlab/service/repos.py
@@ -4,7 +4,7 @@ from openhands.app_server.integrations.service_types import (
     ProviderType,
     Repository,
 )
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.server.types import AppMode
 
 

--- a/openhands/app_server/integrations/protocols/http_client.py
+++ b/openhands/app_server/integrations/protocols/http_client.py
@@ -14,7 +14,7 @@ from openhands.app_server.integrations.service_types import (
     ResourceNotFoundError,
     UnknownException,
 )
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class HTTPClient(ABC):

--- a/openhands/app_server/integrations/provider.py
+++ b/openhands/app_server/integrations/provider.py
@@ -41,7 +41,7 @@ from openhands.app_server.integrations.service_types import (
     User,
 )
 from openhands.app_server.utils.http_session import httpx_verify_option
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.server.types import AppMode
 
 

--- a/openhands/app_server/integrations/utils.py
+++ b/openhands/app_server/integrations/utils.py
@@ -13,7 +13,7 @@ from openhands.app_server.integrations.forgejo.forgejo_service import ForgejoSer
 from openhands.app_server.integrations.github.github_service import GitHubService
 from openhands.app_server.integrations.gitlab.gitlab_service import GitLabService
 from openhands.app_server.integrations.provider import ProviderType
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 async def validate_provider_token(

--- a/openhands/app_server/mcp/mcp_router.py
+++ b/openhands/app_server/mcp/mcp_router.py
@@ -35,7 +35,7 @@ from openhands.app_server.user_auth import (
     get_provider_tokens,
     get_user_id,
 )
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.server.types import AppMode
 
 mcp_server = FastMCP('mcp', mask_error_details=True)

--- a/openhands/app_server/settings/llm_profiles.py
+++ b/openhands/app_server/settings/llm_profiles.py
@@ -13,7 +13,7 @@ from pydantic import (
     model_validator,
 )
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.sdk.llm import LLM
 
 # Soft cap — keeps Settings payload bounded and blocks per-user storage

--- a/openhands/app_server/settings/settings_router.py
+++ b/openhands/app_server/settings/settings_router.py
@@ -42,11 +42,11 @@ from openhands.app_server.utils.llm import (
     is_openhands_model,
     resolve_llm_base_url,
 )
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.app_server.utils.sdk_settings_compat import (
     LLMAgentSettings,
     export_agent_settings_schema,
 )
-from openhands.core.logger import openhands_logger as logger
 from openhands.sdk.llm import LLM
 from openhands.sdk.settings import ConversationSettings
 from openhands.server.shared import config

--- a/openhands/app_server/user/skills_router.py
+++ b/openhands/app_server/user/skills_router.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 import openhands
 from openhands.app_server.utils.dependencies import get_dependencies
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 router = APIRouter(prefix='/skills', tags=['Skills'], dependencies=get_dependencies())
 

--- a/openhands/app_server/utils/chunk_localizer.py
+++ b/openhands/app_server/utils/chunk_localizer.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from rapidfuzz.distance import LCSseq
 from tree_sitter_language_pack import get_parser
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class Chunk(BaseModel):

--- a/openhands/app_server/utils/llm.py
+++ b/openhands/app_server/utils/llm.py
@@ -9,8 +9,8 @@ with warnings.catch_warnings():
     import litellm
     from litellm import LlmProviders, ProviderConfigManager, get_llm_provider
 
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.core.config import LLMConfig, OpenHandsConfig
-from openhands.core.logger import openhands_logger as logger
 
 # ---------------------------------------------------------------------------
 # The ``openhands-sdk`` package is the **single source of truth** for which

--- a/openhands/app_server/utils/logger.py
+++ b/openhands/app_server/utils/logger.py
@@ -1,10 +1,3 @@
-# IMPORTANT: LEGACY V0 CODE - Deprecated since version 1.0.0, scheduled for removal April 1, 2026
-# This file is part of the legacy (V0) implementation of OpenHands and will be removed soon as we complete the migration to V1.
-# OpenHands V1 uses the Software Agent SDK for the agentic core and runs a new application server. Please refer to:
-#   - V1 agentic core (SDK): https://github.com/OpenHands/software-agent-sdk
-#   - V1 application server (in this repo): openhands/app_server/
-# Unless you are working on deprecation, please avoid extending this legacy file and consult the V1 codepaths above.
-# Tag: Legacy-V0
 import copy
 import logging
 import os
@@ -608,7 +601,7 @@ def _uvicorn_json_log_config() -> dict:
         'disable_existing_loggers': False,
         'filters': {
             'redact_url_params': {
-                '()': 'openhands.core.logger.RedactURLParamsFilter',
+                '()': 'openhands.app_server.utils.logger.RedactURLParamsFilter',
             },
         },
         'formatters': {
@@ -695,7 +688,7 @@ def _uvicorn_default_log_config() -> dict:
         'disable_existing_loggers': False,
         'filters': {
             'redact_url_params': {
-                '()': 'openhands.core.logger.RedactURLParamsFilter',
+                '()': 'openhands.app_server.utils.logger.RedactURLParamsFilter',
             },
         },
         'formatters': {

--- a/openhands/app_server/utils/shutdown_listener.py
+++ b/openhands/app_server/utils/shutdown_listener.py
@@ -11,7 +11,7 @@ from uuid import UUID, uuid4
 
 from uvicorn.server import HANDLED_SIGNALS
 
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 _should_exit = None
 _shutdown_listeners: dict[UUID, Callable] = {}

--- a/openhands/core/config/llm_config.py
+++ b/openhands/core/config/llm_config.py
@@ -12,8 +12,8 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, ValidationError
 
-from openhands.core.logger import LOG_DIR
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import LOG_DIR
+from openhands.app_server.utils.logger import openhands_logger as logger
 
 
 class LLMConfig(BaseModel):

--- a/openhands/core/config/openhands_config.py
+++ b/openhands/core/config/openhands_config.py
@@ -10,7 +10,7 @@ from typing import Any, ClassVar
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
-from openhands.core import logger
+from openhands.app_server.utils import logger
 from openhands.core.config.config_utils import (
     DEFAULT_WORKSPACE_MOUNT_PATH_IN_SANDBOX,
     OH_DEFAULT_AGENT,

--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel, SecretStr, ValidationError
 
 from openhands.app_server.file_store import get_file_store
 from openhands.app_server.file_store.files import FileStore
-from openhands.core import logger
+from openhands.app_server.utils import logger
 from openhands.core.config.arg_utils import get_headless_parser
 from openhands.core.config.llm_config import LLMConfig
 from openhands.core.config.mcp_config import mcp_config_from_toml

--- a/openhands/server/__main__.py
+++ b/openhands/server/__main__.py
@@ -10,7 +10,7 @@ import os
 
 import uvicorn
 
-from openhands.core.logger import LOG_JSON, get_uvicorn_log_config
+from openhands.app_server.utils.logger import LOG_JSON, get_uvicorn_log_config
 
 
 def main():

--- a/openhands/server/config/server_config.py
+++ b/openhands/server/config/server_config.py
@@ -9,7 +9,7 @@
 import os
 
 from openhands.app_server.utils.import_utils import get_impl
-from openhands.core.logger import openhands_logger as logger
+from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.server.types import AppMode, ServerConfigInterface
 
 

--- a/tests/unit/core/config/test_config.py
+++ b/tests/unit/core/config/test_config.py
@@ -4,6 +4,7 @@ from io import StringIO
 
 import pytest
 
+from openhands.app_server.utils.logger import openhands_logger
 from openhands.core.config import (
     LLMConfig,
     OpenHandsConfig,
@@ -12,7 +13,6 @@ from openhands.core.config import (
     load_from_env,
     load_from_toml,
 )
-from openhands.core.logger import openhands_logger
 
 
 @pytest.fixture

--- a/tests/unit/core/logger/test_logger.py
+++ b/tests/unit/core/logger/test_logger.py
@@ -1,7 +1,7 @@
 import logging
 from unittest.mock import patch
 
-from openhands.core.logger import (
+from openhands.app_server.utils.logger import (
     RedactURLParamsFilter,
     SensitiveDataFilter,
     _uvicorn_default_log_config,

--- a/tests/unit/core/logger/test_logger_litellm.py
+++ b/tests/unit/core/logger/test_logger_litellm.py
@@ -14,16 +14,16 @@ def reset_litellm():
     litellm.suppress_debug_info = False
     litellm.set_verbose = False
     # Remove logger module from sys.modules to force reload
-    if 'openhands.core.logger' in sys.modules:
-        del sys.modules['openhands.core.logger']
+    if 'openhands.app_server.utils.logger' in sys.modules:
+        del sys.modules['openhands.app_server.utils.logger']
 
 
 def test_litellm_settings_debug_llm_disabled(reset_litellm):
     """Test that litellm settings are properly configured when DEBUG_LLM is disabled."""
     with mock.patch.dict(os.environ, {'DEBUG_LLM': 'false'}):
-        import openhands.core.logger  # noqa: F401
+        import openhands.app_server.utils.logger  # noqa: F401
 
-        importlib.reload(openhands.core.logger)
+        importlib.reload(openhands.app_server.utils.logger)
 
         assert litellm.suppress_debug_info is True
         assert litellm.set_verbose is False
@@ -35,9 +35,9 @@ def test_litellm_settings_debug_llm_enabled(reset_litellm):
         mock.patch.dict(os.environ, {'DEBUG_LLM': 'true'}),
         mock.patch('builtins.input', return_value='y'),
     ):
-        import openhands.core.logger  # noqa: F401
+        import openhands.app_server.utils.logger  # noqa: F401
 
-        importlib.reload(openhands.core.logger)
+        importlib.reload(openhands.app_server.utils.logger)
 
         assert litellm.suppress_debug_info is False
         assert litellm.set_verbose is True
@@ -49,9 +49,9 @@ def test_litellm_settings_debug_llm_enabled_but_declined(reset_litellm):
         mock.patch.dict(os.environ, {'DEBUG_LLM': 'true'}),
         mock.patch('builtins.input', return_value='n'),
     ):
-        import openhands.core.logger  # noqa: F401
+        import openhands.app_server.utils.logger  # noqa: F401
 
-        importlib.reload(openhands.core.logger)
+        importlib.reload(openhands.app_server.utils.logger)
 
         assert litellm.suppress_debug_info is True
         assert litellm.set_verbose is False
@@ -74,10 +74,10 @@ def test_litellm_loggers_suppressed_with_uvicorn_json_config(reset_litellm):
 
     # Find the logger.py file path relative to the openhands package
     # __file__ is tests/unit/core/logger/test_logger_litellm.py
-    # We need to go up to tests/, then find openhands/core/logger.py
+    # We need to go up to tests/, then find openhands/app_server/utils/logger.py
     test_dir = pathlib.Path(__file__).parent  # tests/unit/core/logger
     project_root = test_dir.parent.parent.parent.parent  # workspace/openhands
-    logger_file = project_root / 'openhands' / 'core' / 'logger.py'
+    logger_file = project_root / 'openhands' / 'app_server' / 'utils' / 'logger.py'
 
     # Read the actual source file
     with open(logger_file, 'r') as f:

--- a/tests/unit/core/logger/test_logging.py
+++ b/tests/unit/core/logger/test_logging.py
@@ -5,13 +5,13 @@ from unittest.mock import patch
 
 import pytest
 
-from openhands.core.config import LLMConfig, OpenHandsConfig
-from openhands.core.logger import (
+from openhands.app_server.utils.logger import (
     LOG_JSON_LEVEL_KEY,
     OpenHandsLoggerAdapter,
     json_log_handler,
 )
-from openhands.core.logger import openhands_logger as openhands_logger
+from openhands.app_server.utils.logger import openhands_logger as openhands_logger
+from openhands.core.config import LLMConfig, OpenHandsConfig
 
 
 @pytest.fixture
@@ -107,7 +107,9 @@ def test_sensitive_env_vars_masking(test_handler):
         'JWT_SECRET': 'JWT_SECRET_VALUE',
     }
 
-    with patch.dict('openhands.core.logger.os.environ', environ, clear=True):
+    with patch.dict(
+        'openhands.app_server.utils.logger.os.environ', environ, clear=True
+    ):
         log_message = ' '.join(f"{attr}='{value}'" for attr, value in environ.items())
         logger.info(log_message)
 
@@ -123,7 +125,9 @@ def test_special_cases_masking(test_handler):
         'SANDBOX_ENV_GITHUB_TOKEN': 'SANDBOX_ENV_GITHUB_TOKEN_VALUE',
     }
 
-    with patch.dict('openhands.core.logger.os.environ', environ, clear=True):
+    with patch.dict(
+        'openhands.app_server.utils.logger.os.environ', environ, clear=True
+    ):
         log_message = ' '.join(
             f"{attr}={value} with no single quotes' and something"
             for attr, value in environ.items()


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why

As part of the consolidation effort to have all packages under `openhands.app_server` for compatibility with other projects using the `openhands` package space, the logger module needs to be moved from its current location.

## Summary

- Move `openhands/core/logger.py` to `openhands/app_server/utils/logger.py`
- Update all 115 files with imports across `openhands/`, `enterprise/`, and `tests/`
- Update uvicorn log config filter class references
- Remove legacy V0 comment since this is now the V1 location

## Issue Number

N/A

## How to Test

```bash
# Run the logger tests
poetry run pytest tests/unit/core/logger/ -v

# Verify the import works
poetry run python -c "from openhands.app_server.utils.logger import openhands_logger; print('OK')"

# Run pre-commit checks
poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml
```

## Video/Screenshots

This merely moves a module - there are no logic changes. The application works exactly as it did before:
<img width="735" height="751" alt="image" src="https://github.com/user-attachments/assets/528eb6ea-faf2-42a7-87ee-f3847d38c4cb" />

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- All 32 logger-related tests pass
- Both main and enterprise pre-commit hooks pass
- This follows the pattern established in PR #14223 which moved `openhands.utils` to `openhands.app_server.utils`

---

_This pull request was created by an AI agent (OpenHands) on behalf of the user._

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3c44d417-7512-4fc6-ac78-165da8d221dc)

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-918741d   docker.openhands.dev/openhands/openhands:918741d
```