### PR TITLE
fix: infer docker sandbox host port from web url

### DIFF
--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -3,6 +3,7 @@
 import os
 from pathlib import Path
 from typing import AsyncContextManager
+from urllib.parse import urlparse
 
 import httpx
 from fastapi import Depends, Request
@@ -108,6 +109,15 @@ def get_default_permitted_cors_origins() -> list[str]:
     if legacy:
         return [o.strip() for o in legacy.split(',') if o.strip()]
     return []
+
+
+def _get_explicit_port(url: str | None) -> int | None:
+    if not url:
+        return None
+    try:
+        return urlparse(url).port
+    except ValueError:
+        return None
 
 
 def get_openhands_provider_base_url() -> str | None:
@@ -344,6 +354,8 @@ def config_from_env() -> AppServerConfig:
                 docker_sandbox_kwargs['host_port'] = int(
                     os.environ['SANDBOX_HOST_PORT']
                 )
+            elif web_url_port := _get_explicit_port(config.web_url):
+                docker_sandbox_kwargs['host_port'] = web_url_port
             if os.getenv('SANDBOX_CONTAINER_URL_PATTERN'):
                 docker_sandbox_kwargs['container_url_pattern'] = os.environ[
                     'SANDBOX_CONTAINER_URL_PATTERN'

--- a/tests/unit/app_server/test_docker_sandbox_service.py
+++ b/tests/unit/app_server/test_docker_sandbox_service.py
@@ -1320,7 +1320,7 @@ class TestDockerSandboxServiceInjectorFromEnv:
             'SANDBOX_HOST_PORT': '4000',
         }
 
-        with patch.dict(os.environ, env_vars, clear=False):
+        with patch.dict(os.environ, env_vars, clear=True):
             # Clear the global config to force reload
             import openhands.app_server.config as config_module
             from openhands.app_server.config import config_from_env
@@ -1330,6 +1330,49 @@ class TestDockerSandboxServiceInjectorFromEnv:
             config = config_from_env()
             assert config.sandbox is not None
             assert config.sandbox.host_port == 4000
+
+    def test_config_from_env_infers_host_port_from_web_url(self):
+        """Test that OH_WEB_URL port is used for Docker webhook callbacks."""
+        import os
+        from unittest.mock import patch
+
+        env_vars = {
+            'OH_WEB_URL': 'http://192.168.1.220:4000',
+            'SANDBOX_CONTAINER_URL_PATTERN': 'http://192.168.1.220:{port}',
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            # Clear the global config to force reload
+            import openhands.app_server.config as config_module
+            from openhands.app_server.config import config_from_env
+
+            config_module._global_config = None
+
+            config = config_from_env()
+            assert config.sandbox is not None
+            assert config.sandbox.host_port == 4000
+            assert config.sandbox.container_url_pattern == 'http://192.168.1.220:{port}'
+
+    def test_config_from_env_prefers_explicit_sandbox_host_port(self):
+        """Test that SANDBOX_HOST_PORT overrides the OH_WEB_URL port."""
+        import os
+        from unittest.mock import patch
+
+        env_vars = {
+            'OH_WEB_URL': 'http://192.168.1.220:4000',
+            'SANDBOX_HOST_PORT': '5000',
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            # Clear the global config to force reload
+            import openhands.app_server.config as config_module
+            from openhands.app_server.config import config_from_env
+
+            config_module._global_config = None
+
+            config = config_from_env()
+            assert config.sandbox is not None
+            assert config.sandbox.host_port == 5000
 
     def test_config_from_env_with_sandbox_container_url_pattern(self):
         """Test that SANDBOX_CONTAINER_URL_PATTERN environment variable is respected."""


### PR DESCRIPTION
## Summary
- Infer Docker sandbox `host_port` from `OH_WEB_URL` when `SANDBOX_HOST_PORT` is not set
- Keep explicit `SANDBOX_HOST_PORT` as the override
- Add regression coverage for non-default host port Docker deployments

Fixes OpenHands/software-agent-sdk#4245.

## Why
When OpenHands is exposed with `-p 4000:3000` and `OH_WEB_URL=http://host:4000`, agent-server webhook callbacks still defaulted to `http://host.docker.internal:3000/api/v1/webhooks` unless users also set `SANDBOX_HOST_PORT`. That sends callbacks to the wrong host port and can leave conversations stuck after webhook retries fail.

## Tests
- `poetry run pytest tests/unit/app_server/test_docker_sandbox_service.py -q`
- `poetry run ruff check --config dev_config/python/ruff.toml openhands/app_server/config.py tests/unit/app_server/test_docker_sandbox_service.py`
- `poetry run ruff format --config dev_config/python/ruff.toml --check openhands/app_server/config.py tests/unit/app_server/test_docker_sandbox_service.py`