### PR TITLE
fix: correctly raise 404 when updating or deleting a nonexistent custom secret

### DIFF
--- a/openhands/app_server/secrets/secrets_router.py
+++ b/openhands/app_server/secrets/secrets_router.py
@@ -308,37 +308,35 @@ async def update_custom_secret(
         500: Error updating secret
     """
     existing_secrets = await secrets_store.load()
-    if existing_secrets:
-        # Check if the secret to update exists
-        if secret_id not in existing_secrets.custom_secrets:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f'Secret with ID {secret_id} not found',
-            )
-
-        secret_name = incoming_secret.name
-        secret_description = incoming_secret.description
-
-        custom_secrets = dict(existing_secrets.custom_secrets)
-        existing_secret = custom_secrets.pop(secret_id)
-
-        if secret_name != secret_id and secret_name in custom_secrets:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f'Secret {secret_name} already exists',
-            )
-
-        custom_secrets[secret_name] = CustomSecret(
-            secret=existing_secret.secret,
-            description=secret_description or '',
+    if not existing_secrets or secret_id not in existing_secrets.custom_secrets:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f'Secret with ID {secret_id} not found',
         )
 
-        updated_secrets = Secrets(
-            custom_secrets=custom_secrets,  # type: ignore[arg-type]
-            provider_tokens=existing_secrets.provider_tokens,
+    secret_name = incoming_secret.name
+    secret_description = incoming_secret.description
+
+    custom_secrets = dict(existing_secrets.custom_secrets)
+    existing_secret = custom_secrets.pop(secret_id)
+
+    if secret_name != secret_id and secret_name in custom_secrets:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f'Secret {secret_name} already exists',
         )
 
-        await secrets_store.store(updated_secrets)
+    custom_secrets[secret_name] = CustomSecret(
+        secret=existing_secret.secret,
+        description=secret_description or '',
+    )
+
+    updated_secrets = Secrets(
+        custom_secrets=custom_secrets,  # type: ignore[arg-type]
+        provider_tokens=existing_secrets.provider_tokens,
+    )
+
+    await secrets_store.store(updated_secrets)
 
     return EditResponse(
         message='Secret updated successfully',
@@ -360,27 +358,25 @@ async def delete_custom_secret(
         500: Error deleting secret
     """
     existing_secrets = await secrets_store.load()
-    if existing_secrets:
-        # Get existing custom secrets
-        custom_secrets = dict(existing_secrets.custom_secrets)
-
-        # Check if the secret to delete exists
-        if secret_id not in custom_secrets:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f'Secret with ID {secret_id} not found',
-            )
-
-        # Remove the secret
-        custom_secrets.pop(secret_id)
-
-        # Create a new Secrets that preserves provider tokens and remaining secrets
-        updated_secrets = Secrets(
-            custom_secrets=custom_secrets,  # type: ignore[arg-type]
-            provider_tokens=existing_secrets.provider_tokens,
+    if not existing_secrets or secret_id not in existing_secrets.custom_secrets:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f'Secret with ID {secret_id} not found',
         )
 
-        await secrets_store.store(updated_secrets)
+    # Get existing custom secrets
+    custom_secrets = dict(existing_secrets.custom_secrets)
+
+    # Remove the secret
+    custom_secrets.pop(secret_id)
+
+    # Create a new Secrets that preserves provider tokens and remaining secrets
+    updated_secrets = Secrets(
+        custom_secrets=custom_secrets,  # type: ignore[arg-type]
+        provider_tokens=existing_secrets.provider_tokens,
+    )
+
+    await secrets_store.store(updated_secrets)
 
     return EditResponse(
         message='Secret deleted successfully',

--- a/tests/unit/app_server/test_secrets_api.py
+++ b/tests/unit/app_server/test_secrets_api.py
@@ -282,6 +282,48 @@ async def test_update_existing_custom_secret(test_client, file_secrets_store):
 
 
 @pytest.mark.asyncio
+async def test_update_nonexistent_custom_secret(test_client, file_secrets_store):
+    """Test updating a custom secret that doesn't exist."""
+    custom_secrets = {'API_KEY': CustomSecret(secret=SecretStr('api-key-value'))}
+    provider_tokens = {
+        ProviderType.GITHUB: ProviderToken(token=SecretStr('github-token'))
+    }
+    user_secrets = Secrets(
+        custom_secrets=custom_secrets, provider_tokens=provider_tokens
+    )
+    await file_secrets_store.store(user_secrets)
+
+    update_secret_data = {
+        'name': 'NONEXISTENT_KEY',
+        'description': None,
+    }
+    response = test_client.put('/secrets/NONEXISTENT_KEY', json=update_secret_data)
+    assert response.status_code == 404
+
+    stored_settings = await file_secrets_store.load()
+    assert 'API_KEY' in stored_settings.custom_secrets
+    assert (
+        stored_settings.custom_secrets['API_KEY'].secret.get_secret_value()
+        == 'api-key-value'
+    )
+    assert ProviderType.GITHUB in stored_settings.provider_tokens
+
+
+@pytest.mark.asyncio
+async def test_update_custom_secret_with_no_existing_secrets(
+    test_client, file_secrets_store
+):
+    """Test updating a custom secret when no secrets store exists."""
+    update_secret_data = {
+        'name': 'NONEXISTENT_KEY',
+        'description': None,
+    }
+    response = test_client.put('/secrets/NONEXISTENT_KEY', json=update_secret_data)
+    assert response.status_code == 404
+    assert await file_secrets_store.load() is None
+
+
+@pytest.mark.asyncio
 async def test_add_multiple_custom_secrets(test_client, file_secrets_store):
     """Test adding multiple custom secrets at once."""
     # Create initial settings with one custom secret
@@ -414,6 +456,16 @@ async def test_delete_nonexistent_custom_secret(test_client, file_secrets_store)
 
     # Check that other settings were preserved
     assert ProviderType.GITHUB in stored_settings.provider_tokens
+
+
+@pytest.mark.asyncio
+async def test_delete_custom_secret_with_no_existing_secrets(
+    test_client, file_secrets_store
+):
+    """Test deleting a custom secret when no secrets store exists."""
+    response = test_client.delete('/secrets/NONEXISTENT_KEY')
+    assert response.status_code == 404
+    assert await file_secrets_store.load() is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why

Updating or deleting a custom secret that does not exist should return `404 Not Found` instead of behaving like a successful mutation.

## Summary

- Return `404 Not Found` when updating a nonexistent custom secret
- Return `404 Not Found` when deleting a nonexistent custom secret
- Keep the existing success path unchanged for valid custom secret operations

## Issue Number

Fixes #14204

## How to Test

- Run `poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files openhands/app_server/secrets/secrets_router.py`
- Verify that updating a nonexistent custom secret returns `404`
- Verify that deleting a nonexistent custom secret returns `404`

## Video/Screenshots

N/A

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- This is a minimal backend-only fix in `secrets_router.py`.
- Local backend pre-commit checks passed.
