### PR TITLE
perf(event-service): O(limit) reads for TIMESTAMP_DESC queries via storage-layer hints

### DIFF
--- a/openhands/app_server/event/aws_event_service.py
+++ b/openhands/app_server/event/aws_event_service.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any, AsyncGenerator
 
@@ -61,19 +62,31 @@ class AwsEventService(EventServiceBase):
             Body=json_str.encode('utf-8'),
         )
 
-    def _search_paths(self, prefix: Path, page_id: str | None = None) -> list[Path]:
-        """Search paths."""
+    def _search_paths(self, prefix: Path) -> list[tuple[Path, datetime | None]]:
+        """Return all event paths under *prefix* with S3 LastModified as hint.
+
+        ``list_objects_v2`` already returns ``LastModified`` (a timezone-aware
+        ``datetime``) for every object at no additional cost, so we can use it
+        to pre-sort and pre-filter candidates in the base class without extra
+        S3 calls.  If the bucket contains more than 1 000 objects the method
+        pages through all of them to ensure every event is visible.
+        """
+        result: list[tuple[Path, datetime | None]] = []
         kwargs: dict[str, Any] = {
             'Bucket': self.bucket_name,
             'Prefix': str(prefix),
         }
-        if page_id:
-            kwargs['ContinuationToken'] = page_id
-
-        response = self.s3_client.list_objects_v2(**kwargs)
-        contents = response.get('Contents', [])
-        paths = [Path(obj['Key']) for obj in contents]
-        return paths
+        while True:
+            response = self.s3_client.list_objects_v2(**kwargs)
+            for obj in response.get('Contents', []):
+                path = Path(obj['Key'])
+                last_modified: datetime | None = obj.get('LastModified')
+                result.append((path, last_modified))
+            if response.get('IsTruncated'):
+                kwargs['ContinuationToken'] = response['NextContinuationToken']
+            else:
+                break
+        return result
 
 
 def _get_default_aws_endpoint_url() -> str | None:

--- a/openhands/app_server/event/event_service_base.py
+++ b/openhands/app_server/event/event_service_base.py
@@ -1,7 +1,7 @@
 import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from uuid import UUID
 
@@ -17,6 +17,14 @@ from openhands.app_server.event.event_service import EventService
 from openhands.app_server.event_callback.event_callback_models import EventKind
 from openhands.sdk import Event
 from openhands.sdk.utils.paging import page_iterator
+
+# When using storage-metadata hints for the TIMESTAMP_DESC initial-load
+# optimisation, load this multiple of `limit` events to absorb any small
+# discrepancy between the storage-layer hint timestamp and the logical
+# event.timestamp.  A factor of 2 means we load at most 2×limit events
+# (e.g. 100 for the default limit of 50) instead of every event in the
+# conversation.
+_HINT_OVERSHOOT_FACTOR = 2
 
 
 @dataclass
@@ -41,8 +49,17 @@ class EventServiceBase(EventService, ABC):
         """Store the event given at the path given."""
 
     @abstractmethod
-    def _search_paths(self, prefix: Path) -> list[Path]:
-        """Search paths."""
+    def _search_paths(self, prefix: Path) -> list[tuple[Path, datetime | None]]:
+        """Return all event paths under *prefix* together with a storage-layer
+        timestamp hint for each path (e.g. filesystem mtime, S3 LastModified,
+        GCS time_created).  The hint is used to pre-sort and pre-filter the
+        candidate set before loading event JSON, keeping the common case to
+        O(limit) reads rather than O(N).
+
+        Implementations that cannot cheaply obtain a per-path timestamp should
+        return ``None`` as the hint; the base-class will then fall back to
+        loading every event (original behaviour).
+        """
 
     async def get_conversation_path(self, conversation_id: UUID) -> Path:
         """Get a path for a conversation. Ensure user_id is included if possible."""
@@ -72,6 +89,17 @@ class EventServiceBase(EventService, ABC):
         event: Event = await loop.run_in_executor(None, self._load_event, path)  # type: ignore[arg-type]
         return event
 
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _load_paths(
+        self, loop: asyncio.AbstractEventLoop, paths: list[Path]
+    ) -> list[Event | None]:
+        return await asyncio.gather(  # type: ignore[return-value]
+            *[loop.run_in_executor(None, self._load_event, p) for p in paths]
+        )
+
     async def search_events(
         self,
         conversation_id: UUID,
@@ -82,22 +110,69 @@ class EventServiceBase(EventService, ABC):
         page_id: str | None = None,
         limit: int = 100,
     ) -> EventPage:
-        """Search events matching the given filters."""
+        """Search events matching the given filters.
+
+        When the storage backend provides per-path timestamp hints (filesystem
+        mtime, S3 LastModified, GCS time_created) **and** no offset page_id is
+        active, the method uses those hints to load only the events that are
+        likely to appear in the result page — typically O(limit) reads instead
+        of O(N).  It always validates against the real ``event.timestamp`` field
+        before returning, so a slightly inaccurate hint never produces wrong
+        results; in the rare case where hints are too imprecise, the method
+        falls back to loading the full event set.
+        """
         loop = asyncio.get_running_loop()
         prefix = await self.get_conversation_path(conversation_id)
-        paths = await loop.run_in_executor(None, self._search_paths, prefix)
-
-        # Type error: run_in_executor expects a return value, but self._load_event is typed return Event | None.
-        events = await asyncio.gather(
-            *[loop.run_in_executor(None, self._load_event, path) for path in paths]  # type: ignore[arg-type]
+        path_hints: list[tuple[Path, datetime | None]] = await loop.run_in_executor(
+            None, self._search_paths, prefix
         )
+
         # Convert datetime filters to ISO strings so they can be compared
         # against event.timestamp (which is stored as an ISO 8601 string).
         timestamp_gte_str = timestamp__gte.isoformat() if timestamp__gte else None
         timestamp_lt_str = timestamp__lt.isoformat() if timestamp__lt else None
 
-        items = []
-        for event in events:
+        # ------------------------------------------------------------------
+        # Hint-based early-stopping optimisation
+        #
+        # Eligible when:
+        #   • sort_order is TIMESTAMP_DESC (the only order the REST clients
+        #     use for pagination)
+        #   • every path has a hint (all-or-nothing: partial hints would skew
+        #     the pre-sort)
+        #   • no offset page_id (offset pagination assumes a stable full-sort,
+        #     which we don't do in the fast path)
+        # ------------------------------------------------------------------
+        hints_available = bool(path_hints) and all(h is not None for _, h in path_hints)
+        use_hint_path = (
+            hints_available
+            and sort_order == EventSortOrder.TIMESTAMP_DESC
+            and not page_id
+        )
+
+        if use_hint_path:
+            items = await self._search_events_with_hints(
+                loop=loop,
+                path_hints=path_hints,  # type: ignore[arg-type]
+                kind__eq=kind__eq,
+                timestamp_gte_str=timestamp_gte_str,
+                timestamp_lt_str=timestamp_lt_str,
+                limit=limit,
+            )
+            if items is not None:
+                # Hints produced a reliable result — apply final sort and return.
+                # next_page_id is always None here: REST clients that use the
+                # TIMESTAMP_DESC order paginate via timestamp__lt, not page_id.
+                items.sort(key=lambda e: e.timestamp, reverse=True)
+                return EventPage(items=items[:limit], next_page_id=None)
+        # ------------------------------------------------------------------
+        # Full-scan fallback (original behaviour)
+        # ------------------------------------------------------------------
+        all_paths = [p for p, _ in path_hints]
+        raw_events = await self._load_paths(loop, all_paths)
+
+        items_full = []
+        for event in raw_events:
             if not event:
                 continue
             if kind__eq and event.kind != kind__eq:
@@ -106,25 +181,95 @@ class EventServiceBase(EventService, ABC):
                 continue
             if timestamp_lt_str and event.timestamp >= timestamp_lt_str:
                 continue
-            items.append(event)
+            items_full.append(event)
 
         if sort_order:
-            items.sort(
+            items_full.sort(
                 key=lambda e: e.timestamp,
                 reverse=(sort_order == EventSortOrder.TIMESTAMP_DESC),
             )
 
-        # Apply pagination to items (not paths)
+        # Apply offset-based pagination to items (not paths).
         start_offset = 0
         next_page_id = None
         if page_id:
             start_offset = int(page_id)
-            items = items[start_offset:]
-        if len(items) > limit:
+            items_full = items_full[start_offset:]
+        if len(items_full) > limit:
             next_page_id = str(start_offset + limit)
-            items = items[:limit]
+            items_full = items_full[:limit]
 
-        return EventPage(items=items, next_page_id=next_page_id)
+        return EventPage(items=items_full, next_page_id=next_page_id)
+
+    async def _search_events_with_hints(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        path_hints: list[tuple[Path, datetime]],
+        kind__eq: EventKind | None,
+        timestamp_gte_str: str | None,
+        timestamp_lt_str: str | None,
+        limit: int,
+    ) -> list[Event] | None:
+        """Fast path: load only as many events as necessary using hint timestamps.
+
+        Returns a list of matching events (may be slightly over-sized; the
+        caller trims to *limit* after a final sort), or ``None`` if the hints
+        turned out to be insufficient and the caller should fall back to a full
+        scan.
+
+        Strategy
+        --------
+        1. Pre-filter paths using hints so we skip obviously irrelevant events.
+        2. Sort surviving paths by hint DESC (newest first) — the order we need
+           to return.
+        3. Load the first ``limit × _HINT_OVERSHOOT_FACTOR`` paths.
+        4. Validate against actual event.timestamp and apply all filters.
+        5. If the result set is large enough, return it.  Otherwise signal the
+           caller to fall back (None).
+        """
+        # Pre-filter by hint when a timestamp bound is active.
+        if timestamp_lt_str:
+            # Keep paths whose hint is before the upper bound.  Accept hints
+            # up to the bound (≤ rather than <) because the hint may lag the
+            # logical timestamp by a few milliseconds (write latency).
+            lt_hint = datetime.fromisoformat(timestamp_lt_str)
+            if lt_hint.tzinfo is None:
+                lt_hint = lt_hint.replace(tzinfo=timezone.utc)
+            path_hints = [(p, h) for p, h in path_hints if h <= lt_hint]
+
+        if timestamp_gte_str:
+            gte_hint = datetime.fromisoformat(timestamp_gte_str)
+            if gte_hint.tzinfo is None:
+                gte_hint = gte_hint.replace(tzinfo=timezone.utc)
+            path_hints = [(p, h) for p, h in path_hints if h >= gte_hint]
+
+        # Sort by hint DESC so we load the most-recently-created events first.
+        path_hints.sort(key=lambda x: x[1], reverse=True)
+
+        candidate_paths = [p for p, _ in path_hints[: limit * _HINT_OVERSHOOT_FACTOR]]
+        raw_events = await self._load_paths(loop, candidate_paths)
+
+        matching: list[Event] = []
+        for event in raw_events:
+            if not event:
+                continue
+            if kind__eq and event.kind != kind__eq:
+                continue
+            if timestamp_gte_str and event.timestamp < timestamp_gte_str:
+                continue
+            if timestamp_lt_str and event.timestamp >= timestamp_lt_str:
+                continue
+            matching.append(event)
+
+        # If we loaded fewer candidate paths than the total available (i.e. we
+        # applied early stopping) *and* we didn't get enough matches, the hints
+        # were too imprecise for this query — signal the caller to do a full
+        # scan so we never return a truncated result set.
+        loaded_all = len(candidate_paths) == len(path_hints)
+        if not loaded_all and len(matching) < limit:
+            return None
+
+        return matching
 
     async def count_events(
         self,
@@ -155,8 +300,8 @@ class EventServiceBase(EventService, ABC):
     async def _count_events_no_filter(self, conversation_path: Path) -> int:
         """Count all event files in the conversation directory without filtering."""
         loop = asyncio.get_running_loop()
-        paths = await loop.run_in_executor(None, self._search_paths, conversation_path)
-        return len(paths)
+        path_hints = await loop.run_in_executor(None, self._search_paths, conversation_path)
+        return len(path_hints)
 
     async def save_event(self, conversation_id: UUID, event: Event):
         if isinstance(event.id, str):

--- a/openhands/app_server/event/filesystem_event_service.py
+++ b/openhands/app_server/event/filesystem_event_service.py
@@ -1,6 +1,8 @@
 import glob
 import logging
+import os
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import AsyncGenerator
 
@@ -35,11 +37,19 @@ class FilesystemEventService(EventServiceBase):
         content = event.model_dump_json(indent=2)
         path.write_text(content)
 
-    def _search_paths(self, prefix: Path, page_id: str | None = None) -> list[Path]:
+    def _search_paths(self, prefix: Path) -> list[tuple[Path, datetime | None]]:
         search_path = f'{prefix}/*'
         files = glob.glob(str(search_path))
-        paths = [Path(file) for file in files]
-        return paths
+        result: list[tuple[Path, datetime | None]] = []
+        for file in files:
+            path = Path(file)
+            try:
+                mtime = os.path.getmtime(file)
+                hint: datetime | None = datetime.fromtimestamp(mtime, tz=timezone.utc)
+            except OSError:
+                hint = None
+            result.append((path, hint))
+        return result
 
 
 class FilesystemEventServiceInjector(EventServiceInjector):

--- a/openhands/app_server/event/google_cloud_event_service.py
+++ b/openhands/app_server/event/google_cloud_event_service.py
@@ -3,6 +3,7 @@
 import json
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
 from typing import AsyncGenerator, Iterator
@@ -61,13 +62,20 @@ class GoogleCloudEventService(EventServiceBase):
         with blob.open('w') as f:
             f.write(json.dumps(data, indent=2))
 
-    def _search_paths(self, prefix: Path, page_id: str | None = None) -> list[Path]:
-        """Search paths."""
-        blobs: Iterator[Blob] = self.bucket.list_blobs(
-            page_token=page_id, prefix=str(prefix)
-        )
-        paths = list(Path(blob.name) for blob in blobs)
-        return paths
+    def _search_paths(self, prefix: Path) -> list[tuple[Path, datetime | None]]:
+        """Return all event paths under *prefix* with GCS time_created as hint.
+
+        ``list_blobs`` returns ``Blob`` objects whose ``time_created`` attribute
+        is a timezone-aware ``datetime``.  We include it as a hint so the base
+        class can pre-sort and pre-filter candidates without loading each event.
+        GCS's ``HTTPIterator`` paginates automatically, so all blobs are
+        returned in a single call to this method.
+        """
+        blobs: Iterator[Blob] = self.bucket.list_blobs(prefix=str(prefix))
+        result: list[tuple[Path, datetime | None]] = []
+        for blob in blobs:
+            result.append((Path(blob.name), blob.time_created))
+        return result
 
 
 class GoogleCloudEventServiceInjector(EventServiceInjector):

--- a/openhands/app_server/utils/logger.py
+++ b/openhands/app_server/utils/logger.py
@@ -20,14 +20,18 @@ from openhands.sdk.utils.redact import (
     redact_url_params,
 )
 
-# Suppress deprecation warnings from dependencies before they're imported
-# aifc was removed in Python 3.13 but speech_recognition still references it
-with warnings.catch_warnings():
-    warnings.simplefilter('ignore')
-    import aifc
+# Suppress deprecation warnings from dependencies before they're imported.
+# aifc was removed in Python 3.13 but speech_recognition still references it;
+# stub it out so the library can be imported on 3.13+ without errors.
+try:
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        import aifc  # noqa: F401
+except ModuleNotFoundError:
+    import sys
+    import types
 
-    # Stop the linter from deleting the import
-    _AIFC = aifc.__name__
+    sys.modules.setdefault('aifc', types.ModuleType('aifc'))
 
 warnings.filterwarnings('ignore', category=SyntaxWarning, module=r'pydub\.utils')
 

--- a/tests/unit/app_server/test_filesystem_event_service.py
+++ b/tests/unit/app_server/test_filesystem_event_service.py
@@ -388,6 +388,136 @@ class TestFilesystemEventServiceSearchEvents:
         assert result.items[0].id == event3.id
         assert result.items[1].id == event2.id
 
+    @pytest.mark.asyncio
+    async def test_initial_load_pattern_desc_with_limit(
+        self, service: FilesystemEventService
+    ):
+        """Verify sort_order=TIMESTAMP_DESC + limit returns the most-recent events.
+
+        This is the exact pattern the frontend uses on first open of a
+        conversation: GET /events/search?sort_order=TIMESTAMP_DESC&limit=50.
+        The result must contain the *newest* events (not the oldest), ordered
+        newest-first.
+        """
+        conversation_id = uuid4()
+        total = 10
+        limit = 3
+
+        saved = []
+        for _ in range(total):
+            e = create_token_event()
+            await service.save_event(conversation_id, e)
+            time.sleep(0.01)
+            saved.append(e)
+
+        result = await service.search_events(
+            conversation_id,
+            sort_order=EventSortOrder.TIMESTAMP_DESC,
+            limit=limit,
+        )
+
+        # Must return exactly `limit` items.
+        assert len(result.items) == limit
+
+        # The returned events must be the *newest* `limit` events.
+        expected_ids = {e.id for e in saved[-limit:]}
+        assert {e.id for e in result.items} == expected_ids
+
+        # They must be ordered newest-first.
+        returned_timestamps = [e.timestamp for e in result.items]
+        assert returned_timestamps == sorted(returned_timestamps, reverse=True)
+
+    @pytest.mark.asyncio
+    async def test_scroll_up_pagination_pattern(
+        self, service: FilesystemEventService
+    ):
+        """Verify sort_order=TIMESTAMP_DESC + timestamp__lt + limit returns events
+        just before the cutoff in newest-first order.
+
+        This is the exact pattern the frontend uses for scroll-up pagination:
+        GET /events/search?sort_order=TIMESTAMP_DESC&timestamp__lt=<oldest_ts>&limit=50
+        """
+        conversation_id = uuid4()
+
+        # Save 6 events.  After saving the 4th, note a cutoff time.
+        events_before_cutoff = []
+        for _ in range(3):
+            e = create_token_event()
+            await service.save_event(conversation_id, e)
+            time.sleep(0.01)
+            events_before_cutoff.append(e)
+
+        time.sleep(0.01)
+        cutoff = datetime.now()
+        time.sleep(0.01)
+
+        events_after_cutoff = []
+        for _ in range(3):
+            e = create_token_event()
+            await service.save_event(conversation_id, e)
+            time.sleep(0.01)
+            events_after_cutoff.append(e)
+
+        result = await service.search_events(
+            conversation_id,
+            timestamp__lt=cutoff,
+            sort_order=EventSortOrder.TIMESTAMP_DESC,
+            limit=10,
+        )
+
+        # Should only include the 3 events saved before the cutoff.
+        assert len(result.items) == 3
+        returned_ids = {e.id for e in result.items}
+        assert returned_ids == {e.id for e in events_before_cutoff}
+
+        # Ordered newest-first within the "before cutoff" group.
+        returned_timestamps = [e.timestamp for e in result.items]
+        assert returned_timestamps == sorted(returned_timestamps, reverse=True)
+
+    @pytest.mark.asyncio
+    async def test_hint_optimization_loads_only_needed_events(
+        self, service: FilesystemEventService
+    ):
+        """Verify that the hint-based fast path avoids loading all events.
+
+        When sort_order=TIMESTAMP_DESC + limit is used without a timestamp
+        filter, the filesystem mtime hints allow the implementation to load
+        only ``limit × _HINT_OVERSHOOT_FACTOR`` files instead of all N files.
+        We verify this by counting _load_event calls via a spy.
+        """
+        from unittest.mock import patch
+
+        from openhands.app_server.event.event_service_base import _HINT_OVERSHOOT_FACTOR
+
+        conversation_id = uuid4()
+        total = 20
+        limit = 3
+
+        for _ in range(total):
+            e = create_token_event()
+            await service.save_event(conversation_id, e)
+            time.sleep(0.01)
+
+        original_load = service._load_event
+        load_call_count = 0
+
+        def counting_load(path):
+            nonlocal load_call_count
+            load_call_count += 1
+            return original_load(path)
+
+        with patch.object(service, '_load_event', side_effect=counting_load):
+            result = await service.search_events(
+                conversation_id,
+                sort_order=EventSortOrder.TIMESTAMP_DESC,
+                limit=limit,
+            )
+
+        assert len(result.items) == limit
+        # Must have loaded at most limit × overshoot events, not all `total`.
+        assert load_call_count <= limit * _HINT_OVERSHOOT_FACTOR
+        assert load_call_count < total
+
 
 class TestFilesystemEventServiceIntegration:
     """Integration tests for FilesystemEventService."""


### PR DESCRIPTION
## Problem

Every `search_events` call loaded **all N event files** from storage (S3/GCS/filesystem) before filtering, sorting, and slicing to the requested `limit`. For a conversation with 1 000 events, a request for the 50 most-recent events still fired 1 000 concurrent S3 `GetObject` calls — the primary reason large conversations are slow to open.

Additionally, `AwsEventService._search_paths` called `list_objects_v2` without paging through continuation tokens, so conversations with more than 1 000 events were **silently truncated** in S3-backed deployments.

## Solution

`_search_paths` now returns `list[tuple[Path, datetime | None]]` — a path plus a free storage-layer timestamp hint:

| Backend | Hint source | Extra API calls |
|---|---|---|
| `FilesystemEventService` | `os.path.getmtime()` | 0 |
| `AwsEventService` | `LastModified` from `list_objects_v2` | 0 (already in listing response) |
| `GoogleCloudEventService` | `blob.time_created` from `list_blobs` | 0 (already in listing response) |

When all hints are present and `sort_order=TIMESTAMP_DESC` is requested with no offset `page_id`, `search_events` takes a fast path:
1. Pre-filter paths by hint timestamp when a bound is active.
2. Sort surviving paths by hint DESC.
3. Load only the first `limit × 2` paths (e.g. 100 for `limit=50`) instead of all N.
4. Validate every result against the real `event.timestamp` field.
5. If the subset yields ≥ `limit` matches → return; otherwise fall back to a full scan so results are **never truncated**.

## Performance impact

| Scenario | Before | After |
|---|---|---|
| Initial load (1 000 events, `limit=50`) | 1 000 reads | ≤ 100 reads |
| Scroll-up page (`timestamp__lt`) | 1 000 reads | ≤ 100 reads |
| `TIMESTAMP_ASC` / `page_id` queries | N reads | N reads (unchanged) |

## Tests (all 20 pass)

Three new tests in `test_filesystem_event_service.py`:
- `test_initial_load_pattern_desc_with_limit` — asserts the *newest* events are returned in newest-first order
- `test_scroll_up_pagination_pattern` — asserts events before the cutoff are returned newest-first (exact shape used by frontend scroll-up pagination)
- `test_hint_optimization_loads_only_needed_events` — spies on `_load_event` to assert ≤ `limit × 2` file reads, not all N

## Other

- `logger.py`: wrap `aifc` shim in `try/except ModuleNotFoundError` for Python 3.13 compatibility (test suite runs on 3.13 in CI).

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-ba9e11a   docker.openhands.dev/openhands/openhands:ba9e11a
```