### PR TITLE
fix: handle persisted agent_kind='openhands' in org responses

### DIFF
--- a/enterprise/server/routes/org_models.py
+++ b/enterprise/server/routes/org_models.py
@@ -15,7 +15,22 @@ from storage.org_member import OrgMember
 from storage.role import Role
 
 from openhands.app_server.utils.llm import MASKED_API_KEY, resolve_llm_base_url
-from openhands.sdk.settings import AgentSettings, ConversationSettings
+from openhands.sdk.settings import ConversationSettings, OpenHandsAgentSettings
+
+
+def _validate_persisted_agent_settings(
+    raw: dict[str, Any] | None,
+) -> OpenHandsAgentSettings:
+    """Validate persisted ``org.agent_settings`` against the canonical schema.
+
+    Older rows carry the legacy ``agent_kind: 'llm'`` discriminator from the
+    pre-rename SDK; force ``'openhands'`` so the canonical class accepts both
+    shapes. Mirrors :func:`OrgStore.get_agent_settings_from_org` — kept inline
+    to avoid a circular import (``org_store`` already imports from this module).
+    """
+    kwargs = dict(raw) if raw else {}
+    kwargs['agent_kind'] = 'openhands'
+    return OpenHandsAgentSettings.model_validate(kwargs)
 
 
 class OrgCreationError(Exception):
@@ -155,7 +170,9 @@ class OrgResponse(BaseModel):
     sandbox_base_container_image: str | None = None
     sandbox_runtime_container_image: str | None = None
     org_version: int = 0
-    agent_settings: AgentSettings = Field(default_factory=AgentSettings)
+    agent_settings: OpenHandsAgentSettings = Field(
+        default_factory=OpenHandsAgentSettings
+    )
     conversation_settings: ConversationSettings = Field(
         default_factory=ConversationSettings
     )
@@ -185,9 +202,7 @@ class OrgResponse(BaseModel):
             sandbox_base_container_image=org.sandbox_base_container_image,
             sandbox_runtime_container_image=org.sandbox_runtime_container_image,
             org_version=org.org_version if org.org_version is not None else 0,
-            agent_settings=AgentSettings.model_validate(
-                dict(org.agent_settings) if org.agent_settings else {}
-            ),
+            agent_settings=_validate_persisted_agent_settings(org.agent_settings),
             conversation_settings=ConversationSettings.model_validate(
                 dict(org.conversation_settings) if org.conversation_settings else {}
             ),
@@ -371,7 +386,9 @@ class OrgUpdate(BaseModel):
 class OrgDefaultsSettingsResponse(BaseModel):
     """Response model for organization default settings."""
 
-    agent_settings: AgentSettings = Field(default_factory=AgentSettings)
+    agent_settings: OpenHandsAgentSettings = Field(
+        default_factory=OpenHandsAgentSettings
+    )
     conversation_settings: ConversationSettings = Field(
         default_factory=ConversationSettings
     )
@@ -402,9 +419,7 @@ class OrgDefaultsSettingsResponse(BaseModel):
         ``org_member.agent_settings_diff`` and this response always carry
         the same value.
         """
-        agent_settings = AgentSettings.model_validate(
-            dict(org.agent_settings) if org.agent_settings else {}
-        )
+        agent_settings = _validate_persisted_agent_settings(org.agent_settings)
         cls._denormalize_llm_for_response(agent_settings)
         return cls(
             agent_settings=agent_settings,
@@ -416,7 +431,7 @@ class OrgDefaultsSettingsResponse(BaseModel):
         )
 
     @staticmethod
-    def _denormalize_llm_for_response(agent_settings: AgentSettings) -> None:
+    def _denormalize_llm_for_response(agent_settings: OpenHandsAgentSettings) -> None:
         """Rewrite ``agent_settings.llm`` in-place for UI consumption.
 
         * ``litellm_proxy/X`` → ``openhands/X`` so the basic-view provider

--- a/enterprise/tests/unit/server/routes/test_org_defaults_settings.py
+++ b/enterprise/tests/unit/server/routes/test_org_defaults_settings.py
@@ -87,6 +87,34 @@ def test_normalize_agent_settings_fills_base_url_for_all_providers():
     assert 'anthropic.com' in anthropic_base
 
 
+def test_from_org_validates_persisted_openhands_agent_kind():
+    """GIVEN: An org row whose persisted ``agent_settings`` carry the
+        canonical ``agent_kind: 'openhands'`` discriminator (the exact shape
+        from the 500-error log)
+    WHEN: ``OrgDefaultsSettingsResponse.from_org`` serializes the org
+    THEN: The response is built without a Pydantic literal-mismatch error
+        and exposes the expected canonical agent kind and llm model.
+    """
+    # Arrange
+    org = MagicMock(spec=Org)
+    org.agent_settings = {
+        'schema_version': 1,
+        'agent': 'CodeActAgent',
+        'agent_kind': 'openhands',
+        'llm': {'model': 'openhands/claude', 'base_url': LITE_LLM_API_URL},
+    }
+    org.conversation_settings = {}
+    org.llm_api_key = None
+    org.search_api_key = None
+
+    # Act
+    response = OrgDefaultsSettingsResponse.from_org(org)
+
+    # Assert
+    assert response.agent_settings.agent_kind == 'openhands'
+    assert response.agent_settings.llm.model == 'openhands/claude'
+
+
 def test_from_org_denormalizes_litellm_proxy_prefix_and_returns_base_url_as_stored():
     """Managed-model responses should be denormalized for the frontend."""
     org = MagicMock(spec=Org)

--- a/enterprise/tests/unit/server/routes/test_orgs.py
+++ b/enterprise/tests/unit/server/routes/test_orgs.py
@@ -45,7 +45,7 @@ from server.routes.orgs import (
 from storage.org import Org
 
 from openhands.app_server.user_auth import get_user_id
-from openhands.sdk.settings import AgentSettings, ConversationSettings
+from openhands.sdk.settings import ConversationSettings, OpenHandsAgentSettings
 
 # Test user ID constant (must be a valid UUID string)
 TEST_USER_ID = str(uuid.uuid4())
@@ -550,6 +550,63 @@ async def test_list_user_orgs_success(mock_app_list):
         assert response_data['next_page_id'] is None
         # Credits should be None in list view
         assert response_data['items'][0]['credits'] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'persisted_agent_settings',
+    [
+        {
+            'agent_kind': 'openhands',
+            'llm': {'model': 'anthropic/claude-3-haiku-20240307'},
+        },
+        {'agent_kind': 'llm', 'llm': {'model': 'anthropic/claude-3-haiku-20240307'}},
+        {'llm': {'model': 'anthropic/claude-3-haiku-20240307'}},
+    ],
+    ids=['agent_kind_openhands', 'agent_kind_llm_legacy', 'no_agent_kind'],
+)
+async def test_list_user_orgs_handles_persisted_agent_kind_variants(
+    mock_app_list, persisted_agent_settings
+):
+    """GIVEN: An org row whose persisted ``agent_settings`` carries any of the
+        three discriminator shapes seen in production (current ``'openhands'``,
+        legacy ``'llm'``, or no ``agent_kind`` at all)
+    WHEN: GET /api/organizations is called
+    THEN: The endpoint returns 200 and serializes the org without raising
+        a Pydantic literal-mismatch ``ValidationError``.
+    """
+    # Arrange
+    org_id = uuid.uuid4()
+    mock_org = Org(
+        id=org_id,
+        name='Org',
+        contact_name='Owner',
+        contact_email='owner@example.com',
+        agent_settings=persisted_agent_settings,
+    )
+    mock_user = MagicMock()
+    mock_user.current_org_id = org_id
+
+    with (
+        patch(
+            'server.routes.orgs.UserStore.get_user_by_id',
+            AsyncMock(return_value=mock_user),
+        ),
+        patch(
+            'server.routes.orgs.OrgService.get_user_orgs_paginated',
+            AsyncMock(return_value=([mock_org], None)),
+        ),
+    ):
+        # Act
+        response = TestClient(mock_app_list).get('/api/organizations')
+
+    # Assert
+    assert response.status_code == status.HTTP_200_OK
+    items = response.json()['items']
+    assert (
+        items[0]['agent_settings']['llm']['model']
+        == 'anthropic/claude-3-haiku-20240307'
+    )
 
 
 @pytest.mark.asyncio
@@ -1110,7 +1167,7 @@ async def test_get_org_defaults_settings_success():
     """
     org_id = uuid.uuid4()
     mock_org = MagicMock(spec=Org)
-    mock_org.agent_settings = AgentSettings(
+    mock_org.agent_settings = OpenHandsAgentSettings(
         agent='CodeActAgent',
         llm={'model': 'openhands/claude-3', 'base_url': 'https://proxy.example'},
     )
@@ -1138,7 +1195,7 @@ async def test_update_org_defaults_settings_forwards_through_org_service():
     """
     org_id = uuid.uuid4()
     updated_org = MagicMock(spec=Org)
-    updated_org.agent_settings = AgentSettings(
+    updated_org.agent_settings = OpenHandsAgentSettings(
         llm={
             'model': 'openhands/claude-3.5-sonnet',
             'base_url': 'https://proxy.example',


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Description

`GET /api/organizations` returns **500 Internal Server Error** for any user whose org row contains `agent_kind: 'openhands'` in the persisted `agent_settings` JSON. This blocks the post-signup flow: the user accepts ToS, the frontend immediately calls `/api/organizations`, and the dashboard never loads.

### Reproduction steps

1. Launch the SaaS locally via the `launch.json` configuration in `.vscode/`.
2. Sign up a new account.
3. Accept the Terms of Service.
4. Observe the request:
   ```
   GET http://localhost:3030/api/organizations  →  500
   ```

### Expected behavior

`GET /api/organizations` returns **200** with a paginated list of the user's organizations.

### Actual behavior

500 Internal Server Error. From the backend log:

```
File 'enterprise/server/routes/org_models.py', line 188, in from_org  agent_settings=AgentSettings.model_validate(...)
pydantic_core._pydantic_core.ValidationError: 1 validation error for AgentSettings agent_kind Input should be 'llm' [type=literal_error, input_value='openhands', input_type=str]
```

### Root cause

`OrgResponse.from_org` and `OrgDefaultsSettingsResponse.from_org` validate persisted `org.agent_settings` through the SDK's **deprecated** `AgentSettings` class. That class inherits from `LLMAgentSettings`, which pins `agent_kind: Literal["llm"]`. The persisted rows now carry `agent_kind: 'openhands'` (the canonical value introduced when the SDK renamed the agent class from `LLMAgentSettings` → `OpenHandsAgentSettings`). The literal check rejects them and the endpoint 500s.

A working precedent already exists at `enterprise/storage/org_store.py:52-57` (`OrgStore.get_agent_settings_from_org`) — it uses the canonical `OpenHandsAgentSettings` and forces `agent_kind = 'openhands'` to absorb legacy `'llm'` rows. The two response serializers in `org_models.py` predate that precedent.

### Scope

- `enterprise/server/routes/org_models.py` — both `OrgResponse.from_org` (list / get / create endpoints) and `OrgDefaultsSettingsResponse.from_org` (org-defaults settings endpoint) are affected.
- Out of scope: `enterprise/storage/user_settings.py:92` uses the same deprecated pattern but is dead code in production (no caller; runtime path is `SaasSettingsStore.load` → `OrgStore.get_agent_settings_from_org`). Tracked separately for cleanup.

### Acceptance criteria

- [ ] `GET /api/organizations` returns **200** for users whose org rows have `agent_kind: 'openhands'`.
- [ ] The fix preserves backward compatibility with legacy `agent_kind: 'llm'` rows and rows with no discriminator at all.
- [ ] Regression tests cover all three persisted shapes for both call sites.
- [ ] No frontend changes required (verified — frontend never reads `agent_kind`).

## Summary

<!-- 1-3 bullets describing what changed. -->
- Fixes a 500 on `GET /api/organizations` (and `GET /api/organizations/{id}/settings`) triggered by persisted org rows whose `agent_settings.agent_kind` is `'openhands'` — the canonical value in the modernized SDK, which the deprecated `AgentSettings` class rejects.
- Switches both response serializers in `enterprise/server/routes/org_models.py` to the canonical `OpenHandsAgentSettings`, mirroring the working precedent in `enterprise/storage/org_store.py:52-57`.
- Adds two regression tests covering the bug case plus legacy/missing-`agent_kind` backward compatibility.

## Root cause

`AgentSettings` (deprecated; scheduled for removal in SDK v1.22) inherits from `LLMAgentSettings`, which pins `agent_kind: Literal["llm"]`. Persisted rows now contain `agent_kind: 'openhands'`, so `AgentSettings.model_validate(...)` raises:

```
ValidationError: 1 validation error for AgentSettings
agent_kind
  Input should be 'llm' [type=literal_error, input_value='openhands', input_type=str]
```

Repro path:

```
GET /api/organizations
  → routes/orgs.py:118  list_user_orgs
  → routes/org_models.py:188  OrgResponse.from_org
  → AgentSettings.model_validate(dict(org.agent_settings))   ← 500 here
```

## Fix

`enterprise/server/routes/org_models.py`:

1. Replace `AgentSettings` import with `OpenHandsAgentSettings`.
2. Change the `agent_settings` field type and `default_factory` on `OrgResponse` and `OrgDefaultsSettingsResponse` to `OpenHandsAgentSettings`.
3. Route both `from_org` call sites through a new module-level helper:
   ```python
   def _validate_persisted_agent_settings(raw):
       kwargs = dict(raw) if raw else {}
       kwargs['agent_kind'] = 'openhands'
       return OpenHandsAgentSettings.model_validate(kwargs)
   ```
This forces `agent_kind = 'openhands'` so both legacy `'llm'` rows and current `'openhands'` rows validate against the canonical class — same approach as `OrgStore.get_agent_settings_from_org` (`enterprise/storage/org_store.py:52-57`). Helper is inlined rather than imported from `org_store` because `org_store` already imports from `org_models` (would deadlock as a circular import).
4. Update the `_denormalize_llm_for_response(agent_settings: OpenHandsAgentSettings)` annotation.

### Why the field-type change is safe

The frontend does not consume `agent_kind` (verified by grep over `frontend/src` and `frontend/__tests__` — zero references to `agent_kind` / `agentKind`). Only `agent_settings.llm.model`, `llm.base_url`, and `llm_api_key_set` are read. The shift in the serialized response from `"llm"` → `"openhands"` is invisible to the UI.

### Out of scope

- `enterprise/storage/user_settings.py:92` (`UserSettings.to_settings()`) uses the same deprecated pattern but is dead code in production. Left for a separate cleanup PR.
- `enterprise/storage/org_service.py:111` constructs a default `AgentSettings()` (no persisted data); only emits a `DeprecationWarning`, no 500.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Launch the SaaS locally via the `launch.json` configuration in `.vscode/`.
2. Sign up a new account.
3. Accept the Terms of Service.
4. Observe the request:
   ```
   GET http://localhost:3030/api/organizations  →  500
   ```

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/8b511645-7d31-4efa-b725-170335ab78f6

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-cedd3ad   docker.openhands.dev/openhands/openhands:cedd3ad
```