### PR TITLE
Fix SaaS routes shadowed by frontend mount

### DIFF
--- a/enterprise/saas_server.py
+++ b/enterprise/saas_server.py
@@ -8,6 +8,10 @@ load_dotenv()
 if not os.getenv('OPENHANDS_CONFIG_CLS'):
     os.environ['OPENHANDS_CONFIG_CLS'] = 'server.config.SaaSServerConfig'
 
+# SaaS registers enterprise routes below, then mounts the frontend last. Avoid
+# the base app's import-time SPA mount from shadowing those routes.
+os.environ['SERVE_FRONTEND'] = 'false'
+
 from fastapi import Request, status  # noqa: E402
 from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 from fastapi.responses import JSONResponse  # noqa: E402

--- a/enterprise/tests/unit/test_saas_server.py
+++ b/enterprise/tests/unit/test_saas_server.py
@@ -1,0 +1,61 @@
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_oauth_callback_route_precedes_spa_mount(tmp_path):
+    frontend_build = tmp_path / 'frontend' / 'build'
+    frontend_build.mkdir(parents=True)
+    (frontend_build / 'index.html').write_text('<html></html>')
+
+    repo_root = Path(__file__).resolve().parents[3]
+    env = os.environ.copy()
+    env['FRONTEND_DIRECTORY'] = str(frontend_build)
+    env['PYTHONPATH'] = (
+        f"{repo_root / 'enterprise'}:{repo_root}:{env.get('PYTHONPATH', '')}"
+    )
+    env['OPENHANDS_SUPPRESS_BANNER'] = '1'
+    env['POSTHOG_CLIENT_KEY'] = 'test-posthog-key'
+    env['SERVE_FRONTEND'] = 'true'
+
+    script = textwrap.dedent(
+        """
+        from starlette.routing import Match
+
+        import saas_server
+
+        scope = {
+            'type': 'http',
+            'path': '/oauth/keycloak/callback',
+            'root_path': '',
+            'method': 'GET',
+            'scheme': 'http',
+            'server': ('testserver', 80),
+            'client': ('testclient', 50000),
+            'headers': [],
+            'query_string': b'',
+        }
+
+        for route in saas_server.app.router.routes:
+            match, _ = route.matches(scope)
+            if match != Match.NONE:
+                print(getattr(route, 'name', None))
+                break
+        else:
+            raise SystemExit('no route matched')
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, '-c', script],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    matched_route = result.stdout.strip().splitlines()[-1]
+
+    assert matched_route == 'keycloak_callback'


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Feature SaaS deployments can load the base OpenHands app with a built frontend present before enterprise routers are registered. The base app can mount the SPA at `/` first, which makes `/oauth/keycloak/callback` hit the frontend shell instead of the SaaS OAuth handler.

## Summary

- Disable the base app import-time frontend mount from the SaaS entrypoint.
- Keep the SaaS frontend mount at the end, after enterprise routes are registered.
- Add a regression test that imports the SaaS server with a frontend build present and verifies the OAuth callback route wins over the SPA mount.

## Issue Number

N/A

## How to Test

- `cd enterprise && PYTHONPATH=".:$PYTHONPATH" poetry run pytest tests/unit/test_saas_server.py --confcutdir=tests/unit -q`
- `cd enterprise && poetry run pre-commit run --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml --files saas_server.py tests/unit/test_saas_server.py`

## Video/Screenshots

N/A

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

I will verify the callback route again on a staging feature deployment after the enterprise image is available.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-95d7153   docker.openhands.dev/openhands/openhands:95d7153
```