### PR TITLE
fix(git): support paginated branch search queries

### DIFF
--- a/openhands/app_server/git/git_router.py
+++ b/openhands/app_server/git/git_router.py
@@ -244,20 +244,13 @@ async def search_branches(
         page = decoded_page_id
 
     if query:
-        if page != 1:
-            # TODO(#13883): Support pagination for branch search after refactoring.
-            # The search_branches method does not support paging in the same way as
-            # get_branches - those should be merged into a single paginated method
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail='Pagination not yet supported for branch search queries. Use empty query to list all branches with pagination.',
-            )
-        # Get search results - we'll handle pagination ourselves
+        # Get search results with pagination support
         branches: list[Branch] = await client.search_branches(
             selected_provider=provider,
             repository=repository,
             query=query,
             per_page=limit + 1,
+            page=page,
         )
     else:
         current_page = await client.get_branches(

--- a/openhands/app_server/integrations/azure_devops/service/branches.py
+++ b/openhands/app_server/integrations/azure_devops/service/branches.py
@@ -140,7 +140,7 @@ class AzureDevOpsBranchesMixin(AzureDevOpsMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, per_page: int = 30, page: int = 1
     ) -> list[Branch]:
         """Search for branches within a repository."""
         # Parse repository string: organization/project/repo
@@ -166,7 +166,7 @@ class AzureDevOpsBranchesMixin(AzureDevOpsMixinBase):
             branches_data = response.get('value', [])
 
             # Filter branches by query
-            filtered_branches = []
+            matching_names: list[tuple[str, str]] = []
             for branch_data in branches_data:
                 # Extract branch name from the ref (e.g., "refs/heads/main" -> "main")
                 name = branch_data.get('name', '').replace('refs/heads/', '')
@@ -174,25 +174,30 @@ class AzureDevOpsBranchesMixin(AzureDevOpsMixinBase):
                 # Check if query matches branch name
                 if query.lower() in name.lower():
                     object_id = branch_data.get('objectId', '')
+                    matching_names.append((name, object_id))
 
-                    # Get commit details for this branch
-                    commit_url = f'https://dev.azure.com/{org_enc}/{project_enc}/_apis/git/repositories/{repo_enc}/commits/{object_id}?api-version=7.1'
-                    try:
-                        commit_data, _ = await self._make_request(commit_url)
-                        last_push_date = commit_data.get('committer', {}).get('date')
-                    except Exception:
-                        last_push_date = None
+            # Apply pagination to filtered results
+            start_idx = (page - 1) * per_page
+            end_idx = start_idx + per_page
+            paginated = matching_names[start_idx:end_idx]
 
-                    branch = Branch(
-                        name=name,
-                        commit_sha=object_id,
-                        protected=False,  # Skip protected check for search to improve performance
-                        last_push_date=last_push_date,
-                    )
-                    filtered_branches.append(branch)
+            filtered_branches = []
+            for name, object_id in paginated:
+                # Get commit details for this branch
+                commit_url = f'https://dev.azure.com/{org_enc}/{project_enc}/_apis/git/repositories/{repo_enc}/commits/{object_id}?api-version=7.1'
+                try:
+                    commit_data, _ = await self._make_request(commit_url)
+                    last_push_date = commit_data.get('committer', {}).get('date')
+                except Exception:
+                    last_push_date = None
 
-                    if len(filtered_branches) >= per_page:
-                        break
+                branch = Branch(
+                    name=name,
+                    commit_sha=object_id,
+                    protected=False,  # Skip protected check for search to improve performance
+                    last_push_date=last_push_date,
+                )
+                filtered_branches.append(branch)
 
             return filtered_branches
         except Exception:

--- a/openhands/app_server/integrations/bitbucket/service/branches.py
+++ b/openhands/app_server/integrations/bitbucket/service/branches.py
@@ -87,7 +87,7 @@ class BitBucketBranchesMixin(BitBucketMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, per_page: int = 30, page: int = 1
     ) -> list[Branch]:
         """Search branches by name using Bitbucket API with `q` param."""
         parts = repository.split('/')
@@ -101,6 +101,7 @@ class BitBucketBranchesMixin(BitBucketMixinBase):
         # Bitbucket filtering: name ~ "query"
         params = {
             'pagelen': per_page,
+            'page': page,
             'q': f'name~"{query}"',
             'sort': '-target.date',
         }

--- a/openhands/app_server/integrations/bitbucket_data_center/service/branches.py
+++ b/openhands/app_server/integrations/bitbucket_data_center/service/branches.py
@@ -72,14 +72,16 @@ class BitbucketDCBranchesMixin(BitbucketDCMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, per_page: int = 30, page: int = 1
     ) -> list[Branch]:
-        """Search branches by name using Bitbucket data center API with `q` param."""
+        """Search branches by name using Bitbucket data center API with `filterText` param."""
         owner, repo = self._extract_owner_and_repo(repository)
 
         url = f'{self._repo_api_base(owner, repo)}/branches'
+        start = max((page - 1) * per_page, 0)
         params = {
             'limit': per_page,
+            'start': start,
             'filterText': query,
             'orderBy': 'MODIFICATION',
         }

--- a/openhands/app_server/integrations/forgejo/service/branches.py
+++ b/openhands/app_server/integrations/forgejo/service/branches.py
@@ -68,10 +68,11 @@ class ForgejoBranchesMixin(ForgejoMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, per_page: int = 30, page: int = 1
     ) -> list[Branch]:  # type: ignore[override]
         all_branches = await self.get_branches(repository)
         lowered = query.lower()
-        return [branch for branch in all_branches if lowered in branch.name.lower()][
-            :per_page
-        ]
+        filtered = [branch for branch in all_branches if lowered in branch.name.lower()]
+        start_idx = (page - 1) * per_page
+        end_idx = start_idx + per_page
+        return filtered[start_idx:end_idx]

--- a/openhands/app_server/integrations/github/queries.py
+++ b/openhands/app_server/integrations/github/queries.py
@@ -128,15 +128,21 @@ query ($threadId: ID!, $page: Int = 50, $after: String) {
 # - refPrefix: "refs/heads/" to restrict to branches
 # - query: partial branch name provided by the user
 # - first: pagination size (clamped by caller to GitHub limits)
+# - after: optional cursor for pagination (from previous pageInfo.endCursor)
 search_branches_graphql_query = """
-    query SearchBranches($owner: String!, $name: String!, $query: String!, $perPage: Int!) {
+    query SearchBranches($owner: String!, $name: String!, $query: String!, $perPage: Int!, $after: String) {
         repository(owner: $owner, name: $name) {
             refs(
                 refPrefix: "refs/heads/",
                 query: $query,
                 first: $perPage,
+                after: $after,
                 orderBy: { field: ALPHABETICAL, direction: ASC }
             ) {
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
                 nodes {
                     name
                     target {

--- a/openhands/app_server/integrations/github/service/branches_prs.py
+++ b/openhands/app_server/integrations/github/service/branches_prs.py
@@ -103,7 +103,7 @@ class GitHubBranchesMixin(GitHubMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, per_page: int = 30, page: int = 1
     ) -> list[Branch]:
         """Search branches by name using GitHub GraphQL with a partial query."""
         # Require a non-empty query
@@ -119,11 +119,44 @@ class GitHubBranchesMixin(GitHubMixinBase):
             return []
         owner, name = parts[-2], parts[-1]
 
+        # For page > 1, we need to skip (page-1)*per_page items using cursor pagination.
+        # We fetch pages sequentially until we reach the desired page.
+        cursor: str | None = None
+        if page > 1:
+            # Fetch preceding pages to get the cursor for the desired page
+            skip_count = per_page
+            for _ in range(page - 1):
+                variables = {
+                    'owner': owner,
+                    'name': name,
+                    'query': query or '',
+                    'perPage': skip_count,
+                    'after': cursor,
+                }
+                try:
+                    result = await self.execute_graphql_query(
+                        search_branches_graphql_query, variables
+                    )
+                except Exception as e:
+                    logger.warning(f'Failed to search for branches: {e}')
+                    return []
+
+                repo_data = result.get('data', {}).get('repository')
+                if not repo_data or not repo_data.get('refs'):
+                    return []
+
+                page_info = repo_data['refs'].get('pageInfo', {})
+                if not page_info.get('hasNextPage'):
+                    # No more pages available
+                    return []
+                cursor = page_info.get('endCursor')
+
         variables = {
             'owner': owner,
             'name': name,
             'query': query or '',
             'perPage': per_page,
+            'after': cursor,
         }
 
         try:
@@ -135,12 +168,12 @@ class GitHubBranchesMixin(GitHubMixinBase):
             # Fallback to empty result on any GraphQL error
             return []
 
-        repo = result.get('data', {}).get('repository')
-        if not repo or not repo.get('refs'):
+        repo_data = result.get('data', {}).get('repository')
+        if not repo_data or not repo_data.get('refs'):
             return []
 
         branches: list[Branch] = []
-        for node in repo['refs'].get('nodes', []):
+        for node in repo_data['refs'].get('nodes', []):
             bname = node.get('name') or ''
             target = node.get('target') or {}
             typename = target.get('__typename')

--- a/openhands/app_server/integrations/gitlab/service/branches.py
+++ b/openhands/app_server/integrations/gitlab/service/branches.py
@@ -88,13 +88,13 @@ class GitLabBranchesMixin(GitLabMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, per_page: int = 30, page: int = 1
     ) -> list[Branch]:
         """Search branches using GitLab API which supports `search` param."""
         encoded_name = repository.replace('/', '%2F')
         url = f'{self.BASE_URL}/projects/{encoded_name}/repository/branches'
 
-        params = {'per_page': str(per_page), 'search': query}
+        params = {'per_page': str(per_page), 'page': str(page), 'search': query}
         response, _ = await self._make_request(url, params)
 
         branches: list[Branch] = []

--- a/openhands/app_server/integrations/provider.py
+++ b/openhands/app_server/integrations/provider.py
@@ -327,12 +327,13 @@ class ProviderHandler:
         repository: str,
         query: str,
         per_page: int = 30,
+        page: int = 1,
     ) -> list[Branch]:
         """Search for branches within a repository using the appropriate provider service."""
         if selected_provider:
             service = self.get_service(selected_provider)
             try:
-                return await service.search_branches(repository, query, per_page)
+                return await service.search_branches(repository, query, per_page, page)
             except Exception as e:
                 logger.warning(
                     f'Error searching branches from selected provider {selected_provider}: {e}'
@@ -343,7 +344,7 @@ class ProviderHandler:
         try:
             repo_details = await self.verify_repo_provider(repository)
             service = self.get_service(repo_details.git_provider)
-            return await service.search_branches(repository, query, per_page)
+            return await service.search_branches(repository, query, per_page, page)
         except Exception as e:
             logger.warning(f'Error searching branches for {repository}: {e}')
             return []

--- a/openhands/app_server/integrations/service_types.py
+++ b/openhands/app_server/integrations/service_types.py
@@ -302,7 +302,7 @@ class GitService(Protocol):
         """Get branches for a repository with pagination"""
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, per_page: int = 30, page: int = 1
     ) -> list[Branch]:
         """Search for branches within a repository"""
 

--- a/tests/unit/app_server/test_git_router.py
+++ b/tests/unit/app_server/test_git_router.py
@@ -773,6 +773,155 @@ class TestSearchBranches:
         assert call_kwargs.get('repository') == 'user/repo'
         assert call_kwargs.get('query') == 'feature'
         assert call_kwargs.get('per_page') == 11  # limit + 1
+        assert call_kwargs.get('page') == 1  # first page
+
+    @pytest.mark.asyncio
+    @patch('openhands.app_server.git.git_router.ProviderHandler')
+    async def test_search_with_page_id_does_not_return_400(self, mock_handler_cls):
+        """Test that search with query and page_id no longer returns 400.
+
+        This is the core fix for issue #13883 - previously the endpoint would
+        return HTTP 400 when both query and page_id were provided.
+        """
+        # Arrange
+        mock_handler = MagicMock()
+        mock_handler.search_branches = AsyncMock(
+            return_value=[
+                Branch(name='feature-2', commit_sha='aaa111', protected=False),
+                Branch(name='feature-3', commit_sha='bbb222', protected=False),
+            ]
+        )
+        mock_handler_cls.return_value = mock_handler
+
+        mock_context = _make_mock_user_context(
+            provider_tokens={
+                ProviderType.GITHUB: ProviderToken(user_id='user-123', token='token')
+            },
+            user_id='user-123',
+        )
+
+        # Act - request second page with a query (previously returned 400)
+        result = await search_branches(
+            provider=ProviderType.GITHUB,
+            repository='user/repo',
+            query='feature',
+            page_id=encode_page_id(2),
+            limit=2,
+            user_context=mock_context,
+        )
+
+        # Assert - should succeed and return results
+        assert len(result.items) == 2
+        assert result.items[0].name == 'feature-2'
+        assert result.items[1].name == 'feature-3'
+        assert result.next_page_id is None  # No more pages (2 items <= limit)
+
+    @pytest.mark.asyncio
+    @patch('openhands.app_server.git.git_router.ProviderHandler')
+    async def test_search_passes_page_to_provider(self, mock_handler_cls):
+        """Test that page_id is decoded and passed as page to the provider."""
+        # Arrange
+        mock_handler = MagicMock()
+        mock_handler.search_branches = AsyncMock(return_value=[])
+        mock_handler_cls.return_value = mock_handler
+
+        mock_context = _make_mock_user_context(
+            provider_tokens={
+                ProviderType.GITHUB: ProviderToken(user_id='user-123', token='token')
+            },
+            user_id='user-123',
+        )
+
+        # Act - request page 3
+        await search_branches(
+            provider=ProviderType.GITHUB,
+            repository='user/repo',
+            query='feature',
+            page_id=encode_page_id(3),
+            limit=10,
+            user_context=mock_context,
+        )
+
+        # Assert - page should be decoded and passed to provider
+        mock_handler.search_branches.assert_called_once()
+        call_kwargs = mock_handler.search_branches.call_args.kwargs
+        assert call_kwargs.get('page') == 3
+
+    @pytest.mark.asyncio
+    @patch('openhands.app_server.git.git_router.ProviderHandler')
+    async def test_search_pagination_returns_next_page_id(self, mock_handler_cls):
+        """Test that search returns next_page_id when there are more results."""
+        # Arrange - return limit+1 items to indicate more pages
+        mock_handler = MagicMock()
+        mock_handler.search_branches = AsyncMock(
+            return_value=[
+                Branch(name='feat-1', commit_sha='a1', protected=False),
+                Branch(name='feat-2', commit_sha='a2', protected=False),
+                Branch(name='feat-3', commit_sha='a3', protected=False),
+            ]
+        )
+        mock_handler_cls.return_value = mock_handler
+
+        mock_context = _make_mock_user_context(
+            provider_tokens={
+                ProviderType.GITHUB: ProviderToken(user_id='user-123', token='token')
+            },
+            user_id='user-123',
+        )
+
+        # Act - request first page with limit=2 (provider returns 3 = limit+1)
+        result = await search_branches(
+            provider=ProviderType.GITHUB,
+            repository='user/repo',
+            query='feat',
+            page_id=None,
+            limit=2,
+            user_context=mock_context,
+        )
+
+        # Assert - should return 2 items and a next_page_id
+        assert len(result.items) == 2
+        assert result.items[0].name == 'feat-1'
+        assert result.items[1].name == 'feat-2'
+        assert result.next_page_id == encode_page_id(2)
+
+    @pytest.mark.asyncio
+    @patch('openhands.app_server.git.git_router.ProviderHandler')
+    async def test_search_second_page_returns_next_page_id(self, mock_handler_cls):
+        """Test pagination across multiple pages for branch search."""
+        # Arrange - simulate second page also having more results
+        mock_handler = MagicMock()
+        mock_handler.search_branches = AsyncMock(
+            return_value=[
+                Branch(name='feat-3', commit_sha='a3', protected=False),
+                Branch(name='feat-4', commit_sha='a4', protected=False),
+                Branch(name='feat-5', commit_sha='a5', protected=False),
+            ]
+        )
+        mock_handler_cls.return_value = mock_handler
+
+        mock_context = _make_mock_user_context(
+            provider_tokens={
+                ProviderType.GITHUB: ProviderToken(user_id='user-123', token='token')
+            },
+            user_id='user-123',
+        )
+
+        # Act - request second page with limit=2
+        result = await search_branches(
+            provider=ProviderType.GITHUB,
+            repository='user/repo',
+            query='feat',
+            page_id=encode_page_id(2),
+            limit=2,
+            user_context=mock_context,
+        )
+
+        # Assert - should return 2 items and next_page_id for page 3
+        assert len(result.items) == 2
+        assert result.items[0].name == 'feat-3'
+        assert result.items[1].name == 'feat-4'
+        assert result.next_page_id == encode_page_id(3)
 
     def test_returns_403_when_no_provider_tokens(self, test_client):
         """Test that 403 is returned when no provider tokens."""


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why

The `/api/v1/git/branches/search` endpoint advertises pagination support (accepts `page_id` parameter) but returns HTTP 400 when both `query` and `page_id` are provided. The frontend already passes `page_id` for branch search, so this is a backend-only bug that prevents users from paginating through branch search results.

## Summary

- Removed the HTTP 400 restriction in `git_router.py` that blocked paginated branch search
- Added `page` parameter to `search_branches` across all 6 git provider implementations (GitHub, GitLab, Bitbucket, Bitbucket DC, Azure DevOps, Forgejo)
- Added `pageInfo` cursor support to the GitHub GraphQL branch search query
- Added 4 regression tests covering paginated branch search

## Issue Number

Fixes OpenHands/enterprise#22

## How to Test

```bash
poetry run pytest tests/unit/app_server/test_git_router.py -v
pre-commit run --config ./dev_config/python/.pre-commit-config.yaml
```

Key tests added:
- `test_search_with_page_id_does_not_return_400` — core regression test
- `test_search_passes_page_to_provider` — verifies page decoding
- `test_search_pagination_returns_next_page_id` — first page pagination
- `test_search_second_page_returns_next_page_id` — multi-page pagination

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The fix is backend-only. The frontend already sends `page_id` to the branch search endpoint.
- For GitHub, pagination uses GraphQL cursor (`after` + `pageInfo.endCursor`). For providers without native search pagination (Azure DevOps, Forgejo), client-side offset pagination is applied after filtering.
- The `.pr/` directory contains temporary reproduction artifacts from initial investigation.
