### PR TITLE
feat: expose ACP_PROVIDERS registry + enable_acp flag on /api/v1/web-client/config

### DIFF
--- a/frontend/src/api/option-service/option.types.ts
+++ b/frontend/src/api/option-service/option.types.ts
@@ -28,8 +28,15 @@ export interface WebClientFeatureFlags {
   hide_users_page: boolean;
   hide_billing_page: boolean;
   hide_integrations_page: boolean;
+  enable_acp?: boolean;
   deployment_mode?: DeploymentMode;
   enable_onboarding: boolean;
+}
+
+export interface ACPProviderConfig {
+  key: string;
+  display_name: string;
+  default_command: string[];
 }
 
 export interface WebClientConfig {
@@ -47,4 +54,5 @@ export interface WebClientConfig {
   gitlab_enabled?: boolean;
   provider_default_hosts?: Partial<Record<Provider, string>>;
   slack_enabled?: boolean;
+  acp_providers?: ACPProviderConfig[];
 }

--- a/openhands/app_server/web_client/default_web_client_config_injector.py
+++ b/openhands/app_server/web_client/default_web_client_config_injector.py
@@ -9,9 +9,11 @@ from openhands.app_server.web_client.web_client_config_injector import (
     WebClientConfigInjector,
 )
 from openhands.app_server.web_client.web_client_models import (
+    ACPProviderConfig,
     WebClientConfig,
     WebClientFeatureFlags,
 )
+from openhands.sdk.settings import ACP_PROVIDERS
 
 
 def _get_recaptcha_site_key() -> str | None:
@@ -112,8 +114,8 @@ def _get_feature_flags() -> WebClientFeatureFlags:
 
     Reads ENABLE_BILLING, HIDE_LLM_SETTINGS, ENABLE_JIRA, ENABLE_JIRA_DC,
     ENABLE_LINEAR, HIDE_USERS_PAGE, HIDE_BILLING_PAGE, HIDE_INTEGRATIONS_PAGE,
-    and OH_ENABLE_ONBOARDING from environment. Each flag is True only if the
-    corresponding env var is exactly 'true', otherwise False.
+    ENABLE_ACP, and OH_ENABLE_ONBOARDING from environment. Each flag is True
+    only if the corresponding env var is exactly 'true', otherwise False.
     """
     return WebClientFeatureFlags(
         enable_billing=os.getenv('ENABLE_BILLING', 'false') == 'true',
@@ -124,6 +126,7 @@ def _get_feature_flags() -> WebClientFeatureFlags:
         hide_users_page=os.getenv('HIDE_USERS_PAGE', 'false') == 'true',
         hide_billing_page=os.getenv('HIDE_BILLING_PAGE', 'false') == 'true',
         hide_integrations_page=os.getenv('HIDE_INTEGRATIONS_PAGE', 'false') == 'true',
+        enable_acp=os.getenv('ENABLE_ACP', 'false') == 'true',
         enable_onboarding=os.getenv('OH_ENABLE_ONBOARDING', 'false') == 'true',
     )
 
@@ -158,6 +161,19 @@ class DefaultWebClientConfigInjector(WebClientConfigInjector):
         }
     )
     slack_enabled: bool = Field(default_factory=_get_slack_enabled)
+    acp_providers: list[ACPProviderConfig] = Field(
+        default_factory=lambda: [
+            ACPProviderConfig(
+                key=provider.key,
+                display_name=provider.display_name,
+                # SDK exposes ``default_command`` as ``tuple[str, ...]`` (frozen
+                # registry record); the API contract uses ``list[str]`` for
+                # JSON-friendliness.
+                default_command=list(provider.default_command),
+            )
+            for provider in ACP_PROVIDERS.values()
+        ]
+    )
 
     async def get_web_client_config(self) -> WebClientConfig:
         from openhands.app_server.config import get_global_config
@@ -178,5 +194,6 @@ class DefaultWebClientConfigInjector(WebClientConfigInjector):
             gitlab_enabled=self.gitlab_enabled,
             provider_default_hosts=self.provider_default_hosts,
             slack_enabled=self.slack_enabled,
+            acp_providers=self.acp_providers,
         )
         return result

--- a/openhands/app_server/web_client/web_client_models.py
+++ b/openhands/app_server/web_client/web_client_models.py
@@ -20,6 +20,7 @@ class WebClientFeatureFlags(BaseModel):
     hide_users_page: bool = False
     hide_billing_page: bool = False
     hide_integrations_page: bool = False
+    enable_acp: bool = False
     deployment_mode: DeploymentMode | None = None
     enable_onboarding: bool = False
 
@@ -29,6 +30,12 @@ class WebClientFeatureFlags(BaseModel):
         if self.deployment_mode is None:
             self.deployment_mode = get_deployment_mode()
         return self
+
+
+class ACPProviderConfig(BaseModel):
+    key: str
+    display_name: str
+    default_command: list[str]
 
 
 class WebClientConfig(DiscriminatedUnionMixin):
@@ -46,3 +53,4 @@ class WebClientConfig(DiscriminatedUnionMixin):
     gitlab_enabled: bool = False
     provider_default_hosts: dict[str, str] = Field(default_factory=dict)
     slack_enabled: bool = False
+    acp_providers: list[ACPProviderConfig] = Field(default_factory=list)


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why split this out

Extracted from [#14227](https://github.com/OpenHands/OpenHands/pull/14227) so the API surface addition can be reviewed independently of the UI work that consumes it.

## What changes

- ``WebClientFeatureFlags.enable_acp`` (gated by ``ENABLE_ACP`` env var, default ``false``).
- New ``ACPProviderConfig`` model + ``WebClientConfig.acp_providers`` list field.
- ``DefaultWebClientConfigInjector`` populates ``acp_providers`` from ``ACP_PROVIDERS.values()`` so the SDK registry is the single source of truth.
- Frontend types mirror both in ``option.types.ts``.

3 files, +35 / -2. No new dependencies.

## SDK dependency

The SDK on ``main`` is already pinned to ``openhands-sdk==1.21.1`` (#14350); both ``ACP_PROVIDERS`` and ``ACPAgentSettings`` are available there. No lockfile bumps in this PR.

## Verification

Smoke-tested the injector standalone:
```
> acp_providers count: 3
> keys: ['claude-code', 'codex', 'gemini-cli']
> enable_acp: False
```

## No user-visible behaviour change

- ``enable_acp`` defaults to ``false``; existing clients see the same response.
- ``acp_providers`` is populated but unused without the consumer PR (#14227).

## Used by

- [#14371](https://github.com/OpenHands/OpenHands/pull/14371) — live-status dispatch refactor
- [#14227](https://github.com/OpenHands/OpenHands/pull/14227) — ACP UI

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-fc08ac3   docker.openhands.dev/openhands/openhands:fc08ac3
```