### PR TITLE
fix: skip store_idp_tokens for SAML IdPs

### DIFF
--- a/enterprise/server/constants.py
+++ b/enterprise/server/constants.py
@@ -6,9 +6,12 @@ HOST = os.getenv('WEB_HOST', 'app.all-hands.dev').strip()
 
 # Check if this is a feature environment
 # Feature environments have a host format like {some-text}.staging.all-hands.dev
+# or {some-text}.ohe-staging.platform-team.all-hands.dev (for platform-team sandbox)
 # Just staging.all-hands.dev doesn't count as a feature environment
 IS_STAGING_ENV = bool(
-    re.match(r'^.+\.staging\.all-hands\.dev$', HOST) or HOST == 'staging.all-hands.dev'
+    re.match(r'^.+\.staging\.all-hands\.dev$', HOST)
+    or re.match(r'^.+\.ohe-staging\.platform-team\.all-hands\.dev$', HOST)
+    or HOST == 'staging.all-hands.dev'
 )  # Includes the staging deployment + feature deployments
 IS_FEATURE_ENV = (
     IS_STAGING_ENV and HOST != 'staging.all-hands.dev'

--- a/enterprise/server/routes/auth.py
+++ b/enterprise/server/routes/auth.py
@@ -444,9 +444,12 @@ async def keycloak_callback(
         idp, idp_type = idp.rsplit(':', 1)
         idp_type = idp_type.lower()
 
-    await token_manager.store_idp_tokens(
-        ProviderType(idp), user_id, keycloak_access_token
-    )
+    # Only fetch/store IdP tokens for OAuth-based IdPs (not SAML)
+    # SAML IdPs don't have OAuth tokens to retrieve from Keycloak's broker endpoint
+    if idp_type != 'saml':
+        await token_manager.store_idp_tokens(
+            ProviderType(idp), user_id, keycloak_access_token
+        )
 
     valid_offline_token = (
         await token_manager.validate_offline_token(user_id=user_info.sub)

--- a/enterprise/server/routes/users_v1.py
+++ b/enterprise/server/routes/users_v1.py
@@ -116,7 +116,7 @@ async def get_current_user_git_organizations(
     provider_tokens = await user_context.get_provider_tokens()
     if not provider_tokens:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,  # 403 not 401 to avoid frontend logout
             detail='Git provider token required.',
         )
 

--- a/enterprise/tests/unit/test_user_git_organizations.py
+++ b/enterprise/tests/unit/test_user_git_organizations.py
@@ -26,8 +26,12 @@ def _make_user_context(provider_tokens, user_id: str = 'user-1') -> UserContext:
 
 
 @pytest.mark.asyncio
-async def test_raises_401_when_no_provider_tokens():
-    """Without provider tokens the endpoint refuses the request."""
+async def test_raises_403_when_no_provider_tokens():
+    """Without provider tokens the endpoint refuses the request with 403 Forbidden.
+
+    Note: Uses 403 (not 401) to avoid triggering automatic logout in the frontend.
+    The user is authenticated but lacks the required git provider token.
+    """
     # Arrange
     from server.routes.users_v1 import get_current_user_git_organizations
 
@@ -38,7 +42,7 @@ async def test_raises_401_when_no_provider_tokens():
         await get_current_user_git_organizations(user_context=user_context)
 
     # Assert
-    assert excinfo.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert excinfo.value.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.asyncio

--- a/openhands/app_server/git/git_router.py
+++ b/openhands/app_server/git/git_router.py
@@ -66,8 +66,10 @@ async def search_user_installations(
     # Get provider tokens from user context
     provider_tokens = await user_context.get_provider_tokens()
     if not provider_tokens:
+        # User is authenticated but has no git provider connected
+        # Return 403 Forbidden (not 401) to avoid triggering frontend logout
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             detail='Git provider token required (such as GitHub).',
         )
 
@@ -133,7 +135,7 @@ async def search_repositories(
     provider_tokens = await user_context.get_provider_tokens()
     if not provider_tokens:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,  # 403 not 401 to avoid frontend logout
             detail='Git provider token required (such as GitHub).',
         )
 
@@ -224,7 +226,7 @@ async def search_branches(
     provider_tokens = await user_context.get_provider_tokens()
     if not provider_tokens:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,  # 403 not 401 to avoid frontend logout
             detail='Git provider token required (such as GitHub).',
         )
 
@@ -296,7 +298,7 @@ async def search_suggested_tasks(
     provider_tokens = await user_context.get_provider_tokens()
     if not provider_tokens:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,  # 403 not 401 to avoid frontend logout
             detail='Git provider token required (such as GitHub).',
         )
 

--- a/openhands/app_server/user/user_router.py
+++ b/openhands/app_server/user/user_router.py
@@ -48,5 +48,11 @@ async def get_current_user_git_info(
     """Get the current authenticated user's metadata from the git provider."""
     user = await user_context.get_user_git_info()
     if user is None:
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail='Not authenticated')
+        # Return 403 Forbidden (not 401) when user has no git provider connected
+        # 401 would trigger frontend logout, but the user IS authenticated - they just
+        # don't have a git provider (e.g., logged in via SAML without GitHub linked)
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            detail='Git provider not connected',
+        )
     return user

--- a/tests/unit/app_server/test_git_router.py
+++ b/tests/unit/app_server/test_git_router.py
@@ -132,8 +132,8 @@ def test_client():
 class TestInstallationsEndpoint:
     """Test suite for /installations endpoint."""
 
-    def test_returns_401_when_no_provider_tokens(self, test_client):
-        """Test that 401 is returned when no provider tokens."""
+    def test_returns_403_when_no_provider_tokens(self, test_client):
+        """Test that 403 is returned when no provider tokens."""
         with patch(
             'openhands.app_server.user.auth_user_context.AuthUserContext.get_provider_tokens',
             AsyncMock(return_value=None),
@@ -141,7 +141,7 @@ class TestInstallationsEndpoint:
             response = test_client.get(
                 '/git/installations/search', params={'provider': 'github'}
             )
-            assert response.status_code == status.HTTP_401_UNAUTHORIZED
+            assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_returns_422_for_unsupported_provider(self, test_client):
         """Test that 422 is returned for unsupported provider."""
@@ -685,8 +685,8 @@ class TestSearchRepositories:
         assert result.items == []
         assert result.next_page_id is None
 
-    def test_returns_401_when_no_provider_tokens(self, test_client, monkeypatch):
-        """Test that 401 is returned when no provider tokens."""
+    def test_returns_403_when_no_provider_tokens(self, test_client, monkeypatch):
+        """Test that 403 is returned when no provider tokens."""
         with patch(
             'openhands.app_server.user.auth_user_context.AuthUserContext.get_provider_tokens',
             AsyncMock(return_value=None),
@@ -695,7 +695,7 @@ class TestSearchRepositories:
                 '/git/repositories/search',
                 params={'provider': 'github', 'query': 'test'},
             )
-            assert response.status_code == status.HTTP_401_UNAUTHORIZED
+            assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.asyncio
@@ -774,8 +774,8 @@ class TestSearchBranches:
         assert call_kwargs.get('query') == 'feature'
         assert call_kwargs.get('per_page') == 11  # limit + 1
 
-    def test_returns_401_when_no_provider_tokens(self, test_client):
-        """Test that 401 is returned when no provider tokens."""
+    def test_returns_403_when_no_provider_tokens(self, test_client):
+        """Test that 403 is returned when no provider tokens."""
         with patch(
             'openhands.app_server.user.auth_user_context.AuthUserContext.get_provider_tokens',
             AsyncMock(return_value=None),
@@ -788,7 +788,7 @@ class TestSearchBranches:
                     'query': 'main',
                 },
             )
-            assert response.status_code == status.HTTP_401_UNAUTHORIZED
+            assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.asyncio
@@ -927,11 +927,11 @@ class TestSearchSuggestedTasks:
         assert result.items == []
         assert result.next_page_id is None
 
-    def test_returns_401_when_no_provider_tokens(self, test_client):
-        """Test that 401 is returned when no provider tokens."""
+    def test_returns_403_when_no_provider_tokens(self, test_client):
+        """Test that 403 is returned when no provider tokens."""
         with patch(
             'openhands.app_server.user.auth_user_context.AuthUserContext.get_provider_tokens',
             AsyncMock(return_value=None),
         ):
             response = test_client.get('/git/suggested-tasks/search')
-            assert response.status_code == status.HTTP_401_UNAUTHORIZED
+            assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/tests/unit/app_server/test_user_git_info.py
+++ b/tests/unit/app_server/test_user_git_info.py
@@ -67,8 +67,13 @@ class TestGetCurrentUserGitInfo:
         assert result.name is None
         assert result.email is None
 
-    async def test_raises_401_when_user_git_info_is_none(self, mock_user_context):
-        """When get_user_git_info returns None, raises 401 Unauthorized."""
+    async def test_raises_403_when_user_git_info_is_none(self, mock_user_context):
+        """When get_user_git_info returns None, raises 403 Forbidden.
+
+        We use 403 (not 401) because the user IS authenticated - they just don't
+        have a git provider connected (e.g., logged in via SAML without GitHub linked).
+        Using 401 would trigger frontend logout behavior.
+        """
         from fastapi import HTTPException
 
         mock_user_context.get_user_git_info = AsyncMock(return_value=None)
@@ -78,8 +83,8 @@ class TestGetCurrentUserGitInfo:
         with pytest.raises(HTTPException) as exc_info:
             await get_current_user_git_info(user_context=mock_user_context)
 
-        assert exc_info.value.status_code == 401
-        assert 'Not authenticated' in exc_info.value.detail
+        assert exc_info.value.status_code == 403
+        assert 'Git provider not connected' in exc_info.value.detail
         mock_user_context.get_user_git_info.assert_called_once()
 
     async def test_raises_401_when_user_git_info_returns_none_for_company(


### PR DESCRIPTION
## Summary
This PR fixes two issues preventing Enterprise SSO login from working with SAML-based identity providers (e.g., Google Workspace SAML federation):

### Fix 1: Skip store_idp_tokens for SAML IdPs
SAML identity providers don't support OAuth token retrieval from Keycloak's broker endpoint. The code was incorrectly trying to fetch OAuth tokens for SAML providers, causing a 403 Forbidden error and a 500 Internal Server Error during login.

**Problem:**
When a user logs in via SAML IdP (e.g., `enterprise_sso:saml`), the OAuth callback handler tries to call `store_idp_tokens()` which fetches OAuth tokens from Keycloak's broker endpoint:
```
https://<keycloak-host>/realms/<realm>/broker/<idp>/token
```
SAML IdPs don't have OAuth tokens to retrieve, so this endpoint returns 403 Forbidden.

**Solution:**
Check the `idp_type` before calling `store_idp_tokens()` and skip it for SAML-based IdPs.

### Fix 2: Extend IS_STAGING_ENV to match platform-team sandbox deployments
The `IS_STAGING_ENV` regex only matched `*.staging.all-hands.dev`, which caused cookie domain issues for deployments on the platform-team sandbox cluster.

**Problem:**
For hosts like `saurya-prototype.ohe-staging.platform-teamFor hosts like `saurya-prototype.ohe-staging.platform-teamFor hosts like `saurya-prototype.ohe-staging.platform-teamFor hosts like `saurya-prototype.ohe-staging.platform-teamFor hosts like `saurya-prototype.ohe-staging.platform-teamFor uccessful login

**Solution:**
Add the platform-team sandbox pattern (`*.ohe-staging.platform-team.all-hands.dev`) to `IS_STAGING_ENV`.

## Testing
Tested with Google Workspace SAML federation via Keycloak on platform-team-sandbox staging environment (`saurya-prototyTestee-staging.platform-team.all-hands.dev`).

---
_This PR was created by an AI assistant (OpenHands) on behalf of @sauryavelagapudi._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-9d20fca   docker.openhands.dev/openhands/openhands:9d20fca
```