### PR TITLE
fix: avoid rewriting provider credit errors

### DIFF
--- a/frontend/__tests__/utils/error-handler.test.ts
+++ b/frontend/__tests__/utils/error-handler.test.ts
@@ -3,6 +3,7 @@ import {
   trackError,
   showErrorToast,
   showChatError,
+  isBudgetOrCreditError,
 } from "#/utils/error-handler";
 import * as Actions from "#/services/actions";
 import * as CustomToast from "#/utils/custom-toast-handlers";
@@ -83,6 +84,33 @@ describe("Error Handler", () => {
         id: undefined,
         status_update: true,
       });
+    });
+  });
+
+  describe("isBudgetOrCreditError", () => {
+    it("identifies OpenHands budget and credit limit errors", () => {
+      expect(
+        isBudgetOrCreditError(
+          "Budget has been exceeded! Current cost: 18.51, Max budget: 18.24",
+        ),
+      ).toBe(true);
+      expect(isBudgetOrCreditError("OpenHands Credits are exhausted")).toBe(
+        true,
+      );
+      expect(isBudgetOrCreditError("Credit limit reached")).toBe(true);
+    });
+
+    it("does not rewrite provider-side credit messages as OpenHands billing errors", () => {
+      expect(
+        isBudgetOrCreditError(
+          "OpenrouterException - This model requires provider credits. Check your OpenRouter account.",
+        ),
+      ).toBe(false);
+      expect(
+        isBudgetOrCreditError(
+          "Provider returned insufficient credits for minimax/minimax-m2.5:free",
+        ),
+      ).toBe(false);
     });
   });
 });

--- a/frontend/src/utils/error-handler.ts
+++ b/frontend/src/utils/error-handler.ts
@@ -38,9 +38,18 @@ export function showChatError({
 }
 
 /**
- * Checks if an error message indicates a budget or credit limit issue
+ * Checks if an error message indicates an OpenHands budget or credit limit issue.
+ * Provider-side errors can also mention "credits"; those should stay as raw
+ * provider errors instead of being rewritten as OpenHands billing failures.
  */
 export function isBudgetOrCreditError(errorMessage: string): boolean {
   const lowerCaseError = errorMessage.toLowerCase();
-  return lowerCaseError.includes("budget") || lowerCaseError.includes("credit");
+  const isBudgetLimitError =
+    lowerCaseError.includes("budget") &&
+    /(exceed|exceeded|limit|max budget|spent)/.test(lowerCaseError);
+  const isOpenHandsCreditError =
+    /openhands\s+credits?/.test(lowerCaseError) ||
+    lowerCaseError.includes("credit limit reached");
+
+  return isBudgetLimitError || isOpenHandsCreditError;
 }


### PR DESCRIPTION
## Summary
- tighten the frontend budget/credit error classifier so provider-side credit messages are not rewritten as OpenHands billing failures
- keep true OpenHands budget and credit-limit messages mapped to the friendly billing banner
- add regression coverage for OpenRouter/provider credit text

Fixes #14419.

## Verification
- `npx -y -p node@22 -p npm@10.5.0 npm run test -- __tests__/utils/error-handler.test.ts`
- `npx -y -p node@22 -p npm@10.5.0 npm run lint:fix -- --quiet` (passes with existing unrelated warnings)
- `npx -y -p node@22 -p npm@10.5.0 npm run build`