### PR TITLE
fix: preserve configured LLM settings

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -921,11 +921,13 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             provider_base_url=self.openhands_provider_base_url,
         )
 
-        return LLM(
-            model=model,
-            base_url=base_url,
-            api_key=user.agent_settings.llm.api_key,
-            usage_id='agent',
+        return user.agent_settings.llm.model_copy(
+            update={
+                'model': model,
+                'base_url': base_url,
+                'api_key': user.agent_settings.llm.api_key,
+                'usage_id': 'agent',
+            }
         )
 
     async def _add_system_mcp_servers(

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -567,6 +567,35 @@ class TestLiveStatusAppConversationService:
         assert llm.base_url == 'https://sdk-llm.example.com'
 
     @pytest.mark.asyncio
+    async def test_configure_llm_and_mcp_preserves_user_llm_overrides(self):
+        """User LLM overrides should not be replaced by SDK defaults."""
+        self.mock_user.agent_settings = OpenHandsAgentSettings(
+            llm=LLM(
+                model='anthropic/claude-opus-4-7',
+                api_key=SecretStr('test-key'),
+                base_url='https://sdk-llm.example.com',
+                reasoning_effort=None,
+                extended_thinking_budget=None,
+                drop_params=False,
+                max_output_tokens=4096,
+            )
+        )
+        self.mock_user_context.get_mcp_api_key.return_value = None
+
+        llm, _ = await self.service._configure_llm_and_mcp(
+            self.mock_user, None, self.conversation_id
+        )
+
+        assert llm.model == 'anthropic/claude-opus-4-7'
+        assert llm.base_url == 'https://sdk-llm.example.com'
+        assert llm.api_key.get_secret_value() == 'test-key'
+        assert llm.usage_id == 'agent'
+        assert llm.reasoning_effort is None
+        assert llm.extended_thinking_budget is None
+        assert llm.drop_params is False
+        assert llm.max_output_tokens == 4096
+
+    @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_openhands_model_uses_user_base_url(
         self,
     ):


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

`_configure_llm()` created a fresh SDK `LLM` with only model, base URL, API key, and usage ID. That discarded user-configured LLM fields such as `reasoning_effort=None`, causing Claude Opus 4.7 deployments to fall back to SDK defaults.

## Summary

- Preserve the user's existing `LLM` config with `model_copy()` while overriding only runtime-specific fields.
- Add a regression test covering `reasoning_effort=None` and other non-explicit LLM overrides.

## Issue Number

Fixes #14450

## How to Test

- `uv run pytest tests/unit/app_server/test_live_status_app_conversation_service.py -q`
- `uv run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml`

Note: `make install-pre-commit-hooks` was attempted first but failed because `poetry` is not installed on PATH in this environment.

## Video/Screenshots

N/A, backend-only fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No migrations or config changes.
