### PR TITLE
prep(acp): dispatch live-status conversations by agent_kind

### DIFF
--- a/dev_config/python/.pre-commit-config.yaml
+++ b/dev_config/python/.pre-commit-config.yaml
@@ -59,8 +59,8 @@ repos:
             types-Markdown,
             pydantic,
             lxml,
-            "openhands-sdk==1.19.1",
-            "openhands-tools==1.19.1",
+            "openhands-sdk==1.21.1",
+            "openhands-tools==1.21.1",
             "sqlalchemy>=2.0",
           ]
         # To see gaps add `--html-report mypy-report/`

--- a/openhands/app_server/app_conversation/agent_server_routing.py
+++ b/openhands/app_server/app_conversation/agent_server_routing.py
@@ -1,0 +1,12 @@
+# Conversation tag key holding the ACP provider discriminator (e.g.
+# ``"claude-code"``, ``"codex"``, ``"gemini-cli"``, ``"custom"``). Single
+# source of truth for backend writers and frontend readers — see
+# ``frontend/src/utils/agent-display-label.ts`` for the matching constant.
+ACP_SERVER_TAG = 'acp_server'
+
+
+def agent_kind_to_router_path(agent_kind: str | None) -> str:
+    """Map an app conversation agent kind to the agent-server route prefix."""
+    if agent_kind == 'acp':
+        return 'acp/conversations'
+    return 'conversations'

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -23,6 +23,10 @@ from openhands.agent_server.models import (
     StartConversationRequest,
     TextContent,
 )
+from openhands.app_server.app_conversation.agent_server_routing import (
+    ACP_SERVER_TAG,
+    agent_kind_to_router_path,
+)
 from openhands.app_server.app_conversation.app_conversation_info_service import (
     AppConversationInfoService,
 )
@@ -96,7 +100,6 @@ from openhands.app_server.utils.llm_metadata import (
     should_set_litellm_extra_body,
 )
 from openhands.sdk import Agent, AgentContext, LocalWorkspace
-from openhands.sdk.agent.acp_agent import ACPAgent
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.llm import LLM
 from openhands.sdk.plugin import PluginSource
@@ -122,28 +125,23 @@ _acp_conversation_info_type_adapter = TypeAdapter(list[ACPConversationInfo | Non
 _logger = logging.getLogger(__name__)
 
 
-def _agent_kind_to_router_path(agent_kind: str) -> str:
-    """Map agent_kind discriminator to the agent-server router path prefix."""
-    if agent_kind == 'acp':
-        return 'acp/conversations'
-    return 'conversations'
-
-
 def _split_ids_by_kind(
-    conversation_ids: list[str],
+    conversation_ids: list[str] | list[UUID],
     conversation_kind_by_id: dict[str, str],
-) -> tuple[list[str], list[str]]:
-    """Split conversation IDs into (openhands_ids, acp_ids) by agent_kind."""
-    openhands_ids = [
-        cid
-        for cid in conversation_ids
-        if conversation_kind_by_id.get(cid, 'openhands') != 'acp'
-    ]
-    acp_ids = [
-        cid
-        for cid in conversation_ids
-        if conversation_kind_by_id.get(cid, 'openhands') == 'acp'
-    ]
+) -> tuple[list, list]:
+    """Split conversation IDs into (openhands_ids, acp_ids) by agent_kind.
+
+    ``conversation_ids`` may be either UUIDs (the runtime shape produced by
+    ``_get_sandbox_id_to_conversation_ids``) or strings; the lookup is
+    normalised to ``str`` because the kind map is keyed by ``str(info.id)``.
+    """
+    openhands_ids: list = []
+    acp_ids: list = []
+    for cid in conversation_ids:
+        if conversation_kind_by_id.get(str(cid), 'openhands') == 'acp':
+            acp_ids.append(cid)
+        else:
+            openhands_ids.append(cid)
     return openhands_ids, acp_ids
 
 
@@ -362,7 +360,8 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 else {}
             )
             is_acp = isinstance(start_conversation_request, StartACPConversationRequest)
-            router_path = 'acp/conversations' if is_acp else 'conversations'
+            agent_kind = 'acp' if is_acp else 'openhands'
+            router_path = agent_kind_to_router_path(agent_kind)
             response = await self.httpx_client.post(
                 f'{agent_server_url}/api/{router_path}',
                 json=body_json,
@@ -371,14 +370,19 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             )
 
             response.raise_for_status()
+            tags: dict[str, str] = {}
             if is_acp:
                 info = ACPConversationInfo.model_validate(response.json())
-                agent_kind = 'acp'
-                display_model = start_conversation_request.agent.acp_model
+                llm_model = None
+                # Persist the active ACP provider key so the conversation UI
+                # can resolve a brand label ("Claude Code", "Codex", …) via
+                # the SDK registry without keeping a per-conversation column.
+                user = await self.user_context.get_user_info()
+                if isinstance(user.agent_settings, ACPAgentSettings):
+                    tags[ACP_SERVER_TAG] = user.agent_settings.acp_server
             else:
                 info = ConversationInfo.model_validate(response.json())
-                agent_kind = 'openhands'
-                display_model = start_conversation_request.agent.llm.model
+                llm_model = start_conversation_request.agent.llm.model
 
             # Store info...
             user_id = await self.user_context.get_user_id()
@@ -387,8 +391,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 title=f'Conversation {info.id.hex[:5]}',
                 sandbox_id=sandbox.id,
                 created_by_user_id=user_id,
-                llm_model=display_model,
+                llm_model=llm_model,
                 agent_kind=agent_kind,
+                tags=tags,
                 # Git parameters
                 selected_repository=request.selected_repository,
                 selected_branch=request.selected_branch,
@@ -595,7 +600,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 None,
             )
             if conversation_url:
-                router_path = _agent_kind_to_router_path(
+                router_path = agent_kind_to_router_path(
                     app_conversation_info.agent_kind
                 )
                 conversation_url += f'/api/{router_path}/{app_conversation_info.id.hex}'
@@ -1305,7 +1310,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
 
         # Route ACP agent settings to the ACP-specific builder
         if isinstance(user.agent_settings, ACPAgentSettings):
-            return await self._build_acp_start_conversation_request(
+            acp_request = await self._build_acp_start_conversation_request(
                 sandbox=sandbox,
                 conversation_id=conversation_id,
                 initial_message=initial_message,
@@ -1314,6 +1319,24 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 plugins=plugins,
                 api_secrets=api_secrets,
             )
+            # --- skills (mirrors the LLM skill-loading block below) ----------
+            if remote_workspace:
+                try:
+                    acp_request = acp_request.model_copy(
+                        update={
+                            'agent': await self._load_skills_and_update_agent(
+                                sandbox,
+                                acp_request.agent,
+                                remote_workspace,
+                                selected_repository,
+                                get_project_dir(working_dir, selected_repository),
+                                disabled_skills=user.disabled_skills,
+                            )
+                        }
+                    )
+                except Exception as e:
+                    _logger.warning(f'Failed to load skills: {e}', exc_info=True)
+            return acp_request
 
         project_dir = get_project_dir(working_dir, selected_repository)
         workspace = LocalWorkspace(working_dir=project_dir)
@@ -1459,56 +1482,6 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         # prompts, LLM metadata, skills) applied after create_agent().
         return conv_settings.create_request(StartConversationRequest, agent=agent)
 
-    @staticmethod
-    def _acp_provider_env(user: UserInfo) -> dict[str, str]:
-        """Translate UI-saved LLM credentials into provider-native env vars.
-
-        The ACP subprocess reads provider credentials from environment variables.
-        Maps the user's LLM API key to the env var expected by the active ACP
-        server via ``ACPAgentSettings.api_key_env_var``. Custom servers return
-        ``None`` — users manage credentials entirely via ``acp_env``.
-
-        Args:
-            user: User information containing ACP agent settings.
-
-        Returns:
-            Dict of env var name → value to inject into the ACP subprocess.
-        """
-        if not isinstance(user.agent_settings, ACPAgentSettings):
-            return {}
-
-        acp_settings = user.agent_settings
-        env: dict[str, str] = {}
-
-        llm_api_key = acp_settings.llm.api_key
-        if not llm_api_key:
-            return env
-
-        key_value = (
-            llm_api_key.get_secret_value()
-            if isinstance(llm_api_key, SecretStr)
-            else str(llm_api_key)
-        )
-        if not key_value or not key_value.strip():
-            return env
-
-        # TODO: simplify to `acp_settings.api_key_env_var` once OpenHands is
-        # pinned to an SDK version that includes software-agent-sdk PR #2984.
-        # The fallback per-server mapping below duplicates that SDK property.
-        api_key_env: str | None = getattr(acp_settings, 'api_key_env_var', None)
-        if api_key_env is None:
-            _SERVER_KEY_MAP = {
-                'claude-code': 'ANTHROPIC_API_KEY',
-                'codex': 'OPENAI_API_KEY',
-                'gemini-cli': 'GEMINI_API_KEY',
-            }
-            api_key_env = _SERVER_KEY_MAP.get(acp_settings.acp_server)
-
-        if api_key_env:
-            env[api_key_env] = key_value
-
-        return env
-
     async def _build_acp_start_conversation_request(
         self,
         sandbox: SandboxInfo,
@@ -1524,9 +1497,13 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         Unlike the LLM path, ACP agents run as separate subprocesses; we pass
         credentials via environment variables rather than injecting an LLM object.
 
-        User secrets (Secrets panel + git provider tokens) are also passed through
-        ``AgentContext.secrets`` so the SDK renders a ``<CUSTOM_SECRETS>`` block
-        in the ACP prompt and injects values into the subprocess env at start time.
+        User secrets (Secrets panel + git provider tokens) flow through two
+        complementary channels: they're rendered into the ACP prompt as a
+        ``<CUSTOM_SECRETS>`` block via ``AgentContext.secrets`` (so the agent
+        knows the names) and also pre-exported as environment variables on
+        the ACP subprocess via ``acp_env`` (so plain CLI commands like
+        ``gh`` / ``aws`` / ``git`` pick them up from env without the agent
+        having to manually export them).
 
         Args:
             sandbox: Sandbox information
@@ -1564,42 +1541,59 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         acp_settings = user.agent_settings  # already verified to be ACPAgentSettings
         assert isinstance(acp_settings, ACPAgentSettings)
 
-        # Merge provider env vars (API keys etc.) into acp_env.
-        # Priority (highest → lowest): acp_env > provider_env
-        provider_env = self._acp_provider_env(user)
-        merged_env: dict[str, str] = {
-            **provider_env,
-            **dict(acp_settings.acp_env or {}),
-        }
+        # Pass user secrets via AgentContext so the SDK renders a <CUSTOM_SECRETS>
+        # block in the ACP prompt; this lets the agent know which secret names
+        # are available and what they're for.
+        agent_context = AgentContext(secrets=secrets) if secrets else None
 
-        # Pass user secrets via AgentContext so the SDK renders a
-        # <CUSTOM_SECRETS> block in the ACP prompt and injects values into
-        # the subprocess env at start time (SDK PR #2984).
-        # TODO: remove the _sdk_supports_acp_secrets guard once OpenHands pins
-        # to an SDK version that includes PR #2984 (secrets acp_compatible=True).
-        _sdk_supports_acp_secrets = (
-            AgentContext.model_fields.get('secrets') is not None
-            and isinstance(AgentContext.model_fields['secrets'].json_schema_extra, dict)
-            and AgentContext.model_fields['secrets'].json_schema_extra.get(
-                'acp_compatible'
+        # Also resolve those same secrets into ``acp_env`` so they appear as
+        # real environment variables on the ACP subprocess. The SDK Terminal
+        # tool (used by the regular OpenHands agent) does an analogous
+        # ``export KEY=value`` before each bash command via
+        # ``secret_registry.get_secrets_as_env_vars(command)``; ACP servers
+        # use their own bash tooling that the SDK doesn't intercept, so we
+        # pre-export at subprocess-launch time instead. Net effect: commands
+        # like ``gh pr view`` pick up ``GH_TOKEN`` from env without the agent
+        # having to manually ``export`` it from the prompt block.
+        #
+        # Precedence (preserves the SDK's ``acp_env > provider env`` rule):
+        # explicit ``acp_env`` from settings wins, then provider env derived
+        # from ``llm.api_key``, then panel-secret values fill remaining gaps.
+        # That way a user-set ``llm.api_key`` keeps owning
+        # ``ANTHROPIC_API_KEY`` even if a same-named secret exists in the
+        # panel; arbitrary credentials like ``GH_TOKEN`` (which have no
+        # provider-registry entry) still get injected.
+        gap_filling_env: dict[str, str] = {}
+        already_resolved = set(acp_settings.acp_env or {}) | set(
+            acp_settings.resolve_provider_env()
+        )
+        for name, source in (secrets or {}).items():
+            if name in already_resolved:
+                continue
+            try:
+                resolved: str | None = source.get_value()
+            except Exception as exc:
+                _logger.warning(
+                    'Could not resolve secret %r for ACP env: %s', name, exc
+                )
+                continue
+            if isinstance(resolved, str) and resolved:
+                gap_filling_env[name] = resolved
+
+        if gap_filling_env:
+            acp_settings = acp_settings.model_copy(
+                update={
+                    'acp_env': {
+                        **gap_filling_env,
+                        **(acp_settings.acp_env or {}),
+                    }
+                }
             )
-            is True
-        )
-        agent_context = (
-            AgentContext(secrets=secrets)
-            if secrets and _sdk_supports_acp_secrets
-            else None
-        )
 
-        acp_agent = ACPAgent(
-            acp_command=acp_settings.acp_command,
-            acp_args=acp_settings.acp_args,
-            acp_env=merged_env,
-            acp_model=acp_settings.acp_model,
-            acp_session_mode=acp_settings.acp_session_mode,
-            acp_prompt_timeout=acp_settings.acp_prompt_timeout,
-            agent_context=agent_context,
+        settings_update = (
+            {'agent_context': agent_context} if agent_context is not None else {}
         )
+        acp_agent = acp_settings.model_copy(update=settings_update).create_agent()
 
         sdk_plugins: list[PluginSource] | None = None
         if plugins:
@@ -1608,15 +1602,21 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 for p in plugins
             ]
 
-        return StartACPConversationRequest(
-            workspace=workspace,
-            conversation_id=conversation_id,
-            initial_message=self._construct_initial_message_with_plugin_params(
-                initial_message, plugins
-            ),
-            secrets=secrets,
-            plugins=sdk_plugins,
-            agent=acp_agent,
+        # Mirror the regular path: populate ConversationSettings and delegate
+        # to create_request() so that max_iterations, confirmation_mode, and
+        # security_analyzer flow through to ACP conversations too.
+        conv_settings = user.conversation_settings.model_copy(
+            update={
+                'workspace': workspace,
+                'conversation_id': conversation_id,
+                'initial_message': self._construct_initial_message_with_plugin_params(
+                    initial_message, plugins
+                ),
+                'plugins': sdk_plugins,
+            }
+        )
+        return conv_settings.create_request(
+            StartACPConversationRequest, agent=acp_agent
         )
 
     async def _process_pending_messages(

--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -16,8 +16,15 @@ from sqlalchemy import String, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
 
-from openhands.agent_server.models import ConversationInfo, EventPage
+from openhands.agent_server.models import (
+    ACPConversationInfo,
+    ConversationInfo,
+    EventPage,
+)
 from openhands.agent_server.utils import utc_now
+from openhands.app_server.app_conversation.agent_server_routing import (
+    agent_kind_to_router_path,
+)
 from openhands.app_server.app_conversation.app_conversation_info_service import (
     AppConversationInfoService,
 )
@@ -806,14 +813,21 @@ async def refresh_conversation(
 
         # TODO: Maybe we can use RemoteConversation here?
 
+        router_path = agent_kind_to_router_path(app_conversation_info.agent_kind)
+
         # First get conversation...
-        conversation_url = f'{url}/api/conversations/{app_conversation_info.id.hex}'
+        conversation_url = f'{url}/api/{router_path}/{app_conversation_info.id.hex}'
         response = await httpx_client.get(
             conversation_url, headers={'X-Session-API-Key': runtime['session_api_key']}
         )
         response.raise_for_status()
 
-        updated_conversation_info = ConversationInfo.model_validate(response.json())
+        info_type = (
+            ACPConversationInfo
+            if app_conversation_info.agent_kind == 'acp'
+            else ConversationInfo
+        )
+        updated_conversation_info = info_type.model_validate(response.json())
 
         app_conversation_info.updated_at = updated_conversation_info.updated_at
 
@@ -836,7 +850,7 @@ async def refresh_conversation(
         # TODO: It would be nice to have an updated_at__gte filter parameter in the
         # agent server so that we don't pull the full event list each time
         event_url = (
-            f'{url}/api/conversations/{app_conversation_info.id.hex}/events/search'
+            f'{url}/api/{router_path}/{app_conversation_info.id.hex}/events/search'
         )
 
         async def fetch_events_page(page_id: str | None = None) -> EventPage:

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -25,6 +25,7 @@ from openhands.app_server.app_conversation.app_conversation_models import (
 )
 from openhands.app_server.app_conversation.live_status_app_conversation_service import (
     LiveStatusAppConversationService,
+    _split_ids_by_kind,
 )
 from openhands.app_server.integrations.provider import ProviderToken, ProviderType
 from openhands.app_server.integrations.service_types import SuggestedTask, TaskType
@@ -42,20 +43,10 @@ from openhands.app_server.settings.settings_models import (
 )
 from openhands.app_server.user.user_context import UserContext
 from openhands.sdk import Agent, Event
-from openhands.sdk.context.agent_context import AgentContext as _AgentContext
 from openhands.sdk.llm import LLM
 from openhands.sdk.secret import LookupSecret, StaticSecret
 from openhands.sdk.settings import AgentSettings, ConversationSettings
 from openhands.sdk.workspace.remote.async_remote_workspace import AsyncRemoteWorkspace
-
-# True only on SDK versions that include PR #2984 (secrets acp_compatible=True).
-# When False, _build_acp_start_conversation_request skips the agent_context path.
-_SDK_SUPPORTS_ACP_SECRETS = (
-    _AgentContext.model_fields.get('secrets') is not None
-    and isinstance(_AgentContext.model_fields['secrets'].json_schema_extra, dict)
-    and _AgentContext.model_fields['secrets'].json_schema_extra.get('acp_compatible')
-    is True
-)
 
 
 def _build_test_user_agent_settings(user: SimpleNamespace) -> AgentSettings:
@@ -3075,94 +3066,6 @@ class TestLoadHooksFromWorkspace:
         )
 
 
-class TestAcpProviderEnv:
-    """Unit tests for ``LiveStatusAppConversationService._acp_provider_env``.
-
-    Tests the helper that translates UI-saved LLM credentials into the
-    provider env vars the chosen ACP subprocess expects.
-    """
-
-    @pytest.fixture
-    def _user_factory(self):
-        try:
-            from openhands.sdk.settings import (
-                ACPAgentSettings,  # type: ignore[attr-defined]
-            )
-        except ImportError:
-            pytest.skip('ACPAgentSettings not available in this SDK build')
-
-        def _make(
-            *,
-            acp_server: str = 'claude-code',
-            api_key: str | None = None,
-            base_url: str | None = None,
-            acp_env: dict[str, str] | None = None,
-        ):
-            user = _TestUserInfo(
-                id='user1',
-                llm_model='',
-                llm_base_url=None,
-                llm_api_key=None,
-                sandbox_grouping_strategy=SandboxGroupingStrategy.ADD_TO_ANY,
-                confirmation_mode=False,
-                security_analyzer=None,
-                search_api_key=None,
-                mcp_config=None,
-                disabled_skills=[],
-            )
-            user.agent_settings = ACPAgentSettings(
-                acp_server=acp_server,  # type: ignore[arg-type]
-                llm=LLM(
-                    model='claude-sonnet-4-5',
-                    api_key=SecretStr(api_key) if api_key else None,
-                    base_url=base_url,
-                ),
-                acp_env=acp_env or {},
-            )
-            return user
-
-        return _make
-
-    def test_claude_code_translates_to_anthropic_vars(self, _user_factory):
-        user = _user_factory(acp_server='claude-code', api_key='sk-test-anthropic')
-        env = LiveStatusAppConversationService._acp_provider_env(user)
-        assert env == {'ANTHROPIC_API_KEY': 'sk-test-anthropic'}
-
-    def test_codex_translates_to_openai_vars(self, _user_factory):
-        user = _user_factory(acp_server='codex', api_key='sk-test-openai')
-        env = LiveStatusAppConversationService._acp_provider_env(user)
-        assert env == {'OPENAI_API_KEY': 'sk-test-openai'}
-
-    def test_gemini_translates_to_gemini_vars(self, _user_factory):
-        user = _user_factory(acp_server='gemini-cli', api_key='sk-test-gemini')
-        env = LiveStatusAppConversationService._acp_provider_env(user)
-        assert env == {'GEMINI_API_KEY': 'sk-test-gemini'}
-
-    def test_custom_server_returns_empty(self, _user_factory):
-        """For acp_server='custom', the user is on their own via acp_env."""
-        user = _user_factory(
-            acp_server='custom',
-            api_key='sk-test',
-            base_url='https://proxy.example.com',
-        )
-        env = LiveStatusAppConversationService._acp_provider_env(user)
-        assert env == {}
-
-    def test_no_credentials_returns_empty(self, _user_factory):
-        """No api_key + no base_url → nothing synthesized."""
-        user = _user_factory(acp_server='claude-code')
-        env = LiveStatusAppConversationService._acp_provider_env(user)
-        assert env == {}
-
-    def test_no_api_key_returns_empty(self, _user_factory):
-        """No api_key → nothing synthesized."""
-        user = _user_factory(
-            acp_server='claude-code', base_url='https://api.anthropic.com'
-        )
-        env = LiveStatusAppConversationService._acp_provider_env(user)
-        assert env == {}
-
-
 class TestAgentKindConversationUrl:
     """Regression tests for conversation_url / live-status route dispatch.
 
@@ -3253,12 +3156,12 @@ class TestAgentKindConversationUrl:
 
     def test_agent_kind_to_router_path_known_kinds(self):
         """``'openhands'`` routes to standard conversations; ``'acp'`` to ACP."""
-        from openhands.app_server.app_conversation.live_status_app_conversation_service import (  # noqa: E501
-            _agent_kind_to_router_path,
+        from openhands.app_server.app_conversation.agent_server_routing import (
+            agent_kind_to_router_path,
         )
 
-        assert _agent_kind_to_router_path('openhands') == 'conversations'
-        assert _agent_kind_to_router_path('acp') == 'acp/conversations'
+        assert agent_kind_to_router_path('openhands') == 'conversations'
+        assert agent_kind_to_router_path('acp') == 'acp/conversations'
 
     def test_agent_kind_to_router_path_unknown_falls_back(self):
         """Any value that is not 'acp' routes to 'conversations'.
@@ -3267,12 +3170,12 @@ class TestAgentKindConversationUrl:
         before the rename, so rows stored with ``agent_kind='llm'`` continue to
         route correctly without a migration.
         """
-        from openhands.app_server.app_conversation.live_status_app_conversation_service import (  # noqa: E501
-            _agent_kind_to_router_path,
+        from openhands.app_server.app_conversation.agent_server_routing import (
+            agent_kind_to_router_path,
         )
 
-        assert _agent_kind_to_router_path('llm') == 'conversations'
-        assert _agent_kind_to_router_path('future-variant') == 'conversations'
+        assert agent_kind_to_router_path('llm') == 'conversations'
+        assert agent_kind_to_router_path('future-variant') == 'conversations'
 
 
 class TestBuildAcpStartConversationRequestSecrets:
@@ -3361,14 +3264,10 @@ class TestBuildAcpStartConversationRequestSecrets:
 
         request = await self._call_build(service, user, tmp_path)
 
-        if _SDK_SUPPORTS_ACP_SECRETS:
-            assert request.agent.agent_context is not None
-            ctx = request.agent.agent_context.secrets
-            assert ctx.get('GITHUB_TOKEN') is github_secret
-            assert ctx.get('MY_API_KEY') is api_secret
-        else:
-            # Pinned SDK doesn't support ACP secrets yet; agent_context stays unset.
-            assert request.agent.agent_context is None
+        assert request.agent.agent_context is not None
+        ctx = request.agent.agent_context.secrets
+        assert ctx.get('GITHUB_TOKEN') is github_secret
+        assert ctx.get('MY_API_KEY') is api_secret
 
     @pytest.mark.asyncio
     async def test_lookup_secret_forwarded_as_source(self, service, tmp_path):
@@ -3381,11 +3280,8 @@ class TestBuildAcpStartConversationRequestSecrets:
 
         request = await self._call_build(service, user, tmp_path)
 
-        if _SDK_SUPPORTS_ACP_SECRETS:
-            assert request.agent.agent_context is not None
-            assert request.agent.agent_context.secrets.get('GITHUB_TOKEN') is lookup
-        else:
-            assert request.agent.agent_context is None
+        assert request.agent.agent_context is not None
+        assert request.agent.agent_context.secrets.get('GITHUB_TOKEN') is lookup
 
     @pytest.mark.asyncio
     async def test_explicit_acp_env_preserved(self, service, tmp_path):
@@ -3413,14 +3309,10 @@ class TestBuildAcpStartConversationRequestSecrets:
         request = await self._call_build(service, user, tmp_path)
 
         assert request.agent.acp_env.get('ANTHROPIC_API_KEY') == 'sk-ui-key'
-        if _SDK_SUPPORTS_ACP_SECRETS:
-            assert request.agent.agent_context is not None
-            assert (
-                request.agent.agent_context.secrets.get('ANTHROPIC_API_KEY')
-                is panel_secret
-            )
-        else:
-            assert request.agent.agent_context is None
+        assert request.agent.agent_context is not None
+        assert (
+            request.agent.agent_context.secrets.get('ANTHROPIC_API_KEY') is panel_secret
+        )
 
     @pytest.mark.asyncio
     async def test_no_secrets_no_agent_context(self, service, tmp_path):
@@ -3437,8 +3329,8 @@ class TestBuildAcpStartConversationRequestSecrets:
         """Explicit acp_env entries take priority over auto-generated provider_env.
 
         When a user sets ANTHROPIC_API_KEY explicitly in acp_env, it must win
-        over the same key that _acp_provider_env derives from the UI-saved LLM
-        credentials.  This exercises the merge priority:
+        over the same key the SDK derives from the UI-saved LLM credentials.
+        This exercises the merge priority:
           acp_env > provider_env > agent_context.secrets
         """
         user = self._make_acp_user(
@@ -3452,3 +3344,104 @@ class TestBuildAcpStartConversationRequestSecrets:
 
         # acp_env must win; the UI-saved key must NOT overwrite it
         assert request.agent.acp_env.get('ANTHROPIC_API_KEY') == 'sk-explicit-override'
+
+    @pytest.mark.asyncio
+    async def test_secrets_exported_as_env_vars(self, service, tmp_path):
+        """Panel secrets are pre-exported as env vars on the ACP subprocess.
+
+        Mirrors the OpenHands Terminal tool's per-command ``export KEY=value``
+        flow. Without this, plain CLI tools like ``gh`` inside the ACP
+        subprocess shell can't authenticate from the ``<CUSTOM_SECRETS>``
+        prompt block alone.
+        """
+        gh_secret = StaticSecret(value=SecretStr('ghp_test123'))
+        user = self._make_acp_user()
+        service._setup_secrets_for_git_providers = AsyncMock(
+            return_value={'GH_TOKEN': gh_secret}
+        )
+
+        request = await self._call_build(service, user, tmp_path)
+
+        # Resolved into acp_env so the subprocess shell sees it.
+        assert request.agent.acp_env.get('GH_TOKEN') == 'ghp_test123'
+        # AND still in agent_context.secrets so the agent knows it exists.
+        assert request.agent.agent_context is not None
+        assert request.agent.agent_context.secrets.get('GH_TOKEN') is gh_secret
+
+    @pytest.mark.asyncio
+    async def test_panel_secret_does_not_override_provider_env(self, service, tmp_path):
+        """Provider env (from ``llm.api_key``) keeps priority over panel secrets.
+
+        If a user has both a UI-saved Claude Code LLM key AND a same-named
+        ``ANTHROPIC_API_KEY`` in the Secrets panel, the LLM-saved one wins —
+        matches the SDK's ``acp_env > provider_env > secrets`` precedence
+        and avoids surprising silent overrides of the canonical model
+        credential.
+        """
+        user = self._make_acp_user(acp_server='claude-code', api_key='sk-ui-key')
+        panel_secret = StaticSecret(value=SecretStr('sk-from-secrets-panel'))
+        service._setup_secrets_for_git_providers = AsyncMock(
+            return_value={'ANTHROPIC_API_KEY': panel_secret}
+        )
+
+        request = await self._call_build(service, user, tmp_path)
+
+        # llm.api_key-derived provider env wins.
+        assert request.agent.acp_env.get('ANTHROPIC_API_KEY') == 'sk-ui-key'
+        # The panel secret is still surfaced in agent_context.secrets so
+        # the agent could reference it explicitly if needed.
+        assert request.agent.agent_context is not None
+        assert (
+            request.agent.agent_context.secrets.get('ANTHROPIC_API_KEY') is panel_secret
+        )
+
+    @pytest.mark.asyncio
+    async def test_explicit_acp_env_wins_over_panel_secret(self, service, tmp_path):
+        """Same-named explicit acp_env overrides a panel secret of the same name."""
+        user = self._make_acp_user(acp_env={'GH_TOKEN': 'explicit-token'})
+        service._setup_secrets_for_git_providers = AsyncMock(
+            return_value={'GH_TOKEN': StaticSecret(value=SecretStr('panel-token'))}
+        )
+
+        request = await self._call_build(service, user, tmp_path)
+
+        assert request.agent.acp_env.get('GH_TOKEN') == 'explicit-token'
+
+
+class TestSplitIdsByKind:
+    """``_split_ids_by_kind`` routes ACP vs OpenHands conversation IDs.
+
+    The kind map is keyed by ``str(info.id)`` (see ``_build_app_conversations``)
+    but the IDs flowing in from ``_get_sandbox_id_to_conversation_ids`` are raw
+    ``UUID`` instances. A naive ``dict.get(cid)`` would always miss and silently
+    route ACP conversations to ``/api/conversations``.
+    """
+
+    def test_uuid_ids_against_string_keyed_map_routes_correctly(self):
+        oh_id = uuid4()
+        acp_id = uuid4()
+        kind_map = {str(oh_id): 'openhands', str(acp_id): 'acp'}
+
+        openhands_ids, acp_ids = _split_ids_by_kind([oh_id, acp_id], kind_map)
+
+        assert openhands_ids == [oh_id]
+        assert acp_ids == [acp_id]
+
+    def test_string_ids_work_too(self):
+        oh_id = uuid4()
+        acp_id = uuid4()
+        kind_map = {str(oh_id): 'openhands', str(acp_id): 'acp'}
+
+        openhands_ids, acp_ids = _split_ids_by_kind([str(oh_id), str(acp_id)], kind_map)
+
+        assert openhands_ids == [str(oh_id)]
+        assert acp_ids == [str(acp_id)]
+
+    def test_unknown_id_defaults_to_openhands(self):
+        unknown = uuid4()
+        openhands_ids, acp_ids = _split_ids_by_kind([unknown], {})
+        assert openhands_ids == [unknown]
+        assert acp_ids == []
+
+    def test_empty_input(self):
+        assert _split_ids_by_kind([], {}) == ([], [])


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why split this out

[#14227](https://github.com/OpenHands/OpenHands/pull/14227) bundles the minimal ACP settings UI together with a refactor of the live-status / sandbox-refresh code paths to dispatch by ``agent_kind``. The refactor is large but mechanical and conceptually independent — restructuring agent-server-call paths to be kind-aware without referencing the ACP UI, feature flag, conversation chip, or any other ACP feature surface.

Splitting it out lets reviewers evaluate the dispatch infrastructure separately from the additive feature work it enables.

## Stacked on #14373

This PR depends on [#14373](https://github.com/OpenHands/OpenHands/pull/14373) (which exposes the ``ACP_PROVIDERS`` registry + ``enable_acp`` flag). Targets `chore/sdk-bump-acp-registry`. Once #14373 merges, this PR's base auto-retargets to `main` and the diff stays the same.

## What changes

- **New ``openhands/app_server/app_conversation/agent_server_routing.py``** — ``agent_kind_to_router_path()`` maps an ``AppConversationInfo.agent_kind`` string to the agent-server route prefix (``conversations`` for OpenHands, ``acp/conversations`` for ACP). Also exposes ``ACP_SERVER_TAG`` as a single source of truth for the ``tags['acp_server']`` key (consumed by the feature PR).
- **``live_status_app_conversation_service.py``** — ``_get_live_conversation_info`` splits the incoming ID list by agent kind via the new ``_split_ids_by_kind`` helper, then fetches each bucket from the appropriate endpoint and merges the results. The request-build path delegates env-var resolution, session-mode selection, and command resolution to the SDK via ``ACPAgentSettings`` rather than the bespoke ``_acp_provider_env`` + ``_SERVER_KEY_MAP`` fallbacks that lived here before. Conversation URLs in ``_build_conversation`` use the new dispatcher.
- **``remote_sandbox_service.refresh_conversation``** — pulls the agent-server conversation URL through the same dispatcher so the refresh path is symmetric with start/live-status.

No lockfile changes — the SDK on ``main`` is already pinned to ``openhands-sdk==1.21.1`` (#14350); ``ACPAgentSettings.resolve_provider_env()`` and ``ACP_PROVIDERS`` ship from 1.21.0+.

## Tests

- Drops the ``TestAcpProviderEnv`` suite that covered the now-deleted ``_acp_provider_env`` helper.
- Adds ``TestSplitIdsByKind`` covering the UUID/string lookup against the str-keyed kind map. Without the ``str(cid)`` normalisation, ACP conversations silently routed to the OpenHands endpoint — this test is the regression guard for that.

``uv run pytest tests/unit/app_server/test_live_status_app_conversation_service.py -q`` → 118 passed.

## No user-visible behaviour change

The dispatcher returns the same endpoint that was previously hard-coded for each path; the only new behaviour is "route by ``agent_kind``" which on ``main`` always evaluates to ``conversations`` (no ACP conversations exist until #14227's feature flag lands).

## Followed by

- [#14227](https://github.com/OpenHands/OpenHands/pull/14227) — additive ACP UI + routing wire-up.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-c1bb956   docker.openhands.dev/openhands/openhands:c1bb956
```