### PR TITLE
fix: preserve returnTo parameter through onboarding flow

### DIFF
--- a/enterprise/server/routes/auth.py
+++ b/enterprise/server/routes/auth.py
@@ -905,10 +905,17 @@ async def complete_onboarding(request: Request):
     redirect_url = '/'
     try:
         body = await request.json()
+        logger.info(
+            'complete_onboarding request body',
+            extra={'user_id': user_id, 'has_redirect_url': 'redirect_url' in body, 'redirect_url': body.get('redirect_url', 'NOT_SET')},
+        )
         if body.get('redirect_url'):
             redirect_url = body['redirect_url']
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(
+            'complete_onboarding failed to parse body',
+            extra={'user_id': user_id, 'error': str(e)},
+        )
 
     user = await UserStore.mark_onboarding_completed(user_id)
     if not user:

--- a/enterprise/server/routes/auth.py
+++ b/enterprise/server/routes/auth.py
@@ -586,7 +586,9 @@ async def keycloak_callback(
         # Only redirect to onboarding if user has a valid offline token,
         # otherwise they need to complete the Keycloak offline token flow first
         if valid_offline_token and await _should_redirect_to_onboarding(user_id, user):
-            redirect_url = f'{web_url}/onboarding'
+            # Preserve original destination as returnTo param on onboarding URL
+            encoded_return_to = quote(redirect_url, safe='')
+            redirect_url = f'{web_url}/onboarding?returnTo={encoded_return_to}'
             logger.info(
                 'Redirecting returning user to onboarding',
                 extra={'user_id': user_id, 'deployment_mode': DEPLOYMENT_MODE},
@@ -755,7 +757,9 @@ async def _get_post_auth_redirect(
             'Redirecting user to onboarding',
             extra={'user_id': user_id, 'deployment_mode': DEPLOYMENT_MODE},
         )
-        return f'{web_url}/onboarding'
+        # Preserve original destination as returnTo param on onboarding URL
+        encoded_return_to = quote(default_url, safe='')
+        return f'{web_url}/onboarding?returnTo={encoded_return_to}'
     return default_url
 
 
@@ -897,6 +901,15 @@ async def complete_onboarding(request: Request):
             content={'error': 'User is not authenticated'},
         )
 
+    # Get redirect_url from request body if provided
+    redirect_url = '/'
+    try:
+        body = await request.json()
+        if body.get('redirect_url'):
+            redirect_url = body['redirect_url']
+    except Exception:
+        pass
+
     user = await UserStore.mark_onboarding_completed(user_id)
     if not user:
         return JSONResponse(
@@ -911,7 +924,7 @@ async def complete_onboarding(request: Request):
 
     return JSONResponse(
         status_code=status.HTTP_200_OK,
-        content={'message': 'Onboarding completed'},
+        content={'message': 'Onboarding completed', 'redirect_url': redirect_url},
     )
 
 

--- a/frontend/src/components/features/guards/onboarding-guard.tsx
+++ b/frontend/src/components/features/guards/onboarding-guard.tsx
@@ -11,7 +11,7 @@ export function OnboardingGuard({ children }: { children: React.ReactNode }) {
   const { data, isLoading } = useOnboardingStatus();
   const { data: config } = useConfig();
   const navigate = useNavigate();
-  const { pathname } = useLocation();
+  const { pathname, search } = useLocation();
 
   React.useEffect(() => {
     if (isLoading) return;
@@ -21,13 +21,16 @@ export function OnboardingGuard({ children }: { children: React.ReactNode }) {
       data?.should_complete_onboarding &&
       pathname !== "/onboarding"
     ) {
-      navigate("/onboarding", { replace: true });
+      // Preserve current path as returnTo so user returns here after onboarding
+      const returnTo = encodeURIComponent(pathname + search);
+      navigate(`/onboarding?returnTo=${returnTo}`, { replace: true });
     }
   }, [
     config?.feature_flags?.enable_onboarding,
     data?.should_complete_onboarding,
     isLoading,
     pathname,
+    search,
     navigate,
   ]);
 

--- a/frontend/src/hooks/mutation/use-submit-onboarding.ts
+++ b/frontend/src/hooks/mutation/use-submit-onboarding.ts
@@ -6,6 +6,7 @@ import { displayErrorToast } from "#/utils/custom-toast-handlers";
 
 type SubmitOnboardingArgs = {
   selections: Record<string, string | string[]>;
+  returnTo?: string;
 };
 
 interface OnboardingResponse {
@@ -18,10 +19,10 @@ export const useSubmitOnboarding = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ selections }: SubmitOnboardingArgs) => {
+    mutationFn: async ({ selections, returnTo }: SubmitOnboardingArgs) => {
       const { data } = await openHands.post<OnboardingResponse>(
         "/api/complete_onboarding",
-        { selections },
+        { selections, redirect_url: returnTo },
       );
       return data;
     },

--- a/frontend/src/hooks/mutation/use-submit-onboarding.ts
+++ b/frontend/src/hooks/mutation/use-submit-onboarding.ts
@@ -31,6 +31,10 @@ export const useSubmitOnboarding = () => {
       queryClient.invalidateQueries({ queryKey: ["onboarding-status"] });
 
       const finalRedirectUrl = data.redirect_url || "/";
+      // eslint-disable-next-line no-console
+      console.log("[onboarding] redirect_url from API:", data.redirect_url);
+      // eslint-disable-next-line no-console
+      console.log("[onboarding] finalRedirectUrl:", finalRedirectUrl);
       // Check if the redirect URL is an external URL (starts with http or https)
       if (
         finalRedirectUrl.startsWith("http://") ||

--- a/frontend/src/routes/onboarding-form.tsx
+++ b/frontend/src/routes/onboarding-form.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate, redirect, useLoaderData } from "react-router";
+import {
+  useNavigate,
+  redirect,
+  useLoaderData,
+  useSearchParams,
+} from "react-router";
 import StepHeader from "#/components/features/onboarding/step-header";
 import { StepContent } from "#/components/features/onboarding/step-content";
 import { BrandButton } from "#/components/features/settings/brand-button";
@@ -83,6 +88,8 @@ function getTranslatedInputFields(
 function OnboardingForm() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const returnTo = searchParams.get("returnTo");
   const loaderData = useLoaderData<typeof clientLoader>();
   const config = loaderData?.config;
   const { data: onboardingStatus, isLoading: isOnboardingStatusLoading } =
@@ -92,12 +99,14 @@ function OnboardingForm() {
   React.useEffect(() => {
     if (isOnboardingStatusLoading) return;
     if (onboardingStatus?.should_complete_onboarding === false) {
-      navigate("/", { replace: true });
+      // Redirect to returnTo if provided, otherwise to home
+      navigate(returnTo || "/", { replace: true });
     }
   }, [
     onboardingStatus?.should_complete_onboarding,
     isOnboardingStatusLoading,
     navigate,
+    returnTo,
   ]);
 
   const onboardingAppMode: OnboardingAppMode = getOnboardingAppMode(
@@ -181,7 +190,10 @@ function OnboardingForm() {
 
   const handleNext = () => {
     if (isLastStep) {
-      submitOnboarding({ selections: answers });
+      submitOnboarding({
+        selections: answers,
+        returnTo: returnTo || undefined,
+      });
     } else {
       setCurrentStepIndex((prev) => prev + 1);
     }

--- a/frontend/src/routes/onboarding-form.tsx
+++ b/frontend/src/routes/onboarding-form.tsx
@@ -90,6 +90,8 @@ function OnboardingForm() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const returnTo = searchParams.get("returnTo");
+  // eslint-disable-next-line no-console
+  console.log("[onboarding-form] returnTo from URL:", returnTo);
   const loaderData = useLoaderData<typeof clientLoader>();
   const config = loaderData?.config;
   const { data: onboardingStatus, isLoading: isOnboardingStatusLoading } =


### PR DESCRIPTION
## Summary

When users log in with a `returnTo` parameter (e.g., `/login?returnTo=/settings/user`), the flow would lose the destination when redirecting through onboarding, always ending up at the main page instead.

## Problem

The login flow goes:
1. User visits `/login?returnTo=/settings/user`
2. OAuth flow redirects back with `returnTo` preserved
3. Backend checks if user needs onboarding and redirects to `/onboarding`
4. After onboarding, user ends up at `/` instead of `/settings/user`

The issue was that the `returnTo` destination was being discarded when redirecting to the onboarding page.

## Solution

Changes across backend and frontend to preserve `returnTo` through the onboarding flow:

### Backend (`enterprise/server/routes/auth.py`)
- Pass `returnTo` as URL-encoded query param when redirecting to `/onboarding`
- Accept and return `redirect_url` in `/api/complete_onboarding` endpoint

### Frontend
- **`onboarding-guard.tsx`**: Preserve current path+search as `returnTo` when redirecting to onboarding
- **`onboarding-form.tsx`**: Read `returnTo` from URL params and pass to submit handler
- **`use-submit-onboarding.ts`**: Send `returnTo` to backend and respect returned `redirect_url`

## Testing

- All existing onboarding tests pass
- Tested the full flow:
  1. User logs in with `returnTo=/settings/user`
  2. Gets redirected to `/onboarding?returnTo=/settings/user`
  3. After completing onboarding, redirected to `/settings/user`

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@chuckbutkus can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6585f8f1-39c4-4578-b358-c432cc7957b0)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-f77deb8   docker.openhands.dev/openhands/openhands:f77deb8
```