### PR TITLE
fix(api): add title field to AppConversationUpdateRequest

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_models.py
+++ b/openhands/app_server/app_conversation/app_conversation_models.py
@@ -214,6 +214,7 @@ class AppConversationUpdateRequest(BaseModel):
     All fields are optional - only provided fields will be updated.
     """
 
+    title: str | None = None
     public: bool | None = None
     selected_repository: str | None = None
     selected_branch: str | None = None

--- a/tests/unit/app_server/test_models.py
+++ b/tests/unit/app_server/test_models.py
@@ -4,7 +4,9 @@ from uuid import UUID, uuid4
 import pytest
 
 from openhands.app_server.app_conversation.app_conversation_models import (
+    AppConversationInfo,
     AppConversationStartRequest,
+    AppConversationUpdateRequest,
 )
 from openhands.app_server.event_callback.event_callback_models import (
     EventCallback,
@@ -39,3 +41,60 @@ async def test_app_conversation_start_request_polymorphism():
     processor = req.processors[0]
     result = await processor(uuid4(), MagicMock(id=uuid4()), MagicMock(id=str(uuid4())))
     assert result.detail == 'Live long and prosper!'
+
+
+def test_app_conversation_update_request_includes_title_field():
+    """Test that AppConversationUpdateRequest supports updating the title field.
+
+    The frontend sends a 'title' field when renaming conversations via
+    PATCH /api/v1/app-conversations/{id}. The backend model must include
+    this field so that title updates are not silently ignored.
+
+    This test verifies that:
+    1. The title field exists in the model
+    2. When title is provided, it appears in model_fields_set
+    3. The title value can be retrieved from the request object
+
+    The service layer uses model_fields_set to determine which fields to update,
+    so if title is not in model_fields_set, the update will be silently ignored.
+    """
+    # Simulate what the frontend sends when renaming a conversation
+    update_data = {'title': 'My New Conversation Title'}
+    request = AppConversationUpdateRequest.model_validate(update_data)
+
+    # The title field must be recognized and tracked in model_fields_set
+    assert 'title' in request.model_fields_set, (
+        "title field is not in model_fields_set - title updates will be silently ignored! "
+        "Add 'title: str | None = None' to AppConversationUpdateRequest."
+    )
+
+    # The title value must be accessible
+    assert request.title == 'My New Conversation Title'
+
+
+def test_app_conversation_update_request_title_field_updates_conversation_info():
+    """Test that title from update request can be applied to AppConversationInfo.
+
+    This simulates the service layer logic that iterates over model_fields_set
+    and applies each field to the conversation info object.
+    """
+    # Create a conversation info with default title
+    info = AppConversationInfo(
+        created_by_user_id='user-123',
+        sandbox_id='sandbox-456',
+        title='Original Title',
+    )
+
+    # Create an update request with a new title
+    request = AppConversationUpdateRequest(title='Updated Title')
+
+    # Simulate the service layer update logic
+    for field_name in request.model_fields_set:
+        value = getattr(request, field_name)
+        setattr(info, field_name, value)
+
+    # Verify the title was updated
+    assert info.title == 'Updated Title', (
+        "Title was not updated on AppConversationInfo. "
+        "Ensure 'title' is in AppConversationUpdateRequest.model_fields_set."
+    )

--- a/tests/unit/app_server/test_models.py
+++ b/tests/unit/app_server/test_models.py
@@ -64,7 +64,7 @@ def test_app_conversation_update_request_includes_title_field():
 
     # The title field must be recognized and tracked in model_fields_set
     assert 'title' in request.model_fields_set, (
-        "title field is not in model_fields_set - title updates will be silently ignored! "
+        'title field is not in model_fields_set - title updates will be silently ignored! '
         "Add 'title: str | None = None' to AppConversationUpdateRequest."
     )
 
@@ -95,6 +95,6 @@ def test_app_conversation_update_request_title_field_updates_conversation_info()
 
     # Verify the title was updated
     assert info.title == 'Updated Title', (
-        "Title was not updated on AppConversationInfo. "
+        'Title was not updated on AppConversationInfo. '
         "Ensure 'title' is in AppConversationUpdateRequest.model_fields_set."
     )


### PR DESCRIPTION
## Summary

The frontend sends a `title` field when renaming conversations via `PATCH /api/v1/app-conversations/{id}`, but the backend `AppConversationUpdateRequest` model was missing this field. This caused title updates to be **silently ignored** by Pydantic since extra fields are dropped when not defined in the model.

## Problem

When users rename conversations via the UI (or API), the request looks like:
```json
PATCH /api/v1/app-conversations/{id}
{"title": "My New Title"}
```

But `AppConversationUpdateRequest` only had these fields:
- `public`
- `selected_repository`
- `selected_branch`
- `git_provider`

Since `title` wasn't in the model, Pydantic would silently ignore it. The service layer iterates over `model_fields_set` to apply updates, so the title field was never recognized.

## Solution

Add `title: str | None = None` to `AppConversationUpdateRequest`. The service layer already uses a generic loop over `model_fields_set`, so this one-line change enables conversation renaming via the API.

## Testing

Added two tests to verify:
1. `test_app_conversation_update_request_includes_title_field` - Verifies the title field is recognized in `model_fields_set`
2. `test_app_conversation_update_request_title_field_updates_conversation_info` - Simulates the service layer logic to verify title updates are properly applied

Both tests **fail before the fix** and **pass after**.

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*
