### PR TITLE
feat(settings): add saved LLM profiles - SaaS

### DIFF
--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -310,6 +310,60 @@ class SaasSettingsStore(SettingsStore):
 
             await session.commit()
 
+    async def store_profiles(self, item: Settings) -> None:
+        """Persist only the user's LLM profiles and their personal LLM override.
+
+        Unlike :meth:`store`, this method **never** touches org-level
+        defaults or other org members. It updates:
+
+        1. ``user.llm_profiles`` — the saved profiles dict + active flag.
+        2. The current ``org_member.agent_settings_diff["llm"]`` — so the
+           user's personal LLM matches the activated profile without
+           changing org defaults.
+
+        Profile endpoints must call this instead of ``store()`` to avoid
+        the "activate my profile → overwrite org defaults for everyone"
+        bug.
+        """
+        async with a_session_maker() as session:
+            if not item:
+                return
+
+            result = await session.execute(
+                select(User)
+                .options(joinedload(User.org_members))
+                .filter(User.id == uuid.UUID(self.user_id))
+            )
+            user = result.scalars().first()
+            if not user:
+                logger.error(f'store_profiles: user not found for {self.user_id}')
+                return
+
+            # Persist profiles on the User row (EncryptedJSON column).
+            user.llm_profiles = item.llm_profiles.model_dump(
+                mode='json', context={'expose_secrets': True}
+            )
+
+            # Update only *this* member's personal LLM override so the
+            # activated profile takes effect for this user without touching
+            # the org-level defaults.
+            org_id = self._resolve_org_id(user)
+            org_member: OrgMember | None = None
+            for om in user.org_members:
+                if om.org_id == org_id:
+                    org_member = om
+                    break
+
+            if org_member is not None:
+                llm_dump = item.agent_settings.llm.model_dump(
+                    mode='json', context={'expose_secrets': True}
+                )
+                member_diff = dict(org_member.agent_settings_diff)
+                member_diff['llm'] = llm_dump
+                org_member.agent_settings_diff = member_diff
+
+            await session.commit()
+
     @classmethod
     async def get_instance(  # type: ignore[override]
         cls,

--- a/frontend/__tests__/components/features/user/user-context-menu.test.tsx
+++ b/frontend/__tests__/components/features/user/user-context-menu.test.tsx
@@ -393,9 +393,10 @@ describe("UserContextMenu", () => {
       renderUserContextMenu({ type: "member", onClose: vi.fn, onOpenInviteModal: vi.fn });
 
       await waitFor(() => {
+        // Both personal LLM (profiles) and org-defaults LLM are shown in SaaS
         expect(
-          screen.getByText("COMMON$LANGUAGE_MODEL_LLM"),
-        ).toBeInTheDocument();
+          screen.getAllByText("COMMON$LANGUAGE_MODEL_LLM").length,
+        ).toBeGreaterThanOrEqual(1);
       });
     });
   });

--- a/frontend/__tests__/hooks/use-settings-nav-items.test.tsx
+++ b/frontend/__tests__/hooks/use-settings-nav-items.test.tsx
@@ -113,9 +113,11 @@ describe("useSettingsNavItems", () => {
       expect(findItemByPath(result.current, "/settings/billing")).toBeUndefined();
       expect(findItemByPath(result.current, "/settings/org")).toBeUndefined();
       expect(findItemByPath(result.current, "/settings/org-members")).toBeUndefined();
-      // Personal LLM/Condenser/Verification routes are hidden in SaaS;
-      // members see the org-defaults equivalents (read-only on the page itself).
-      expect(findItemByPath(result.current, "/settings")).toBeUndefined();
+      // Personal LLM page ("/settings") is visible in SaaS for LLM Profiles;
+      // condenser/verification personal routes stay hidden.
+      expect(findItemByPath(result.current, "/settings")).toBeDefined();
+      expect(findItemByPath(result.current, "/settings/condenser")).toBeUndefined();
+      expect(findItemByPath(result.current, "/settings/verification")).toBeUndefined();
       expect(
         findItemByPath(result.current, "/settings/org-defaults"),
       ).toBeDefined();
@@ -379,11 +381,11 @@ describe("useSettingsNavItems", () => {
         expect(
           findItemByPath(result.current, "/settings/integrations"),
         ).toBeUndefined();
-        // Personal LLM is hidden in SaaS; the org-defaults equivalent
-        // shows up instead (an org is selected in this test's setup).
+        // Personal LLM is visible in SaaS (LLM Profiles); org-defaults
+        // is also present since an org is selected in this test's setup.
         expect(
           findItemByPath(result.current, "/settings"),
-        ).toBeUndefined();
+        ).toBeDefined();
         expect(
           findItemByPath(result.current, "/settings/org-defaults"),
         ).toBeDefined();
@@ -414,10 +416,10 @@ describe("useSettingsNavItems", () => {
         expect(
           findItemByPath(result.current, "/settings/integrations"),
         ).toBeDefined();
-        // Personal LLM is hidden in SaaS; users see /settings/org-defaults instead.
+        // Personal LLM is visible in SaaS (LLM Profiles).
         expect(
           findItemByPath(result.current, "/settings"),
-        ).toBeUndefined();
+        ).toBeDefined();
         expect(
           findItemByPath(result.current, "/settings/org-defaults"),
         ).toBeDefined();
@@ -448,7 +450,7 @@ describe("useSettingsNavItems", () => {
       });
     });
 
-    it("hides personal LLM/Condenser/Verification when org-defaults versions are visible (team-org admin)", async () => {
+    it("hides personal Condenser/Verification when org-defaults versions are visible, but keeps personal LLM for profiles (team-org admin)", async () => {
       mockConfig("saas");
       mockOrgTypeAndAccess.isTeamOrg = true;
       mockOrgTypeAndAccess.isPersonalOrg = false;
@@ -468,7 +470,9 @@ describe("useSettingsNavItems", () => {
           findItemByPath(result.current, "/settings/org-defaults/verification"),
         ).toBeDefined();
 
-        expect(findItemByPath(result.current, "/settings")).toBeUndefined();
+        // Personal LLM page stays visible (LLM Profiles); condenser and
+        // verification personal pages are hidden in SaaS.
+        expect(findItemByPath(result.current, "/settings")).toBeDefined();
         expect(
           findItemByPath(result.current, "/settings/condenser"),
         ).toBeUndefined();
@@ -478,7 +482,7 @@ describe("useSettingsNavItems", () => {
       });
     });
 
-    it("hides personal LLM/Condenser/Verification for any user in a non-personal org (team-org member)", async () => {
+    it("hides personal Condenser/Verification for any user in a non-personal org, keeps personal LLM for profiles (team-org member)", async () => {
       mockConfig("saas");
       mockOrgTypeAndAccess.isTeamOrg = true;
       mockOrgTypeAndAccess.isPersonalOrg = false;
@@ -491,7 +495,8 @@ describe("useSettingsNavItems", () => {
         expect(
           findItemByPath(result.current, "/settings/user"),
         ).toBeDefined();
-        expect(findItemByPath(result.current, "/settings")).toBeUndefined();
+        // Personal LLM page visible for LLM Profiles
+        expect(findItemByPath(result.current, "/settings")).toBeDefined();
         expect(
           findItemByPath(result.current, "/settings/condenser"),
         ).toBeUndefined();

--- a/frontend/__tests__/routes/settings.test.tsx
+++ b/frontend/__tests__/routes/settings.test.tsx
@@ -826,9 +826,10 @@ describe("Settings Screen", () => {
       expect(
         within(navbar).getByText("Application", { exact: false }),
       ).toBeInTheDocument();
+      // Both personal LLM (profiles) and org-defaults LLM are visible in SaaS
       expect(
-        within(navbar).getByText("LLM", { exact: false }),
-      ).toBeInTheDocument();
+        within(navbar).getAllByText("LLM", { exact: false }).length,
+      ).toBeGreaterThanOrEqual(1);
     });
 
     it("should hide integrations page in OSS mode when hide_integrations_page is true", async () => {

--- a/frontend/src/hooks/use-settings-nav-items.ts
+++ b/frontend/src/hooks/use-settings-nav-items.ts
@@ -77,13 +77,15 @@ export function useSettingsNavItems(): SettingsNavRenderedItem[] {
     );
   }
 
-  const PERSONAL_LLM_PATHS = new Set([
-    "/settings",
+  // Personal condenser/verification pages don't have profiles yet, so
+  // hide them in SaaS mode. The personal LLM page ("/settings") is kept
+  // because it hosts the user's LLM Profiles manager.
+  const HIDDEN_PERSONAL_PATHS_SAAS = new Set([
     "/settings/condenser",
     "/settings/verification",
   ]);
   if (isSaasMode) {
-    items = items.filter((item) => !PERSONAL_LLM_PATHS.has(item.to));
+    items = items.filter((item) => !HIDDEN_PERSONAL_PATHS_SAAS.has(item.to));
   }
 
   // For OSS mode or non-SaaS, return flat list without sections

--- a/frontend/src/routes/llm-settings.tsx
+++ b/frontend/src/routes/llm-settings.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from "react-i18next";
 import { FaChevronLeft } from "react-icons/fa6";
 import { ModelSelector } from "#/components/shared/modals/settings/model-selector";
 import { createPermissionGuard } from "#/utils/org/permission-guard";
-import { requireOrgDefaultsRedirect } from "#/utils/org/saas-redirect-to-org-defaults-guard";
 import { useAgentSettingsSchema } from "#/hooks/query/use-agent-settings-schema";
 import { useSettings } from "#/hooks/query/use-settings";
 import { SettingsInput } from "#/components/features/settings/settings-input";
@@ -540,15 +539,13 @@ export function LlmSettingsScreen({
   );
 }
 
-const orgDefaultsRedirectGuard = requireOrgDefaultsRedirect(
-  "/settings/org-defaults",
-);
 const llmPermissionGuard = createPermissionGuard("view_llm_settings");
 
-export const clientLoader = async (args: { request: Request }) => {
-  const blocked = await orgDefaultsRedirectGuard(args);
-  if (blocked) return blocked;
-  return llmPermissionGuard(args);
-};
+// The personal LLM settings page ("/settings") hosts the LLM Profiles
+// manager, so SaaS users must be able to reach it. We no longer redirect
+// to org-defaults; the org-defaults page is still accessible via its own
+// route ("/settings/org-defaults").
+export const clientLoader = async (args: { request: Request }) =>
+  llmPermissionGuard(args);
 
 export default LlmSettingsScreen;

--- a/openhands/app_server/settings/settings_router.py
+++ b/openhands/app_server/settings/settings_router.py
@@ -517,7 +517,7 @@ async def save_profile(
         # Without this, overwriting the active profile leaves
         # agent_settings.llm stale — active would lie about what's running.
         settings.reconcile_active_profile()
-        await settings_store.store(settings)
+        await settings_store.store_profiles(settings)
 
     return ProfileMutationResponse(name=name, message=f"Profile '{name}' saved")
 
@@ -535,7 +535,7 @@ async def delete_profile(
     async with _user_profile_locks[_profile_lock_key(user_id)]:
         settings = await settings_store.load()
         if settings is not None and settings.delete_profile(name):
-            await settings_store.store(settings)
+            await settings_store.store_profiles(settings)
 
     return ProfileMutationResponse(name=name, message=f"Profile '{name}' deleted")
 
@@ -569,7 +569,7 @@ async def activate_profile(
             ) from exc
 
         _post_merge_llm_fixups(settings)
-        await settings_store.store(settings)
+        await settings_store.store_profiles(settings)
 
     return ActivateProfileResponse(
         name=name,
@@ -608,7 +608,7 @@ async def rename_profile(
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT, detail=str(exc)
             ) from exc
-        await settings_store.store(settings)
+        await settings_store.store_profiles(settings)
 
     return ProfileMutationResponse(
         name=request.new_name,

--- a/openhands/app_server/settings/settings_store.py
+++ b/openhands/app_server/settings/settings_store.py
@@ -27,6 +27,17 @@ class SettingsStore(ABC):
     async def store(self, settings: Settings) -> None:
         """Store session init data."""
 
+    async def store_profiles(self, settings: Settings) -> None:
+        """Persist only the user's LLM profiles and (optionally) their
+        personal LLM override.
+
+        The default implementation delegates to :meth:`store`, which is
+        correct for single-user stores (OSS / file-based). Multi-tenant
+        stores (SaaS) **must** override this so that profile changes do
+        not propagate to organisation defaults or other org members.
+        """
+        await self.store(settings)
+
     @classmethod
     @abstractmethod
     async def get_instance(cls, user_id: str | None) -> SettingsStore:


### PR DESCRIPTION
## Description

LLM Profiles (introduced in #14149) were only working for OSS users because SaaS mode
filtered out the personal LLM settings page (`/settings`) from the nav and redirected
users to `/settings/org-defaults`. This PR makes LLM Profiles available in SaaS by:

### Frontend Changes

1. **Remove redirect guard** — The `requireOrgDefaultsRedirect` guard on `llm-settings.tsx`
   is removed so SaaS users can reach `/settings` (the personal LLM page that hosts
   the Profiles manager). The org-defaults page remains accessible at its own route.

2. **Keep `/settings` visible in SaaS nav** — Previously all three personal paths
   (`/settings`, `/settings/condenser`, `/settings/verification`) were hidden in SaaS.
   Now only condenser and verification remain hidden; the personal LLM page is shown
   because it hosts the LLM Profiles manager.

3. **Updated tests** — Adjusted `use-settings-nav-items`, `settings.test.tsx`, and
   `user-context-menu.test.tsx` to match the new visibility rules (two "LLM" nav items
   now appear in SaaS: personal + org-defaults).

### Backend Changes

1. **`SettingsStore.store_profiles()`** — New method on the abstract base class with a
   default implementation that delegates to `store()` (correct for OSS / file-based stores).

2. **`SaasSettingsStore.store_profiles()`** — Override that persists **only**:
   - `user.llm_profiles` (the profiles dictionary + active flag on the `User` row)
   - The current `org_member.agent_settings_diff["llm"]` (personal LLM override)

   This prevents profile CRUD operations from inadvertently overwriting org-level
   defaults for all members, which is what happens when the generic `store()` is used.

3. **Profile endpoints use `store_profiles()`** — All four mutation endpoints (`save`,
   `delete`, `activate`, `rename`) now call `store_profiles()` instead of `store()`.

### Known Limitation / Follow-up

When a SaaS user saves the LLM form from the personal settings page, the form's general
save (`POST /api/v1/settings`) still goes through `SaasSettingsStore.store()`, which
deep-merges into org defaults. This is a pre-existing architectural issue with the
personal-vs-org settings boundary in SaaS — not specific to profiles — and should be
addressed in a follow-up PR. The profile-specific endpoints are safe with this change.

### How to Test

1. Log in to a SaaS instance
2. Navigate to Settings — the personal "LLM" nav item should now appear alongside the
   org-defaults LLM item
3. Click the personal LLM item → the LLM Profiles manager should be visible
4. Create, save, activate, rename, and delete profiles
5. Verify that profile operations do **not** change the org-defaults LLM configuration
   (check `/settings/org-defaults` before and after)
6. Verify the OSS experience is unchanged

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@VascoSch92 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/cfd21161-5e85-4a44-8169-623fdfc008ad)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-bb986d1   docker.openhands.dev/openhands/openhands:bb986d1
```