### PR TITLE
Add failing regression test for V1 history pagination

### DIFF
--- a/frontend/src/api/event-service/event-service.api.test.ts
+++ b/frontend/src/api/event-service/event-service.api.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import EventService from "./event-service.api";
+import { openHands } from "../open-hands-axios";
+import type { OpenHandsEvent } from "#/types/v1/core";
+
+vi.mock("../open-hands-axios", () => ({
+  openHands: {
+    get: vi.fn(),
+  },
+}));
+
+const completedPreviousActionObservation = {
+  id: "observation-previous-action",
+  timestamp: "2026-05-05T00:45:10.200000",
+  source: "environment",
+  tool_name: "file_editor",
+  tool_call_id: "call_previous",
+  action_id: "action-previous",
+  observation: {
+    kind: "FileEditorObservation",
+    command: "str_replace",
+    path: "/workspace/project/src/components/product-feature-page.tsx",
+  },
+  kind: "ObservationEvent",
+} as unknown as OpenHandsEvent;
+
+const runningLongAction = {
+  id: "action-running-parity",
+  timestamp: "2026-05-05T00:45:14.765343",
+  source: "agent",
+  tool_name: "terminal",
+  tool_call_id: "call_running",
+  summary: "Run parity after product image matching",
+  action: {
+    kind: "TerminalAction",
+    command:
+      "npm run typecheck && PARITY_OUTPUT_DIR=.agent_tmp/parity-after-product-images npm run parity:checklist",
+  },
+  kind: "ActionEvent",
+} as unknown as OpenHandsEvent;
+
+describe("EventService.searchEventsV1", () => {
+  const mockGet = vi.mocked(openHands.get);
+
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it("loads the next history page so reloads do not stop on a completed action before a running action", async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        data: {
+          items: [completedPreviousActionObservation],
+          next_page_id: "page-containing-running-action",
+        },
+      } as never)
+      .mockResolvedValueOnce({
+        data: {
+          items: [runningLongAction],
+          next_page_id: null,
+        },
+      } as never);
+
+    const events = await EventService.searchEventsV1("conversation-id", 1);
+
+    expect(mockGet).toHaveBeenNthCalledWith(
+      1,
+      "/api/v1/conversation/conversation-id/events/search",
+      { params: { limit: 1 } },
+    );
+    expect(mockGet).toHaveBeenNthCalledWith(
+      2,
+      "/api/v1/conversation/conversation-id/events/search",
+      {
+        params: {
+          limit: 1,
+          page_id: "page-containing-running-action",
+        },
+      },
+    );
+    expect(events).toEqual([
+      completedPreviousActionObservation,
+      runningLongAction,
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

A conversation reload can appear stuck on the last completed action if the initial V1 event history request stops at a page boundary just before the currently running action. `EventService.searchEventsV1` currently returns only the first `events/search` page and ignores `next_page_id`.

This was observed in conversation `e614787ff23f4f3680323e6040717e9a`: the UI showed `Match live product image element dimensions` with a completed checkmark even though the next action, `Run parity after product image matching`, was the long-running action.

## Summary

- Adds a failing reproduction test for `EventService.searchEventsV1`.
- The test models a completed previous action at the end of one history page and a running long action on the next page.
- The failure demonstrates that V1 history loading does not currently follow `next_page_id`.

## Issue Number

N/A

## How to Test

```bash
cd frontend
npm run typecheck
npm run test -- src/api/event-service/event-service.api.test.ts
```

Current expected result for this draft reproduction PR: the targeted test fails because only the first page is fetched.

## Video/Screenshots

N/A

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This PR intentionally contains only a failing regression test, per the debugging request. It does not include the implementation fix.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-95e6caa   docker.openhands.dev/openhands/openhands:95e6caa
```