### PR TITLE
fix(acp): route pending message delivery through correct agent-server prefix

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -433,6 +433,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                     conversation_id=info.id,
                     agent_server_url=agent_server_url,
                     session_api_key=sandbox.session_api_key,
+                    agent_kind=agent_kind,
                 )
 
         except Exception as exc:
@@ -1619,6 +1620,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         conversation_id: UUID,
         agent_server_url: str,
         session_api_key: str,
+        agent_kind: str = 'openhands',
     ) -> None:
         """Process pending messages queued before conversation was ready.
 
@@ -1630,6 +1632,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             conversation_id: The real conversation ID
             agent_server_url: URL of the agent server
             session_api_key: API key for authenticating with agent server
+            agent_kind: Discriminator for agent-server route prefix ('acp' or 'openhands')
         """
         # Convert UUIDs to strings for the pending message service
         # The frontend uses task-{uuid.hex} format (no hyphens), matching OpenHandsUUID serialization
@@ -1669,9 +1672,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             try:
                 # Serialize content objects to JSON-compatible dicts
                 content_json = [item.model_dump() for item in msg.content]
-                # Use the events endpoint which handles message sending
+                router_path = _agent_kind_to_router_path(agent_kind)
                 response = await self.httpx_client.post(
-                    f'{agent_server_url}/api/conversations/{conversation_id_str}/events',
+                    f'{agent_server_url}/api/{router_path}/{conversation_id_str}/events',
                     json={
                         'role': msg.role,
                         'content': content_json,

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3388,3 +3388,122 @@ class TestBuildAcpStartConversationRequestSecrets:
 
         # acp_env must win; the UI-saved key must NOT overwrite it
         assert request.agent.acp_env.get('ANTHROPIC_API_KEY') == 'sk-explicit-override'
+
+
+class TestProcessPendingMessages:
+    """Unit tests for _process_pending_messages URL routing.
+
+    Verifies that pending messages are delivered to the correct agent-server
+    endpoint depending on agent_kind: /api/conversations/ for 'openhands' and
+    /api/acp/conversations/ for 'acp'.
+    """
+
+    def _make_service(self, mock_httpx_client, mock_pending_service):
+        service = LiveStatusAppConversationService.__new__(
+            LiveStatusAppConversationService
+        )
+        service.httpx_client = mock_httpx_client
+        service.pending_message_service = mock_pending_service
+        return service
+
+    @pytest.mark.asyncio
+    async def test_openhands_agent_uses_standard_events_url(self):
+        from openhands.agent_server.models import TextContent
+
+        task_id = uuid4()
+        conversation_id = uuid4()
+        agent_server_url = 'http://agent-server:8000'
+        session_api_key = 'sk-test'
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+
+        mock_httpx = Mock()
+        mock_httpx.post = AsyncMock(return_value=mock_response)
+
+        mock_pending = Mock()
+        mock_pending.update_conversation_id = AsyncMock(return_value=0)
+        mock_pending.get_pending_messages = AsyncMock(
+            return_value=[
+                Mock(
+                    id='msg-1',
+                    role='user',
+                    content=[TextContent(type='text', text='hello')],
+                )
+            ]
+        )
+        mock_pending.delete_messages_for_conversation = AsyncMock(return_value=1)
+
+        service = self._make_service(mock_httpx, mock_pending)
+        await service._process_pending_messages(
+            task_id=task_id,
+            conversation_id=conversation_id,
+            agent_server_url=agent_server_url,
+            session_api_key=session_api_key,
+            agent_kind='openhands',
+        )
+
+        posted_url = mock_httpx.post.call_args[0][0]
+        assert '/api/conversations/' in posted_url
+        assert '/api/acp/' not in posted_url
+        assert str(conversation_id) in posted_url
+
+    @pytest.mark.asyncio
+    async def test_acp_agent_uses_acp_events_url(self):
+        from openhands.agent_server.models import TextContent
+
+        task_id = uuid4()
+        conversation_id = uuid4()
+        agent_server_url = 'http://agent-server:8000'
+        session_api_key = 'sk-test'
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+
+        mock_httpx = Mock()
+        mock_httpx.post = AsyncMock(return_value=mock_response)
+
+        mock_pending = Mock()
+        mock_pending.update_conversation_id = AsyncMock(return_value=0)
+        mock_pending.get_pending_messages = AsyncMock(
+            return_value=[
+                Mock(
+                    id='msg-1',
+                    role='user',
+                    content=[TextContent(type='text', text='hello')],
+                )
+            ]
+        )
+        mock_pending.delete_messages_for_conversation = AsyncMock(return_value=1)
+
+        service = self._make_service(mock_httpx, mock_pending)
+        await service._process_pending_messages(
+            task_id=task_id,
+            conversation_id=conversation_id,
+            agent_server_url=agent_server_url,
+            session_api_key=session_api_key,
+            agent_kind='acp',
+        )
+
+        posted_url = mock_httpx.post.call_args[0][0]
+        assert '/api/acp/conversations/' in posted_url
+        assert str(conversation_id) in posted_url
+
+    @pytest.mark.asyncio
+    async def test_no_pending_messages_skips_post(self):
+        mock_httpx = Mock()
+        mock_httpx.post = AsyncMock()
+
+        mock_pending = Mock()
+        mock_pending.update_conversation_id = AsyncMock(return_value=0)
+        mock_pending.get_pending_messages = AsyncMock(return_value=[])
+
+        service = self._make_service(mock_httpx, mock_pending)
+        await service._process_pending_messages(
+            task_id=uuid4(),
+            conversation_id=uuid4(),
+            agent_server_url='http://agent-server:8000',
+            session_api_key='sk-test',
+        )
+
+        mock_httpx.post.assert_not_called()


### PR DESCRIPTION
## Why

`_process_pending_messages` hardcoded `/api/conversations/` for all conversation kinds. ACP conversations must use `/api/acp/conversations/` so the agent server routes the event to the ACP handler. In cloud environments, a user who sends a message while an ACP sandbox is still starting would have that message silently dropped.

The bug is latent in local dev because `sandbox.session_api_key` is `None` without a remote runtime, so `_process_pending_messages` is never called. In cloud + ACP + sandbox-startup race, the POST hits the wrong endpoint, the agent server returns a 404, the exception is caught as a warning, and the message is lost.

## Summary

- Add `agent_kind: str = 'openhands'` parameter to `_process_pending_messages`
- Use `_agent_kind_to_router_path(agent_kind)` to build the events URL (same helper used by all other agent-server call sites)
- Pass `agent_kind` through at the single call site

## Test plan

- `uv run pytest tests/unit/app_server/ -q` — all 1084 tests pass
- No new test needed: the code path only fires in cloud + ACP + timing race; the correctness follows directly from using the same `_agent_kind_to_router_path` helper that all other call sites already use

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-7f0514f   docker.openhands.dev/openhands/openhands:7f0514f
```