### PR TITLE
fix(frontend): skip Git-related API calls when no Git provider is configured

### DIFF
--- a/frontend/__tests__/hooks/use-git-user.test.tsx
+++ b/frontend/__tests__/hooks/use-git-user.test.tsx
@@ -5,11 +5,11 @@ import React from "react";
 import { useGitUser } from "#/hooks/query/use-git-user";
 import { useLogout } from "#/hooks/mutation/use-logout";
 import UserService from "#/api/user-service/user-service.api";
-import * as useShouldShowUserFeaturesModule from "#/hooks/use-should-show-user-features";
+import * as useShouldShowGitFeaturesModule from "#/hooks/use-should-show-git-features";
 import * as useConfigModule from "#/hooks/query/use-config";
 import { AxiosError } from "axios";
 
-vi.mock("#/hooks/use-should-show-user-features");
+vi.mock("#/hooks/use-should-show-git-features");
 vi.mock("#/hooks/query/use-config");
 vi.mock("#/hooks/mutation/use-logout");
 vi.mock("#/api/user-service/user-service.api");
@@ -38,7 +38,7 @@ describe("useGitUser", () => {
       status: "idle",
     } as unknown as ReturnType<typeof useLogout>;
 
-    vi.mocked(useShouldShowUserFeaturesModule.useShouldShowUserFeatures).mockReturnValue(true);
+    vi.mocked(useShouldShowGitFeaturesModule.useShouldShowGitFeatures).mockReturnValue(true);
     vi.mocked(useConfigModule.useConfig).mockReturnValue({
       data: { app_mode: "saas" },
       isLoading: false,

--- a/frontend/__tests__/hooks/use-should-show-git-features.test.tsx
+++ b/frontend/__tests__/hooks/use-should-show-git-features.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useShouldShowGitFeatures } from "#/hooks/use-should-show-git-features";
+import * as useConfigModule from "#/hooks/query/use-config";
+import * as useIsAuthedModule from "#/hooks/query/use-is-authed";
+import * as useUserProvidersModule from "#/hooks/use-user-providers";
+
+vi.mock("#/hooks/query/use-config");
+vi.mock("#/hooks/query/use-is-authed");
+vi.mock("#/hooks/use-user-providers");
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useShouldShowGitFeatures", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return false when config is not loaded", () => {
+    vi.mocked(useConfigModule.useConfig).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as any);
+    vi.mocked(useIsAuthedModule.useIsAuthed).mockReturnValue({
+      data: true,
+    } as any);
+    vi.mocked(useUserProvidersModule.useUserProviders).mockReturnValue({
+      providers: ["github"],
+      isLoadingSettings: false,
+    });
+
+    const { result } = renderHook(() => useShouldShowGitFeatures(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("should return false when not authenticated", () => {
+    vi.mocked(useConfigModule.useConfig).mockReturnValue({
+      data: { app_mode: "saas" },
+      isLoading: false,
+      error: null,
+    } as any);
+    vi.mocked(useIsAuthedModule.useIsAuthed).mockReturnValue({
+      data: false,
+    } as any);
+    vi.mocked(useUserProvidersModule.useUserProviders).mockReturnValue({
+      providers: ["github"],
+      isLoadingSettings: false,
+    });
+
+    const { result } = renderHook(() => useShouldShowGitFeatures(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("should return false when no providers are configured in SaaS mode", () => {
+    vi.mocked(useConfigModule.useConfig).mockReturnValue({
+      data: { app_mode: "saas" },
+      isLoading: false,
+      error: null,
+    } as any);
+    vi.mocked(useIsAuthedModule.useIsAuthed).mockReturnValue({
+      data: true,
+    } as any);
+    vi.mocked(useUserProvidersModule.useUserProviders).mockReturnValue({
+      providers: [],
+      isLoadingSettings: false,
+    });
+
+    const { result } = renderHook(() => useShouldShowGitFeatures(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("should return false when no providers are configured in OSS mode", () => {
+    vi.mocked(useConfigModule.useConfig).mockReturnValue({
+      data: { app_mode: "oss" },
+      isLoading: false,
+      error: null,
+    } as any);
+    vi.mocked(useIsAuthedModule.useIsAuthed).mockReturnValue({
+      data: true,
+    } as any);
+    vi.mocked(useUserProvidersModule.useUserProviders).mockReturnValue({
+      providers: [],
+      isLoadingSettings: false,
+    });
+
+    const { result } = renderHook(() => useShouldShowGitFeatures(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("should return true when authenticated with a provider in SaaS mode", () => {
+    vi.mocked(useConfigModule.useConfig).mockReturnValue({
+      data: { app_mode: "saas" },
+      isLoading: false,
+      error: null,
+    } as any);
+    vi.mocked(useIsAuthedModule.useIsAuthed).mockReturnValue({
+      data: true,
+    } as any);
+    vi.mocked(useUserProvidersModule.useUserProviders).mockReturnValue({
+      providers: ["github"],
+      isLoadingSettings: false,
+    });
+
+    const { result } = renderHook(() => useShouldShowGitFeatures(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("should return true when authenticated with a provider in OSS mode", () => {
+    vi.mocked(useConfigModule.useConfig).mockReturnValue({
+      data: { app_mode: "oss" },
+      isLoading: false,
+      error: null,
+    } as any);
+    vi.mocked(useIsAuthedModule.useIsAuthed).mockReturnValue({
+      data: true,
+    } as any);
+    vi.mocked(useUserProvidersModule.useUserProviders).mockReturnValue({
+      providers: ["gitlab"],
+      isLoadingSettings: false,
+    });
+
+    const { result } = renderHook(() => useShouldShowGitFeatures(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("should return true when multiple providers are configured", () => {
+    vi.mocked(useConfigModule.useConfig).mockReturnValue({
+      data: { app_mode: "saas" },
+      isLoading: false,
+      error: null,
+    } as any);
+    vi.mocked(useIsAuthedModule.useIsAuthed).mockReturnValue({
+      data: true,
+    } as any);
+    vi.mocked(useUserProvidersModule.useUserProviders).mockReturnValue({
+      providers: ["github", "gitlab"],
+      isLoadingSettings: false,
+    });
+
+    const { result } = renderHook(() => useShouldShowGitFeatures(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/frontend/__tests__/use-suggested-tasks.test.ts
+++ b/frontend/__tests__/use-suggested-tasks.test.ts
@@ -3,17 +3,17 @@ import { renderHook } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 import { useSuggestedTasks } from "../src/hooks/query/use-suggested-tasks";
-import { useShouldShowUserFeatures } from "../src/hooks/use-should-show-user-features";
+import { useShouldShowGitFeatures } from "../src/hooks/use-should-show-git-features";
 
 // Mock the dependencies
-vi.mock("../src/hooks/use-should-show-user-features");
+vi.mock("../src/hooks/use-should-show-git-features");
 vi.mock("#/api/suggestions-service/suggestions-service.api", () => ({
   SuggestionsService: {
     getSuggestedTasks: vi.fn().mockResolvedValue([]),
   },
 }));
 
-const mockUseShouldShowUserFeatures = vi.mocked(useShouldShowUserFeatures);
+const mockUseShouldShowGitFeatures = vi.mocked(useShouldShowGitFeatures);
 
 const createWrapper = () => {
   const queryClient = new QueryClient({
@@ -32,11 +32,11 @@ describe("useSuggestedTasks", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Default to disabled
-    mockUseShouldShowUserFeatures.mockReturnValue(false);
+    mockUseShouldShowGitFeatures.mockReturnValue(false);
   });
 
-  it("should be disabled when useShouldShowUserFeatures returns false", () => {
-    mockUseShouldShowUserFeatures.mockReturnValue(false);
+  it("should be disabled when useShouldShowGitFeatures returns false", () => {
+    mockUseShouldShowGitFeatures.mockReturnValue(false);
 
     const { result } = renderHook(() => useSuggestedTasks(), {
       wrapper: createWrapper(),
@@ -46,8 +46,8 @@ describe("useSuggestedTasks", () => {
     expect(result.current.isFetching).toBe(false);
   });
 
-  it("should be enabled when useShouldShowUserFeatures returns true", () => {
-    mockUseShouldShowUserFeatures.mockReturnValue(true);
+  it("should be enabled when useShouldShowGitFeatures returns true", () => {
+    mockUseShouldShowGitFeatures.mockReturnValue(true);
 
     const { result } = renderHook(() => useSuggestedTasks(), {
       wrapper: createWrapper(),

--- a/frontend/src/hooks/query/use-git-user.ts
+++ b/frontend/src/hooks/query/use-git-user.ts
@@ -3,7 +3,7 @@ import React from "react";
 import { usePostHog } from "posthog-js/react";
 import { useConfig } from "./use-config";
 import UserService from "#/api/user-service/user-service.api";
-import { useShouldShowUserFeatures } from "#/hooks/use-should-show-user-features";
+import { useShouldShowGitFeatures } from "#/hooks/use-should-show-git-features";
 import { useLogout } from "../mutation/use-logout";
 
 export const useGitUser = () => {
@@ -11,8 +11,9 @@ export const useGitUser = () => {
   const { data: config } = useConfig();
   const logout = useLogout();
 
-  // Use the shared hook to determine if we should fetch user data
-  const shouldFetchUser = useShouldShowUserFeatures();
+  // Use the Git-specific hook to determine if we should fetch user data.
+  // This requires a Git provider to be configured, not just authentication.
+  const shouldFetchUser = useShouldShowGitFeatures();
 
   const user = useQuery({
     queryKey: ["user"],

--- a/frontend/src/hooks/query/use-suggested-tasks.ts
+++ b/frontend/src/hooks/query/use-suggested-tasks.ts
@@ -1,15 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { SuggestionsService } from "#/api/suggestions-service/suggestions-service.api";
 import { groupSuggestedTasks } from "#/utils/group-suggested-tasks";
-import { useShouldShowUserFeatures } from "../use-should-show-user-features";
+import { useShouldShowGitFeatures } from "../use-should-show-git-features";
 
 export const useSuggestedTasks = () => {
-  const shouldShowUserFeatures = useShouldShowUserFeatures();
+  // Use the Git-specific hook since suggested tasks require a Git provider
+  // to be configured (they come from Git repositories).
+  const shouldShowGitFeatures = useShouldShowGitFeatures();
 
   return useQuery({
     queryKey: ["tasks"],
     queryFn: () => SuggestionsService.getSuggestedTasks(),
     select: groupSuggestedTasks,
-    enabled: shouldShowUserFeatures,
+    enabled: shouldShowGitFeatures,
   });
 };

--- a/frontend/src/hooks/use-should-show-git-features.ts
+++ b/frontend/src/hooks/use-should-show-git-features.ts
@@ -1,0 +1,29 @@
+import React from "react";
+import { useConfig } from "./query/use-config";
+import { useIsAuthed } from "./query/use-is-authed";
+import { useUserProviders } from "./use-user-providers";
+
+/**
+ * Hook to determine if Git-related features should be shown or enabled
+ * based on authentication status and Git provider configuration.
+ *
+ * Unlike useShouldShowUserFeatures, this hook ALWAYS requires a Git provider
+ * to be configured, regardless of app mode. This is because Git features
+ * (like fetching user info or suggested tasks) require an actual Git
+ * provider token to function.
+ *
+ * @returns boolean indicating if Git features should be shown
+ */
+export const useShouldShowGitFeatures = (): boolean => {
+  const { data: config } = useConfig();
+  const { data: isAuthed } = useIsAuthed();
+  const { providers } = useUserProviders();
+
+  return React.useMemo(() => {
+    if (!config?.app_mode || !isAuthed) return false;
+
+    // Git features always require a provider to be configured,
+    // regardless of app mode (oss, saas, or enterprise)
+    return providers.length > 0;
+  }, [config?.app_mode, isAuthed, providers.length]);
+};


### PR DESCRIPTION
## Summary

This PR fixes 403 errors that occur when users are authenticated via SAML but don't have a Git provider (GitHub/GitLab) configured.

## Problem

When users authenticate through SAML SSO (enterprise deployments), the frontend was making API calls to:
- `/api/v1/git/suggested-tasks/search`
- `/api/v1/users/git-info`

These endpoints require a Git provider token to work, but SAML-authenticated users may not have connected a Git provider. This resulted in 403 Forbidden errors in the browser console and degraded user experience.

## Solution

Added a new hook `useShouldShowGitFeatures` that checks **both**:
1. User is authenticated (`isAuthed`)
2. At least one Git provider is configured (`providers.length > 0`)

This differs from the existing `useShouldShowUserFeatures` hook, which only checks authentication status and app mode, but doesn't verify Git provider availability.

## Changes

- **New file**: `frontend/src/hooks/use-should-show-git-features.ts` - Hook that gates Git-re- **New file**: `fModified**: `frontend/src/hooks/query/use-git-user.ts` - Uses `useShouldShowGitFeatures` instead of `useShouldShowUserFeatures`
- **Modified**: `frontend/src/hooks/query/use-suggested-tasks.ts` - Uses `useShouldShowGitFeatures` instead of `us- **Modified**: `frontend/src/hooks/quAdded comprehensive test coverage for the new hook and updated existing tests

## Testing

- All unit tests passing
- Verified on staging environment with SAML authentication (no Git provider configured)

---
_This PR was created by an AI agent (OpenHands) on behalf of Saurya Velagapudi._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-079db90   docker.openhands.dev/openhands/openhands:079db90
```