### PR TITLE
Plumb effective_org_id through SaasSettingsStore and SaasSecretsStore

### DIFF
--- a/enterprise/server/auth/saas_user_auth.py
+++ b/enterprise/server/auth/saas_user_auth.py
@@ -258,7 +258,15 @@ class SaasUserAuth(UserAuth):
         secrets_store = self.secrets_store
         if secrets_store:
             return secrets_store
-        secrets_store = await SaasSecretsStore.get_instance(self.user_id)
+        # Scope secrets to the request's effective org so that callers
+        # using an API key bound to org A — or supplying an X-Org-Id
+        # header — read/write secrets under that org, not under whatever
+        # `user.current_org_id` happens to point at.
+        effective_org_id = await self.get_effective_org_id()
+        secrets_store = await SaasSecretsStore.get_instance(
+            self.user_id,
+            effective_org_id=effective_org_id,
+        )
         self.secrets_store = secrets_store
         return secrets_store
 
@@ -361,7 +369,15 @@ class SaasUserAuth(UserAuth):
         settings_store = self.settings_store
         if settings_store:
             return settings_store
-        settings_store = SaasSettingsStore(self.user_id)
+        # Scope settings to the request's effective org. See
+        # `get_secrets_store` for the same rationale: the store mutates
+        # the resolved Org row (and per-member overrides), so the
+        # effective org must flow through here rather than letting the
+        # store fall back to `user.current_org_id`.
+        effective_org_id = await self.get_effective_org_id()
+        settings_store = SaasSettingsStore(
+            self.user_id, effective_org_id=effective_org_id
+        )
         self.settings_store = settings_store
         return settings_store
 

--- a/enterprise/storage/saas_secrets_store.py
+++ b/enterprise/storage/saas_secrets_store.py
@@ -125,9 +125,9 @@ class SaasSecretsStore(SecretsStore):
                 kwargs[key] = self._jwt_svc.encrypt_value(value)
 
     @classmethod
-    async def get_instance(
+    async def get_instance(  # type: ignore[override]
         cls,
-        user_id: str,  # type: ignore[override]
+        user_id: str,
         effective_org_id: UUID | None = None,
     ) -> SaasSecretsStore:
         """Get a SaasSecretsStore instance for the given user.

--- a/enterprise/storage/saas_secrets_store.py
+++ b/enterprise/storage/saas_secrets_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from uuid import UUID
 
 from sqlalchemy import delete, select
 from storage.database import a_session_maker
@@ -17,12 +18,18 @@ from openhands.app_server.utils.logger import openhands_logger as logger
 class SaasSecretsStore(SecretsStore):
     user_id: str
     _jwt_svc: JwtService = field(repr=False)
+    # When set, overrides the user's `current_org_id` for both load and
+    # store. Used to honor a request's effective org (api_key_org_id >
+    # X-Org-Id header > user.current_org_id). Secrets are stored per
+    # (user_id, org_id), so the effective org must flow through here for
+    # the right rows to be read/written.
+    effective_org_id: UUID | None = None
 
     async def load(self) -> Secrets | None:
         if not self.user_id:
             return None
         user = await UserStore.get_user_by_id(self.user_id)
-        org_id = user.current_org_id if user else None
+        org_id = self.effective_org_id or (user.current_org_id if user else None)
 
         async with a_session_maker() as session:
             # Fetch all secrets for the given user ID
@@ -52,12 +59,13 @@ class SaasSecretsStore(SecretsStore):
         user = await UserStore.get_user_by_id(self.user_id)
         if user is None:
             raise ValueError(f'User not found: {self.user_id}')
-        org_id = user.current_org_id
+        org_id = self.effective_org_id or user.current_org_id
 
         async with a_session_maker() as session:
             # Incoming secrets are always the most updated ones
             # Delete existing records for this user AND organization only
-            # Note: user.current_org_id is non-nullable, so org_id is always set
+            # org_id is always set: it's either the effective org from
+            # the request or the user's non-nullable current_org_id.
             delete_query = delete(StoredCustomSecrets).filter(
                 StoredCustomSecrets.keycloak_user_id == self.user_id,
                 StoredCustomSecrets.org_id == org_id,
@@ -120,12 +128,25 @@ class SaasSecretsStore(SecretsStore):
     async def get_instance(
         cls,
         user_id: str,  # type: ignore[override]
+        effective_org_id: UUID | None = None,
     ) -> SaasSecretsStore:
         """Get a SaasSecretsStore instance for the given user.
+
+        Args:
+            user_id: Keycloak user id.
+            effective_org_id: Optional org id resolved from the request
+                (see SaasUserAuth.get_effective_org_id). When None the
+                store falls back to ``user.current_org_id`` to preserve
+                legacy behavior for background / non-request callers
+                (e.g. webhook resolvers).
 
         TODO: This method should be replaced with dependency injection.
         """
         logger.debug(f'saas_secrets_store.get_instance::{user_id}')
         from storage.encrypt_utils import get_jwt_service
 
-        return SaasSecretsStore(user_id, get_jwt_service())
+        return SaasSecretsStore(
+            user_id,
+            get_jwt_service(),
+            effective_org_id=effective_org_id,
+        )

--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 from typing import Any
+from uuid import UUID
 
 from pydantic import SecretStr
 from server.auth.token_manager import TokenManager
@@ -30,6 +31,20 @@ from openhands.app_server.utils.llm import is_openhands_model
 @dataclass
 class SaasSettingsStore(SettingsStore):
     user_id: str
+    # When set, overrides the user's `current_org_id` for both `load()` and
+    # `store()`. Used to honor a request's effective org (api_key_org_id >
+    # X-Org-Id header > user.current_org_id) so an API key minted for org A
+    # used by a user whose `current_org_id` later switched to B still
+    # reads/writes settings under org A.
+    effective_org_id: UUID | None = None
+
+    def _resolve_org_id(self, user: User) -> UUID | None:
+        """Return the effective org id for this request, or the user's
+        current org id as a fallback. The caller still needs to verify
+        that the user is a member of the returned org (handled in load/
+        store by the existing org_members lookup).
+        """
+        return self.effective_org_id or user.current_org_id
 
     async def _get_user_settings_by_keycloak_id_async(
         self, keycloak_user_id: str, session=None
@@ -84,7 +99,7 @@ class SaasSettingsStore(SettingsStore):
             logger.error(f'User not found for ID {self.user_id}')
             return None
 
-        org_id = user.current_org_id
+        org_id = self._resolve_org_id(user)
         org_member: OrgMember | None = None
         for om in user.org_members:
             if om.org_id == org_id:
@@ -189,7 +204,7 @@ class SaasSettingsStore(SettingsStore):
                     logger.error(f'User not found for ID {self.user_id}')
                     return None
 
-            org_id = user.current_org_id
+            org_id = self._resolve_org_id(user)
 
             org_member: OrgMember | None = None
             for om in user.org_members:
@@ -296,13 +311,21 @@ class SaasSettingsStore(SettingsStore):
     async def get_instance(
         cls,
         user_id: str,  # type: ignore[override]
+        effective_org_id: UUID | None = None,
     ) -> SaasSettingsStore:
         """Get a SaasSettingsStore instance for the given user.
+
+        Args:
+            user_id: Keycloak user id.
+            effective_org_id: Optional org id resolved from the request
+                (see SaasUserAuth.get_effective_org_id). When None the
+                store falls back to ``user.current_org_id`` to preserve
+                legacy behavior for background / non-request callers.
 
         TODO: This method should be replaced with dependency injection.
         """
         logger.debug(f'saas_settings_store.get_instance::{user_id}')
-        return SaasSettingsStore(user_id)
+        return SaasSettingsStore(user_id, effective_org_id=effective_org_id)
 
     async def _ensure_api_key(
         self, item: Settings, org_id: str, openhands_type: bool = False

--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -38,11 +38,14 @@ class SaasSettingsStore(SettingsStore):
     # reads/writes settings under org A.
     effective_org_id: UUID | None = None
 
-    def _resolve_org_id(self, user: User) -> UUID | None:
+    def _resolve_org_id(self, user: User) -> UUID:
         """Return the effective org id for this request, or the user's
         current org id as a fallback. The caller still needs to verify
         that the user is a member of the returned org (handled in load/
         store by the existing org_members lookup).
+
+        `user.current_org_id` is non-nullable on the ORM model, so the
+        result is always a UUID.
         """
         return self.effective_org_id or user.current_org_id
 
@@ -308,9 +311,9 @@ class SaasSettingsStore(SettingsStore):
             await session.commit()
 
     @classmethod
-    async def get_instance(
+    async def get_instance(  # type: ignore[override]
         cls,
-        user_id: str,  # type: ignore[override]
+        user_id: str,
         effective_org_id: UUID | None = None,
     ) -> SaasSettingsStore:
         """Get a SaasSettingsStore instance for the given user.

--- a/enterprise/tests/unit/storage/test_saas_stores_effective_org.py
+++ b/enterprise/tests/unit/storage/test_saas_stores_effective_org.py
@@ -185,10 +185,12 @@ async def test_secrets_store_load_filters_by_resolved_org_id(
 
     # Compile the SELECT with literal binds so we can read the org id
     # value out of the WHERE clause without needing a real DB driver.
+    # SQLAlchemy renders UUID literals as the 32-char hex form (no
+    # hyphens), so compare against `.hex` rather than `str(...)`.
     compiled = str(captured_queries[-1].compile(compile_kwargs={'literal_binds': True}))
-    assert str(expected_org_id) in compiled, (
-        f'Expected query to filter by org_id={expected_org_id!s}, '
-        f'compiled SQL was: {compiled}'
+    assert expected_org_id.hex in compiled, (
+        f'Expected query to filter by org_id={expected_org_id!s} '
+        f'(hex={expected_org_id.hex}), compiled SQL was: {compiled}'
     )
 
 
@@ -244,9 +246,9 @@ async def test_secrets_store_store_uses_effective_org_id_when_set():
     ):
         await store.store(item)
 
-    assert captured_org_ids == [EFFECTIVE_ORG_ID], (
-        f'store() wrote under {captured_org_ids[0]!s}, expected {EFFECTIVE_ORG_ID!s}'
-    )
+    assert captured_org_ids == [
+        EFFECTIVE_ORG_ID
+    ], f'store() wrote under {captured_org_ids[0]!s}, expected {EFFECTIVE_ORG_ID!s}'
 
 
 @pytest.mark.asyncio

--- a/enterprise/tests/unit/storage/test_saas_stores_effective_org.py
+++ b/enterprise/tests/unit/storage/test_saas_stores_effective_org.py
@@ -1,0 +1,380 @@
+"""Unit tests for ``effective_org_id`` plumbing through the SaaS stores.
+
+The SaaS settings / secrets stores have historically scoped all reads
+and writes to ``user.current_org_id``. That made every API-key-driven
+request load the *user's last-selected* org's data — even when the
+caller was authenticated via an API key bound to a *different* org.
+
+These tests verify that:
+
+* When ``effective_org_id`` is supplied to the store constructor or
+  ``get_instance``, the store uses it instead of ``user.current_org_id``.
+* When it is not supplied, the store still falls back to
+  ``user.current_org_id`` so background callers (webhook resolvers,
+  CLI flows) keep working.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from storage.saas_secrets_store import SaasSecretsStore
+from storage.saas_settings_store import SaasSettingsStore
+
+USER_ID = '00000000-0000-0000-0000-00000000aaaa'
+CURRENT_ORG_ID = UUID('00000000-0000-0000-0000-00000000bbbb')
+EFFECTIVE_ORG_ID = UUID('00000000-0000-0000-0000-00000000cccc')
+
+
+# --------------------------------------------------------------------- #
+# Lightweight fakes — we explicitly do NOT spin up SQLite for these
+# tests. We're verifying which org_id is *chosen* by the store, not the
+# SQL it emits. Hitting the DB would test SQLAlchemy more than the
+# resolver, and would tie the test to schema details unrelated to the
+# bug we're guarding against.
+# --------------------------------------------------------------------- #
+
+
+@dataclass
+class FakeOrgMember:
+    org_id: UUID
+
+
+@dataclass
+class FakeUser:
+    """Minimal stand-in for ``storage.user.User`` covering only the
+    attributes the stores touch on the happy path of load().
+    """
+
+    current_org_id: UUID
+    org_members: list[FakeOrgMember] = field(default_factory=list)
+
+
+# ----------------------------- SettingsStore --------------------------- #
+
+
+def test_settings_store_default_effective_org_id_is_none():
+    """The new field must default to None so existing constructions
+    (e.g. ``SaasSettingsStore(user_id)``) keep working unchanged."""
+    store = SaasSettingsStore(user_id=USER_ID)
+    assert store.effective_org_id is None
+
+
+def test_settings_store_resolve_org_id_prefers_effective_over_current():
+    user = FakeUser(current_org_id=CURRENT_ORG_ID)
+    store = SaasSettingsStore(user_id=USER_ID, effective_org_id=EFFECTIVE_ORG_ID)
+    assert store._resolve_org_id(user) == EFFECTIVE_ORG_ID
+
+
+def test_settings_store_resolve_org_id_falls_back_to_current_org():
+    user = FakeUser(current_org_id=CURRENT_ORG_ID)
+    store = SaasSettingsStore(user_id=USER_ID)  # no effective_org_id
+    assert store._resolve_org_id(user) == CURRENT_ORG_ID
+
+
+@pytest.mark.asyncio
+async def test_settings_store_load_returns_none_when_user_not_member_of_effective_org():
+    """If the request resolved an effective org the user isn't a member
+    of, the store must NOT silently fall back to current_org_id — it
+    must refuse the load (the upstream resolver is responsible for
+    rejecting unauthorized X-Org-Id values; this is defense-in-depth)."""
+    user = FakeUser(
+        current_org_id=CURRENT_ORG_ID,
+        org_members=[FakeOrgMember(org_id=CURRENT_ORG_ID)],
+    )
+    store = SaasSettingsStore(user_id=USER_ID, effective_org_id=EFFECTIVE_ORG_ID)
+
+    with patch(
+        'storage.saas_settings_store.UserStore.get_user_by_id',
+        new=AsyncMock(return_value=user),
+    ):
+        result = await store.load()
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_settings_store_get_instance_propagates_effective_org_id():
+    store = await SaasSettingsStore.get_instance(
+        USER_ID, effective_org_id=EFFECTIVE_ORG_ID
+    )
+    assert isinstance(store, SaasSettingsStore)
+    assert store.user_id == USER_ID
+    assert store.effective_org_id == EFFECTIVE_ORG_ID
+
+
+@pytest.mark.asyncio
+async def test_settings_store_get_instance_defaults_to_none():
+    """Webhook resolvers call ``get_instance(user_id)`` without an org;
+    that path must remain legal."""
+    store = await SaasSettingsStore.get_instance(USER_ID)
+    assert store.effective_org_id is None
+
+
+# ----------------------------- SecretsStore ---------------------------- #
+
+
+def _make_secrets_store(effective_org_id: UUID | None = None) -> SaasSecretsStore:
+    return SaasSecretsStore(
+        user_id=USER_ID,
+        _jwt_svc=MagicMock(),
+        effective_org_id=effective_org_id,
+    )
+
+
+def test_secrets_store_default_effective_org_id_is_none():
+    store = _make_secrets_store()
+    assert store.effective_org_id is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'effective_org_id,expected_org_id',
+    [
+        (EFFECTIVE_ORG_ID, EFFECTIVE_ORG_ID),  # uses effective override
+        (None, CURRENT_ORG_ID),  # falls back to user.current_org_id
+    ],
+)
+async def test_secrets_store_load_filters_by_resolved_org_id(
+    effective_org_id, expected_org_id
+):
+    """``load()`` builds a query of the shape
+    ``SELECT … WHERE keycloak_user_id = :u AND org_id = :o`` — assert
+    the org id bound into that filter matches the resolved org."""
+    user = FakeUser(current_org_id=CURRENT_ORG_ID)
+
+    captured_queries: list[object] = []
+
+    class _Result:
+        def scalars(self):
+            return self
+
+        def all(self):
+            return []
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def execute(self, query):
+            captured_queries.append(query)
+            return _Result()
+
+    store = _make_secrets_store(effective_org_id=effective_org_id)
+
+    with (
+        patch(
+            'storage.saas_secrets_store.UserStore.get_user_by_id',
+            new=AsyncMock(return_value=user),
+        ),
+        patch(
+            'storage.saas_secrets_store.a_session_maker',
+            return_value=_FakeSession(),
+        ),
+    ):
+        result = await store.load()
+
+    assert result is not None
+    assert captured_queries, 'load() should have executed at least one query'
+
+    # Compile the SELECT with literal binds so we can read the org id
+    # value out of the WHERE clause without needing a real DB driver.
+    compiled = str(captured_queries[-1].compile(compile_kwargs={'literal_binds': True}))
+    assert str(expected_org_id) in compiled, (
+        f'Expected query to filter by org_id={expected_org_id!s}, '
+        f'compiled SQL was: {compiled}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_secrets_store_store_uses_effective_org_id_when_set():
+    """``store()`` must delete/insert under the effective org, not the
+    user's current org. We capture the org id by intercepting the
+    ``StoredCustomSecrets`` row that would be inserted."""
+
+    captured_org_ids: list[UUID] = []
+    user = FakeUser(current_org_id=CURRENT_ORG_ID)
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def execute(self, _query):
+            return MagicMock()
+
+        def add(self, row):
+            captured_org_ids.append(row.org_id)
+
+        async def commit(self):
+            return None
+
+    # Build a Secrets object with one custom secret. We use the real
+    # model so encryption / model_dump behave correctly.
+    from pydantic import SecretStr
+
+    from openhands.app_server.integrations.provider import CustomSecret
+    from openhands.app_server.secrets.secrets_models import Secrets
+
+    item = Secrets(
+        custom_secrets={
+            'API_KEY': CustomSecret(secret=SecretStr('shh'), description='example'),
+        }
+    )
+
+    store = _make_secrets_store(effective_org_id=EFFECTIVE_ORG_ID)
+
+    with (
+        patch(
+            'storage.saas_secrets_store.UserStore.get_user_by_id',
+            new=AsyncMock(return_value=user),
+        ),
+        patch(
+            'storage.saas_secrets_store.a_session_maker',
+            return_value=_FakeSession(),
+        ),
+    ):
+        await store.store(item)
+
+    assert captured_org_ids == [EFFECTIVE_ORG_ID], (
+        f'store() wrote under {captured_org_ids[0]!s}, expected {EFFECTIVE_ORG_ID!s}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_secrets_store_store_falls_back_to_current_org_when_unset():
+    """The legacy/webhook code path (no effective org supplied) must
+    keep writing under user.current_org_id."""
+    captured_org_ids: list[UUID] = []
+    user = FakeUser(current_org_id=CURRENT_ORG_ID)
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def execute(self, _query):
+            return MagicMock()
+
+        def add(self, row):
+            captured_org_ids.append(row.org_id)
+
+        async def commit(self):
+            return None
+
+    from pydantic import SecretStr
+
+    from openhands.app_server.integrations.provider import CustomSecret
+    from openhands.app_server.secrets.secrets_models import Secrets
+
+    item = Secrets(
+        custom_secrets={
+            'API_KEY': CustomSecret(secret=SecretStr('shh'), description='example'),
+        }
+    )
+
+    store = _make_secrets_store()  # no effective org
+
+    with (
+        patch(
+            'storage.saas_secrets_store.UserStore.get_user_by_id',
+            new=AsyncMock(return_value=user),
+        ),
+        patch(
+            'storage.saas_secrets_store.a_session_maker',
+            return_value=_FakeSession(),
+        ),
+    ):
+        await store.store(item)
+
+    assert captured_org_ids == [CURRENT_ORG_ID]
+
+
+@pytest.mark.asyncio
+async def test_secrets_store_get_instance_propagates_effective_org_id():
+    with patch(
+        'storage.encrypt_utils.get_jwt_service',
+        return_value=MagicMock(),
+    ):
+        store = await SaasSecretsStore.get_instance(
+            USER_ID, effective_org_id=EFFECTIVE_ORG_ID
+        )
+    assert store.effective_org_id == EFFECTIVE_ORG_ID
+
+
+@pytest.mark.asyncio
+async def test_secrets_store_get_instance_defaults_to_none():
+    with patch(
+        'storage.encrypt_utils.get_jwt_service',
+        return_value=MagicMock(),
+    ):
+        store = await SaasSecretsStore.get_instance(USER_ID)
+    assert store.effective_org_id is None
+
+
+# ----------------- SaasUserAuth -> store wiring ----------------------- #
+
+
+def _make_saas_user_auth():
+    """``SaasUserAuth`` requires a refresh_token; tests don't exercise
+    it, so a dummy SecretStr is sufficient."""
+    from pydantic import SecretStr
+    from server.auth.saas_user_auth import SaasUserAuth
+
+    return SaasUserAuth(refresh_token=SecretStr('test-refresh'), user_id=USER_ID)
+
+
+@pytest.mark.asyncio
+async def test_saas_user_auth_get_user_settings_store_passes_effective_org():
+    """The auth helper must pull the effective org from
+    ``get_effective_org_id()`` and hand it to the settings store."""
+    from server.auth.saas_user_auth import SaasUserAuth
+
+    auth = _make_saas_user_auth()
+
+    with patch.object(
+        SaasUserAuth,
+        'get_effective_org_id',
+        new=AsyncMock(return_value=EFFECTIVE_ORG_ID),
+    ):
+        store = await auth.get_user_settings_store()
+
+    assert isinstance(store, SaasSettingsStore)
+    assert store.effective_org_id == EFFECTIVE_ORG_ID
+
+    # Second call returns the cached instance, doesn't re-resolve.
+    cached = await auth.get_user_settings_store()
+    assert cached is store
+
+
+@pytest.mark.asyncio
+async def test_saas_user_auth_get_secrets_store_passes_effective_org():
+    from server.auth.saas_user_auth import SaasUserAuth
+
+    auth = _make_saas_user_auth()
+
+    with (
+        patch.object(
+            SaasUserAuth,
+            'get_effective_org_id',
+            new=AsyncMock(return_value=EFFECTIVE_ORG_ID),
+        ),
+        patch(
+            'storage.encrypt_utils.get_jwt_service',
+            return_value=MagicMock(),
+        ),
+    ):
+        store = await auth.get_secrets_store()
+
+    assert isinstance(store, SaasSecretsStore)
+    assert store.effective_org_id == EFFECTIVE_ORG_ID

--- a/enterprise/tests/unit/test_saas_user_auth.py
+++ b/enterprise/tests/unit/test_saas_user_auth.py
@@ -371,19 +371,28 @@ async def test_get_provider_tokens_cached(mock_token_manager):
 @pytest.mark.asyncio
 async def test_get_user_settings_store():
     """Test that get_user_settings_store returns a settings store."""
-    with patch('server.auth.saas_user_auth.SaasSettingsStore') as mock_store_cls:
+    user_id = str(uuid.uuid4())
+    org_id = uuid.uuid4()
+    mock_user = MagicMock()
+    mock_user.current_org_id = org_id
+
+    with (
+        patch('server.auth.saas_user_auth.SaasSettingsStore') as mock_store_cls,
+        patch('server.auth.saas_user_auth.UserStore') as mock_user_store,
+    ):
         mock_store = MagicMock()
         mock_store_cls.return_value = mock_store
+        mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
 
         user_auth = SaasUserAuth(
-            user_id='test_user_id',
+            user_id=user_id,
             refresh_token=SecretStr('refresh_token'),
         )
 
         result = await user_auth.get_user_settings_store()
 
         assert result == mock_store
-        mock_store_cls.assert_called_once()
+        mock_store_cls.assert_called_once_with(user_id, effective_org_id=org_id)
         assert user_auth.settings_store == mock_store
 
 


### PR DESCRIPTION
Follow-up to openhands/x-org-id-header-validation. The first PR rewired the route layer to honor the request's effective org (api_key_org_id > X-Org-Id header > user.current_org_id), but the SaaS settings and secrets stores still resolved the org from `user.current_org_id` internally. That meant /api/v1/settings/* and /api/v1/secrets/* endpoints read and wrote against the user's last-selected org, even when the request was authenticated via an API key bound to a different org. Same bug class the parent PR set out to close.

Changes:
- SaasSettingsStore gains an `effective_org_id: UUID | None = None` field. `load()` and `store()` resolve the org via a new `_resolve_org_id(user)` helper that prefers effective_org_id and falls back to `user.current_org_id` when unset. The existing org_members membership check is preserved as defense-in-depth.
- SaasSecretsStore gains the same field, used in both load and store WHERE/INSERT clauses (secrets are stored per (user_id, org_id)).
- Both stores' `get_instance(user_id, effective_org_id=None)` take an optional org argument; the no-arg form is preserved for webhook callers (github_view, gitlab_view) that don't carry an org context.
- SaasUserAuth.get_user_settings_store() and get_secrets_store() now resolve `await self.get_effective_org_id()` and pass it through. The cached store handle is reused across calls within a request.

The cached settings/secrets stores live on the user-auth instance (which is per-request), so the org binding is captured for the lifetime of the request without re-resolving on each access.

Affected endpoints (now correctly org-scoped via the effective org):
  Settings: GET/POST /api/v1/settings,
            GET /api/v1/settings/agent-schema, /conversation-schema,
            GET/POST/DELETE /api/v1/settings/profiles,
            POST /api/v1/settings/profiles/{name}/activate, /rename
  Secrets:  GET /api/v1/secrets/search,
            POST/PUT/DELETE /api/v1/secrets[/{secret_id}],
            POST/DELETE /api/v1/secrets/git-providers

Tests:
  enterprise/tests/unit/storage/test_saas_stores_effective_org.py
  - field default is None (backward compat)
  - _resolve_org_id prefers effective over current
  - load() refuses unknown effective org (not a fallback to current)
  - load() compiles the right org id into the SQL filter
  - store() writes the StoredCustomSecrets row under the right org
  - get_instance variants (with and without effective_org_id)
  - SaasUserAuth wiring: both store getters call get_effective_org_id and propagate the resolved value to the store constructor

Not tested in this env: full pytest run requires Python 3.12 (this sandbox is 3.13, where `aifc` is removed; the openhands logger still imports it for speech_recognition compat). Static checks (py_compile, ruff check, ruff format) all pass.

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-d80b1b9   docker.openhands.dev/openhands/openhands:d80b1b9
```