### PR TITLE
Fix CVE-2026-42264: Update axios to 1.15.2

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
         "@uidotdev/usehooks": "^2.4.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
-        "axios": "1.15.0",
+        "axios": "1.15.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "downshift": "^9.0.13",
@@ -7361,9 +7361,10 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "@uidotdev/usehooks": "^2.4.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "downshift": "^9.0.13",


### PR DESCRIPTION
## Security Fix: CVE-2026-42264

### Summary
Updates `axios` from `1.15.0` to `1.15.2` to address CVE-2026-42264.

### Changes
- Updated `axios` version in `frontend/package.json` from `1.15.0` to `1.15.2`
- Regenerated `frontend/package-lock.json` to reflect the updated dependency

### Details
- **CVE ID**: CVE-2026-42264
- **Package**: axios
- **Previous Version**: 1.15.0
- **Fixed Version**: 1.15.2
- **Dependency Type**: Direct dependency (frontend)

---
_This PR was created by an AI agent (OpenHands) to remediate a security vulnerability._

@aivong-openhands can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9bf8e7b4-86f2-48dc-8971-c0f5154eecc2)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-e4573d7   docker.openhands.dev/openhands/openhands:e4573d7
```