### PR TITLE
fix(i18n): disable i18next escapeValue (React renderer is the safety boundary)

### DIFF
--- a/frontend/__tests__/components/shared/modals/settings/settings-form.test.tsx
+++ b/frontend/__tests__/components/shared/modals/settings/settings-form.test.tsx
@@ -2,7 +2,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "test-utils";
 import { createRoutesStub } from "react-router";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import SettingsService from "#/api/settings-service/settings-service.api";
 import { SettingsForm } from "#/components/shared/modals/settings/settings-form";
 import { DEFAULT_SETTINGS } from "#/services/settings";
@@ -28,14 +28,16 @@ describe("SettingsForm", () => {
     const saveButton = screen.getByRole("button", { name: /save/i });
     await user.click(saveButton);
 
-    expect(saveSettingsSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        agent_settings_diff: expect.objectContaining({
-          llm: expect.objectContaining({
-            model: getAgentSettingValue(DEFAULT_SETTINGS, "llm.model"),
+    await waitFor(() =>
+      expect(saveSettingsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent_settings_diff: expect.objectContaining({
+            llm: expect.objectContaining({
+              model: getAgentSettingValue(DEFAULT_SETTINGS, "llm.model"),
+            }),
           }),
         }),
-      }),
+      ),
     );
   });
 });

--- a/frontend/__tests__/i18n/escape-value.test.tsx
+++ b/frontend/__tests__/i18n/escape-value.test.tsx
@@ -1,0 +1,53 @@
+import { render } from "@testing-library/react";
+import { Trans } from "react-i18next";
+import { describe, it, expect, beforeAll } from "vitest";
+import i18n from "#/i18n";
+
+/**
+ * Regression: i18next's default ``escapeValue: true`` double-escaped
+ * interpolated values because React's text renderer also escapes —
+ * producing entity-encoded text like ``&#x2F;tmp&#x2F;foo`` in the DOM.
+ * ``index.ts`` flips it to ``false``; this test guards against accidental
+ * reversion.
+ */
+describe("i18next interpolation", () => {
+  beforeAll(async () => {
+    // Register a tiny test bundle so we don't depend on translation.json.
+    i18n.addResourceBundle(
+      "en",
+      "translation",
+      { TEST_PATH_INTERPOLATION: "Reading {{path}}" },
+      true,
+      true,
+    );
+    await i18n.changeLanguage("en");
+  });
+
+  it("renders interpolated paths verbatim (no HTML-entity escaping)", () => {
+    const { container } = render(
+      <Trans
+        i18nKey="TEST_PATH_INTERPOLATION"
+        values={{ path: "/tmp/pr14227/part_037.diff" }}
+      />,
+    );
+    expect(container.textContent).toBe(
+      "Reading /tmp/pr14227/part_037.diff",
+    );
+    // Specifically: the forward slashes must not be encoded.
+    expect(container.innerHTML).not.toContain("&#x2F;");
+    expect(container.innerHTML).not.toContain("&#x2f;");
+  });
+
+  it("still renders potentially-dangerous characters as literal text (React-side safety boundary)", () => {
+    const { container } = render(
+      <Trans
+        i18nKey="TEST_PATH_INTERPOLATION"
+        values={{ path: "<script>alert(1)</script>" }}
+      />,
+    );
+    // React's text renderer turns ``<``/``>`` into entity references — they
+    // appear as literal characters in textContent and do NOT execute.
+    expect(container.textContent).toContain("<script>alert(1)</script>");
+    expect(container.querySelector("script")).toBeNull();
+  });
+});

--- a/frontend/src/components/features/chat/mono-component.tsx
+++ b/frontend/src/components/features/chat/mono-component.tsx
@@ -1,36 +1,13 @@
 import { ReactNode } from "react";
-import EventLogger from "#/utils/event-logger";
 
-const decodeHtmlEntities = (text: string): string => {
-  const textarea = document.createElement("textarea");
-  textarea.innerHTML = text;
-  return textarea.value;
-};
-
-function MonoComponent(props: { children?: ReactNode }) {
-  const { children } = props;
-
-  const decodeString = (str: string): string => {
-    try {
-      return decodeHtmlEntities(str);
-    } catch (e) {
-      EventLogger.error(String(e));
-      return str;
-    }
-  };
-
-  if (Array.isArray(children)) {
-    const processedChildren = children.map((child) =>
-      typeof child === "string" ? decodeString(child) : child,
-    );
-
-    return <strong className="font-mono">{processedChildren}</strong>;
-  }
-
-  if (typeof children === "string") {
-    return <strong className="font-mono">{decodeString(children)}</strong>;
-  }
-
+/**
+ * Renders monospaced bold text. Used as a ``<Trans>`` component override
+ * for the ``<cmd>`` tag in translation strings. Receives children verbatim
+ * — i18next no longer double-escapes interpolated values (see
+ * ``i18n/index.ts``'s ``escapeValue: false``), so the prior
+ * ``decodeHtmlEntities`` step had nothing to undo.
+ */
+function MonoComponent({ children }: { children?: ReactNode }) {
   return <strong className="font-mono">{children}</strong>;
 }
 

--- a/frontend/src/components/features/chat/path-component.tsx
+++ b/frontend/src/components/features/chat/path-component.tsx
@@ -1,16 +1,4 @@
 import { ReactNode } from "react";
-import EventLogger from "#/utils/event-logger";
-
-/**
- * Decodes HTML entities in a string
- * @param text The text to decode
- * @returns The decoded text
- */
-const decodeHtmlEntities = (text: string): string => {
-  const textarea = document.createElement("textarea");
-  textarea.innerHTML = text;
-  return textarea.value;
-};
 
 /**
  * Checks if a path is likely a directory
@@ -47,40 +35,32 @@ const extractFilename = (path: string): string => {
 };
 
 /**
- * Component that displays only the filename in the text but shows the full path on hover
- * Similar to MonoComponent but with path-specific functionality
+ * ``<Trans>`` component override for the ``<path>`` tag in translation
+ * strings: displays the filename in the visible text and the full path
+ * on hover (via the ``title`` attribute).
+ *
+ * Receives children verbatim — i18next no longer double-escapes
+ * interpolated values (see ``i18n/index.ts``'s ``escapeValue: false``),
+ * so the prior ``decodeHtmlEntities`` step had nothing to undo.
  */
 function PathComponent(props: { children?: ReactNode }) {
   const { children } = props;
 
-  const processPath = (path: string) => {
-    try {
-      // First decode any HTML entities in the path
-      const decodedPath = decodeHtmlEntities(path);
-      // Extract the filename from the decoded path
-      const filename = extractFilename(decodedPath);
-      return (
-        <span className="font-mono" title={decodedPath}>
-          {filename}
-        </span>
-      );
-    } catch (e) {
-      // Just log the error without any message to avoid localization issues
-      EventLogger.error(String(e));
-      return <span className="font-mono">{path}</span>;
-    }
-  };
+  const renderPath = (path: string) => (
+    <span className="font-mono" title={path}>
+      {extractFilename(path)}
+    </span>
+  );
 
   if (Array.isArray(children)) {
     const processedChildren = children.map((child) =>
-      typeof child === "string" ? processPath(child) : child,
+      typeof child === "string" ? renderPath(child) : child,
     );
-
     return <strong className="font-mono">{processedChildren}</strong>;
   }
 
   if (typeof children === "string") {
-    return <strong>{processPath(children)}</strong>;
+    return <strong>{renderPath(children)}</strong>;
   }
 
   return <strong className="font-mono">{children}</strong>;

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -37,6 +37,17 @@ i18n
     // Do NOT set nonExplicitSupportedLngs: true as it causes 404 errors
     // for region-specific codes not in supportedLngs (per i18next developer)
     nonExplicitSupportedLngs: false,
+
+    interpolation: {
+      // React already escapes text content before rendering, so i18next's
+      // default ``escapeValue: true`` produces double-escaped output —
+      // an interpolated path like ``/tmp/foo`` surfaces as
+      // ``&#x2F;tmp&#x2F;foo`` in the rendered DOM because React's text
+      // pipeline doesn't decode entities back. Disable here; React's
+      // renderer is the proper safety boundary against XSS in interpolated
+      // strings. See: https://www.i18next.com/translation-function/interpolation
+      escapeValue: false,
+    },
   });
 
 export default i18n;


### PR DESCRIPTION
## Why

i18next's default `escapeValue: true` HTML-escapes interpolated values *before* handing them to the renderer. React's own text pipeline then treats the result as plain text — it does **not** decode entities back. So an interpolated path like `/tmp/foo` lands in the DOM as `&#x2F;tmp&#x2F;foo`, an ACP tool-call title reads "Reading &#x2F;tmp&#x2F;pr14227/part_037.diff", and any `<Trans values={{ … }} />` with a URL/path/separator-bearing value renders entity-encoded.

This is the standard i18next-with-React footgun. The [i18next docs](https://www.i18next.com/translation-function/interpolation) explicitly call it out:

> If you're using a frontend framework like React, you should set `escapeValue: false` because the framework already escapes the value.

## Change

- `frontend/src/i18n/index.ts` — `interpolation: { escapeValue: false }`. React's renderer remains the XSS boundary for interpolated values.
- `frontend/src/components/features/chat/mono-component.tsx` — drop the `decodeHtmlEntities` (textarea-roundtrip) workaround. With escapeValue off the call was a no-op; component simplifies to a plain `<strong className="font-mono">{children}</strong>`.
- `frontend/src/components/features/chat/path-component.tsx` — same `decodeHtmlEntities` removal; filename-extraction / directory-heuristic logic is unchanged.

## Tests

New `frontend/__tests__/i18n/escape-value.test.tsx` with two cases:

- **Path-shaped interpolation**: `<Trans>` interpolating `/tmp/pr14227/part_037.diff` must produce literal forward slashes — no `&#x2F;` anywhere in the rendered HTML.
- **Safety boundary**: interpolating `<script>alert(1)</script>` must render as literal text (`container.textContent` contains the string verbatim) and **not** spawn a `<script>` element. Proves React's own escaping still protects after we disable i18next's.

Existing `__tests__/components/chat/model-messages.test.tsx` (the only direct caller of `MonoComponent` / `PathComponent` in tests) continues to pass unchanged.

## Issue Number

Companion to #14227 — the ACP UI PR surfaced the bug in tool-call titles; reviewer asked for the i18n fix to land as its own change so it gets independent review (it's a global behaviour change affecting every translated string with interpolation).

## How to Test

1. Run on a branch where this is applied.
2. Anywhere a translated message interpolates a value containing `/`, `&`, `<`, `>`, or a quote — e.g. an action card titled "Reading `<path>`" — the rendered text contains the literal characters, not their HTML entity forms.
3. Build a deliberately malicious value like `<img src=x onerror=alert(1)>` and confirm it renders as literal text via `textContent` and **doesn't** execute (React's escape still applies).

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Subtly *changes* observable rendered output for any existing `<Trans>` call whose interpolated values previously contained characters that get HTML-escaped — they will now render as literal characters instead of entity references. The intended fix; not a regression.
- Doesn't touch translation copy or message keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-7277397   docker.openhands.dev/openhands/openhands:7277397
```