### PR TITLE
debug(auth): log auth type and stack trace on /api/v1/logout

### DIFF
--- a/enterprise/server/routes/auth.py
+++ b/enterprise/server/routes/auth.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import traceback
 import uuid
 import warnings
 from datetime import datetime, timedelta, timezone
@@ -933,6 +934,20 @@ async def logout(request: Request):
     # Try to properly logout from Keycloak, but don't fail if it doesn't work
     try:
         user_auth = cast(SaasUserAuth, await get_user_auth(request))
+        # Temporary debug logging to diagnose offline sessions being terminated
+        # on logout. If `auth_type` is BEARER (or any bearer-style header is
+        # set), `user_auth.refresh_token` is the offline token, and handing it
+        # to Keycloak's /logout endpoint will end the offline session.
+        logger.info(
+            'logout_debug',
+            extra={
+                'auth_type': getattr(user_auth, 'auth_type', None),
+                'has_authorization': 'Authorization' in request.headers,
+                'has_x_session_api_key': 'X-Session-API-Key' in request.headers,
+                'has_x_access_token': 'X-Access-Token' in request.headers,
+            },
+        )
+        logger.info('logout_debug_stack:\n%s', ''.join(traceback.format_stack()))
         if user_auth and user_auth.refresh_token:
             refresh_token = user_auth.refresh_token.get_secret_value()
             await token_manager.logout(refresh_token)


### PR DESCRIPTION
## Why

We're seeing offline Keycloak sessions disappear when users log out, even though logout is only supposed to terminate the regular session. The `OfflineTokenStore` has no delete method, and `enterprise/server/routes/auth.py::logout` hasn't materially changed in over a year — so the offline session must be getting killed by Keycloak in response to our call to `token_manager.logout(refresh_token)`.

`SaasUserAuth.refresh_token` is overloaded:

- `saas_user_auth_from_cookie` → the **regular** refresh token from the `keycloak_auth` cookie
- `saas_user_auth_from_bearer` (and `get_for_user` / `get_user_auth_from_keycloak_id`) → the **offline** refresh token loaded via `token_manager.load_offline_token(...)`

`SaasUserAuth.get_instance` tries the Bearer path **first**, so any logout request that carries `Authorization: Bearer …`, `X-Session-API-Key`, or `X-Access-Token` resolving to a valid API key ends up sending the offline token to Keycloak's `/protocol/openid-connect/logout`, terminating the offline session.

We want to confirm this hypothesis in production before changing behavior.

## What

Adds temporary debug logging at the top of the `try` block in `logout`:

1. An `info` log (`logout_debug`) recording:
   - the resolved `user_auth.auth_type` (`COOKIE` vs `BEARER`)
   - whether each of `Authorization`, `X-Session-API-Key`, `X-Access-Token` was present on the request
2. A follow-up `info` log (`logout_debug_stack`) with a full Python stack trace at the call site, so we can identify which client/caller is triggering bearer-authenticated logouts.

If we see `auth_type=AuthType.BEARER` on the offending request, the structural fix is to either (a) gate `token_manager.logout(...)` on `auth_type == AuthType.COOKIE`, or (b) read the regular refresh token directly out of the `keycloak_auth` cookie inside the handler rather than from `user_auth.refresh_token`.

## Plan

- [x] Add the two debug logs (this PR).
- [ ] Deploy to staging/prod, capture logs from a real logout that kills the offline session.
- [ ] Open a follow-up PR with the actual fix and revert this debug logging.

## Testing

Pre-commit checks pass:

- `pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files enterprise/server/routes/auth.py` — Passed
- `pre-commit run --config ./enterprise/dev_config/python/.pre-commit-config.yaml --files enterprise/server/routes/auth.py` — Passed (ruff, ruff-format, mypy)

No functional change — only adds two `logger.info(...)` calls; existing logout behavior is preserved.

---

_This pull request was created by an AI agent (OpenHands) on behalf of the requesting user._


@chuckbutkus can click here to [continue refining the PR](https://app.all-hands.dev/conversations/eca52f19-0c98-4745-a2ed-6c7dd401cbad)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-47e4f06   docker.openhands.dev/openhands/openhands:47e4f06
```