### PR TITLE
fix(resend-sync): switch to createdAfter delta fetch

### DIFF
--- a/enterprise/sync/resend_keycloak.py
+++ b/enterprise/sync/resend_keycloak.py
@@ -430,9 +430,7 @@ def sync_users_to_resend():
             synced_user_store, RESEND_AUDIENCE_ID
         )
 
-        created_after_ms = int(
-            (time.time() - CREATED_AFTER_DAYS * 86400) * 1000
-        )
+        created_after_ms = int((time.time() - CREATED_AFTER_DAYS * 86400) * 1000)
         logger.info(
             f'Fetching Keycloak users created in the last {CREATED_AFTER_DAYS} '
             f'days (createdAfter={created_after_ms})'

--- a/enterprise/sync/resend_keycloak.py
+++ b/enterprise/sync/resend_keycloak.py
@@ -65,6 +65,7 @@ INITIAL_BACKOFF_SECONDS = float(os.environ.get('INITIAL_BACKOFF_SECONDS', '1'))
 MAX_BACKOFF_SECONDS = float(os.environ.get('MAX_BACKOFF_SECONDS', '60'))
 BACKOFF_FACTOR = float(os.environ.get('BACKOFF_FACTOR', '2'))
 RATE_LIMIT = float(os.environ.get('RATE_LIMIT', '2'))  # Requests per second
+CREATED_AFTER_DAYS = int(os.environ.get('CREATED_AFTER_DAYS', '7'))
 
 # Set up Resend API
 resend.api_key = RESEND_API_KEY
@@ -113,12 +114,19 @@ def is_valid_email(email: Optional[str]) -> bool:
     return bool(EMAIL_REGEX.match(email))
 
 
-def get_keycloak_users(offset: int = 0, limit: int = 100) -> List[Dict[str, Any]]:
+def get_keycloak_users(
+    offset: int = 0,
+    limit: int = 100,
+    created_after_ms: Optional[int] = None,
+) -> List[Dict[str, Any]]:
     """Get users from Keycloak using the admin client.
 
     Args:
         offset: The offset to start from.
         limit: The maximum number of users to return.
+        created_after_ms: If set, only return users created after this epoch
+            millisecond timestamp. Forwarded as the Keycloak `createdAfter`
+            query parameter.
 
     Returns:
         A list of users.
@@ -134,8 +142,10 @@ def get_keycloak_users(offset: int = 0, limit: int = 100) -> List[Dict[str, Any]
         params: Dict[str, Any] = {
             'first': offset,
             'max': limit,
-            'briefRepresentation': False,  # Get full user details
+            'briefRepresentation': True,
         }
+        if created_after_ms is not None:
+            params['createdAfter'] = created_after_ms
 
         users_data = keycloak_admin.get_users(params)
         logger.info(f'Fetched {len(users_data)} users from Keycloak')
@@ -160,27 +170,6 @@ def get_keycloak_users(offset: int = 0, limit: int = 100) -> List[Dict[str, Any]
         raise
     except Exception:
         logger.exception('Unexpected error getting users from Keycloak')
-        raise
-
-
-def get_total_keycloak_users() -> int:
-    """Get the total number of users in Keycloak.
-
-    Returns:
-        The total number of users.
-
-    Raises:
-        KeycloakClientError: If the API call fails.
-    """
-    try:
-        keycloak_admin = get_keycloak_admin()
-        count = keycloak_admin.users_count()
-        return count
-    except KeycloakError:
-        logger.exception('Failed to get total users from Keycloak')
-        raise
-    except Exception:
-        logger.exception('Unexpected error getting total users from Keycloak')
         raise
 
 
@@ -441,15 +430,16 @@ def sync_users_to_resend():
             synced_user_store, RESEND_AUDIENCE_ID
         )
 
-        # Get the total number of users
-        total_users = get_total_keycloak_users()
+        created_after_ms = int(
+            (time.time() - CREATED_AFTER_DAYS * 86400) * 1000
+        )
         logger.info(
-            f'Found {total_users} users in Keycloak realm {KEYCLOAK_REALM_NAME}'
+            f'Fetching Keycloak users created in the last {CREATED_AFTER_DAYS} '
+            f'days (createdAfter={created_after_ms})'
         )
 
-        # Stats
         stats = {
-            'total_users': total_users,
+            'users_seen': 0,
             'backfilled_contacts': backfilled_count,
             'already_synced': 0,
             'added_contacts': 0,
@@ -462,10 +452,13 @@ def sync_users_to_resend():
         )
         logger.info(f'Found {len(synced_emails)} already synced emails in database')
 
-        # Process users in batches
+        # Process users in batches, paging until an empty result terminates the loop.
         offset = 0
-        while offset < total_users:
-            users = get_keycloak_users(offset, BATCH_SIZE)
+        while True:
+            users = get_keycloak_users(offset, BATCH_SIZE, created_after_ms)
+            if not users:
+                break
+            stats['users_seen'] += len(users)
             logger.info(f'Processing batch of {len(users)} users (offset {offset})')
 
             for user in users:

--- a/enterprise/tests/unit/sync/test_resend_keycloak.py
+++ b/enterprise/tests/unit/sync/test_resend_keycloak.py
@@ -17,6 +17,7 @@ os.environ['KEYCLOAK_ADMIN_PASSWORD'] = 'test_password'
 
 from enterprise.sync.resend_keycloak import (  # noqa: E402
     add_contact_to_resend,
+    get_keycloak_users,
     is_valid_email,
     send_welcome_email,
 )
@@ -265,3 +266,38 @@ class TestAddContactToResend:
 
         assert result == {'id': 'contact_123'}
         assert mock_create.call_count == 2
+
+
+class TestGetKeycloakUsers:
+    """Tests for the createdAfter / briefRepresentation behavior of get_keycloak_users."""
+
+    @patch('enterprise.sync.resend_keycloak.get_keycloak_admin')
+    def test_passes_created_after_ms(self, mock_get_admin: MagicMock) -> None:
+        """createdAfter is forwarded as a query param when supplied."""
+        mock_admin = MagicMock()
+        mock_admin.get_users.return_value = []
+        mock_get_admin.return_value = mock_admin
+
+        get_keycloak_users(offset=0, limit=100, created_after_ms=1700000000000)
+
+        mock_admin.get_users.assert_called_once()
+        params = mock_admin.get_users.call_args[0][0]
+        assert params['createdAfter'] == 1700000000000
+        assert params['briefRepresentation'] is True
+        assert params['first'] == 0
+        assert params['max'] == 100
+
+    @patch('enterprise.sync.resend_keycloak.get_keycloak_admin')
+    def test_omits_created_after_when_none(self, mock_get_admin: MagicMock) -> None:
+        """createdAfter is absent from the request when not supplied."""
+        mock_admin = MagicMock()
+        mock_admin.get_users.return_value = []
+        mock_get_admin.return_value = mock_admin
+
+        get_keycloak_users(offset=200, limit=50)
+
+        params = mock_admin.get_users.call_args[0][0]
+        assert 'createdAfter' not in params
+        assert params['briefRepresentation'] is True
+        assert params['first'] == 200
+        assert params['max'] == 50


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

`sync/resend_keycloak.py` enumerates every user in the configured Keycloak realm every run — both an unfiltered `/users/count` and a full paginated walk of `/users` with `briefRepresentation=false`. For realms with many users this is expensive: the count generates a `count(distinct USER_ENTITY.ID) WHERE SERVICE_ACCOUNT_CLIENT_LINK IS NULL` over the whole table, the paginated listing produces a `SELECT DISTINCT ... ORDER BY USERNAME` that sorts the full result set with no usable index for the predicate, and `briefRepresentation=false` triggers a USER_ATTRIBUTE fetch per user.

The script's actual work is "add new users to Resend" — everything else is already dedup'd in Python via the `synced_emails` set. Fetching the full user base every run to find the handful of new ones is wasted load on Keycloak's database. This switches to a delta fetch keyed on Keycloak's `createdAfter` query parameter, making each run O(new users in the lookback window) instead of O(total users).

## Summary

- Drop `users_count()`; page until `get_users()` returns empty.
- Pass `createdAfter` (epoch ms), controlled by a new `CREATED_AFTER_DAYS` env var (default 7). The existing `synced_emails` set handles lookback overlap.
- Switch to `briefRepresentation=true`; only `id` / `email` / `firstName` / `lastName` are read downstream.

## Issue Number

n/a

## How to Test

Unit tests: `poetry run pytest enterprise/tests/unit/sync/test_resend_keycloak.py -v` — all 29 should pass (27 pre-existing + 2 new in `TestGetKeycloakUsers`).

Integration: against a Keycloak instance with at least one recently-created user, set `CREATED_AFTER_DAYS=1` and run `python -m sync.resend_keycloak`. Logs should include `Fetching Keycloak users created in the last 1 days (createdAfter=...)`, the loop should terminate on the first empty page, and only users created in the last 24h should appear in batches. Already-synced users still skip via the existing dedup.

## Video/Screenshots

n/a — backend job, no UI surface.

## Type

- [x] Bug fix

## Notes

- **Implicit behavior change**: prior code keys dedup on email, so it incidentally re-synced users who changed their email (their new email wasn't in `synced_emails`). With `createdAfter`, users created more than 7 days ago who change their email will be missed. Never documented as a feature; flagging it. Preserving it would need either a low-frequency full scan or a Keycloak `UPDATE_EMAIL` event listener.
- Keycloak 26.6.0+ adds `IDX_USER_CREATED_TIMESTAMP(REALM_ID, CREATED_TIMESTAMP)`, which lets `createdAfter` queries hit an index directly. On older versions the query still seq-scans, just over a much smaller result set.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-e9146c9   docker.openhands.dev/openhands/openhands:e9146c9
```