### PR TITLE
fix: share GCS storage.Client() across requests to prevent connection pool exhaustion

### DIFF
--- a/enterprise/server/sharing/google_cloud_shared_event_service.py
+++ b/enterprise/server/sharing/google_cloud_shared_event_service.py
@@ -17,9 +17,7 @@ from typing import AsyncGenerator
 from uuid import UUID
 
 from fastapi import Request
-from google.cloud import storage
 from google.cloud.storage.bucket import Bucket
-from google.cloud.storage.client import Client
 from pydantic import Field
 from server.sharing.shared_conversation_info_service import (
     SharedConversationInfoService,
@@ -36,6 +34,7 @@ from openhands.agent_server.models import EventPage, EventSortOrder
 from openhands.app_server.event.event_service import EventService
 from openhands.app_server.event.google_cloud_event_service import (
     GoogleCloudEventService,
+    _get_shared_storage_client,
 )
 from openhands.app_server.event_callback.event_callback_models import EventKind
 from openhands.app_server.services.injector import InjectorState
@@ -148,8 +147,7 @@ class GoogleCloudSharedEventServiceInjector(SharedEventServiceInjector):
             )
 
             bucket_name = self.bucket_name
-            storage_client: Client = storage.Client()
-            bucket: Bucket = storage_client.bucket(bucket_name)
+            bucket: Bucket = _get_shared_storage_client().bucket(bucket_name)
 
             service = GoogleCloudSharedEventService(
                 shared_conversation_info_service=shared_conversation_info_service,

--- a/enterprise/tests/unit/test_sharing/test_sharing_shared_event_service.py
+++ b/enterprise/tests/unit/test_sharing/test_sharing_shared_event_service.py
@@ -450,14 +450,14 @@ class TestGoogleCloudSharedEventServiceInjector:
         mock_db_context.__aenter__.return_value = mock_db_session
         mock_db_context.__aexit__.return_value = None
 
-        # Mock storage.Client and bucket
+        # Mock shared storage client and bucket
         mock_storage_client = MagicMock()
         mock_bucket = MagicMock()
         mock_storage_client.bucket.return_value = mock_bucket
 
         with (
             patch(
-                'server.sharing.google_cloud_shared_event_service.storage.Client',
+                'server.sharing.google_cloud_shared_event_service._get_shared_storage_client',
                 return_value=mock_storage_client,
             ),
             patch(
@@ -489,14 +489,14 @@ class TestGoogleCloudSharedEventServiceInjector:
         mock_db_context.__aenter__.return_value = mock_db_session
         mock_db_context.__aexit__.return_value = None
 
-        # Mock storage.Client and bucket
+        # Mock shared storage client and bucket
         mock_storage_client = MagicMock()
         mock_bucket = MagicMock()
         mock_storage_client.bucket.return_value = mock_bucket
 
         with (
             patch(
-                'server.sharing.google_cloud_shared_event_service.storage.Client',
+                'server.sharing.google_cloud_shared_event_service._get_shared_storage_client',
                 return_value=mock_storage_client,
             ),
             patch(
@@ -526,14 +526,14 @@ class TestGoogleCloudSharedEventServiceInjector:
         mock_db_context.__aenter__.return_value = mock_db_session
         mock_db_context.__aexit__.return_value = None
 
-        # Mock storage.Client and bucket
+        # Mock shared storage client and bucket
         mock_storage_client = MagicMock()
         mock_bucket = MagicMock()
         mock_storage_client.bucket.return_value = mock_bucket
 
         with (
             patch(
-                'server.sharing.google_cloud_shared_event_service.storage.Client',
+                'server.sharing.google_cloud_shared_event_service._get_shared_storage_client',
                 return_value=mock_storage_client,
             ),
             patch(
@@ -569,13 +569,13 @@ class TestGoogleCloudSharedEventServiceInjector:
         mock_db_context.__aenter__.return_value = mock_db_session
         mock_db_context.__aexit__.return_value = None
 
-        # Mock storage.Client and bucket
+        # Mock shared storage client and bucket
         mock_storage_client = MagicMock()
         mock_bucket = MagicMock()
         mock_storage_client.bucket.return_value = mock_bucket
 
         with patch(
-            'server.sharing.google_cloud_shared_event_service.storage.Client',
+            'server.sharing.google_cloud_shared_event_service._get_shared_storage_client',
             return_value=mock_storage_client,
         ):
             with patch(

--- a/openhands/app_server/event/google_cloud_event_service.py
+++ b/openhands/app_server/event/google_cloud_event_service.py
@@ -3,6 +3,7 @@
 import json
 import logging
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import AsyncGenerator, Iterator
 
@@ -20,6 +21,17 @@ from openhands.app_server.services.injector import InjectorState
 from openhands.sdk import Event
 
 _logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)
+def _get_shared_storage_client() -> Client:
+    """Return a process-wide shared GCS client.
+
+    google.cloud.storage.Client is thread-safe and manages its own urllib3
+    connection pool.  Creating one per request leads to pool exhaustion under
+    load ("Connection pool is full, discarding connection").
+    """
+    return storage.Client()
 
 
 @dataclass
@@ -78,8 +90,7 @@ class GoogleCloudEventServiceInjector(EventServiceInjector):
             user_id = await user_context.get_user_id()
 
             bucket_name = self.bucket_name
-            storage_client: Client = storage.Client()
-            bucket: Bucket = storage_client.bucket(bucket_name)
+            bucket: Bucket = _get_shared_storage_client().bucket(bucket_name)
 
             yield GoogleCloudEventService(
                 prefix=self.prefix,


### PR DESCRIPTION
## Summary

Fixes #14268

The `GoogleCloudEventServiceInjector.inject()` and `GoogleCloudSharedEventServiceInjector.inject()` methods were creating a **new `google.cloud.storage.Client()`** on every HTTP request. Each client initializes its own urllib3 connection pool to `storage.googleapis.com`. Under production load, this causes pool exhaustion:

```
Connection pool is full, discarding connection: storage.googleapis.com. Connection pool size: 10
```

This was observed 100+ times across all 7 openhands pods during the 2026-05-01 production incident, contributing to cascading failures.

## Changes

- Add a process-wide shared GCS client via `@lru_cache(maxsize=1)` in `google_cloud_event_service.py`
- Replace per-request `storage.Client()` calls in both `GoogleCloudEventServiceInjector.inject()` and `GoogleCloudSharedEventServiceInjector.inject()` with the shared client
- Remove unused `storage` and `Client` imports from `google_cloud_shared_event_service.py`

The `google.cloud.storage.Client` is thread-safe and designed to be reused. This matches the pattern already used by `GoogleCloudFileStore` in `openhands/app_server/file_store/google_cloud.py`, which correctly caches its client via a lazy `_storage_client` property.

## Impact

This eliminates the "Connection pool is full" warnings and reduces per-request overhead (no more TCP handshakes to GCS on every request). Under incident conditions, this prevents GCS pool exhaustion from compounding other failures.

_This PR was created by an AI assistant (OpenHands) on behalf of @neubig._