### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -73,6 +73,22 @@
 # Name of the default agent
 #default_agent = "CodeActAgent"
 
+# Example: use Astraflow (global) as the LLM provider
+# Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (global endpoint)
+# Sign up at https://astraflow.ucloud-global.com
+#[llm]
+#model = "astraflow/gpt-4o"
+#api_key = "<your-ASTRAFLOW_API_KEY>"
+#base_url = "https://api-us-ca.umodelverse.ai/v1"
+
+# Example: use Astraflow CN (China endpoint) as the LLM provider
+# Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (China endpoint)
+# Sign up at https://astraflow.ucloud.cn
+#[llm]
+#model = "astraflow_cn/gpt-4o"
+#api_key = "<your-ASTRAFLOW_CN_API_KEY>"
+#base_url = "https://api.modelverse.cn/v1"
+
 # JWT secret for authentication
 #jwt_secret = ""
 

--- a/frontend/src/utils/map-provider.ts
+++ b/frontend/src/utils/map-provider.ts
@@ -26,6 +26,8 @@ export const MAP_PROVIDER = {
   openhands: "OpenHands",
   lemonade: "Lemonade",
   clarifai: "Clarifai",
+  astraflow: "Astraflow",
+  astraflow_cn: "Astraflow CN",
 };
 
 export const mapProvider = (provider: string) =>


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

Astraflow (by UCloud / 优刻得) is an OpenAI-compatible AI model aggregation platform supporting 200+ models. Adding it as a provider gives users access to a broad model catalog via both a global and a China endpoint, with no new SDK or subpackage required.

## Summary

- Adds `astraflow` → `"Astraflow"` and `astraflow_cn` → `"Astraflow CN"` to the `MAP_PROVIDER` lookup table in `frontend/src/utils/map-provider.ts` so the frontend correctly displays human-readable provider names.
- Adds commented-out example configuration blocks for both the global and China endpoints in `config.template.toml` as a ready-made reference for users.

## Issue Number

N/A

## How to Test

1. Start the OpenHands frontend.
2. Select a model prefixed with `astraflow/` (e.g. `astraflow/gpt-4o`) — verify the provider name displays as `"Astraflow"`.
3. Select a model prefixed with `astraflow_cn/` — verify the provider name displays as `"Astraflow CN"`.
4. Configure `config.toml` using the new example blocks (global or China endpoint) and confirm the LLM calls succeed with a valid Astraflow API key.

## Video/Screenshots

N/A

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Integration is purely additive and OpenAI-compatible — no new SDK, subpackage, or breaking changes. Provider details for reference:

| | Global | China |
|---|---|---|
| **Env var** | `ASTRAFLOW_API_KEY` | `ASTRAFLOW_CN_API_KEY` |
| **Base URL** | `https://api-us-ca.umodelverse.ai/v1` | `https://api.modelverse.cn/v1` |
| **Website** | https://astraflow.ucloud-global.com | https://astraflow.ucloud.cn |
| **LiteLLM prefix** | `astraflow/` | `astraflow_cn/` |