### PR TITLE
Persist Claude ACP resume state

### DIFF
--- a/enterprise/migrations/versions/113_add_acp_session_state_to_conversation_metadata.py
+++ b/enterprise/migrations/versions/113_add_acp_session_state_to_conversation_metadata.py
@@ -1,0 +1,32 @@
+"""Add ACP session state to conversation_metadata table.
+
+Revision ID: 113
+Revises: 112
+Create Date: 2026-05-04 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '113'
+down_revision: Union[str, None] = '112'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'conversation_metadata',
+        sa.Column('acp_session_id', sa.String(), nullable=True),
+    )
+    op.add_column(
+        'conversation_metadata',
+        sa.Column('acp_session_cwd', sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('conversation_metadata', 'acp_session_cwd')
+    op.drop_column('conversation_metadata', 'acp_session_id')

--- a/frontend/src/api/conversation-service/v1-conversation-service.types.ts
+++ b/frontend/src/api/conversation-service/v1-conversation-service.types.ts
@@ -111,6 +111,9 @@ export interface V1AppConversation {
   trigger: ConversationTrigger | null;
   pr_number: number[];
   llm_model: string | null;
+  agent_kind?: string;
+  acp_session_id?: string | null;
+  acp_session_cwd?: string | null;
   metrics: V1MetricsSnapshot | null;
   created_at: string;
   updated_at: string;

--- a/openhands/app_server/app_conversation/acp_resume.py
+++ b/openhands/app_server/app_conversation/acp_resume.py
@@ -1,0 +1,336 @@
+"""Helpers for durable ACP resume state.
+
+ACP ``session/load`` can only work after a sandbox recycle if both OpenHands'
+resume signal and the ACP server's own session file are restored into the new
+sandbox before the SDK creates the conversation.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shlex
+import tempfile
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+from openhands.agent_server.models import StartACPConversationRequest
+from openhands.app_server.file_store.files import FileStore
+from openhands.app_server.utils.async_utils import call_sync_from_async
+from openhands.sdk.event import ConversationStateUpdateEvent
+from openhands.sdk.workspace.remote.async_remote_workspace import AsyncRemoteWorkspace
+
+ACP_STATE_SNAPSHOT_FILE = "state.json"
+CLAUDE_SESSION_SNAPSHOT_FILE = "claude-session.jsonl.b64"
+REMOTE_CONVERSATIONS_DIR_ENV = "OH_CONVERSATIONS_PATH"
+REMOTE_DEFAULT_CONVERSATIONS_DIR = "/workspace/conversations"
+
+
+@dataclass(frozen=True)
+class ACPSessionState:
+    session_id: str
+    cwd: str
+    state_snapshot: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class ACPRestoreResult:
+    restored_base_state: bool = False
+    restored_claude_session: bool = False
+
+
+def extract_acp_session_state(
+    event: ConversationStateUpdateEvent,
+) -> ACPSessionState | None:
+    """Extract ACP session state from a ConversationStateUpdateEvent."""
+    state_snapshot: dict[str, Any] | None = None
+    agent_state: dict[str, Any] | None = None
+
+    if event.key == "full_state" and isinstance(event.value, dict):
+        state_snapshot = event.value
+        maybe_agent_state = state_snapshot.get("agent_state")
+        if isinstance(maybe_agent_state, dict):
+            agent_state = maybe_agent_state
+    elif event.key == "agent_state" and isinstance(event.value, dict):
+        agent_state = event.value
+
+    if not agent_state:
+        return None
+
+    session_id = agent_state.get("acp_session_id")
+    cwd = agent_state.get("acp_session_cwd")
+    if not isinstance(session_id, str) or not session_id.strip():
+        return None
+    if not isinstance(cwd, str) or not cwd.strip():
+        return None
+
+    return ACPSessionState(
+        session_id=session_id,
+        cwd=cwd,
+        state_snapshot=state_snapshot,
+    )
+
+
+def encode_claude_project_path(cwd: str) -> str:
+    """Match Claude Code's ``~/.claude/projects`` path encoding."""
+    return "".join(c if c.isalnum() else "-" for c in cwd)
+
+
+def _conversation_store_prefix(conversation_id: UUID) -> str:
+    return f"app-conversations/{conversation_id.hex}/acp"
+
+
+def _store_path(conversation_id: UUID, filename: str) -> str:
+    return f"{_conversation_store_prefix(conversation_id)}/{filename}"
+
+
+async def persist_acp_state_snapshot(
+    file_store: FileStore,
+    conversation_id: UUID,
+    state_snapshot: dict[str, Any],
+) -> None:
+    """Persist the latest SDK full-state snapshot durably."""
+    await call_sync_from_async(
+        file_store.write,
+        _store_path(conversation_id, ACP_STATE_SNAPSHOT_FILE),
+        json.dumps(state_snapshot, separators=(",", ":")),
+    )
+
+
+async def load_acp_state_snapshot(
+    file_store: FileStore,
+    conversation_id: UUID,
+) -> dict[str, Any] | None:
+    try:
+        snapshot = await call_sync_from_async(
+            file_store.read,
+            _store_path(conversation_id, ACP_STATE_SNAPSHOT_FILE),
+        )
+    except FileNotFoundError:
+        return None
+    return json.loads(snapshot)
+
+
+async def persist_claude_session_snapshot(
+    file_store: FileStore,
+    remote_workspace: AsyncRemoteWorkspace,
+    conversation_id: UUID,
+    session_state: ACPSessionState,
+) -> bool:
+    """Snapshot Claude Code's per-session JSONL file from the sandbox."""
+    command = _build_read_claude_session_command(
+        session_state.cwd, session_state.session_id
+    )
+    result = await remote_workspace.execute_command(command, timeout=30.0)
+    if result.exit_code != 0:
+        return False
+
+    encoded = result.stdout.strip()
+    if not encoded:
+        return False
+
+    await call_sync_from_async(
+        file_store.write,
+        _store_path(conversation_id, CLAUDE_SESSION_SNAPSHOT_FILE),
+        encoded,
+    )
+    return True
+
+
+async def restore_acp_resume_artifacts(
+    file_store: FileStore,
+    remote_workspace: AsyncRemoteWorkspace,
+    start_request: StartACPConversationRequest,
+    session_id: str,
+    session_cwd: str,
+) -> ACPRestoreResult:
+    """Restore OpenHands and Claude Code ACP resume artifacts into a sandbox."""
+    base_state_restored = await _restore_base_state(
+        file_store=file_store,
+        remote_workspace=remote_workspace,
+        start_request=start_request,
+        session_id=session_id,
+        session_cwd=session_cwd,
+    )
+    claude_restored = await _restore_claude_session_file(
+        file_store=file_store,
+        remote_workspace=remote_workspace,
+        conversation_id=start_request.conversation_id,
+        session_id=session_id,
+        session_cwd=session_cwd,
+    )
+    return ACPRestoreResult(
+        restored_base_state=base_state_restored,
+        restored_claude_session=claude_restored,
+    )
+
+
+async def _restore_base_state(
+    file_store: FileStore,
+    remote_workspace: AsyncRemoteWorkspace,
+    start_request: StartACPConversationRequest,
+    session_id: str,
+    session_cwd: str,
+) -> bool:
+    snapshot = await load_acp_state_snapshot(file_store, start_request.conversation_id)
+    if snapshot is None:
+        snapshot = build_minimal_acp_base_state(
+            start_request=start_request,
+            session_id=session_id,
+            session_cwd=session_cwd,
+        )
+    else:
+        agent_state = snapshot.get("agent_state")
+        if not isinstance(agent_state, dict):
+            agent_state = {}
+        agent_state["acp_session_id"] = session_id
+        agent_state["acp_session_cwd"] = session_cwd
+        snapshot["agent_state"] = agent_state
+
+    remote_base_state_path = await _remote_base_state_path(
+        remote_workspace, start_request.conversation_id
+    )
+    await _upload_bytes(
+        remote_workspace,
+        json.dumps(snapshot, separators=(",", ":")).encode("utf-8"),
+        remote_base_state_path,
+    )
+    return True
+
+
+def build_minimal_acp_base_state(
+    start_request: StartACPConversationRequest,
+    session_id: str,
+    session_cwd: str,
+) -> dict[str, Any]:
+    """Build the smallest SDK base_state.json needed to trigger ACP load_session."""
+    return {
+        "id": str(start_request.conversation_id),
+        "agent": start_request.agent.model_dump(
+            mode="json", context={"expose_secrets": True}
+        ),
+        "workspace": start_request.workspace.model_dump(mode="json"),
+        "max_iterations": start_request.max_iterations,
+        "stuck_detection": start_request.stuck_detection,
+        "agent_state": {
+            "acp_session_id": session_id,
+            "acp_session_cwd": session_cwd,
+        },
+        "tags": start_request.tags or {},
+    }
+
+
+async def _restore_claude_session_file(
+    file_store: FileStore,
+    remote_workspace: AsyncRemoteWorkspace,
+    conversation_id: UUID,
+    session_id: str,
+    session_cwd: str,
+) -> bool:
+    try:
+        encoded = await call_sync_from_async(
+            file_store.read,
+            _store_path(conversation_id, CLAUDE_SESSION_SNAPSHOT_FILE),
+        )
+    except FileNotFoundError:
+        return False
+
+    try:
+        contents = base64.b64decode(encoded.encode("ascii"), validate=True)
+    except Exception:
+        return False
+
+    destination = await _remote_claude_session_path(
+        remote_workspace, session_cwd, session_id
+    )
+    await _upload_bytes(remote_workspace, contents, destination)
+    return True
+
+
+async def _upload_bytes(
+    remote_workspace: AsyncRemoteWorkspace,
+    contents: bytes,
+    destination: str,
+) -> None:
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        tmp.write(contents)
+        tmp_path = tmp.name
+    try:
+        result = await remote_workspace.file_upload(tmp_path, destination)
+        if not result.success:
+            raise RuntimeError(
+                f"Failed to upload {destination}: {result.error or 'unknown error'}"
+            )
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
+
+
+async def _remote_base_state_path(
+    remote_workspace: AsyncRemoteWorkspace,
+    conversation_id: UUID,
+) -> str:
+    command = (
+        "python3 - <<'PY'\n"
+        "import os\n"
+        "from pathlib import Path\n"
+        f"base = os.environ.get({REMOTE_CONVERSATIONS_DIR_ENV!r}, "
+        f"{REMOTE_DEFAULT_CONVERSATIONS_DIR!r})\n"
+        f"path = Path(base) / {conversation_id.hex!r}\n"
+        "path.mkdir(parents=True, exist_ok=True)\n"
+        'print(path / "base_state.json")\n'
+        "PY"
+    )
+    result = await remote_workspace.execute_command(command, timeout=10.0)
+    if result.exit_code != 0:
+        raise RuntimeError(result.stderr or "Failed to create conversation state dir")
+    return result.stdout.strip()
+
+
+async def _remote_claude_session_path(
+    remote_workspace: AsyncRemoteWorkspace,
+    cwd: str,
+    session_id: str,
+) -> str:
+    encoded = encode_claude_project_path(cwd)
+    command = (
+        "python3 - <<'PY'\n"
+        "import os\n"
+        "from pathlib import Path\n"
+        'config = os.environ.get("CLAUDE_CONFIG_DIR") or '
+        'str(Path.home() / ".claude")\n'
+        f'path = Path(config) / "projects" / {encoded!r}\n'
+        "path.mkdir(parents=True, exist_ok=True)\n"
+        f'print(path / ({session_id!r} + ".jsonl"))\n'
+        "PY"
+    )
+    result = await remote_workspace.execute_command(command, timeout=10.0)
+    if result.exit_code != 0:
+        raise RuntimeError(result.stderr or "Failed to create Claude session dir")
+    return result.stdout.strip()
+
+
+def _build_read_claude_session_command(cwd: str, session_id: str) -> str:
+    return (
+        f"ACP_SESSION_CWD={shlex.quote(cwd)} "
+        f"ACP_SESSION_ID={shlex.quote(session_id)} "
+        "python3 - <<'PY'\n"
+        "import base64\n"
+        "import os\n"
+        "import sys\n"
+        "from pathlib import Path\n"
+        'cwd = os.environ["ACP_SESSION_CWD"]\n'
+        'sid = os.environ["ACP_SESSION_ID"]\n'
+        'encoded = "".join(c if c.isalnum() else "-" for c in cwd)\n'
+        'config = os.environ.get("CLAUDE_CONFIG_DIR") or '
+        'str(Path.home() / ".claude")\n'
+        'path = Path(config) / "projects" / encoded / f"{sid}.jsonl"\n'
+        "if not path.is_file():\n"
+        "    sys.exit(42)\n"
+        'sys.stdout.write(base64.b64encode(path.read_bytes()).decode("ascii"))\n'
+        "PY"
+    )

--- a/openhands/app_server/app_conversation/app_conversation_models.py
+++ b/openhands/app_server/app_conversation/app_conversation_models.py
@@ -103,6 +103,8 @@ class AppConversationInfo(BaseModel):
     pr_number: list[int] = Field(default_factory=list)
     llm_model: str | None = None
     agent_kind: str = 'openhands'
+    acp_session_id: str | None = None
+    acp_session_cwd: str | None = None
 
     metrics: MetricsSnapshot | None = None
 

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -23,6 +23,9 @@ from openhands.agent_server.models import (
     StartConversationRequest,
     TextContent,
 )
+from openhands.app_server.app_conversation.acp_resume import (
+    restore_acp_resume_artifacts,
+)
 from openhands.app_server.app_conversation.app_conversation_info_service import (
     AppConversationInfoService,
 )
@@ -70,6 +73,7 @@ from openhands.app_server.event_callback.event_callback_service import (
 from openhands.app_server.event_callback.set_title_callback_processor import (
     SetTitleCallbackProcessor,
 )
+from openhands.app_server.file_store.files import FileStore
 from openhands.app_server.integrations.provider import PROVIDER_TOKEN_TYPE, ProviderType
 from openhands.app_server.integrations.service_types import SuggestedTask
 from openhands.app_server.pending_messages.pending_message_service import (
@@ -178,6 +182,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
     web_url: str | None
     openhands_provider_base_url: str | None
     access_token_hard_timeout: timedelta | None
+    file_store: FileStore | None = None
     app_mode: str | None = None
 
     async def _get_sandbox_grouping_strategy(self) -> SandboxGroupingStrategy:
@@ -307,6 +312,13 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
 
             # Set up conversation id
             conversation_id = request.conversation_id or uuid4()
+            existing_app_conversation_info = None
+            if request.conversation_id:
+                existing_app_conversation_info = (
+                    await self.app_conversation_info_service.get_app_conversation_info(
+                        request.conversation_id
+                    )
+                )
 
             # Setup working dir based on grouping
             working_dir = sandbox_spec.working_dir
@@ -342,6 +354,12 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                     api_secrets=request.secrets,
                 )
             )
+            if isinstance(start_conversation_request, StartACPConversationRequest):
+                await self._restore_acp_resume_artifacts(
+                    existing_app_conversation_info,
+                    remote_workspace,
+                    start_conversation_request,
+                )
 
             # update status
             task.status = AppConversationStartTaskStatus.STARTING_CONVERSATION
@@ -386,11 +404,26 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             user_id = await self.user_context.get_user_id()
             app_conversation_info = AppConversationInfo(
                 id=info.id,
-                title=f'Conversation {info.id.hex[:5]}',
+                title=(
+                    existing_app_conversation_info.title
+                    if existing_app_conversation_info
+                    and existing_app_conversation_info.title
+                    else f'Conversation {info.id.hex[:5]}'
+                ),
                 sandbox_id=sandbox.id,
                 created_by_user_id=user_id,
                 llm_model=display_model,
                 agent_kind=agent_kind,
+                acp_session_id=(
+                    existing_app_conversation_info.acp_session_id
+                    if existing_app_conversation_info
+                    else None
+                ),
+                acp_session_cwd=(
+                    existing_app_conversation_info.acp_session_cwd
+                    if existing_app_conversation_info
+                    else None
+                ),
                 # Git parameters
                 selected_repository=request.selected_repository,
                 selected_branch=request.selected_branch,
@@ -398,6 +431,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 trigger=request.trigger,
                 pr_number=request.pr_number,
                 parent_conversation_id=request.parent_conversation_id,
+                tags=existing_app_conversation_info.tags
+                if existing_app_conversation_info
+                else {},
             )
             await self.app_conversation_info_service.save_app_conversation_info(
                 app_conversation_info
@@ -831,6 +867,48 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         )
         agent_server_url = replace_localhost_hostname_for_docker(agent_server_url)
         return agent_server_url
+
+    async def _restore_acp_resume_artifacts(
+        self,
+        existing_info: AppConversationInfo | None,
+        remote_workspace: AsyncRemoteWorkspace,
+        start_request: StartACPConversationRequest,
+    ) -> None:
+        """Restore ACP resume state before recreating an ACP conversation."""
+        if (
+            existing_info is None
+            or existing_info.agent_kind != 'acp'
+            or not existing_info.acp_session_id
+            or not existing_info.acp_session_cwd
+        ):
+            return
+        if self.file_store is None:
+            _logger.warning(
+                'Cannot restore ACP session for conversation %s: no file_store',
+                existing_info.id,
+            )
+            return
+
+        try:
+            result = await restore_acp_resume_artifacts(
+                file_store=self.file_store,
+                remote_workspace=remote_workspace,
+                start_request=start_request,
+                session_id=existing_info.acp_session_id,
+                session_cwd=existing_info.acp_session_cwd,
+            )
+            _logger.info(
+                'Restored ACP resume artifacts for conversation %s: '
+                'base_state=%s claude_session=%s',
+                existing_info.id,
+                result.restored_base_state,
+                result.restored_claude_session,
+            )
+        except Exception:
+            _logger.exception(
+                'Failed to restore ACP resume artifacts for conversation %s',
+                existing_info.id,
+            )
 
     def _inherit_configuration_from_parent(
         self, request: AppConversationStartRequest, parent_info: AppConversationInfo
@@ -2136,5 +2214,6 @@ class LiveStatusAppConversationServiceInjector(AppConversationServiceInjector):
                 web_url=web_url,
                 openhands_provider_base_url=config.openhands_provider_base_url,
                 access_token_hard_timeout=access_token_hard_timeout,
+                file_store=config.file_store,
                 app_mode=app_mode,
             )

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -101,6 +101,8 @@ class StoredConversationMetadata(Base):
     # LLM model used for the conversation
     llm_model: Mapped[str | None] = mapped_column(String, nullable=True)
     agent_kind: Mapped[str | None] = mapped_column(String, nullable=True)
+    acp_session_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    acp_session_cwd: Mapped[str | None] = mapped_column(String, nullable=True)
 
     conversation_version: Mapped[str] = mapped_column(
         String, nullable=False, default='V0', index=True
@@ -372,6 +374,8 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             per_turn_token=usage.per_turn_token,
             llm_model=info.llm_model,
             agent_kind=info.agent_kind,
+            acp_session_id=info.acp_session_id,
+            acp_session_cwd=info.acp_session_cwd,
             conversation_version='V1',
             sandbox_id=info.sandbox_id,
             parent_conversation_id=(
@@ -561,6 +565,8 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             pr_number=stored.pr_number or [],
             llm_model=stored.llm_model,
             agent_kind=stored.agent_kind or 'openhands',
+            acp_session_id=stored.acp_session_id,
+            acp_session_cwd=stored.acp_session_cwd,
             metrics=metrics,
             parent_conversation_id=(
                 UUID(stored.parent_conversation_id)

--- a/openhands/app_server/app_lifespan/alembic/versions/010.py
+++ b/openhands/app_server/app_lifespan/alembic/versions/010.py
@@ -1,0 +1,32 @@
+"""Add ACP session columns to conversation_metadata
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-05-04 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '010'
+down_revision: Union[str, None] = '009'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'conversation_metadata',
+        sa.Column('acp_session_id', sa.String(), nullable=True),
+    )
+    op.add_column(
+        'conversation_metadata',
+        sa.Column('acp_session_cwd', sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('conversation_metadata', 'acp_session_cwd')
+    op.drop_column('conversation_metadata', 'acp_session_id')

--- a/openhands/app_server/event_callback/webhook_router.py
+++ b/openhands/app_server/event_callback/webhook_router.py
@@ -14,6 +14,11 @@ from pydantic import SecretStr
 from openhands import tools  # type: ignore[attr-defined]
 from openhands.agent_server.models import ConversationInfo, Success
 from openhands.analytics import get_analytics_service, resolve_analytics_context
+from openhands.app_server.app_conversation.acp_resume import (
+    extract_acp_session_state,
+    persist_acp_state_snapshot,
+    persist_claude_session_snapshot,
+)
 from openhands.app_server.app_conversation.app_conversation_info_service import (
     AppConversationInfoService,
 )
@@ -25,6 +30,7 @@ from openhands.app_server.config import (
     depends_app_conversation_info_service,
     depends_event_service,
     depends_jwt_service,
+    depends_sandbox_service,
     get_event_callback_service,
     get_global_config,
     get_sandbox_service,
@@ -37,7 +43,12 @@ from openhands.app_server.event_callback.set_title_callback_processor import (
     SetTitleCallbackProcessor,
 )
 from openhands.app_server.integrations.provider import ProviderType
-from openhands.app_server.sandbox.sandbox_models import SandboxInfo
+from openhands.app_server.sandbox.sandbox_models import (
+    AGENT_SERVER,
+    SandboxInfo,
+    SandboxStatus,
+)
+from openhands.app_server.sandbox.sandbox_service import SandboxService
 from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.services.jwt_service import JwtService
 from openhands.app_server.user.auth_user_context import AuthUserContext
@@ -50,12 +61,17 @@ from openhands.app_server.user_auth.default_user_auth import DefaultUserAuth
 from openhands.app_server.user_auth.user_auth import (
     get_for_user as get_user_auth_for_user,
 )
+from openhands.app_server.utils.docker_utils import (
+    replace_localhost_hostname_for_docker,
+)
 from openhands.sdk import ConversationExecutionStatus, Event
 from openhands.sdk.event import ConversationStateUpdateEvent
+from openhands.sdk.workspace.remote.async_remote_workspace import AsyncRemoteWorkspace
 
 router = APIRouter(prefix='/webhooks', tags=['Webhooks'])
 event_service_dependency = depends_event_service()
 app_conversation_info_service_dependency = depends_app_conversation_info_service()
+sandbox_service_dependency = depends_sandbox_service()
 jwt_dependency = depends_jwt_service()
 app_mode = get_global_config().app_mode
 _logger = logging.getLogger(__name__)
@@ -295,6 +311,77 @@ async def valid_conversation(
     return app_conversation_info
 
 
+async def _persist_acp_resume_state(
+    event: ConversationStateUpdateEvent,
+    app_conversation_info: AppConversationInfo,
+    app_conversation_info_service: AppConversationInfoService,
+    sandbox_service: SandboxService,
+) -> None:
+    session_state = extract_acp_session_state(event)
+    if session_state is None:
+        return
+
+    should_save_info = (
+        app_conversation_info.acp_session_id != session_state.session_id
+        or app_conversation_info.acp_session_cwd != session_state.cwd
+    )
+    if should_save_info:
+        app_conversation_info.acp_session_id = session_state.session_id
+        app_conversation_info.acp_session_cwd = session_state.cwd
+        await app_conversation_info_service.save_app_conversation_info(
+            app_conversation_info
+        )
+
+    file_store = get_global_config().file_store
+    if session_state.state_snapshot is not None:
+        await persist_acp_state_snapshot(
+            file_store,
+            app_conversation_info.id,
+            session_state.state_snapshot,
+        )
+
+    if app_conversation_info.agent_kind != 'acp':
+        return
+
+    try:
+        sandbox = await sandbox_service.get_sandbox(app_conversation_info.sandbox_id)
+        if (
+            sandbox is None
+            or sandbox.status != SandboxStatus.RUNNING
+            or not sandbox.exposed_urls
+        ):
+            return
+
+        agent_server_url = next(
+            (
+                exposed_url.url
+                for exposed_url in sandbox.exposed_urls
+                if exposed_url.name == AGENT_SERVER
+            ),
+            None,
+        )
+        if not agent_server_url:
+            return
+        agent_server_url = replace_localhost_hostname_for_docker(agent_server_url)
+        remote_workspace = AsyncRemoteWorkspace(
+            host=agent_server_url,
+            api_key=sandbox.session_api_key,
+            working_dir=session_state.cwd,
+        )
+        await persist_claude_session_snapshot(
+            file_store=file_store,
+            remote_workspace=remote_workspace,
+            conversation_id=app_conversation_info.id,
+            session_state=session_state,
+        )
+    except Exception:
+        _logger.warning(
+            'Failed to snapshot Claude ACP session for conversation %s',
+            app_conversation_info.id,
+            exc_info=True,
+        )
+
+
 @router.post('/conversations')
 async def on_conversation_update(
     conversation_info: ConversationInfo,
@@ -332,6 +419,9 @@ async def on_conversation_update(
         sandbox_id=sandbox_info.id,
         created_by_user_id=sandbox_info.created_by_user_id,
         llm_model=conversation_info.agent.llm.model,
+        agent_kind=existing.agent_kind,
+        acp_session_id=existing.acp_session_id,
+        acp_session_cwd=existing.acp_session_cwd,
         # Git parameters
         selected_repository=existing.selected_repository,
         selected_branch=existing.selected_branch,
@@ -392,6 +482,7 @@ async def on_event(
     conversation_id: UUID,
     app_conversation_info: AppConversationInfo = Depends(valid_conversation),
     app_conversation_info_service: AppConversationInfoService = app_conversation_info_service_dependency,
+    sandbox_service: SandboxService = sandbox_service_dependency,
     event_service: EventService = event_service_dependency,
 ) -> Success:
     """Webhook callback for when event stream events occur."""
@@ -406,6 +497,13 @@ async def on_event(
             if isinstance(event, ConversationStateUpdateEvent) and event.key == 'stats':
                 await app_conversation_info_service.process_stats_event(
                     event, conversation_id
+                )
+            if isinstance(event, ConversationStateUpdateEvent):
+                await _persist_acp_resume_state(
+                    event,
+                    app_conversation_info,
+                    app_conversation_info_service,
+                    sandbox_service,
                 )
 
         # Analytics: conversation terminal state detection

--- a/tests/unit/app_server/test_acp_resume.py
+++ b/tests/unit/app_server/test_acp_resume.py
@@ -1,0 +1,150 @@
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from openhands.agent_server.models import StartACPConversationRequest
+from openhands.app_server.app_conversation.acp_resume import (
+    ACPSessionState,
+    encode_claude_project_path,
+    extract_acp_session_state,
+    persist_claude_session_snapshot,
+    restore_acp_resume_artifacts,
+)
+from openhands.app_server.file_store.memory import InMemoryFileStore
+from openhands.sdk import LocalWorkspace
+from openhands.sdk.agent.acp_agent import ACPAgent
+from openhands.sdk.conversation.state import ConversationState
+from openhands.sdk.event import ConversationStateUpdateEvent
+from openhands.sdk.workspace import CommandResult, FileOperationResult
+
+
+class LocalRemoteWorkspace:
+    def __init__(self, home: Path, conversations_dir: Path):
+        self.home = home
+        self.conversations_dir = conversations_dir
+
+    async def execute_command(
+        self,
+        command: str,
+        cwd: str | Path | None = None,
+        timeout: float = 30.0,
+    ) -> CommandResult:
+        env = {
+            **os.environ,
+            "HOME": str(self.home),
+            "OH_CONVERSATIONS_PATH": str(self.conversations_dir),
+        }
+        result = subprocess.run(
+            command,
+            shell=True,
+            executable="/bin/bash",
+            cwd=str(cwd) if cwd else None,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+        )
+        return CommandResult(
+            command=command,
+            exit_code=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+            timeout_occurred=False,
+        )
+
+    async def file_upload(
+        self,
+        source_path: str | Path,
+        destination_path: str | Path,
+    ) -> FileOperationResult:
+        destination = Path(destination_path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source_path, destination)
+        return FileOperationResult(
+            success=True,
+            source_path=str(source_path),
+            destination_path=str(destination_path),
+            file_size=destination.stat().st_size,
+        )
+
+
+def test_extract_acp_session_state_from_full_state():
+    event = ConversationStateUpdateEvent(
+        key="full_state",
+        value={
+            "agent_state": {
+                "acp_session_id": "sid-123",
+                "acp_session_cwd": "/workspace/project",
+            }
+        },
+    )
+
+    state = extract_acp_session_state(event)
+
+    assert state == ACPSessionState(
+        session_id="sid-123",
+        cwd="/workspace/project",
+        state_snapshot=event.value,
+    )
+
+
+@pytest.mark.asyncio
+async def test_persist_and_restore_claude_session_snapshot(tmp_path: Path):
+    home = tmp_path / "home"
+    conversations_dir = tmp_path / "conversations"
+    remote = LocalRemoteWorkspace(home=home, conversations_dir=conversations_dir)
+    file_store = InMemoryFileStore()
+    conversation_id = uuid4()
+    session_id = "b9d174a1-b4a6-4bb5-a5f7-a389d04c4d6f"
+    cwd = "/private/tmp/acp-live-verify-workspace"
+    encoded_cwd = encode_claude_project_path(cwd)
+    claude_session = home / ".claude" / "projects" / encoded_cwd / f"{session_id}.jsonl"
+    claude_session.parent.mkdir(parents=True)
+    real_shape_jsonl = (
+        json.dumps({"type": "user", "message": {"content": "remember blue"}})
+        + "\n"
+        + json.dumps({"type": "assistant", "message": {"content": "noted"}})
+        + "\n"
+    ).encode()
+    claude_session.write_bytes(real_shape_jsonl)
+
+    snapshotted = await persist_claude_session_snapshot(
+        file_store=file_store,
+        remote_workspace=remote,  # type: ignore[arg-type]
+        conversation_id=conversation_id,
+        session_state=ACPSessionState(session_id=session_id, cwd=cwd),
+    )
+    claude_session.unlink()
+
+    request = StartACPConversationRequest(
+        workspace=LocalWorkspace(working_dir=cwd),
+        conversation_id=conversation_id,
+        agent=ACPAgent(acp_command=["claude-agent-acp"]),
+    )
+    result = await restore_acp_resume_artifacts(
+        file_store=file_store,
+        remote_workspace=remote,  # type: ignore[arg-type]
+        start_request=request,
+        session_id=session_id,
+        session_cwd=cwd,
+    )
+
+    assert snapshotted is True
+    assert result.restored_base_state is True
+    assert result.restored_claude_session is True
+    assert claude_session.read_bytes() == real_shape_jsonl
+
+    base_state = json.loads(
+        (conversations_dir / conversation_id.hex / "base_state.json").read_text()
+    )
+    assert base_state["agent_state"] == {
+        "acp_session_id": session_id,
+        "acp_session_cwd": cwd,
+    }
+    validated_state = ConversationState.model_validate(base_state)
+    assert validated_state.agent_state["acp_session_id"] == session_id

--- a/tests/unit/app_server/test_sql_app_conversation_info_service.py
+++ b/tests/unit/app_server/test_sql_app_conversation_info_service.py
@@ -165,6 +165,14 @@ class TestSQLAppConversationInfoService:
         assert retrieved_info.trigger == sample_conversation_info.trigger
         assert retrieved_info.pr_number == sample_conversation_info.pr_number
         assert retrieved_info.llm_model == sample_conversation_info.llm_model
+        assert (
+            retrieved_info.acp_session_id
+            == sample_conversation_info.acp_session_id
+        )
+        assert (
+            retrieved_info.acp_session_cwd
+            == sample_conversation_info.acp_session_cwd
+        )
 
     @pytest.mark.asyncio
     async def test_get_nonexistent_conversation_info(
@@ -191,6 +199,9 @@ class TestSQLAppConversationInfoService:
             trigger=ConversationTrigger.RESOLVER,
             pr_number=[789, 101112],
             llm_model='claude-3',
+            agent_kind='acp',
+            acp_session_id='session-123',
+            acp_session_cwd='/workspace/project',
             metrics=MetricsSnapshot(accumulated_token_usage=TokenUsage()),
             created_at=datetime(2024, 2, 15, 10, 30, 0, tzinfo=timezone.utc),
             updated_at=datetime(2024, 2, 15, 11, 45, 0, tzinfo=timezone.utc),
@@ -211,6 +222,9 @@ class TestSQLAppConversationInfoService:
         assert retrieved_info.trigger == original_info.trigger
         assert retrieved_info.pr_number == original_info.pr_number
         assert retrieved_info.llm_model == original_info.llm_model
+        assert retrieved_info.agent_kind == original_info.agent_kind
+        assert retrieved_info.acp_session_id == original_info.acp_session_id
+        assert retrieved_info.acp_session_cwd == original_info.acp_session_cwd
         assert retrieved_info.metrics == original_info.metrics
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Persist ACP session id/cwd on app conversation metadata and snapshot ACP full-state updates durably.
- Mirror Claude Code's native `~/.claude/projects/<encoded-cwd>/<sid>.jsonl` session file into app storage and restore it into the new sandbox before ACP conversation recreation.
- Add OSS/enterprise migrations, API type fields, and focused unit coverage for ACP resume extraction and Claude session restore.

Fixes #14260

## Validation

- `.venv/bin/ruff check --select F,I openhands/app_server/app_conversation/acp_resume.py openhands/app_server/app_conversation/live_status_app_conversation_service.py openhands/app_server/event_callback/webhook_router.py openhands/app_server/app_conversation/app_conversation_models.py openhands/app_server/app_conversation/sql_app_conversation_info_service.py tests/unit/app_server/test_acp_resume.py tests/unit/app_server/test_sql_app_conversation_info_service.py`
- `.venv/bin/pytest tests/unit/app_server/test_acp_resume.py tests/unit/app_server/test_sql_app_conversation_info_service.py tests/unit/app_server/test_live_status_app_conversation_service.py tests/unit/app_server/test_webhook_router_stats.py -q` (`161 passed`)
- `git diff --check`
- Real Claude Code JSONL round-trip using `/Users/simonrosenberg/.claude/projects/-private-tmp-acp-live-verify-workspace/b9d174a1-b4a6-4bb5-a5f7-a389d04c4d6f.jsonl`: snapshotted and restored 16,235 bytes with matching SHA-256 and expected ACP session id/cwd in restored `base_state.json`.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-1f672f5   docker.openhands.dev/openhands/openhands:1f672f5
```