### PR TITLE
Pass user_id to StartConversationRequest for Laminar tracing

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -329,6 +329,19 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             body_json = start_conversation_request.model_dump(
                 mode='json', context={'expose_secrets': True}
             )
+            # Inject ``user_id`` into the start-conversation body so the
+            # agent-server can call ``Laminar.set_trace_user_id()`` and tag
+            # traces with the authenticated user. The currently pinned
+            # ``openhands-sdk`` release does not yet expose ``user_id`` on
+            # ``StartConversationRequest`` (added in software-agent-sdk#3242),
+            # so passing ``user_id=user.id`` to ``create_request(...)`` is
+            # silently dropped by pydantic. The agent-server reads the field
+            # directly from the request body, so injecting it here works
+            # regardless of whether the local SDK model knows about it.
+            # Remove this once OpenHands pins to an SDK release that exposes
+            # ``user_id`` on ``StartConversationRequest``.
+            if user_id:
+                body_json['user_id'] = user_id
             headers = (
                 {'X-Session-API-Key': sandbox.session_api_key}
                 if sandbox.session_api_key
@@ -1397,7 +1410,14 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
 
         # Pass agent explicitly — it has server-only overrides (system
         # prompts, LLM metadata, skills) applied after create_agent().
-        request = conv_settings.create_request(StartConversationRequest, agent=agent)
+        # ``user_id`` is forwarded so the agent-server can attach it to
+        # observability spans (see software-agent-sdk#3242). It is dropped
+        # silently by pydantic on SDK versions that don't yet expose the
+        # field; the start-conversation POST also injects it directly into
+        # the JSON body as a forward-compatible fallback.
+        request = conv_settings.create_request(
+            StartConversationRequest, agent=agent, user_id=user.id
+        )
 
         # --- skills (require remote workspace) ------------------------------
         if remote_workspace:
@@ -1535,7 +1555,11 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 'plugins': sdk_plugins,
             }
         )
-        return conv_settings.create_request(StartConversationRequest, agent=acp_agent)
+        # ``user_id`` is forwarded for observability; see the LLM path above
+        # for behavior on SDK versions that don't yet expose the field.
+        return conv_settings.create_request(
+            StartConversationRequest, agent=acp_agent, user_id=user.id
+        )
 
     async def _process_pending_messages(
         self,


### PR DESCRIPTION
## Summary

Pass the authenticated user's ID into `StartConversationRequest` so Laminar traces include `user_id`. This wires the user through to the agent-server's observability span via the field added in [OpenHands/software-agent-sdk#3242](https://github.com/OpenHands/software-agent-sdk/pull/3242).

## Changes

`openhands/app_server/app_conversation/live_status_app_conversation_service.py`:

- **Normal path**: pass `user_id=user.id` to `conv_settings.create_request(StartConversationRequest, agent=agent, user_id=user.id)`.
- **ACP path**: pass `user_id=user.id` on `StartACPConversationRequest(...)`.
- **JSON-body workaround**: inject `user_id` directly into the start-conversation JSON body after `model_dump`. The currently pinned `openhands-sdk==1.21.1` does not yet expose `user_id` on `StartConversationRequest` (added in software-agent-sdk#3242), so pydantic silently drops the kwarg. Injecting it into the body lets the agent-server (which is on the new SDK) pick it up. This workaround is a no-op once OpenHands pins to an SDK release that includes the field.

## Notes

- The `AGENT_SERVER_IMAGE` pin used for staging validation has been dropped; the image will update naturally with the next SDK release.
- Verified end-to-end on a staging feature deployment: `user_id` reaches `Laminar.set_trace_user_id()` and shows up on traces.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-aceab3c   docker.openhands.dev/openhands/openhands:aceab3c
```