### PR TITLE
fix(dev): run pre-commit on staged files instead of broken sh glob

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -6,4 +6,9 @@ npx lint-staged
 # Run backend pre-commit
 echo "Running backend pre-commit..."
 cd ..
-poetry run pre-commit run --files openhands/**/* evaluation/**/* tests/**/* --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml
+# Pre-commit defaults to operating on staged files; the per-hook ``types_or``
+# and ``exclude`` filters keep Python-only hooks (ruff, mypy, …) from running on
+# unrelated files. The previous ``--files openhands/**/* evaluation/**/* tests/**/*``
+# argument relied on bash globstar which husky's /bin/sh does not enable, so the
+# patterns matched only one directory level deep and silently skipped most files.
+poetry run pre-commit run --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml


### PR DESCRIPTION
## Summary

The husky hook passed `--files openhands/**/* evaluation/**/* tests/**/*` to pre-commit, but husky runs the script under `/bin/sh`, which doesn't enable the bash globstar (`**`). In sh, `**` is treated as a single `*`, so the patterns matched only one directory level deep and silently skipped most staged files (e.g. anything at `openhands/foo/bar/baz.py`).

Drop the `--files` argument and rely on pre-commit's default staged-file behaviour. The per-hook `types_or` / `exclude` filters in `dev_config/python/.pre-commit-config.yaml` already keep Python-only hooks (ruff, mypy) from running on unrelated files.

## Why this is correct

- `pre-commit run` (no `--files`) operates on files staged for the commit.
- The hooks in this config already filter themselves: ruff/ruff-format/mypy use `types_or: [python, pyi, jupyter]`; `trailing-whitespace`/`end-of-file-fixer` `exclude: ^(docs/|modules/|python/|openhands-ui/|enterprise/)`; `warn-appmode-oss` is `pass_filenames: false` and runs `rg` on a fixed scope.
- So running on JS-only or doc-only commits will still skip the Python checks, just by hook-level filtering instead of by a shell-level file list.

## Test plan
- [ ] Stage a Python file under a deep path (e.g. `openhands/foo/bar/baz.py`), commit, and confirm ruff/ruff-format actually run on it (this previously slipped through).
- [ ] Stage a frontend-only change and commit; confirm `lint-staged` still runs and Python hooks correctly produce no work.
- [ ] Stage a mixed Python + frontend change; both check sets run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-2af4267   docker.openhands.dev/openhands/openhands:2af4267
```