### PR TITLE
fix(frontend): use onSelectionChange for Language dropdown dirty-flag

### DIFF
--- a/frontend/src/components/features/settings/app-settings/language-input.tsx
+++ b/frontend/src/components/features/settings/app-settings/language-input.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useTranslation } from "react-i18next";
 import { AvailableLanguages } from "#/i18n";
 import { I18nKey } from "#/i18n/declaration";
@@ -5,7 +6,7 @@ import { SettingsDropdownInput } from "../settings-dropdown-input";
 
 interface LanguageInputProps {
   name: string;
-  onChange: (value: string) => void;
+  onChange: (key: React.Key | null) => void;
   defaultKey: string;
 }
 
@@ -20,7 +21,7 @@ export function LanguageInput({
     <SettingsDropdownInput
       testId={name}
       name={name}
-      onInputChange={onChange}
+      onSelectionChange={onChange}
       label={t(I18nKey.SETTINGS$LANGUAGE)}
       items={AvailableLanguages.map((l) => ({
         key: l.value,

--- a/frontend/src/routes/app-settings.tsx
+++ b/frontend/src/routes/app-settings.tsx
@@ -139,15 +139,12 @@ function AppSettingsScreen() {
     );
   };
 
-  const checkIfLanguageInputHasChanged = (value: string) => {
-    const selectedLanguage = AvailableLanguages.find(
-      ({ label: langValue }) => langValue === value,
-    )?.label;
-    const currentLanguage = AvailableLanguages.find(
-      ({ value: langValue }) => langValue === settings?.language,
-    )?.label;
-
-    setLanguageInputHasChanged(selectedLanguage !== currentLanguage);
+  const checkIfLanguageInputHasChanged = (key: React.Key | null) => {
+    if (key === null) {
+      setLanguageInputHasChanged(false);
+      return;
+    }
+    setLanguageInputHasChanged(key !== settings?.language);
   };
 
   const checkIfAnalyticsSwitchHasChanged = (checked: boolean) => {


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why

The Language dropdown on `/settings` wires its callback to the autocomplete's `onInputChange`, so `checkIfLanguageInputHasChanged` runs on every keystroke with the partial input (e.g. `"Fre"` while typing `"French"`). Looking that up in `AvailableLanguages` by label returns `undefined`, and `undefined !== currentLanguage` flips the dirty flag to true. **Save Changes** then becomes enabled as soon as the user types in the field, even if they close the dropdown without selecting anything or end up on the same language they started with. The LLM Provider selector (`model-selector.tsx`) handles the same pattern correctly via `onSelectionChange`.

## Summary

- `language-input.tsx`: swap `onInputChange` for `onSelectionChange` so the callback only fires on actual item selection. The `onChange` prop now takes `React.Key | null` to match what HeroUI Autocomplete delivers.
- `app-settings.tsx`: simplify `checkIfLanguageInputHasChanged` to compare the selected key against `settings?.language` directly (both are language codes), and treat a cleared selection as not-dirty.

## Issue Number

Fixes #14249

## How to Test

1. `cd frontend && npm install && npm run dev`
2. Open `/settings`.
3. Click the **Language** dropdown, type a few characters (e.g. `En`) to filter, then press Escape or click away without selecting. **Save Changes** stays disabled.
4. Pick the same language you already had. Save stays disabled.
5. Pick a different language. Save becomes enabled.
6. `npm run typecheck` and `npm run lint` pass.

The existing vitest case in `frontend/__tests__/routes/app-settings.test.tsx` (the language-dropdown block) drives the autocomplete via `userEvent.click`, which now flows through `onSelectionChange`.

## Video/Screenshots

N/A. See issue #14249 for the original repro video.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore