### PR TITLE
fix: quote Bitbucket clone credentials

### DIFF
--- a/openhands/app_server/integrations/provider.py
+++ b/openhands/app_server/integrations/provider.py
@@ -556,15 +556,14 @@ class ProviderHandler:
                         f'{protocol}://oauth2:{token_value}@{domain}/{repo_name}.git'
                     )
                 elif provider == ProviderType.BITBUCKET:
-                    # For Bitbucket, handle username:app_password format
                     if ':' in token_value:
-                        # App token format: username:app_password
-                        remote_url = (
-                            f'{protocol}://{token_value}@{domain}/{repo_name}.git'
+                        bb_user, bb_pass = token_value.split(':', 1)
+                        url_creds = (
+                            f'{quote(bb_user, safe="")}:{quote(bb_pass, safe="")}'
                         )
                     else:
-                        # Access token format: use x-token-auth
-                        remote_url = f'{protocol}://x-token-auth:{token_value}@{domain}/{repo_name}.git'
+                        url_creds = f'x-token-auth:{quote(token_value, safe="")}'
+                    remote_url = f'{protocol}://{url_creds}@{domain}/{repo_name}.git'
                 elif provider == ProviderType.BITBUCKET_DATA_CENTER:
                     # DC uses HTTP Basic auth — token must be in username:token format
                     project, repo_slug = (

--- a/tests/unit/integrations/test_provider_immutability.py
+++ b/tests/unit/integrations/test_provider_immutability.py
@@ -9,6 +9,7 @@ from openhands.app_server.integrations.provider import (
     ProviderToken,
     ProviderType,
 )
+from openhands.app_server.integrations.service_types import Repository
 from openhands.app_server.secrets.secrets_models import Secrets
 from openhands.app_server.settings.settings_models import Settings
 
@@ -207,6 +208,62 @@ def test_get_provider_env_key():
     """Test provider environment key generation"""
     assert ProviderHandler.get_provider_env_key(ProviderType.GITHUB) == 'github_token'
     assert ProviderHandler.get_provider_env_key(ProviderType.GITLAB) == 'gitlab_token'
+
+
+@pytest.mark.asyncio
+async def test_get_authenticated_git_url_quotes_bitbucket_app_password():
+    tokens = MappingProxyType(
+        {
+            ProviderType.BITBUCKET: ProviderToken(
+                token=SecretStr('user@example.com:abc#123/def')
+            )
+        }
+    )
+    handler = ProviderHandler(provider_tokens=tokens)
+    repo = Repository(
+        id='repo-id',
+        full_name='workspace/repo',
+        git_provider=ProviderType.BITBUCKET,
+        is_public=False,
+    )
+
+    with patch.object(
+        handler, 'verify_repo_provider', new=AsyncMock(return_value=repo)
+    ):
+        result = await handler.get_authenticated_git_url('workspace/repo')
+
+    assert (
+        result
+        == 'https://user%40example.com:abc%23123%2Fdef@bitbucket.org/workspace/repo.git'
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_authenticated_git_url_quotes_bitbucket_access_token():
+    tokens = MappingProxyType(
+        {
+            ProviderType.BITBUCKET: ProviderToken(
+                token=SecretStr('plain#token/with space')
+            )
+        }
+    )
+    handler = ProviderHandler(provider_tokens=tokens)
+    repo = Repository(
+        id='repo-id',
+        full_name='workspace/repo',
+        git_provider=ProviderType.BITBUCKET,
+        is_public=False,
+    )
+
+    with patch.object(
+        handler, 'verify_repo_provider', new=AsyncMock(return_value=repo)
+    ):
+        result = await handler.get_authenticated_git_url('workspace/repo')
+
+    assert (
+        result
+        == 'https://x-token-auth:plain%23token%2Fwith%20space@bitbucket.org/workspace/repo.git'
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #14304.

## Summary
- percent-encode Bitbucket Cloud `username:token` credentials before embedding them in the clone URL
- also quote the `x-token-auth` access-token path
- add regression coverage for email-style usernames and special characters in tokens

## To verify
- `python -m pytest tests/unit/integrations/test_provider_immutability.py -q --basetemp .tmp/pytest-bitbucket-url`
- `python -m ruff check --config dev_config/python/ruff.toml openhands/app_server/integrations/provider.py tests/unit/integrations/test_provider_immutability.py`
- `python -m ruff format --config dev_config/python/ruff.toml --check openhands/app_server/integrations/provider.py tests/unit/integrations/test_provider_immutability.py`
- `python -m py_compile openhands/app_server/integrations/provider.py tests/unit/integrations/test_provider_immutability.py`
- `git diff --check`

Note: the local husky pre-commit hook could not finish on Windows because its pre-commit environment hit a long-path failure while installing `litellm`; the checks above were run directly.
