### PR TITLE
fix: cloud event search timestamp comparison (str vs datetime)

### DIFF
--- a/openhands/app_server/event/event_service_base.py
+++ b/openhands/app_server/event/event_service_base.py
@@ -91,16 +91,20 @@ class EventServiceBase(EventService, ABC):
         events = await asyncio.gather(
             *[loop.run_in_executor(None, self._load_event, path) for path in paths]  # type: ignore[arg-type]
         )
+        # Convert datetime filters to ISO strings so they can be compared
+        # against event.timestamp (which is stored as an ISO 8601 string).
+        timestamp_gte_str = timestamp__gte.isoformat() if timestamp__gte else None
+        timestamp_lt_str = timestamp__lt.isoformat() if timestamp__lt else None
+
         items = []
         for event in events:
             if not event:
                 continue
             if kind__eq and event.kind != kind__eq:
                 continue
-            # TODO: Are these comparison operators valid?
-            if timestamp__gte and event.timestamp < timestamp__gte:  # type: ignore[operator]
+            if timestamp_gte_str and event.timestamp < timestamp_gte_str:
                 continue
-            if timestamp__lt and event.timestamp >= timestamp__lt:  # type: ignore[operator]
+            if timestamp_lt_str and event.timestamp >= timestamp_lt_str:
                 continue
             items.append(event)
 

--- a/tests/unit/app_server/test_filesystem_event_service.py
+++ b/tests/unit/app_server/test_filesystem_event_service.py
@@ -5,6 +5,8 @@ focusing on search functionality.
 """
 
 import tempfile
+import time
+from datetime import datetime
 from pathlib import Path
 from uuid import uuid4
 
@@ -267,6 +269,129 @@ class TestFilesystemEventServiceSearchEvents:
 
         # Should have found all 5 token events
         assert len(collected_ids) == 5
+
+
+    @pytest.mark.asyncio
+    async def test_search_events_filter_by_timestamp_gte(
+        self, service: FilesystemEventService
+    ):
+        """Test that search_events filters events by timestamp__gte.
+
+        This verifies the fix for a bug where event.timestamp (str) was
+        compared directly against a datetime object, raising TypeError.
+        """
+        conversation_id = uuid4()
+
+        # Create events with a small delay so timestamps differ
+        early_event = create_token_event()
+        await service.save_event(conversation_id, early_event)
+        time.sleep(0.01)
+
+        cutoff = datetime.now()
+        time.sleep(0.01)
+
+        late_event = create_token_event()
+        await service.save_event(conversation_id, late_event)
+
+        result = await service.search_events(
+            conversation_id, timestamp__gte=cutoff
+        )
+
+        assert len(result.items) == 1
+        assert result.items[0].id == late_event.id
+
+    @pytest.mark.asyncio
+    async def test_search_events_filter_by_timestamp_lt(
+        self, service: FilesystemEventService
+    ):
+        """Test that search_events filters events by timestamp__lt.
+
+        This verifies the fix for a bug where event.timestamp (str) was
+        compared directly against a datetime object, raising TypeError.
+        """
+        conversation_id = uuid4()
+
+        early_event = create_token_event()
+        await service.save_event(conversation_id, early_event)
+        time.sleep(0.01)
+
+        cutoff = datetime.now()
+        time.sleep(0.01)
+
+        late_event = create_token_event()
+        await service.save_event(conversation_id, late_event)
+
+        result = await service.search_events(
+            conversation_id, timestamp__lt=cutoff
+        )
+
+        assert len(result.items) == 1
+        assert result.items[0].id == early_event.id
+
+    @pytest.mark.asyncio
+    async def test_search_events_filter_by_timestamp_range(
+        self, service: FilesystemEventService
+    ):
+        """Test that search_events filters events by a timestamp range."""
+        conversation_id = uuid4()
+
+        event1 = create_token_event()
+        await service.save_event(conversation_id, event1)
+        time.sleep(0.01)
+
+        range_start = datetime.now()
+        time.sleep(0.01)
+
+        event2 = create_token_event()
+        await service.save_event(conversation_id, event2)
+        time.sleep(0.01)
+
+        range_end = datetime.now()
+        time.sleep(0.01)
+
+        event3 = create_token_event()
+        await service.save_event(conversation_id, event3)
+
+        result = await service.search_events(
+            conversation_id,
+            timestamp__gte=range_start,
+            timestamp__lt=range_end,
+        )
+
+        assert len(result.items) == 1
+        assert result.items[0].id == event2.id
+
+    @pytest.mark.asyncio
+    async def test_search_events_timestamp_filter_with_desc_sort(
+        self, service: FilesystemEventService
+    ):
+        """Test timestamp filters combined with TIMESTAMP_DESC sort order."""
+        conversation_id = uuid4()
+
+        event1 = create_token_event()
+        await service.save_event(conversation_id, event1)
+        time.sleep(0.01)
+
+        cutoff = datetime.now()
+        time.sleep(0.01)
+
+        event2 = create_token_event()
+        await service.save_event(conversation_id, event2)
+        time.sleep(0.01)
+
+        event3 = create_token_event()
+        await service.save_event(conversation_id, event3)
+
+        result = await service.search_events(
+            conversation_id,
+            timestamp__gte=cutoff,
+            sort_order=EventSortOrder.TIMESTAMP_DESC,
+        )
+
+        assert len(result.items) == 2
+        # Descending: event3 before event2
+        assert result.items[0].id == event3.id
+        assert result.items[1].id == event2.id
 
 
 class TestFilesystemEventServiceIntegration:

--- a/tests/unit/app_server/test_filesystem_event_service.py
+++ b/tests/unit/app_server/test_filesystem_event_service.py
@@ -270,7 +270,6 @@ class TestFilesystemEventServiceSearchEvents:
         # Should have found all 5 token events
         assert len(collected_ids) == 5
 
-
     @pytest.mark.asyncio
     async def test_search_events_filter_by_timestamp_gte(
         self, service: FilesystemEventService
@@ -293,9 +292,7 @@ class TestFilesystemEventServiceSearchEvents:
         late_event = create_token_event()
         await service.save_event(conversation_id, late_event)
 
-        result = await service.search_events(
-            conversation_id, timestamp__gte=cutoff
-        )
+        result = await service.search_events(conversation_id, timestamp__gte=cutoff)
 
         assert len(result.items) == 1
         assert result.items[0].id == late_event.id
@@ -321,9 +318,7 @@ class TestFilesystemEventServiceSearchEvents:
         late_event = create_token_event()
         await service.save_event(conversation_id, late_event)
 
-        result = await service.search_events(
-            conversation_id, timestamp__lt=cutoff
-        )
+        result = await service.search_events(conversation_id, timestamp__lt=cutoff)
 
         assert len(result.items) == 1
         assert result.items[0].id == early_event.id


### PR DESCRIPTION
## Summary

Fixes a `TypeError` in `EventServiceBase.search_events` that crashes the cloud event search endpoint when `timestamp__gte` or `timestamp__lt` filters are used.

## Root Cause

In `openhands/app_server/event/event_service_base.py` (lines 101–103), `event.timestamp` (a `str` in ISO 8601 format) was compared directly against `timestamp__gte`/`timestamp__lt` (`datetime` objects parsed by FastAPI):

```python
# Before (broken)
if timestamp__gte and event.timestamp < timestamp__gte:  # type: ignore[operator]
if timestamp__lt and event.timestamp >= timestamp__lt:  # type: ignore[operator]
```

Python 3 raises: `TypeError: '<' not supported between instances of 'str' and 'datetime.datetime'`

The `# type: ignore[operator]` comments and `# TODO: Are these comparison operators valid?` confirm this was a known issue.

## Fix

Convert the `datetime` params to ISO strings before comparison, matching the approach used in the SDK's local server (`_search_events_sync` in `software-agent-sdk`):

```python
# After (fixed)
timestamp_gte_str = timestamp__gte.isoformat() if timestamp__gte else None
timestamp_lt_str = timestamp__lt.isoformat() if timestamp__lt else None
# ...
if timestamp_gte_str and event.timestamp < timestamp_gte_str:
if timestamp_lt_str and event.timestamp >= timestamp_lt_str:
```

ISO 8601 strings are lexicographically comparable, so string comparison produces correct results.

## Why This Matters

This bug blocks **paginated event loading** in [agent-canvas](https://github.com/OpenHands/agent-canvas). The UI uses `timestamp__lt` with `sort_order=TIMESTAMP_DESC` to lazily load older events when the user scrolls up in a long conversation. Because this endpoint crashes on cloud backends, all pagination is disabled for cloud mode — forcing the UI to load everything at once (capped at 100 events), making long conversations unusable.

Related: https://github.com/OpenHands/agent-canvas/issues/2268

## Tests

Added 4 tests to `tests/unit/app_server/test_filesystem_event_service.py`:
- `test_search_events_filter_by_timestamp_gte` — verifies `>=` filter works
- `test_search_events_filter_by_timestamp_lt` — verifies `<` filter works  
- `test_search_events_filter_by_timestamp_range` — verifies combined range filter
- `test_search_events_timestamp_filter_with_desc_sort` — verifies timestamp filters + `TIMESTAMP_DESC` sort

All 4 tests would raise `TypeError` before this fix.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-48664ca   docker.openhands.dev/openhands/openhands:48664ca
```