### PR TITLE
fix: submit attachment-only chat messages

### DIFF
--- a/frontend/__tests__/components/interactive-chat-box.test.tsx
+++ b/frontend/__tests__/components/interactive-chat-box.test.tsx
@@ -1,6 +1,15 @@
-import { screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { MemoryRouter } from "react-router";
 import { InteractiveChatBox } from "#/components/features/chat/interactive-chat-box";
 import { renderWithProviders } from "../../test-utils";
@@ -57,7 +66,8 @@ describe("InteractiveChatBox", () => {
 
   const mockStores = (agentState: AgentState = AgentState.INIT) => {
     vi.mocked(useAgentState).mockReturnValue({
-      curAgentState: agentState, isArchived: false,
+      curAgentState: agentState,
+      isArchived: false,
     });
 
     useConversationStore.setState({
@@ -76,10 +86,13 @@ describe("InteractiveChatBox", () => {
   };
 
   // Helper function to render with Router context
-  const renderInteractiveChatBox = (props: any, options: any = {}) =>
+  const renderInteractiveChatBox = (
+    { onSubmit, disabled }: ComponentProps<typeof InteractiveChatBox>,
+    options: Parameters<typeof renderWithProviders>[1] = {},
+  ) =>
     renderWithProviders(
       <MemoryRouter>
-        <InteractiveChatBox {...props} />
+        <InteractiveChatBox onSubmit={onSubmit} disabled={disabled} />
       </MemoryRouter>,
       options,
     );
@@ -88,6 +101,16 @@ describe("InteractiveChatBox", () => {
     global.URL.createObjectURL = vi
       .fn()
       .mockReturnValue("blob:http://example.com");
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: query === "(pointer: fine)",
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
   });
 
   afterEach(() => {
@@ -199,6 +222,43 @@ describe("InteractiveChatBox", () => {
     await user.click(submitButton);
 
     expect(onSubmitMock).toHaveBeenCalledWith("Hello, world!", [], []);
+  });
+
+  it("should submit when only an image is attached", async () => {
+    const user = userEvent.setup();
+    const image = new File(["image"], "screenshot.png", { type: "image/png" });
+    mockStores(AgentState.AWAITING_USER_INPUT);
+    useConversationStore.setState({ images: [image] });
+
+    renderInteractiveChatBox({
+      onSubmit: onSubmitMock,
+    });
+
+    const submitButton = screen.getByTestId("submit-button");
+    await user.click(submitButton);
+
+    expect(onSubmitMock).toHaveBeenCalledWith("", [image], []);
+    expect(useConversationStore.getState().images).toEqual([]);
+  });
+
+  it("should submit on Enter when only a file is attached", async () => {
+    const file = new File(["content"], "notes.txt", { type: "text/plain" });
+    mockStores(AgentState.AWAITING_USER_INPUT);
+    useConversationStore.setState({ files: [file] });
+
+    renderInteractiveChatBox({
+      onSubmit: onSubmitMock,
+    });
+
+    const chatInput = screen.getByTestId("chat-input");
+    fireEvent.keyDown(chatInput, {
+      key: "Enter",
+      code: "Enter",
+      shiftKey: false,
+    });
+
+    expect(onSubmitMock).toHaveBeenCalledWith("", [], [file]);
+    expect(useConversationStore.getState().files).toEqual([]);
   });
 
   it("should disable the submit button when awaiting user confirmation", async () => {

--- a/frontend/src/hooks/chat/use-chat-input-events.ts
+++ b/frontend/src/hooks/chat/use-chat-input-events.ts
@@ -4,6 +4,7 @@ import {
   ensureCursorVisible,
   clearEmptyContent,
 } from "#/components/features/chat/utils/chat-input.utils";
+import { useConversationStore } from "#/stores/conversation-store";
 
 /**
  * Hook for handling chat input events
@@ -17,6 +18,8 @@ export const useChatInputEvents = (
   onFocus?: () => void,
   onBlur?: () => void,
 ) => {
+  const { images, files: attachedFiles } = useConversationStore();
+
   // Handle input events
   const handleInput = useCallback(() => {
     smartResize();
@@ -36,14 +39,14 @@ export const useChatInputEvents = (
       e.preventDefault();
 
       // Check if there are files in the clipboard
-      const files = Array.from(e.clipboardData.files);
-      const hasFiles = files.length > 0;
+      const clipboardFiles = Array.from(e.clipboardData.files);
+      const hasFiles = clipboardFiles.length > 0;
 
       if (hasFiles) {
         // Handle file paste - let the file handling system process the files
         // We'll trigger a custom event that the file handling system can listen to
         const customEvent = new CustomEvent("pasteFiles", {
-          detail: { files },
+          detail: { files: clipboardFiles },
         });
         document.dispatchEvent(customEvent);
         return;
@@ -74,7 +77,11 @@ export const useChatInputEvents = (
         return;
       }
 
-      if (checkIsContentEmpty()) {
+      if (
+        checkIsContentEmpty() &&
+        images.length === 0 &&
+        attachedFiles.length === 0
+      ) {
         e.preventDefault();
         increaseHeightForEmptyContent();
         return;
@@ -86,7 +93,12 @@ export const useChatInputEvents = (
         handleSubmit();
       }
     },
-    [checkIsContentEmpty, increaseHeightForEmptyContent],
+    [
+      checkIsContentEmpty,
+      increaseHeightForEmptyContent,
+      images.length,
+      attachedFiles.length,
+    ],
   );
 
   // Handle blur events to ensure placeholder shows when empty

--- a/frontend/src/hooks/chat/use-chat-submission.ts
+++ b/frontend/src/hooks/chat/use-chat-submission.ts
@@ -3,6 +3,7 @@ import {
   clearTextContent,
   clearFileInput,
 } from "#/components/features/chat/utils/chat-input.utils";
+import { useConversationStore } from "#/stores/conversation-store";
 
 /**
  * Hook for handling chat message submission
@@ -14,12 +15,15 @@ export const useChatSubmission = (
   onSubmit: (message: string) => void,
   resetManualResize?: () => void,
 ) => {
+  const { images, files } = useConversationStore();
+
   // Send button click handler
   const handleSubmit = useCallback(() => {
     const message = chatInputRef.current?.innerText || "";
     const trimmedMessage = message.trim();
+    const hasAttachments = images.length > 0 || files.length > 0;
 
-    if (!trimmedMessage) {
+    if (!trimmedMessage && !hasAttachments) {
       return;
     }
 
@@ -34,7 +38,15 @@ export const useChatSubmission = (
 
     // Reset manual resize state for next message
     resetManualResize?.();
-  }, [chatInputRef, fileInputRef, smartResize, onSubmit, resetManualResize]);
+  }, [
+    chatInputRef,
+    fileInputRef,
+    smartResize,
+    onSubmit,
+    resetManualResize,
+    images.length,
+    files.length,
+  ]);
 
   // Handle stop button click
   const handleStop = useCallback((onStop?: () => void) => {


### PR DESCRIPTION
﻿- [ ] A human has tested these changes.

---

## Why

In the V1 chat input, submitting currently depends on non-empty text. That makes attachment-only messages look ready to send, but clicking the send button or pressing Enter does not submit them.

Fixes #14047.

## Summary

- Allow `useChatSubmission` to submit when images or files are attached, even if the text field is empty.
- Let the desktop Enter handler use the same attachment-aware empty-input check.
- Add coverage for image-only button submit and file-only Enter submit.

## Issue Number

Fixes #14047

## How to Test

```
cd frontend
npm test -- __tests__/components/interactive-chat-box.test.tsx
npx eslint src/hooks/chat/use-chat-submission.ts src/hooks/chat/use-chat-input-events.ts __tests__/components/interactive-chat-box.test.tsx
npx prettier --check src/hooks/chat/use-chat-submission.ts src/hooks/chat/use-chat-input-events.ts __tests__/components/interactive-chat-box.test.tsx
npm run typecheck:staged
```

The pre-commit hook also passed locally with `PRE_COMMIT_HOME=C:\pc-oh` and Git Bash plus the repo `.venv\Scripts` on `PATH`.

## Video/Screenshots

Not included; this path is covered by the focused component tests above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No API or backend behavior changes.
