### PR TITLE
APP-1546 feat(frontend): expose sandbox grouping strategy UI to all users

### DIFF
--- a/frontend/src/routes/app-settings.tsx
+++ b/frontend/src/routes/app-settings.tsx
@@ -24,7 +24,6 @@ import {
   SandboxGroupingStrategy,
   SandboxGroupingStrategyOptions,
 } from "#/types/settings";
-import { ENABLE_SANDBOX_GROUPING } from "#/utils/feature-flags";
 import { createPermissionGuard } from "#/utils/org/permission-guard";
 
 export const clientLoader = createPermissionGuard(
@@ -274,25 +273,23 @@ function AppSettingsScreen() {
             </SettingsSwitch>
           )}
 
-          {ENABLE_SANDBOX_GROUPING() && (
-            <SettingsDropdownInput
-              testId="sandbox-grouping-strategy-input"
-              name="sandbox-grouping-strategy-input"
-              label={t(I18nKey.SETTINGS$SANDBOX_GROUPING_STRATEGY)}
-              items={Object.keys(SandboxGroupingStrategyOptions).map((key) => ({
-                key,
-                label: t(`SETTINGS$SANDBOX_GROUPING_${key}` as I18nKey),
-              }))}
-              selectedKey={
-                selectedSandboxGroupingStrategy ||
-                settings.sandbox_grouping_strategy ||
-                DEFAULT_SETTINGS.sandbox_grouping_strategy
-              }
-              isClearable={false}
-              onSelectionChange={handleSandboxGroupingStrategyChange}
-              wrapperClassName="w-full max-w-[680px]"
-            />
-          )}
+          <SettingsDropdownInput
+            testId="sandbox-grouping-strategy-input"
+            name="sandbox-grouping-strategy-input"
+            label={t(I18nKey.SETTINGS$SANDBOX_GROUPING_STRATEGY)}
+            items={Object.keys(SandboxGroupingStrategyOptions).map((key) => ({
+              key,
+              label: t(`SETTINGS$SANDBOX_GROUPING_${key}` as I18nKey),
+            }))}
+            selectedKey={
+              selectedSandboxGroupingStrategy ||
+              settings.sandbox_grouping_strategy ||
+              DEFAULT_SETTINGS.sandbox_grouping_strategy
+            }
+            isClearable={false}
+            onSelectionChange={handleSandboxGroupingStrategyChange}
+            wrapperClassName="w-full max-w-[680px]"
+          />
 
           {!settings?.v1_enabled && (
             <SettingsInput

--- a/frontend/src/utils/feature-flags.ts
+++ b/frontend/src/utils/feature-flags.ts
@@ -17,6 +17,4 @@ export const HIDE_LLM_SETTINGS = () => loadFeatureFlag("HIDE_LLM_SETTINGS");
 export const VSCODE_IN_NEW_TAB = () => loadFeatureFlag("VSCODE_IN_NEW_TAB");
 export const ENABLE_TRAJECTORY_REPLAY = () =>
   loadFeatureFlag("TRAJECTORY_REPLAY");
-export const ENABLE_SANDBOX_GROUPING = () =>
-  loadFeatureFlag("SANDBOX_GROUPING");
 export const ENABLE_AUTOMATIONS = () => loadFeatureFlag("AUTOMATIONS");


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why

The sandbox grouping strategy UI was hidden behind a feature flag (`ENABLE_SANDBOX_GROUPING`). This PR removes the feature flag to expose the UI element to all users.

## Summary

- Removed the `ENABLE_SANDBOX_GROUPING` feature flag conditional wrapper from the sandbox grouping strategy dropdown in Application Settings
- Removed the unused `ENABLE_SANDBOX_GROUPING` import and function definition from `feature-flags.ts`

## Issue Number

N/A - Feature flag removal request

## How to Test

1. Navigate to Application Settings
2. Verify the "Sandbox Grouping Strategy" dropdown is now visible
3. Confirm users can select different grouping strategies

## Video/Screenshots

The Sandbox Grouping Strategy UI Element is now displayed for all users:
<img width="1284" height="863" alt="image" src="https://github.com/user-attachments/assets/d34ef50a-244b-4e1c-b81a-f3f1fa052db9" />

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The sandbox grouping strategy dropdown will now be visible to all users in the Application Settings screen, allowing them to choose how their sandboxes are grouped.

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/633cd70c-108a-451e-9854-dac6207006ab)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-ca0ef70   docker.openhands.dev/openhands/openhands:ca0ef70
```