### PR TITLE
fix(security): escape LIKE wildcards in conversation title search

### DIFF
--- a/enterprise/server/utils/saas_app_conversation_info_injector.py
+++ b/enterprise/server/utils/saas_app_conversation_info_injector.py
@@ -245,7 +245,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         conditions = []
         if title__contains is not None:
             conditions.append(
-                StoredConversationMetadata.title.like(f'%{title__contains}%')
+                StoredConversationMetadata.title.contains(title__contains, autoescape=True)
             )
 
         if created_at__gte is not None:

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -232,7 +232,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
         conditions = []
         if title__contains is not None:
             conditions.append(
-                StoredConversationMetadata.title.like(f'%{title__contains}%')
+                StoredConversationMetadata.title.contains(title__contains, autoescape=True)
             )
 
         if created_at__gte is not None:


### PR DESCRIPTION
## Summary

Fixes a LIKE-wildcard injection (CWE-89-adjacent) in the conversation search filter for both the OSS `SQLAppConversationInfoService` and the SaaS `SaasSQLAppConversationInfoService`. The `title__contains` query parameter is interpolated into a SQL `LIKE` pattern without escaping, so `%` and `_` are interpreted as wildcards.

## Vulnerable code

Both services build the title filter the same way:

```python
StoredConversationMetadata.title.like(f'%{title__contains}%')
```

- `openhands/app_server/app_conversation/sql_app_conversation_info_service.py` (~line 248)
- `enterprise/server/utils/saas_app_conversation_info_injector.py` (~line 247)

SQLAlchemy correctly binds `title__contains` as a parameter, so this is **not** classical SQL injection — an attacker cannot break out of the string or execute arbitrary SQL. However, the `%` and `_` characters inside the bound value are still treated as `LIKE` metacharacters by the database. This lets a caller:

1. Submit crafted patterns (e.g. `a%b%c`) that match conversations they would not match with literal substring semantics — i.e. the search behaves differently from what the API name (`title__contains`) implies.
2. Submit pathological patterns such as `%a%b%c%d%e%f%g%` that force expensive scans, enabling lightweight DoS against the conversations table.

## Fix

Switch both call sites to SQLAlchemy's `ColumnOperators.contains(..., autoescape=True)`, which escapes `%`, `_`, and the escape character itself before binding, while keeping the same "substring match" semantics that the parameter name promises.

```diff
- StoredConversationMetadata.title.like(f'%{title__contains}%')
+ StoredConversationMetadata.title.contains(title__contains, autoescape=True)
```

Two-line change, no behaviour change for normal (non-metacharacter) inputs. `autoescape=True` is the documented SQLAlchemy idiom for this exact case.

## Security analysis

- **Auth scope:** The query is executed via `_secure_select()`, which restricts results to conversations owned by the authenticated user. There is no cross-tenant leak — an attacker can only run wildcard searches over their own data.
- **Realistic impact:**
  - Search-semantics confusion / enumeration over the caller's own conversations.
  - Modest DoS via expensive `LIKE` patterns against the indexed title column.
- **Not exploitable for:** arbitrary SQL execution, cross-user data exfiltration, auth bypass.

Severity is therefore low, but the fix is unambiguously correct, narrow, and removes a real footgun before the pattern gets copied elsewhere.

## Adversarial review

Before submitting we tried to disprove this. We checked whether SQLAlchemy or the underlying driver escapes `LIKE` metacharacters automatically — they do not; parameter binding only handles SQL syntax safety, not `LIKE` pattern semantics. We checked whether `_secure_select()` or any upstream middleware sanitises the value — it does not, it only enforces ownership. We grepped for other `title.like(f'%{...}%')` patterns in the repo and found no further instances, so the fix is complete. The only reason this isn't a higher-severity finding is the per-user scoping, not any existing mitigation against the wildcard issue itself.

## Testing

- `git diff` confirms the change is exactly two lines, both call sites updated identically.
- Verified the SQLAlchemy semantics: `Column.contains("a%b", autoescape=True)` emits a bound `LIKE` with `%` escaped (e.g. `LIKE '%a/%b%' ESCAPE '/'`), preserving literal substring matching.
- No existing tests assert on wildcard behaviour of `title__contains`, so behaviour for normal inputs is unchanged.

cc @lewiswigmore
