### PR TITLE
fix: Normalize agent_kind to 'llm' in OrgResponse

### DIFF
--- a/enterprise/server/routes/org_models.py
+++ b/enterprise/server/routes/org_models.py
@@ -171,6 +171,13 @@ class OrgResponse(BaseModel):
         cls, org: Org, credits: float | None = None, user_id: str | None = None
     ) -> 'OrgResponse':
         """Create an OrgResponse from an Org entity."""
+        agent_settings = org.agent_settings or {}
+        if agent_settings and agent_settings.get('agent_kind') != 'llm':
+            agent_settings = {**agent_settings, 'agent_kind': 'llm'}
+        conversation_settings = org.conversation_settings or {}
+        conversation_agent_settings = conversation_settings.get('agent_settings')
+        if conversation_agent_settings and conversation_agent_settings.get('agent_kind') != 'llm':
+            conversation_settings = {**conversation_settings, 'agent_settings': {**conversation_agent_settings, 'agent_kind': 'llm'}}
         return cls(
             id=str(org.id),
             name=org.name,
@@ -185,11 +192,9 @@ class OrgResponse(BaseModel):
             sandbox_base_container_image=org.sandbox_base_container_image,
             sandbox_runtime_container_image=org.sandbox_runtime_container_image,
             org_version=org.org_version if org.org_version is not None else 0,
-            agent_settings=AgentSettings.model_validate(
-                dict(org.agent_settings) if org.agent_settings else {}
-            ),
+            agent_settings=AgentSettings.model_validate(agent_settings),
             conversation_settings=ConversationSettings.model_validate(
-                dict(org.conversation_settings) if org.conversation_settings else {}
+                conversation_settings
             ),
             search_api_key=None,
             sandbox_api_key=None,


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

When an organization is created during sign up, the `agent_kind` field in `agent_settings` and `conversation_settings.agent_settings` may have an incorrect or unexpected value. This causes issues when the frontend or other services expect the value to be `'llm'`.

## Summary

- Normalize `agent_kind` to `'llm'` in `OrgResponse.from_org()` before returning the response
- Applies to both `agent_settings` and `conversation_settings.agent_settings`
- Ensures backward compatibility by only modifying values that are not already `'llm'`

## Issue Number

<!-- Required if there is a relevant issue to this PR. -->

## How to Test

1. Sign up for a new account and create an organization
2. Verify that the organization response has `agent_kind: 'llm'` in both `agent_settings` and `conversation_settings.agent_settings`
3. Existing organizations with correct `agent_kind` values should be unaffected

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is a workaround that normalizes the value at the API response level. A deeper investigation may be needed to understand why `agent_kind` gets set to incorrect values during sign up.

---
_This pull request was created by an AI agent (OpenHands) on behalf of the user._

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e2529062-a880-4c4d-a810-9cdce9b63195)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-48e9952   docker.openhands.dev/openhands/openhands:48e9952
```