### PR TITLE
fix: hide generated JSON action summaries

### DIFF
--- a/frontend/__tests__/components/v1/get-event-content.test.tsx
+++ b/frontend/__tests__/components/v1/get-event-content.test.tsx
@@ -81,6 +81,21 @@ describe("getEventContent", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("falls back to action title when summary is SDK-generated JSON", () => {
+    const actionWithGeneratedSummary = {
+      ...terminalActionEvent,
+      summary: 'terminal: {"command":"git status"}',
+    };
+    const { title } = getEventContent(actionWithGeneratedSummary);
+
+    render(<span>{title}</span>);
+
+    expect(screen.getByText("ACTION_MESSAGE$RUN")).toBeInTheDocument();
+    expect(
+      screen.queryByText('terminal: {"command":"git status"}'),
+    ).not.toBeInTheDocument();
+  });
+
   it("returns empty details for file view action instead of 'Unknown event'", () => {
     const fileViewAction: ActionEvent = {
       id: "action-2",
@@ -110,6 +125,7 @@ describe("getEventContent", () => {
       },
       llm_response_id: "response-2",
       security_risk: SecurityRisk.LOW,
+      summary: 'file_editor: {"command":"view","path":"/workspace/README.md"}',
     };
 
     const { title, details } = getEventContent(fileViewAction);
@@ -144,5 +160,23 @@ describe("getEventContent", () => {
 
     expect(screen.getByText("Check repository status")).toBeInTheDocument();
     expect(screen.queryByText("$ git status")).not.toBeInTheDocument();
+  });
+
+  it("falls back to observation title when paired action summary is SDK-generated JSON", () => {
+    const actionWithGeneratedSummary = {
+      ...terminalActionEvent,
+      summary: 'terminal: {"command":"git status"}',
+    };
+    const { title } = getEventContent(
+      terminalObservationEvent,
+      actionWithGeneratedSummary,
+    );
+
+    render(<span>{title}</span>);
+
+    expect(screen.getByText("OBSERVATION_MESSAGE$RUN")).toBeInTheDocument();
+    expect(
+      screen.queryByText('terminal: {"command":"git status"}'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/v1/chat/event-content-helpers/get-event-content.tsx
+++ b/frontend/src/components/v1/chat/event-content-helpers/get-event-content.tsx
@@ -42,10 +42,40 @@ const createTitleFromKey = (
   );
 };
 
+const isGeneratedJsonSummary = (
+  event: ActionEvent,
+  summary: string,
+): boolean => {
+  const toolName = event.tool_name?.trim();
+  if (!toolName) {
+    return false;
+  }
+
+  const prefix = `${toolName}:`;
+  if (!summary.startsWith(prefix)) {
+    return false;
+  }
+
+  const payload = summary.slice(prefix.length).trim();
+  if (!payload.startsWith("{")) {
+    return false;
+  }
+
+  try {
+    JSON.parse(payload);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 const getSummaryTitleForActionEvent = (
   event: ActionEvent,
 ): React.ReactNode | null => {
   const summary = event.summary?.trim().replace(/\s+/g, " ") || "";
+  if (summary && isGeneratedJsonSummary(event, summary)) {
+    return null;
+  }
   return summary || null;
 };
 


### PR DESCRIPTION
## Summary
- ignore SDK-generated JSON fallback summaries like `tool: { ... }` when choosing V1 chat card titles
- let affected actions and paired observations fall back to their existing translated titles
- add regression coverage for generated action and observation summaries

Fixes #13690

## Tests
- `npx -y -p node@22 -p npm@10.5.0 npm run test -- __tests__/components/v1/get-event-content.test.tsx __tests__/components/v1/chat/event-message-think-action.test.tsx`
- `npx -y -p node@22 -p npm@10.5.0 npm run lint:fix -- --quiet`
- `npx -y -p node@22 -p npm@10.5.0 npm run build`