### PR TITLE
fix: return 404 for missing custom secrets

### DIFF
--- a/openhands/app_server/secrets/secrets_router.py
+++ b/openhands/app_server/secrets/secrets_router.py
@@ -308,37 +308,35 @@ async def update_custom_secret(
         500: Error updating secret
     """
     existing_secrets = await secrets_store.load()
-    if existing_secrets:
-        # Check if the secret to update exists
-        if secret_id not in existing_secrets.custom_secrets:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f'Secret with ID {secret_id} not found',
-            )
-
-        secret_name = incoming_secret.name
-        secret_description = incoming_secret.description
-
-        custom_secrets = dict(existing_secrets.custom_secrets)
-        existing_secret = custom_secrets.pop(secret_id)
-
-        if secret_name != secret_id and secret_name in custom_secrets:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f'Secret {secret_name} already exists',
-            )
-
-        custom_secrets[secret_name] = CustomSecret(
-            secret=existing_secret.secret,
-            description=secret_description or '',
+    if not existing_secrets or secret_id not in existing_secrets.custom_secrets:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f'Secret with ID {secret_id} not found',
         )
 
-        updated_secrets = Secrets(
-            custom_secrets=custom_secrets,  # type: ignore[arg-type]
-            provider_tokens=existing_secrets.provider_tokens,
+    secret_name = incoming_secret.name
+    secret_description = incoming_secret.description
+
+    custom_secrets = dict(existing_secrets.custom_secrets)
+    existing_secret = custom_secrets.pop(secret_id)
+
+    if secret_name != secret_id and secret_name in custom_secrets:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f'Secret {secret_name} already exists',
         )
 
-        await secrets_store.store(updated_secrets)
+    custom_secrets[secret_name] = CustomSecret(
+        secret=existing_secret.secret,
+        description=secret_description or '',
+    )
+
+    updated_secrets = Secrets(
+        custom_secrets=custom_secrets,  # type: ignore[arg-type]
+        provider_tokens=existing_secrets.provider_tokens,
+    )
+
+    await secrets_store.store(updated_secrets)
 
     return EditResponse(
         message='Secret updated successfully',
@@ -360,27 +358,22 @@ async def delete_custom_secret(
         500: Error deleting secret
     """
     existing_secrets = await secrets_store.load()
-    if existing_secrets:
-        # Get existing custom secrets
-        custom_secrets = dict(existing_secrets.custom_secrets)
-
-        # Check if the secret to delete exists
-        if secret_id not in custom_secrets:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f'Secret with ID {secret_id} not found',
-            )
-
-        # Remove the secret
-        custom_secrets.pop(secret_id)
-
-        # Create a new Secrets that preserves provider tokens and remaining secrets
-        updated_secrets = Secrets(
-            custom_secrets=custom_secrets,  # type: ignore[arg-type]
-            provider_tokens=existing_secrets.provider_tokens,
+    if not existing_secrets or secret_id not in existing_secrets.custom_secrets:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f'Secret with ID {secret_id} not found',
         )
 
-        await secrets_store.store(updated_secrets)
+    custom_secrets = dict(existing_secrets.custom_secrets)
+    custom_secrets.pop(secret_id)
+
+    # Create a new Secrets that preserves provider tokens and remaining secrets
+    updated_secrets = Secrets(
+        custom_secrets=custom_secrets,  # type: ignore[arg-type]
+        provider_tokens=existing_secrets.provider_tokens,
+    )
+
+    await secrets_store.store(updated_secrets)
 
     return EditResponse(
         message='Secret deleted successfully',

--- a/tests/unit/app_server/test_secrets_api.py
+++ b/tests/unit/app_server/test_secrets_api.py
@@ -282,6 +282,23 @@ async def test_update_existing_custom_secret(test_client, file_secrets_store):
 
 
 @pytest.mark.asyncio
+async def test_update_custom_secret_with_no_existing_secrets(
+    test_client, file_secrets_store
+):
+    """Test updating a custom secret when the secrets store is empty."""
+    update_secret_data = {
+        'name': 'API_KEY',
+        'description': None,
+    }
+
+    response = test_client.put('/secrets/API_KEY', json=update_secret_data)
+
+    assert response.status_code == 404
+    assert response.json()['detail'] == 'Secret with ID API_KEY not found'
+    assert await file_secrets_store.load() is None
+
+
+@pytest.mark.asyncio
 async def test_add_multiple_custom_secrets(test_client, file_secrets_store):
     """Test adding multiple custom secrets at once."""
     # Create initial settings with one custom secret
@@ -414,6 +431,18 @@ async def test_delete_nonexistent_custom_secret(test_client, file_secrets_store)
 
     # Check that other settings were preserved
     assert ProviderType.GITHUB in stored_settings.provider_tokens
+
+
+@pytest.mark.asyncio
+async def test_delete_custom_secret_with_no_existing_secrets(
+    test_client, file_secrets_store
+):
+    """Test deleting a custom secret when the secrets store is empty."""
+    response = test_client.delete('/secrets/API_KEY')
+
+    assert response.status_code == 404
+    assert response.json()['detail'] == 'Secret with ID API_KEY not found'
+    assert await file_secrets_store.load() is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #14204.

- return 404 when updating a custom secret and the secrets store is empty
- return 404 when deleting a custom secret and the secrets store is empty
- add regression coverage for both empty-store paths

## Tests

- uv run pytest tests/unit/app_server/test_secrets_api.py -q
- uv run ruff check openhands/app_server/secrets/secrets_router.py tests/unit/app_server/test_secrets_api.py

Note: I also attempted the repo-mandated `make install-pre-commit-hooks`. It initially failed because the system Python is 3.9; after creating a Python 3.12 venv, Poetry failed while uninstalling `matplotlib` due a missing embedded pip wheel path in the local venv. The focused pytest and Ruff checks above passed.