### PR TITLE
fix: title API conversations from initial message

### DIFF
--- a/openhands/app_server/event_callback/set_title_callback_processor.py
+++ b/openhands/app_server/event_callback/set_title_callback_processor.py
@@ -30,13 +30,14 @@ _logger = logging.getLogger(__name__)
 _POLL_DELAY_S = 3
 # Number of attempts to poll title
 _NUM_POLL_ATTEMPTS = 4
+_MAX_FALLBACK_TITLE_CHARS = 60
 
 
 async def _poll_for_title(
     httpx_client: httpx.AsyncClient,
     url: str,
     session_api_key: str | None,
-) -> str | None:
+) -> tuple[str | None, bool]:
     """Poll the agent server for the conversation title.
 
     Args:
@@ -45,8 +46,9 @@ async def _poll_for_title(
         session_api_key: The session API key for authentication.
 
     Returns:
-        The title if available, None otherwise.
+        The title if available, and whether any poll response succeeded.
     """
+    has_successful_response = False
     for _ in range(_NUM_POLL_ATTEMPTS):
         await asyncio.sleep(_POLL_DELAY_S)
         try:
@@ -70,11 +72,36 @@ async def _poll_for_title(
                 exc,
             )
         else:
+            has_successful_response = True
             title = response.json().get('title')
             if title:
-                return title
+                return title, True
 
-    return None
+    return None, has_successful_response
+
+
+def _fallback_title_from_event(event: MessageEvent) -> str | None:
+    if event.source != 'user':
+        return None
+
+    content = getattr(event.llm_message, 'content', None)
+    text_parts: list[str] = []
+    if isinstance(content, str):
+        text_parts.append(content)
+    else:
+        for part in content or []:
+            text = getattr(part, 'text', None)
+            if isinstance(text, str):
+                text_parts.append(text)
+
+    title = ' '.join(' '.join(text_parts).split())
+    if not title:
+        return None
+
+    if len(title) > _MAX_FALLBACK_TITLE_CHARS:
+        title = f'{title[: _MAX_FALLBACK_TITLE_CHARS - 3].rstrip()}...'
+
+    return title
 
 
 class SetTitleCallbackProcessor(EventCallbackProcessor):
@@ -119,19 +146,23 @@ class SetTitleCallbackProcessor(EventCallbackProcessor):
                 app_conversation_url
             )
 
-            title = await _poll_for_title(
+            title, title_poll_succeeded = await _poll_for_title(
                 httpx_client,
                 app_conversation_url,
                 app_conversation.session_api_key,
             )
 
             if not title:
-                # Keep the callback active so later message events can retry.
-                _logger.info(
-                    f'Conversation {conversation_id} title not available yet; '
-                    'will retry on a future message event.'
+                title = (
+                    _fallback_title_from_event(event) if title_poll_succeeded else None
                 )
-                return None
+                if not title:
+                    # Keep the callback active so later message events can retry.
+                    _logger.info(
+                        f'Conversation {conversation_id} title not available yet; '
+                        'will retry on a future message event.'
+                    )
+                    return None
 
             # Save the conversation info
             info = AppConversationInfo(

--- a/tests/unit/app_server/test_set_title_callback_processor.py
+++ b/tests/unit/app_server/test_set_title_callback_processor.py
@@ -135,7 +135,7 @@ async def test_set_title_callback_processor_fetches_title_from_conversation():
 
 
 @pytest.mark.asyncio
-async def test_set_title_callback_processor_no_title_yet_returns_none():
+async def test_set_title_callback_processor_falls_back_to_user_message_title():
     conversation_id = uuid4()
     session_api_key = 'test-session-key'
     conversation_url = f'http://localhost:8000/api/conversations/{conversation_id.hex}'
@@ -201,11 +201,15 @@ async def test_set_title_callback_processor_no_title_yet_returns_none():
     ):
         result = await processor(conversation_id, callback, event)
 
-    assert result is None
+    assert result is not None
 
-    app_conversation_info_service.save_app_conversation_info.assert_not_called()
-    event_callback_service.save_event_callback.assert_not_called()
-    assert callback.status == EventCallbackStatus.ACTIVE
+    app_conversation_info_service.save_app_conversation_info.assert_called_once()
+    saved_info = app_conversation_info_service.save_app_conversation_info.call_args[0][
+        0
+    ]
+    assert saved_info.title == 'hi'
+    assert callback.status == EventCallbackStatus.DISABLED
+    event_callback_service.save_event_callback.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -292,3 +296,154 @@ async def test_set_title_callback_processor_request_errors_return_none():
     app_conversation_info_service.save_app_conversation_info.assert_not_called()
     event_callback_service.save_event_callback.assert_not_called()
     assert callback.status == EventCallbackStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_set_title_callback_processor_keeps_callback_active_without_user_text():
+    conversation_id = uuid4()
+    session_api_key = 'test-session-key'
+    conversation_url = f'http://localhost:8000/api/conversations/{conversation_id.hex}'
+
+    app_conversation = AppConversation(
+        id=conversation_id,
+        created_by_user_id='user',
+        sandbox_id='sandbox',
+        title=f'Conversation {conversation_id.hex[:5]}',
+        conversation_url=conversation_url,
+        session_api_key=session_api_key,
+    )
+
+    app_conversation_service = AsyncMock()
+    app_conversation_service.get_app_conversation.return_value = app_conversation
+
+    app_conversation_info_service = AsyncMock()
+    event_callback_service = AsyncMock()
+
+    httpx_client = _FakeHttpxClient(titles=[None])
+
+    def get_app_conversation_service(_state):
+        return _ctx(app_conversation_service)
+
+    def get_app_conversation_info_service(_state):
+        return _ctx(app_conversation_info_service)
+
+    def get_event_callback_service(_state):
+        return _ctx(event_callback_service)
+
+    def get_httpx_client(_state):
+        return _ctx(httpx_client)
+
+    callback = EventCallback(
+        conversation_id=conversation_id, processor=SetTitleCallbackProcessor()
+    )
+    event = MessageEvent(
+        source='agent',
+        llm_message=Message(role='assistant', content=[TextContent(text='hello')]),
+    )
+
+    processor = SetTitleCallbackProcessor()
+
+    with (
+        patch(
+            'openhands.app_server.config.get_app_conversation_service',
+            get_app_conversation_service,
+        ),
+        patch(
+            'openhands.app_server.config.get_app_conversation_info_service',
+            get_app_conversation_info_service,
+        ),
+        patch(
+            'openhands.app_server.config.get_event_callback_service',
+            get_event_callback_service,
+        ),
+        patch('openhands.app_server.config.get_httpx_client', get_httpx_client),
+        patch(
+            'openhands.app_server.event_callback.'
+            'set_title_callback_processor.asyncio.sleep',
+            new=AsyncMock(),
+        ),
+    ):
+        result = await processor(conversation_id, callback, event)
+
+    assert result is None
+    app_conversation_info_service.save_app_conversation_info.assert_not_called()
+    event_callback_service.save_event_callback.assert_not_called()
+    assert callback.status == EventCallbackStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_set_title_callback_processor_truncates_fallback_title():
+    conversation_id = uuid4()
+    conversation_url = f'http://localhost:8000/api/conversations/{conversation_id.hex}'
+    long_message = (
+        'Fix the authentication bug in login.py and update every related test'
+    )
+
+    app_conversation = AppConversation(
+        id=conversation_id,
+        created_by_user_id='user',
+        sandbox_id='sandbox',
+        title=f'Conversation {conversation_id.hex[:5]}',
+        conversation_url=conversation_url,
+    )
+
+    app_conversation_service = AsyncMock()
+    app_conversation_service.get_app_conversation.return_value = app_conversation
+
+    app_conversation_info_service = AsyncMock()
+    event_callback_service = AsyncMock()
+
+    httpx_client = _FakeHttpxClient(titles=[None])
+
+    def get_app_conversation_service(_state):
+        return _ctx(app_conversation_service)
+
+    def get_app_conversation_info_service(_state):
+        return _ctx(app_conversation_info_service)
+
+    def get_event_callback_service(_state):
+        return _ctx(event_callback_service)
+
+    def get_httpx_client(_state):
+        return _ctx(httpx_client)
+
+    callback = EventCallback(
+        conversation_id=conversation_id, processor=SetTitleCallbackProcessor()
+    )
+    event = MessageEvent(
+        source='user',
+        llm_message=Message(role='user', content=[TextContent(text=long_message)]),
+    )
+
+    processor = SetTitleCallbackProcessor()
+
+    with (
+        patch(
+            'openhands.app_server.config.get_app_conversation_service',
+            get_app_conversation_service,
+        ),
+        patch(
+            'openhands.app_server.config.get_app_conversation_info_service',
+            get_app_conversation_info_service,
+        ),
+        patch(
+            'openhands.app_server.config.get_event_callback_service',
+            get_event_callback_service,
+        ),
+        patch('openhands.app_server.config.get_httpx_client', get_httpx_client),
+        patch(
+            'openhands.app_server.event_callback.'
+            'set_title_callback_processor.asyncio.sleep',
+            new=AsyncMock(),
+        ),
+    ):
+        result = await processor(conversation_id, callback, event)
+
+    assert result is not None
+    saved_info = app_conversation_info_service.save_app_conversation_info.call_args[0][
+        0
+    ]
+    assert (
+        saved_info.title
+        == 'Fix the authentication bug in login.py and update every r...'
+    )


### PR DESCRIPTION
## Summary
- Add a conservative fallback title for app conversations when the agent-server title endpoint is reachable but never returns a title
- Use only user text message events for the fallback title
- Keep the title callback active when polling fails or the event has no user text

Fixes #13125.

## Why
API-triggered conversations can stay visible as `Conversation {id}` when the runtime never produces an auto-generated title. Since the title callback already receives the initial user message event, it can safely fall back to a short title from that message after successful empty title polls.

## Tests
- `poetry run pytest tests/unit/app_server/test_set_title_callback_processor.py -q`
- `poetry run ruff check --config dev_config/python/ruff.toml openhands/app_server/event_callback/set_title_callback_processor.py tests/unit/app_server/test_set_title_callback_processor.py`
- `poetry run ruff format --config dev_config/python/ruff.toml --check openhands/app_server/event_callback/set_title_callback_processor.py tests/unit/app_server/test_set_title_callback_processor.py`