### PR TITLE
Fix CVE-2026-41140: Update poetry to 2.3.4

### DIFF
--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -21,7 +21,7 @@ ENV POETRY_NO_INTERACTION=1 \
     POETRY_CACHE_DIR=/tmp/poetry_cache
 
 # Pin Poetry version to match the version used to generate poetry.lock
-ARG POETRY_VERSION=2.3.3
+ARG POETRY_VERSION=2.3.4
 RUN apt-get update -y \
     && apt-get install -y curl make git build-essential jq gettext \
     && python3 -m pip install "poetry==${POETRY_VERSION}" --break-system-packages

--- a/enterprise/poetry.lock
+++ b/enterprise/poetry.lock
@@ -6508,7 +6508,7 @@ pexpect = "*"
 pg8000 = ">=1.31.5"
 pillow = ">=12.1.1"
 playwright = ">=1.55"
-poetry = ">=2.3.3"
+poetry = ">=2.3.4,<2.4.0"
 prompt-toolkit = ">=3.0.50"
 protobuf = ">=5.29.6,<6"
 psutil = "*"
@@ -7308,14 +7308,14 @@ testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "poetry"
-version = "2.3.3"
+version = "2.3.4"
 description = "Python dependency management and packaging made easy."
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "poetry-2.3.3-py3-none-any.whl", hash = "sha256:dbbbd77c3c2782aed85be6f5cb00e7803d1e36376709d58b80f96686e601290b"},
-    {file = "poetry-2.3.3.tar.gz", hash = "sha256:fbffbca25cec43218779b60a1f754916d2f3d54f9642d66cf12729646c36edb7"},
+    {file = "poetry-2.3.4-py3-none-any.whl", hash = "sha256:2755806ed8a9f31340ea1b5f0e507da54c96437647ebf2873b6ca349be04e231"},
+    {file = "poetry-2.3.4.tar.gz", hash = "sha256:b293572d366569360c79d7caa6980c9b404d2b89530ed451a5b4570d248de3af"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -14539,4 +14539,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12,<3.14"
-content-hash = "19c5183f11f4f7bab38eaefd92d638fd70ef7e5025d921806ca5347c0fd2ea8c"
+content-hash = "31ab69356a11bde71bb393134ca64b5744901038a1742b299f5cc9242de562a3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
   "pg8000>=1.31.5",
   "pillow>=12.1.1",
   "playwright>=1.55",
-  "poetry>=2.3.3",
+  "poetry>=2.3.4,<2.4.0",
   "prompt-toolkit>=3.0.50",
   "protobuf>=5.29.6,<6",
   "psutil",
@@ -204,7 +204,7 @@ sse-starlette = "^3.0.2"
 psutil = "*"
 python-json-logger = ">=3.2.1,<5.0.0"
 prompt-toolkit = "^3.0.50"
-poetry = "^2.3.3"
+poetry = ">=2.3.4,<2.4.0"
 anyio = "4.9.0"
 pythonnet = { version = "*", markers = "sys_platform == 'win32'" }
 fastmcp = ">=3.2,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -3696,7 +3696,7 @@ requires-dist = [
     { name = "pg8000", specifier = ">=1.31.5" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "playwright", specifier = ">=1.55" },
-    { name = "poetry", specifier = ">=2.3.3" },
+    { name = "poetry", specifier = ">=2.3.4,<2.4.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.50" },
     { name = "protobuf", specifier = ">=5.29.6,<6" },
     { name = "psutil" },


### PR DESCRIPTION
Security fix for CVE-2026-41140.

This pull request was created by an AI agent (OpenHands) on behalf of the user.

@aivong-openhands can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3e893a06-9bb3-43f7-a530-8c573c52cf44)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-d00d5fe   docker.openhands.dev/openhands/openhands:d00d5fe
```