### PR TITLE
Bump SDK packages to v1.21.0

### DIFF
--- a/dev_config/python/.pre-commit-config.yaml
+++ b/dev_config/python/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
     rev: v2.5.1
     hooks:
       - id: pyproject-fmt
+        args: [--keep-full-version]
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.24.1
     hooks:

--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -31,7 +31,6 @@ from openhands.app_server.user.user_context import UserContext
 from openhands.app_server.utils.git import ensure_valid_git_branch_name
 from openhands.sdk import Agent, LLMSummarizingCondenser
 from openhands.sdk.context import AgentContext
-from openhands.sdk.context.skills import Skill
 from openhands.sdk.llm import LLM
 from openhands.sdk.security import (
     AlwaysConfirm,
@@ -41,6 +40,7 @@ from openhands.sdk.security import (
     NeverConfirm,
     SecurityAnalyzerBase,
 )
+from openhands.sdk.skills import Skill
 from openhands.sdk.workspace.remote.async_remote_workspace import AsyncRemoteWorkspace
 
 _logger = logging.getLogger(__name__)

--- a/openhands/app_server/app_conversation/skill_loader.py
+++ b/openhands/app_server/app_conversation/skill_loader.py
@@ -19,7 +19,7 @@ from openhands.app_server.integrations.provider import ProviderType
 from openhands.app_server.integrations.service_types import AuthenticationError
 from openhands.app_server.sandbox.sandbox_models import SandboxInfo
 from openhands.app_server.user.user_context import UserContext
-from openhands.sdk.context.skills import KeywordTrigger, Skill, TaskTrigger
+from openhands.sdk.skills import KeywordTrigger, Skill, TaskTrigger
 
 _logger = logging.getLogger(__name__)
 

--- a/openhands/app_server/sandbox/sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/sandbox_spec_service.py
@@ -13,7 +13,7 @@ from openhands.sdk.utils.models import DiscriminatedUnionMixin
 
 # The version of the agent server to use for deployments.
 # Typically this will be the same as the values from the pyproject.toml
-AGENT_SERVER_IMAGE = 'ghcr.io/openhands/agent-server:1.20.1-python'
+AGENT_SERVER_IMAGE = 'ghcr.io/openhands/agent-server:1.21.0-python'
 
 
 class SandboxSpecService(ABC):

--- a/poetry.lock
+++ b/poetry.lock
@@ -6169,14 +6169,14 @@ llama = ["llama-index (>=0.12.29,<0.13.0)", "llama-index-core (>=0.12.29,<0.13.0
 
 [[package]]
 name = "openhands-agent-server"
-version = "1.20.1"
+version = "1.21.0"
 description = "OpenHands Agent Server - REST/WebSocket interface for OpenHands AI Agent"
 optional = false
 python-versions = ">=3.12"
 groups = ["main"]
 files = [
-    {file = "openhands_agent_server-1.20.1-py3-none-any.whl", hash = "sha256:e21a9280dee0609ff763ed148d3e2b58a46ca00af1b3213dd91fa259a0c7a1c2"},
-    {file = "openhands_agent_server-1.20.1.tar.gz", hash = "sha256:16194e084ccdb246a42046c662c41b228d59b3a0f89b6b0c849a92381e827be8"},
+    {file = "openhands_agent_server-1.21.0-py3-none-any.whl", hash = "sha256:56ecff77be99d0ed08c02c6894ed9fd235edad3432b5b9dddba9909d5c8b9594"},
+    {file = "openhands_agent_server-1.21.0.tar.gz", hash = "sha256:eacd6b34bb57799244c0ada49237707779ea92ae2e3fff3b28cadb44a26cdf4d"},
 ]
 
 [package.dependencies]
@@ -6193,14 +6193,14 @@ wsproto = ">=1.2.0"
 
 [[package]]
 name = "openhands-sdk"
-version = "1.20.1"
+version = "1.21.0"
 description = "OpenHands SDK - Core functionality for building AI agents"
 optional = false
 python-versions = ">=3.12"
 groups = ["main"]
 files = [
-    {file = "openhands_sdk-1.20.1-py3-none-any.whl", hash = "sha256:500fa80bfae0a2c7457733e0c7174f68e769b7cbee57e38997cea669b10ed78c"},
-    {file = "openhands_sdk-1.20.1.tar.gz", hash = "sha256:9a2d4aa53d53d1a97adf0007aaca1dba880a8637a2abaf6479e6102564eca53c"},
+    {file = "openhands_sdk-1.21.0-py3-none-any.whl", hash = "sha256:4bf77fe25c9dd4908f70fef2a2e90fede32ff555359ca08fe9f4f3a3acee930b"},
+    {file = "openhands_sdk-1.21.0.tar.gz", hash = "sha256:c93808a2bbbe4031895c926db7f9b40c7ec8fa44ea05e64968076773bc249b22"},
 ]
 
 [package.dependencies]
@@ -6224,14 +6224,14 @@ boto3 = ["boto3 (>=1.35.0)"]
 
 [[package]]
 name = "openhands-tools"
-version = "1.20.1"
+version = "1.21.0"
 description = "OpenHands Tools - Runtime tools for AI agents"
 optional = false
 python-versions = ">=3.12"
 groups = ["main"]
 files = [
-    {file = "openhands_tools-1.20.1-py3-none-any.whl", hash = "sha256:6f7c9753e92638dad2a0bc984434161386efe58f757b18a73d26c785a8ab920a"},
-    {file = "openhands_tools-1.20.1.tar.gz", hash = "sha256:feb5286d4b88db9aa48037705010cf7a7175053a71149d6b7403592bf8c9eac4"},
+    {file = "openhands_tools-1.21.0-py3-none-any.whl", hash = "sha256:97a0a910388881525e964165686a114d48cdb70788797f7048584d5aa839a61a"},
+    {file = "openhands_tools-1.21.0.tar.gz", hash = "sha256:d98d732c4c3e02ba11e9e44a73736baa491882e9d9bc5cdc6b9acd5489d969cd"},
 ]
 
 [package.dependencies]
@@ -14534,4 +14534,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12,<3.14"
-content-hash = "a87ae67b17a0e979b8e2032a7e8c4c8592de13ea864c25fea2d42e11dd54ff3e"
+content-hash = "0492f29749da5912d8df9b9f87fbbfec31eb14d1ba052ddbcf11797086ce6d48"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,9 @@ dependencies = [
   "numpy",
   "openai==2.24",
   "openhands-aci==0.3.3",
-  "openhands-agent-server==1.20.1",
-  "openhands-sdk==1.20.1",
-  "openhands-tools==1.20.1",
+  "openhands-agent-server==1.21.0",
+  "openhands-sdk==1.21.0",
+  "openhands-tools==1.21.0",
   "opentelemetry-api>=1.33.1",
   "opentelemetry-exporter-otlp-proto-grpc>=1.33.1",
   "orjson>=3.11.6",
@@ -244,9 +244,9 @@ e2b-code-interpreter = { version = "^2.0.0", optional = true }
 pybase62 = "^1.0.0"
 
 # V1 dependencies
-openhands-sdk = "1.20.1"
-openhands-agent-server = "1.20.1"
-openhands-tools = "1.20.1"
+openhands-sdk = "==1.21.0"
+openhands-agent-server = "==1.21.0"
+openhands-tools = "==1.21.0"
 jwcrypto = ">=1.5.6"
 sqlalchemy = { extras = [ "asyncio" ], version = "^2.0.40" }
 pg8000 = "^1.31.5"


### PR DESCRIPTION
## Automated Version Bump

This PR updates the following packages to version **1.21.0**:
- `openhands-sdk`
- `openhands-tools`
- `openhands-agent-server`

### Changes
- Updated SDK packages in `pyproject.toml` with exact pins
- Regenerated `poetry.lock` with Poetry 2.2.1
- Updated `AGENT_SERVER_IMAGE` to `1.21.0` in `sandbox_spec_service.py`
- Updated SDK skill import paths for SDK 1.21.0 compatibility
- Added `--keep-full-version` to preserve exact patch versions in `pyproject.toml`

Supersedes #14336, which has the same fixed changes but cannot receive a formal approval from its author account.

**Triggered by:** Release of [software-agent-sdk v1.21.0](https://github.com/OpenHands/software-agent-sdk/releases/tag/v1.21.0)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-a23ef59   docker.openhands.dev/openhands/openhands:a23ef59
```