### PR TITLE
fix: paginate branch search results

### DIFF
--- a/openhands/app_server/git/git_router.py
+++ b/openhands/app_server/git/git_router.py
@@ -244,21 +244,15 @@ async def search_branches(
         page = decoded_page_id
 
     if query:
-        if page != 1:
-            # TODO(#13883): Support pagination for branch search after refactoring.
-            # The search_branches method does not support paging in the same way as
-            # get_branches - those should be merged into a single paginated method
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail='Pagination not yet supported for branch search queries. Use empty query to list all branches with pagination.',
-            )
-        # Get search results - we'll handle pagination ourselves
+        # Branch search providers only expose a per_page argument today. Fetch
+        # enough results to cover the requested page and slice locally.
         branches: list[Branch] = await client.search_branches(
             selected_provider=provider,
             repository=repository,
             query=query,
-            per_page=limit + 1,
+            per_page=page * limit + 1,
         )
+        branches = branches[(page - 1) * limit :]
     else:
         current_page = await client.get_branches(
             repository=repository,

--- a/tests/unit/app_server/test_git_router.py
+++ b/tests/unit/app_server/test_git_router.py
@@ -742,6 +742,46 @@ class TestSearchBranches:
 
     @pytest.mark.asyncio
     @patch('openhands.app_server.git.git_router.ProviderHandler')
+    async def test_returns_second_page_of_branch_search(self, mock_handler_cls):
+        """Test that branch search supports page_id pagination."""
+        # Arrange
+        mock_handler = MagicMock()
+        mock_handler.search_branches = AsyncMock(
+            return_value=[
+                Branch(name='feature-1', commit_sha='abc123', protected=False),
+                Branch(name='feature-2', commit_sha='def456', protected=False),
+                Branch(name='feature-3', commit_sha='ghi789', protected=False),
+                Branch(name='feature-4', commit_sha='jkl012', protected=False),
+                Branch(name='feature-5', commit_sha='mno345', protected=False),
+            ]
+        )
+        mock_handler_cls.return_value = mock_handler
+
+        mock_context = _make_mock_user_context(
+            provider_tokens={
+                ProviderType.GITHUB: ProviderToken(user_id='user-123', token='token')
+            },
+            user_id='user-123',
+        )
+
+        # Act
+        result = await search_branches(
+            provider=ProviderType.GITHUB,
+            repository='user/repo',
+            query='feature',
+            page_id=encode_page_id(2),
+            limit=2,
+            user_context=mock_context,
+        )
+
+        # Assert
+        assert [branch.name for branch in result.items] == ['feature-3', 'feature-4']
+        assert result.next_page_id == encode_page_id(3)
+        mock_handler.search_branches.assert_called_once()
+        assert mock_handler.search_branches.call_args.kwargs.get('per_page') == 5
+
+    @pytest.mark.asyncio
+    @patch('openhands.app_server.git.git_router.ProviderHandler')
     async def test_passes_parameters_to_provider(self, mock_handler_cls):
         """Test that all parameters are passed through to the provider."""
         # Arrange


### PR DESCRIPTION
## Summary

Fixes OpenHands/enterprise#22.

- allow page_id on branch search requests
- fetch enough provider search results to cover the requested page, then slice locally
- add regression coverage for the second page of branch search results

## Tests

- PATH="/Users/kushaljain/Documents/Codex/oss/openhands/.venv/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Users/kushaljain/.codex/tmp/arg0/codex-arg0ppRNU0:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/kushaljain/.antigravity/antigravity/bin:/Users/kushaljain/.local/bin" poetry run pytest tests/unit/app_server/test_git_router.py -q