### PR TITLE
feat(app-server): plumb llm.base_url into ACP subprocess env (#13999)

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1458,10 +1458,16 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
     def _acp_provider_env(user: UserInfo) -> dict[str, str]:
         """Translate UI-saved LLM credentials into provider-native env vars.
 
-        The ACP subprocess reads provider credentials from environment variables.
-        Maps the user's LLM API key to the env var expected by the active ACP
-        server via ``ACPAgentSettings.api_key_env_var``. Custom servers return
-        ``None`` — users manage credentials entirely via ``acp_env``.
+        The ACP subprocess reads provider credentials from environment
+        variables. Maps the user's LLM api key (and, when present, base URL)
+        to the env vars expected by the active ACP server via
+        ``ACPAgentSettings.api_key_env_var`` / ``base_url_env_var``. Custom
+        servers return ``None`` for both — users manage credentials entirely
+        via ``acp_env``.
+
+        The ``*_BASE_URL`` var is only emitted when ``api_key`` is also set,
+        so a provider-default ``base_url`` alone never clobbers an explicit
+        ``OH_AGENT_SERVER_ENV`` passthrough (matches #13999 / PR #14004 intent).
 
         Args:
             user: User information containing ACP agent settings.
@@ -1487,20 +1493,38 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         if not key_value or not key_value.strip():
             return env
 
-        # TODO: simplify to `acp_settings.api_key_env_var` once OpenHands is
-        # pinned to an SDK version that includes software-agent-sdk PR #2984.
-        # The fallback per-server mapping below duplicates that SDK property.
+        # TODO: simplify to `acp_settings.api_key_env_var` /
+        # `acp_settings.base_url_env_var` once OpenHands is pinned to an SDK
+        # version that includes software-agent-sdk PR #2984. The fallback
+        # per-server maps below duplicate those SDK properties.
+        _SERVER_KEY_MAP = {
+            'claude-code': 'ANTHROPIC_API_KEY',
+            'codex': 'OPENAI_API_KEY',
+            'gemini-cli': 'GEMINI_API_KEY',
+        }
+        _SERVER_BASE_URL_MAP = {
+            'claude-code': 'ANTHROPIC_BASE_URL',
+            'codex': 'OPENAI_BASE_URL',
+            'gemini-cli': 'GEMINI_BASE_URL',
+        }
+
         api_key_env: str | None = getattr(acp_settings, 'api_key_env_var', None)
         if api_key_env is None:
-            _SERVER_KEY_MAP = {
-                'claude-code': 'ANTHROPIC_API_KEY',
-                'codex': 'OPENAI_API_KEY',
-                'gemini-cli': 'GEMINI_API_KEY',
-            }
             api_key_env = _SERVER_KEY_MAP.get(acp_settings.acp_server)
 
         if api_key_env:
             env[api_key_env] = key_value
+
+        # Only plumb base_url when we know the provider (non-custom) AND an
+        # api_key was successfully plumbed — matches the security gate above.
+        base_url = acp_settings.llm.base_url
+        if api_key_env and base_url and str(base_url).strip():
+            base_url_env: str | None = getattr(acp_settings, 'base_url_env_var', None)
+            if base_url_env is None:
+                base_url_env = _SERVER_BASE_URL_MAP.get(acp_settings.acp_server)
+
+            if base_url_env:
+                env[base_url_env] = str(base_url)
 
         return env
 

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3098,6 +3098,67 @@ class TestAcpProviderEnv:
         env = LiveStatusAppConversationService._acp_provider_env(user)
         assert env == {}
 
+    def test_claude_code_with_base_url_plumbs_both(self, _user_factory):
+        """When api_key + base_url are both set, plumb ANTHROPIC_BASE_URL too.
+
+        Regression for #13999 acceptance criterion: a user who configures a
+        LiteLLM proxy in the UI must reach it from the ACP subprocess.
+        """
+        user = _user_factory(
+            acp_server='claude-code',
+            api_key='sk-test-anthropic',
+            base_url='https://llm-proxy.eval.all-hands.dev',
+        )
+        env = LiveStatusAppConversationService._acp_provider_env(user)
+        assert env == {
+            'ANTHROPIC_API_KEY': 'sk-test-anthropic',
+            'ANTHROPIC_BASE_URL': 'https://llm-proxy.eval.all-hands.dev',
+        }
+
+    def test_codex_with_base_url_plumbs_both(self, _user_factory):
+        user = _user_factory(
+            acp_server='codex',
+            api_key='sk-test-openai',
+            base_url='https://proxy.example.com/v1',
+        )
+        env = LiveStatusAppConversationService._acp_provider_env(user)
+        assert env == {
+            'OPENAI_API_KEY': 'sk-test-openai',
+            'OPENAI_BASE_URL': 'https://proxy.example.com/v1',
+        }
+
+    def test_gemini_with_base_url_plumbs_both(self, _user_factory):
+        user = _user_factory(
+            acp_server='gemini-cli',
+            api_key='sk-test-gemini',
+            base_url='https://gemini-proxy.internal/v1',
+        )
+        env = LiveStatusAppConversationService._acp_provider_env(user)
+        assert env == {
+            'GEMINI_API_KEY': 'sk-test-gemini',
+            'GEMINI_BASE_URL': 'https://gemini-proxy.internal/v1',
+        }
+
+    def test_custom_server_with_base_url_returns_empty(self, _user_factory):
+        """Custom servers never get auto-plumbed vars, even with base_url."""
+        user = _user_factory(
+            acp_server='custom',
+            api_key='sk-test',
+            base_url='https://proxy.example.com',
+        )
+        env = LiveStatusAppConversationService._acp_provider_env(user)
+        assert env == {}
+
+    def test_blank_base_url_not_emitted(self, _user_factory):
+        """Empty / whitespace base_url must not emit a ``*_BASE_URL`` entry."""
+        user = _user_factory(
+            acp_server='claude-code',
+            api_key='sk-test-anthropic',
+            base_url='   ',
+        )
+        env = LiveStatusAppConversationService._acp_provider_env(user)
+        assert env == {'ANTHROPIC_API_KEY': 'sk-test-anthropic'}
+
 
 class TestAgentKindConversationUrl:
     """Regression tests for conversation_url / live-status route dispatch.

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3304,7 +3304,9 @@ class TestBuildAcpStartConversationRequestSecrets:
             app_mode='test',
         )
 
-    def _make_acp_user(self, acp_server='claude-code', acp_env=None, api_key=None):
+    def _make_acp_user(
+        self, acp_server='claude-code', acp_env=None, api_key=None, base_url=None
+    ):
         try:
             from openhands.sdk.settings import (
                 ACPAgentSettings,  # type: ignore[attr-defined]
@@ -3329,6 +3331,7 @@ class TestBuildAcpStartConversationRequestSecrets:
             llm=LLM(
                 model='claude-sonnet-4-5',
                 api_key=SecretStr(api_key) if api_key else None,
+                base_url=base_url,
             ),
             acp_env=acp_env or {},
         )
@@ -3418,6 +3421,31 @@ class TestBuildAcpStartConversationRequestSecrets:
             )
         else:
             assert request.agent.agent_context is None
+
+    @pytest.mark.asyncio
+    async def test_provider_env_plumbs_base_url_end_to_end(self, service, tmp_path):
+        """Both *_API_KEY and *_BASE_URL land in acp_env when UI sets both.
+
+        End-to-end coverage for issue #13999: a user who configures
+        ``llm.api_key`` + ``llm.base_url`` in the Settings UI and picks
+        ACP must see both vars reach the ACP subprocess via ``acp_env``.
+        This exercises ``_build_acp_start_conversation_request``'s full
+        env-merge flow, not just the ``_acp_provider_env`` helper.
+        """
+        user = self._make_acp_user(
+            acp_server='claude-code',
+            api_key='sk-ui-key',
+            base_url='https://llm-proxy.eval.all-hands.dev',
+        )
+        service._setup_secrets_for_git_providers = AsyncMock(return_value={})
+
+        request = await self._call_build(service, user, tmp_path)
+
+        assert request.agent.acp_env.get('ANTHROPIC_API_KEY') == 'sk-ui-key'
+        assert (
+            request.agent.acp_env.get('ANTHROPIC_BASE_URL')
+            == 'https://llm-proxy.eval.all-hands.dev'
+        )
 
     @pytest.mark.asyncio
     async def test_no_secrets_no_agent_context(self, service, tmp_path):


### PR DESCRIPTION
## Why

Closes #13999.

When a user configures both `llm.api_key` and `llm.base_url` in the UI (for example, pointing at a LiteLLM proxy), the ACP path today only plumbs `api_key` into the subprocess env. The `base_url` is silently dropped, so the ACP subprocess hits the provider default endpoint instead of the user-configured one — breaking the user's LiteLLM / proxy setup with no indication in the UI.

PR #14004 introduced `_acp_provider_env` and claimed in its description to plumb `*_BASE_URL` vars as well, but the merged implementation only emits `*_API_KEY`. This PR closes that gap.

## Summary

- Extend `LiveStatusAppConversationService._acp_provider_env` to also emit `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` / `GEMINI_BASE_URL` when `llm.base_url` is set.
- Gate `*_BASE_URL` emission on `api_key` also being present, preserving PR #14004's security guarantee: "a provider-default `base_url` alone never clobbers an explicit `OH_AGENT_SERVER_ENV` passthrough".
- Mirror the existing SDK forward-compat pattern: prefer `acp_settings.base_url_env_var` when the SDK exposes it (per software-agent-sdk PR #2984 TODO), fall back to a per-server map for the current pinned SDK.
- Blank / whitespace-only `base_url` is treated as unset.
- Behavior for `custom` ACP servers is unchanged: no auto-plumbing, users continue to manage env via `acp_env`.

The end-to-end result: the acceptance criterion in #13999 holds — a user who saves `llm.api_key` + `llm.base_url` in the GUI, picks ACP, and starts a conversation will have the ACP subprocess reach the configured base URL with the configured key, no `OH_AGENT_SERVER_ENV` needed.

## Test plan

New unit tests in `TestAcpProviderEnv`:

- `test_claude_code_with_base_url_plumbs_both` — both vars emitted for `claude-code`.
- `test_codex_with_base_url_plumbs_both` — both vars emitted for `codex`.
- `test_gemini_with_base_url_plumbs_both` — both vars emitted for `gemini-cli`.
- `test_custom_server_with_base_url_returns_empty` — `custom` still returns `{}`.
- `test_blank_base_url_not_emitted` — whitespace-only `base_url` does not emit a `*_BASE_URL` entry.

The existing 6 tests (which did not set `base_url`) continue to pass unchanged.

Test command run locally:

```
.venv/bin/python -m pytest tests/unit/app_server/test_live_status_app_conversation_service.py -q
# 123 passed in 5.16s

.venv/bin/python -m pytest tests/unit/app_server/ -q
# 1092 passed in 33.38s
```

Ruff format + lint on the two changed files: clean (no new errors introduced; pre-existing ASYNC240 / I001 findings on the surrounding codebase are unchanged).

## AI assistance

AI assistance was used while investigating the gap between #13999's acceptance criteria and the merged #14004 implementation, and while drafting the test cases. A human author reviewed every changed line, ran the test suite locally, and is accountable for the change end-to-end.

- Why this isn't a duplicate: No open PR currently targets #13999 (only #14004 which is merged but incomplete on `base_url`).
- Tests run and results: see Test plan above (123 passed in file, 1092 passed in app_server tree).
