### PR TITLE
fix: only mark language dirty on selection

### DIFF
--- a/frontend/__tests__/routes/app-settings.test.tsx
+++ b/frontend/__tests__/routes/app-settings.test.tsx
@@ -145,6 +145,10 @@ describe("Form submission", () => {
     // Language check
     const language = await screen.findByTestId("language-input");
     await userEvent.click(language);
+    await userEvent.type(language, "Nor");
+    expect(submit).toBeDisabled();
+
+    await userEvent.click(language);
     const norsk = screen.getByText("Norsk");
     await userEvent.click(norsk);
     expect(submit).not.toBeDisabled();

--- a/frontend/src/components/features/settings/app-settings/language-input.tsx
+++ b/frontend/src/components/features/settings/app-settings/language-input.tsx
@@ -20,7 +20,7 @@ export function LanguageInput({
     <SettingsDropdownInput
       testId={name}
       name={name}
-      onInputChange={onChange}
+      onSelectionChange={(key) => onChange(key?.toString() || "")}
       label={t(I18nKey.SETTINGS$LANGUAGE)}
       items={AvailableLanguages.map((l) => ({
         key: l.value,

--- a/frontend/src/routes/app-settings.tsx
+++ b/frontend/src/routes/app-settings.tsx
@@ -140,14 +140,7 @@ function AppSettingsScreen() {
   };
 
   const checkIfLanguageInputHasChanged = (value: string) => {
-    const selectedLanguage = AvailableLanguages.find(
-      ({ label: langValue }) => langValue === value,
-    )?.label;
-    const currentLanguage = AvailableLanguages.find(
-      ({ value: langValue }) => langValue === settings?.language,
-    )?.label;
-
-    setLanguageInputHasChanged(selectedLanguage !== currentLanguage);
+    setLanguageInputHasChanged(value !== settings?.language);
   };
 
   const checkIfAnalyticsSwitchHasChanged = (checked: boolean) => {


### PR DESCRIPTION
## Summary

Fixes #14249.

- use language autocomplete selection events instead of input typing events for dirty-state checks
- compare selected language keys directly against the saved settings language
- add regression coverage so filtering the language dropdown does not enable Save

## Tests

- npm run test -- __tests__/routes/app-settings.test.tsx
- npm run lint:fix
- npm run build