### PR TITLE
fix: honor sandbox runtime image override

### DIFF
--- a/openhands/app_server/sandbox/sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/sandbox_spec_service.py
@@ -13,7 +13,7 @@ from openhands.sdk.utils.models import DiscriminatedUnionMixin
 
 # The version of the agent server to use for deployments.
 # Typically this will be the same as the values from the pyproject.toml
-AGENT_SERVER_IMAGE = "ghcr.io/openhands/agent-server:1.22.1-python"
+AGENT_SERVER_IMAGE = 'ghcr.io/openhands/agent-server:1.22.1-python'
 
 
 class SandboxSpecService(ABC):
@@ -39,7 +39,7 @@ class SandboxSpecService(ABC):
         """Get the default sandbox spec."""
         page = await self.search_sandbox_specs()
         if not page.items:
-            raise SandboxError("No sandbox specs available!")
+            raise SandboxError('No sandbox specs available!')
         return page.items[0]
 
     async def batch_get_sandbox_specs(
@@ -64,20 +64,20 @@ class SandboxSpecServiceInjector(
 def get_agent_server_image() -> str:
     # Backward compatibility for docker-compose setups that still configure
     # custom runtimes via the pre-V1 sandbox image variable.
-    sandbox_runtime_container_image = os.getenv("SANDBOX_RUNTIME_CONTAINER_IMAGE")
+    sandbox_runtime_container_image = os.getenv('SANDBOX_RUNTIME_CONTAINER_IMAGE')
     if sandbox_runtime_container_image:
         return sandbox_runtime_container_image
 
-    agent_server_image_repository = os.getenv("AGENT_SERVER_IMAGE_REPOSITORY")
-    agent_server_image_tag = os.getenv("AGENT_SERVER_IMAGE_TAG")
+    agent_server_image_repository = os.getenv('AGENT_SERVER_IMAGE_REPOSITORY')
+    agent_server_image_tag = os.getenv('AGENT_SERVER_IMAGE_TAG')
     if agent_server_image_repository and agent_server_image_tag:
-        return f"{agent_server_image_repository}:{agent_server_image_tag}"
+        return f'{agent_server_image_repository}:{agent_server_image_tag}'
     return AGENT_SERVER_IMAGE
 
 
 # Prefixes for environment variables that should be auto-forwarded to agent-server
 # These are typically configuration variables that affect the agent's behavior
-AUTO_FORWARD_PREFIXES = ("LLM_", "LMNR_")
+AUTO_FORWARD_PREFIXES = ('LLM_', 'LMNR_')
 
 
 def get_agent_server_env() -> dict[str, str]:
@@ -133,7 +133,7 @@ def get_agent_server_env() -> dict[str, str]:
 
     # Step 2: Apply explicit overrides from OH_AGENT_SERVER_ENV
     # These take precedence over auto-forwarded variables
-    explicit_env = env_parser.from_env(dict[str, str], "OH_AGENT_SERVER_ENV")
+    explicit_env = env_parser.from_env(dict[str, str], 'OH_AGENT_SERVER_ENV')
     result.update(explicit_env)
 
     return result

--- a/openhands/app_server/sandbox/sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/sandbox_spec_service.py
@@ -13,7 +13,7 @@ from openhands.sdk.utils.models import DiscriminatedUnionMixin
 
 # The version of the agent server to use for deployments.
 # Typically this will be the same as the values from the pyproject.toml
-AGENT_SERVER_IMAGE = 'ghcr.io/openhands/agent-server:1.22.1-python'
+AGENT_SERVER_IMAGE = "ghcr.io/openhands/agent-server:1.22.1-python"
 
 
 class SandboxSpecService(ABC):
@@ -39,7 +39,7 @@ class SandboxSpecService(ABC):
         """Get the default sandbox spec."""
         page = await self.search_sandbox_specs()
         if not page.items:
-            raise SandboxError('No sandbox specs available!')
+            raise SandboxError("No sandbox specs available!")
         return page.items[0]
 
     async def batch_get_sandbox_specs(
@@ -62,16 +62,22 @@ class SandboxSpecServiceInjector(
 
 
 def get_agent_server_image() -> str:
-    agent_server_image_repository = os.getenv('AGENT_SERVER_IMAGE_REPOSITORY')
-    agent_server_image_tag = os.getenv('AGENT_SERVER_IMAGE_TAG')
+    # Backward compatibility for docker-compose setups that still configure
+    # custom runtimes via the pre-V1 sandbox image variable.
+    sandbox_runtime_container_image = os.getenv("SANDBOX_RUNTIME_CONTAINER_IMAGE")
+    if sandbox_runtime_container_image:
+        return sandbox_runtime_container_image
+
+    agent_server_image_repository = os.getenv("AGENT_SERVER_IMAGE_REPOSITORY")
+    agent_server_image_tag = os.getenv("AGENT_SERVER_IMAGE_TAG")
     if agent_server_image_repository and agent_server_image_tag:
-        return f'{agent_server_image_repository}:{agent_server_image_tag}'
+        return f"{agent_server_image_repository}:{agent_server_image_tag}"
     return AGENT_SERVER_IMAGE
 
 
 # Prefixes for environment variables that should be auto-forwarded to agent-server
 # These are typically configuration variables that affect the agent's behavior
-AUTO_FORWARD_PREFIXES = ('LLM_', 'LMNR_')
+AUTO_FORWARD_PREFIXES = ("LLM_", "LMNR_")
 
 
 def get_agent_server_env() -> dict[str, str]:
@@ -127,7 +133,7 @@ def get_agent_server_env() -> dict[str, str]:
 
     # Step 2: Apply explicit overrides from OH_AGENT_SERVER_ENV
     # These take precedence over auto-forwarded variables
-    explicit_env = env_parser.from_env(dict[str, str], 'OH_AGENT_SERVER_ENV')
+    explicit_env = env_parser.from_env(dict[str, str], "OH_AGENT_SERVER_ENV")
     result.update(explicit_env)
 
     return result

--- a/tests/unit/app_server/test_agent_server_image.py
+++ b/tests/unit/app_server/test_agent_server_image.py
@@ -10,34 +10,34 @@ from openhands.app_server.sandbox.sandbox_spec_service import get_agent_server_i
 class TestGetAgentServerImage:
     def test_uses_agent_server_repository_and_tag(self):
         env_vars = {
-            "AGENT_SERVER_IMAGE_REPOSITORY": "example.com/custom-agent-server",
-            "AGENT_SERVER_IMAGE_TAG": "v1-python",
+            'AGENT_SERVER_IMAGE_REPOSITORY': 'example.com/custom-agent-server',
+            'AGENT_SERVER_IMAGE_TAG': 'v1-python',
         }
 
         with patch.dict(os.environ, env_vars, clear=True):
             assert (
-                get_agent_server_image() == "example.com/custom-agent-server:v1-python"
+                get_agent_server_image() == 'example.com/custom-agent-server:v1-python'
             )
 
     def test_sandbox_runtime_container_image_legacy_override_wins(self):
         env_vars = {
-            "SANDBOX_RUNTIME_CONTAINER_IMAGE": "example.com/custom-runtime:latest",
-            "AGENT_SERVER_IMAGE_REPOSITORY": "ghcr.io/openhands/agent-server",
-            "AGENT_SERVER_IMAGE_TAG": "1.19.1-python",
+            'SANDBOX_RUNTIME_CONTAINER_IMAGE': 'example.com/custom-runtime:latest',
+            'AGENT_SERVER_IMAGE_REPOSITORY': 'ghcr.io/openhands/agent-server',
+            'AGENT_SERVER_IMAGE_TAG': '1.19.1-python',
         }
 
         with patch.dict(os.environ, env_vars, clear=True):
-            assert get_agent_server_image() == "example.com/custom-runtime:latest"
+            assert get_agent_server_image() == 'example.com/custom-runtime:latest'
 
     def test_docker_spec_uses_sandbox_runtime_container_image(self):
         env_vars = {
-            "SANDBOX_RUNTIME_CONTAINER_IMAGE": "example.com/custom-runtime:latest",
-            "AGENT_SERVER_IMAGE_REPOSITORY": "ghcr.io/openhands/agent-server",
-            "AGENT_SERVER_IMAGE_TAG": "1.19.1-python",
+            'SANDBOX_RUNTIME_CONTAINER_IMAGE': 'example.com/custom-runtime:latest',
+            'AGENT_SERVER_IMAGE_REPOSITORY': 'ghcr.io/openhands/agent-server',
+            'AGENT_SERVER_IMAGE_TAG': '1.19.1-python',
         }
 
         with patch.dict(os.environ, env_vars, clear=True):
             specs = get_default_docker_sandbox_specs()
 
             assert len(specs) == 1
-            assert specs[0].id == "example.com/custom-runtime:latest"
+            assert specs[0].id == 'example.com/custom-runtime:latest'

--- a/tests/unit/app_server/test_agent_server_image.py
+++ b/tests/unit/app_server/test_agent_server_image.py
@@ -1,0 +1,43 @@
+import os
+from unittest.mock import patch
+
+from openhands.app_server.sandbox.docker_sandbox_spec_service import (
+    get_default_sandbox_specs as get_default_docker_sandbox_specs,
+)
+from openhands.app_server.sandbox.sandbox_spec_service import get_agent_server_image
+
+
+class TestGetAgentServerImage:
+    def test_uses_agent_server_repository_and_tag(self):
+        env_vars = {
+            "AGENT_SERVER_IMAGE_REPOSITORY": "example.com/custom-agent-server",
+            "AGENT_SERVER_IMAGE_TAG": "v1-python",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            assert (
+                get_agent_server_image() == "example.com/custom-agent-server:v1-python"
+            )
+
+    def test_sandbox_runtime_container_image_legacy_override_wins(self):
+        env_vars = {
+            "SANDBOX_RUNTIME_CONTAINER_IMAGE": "example.com/custom-runtime:latest",
+            "AGENT_SERVER_IMAGE_REPOSITORY": "ghcr.io/openhands/agent-server",
+            "AGENT_SERVER_IMAGE_TAG": "1.19.1-python",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            assert get_agent_server_image() == "example.com/custom-runtime:latest"
+
+    def test_docker_spec_uses_sandbox_runtime_container_image(self):
+        env_vars = {
+            "SANDBOX_RUNTIME_CONTAINER_IMAGE": "example.com/custom-runtime:latest",
+            "AGENT_SERVER_IMAGE_REPOSITORY": "ghcr.io/openhands/agent-server",
+            "AGENT_SERVER_IMAGE_TAG": "1.19.1-python",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            specs = get_default_docker_sandbox_specs()
+
+            assert len(specs) == 1
+            assert specs[0].id == "example.com/custom-runtime:latest"


### PR DESCRIPTION
## Summary
- honor the legacy `SANDBOX_RUNTIME_CONTAINER_IMAGE` override when resolving the Docker agent-server sandbox image
- keep existing `AGENT_SERVER_IMAGE_REPOSITORY` + `AGENT_SERVER_IMAGE_TAG` support as the fallback path
- add regression coverage that docker-compose-style default `AGENT_SERVER_IMAGE_*` values do not mask an explicit runtime image override

Fixes #14082.

## Verification
- `poetry run ruff format --check openhands/app_server/sandbox/sandbox_spec_service.py tests/unit/app_server/test_agent_server_image.py`
- `poetry run ruff check openhands/app_server/sandbox/sandbox_spec_service.py tests/unit/app_server/test_agent_server_image.py`
- `poetry run pytest tests/unit/app_server/test_agent_server_image.py -q`
- `poetry run pytest tests/unit/app_server/test_agent_server_image.py tests/unit/app_server/test_agent_server_env_override.py -q`