### PR TITLE
fix(acp): suppress in_progress tool call events to prevent empty-args flash

### DIFF
--- a/frontend/__tests__/components/v1/chat/event-content-helpers/should-render-event.test.ts
+++ b/frontend/__tests__/components/v1/chat/event-content-helpers/should-render-event.test.ts
@@ -6,6 +6,25 @@ import {
   createPlanningObservationEvent,
   createUserMessageEvent,
 } from "test-utils";
+import { ACPToolCallEvent } from "#/types/v1/core/events/acp-tool-call-event";
+
+const makeACPEvent = (
+  overrides: Partial<ACPToolCallEvent> = {},
+): ACPToolCallEvent => ({
+  id: "acp-1",
+  kind: "ACPToolCallEvent",
+  timestamp: "2024-01-01T00:00:00Z",
+  source: "agent",
+  tool_call_id: "tc-1",
+  title: "Run command",
+  status: "completed",
+  tool_kind: "execute",
+  raw_input: { command: "ls" },
+  raw_output: "file.txt",
+  content: null,
+  is_error: false,
+  ...overrides,
+});
 
 describe("shouldRenderEvent - PlanningFileEditorAction", () => {
   it("should return false for PlanningFileEditorAction", () => {
@@ -29,6 +48,32 @@ describe("shouldRenderEvent - PlanningFileEditorAction", () => {
 
   it("should return true for user message events", () => {
     const event = createUserMessageEvent("msg-1");
+
+    expect(shouldRenderEvent(event)).toBe(true);
+  });
+});
+
+describe("shouldRenderEvent - ACPToolCallEvent", () => {
+  it("should return false for in_progress events (suppress empty-args flash)", () => {
+    const event = makeACPEvent({ status: "in_progress", raw_input: {} });
+
+    expect(shouldRenderEvent(event)).toBe(false);
+  });
+
+  it("should return true for completed events", () => {
+    const event = makeACPEvent({ status: "completed" });
+
+    expect(shouldRenderEvent(event)).toBe(true);
+  });
+
+  it("should return true for failed events", () => {
+    const event = makeACPEvent({ status: "failed", is_error: true });
+
+    expect(shouldRenderEvent(event)).toBe(true);
+  });
+
+  it("should return true for null status (backwards compat)", () => {
+    const event = makeACPEvent({ status: null });
 
     expect(shouldRenderEvent(event)).toBe(true);
   });

--- a/frontend/src/components/v1/chat/event-content-helpers/should-render-event.ts
+++ b/frontend/src/components/v1/chat/event-content-helpers/should-render-event.ts
@@ -57,9 +57,10 @@ export const shouldRenderEvent = (event: OpenHandsEvent) => {
     return true;
   }
 
-  // Render ACP sub-agent tool call events
+  // Render ACP sub-agent tool call events — suppress in_progress (empty args)
+  // so the card only appears once fully populated.
   if (isACPToolCallEvent(event)) {
-    return true;
+    return event.status !== "in_progress";
   }
 
   // Don't render any other event types (system events, etc.)


### PR DESCRIPTION
## Summary

- ACP emits an `in_progress` event with empty `raw_input: {}` before the `completed` event arrives with real args
- The UI was rendering the `in_progress` card immediately, causing a visible `{}` flash, then replacing it when `completed` arrived
- Filter out `in_progress` events in `shouldRenderEvent` so the card only appears once, fully populated
- `handleEventForUI` already tracks `in_progress` events for dedup (so the `completed` event replaces them in place) — this change simply keeps them off-screen until the terminal state arrives

## Test plan

- [ ] Added 4 tests to `should-render-event.test.ts` covering `in_progress` (false), `completed` (true), `failed` (true), and `null` status (true for backwards compat)
- [ ] All 8 tests in `should-render-event.test.ts` pass
- [ ] All related ACP tests pass (`handle-event-for-ui`, `event-message-acp-tool-call`, `get-acp-tool-call-content`)

Closes #14245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-581ca5f   docker.openhands.dev/openhands/openhands:581ca5f
```