### PR TITLE
docs: document truthy value convention for env var enable toggles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -453,6 +453,24 @@ To add a new LLM model to OpenHands, you need to update multiple files across bo
 - The `organize_models_and_providers` function groups models by provider
 - Default model selection prioritizes verified models for each provider
 
+### Environment Variable Enable Toggles
+
+When adding a new boolean enable toggle read from an environment variable (e.g. `FEATURE_ENABLED`, `SLACK_WEBHOOKS_ENABLED`), the check **must** accept both `'true'` and `'1'` as truthy values. Older Helm chart versions default to `'1'` rather than `'true'`, so accepting only one form silently disables the feature in those deployments.
+
+**Required pattern:**
+```python
+os.getenv('MY_FEATURE_ENABLED', 'false').lower() in ('true', '1')
+```
+
+**Do not use:**
+```python
+os.getenv('MY_FEATURE_ENABLED', 'false').lower() == 'true'  # breaks when value is '1'
+os.getenv('MY_FEATURE_ENABLED', 'false') == '1'             # breaks when value is 'true'
+bool(os.getenv('MY_FEATURE_ENABLED'))                       # treats any non-empty string as True
+```
+
+This applies anywhere an env var gates a feature: backend config, web client config injectors, integration service initialization, etc. Add a unit test for the `'1'` case alongside the `'true'` case.
+
 ### Sandbox Settings API (SDK Credential Inheritance)
 
 The sandbox settings API allows SDK-created conversations to inherit the user's SaaS credentials


### PR DESCRIPTION
## Why

Older Helm chart versions set enable toggles to `'1'` rather than `'true'`. The check introduced in #14097 only accepted `'true'`, which silently disabled Slack integration on those deployments — fixed in #14255.

To prevent the same class of bug from recurring on future toggles, this PR codifies the required pattern in `AGENTS.md`.

## Summary

- Add a new "Environment Variable Enable Toggles" section to `AGENTS.md` under Implementation Details
- Documents that all boolean env var feature gates must accept both `'true'` and `'1'`
- Provides the required pattern and anti-patterns with inline comments
- Notes that a unit test for the `'1'` case is required alongside the `'true'` case

## Issue Number

Related: #14097, #14255

## How to Test

N/A — documentation only.

## Type

- [x] Documentation