### PR TITLE
fix: _configure_llm now preserves user LLM settings

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -902,6 +902,12 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
     def _configure_llm(self, user: UserInfo, llm_model: str | None) -> LLM:
         """Configure LLM settings.
 
+        Starts from the user's saved LLM configuration and overrides only
+        the fields that the server needs to resolve (model name, base URL,
+        and usage ID).  All other user-configured fields (e.g.
+        ``reasoning_effort``, ``extended_thinking_budget``, ``drop_params``)
+        are preserved so that they reach the agent-server unchanged.
+
         Args:
             user: User information containing LLM preferences
             llm_model: Optional specific model to use, falls back to user default
@@ -921,11 +927,13 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             provider_base_url=self.openhands_provider_base_url,
         )
 
-        return LLM(
-            model=model,
-            base_url=base_url,
-            api_key=user.agent_settings.llm.api_key,
-            usage_id='agent',
+        return user.agent_settings.llm.model_copy(
+            update={
+                'model': model,
+                'base_url': base_url,
+                'api_key': user.agent_settings.llm.api_key,
+                'usage_id': 'agent',
+            }
         )
 
     async def _add_system_mcp_servers(

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -567,6 +567,41 @@ class TestLiveStatusAppConversationService:
         assert llm.base_url == 'https://sdk-llm.example.com'
 
     @pytest.mark.asyncio
+    async def test_configure_llm_preserves_reasoning_effort(self):
+        """User-configured reasoning_effort must survive _configure_llm.
+
+        Previously _configure_llm created a bare LLM() which reset every
+        field to its Pydantic default (reasoning_effort='high').  Users who
+        set reasoning_effort=None (to disable thinking parameters for models
+        whose litellm version cannot handle them) had their override silently
+        discarded.
+        """
+        from pydantic import SecretStr as _SecretStr
+
+        user_llm = LLM(
+            model='anthropic/claude-opus-4-7',
+            api_key=_SecretStr('test-key'),
+            reasoning_effort=None,
+            extended_thinking_budget=None,
+        )
+        agent_settings = self.mock_user.agent_settings.model_copy(
+            update={'llm': user_llm}
+        )
+        self.mock_user.agent_settings = agent_settings
+        self.mock_user_context.get_mcp_api_key.return_value = None
+
+        llm, _ = await self.service._configure_llm_and_mcp(
+            self.mock_user, None, self.conversation_id
+        )
+
+        assert llm.model == 'anthropic/claude-opus-4-7'
+        assert llm.reasoning_effort is None, (
+            '_configure_llm must preserve reasoning_effort=None '
+            'instead of resetting it to the SDK default'
+        )
+        assert llm.extended_thinking_budget is None
+
+    @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_openhands_model_uses_user_base_url(
         self,
     ):


### PR DESCRIPTION
Fixes #14450

## What

`_configure_llm()` was constructing a brand-new `LLM()` instance from scratch, passing only `model`, `base_url`, `api_key`, and `usage_id`. Every other field from the user's saved LLM configuration was silently replaced by the SDK's Pydantic defaults.

This broke Claude Opus 4.7 on self-hosted deployments because the SDK defaults `reasoning_effort` to `"high"`, which the bundled litellm (v1.83.0) maps to `thinking.type=enabled` -- a parameter that Opus 4.7 does not accept. Users who set `reasoning_effort=None` in their settings to work around this had their override discarded.

## Fix

Replace `LLM(model=..., base_url=..., api_key=..., usage_id=...)` with `user.agent_settings.llm.model_copy(update={...})`. This preserves all user-configured fields while still allowing the server to override the model name, base URL, and usage ID.

## Test

Adds a regression test (`test_configure_llm_preserves_reasoning_effort`) that sets `reasoning_effort=None` and `extended_thinking_budget=None` on the user's LLM config and verifies both survive through `_configure_llm_and_mcp`.
