### PR TITLE
refactor: remove OpenHandsConfig from settings and secrets stores

### DIFF
--- a/enterprise/integrations/github/github_view.py
+++ b/enterprise/integrations/github/github_view.py
@@ -135,7 +135,7 @@ class GithubIssue(ResolverViewInterface):
 
     async def _get_user_secrets(self):
         secrets_store = await SaasSecretsStore.get_instance(
-            None, self.user_info.keycloak_user_id
+            self.user_info.keycloak_user_id
         )
         user_secrets = await secrets_store.load()
 

--- a/enterprise/integrations/gitlab/gitlab_view.py
+++ b/enterprise/integrations/gitlab/gitlab_view.py
@@ -97,7 +97,7 @@ class GitlabIssue(ResolverViewInterface):
 
     async def _get_user_secrets(self):
         secrets_store = await SaasSecretsStore.get_instance(
-            None, self.user_info.keycloak_user_id
+            self.user_info.keycloak_user_id
         )
         user_secrets = await secrets_store.load()
 

--- a/enterprise/server/auth/saas_user_auth.py
+++ b/enterprise/server/auth/saas_user_auth.py
@@ -20,7 +20,6 @@ from server.auth.authorization import (
 )
 from server.auth.constants import BITBUCKET_DATA_CENTER_HOST
 from server.auth.token_manager import TokenManager
-from server.config import get_config
 from server.logger import logger
 from server.rate_limit import RateLimiter, create_redis_rate_limiter
 from sqlalchemy import delete, select
@@ -153,7 +152,7 @@ class SaasUserAuth(UserAuth):
         secrets_store = self.secrets_store
         if secrets_store:
             return secrets_store
-        secrets_store = await SaasSecretsStore.get_instance(None, self.user_id)
+        secrets_store = await SaasSecretsStore.get_instance(self.user_id)
         self.secrets_store = secrets_store
         return secrets_store
 
@@ -256,7 +255,7 @@ class SaasUserAuth(UserAuth):
         settings_store = self.settings_store
         if settings_store:
             return settings_store
-        settings_store = SaasSettingsStore(self.user_id, get_config())
+        settings_store = SaasSettingsStore(self.user_id)
         self.settings_store = settings_store
         return settings_store
 

--- a/enterprise/server/auth/token_manager.py
+++ b/enterprise/server/auth/token_manager.py
@@ -38,7 +38,6 @@ from server.auth.email_validation import (
     matches_base_email,
 )
 from server.auth.keycloak_manager import get_keycloak_admin, get_keycloak_openid
-from server.config import get_config
 from server.logger import logger
 from sqlalchemy import String as SQLString
 from sqlalchemy import select, type_coerce
@@ -871,7 +870,7 @@ class TokenManager:
             return token
 
     async def store_offline_token(self, user_id: str, offline_token: str):
-        token_store = await OfflineTokenStore.get_instance(get_config(), user_id)
+        token_store = await OfflineTokenStore.get_instance(user_id)
         encrypted_tokens = self.encrypt_payload({'refresh_token': offline_token})
         payload = {'tokens': encrypted_tokens}
         await token_store.store_token(json.dumps(payload))
@@ -940,7 +939,7 @@ class TokenManager:
         return active
 
     async def load_offline_token(self, user_id: str) -> str | None:
-        token_store = await OfflineTokenStore.get_instance(get_config(), user_id)
+        token_store = await OfflineTokenStore.get_instance(user_id)
         payload = await token_store.load_token()
         if not payload:
             return None

--- a/enterprise/storage/offline_token_store.py
+++ b/enterprise/storage/offline_token_store.py
@@ -7,13 +7,11 @@ from storage.database import a_session_maker
 from storage.stored_offline_token import StoredOfflineToken
 
 from openhands.app_server.utils.logger import openhands_logger as logger
-from openhands.core.config.openhands_config import OpenHandsConfig
 
 
 @dataclass
 class OfflineTokenStore:
     user_id: str
-    config: OpenHandsConfig
 
     async def store_token(self, offline_token: str) -> None:
         """Store an offline token in the database."""
@@ -52,9 +50,11 @@ class OfflineTokenStore:
     @classmethod
     async def get_instance(
         cls,
-        config: OpenHandsConfig,
-        user_id: str,  # type: ignore[override]
+        user_id: str,
     ) -> OfflineTokenStore:
-        """Get an instance of the OfflineTokenStore."""
+        """Get an instance of the OfflineTokenStore.
+
+        TODO: This method should be replaced with dependency injection.
+        """
         logger.debug(f'offline_token_store.get_instance::{user_id}')
-        return OfflineTokenStore(user_id, config)
+        return OfflineTokenStore(user_id)

--- a/enterprise/storage/saas_secrets_store.py
+++ b/enterprise/storage/saas_secrets_store.py
@@ -119,9 +119,12 @@ class SaasSecretsStore(SecretsStore):
     @classmethod
     async def get_instance(
         cls,
-        config: object,
         user_id: str,  # type: ignore[override]
     ) -> SaasSecretsStore:
+        """Get a SaasSecretsStore instance for the given user.
+
+        TODO: This method should be replaced with dependency injection.
+        """
         logger.debug(f'saas_secrets_store.get_instance::{user_id}')
         from storage.encrypt_utils import get_jwt_service
 

--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -25,13 +25,11 @@ from openhands.app_server.settings.settings_models import Settings
 from openhands.app_server.settings.settings_store import SettingsStore
 from openhands.app_server.utils.jsonpatch_compat import deep_merge
 from openhands.app_server.utils.llm import is_openhands_model
-from openhands.core.config.openhands_config import OpenHandsConfig
 
 
 @dataclass
 class SaasSettingsStore(SettingsStore):
     user_id: str
-    config: OpenHandsConfig
 
     async def _get_user_settings_by_keycloak_id_async(
         self, keycloak_user_id: str, session=None
@@ -297,11 +295,14 @@ class SaasSettingsStore(SettingsStore):
     @classmethod
     async def get_instance(
         cls,
-        config: OpenHandsConfig,
         user_id: str,  # type: ignore[override]
     ) -> SaasSettingsStore:
+        """Get a SaasSettingsStore instance for the given user.
+
+        TODO: This method should be replaced with dependency injection.
+        """
         logger.debug(f'saas_settings_store.get_instance::{user_id}')
-        return SaasSettingsStore(user_id, config)
+        return SaasSettingsStore(user_id)
 
     async def _ensure_api_key(
         self, item: Settings, org_id: str, openhands_type: bool = False

--- a/enterprise/tests/unit/test_offline_token_store.py
+++ b/enterprise/tests/unit/test_offline_token_store.py
@@ -4,19 +4,14 @@ from storage.offline_token_store import OfflineTokenStore
 from storage.stored_offline_token import StoredOfflineToken
 
 
-@pytest.fixture
-def mock_config():
-    return None  # Not used in tests
-
-
 @pytest.mark.asyncio
-async def test_store_token_new_record(async_session_maker, mock_config):
+async def test_store_token_new_record(async_session_maker):
     # Setup - inject the test session maker into the store module
     import storage.offline_token_store as store_module
 
     store_module.a_session_maker = async_session_maker
 
-    token_store = OfflineTokenStore('test_user_id', mock_config)
+    token_store = OfflineTokenStore('test_user_id')
     test_token = 'test_offline_token'
 
     # Execute
@@ -36,13 +31,13 @@ async def test_store_token_new_record(async_session_maker, mock_config):
 
 
 @pytest.mark.asyncio
-async def test_store_token_existing_record(async_session_maker, mock_config):
+async def test_store_token_existing_record(async_session_maker):
     # Setup - inject the test session maker into the store module
     import storage.offline_token_store as store_module
 
     store_module.a_session_maker = async_session_maker
 
-    token_store = OfflineTokenStore('test_user_id', mock_config)
+    token_store = OfflineTokenStore('test_user_id')
 
     async with async_session_maker() as session:
         session.add(
@@ -70,13 +65,13 @@ async def test_store_token_existing_record(async_session_maker, mock_config):
 
 
 @pytest.mark.asyncio
-async def test_load_token_existing(async_session_maker, mock_config):
+async def test_load_token_existing(async_session_maker):
     # Setup - inject the test session maker into the store module
     import storage.offline_token_store as store_module
 
     store_module.a_session_maker = async_session_maker
 
-    token_store = OfflineTokenStore('test_user_id', mock_config)
+    token_store = OfflineTokenStore('test_user_id')
 
     async with async_session_maker() as session:
         session.add(
@@ -94,13 +89,13 @@ async def test_load_token_existing(async_session_maker, mock_config):
 
 
 @pytest.mark.asyncio
-async def test_load_token_not_found(async_session_maker, mock_config):
+async def test_load_token_not_found(async_session_maker):
     # Setup - inject the test session maker into the store module
     import storage.offline_token_store as store_module
 
     store_module.a_session_maker = async_session_maker
 
-    token_store = OfflineTokenStore('nonexistent_user', mock_config)
+    token_store = OfflineTokenStore('nonexistent_user')
 
     # Execute
     result = await token_store.load_token()
@@ -110,12 +105,12 @@ async def test_load_token_not_found(async_session_maker, mock_config):
 
 
 @pytest.mark.asyncio
-async def test_get_instance(mock_config):
+async def test_get_instance():
     # Setup
     test_user_id = 'test_user_id'
 
     # Execute
-    result = await OfflineTokenStore.get_instance(mock_config, test_user_id)
+    result = await OfflineTokenStore.get_instance(test_user_id)
 
     # Verify
     assert isinstance(result, OfflineTokenStore)

--- a/enterprise/tests/unit/test_saas_secrets_store.py
+++ b/enterprise/tests/unit/test_saas_secrets_store.py
@@ -247,7 +247,7 @@ class TestSaasSecretsStore:
     async def test_get_instance(self, jwt_svc):
         # Test the get_instance class method
         with patch('storage.encrypt_utils.get_jwt_service', return_value=jwt_svc):
-            store = await SaasSecretsStore.get_instance(None, 'test-user-id')
+            store = await SaasSecretsStore.get_instance('test-user-id')
         assert isinstance(store, SaasSecretsStore)
         assert store.user_id == 'test-user-id'
         assert store._jwt_svc is jwt_svc

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -6,7 +6,6 @@ from pydantic import SecretStr
 
 from openhands.app_server.settings.settings_models import Settings
 from openhands.app_server.settings.settings_models import Settings as DataSettings
-from openhands.core.config.openhands_config import OpenHandsConfig
 
 
 def _agent_value(settings: Settings, key: str):
@@ -73,16 +72,7 @@ with patch('storage.database.a_session_maker'):
     from storage.user_settings import UserSettings
 
 
-@pytest.fixture
-def mock_config():
-    config = MagicMock(spec=OpenHandsConfig)
-    config.jwt_secret = SecretStr('test_secret')
-    config.file_store = 'google_cloud'
-    config.file_store_path = 'bucket'
-    return config
-
-
-def test_member_settings_persist_full_effective_agent_settings(mock_config):
+def test_member_settings_persist_full_effective_agent_settings():
     settings = Settings()
     settings.update(
         {
@@ -119,8 +109,8 @@ def test_member_settings_persist_full_effective_agent_settings(mock_config):
 
 
 @pytest.fixture
-def settings_store(async_session_maker, mock_config):
-    store = SaasSettingsStore('5594c7b6-f959-4b81-92e9-b09c206f5081', mock_config)
+def settings_store(async_session_maker):
+    store = SaasSettingsStore('5594c7b6-f959-4b81-92e9-b09c206f5081')
     store.a_session_maker = async_session_maker
 
     # Patch the load method to read from UserSettings table directly (for testing)
@@ -318,9 +308,9 @@ async def test_encryption(settings_store):
 
 
 @pytest.mark.asyncio
-async def test_ensure_api_key_keeps_valid_key(mock_config):
+async def test_ensure_api_key_keeps_valid_key():
     """When the existing key is valid, it should be kept unchanged."""
-    store = SaasSettingsStore('test-user-id-123', mock_config)
+    store = SaasSettingsStore('test-user-id-123')
     existing_key = 'sk-existing-key'
     item = _make_settings(model='openhands/gpt-4', api_key=existing_key)
 
@@ -337,11 +327,9 @@ async def test_ensure_api_key_keeps_valid_key(mock_config):
 
 
 @pytest.mark.asyncio
-async def test_ensure_api_key_generates_new_key_when_verification_fails(
-    mock_config,
-):
+async def test_ensure_api_key_generates_new_key_when_verification_fails():
     """When verification fails, a new key should be generated."""
-    store = SaasSettingsStore('test-user-id-123', mock_config)
+    store = SaasSettingsStore('test-user-id-123')
     new_key = 'sk-new-key'
     item = _make_settings(model='openhands/gpt-4', api_key='sk-invalid-key')
 
@@ -464,7 +452,7 @@ def org_with_multiple_members_fixture(session_maker):
 
 @pytest.mark.asyncio
 async def test_store_updates_org_defaults_and_all_members_for_shared_keys(
-    session_maker, async_session_maker, mock_config, org_with_multiple_members_fixture
+    session_maker, async_session_maker,  org_with_multiple_members_fixture
 ):
     """External provider keys should still sync as an org-wide shared snapshot."""
     from sqlalchemy import select
@@ -475,7 +463,7 @@ async def test_store_updates_org_defaults_and_all_members_for_shared_keys(
     org_id = fixture['org_id']
     decrypt_value = fixture['decrypt_value']
 
-    store = SaasSettingsStore(str(fixture['admin_user_id']), mock_config)
+    store = SaasSettingsStore(str(fixture['admin_user_id']))
     new_settings = _make_settings(
         model='anthropic/claude-sonnet-4',
         base_url='https://api.anthropic.com/v1',
@@ -518,7 +506,7 @@ async def test_store_updates_org_defaults_and_all_members_for_shared_keys(
 
 @pytest.mark.asyncio
 async def test_store_keeps_openhands_managed_keys_member_specific(
-    session_maker, async_session_maker, mock_config, org_with_multiple_members_fixture
+    session_maker, async_session_maker,  org_with_multiple_members_fixture
 ):
     """Managed OpenHands keys should not be copied from one member to everyone else."""
     from sqlalchemy import select
@@ -530,7 +518,7 @@ async def test_store_keeps_openhands_managed_keys_member_specific(
     admin_user_id = str(fixture['admin_user_id'])
     decrypt_value = fixture['decrypt_value']
 
-    store = SaasSettingsStore(admin_user_id, mock_config)
+    store = SaasSettingsStore(admin_user_id)
     new_settings = _make_settings(
         model='openhands/claude-opus-4-5-20251101',
         base_url=LITE_LLM_API_URL,
@@ -588,7 +576,7 @@ async def test_store_keeps_openhands_managed_keys_member_specific(
 
 @pytest.mark.asyncio
 async def test_store_saves_mcp_config_in_agent_settings(
-    session_maker, async_session_maker, mock_config, org_with_multiple_members_fixture
+    session_maker, async_session_maker,  org_with_multiple_members_fixture
 ):
     """mcp_config now flows through agent_settings / agent_settings_diff,
     so it is persisted on both the org and all members."""
@@ -602,7 +590,7 @@ async def test_store_saves_mcp_config_in_agent_settings(
     member1_user_id = str(fixture['member1_user_id'])
     member2_user_id = str(fixture['member2_user_id'])
 
-    store = SaasSettingsStore(admin_user_id, mock_config)
+    store = SaasSettingsStore(admin_user_id)
     user_mcp_config = {
         'mcpServers': {
             'user1': {'url': 'https://user1-mcp-server.com', 'transport': 'sse'}
@@ -654,7 +642,7 @@ async def test_store_saves_mcp_config_in_agent_settings(
 
 @pytest.mark.asyncio
 async def test_store_skips_ensure_api_key_for_non_openhands_model_without_base_url(
-    session_maker, async_session_maker, mock_config, org_with_multiple_members_fixture
+    session_maker, async_session_maker,  org_with_multiple_members_fixture
 ):
     """When saving a non-OpenHands model with no base URL (basic view BYOR),
     _ensure_api_key should NOT be called, preserving the user's custom API key.
@@ -664,7 +652,7 @@ async def test_store_skips_ensure_api_key_for_non_openhands_model_without_base_u
     """
     fixture = org_with_multiple_members_fixture
     admin_user_id = str(fixture['admin_user_id'])
-    store = SaasSettingsStore(admin_user_id, mock_config)
+    store = SaasSettingsStore(admin_user_id)
 
     settings = _make_settings(
         model='openai/gpt-5.2',
@@ -682,12 +670,12 @@ async def test_store_skips_ensure_api_key_for_non_openhands_model_without_base_u
 
 @pytest.mark.asyncio
 async def test_store_calls_ensure_api_key_for_openhands_model_without_base_url(
-    session_maker, async_session_maker, mock_config, org_with_multiple_members_fixture
+    session_maker, async_session_maker,  org_with_multiple_members_fixture
 ):
     """OpenHands models still require proxy-key verification without a base URL."""
     fixture = org_with_multiple_members_fixture
     admin_user_id = str(fixture['admin_user_id'])
-    store = SaasSettingsStore(admin_user_id, mock_config)
+    store = SaasSettingsStore(admin_user_id)
 
     settings = _make_settings(
         model='openhands/claude-opus-4-5-20251101',
@@ -705,12 +693,12 @@ async def test_store_calls_ensure_api_key_for_openhands_model_without_base_url(
 
 @pytest.mark.asyncio
 async def test_store_calls_ensure_api_key_when_base_url_is_litellm_proxy(
-    session_maker, async_session_maker, mock_config, org_with_multiple_members_fixture
+    session_maker, async_session_maker,  org_with_multiple_members_fixture
 ):
     """Explicit LiteLLM proxy usage should always verify/generate the API key."""
     fixture = org_with_multiple_members_fixture
     admin_user_id = str(fixture['admin_user_id'])
-    store = SaasSettingsStore(admin_user_id, mock_config)
+    store = SaasSettingsStore(admin_user_id)
 
     settings = _make_settings(
         model='openai/gpt-5.2',
@@ -729,7 +717,7 @@ async def test_store_calls_ensure_api_key_when_base_url_is_litellm_proxy(
 
 @pytest.mark.asyncio
 async def test_store_and_load_mcp_config_via_agent_settings(
-    async_session_maker, mock_config, org_with_multiple_members_fixture
+    async_session_maker,  org_with_multiple_members_fixture
 ):
     """mcp_config is persisted inside agent_settings / agent_settings_diff and
     round-trips correctly through store → load."""
@@ -742,7 +730,7 @@ async def test_store_and_load_mcp_config_via_agent_settings(
         },
     }
 
-    admin_store = SaasSettingsStore(admin_user_id, mock_config)
+    admin_store = SaasSettingsStore(admin_user_id)
 
     admin_settings = DataSettings()
     admin_settings.update(
@@ -778,7 +766,7 @@ async def test_store_and_load_mcp_config_via_agent_settings(
 
 @pytest.mark.asyncio
 async def test_store_and_load_llm_profiles_round_trip(
-    async_session_maker, mock_config, org_with_multiple_members_fixture
+    async_session_maker,  org_with_multiple_members_fixture
 ):
     """Saved llm_profiles must persist on the User row and round-trip through
     store → load. Without the user.llm_profiles column they are silently
@@ -787,7 +775,7 @@ async def test_store_and_load_llm_profiles_round_trip(
 
     fixture = org_with_multiple_members_fixture
     admin_user_id = str(fixture['admin_user_id'])
-    admin_store = SaasSettingsStore(admin_user_id, mock_config)
+    admin_store = SaasSettingsStore(admin_user_id)
 
     settings = DataSettings()
     settings.update(
@@ -846,7 +834,7 @@ async def test_store_and_load_llm_profiles_round_trip(
 
 @pytest.mark.asyncio
 async def test_load_with_null_llm_profiles_column_uses_default_factory(
-    async_session_maker, mock_config, org_with_multiple_members_fixture
+    async_session_maker,  org_with_multiple_members_fixture
 ):
     """Rows predating the user.llm_profiles column read back as None.
     Settings.llm_profiles is non-nullable (default_factory=LLMProfiles), so
@@ -857,7 +845,7 @@ async def test_load_with_null_llm_profiles_column_uses_default_factory(
 
     fixture = org_with_multiple_members_fixture
     admin_user_id = fixture['admin_user_id']
-    admin_store = SaasSettingsStore(str(admin_user_id), mock_config)
+    admin_store = SaasSettingsStore(str(admin_user_id))
 
     seed_settings = _make_settings(
         model='anthropic/claude-sonnet-4-5-20250929',
@@ -887,7 +875,7 @@ async def test_load_with_null_llm_profiles_column_uses_default_factory(
 
 @pytest.mark.asyncio
 async def test_llm_profiles_are_encrypted_at_rest(
-    async_session_maker, mock_config, org_with_multiple_members_fixture
+    async_session_maker,  org_with_multiple_members_fixture
 ):
     """The raw value in the user.llm_profiles column must be ciphertext, not
     a JSON dict — profile api_keys would otherwise leak in DB dumps,
@@ -900,7 +888,7 @@ async def test_llm_profiles_are_encrypted_at_rest(
 
     fixture = org_with_multiple_members_fixture
     admin_user_id = fixture['admin_user_id']
-    admin_store = SaasSettingsStore(str(admin_user_id), mock_config)
+    admin_store = SaasSettingsStore(str(admin_user_id))
 
     settings = DataSettings()
     settings.update(

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -452,7 +452,7 @@ def org_with_multiple_members_fixture(session_maker):
 
 @pytest.mark.asyncio
 async def test_store_updates_org_defaults_and_all_members_for_shared_keys(
-    session_maker, async_session_maker,  org_with_multiple_members_fixture
+    session_maker, async_session_maker, org_with_multiple_members_fixture
 ):
     """External provider keys should still sync as an org-wide shared snapshot."""
     from sqlalchemy import select
@@ -506,7 +506,7 @@ async def test_store_updates_org_defaults_and_all_members_for_shared_keys(
 
 @pytest.mark.asyncio
 async def test_store_keeps_openhands_managed_keys_member_specific(
-    session_maker, async_session_maker,  org_with_multiple_members_fixture
+    session_maker, async_session_maker, org_with_multiple_members_fixture
 ):
     """Managed OpenHands keys should not be copied from one member to everyone else."""
     from sqlalchemy import select
@@ -576,7 +576,7 @@ async def test_store_keeps_openhands_managed_keys_member_specific(
 
 @pytest.mark.asyncio
 async def test_store_saves_mcp_config_in_agent_settings(
-    session_maker, async_session_maker,  org_with_multiple_members_fixture
+    session_maker, async_session_maker, org_with_multiple_members_fixture
 ):
     """mcp_config now flows through agent_settings / agent_settings_diff,
     so it is persisted on both the org and all members."""
@@ -642,7 +642,7 @@ async def test_store_saves_mcp_config_in_agent_settings(
 
 @pytest.mark.asyncio
 async def test_store_skips_ensure_api_key_for_non_openhands_model_without_base_url(
-    session_maker, async_session_maker,  org_with_multiple_members_fixture
+    session_maker, async_session_maker, org_with_multiple_members_fixture
 ):
     """When saving a non-OpenHands model with no base URL (basic view BYOR),
     _ensure_api_key should NOT be called, preserving the user's custom API key.
@@ -670,7 +670,7 @@ async def test_store_skips_ensure_api_key_for_non_openhands_model_without_base_u
 
 @pytest.mark.asyncio
 async def test_store_calls_ensure_api_key_for_openhands_model_without_base_url(
-    session_maker, async_session_maker,  org_with_multiple_members_fixture
+    session_maker, async_session_maker, org_with_multiple_members_fixture
 ):
     """OpenHands models still require proxy-key verification without a base URL."""
     fixture = org_with_multiple_members_fixture
@@ -693,7 +693,7 @@ async def test_store_calls_ensure_api_key_for_openhands_model_without_base_url(
 
 @pytest.mark.asyncio
 async def test_store_calls_ensure_api_key_when_base_url_is_litellm_proxy(
-    session_maker, async_session_maker,  org_with_multiple_members_fixture
+    session_maker, async_session_maker, org_with_multiple_members_fixture
 ):
     """Explicit LiteLLM proxy usage should always verify/generate the API key."""
     fixture = org_with_multiple_members_fixture
@@ -717,7 +717,7 @@ async def test_store_calls_ensure_api_key_when_base_url_is_litellm_proxy(
 
 @pytest.mark.asyncio
 async def test_store_and_load_mcp_config_via_agent_settings(
-    async_session_maker,  org_with_multiple_members_fixture
+    async_session_maker, org_with_multiple_members_fixture
 ):
     """mcp_config is persisted inside agent_settings / agent_settings_diff and
     round-trips correctly through store → load."""
@@ -766,7 +766,7 @@ async def test_store_and_load_mcp_config_via_agent_settings(
 
 @pytest.mark.asyncio
 async def test_store_and_load_llm_profiles_round_trip(
-    async_session_maker,  org_with_multiple_members_fixture
+    async_session_maker, org_with_multiple_members_fixture
 ):
     """Saved llm_profiles must persist on the User row and round-trip through
     store → load. Without the user.llm_profiles column they are silently
@@ -834,7 +834,7 @@ async def test_store_and_load_llm_profiles_round_trip(
 
 @pytest.mark.asyncio
 async def test_load_with_null_llm_profiles_column_uses_default_factory(
-    async_session_maker,  org_with_multiple_members_fixture
+    async_session_maker, org_with_multiple_members_fixture
 ):
     """Rows predating the user.llm_profiles column read back as None.
     Settings.llm_profiles is non-nullable (default_factory=LLMProfiles), so
@@ -875,7 +875,7 @@ async def test_load_with_null_llm_profiles_column_uses_default_factory(
 
 @pytest.mark.asyncio
 async def test_llm_profiles_are_encrypted_at_rest(
-    async_session_maker,  org_with_multiple_members_fixture
+    async_session_maker, org_with_multiple_members_fixture
 ):
     """The raw value in the user.llm_profiles column must be ciphertext, not
     a JSON dict — profile api_keys would otherwise leak in DB dumps,

--- a/enterprise/tests/unit/test_saas_user_auth.py
+++ b/enterprise/tests/unit/test_saas_user_auth.py
@@ -77,12 +77,8 @@ def mock_config():
     jwt_svc = JwtService(
         keys=[EncryptionKey(kid='test', key=SecretStr('test_secret'), active=True)]
     )
-    with (
-        patch('server.auth.saas_user_auth.get_config') as mock_get_config,
-        patch('storage.encrypt_utils.get_jwt_service', return_value=jwt_svc),
-    ):
-        mock_cfg = mock_get_config.return_value
-        yield mock_cfg
+    with patch('storage.encrypt_utils.get_jwt_service', return_value=jwt_svc):
+        yield
 
 
 @pytest.mark.asyncio
@@ -1038,7 +1034,6 @@ class TestOpenHandsApiKey:
             patch(
                 'server.auth.saas_user_auth.SaasSecretsStore'
             ) as mock_secrets_store_cls,
-            patch('server.auth.saas_user_auth.get_config') as mock_get_config,
         ):
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
 
@@ -1053,8 +1048,6 @@ class TestOpenHandsApiKey:
             mock_secrets_store_cls.get_instance = AsyncMock(
                 return_value=mock_secrets_store
             )
-
-            mock_get_config.return_value = MagicMock()
 
             # Act
             result = await user_auth.get_secrets()
@@ -1096,7 +1089,6 @@ class TestOpenHandsApiKey:
             patch(
                 'server.auth.saas_user_auth.SaasSecretsStore'
             ) as mock_secrets_store_cls,
-            patch('server.auth.saas_user_auth.get_config') as mock_get_config,
         ):
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
 
@@ -1111,8 +1103,6 @@ class TestOpenHandsApiKey:
             mock_secrets_store_cls.get_instance = AsyncMock(
                 return_value=mock_secrets_store
             )
-
-            mock_get_config.return_value = MagicMock()
 
             # Act - call get_secrets twice
             result1 = await user_auth.get_secrets()
@@ -1146,7 +1136,6 @@ class TestOpenHandsApiKey:
             patch(
                 'server.auth.saas_user_auth.SaasSecretsStore'
             ) as mock_secrets_store_cls,
-            patch('server.auth.saas_user_auth.get_config') as mock_get_config,
         ):
             mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
 
@@ -1161,8 +1150,6 @@ class TestOpenHandsApiKey:
             mock_secrets_store_cls.get_instance = AsyncMock(
                 return_value=mock_secrets_store
             )
-
-            mock_get_config.return_value = MagicMock()
 
             # Act
             result = await user_auth.get_secrets()

--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -37,6 +37,8 @@ from openhands.app_server.event_callback.event_callback_service import (
     EventCallbackService,
     EventCallbackServiceInjector,
 )
+from openhands.app_server.file_store.files import FileStore
+from openhands.app_server.file_store.local import LocalFileStore
 from openhands.app_server.pending_messages.pending_message_service import (
     PendingMessageService,
     PendingMessageServiceInjector,
@@ -168,8 +170,14 @@ def _get_default_lifespan():
     return OssAppLifespanService()
 
 
+def _get_default_file_store() -> FileStore:
+    """Create a default LocalFileStore using the default persistence directory."""
+    return LocalFileStore(root=str(get_default_persistence_dir()))
+
+
 class AppServerConfig(OpenHandsModel):
     persistence_dir: Path = Field(default_factory=get_default_persistence_dir)
+    file_store: FileStore = Field(default_factory=_get_default_file_store)
     web_url: str | None = Field(
         default_factory=get_default_web_url,
         description='The URL where OpenHands is running (e.g., http://localhost:3000)',

--- a/openhands/app_server/secrets/file_secrets_store.py
+++ b/openhands/app_server/secrets/file_secrets_store.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 
-from openhands.app_server.file_store import get_file_store
 from openhands.app_server.file_store.files import FileStore
 from openhands.app_server.secrets.secrets_models import Secrets
 from openhands.app_server.secrets.secrets_store import SecretsStore
 from openhands.app_server.utils.async_utils import call_sync_from_async
-from openhands.core.config.openhands_config import OpenHandsConfig
 
 
 @dataclass
@@ -36,11 +34,12 @@ class FileSecretsStore(SecretsStore):
         await call_sync_from_async(self.file_store.write, self.path, json_str)
 
     @classmethod
-    async def get_instance(
-        cls, config: OpenHandsConfig, user_id: str | None
-    ) -> FileSecretsStore:
-        file_store = get_file_store(
-            file_store_type=config.file_store,
-            file_store_path=config.file_store_path,
-        )
+    async def get_instance(cls, user_id: str | None) -> FileSecretsStore:
+        """Get a FileSecretsStore instance using the global config's file_store.
+
+        TODO: This method should be replaced with dependency injection.
+        """
+        from openhands.app_server.config import get_global_config
+
+        file_store = get_global_config().file_store
         return FileSecretsStore(file_store)

--- a/openhands/app_server/secrets/secrets_store.py
+++ b/openhands/app_server/secrets/secrets_store.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 from openhands.app_server.secrets.secrets_models import Secrets
-from openhands.core.config.openhands_config import OpenHandsConfig
 
 
 class SecretsStore(ABC):
@@ -30,7 +29,8 @@ class SecretsStore(ABC):
 
     @classmethod
     @abstractmethod
-    async def get_instance(
-        cls, config: OpenHandsConfig, user_id: str | None
-    ) -> SecretsStore:
-        """Get a store for the user represented by the token given."""
+    async def get_instance(cls, user_id: str | None) -> SecretsStore:
+        """Get a store for the user represented by the token given.
+
+        TODO: This method should be replaced with dependency injection.
+        """

--- a/openhands/app_server/settings/file_settings_store.py
+++ b/openhands/app_server/settings/file_settings_store.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 
-from openhands.app_server.file_store import get_file_store
 from openhands.app_server.file_store.files import FileStore
 from openhands.app_server.settings.settings_models import Settings
 from openhands.app_server.settings.settings_store import SettingsStore
 from openhands.app_server.utils.async_utils import call_sync_from_async
-from openhands.core.config.openhands_config import OpenHandsConfig
 
 
 @dataclass
@@ -37,11 +35,12 @@ class FileSettingsStore(SettingsStore):
         await call_sync_from_async(self.file_store.write, self.path, json_str)
 
     @classmethod
-    async def get_instance(
-        cls, config: OpenHandsConfig, user_id: str | None
-    ) -> FileSettingsStore:
-        file_store = get_file_store(
-            file_store_type=config.file_store,
-            file_store_path=config.file_store_path,
-        )
+    async def get_instance(cls, user_id: str | None) -> FileSettingsStore:
+        """Get a FileSettingsStore instance using the global config's file_store.
+
+        TODO: This method should be replaced with dependency injection.
+        """
+        from openhands.app_server.config import get_global_config
+
+        file_store = get_global_config().file_store
         return FileSettingsStore(file_store)

--- a/openhands/app_server/settings/settings_store.py
+++ b/openhands/app_server/settings/settings_store.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 from openhands.app_server.settings.settings_models import Settings
-from openhands.core.config.openhands_config import OpenHandsConfig
 
 
 class SettingsStore(ABC):
@@ -30,7 +29,8 @@ class SettingsStore(ABC):
 
     @classmethod
     @abstractmethod
-    async def get_instance(
-        cls, config: OpenHandsConfig, user_id: str | None
-    ) -> SettingsStore:
-        """Get a store for the user represented by the token given."""
+    async def get_instance(cls, user_id: str | None) -> SettingsStore:
+        """Get a store for the user represented by the token given.
+
+        TODO: This method should be replaced with dependency injection.
+        """

--- a/openhands/app_server/user_auth/default_user_auth.py
+++ b/openhands/app_server/user_auth/default_user_auth.py
@@ -46,9 +46,7 @@ class DefaultUserAuth(UserAuth):
         if settings_store:
             return settings_store
         user_id = await self.get_user_id()
-        settings_store = await shared.SettingsStoreImpl.get_instance(
-            shared.config, user_id
-        )
+        settings_store = await shared.SettingsStoreImpl.get_instance(user_id)
         if settings_store is None:
             raise ValueError('Failed to get settings store instance')
         self._settings_store = settings_store
@@ -68,9 +66,7 @@ class DefaultUserAuth(UserAuth):
         if secrets_store:
             return secrets_store
         user_id = await self.get_user_id()
-        secret_store = await shared.SecretsStoreImpl.get_instance(
-            shared.config, user_id
-        )
+        secret_store = await shared.SecretsStoreImpl.get_instance(user_id)
         if secret_store is None:
             raise ValueError('Failed to get secrets store instance')
         self._secrets_store = secret_store

--- a/tests/unit/storage/settings/test_file_settings_store.py
+++ b/tests/unit/storage/settings/test_file_settings_store.py
@@ -100,9 +100,7 @@ async def test_store_and_load_data(file_settings_store):
 async def test_get_instance():
     mock_store = MagicMock(spec=FileStore)
 
-    with patch(
-        'openhands.app_server.config.get_global_config'
-    ) as mock_get_config:
+    with patch('openhands.app_server.config.get_global_config') as mock_get_config:
         mock_config = MagicMock()
         mock_config.file_store = mock_store
         mock_get_config.return_value = mock_config

--- a/tests/unit/storage/settings/test_file_settings_store.py
+++ b/tests/unit/storage/settings/test_file_settings_store.py
@@ -7,7 +7,6 @@ from pydantic import SecretStr
 from openhands.app_server.file_store.files import FileStore
 from openhands.app_server.settings.file_settings_store import FileSettingsStore
 from openhands.app_server.settings.settings_models import Settings
-from openhands.core.config.openhands_config import OpenHandsConfig
 from openhands.sdk.llm import LLM
 from openhands.sdk.settings import AgentSettings, ConversationSettings
 
@@ -99,19 +98,17 @@ async def test_store_and_load_data(file_settings_store):
 
 @pytest.mark.asyncio
 async def test_get_instance():
-    config = OpenHandsConfig(file_store='local', file_store_path='/test/path')
+    mock_store = MagicMock(spec=FileStore)
 
     with patch(
-        'openhands.app_server.settings.file_settings_store.get_file_store'
-    ) as mock_get_store:
-        mock_store = MagicMock(spec=FileStore)
-        mock_get_store.return_value = mock_store
+        'openhands.app_server.settings.file_settings_store.get_global_config'
+    ) as mock_get_config:
+        mock_config = MagicMock()
+        mock_config.file_store = mock_store
+        mock_get_config.return_value = mock_config
 
-        store = await FileSettingsStore.get_instance(config, None)
+        store = await FileSettingsStore.get_instance(None)
 
         assert isinstance(store, FileSettingsStore)
         assert store.file_store == mock_store
-        mock_get_store.assert_called_once_with(
-            file_store_type='local',
-            file_store_path='/test/path',
-        )
+        mock_get_config.assert_called_once()

--- a/tests/unit/storage/settings/test_file_settings_store.py
+++ b/tests/unit/storage/settings/test_file_settings_store.py
@@ -101,7 +101,7 @@ async def test_get_instance():
     mock_store = MagicMock(spec=FileStore)
 
     with patch(
-        'openhands.app_server.settings.file_settings_store.get_global_config'
+        'openhands.app_server.config.get_global_config'
     ) as mock_get_config:
         mock_config = MagicMock()
         mock_config.file_store = mock_store


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why

This is part of the ongoing effort to remove `OpenHandsConfig` usage from the V1 codebase. The settings and secrets stores were still accepting `OpenHandsConfig` as a parameter to their `get_instance()` methods, even though only the `file_store` and `file_store_path` fields were being used.

## Summary

- Add `file_store` field to `AppServerConfig` with a default `LocalFileStore` using `get_default_persistence_dir()`
- Update `SettingsStore` and `SecretsStore` abstract `get_instance()` methods to remove the `config` parameter
- Update `FileSettingsStore` and `FileSecretsStore` to use `get_global_config().file_store` instead of the passed config
- Remove unused `OpenHandsConfig` imports and `config` fields from enterprise stores (`SaasSettingsStore`, `SaasSecretsStore`, `OfflineTokenStore`)
- Add TODO comments indicating `get_instance()` methods should be replaced with dependency injection
- Update all callers and tests

## Issue Number

N/A - Part of V0 deprecation effort

## How to Test

1. Run pre-commit checks: `pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --all-files`
2. Run enterprise pre-commit checks: `cd enterprise && pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --all-files`
3. Run unit tests for the modified files

## Screenshots

Both OSS and Cloud still work as previously
<img width="1093" height="723" alt="image" src="https://github.com/user-attachments/assets/5d3d7a13-4eb5-4bda-92c2-f48f4d01ab85" />

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The `get_instance()` class methods on stores are marked with TODO comments to be replaced with dependency injection in a future refactor. This PR focuses on removing the `OpenHandsConfig` dependency while maintaining the existing pattern.

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/da6ab6e5-b466-4af6-8da5-e14d9a32ba51)

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-d89c4b2   docker.openhands.dev/openhands/openhands:d89c4b2
```