### PR TITLE
PLTF-2295: org settings PATCH for legacy agent_kind rows

### DIFF
--- a/enterprise/storage/org_store.py
+++ b/enterprise/storage/org_store.py
@@ -250,7 +250,8 @@ class OrgStore:
         """Deep-merge a sparse settings diff and validate the merged result."""
         merged_settings = deep_merge(current_settings or {}, settings_diff)
         if settings_type is OpenHandsAgentSettings:
-            merged_settings['agent_kind'] = 'openhands'
+if settings_type is OpenHandsAgentSettings and merged_settings.get('agent_kind') == 'llm':
+    merged_settings['agent_kind'] = 'openhands'
         return settings_type.model_validate(merged_settings)
 
     @staticmethod

--- a/enterprise/storage/org_store.py
+++ b/enterprise/storage/org_store.py
@@ -249,6 +249,8 @@ class OrgStore:
     ) -> OpenHandsAgentSettings | ConversationSettings:
         """Deep-merge a sparse settings diff and validate the merged result."""
         merged_settings = deep_merge(current_settings or {}, settings_diff)
+        if settings_type is OpenHandsAgentSettings:
+            merged_settings['agent_kind'] = 'openhands'
         return settings_type.model_validate(merged_settings)
 
     @staticmethod

--- a/enterprise/storage/org_store.py
+++ b/enterprise/storage/org_store.py
@@ -249,9 +249,12 @@ class OrgStore:
     ) -> OpenHandsAgentSettings | ConversationSettings:
         """Deep-merge a sparse settings diff and validate the merged result."""
         merged_settings = deep_merge(current_settings or {}, settings_diff)
-        if settings_type is OpenHandsAgentSettings:
-if settings_type is OpenHandsAgentSettings and merged_settings.get('agent_kind') == 'llm':
-    merged_settings['agent_kind'] = 'openhands'
+        if (
+            settings_type is OpenHandsAgentSettings
+            and (current_settings or {}).get('agent_kind') == 'llm'
+            and 'agent_kind' not in settings_diff
+        ):
+            merged_settings['agent_kind'] = 'openhands'
         return settings_type.model_validate(merged_settings)
 
     @staticmethod

--- a/enterprise/tests/unit/test_org_store.py
+++ b/enterprise/tests/unit/test_org_store.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 from server.routes.org_models import OrgUpdate
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -1153,6 +1154,54 @@ async def test_update_org_defaults_async_normalizes_legacy_agent_kind():
     assert result is not None
     assert result.agent_settings['agent_kind'] == 'openhands'
     assert result.agent_settings['llm']['model'] == 'new-model'
+
+@pytest.mark.asyncio
+async def test_update_org_defaults_async_rejects_explicit_legacy_agent_kind():
+    """GIVEN: An explicit legacy agent_kind in the incoming diff
+    WHEN: org defaults are patched
+    THEN: validation fails instead of silently rewriting user input
+    """
+    org_id = uuid.uuid4()
+    user_id = str(uuid.uuid4())
+    mock_org = Org(
+        id=org_id,
+        name='Explicit Agent Kind Organization',
+        agent_settings=OpenHandsAgentSettings(llm={'model': 'old-model'}),
+    )
+    update_data = OrgUpdate(
+        agent_settings_diff={
+            'agent_kind': 'llm',
+            'llm': {'model': 'new-model'},
+        }
+    )
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.first.return_value = mock_org
+    mock_session.execute.return_value = mock_result
+    mock_session.commit = AsyncMock()
+    mock_session.refresh = AsyncMock()
+
+    @asynccontextmanager
+    async def mock_a_session_maker():
+        yield mock_session
+
+    with (
+        patch('storage.org_store.a_session_maker', mock_a_session_maker),
+        patch(
+            'storage.org_store.OrgStore._maybe_get_managed_llm_key_for_user',
+            AsyncMock(return_value=None),
+        ),
+        patch(
+            'storage.org_member_store.OrgMemberStore.update_all_members_settings_async',
+            AsyncMock(),
+        ) as mock_member_update,
+    ):
+        with pytest.raises(ValidationError, match="Input should be 'openhands'"):
+            await OrgStore.update_org_defaults_async(org_id, update_data, user_id)
+
+    mock_member_update.assert_not_called()
+
 
 
 @pytest.mark.asyncio

--- a/enterprise/tests/unit/test_org_store.py
+++ b/enterprise/tests/unit/test_org_store.py
@@ -1155,6 +1155,7 @@ async def test_update_org_defaults_async_normalizes_legacy_agent_kind():
     assert result.agent_settings['agent_kind'] == 'openhands'
     assert result.agent_settings['llm']['model'] == 'new-model'
 
+
 @pytest.mark.asyncio
 async def test_update_org_defaults_async_rejects_explicit_legacy_agent_kind():
     """GIVEN: An explicit legacy agent_kind in the incoming diff
@@ -1201,7 +1202,6 @@ async def test_update_org_defaults_async_rejects_explicit_legacy_agent_kind():
             await OrgStore.update_org_defaults_async(org_id, update_data, user_id)
 
     mock_member_update.assert_not_called()
-
 
 
 @pytest.mark.asyncio

--- a/enterprise/tests/unit/test_org_store.py
+++ b/enterprise/tests/unit/test_org_store.py
@@ -1106,6 +1106,56 @@ async def test_update_org_defaults_async_with_llm_api_key():
 
 
 @pytest.mark.asyncio
+async def test_update_org_defaults_async_normalizes_legacy_agent_kind():
+    """GIVEN: A persisted org row with legacy agent_kind='llm'
+    WHEN: org defaults are patched without specifying agent_kind
+    THEN: the merged settings validate and are normalized to 'openhands'
+    """
+    from server.routes.org_models import OrgUpdate
+
+    org_id = uuid.uuid4()
+    user_id = str(uuid.uuid4())
+    mock_org = Org(
+        id=org_id,
+        name='Legacy Organization',
+        agent_settings={
+            'agent_kind': 'llm',
+            'agent': 'CodeActAgent',
+            'llm': {'model': 'old-model'},
+        },
+    )
+    update_data = OrgUpdate(agent_settings_diff={'llm': {'model': 'new-model'}})
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.first.return_value = mock_org
+    mock_session.execute.return_value = mock_result
+    mock_session.commit = AsyncMock()
+    mock_session.refresh = AsyncMock()
+
+    @asynccontextmanager
+    async def mock_a_session_maker():
+        yield mock_session
+
+    with (
+        patch('storage.org_store.a_session_maker', mock_a_session_maker),
+        patch(
+            'storage.org_store.OrgStore._maybe_get_managed_llm_key_for_user',
+            AsyncMock(return_value=None),
+        ),
+        patch(
+            'storage.org_member_store.OrgMemberStore.update_all_members_settings_async',
+            AsyncMock(),
+        ),
+    ):
+        result = await OrgStore.update_org_defaults_async(org_id, update_data, user_id)
+
+    assert result is not None
+    assert result.agent_settings['agent_kind'] == 'openhands'
+    assert result.agent_settings['llm']['model'] == 'new-model'
+
+
+@pytest.mark.asyncio
 async def test_update_org_defaults_async_propagates_managed_key_reset():
     """GIVEN: A unified OrgUpdate save that resolves to a managed org key
     WHEN: update_org_defaults_async is called


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why

`PATCH /api/organizations/{id}/settings` can fail with a 500 on upgraded installs when persisted org `agent_settings` still carry the legacy `agent_kind='llm'` discriminator. The write path was still validating the merged settings against `OpenHandsAgentSettings` without normalizing that legacy value.

## Summary

- normalize merged org agent settings to `agent_kind='openhands'` before validating `OpenHandsAgentSettings` on the write path
- add a regression test covering org-defaults updates for legacy persisted rows with `agent_kind='llm'`
- keep the fix scoped to org agent settings merges so conversation settings validation is unchanged

## Issue Number

Closes #14325

## How to Test

- `cd /workspace/project/OpenHands && PYTHONPATH="/workspace/project/OpenHands/enterprise:$PYTHONPATH" poetry run pytest --noconftest enterprise/tests/unit/test_org_store.py -k "legacy_agent_kind or with_llm_api_key"`
- `cd /workspace/project/OpenHands && poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files enterprise/storage/org_store.py enterprise/tests/unit/test_org_store.py`

## Video/Screenshots

Tested in All-Hands-AI/OpenHands-Cloud#616 on a Replicated embedded cluster VM using enterprise-server `sha-d316113`:

- **Upgrade install** (0.7.3 → 0.7.8): org had legacy `agent_kind='llm'` in DB before upgrade; after upgrade, org settings saved successfully with `agent_kind` normalized to `'openhands'` and model updated to `litellm_proxy/claude-opus-4-7` confirmed in the DB ✅
- **Fresh install** (0.7.8): org created with `agent_kind='openhands'`, org settings saved successfully, conversation completed using `litellm_proxy/claude-opus-4-7` confirmed via `conversation_metadata.llm_model` in the DB ✅

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- I used `--noconftest` plus `PYTHONPATH=/workspace/project/OpenHands/enterprise` for the targeted pytest run because the sandbox root Poetry environment does not include the enterprise test environment by default.
- This PR was created by an AI agent (OpenHands) on behalf of the user.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-f969204   docker.openhands.dev/openhands/openhands:f969204
```