### PR TITLE
fix: replace datetime.now() with datetime.now(timezone.utc) to prevent negative timestamps

### DIFF
--- a/enterprise/server/auth/sheets_client.py
+++ b/enterprise/server/auth/sheets_client.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Tuple
 
 import gspread
@@ -42,7 +42,7 @@ class GoogleSheetsClient:
             return None
 
         usernames, timestamp = self._cache[cache_key]
-        if datetime.now() - timestamp > self._cache_ttl:
+        if datetime.now(timezone.utc) - timestamp > self._cache_ttl:
             logger.info('Cache expired, will fetch fresh data')
             return None
 
@@ -62,7 +62,7 @@ class GoogleSheetsClient:
             usernames: List of usernames to cache
         """
         cache_key = (spreadsheet_id, range_name)
-        self._cache[cache_key] = (usernames, datetime.now())
+        self._cache[cache_key] = (usernames, datetime.now(timezone.utc))
 
     def get_usernames(self, spreadsheet_id: str, range_name: str = 'A:A') -> List[str]:
         """Get list of usernames from specified Google Sheet.

--- a/enterprise/server/logger.py
+++ b/enterprise/server/logger.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TextIO
 
@@ -39,7 +39,7 @@ def custom_json_serializer(obj, **kwargs):
     if LOG_JSON_FOR_CONSOLE:
         # Format json output
         kwargs['indent'] = 2
-        obj = {'ts': datetime.now().isoformat(), **obj}
+        obj = {'ts': datetime.now(timezone.utc).isoformat(), **obj}
 
         # Format stack traces
         if isinstance(obj, dict):

--- a/enterprise/tests/unit/test_logger.py
+++ b/enterprise/tests/unit/test_logger.py
@@ -11,8 +11,8 @@ from server.logger import format_stack, setup_json_logger
 from openhands.app_server.utils.logger import openhands_logger
 
 FROZEN_TIMESTAMP = '2024-01-15T10:30:00+00:00'
-# datetime.now().isoformat() doesn't include timezone info
-FROZEN_TIMESTAMP_NO_TZ = '2024-01-15T10:30:00'
+# datetime.now(timezone.utc).isoformat() includes timezone info
+FROZEN_TIMESTAMP_WITH_TZ = '2024-01-15T10:30:00+00:00'
 
 
 @pytest.fixture
@@ -344,6 +344,6 @@ class TestLogOutput:
         ), f"'ts' should appear exactly once, found in: {raw_output}"
         assert output['message'] == 'Test both modes message'
         assert output['severity'] == 'INFO'
-        # When LOG_JSON_FOR_CONSOLE=1, custom_json_serializer uses datetime.now().isoformat()
-        # which doesn't include timezone info
-        assert output['ts'] == FROZEN_TIMESTAMP_NO_TZ
+        # When LOG_JSON_FOR_CONSOLE=1, custom_json_serializer uses datetime.now(timezone.utc).isoformat()
+        # which includes timezone info
+        assert output['ts'] == FROZEN_TIMESTAMP_WITH_TZ

--- a/openhands/app_server/middleware.py
+++ b/openhands/app_server/middleware.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse
 
 from fastapi import Request
@@ -86,13 +86,13 @@ class InMemoryRateLimiter:
         self.sleep_seconds = sleep_seconds
 
     def _clean_old_requests(self, key: str) -> None:
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         cutoff = now - timedelta(seconds=self.seconds)
         self.history[key] = [ts for ts in self.history[key] if ts > cutoff]
 
     async def __call__(self, request: Request) -> bool:
         key = request.client.host
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
 
         self._clean_old_requests(key)
 

--- a/openhands/app_server/utils/logger.py
+++ b/openhands/app_server/utils/logger.py
@@ -5,7 +5,7 @@ import re
 import sys
 import traceback
 import warnings
-from datetime import datetime
+from datetime import datetime, timezone
 from logging.handlers import TimedRotatingFileHandler
 from types import TracebackType
 from typing import Any, Literal, Mapping, MutableMapping, TextIO
@@ -452,7 +452,7 @@ class LlmFileHandler(logging.FileHandler):
         self.filename = filename
         self.message_counter = 1
         if DEBUG:
-            self.session = datetime.now().strftime('%y-%m-%d_%H-%M')
+            self.session = datetime.now(timezone.utc).strftime('%y-%m-%d_%H-%M')
         else:
             self.session = 'default'
         self.log_directory = os.path.join(LOG_DIR, 'llm', self.session)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -302,10 +302,15 @@ ignore = [ "E501" ]
 skip-string-normalization = true
 
 [tool.ruff]
-lint.select = [ "D" ]
+lint.select = [ "D", "DTZ005" ]
 # ignore warnings for missing docstrings
 lint.ignore = [ "D1" ]
 lint.pydocstyle.convention = "google"
+
+[tool.ruff.lint.per-file-ignores]
+# Allow datetime.now() without tz in tests (not user-facing)
+"**/tests/**" = [ "DTZ005" ]
+"**/test_*" = [ "DTZ005" ]
 
 [tool.coverage.run]
 concurrency = [ "gevent" ]


### PR DESCRIPTION
## Summary

Fixes OpenHands/enterprise#23 — Negative time values displayed in UI due to timezone mismatch.

## Problem

When the server runs in a non-UTC timezone (e.g., `Europe/Berlin`), `datetime.now()` writes local time without timezone info. The frontend's `parseDateAsUTC()` assumes naive timestamps are UTC, causing timestamps to appear in the future and resulting in negative time values (e.g., "-850 seconds ago").

## Changes

### 1. Fix existing `datetime.now()` calls

Replaced all `datetime.now()` calls in production (non-test) code with `datetime.now(timezone.utc)`:

| File | Context |
|------|--------|
| `enterprise/server/logger.py` | JSON log timestamp in console mode |
| `enterprise/server/auth/sheets_client.py` | Cache TTL read/write timestamps |
| `openhands/app_server/middleware.py` | Rate limiter request tracking |
| `openhands/app_server/utils/logger.py` | Debug log directory naming |
| `enterprise/tests/unit/test_logger.py` | Updated test to expect UTC-aware format |

### 2. Add Ruff lint rule to prevent regressions (per [PHclaw's suggestion](https://github.com/OpenHands/enterprise/issues/23#issuecomment-2840660073))

Added the `DTZ005` rule (from `flake8-datetimez`) to the Ruff config in `pyproject.toml`. This flags any future `datetime.now()` calls without a timezone argument at lint time. Test files are exempted via `per-file-ignores` since their datetime usage is not user-facing.

## Notes

- Some files mentioned in the issue (`openhands/events/stream.py`, `enterprise/server/utils/conversation_callback_utils.py`) don't exist in the current codebase — they may have been refactored or already fixed.
- After this change, zero `datetime.now()` calls remain in non-test production code.
- The `FROZEN_TIMESTAMP_NO_TZ` test constant was replaced with `FROZEN_TIMESTAMP_WITH_TZ` since `datetime.now(timezone.utc).isoformat()` now includes the `+00:00` suffix.

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*