### PR TITLE
Add 👀 eye reaction acknowledgement for BBDC PR comments (Part 3)

### DIFF
--- a/enterprise/integrations/bitbucket_data_center/bitbucket_dc_manager.py
+++ b/enterprise/integrations/bitbucket_data_center/bitbucket_dc_manager.py
@@ -92,6 +92,53 @@ class BitbucketDCManager(Manager[BitbucketDCViewType]):
             )
             return False
 
+    async def _add_eyes_reaction(
+        self,
+        message: Message,
+        installer_user_id: str,
+        project_key: str,
+        repo_slug: str,
+    ) -> None:
+        """Best-effort 👀 acknowledgement on the triggering PR comment.
+
+        Mirrors ``GithubManager._add_reaction``: posted as soon as we've
+        decided the request will be acted on (permission check passed),
+        before view construction or conversation creation. Uses the
+        webhook installer's BBDC token (the user whose OAuth backs the
+        webhook enrollment), since the commenter's own token isn't on
+        hand from the webhook payload alone.
+
+        Any failure here is logged at INFO and swallowed — older BBDC
+        installs (< 7.0) return 404 on the reactions endpoint, and a
+        missing acknowledgement must never block conversation creation.
+        """
+        payload = message.message.get('payload') or {}
+        comment = payload.get('comment') or {}
+        pull_request = payload.get('pullRequest') or {}
+        comment_id = comment.get('id')
+        pr_id = pull_request.get('id')
+        if comment_id is None or pr_id is None:
+            return
+
+        from integrations.bitbucket_data_center.bitbucket_dc_service import (
+            SaaSBitbucketDCService,
+        )
+
+        try:
+            service = SaaSBitbucketDCService(external_auth_id=installer_user_id)
+            await service.add_comment_reaction(
+                owner=project_key,
+                repo_slug=repo_slug,
+                pr_id=int(pr_id),
+                comment_id=int(comment_id),
+                emoticon=':eyes:',
+            )
+        except Exception as e:
+            logger.info(
+                f'[Bitbucket DC] Could not add eyes reaction on '
+                f'{project_key}/{repo_slug} PR#{pr_id} comment#{comment_id}: {e}'
+            )
+
     async def receive_message(self, message: Message) -> None:
         self._confirm_incoming_source_type(message)
         if not self.is_job_requested(message):
@@ -116,6 +163,14 @@ class BitbucketDCManager(Manager[BitbucketDCViewType]):
                 f'access to {project_key}/{repo_slug}; ignoring.'
             )
             return
+
+        # Acknowledge receipt with a 👀 reaction on the triggering comment,
+        # mirroring the GitHub manager's behaviour. Best-effort: failures
+        # (e.g. legacy BBDC < 7.0 without the reactions endpoint) must not
+        # block conversation creation.
+        await self._add_eyes_reaction(
+            message, installer_user_id, project_key, repo_slug
+        )
 
         bitbucket_view = await BitbucketDCFactory.create_bitbucket_dc_view_from_payload(
             message, installer_user_id

--- a/openhands/app_server/integrations/bitbucket_data_center/service/resolver.py
+++ b/openhands/app_server/integrations/bitbucket_data_center/service/resolver.py
@@ -141,6 +141,30 @@ class BitbucketDCResolverMixin(BitbucketDCMixinBase):
 
         await self._make_request(url, params=payload, method=RequestMethod.POST)
 
+    async def add_comment_reaction(
+        self,
+        owner: str,
+        repo_slug: str,
+        pr_id: int,
+        comment_id: int,
+        emoticon: str,
+    ) -> None:
+        """Post a reaction emoticon on a Bitbucket Data Center PR comment.
+
+        Uses BBDC's comment reactions endpoint (Bitbucket Server / Data
+        Center 7.0+). Common emoticon strings: ``:eyes:``, ``:+1:``,
+        ``:-1:``, ``:heart:``, ``:smile:``. Callers should treat reaction
+        failures as non-fatal — older BBDC versions return 404 on this
+        endpoint and a missing reaction should not block event processing.
+        """
+        url = (
+            f'{self.BASE_URL}/projects/{owner}/repos/{repo_slug}'
+            f'/pull-requests/{pr_id}/comments/{comment_id}/reactions'
+        )
+        await self._make_request(
+            url, params={'emoticon': emoticon}, method=RequestMethod.POST
+        )
+
     async def user_has_write_access(self, owner: str, repo_slug: str) -> bool:
         """Self-permission analog of :meth:`user_has_write_access_for`.
 


### PR DESCRIPTION
## Summary

Stacks on top of [Part 2 — Bitbucket Cloud webhook enrollment lifecycle](https://github.com/OpenHands/OpenHands/tree/alona/bitbucket-cloud-webhook-enrollment-pr2). When a Bitbucket Data Center user @-mentions the resolver in a PR comment, the agent now posts a 👀 reaction on that comment **immediately** after the permission check passes — before the conversation is created and the agent's reply is posted. Mirrors the GitHub manager's existing 'eyes' reaction UX so the user gets fast visual feedback that the request was received.

## Why

Tested manually against `bitbucket-02.aivong.platform-team.all-hands.dev` and confirmed the BBDC integration works end-to-end **but provides no acknowledgement** between the user's `@openhands` comment and the agent's eventual reply (~tens of seconds while the conversation spins up). GitHub has had this UX since forever (`github_manager.py:276-277` — `_add_reaction(view, 'eyes', installation_token)`); BBDC and Bitbucket Cloud both lacked it. This closes the gap for BBDC.

## Scope

- **BBDC only.** Bitbucket Cloud's public REST API does not expose a reactions endpoint for PR comments — the reactions feature exists in the Cloud UI but isn't reachable via API, so parity there isn't possible without an upstream change.
- **BBDC 7.0+ required** for the reactions endpoint (`/rest/api/1.0/projects/{key}/repos/{slug}/pull-requests/{id}/comments/{cid}/reactions`). Older installs return 404; the helper logs at INFO and swallows the exception so a missing reaction never blocks conversation creation.

## Changes

| File | Lines | What |
|---|---|---|
| `openhands/app_server/integrations/bitbucket_data_center/service/resolver.py` | +24 | New `add_comment_reaction(owner, repo_slug, pr_id, comment_id, emoticon)` on `BitbucketDCResolverMixin` — POSTs `{'emoticon': ...}` via the existing `_make_request` helper. |
| `enterprise/integrations/bitbucket_data_center/bitbucket_dc_manager.py` | +55 | New `_add_eyes_reaction(message, installer_user_id, project_key, repo_slug)` helper + call site in `receive_message` right after `_commenter_has_write_access` returns True. Uses the webhook installer's BBDC token (the user whose OAuth backs the enrollment). |

Total: 79 LOC, no tests yet (see below).

## Verification done

- ✅ Manual end-to-end test against bitbucket-02 prior to this PR — `@openhands` mention → conversation created → agent replied. Today the missing reaction is the only UX gap.
- ✅ `python -m ast` parses both files clean.
- ✅ Pre-commit mypy passed locally.
- ✅ Reaction is no-op when the payload is missing `comment.id` or `pullRequest.id` (defensive early-return).
- ✅ `try/except Exception` around the reaction call — verified by inspection that no path can raise out of `_add_eyes_reaction`.

## TODO before merge

- [ ] **Unit tests** — at minimum: (1) `add_comment_reaction` builds the right URL + body, (2) `_add_eyes_reaction` swallows a service exception, (3) `receive_message` calls the reaction *after* permission check and *before* view creation. Skipped here for speed; happy to add in a fixup.
- [ ] **Live verification on bitbucket-02** — confirm the eye actually appears on the triggering comment after merge into Part 2 + deploy.
- [ ] (Optional) Refactor `_add_eyes_reaction` to a generic `_add_reaction(emoticon)` so future reactions (e.g. ✅ on success, ❌ on failure) can reuse it.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-fcf71f3   docker.openhands.dev/openhands/openhands:fcf71f3
```