### PR TITLE
fix(secrets): return 404 when secret not found in update_custom_secret

### DIFF
--- a/openhands/app_server/secrets/secrets_router.py
+++ b/openhands/app_server/secrets/secrets_router.py
@@ -308,13 +308,14 @@ async def update_custom_secret(
         500: Error updating secret
     """
     existing_secrets = await secrets_store.load()
-    if existing_secrets:
-        # Check if the secret to update exists
-        if secret_id not in existing_secrets.custom_secrets:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f'Secret with ID {secret_id} not found',
-            )
+    if not existing_secrets or secret_id not in existing_secrets.custom_secrets:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f'Secret with ID {secret_id} not found',
+        )
+
+    # At this point, existing_secrets exists and contains the secret
+    secret_name = incoming_secret.name
 
         secret_name = incoming_secret.name
         secret_description = incoming_secret.description


### PR DESCRIPTION
## Summary

Fixes #14204

## Bug

In `update_custom_secret`, when `existing_secrets` is `None` (empty store), the `if existing_secrets:` guard skips all validation and the function falls through to return `EditResponse(message='Secret updated successfully')` even though no update occurred.

## Fix

Consolidate the None check and secret existence check at the start:

```python
existing_secrets = await secrets_store.load()
if not existing_secrets or secret_id not in existing_secrets.custom_secrets:
    raise HTTPException(
        status_code=status.HTTP_404_NOT_FOUND,
        detail=f'Secret with ID {secret_id} not found',
    )
```

## Impact

- Returns 404 when secret doesn't exist (correct HTTP semantics)
- Returns 404 when store is empty (fail closed)
- No behavior change for successful updates
