### PR TITLE
fix: quote Bitbucket cloud credentials in git URLs

### DIFF
--- a/openhands/app_server/integrations/provider.py
+++ b/openhands/app_server/integrations/provider.py
@@ -556,15 +556,16 @@ class ProviderHandler:
                         f'{protocol}://oauth2:{token_value}@{domain}/{repo_name}.git'
                     )
                 elif provider == ProviderType.BITBUCKET:
-                    # For Bitbucket, handle username:app_password format
+                    # Bitbucket Cloud uses HTTP Basic auth with email:api_token.
                     if ':' in token_value:
-                        # App token format: username:app_password
-                        remote_url = (
-                            f'{protocol}://{token_value}@{domain}/{repo_name}.git'
+                        bb_user, bb_pass = token_value.split(':', 1)
+                        url_creds = (
+                            f'{quote(bb_user, safe="")}:{quote(bb_pass, safe="")}'
                         )
                     else:
                         # Access token format: use x-token-auth
-                        remote_url = f'{protocol}://x-token-auth:{token_value}@{domain}/{repo_name}.git'
+                        url_creds = f'x-token-auth:{quote(token_value, safe="")}'
+                    remote_url = f'{protocol}://{url_creds}@{domain}/{repo_name}.git'
                 elif provider == ProviderType.BITBUCKET_DATA_CENTER:
                     # DC uses HTTP Basic auth — token must be in username:token format
                     project, repo_slug = (

--- a/tests/unit/integrations/test_provider_immutability.py
+++ b/tests/unit/integrations/test_provider_immutability.py
@@ -1,4 +1,4 @@
-from types import MappingProxyType
+from types import MappingProxyType, SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -207,6 +207,52 @@ def test_get_provider_env_key():
     """Test provider environment key generation"""
     assert ProviderHandler.get_provider_env_key(ProviderType.GITHUB) == 'github_token'
     assert ProviderHandler.get_provider_env_key(ProviderType.GITLAB) == 'gitlab_token'
+
+
+@pytest.mark.asyncio
+async def test_get_authenticated_git_url_quotes_bitbucket_basic_credentials():
+    tokens = MappingProxyType(
+        {
+            ProviderType.BITBUCKET: ProviderToken(
+                token=SecretStr('user@example.com:api/token#1')
+            )
+        }
+    )
+    handler = ProviderHandler(provider_tokens=tokens)
+    handler.verify_repo_provider = AsyncMock(
+        return_value=SimpleNamespace(
+            git_provider=ProviderType.BITBUCKET,
+            full_name='workspace/repo',
+        )
+    )
+
+    result = await handler.get_authenticated_git_url('workspace/repo')
+
+    assert (
+        result
+        == 'https://user%40example.com:api%2Ftoken%231@bitbucket.org/workspace/repo.git'
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_authenticated_git_url_quotes_bitbucket_token_credentials():
+    tokens = MappingProxyType(
+        {ProviderType.BITBUCKET: ProviderToken(token=SecretStr('api/token#1'))}
+    )
+    handler = ProviderHandler(provider_tokens=tokens)
+    handler.verify_repo_provider = AsyncMock(
+        return_value=SimpleNamespace(
+            git_provider=ProviderType.BITBUCKET,
+            full_name='workspace/repo',
+        )
+    )
+
+    result = await handler.get_authenticated_git_url('workspace/repo')
+
+    assert (
+        result
+        == 'https://x-token-auth:api%2Ftoken%231@bitbucket.org/workspace/repo.git'
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
﻿## Summary
- percent-encode Bitbucket Cloud `email:api_token` credentials before embedding them in git clone URLs
- keep the existing `x-token-auth` fallback, but encode the token value as well
- add unit coverage for both credential forms with URL-sensitive characters

Closes #14304

## To verify
- `uv run --group dev --group test python -m pytest tests\unit\integrations\test_provider_immutability.py -q`
- `uv run --group dev ruff check --config dev_config/python/ruff.toml openhands\app_server\integrations\provider.py tests\unit\integrations\test_provider_immutability.py`
- `uv run --group dev ruff format --check --config dev_config/python/ruff.toml openhands\app_server\integrations\provider.py tests\unit\integrations\test_provider_immutability.py`
- `uv run python -m py_compile openhands\app_server\integrations\provider.py tests\unit\integrations\test_provider_immutability.py`
- `git diff --check`

Note: `pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files ...` could not complete on my Windows machine because the mypy hook dependency install hit the Windows long-path limit inside `litellm`. The targeted tests and ruff checks above pass.
