### PR TITLE
Add PR readiness confirmation CI workflow

### DIFF
--- a/.github/workflows/pr-readiness-confirm.yml
+++ b/.github/workflows/pr-readiness-confirm.yml
@@ -1,0 +1,155 @@
+---
+name: PR Readiness Confirmation
+
+on:
+  # Trigger when a PR is opened (non-draft) or converted from draft to ready.
+  pull_request:
+    types: [opened, ready_for_review]
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+  # Daily check for stale unconfirmed PRs.
+  schedule:
+    - cron: '0 9 * * *'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  # ── Post a confirmation request when a PR becomes ready for review ──
+  ask-confirmation:
+    if: |
+      github.event_name != 'schedule' &&
+      github.event.pull_request.draft == false &&
+      (
+        (
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        ) ||
+        (
+          github.event_name == 'pull_request_target' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        )
+      ) &&
+      (
+        github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
+        github.event.pull_request.author_association == 'NONE'
+      )
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check for existing confirmation comment
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- pr-readiness-confirm -->';
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const existing = comments.data.find(c => c.body.includes(marker));
+            core.setOutput('exists', existing ? 'true' : 'false');
+
+      - name: Post confirmation request
+        if: steps.check.outputs.exists != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- pr-readiness-confirm -->';
+            const body = [
+              marker,
+              '👋 Thanks for opening this PR!',
+              '',
+              'Your PR is marked for review. Can you confirm with a 👍 reaction **on this comment** or a reply that this PR is ready to review?',
+              '',
+              '> If no confirmation is received within 7 days, this PR will be converted back to a draft.',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });
+
+  # ── Convert stale unconfirmed PRs back to draft ──
+  check-stale-unconfirmed:
+    if: github.event_name == 'schedule' && github.repository == 'OpenHands/OpenHands'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Find and convert stale unconfirmed PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const STALE_DAYS = 7;
+            const marker = '<!-- pr-readiness-confirm -->';
+            const cutoff = new Date(Date.now() - STALE_DAYS * 24 * 60 * 60 * 1000);
+
+            // List open, non-draft PRs
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            for (const pr of prs) {
+              if (pr.draft) continue;
+
+              // Look for the bot's confirmation comment
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              });
+
+              const botComment = comments.data.find(c => c.body.includes(marker));
+              if (!botComment) continue;
+
+              const commentDate = new Date(botComment.created_at);
+              if (commentDate > cutoff) continue; // not stale yet
+
+              // Check for a 👍 reaction from the PR author
+              const reactions = await github.rest.reactions.listForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                per_page: 100,
+              });
+              const authorReacted = reactions.data.some(
+                r => r.user.login === pr.user.login && r.content === '+1'
+              );
+              if (authorReacted) continue;
+
+              // Check for any comment from the PR author after the bot comment
+              const authorReplied = comments.data.some(
+                c => c.user.login === pr.user.login &&
+                     new Date(c.created_at) > commentDate
+              );
+              if (authorReplied) continue;
+
+              // Convert to draft via GraphQL
+              core.info(`Converting PR #${pr.number} back to draft (no confirmation after ${STALE_DAYS} days)`);
+              await github.graphql(`
+                mutation($id: ID!) {
+                  convertPullRequestToDraft(input: { pullRequestId: $id }) {
+                    pullRequest { number }
+                  }
+                }
+              `, { id: pr.node_id });
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: [
+                  `This PR has been converted back to a draft because no confirmation was received within ${STALE_DAYS} days.`,
+                  '',
+                  'When you\'re ready, please mark it as ready for review again.',
+                ].join('\n'),
+              });
+            }

--- a/.github/workflows/pr-readiness-confirm.yml
+++ b/.github/workflows/pr-readiness-confirm.yml
@@ -36,6 +36,9 @@ jobs:
         github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
         github.event.pull_request.author_association == 'NONE'
       )
+    concurrency:
+      group: pr-readiness-confirm-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-24.04
     steps:
       - name: Check for existing confirmation comment
@@ -44,13 +47,12 @@ jobs:
         with:
           script: |
             const marker = '<!-- pr-readiness-confirm -->';
-            const comments = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              per_page: 100,
             });
-            const existing = comments.data.find(c => c.body.includes(marker));
+            const existing = comments.find(c => c.body.includes(marker));
             core.setOutput('exists', existing ? 'true' : 'false');
 
       - name: Post confirmation request
@@ -100,56 +102,58 @@ jobs:
               if (pr.draft) continue;
 
               // Look for the bot's confirmation comment
-              const comments = await github.rest.issues.listComments({
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
-                per_page: 100,
               });
 
-              const botComment = comments.data.find(c => c.body.includes(marker));
+              const botComment = comments.find(c => c.body.includes(marker));
               if (!botComment) continue;
 
               const commentDate = new Date(botComment.created_at);
               if (commentDate > cutoff) continue; // not stale yet
 
               // Check for a 👍 reaction from the PR author
-              const reactions = await github.rest.reactions.listForIssueComment({
+              const reactions = await github.paginate(github.rest.reactions.listForIssueComment, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: botComment.id,
-                per_page: 100,
               });
-              const authorReacted = reactions.data.some(
+              const authorReacted = reactions.some(
                 r => r.user.login === pr.user.login && r.content === '+1'
               );
               if (authorReacted) continue;
 
               // Check for any comment from the PR author after the bot comment
-              const authorReplied = comments.data.some(
+              const authorReplied = comments.some(
                 c => c.user.login === pr.user.login &&
                      new Date(c.created_at) > commentDate
               );
               if (authorReplied) continue;
 
               // Convert to draft via GraphQL
-              core.info(`Converting PR #${pr.number} back to draft (no confirmation after ${STALE_DAYS} days)`);
-              await github.graphql(`
-                mutation($id: ID!) {
-                  convertPullRequestToDraft(input: { pullRequestId: $id }) {
-                    pullRequest { number }
+              try {
+                core.info(`Converting PR #${pr.number} back to draft (no confirmation after ${STALE_DAYS} days)`);
+                await github.graphql(`
+                  mutation($id: ID!) {
+                    convertPullRequestToDraft(input: { pullRequestId: $id }) {
+                      pullRequest { number }
+                    }
                   }
-                }
-              `, { id: pr.node_id });
+                `, { id: pr.node_id });
 
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                body: [
-                  `This PR has been converted back to a draft because no confirmation was received within ${STALE_DAYS} days.`,
-                  '',
-                  'When you\'re ready, please mark it as ready for review again.',
-                ].join('\n'),
-              });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: [
+                    `This PR has been converted back to a draft because no confirmation was received within ${STALE_DAYS} days.`,
+                    '',
+                    'When you\'re ready, please mark it as ready for review again.',
+                  ].join('\n'),
+                });
+              } catch (error) {
+                core.warning(`Failed to convert PR #${pr.number} to draft: ${error.message}`);
+              }
             }


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

The automated PR review bot currently has no mechanism to verify that first-time or external contributors actually intend their PRs to be reviewed. This leads to reviewer time spent on AI-generated or abandoned PRs that were never truly ready.

This was originally proposed as Gate #2 in PR #14410 but was removed from the code review guidelines because (1) a bot guideline cannot trigger a follow-up after a timeout, and (2) the confirmation is better handled as a CI workflow. See the [review discussion](https://github.com/OpenHands/OpenHands/pull/14410#discussion_r3235910036).

## Summary

- Added `pr-readiness-confirm.yml` GitHub Actions workflow with two jobs:
  - **`ask-confirmation`**: When a PR from a first-time or external contributor (`FIRST_TIME_CONTRIBUTOR` / `NONE`) is opened or marked ready for review, posts a comment asking the author to confirm readiness with a 👍 reaction or reply.
  - **`check-stale-unconfirmed`**: Runs daily at 09:00 UTC. Finds PRs where the confirmation comment is older than 7 days with no author reaction or reply, and converts them back to draft via the GraphQL API.

## Issue Number

Follow-up to PR #14410

## How to Test

1. Review the workflow YAML for correctness.
2. After merge, open a test PR from a non-member account to verify the confirmation comment is posted.
3. Verify the scheduled job runs and correctly identifies stale unconfirmed PRs (can test by manually triggering the workflow).

## Video/Screenshots

N/A — CI workflow only.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Only targets `FIRST_TIME_CONTRIBUTOR` and `NONE` author associations to avoid adding friction for established contributors (matches the PR review bot's existing behavior).
- Uses the same same-repo/fork routing pattern (`pull_request` vs `pull_request_target`) as `pr-review-by-openhands.yml`.
- Idempotent: won't re-post if a confirmation comment already exists on the PR.
- Uses 7-day timeout per [jamiechicago312's suggestion](https://github.com/OpenHands/OpenHands/pull/14410#discussion_r3236749311) to account for weekends.

This PR was created by an AI agent (OpenHands) on behalf of the user.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-1e3327f   docker.openhands.dev/openhands/openhands:1e3327f
```