### PR TITLE
fix: allow attachment-only chat submit

### DIFF
--- a/frontend/__tests__/components/interactive-chat-box.test.tsx
+++ b/frontend/__tests__/components/interactive-chat-box.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router";
@@ -199,6 +199,44 @@ describe("InteractiveChatBox", () => {
     await user.click(submitButton);
 
     expect(onSubmitMock).toHaveBeenCalledWith("Hello, world!", [], []);
+  });
+
+  it("should submit attachments without text from the send button", async () => {
+    const user = userEvent.setup();
+    mockStores(AgentState.INIT);
+    const image = new File(["image-content"], "screenshot.png", {
+      type: "image/png",
+    });
+    useConversationStore.setState({ images: [image], files: [] });
+
+    renderInteractiveChatBox({
+      onSubmit: onSubmitMock,
+    });
+
+    await user.click(screen.getByTestId("submit-button"));
+
+    expect(onSubmitMock).toHaveBeenCalledWith("", [image], []);
+  });
+
+  it("should submit attachments without text from Enter", () => {
+    mockStores(AgentState.INIT);
+    const file = new File(["file-content"], "notes.txt", {
+      type: "text/plain",
+    });
+    useConversationStore.setState({ images: [], files: [file] });
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: true }));
+
+    renderInteractiveChatBox({
+      onSubmit: onSubmitMock,
+    });
+
+    fireEvent.keyDown(screen.getByTestId("chat-input"), {
+      key: "Enter",
+      code: "Enter",
+      charCode: 13,
+    });
+
+    expect(onSubmitMock).toHaveBeenCalledWith("", [], [file]);
   });
 
   it("should disable the submit button when awaiting user confirmation", async () => {

--- a/frontend/src/components/features/chat/custom-chat-input.tsx
+++ b/frontend/src/components/features/chat/custom-chat-input.tsx
@@ -37,11 +37,14 @@ export function CustomChatInput({
   buttonClassName = "",
 }: CustomChatInputProps) {
   const {
+    images,
+    files,
     submittedMessage,
     clearAllFiles,
     setShouldHideSuggestions,
     setSubmittedMessage,
   } = useConversationStore();
+  const hasAttachments = images.length > 0 || files.length > 0;
 
   // Disable input when conversation is stopped
   const isConversationStopped = sandboxStatus === "MISSING";
@@ -95,6 +98,7 @@ export function CustomChatInput({
     fileInputRef as React.RefObject<HTMLInputElement | null>,
     smartResize,
     onSubmit,
+    hasAttachments,
     resetManualResize,
   );
 
@@ -166,7 +170,7 @@ export function CustomChatInput({
           onPaste={handlePaste}
           onKeyDown={(e) => {
             if (handleSlashKeyDown(e)) return;
-            handleKeyDown(e, isDisabled, handleSubmit);
+            handleKeyDown(e, isDisabled, handleSubmit, hasAttachments);
           }}
           onFocus={handleFocus}
           onBlur={() => {

--- a/frontend/src/hooks/chat/use-chat-input-events.ts
+++ b/frontend/src/hooks/chat/use-chat-input-events.ts
@@ -63,7 +63,12 @@ export const useChatInputEvents = (
 
   // Handle key events
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent, disabled: boolean, handleSubmit: () => void) => {
+    (
+      e: React.KeyboardEvent,
+      disabled: boolean,
+      handleSubmit: () => void,
+      hasAttachments = false,
+    ) => {
       if (e.key !== "Enter") {
         return;
       }
@@ -74,7 +79,7 @@ export const useChatInputEvents = (
         return;
       }
 
-      if (checkIsContentEmpty()) {
+      if (checkIsContentEmpty() && !hasAttachments) {
         e.preventDefault();
         increaseHeightForEmptyContent();
         return;

--- a/frontend/src/hooks/chat/use-chat-submission.ts
+++ b/frontend/src/hooks/chat/use-chat-submission.ts
@@ -12,6 +12,7 @@ export const useChatSubmission = (
   fileInputRef: React.RefObject<HTMLInputElement | null>,
   smartResize: () => void,
   onSubmit: (message: string) => void,
+  hasAttachments = false,
   resetManualResize?: () => void,
 ) => {
   // Send button click handler
@@ -19,7 +20,7 @@ export const useChatSubmission = (
     const message = chatInputRef.current?.innerText || "";
     const trimmedMessage = message.trim();
 
-    if (!trimmedMessage) {
+    if (!trimmedMessage && !hasAttachments) {
       return;
     }
 
@@ -34,7 +35,14 @@ export const useChatSubmission = (
 
     // Reset manual resize state for next message
     resetManualResize?.();
-  }, [chatInputRef, fileInputRef, smartResize, onSubmit, resetManualResize]);
+  }, [
+    chatInputRef,
+    fileInputRef,
+    smartResize,
+    onSubmit,
+    hasAttachments,
+    resetManualResize,
+  ]);
 
   // Handle stop button click
   const handleStop = useCallback((onStop?: () => void) => {


### PR DESCRIPTION
## Summary
- allow chat submits when the editor is empty but uploaded images or files are present
- pass attachment presence into both send-button and desktop Enter-key submit guards
- add coverage for attachment-only send-button and Enter submissions

Fixes #14047

## Tests
- `npx -y -p node@22 -p npm@10.5.0 npm run test -- __tests__/components/interactive-chat-box.test.tsx`
- `npx -y -p node@22 -p npm@10.5.0 npm run lint:fix`
- `npx -y -p node@22 -p npm@10.5.0 npm run build`