### PR TITLE
refactor(acp): use SDK provider registry in app UI

### DIFF
--- a/frontend/__tests__/routes/agent-settings.test.tsx
+++ b/frontend/__tests__/routes/agent-settings.test.tsx
@@ -208,6 +208,55 @@ describe("AgentSettingsScreen — minimal generic ACP UX", () => {
     });
   });
 
+  it("saves as custom when acp_server is built-in but command differs from default", async () => {
+    // If the persisted command doesn't match the provider default, the UI must
+    // treat it as "custom" and save it that way — even if acp_server says
+    // "claude-code". This prevents silent round-trip corruption where the UI
+    // shows a built-in preset but saving overwrites the custom command with [].
+    vi.spyOn(OptionService, "getConfig").mockResolvedValue(baseConfig);
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue({
+      ...MOCK_DEFAULT_USER_SETTINGS,
+      agent_settings: {
+        agent_kind: "acp",
+        acp_server: "claude-code",
+        acp_command: ["npx", "-y", "@custom/my-agent"],
+        acp_args: [],
+        acp_env: {},
+        acp_model: null,
+      },
+    });
+    const saveSpy = vi
+      .spyOn(SettingsService, "saveSettings")
+      .mockResolvedValue(true);
+
+    renderAgentSettings();
+
+    await waitFor(() => {
+      expect(
+        (screen.getByTestId("agent-command-input") as HTMLTextAreaElement)
+          .value,
+      ).toBe("npx -y @custom/my-agent");
+    });
+
+    // Touch the model field to dirty the form (so save is enabled).
+    await userEvent.type(screen.getByTestId("agent-model-input"), "x");
+    await userEvent.clear(screen.getByTestId("agent-model-input"));
+    await userEvent.click(screen.getByTestId("agent-save-button"));
+
+    await waitFor(() => {
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // Since the command doesn't match the claude-code default, it must save as
+    // custom with the full command — NOT as acp_server="claude-code" + acp_command=[].
+    expect(saveSpy.mock.calls[0][0]).toMatchObject({
+      agent_settings_diff: {
+        acp_server: "custom",
+        acp_command: ["npx", "-y", "@custom/my-agent"],
+      },
+    });
+  });
+
   it("keeps a useful command placeholder if no provider metadata is available", async () => {
     vi.spyOn(OptionService, "getConfig").mockResolvedValue({
       ...baseConfig,

--- a/frontend/__tests__/routes/agent-settings.test.tsx
+++ b/frontend/__tests__/routes/agent-settings.test.tsx
@@ -7,6 +7,7 @@ import userEvent from "@testing-library/user-event";
 import AgentSettingsScreen from "#/routes/agent-settings";
 import SettingsService from "#/api/settings-service/settings-service.api";
 import OptionService from "#/api/option-service/option-service.api";
+import type { ACPProviderConfig } from "#/api/option-service/option.types";
 import { MOCK_DEFAULT_USER_SETTINGS } from "#/mocks/handlers";
 import { useSelectedOrganizationStore } from "#/stores/selected-organization-store";
 
@@ -32,6 +33,27 @@ const renderAgentSettings = () =>
     },
   );
 
+// Mirrors the SDK registry-backed web-client config. Frontend tests cannot
+// import the Python SDK source directly, but keeping this as a typed fixture
+// catches frontend drift in the API shape.
+const ACP_PROVIDERS_FIXTURE: ACPProviderConfig[] = [
+  {
+    key: "claude-code",
+    display_name: "Claude Code",
+    default_command: ["npx", "-y", "@agentclientprotocol/claude-agent-acp"],
+  },
+  {
+    key: "codex",
+    display_name: "Codex",
+    default_command: ["npx", "-y", "@zed-industries/codex-acp"],
+  },
+  {
+    key: "gemini-cli",
+    display_name: "Gemini CLI",
+    default_command: ["npx", "-y", "@google/gemini-cli", "--acp"],
+  },
+];
+
 const baseConfig = {
   app_mode: "oss" as const,
   posthog_client_key: null,
@@ -55,6 +77,7 @@ const baseConfig = {
   error_message: null,
   updated_at: "2026-01-01T00:00:00Z",
   github_app_slug: null,
+  acp_providers: ACP_PROVIDERS_FIXTURE,
 };
 
 describe("AgentSettingsScreen — minimal generic ACP UX", () => {
@@ -133,5 +156,80 @@ describe("AgentSettingsScreen — minimal generic ACP UX", () => {
         acp_model: null,
       },
     });
+  });
+
+  it("saves built-in presets via acp_server and lets the SDK resolve defaults", async () => {
+    vi.spyOn(OptionService, "getConfig").mockResolvedValue(baseConfig);
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue({
+      ...MOCK_DEFAULT_USER_SETTINGS,
+      agent_settings: {
+        agent_kind: "acp",
+        acp_server: "custom",
+        acp_command: ["npx", "-y", "@agentclientprotocol/claude-agent-acp"],
+        acp_args: [],
+        acp_env: {},
+        acp_model: null,
+      },
+    });
+    const saveSpy = vi
+      .spyOn(SettingsService, "saveSettings")
+      .mockResolvedValue(true);
+
+    renderAgentSettings();
+
+    await waitFor(() => {
+      expect(
+        (screen.getByTestId("agent-command-input") as HTMLTextAreaElement)
+          .value,
+      ).toBe("npx -y @agentclientprotocol/claude-agent-acp");
+    });
+
+    const commandInput = screen.getByTestId("agent-command-input");
+    await userEvent.clear(commandInput);
+    await userEvent.type(
+      commandInput,
+      "npx   -y{enter}@agentclientprotocol/claude-agent-acp",
+    );
+    await userEvent.type(screen.getByTestId("agent-model-input"), "opus");
+    await userEvent.click(screen.getByTestId("agent-save-button"));
+
+    await waitFor(() => {
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+    });
+
+    expect(saveSpy.mock.calls[0][0]).toMatchObject({
+      agent_settings_diff: {
+        agent_kind: "acp",
+        acp_server: "claude-code",
+        acp_command: [],
+        acp_args: [],
+        acp_model: "opus",
+      },
+    });
+  });
+
+  it("keeps a useful command placeholder if no provider metadata is available", async () => {
+    vi.spyOn(OptionService, "getConfig").mockResolvedValue({
+      ...baseConfig,
+      acp_providers: [],
+    });
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue({
+      ...MOCK_DEFAULT_USER_SETTINGS,
+      agent_settings: {
+        agent_kind: "acp",
+        acp_server: "custom",
+        acp_command: [],
+        acp_args: [],
+        acp_env: {},
+        acp_model: null,
+      },
+    });
+
+    renderAgentSettings();
+
+    expect(await screen.findByTestId("agent-command-input")).toHaveAttribute(
+      "placeholder",
+      "npx -y <package-name>",
+    );
   });
 });

--- a/frontend/src/api/option-service/option.types.ts
+++ b/frontend/src/api/option-service/option.types.ts
@@ -33,6 +33,12 @@ export interface WebClientFeatureFlags {
   enable_onboarding: boolean;
 }
 
+export interface ACPProviderConfig {
+  key: string;
+  display_name: string;
+  default_command: string[];
+}
+
 export interface WebClientConfig {
   app_mode: "saas" | "oss";
   posthog_client_key: string | null;
@@ -48,4 +54,5 @@ export interface WebClientConfig {
   gitlab_enabled?: boolean;
   provider_default_hosts?: Partial<Record<Provider, string>>;
   slack_enabled?: boolean;
+  acp_providers?: ACPProviderConfig[];
 }

--- a/frontend/src/hooks/use-settings-nav-items.ts
+++ b/frontend/src/hooks/use-settings-nav-items.ts
@@ -33,12 +33,6 @@ const ACP_DISABLED_PATHS = new Set<string>([
   "/settings/mcp",
 ]);
 
-const ACP_SERVER_NAMES: Record<string, string> = {
-  "claude-code": "Claude Code",
-  codex: "Codex",
-  "gemini-cli": "Gemini CLI",
-};
-
 // Section header text mapping
 const SECTION_HEADERS: Partial<Record<SettingsNavSection, I18nKey>> = {
   org: I18nKey.SETTINGS$ORG_SETTINGS_HEADER,
@@ -71,9 +65,9 @@ export function useSettingsNavItems(): SettingsNavRenderedItem[] {
   const isAcpEnabled = !!featureFlags?.enable_acp;
   const isAcpAgent = settings?.agent_settings?.agent_kind === "acp";
   const acpServerName = isAcpAgent
-    ? (ACP_SERVER_NAMES[
-        (settings?.agent_settings?.acp_server as string) ?? ""
-      ] ?? "ACP Agent")
+    ? (config?.acp_providers?.find(
+        ({ key }) => key === settings?.agent_settings?.acp_server,
+      )?.display_name ?? "ACP Agent")
     : null;
 
   let items = isSaasMode ? [...SAAS_NAV_ITEMS] : [...OSS_NAV_ITEMS];

--- a/frontend/src/routes/agent-settings.tsx
+++ b/frontend/src/routes/agent-settings.tsx
@@ -15,30 +15,45 @@ import {
   displaySuccessToast,
 } from "#/utils/custom-toast-handlers";
 import { retrieveAxiosErrorMessage } from "#/utils/retrieve-axios-error-message";
+import type { ACPProviderConfig } from "#/api/option-service/option.types";
 
 export const handle = { hideTitle: true };
 
 type AgentType = "openhands" | "acp";
-type CommandPreset = "claude-code" | "codex" | "gemini-cli" | "custom";
-
-const PRESET_COMMANDS: Record<Exclude<CommandPreset, "custom">, string> = {
-  "claude-code": "npx -y @agentclientprotocol/claude-agent-acp",
-  codex: "npx -y @zed-industries/codex-acp",
-  "gemini-cli": "npx -y @google/gemini-cli --acp",
-};
-
-const COMMAND_PLACEHOLDER = PRESET_COMMANDS["claude-code"];
+const CUSTOM_PRESET = "custom";
+const EMPTY_ACP_PROVIDERS: ACPProviderConfig[] = [];
+const COMMAND_PLACEHOLDER_FALLBACK = "npx -y <package-name>";
 
 function tokenizeCommand(value: string): string[] {
   return value.split(/\s+/).filter(Boolean);
 }
 
-function detectPreset(text: string): CommandPreset {
-  const trimmed = text.trim();
-  for (const [key, cmd] of Object.entries(PRESET_COMMANDS)) {
-    if (trimmed === cmd) return key as CommandPreset;
+function formatCommand(command: string[]): string {
+  return command.join(" ");
+}
+
+function normalizeCommand(command: string): string {
+  return command.trim().split(/\s+/).filter(Boolean).join(" ");
+}
+
+function detectPreset(
+  acpServer: string | null | undefined,
+  commandText: string,
+  providers: ACPProviderConfig[],
+): string {
+  if (acpServer) {
+    const provider = providers.find(({ key }) => key === acpServer);
+    if (provider) return provider.key;
   }
-  return "custom";
+  const normalized = normalizeCommand(commandText);
+  for (const provider of providers) {
+    if (
+      normalized === normalizeCommand(formatCommand(provider.default_command))
+    ) {
+      return provider.key;
+    }
+  }
+  return CUSTOM_PRESET;
 }
 
 function AgentSettingsScreen() {
@@ -47,11 +62,11 @@ function AgentSettingsScreen() {
   const { data: settings, isLoading } = useSettings();
   const { data: config, isLoading: isConfigLoading } = useConfig();
   const { mutate: saveSettings, isPending: isSaving } = useSaveSettings();
+  const acpProviders = config?.acp_providers ?? EMPTY_ACP_PROVIDERS;
 
   const [agentType, setAgentType] = useState<AgentType>("openhands");
   const [commandText, setCommandText] = useState("");
-  const [selectedPreset, setSelectedPreset] =
-    useState<CommandPreset>("claude-code");
+  const [selectedPreset, setSelectedPreset] = useState(CUSTOM_PRESET);
   const [acpModel, setAcpModel] = useState("");
   const [isDirty, setIsDirty] = useState(false);
 
@@ -72,8 +87,16 @@ function AgentSettingsScreen() {
           : []),
       ];
       const joined = tokens.join(" ");
-      setCommandText(joined);
-      setSelectedPreset(detectPreset(joined));
+      const rawAcpServer = settings.agent_settings?.acp_server;
+      const acpServer =
+        typeof rawAcpServer === "string" ? rawAcpServer : undefined;
+      const provider = acpProviders.find(({ key }) => key === acpServer);
+      const effectiveCommand =
+        joined || formatCommand(provider?.default_command ?? []);
+      setCommandText(effectiveCommand);
+      setSelectedPreset(
+        detectPreset(acpServer, effectiveCommand, acpProviders),
+      );
 
       const savedModel = settings.agent_settings?.acp_model;
       setAcpModel(typeof savedModel === "string" ? savedModel : "");
@@ -83,7 +106,7 @@ function AgentSettingsScreen() {
       setAcpModel("");
     }
     setIsDirty(false);
-  }, [settings]);
+  }, [settings, acpProviders]);
 
   const isAcpEnabled = !!config?.feature_flags?.enable_acp;
 
@@ -98,14 +121,28 @@ function AgentSettingsScreen() {
   const isAcp = agentType === "acp";
   const commandTokens = tokenizeCommand(commandText);
   const isAcpInvalid = isAcp && commandTokens.length === 0;
+  const selectedProvider = acpProviders.find(
+    ({ key }) => key === selectedPreset,
+  );
+  const isDefaultProviderCommand =
+    !!selectedProvider &&
+    normalizeCommand(commandText) ===
+      normalizeCommand(formatCommand(selectedProvider.default_command));
+  const commandPlaceholder =
+    formatCommand(acpProviders[0]?.default_command ?? []) ||
+    COMMAND_PLACEHOLDER_FALLBACK;
 
   const handleSave = () => {
     let agentSettingsDiff: Record<string, unknown>;
     if (isAcp) {
       agentSettingsDiff = {
         agent_kind: "acp",
-        acp_server: "custom",
-        acp_command: commandTokens,
+        acp_server:
+          selectedProvider && isDefaultProviderCommand
+            ? selectedProvider.key
+            : CUSTOM_PRESET,
+        acp_command:
+          selectedProvider && isDefaultProviderCommand ? [] : commandTokens,
         acp_args: [],
         acp_model: acpModel.trim() || null,
       };
@@ -171,21 +208,23 @@ function AgentSettingsScreen() {
             name="agent-preset"
             label={t(I18nKey.SETTINGS$AGENT_PRESET)}
             items={[
-              { key: "claude-code", label: "Claude Code" },
-              { key: "codex", label: "Codex" },
-              { key: "gemini-cli", label: "Gemini CLI" },
+              ...acpProviders.map((provider) => ({
+                key: provider.key,
+                label: provider.display_name,
+              })),
               {
-                key: "custom",
+                key: CUSTOM_PRESET,
                 label: t(I18nKey.SETTINGS$AGENT_PRESET_CUSTOM),
               },
             ]}
             selectedKey={selectedPreset}
             onSelectionChange={(key) => {
               if (!key) return;
-              const preset = key as CommandPreset;
+              const preset = String(key);
               setSelectedPreset(preset);
-              if (preset !== "custom") {
-                setCommandText(PRESET_COMMANDS[preset]);
+              const provider = acpProviders.find(({ key: k }) => k === preset);
+              if (provider) {
+                setCommandText(formatCommand(provider.default_command));
               }
               setIsDirty(true);
             }}
@@ -199,11 +238,11 @@ function AgentSettingsScreen() {
               data-testid="agent-command-input"
               className="bg-tertiary border border-[#717888] rounded-sm p-2 text-sm font-mono text-white placeholder:italic placeholder:text-[#717888] min-h-[60px] resize-y focus:outline-none focus:border-white"
               value={commandText}
-              placeholder={COMMAND_PLACEHOLDER}
+              placeholder={commandPlaceholder}
               onChange={(e) => {
                 const text = e.target.value;
                 setCommandText(text);
-                setSelectedPreset(detectPreset(text));
+                setSelectedPreset(detectPreset(undefined, text, acpProviders));
                 setIsDirty(true);
               }}
             />

--- a/frontend/src/routes/agent-settings.tsx
+++ b/frontend/src/routes/agent-settings.tsx
@@ -37,14 +37,9 @@ function normalizeCommand(command: string): string {
 }
 
 function detectPreset(
-  acpServer: string | null | undefined,
   commandText: string,
   providers: ACPProviderConfig[],
 ): string {
-  if (acpServer) {
-    const provider = providers.find(({ key }) => key === acpServer);
-    if (provider) return provider.key;
-  }
   const normalized = normalizeCommand(commandText);
   for (const provider of providers) {
     if (
@@ -94,9 +89,7 @@ function AgentSettingsScreen() {
       const effectiveCommand =
         joined || formatCommand(provider?.default_command ?? []);
       setCommandText(effectiveCommand);
-      setSelectedPreset(
-        detectPreset(acpServer, effectiveCommand, acpProviders),
-      );
+      setSelectedPreset(detectPreset(effectiveCommand, acpProviders));
 
       const savedModel = settings.agent_settings?.acp_model;
       setAcpModel(typeof savedModel === "string" ? savedModel : "");
@@ -242,7 +235,7 @@ function AgentSettingsScreen() {
               onChange={(e) => {
                 const text = e.target.value;
                 setCommandText(text);
-                setSelectedPreset(detectPreset(undefined, text, acpProviders));
+                setSelectedPreset(detectPreset(text, acpProviders));
                 setIsDirty(true);
               }}
             />

--- a/openhands/app_server/app_conversation/agent_server_routing.py
+++ b/openhands/app_server/app_conversation/agent_server_routing.py
@@ -16,7 +16,7 @@ def acp_display_name(acp_command: Sequence[str] | None) -> str:
         return 'ACP'
     command = list(acp_command)
     for provider in ACP_PROVIDERS.values():
-        if command == provider.default_command:
+        if command == list(provider.default_command):
             return provider.display_name
     token = acp_command[-1]
     if not token:

--- a/openhands/app_server/app_conversation/agent_server_routing.py
+++ b/openhands/app_server/app_conversation/agent_server_routing.py
@@ -1,5 +1,7 @@
 from collections.abc import Sequence
 
+from openhands.sdk.settings import ACP_PROVIDERS
+
 
 def agent_kind_to_router_path(agent_kind: str | None) -> str:
     """Map an app conversation agent kind to the agent-server route prefix."""
@@ -12,6 +14,10 @@ def acp_display_name(acp_command: Sequence[str] | None) -> str:
     """Return a display-safe ACP label from the configured command."""
     if not acp_command:
         return 'ACP'
+    command = list(acp_command)
+    for provider in ACP_PROVIDERS.values():
+        if command == provider.default_command:
+            return provider.display_name
     token = acp_command[-1]
     if not token:
         return 'ACP'

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1491,43 +1491,6 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         # prompts, LLM metadata, skills) applied after create_agent().
         return conv_settings.create_request(StartConversationRequest, agent=agent)
 
-    @staticmethod
-    def _acp_provider_env(user: UserInfo) -> dict[str, str]:
-        """Translate UI-saved LLM credentials into provider-native env vars.
-
-        The ACP subprocess reads provider credentials from environment variables.
-        Maps the user's LLM API key to the env var expected by the active ACP
-        server via ``ACPAgentSettings.api_key_env_var``. Custom servers return
-        ``None`` — users manage credentials entirely via ``acp_env``.
-
-        Args:
-            user: User information containing ACP agent settings.
-
-        Returns:
-            Dict of env var name → value to inject into the ACP subprocess.
-        """
-        if not isinstance(user.agent_settings, ACPAgentSettings):
-            return {}
-
-        acp_settings = user.agent_settings
-        env: dict[str, str] = {}
-
-        llm_api_key = acp_settings.llm.api_key
-        if llm_api_key:
-            key_value = (
-                llm_api_key.get_secret_value()
-                if isinstance(llm_api_key, SecretStr)
-                else str(llm_api_key)
-            )
-            if key_value and key_value.strip() and acp_settings.api_key_env_var:
-                env[acp_settings.api_key_env_var] = key_value
-
-        base_url = acp_settings.llm.base_url
-        if base_url and base_url.strip() and acp_settings.base_url_env_var:
-            env[acp_settings.base_url_env_var] = base_url
-
-        return env
-
     async def _build_acp_start_conversation_request(
         self,
         sandbox: SandboxInfo,
@@ -1583,23 +1546,14 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         acp_settings = user.agent_settings  # already verified to be ACPAgentSettings
         assert isinstance(acp_settings, ACPAgentSettings)
 
-        # Merge provider env vars (API keys etc.) into acp_env.
-        # Priority (highest → lowest): acp_env > provider_env
-        provider_env = self._acp_provider_env(user)
-        merged_env: dict[str, str] = {
-            **provider_env,
-            **dict(acp_settings.acp_env or {}),
-        }
-
         # Pass user secrets via AgentContext so the SDK renders a <CUSTOM_SECRETS>
         # block in the ACP prompt and injects values into the subprocess env.
         agent_context = AgentContext(secrets=secrets) if secrets else None
 
-        acp_agent = acp_settings.model_copy(
-            update={'acp_env': merged_env}
-        ).create_agent()
-        if agent_context is not None:
-            acp_agent = acp_agent.model_copy(update={'agent_context': agent_context})
+        settings_update = (
+            {'agent_context': agent_context} if agent_context is not None else {}
+        )
+        acp_agent = acp_settings.model_copy(update=settings_update).create_agent()
 
         sdk_plugins: list[PluginSource] | None = None
         if plugins:

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1591,24 +1591,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             **dict(acp_settings.acp_env or {}),
         }
 
-        # Pass user secrets via AgentContext so the SDK renders a
-        # <CUSTOM_SECRETS> block in the ACP prompt and injects values into
-        # the subprocess env at start time (SDK PR #2984).
-        # TODO: remove the _sdk_supports_acp_secrets guard once OpenHands pins
-        # to an SDK version that includes PR #2984 (secrets acp_compatible=True).
-        _sdk_supports_acp_secrets = (
-            AgentContext.model_fields.get('secrets') is not None
-            and isinstance(AgentContext.model_fields['secrets'].json_schema_extra, dict)
-            and AgentContext.model_fields['secrets'].json_schema_extra.get(
-                'acp_compatible'
-            )
-            is True
-        )
-        agent_context = (
-            AgentContext(secrets=secrets)
-            if secrets and _sdk_supports_acp_secrets
-            else None
-        )
+        # Pass user secrets via AgentContext so the SDK renders a <CUSTOM_SECRETS>
+        # block in the ACP prompt and injects values into the subprocess env.
+        agent_context = AgentContext(secrets=secrets) if secrets else None
 
         acp_agent = acp_settings.model_copy(
             update={'acp_env': merged_env}
@@ -1626,8 +1611,6 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         # Mirror the regular path: populate ConversationSettings and delegate
         # to create_request() so that max_iterations, confirmation_mode, and
         # security_analyzer flow through to ACP conversations too.
-        # create_request() extracts secrets from acp_agent.agent_context.secrets;
-        # fall back to explicit kwarg on older SDKs where agent_context is unset.
         conv_settings = user.conversation_settings.model_copy(
             update={
                 'workspace': workspace,
@@ -1638,9 +1621,8 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 'plugins': sdk_plugins,
             }
         )
-        secrets_kwarg = {} if _sdk_supports_acp_secrets else {'secrets': secrets}
         return conv_settings.create_request(
-            StartACPConversationRequest, agent=acp_agent, **secrets_kwarg
+            StartACPConversationRequest, agent=acp_agent
         )
 
     async def _process_pending_messages(

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -26,6 +26,9 @@ from openhands.agent_server.models import (
 from openhands.app_server.app_conversation.agent_server_routing import (
     acp_display_name as _acp_display_name,
 )
+from openhands.app_server.app_conversation.agent_server_routing import (
+    agent_kind_to_router_path,
+)
 from openhands.app_server.app_conversation.app_conversation_info_service import (
     AppConversationInfoService,
 )
@@ -101,7 +104,6 @@ from openhands.app_server.utils.llm_metadata import (
     should_set_litellm_extra_body,
 )
 from openhands.sdk import Agent, AgentContext, LocalWorkspace
-from openhands.sdk.agent.acp_agent import ACPAgent
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.llm import LLM
 from openhands.sdk.plugin import PluginSource
@@ -120,13 +122,6 @@ from openhands.tools.preset.planning import (
 _conversation_info_type_adapter = TypeAdapter(list[ConversationInfo | None])
 _acp_conversation_info_type_adapter = TypeAdapter(list[ACPConversationInfo | None])
 _logger = logging.getLogger(__name__)
-
-
-def _agent_kind_to_router_path(agent_kind: str) -> str:
-    """Map agent_kind discriminator to the agent-server router path prefix."""
-    if agent_kind == 'acp':
-        return 'acp/conversations'
-    return 'conversations'
 
 
 def _split_ids_by_kind(
@@ -369,7 +364,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 else {}
             )
             is_acp = isinstance(start_conversation_request, StartACPConversationRequest)
-            router_path = _agent_kind_to_router_path('acp' if is_acp else 'openhands')
+            router_path = agent_kind_to_router_path('acp' if is_acp else 'openhands')
             response = await self.httpx_client.post(
                 f'{agent_server_url}/api/{router_path}',
                 json=body_json,
@@ -607,7 +602,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 None,
             )
             if conversation_url:
-                router_path = _agent_kind_to_router_path(
+                router_path = agent_kind_to_router_path(
                     app_conversation_info.agent_kind
                 )
                 conversation_url += f'/api/{router_path}/{app_conversation_info.id.hex}'
@@ -1518,31 +1513,18 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         env: dict[str, str] = {}
 
         llm_api_key = acp_settings.llm.api_key
-        if not llm_api_key:
-            return env
+        if llm_api_key:
+            key_value = (
+                llm_api_key.get_secret_value()
+                if isinstance(llm_api_key, SecretStr)
+                else str(llm_api_key)
+            )
+            if key_value and key_value.strip() and acp_settings.api_key_env_var:
+                env[acp_settings.api_key_env_var] = key_value
 
-        key_value = (
-            llm_api_key.get_secret_value()
-            if isinstance(llm_api_key, SecretStr)
-            else str(llm_api_key)
-        )
-        if not key_value or not key_value.strip():
-            return env
-
-        # TODO: simplify to `acp_settings.api_key_env_var` once OpenHands is
-        # pinned to an SDK version that includes software-agent-sdk PR #2984.
-        # The fallback per-server mapping below duplicates that SDK property.
-        api_key_env: str | None = getattr(acp_settings, 'api_key_env_var', None)
-        if api_key_env is None:
-            _SERVER_KEY_MAP = {
-                'claude-code': 'ANTHROPIC_API_KEY',
-                'codex': 'OPENAI_API_KEY',
-                'gemini-cli': 'GEMINI_API_KEY',
-            }
-            api_key_env = _SERVER_KEY_MAP.get(acp_settings.acp_server)
-
-        if api_key_env:
-            env[api_key_env] = key_value
+        base_url = acp_settings.llm.base_url
+        if base_url and base_url.strip() and acp_settings.base_url_env_var:
+            env[acp_settings.base_url_env_var] = base_url
 
         return env
 
@@ -1628,15 +1610,11 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             else None
         )
 
-        acp_agent = ACPAgent(
-            acp_command=acp_settings.acp_command,
-            acp_args=acp_settings.acp_args,
-            acp_env=merged_env,
-            acp_model=acp_settings.acp_model,
-            acp_session_mode=acp_settings.acp_session_mode,
-            acp_prompt_timeout=acp_settings.acp_prompt_timeout,
-            agent_context=agent_context,
-        )
+        acp_agent = acp_settings.model_copy(
+            update={'acp_env': merged_env}
+        ).create_agent()
+        if agent_context is not None:
+            acp_agent = acp_agent.model_copy(update={'agent_context': agent_context})
 
         sdk_plugins: list[PluginSource] | None = None
         if plugins:

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1623,15 +1623,24 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 for p in plugins
             ]
 
-        return StartACPConversationRequest(
-            workspace=workspace,
-            conversation_id=conversation_id,
-            initial_message=self._construct_initial_message_with_plugin_params(
-                initial_message, plugins
-            ),
-            secrets=secrets,
-            plugins=sdk_plugins,
-            agent=acp_agent,
+        # Mirror the regular path: populate ConversationSettings and delegate
+        # to create_request() so that max_iterations, confirmation_mode, and
+        # security_analyzer flow through to ACP conversations too.
+        # create_request() extracts secrets from acp_agent.agent_context.secrets;
+        # fall back to explicit kwarg on older SDKs where agent_context is unset.
+        conv_settings = user.conversation_settings.model_copy(
+            update={
+                'workspace': workspace,
+                'conversation_id': conversation_id,
+                'initial_message': self._construct_initial_message_with_plugin_params(
+                    initial_message, plugins
+                ),
+                'plugins': sdk_plugins,
+            }
+        )
+        secrets_kwarg = {} if _sdk_supports_acp_secrets else {'secrets': secrets}
+        return conv_settings.create_request(
+            StartACPConversationRequest, agent=acp_agent, **secrets_kwarg
         )
 
     async def _process_pending_messages(

--- a/openhands/app_server/event_callback/webhook_router.py
+++ b/openhands/app_server/event_callback/webhook_router.py
@@ -228,8 +228,8 @@ async def on_conversation_update(
 
     agent = conversation_info.agent
     is_acp = (
-        getattr(agent, 'supports_openhands_tools', True) is False
-        or getattr(agent, 'kind', None) == 'ACPAgent'
+        getattr(agent, 'kind', None) == 'ACPAgent'
+        or getattr(agent, 'supports_openhands_tools', True) is False
     )
     if is_acp:
         agent_kind = 'acp'

--- a/openhands/app_server/event_callback/webhook_router.py
+++ b/openhands/app_server/event_callback/webhook_router.py
@@ -227,10 +227,7 @@ async def on_conversation_update(
     )
 
     agent = conversation_info.agent
-    is_acp = (
-        getattr(agent, 'kind', None) == 'ACPAgent'
-        or getattr(agent, 'supports_openhands_tools', True) is False
-    )
+    is_acp = getattr(agent, 'kind', None) == 'ACPAgent'
     if is_acp:
         agent_kind = 'acp'
         llm_model = None

--- a/openhands/app_server/event_callback/webhook_router.py
+++ b/openhands/app_server/event_callback/webhook_router.py
@@ -227,7 +227,7 @@ async def on_conversation_update(
     )
 
     agent = conversation_info.agent
-    is_acp = getattr(agent, 'kind', None) == 'ACPAgent'
+    is_acp = getattr(agent, 'conversation_contract', None) == 'acp'
     if is_acp:
         agent_kind = 'acp'
         llm_model = None

--- a/openhands/app_server/event_callback/webhook_router.py
+++ b/openhands/app_server/event_callback/webhook_router.py
@@ -227,7 +227,7 @@ async def on_conversation_update(
     )
 
     agent = conversation_info.agent
-    is_acp = getattr(agent, 'conversation_contract', None) == 'acp'
+    is_acp = getattr(agent, 'agent_kind', None) == 'acp'
     if is_acp:
         agent_kind = 'acp'
         llm_model = None

--- a/openhands/app_server/event_callback/webhook_router.py
+++ b/openhands/app_server/event_callback/webhook_router.py
@@ -51,7 +51,6 @@ from openhands.app_server.user_auth.user_auth import (
     get_for_user as get_user_auth_for_user,
 )
 from openhands.sdk import ConversationExecutionStatus, Event
-from openhands.sdk.agent.acp_agent import ACPAgent
 from openhands.sdk.event import ConversationStateUpdateEvent
 
 router = APIRouter(prefix='/webhooks', tags=['Webhooks'])
@@ -227,14 +226,18 @@ async def on_conversation_update(
         sandbox_id=sandbox_info.id,
     )
 
-    is_acp = isinstance(conversation_info.agent, ACPAgent)
+    agent = conversation_info.agent
+    is_acp = (
+        getattr(agent, 'supports_openhands_tools', True) is False
+        or getattr(agent, 'kind', None) == 'ACPAgent'
+    )
     if is_acp:
         agent_kind = 'acp'
         llm_model = None
-        display_name = acp_display_name(conversation_info.agent.acp_command)
+        display_name = acp_display_name(agent.acp_command)
     else:
         agent_kind = existing.agent_kind or 'openhands'
-        llm_model = conversation_info.agent.llm.model
+        llm_model = agent.llm.model
         display_name = None
 
     app_conversation_info = AppConversationInfo(

--- a/openhands/app_server/web_client/default_web_client_config_injector.py
+++ b/openhands/app_server/web_client/default_web_client_config_injector.py
@@ -9,9 +9,11 @@ from openhands.app_server.web_client.web_client_config_injector import (
     WebClientConfigInjector,
 )
 from openhands.app_server.web_client.web_client_models import (
+    ACPProviderConfig,
     WebClientConfig,
     WebClientFeatureFlags,
 )
+from openhands.sdk.settings import ACP_PROVIDERS
 
 
 def _get_recaptcha_site_key() -> str | None:
@@ -159,6 +161,16 @@ class DefaultWebClientConfigInjector(WebClientConfigInjector):
         }
     )
     slack_enabled: bool = Field(default_factory=_get_slack_enabled)
+    acp_providers: list[ACPProviderConfig] = Field(
+        default_factory=lambda: [
+            ACPProviderConfig(
+                key=provider.key,
+                display_name=provider.display_name,
+                default_command=provider.default_command,
+            )
+            for provider in ACP_PROVIDERS.values()
+        ]
+    )
 
     async def get_web_client_config(self) -> WebClientConfig:
         from openhands.app_server.config import get_global_config
@@ -179,5 +191,6 @@ class DefaultWebClientConfigInjector(WebClientConfigInjector):
             gitlab_enabled=self.gitlab_enabled,
             provider_default_hosts=self.provider_default_hosts,
             slack_enabled=self.slack_enabled,
+            acp_providers=self.acp_providers,
         )
         return result

--- a/openhands/app_server/web_client/web_client_models.py
+++ b/openhands/app_server/web_client/web_client_models.py
@@ -32,6 +32,12 @@ class WebClientFeatureFlags(BaseModel):
         return self
 
 
+class ACPProviderConfig(BaseModel):
+    key: str
+    display_name: str
+    default_command: list[str]
+
+
 class WebClientConfig(DiscriminatedUnionMixin):
     app_mode: AppMode
     posthog_client_key: str | None
@@ -47,3 +53,4 @@ class WebClientConfig(DiscriminatedUnionMixin):
     gitlab_enabled: bool = False
     provider_default_hosts: dict[str, str] = Field(default_factory=dict)
     slack_enabled: bool = False
+    acp_providers: list[ACPProviderConfig] = Field(default_factory=list)

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -43,20 +43,10 @@ from openhands.app_server.settings.settings_models import (
 )
 from openhands.app_server.user.user_context import UserContext
 from openhands.sdk import Agent, Event
-from openhands.sdk.context.agent_context import AgentContext as _AgentContext
 from openhands.sdk.llm import LLM
 from openhands.sdk.secret import LookupSecret, StaticSecret
 from openhands.sdk.settings import AgentSettings, ConversationSettings
 from openhands.sdk.workspace.remote.async_remote_workspace import AsyncRemoteWorkspace
-
-# True only on SDK versions that include PR #2984 (secrets acp_compatible=True).
-# When False, _build_acp_start_conversation_request skips the agent_context path.
-_SDK_SUPPORTS_ACP_SECRETS = (
-    _AgentContext.model_fields.get('secrets') is not None
-    and isinstance(_AgentContext.model_fields['secrets'].json_schema_extra, dict)
-    and _AgentContext.model_fields['secrets'].json_schema_extra.get('acp_compatible')
-    is True
-)
 
 
 def _build_test_user_agent_settings(user: SimpleNamespace) -> AgentSettings:
@@ -3487,14 +3477,10 @@ class TestBuildAcpStartConversationRequestSecrets:
 
         request = await self._call_build(service, user, tmp_path)
 
-        if _SDK_SUPPORTS_ACP_SECRETS:
-            assert request.agent.agent_context is not None
-            ctx = request.agent.agent_context.secrets
-            assert ctx.get('GITHUB_TOKEN') is github_secret
-            assert ctx.get('MY_API_KEY') is api_secret
-        else:
-            # Pinned SDK doesn't support ACP secrets yet; agent_context stays unset.
-            assert request.agent.agent_context is None
+        assert request.agent.agent_context is not None
+        ctx = request.agent.agent_context.secrets
+        assert ctx.get('GITHUB_TOKEN') is github_secret
+        assert ctx.get('MY_API_KEY') is api_secret
 
     @pytest.mark.asyncio
     async def test_lookup_secret_forwarded_as_source(self, service, tmp_path):
@@ -3507,11 +3493,8 @@ class TestBuildAcpStartConversationRequestSecrets:
 
         request = await self._call_build(service, user, tmp_path)
 
-        if _SDK_SUPPORTS_ACP_SECRETS:
-            assert request.agent.agent_context is not None
-            assert request.agent.agent_context.secrets.get('GITHUB_TOKEN') is lookup
-        else:
-            assert request.agent.agent_context is None
+        assert request.agent.agent_context is not None
+        assert request.agent.agent_context.secrets.get('GITHUB_TOKEN') is lookup
 
     @pytest.mark.asyncio
     async def test_explicit_acp_env_preserved(self, service, tmp_path):
@@ -3539,14 +3522,11 @@ class TestBuildAcpStartConversationRequestSecrets:
         request = await self._call_build(service, user, tmp_path)
 
         assert request.agent.acp_env.get('ANTHROPIC_API_KEY') == 'sk-ui-key'
-        if _SDK_SUPPORTS_ACP_SECRETS:
-            assert request.agent.agent_context is not None
-            assert (
-                request.agent.agent_context.secrets.get('ANTHROPIC_API_KEY')
-                is panel_secret
-            )
-        else:
-            assert request.agent.agent_context is None
+        assert request.agent.agent_context is not None
+        assert (
+            request.agent.agent_context.secrets.get('ANTHROPIC_API_KEY')
+            is panel_secret
+        )
 
     @pytest.mark.asyncio
     async def test_no_secrets_no_agent_context(self, service, tmp_path):

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3281,6 +3281,13 @@ class TestAcpProviderEnv:
         env = LiveStatusAppConversationService._acp_provider_env(user)
         assert env == {}
 
+    def test_provider_base_url_env_var_is_synthesized(self, _user_factory):
+        user = _user_factory(
+            acp_server='gemini-cli', base_url='https://gemini-proxy.example.com'
+        )
+        env = LiveStatusAppConversationService._acp_provider_env(user)
+        assert env == {'GEMINI_BASE_URL': 'https://gemini-proxy.example.com'}
+
 
 class TestAgentKindConversationUrl:
     """Regression tests for conversation_url / live-status route dispatch.
@@ -3372,12 +3379,12 @@ class TestAgentKindConversationUrl:
 
     def test_agent_kind_to_router_path_known_kinds(self):
         """``'openhands'`` routes to standard conversations; ``'acp'`` to ACP."""
-        from openhands.app_server.app_conversation.live_status_app_conversation_service import (  # noqa: E501
-            _agent_kind_to_router_path,
+        from openhands.app_server.app_conversation.agent_server_routing import (
+            agent_kind_to_router_path,
         )
 
-        assert _agent_kind_to_router_path('openhands') == 'conversations'
-        assert _agent_kind_to_router_path('acp') == 'acp/conversations'
+        assert agent_kind_to_router_path('openhands') == 'conversations'
+        assert agent_kind_to_router_path('acp') == 'acp/conversations'
 
     def test_agent_kind_to_router_path_unknown_falls_back(self):
         """Any value that is not 'acp' routes to 'conversations'.
@@ -3386,12 +3393,12 @@ class TestAgentKindConversationUrl:
         before the rename, so rows stored with ``agent_kind='llm'`` continue to
         route correctly without a migration.
         """
-        from openhands.app_server.app_conversation.live_status_app_conversation_service import (  # noqa: E501
-            _agent_kind_to_router_path,
+        from openhands.app_server.app_conversation.agent_server_routing import (
+            agent_kind_to_router_path,
         )
 
-        assert _agent_kind_to_router_path('llm') == 'conversations'
-        assert _agent_kind_to_router_path('future-variant') == 'conversations'
+        assert agent_kind_to_router_path('llm') == 'conversations'
+        assert agent_kind_to_router_path('future-variant') == 'conversations'
 
 
 class TestBuildAcpStartConversationRequestSecrets:

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3184,101 +3184,6 @@ class TestLoadHooksFromWorkspace:
         )
 
 
-class TestAcpProviderEnv:
-    """Unit tests for ``LiveStatusAppConversationService._acp_provider_env``.
-
-    Tests the helper that translates UI-saved LLM credentials into the
-    provider env vars the chosen ACP subprocess expects.
-    """
-
-    @pytest.fixture
-    def _user_factory(self):
-        try:
-            from openhands.sdk.settings import (
-                ACPAgentSettings,  # type: ignore[attr-defined]
-            )
-        except ImportError:
-            pytest.skip('ACPAgentSettings not available in this SDK build')
-
-        def _make(
-            *,
-            acp_server: str = 'claude-code',
-            api_key: str | None = None,
-            base_url: str | None = None,
-            acp_env: dict[str, str] | None = None,
-        ):
-            user = _TestUserInfo(
-                id='user1',
-                llm_model='',
-                llm_base_url=None,
-                llm_api_key=None,
-                sandbox_grouping_strategy=SandboxGroupingStrategy.ADD_TO_ANY,
-                confirmation_mode=False,
-                security_analyzer=None,
-                search_api_key=None,
-                mcp_config=None,
-                disabled_skills=[],
-            )
-            user.agent_settings = ACPAgentSettings(
-                acp_server=acp_server,  # type: ignore[arg-type]
-                llm=LLM(
-                    model='claude-sonnet-4-5',
-                    api_key=SecretStr(api_key) if api_key else None,
-                    base_url=base_url,
-                ),
-                acp_env=acp_env or {},
-            )
-            return user
-
-        return _make
-
-    def test_claude_code_translates_to_anthropic_vars(self, _user_factory):
-        user = _user_factory(acp_server='claude-code', api_key='sk-test-anthropic')
-        env = LiveStatusAppConversationService._acp_provider_env(user)
-        assert env == {'ANTHROPIC_API_KEY': 'sk-test-anthropic'}
-
-    def test_codex_translates_to_openai_vars(self, _user_factory):
-        user = _user_factory(acp_server='codex', api_key='sk-test-openai')
-        env = LiveStatusAppConversationService._acp_provider_env(user)
-        assert env == {'OPENAI_API_KEY': 'sk-test-openai'}
-
-    def test_gemini_translates_to_gemini_vars(self, _user_factory):
-        user = _user_factory(acp_server='gemini-cli', api_key='sk-test-gemini')
-        env = LiveStatusAppConversationService._acp_provider_env(user)
-        assert env == {'GEMINI_API_KEY': 'sk-test-gemini'}
-
-    def test_custom_server_returns_empty(self, _user_factory):
-        """For acp_server='custom', the user is on their own via acp_env."""
-        user = _user_factory(
-            acp_server='custom',
-            api_key='sk-test',
-            base_url='https://proxy.example.com',
-        )
-        env = LiveStatusAppConversationService._acp_provider_env(user)
-        assert env == {}
-
-    def test_no_credentials_returns_empty(self, _user_factory):
-        """No api_key + no base_url → nothing synthesized."""
-        user = _user_factory(acp_server='claude-code')
-        env = LiveStatusAppConversationService._acp_provider_env(user)
-        assert env == {}
-
-    def test_no_api_key_returns_empty(self, _user_factory):
-        """No api_key → nothing synthesized."""
-        user = _user_factory(
-            acp_server='claude-code', base_url='https://api.anthropic.com'
-        )
-        env = LiveStatusAppConversationService._acp_provider_env(user)
-        assert env == {}
-
-    def test_provider_base_url_env_var_is_synthesized(self, _user_factory):
-        user = _user_factory(
-            acp_server='gemini-cli', base_url='https://gemini-proxy.example.com'
-        )
-        env = LiveStatusAppConversationService._acp_provider_env(user)
-        assert env == {'GEMINI_BASE_URL': 'https://gemini-proxy.example.com'}
-
-
 class TestAgentKindConversationUrl:
     """Regression tests for conversation_url / live-status route dispatch.
 
@@ -3543,8 +3448,8 @@ class TestBuildAcpStartConversationRequestSecrets:
         """Explicit acp_env entries take priority over auto-generated provider_env.
 
         When a user sets ANTHROPIC_API_KEY explicitly in acp_env, it must win
-        over the same key that _acp_provider_env derives from the UI-saved LLM
-        credentials.  This exercises the merge priority:
+        over the same key the SDK derives from the UI-saved LLM credentials.
+        This exercises the merge priority:
           acp_env > provider_env > agent_context.secrets
         """
         user = self._make_acp_user(

--- a/tests/unit/app_server/test_webhook_router_acp.py
+++ b/tests/unit/app_server/test_webhook_router_acp.py
@@ -88,6 +88,7 @@ def _make_acp_conversation_info(acp_command: list[str]) -> ACPConversationInfo:
     info.id = uuid4()
     info.execution_status = ConversationExecutionStatus.RUNNING
     acp_agent = MagicMock(spec=ACPAgent)
+    acp_agent.kind = 'ACPAgent'
     acp_agent.supports_openhands_tools = False
     acp_agent.acp_command = acp_command
     info.agent = acp_agent
@@ -113,6 +114,29 @@ def test_regular_agent_capability_defaults_to_openhands_tools():
     """A regular Agent mock keeps the default OpenHands tool capability."""
     regular_agent = MagicMock()
     assert getattr(regular_agent, 'supports_openhands_tools', True) is not False
+
+
+def test_acp_detection_by_kind_takes_precedence():
+    """kind == 'ACPAgent' classifies an agent as ACP even without capability flag."""
+    agent = MagicMock()
+    agent.kind = 'ACPAgent'
+    # supports_openhands_tools not explicitly set — getattr default is True
+    is_acp = (
+        getattr(agent, 'kind', None) == 'ACPAgent'
+        or getattr(agent, 'supports_openhands_tools', True) is False
+    )
+    assert is_acp is True
+
+
+def test_non_acp_agent_not_classified_as_acp():
+    """A generic agent without ACP identity or capability flag is not ACP."""
+    agent = MagicMock()
+    agent.kind = 'Agent'
+    is_acp = (
+        getattr(agent, 'kind', None) == 'ACPAgent'
+        or getattr(agent, 'supports_openhands_tools', True) is False
+    )
+    assert is_acp is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/app_server/test_webhook_router_acp.py
+++ b/tests/unit/app_server/test_webhook_router_acp.py
@@ -88,6 +88,7 @@ def _make_acp_conversation_info(acp_command: list[str]) -> ACPConversationInfo:
     info.id = uuid4()
     info.execution_status = ConversationExecutionStatus.RUNNING
     acp_agent = MagicMock(spec=ACPAgent)
+    acp_agent.supports_openhands_tools = False
     acp_agent.acp_command = acp_command
     info.agent = acp_agent
     info.stats = MagicMock()
@@ -101,16 +102,17 @@ def _make_acp_conversation_info(acp_command: list[str]) -> ACPConversationInfo:
 # ---------------------------------------------------------------------------
 
 
-def test_acp_agent_isinstance_check_is_true_for_acp_agent():
-    """ACPAgent payload in ACPConversationInfo satisfies isinstance check."""
+def test_acp_agent_capability_check_is_false_for_openhands_tools():
+    """ACPAgent payload advertises that the ACP server owns its tools."""
     acp_agent = MagicMock(spec=ACPAgent)
-    assert isinstance(acp_agent, ACPAgent)
+    acp_agent.supports_openhands_tools = False
+    assert acp_agent.supports_openhands_tools is False
 
 
-def test_regular_agent_isinstance_check_is_false():
-    """A regular Agent mock does NOT satisfy ACPAgent isinstance check."""
+def test_regular_agent_capability_defaults_to_openhands_tools():
+    """A regular Agent mock keeps the default OpenHands tool capability."""
     regular_agent = MagicMock()
-    assert not isinstance(regular_agent, ACPAgent)
+    assert getattr(regular_agent, 'supports_openhands_tools', True) is not False
 
 
 # ---------------------------------------------------------------------------
@@ -182,7 +184,7 @@ async def test_acp_conversation_stores_display_name(
     saved = await service.get_app_conversation_info(conversation_id)
     assert saved is not None
     assert saved.llm_model is None
-    assert saved.display_name == 'ACP: claude-agent-acp'
+    assert saved.display_name == 'Claude Code'
     assert saved.agent_kind == 'acp'
 
 

--- a/tests/unit/app_server/test_webhook_router_acp.py
+++ b/tests/unit/app_server/test_webhook_router_acp.py
@@ -88,7 +88,7 @@ def _make_acp_conversation_info(acp_command: list[str]) -> ACPConversationInfo:
     info.id = uuid4()
     info.execution_status = ConversationExecutionStatus.RUNNING
     acp_agent = MagicMock(spec=ACPAgent)
-    acp_agent.kind = 'ACPAgent'
+    acp_agent.conversation_contract = 'acp'
     acp_agent.acp_command = acp_command
     info.agent = acp_agent
     info.stats = MagicMock()
@@ -102,19 +102,19 @@ def _make_acp_conversation_info(acp_command: list[str]) -> ACPConversationInfo:
 # ---------------------------------------------------------------------------
 
 
-def test_acp_agent_classified_by_kind():
-    """kind == 'ACPAgent' is the sole identity check."""
+def test_acp_agent_classified_by_conversation_contract():
+    """conversation_contract == 'acp' is the ACP identity check."""
     agent = MagicMock()
-    agent.kind = 'ACPAgent'
-    assert getattr(agent, 'kind', None) == 'ACPAgent'
+    agent.conversation_contract = 'acp'
+    assert getattr(agent, 'conversation_contract', None) == 'acp'
 
 
 def test_non_acp_agent_not_classified_as_acp():
-    """An agent whose kind is not 'ACPAgent' is never classified as ACP."""
-    for kind in ('Agent', 'CustomAgent', None):
+    """An agent whose conversation contract is not 'acp' is not ACP."""
+    for conversation_contract in ('openhands', 'custom', None):
         agent = MagicMock()
-        agent.kind = kind
-        assert getattr(agent, 'kind', None) != 'ACPAgent'
+        agent.conversation_contract = conversation_contract
+        assert getattr(agent, 'conversation_contract', None) != 'acp'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/app_server/test_webhook_router_acp.py
+++ b/tests/unit/app_server/test_webhook_router_acp.py
@@ -89,7 +89,6 @@ def _make_acp_conversation_info(acp_command: list[str]) -> ACPConversationInfo:
     info.execution_status = ConversationExecutionStatus.RUNNING
     acp_agent = MagicMock(spec=ACPAgent)
     acp_agent.kind = 'ACPAgent'
-    acp_agent.supports_openhands_tools = False
     acp_agent.acp_command = acp_command
     info.agent = acp_agent
     info.stats = MagicMock()
@@ -103,40 +102,19 @@ def _make_acp_conversation_info(acp_command: list[str]) -> ACPConversationInfo:
 # ---------------------------------------------------------------------------
 
 
-def test_acp_agent_capability_check_is_false_for_openhands_tools():
-    """ACPAgent payload advertises that the ACP server owns its tools."""
-    acp_agent = MagicMock(spec=ACPAgent)
-    acp_agent.supports_openhands_tools = False
-    assert acp_agent.supports_openhands_tools is False
-
-
-def test_regular_agent_capability_defaults_to_openhands_tools():
-    """A regular Agent mock keeps the default OpenHands tool capability."""
-    regular_agent = MagicMock()
-    assert getattr(regular_agent, 'supports_openhands_tools', True) is not False
-
-
-def test_acp_detection_by_kind_takes_precedence():
-    """kind == 'ACPAgent' classifies an agent as ACP even without capability flag."""
+def test_acp_agent_classified_by_kind():
+    """kind == 'ACPAgent' is the sole identity check."""
     agent = MagicMock()
     agent.kind = 'ACPAgent'
-    # supports_openhands_tools not explicitly set — getattr default is True
-    is_acp = (
-        getattr(agent, 'kind', None) == 'ACPAgent'
-        or getattr(agent, 'supports_openhands_tools', True) is False
-    )
-    assert is_acp is True
+    assert getattr(agent, 'kind', None) == 'ACPAgent'
 
 
 def test_non_acp_agent_not_classified_as_acp():
-    """A generic agent without ACP identity or capability flag is not ACP."""
-    agent = MagicMock()
-    agent.kind = 'Agent'
-    is_acp = (
-        getattr(agent, 'kind', None) == 'ACPAgent'
-        or getattr(agent, 'supports_openhands_tools', True) is False
-    )
-    assert is_acp is False
+    """An agent whose kind is not 'ACPAgent' is never classified as ACP."""
+    for kind in ('Agent', 'CustomAgent', None):
+        agent = MagicMock()
+        agent.kind = kind
+        assert getattr(agent, 'kind', None) != 'ACPAgent'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/app_server/test_webhook_router_acp.py
+++ b/tests/unit/app_server/test_webhook_router_acp.py
@@ -88,7 +88,7 @@ def _make_acp_conversation_info(acp_command: list[str]) -> ACPConversationInfo:
     info.id = uuid4()
     info.execution_status = ConversationExecutionStatus.RUNNING
     acp_agent = MagicMock(spec=ACPAgent)
-    acp_agent.conversation_contract = 'acp'
+    acp_agent.agent_kind = 'acp'
     acp_agent.acp_command = acp_command
     info.agent = acp_agent
     info.stats = MagicMock()
@@ -102,19 +102,19 @@ def _make_acp_conversation_info(acp_command: list[str]) -> ACPConversationInfo:
 # ---------------------------------------------------------------------------
 
 
-def test_acp_agent_classified_by_conversation_contract():
-    """conversation_contract == 'acp' is the ACP identity check."""
+def test_acp_agent_classified_by_agent_kind():
+    """agent_kind == 'acp' is the ACP identity check."""
     agent = MagicMock()
-    agent.conversation_contract = 'acp'
-    assert getattr(agent, 'conversation_contract', None) == 'acp'
+    agent.agent_kind = 'acp'
+    assert getattr(agent, 'agent_kind', None) == 'acp'
 
 
 def test_non_acp_agent_not_classified_as_acp():
     """An agent whose conversation contract is not 'acp' is not ACP."""
-    for conversation_contract in ('openhands', 'custom', None):
+    for agent_kind in ('openhands', 'custom', None):
         agent = MagicMock()
-        agent.conversation_contract = conversation_contract
-        assert getattr(agent, 'conversation_contract', None) != 'acp'
+        agent.agent_kind = agent_kind
+        assert getattr(agent, 'agent_kind', None) != 'acp'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Expose SDK ACP provider metadata in the web-client config and use it for Agent Settings presets/tooltips.
- Save built-in ACP presets as `acp_server` with an empty command so `ACPAgentSettings.resolve_acp_command()` owns defaults.
- Simplify backend ACP env/display/routing logic to use SDK provider helpers and agent capability flags while preserving existing custom-command fallback behavior.

## Assumptions
- Stacked on top of #14227 / `feat/acp-minimal-generic-ui`.
- Assumes OpenHands has already been pinned to the SDK release containing OpenHands/software-agent-sdk#3022.
- I did not commit a speculative package bump because `openhands-*==1.19.2` is not published in the current index, so `uv lock` cannot resolve it locally.

## Migration
- Existing settings saved as `acp_server: custom` plus a built-in default command are detected as that built-in provider in the UI.
- On the next save, built-in presets normalize to `acp_server` + `acp_command: []`; truly custom commands keep `acp_server: custom` and their tokenized command.
- Unknown/legacy ACP webhook payloads still fall back to `kind == "ACPAgent"` so rolling upgrades do not misclassify ACP conversations.

## Test plan
- `npx vitest run __tests__/routes/agent-settings.test.tsx __tests__/hooks/use-settings-nav-items.test.tsx`
- `PYTHONPATH=/tmp/software-agent-sdk-pr3022/openhands-sdk uv run pytest tests/unit/app_server/test_webhook_router_acp.py tests/unit/app_server/test_live_status_app_conversation_service.py -q`
- `PYTHONPATH=/tmp/software-agent-sdk-pr3022/openhands-sdk uv run ruff check --select F,I openhands/app_server/app_conversation/agent_server_routing.py openhands/app_server/app_conversation/live_status_app_conversation_service.py openhands/app_server/event_callback/webhook_router.py openhands/app_server/web_client/default_web_client_config_injector.py openhands/app_server/web_client/web_client_models.py tests/unit/app_server/test_live_status_app_conversation_service.py tests/unit/app_server/test_webhook_router_acp.py`
