### PR TITLE
Update AgentSettings usage for SDK removal

### DIFF
--- a/enterprise/storage/org_service.py
+++ b/enterprise/storage/org_service.py
@@ -26,7 +26,7 @@ from storage.user_store import UserStore
 
 from openhands.app_server.settings.settings_models import Settings
 from openhands.app_server.utils.logger import openhands_logger as logger
-from openhands.sdk.settings import AgentSettings, ConversationSettings
+from openhands.sdk.settings import ConversationSettings, default_agent_settings
 
 
 class OrgService:
@@ -108,15 +108,15 @@ class OrgService:
         Returns:
             Org: New organization entity (not yet persisted)
         """
-        default_agent_settings = AgentSettings()
-        default_agent_settings.llm.model = get_default_litellm_model()
+        agent_settings = default_agent_settings()
+        agent_settings.llm.model = get_default_litellm_model()
         return Org(
             id=org_id,
             name=name,
             contact_name=contact_name,
             contact_email=contact_email,
             org_version=ORG_SETTINGS_VERSION,
-            agent_settings=default_agent_settings,
+            agent_settings=agent_settings,
             conversation_settings=ConversationSettings(),
         )
 

--- a/enterprise/tests/unit/server/routes/test_users_v1.py
+++ b/enterprise/tests/unit/server/routes/test_users_v1.py
@@ -273,11 +273,11 @@ class TestSdkCompatFields:
 
         from openhands.app_server.user.user_models import UserInfo
         from openhands.sdk.llm import LLM
-        from openhands.sdk.settings import AgentSettings
+        from openhands.sdk.settings import OpenHandsAgentSettings
 
         base_user_info = UserInfo(
             id='user-123',
-            agent_settings=AgentSettings(
+            agent_settings=OpenHandsAgentSettings(
                 llm=LLM(model='test-model', base_url='https://test.com')
             ),
         )
@@ -307,11 +307,11 @@ class TestSdkCompatFields:
 
         from openhands.app_server.user.user_models import UserInfo
         from openhands.sdk.llm import LLM
-        from openhands.sdk.settings import AgentSettings
+        from openhands.sdk.settings import OpenHandsAgentSettings
 
         base_user_info = UserInfo(
             id='user-123',
-            agent_settings=AgentSettings(
+            agent_settings=OpenHandsAgentSettings(
                 llm=LLM(
                     model='test-model',
                     api_key='sk-test-secret',
@@ -374,11 +374,11 @@ class TestSdkCompatFields:
 
         from openhands.app_server.user.user_models import UserInfo
         from openhands.sdk.llm import LLM
-        from openhands.sdk.settings import AgentSettings
+        from openhands.sdk.settings import OpenHandsAgentSettings
 
         base_user_info = UserInfo(
             id='user-123',
-            agent_settings=AgentSettings(llm=LLM(model='test-model')),
+            agent_settings=OpenHandsAgentSettings(llm=LLM(model='test-model')),
         )
         mock_user_context.get_user_info = AsyncMock(return_value=base_user_info)
 

--- a/openhands/app_server/settings/settings_models.py
+++ b/openhands/app_server/settings/settings_models.py
@@ -31,7 +31,6 @@ from openhands.app_server.settings.llm_profiles import LLMProfiles
 from openhands.app_server.utils.jsonpatch_compat import deep_merge
 from openhands.sdk.settings import (
     ACPAgentSettings,
-    AgentSettings,
     AgentSettingsConfig,
     ConversationSettings,
     OpenHandsAgentSettings,
@@ -65,11 +64,11 @@ def _load_persisted_agent_settings(
 ) -> OpenHandsAgentSettings | ACPAgentSettings:
     """Load persisted agent settings via the SDK loader.
 
-    Routes the raw payload through :meth:`AgentSettings.from_persisted` so any
+    Routes the raw payload through :func:`validate_agent_settings` so any
     schema migrations registered with the SDK are applied before validation
     against the discriminated :data:`AgentSettingsConfig` union.
     """
-    return AgentSettings.from_persisted(data or {})
+    return validate_agent_settings(data or {})
 
 
 def _load_persisted_conversation_settings(data: Any) -> ConversationSettings:

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -45,7 +45,7 @@ from openhands.sdk import Agent, Event
 from openhands.sdk.context.agent_context import AgentContext as _AgentContext
 from openhands.sdk.llm import LLM
 from openhands.sdk.secret import LookupSecret, StaticSecret
-from openhands.sdk.settings import AgentSettings, ConversationSettings
+from openhands.sdk.settings import ConversationSettings, OpenHandsAgentSettings
 from openhands.sdk.workspace.remote.async_remote_workspace import AsyncRemoteWorkspace
 
 # True only on SDK versions that include PR #2984 (secrets acp_compatible=True).
@@ -58,7 +58,7 @@ _SDK_SUPPORTS_ACP_SECRETS = (
 )
 
 
-def _build_test_user_agent_settings(user: SimpleNamespace) -> AgentSettings:
+def _build_test_user_agent_settings(user: SimpleNamespace) -> OpenHandsAgentSettings:
     llm_vals: dict = {}
     model = getattr(user, 'llm_model', '') or ''
     llm_vals['model'] = model
@@ -82,7 +82,7 @@ def _build_test_user_agent_settings(user: SimpleNamespace) -> AgentSettings:
 
 class _TestUserInfo(SimpleNamespace):
     @property
-    def agent_settings(self) -> AgentSettings:
+    def agent_settings(self) -> OpenHandsAgentSettings:
         override = getattr(self, '_agent_settings_override', None)
         if override is not None:
             return override
@@ -103,7 +103,7 @@ class _TestUserInfo(SimpleNamespace):
             kwargs['max_iterations'] = max_iter
         return ConversationSettings(**kwargs)
 
-    def to_agent_settings(self) -> AgentSettings:
+    def to_agent_settings(self) -> OpenHandsAgentSettings:
         return self.agent_settings
 
 

--- a/tests/unit/app_server/test_profiles_api.py
+++ b/tests/unit/app_server/test_profiles_api.py
@@ -28,7 +28,7 @@ from openhands.app_server.settings.settings_router import _user_profile_locks
 from openhands.app_server.settings.settings_store import SettingsStore
 from openhands.app_server.user_auth.user_auth import UserAuth
 from openhands.sdk.llm import LLM
-from openhands.sdk.settings import AgentSettings
+from openhands.sdk.settings import OpenHandsAgentSettings
 
 
 @pytest.fixture(autouse=True)
@@ -115,7 +115,7 @@ def test_client(settings_store):
 def _base_settings() -> Settings:
     """A Settings instance with an LLM configured so 'snapshot current' works."""
     return Settings(
-        agent_settings=AgentSettings(
+        agent_settings=OpenHandsAgentSettings(
             llm=LLM(
                 model='openai/gpt-4o',
                 api_key=SecretStr('sk-current'),

--- a/tests/unit/app_server/test_sandbox_secrets_router.py
+++ b/tests/unit/app_server/test_sandbox_secrets_router.py
@@ -36,7 +36,7 @@ from openhands.app_server.user.user_models import UserInfo
 from openhands.app_server.user.user_router import get_current_user
 from openhands.sdk.llm import LLM
 from openhands.sdk.secret import StaticSecret
-from openhands.sdk.settings import AgentSettings
+from openhands.sdk.settings import OpenHandsAgentSettings
 
 SANDBOX_ID = 'sb-test-123'
 USER_ID = 'test-user-id'
@@ -257,7 +257,7 @@ class TestGetCurrentUserExposeSecrets:
         """With valid session key, expose_secrets=true returns unmasked llm_api_key."""
         user_info = UserInfo(
             id=USER_ID,
-            agent_settings=AgentSettings(
+            agent_settings=OpenHandsAgentSettings(
                 llm=LLM(
                     model='anthropic/claude-sonnet-4-20250514',
                     api_key=SecretStr('sk-test-key-123'),
@@ -337,7 +337,7 @@ class TestGetCurrentUserExposeSecrets:
         """Without expose_secrets, llm_api_key is masked (no session key needed)."""
         user_info = UserInfo(
             id=USER_ID,
-            agent_settings=AgentSettings(
+            agent_settings=OpenHandsAgentSettings(
                 llm=LLM(model='gpt-4o', api_key=SecretStr('sk-test-key-123')),
             ),
         )
@@ -553,7 +553,7 @@ class TestExposeSecretsIntegration:
         mock_user_ctx.get_user_info = AsyncMock(
             return_value=UserInfo(
                 id=USER_ID,
-                agent_settings=AgentSettings(
+                agent_settings=OpenHandsAgentSettings(
                     llm=LLM(model='gpt-4o', api_key=SecretStr('sk-secret-123')),
                 ),
             )
@@ -574,7 +574,7 @@ class TestExposeSecretsIntegration:
         mock_user_ctx.get_user_info = AsyncMock(
             return_value=UserInfo(
                 id=USER_ID,
-                agent_settings=AgentSettings(
+                agent_settings=OpenHandsAgentSettings(
                     llm=LLM(model='gpt-4o', api_key=SecretStr('sk-secret-123')),
                 ),
             )
@@ -606,7 +606,7 @@ class TestExposeSecretsIntegration:
         mock_user_ctx.get_user_info = AsyncMock(
             return_value=UserInfo(
                 id='user-A',
-                agent_settings=AgentSettings(
+                agent_settings=OpenHandsAgentSettings(
                     llm=LLM(model='gpt-4o', api_key=SecretStr('sk-secret-123')),
                 ),
             )
@@ -642,7 +642,7 @@ class TestExposeSecretsIntegration:
         mock_user_ctx.get_user_info = AsyncMock(
             return_value=UserInfo(
                 id=USER_ID,
-                agent_settings=AgentSettings(
+                agent_settings=OpenHandsAgentSettings(
                     llm=LLM(
                         model='anthropic/claude-sonnet-4-20250514',
                         api_key=SecretStr('sk-real-secret'),
@@ -684,7 +684,7 @@ class TestExposeSecretsIntegration:
         mock_user_ctx.get_user_info = AsyncMock(
             return_value=UserInfo(
                 id=USER_ID,
-                agent_settings=AgentSettings(
+                agent_settings=OpenHandsAgentSettings(
                     llm=LLM(
                         model='gpt-4o',
                         api_key=SecretStr('sk-should-be-masked'),

--- a/tests/unit/app_server/test_settings_api.py
+++ b/tests/unit/app_server/test_settings_api.py
@@ -18,8 +18,8 @@ from openhands.app_server.settings.settings_store import SettingsStore
 from openhands.app_server.user_auth.user_auth import UserAuth
 from openhands.sdk.llm import LLM
 from openhands.sdk.settings import (
-    OpenHandsAgentSettings,
     ConversationSettings,
+    OpenHandsAgentSettings,
     VerificationSettings,
 )
 

--- a/tests/unit/app_server/test_settings_api.py
+++ b/tests/unit/app_server/test_settings_api.py
@@ -18,7 +18,7 @@ from openhands.app_server.settings.settings_store import SettingsStore
 from openhands.app_server.user_auth.user_auth import UserAuth
 from openhands.sdk.llm import LLM
 from openhands.sdk.settings import (
-    AgentSettings,
+    OpenHandsAgentSettings,
     ConversationSettings,
     VerificationSettings,
 )
@@ -148,7 +148,7 @@ async def test_settings_api_endpoints(test_client):
     settings = Settings(
         language='en',
         remote_runtime_resource_factor=2,
-        agent_settings=AgentSettings(
+        agent_settings=OpenHandsAgentSettings(
             agent='test-agent',
             llm=LLM(
                 model='test-model',
@@ -241,7 +241,7 @@ async def test_saving_settings_with_frozen_secrets_store(test_client):
     payload = _dump_update(
         Settings(
             language='en',
-            agent_settings=AgentSettings(llm=LLM(model='gpt-4')),
+            agent_settings=OpenHandsAgentSettings(llm=LLM(model='gpt-4')),
         )
     )
     # Inject an extra key the API should ignore gracefully
@@ -258,7 +258,7 @@ async def test_search_api_key_explicit_clear(test_client):
         json=_dump_update(
             Settings(
                 search_api_key='initial-secret-key',
-                agent_settings=AgentSettings(llm=LLM(model='gpt-4')),
+                agent_settings=OpenHandsAgentSettings(llm=LLM(model='gpt-4')),
             )
         ),
     )
@@ -273,7 +273,7 @@ async def test_search_api_key_explicit_clear(test_client):
         json=_dump_update(
             Settings(
                 search_api_key='',
-                agent_settings=AgentSettings(llm=LLM(model='claude-3-opus')),
+                agent_settings=OpenHandsAgentSettings(llm=LLM(model='claude-3-opus')),
             )
         ),
     )
@@ -293,7 +293,7 @@ async def test_disabled_skills_persistence(test_client):
         json=_dump_update(
             Settings(
                 disabled_skills=['skill_a', 'skill_b'],
-                agent_settings=AgentSettings(llm=LLM(model='test-model')),
+                agent_settings=OpenHandsAgentSettings(llm=LLM(model='test-model')),
             )
         ),
     )

--- a/tests/unit/mcp/test_mcp_integration.py
+++ b/tests/unit/mcp/test_mcp_integration.py
@@ -9,14 +9,14 @@ from openhands.app_server.settings.file_settings_store import FileSettingsStore
 from openhands.app_server.settings.settings_models import Settings
 from openhands.app_server.user_auth.default_user_auth import DefaultUserAuth
 from openhands.sdk.llm import LLM
-from openhands.sdk.settings import AgentSettings
+from openhands.sdk.settings import OpenHandsAgentSettings
 
 
 @pytest.mark.asyncio
 async def test_user_auth_returns_stored_settings():
     """Test that user auth returns stored settings."""
     stored_settings = Settings(
-        agent_settings=AgentSettings(
+        agent_settings=OpenHandsAgentSettings(
             llm=LLM(model='anthropic/claude-sonnet-4-5-20250929'),
             mcp_config=MCPConfig(
                 mcpServers={
@@ -50,7 +50,7 @@ async def test_user_auth_returns_stored_settings():
 async def test_user_auth_caching_behavior():
     """Test that user auth caches settings correctly."""
     stored_settings = Settings(
-        agent_settings=AgentSettings(
+        agent_settings=OpenHandsAgentSettings(
             llm=LLM(model='anthropic/claude-sonnet-4-5-20250929'),
             mcp_config=MCPConfig(
                 mcpServers={

--- a/tests/unit/storage/data_models/test_settings.py
+++ b/tests/unit/storage/data_models/test_settings.py
@@ -13,7 +13,7 @@ from openhands.app_server.settings.settings_router import LITE_LLM_API_URL
 from openhands.sdk.llm import LLM
 from openhands.sdk.settings import (
     AGENT_SETTINGS_SCHEMA_VERSION,
-    AgentSettings,
+    OpenHandsAgentSettings,
     ConversationSettings,
 )
 from openhands.sdk.settings.model import CondenserSettings, VerificationSettings
@@ -22,7 +22,7 @@ from openhands.sdk.settings.model import CondenserSettings, VerificationSettings
 def test_settings_handles_sensitive_data():
     settings = Settings(
         language='en',
-        agent_settings=AgentSettings(
+        agent_settings=OpenHandsAgentSettings(
             agent='test-agent',
             llm=LLM(
                 model='test-model',
@@ -43,14 +43,14 @@ def test_settings_handles_sensitive_data():
     assert llm_api_key.get_secret_value() == 'test-key'
 
 
-def test_settings_loads_persisted_settings_via_from_persisted():
-    loaded_agent_settings = AgentSettings(agent='migrated-agent')
+def test_settings_loads_persisted_settings_via_sdk_loaders():
+    loaded_agent_settings = OpenHandsAgentSettings(agent='migrated-agent')
     loaded_conversation_settings = ConversationSettings(max_iterations=77)
 
     with (
         patch.object(
-            AgentSettings,
-            'from_persisted',
+            settings_module,
+            'validate_agent_settings',
             return_value=loaded_agent_settings,
         ) as agent_loader,
         patch.object(
@@ -73,7 +73,7 @@ def test_settings_loads_persisted_settings_via_from_persisted():
 def test_settings_update_deep_merges_agent_settings():
     """Updating agent_settings with a partial dict must not overwrite sibling sub-fields."""
     settings = Settings(
-        agent_settings=AgentSettings(
+        agent_settings=OpenHandsAgentSettings(
             llm=LLM(model='existing-model', api_key=SecretStr('existing-key')),
             condenser=CondenserSettings(enabled=True, max_size=200),
         ),
@@ -89,7 +89,7 @@ def test_settings_update_deep_merges_agent_settings():
 
 def test_settings_preserve_agent_settings():
     settings = Settings(
-        agent_settings=AgentSettings(
+        agent_settings=OpenHandsAgentSettings(
             llm=LLM(
                 model='test-model',
                 api_key=SecretStr('test-key'),
@@ -117,7 +117,7 @@ def test_settings_preserve_agent_settings():
 
 def test_settings_to_agent_settings_uses_agent_vals():
     settings = Settings(
-        agent_settings=AgentSettings(
+        agent_settings=OpenHandsAgentSettings(
             llm=LLM(
                 model='sdk-model',
                 base_url='https://sdk.example.com',
@@ -143,7 +143,7 @@ def test_settings_to_agent_settings_uses_agent_vals():
 
 def test_settings_agent_settings_keeps_sdk_mcp_shape_canonical():
     settings = Settings(
-        agent_settings=AgentSettings(
+        agent_settings=OpenHandsAgentSettings(
             llm=LLM(model='sdk-model'),
             mcp_config=MCPConfig(
                 mcpServers={
@@ -168,7 +168,7 @@ def test_settings_agent_settings_keeps_sdk_mcp_shape_canonical():
 
 
 def test_settings_update_mcp_config():
-    settings = Settings(agent_settings=AgentSettings(llm=LLM(model='sdk-model')))
+    settings = Settings(agent_settings=OpenHandsAgentSettings(llm=LLM(model='sdk-model')))
 
     settings.update(
         {
@@ -194,7 +194,7 @@ def test_settings_update_mcp_config():
 
 def test_settings_update_replaces_existing_mcp_servers():
     settings = Settings(
-        agent_settings=AgentSettings(
+        agent_settings=OpenHandsAgentSettings(
             llm=LLM(model='sdk-model'),
             mcp_config=MCPConfig(
                 mcpServers={
@@ -230,7 +230,7 @@ def test_settings_update_replaces_existing_mcp_servers():
 
 def test_settings_update_can_clear_mcp_config():
     settings = Settings(
-        agent_settings=AgentSettings(
+        agent_settings=OpenHandsAgentSettings(
             llm=LLM(model='sdk-model'),
             mcp_config=MCPConfig(
                 mcpServers={
@@ -317,7 +317,7 @@ def test_switch_to_profile_preserves_other_agent_settings():
     ``switch_to_profile`` would silently drop those sibling configs.
     """
     settings = Settings(
-        agent_settings=AgentSettings(
+        agent_settings=OpenHandsAgentSettings(
             llm=LLM(model='openai/gpt-4o'),
             condenser=CondenserSettings(enabled=True, max_size=321),
             verification=VerificationSettings(
@@ -407,7 +407,7 @@ def test_update_ignores_llm_profiles_payload():
 def test_update_clears_active_when_llm_diverges():
     """Editing agent_settings.llm via ``update`` must drop a now-stale active profile."""
     settings = Settings(
-        agent_settings=AgentSettings(
+        agent_settings=OpenHandsAgentSettings(
             llm=LLM(model='openai/gpt-4o', api_key=SecretStr('sk-a'))
         )
     )
@@ -427,7 +427,7 @@ def test_update_clears_active_when_llm_diverges():
 def test_update_keeps_active_when_llm_unchanged():
     """A no-op LLM update must not spuriously clear ``active``."""
     settings = Settings(
-        agent_settings=AgentSettings(
+        agent_settings=OpenHandsAgentSettings(
             llm=LLM(model='openai/gpt-4o', api_key=SecretStr('sk-a'))
         )
     )
@@ -487,7 +487,7 @@ def test_settings_no_pydantic_frozen_field_warning():
 def test_litellm_proxy_to_openhands_conversion_with_openhands_proxy():
     """Test that litellm_proxy/ is converted to openhands/ when using OpenHands proxy."""
     settings = Settings(
-        agent_settings=AgentSettings(
+        agent_settings=OpenHandsAgentSettings(
             llm=LLM(
                 model='litellm_proxy/claude-opus-4-5-20251101',
                 base_url=LITE_LLM_API_URL,
@@ -506,7 +506,7 @@ def test_litellm_proxy_to_openhands_conversion_with_openhands_proxy():
 def test_litellm_proxy_custom_endpoint_keeps_prefix():
     """Test that custom litellm_proxy endpoints keep their litellm_proxy/ prefix."""
     settings = Settings(
-        agent_settings=AgentSettings(
+        agent_settings=OpenHandsAgentSettings(
             llm=LLM(
                 model='litellm_proxy/gpt-5.3-codex',
                 base_url='http://custom-proxy.example.com:4000',
@@ -525,7 +525,7 @@ def test_litellm_proxy_custom_endpoint_keeps_prefix():
 def test_openhands_model_converts_to_litellm_proxy_internally():
     """Test that openhands/ models are stored as litellm_proxy/ internally."""
     settings = Settings(
-        agent_settings=AgentSettings(
+        agent_settings=OpenHandsAgentSettings(
             llm=LLM(model='openhands/claude-opus-4-5-20251101')
         )
     )

--- a/tests/unit/storage/data_models/test_settings.py
+++ b/tests/unit/storage/data_models/test_settings.py
@@ -13,8 +13,8 @@ from openhands.app_server.settings.settings_router import LITE_LLM_API_URL
 from openhands.sdk.llm import LLM
 from openhands.sdk.settings import (
     AGENT_SETTINGS_SCHEMA_VERSION,
-    OpenHandsAgentSettings,
     ConversationSettings,
+    OpenHandsAgentSettings,
 )
 from openhands.sdk.settings.model import CondenserSettings, VerificationSettings
 
@@ -168,7 +168,9 @@ def test_settings_agent_settings_keeps_sdk_mcp_shape_canonical():
 
 
 def test_settings_update_mcp_config():
-    settings = Settings(agent_settings=OpenHandsAgentSettings(llm=LLM(model='sdk-model')))
+    settings = Settings(
+        agent_settings=OpenHandsAgentSettings(llm=LLM(model='sdk-model'))
+    )
 
     settings.update(
         {

--- a/tests/unit/storage/settings/test_file_settings_store.py
+++ b/tests/unit/storage/settings/test_file_settings_store.py
@@ -9,7 +9,7 @@ from openhands.app_server.file_store.files import FileStore
 from openhands.app_server.settings.file_settings_store import FileSettingsStore
 from openhands.app_server.settings.settings_models import Settings
 from openhands.sdk.llm import LLM
-from openhands.sdk.settings import AgentSettings, ConversationSettings
+from openhands.sdk.settings import ConversationSettings, OpenHandsAgentSettings
 
 
 @pytest.fixture(autouse=True)
@@ -39,7 +39,7 @@ async def test_store_and_load_data(file_settings_store):
     # Test data
     init_data = Settings(
         language='python',
-        agent_settings=AgentSettings(
+        agent_settings=OpenHandsAgentSettings(
             agent='test-agent',
             llm=LLM(
                 model='test-model',


### PR DESCRIPTION
## Summary
- replace direct uses of the deprecated `AgentSettings` class with `OpenHandsAgentSettings` or `default_agent_settings()`
- route persisted agent settings through `validate_agent_settings()` instead of `AgentSettings.from_persisted()`
- update affected tests to use the canonical settings class

This prepares OpenHands for OpenHands/software-agent-sdk#3208, which removes the deprecated `AgentSettings` public alias.

## Testing
- `PYTHONPATH=$PWD uv run pytest tests/unit/storage/data_models/test_settings.py tests/unit/app_server/test_settings_api.py tests/unit/mcp/test_mcp_integration.py -q`

This PR was created by an AI agent (OpenHands) on behalf of the user.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-9d26489   docker.openhands.dev/openhands/openhands:9d26489
```