### PR TITLE
fix: use shared GCS client to prevent connection pool exhaustion

### DIFF
--- a/enterprise/server/sharing/google_cloud_shared_event_service.py
+++ b/enterprise/server/sharing/google_cloud_shared_event_service.py
@@ -17,9 +17,7 @@ from typing import AsyncGenerator
 from uuid import UUID
 
 from fastapi import Request
-from google.cloud import storage
 from google.cloud.storage.bucket import Bucket
-from google.cloud.storage.client import Client
 from pydantic import Field
 from server.sharing.shared_conversation_info_service import (
     SharedConversationInfoService,
@@ -38,6 +36,7 @@ from openhands.app_server.event.google_cloud_event_service import (
     GoogleCloudEventService,
 )
 from openhands.app_server.event_callback.event_callback_models import EventKind
+from openhands.app_server.file_store.gcs_client import get_gcs_client
 from openhands.app_server.services.injector import InjectorState
 from openhands.sdk import Event
 
@@ -147,9 +146,8 @@ class GoogleCloudSharedEventServiceInjector(SharedEventServiceInjector):
                 db_session=db_session
             )
 
-            bucket_name = self.bucket_name
-            storage_client: Client = storage.Client()
-            bucket: Bucket = storage_client.bucket(bucket_name)
+            # Use shared client to avoid connection pool exhaustion
+            bucket: Bucket = get_gcs_client().bucket(self.bucket_name)
 
             service = GoogleCloudSharedEventService(
                 shared_conversation_info_service=shared_conversation_info_service,

--- a/enterprise/tests/unit/test_sharing/test_sharing_shared_event_service.py
+++ b/enterprise/tests/unit/test_sharing/test_sharing_shared_event_service.py
@@ -17,7 +17,16 @@ from server.sharing.shared_conversation_models import SharedConversation
 
 from openhands.agent_server.models import EventPage, EventSortOrder
 from openhands.app_server.event.event_service import EventService
+from openhands.app_server.file_store import gcs_client
 from openhands.sdk.llm import MetricsSnapshot, TokenUsage
+
+
+@pytest.fixture(autouse=True)
+def reset_gcs_client():
+    """Reset the shared GCS client singleton before each test."""
+    gcs_client._client = None
+    yield
+    gcs_client._client = None
 
 
 @pytest.fixture
@@ -457,7 +466,7 @@ class TestGoogleCloudSharedEventServiceInjector:
 
         with (
             patch(
-                'server.sharing.google_cloud_shared_event_service.storage.Client',
+                'openhands.app_server.file_store.gcs_client.storage.Client',
                 return_value=mock_storage_client,
             ),
             patch(
@@ -496,7 +505,7 @@ class TestGoogleCloudSharedEventServiceInjector:
 
         with (
             patch(
-                'server.sharing.google_cloud_shared_event_service.storage.Client',
+                'openhands.app_server.file_store.gcs_client.storage.Client',
                 return_value=mock_storage_client,
             ),
             patch(
@@ -533,7 +542,7 @@ class TestGoogleCloudSharedEventServiceInjector:
 
         with (
             patch(
-                'server.sharing.google_cloud_shared_event_service.storage.Client',
+                'openhands.app_server.file_store.gcs_client.storage.Client',
                 return_value=mock_storage_client,
             ),
             patch(
@@ -575,7 +584,7 @@ class TestGoogleCloudSharedEventServiceInjector:
         mock_storage_client.bucket.return_value = mock_bucket
 
         with patch(
-            'server.sharing.google_cloud_shared_event_service.storage.Client',
+            'openhands.app_server.file_store.gcs_client.storage.Client',
             return_value=mock_storage_client,
         ):
             with patch(

--- a/openhands/app_server/event/google_cloud_event_service.py
+++ b/openhands/app_server/event/google_cloud_event_service.py
@@ -8,14 +8,13 @@ from typing import AsyncGenerator, Iterator
 
 from fastapi import Request
 from google.api_core.exceptions import NotFound
-from google.cloud import storage
 from google.cloud.storage.blob import Blob
 from google.cloud.storage.bucket import Bucket
-from google.cloud.storage.client import Client
 
 from openhands.app_server.config import get_app_conversation_info_service
 from openhands.app_server.event.event_service import EventService, EventServiceInjector
 from openhands.app_server.event.event_service_base import EventServiceBase
+from openhands.app_server.file_store.gcs_client import get_gcs_client
 from openhands.app_server.services.injector import InjectorState
 from openhands.sdk import Event
 
@@ -77,9 +76,8 @@ class GoogleCloudEventServiceInjector(EventServiceInjector):
         ):
             user_id = await user_context.get_user_id()
 
-            bucket_name = self.bucket_name
-            storage_client: Client = storage.Client()
-            bucket: Bucket = storage_client.bucket(bucket_name)
+            # Use shared client to avoid connection pool exhaustion
+            bucket: Bucket = get_gcs_client().bucket(self.bucket_name)
 
             yield GoogleCloudEventService(
                 prefix=self.prefix,

--- a/openhands/app_server/file_store/gcs_client.py
+++ b/openhands/app_server/file_store/gcs_client.py
@@ -1,0 +1,53 @@
+"""Shared Google Cloud Storage client.
+
+This module provides a singleton GCS client to avoid connection pool exhaustion.
+The default urllib3 pool size (10 connections) is easily exceeded under load when
+each request creates its own storage.Client(). By sharing a single client instance,
+we reuse the underlying HTTP connection pool across all requests.
+"""
+
+import threading
+from functools import lru_cache
+
+from google.cloud import storage
+from google.cloud.storage.client import Client
+
+_client_lock = threading.Lock()
+_client: Client | None = None
+
+
+def get_gcs_client() -> Client:
+    """Get the shared GCS client instance.
+
+    The client is created lazily on first access and reused for all subsequent
+    calls. This is thread-safe and the GCS client itself is designed to be
+    shared across threads.
+
+    Returns:
+        A shared google.cloud.storage.Client instance.
+    """
+    global _client
+    if _client is not None:
+        return _client
+
+    with _client_lock:
+        # Double-check after acquiring lock
+        if _client is None:
+            _client = storage.Client()
+        return _client
+
+
+@lru_cache(maxsize=128)
+def get_bucket(bucket_name: str):
+    """Get a bucket reference from the shared client.
+
+    Bucket references are cached since they're lightweight objects that just
+    hold the bucket name and client reference.
+
+    Args:
+        bucket_name: Name of the GCS bucket.
+
+    Returns:
+        A google.cloud.storage.Bucket instance.
+    """
+    return get_gcs_client().bucket(bucket_name)

--- a/openhands/app_server/file_store/google_cloud.py
+++ b/openhands/app_server/file_store/google_cloud.py
@@ -1,13 +1,13 @@
 import os
 
 from google.api_core.exceptions import NotFound
-from google.cloud import storage
 from google.cloud.storage.blob import Blob
 from google.cloud.storage.bucket import Bucket
 from google.cloud.storage.client import Client
 from pydantic import Field, PrivateAttr
 
 from openhands.app_server.file_store.files import FileStore
+from openhands.app_server.file_store.gcs_client import get_gcs_client
 
 
 class GoogleCloudFileStore(FileStore):
@@ -16,12 +16,11 @@ class GoogleCloudFileStore(FileStore):
     If GOOGLE_APPLICATION_CREDENTIALS is defined in the environment it will be used
     for authentication. Otherwise access will be anonymous.
 
-    The storage client and bucket are initialized lazily on first access.
+    Uses a shared GCS client to avoid connection pool exhaustion under load.
     """
 
     bucket_name: str = Field(default='')
 
-    _storage_client: Client | None = PrivateAttr(default=None)
     _bucket: Bucket | None = PrivateAttr(default=None)
 
     def _get_bucket_name(self) -> str:
@@ -32,10 +31,8 @@ class GoogleCloudFileStore(FileStore):
 
     @property
     def storage_client(self) -> Client:
-        """Get the storage client, initializing lazily on first access."""
-        if self._storage_client is None:
-            self._storage_client = storage.Client()
-        return self._storage_client
+        """Get the shared storage client."""
+        return get_gcs_client()
 
     @property
     def bucket(self) -> Bucket:

--- a/tests/unit/app_server/file_store/test_file_store.py
+++ b/tests/unit/app_server/file_store/test_file_store.py
@@ -325,11 +325,15 @@ class TestInMemoryFileStore(TestCase, _StorageTest):
 
 
 @patch(
-    'openhands.app_server.file_store.google_cloud.storage.Client',
+    'openhands.app_server.file_store.gcs_client.storage.Client',
     _MockGoogleCloudClient,
 )
 class TestGoogleCloudFileStore(TestCase, _StorageTest):
     def setUp(self):
+        # Reset the singleton client before each test
+        import openhands.app_server.file_store.gcs_client as gcs_client
+
+        gcs_client._client = None
         self.store = GoogleCloudFileStore(bucket_name='dear-liza')
 
 


### PR DESCRIPTION
Under high load, creating a new storage.Client() per request exhausts the default urllib3 connection pool (10 connections), resulting in:
  'Connection pool is full, discarding connection: storage.googleapis.com'

This change introduces a shared singleton GCS client that is reused across all requests, properly utilizing the connection pool.

Changes:
- Add gcs_client.py module with thread-safe singleton client factory
- Update GoogleCloudFileStore to use shared client
- Update GoogleCloudEventServiceInjector to use shared client
- Update GoogleCloudSharedEventServiceInjector to use shared client
- Update tests to reset singleton between test runs

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-4ba8884   docker.openhands.dev/openhands/openhands:4ba8884
```