### PR TITLE
fix(security): remove debug log that exposes hook_config secrets

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -352,12 +352,6 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             body_json = start_conversation_request.model_dump(
                 mode='json', context={'expose_secrets': True}
             )
-            # Log hook_config to verify it's being passed
-            hook_config_in_request = body_json.get('hook_config')
-            _logger.debug(
-                f'Sending StartConversationRequest with hook_config: '
-                f'{hook_config_in_request}'
-            )
             headers = (
                 {'X-Session-API-Key': sandbox.session_api_key}
                 if sandbox.session_api_key


### PR DESCRIPTION
## Summary

Removes a debug-level log statement in `live_status_app_conversation_service.py` that could expose hook config secrets in plaintext.

**The problem:**
- `StartConversationRequest` was serialized with `context={'expose_secrets': True}` (full plaintext secrets)
- The `hook_config` dict from that serialization was logged at DEBUG level without any redaction
- `_logger` here is `logging.getLogger(__name__)` — a child logger whose records propagate to `openhands_logger` via `callHandlers`, **bypassing** the `SensitiveDataFilter` added to `openhands_logger`
- If `LOG_LEVEL=DEBUG` is ever set in a runtime pod, hook config secrets (API keys, tokens) would land in Datadog logs

**Why it wasn't caught sooner:** DEBUG is not the default log level, so this doesn't fire in production under normal conditions. The comment `# Log hook_config to verify it's being passed` identifies it as a temporary debugging artifact that was never removed.

**Context:** This was found while auditing the new `app_server/` code for the same class of vulnerability fixed in (now-obsolete) PR #14084, which patched the old runtime layer before it was restructured.

## What changed

Deleted the 6-line debug block. The surrounding code is unaffected.

## Test plan
- [ ] No functional change — only a log statement removed
- [ ] Verify lint passes (`ruff`, `mypy`)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-862f230   docker.openhands.dev/openhands/openhands:862f230
```