### PR TITLE
feat(sandbox): add boxd cloud microVM backend

### DIFF
--- a/openhands/app_server/app_lifespan/alembic/versions/010.py
+++ b/openhands/app_server/app_lifespan/alembic/versions/010.py
@@ -11,68 +11,68 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = '010'
-down_revision: Union[str, None] = '009'
+revision: str = "010"
+down_revision: Union[str, None] = "009"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
     op.create_table(
-        'v1_boxd_sandbox',
-        sa.Column('id', sa.String(), nullable=False),
-        sa.Column('created_by_user_id', sa.String(), nullable=True),
-        sa.Column('sandbox_spec_id', sa.String(), nullable=False),
-        sa.Column('session_api_key_hash', sa.String(), nullable=True),
+        "v1_boxd_sandbox",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("created_by_user_id", sa.String(), nullable=True),
+        sa.Column("sandbox_spec_id", sa.String(), nullable=False),
+        sa.Column("session_api_key_hash", sa.String(), nullable=True),
         sa.Column(
-            'created_at',
+            "created_at",
             sa.DateTime(timezone=True),
-            server_default=sa.text('(CURRENT_TIMESTAMP)'),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
             nullable=True,
         ),
-        sa.PrimaryKeyConstraint('id'),
+        sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(
-        op.f('ix_v1_boxd_sandbox_created_at'),
-        'v1_boxd_sandbox',
-        ['created_at'],
+        op.f("ix_v1_boxd_sandbox_created_at"),
+        "v1_boxd_sandbox",
+        ["created_at"],
         unique=False,
     )
     op.create_index(
-        op.f('ix_v1_boxd_sandbox_created_by_user_id'),
-        'v1_boxd_sandbox',
-        ['created_by_user_id'],
+        op.f("ix_v1_boxd_sandbox_created_by_user_id"),
+        "v1_boxd_sandbox",
+        ["created_by_user_id"],
         unique=False,
     )
     op.create_index(
-        op.f('ix_v1_boxd_sandbox_sandbox_spec_id'),
-        'v1_boxd_sandbox',
-        ['sandbox_spec_id'],
+        op.f("ix_v1_boxd_sandbox_sandbox_spec_id"),
+        "v1_boxd_sandbox",
+        ["sandbox_spec_id"],
         unique=False,
     )
     op.create_index(
-        op.f('ix_v1_boxd_sandbox_session_api_key_hash'),
-        'v1_boxd_sandbox',
-        ['session_api_key_hash'],
+        op.f("ix_v1_boxd_sandbox_session_api_key_hash"),
+        "v1_boxd_sandbox",
+        ["session_api_key_hash"],
         unique=False,
     )
 
 
 def downgrade() -> None:
     op.drop_index(
-        op.f('ix_v1_boxd_sandbox_session_api_key_hash'),
-        table_name='v1_boxd_sandbox',
+        op.f("ix_v1_boxd_sandbox_session_api_key_hash"),
+        table_name="v1_boxd_sandbox",
     )
     op.drop_index(
-        op.f('ix_v1_boxd_sandbox_sandbox_spec_id'),
-        table_name='v1_boxd_sandbox',
+        op.f("ix_v1_boxd_sandbox_sandbox_spec_id"),
+        table_name="v1_boxd_sandbox",
     )
     op.drop_index(
-        op.f('ix_v1_boxd_sandbox_created_by_user_id'),
-        table_name='v1_boxd_sandbox',
+        op.f("ix_v1_boxd_sandbox_created_by_user_id"),
+        table_name="v1_boxd_sandbox",
     )
     op.drop_index(
-        op.f('ix_v1_boxd_sandbox_created_at'),
-        table_name='v1_boxd_sandbox',
+        op.f("ix_v1_boxd_sandbox_created_at"),
+        table_name="v1_boxd_sandbox",
     )
-    op.drop_table('v1_boxd_sandbox')
+    op.drop_table("v1_boxd_sandbox")

--- a/openhands/app_server/app_lifespan/alembic/versions/010.py
+++ b/openhands/app_server/app_lifespan/alembic/versions/010.py
@@ -11,68 +11,68 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "010"
-down_revision: Union[str, None] = "009"
+revision: str = '010'
+down_revision: Union[str, None] = '009'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
     op.create_table(
-        "v1_boxd_sandbox",
-        sa.Column("id", sa.String(), nullable=False),
-        sa.Column("created_by_user_id", sa.String(), nullable=True),
-        sa.Column("sandbox_spec_id", sa.String(), nullable=False),
-        sa.Column("session_api_key_hash", sa.String(), nullable=True),
+        'v1_boxd_sandbox',
+        sa.Column('id', sa.String(), nullable=False),
+        sa.Column('created_by_user_id', sa.String(), nullable=True),
+        sa.Column('sandbox_spec_id', sa.String(), nullable=False),
+        sa.Column('session_api_key_hash', sa.String(), nullable=True),
         sa.Column(
-            "created_at",
+            'created_at',
             sa.DateTime(timezone=True),
-            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            server_default=sa.text('(CURRENT_TIMESTAMP)'),
             nullable=True,
         ),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint('id'),
     )
     op.create_index(
-        op.f("ix_v1_boxd_sandbox_created_at"),
-        "v1_boxd_sandbox",
-        ["created_at"],
+        op.f('ix_v1_boxd_sandbox_created_at'),
+        'v1_boxd_sandbox',
+        ['created_at'],
         unique=False,
     )
     op.create_index(
-        op.f("ix_v1_boxd_sandbox_created_by_user_id"),
-        "v1_boxd_sandbox",
-        ["created_by_user_id"],
+        op.f('ix_v1_boxd_sandbox_created_by_user_id'),
+        'v1_boxd_sandbox',
+        ['created_by_user_id'],
         unique=False,
     )
     op.create_index(
-        op.f("ix_v1_boxd_sandbox_sandbox_spec_id"),
-        "v1_boxd_sandbox",
-        ["sandbox_spec_id"],
+        op.f('ix_v1_boxd_sandbox_sandbox_spec_id'),
+        'v1_boxd_sandbox',
+        ['sandbox_spec_id'],
         unique=False,
     )
     op.create_index(
-        op.f("ix_v1_boxd_sandbox_session_api_key_hash"),
-        "v1_boxd_sandbox",
-        ["session_api_key_hash"],
+        op.f('ix_v1_boxd_sandbox_session_api_key_hash'),
+        'v1_boxd_sandbox',
+        ['session_api_key_hash'],
         unique=False,
     )
 
 
 def downgrade() -> None:
     op.drop_index(
-        op.f("ix_v1_boxd_sandbox_session_api_key_hash"),
-        table_name="v1_boxd_sandbox",
+        op.f('ix_v1_boxd_sandbox_session_api_key_hash'),
+        table_name='v1_boxd_sandbox',
     )
     op.drop_index(
-        op.f("ix_v1_boxd_sandbox_sandbox_spec_id"),
-        table_name="v1_boxd_sandbox",
+        op.f('ix_v1_boxd_sandbox_sandbox_spec_id'),
+        table_name='v1_boxd_sandbox',
     )
     op.drop_index(
-        op.f("ix_v1_boxd_sandbox_created_by_user_id"),
-        table_name="v1_boxd_sandbox",
+        op.f('ix_v1_boxd_sandbox_created_by_user_id'),
+        table_name='v1_boxd_sandbox',
     )
     op.drop_index(
-        op.f("ix_v1_boxd_sandbox_created_at"),
-        table_name="v1_boxd_sandbox",
+        op.f('ix_v1_boxd_sandbox_created_at'),
+        table_name='v1_boxd_sandbox',
     )
-    op.drop_table("v1_boxd_sandbox")
+    op.drop_table('v1_boxd_sandbox')

--- a/openhands/app_server/app_lifespan/alembic/versions/010.py
+++ b/openhands/app_server/app_lifespan/alembic/versions/010.py
@@ -1,0 +1,78 @@
+"""Add v1_boxd_sandbox table for the boxd sandbox backend.
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-05-18 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '010'
+down_revision: Union[str, None] = '009'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'v1_boxd_sandbox',
+        sa.Column('id', sa.String(), nullable=False),
+        sa.Column('created_by_user_id', sa.String(), nullable=True),
+        sa.Column('sandbox_spec_id', sa.String(), nullable=False),
+        sa.Column('session_api_key_hash', sa.String(), nullable=True),
+        sa.Column(
+            'created_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.text('(CURRENT_TIMESTAMP)'),
+            nullable=True,
+        ),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        op.f('ix_v1_boxd_sandbox_created_at'),
+        'v1_boxd_sandbox',
+        ['created_at'],
+        unique=False,
+    )
+    op.create_index(
+        op.f('ix_v1_boxd_sandbox_created_by_user_id'),
+        'v1_boxd_sandbox',
+        ['created_by_user_id'],
+        unique=False,
+    )
+    op.create_index(
+        op.f('ix_v1_boxd_sandbox_sandbox_spec_id'),
+        'v1_boxd_sandbox',
+        ['sandbox_spec_id'],
+        unique=False,
+    )
+    op.create_index(
+        op.f('ix_v1_boxd_sandbox_session_api_key_hash'),
+        'v1_boxd_sandbox',
+        ['session_api_key_hash'],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f('ix_v1_boxd_sandbox_session_api_key_hash'),
+        table_name='v1_boxd_sandbox',
+    )
+    op.drop_index(
+        op.f('ix_v1_boxd_sandbox_sandbox_spec_id'),
+        table_name='v1_boxd_sandbox',
+    )
+    op.drop_index(
+        op.f('ix_v1_boxd_sandbox_created_by_user_id'),
+        table_name='v1_boxd_sandbox',
+    )
+    op.drop_index(
+        op.f('ix_v1_boxd_sandbox_created_at'),
+        table_name='v1_boxd_sandbox',
+    )
+    op.drop_table('v1_boxd_sandbox')

--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from typing import AsyncContextManager
+from typing import Any, AsyncContextManager
 
 import httpx
 from fastapi import Depends, Request
@@ -277,6 +277,12 @@ def config_from_env() -> AppServerConfig:
     from openhands.app_server.sandbox.remote_sandbox_spec_service import (
         RemoteSandboxSpecServiceInjector,
     )
+    from openhands.app_server.sandbox.boxd_sandbox_service import (
+        BoxdSandboxServiceInjector,
+    )
+    from openhands.app_server.sandbox.boxd_sandbox_spec_service import (
+        BoxdSandboxSpecServiceInjector,
+    )
     from openhands.app_server.user.auth_user_context import (
         AuthUserContextInjector,
     )
@@ -335,6 +341,27 @@ def config_from_env() -> AppServerConfig:
                 api_key=os.environ['SANDBOX_API_KEY'],
                 api_url=os.environ['SANDBOX_REMOTE_RUNTIME_API_URL'],
             )
+        elif os.getenv('RUNTIME') == 'boxd':
+            boxd_kwargs: dict[str, Any] = {}
+            if os.getenv('BOXD_API_KEY'):
+                boxd_kwargs['api_key'] = os.environ['BOXD_API_KEY']
+            if os.getenv('BOXD_API_URL'):
+                boxd_kwargs['api_url'] = os.environ['BOXD_API_URL']
+            if os.getenv('BOXD_AUTO_SUSPEND_TIMEOUT'):
+                boxd_kwargs['auto_suspend_timeout'] = int(
+                    os.environ['BOXD_AUTO_SUSPEND_TIMEOUT']
+                )
+            if os.getenv('BOXD_MAX_NUM_SANDBOXES'):
+                boxd_kwargs['max_num_sandboxes'] = int(
+                    os.environ['BOXD_MAX_NUM_SANDBOXES']
+                )
+            if os.getenv('BOXD_VCPU'):
+                boxd_kwargs['vcpu'] = int(os.environ['BOXD_VCPU'])
+            if os.getenv('BOXD_MEMORY'):
+                boxd_kwargs['memory'] = os.environ['BOXD_MEMORY']
+            if os.getenv('BOXD_DISK'):
+                boxd_kwargs['disk'] = os.environ['BOXD_DISK']
+            config.sandbox = BoxdSandboxServiceInjector(**boxd_kwargs)
         elif os.getenv('RUNTIME') in ('local', 'process'):
             config.sandbox = ProcessSandboxServiceInjector()
         else:
@@ -387,6 +414,8 @@ def config_from_env() -> AppServerConfig:
     if config.sandbox_spec is None:
         if os.getenv('RUNTIME') == 'remote':
             config.sandbox_spec = RemoteSandboxSpecServiceInjector()
+        elif os.getenv('RUNTIME') == 'boxd':
+            config.sandbox_spec = BoxdSandboxSpecServiceInjector()
         elif os.getenv('RUNTIME') in ('local', 'process'):
             config.sandbox_spec = ProcessSandboxSpecServiceInjector()
         else:

--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -71,16 +71,16 @@ from openhands.sdk.utils.models import OpenHandsModel
 
 def get_default_persistence_dir() -> Path:
     # Recheck env because this function is also used to generate other defaults
-    persistence_dir = os.getenv('OH_PERSISTENCE_DIR')
+    persistence_dir = os.getenv("OH_PERSISTENCE_DIR")
 
     # Legacy V0 fallback variable
     if persistence_dir is None:
-        persistence_dir = os.getenv('FILE_STORE_PATH')
+        persistence_dir = os.getenv("FILE_STORE_PATH")
 
     if persistence_dir:
         result = Path(persistence_dir)
     else:
-        result = Path.home() / '.openhands'
+        result = Path.home() / ".openhands"
 
     result.mkdir(parents=True, exist_ok=True)
     return result
@@ -91,10 +91,10 @@ def get_default_web_url() -> str | None:
 
     If present, we assume we are running under https.
     """
-    web_host = os.getenv('WEB_HOST')
+    web_host = os.getenv("WEB_HOST")
     if not web_host:
         return None
-    return f'https://{web_host}'
+    return f"https://{web_host}"
 
 
 def get_default_permitted_cors_origins() -> list[str]:
@@ -104,9 +104,9 @@ def get_default_permitted_cors_origins() -> list[str]:
     (handled by the pydantic from_env parser). This fallback supports the legacy
     comma-separated PERMITTED_CORS_ORIGINS environment variable.
     """
-    legacy = os.getenv('PERMITTED_CORS_ORIGINS', '')
+    legacy = os.getenv("PERMITTED_CORS_ORIGINS", "")
     if legacy:
-        return [o.strip() for o in legacy.split(',') if o.strip()]
+        return [o.strip() for o in legacy.split(",") if o.strip()]
     return []
 
 
@@ -115,7 +115,7 @@ def get_openhands_provider_base_url() -> str | None:
 
     Falls back to LLM_BASE_URL for backward compatibility.
     """
-    return os.getenv('OPENHANDS_PROVIDER_BASE_URL') or os.getenv('LLM_BASE_URL') or None
+    return os.getenv("OPENHANDS_PROVIDER_BASE_URL") or os.getenv("LLM_BASE_URL") or None
 
 
 def get_default_tavily_api_key() -> str | None:
@@ -123,13 +123,13 @@ def get_default_tavily_api_key() -> str | None:
 
     Falls back to SEARCH_API_KEY for backward compatibility.
     """
-    return os.getenv('TAVILY_API_KEY') or os.getenv('SEARCH_API_KEY') or None
+    return os.getenv("TAVILY_API_KEY") or os.getenv("SEARCH_API_KEY") or None
 
 
 # The SDK auto-fills this URL as the default for openhands/ and litellm_proxy/
 # models.  Deployments (e.g. staging) may use a different LLM proxy, configured
 # via OPENHANDS_PROVIDER_BASE_URL.
-_SDK_DEFAULT_PROXY = 'https://llm-proxy.app.all-hands.dev/'
+_SDK_DEFAULT_PROXY = "https://llm-proxy.app.all-hands.dev/"
 
 
 def resolve_provider_llm_base_url(
@@ -152,12 +152,12 @@ def resolve_provider_llm_base_url(
             ``get_openhands_provider_base_url()`` when *None*.
     """
     if not model or not (
-        model.startswith('openhands/') or model.startswith('litellm_proxy/')
+        model.startswith("openhands/") or model.startswith("litellm_proxy/")
     ):
         return base_url
 
-    user_set_custom = base_url and base_url.rstrip('/') != _SDK_DEFAULT_PROXY.rstrip(
-        '/'
+    user_set_custom = base_url and base_url.rstrip("/") != _SDK_DEFAULT_PROXY.rstrip(
+        "/"
     )
     if user_set_custom:
         return base_url
@@ -173,7 +173,7 @@ def resolve_provider_llm_base_url(
 def _get_default_lifespan():
     # Check legacy parameters for saas mode. If we are in SAAS mode use
     # SaasAppLifespanService to initialize PostHog analytics
-    if 'saas' in (os.getenv('OPENHANDS_CONFIG_CLS') or '').lower():
+    if "saas" in (os.getenv("OPENHANDS_CONFIG_CLS") or "").lower():
         from server.app_lifespan.saas_app_lifespan_service import (
             SaasAppLifespanService,
         )
@@ -192,23 +192,23 @@ class AppServerConfig(OpenHandsModel):
     file_store: FileStore = Field(default_factory=_get_default_file_store)
     web_url: str | None = Field(
         default_factory=get_default_web_url,
-        description='The URL where OpenHands is running (e.g., http://localhost:3000)',
+        description="The URL where OpenHands is running (e.g., http://localhost:3000)",
     )
     permitted_cors_origins: list[str] = Field(
         default_factory=get_default_permitted_cors_origins,
         description=(
-            'Additional permitted CORS origins for both the app server and agent '
-            'server containers. Configure via OH_PERMITTED_CORS_ORIGINS_0, _1, etc. '
-            'Falls back to legacy PERMITTED_CORS_ORIGINS env var.'
+            "Additional permitted CORS origins for both the app server and agent "
+            "server containers. Configure via OH_PERMITTED_CORS_ORIGINS_0, _1, etc. "
+            "Falls back to legacy PERMITTED_CORS_ORIGINS env var."
         ),
     )
     openhands_provider_base_url: str | None = Field(
         default_factory=get_openhands_provider_base_url,
-        description='Base URL for the OpenHands provider',
+        description="Base URL for the OpenHands provider",
     )
     tavily_api_key: str | None = Field(
         default_factory=get_default_tavily_api_key,
-        description='Tavily API key for search integration (proxied via MCP server)',
+        description="Tavily API key for search integration (proxied via MCP server)",
     )
     # Dependency Injection Injectors
     llm_model: LLMModelServiceInjector | None = None
@@ -259,6 +259,12 @@ def config_from_env() -> AppServerConfig:
     from openhands.app_server.event_callback.sql_event_callback_service import (
         SQLEventCallbackServiceInjector,
     )
+    from openhands.app_server.sandbox.boxd_sandbox_service import (
+        BoxdSandboxServiceInjector,
+    )
+    from openhands.app_server.sandbox.boxd_sandbox_spec_service import (
+        BoxdSandboxSpecServiceInjector,
+    )
     from openhands.app_server.sandbox.docker_sandbox_service import (
         DockerSandboxServiceInjector,
     )
@@ -277,17 +283,11 @@ def config_from_env() -> AppServerConfig:
     from openhands.app_server.sandbox.remote_sandbox_spec_service import (
         RemoteSandboxSpecServiceInjector,
     )
-    from openhands.app_server.sandbox.boxd_sandbox_service import (
-        BoxdSandboxServiceInjector,
-    )
-    from openhands.app_server.sandbox.boxd_sandbox_spec_service import (
-        BoxdSandboxSpecServiceInjector,
-    )
     from openhands.app_server.user.auth_user_context import (
         AuthUserContextInjector,
     )
 
-    config: AppServerConfig = from_env(AppServerConfig, 'OH')  # type: ignore
+    config: AppServerConfig = from_env(AppServerConfig, "OH")  # type: ignore
 
     if config.llm_model is None:
         from openhands.app_server.config_api.default_llm_model_service import (
@@ -295,17 +295,17 @@ def config_from_env() -> AppServerConfig:
         )
 
         llm_model_kwargs: dict = {}
-        aws_region = os.getenv('AWS_REGION_NAME')
-        aws_key = os.getenv('AWS_ACCESS_KEY_ID')
-        aws_secret = os.getenv('AWS_SECRET_ACCESS_KEY')
+        aws_region = os.getenv("AWS_REGION_NAME")
+        aws_key = os.getenv("AWS_ACCESS_KEY_ID")
+        aws_secret = os.getenv("AWS_SECRET_ACCESS_KEY")
         if aws_region and aws_key and aws_secret:
-            llm_model_kwargs['aws_region_name'] = aws_region
-            llm_model_kwargs['aws_access_key_id'] = SecretStr(aws_key)
-            llm_model_kwargs['aws_secret_access_key'] = SecretStr(aws_secret)
+            llm_model_kwargs["aws_region_name"] = aws_region
+            llm_model_kwargs["aws_access_key_id"] = SecretStr(aws_key)
+            llm_model_kwargs["aws_secret_access_key"] = SecretStr(aws_secret)
 
-        ollama_url = os.getenv('OLLAMA_BASE_URL')
+        ollama_url = os.getenv("OLLAMA_BASE_URL")
         if ollama_url:
-            llm_model_kwargs['ollama_base_url'] = ollama_url
+            llm_model_kwargs["ollama_base_url"] = ollama_url
 
         config.llm_model = DefaultLLMModelServiceInjector(**llm_model_kwargs)
 
@@ -314,18 +314,18 @@ def config_from_env() -> AppServerConfig:
 
         if provider == StorageProvider.AWS:
             # AWS S3 storage configuration
-            bucket_name = os.environ.get('FILE_STORE_PATH')
+            bucket_name = os.environ.get("FILE_STORE_PATH")
             if not bucket_name:
                 raise ValueError(
-                    'FILE_STORE_PATH environment variable is required for S3 storage'
+                    "FILE_STORE_PATH environment variable is required for S3 storage"
                 )
             config.event = AwsEventServiceInjector(bucket_name=bucket_name)
         elif provider == StorageProvider.GCP:
             # Google Cloud storage configuration
-            bucket_name = os.environ.get('FILE_STORE_PATH')
+            bucket_name = os.environ.get("FILE_STORE_PATH")
             if not bucket_name:
                 raise ValueError(
-                    'FILE_STORE_PATH environment variable is required for Google Cloud storage'
+                    "FILE_STORE_PATH environment variable is required for Google Cloud storage"
                 )
             config.event = GoogleCloudEventServiceInjector(bucket_name=bucket_name)
         else:
@@ -336,70 +336,70 @@ def config_from_env() -> AppServerConfig:
 
     if config.sandbox is None:
         # Legacy fallback
-        if os.getenv('RUNTIME') == 'remote':
+        if os.getenv("RUNTIME") == "remote":
             config.sandbox = RemoteSandboxServiceInjector(
-                api_key=os.environ['SANDBOX_API_KEY'],
-                api_url=os.environ['SANDBOX_REMOTE_RUNTIME_API_URL'],
+                api_key=os.environ["SANDBOX_API_KEY"],
+                api_url=os.environ["SANDBOX_REMOTE_RUNTIME_API_URL"],
             )
-        elif os.getenv('RUNTIME') == 'boxd':
+        elif os.getenv("RUNTIME") == "boxd":
             boxd_kwargs: dict[str, Any] = {}
-            if os.getenv('BOXD_API_KEY'):
-                boxd_kwargs['api_key'] = os.environ['BOXD_API_KEY']
-            if os.getenv('BOXD_API_URL'):
-                boxd_kwargs['api_url'] = os.environ['BOXD_API_URL']
-            if os.getenv('BOXD_AUTO_SUSPEND_TIMEOUT'):
-                boxd_kwargs['auto_suspend_timeout'] = int(
-                    os.environ['BOXD_AUTO_SUSPEND_TIMEOUT']
+            if os.getenv("BOXD_API_KEY"):
+                boxd_kwargs["api_key"] = os.environ["BOXD_API_KEY"]
+            if os.getenv("BOXD_API_URL"):
+                boxd_kwargs["api_url"] = os.environ["BOXD_API_URL"]
+            if os.getenv("BOXD_AUTO_SUSPEND_TIMEOUT"):
+                boxd_kwargs["auto_suspend_timeout"] = int(
+                    os.environ["BOXD_AUTO_SUSPEND_TIMEOUT"]
                 )
-            if os.getenv('BOXD_MAX_NUM_SANDBOXES'):
-                boxd_kwargs['max_num_sandboxes'] = int(
-                    os.environ['BOXD_MAX_NUM_SANDBOXES']
+            if os.getenv("BOXD_MAX_NUM_SANDBOXES"):
+                boxd_kwargs["max_num_sandboxes"] = int(
+                    os.environ["BOXD_MAX_NUM_SANDBOXES"]
                 )
-            if os.getenv('BOXD_VCPU'):
-                boxd_kwargs['vcpu'] = int(os.environ['BOXD_VCPU'])
-            if os.getenv('BOXD_MEMORY'):
-                boxd_kwargs['memory'] = os.environ['BOXD_MEMORY']
-            if os.getenv('BOXD_DISK'):
-                boxd_kwargs['disk'] = os.environ['BOXD_DISK']
+            if os.getenv("BOXD_VCPU"):
+                boxd_kwargs["vcpu"] = int(os.environ["BOXD_VCPU"])
+            if os.getenv("BOXD_MEMORY"):
+                boxd_kwargs["memory"] = os.environ["BOXD_MEMORY"]
+            if os.getenv("BOXD_DISK"):
+                boxd_kwargs["disk"] = os.environ["BOXD_DISK"]
             config.sandbox = BoxdSandboxServiceInjector(**boxd_kwargs)
-        elif os.getenv('RUNTIME') in ('local', 'process'):
+        elif os.getenv("RUNTIME") in ("local", "process"):
             config.sandbox = ProcessSandboxServiceInjector()
         else:
             # Support legacy environment variables for Docker sandbox configuration
             docker_sandbox_kwargs: dict = {}
-            if os.getenv('SANDBOX_HOST_PORT'):
-                docker_sandbox_kwargs['host_port'] = int(
-                    os.environ['SANDBOX_HOST_PORT']
+            if os.getenv("SANDBOX_HOST_PORT"):
+                docker_sandbox_kwargs["host_port"] = int(
+                    os.environ["SANDBOX_HOST_PORT"]
                 )
-            if os.getenv('SANDBOX_CONTAINER_URL_PATTERN'):
-                docker_sandbox_kwargs['container_url_pattern'] = os.environ[
-                    'SANDBOX_CONTAINER_URL_PATTERN'
+            if os.getenv("SANDBOX_CONTAINER_URL_PATTERN"):
+                docker_sandbox_kwargs["container_url_pattern"] = os.environ[
+                    "SANDBOX_CONTAINER_URL_PATTERN"
                 ]
             # Allow configuring sandbox startup grace period
             # This is useful for slower machines or cloud environments where
             # the agent-server container takes longer to initialize
-            if os.getenv('SANDBOX_STARTUP_GRACE_SECONDS'):
-                docker_sandbox_kwargs['startup_grace_seconds'] = int(
-                    os.environ['SANDBOX_STARTUP_GRACE_SECONDS']
+            if os.getenv("SANDBOX_STARTUP_GRACE_SECONDS"):
+                docker_sandbox_kwargs["startup_grace_seconds"] = int(
+                    os.environ["SANDBOX_STARTUP_GRACE_SECONDS"]
                 )
             # Parse SANDBOX_VOLUMES and convert to VolumeMount objects
             # This is set by the CLI's --mount-cwd flag
-            sandbox_volumes = os.getenv('SANDBOX_VOLUMES')
+            sandbox_volumes = os.getenv("SANDBOX_VOLUMES")
             if sandbox_volumes:
                 from openhands.app_server.sandbox.docker_sandbox_service import (
                     VolumeMount,
                 )
 
                 mounts = []
-                for mount_spec in sandbox_volumes.split(','):
+                for mount_spec in sandbox_volumes.split(","):
                     mount_spec = mount_spec.strip()
                     if not mount_spec:
                         continue
-                    parts = mount_spec.split(':')
+                    parts = mount_spec.split(":")
                     if len(parts) >= 2:
                         host_path = parts[0]
                         container_path = parts[1]
-                        mode = parts[2] if len(parts) > 2 else 'rw'
+                        mode = parts[2] if len(parts) > 2 else "rw"
                         mounts.append(
                             VolumeMount(
                                 host_path=host_path,
@@ -408,15 +408,15 @@ def config_from_env() -> AppServerConfig:
                             )
                         )
                 if mounts:
-                    docker_sandbox_kwargs['mounts'] = mounts
+                    docker_sandbox_kwargs["mounts"] = mounts
             config.sandbox = DockerSandboxServiceInjector(**docker_sandbox_kwargs)
 
     if config.sandbox_spec is None:
-        if os.getenv('RUNTIME') == 'remote':
+        if os.getenv("RUNTIME") == "remote":
             config.sandbox_spec = RemoteSandboxSpecServiceInjector()
-        elif os.getenv('RUNTIME') == 'boxd':
+        elif os.getenv("RUNTIME") == "boxd":
             config.sandbox_spec = BoxdSandboxSpecServiceInjector()
-        elif os.getenv('RUNTIME') in ('local', 'process'):
+        elif os.getenv("RUNTIME") in ("local", "process"):
             config.sandbox_spec = ProcessSandboxSpecServiceInjector()
         else:
             config.sandbox_spec = DockerSandboxSpecServiceInjector()

--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -71,16 +71,16 @@ from openhands.sdk.utils.models import OpenHandsModel
 
 def get_default_persistence_dir() -> Path:
     # Recheck env because this function is also used to generate other defaults
-    persistence_dir = os.getenv("OH_PERSISTENCE_DIR")
+    persistence_dir = os.getenv('OH_PERSISTENCE_DIR')
 
     # Legacy V0 fallback variable
     if persistence_dir is None:
-        persistence_dir = os.getenv("FILE_STORE_PATH")
+        persistence_dir = os.getenv('FILE_STORE_PATH')
 
     if persistence_dir:
         result = Path(persistence_dir)
     else:
-        result = Path.home() / ".openhands"
+        result = Path.home() / '.openhands'
 
     result.mkdir(parents=True, exist_ok=True)
     return result
@@ -91,10 +91,10 @@ def get_default_web_url() -> str | None:
 
     If present, we assume we are running under https.
     """
-    web_host = os.getenv("WEB_HOST")
+    web_host = os.getenv('WEB_HOST')
     if not web_host:
         return None
-    return f"https://{web_host}"
+    return f'https://{web_host}'
 
 
 def get_default_permitted_cors_origins() -> list[str]:
@@ -104,9 +104,9 @@ def get_default_permitted_cors_origins() -> list[str]:
     (handled by the pydantic from_env parser). This fallback supports the legacy
     comma-separated PERMITTED_CORS_ORIGINS environment variable.
     """
-    legacy = os.getenv("PERMITTED_CORS_ORIGINS", "")
+    legacy = os.getenv('PERMITTED_CORS_ORIGINS', '')
     if legacy:
-        return [o.strip() for o in legacy.split(",") if o.strip()]
+        return [o.strip() for o in legacy.split(',') if o.strip()]
     return []
 
 
@@ -115,7 +115,7 @@ def get_openhands_provider_base_url() -> str | None:
 
     Falls back to LLM_BASE_URL for backward compatibility.
     """
-    return os.getenv("OPENHANDS_PROVIDER_BASE_URL") or os.getenv("LLM_BASE_URL") or None
+    return os.getenv('OPENHANDS_PROVIDER_BASE_URL') or os.getenv('LLM_BASE_URL') or None
 
 
 def get_default_tavily_api_key() -> str | None:
@@ -123,13 +123,13 @@ def get_default_tavily_api_key() -> str | None:
 
     Falls back to SEARCH_API_KEY for backward compatibility.
     """
-    return os.getenv("TAVILY_API_KEY") or os.getenv("SEARCH_API_KEY") or None
+    return os.getenv('TAVILY_API_KEY') or os.getenv('SEARCH_API_KEY') or None
 
 
 # The SDK auto-fills this URL as the default for openhands/ and litellm_proxy/
 # models.  Deployments (e.g. staging) may use a different LLM proxy, configured
 # via OPENHANDS_PROVIDER_BASE_URL.
-_SDK_DEFAULT_PROXY = "https://llm-proxy.app.all-hands.dev/"
+_SDK_DEFAULT_PROXY = 'https://llm-proxy.app.all-hands.dev/'
 
 
 def resolve_provider_llm_base_url(
@@ -152,12 +152,12 @@ def resolve_provider_llm_base_url(
             ``get_openhands_provider_base_url()`` when *None*.
     """
     if not model or not (
-        model.startswith("openhands/") or model.startswith("litellm_proxy/")
+        model.startswith('openhands/') or model.startswith('litellm_proxy/')
     ):
         return base_url
 
-    user_set_custom = base_url and base_url.rstrip("/") != _SDK_DEFAULT_PROXY.rstrip(
-        "/"
+    user_set_custom = base_url and base_url.rstrip('/') != _SDK_DEFAULT_PROXY.rstrip(
+        '/'
     )
     if user_set_custom:
         return base_url
@@ -173,7 +173,7 @@ def resolve_provider_llm_base_url(
 def _get_default_lifespan():
     # Check legacy parameters for saas mode. If we are in SAAS mode use
     # SaasAppLifespanService to initialize PostHog analytics
-    if "saas" in (os.getenv("OPENHANDS_CONFIG_CLS") or "").lower():
+    if 'saas' in (os.getenv('OPENHANDS_CONFIG_CLS') or '').lower():
         from server.app_lifespan.saas_app_lifespan_service import (
             SaasAppLifespanService,
         )
@@ -192,23 +192,23 @@ class AppServerConfig(OpenHandsModel):
     file_store: FileStore = Field(default_factory=_get_default_file_store)
     web_url: str | None = Field(
         default_factory=get_default_web_url,
-        description="The URL where OpenHands is running (e.g., http://localhost:3000)",
+        description='The URL where OpenHands is running (e.g., http://localhost:3000)',
     )
     permitted_cors_origins: list[str] = Field(
         default_factory=get_default_permitted_cors_origins,
         description=(
-            "Additional permitted CORS origins for both the app server and agent "
-            "server containers. Configure via OH_PERMITTED_CORS_ORIGINS_0, _1, etc. "
-            "Falls back to legacy PERMITTED_CORS_ORIGINS env var."
+            'Additional permitted CORS origins for both the app server and agent '
+            'server containers. Configure via OH_PERMITTED_CORS_ORIGINS_0, _1, etc. '
+            'Falls back to legacy PERMITTED_CORS_ORIGINS env var.'
         ),
     )
     openhands_provider_base_url: str | None = Field(
         default_factory=get_openhands_provider_base_url,
-        description="Base URL for the OpenHands provider",
+        description='Base URL for the OpenHands provider',
     )
     tavily_api_key: str | None = Field(
         default_factory=get_default_tavily_api_key,
-        description="Tavily API key for search integration (proxied via MCP server)",
+        description='Tavily API key for search integration (proxied via MCP server)',
     )
     # Dependency Injection Injectors
     llm_model: LLMModelServiceInjector | None = None
@@ -287,7 +287,7 @@ def config_from_env() -> AppServerConfig:
         AuthUserContextInjector,
     )
 
-    config: AppServerConfig = from_env(AppServerConfig, "OH")  # type: ignore
+    config: AppServerConfig = from_env(AppServerConfig, 'OH')  # type: ignore
 
     if config.llm_model is None:
         from openhands.app_server.config_api.default_llm_model_service import (
@@ -295,17 +295,17 @@ def config_from_env() -> AppServerConfig:
         )
 
         llm_model_kwargs: dict = {}
-        aws_region = os.getenv("AWS_REGION_NAME")
-        aws_key = os.getenv("AWS_ACCESS_KEY_ID")
-        aws_secret = os.getenv("AWS_SECRET_ACCESS_KEY")
+        aws_region = os.getenv('AWS_REGION_NAME')
+        aws_key = os.getenv('AWS_ACCESS_KEY_ID')
+        aws_secret = os.getenv('AWS_SECRET_ACCESS_KEY')
         if aws_region and aws_key and aws_secret:
-            llm_model_kwargs["aws_region_name"] = aws_region
-            llm_model_kwargs["aws_access_key_id"] = SecretStr(aws_key)
-            llm_model_kwargs["aws_secret_access_key"] = SecretStr(aws_secret)
+            llm_model_kwargs['aws_region_name'] = aws_region
+            llm_model_kwargs['aws_access_key_id'] = SecretStr(aws_key)
+            llm_model_kwargs['aws_secret_access_key'] = SecretStr(aws_secret)
 
-        ollama_url = os.getenv("OLLAMA_BASE_URL")
+        ollama_url = os.getenv('OLLAMA_BASE_URL')
         if ollama_url:
-            llm_model_kwargs["ollama_base_url"] = ollama_url
+            llm_model_kwargs['ollama_base_url'] = ollama_url
 
         config.llm_model = DefaultLLMModelServiceInjector(**llm_model_kwargs)
 
@@ -314,18 +314,18 @@ def config_from_env() -> AppServerConfig:
 
         if provider == StorageProvider.AWS:
             # AWS S3 storage configuration
-            bucket_name = os.environ.get("FILE_STORE_PATH")
+            bucket_name = os.environ.get('FILE_STORE_PATH')
             if not bucket_name:
                 raise ValueError(
-                    "FILE_STORE_PATH environment variable is required for S3 storage"
+                    'FILE_STORE_PATH environment variable is required for S3 storage'
                 )
             config.event = AwsEventServiceInjector(bucket_name=bucket_name)
         elif provider == StorageProvider.GCP:
             # Google Cloud storage configuration
-            bucket_name = os.environ.get("FILE_STORE_PATH")
+            bucket_name = os.environ.get('FILE_STORE_PATH')
             if not bucket_name:
                 raise ValueError(
-                    "FILE_STORE_PATH environment variable is required for Google Cloud storage"
+                    'FILE_STORE_PATH environment variable is required for Google Cloud storage'
                 )
             config.event = GoogleCloudEventServiceInjector(bucket_name=bucket_name)
         else:
@@ -336,70 +336,70 @@ def config_from_env() -> AppServerConfig:
 
     if config.sandbox is None:
         # Legacy fallback
-        if os.getenv("RUNTIME") == "remote":
+        if os.getenv('RUNTIME') == 'remote':
             config.sandbox = RemoteSandboxServiceInjector(
-                api_key=os.environ["SANDBOX_API_KEY"],
-                api_url=os.environ["SANDBOX_REMOTE_RUNTIME_API_URL"],
+                api_key=os.environ['SANDBOX_API_KEY'],
+                api_url=os.environ['SANDBOX_REMOTE_RUNTIME_API_URL'],
             )
-        elif os.getenv("RUNTIME") == "boxd":
+        elif os.getenv('RUNTIME') == 'boxd':
             boxd_kwargs: dict[str, Any] = {}
-            if os.getenv("BOXD_API_KEY"):
-                boxd_kwargs["api_key"] = os.environ["BOXD_API_KEY"]
-            if os.getenv("BOXD_API_URL"):
-                boxd_kwargs["api_url"] = os.environ["BOXD_API_URL"]
-            if os.getenv("BOXD_AUTO_SUSPEND_TIMEOUT"):
-                boxd_kwargs["auto_suspend_timeout"] = int(
-                    os.environ["BOXD_AUTO_SUSPEND_TIMEOUT"]
+            if os.getenv('BOXD_API_KEY'):
+                boxd_kwargs['api_key'] = os.environ['BOXD_API_KEY']
+            if os.getenv('BOXD_API_URL'):
+                boxd_kwargs['api_url'] = os.environ['BOXD_API_URL']
+            if os.getenv('BOXD_AUTO_SUSPEND_TIMEOUT'):
+                boxd_kwargs['auto_suspend_timeout'] = int(
+                    os.environ['BOXD_AUTO_SUSPEND_TIMEOUT']
                 )
-            if os.getenv("BOXD_MAX_NUM_SANDBOXES"):
-                boxd_kwargs["max_num_sandboxes"] = int(
-                    os.environ["BOXD_MAX_NUM_SANDBOXES"]
+            if os.getenv('BOXD_MAX_NUM_SANDBOXES'):
+                boxd_kwargs['max_num_sandboxes'] = int(
+                    os.environ['BOXD_MAX_NUM_SANDBOXES']
                 )
-            if os.getenv("BOXD_VCPU"):
-                boxd_kwargs["vcpu"] = int(os.environ["BOXD_VCPU"])
-            if os.getenv("BOXD_MEMORY"):
-                boxd_kwargs["memory"] = os.environ["BOXD_MEMORY"]
-            if os.getenv("BOXD_DISK"):
-                boxd_kwargs["disk"] = os.environ["BOXD_DISK"]
+            if os.getenv('BOXD_VCPU'):
+                boxd_kwargs['vcpu'] = int(os.environ['BOXD_VCPU'])
+            if os.getenv('BOXD_MEMORY'):
+                boxd_kwargs['memory'] = os.environ['BOXD_MEMORY']
+            if os.getenv('BOXD_DISK'):
+                boxd_kwargs['disk'] = os.environ['BOXD_DISK']
             config.sandbox = BoxdSandboxServiceInjector(**boxd_kwargs)
-        elif os.getenv("RUNTIME") in ("local", "process"):
+        elif os.getenv('RUNTIME') in ('local', 'process'):
             config.sandbox = ProcessSandboxServiceInjector()
         else:
             # Support legacy environment variables for Docker sandbox configuration
             docker_sandbox_kwargs: dict = {}
-            if os.getenv("SANDBOX_HOST_PORT"):
-                docker_sandbox_kwargs["host_port"] = int(
-                    os.environ["SANDBOX_HOST_PORT"]
+            if os.getenv('SANDBOX_HOST_PORT'):
+                docker_sandbox_kwargs['host_port'] = int(
+                    os.environ['SANDBOX_HOST_PORT']
                 )
-            if os.getenv("SANDBOX_CONTAINER_URL_PATTERN"):
-                docker_sandbox_kwargs["container_url_pattern"] = os.environ[
-                    "SANDBOX_CONTAINER_URL_PATTERN"
+            if os.getenv('SANDBOX_CONTAINER_URL_PATTERN'):
+                docker_sandbox_kwargs['container_url_pattern'] = os.environ[
+                    'SANDBOX_CONTAINER_URL_PATTERN'
                 ]
             # Allow configuring sandbox startup grace period
             # This is useful for slower machines or cloud environments where
             # the agent-server container takes longer to initialize
-            if os.getenv("SANDBOX_STARTUP_GRACE_SECONDS"):
-                docker_sandbox_kwargs["startup_grace_seconds"] = int(
-                    os.environ["SANDBOX_STARTUP_GRACE_SECONDS"]
+            if os.getenv('SANDBOX_STARTUP_GRACE_SECONDS'):
+                docker_sandbox_kwargs['startup_grace_seconds'] = int(
+                    os.environ['SANDBOX_STARTUP_GRACE_SECONDS']
                 )
             # Parse SANDBOX_VOLUMES and convert to VolumeMount objects
             # This is set by the CLI's --mount-cwd flag
-            sandbox_volumes = os.getenv("SANDBOX_VOLUMES")
+            sandbox_volumes = os.getenv('SANDBOX_VOLUMES')
             if sandbox_volumes:
                 from openhands.app_server.sandbox.docker_sandbox_service import (
                     VolumeMount,
                 )
 
                 mounts = []
-                for mount_spec in sandbox_volumes.split(","):
+                for mount_spec in sandbox_volumes.split(','):
                     mount_spec = mount_spec.strip()
                     if not mount_spec:
                         continue
-                    parts = mount_spec.split(":")
+                    parts = mount_spec.split(':')
                     if len(parts) >= 2:
                         host_path = parts[0]
                         container_path = parts[1]
-                        mode = parts[2] if len(parts) > 2 else "rw"
+                        mode = parts[2] if len(parts) > 2 else 'rw'
                         mounts.append(
                             VolumeMount(
                                 host_path=host_path,
@@ -408,15 +408,15 @@ def config_from_env() -> AppServerConfig:
                             )
                         )
                 if mounts:
-                    docker_sandbox_kwargs["mounts"] = mounts
+                    docker_sandbox_kwargs['mounts'] = mounts
             config.sandbox = DockerSandboxServiceInjector(**docker_sandbox_kwargs)
 
     if config.sandbox_spec is None:
-        if os.getenv("RUNTIME") == "remote":
+        if os.getenv('RUNTIME') == 'remote':
             config.sandbox_spec = RemoteSandboxSpecServiceInjector()
-        elif os.getenv("RUNTIME") == "boxd":
+        elif os.getenv('RUNTIME') == 'boxd':
             config.sandbox_spec = BoxdSandboxSpecServiceInjector()
-        elif os.getenv("RUNTIME") in ("local", "process"):
+        elif os.getenv('RUNTIME') in ('local', 'process'):
             config.sandbox_spec = ProcessSandboxSpecServiceInjector()
         else:
             config.sandbox_spec = DockerSandboxSpecServiceInjector()

--- a/openhands/app_server/sandbox/README.md
+++ b/openhands/app_server/sandbox/README.md
@@ -17,5 +17,16 @@ Since agents can do things that may harm your system, they are typically run ins
 
 - Secure containerized execution environments
 - Sandbox lifecycle management (create, start, stop, destroy)
-- Multiple sandbox backend support (Docker, Remote, Local)
+- Multiple sandbox backend support (Docker, Remote, Local, boxd)
 - User-scoped sandbox access control
+
+## Backends
+
+| `RUNTIME=` | Class | Isolation | Use case |
+|---|---|---|---|
+| `docker` (default) | `DockerSandboxService` | Docker container | Local dev, single machine |
+| `remote` | `RemoteSandboxService` | All-Hands managed runtime | Managed cloud |
+| `local` / `process` | `ProcessSandboxService` | Local process | Minimal isolation, dev only |
+| `boxd` | `BoxdSandboxService` | KVM microVM | Self-hostable cloud with per-VM IPv4 + sub-ms warm suspend/resume |
+
+See `boxd-runtime.md` for the boxd setup guide.

--- a/openhands/app_server/sandbox/boxd-runtime.md
+++ b/openhands/app_server/sandbox/boxd-runtime.md
@@ -1,0 +1,100 @@
+# boxd Sandbox Runtime
+
+OpenHands can run agent conversations inside [boxd](https://boxd.sh) cloud
+microVMs. Each conversation gets a dedicated KVM-isolated VM with the
+OpenHands agent-server image and a public HTTPS proxy on port 60000.
+
+## When to use boxd
+
+- **Docker**: local dev, single machine.
+- **Remote**: managed cloud, no infra to run.
+- **boxd**: self-hostable cloud (open-source) with per-VM IPv4 and
+  sub-millisecond warm suspend/resume. Pause a conversation, return
+  a week later, the VM resumes with running processes intact.
+
+## Setup
+
+1. Install the boxd SDK (optional extra):
+
+   ```bash
+   pip install boxd
+   ```
+
+2. Get a boxd API key (`bxk_...`) from your boxd cluster — see
+   https://boxd.sh/docs for cluster setup.
+
+3. Set environment variables before starting the OpenHands server:
+
+   ```bash
+   export RUNTIME=boxd
+   export BOXD_API_KEY=bxk_...
+
+   # Optional — defaults shown
+   export BOXD_AUTO_SUSPEND_TIMEOUT=300   # seconds idle before warm-suspend
+   export BOXD_MAX_NUM_SANDBOXES=10       # per-user cap
+   export BOXD_VCPU=2                     # per-VM
+   export BOXD_MEMORY=8G                  # per-VM
+   export BOXD_DISK=100G                  # per-VM
+   ```
+
+4. Start OpenHands as normal.
+
+## What happens under the hood
+
+- Each conversation gets a VM named `oh-<sandbox-id>`.
+- The agent-server image is pulled by the boxd worker — no local
+  Docker pull on the OpenHands host.
+- Two HTTPS subdomain proxies are configured at boot:
+  - `agent-oh-<sandbox-id>.boxd.sh` → port 60000 (agent server)
+  - `vscode-oh-<sandbox-id>.boxd.sh` → port 60001 (VS Code server)
+- After `BOXD_AUTO_SUSPEND_TIMEOUT` seconds of inactivity, boxd
+  warm-suspends the VM. The next request resumes it in sub-millisecond
+  time, preserving running processes and filesystem state.
+
+## Persistence model
+
+A small SQLAlchemy table (`v1_boxd_sandbox`) indexes sandbox metadata
+(id, owning user, spec id, session-key hash, created_at). This mirrors
+the pattern used by `RemoteSandboxService` and is required because the
+boxd SDK doesn't expose environment variables on the returned `Box`
+object, so we can't recover metadata directly from the VM.
+
+The live VM state (running / suspended / etc.) is always fetched from
+boxd; the DB is the index, not the source of truth for status.
+
+## Security model
+
+- `session_api_key` is generated app-side, injected into the VM via
+  the `OH_SESSION_API_KEYS_0` env var, and indexed by SHA-256 hash
+  in the app DB. The raw key never persists on the OpenHands host.
+- On `pause_sandbox`, the stored hash is cleared so leaked keys can't
+  be replayed against the suspended VM until it's resumed.
+- `delete_sandbox` drops the index row first, then asks boxd to
+  destroy the VM. If boxd is unreachable, the row removal still
+  invalidates any leaked keys for that sandbox.
+
+## Known limitations (v1)
+
+- No webhook polling fallback. `RemoteSandboxService` runs a background
+  poller against agent servers when the OpenHands `web_url` is on
+  localhost; we don't yet. If you run boxd from a localhost OpenHands,
+  conversation events from the VM won't reach the app server in real
+  time. Provide a public `web_url` (and matching `OH_WEB_URL`) to use
+  webhook callbacks.
+- The boxd worker pulls the agent-server image lazily on first VM
+  creation. The default `wait_for_sandbox_running` timeout is 120
+  seconds; bump it for slow image registries.
+- Cross-user 404s on `get_sandbox` are deliberate: if you don't own
+  the sandbox, you get `None`, not a permission error.
+
+## Troubleshooting
+
+- **`SandboxError: Failed to start sandbox: ...`**: check that
+  `BOXD_API_KEY` is set and your boxd cluster is reachable.
+- **VM stuck in `STARTING`**: the boxd worker may still be pulling the
+  agent-server image. Watch `boxd box logs <vm>` from your local
+  `boxd` CLI for image-pull progress.
+- **Proxy URL 404**: the agent-server takes ~5–10 seconds to start
+  inside the VM. The app server waits via the `/alive` health check.
+- **OOM kills**: bump `BOXD_MEMORY`. Default 8G is enough for most
+  Python agents but tight for heavy multi-process workloads.

--- a/openhands/app_server/sandbox/boxd_sandbox_service.py
+++ b/openhands/app_server/sandbox/boxd_sandbox_service.py
@@ -1,0 +1,81 @@
+"""Sandbox service backed by boxd cloud microVMs.
+
+boxd (https://boxd.sh) runs each VM as a dedicated KVM process with
+sub-millisecond warm suspend/resume. Each conversation gets one boxd VM
+with the agent-server image installed and a subdomain proxy on port 60000.
+
+Persistent state model: v1 stores sandbox metadata (sandbox_spec_id,
+session_api_key hash, owning user) in the VM's env dict — there is no
+app-side SQL table. This trades a O(1) DB lookup for an O(N)
+``compute.box.list()`` scan on search, which is acceptable at boxd's
+default per-user VM quota.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, AsyncGenerator
+
+import base62
+from fastapi import Request
+from pydantic import Field
+
+from openhands.agent_server.utils import utc_now
+from openhands.app_server.errors import SandboxError
+from openhands.app_server.sandbox.sandbox_models import (
+    AGENT_SERVER,
+    VSCODE,
+    ExposedUrl,
+    SandboxInfo,
+    SandboxPage,
+    SandboxStatus,
+)
+from openhands.app_server.sandbox.sandbox_service import (
+    ALLOW_CORS_ORIGINS_VARIABLE,
+    SESSION_API_KEY_VARIABLE,
+    WEBHOOK_CALLBACK_VARIABLE,
+    SandboxService,
+    SandboxServiceInjector,
+)
+from openhands.app_server.sandbox.sandbox_spec_models import SandboxSpecInfo
+from openhands.app_server.sandbox.sandbox_spec_service import SandboxSpecService
+from openhands.app_server.services.injector import InjectorState
+from openhands.app_server.user.user_context import UserContext
+
+_logger = logging.getLogger(__name__)
+
+# boxd VM status → internal SandboxStatus. Lowercased keys; SDK returns
+# mixed-case strings, we normalize on read.
+STATUS_MAPPING: dict[str, SandboxStatus] = {
+    'running': SandboxStatus.RUNNING,
+    'suspended': SandboxStatus.PAUSED,
+    'starting': SandboxStatus.STARTING,
+    'creating': SandboxStatus.STARTING,
+    'error': SandboxStatus.ERROR,
+    'failed': SandboxStatus.ERROR,
+    'stopped': SandboxStatus.MISSING,
+    'destroyed': SandboxStatus.MISSING,
+}
+
+AGENT_SERVER_PORT = 60000
+VSCODE_PORT = 60001
+AGENT_PROXY_NAME = 'agent'
+VSCODE_PROXY_NAME = 'vscode'
+
+# Env keys stashed on each boxd VM so search/get can reconstruct
+# SandboxInfo without an app-side database.
+SPEC_ID_ENV = 'OH_SANDBOX_SPEC_ID'
+USER_ID_ENV = 'OH_CREATED_BY_USER_ID'
+SESSION_KEY_HASH_ENV = 'OH_SESSION_API_KEY_HASH'
+
+# All boxd VMs we create are prefixed with this so search/list can
+# distinguish ours from VMs created out-of-band by the same user.
+VM_NAME_PREFIX = 'oh-'
+
+
+def _hash_session_api_key(session_api_key: str) -> str:
+    """SHA-256 of the session API key for storage in the box's env dict."""
+    return hashlib.sha256(session_api_key.encode()).hexdigest()

--- a/openhands/app_server/sandbox/boxd_sandbox_service.py
+++ b/openhands/app_server/sandbox/boxd_sandbox_service.py
@@ -60,24 +60,24 @@ _logger = logging.getLogger(__name__)
 # boxd VM status → internal SandboxStatus. Lowercased keys; SDK returns
 # mixed-case strings, we normalize on read.
 STATUS_MAPPING: dict[str, SandboxStatus] = {
-    'running': SandboxStatus.RUNNING,
-    'suspended': SandboxStatus.PAUSED,
-    'starting': SandboxStatus.STARTING,
-    'creating': SandboxStatus.STARTING,
-    'error': SandboxStatus.ERROR,
-    'failed': SandboxStatus.ERROR,
-    'stopped': SandboxStatus.MISSING,
-    'destroyed': SandboxStatus.MISSING,
+    "running": SandboxStatus.RUNNING,
+    "suspended": SandboxStatus.PAUSED,
+    "starting": SandboxStatus.STARTING,
+    "creating": SandboxStatus.STARTING,
+    "error": SandboxStatus.ERROR,
+    "failed": SandboxStatus.ERROR,
+    "stopped": SandboxStatus.MISSING,
+    "destroyed": SandboxStatus.MISSING,
 }
 
 AGENT_SERVER_PORT = 60000
 VSCODE_PORT = 60001
-AGENT_PROXY_NAME = 'agent'
-VSCODE_PROXY_NAME = 'vscode'
+AGENT_PROXY_NAME = "agent"
+VSCODE_PROXY_NAME = "vscode"
 
 # All boxd VMs we create are prefixed so search/list can distinguish
 # ours from VMs created out-of-band by the same user.
-VM_NAME_PREFIX = 'oh-'
+VM_NAME_PREFIX = "oh-"
 
 
 class StoredBoxdSandbox(Base):
@@ -89,7 +89,7 @@ class StoredBoxdSandbox(Base):
     the pattern used by ``StoredRemoteSandbox``.
     """
 
-    __tablename__ = 'v1_boxd_sandbox'
+    __tablename__ = "v1_boxd_sandbox"
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
     created_by_user_id: Mapped[str | None] = mapped_column(
@@ -112,7 +112,7 @@ class BoxdSandboxService(SandboxService):
     """
 
     sandbox_spec_service: SandboxSpecService
-    compute: 'Compute'
+    compute: "Compute"
     web_url: str | None
     max_num_sandboxes: int
     auto_suspend_timeout: int
@@ -177,16 +177,14 @@ class BoxdSandboxService(SandboxService):
         for (name, port), result in zip(proxies, results):
             if isinstance(result, Exception):
                 _logger.warning(
-                    'create_proxy(%s, port=%d) on box %s failed: %s',
+                    "create_proxy(%s, port=%d) on box %s failed: %s",
                     name,
                     port,
-                    getattr(box, 'id', '?'),
+                    getattr(box, "id", "?"),
                     result,
                 )
 
-    async def _build_environment(
-        self, sandbox_spec: SandboxSpecInfo
-    ) -> dict[str, str]:
+    async def _build_environment(self, sandbox_spec: SandboxSpecInfo) -> dict[str, str]:
         """Compose the env dict the box will boot with.
 
         Note: app-side metadata (spec_id, owner) lives in the DB, not the
@@ -194,14 +192,14 @@ class BoxdSandboxService(SandboxService):
         """
         env = dict(sandbox_spec.initial_env)
         if self.web_url:
-            env[WEBHOOK_CALLBACK_VARIABLE] = f'{self.web_url}/api/v1/webhooks'
+            env[WEBHOOK_CALLBACK_VARIABLE] = f"{self.web_url}/api/v1/webhooks"
             env[ALLOW_CORS_ORIGINS_VARIABLE] = self.web_url
         return env
 
     def _derive_status(self, box: Any | None) -> SandboxStatus:
         if box is None:
             return SandboxStatus.MISSING
-        raw = (getattr(box, 'status', '') or '').lower()
+        raw = (getattr(box, "status", "") or "").lower()
         return STATUS_MAPPING.get(raw, SandboxStatus.ERROR)
 
     _PROXY_TO_URL_NAME = {
@@ -217,13 +215,17 @@ class BoxdSandboxService(SandboxService):
     ) -> SandboxInfo:
         """Project (stored row, optional live Box) into a SandboxInfo."""
         status = self._derive_status(box)
-        exposed_urls = await self._exposed_urls(box) if status == SandboxStatus.RUNNING else None
+        exposed_urls = (
+            await self._exposed_urls(box) if status == SandboxStatus.RUNNING else None
+        )
         return SandboxInfo(
             id=stored.id,
             created_by_user_id=stored.created_by_user_id,
             sandbox_spec_id=stored.sandbox_spec_id,
             status=status,
-            session_api_key=session_api_key if status == SandboxStatus.RUNNING else None,
+            session_api_key=session_api_key
+            if status == SandboxStatus.RUNNING
+            else None,
             exposed_urls=exposed_urls,
             created_at=stored.created_at,
         )
@@ -235,8 +237,8 @@ class BoxdSandboxService(SandboxService):
             proxies = await box.proxies()
         except Exception as exc:
             _logger.warning(
-                'Failed to list proxies on box %s: %s',
-                getattr(box, 'id', '?'),
+                "Failed to list proxies on box %s: %s",
+                getattr(box, "id", "?"),
                 exc,
             )
             return []
@@ -247,7 +249,7 @@ class BoxdSandboxService(SandboxService):
                 continue
             url_name, port = mapping
             urls.append(
-                ExposedUrl(name=url_name, url=f'https://{proxy.domain}', port=port)
+                ExposedUrl(name=url_name, url=f"https://{proxy.domain}", port=port)
             )
         return urls
 
@@ -255,7 +257,7 @@ class BoxdSandboxService(SandboxService):
         """Fetch the boxd VM, swallowing NotFound. Other errors propagate."""
         from boxd.aio import NotFoundError
 
-        vm_name = f'{VM_NAME_PREFIX}{sandbox_id}'
+        vm_name = f"{VM_NAME_PREFIX}{sandbox_id}"
         try:
             return await self.compute.box.get(vm_name)
         except NotFoundError:
@@ -278,12 +280,12 @@ class BoxdSandboxService(SandboxService):
                 sandbox_spec_id
             )
             if sandbox_spec_maybe is None:
-                raise SandboxError(f'Sandbox spec not found: {sandbox_spec_id}')
+                raise SandboxError(f"Sandbox spec not found: {sandbox_spec_id}")
             sandbox_spec = sandbox_spec_maybe
 
         if sandbox_id is None:
             sandbox_id = base62.encodebytes(os.urandom(16))
-        vm_name = f'{VM_NAME_PREFIX}{sandbox_id}'
+        vm_name = f"{VM_NAME_PREFIX}{sandbox_id}"
 
         user_id = await self.user_context.get_user_id()
         env = await self._build_environment(sandbox_spec)
@@ -314,17 +316,15 @@ class BoxdSandboxService(SandboxService):
                 image=sandbox_spec.id,
             )
         except BoxdError as exc:
-            _logger.error('Failed to create boxd VM %s: %s', vm_name, exc)
-            raise SandboxError(f'Failed to start sandbox: {exc}')
+            _logger.error("Failed to create boxd VM %s: %s", vm_name, exc)
+            raise SandboxError(f"Failed to start sandbox: {exc}")
 
         await self._ensure_named_proxies(box)
 
         _logger.info(
-            'Started boxd sandbox %s (vm=%s)', sandbox_id, getattr(box, 'id', '?')
+            "Started boxd sandbox %s (vm=%s)", sandbox_id, getattr(box, "id", "?")
         )
-        return await self._to_sandbox_info(
-            stored, box, session_api_key=session_api_key
-        )
+        return await self._to_sandbox_info(stored, box, session_api_key=session_api_key)
 
     async def get_sandbox(self, sandbox_id: str) -> SandboxInfo | None:
         stored = await self._get_stored(sandbox_id)
@@ -384,9 +384,7 @@ class BoxdSandboxService(SandboxService):
         if stored is None:
             return None
         box = await self._get_box_or_none(stored.id)
-        return await self._to_sandbox_info(
-            stored, box, session_api_key=session_api_key
-        )
+        return await self._to_sandbox_info(stored, box, session_api_key=session_api_key)
 
     async def pause_sandbox(self, sandbox_id: str) -> bool:
         stored = await self._get_stored(sandbox_id)
@@ -404,7 +402,7 @@ class BoxdSandboxService(SandboxService):
             await box.suspend()
             return True
         except Exception as exc:
-            _logger.error('Failed to suspend boxd sandbox %s: %s', sandbox_id, exc)
+            _logger.error("Failed to suspend boxd sandbox %s: %s", sandbox_id, exc)
             return False
 
     async def resume_sandbox(self, sandbox_id: str) -> bool:
@@ -420,7 +418,7 @@ class BoxdSandboxService(SandboxService):
             await box.resume()
             return True
         except Exception as exc:
-            _logger.error('Failed to resume boxd sandbox %s: %s', sandbox_id, exc)
+            _logger.error("Failed to resume boxd sandbox %s: %s", sandbox_id, exc)
             return False
 
     async def delete_sandbox(self, sandbox_id: str) -> bool:
@@ -433,7 +431,7 @@ class BoxdSandboxService(SandboxService):
             try:
                 await box.destroy()
             except Exception as exc:
-                _logger.error('Failed to destroy boxd sandbox %s: %s', sandbox_id, exc)
+                _logger.error("Failed to destroy boxd sandbox %s: %s", sandbox_id, exc)
                 destroy_ok = False
         # Always drop the row — even on destroy failure this invalidates
         # the leaked session_api_key_hash and stops the sandbox from
@@ -449,28 +447,27 @@ class BoxdSandboxServiceInjector(SandboxServiceInjector):
     api_key: str | None = Field(
         default=None,
         description=(
-            'boxd API key (e.g. bxk_...). If unset, the boxd SDK falls '
-            'back to the BOXD_API_KEY environment variable.'
+            "boxd API key (e.g. bxk_...). If unset, the boxd SDK falls "
+            "back to the BOXD_API_KEY environment variable."
         ),
     )
     api_url: str | None = Field(
         default=None,
-        description='Optional boxd control-plane URL (defaults to the SDK default).',
+        description="Optional boxd control-plane URL (defaults to the SDK default).",
     )
     auto_suspend_timeout: int = Field(
         default=300,
         description=(
-            'Seconds of inactivity before boxd warm-suspends the VM '
-            '(sub-ms resume).'
+            "Seconds of inactivity before boxd warm-suspends the VM (sub-ms resume)."
         ),
     )
     max_num_sandboxes: int = Field(
         default=10,
-        description='Maximum number of running sandboxes per user.',
+        description="Maximum number of running sandboxes per user.",
     )
-    vcpu: int = Field(default=2, description='vCPUs per VM.')
-    memory: str = Field(default='8G', description='Memory per VM (boxd size string).')
-    disk: str = Field(default='100G', description='Disk per VM (boxd size string).')
+    vcpu: int = Field(default=2, description="vCPUs per VM.")
+    memory: str = Field(default="8G", description="Memory per VM (boxd size string).")
+    disk: str = Field(default="100G", description="Disk per VM (boxd size string).")
 
     async def inject(
         self, state: InjectorState, request: Request | None = None
@@ -490,9 +487,9 @@ class BoxdSandboxServiceInjector(SandboxServiceInjector):
 
         compute_kwargs: dict[str, Any] = {}
         if self.api_key:
-            compute_kwargs['api_key'] = self.api_key
+            compute_kwargs["api_key"] = self.api_key
         if self.api_url:
-            compute_kwargs['api_url'] = self.api_url
+            compute_kwargs["api_url"] = self.api_url
 
         async with (
             get_user_context(state, request) as user_context,

--- a/openhands/app_server/sandbox/boxd_sandbox_service.py
+++ b/openhands/app_server/sandbox/boxd_sandbox_service.py
@@ -14,12 +14,12 @@ for VM status.
 
 from __future__ import annotations
 
-import hashlib
+import asyncio
 import logging
 import os
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, AsyncGenerator
+from typing import TYPE_CHECKING, Any, AsyncGenerator
 
 import base62
 from fastapi import Request
@@ -30,6 +30,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from openhands.agent_server.utils import utc_now
 from openhands.app_server.errors import SandboxError
+from openhands.app_server.sandbox.remote_sandbox_service import _hash_session_api_key
 from openhands.app_server.sandbox.sandbox_models import (
     AGENT_SERVER,
     VSCODE,
@@ -50,6 +51,9 @@ from openhands.app_server.sandbox.sandbox_spec_service import SandboxSpecService
 from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.user.user_context import UserContext
 from openhands.app_server.utils.sql_utils import Base, UtcDateTime
+
+if TYPE_CHECKING:
+    from boxd.aio import Compute
 
 _logger = logging.getLogger(__name__)
 
@@ -74,11 +78,6 @@ VSCODE_PROXY_NAME = 'vscode'
 # All boxd VMs we create are prefixed so search/list can distinguish
 # ours from VMs created out-of-band by the same user.
 VM_NAME_PREFIX = 'oh-'
-
-
-def _hash_session_api_key(session_api_key: str) -> str:
-    """SHA-256 of the session API key for indexed lookup."""
-    return hashlib.sha256(session_api_key.encode()).hexdigest()
 
 
 class StoredBoxdSandbox(Base):
@@ -113,7 +112,7 @@ class BoxdSandboxService(SandboxService):
     """
 
     sandbox_spec_service: SandboxSpecService
-    compute: Any  # boxd.Compute — typed Any so the SDK isn't a hard import
+    compute: 'Compute'
     web_url: str | None
     max_num_sandboxes: int
     auto_suspend_timeout: int
@@ -163,22 +162,26 @@ class BoxdSandboxService(SandboxService):
     async def _ensure_named_proxies(self, box: Any) -> None:
         """Create the agent + vscode subdomain proxies on a fresh VM.
 
-        Idempotent: if a proxy with the same name already exists boxd will
-        return an error which we log and continue past.
+        Independent RPCs are gathered. Per-proxy failures are logged and
+        swallowed so a partial proxy state never blocks the VM coming up
+        (e.g. if one proxy already exists from a prior crash).
         """
-        for name, port in (
+        proxies = (
             (AGENT_PROXY_NAME, AGENT_SERVER_PORT),
             (VSCODE_PROXY_NAME, VSCODE_PORT),
-        ):
-            try:
-                await box.create_proxy(name, port=port)
-            except Exception as exc:
+        )
+        results = await asyncio.gather(
+            *(box.create_proxy(name, port=port) for name, port in proxies),
+            return_exceptions=True,
+        )
+        for (name, port), result in zip(proxies, results):
+            if isinstance(result, Exception):
                 _logger.warning(
                     'create_proxy(%s, port=%d) on box %s failed: %s',
                     name,
                     port,
                     getattr(box, 'id', '?'),
-                    exc,
+                    result,
                 )
 
     async def _build_environment(
@@ -201,6 +204,11 @@ class BoxdSandboxService(SandboxService):
         raw = (getattr(box, 'status', '') or '').lower()
         return STATUS_MAPPING.get(raw, SandboxStatus.ERROR)
 
+    _PROXY_TO_URL_NAME = {
+        AGENT_PROXY_NAME: (AGENT_SERVER, AGENT_SERVER_PORT),
+        VSCODE_PROXY_NAME: (VSCODE, VSCODE_PORT),
+    }
+
     async def _to_sandbox_info(
         self,
         stored: StoredBoxdSandbox,
@@ -209,48 +217,39 @@ class BoxdSandboxService(SandboxService):
     ) -> SandboxInfo:
         """Project (stored row, optional live Box) into a SandboxInfo."""
         status = self._derive_status(box)
-
-        exposed_urls: list[ExposedUrl] | None = None
-        if status == SandboxStatus.RUNNING and box is not None:
-            exposed_urls = []
-            try:
-                proxies = await box.proxies()
-            except Exception as exc:
-                _logger.warning(
-                    'Failed to list proxies on box %s: %s',
-                    getattr(box, 'id', '?'),
-                    exc,
-                )
-                proxies = []
-            for proxy in proxies:
-                if proxy.name == AGENT_PROXY_NAME:
-                    exposed_urls.append(
-                        ExposedUrl(
-                            name=AGENT_SERVER,
-                            url=f'https://{proxy.domain}',
-                            port=AGENT_SERVER_PORT,
-                        )
-                    )
-                elif proxy.name == VSCODE_PROXY_NAME:
-                    exposed_urls.append(
-                        ExposedUrl(
-                            name=VSCODE,
-                            url=f'https://{proxy.domain}',
-                            port=VSCODE_PORT,
-                        )
-                    )
-
+        exposed_urls = await self._exposed_urls(box) if status == SandboxStatus.RUNNING else None
         return SandboxInfo(
             id=stored.id,
             created_by_user_id=stored.created_by_user_id,
             sandbox_spec_id=stored.sandbox_spec_id,
             status=status,
-            session_api_key=session_api_key
-            if status == SandboxStatus.RUNNING
-            else None,
+            session_api_key=session_api_key if status == SandboxStatus.RUNNING else None,
             exposed_urls=exposed_urls,
             created_at=stored.created_at,
         )
+
+    async def _exposed_urls(self, box: Any | None) -> list[ExposedUrl]:
+        if box is None:
+            return []
+        try:
+            proxies = await box.proxies()
+        except Exception as exc:
+            _logger.warning(
+                'Failed to list proxies on box %s: %s',
+                getattr(box, 'id', '?'),
+                exc,
+            )
+            return []
+        urls: list[ExposedUrl] = []
+        for proxy in proxies:
+            mapping = self._PROXY_TO_URL_NAME.get(proxy.name)
+            if mapping is None:
+                continue
+            url_name, port = mapping
+            urls.append(
+                ExposedUrl(name=url_name, url=f'https://{proxy.domain}', port=port)
+            )
+        return urls
 
     async def _get_box_or_none(self, sandbox_id: str) -> Any | None:
         """Fetch the boxd VM, swallowing NotFound. Other errors propagate."""
@@ -360,12 +359,19 @@ class BoxdSandboxService(SandboxService):
 
         next_page_id = str(offset + limit) if has_more else None
 
-        items: list[SandboxInfo] = []
-        for stored in stored_rows:
-            box = await self._get_box_or_none(stored.id)
-            items.append(await self._to_sandbox_info(stored, box))
-
-        return SandboxPage(items=items, next_page_id=next_page_id)
+        # Fan out the per-row boxd lookups so a page of N is one round-trip
+        # of latency, not N. boxd doesn't expose a batch-get; this is the
+        # next-best thing.
+        boxes = await asyncio.gather(
+            *(self._get_box_or_none(stored.id) for stored in stored_rows)
+        )
+        items = await asyncio.gather(
+            *(
+                self._to_sandbox_info(stored, box)
+                for stored, box in zip(stored_rows, boxes)
+            )
+        )
+        return SandboxPage(items=list(items), next_page_id=next_page_id)
 
     async def get_sandbox_by_session_api_key(
         self, session_api_key: str
@@ -421,20 +427,20 @@ class BoxdSandboxService(SandboxService):
         stored = await self._get_stored(sandbox_id)
         if stored is None:
             return False
-        # Drop the row first — deleting the session_api_key_hash
-        # invalidates leaked keys even if the boxd call fails.
-        await self.db_session.delete(stored)
         box = await self._get_box_or_none(sandbox_id)
-        if box is None:
-            # VM was already gone or unreachable; the row removal is
-            # still useful (cleans up our index).
-            return True
-        try:
-            await box.destroy()
-            return True
-        except Exception as exc:
-            _logger.error('Failed to destroy boxd sandbox %s: %s', sandbox_id, exc)
-            return False
+        destroy_ok = True
+        if box is not None:
+            try:
+                await box.destroy()
+            except Exception as exc:
+                _logger.error('Failed to destroy boxd sandbox %s: %s', sandbox_id, exc)
+                destroy_ok = False
+        # Always drop the row — even on destroy failure this invalidates
+        # the leaked session_api_key_hash and stops the sandbox from
+        # showing up in subsequent searches. The user can retry destroy
+        # via the boxd CLI if needed.
+        await self.db_session.delete(stored)
+        return destroy_ok
 
 
 class BoxdSandboxServiceInjector(SandboxServiceInjector):

--- a/openhands/app_server/sandbox/boxd_sandbox_service.py
+++ b/openhands/app_server/sandbox/boxd_sandbox_service.py
@@ -142,8 +142,14 @@ class BoxdSandboxService(SandboxService):
     def _build_box_config(
         self, sandbox_spec: SandboxSpecInfo, env: dict[str, str]
     ) -> Any:
-        """Build a BoxConfig matching our standard agent-server shape."""
-        from boxd import BoxConfig, LifecycleConfig, NetworkConfig, ProxyEntry
+        """Build a BoxConfig matching our standard agent-server shape.
+
+        Note: named subdomain proxies are created post-boot via
+        ``box.create_proxy(...)``; passing them through
+        ``NetworkConfig.proxies`` is silently ignored by the current boxd
+        server (only the default catch-all proxy is auto-created).
+        """
+        from boxd.aio import BoxConfig, LifecycleConfig
 
         return BoxConfig(
             vcpu=self.vcpu,
@@ -152,14 +158,28 @@ class BoxdSandboxService(SandboxService):
             env=env,
             cmd=sandbox_spec.command,
             lifecycle=LifecycleConfig(auto_suspend_timeout=self.auto_suspend_timeout),
-            network=NetworkConfig(
-                ssh=True,
-                proxies=[
-                    ProxyEntry(name=AGENT_PROXY_NAME, port=AGENT_SERVER_PORT),
-                    ProxyEntry(name=VSCODE_PROXY_NAME, port=VSCODE_PORT),
-                ],
-            ),
         )
+
+    async def _ensure_named_proxies(self, box: Any) -> None:
+        """Create the agent + vscode subdomain proxies on a fresh VM.
+
+        Idempotent: if a proxy with the same name already exists boxd will
+        return an error which we log and continue past.
+        """
+        for name, port in (
+            (AGENT_PROXY_NAME, AGENT_SERVER_PORT),
+            (VSCODE_PROXY_NAME, VSCODE_PORT),
+        ):
+            try:
+                await box.create_proxy(name, port=port)
+            except Exception as exc:
+                _logger.warning(
+                    'create_proxy(%s, port=%d) on box %s failed: %s',
+                    name,
+                    port,
+                    getattr(box, 'id', '?'),
+                    exc,
+                )
 
     async def _build_environment(
         self, sandbox_spec: SandboxSpecInfo
@@ -181,7 +201,7 @@ class BoxdSandboxService(SandboxService):
         raw = (getattr(box, 'status', '') or '').lower()
         return STATUS_MAPPING.get(raw, SandboxStatus.ERROR)
 
-    def _to_sandbox_info(
+    async def _to_sandbox_info(
         self,
         stored: StoredBoxdSandbox,
         box: Any | None,
@@ -194,7 +214,7 @@ class BoxdSandboxService(SandboxService):
         if status == SandboxStatus.RUNNING and box is not None:
             exposed_urls = []
             try:
-                proxies = box.proxies()
+                proxies = await box.proxies()
             except Exception as exc:
                 _logger.warning(
                     'Failed to list proxies on box %s: %s',
@@ -232,13 +252,13 @@ class BoxdSandboxService(SandboxService):
             created_at=stored.created_at,
         )
 
-    def _get_box_or_none(self, sandbox_id: str) -> Any | None:
+    async def _get_box_or_none(self, sandbox_id: str) -> Any | None:
         """Fetch the boxd VM, swallowing NotFound. Other errors propagate."""
-        from boxd.errors import NotFoundError
+        from boxd.aio import NotFoundError
 
         vm_name = f'{VM_NAME_PREFIX}{sandbox_id}'
         try:
-            return self.compute.box.get(vm_name)
+            return await self.compute.box.get(vm_name)
         except NotFoundError:
             return None
 
@@ -247,7 +267,7 @@ class BoxdSandboxService(SandboxService):
     async def start_sandbox(
         self, sandbox_spec_id: str | None = None, sandbox_id: str | None = None
     ) -> SandboxInfo:
-        from boxd.errors import BoxdError
+        from boxd.aio import BoxdError
 
         # Enforce per-user sandbox limits before creating another.
         await self.pause_old_sandboxes(self.max_num_sandboxes - 1)
@@ -289,7 +309,7 @@ class BoxdSandboxService(SandboxService):
         config = self._build_box_config(sandbox_spec, env)
 
         try:
-            box = self.compute.box.create(
+            box = await self.compute.box.create(
                 name=vm_name,
                 config=config,
                 image=sandbox_spec.id,
@@ -298,17 +318,21 @@ class BoxdSandboxService(SandboxService):
             _logger.error('Failed to create boxd VM %s: %s', vm_name, exc)
             raise SandboxError(f'Failed to start sandbox: {exc}')
 
+        await self._ensure_named_proxies(box)
+
         _logger.info(
             'Started boxd sandbox %s (vm=%s)', sandbox_id, getattr(box, 'id', '?')
         )
-        return self._to_sandbox_info(stored, box, session_api_key=session_api_key)
+        return await self._to_sandbox_info(
+            stored, box, session_api_key=session_api_key
+        )
 
     async def get_sandbox(self, sandbox_id: str) -> SandboxInfo | None:
         stored = await self._get_stored(sandbox_id)
         if stored is None:
             return None
-        box = self._get_box_or_none(sandbox_id)
-        return self._to_sandbox_info(stored, box)
+        box = await self._get_box_or_none(sandbox_id)
+        return await self._to_sandbox_info(stored, box)
 
     async def search_sandboxes(
         self, page_id: str | None = None, limit: int = 100
@@ -338,8 +362,8 @@ class BoxdSandboxService(SandboxService):
 
         items: list[SandboxInfo] = []
         for stored in stored_rows:
-            box = self._get_box_or_none(stored.id)
-            items.append(self._to_sandbox_info(stored, box))
+            box = await self._get_box_or_none(stored.id)
+            items.append(await self._to_sandbox_info(stored, box))
 
         return SandboxPage(items=items, next_page_id=next_page_id)
 
@@ -353,14 +377,16 @@ class BoxdSandboxService(SandboxService):
         stored = result.scalar_one_or_none()
         if stored is None:
             return None
-        box = self._get_box_or_none(stored.id)
-        return self._to_sandbox_info(stored, box, session_api_key=session_api_key)
+        box = await self._get_box_or_none(stored.id)
+        return await self._to_sandbox_info(
+            stored, box, session_api_key=session_api_key
+        )
 
     async def pause_sandbox(self, sandbox_id: str) -> bool:
         stored = await self._get_stored(sandbox_id)
         if stored is None:
             return False
-        box = self._get_box_or_none(sandbox_id)
+        box = await self._get_box_or_none(sandbox_id)
         if box is None:
             return False
         # Security: invalidate the session key hash so leaked keys can't
@@ -369,7 +395,7 @@ class BoxdSandboxService(SandboxService):
         # restore the hash.
         stored.session_api_key_hash = None
         try:
-            box.suspend()
+            await box.suspend()
             return True
         except Exception as exc:
             _logger.error('Failed to suspend boxd sandbox %s: %s', sandbox_id, exc)
@@ -381,11 +407,11 @@ class BoxdSandboxService(SandboxService):
         stored = await self._get_stored(sandbox_id)
         if stored is None:
             return False
-        box = self._get_box_or_none(sandbox_id)
+        box = await self._get_box_or_none(sandbox_id)
         if box is None:
             return False
         try:
-            box.resume()
+            await box.resume()
             return True
         except Exception as exc:
             _logger.error('Failed to resume boxd sandbox %s: %s', sandbox_id, exc)
@@ -398,13 +424,13 @@ class BoxdSandboxService(SandboxService):
         # Drop the row first — deleting the session_api_key_hash
         # invalidates leaked keys even if the boxd call fails.
         await self.db_session.delete(stored)
-        box = self._get_box_or_none(sandbox_id)
+        box = await self._get_box_or_none(sandbox_id)
         if box is None:
             # VM was already gone or unreachable; the row removal is
             # still useful (cleans up our index).
             return True
         try:
-            box.destroy()
+            await box.destroy()
             return True
         except Exception as exc:
             _logger.error('Failed to destroy boxd sandbox %s: %s', sandbox_id, exc)
@@ -443,7 +469,7 @@ class BoxdSandboxServiceInjector(SandboxServiceInjector):
     async def inject(
         self, state: InjectorState, request: Request | None = None
     ) -> AsyncGenerator[SandboxService, None]:
-        from boxd import Compute
+        from boxd.aio import Compute
 
         # Defer to break the circular path with config.py.
         from openhands.app_server.config import (
@@ -466,21 +492,17 @@ class BoxdSandboxServiceInjector(SandboxServiceInjector):
             get_user_context(state, request) as user_context,
             get_sandbox_spec_service(state, request) as sandbox_spec_service,
             get_db_session(state, request) as db_session,
+            Compute(**compute_kwargs) as compute,
         ):
-            compute = Compute(**compute_kwargs)
-            try:
-                yield BoxdSandboxService(
-                    sandbox_spec_service=sandbox_spec_service,
-                    compute=compute,
-                    web_url=web_url,
-                    max_num_sandboxes=self.max_num_sandboxes,
-                    auto_suspend_timeout=self.auto_suspend_timeout,
-                    vcpu=self.vcpu,
-                    memory=self.memory,
-                    disk=self.disk,
-                    user_context=user_context,
-                    db_session=db_session,
-                )
-            finally:
-                if hasattr(compute, 'close'):
-                    compute.close()
+            yield BoxdSandboxService(
+                sandbox_spec_service=sandbox_spec_service,
+                compute=compute,
+                web_url=web_url,
+                max_num_sandboxes=self.max_num_sandboxes,
+                auto_suspend_timeout=self.auto_suspend_timeout,
+                vcpu=self.vcpu,
+                memory=self.memory,
+                disk=self.disk,
+                user_context=user_context,
+                db_session=db_session,
+            )

--- a/openhands/app_server/sandbox/boxd_sandbox_service.py
+++ b/openhands/app_server/sandbox/boxd_sandbox_service.py
@@ -4,11 +4,12 @@ boxd (https://boxd.sh) runs each VM as a dedicated KVM process with
 sub-millisecond warm suspend/resume. Each conversation gets one boxd VM
 with the agent-server image installed and a subdomain proxy on port 60000.
 
-Persistent state model: v1 stores sandbox metadata (sandbox_spec_id,
-session_api_key hash, owning user) in the VM's env dict — there is no
-app-side SQL table. This trades a O(1) DB lookup for an O(N)
-``compute.box.list()`` scan on search, which is acceptable at boxd's
-default per-user VM quota.
+Persistence model: we mirror :class:`RemoteSandboxService` — sandbox
+metadata (id, owning user, spec id, session-key hash, created_at) lives
+in a small SQLAlchemy table; the live VM state comes from the boxd SDK.
+This keeps fast (indexed) lookups for ``get_sandbox_by_session_api_key``
+and ``search_sandboxes`` while letting boxd remain the source of truth
+for VM status.
 """
 
 from __future__ import annotations
@@ -17,11 +18,15 @@ import hashlib
 import logging
 import os
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, AsyncGenerator
 
 import base62
 from fastapi import Request
 from pydantic import Field
+from sqlalchemy import String, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
 
 from openhands.agent_server.utils import utc_now
 from openhands.app_server.errors import SandboxError
@@ -44,6 +49,7 @@ from openhands.app_server.sandbox.sandbox_spec_models import SandboxSpecInfo
 from openhands.app_server.sandbox.sandbox_spec_service import SandboxSpecService
 from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.user.user_context import UserContext
+from openhands.app_server.utils.sql_utils import Base, UtcDateTime
 
 _logger = logging.getLogger(__name__)
 
@@ -65,17 +71,416 @@ VSCODE_PORT = 60001
 AGENT_PROXY_NAME = 'agent'
 VSCODE_PROXY_NAME = 'vscode'
 
-# Env keys stashed on each boxd VM so search/get can reconstruct
-# SandboxInfo without an app-side database.
-SPEC_ID_ENV = 'OH_SANDBOX_SPEC_ID'
-USER_ID_ENV = 'OH_CREATED_BY_USER_ID'
-SESSION_KEY_HASH_ENV = 'OH_SESSION_API_KEY_HASH'
-
-# All boxd VMs we create are prefixed with this so search/list can
-# distinguish ours from VMs created out-of-band by the same user.
+# All boxd VMs we create are prefixed so search/list can distinguish
+# ours from VMs created out-of-band by the same user.
 VM_NAME_PREFIX = 'oh-'
 
 
 def _hash_session_api_key(session_api_key: str) -> str:
-    """SHA-256 of the session API key for storage in the box's env dict."""
+    """SHA-256 of the session API key for indexed lookup."""
     return hashlib.sha256(session_api_key.encode()).hexdigest()
+
+
+class StoredBoxdSandbox(Base):
+    """App-side index of boxd sandboxes.
+
+    The boxd SDK doesn't expose enough metadata on the Box object to
+    reconstruct a SandboxInfo (no env, no created_at), and listing all
+    user VMs to filter by session API key is O(N). This table mirrors
+    the pattern used by ``StoredRemoteSandbox``.
+    """
+
+    __tablename__ = 'v1_boxd_sandbox'
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    created_by_user_id: Mapped[str | None] = mapped_column(
+        String, nullable=True, index=True
+    )
+    sandbox_spec_id: Mapped[str] = mapped_column(String, index=True)
+    session_api_key_hash: Mapped[str | None] = mapped_column(
+        String, nullable=True, index=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        UtcDateTime, server_default=func.now(), index=True
+    )
+
+
+@dataclass
+class BoxdSandboxService(SandboxService):
+    """Sandbox service backed by boxd cloud microVMs.
+
+    See the module docstring for the persistence model.
+    """
+
+    sandbox_spec_service: SandboxSpecService
+    compute: Any  # boxd.Compute — typed Any so the SDK isn't a hard import
+    web_url: str | None
+    max_num_sandboxes: int
+    auto_suspend_timeout: int
+    vcpu: int
+    memory: str
+    disk: str
+    user_context: UserContext
+    db_session: AsyncSession
+
+    # ── Internal helpers ──────────────────────────────────────────────
+
+    async def _secure_select(self):
+        """SELECT statement scoped to the current user (or all rows for admin)."""
+        query = select(StoredBoxdSandbox)
+        user_id = await self.user_context.get_user_id()
+        if user_id:
+            query = query.where(StoredBoxdSandbox.created_by_user_id == user_id)
+        return query
+
+    async def _get_stored(self, sandbox_id: str) -> StoredBoxdSandbox | None:
+        stmt = await self._secure_select()
+        stmt = stmt.where(StoredBoxdSandbox.id == sandbox_id)
+        result = await self.db_session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    def _build_box_config(
+        self, sandbox_spec: SandboxSpecInfo, env: dict[str, str]
+    ) -> Any:
+        """Build a BoxConfig matching our standard agent-server shape."""
+        from boxd import BoxConfig, LifecycleConfig, NetworkConfig, ProxyEntry
+
+        return BoxConfig(
+            vcpu=self.vcpu,
+            memory=self.memory,
+            disk=self.disk,
+            env=env,
+            cmd=sandbox_spec.command,
+            lifecycle=LifecycleConfig(auto_suspend_timeout=self.auto_suspend_timeout),
+            network=NetworkConfig(
+                ssh=True,
+                proxies=[
+                    ProxyEntry(name=AGENT_PROXY_NAME, port=AGENT_SERVER_PORT),
+                    ProxyEntry(name=VSCODE_PROXY_NAME, port=VSCODE_PORT),
+                ],
+            ),
+        )
+
+    async def _build_environment(
+        self, sandbox_spec: SandboxSpecInfo
+    ) -> dict[str, str]:
+        """Compose the env dict the box will boot with.
+
+        Note: app-side metadata (spec_id, owner) lives in the DB, not the
+        VM env, so we only inject what the agent server itself needs.
+        """
+        env = dict(sandbox_spec.initial_env)
+        if self.web_url:
+            env[WEBHOOK_CALLBACK_VARIABLE] = f'{self.web_url}/api/v1/webhooks'
+            env[ALLOW_CORS_ORIGINS_VARIABLE] = self.web_url
+        return env
+
+    def _derive_status(self, box: Any | None) -> SandboxStatus:
+        if box is None:
+            return SandboxStatus.MISSING
+        raw = (getattr(box, 'status', '') or '').lower()
+        return STATUS_MAPPING.get(raw, SandboxStatus.ERROR)
+
+    def _to_sandbox_info(
+        self,
+        stored: StoredBoxdSandbox,
+        box: Any | None,
+        session_api_key: str | None = None,
+    ) -> SandboxInfo:
+        """Project (stored row, optional live Box) into a SandboxInfo."""
+        status = self._derive_status(box)
+
+        exposed_urls: list[ExposedUrl] | None = None
+        if status == SandboxStatus.RUNNING and box is not None:
+            exposed_urls = []
+            try:
+                proxies = box.proxies()
+            except Exception as exc:
+                _logger.warning(
+                    'Failed to list proxies on box %s: %s',
+                    getattr(box, 'id', '?'),
+                    exc,
+                )
+                proxies = []
+            for proxy in proxies:
+                if proxy.name == AGENT_PROXY_NAME:
+                    exposed_urls.append(
+                        ExposedUrl(
+                            name=AGENT_SERVER,
+                            url=f'https://{proxy.domain}',
+                            port=AGENT_SERVER_PORT,
+                        )
+                    )
+                elif proxy.name == VSCODE_PROXY_NAME:
+                    exposed_urls.append(
+                        ExposedUrl(
+                            name=VSCODE,
+                            url=f'https://{proxy.domain}',
+                            port=VSCODE_PORT,
+                        )
+                    )
+
+        return SandboxInfo(
+            id=stored.id,
+            created_by_user_id=stored.created_by_user_id,
+            sandbox_spec_id=stored.sandbox_spec_id,
+            status=status,
+            session_api_key=session_api_key
+            if status == SandboxStatus.RUNNING
+            else None,
+            exposed_urls=exposed_urls,
+            created_at=stored.created_at,
+        )
+
+    def _get_box_or_none(self, sandbox_id: str) -> Any | None:
+        """Fetch the boxd VM, swallowing NotFound. Other errors propagate."""
+        from boxd.errors import NotFoundError
+
+        vm_name = f'{VM_NAME_PREFIX}{sandbox_id}'
+        try:
+            return self.compute.box.get(vm_name)
+        except NotFoundError:
+            return None
+
+    # ── Public API ────────────────────────────────────────────────────
+
+    async def start_sandbox(
+        self, sandbox_spec_id: str | None = None, sandbox_id: str | None = None
+    ) -> SandboxInfo:
+        from boxd.errors import BoxdError
+
+        # Enforce per-user sandbox limits before creating another.
+        await self.pause_old_sandboxes(self.max_num_sandboxes - 1)
+
+        if sandbox_spec_id is None:
+            sandbox_spec = await self.sandbox_spec_service.get_default_sandbox_spec()
+        else:
+            sandbox_spec_maybe = await self.sandbox_spec_service.get_sandbox_spec(
+                sandbox_spec_id
+            )
+            if sandbox_spec_maybe is None:
+                raise SandboxError(f'Sandbox spec not found: {sandbox_spec_id}')
+            sandbox_spec = sandbox_spec_maybe
+
+        if sandbox_id is None:
+            sandbox_id = base62.encodebytes(os.urandom(16))
+        vm_name = f'{VM_NAME_PREFIX}{sandbox_id}'
+
+        user_id = await self.user_context.get_user_id()
+        env = await self._build_environment(sandbox_spec)
+
+        # Session API key is generated app-side. The VM carries it via
+        # SESSION_API_KEY_VARIABLE; the hash is indexed in our DB.
+        session_api_key = base62.encodebytes(os.urandom(32))
+        env[SESSION_API_KEY_VARIABLE] = session_api_key
+        session_api_key_hash = _hash_session_api_key(session_api_key)
+
+        # Insert the stored row before talking to boxd so the row's
+        # auto-set ``created_at`` reflects creation start, not end.
+        stored = StoredBoxdSandbox(
+            id=sandbox_id,
+            created_by_user_id=user_id,
+            sandbox_spec_id=sandbox_spec.id,
+            session_api_key_hash=session_api_key_hash,
+            created_at=utc_now(),
+        )
+        self.db_session.add(stored)
+
+        config = self._build_box_config(sandbox_spec, env)
+
+        try:
+            box = self.compute.box.create(
+                name=vm_name,
+                config=config,
+                image=sandbox_spec.id,
+            )
+        except BoxdError as exc:
+            _logger.error('Failed to create boxd VM %s: %s', vm_name, exc)
+            raise SandboxError(f'Failed to start sandbox: {exc}')
+
+        _logger.info(
+            'Started boxd sandbox %s (vm=%s)', sandbox_id, getattr(box, 'id', '?')
+        )
+        return self._to_sandbox_info(stored, box, session_api_key=session_api_key)
+
+    async def get_sandbox(self, sandbox_id: str) -> SandboxInfo | None:
+        stored = await self._get_stored(sandbox_id)
+        if stored is None:
+            return None
+        box = self._get_box_or_none(sandbox_id)
+        return self._to_sandbox_info(stored, box)
+
+    async def search_sandboxes(
+        self, page_id: str | None = None, limit: int = 100
+    ) -> SandboxPage:
+        stmt = await self._secure_select()
+        offset = 0
+        if page_id is not None:
+            try:
+                offset = int(page_id)
+            except ValueError:
+                offset = 0
+
+        # Fetch limit+1 to detect "has more" without a separate count.
+        stmt = (
+            stmt.order_by(StoredBoxdSandbox.created_at.desc())
+            .offset(offset)
+            .limit(limit + 1)
+        )
+        result = await self.db_session.execute(stmt)
+        stored_rows = list(result.scalars().all())
+
+        has_more = len(stored_rows) > limit
+        if has_more:
+            stored_rows = stored_rows[:limit]
+
+        next_page_id = str(offset + limit) if has_more else None
+
+        items: list[SandboxInfo] = []
+        for stored in stored_rows:
+            box = self._get_box_or_none(stored.id)
+            items.append(self._to_sandbox_info(stored, box))
+
+        return SandboxPage(items=items, next_page_id=next_page_id)
+
+    async def get_sandbox_by_session_api_key(
+        self, session_api_key: str
+    ) -> SandboxInfo | None:
+        target_hash = _hash_session_api_key(session_api_key)
+        stmt = await self._secure_select()
+        stmt = stmt.where(StoredBoxdSandbox.session_api_key_hash == target_hash)
+        result = await self.db_session.execute(stmt)
+        stored = result.scalar_one_or_none()
+        if stored is None:
+            return None
+        box = self._get_box_or_none(stored.id)
+        return self._to_sandbox_info(stored, box, session_api_key=session_api_key)
+
+    async def pause_sandbox(self, sandbox_id: str) -> bool:
+        stored = await self._get_stored(sandbox_id)
+        if stored is None:
+            return False
+        box = self._get_box_or_none(sandbox_id)
+        if box is None:
+            return False
+        # Security: invalidate the session key hash so leaked keys can't
+        # be used while the sandbox is paused. The VM still has the
+        # original key in env; it becomes valid again on resume when we
+        # restore the hash.
+        stored.session_api_key_hash = None
+        try:
+            box.suspend()
+            return True
+        except Exception as exc:
+            _logger.error('Failed to suspend boxd sandbox %s: %s', sandbox_id, exc)
+            return False
+
+    async def resume_sandbox(self, sandbox_id: str) -> bool:
+        # Enforce per-user limits before another resume puts us over.
+        await self.pause_old_sandboxes(self.max_num_sandboxes - 1)
+        stored = await self._get_stored(sandbox_id)
+        if stored is None:
+            return False
+        box = self._get_box_or_none(sandbox_id)
+        if box is None:
+            return False
+        try:
+            box.resume()
+            return True
+        except Exception as exc:
+            _logger.error('Failed to resume boxd sandbox %s: %s', sandbox_id, exc)
+            return False
+
+    async def delete_sandbox(self, sandbox_id: str) -> bool:
+        stored = await self._get_stored(sandbox_id)
+        if stored is None:
+            return False
+        # Drop the row first — deleting the session_api_key_hash
+        # invalidates leaked keys even if the boxd call fails.
+        await self.db_session.delete(stored)
+        box = self._get_box_or_none(sandbox_id)
+        if box is None:
+            # VM was already gone or unreachable; the row removal is
+            # still useful (cleans up our index).
+            return True
+        try:
+            box.destroy()
+            return True
+        except Exception as exc:
+            _logger.error('Failed to destroy boxd sandbox %s: %s', sandbox_id, exc)
+            return False
+
+
+class BoxdSandboxServiceInjector(SandboxServiceInjector):
+    """Dependency injector for the boxd sandbox service."""
+
+    api_key: str | None = Field(
+        default=None,
+        description=(
+            'boxd API key (e.g. bxk_...). If unset, the boxd SDK falls '
+            'back to the BOXD_API_KEY environment variable.'
+        ),
+    )
+    api_url: str | None = Field(
+        default=None,
+        description='Optional boxd control-plane URL (defaults to the SDK default).',
+    )
+    auto_suspend_timeout: int = Field(
+        default=300,
+        description=(
+            'Seconds of inactivity before boxd warm-suspends the VM '
+            '(sub-ms resume).'
+        ),
+    )
+    max_num_sandboxes: int = Field(
+        default=10,
+        description='Maximum number of running sandboxes per user.',
+    )
+    vcpu: int = Field(default=2, description='vCPUs per VM.')
+    memory: str = Field(default='8G', description='Memory per VM (boxd size string).')
+    disk: str = Field(default='100G', description='Disk per VM (boxd size string).')
+
+    async def inject(
+        self, state: InjectorState, request: Request | None = None
+    ) -> AsyncGenerator[SandboxService, None]:
+        from boxd import Compute
+
+        # Defer to break the circular path with config.py.
+        from openhands.app_server.config import (
+            get_db_session,
+            get_global_config,
+            get_sandbox_spec_service,
+            get_user_context,
+        )
+
+        config = get_global_config()
+        web_url = config.web_url
+
+        compute_kwargs: dict[str, Any] = {}
+        if self.api_key:
+            compute_kwargs['api_key'] = self.api_key
+        if self.api_url:
+            compute_kwargs['api_url'] = self.api_url
+
+        async with (
+            get_user_context(state, request) as user_context,
+            get_sandbox_spec_service(state, request) as sandbox_spec_service,
+            get_db_session(state, request) as db_session,
+        ):
+            compute = Compute(**compute_kwargs)
+            try:
+                yield BoxdSandboxService(
+                    sandbox_spec_service=sandbox_spec_service,
+                    compute=compute,
+                    web_url=web_url,
+                    max_num_sandboxes=self.max_num_sandboxes,
+                    auto_suspend_timeout=self.auto_suspend_timeout,
+                    vcpu=self.vcpu,
+                    memory=self.memory,
+                    disk=self.disk,
+                    user_context=user_context,
+                    db_session=db_session,
+                )
+            finally:
+                if hasattr(compute, 'close'):
+                    compute.close()

--- a/openhands/app_server/sandbox/boxd_sandbox_service.py
+++ b/openhands/app_server/sandbox/boxd_sandbox_service.py
@@ -60,24 +60,24 @@ _logger = logging.getLogger(__name__)
 # boxd VM status → internal SandboxStatus. Lowercased keys; SDK returns
 # mixed-case strings, we normalize on read.
 STATUS_MAPPING: dict[str, SandboxStatus] = {
-    "running": SandboxStatus.RUNNING,
-    "suspended": SandboxStatus.PAUSED,
-    "starting": SandboxStatus.STARTING,
-    "creating": SandboxStatus.STARTING,
-    "error": SandboxStatus.ERROR,
-    "failed": SandboxStatus.ERROR,
-    "stopped": SandboxStatus.MISSING,
-    "destroyed": SandboxStatus.MISSING,
+    'running': SandboxStatus.RUNNING,
+    'suspended': SandboxStatus.PAUSED,
+    'starting': SandboxStatus.STARTING,
+    'creating': SandboxStatus.STARTING,
+    'error': SandboxStatus.ERROR,
+    'failed': SandboxStatus.ERROR,
+    'stopped': SandboxStatus.MISSING,
+    'destroyed': SandboxStatus.MISSING,
 }
 
 AGENT_SERVER_PORT = 60000
 VSCODE_PORT = 60001
-AGENT_PROXY_NAME = "agent"
-VSCODE_PROXY_NAME = "vscode"
+AGENT_PROXY_NAME = 'agent'
+VSCODE_PROXY_NAME = 'vscode'
 
 # All boxd VMs we create are prefixed so search/list can distinguish
 # ours from VMs created out-of-band by the same user.
-VM_NAME_PREFIX = "oh-"
+VM_NAME_PREFIX = 'oh-'
 
 
 class StoredBoxdSandbox(Base):
@@ -89,7 +89,7 @@ class StoredBoxdSandbox(Base):
     the pattern used by ``StoredRemoteSandbox``.
     """
 
-    __tablename__ = "v1_boxd_sandbox"
+    __tablename__ = 'v1_boxd_sandbox'
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
     created_by_user_id: Mapped[str | None] = mapped_column(
@@ -112,7 +112,7 @@ class BoxdSandboxService(SandboxService):
     """
 
     sandbox_spec_service: SandboxSpecService
-    compute: "Compute"
+    compute: 'Compute'
     web_url: str | None
     max_num_sandboxes: int
     auto_suspend_timeout: int
@@ -177,10 +177,10 @@ class BoxdSandboxService(SandboxService):
         for (name, port), result in zip(proxies, results):
             if isinstance(result, Exception):
                 _logger.warning(
-                    "create_proxy(%s, port=%d) on box %s failed: %s",
+                    'create_proxy(%s, port=%d) on box %s failed: %s',
                     name,
                     port,
-                    getattr(box, "id", "?"),
+                    getattr(box, 'id', '?'),
                     result,
                 )
 
@@ -192,14 +192,14 @@ class BoxdSandboxService(SandboxService):
         """
         env = dict(sandbox_spec.initial_env)
         if self.web_url:
-            env[WEBHOOK_CALLBACK_VARIABLE] = f"{self.web_url}/api/v1/webhooks"
+            env[WEBHOOK_CALLBACK_VARIABLE] = f'{self.web_url}/api/v1/webhooks'
             env[ALLOW_CORS_ORIGINS_VARIABLE] = self.web_url
         return env
 
     def _derive_status(self, box: Any | None) -> SandboxStatus:
         if box is None:
             return SandboxStatus.MISSING
-        raw = (getattr(box, "status", "") or "").lower()
+        raw = (getattr(box, 'status', '') or '').lower()
         return STATUS_MAPPING.get(raw, SandboxStatus.ERROR)
 
     _PROXY_TO_URL_NAME = {
@@ -237,8 +237,8 @@ class BoxdSandboxService(SandboxService):
             proxies = await box.proxies()
         except Exception as exc:
             _logger.warning(
-                "Failed to list proxies on box %s: %s",
-                getattr(box, "id", "?"),
+                'Failed to list proxies on box %s: %s',
+                getattr(box, 'id', '?'),
                 exc,
             )
             return []
@@ -249,7 +249,7 @@ class BoxdSandboxService(SandboxService):
                 continue
             url_name, port = mapping
             urls.append(
-                ExposedUrl(name=url_name, url=f"https://{proxy.domain}", port=port)
+                ExposedUrl(name=url_name, url=f'https://{proxy.domain}', port=port)
             )
         return urls
 
@@ -257,7 +257,7 @@ class BoxdSandboxService(SandboxService):
         """Fetch the boxd VM, swallowing NotFound. Other errors propagate."""
         from boxd.aio import NotFoundError
 
-        vm_name = f"{VM_NAME_PREFIX}{sandbox_id}"
+        vm_name = f'{VM_NAME_PREFIX}{sandbox_id}'
         try:
             return await self.compute.box.get(vm_name)
         except NotFoundError:
@@ -280,12 +280,12 @@ class BoxdSandboxService(SandboxService):
                 sandbox_spec_id
             )
             if sandbox_spec_maybe is None:
-                raise SandboxError(f"Sandbox spec not found: {sandbox_spec_id}")
+                raise SandboxError(f'Sandbox spec not found: {sandbox_spec_id}')
             sandbox_spec = sandbox_spec_maybe
 
         if sandbox_id is None:
             sandbox_id = base62.encodebytes(os.urandom(16))
-        vm_name = f"{VM_NAME_PREFIX}{sandbox_id}"
+        vm_name = f'{VM_NAME_PREFIX}{sandbox_id}'
 
         user_id = await self.user_context.get_user_id()
         env = await self._build_environment(sandbox_spec)
@@ -316,13 +316,13 @@ class BoxdSandboxService(SandboxService):
                 image=sandbox_spec.id,
             )
         except BoxdError as exc:
-            _logger.error("Failed to create boxd VM %s: %s", vm_name, exc)
-            raise SandboxError(f"Failed to start sandbox: {exc}")
+            _logger.error('Failed to create boxd VM %s: %s', vm_name, exc)
+            raise SandboxError(f'Failed to start sandbox: {exc}')
 
         await self._ensure_named_proxies(box)
 
         _logger.info(
-            "Started boxd sandbox %s (vm=%s)", sandbox_id, getattr(box, "id", "?")
+            'Started boxd sandbox %s (vm=%s)', sandbox_id, getattr(box, 'id', '?')
         )
         return await self._to_sandbox_info(stored, box, session_api_key=session_api_key)
 
@@ -402,7 +402,7 @@ class BoxdSandboxService(SandboxService):
             await box.suspend()
             return True
         except Exception as exc:
-            _logger.error("Failed to suspend boxd sandbox %s: %s", sandbox_id, exc)
+            _logger.error('Failed to suspend boxd sandbox %s: %s', sandbox_id, exc)
             return False
 
     async def resume_sandbox(self, sandbox_id: str) -> bool:
@@ -418,7 +418,7 @@ class BoxdSandboxService(SandboxService):
             await box.resume()
             return True
         except Exception as exc:
-            _logger.error("Failed to resume boxd sandbox %s: %s", sandbox_id, exc)
+            _logger.error('Failed to resume boxd sandbox %s: %s', sandbox_id, exc)
             return False
 
     async def delete_sandbox(self, sandbox_id: str) -> bool:
@@ -431,7 +431,7 @@ class BoxdSandboxService(SandboxService):
             try:
                 await box.destroy()
             except Exception as exc:
-                _logger.error("Failed to destroy boxd sandbox %s: %s", sandbox_id, exc)
+                _logger.error('Failed to destroy boxd sandbox %s: %s', sandbox_id, exc)
                 destroy_ok = False
         # Always drop the row — even on destroy failure this invalidates
         # the leaked session_api_key_hash and stops the sandbox from
@@ -447,27 +447,27 @@ class BoxdSandboxServiceInjector(SandboxServiceInjector):
     api_key: str | None = Field(
         default=None,
         description=(
-            "boxd API key (e.g. bxk_...). If unset, the boxd SDK falls "
-            "back to the BOXD_API_KEY environment variable."
+            'boxd API key (e.g. bxk_...). If unset, the boxd SDK falls '
+            'back to the BOXD_API_KEY environment variable.'
         ),
     )
     api_url: str | None = Field(
         default=None,
-        description="Optional boxd control-plane URL (defaults to the SDK default).",
+        description='Optional boxd control-plane URL (defaults to the SDK default).',
     )
     auto_suspend_timeout: int = Field(
         default=300,
         description=(
-            "Seconds of inactivity before boxd warm-suspends the VM (sub-ms resume)."
+            'Seconds of inactivity before boxd warm-suspends the VM (sub-ms resume).'
         ),
     )
     max_num_sandboxes: int = Field(
         default=10,
-        description="Maximum number of running sandboxes per user.",
+        description='Maximum number of running sandboxes per user.',
     )
-    vcpu: int = Field(default=2, description="vCPUs per VM.")
-    memory: str = Field(default="8G", description="Memory per VM (boxd size string).")
-    disk: str = Field(default="100G", description="Disk per VM (boxd size string).")
+    vcpu: int = Field(default=2, description='vCPUs per VM.')
+    memory: str = Field(default='8G', description='Memory per VM (boxd size string).')
+    disk: str = Field(default='100G', description='Disk per VM (boxd size string).')
 
     async def inject(
         self, state: InjectorState, request: Request | None = None
@@ -487,9 +487,9 @@ class BoxdSandboxServiceInjector(SandboxServiceInjector):
 
         compute_kwargs: dict[str, Any] = {}
         if self.api_key:
-            compute_kwargs["api_key"] = self.api_key
+            compute_kwargs['api_key'] = self.api_key
         if self.api_url:
-            compute_kwargs["api_url"] = self.api_url
+            compute_kwargs['api_url'] = self.api_url
 
         async with (
             get_user_context(state, request) as user_context,

--- a/openhands/app_server/sandbox/boxd_sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/boxd_sandbox_spec_service.py
@@ -1,0 +1,58 @@
+"""Sandbox spec service for the boxd cloud microVM backend.
+
+boxd uses OCI image references just like Docker, so the default spec is keyed
+by the OpenHands agent-server image tag. The boxd worker pulls the image when
+creating the VM — no local pull step is needed here, in contrast to
+DockerSandboxSpecServiceInjector.
+"""
+
+from typing import AsyncGenerator
+
+from fastapi import Request
+from pydantic import Field
+
+from openhands.app_server.sandbox.preset_sandbox_spec_service import (
+    PresetSandboxSpecService,
+)
+from openhands.app_server.sandbox.sandbox_spec_models import SandboxSpecInfo
+from openhands.app_server.sandbox.sandbox_spec_service import (
+    SandboxSpecService,
+    SandboxSpecServiceInjector,
+    get_agent_server_env,
+    get_agent_server_image,
+)
+from openhands.app_server.services.injector import InjectorState
+
+
+def get_default_boxd_sandbox_specs() -> list[SandboxSpecInfo]:
+    """Return the default sandbox spec for boxd VMs."""
+    return [
+        SandboxSpecInfo(
+            id=get_agent_server_image(),
+            command=['/usr/local/bin/openhands-agent-server', '--port', '60000'],
+            initial_env={
+                'OPENVSCODE_SERVER_ROOT': '/openhands/.openvscode-server',
+                'LOG_JSON': 'true',
+                'OH_ENABLE_VNC': '0',
+                'OH_CONVERSATIONS_PATH': '/workspace/conversations',
+                'OH_BASH_EVENTS_DIR': '/workspace/bash_events',
+                'OH_VSCODE_PORT': '60001',
+                **get_agent_server_env(),
+            },
+            working_dir='/workspace/project',
+        )
+    ]
+
+
+class BoxdSandboxSpecServiceInjector(SandboxSpecServiceInjector):
+    """Dependency injector for the boxd sandbox spec service."""
+
+    specs: list[SandboxSpecInfo] = Field(
+        default_factory=get_default_boxd_sandbox_specs,
+        description='Preset list of sandbox specs',
+    )
+
+    async def inject(
+        self, state: InjectorState, request: Request | None = None
+    ) -> AsyncGenerator[SandboxSpecService, None]:
+        yield PresetSandboxSpecService(self.specs)

--- a/openhands/app_server/sandbox/boxd_sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/boxd_sandbox_spec_service.py
@@ -29,17 +29,17 @@ def get_default_boxd_sandbox_specs() -> list[SandboxSpecInfo]:
     return [
         SandboxSpecInfo(
             id=get_agent_server_image(),
-            command=["/usr/local/bin/openhands-agent-server", "--port", "60000"],
+            command=['/usr/local/bin/openhands-agent-server', '--port', '60000'],
             initial_env={
-                "OPENVSCODE_SERVER_ROOT": "/openhands/.openvscode-server",
-                "LOG_JSON": "true",
-                "OH_ENABLE_VNC": "0",
-                "OH_CONVERSATIONS_PATH": "/workspace/conversations",
-                "OH_BASH_EVENTS_DIR": "/workspace/bash_events",
-                "OH_VSCODE_PORT": "60001",
+                'OPENVSCODE_SERVER_ROOT': '/openhands/.openvscode-server',
+                'LOG_JSON': 'true',
+                'OH_ENABLE_VNC': '0',
+                'OH_CONVERSATIONS_PATH': '/workspace/conversations',
+                'OH_BASH_EVENTS_DIR': '/workspace/bash_events',
+                'OH_VSCODE_PORT': '60001',
                 **get_agent_server_env(),
             },
-            working_dir="/workspace/project",
+            working_dir='/workspace/project',
         )
     ]
 
@@ -49,7 +49,7 @@ class BoxdSandboxSpecServiceInjector(SandboxSpecServiceInjector):
 
     specs: list[SandboxSpecInfo] = Field(
         default_factory=get_default_boxd_sandbox_specs,
-        description="Preset list of sandbox specs",
+        description='Preset list of sandbox specs',
     )
 
     async def inject(

--- a/openhands/app_server/sandbox/boxd_sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/boxd_sandbox_spec_service.py
@@ -29,17 +29,17 @@ def get_default_boxd_sandbox_specs() -> list[SandboxSpecInfo]:
     return [
         SandboxSpecInfo(
             id=get_agent_server_image(),
-            command=['/usr/local/bin/openhands-agent-server', '--port', '60000'],
+            command=["/usr/local/bin/openhands-agent-server", "--port", "60000"],
             initial_env={
-                'OPENVSCODE_SERVER_ROOT': '/openhands/.openvscode-server',
-                'LOG_JSON': 'true',
-                'OH_ENABLE_VNC': '0',
-                'OH_CONVERSATIONS_PATH': '/workspace/conversations',
-                'OH_BASH_EVENTS_DIR': '/workspace/bash_events',
-                'OH_VSCODE_PORT': '60001',
+                "OPENVSCODE_SERVER_ROOT": "/openhands/.openvscode-server",
+                "LOG_JSON": "true",
+                "OH_ENABLE_VNC": "0",
+                "OH_CONVERSATIONS_PATH": "/workspace/conversations",
+                "OH_BASH_EVENTS_DIR": "/workspace/bash_events",
+                "OH_VSCODE_PORT": "60001",
                 **get_agent_server_env(),
             },
-            working_dir='/workspace/project',
+            working_dir="/workspace/project",
         )
     ]
 
@@ -49,7 +49,7 @@ class BoxdSandboxSpecServiceInjector(SandboxSpecServiceInjector):
 
     specs: list[SandboxSpecInfo] = Field(
         default_factory=get_default_boxd_sandbox_specs,
-        description='Preset list of sandbox specs',
+        description="Preset list of sandbox specs",
     )
 
     async def inject(

--- a/poetry.lock
+++ b/poetry.lock
@@ -14555,4 +14555,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12,<3.14"
-content-hash = "d7213cfd49942b2a9a773dec0d9525205dd95f1ef63ae0a59cd5b78960c68bd8"
+content-hash = "729d768a59215e0becd6cdf4302b96e2825243e47443b6f47d898c538147bc21"

--- a/poetry.lock
+++ b/poetry.lock
@@ -14555,4 +14555,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12,<3.14"
-content-hash = "4d8b8eb2c4338968973606b28811f3330bd70062b66059ee1e9f6e9b494a1f8d"
+content-hash = "729d768a59215e0becd6cdf4302b96e2825243e47443b6f47d898c538147bc21"

--- a/poetry.lock
+++ b/poetry.lock
@@ -14555,4 +14555,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12,<3.14"
-content-hash = "729d768a59215e0becd6cdf4302b96e2825243e47443b6f47d898c538147bc21"
+content-hash = "d7213cfd49942b2a9a773dec0d9525205dd95f1ef63ae0a59cd5b78960c68bd8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,6 +283,10 @@ pytest-timeout = "^2.4.0"
 pandas = "*"
 reportlab = "*"
 gevent = ">=24.2.1,<26.0.0"
+# Optional sandbox backends — needed for their respective unit-test
+# modules to import. Production deployments install via the per-backend
+# extra (e.g. `pip install boxd`).
+boxd = ">=0.1.2,<1.0.0"
 
 [tool.poetry.group.runtime]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,6 +241,7 @@ jupyter_kernel_gateway = "*"
 modal = { version = ">=0.66.26,<1.2.0", optional = true }
 runloop-api-client = { version = "0.50.0", optional = true }
 daytona = { version = "0.24.2", optional = true }
+boxd = { version = ">=0.1.2,<1.0.0", optional = true }
 httpx-aiohttp = "^0.1.8"
 e2b-code-interpreter = { version = "^2.0.0", optional = true }
 pybase62 = "^1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,10 +283,6 @@ pytest-timeout = "^2.4.0"
 pandas = "*"
 reportlab = "*"
 gevent = ">=24.2.1,<26.0.0"
-# Optional sandbox backends — needed for their respective unit-test
-# modules to import. Production deployments install via the per-backend
-# extra (e.g. `pip install boxd`).
-boxd = ">=0.1.2,<1.0.0"
 
 [tool.poetry.group.runtime]
 optional = true

--- a/tests/unit/app_server/test_boxd_sandbox_service.py
+++ b/tests/unit/app_server/test_boxd_sandbox_service.py
@@ -62,7 +62,7 @@ def mock_user_context():
 
 @pytest.fixture
 def mock_compute():
-    """boxd Compute client. Tests configure box.create/list/get per case."""
+    """Mock boxd Compute client. Tests configure box.create/list/get per case."""
     return MagicMock()
 
 

--- a/tests/unit/app_server/test_boxd_sandbox_service.py
+++ b/tests/unit/app_server/test_boxd_sandbox_service.py
@@ -34,7 +34,6 @@ from openhands.app_server.sandbox.sandbox_service import (
 from openhands.app_server.sandbox.sandbox_spec_models import SandboxSpecInfo
 from openhands.app_server.user.user_context import UserContext
 
-
 # ─── Fixtures ─────────────────────────────────────────────────────────────
 
 
@@ -43,10 +42,10 @@ def mock_sandbox_spec_service():
     """SandboxSpecService that returns a deterministic spec."""
     mock_service = AsyncMock()
     mock_spec = SandboxSpecInfo(
-        id='ghcr.io/openhands/agent-server:1.22.1-python',
-        command=['/usr/local/bin/openhands-agent-server', '--port', '60000'],
-        initial_env={'LOG_JSON': 'true'},
-        working_dir='/workspace/project',
+        id="ghcr.io/openhands/agent-server:1.22.1-python",
+        command=["/usr/local/bin/openhands-agent-server", "--port", "60000"],
+        initial_env={"LOG_JSON": "true"},
+        working_dir="/workspace/project",
     )
     mock_service.get_default_sandbox_spec.return_value = mock_spec
     mock_service.get_sandbox_spec.return_value = mock_spec
@@ -56,7 +55,7 @@ def mock_sandbox_spec_service():
 @pytest.fixture
 def mock_user_context():
     mock_context = AsyncMock(spec=UserContext)
-    mock_context.get_user_id.return_value = 'test-user-123'
+    mock_context.get_user_id.return_value = "test-user-123"
     return mock_context
 
 
@@ -84,22 +83,22 @@ def boxd_sandbox_service(
     return BoxdSandboxService(
         sandbox_spec_service=mock_sandbox_spec_service,
         compute=mock_compute,
-        web_url='https://web.example.com',
+        web_url="https://web.example.com",
         max_num_sandboxes=10,
         auto_suspend_timeout=300,
         vcpu=2,
-        memory='8G',
-        disk='100G',
+        memory="8G",
+        disk="100G",
         user_context=mock_user_context,
         db_session=mock_db_session,
     )
 
 
 def make_box_mock(
-    box_id: str = 'box-abc',
-    name: str = 'oh-test-sandbox',
-    status: str = 'running',
-    proxy_domain: str = 'agent-oh-test-sandbox.boxd.sh',
+    box_id: str = "box-abc",
+    name: str = "oh-test-sandbox",
+    status: str = "running",
+    proxy_domain: str = "agent-oh-test-sandbox.boxd.sh",
 ):
     """Build a MagicMock Box. Production Box objects don't carry env back."""
     box = MagicMock()
@@ -121,9 +120,9 @@ def make_box_mock(
 
 
 def make_stored(
-    sandbox_id: str = 'test-sandbox-123',
-    user_id: str = 'test-user-123',
-    spec_id: str = 'ghcr.io/openhands/agent-server:1.22.1-python',
+    sandbox_id: str = "test-sandbox-123",
+    user_id: str = "test-user-123",
+    spec_id: str = "ghcr.io/openhands/agent-server:1.22.1-python",
     session_api_key_hash: str | None = None,
     created_at: datetime | None = None,
 ) -> StoredBoxdSandbox:
@@ -157,19 +156,19 @@ def stub_get_stored_returns(boxd_sandbox_service, stored):
 
 class TestStatusMapping:
     def test_running_maps_to_running(self):
-        assert STATUS_MAPPING['running'] == SandboxStatus.RUNNING
+        assert STATUS_MAPPING["running"] == SandboxStatus.RUNNING
 
     def test_suspended_maps_to_paused(self):
-        assert STATUS_MAPPING['suspended'] == SandboxStatus.PAUSED
+        assert STATUS_MAPPING["suspended"] == SandboxStatus.PAUSED
 
     def test_starting_maps_to_starting(self):
-        assert STATUS_MAPPING['starting'] == SandboxStatus.STARTING
+        assert STATUS_MAPPING["starting"] == SandboxStatus.STARTING
 
     def test_error_maps_to_error(self):
-        assert STATUS_MAPPING['error'] == SandboxStatus.ERROR
+        assert STATUS_MAPPING["error"] == SandboxStatus.ERROR
 
     def test_stopped_maps_to_missing(self):
-        assert STATUS_MAPPING['stopped'] == SandboxStatus.MISSING
+        assert STATUS_MAPPING["stopped"] == SandboxStatus.MISSING
 
 
 class TestStartSandbox:
@@ -182,20 +181,18 @@ class TestStartSandbox:
         mock_compute.box.create.return_value = make_box_mock()
         info = await boxd_sandbox_service.start_sandbox()
         assert info.status == SandboxStatus.RUNNING
-        assert info.created_by_user_id == 'test-user-123'
+        assert info.created_by_user_id == "test-user-123"
         mock_compute.box.create.assert_called_once()
         call_kwargs = mock_compute.box.create.call_args.kwargs
-        assert 'config' in call_kwargs
+        assert "config" in call_kwargs
 
     @pytest.mark.asyncio
-    async def test_passes_image_from_spec(
-        self, boxd_sandbox_service, mock_compute
-    ):
+    async def test_passes_image_from_spec(self, boxd_sandbox_service, mock_compute):
         stub_search_returns(boxd_sandbox_service, [])
         mock_compute.box.create.return_value = make_box_mock()
         await boxd_sandbox_service.start_sandbox()
         call_kwargs = mock_compute.box.create.call_args.kwargs
-        assert call_kwargs['image'] == 'ghcr.io/openhands/agent-server:1.22.1-python'
+        assert call_kwargs["image"] == "ghcr.io/openhands/agent-server:1.22.1-python"
 
     @pytest.mark.asyncio
     async def test_sets_env_from_spec_and_webhook(
@@ -204,8 +201,8 @@ class TestStartSandbox:
         stub_search_returns(boxd_sandbox_service, [])
         mock_compute.box.create.return_value = make_box_mock()
         await boxd_sandbox_service.start_sandbox()
-        config = mock_compute.box.create.call_args.kwargs['config']
-        assert config.env['LOG_JSON'] == 'true'
+        config = mock_compute.box.create.call_args.kwargs["config"]
+        assert config.env["LOG_JSON"] == "true"
         assert WEBHOOK_CALLBACK_VARIABLE in config.env
         assert ALLOW_CORS_ORIGINS_VARIABLE in config.env
 
@@ -219,8 +216,8 @@ class TestStartSandbox:
         mock_db_session.add.assert_called_once()
         added = mock_db_session.add.call_args.args[0]
         assert isinstance(added, StoredBoxdSandbox)
-        assert added.created_by_user_id == 'test-user-123'
-        assert added.sandbox_spec_id == 'ghcr.io/openhands/agent-server:1.22.1-python'
+        assert added.created_by_user_id == "test-user-123"
+        assert added.sandbox_spec_id == "ghcr.io/openhands/agent-server:1.22.1-python"
         assert added.session_api_key_hash is not None
 
     @pytest.mark.asyncio
@@ -230,7 +227,7 @@ class TestStartSandbox:
         stub_search_returns(boxd_sandbox_service, [])
         mock_compute.box.create.return_value = make_box_mock()
         await boxd_sandbox_service.start_sandbox()
-        config = mock_compute.box.create.call_args.kwargs['config']
+        config = mock_compute.box.create.call_args.kwargs["config"]
         session_key = config.env[SESSION_API_KEY_VARIABLE]
         added = mock_db_session.add.call_args.args[0]
         assert added.session_api_key_hash == _hash_session_api_key(session_key)
@@ -240,8 +237,9 @@ class TestStartSandbox:
         self, boxd_sandbox_service, mock_compute
     ):
         from boxd.errors import BoxdError
+
         stub_search_returns(boxd_sandbox_service, [])
-        mock_compute.box.create.side_effect = BoxdError('boxd is down')
+        mock_compute.box.create.side_effect = BoxdError("boxd is down")
         with pytest.raises(SandboxError):
             await boxd_sandbox_service.start_sandbox()
 
@@ -261,38 +259,39 @@ class TestStartSandbox:
         await boxd_sandbox_service.start_sandbox()
         assert box.create_proxy.await_count == 2
         proxy_names = {call.args[0] for call in box.create_proxy.await_args_list}
-        assert proxy_names == {'agent', 'vscode'}
+        assert proxy_names == {"agent", "vscode"}
 
 
 class TestGetSandbox:
     @pytest.mark.asyncio
     async def test_returns_none_when_no_stored_row(self, boxd_sandbox_service):
         stub_get_stored_returns(boxd_sandbox_service, None)
-        result = await boxd_sandbox_service.get_sandbox('missing')
+        result = await boxd_sandbox_service.get_sandbox("missing")
         assert result is None
 
     @pytest.mark.asyncio
     async def test_returns_info_when_row_and_vm_exist(
         self, boxd_sandbox_service, mock_compute
     ):
-        stored = make_stored(sandbox_id='abc')
+        stored = make_stored(sandbox_id="abc")
         stub_get_stored_returns(boxd_sandbox_service, stored)
-        mock_compute.box.get.return_value = make_box_mock(name='oh-abc')
-        info = await boxd_sandbox_service.get_sandbox('abc')
+        mock_compute.box.get.return_value = make_box_mock(name="oh-abc")
+        info = await boxd_sandbox_service.get_sandbox("abc")
         assert info is not None
-        assert info.id == 'abc'
+        assert info.id == "abc"
         assert info.status == SandboxStatus.RUNNING
-        assert info.created_by_user_id == 'test-user-123'
+        assert info.created_by_user_id == "test-user-123"
 
     @pytest.mark.asyncio
     async def test_status_missing_when_vm_gone_but_row_present(
         self, boxd_sandbox_service, mock_compute
     ):
         from boxd.errors import NotFoundError
-        stored = make_stored(sandbox_id='abc')
+
+        stored = make_stored(sandbox_id="abc")
         stub_get_stored_returns(boxd_sandbox_service, stored)
-        mock_compute.box.get.side_effect = NotFoundError('gone')
-        info = await boxd_sandbox_service.get_sandbox('abc')
+        mock_compute.box.get.side_effect = NotFoundError("gone")
+        info = await boxd_sandbox_service.get_sandbox("abc")
         assert info is not None
         assert info.status == SandboxStatus.MISSING
 
@@ -302,38 +301,36 @@ class TestSearchSandboxes:
     async def test_returns_page_with_running_status(
         self, boxd_sandbox_service, mock_compute
     ):
-        stored = make_stored(sandbox_id='abc')
+        stored = make_stored(sandbox_id="abc")
         stub_search_returns(boxd_sandbox_service, [stored])
-        mock_compute.box.get.return_value = make_box_mock(name='oh-abc')
+        mock_compute.box.get.return_value = make_box_mock(name="oh-abc")
         page = await boxd_sandbox_service.search_sandboxes()
         assert len(page.items) == 1
-        assert page.items[0].id == 'abc'
+        assert page.items[0].id == "abc"
 
     @pytest.mark.asyncio
     async def test_pagination_sets_next_page_id(
         self, boxd_sandbox_service, mock_compute
     ):
         # limit=3 but we return 4 rows — the +1 sentinel signals "more".
-        rows = [make_stored(sandbox_id=f'sb-{i}') for i in range(4)]
+        rows = [make_stored(sandbox_id=f"sb-{i}") for i in range(4)]
         stub_search_returns(boxd_sandbox_service, rows)
         mock_compute.box.get.return_value = make_box_mock()
         page = await boxd_sandbox_service.search_sandboxes(limit=3)
         assert len(page.items) == 3
-        assert page.next_page_id == '3'
+        assert page.next_page_id == "3"
 
 
 class TestGetSandboxBySessionApiKey:
     @pytest.mark.asyncio
-    async def test_finds_by_session_key(
-        self, boxd_sandbox_service, mock_compute
-    ):
-        session_key = 'session-secret'
+    async def test_finds_by_session_key(self, boxd_sandbox_service, mock_compute):
+        session_key = "session-secret"
         stored = make_stored(
-            sandbox_id='abc',
+            sandbox_id="abc",
             session_api_key_hash=_hash_session_api_key(session_key),
         )
         stub_get_stored_returns(boxd_sandbox_service, stored)
-        mock_compute.box.get.return_value = make_box_mock(name='oh-abc')
+        mock_compute.box.get.return_value = make_box_mock(name="oh-abc")
         info = await boxd_sandbox_service.get_sandbox_by_session_api_key(session_key)
         assert info is not None
         assert info.session_api_key == session_key
@@ -341,19 +338,17 @@ class TestGetSandboxBySessionApiKey:
     @pytest.mark.asyncio
     async def test_returns_none_when_no_match(self, boxd_sandbox_service):
         stub_get_stored_returns(boxd_sandbox_service, None)
-        assert (
-            await boxd_sandbox_service.get_sandbox_by_session_api_key('nope') is None
-        )
+        assert await boxd_sandbox_service.get_sandbox_by_session_api_key("nope") is None
 
 
 class TestLifecycleOperations:
     @pytest.mark.asyncio
     async def test_pause_calls_suspend(self, boxd_sandbox_service, mock_compute):
-        stored = make_stored(sandbox_id='abc', session_api_key_hash='HASH')
+        stored = make_stored(sandbox_id="abc", session_api_key_hash="HASH")
         stub_get_stored_returns(boxd_sandbox_service, stored)
-        box = make_box_mock(name='oh-abc')
+        box = make_box_mock(name="oh-abc")
         mock_compute.box.get.return_value = box
-        ok = await boxd_sandbox_service.pause_sandbox('abc')
+        ok = await boxd_sandbox_service.pause_sandbox("abc")
         assert ok is True
         box.suspend.assert_called_once()
         # Security: hash is cleared on pause
@@ -364,14 +359,14 @@ class TestLifecycleOperations:
         self, boxd_sandbox_service
     ):
         stub_get_stored_returns(boxd_sandbox_service, None)
-        assert await boxd_sandbox_service.pause_sandbox('abc') is False
+        assert await boxd_sandbox_service.pause_sandbox("abc") is False
 
     @pytest.mark.asyncio
     async def test_resume_calls_resume(self, boxd_sandbox_service, mock_compute):
         # resume_sandbox calls pause_old_sandboxes first → needs search stub
         # and _get_stored stub. The mock_db_session is shared, so we install
         # a side_effect that returns different shapes per call.
-        stored = make_stored(sandbox_id='abc')
+        stored = make_stored(sandbox_id="abc")
         search_scalar = MagicMock()
         search_scalar.all.return_value = []
         search_result = MagicMock()
@@ -381,9 +376,9 @@ class TestLifecycleOperations:
         boxd_sandbox_service.db_session.execute = AsyncMock(
             side_effect=[search_result, get_result]
         )
-        box = make_box_mock(name='oh-abc')
+        box = make_box_mock(name="oh-abc")
         mock_compute.box.get.return_value = box
-        ok = await boxd_sandbox_service.resume_sandbox('abc')
+        ok = await boxd_sandbox_service.resume_sandbox("abc")
         assert ok is True
         box.resume.assert_called_once()
 
@@ -391,11 +386,11 @@ class TestLifecycleOperations:
     async def test_delete_calls_destroy_and_drops_row(
         self, boxd_sandbox_service, mock_compute, mock_db_session
     ):
-        stored = make_stored(sandbox_id='abc')
+        stored = make_stored(sandbox_id="abc")
         stub_get_stored_returns(boxd_sandbox_service, stored)
-        box = make_box_mock(name='oh-abc')
+        box = make_box_mock(name="oh-abc")
         mock_compute.box.get.return_value = box
-        ok = await boxd_sandbox_service.delete_sandbox('abc')
+        ok = await boxd_sandbox_service.delete_sandbox("abc")
         assert ok is True
         box.destroy.assert_called_once()
         mock_db_session.delete.assert_called_once_with(stored)
@@ -405,10 +400,11 @@ class TestLifecycleOperations:
         self, boxd_sandbox_service, mock_compute, mock_db_session
     ):
         from boxd.errors import NotFoundError
-        stored = make_stored(sandbox_id='abc')
+
+        stored = make_stored(sandbox_id="abc")
         stub_get_stored_returns(boxd_sandbox_service, stored)
-        mock_compute.box.get.side_effect = NotFoundError('gone')
-        ok = await boxd_sandbox_service.delete_sandbox('abc')
+        mock_compute.box.get.side_effect = NotFoundError("gone")
+        ok = await boxd_sandbox_service.delete_sandbox("abc")
         # We still cleaned the index — return True so callers don't retry.
         assert ok is True
         mock_db_session.delete.assert_called_once_with(stored)
@@ -422,12 +418,12 @@ class TestLifecycleOperations:
         If boxd destroy fails the row must still be dropped so the leaked
         session_api_key_hash can't be used and stale rows don't accumulate.
         """
-        stored = make_stored(sandbox_id='abc')
+        stored = make_stored(sandbox_id="abc")
         stub_get_stored_returns(boxd_sandbox_service, stored)
-        box = make_box_mock(name='oh-abc')
-        box.destroy.side_effect = RuntimeError('boxd flaked')
+        box = make_box_mock(name="oh-abc")
+        box.destroy.side_effect = RuntimeError("boxd flaked")
         mock_compute.box.get.return_value = box
-        ok = await boxd_sandbox_service.delete_sandbox('abc')
+        ok = await boxd_sandbox_service.delete_sandbox("abc")
         assert ok is False
         mock_db_session.delete.assert_called_once_with(stored)
 
@@ -440,17 +436,17 @@ class TestInjector:
         )
 
         injector = BoxdSandboxServiceInjector(
-            api_key='bxk_test',
+            api_key="bxk_test",
             max_num_sandboxes=5,
             auto_suspend_timeout=600,
             vcpu=2,
-            memory='8G',
-            disk='100G',
+            memory="8G",
+            disk="100G",
         )
 
-        assert injector.api_key == 'bxk_test'
+        assert injector.api_key == "bxk_test"
         assert injector.max_num_sandboxes == 5
         assert injector.auto_suspend_timeout == 600
         assert injector.vcpu == 2
-        assert injector.memory == '8G'
-        assert injector.disk == '100G'
+        assert injector.memory == "8G"
+        assert injector.disk == "100G"

--- a/tests/unit/app_server/test_boxd_sandbox_service.py
+++ b/tests/unit/app_server/test_boxd_sandbox_service.py
@@ -19,7 +19,7 @@ import pytest
 # sandbox backends (modal, daytona, e2b, runloop) follow the same
 # pattern of not pinning the SDK in test deps. Reviewers can run these
 # locally with `pip install boxd`.
-pytest.importorskip("boxd")
+pytest.importorskip('boxd')
 
 from sqlalchemy.ext.asyncio import AsyncSession  # noqa: E402
 
@@ -49,10 +49,10 @@ def mock_sandbox_spec_service():
     """SandboxSpecService that returns a deterministic spec."""
     mock_service = AsyncMock()
     mock_spec = SandboxSpecInfo(
-        id="ghcr.io/openhands/agent-server:1.22.1-python",
-        command=["/usr/local/bin/openhands-agent-server", "--port", "60000"],
-        initial_env={"LOG_JSON": "true"},
-        working_dir="/workspace/project",
+        id='ghcr.io/openhands/agent-server:1.22.1-python',
+        command=['/usr/local/bin/openhands-agent-server', '--port', '60000'],
+        initial_env={'LOG_JSON': 'true'},
+        working_dir='/workspace/project',
     )
     mock_service.get_default_sandbox_spec.return_value = mock_spec
     mock_service.get_sandbox_spec.return_value = mock_spec
@@ -62,7 +62,7 @@ def mock_sandbox_spec_service():
 @pytest.fixture
 def mock_user_context():
     mock_context = AsyncMock(spec=UserContext)
-    mock_context.get_user_id.return_value = "test-user-123"
+    mock_context.get_user_id.return_value = 'test-user-123'
     return mock_context
 
 
@@ -90,22 +90,22 @@ def boxd_sandbox_service(
     return BoxdSandboxService(
         sandbox_spec_service=mock_sandbox_spec_service,
         compute=mock_compute,
-        web_url="https://web.example.com",
+        web_url='https://web.example.com',
         max_num_sandboxes=10,
         auto_suspend_timeout=300,
         vcpu=2,
-        memory="8G",
-        disk="100G",
+        memory='8G',
+        disk='100G',
         user_context=mock_user_context,
         db_session=mock_db_session,
     )
 
 
 def make_box_mock(
-    box_id: str = "box-abc",
-    name: str = "oh-test-sandbox",
-    status: str = "running",
-    proxy_domain: str = "agent-oh-test-sandbox.boxd.sh",
+    box_id: str = 'box-abc',
+    name: str = 'oh-test-sandbox',
+    status: str = 'running',
+    proxy_domain: str = 'agent-oh-test-sandbox.boxd.sh',
 ):
     """Build a MagicMock Box. Production Box objects don't carry env back."""
     box = MagicMock()
@@ -127,9 +127,9 @@ def make_box_mock(
 
 
 def make_stored(
-    sandbox_id: str = "test-sandbox-123",
-    user_id: str = "test-user-123",
-    spec_id: str = "ghcr.io/openhands/agent-server:1.22.1-python",
+    sandbox_id: str = 'test-sandbox-123',
+    user_id: str = 'test-user-123',
+    spec_id: str = 'ghcr.io/openhands/agent-server:1.22.1-python',
     session_api_key_hash: str | None = None,
     created_at: datetime | None = None,
 ) -> StoredBoxdSandbox:
@@ -163,19 +163,19 @@ def stub_get_stored_returns(boxd_sandbox_service, stored):
 
 class TestStatusMapping:
     def test_running_maps_to_running(self):
-        assert STATUS_MAPPING["running"] == SandboxStatus.RUNNING
+        assert STATUS_MAPPING['running'] == SandboxStatus.RUNNING
 
     def test_suspended_maps_to_paused(self):
-        assert STATUS_MAPPING["suspended"] == SandboxStatus.PAUSED
+        assert STATUS_MAPPING['suspended'] == SandboxStatus.PAUSED
 
     def test_starting_maps_to_starting(self):
-        assert STATUS_MAPPING["starting"] == SandboxStatus.STARTING
+        assert STATUS_MAPPING['starting'] == SandboxStatus.STARTING
 
     def test_error_maps_to_error(self):
-        assert STATUS_MAPPING["error"] == SandboxStatus.ERROR
+        assert STATUS_MAPPING['error'] == SandboxStatus.ERROR
 
     def test_stopped_maps_to_missing(self):
-        assert STATUS_MAPPING["stopped"] == SandboxStatus.MISSING
+        assert STATUS_MAPPING['stopped'] == SandboxStatus.MISSING
 
 
 class TestStartSandbox:
@@ -188,10 +188,10 @@ class TestStartSandbox:
         mock_compute.box.create.return_value = make_box_mock()
         info = await boxd_sandbox_service.start_sandbox()
         assert info.status == SandboxStatus.RUNNING
-        assert info.created_by_user_id == "test-user-123"
+        assert info.created_by_user_id == 'test-user-123'
         mock_compute.box.create.assert_called_once()
         call_kwargs = mock_compute.box.create.call_args.kwargs
-        assert "config" in call_kwargs
+        assert 'config' in call_kwargs
 
     @pytest.mark.asyncio
     async def test_passes_image_from_spec(self, boxd_sandbox_service, mock_compute):
@@ -199,7 +199,7 @@ class TestStartSandbox:
         mock_compute.box.create.return_value = make_box_mock()
         await boxd_sandbox_service.start_sandbox()
         call_kwargs = mock_compute.box.create.call_args.kwargs
-        assert call_kwargs["image"] == "ghcr.io/openhands/agent-server:1.22.1-python"
+        assert call_kwargs['image'] == 'ghcr.io/openhands/agent-server:1.22.1-python'
 
     @pytest.mark.asyncio
     async def test_sets_env_from_spec_and_webhook(
@@ -208,8 +208,8 @@ class TestStartSandbox:
         stub_search_returns(boxd_sandbox_service, [])
         mock_compute.box.create.return_value = make_box_mock()
         await boxd_sandbox_service.start_sandbox()
-        config = mock_compute.box.create.call_args.kwargs["config"]
-        assert config.env["LOG_JSON"] == "true"
+        config = mock_compute.box.create.call_args.kwargs['config']
+        assert config.env['LOG_JSON'] == 'true'
         assert WEBHOOK_CALLBACK_VARIABLE in config.env
         assert ALLOW_CORS_ORIGINS_VARIABLE in config.env
 
@@ -223,8 +223,8 @@ class TestStartSandbox:
         mock_db_session.add.assert_called_once()
         added = mock_db_session.add.call_args.args[0]
         assert isinstance(added, StoredBoxdSandbox)
-        assert added.created_by_user_id == "test-user-123"
-        assert added.sandbox_spec_id == "ghcr.io/openhands/agent-server:1.22.1-python"
+        assert added.created_by_user_id == 'test-user-123'
+        assert added.sandbox_spec_id == 'ghcr.io/openhands/agent-server:1.22.1-python'
         assert added.session_api_key_hash is not None
 
     @pytest.mark.asyncio
@@ -234,7 +234,7 @@ class TestStartSandbox:
         stub_search_returns(boxd_sandbox_service, [])
         mock_compute.box.create.return_value = make_box_mock()
         await boxd_sandbox_service.start_sandbox()
-        config = mock_compute.box.create.call_args.kwargs["config"]
+        config = mock_compute.box.create.call_args.kwargs['config']
         session_key = config.env[SESSION_API_KEY_VARIABLE]
         added = mock_db_session.add.call_args.args[0]
         assert added.session_api_key_hash == _hash_session_api_key(session_key)
@@ -246,7 +246,7 @@ class TestStartSandbox:
         from boxd.errors import BoxdError
 
         stub_search_returns(boxd_sandbox_service, [])
-        mock_compute.box.create.side_effect = BoxdError("boxd is down")
+        mock_compute.box.create.side_effect = BoxdError('boxd is down')
         with pytest.raises(SandboxError):
             await boxd_sandbox_service.start_sandbox()
 
@@ -266,28 +266,28 @@ class TestStartSandbox:
         await boxd_sandbox_service.start_sandbox()
         assert box.create_proxy.await_count == 2
         proxy_names = {call.args[0] for call in box.create_proxy.await_args_list}
-        assert proxy_names == {"agent", "vscode"}
+        assert proxy_names == {'agent', 'vscode'}
 
 
 class TestGetSandbox:
     @pytest.mark.asyncio
     async def test_returns_none_when_no_stored_row(self, boxd_sandbox_service):
         stub_get_stored_returns(boxd_sandbox_service, None)
-        result = await boxd_sandbox_service.get_sandbox("missing")
+        result = await boxd_sandbox_service.get_sandbox('missing')
         assert result is None
 
     @pytest.mark.asyncio
     async def test_returns_info_when_row_and_vm_exist(
         self, boxd_sandbox_service, mock_compute
     ):
-        stored = make_stored(sandbox_id="abc")
+        stored = make_stored(sandbox_id='abc')
         stub_get_stored_returns(boxd_sandbox_service, stored)
-        mock_compute.box.get.return_value = make_box_mock(name="oh-abc")
-        info = await boxd_sandbox_service.get_sandbox("abc")
+        mock_compute.box.get.return_value = make_box_mock(name='oh-abc')
+        info = await boxd_sandbox_service.get_sandbox('abc')
         assert info is not None
-        assert info.id == "abc"
+        assert info.id == 'abc'
         assert info.status == SandboxStatus.RUNNING
-        assert info.created_by_user_id == "test-user-123"
+        assert info.created_by_user_id == 'test-user-123'
 
     @pytest.mark.asyncio
     async def test_status_missing_when_vm_gone_but_row_present(
@@ -295,10 +295,10 @@ class TestGetSandbox:
     ):
         from boxd.errors import NotFoundError
 
-        stored = make_stored(sandbox_id="abc")
+        stored = make_stored(sandbox_id='abc')
         stub_get_stored_returns(boxd_sandbox_service, stored)
-        mock_compute.box.get.side_effect = NotFoundError("gone")
-        info = await boxd_sandbox_service.get_sandbox("abc")
+        mock_compute.box.get.side_effect = NotFoundError('gone')
+        info = await boxd_sandbox_service.get_sandbox('abc')
         assert info is not None
         assert info.status == SandboxStatus.MISSING
 
@@ -308,36 +308,36 @@ class TestSearchSandboxes:
     async def test_returns_page_with_running_status(
         self, boxd_sandbox_service, mock_compute
     ):
-        stored = make_stored(sandbox_id="abc")
+        stored = make_stored(sandbox_id='abc')
         stub_search_returns(boxd_sandbox_service, [stored])
-        mock_compute.box.get.return_value = make_box_mock(name="oh-abc")
+        mock_compute.box.get.return_value = make_box_mock(name='oh-abc')
         page = await boxd_sandbox_service.search_sandboxes()
         assert len(page.items) == 1
-        assert page.items[0].id == "abc"
+        assert page.items[0].id == 'abc'
 
     @pytest.mark.asyncio
     async def test_pagination_sets_next_page_id(
         self, boxd_sandbox_service, mock_compute
     ):
         # limit=3 but we return 4 rows — the +1 sentinel signals "more".
-        rows = [make_stored(sandbox_id=f"sb-{i}") for i in range(4)]
+        rows = [make_stored(sandbox_id=f'sb-{i}') for i in range(4)]
         stub_search_returns(boxd_sandbox_service, rows)
         mock_compute.box.get.return_value = make_box_mock()
         page = await boxd_sandbox_service.search_sandboxes(limit=3)
         assert len(page.items) == 3
-        assert page.next_page_id == "3"
+        assert page.next_page_id == '3'
 
 
 class TestGetSandboxBySessionApiKey:
     @pytest.mark.asyncio
     async def test_finds_by_session_key(self, boxd_sandbox_service, mock_compute):
-        session_key = "session-secret"
+        session_key = 'session-secret'
         stored = make_stored(
-            sandbox_id="abc",
+            sandbox_id='abc',
             session_api_key_hash=_hash_session_api_key(session_key),
         )
         stub_get_stored_returns(boxd_sandbox_service, stored)
-        mock_compute.box.get.return_value = make_box_mock(name="oh-abc")
+        mock_compute.box.get.return_value = make_box_mock(name='oh-abc')
         info = await boxd_sandbox_service.get_sandbox_by_session_api_key(session_key)
         assert info is not None
         assert info.session_api_key == session_key
@@ -345,17 +345,17 @@ class TestGetSandboxBySessionApiKey:
     @pytest.mark.asyncio
     async def test_returns_none_when_no_match(self, boxd_sandbox_service):
         stub_get_stored_returns(boxd_sandbox_service, None)
-        assert await boxd_sandbox_service.get_sandbox_by_session_api_key("nope") is None
+        assert await boxd_sandbox_service.get_sandbox_by_session_api_key('nope') is None
 
 
 class TestLifecycleOperations:
     @pytest.mark.asyncio
     async def test_pause_calls_suspend(self, boxd_sandbox_service, mock_compute):
-        stored = make_stored(sandbox_id="abc", session_api_key_hash="HASH")
+        stored = make_stored(sandbox_id='abc', session_api_key_hash='HASH')
         stub_get_stored_returns(boxd_sandbox_service, stored)
-        box = make_box_mock(name="oh-abc")
+        box = make_box_mock(name='oh-abc')
         mock_compute.box.get.return_value = box
-        ok = await boxd_sandbox_service.pause_sandbox("abc")
+        ok = await boxd_sandbox_service.pause_sandbox('abc')
         assert ok is True
         box.suspend.assert_called_once()
         # Security: hash is cleared on pause
@@ -366,14 +366,14 @@ class TestLifecycleOperations:
         self, boxd_sandbox_service
     ):
         stub_get_stored_returns(boxd_sandbox_service, None)
-        assert await boxd_sandbox_service.pause_sandbox("abc") is False
+        assert await boxd_sandbox_service.pause_sandbox('abc') is False
 
     @pytest.mark.asyncio
     async def test_resume_calls_resume(self, boxd_sandbox_service, mock_compute):
         # resume_sandbox calls pause_old_sandboxes first → needs search stub
         # and _get_stored stub. The mock_db_session is shared, so we install
         # a side_effect that returns different shapes per call.
-        stored = make_stored(sandbox_id="abc")
+        stored = make_stored(sandbox_id='abc')
         search_scalar = MagicMock()
         search_scalar.all.return_value = []
         search_result = MagicMock()
@@ -383,9 +383,9 @@ class TestLifecycleOperations:
         boxd_sandbox_service.db_session.execute = AsyncMock(
             side_effect=[search_result, get_result]
         )
-        box = make_box_mock(name="oh-abc")
+        box = make_box_mock(name='oh-abc')
         mock_compute.box.get.return_value = box
-        ok = await boxd_sandbox_service.resume_sandbox("abc")
+        ok = await boxd_sandbox_service.resume_sandbox('abc')
         assert ok is True
         box.resume.assert_called_once()
 
@@ -393,11 +393,11 @@ class TestLifecycleOperations:
     async def test_delete_calls_destroy_and_drops_row(
         self, boxd_sandbox_service, mock_compute, mock_db_session
     ):
-        stored = make_stored(sandbox_id="abc")
+        stored = make_stored(sandbox_id='abc')
         stub_get_stored_returns(boxd_sandbox_service, stored)
-        box = make_box_mock(name="oh-abc")
+        box = make_box_mock(name='oh-abc')
         mock_compute.box.get.return_value = box
-        ok = await boxd_sandbox_service.delete_sandbox("abc")
+        ok = await boxd_sandbox_service.delete_sandbox('abc')
         assert ok is True
         box.destroy.assert_called_once()
         mock_db_session.delete.assert_called_once_with(stored)
@@ -408,10 +408,10 @@ class TestLifecycleOperations:
     ):
         from boxd.errors import NotFoundError
 
-        stored = make_stored(sandbox_id="abc")
+        stored = make_stored(sandbox_id='abc')
         stub_get_stored_returns(boxd_sandbox_service, stored)
-        mock_compute.box.get.side_effect = NotFoundError("gone")
-        ok = await boxd_sandbox_service.delete_sandbox("abc")
+        mock_compute.box.get.side_effect = NotFoundError('gone')
+        ok = await boxd_sandbox_service.delete_sandbox('abc')
         # We still cleaned the index — return True so callers don't retry.
         assert ok is True
         mock_db_session.delete.assert_called_once_with(stored)
@@ -425,12 +425,12 @@ class TestLifecycleOperations:
         If boxd destroy fails the row must still be dropped so the leaked
         session_api_key_hash can't be used and stale rows don't accumulate.
         """
-        stored = make_stored(sandbox_id="abc")
+        stored = make_stored(sandbox_id='abc')
         stub_get_stored_returns(boxd_sandbox_service, stored)
-        box = make_box_mock(name="oh-abc")
-        box.destroy.side_effect = RuntimeError("boxd flaked")
+        box = make_box_mock(name='oh-abc')
+        box.destroy.side_effect = RuntimeError('boxd flaked')
         mock_compute.box.get.return_value = box
-        ok = await boxd_sandbox_service.delete_sandbox("abc")
+        ok = await boxd_sandbox_service.delete_sandbox('abc')
         assert ok is False
         mock_db_session.delete.assert_called_once_with(stored)
 
@@ -443,17 +443,17 @@ class TestInjector:
         )
 
         injector = BoxdSandboxServiceInjector(
-            api_key="bxk_test",
+            api_key='bxk_test',
             max_num_sandboxes=5,
             auto_suspend_timeout=600,
             vcpu=2,
-            memory="8G",
-            disk="100G",
+            memory='8G',
+            disk='100G',
         )
 
-        assert injector.api_key == "bxk_test"
+        assert injector.api_key == 'bxk_test'
         assert injector.max_num_sandboxes == 5
         assert injector.auto_suspend_timeout == 600
         assert injector.vcpu == 2
-        assert injector.memory == "8G"
-        assert injector.disk == "100G"
+        assert injector.memory == '8G'
+        assert injector.disk == '100G'

--- a/tests/unit/app_server/test_boxd_sandbox_service.py
+++ b/tests/unit/app_server/test_boxd_sandbox_service.py
@@ -1,0 +1,31 @@
+"""Tests for BoxdSandboxService.
+
+Focuses on:
+- boxd SDK exception handling
+- Sandbox lifecycle management (start, pause, resume, delete)
+- Status mapping from boxd VM status to internal sandbox statuses
+- Environment variable injection for CORS and webhooks
+- Data transformation from boxd Box to SandboxInfo objects
+- User-scoped sandbox operations and security
+- Pagination and search functionality via box.list()
+"""
+
+from openhands.app_server.sandbox.boxd_sandbox_service import STATUS_MAPPING
+from openhands.app_server.sandbox.sandbox_models import SandboxStatus
+
+
+class TestStatusMapping:
+    def test_running_maps_to_running(self):
+        assert STATUS_MAPPING['running'] == SandboxStatus.RUNNING
+
+    def test_suspended_maps_to_paused(self):
+        assert STATUS_MAPPING['suspended'] == SandboxStatus.PAUSED
+
+    def test_starting_maps_to_starting(self):
+        assert STATUS_MAPPING['starting'] == SandboxStatus.STARTING
+
+    def test_error_maps_to_error(self):
+        assert STATUS_MAPPING['error'] == SandboxStatus.ERROR
+
+    def test_stopped_maps_to_missing(self):
+        assert STATUS_MAPPING['stopped'] == SandboxStatus.MISSING

--- a/tests/unit/app_server/test_boxd_sandbox_service.py
+++ b/tests/unit/app_server/test_boxd_sandbox_service.py
@@ -5,13 +5,143 @@ Focuses on:
 - Sandbox lifecycle management (start, pause, resume, delete)
 - Status mapping from boxd VM status to internal sandbox statuses
 - Environment variable injection for CORS and webhooks
-- Data transformation from boxd Box to SandboxInfo objects
+- Data transformation from boxd Box + stored row into SandboxInfo
 - User-scoped sandbox operations and security
-- Pagination and search functionality via box.list()
+- Pagination and search functionality via DB-backed index
 """
 
-from openhands.app_server.sandbox.boxd_sandbox_service import STATUS_MAPPING
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from openhands.app_server.errors import SandboxError
+from openhands.app_server.sandbox.boxd_sandbox_service import (
+    AGENT_PROXY_NAME,
+    AGENT_SERVER_PORT,
+    STATUS_MAPPING,
+    BoxdSandboxService,
+    StoredBoxdSandbox,
+    _hash_session_api_key,
+)
 from openhands.app_server.sandbox.sandbox_models import SandboxStatus
+from openhands.app_server.sandbox.sandbox_service import (
+    ALLOW_CORS_ORIGINS_VARIABLE,
+    SESSION_API_KEY_VARIABLE,
+    WEBHOOK_CALLBACK_VARIABLE,
+)
+from openhands.app_server.sandbox.sandbox_spec_models import SandboxSpecInfo
+from openhands.app_server.user.user_context import UserContext
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_sandbox_spec_service():
+    """SandboxSpecService that returns a deterministic spec."""
+    mock_service = AsyncMock()
+    mock_spec = SandboxSpecInfo(
+        id='ghcr.io/openhands/agent-server:1.22.1-python',
+        command=['/usr/local/bin/openhands-agent-server', '--port', '60000'],
+        initial_env={'LOG_JSON': 'true'},
+        working_dir='/workspace/project',
+    )
+    mock_service.get_default_sandbox_spec.return_value = mock_spec
+    mock_service.get_sandbox_spec.return_value = mock_spec
+    return mock_service
+
+
+@pytest.fixture
+def mock_user_context():
+    mock_context = AsyncMock(spec=UserContext)
+    mock_context.get_user_id.return_value = 'test-user-123'
+    return mock_context
+
+
+@pytest.fixture
+def mock_compute():
+    """boxd Compute client. Tests configure box.create/list/get per case."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_db_session():
+    return AsyncMock(spec=AsyncSession)
+
+
+@pytest.fixture
+def boxd_sandbox_service(
+    mock_sandbox_spec_service, mock_user_context, mock_compute, mock_db_session
+):
+    return BoxdSandboxService(
+        sandbox_spec_service=mock_sandbox_spec_service,
+        compute=mock_compute,
+        web_url='https://web.example.com',
+        max_num_sandboxes=10,
+        auto_suspend_timeout=300,
+        vcpu=2,
+        memory='8G',
+        disk='100G',
+        user_context=mock_user_context,
+        db_session=mock_db_session,
+    )
+
+
+def make_box_mock(
+    box_id: str = 'box-abc',
+    name: str = 'oh-test-sandbox',
+    status: str = 'running',
+    proxy_domain: str = 'agent-oh-test-sandbox.boxd.sh',
+):
+    """Build a MagicMock Box. Production Box objects don't carry env back."""
+    box = MagicMock()
+    box.id = box_id
+    box.name = name
+    box.status = status
+    proxy = MagicMock()
+    proxy.name = AGENT_PROXY_NAME
+    proxy.domain = proxy_domain
+    proxy.port = AGENT_SERVER_PORT
+    proxy.is_default = False
+    box.proxies.return_value = [proxy]
+    return box
+
+
+def make_stored(
+    sandbox_id: str = 'test-sandbox-123',
+    user_id: str = 'test-user-123',
+    spec_id: str = 'ghcr.io/openhands/agent-server:1.22.1-python',
+    session_api_key_hash: str | None = None,
+    created_at: datetime | None = None,
+) -> StoredBoxdSandbox:
+    return StoredBoxdSandbox(
+        id=sandbox_id,
+        created_by_user_id=user_id,
+        sandbox_spec_id=spec_id,
+        session_api_key_hash=session_api_key_hash,
+        created_at=created_at or datetime.now(timezone.utc),
+    )
+
+
+def stub_search_returns(boxd_sandbox_service, stored_rows):
+    """Make _secure_select() / db_session.execute return the given rows."""
+    scalar_result = MagicMock()
+    scalar_result.all.return_value = stored_rows
+    exec_result = MagicMock()
+    exec_result.scalars.return_value = scalar_result
+    boxd_sandbox_service.db_session.execute = AsyncMock(return_value=exec_result)
+
+
+def stub_get_stored_returns(boxd_sandbox_service, stored):
+    """Make a single-row select return the given stored row (or None)."""
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none.return_value = stored
+    boxd_sandbox_service.db_session.execute = AsyncMock(return_value=exec_result)
+
+
+# ─── Tests ────────────────────────────────────────────────────────────────
 
 
 class TestStatusMapping:
@@ -29,3 +159,251 @@ class TestStatusMapping:
 
     def test_stopped_maps_to_missing(self):
         assert STATUS_MAPPING['stopped'] == SandboxStatus.MISSING
+
+
+class TestStartSandbox:
+    @pytest.mark.asyncio
+    async def test_creates_box_with_default_spec(
+        self, boxd_sandbox_service, mock_compute
+    ):
+        # pause_old_sandboxes will call search_sandboxes — stub it empty.
+        stub_search_returns(boxd_sandbox_service, [])
+        mock_compute.box.create.return_value = make_box_mock()
+        info = await boxd_sandbox_service.start_sandbox()
+        assert info.status == SandboxStatus.RUNNING
+        assert info.created_by_user_id == 'test-user-123'
+        mock_compute.box.create.assert_called_once()
+        call_kwargs = mock_compute.box.create.call_args.kwargs
+        assert 'config' in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_passes_image_from_spec(
+        self, boxd_sandbox_service, mock_compute
+    ):
+        stub_search_returns(boxd_sandbox_service, [])
+        mock_compute.box.create.return_value = make_box_mock()
+        await boxd_sandbox_service.start_sandbox()
+        call_kwargs = mock_compute.box.create.call_args.kwargs
+        assert call_kwargs['image'] == 'ghcr.io/openhands/agent-server:1.22.1-python'
+
+    @pytest.mark.asyncio
+    async def test_sets_env_from_spec_and_webhook(
+        self, boxd_sandbox_service, mock_compute
+    ):
+        stub_search_returns(boxd_sandbox_service, [])
+        mock_compute.box.create.return_value = make_box_mock()
+        await boxd_sandbox_service.start_sandbox()
+        config = mock_compute.box.create.call_args.kwargs['config']
+        assert config.env['LOG_JSON'] == 'true'
+        assert WEBHOOK_CALLBACK_VARIABLE in config.env
+        assert ALLOW_CORS_ORIGINS_VARIABLE in config.env
+
+    @pytest.mark.asyncio
+    async def test_inserts_stored_row(
+        self, boxd_sandbox_service, mock_compute, mock_db_session
+    ):
+        stub_search_returns(boxd_sandbox_service, [])
+        mock_compute.box.create.return_value = make_box_mock()
+        await boxd_sandbox_service.start_sandbox()
+        mock_db_session.add.assert_called_once()
+        added = mock_db_session.add.call_args.args[0]
+        assert isinstance(added, StoredBoxdSandbox)
+        assert added.created_by_user_id == 'test-user-123'
+        assert added.sandbox_spec_id == 'ghcr.io/openhands/agent-server:1.22.1-python'
+        assert added.session_api_key_hash is not None
+
+    @pytest.mark.asyncio
+    async def test_session_api_key_in_env_matches_hash_in_row(
+        self, boxd_sandbox_service, mock_compute, mock_db_session
+    ):
+        stub_search_returns(boxd_sandbox_service, [])
+        mock_compute.box.create.return_value = make_box_mock()
+        await boxd_sandbox_service.start_sandbox()
+        config = mock_compute.box.create.call_args.kwargs['config']
+        session_key = config.env[SESSION_API_KEY_VARIABLE]
+        added = mock_db_session.add.call_args.args[0]
+        assert added.session_api_key_hash == _hash_session_api_key(session_key)
+
+    @pytest.mark.asyncio
+    async def test_raises_sandbox_error_on_sdk_failure(
+        self, boxd_sandbox_service, mock_compute
+    ):
+        from boxd.errors import BoxdError
+        stub_search_returns(boxd_sandbox_service, [])
+        mock_compute.box.create.side_effect = BoxdError('boxd is down')
+        with pytest.raises(SandboxError):
+            await boxd_sandbox_service.start_sandbox()
+
+
+class TestGetSandbox:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_stored_row(self, boxd_sandbox_service):
+        stub_get_stored_returns(boxd_sandbox_service, None)
+        result = await boxd_sandbox_service.get_sandbox('missing')
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_info_when_row_and_vm_exist(
+        self, boxd_sandbox_service, mock_compute
+    ):
+        stored = make_stored(sandbox_id='abc')
+        stub_get_stored_returns(boxd_sandbox_service, stored)
+        mock_compute.box.get.return_value = make_box_mock(name='oh-abc')
+        info = await boxd_sandbox_service.get_sandbox('abc')
+        assert info is not None
+        assert info.id == 'abc'
+        assert info.status == SandboxStatus.RUNNING
+        assert info.created_by_user_id == 'test-user-123'
+
+    @pytest.mark.asyncio
+    async def test_status_missing_when_vm_gone_but_row_present(
+        self, boxd_sandbox_service, mock_compute
+    ):
+        from boxd.errors import NotFoundError
+        stored = make_stored(sandbox_id='abc')
+        stub_get_stored_returns(boxd_sandbox_service, stored)
+        mock_compute.box.get.side_effect = NotFoundError('gone')
+        info = await boxd_sandbox_service.get_sandbox('abc')
+        assert info is not None
+        assert info.status == SandboxStatus.MISSING
+
+
+class TestSearchSandboxes:
+    @pytest.mark.asyncio
+    async def test_returns_page_with_running_status(
+        self, boxd_sandbox_service, mock_compute
+    ):
+        stored = make_stored(sandbox_id='abc')
+        stub_search_returns(boxd_sandbox_service, [stored])
+        mock_compute.box.get.return_value = make_box_mock(name='oh-abc')
+        page = await boxd_sandbox_service.search_sandboxes()
+        assert len(page.items) == 1
+        assert page.items[0].id == 'abc'
+
+    @pytest.mark.asyncio
+    async def test_pagination_sets_next_page_id(
+        self, boxd_sandbox_service, mock_compute
+    ):
+        # limit=3 but we return 4 rows — the +1 sentinel signals "more".
+        rows = [make_stored(sandbox_id=f'sb-{i}') for i in range(4)]
+        stub_search_returns(boxd_sandbox_service, rows)
+        mock_compute.box.get.return_value = make_box_mock()
+        page = await boxd_sandbox_service.search_sandboxes(limit=3)
+        assert len(page.items) == 3
+        assert page.next_page_id == '3'
+
+
+class TestGetSandboxBySessionApiKey:
+    @pytest.mark.asyncio
+    async def test_finds_by_session_key(
+        self, boxd_sandbox_service, mock_compute
+    ):
+        session_key = 'session-secret'
+        stored = make_stored(
+            sandbox_id='abc',
+            session_api_key_hash=_hash_session_api_key(session_key),
+        )
+        stub_get_stored_returns(boxd_sandbox_service, stored)
+        mock_compute.box.get.return_value = make_box_mock(name='oh-abc')
+        info = await boxd_sandbox_service.get_sandbox_by_session_api_key(session_key)
+        assert info is not None
+        assert info.session_api_key == session_key
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_match(self, boxd_sandbox_service):
+        stub_get_stored_returns(boxd_sandbox_service, None)
+        assert (
+            await boxd_sandbox_service.get_sandbox_by_session_api_key('nope') is None
+        )
+
+
+class TestLifecycleOperations:
+    @pytest.mark.asyncio
+    async def test_pause_calls_suspend(self, boxd_sandbox_service, mock_compute):
+        stored = make_stored(sandbox_id='abc', session_api_key_hash='HASH')
+        stub_get_stored_returns(boxd_sandbox_service, stored)
+        box = make_box_mock(name='oh-abc')
+        mock_compute.box.get.return_value = box
+        ok = await boxd_sandbox_service.pause_sandbox('abc')
+        assert ok is True
+        box.suspend.assert_called_once()
+        # Security: hash is cleared on pause
+        assert stored.session_api_key_hash is None
+
+    @pytest.mark.asyncio
+    async def test_pause_returns_false_when_stored_row_missing(
+        self, boxd_sandbox_service
+    ):
+        stub_get_stored_returns(boxd_sandbox_service, None)
+        assert await boxd_sandbox_service.pause_sandbox('abc') is False
+
+    @pytest.mark.asyncio
+    async def test_resume_calls_resume(self, boxd_sandbox_service, mock_compute):
+        # resume_sandbox calls pause_old_sandboxes first → needs search stub
+        # and _get_stored stub. The mock_db_session is shared, so we install
+        # a side_effect that returns different shapes per call.
+        stored = make_stored(sandbox_id='abc')
+        search_scalar = MagicMock()
+        search_scalar.all.return_value = []
+        search_result = MagicMock()
+        search_result.scalars.return_value = search_scalar
+        get_result = MagicMock()
+        get_result.scalar_one_or_none.return_value = stored
+        boxd_sandbox_service.db_session.execute = AsyncMock(
+            side_effect=[search_result, get_result]
+        )
+        box = make_box_mock(name='oh-abc')
+        mock_compute.box.get.return_value = box
+        ok = await boxd_sandbox_service.resume_sandbox('abc')
+        assert ok is True
+        box.resume.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_calls_destroy_and_drops_row(
+        self, boxd_sandbox_service, mock_compute, mock_db_session
+    ):
+        stored = make_stored(sandbox_id='abc')
+        stub_get_stored_returns(boxd_sandbox_service, stored)
+        box = make_box_mock(name='oh-abc')
+        mock_compute.box.get.return_value = box
+        ok = await boxd_sandbox_service.delete_sandbox('abc')
+        assert ok is True
+        box.destroy.assert_called_once()
+        mock_db_session.delete.assert_called_once_with(stored)
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_true_when_vm_already_gone(
+        self, boxd_sandbox_service, mock_compute, mock_db_session
+    ):
+        from boxd.errors import NotFoundError
+        stored = make_stored(sandbox_id='abc')
+        stub_get_stored_returns(boxd_sandbox_service, stored)
+        mock_compute.box.get.side_effect = NotFoundError('gone')
+        ok = await boxd_sandbox_service.delete_sandbox('abc')
+        # We still cleaned the index — return True so callers don't retry.
+        assert ok is True
+        mock_db_session.delete.assert_called_once_with(stored)
+
+
+class TestInjector:
+    @pytest.mark.asyncio
+    async def test_injector_carries_config(self):
+        from openhands.app_server.sandbox.boxd_sandbox_service import (
+            BoxdSandboxServiceInjector,
+        )
+
+        injector = BoxdSandboxServiceInjector(
+            api_key='bxk_test',
+            max_num_sandboxes=5,
+            auto_suspend_timeout=600,
+            vcpu=2,
+            memory='8G',
+            disk='100G',
+        )
+
+        assert injector.api_key == 'bxk_test'
+        assert injector.max_num_sandboxes == 5
+        assert injector.auto_suspend_timeout == 600
+        assert injector.vcpu == 2
+        assert injector.memory == '8G'
+        assert injector.disk == '100G'

--- a/tests/unit/app_server/test_boxd_sandbox_service.py
+++ b/tests/unit/app_server/test_boxd_sandbox_service.py
@@ -249,8 +249,12 @@ class TestStartSandbox:
     async def test_creates_named_proxies_after_vm_create(
         self, boxd_sandbox_service, mock_compute
     ):
-        """Named proxies aren't auto-created by BoxConfig — start_sandbox must
-        explicitly call box.create_proxy for agent + vscode."""
+        """Named proxies must be created post-create.
+
+        Pre-declaring them via BoxConfig.network.proxies is silently
+        dropped by the current boxd server, so start_sandbox must call
+        box.create_proxy() for agent + vscode explicitly.
+        """
         stub_search_returns(boxd_sandbox_service, [])
         box = make_box_mock()
         mock_compute.box.create.return_value = box
@@ -407,6 +411,24 @@ class TestLifecycleOperations:
         ok = await boxd_sandbox_service.delete_sandbox('abc')
         # We still cleaned the index — return True so callers don't retry.
         assert ok is True
+        mock_db_session.delete.assert_called_once_with(stored)
+
+    @pytest.mark.asyncio
+    async def test_delete_drops_row_even_when_destroy_fails(
+        self, boxd_sandbox_service, mock_compute, mock_db_session
+    ):
+        """Destroy failure must not block index cleanup.
+
+        If boxd destroy fails the row must still be dropped so the leaked
+        session_api_key_hash can't be used and stale rows don't accumulate.
+        """
+        stored = make_stored(sandbox_id='abc')
+        stub_get_stored_returns(boxd_sandbox_service, stored)
+        box = make_box_mock(name='oh-abc')
+        box.destroy.side_effect = RuntimeError('boxd flaked')
+        mock_compute.box.get.return_value = box
+        ok = await boxd_sandbox_service.delete_sandbox('abc')
+        assert ok is False
         mock_db_session.delete.assert_called_once_with(stored)
 
 

--- a/tests/unit/app_server/test_boxd_sandbox_service.py
+++ b/tests/unit/app_server/test_boxd_sandbox_service.py
@@ -63,7 +63,13 @@ def mock_user_context():
 @pytest.fixture
 def mock_compute():
     """Mock boxd Compute client. Tests configure box.create/list/get per case."""
-    return MagicMock()
+    # Use MagicMock with async methods explicitly stubbed per test, since the
+    # boxd async SDK exposes coroutine methods on box.create / box.get / etc.
+    mock = MagicMock()
+    mock.box.create = AsyncMock()
+    mock.box.get = AsyncMock()
+    mock.box.list = AsyncMock()
+    return mock
 
 
 @pytest.fixture
@@ -105,7 +111,12 @@ def make_box_mock(
     proxy.domain = proxy_domain
     proxy.port = AGENT_SERVER_PORT
     proxy.is_default = False
-    box.proxies.return_value = [proxy]
+    # Async SDK: lifecycle and proxy methods are coroutines
+    box.proxies = AsyncMock(return_value=[proxy])
+    box.create_proxy = AsyncMock(return_value=proxy)
+    box.suspend = AsyncMock()
+    box.resume = AsyncMock()
+    box.destroy = AsyncMock()
     return box
 
 
@@ -233,6 +244,20 @@ class TestStartSandbox:
         mock_compute.box.create.side_effect = BoxdError('boxd is down')
         with pytest.raises(SandboxError):
             await boxd_sandbox_service.start_sandbox()
+
+    @pytest.mark.asyncio
+    async def test_creates_named_proxies_after_vm_create(
+        self, boxd_sandbox_service, mock_compute
+    ):
+        """Named proxies aren't auto-created by BoxConfig — start_sandbox must
+        explicitly call box.create_proxy for agent + vscode."""
+        stub_search_returns(boxd_sandbox_service, [])
+        box = make_box_mock()
+        mock_compute.box.create.return_value = box
+        await boxd_sandbox_service.start_sandbox()
+        assert box.create_proxy.await_count == 2
+        proxy_names = {call.args[0] for call in box.create_proxy.await_args_list}
+        assert proxy_names == {'agent', 'vscode'}
 
 
 class TestGetSandbox:

--- a/tests/unit/app_server/test_boxd_sandbox_service.py
+++ b/tests/unit/app_server/test_boxd_sandbox_service.py
@@ -14,7 +14,14 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession
+
+# boxd is an optional dependency; the in-repo tests for the other
+# sandbox backends (modal, daytona, e2b, runloop) follow the same
+# pattern of not pinning the SDK in test deps. Reviewers can run these
+# locally with `pip install boxd`.
+pytest.importorskip("boxd")
+
+from sqlalchemy.ext.asyncio import AsyncSession  # noqa: E402
 
 from openhands.app_server.errors import SandboxError
 from openhands.app_server.sandbox.boxd_sandbox_service import (

--- a/tests/unit/app_server/test_boxd_sandbox_spec_service.py
+++ b/tests/unit/app_server/test_boxd_sandbox_spec_service.py
@@ -1,0 +1,51 @@
+"""Tests for BoxdSandboxSpecServiceInjector and the default boxd sandbox spec."""
+
+import pytest
+
+from openhands.app_server.sandbox.boxd_sandbox_spec_service import (
+    BoxdSandboxSpecServiceInjector,
+    get_default_boxd_sandbox_specs,
+)
+from openhands.app_server.sandbox.preset_sandbox_spec_service import (
+    PresetSandboxSpecService,
+)
+from openhands.app_server.services.injector import InjectorState
+
+
+class TestBoxdSandboxSpecDefaults:
+    def test_default_specs_returns_one_spec(self):
+        specs = get_default_boxd_sandbox_specs()
+        assert len(specs) == 1
+
+    def test_default_spec_uses_agent_server_image(self):
+        specs = get_default_boxd_sandbox_specs()
+        # The spec id IS the image tag — agent-server is keyed by image.
+        assert 'agent-server' in specs[0].id
+
+    def test_default_spec_has_agent_server_command(self):
+        specs = get_default_boxd_sandbox_specs()
+        cmd = specs[0].command
+        assert cmd is not None
+        assert any('openhands-agent-server' in part for part in cmd)
+        assert '--port' in cmd
+        assert '60000' in cmd
+
+    def test_default_spec_working_dir_is_project(self):
+        specs = get_default_boxd_sandbox_specs()
+        assert specs[0].working_dir == '/workspace/project'
+
+    def test_default_spec_initial_env_includes_log_json(self):
+        specs = get_default_boxd_sandbox_specs()
+        assert specs[0].initial_env.get('LOG_JSON') == 'true'
+
+
+class TestBoxdSandboxSpecServiceInjector:
+    @pytest.mark.asyncio
+    async def test_inject_yields_preset_service(self):
+        injector = BoxdSandboxSpecServiceInjector()
+        state = InjectorState()
+        async for service in injector.inject(state, request=None):
+            assert isinstance(service, PresetSandboxSpecService)
+            page = await service.search_sandbox_specs()
+            assert len(page.items) == 1
+            break

--- a/tests/unit/app_server/test_boxd_sandbox_spec_service.py
+++ b/tests/unit/app_server/test_boxd_sandbox_spec_service.py
@@ -20,23 +20,23 @@ class TestBoxdSandboxSpecDefaults:
     def test_default_spec_uses_agent_server_image(self):
         specs = get_default_boxd_sandbox_specs()
         # The spec id IS the image tag — agent-server is keyed by image.
-        assert 'agent-server' in specs[0].id
+        assert "agent-server" in specs[0].id
 
     def test_default_spec_has_agent_server_command(self):
         specs = get_default_boxd_sandbox_specs()
         cmd = specs[0].command
         assert cmd is not None
-        assert any('openhands-agent-server' in part for part in cmd)
-        assert '--port' in cmd
-        assert '60000' in cmd
+        assert any("openhands-agent-server" in part for part in cmd)
+        assert "--port" in cmd
+        assert "60000" in cmd
 
     def test_default_spec_working_dir_is_project(self):
         specs = get_default_boxd_sandbox_specs()
-        assert specs[0].working_dir == '/workspace/project'
+        assert specs[0].working_dir == "/workspace/project"
 
     def test_default_spec_initial_env_includes_log_json(self):
         specs = get_default_boxd_sandbox_specs()
-        assert specs[0].initial_env.get('LOG_JSON') == 'true'
+        assert specs[0].initial_env.get("LOG_JSON") == "true"
 
 
 class TestBoxdSandboxSpecServiceInjector:

--- a/tests/unit/app_server/test_boxd_sandbox_spec_service.py
+++ b/tests/unit/app_server/test_boxd_sandbox_spec_service.py
@@ -20,23 +20,23 @@ class TestBoxdSandboxSpecDefaults:
     def test_default_spec_uses_agent_server_image(self):
         specs = get_default_boxd_sandbox_specs()
         # The spec id IS the image tag — agent-server is keyed by image.
-        assert "agent-server" in specs[0].id
+        assert 'agent-server' in specs[0].id
 
     def test_default_spec_has_agent_server_command(self):
         specs = get_default_boxd_sandbox_specs()
         cmd = specs[0].command
         assert cmd is not None
-        assert any("openhands-agent-server" in part for part in cmd)
-        assert "--port" in cmd
-        assert "60000" in cmd
+        assert any('openhands-agent-server' in part for part in cmd)
+        assert '--port' in cmd
+        assert '60000' in cmd
 
     def test_default_spec_working_dir_is_project(self):
         specs = get_default_boxd_sandbox_specs()
-        assert specs[0].working_dir == "/workspace/project"
+        assert specs[0].working_dir == '/workspace/project'
 
     def test_default_spec_initial_env_includes_log_json(self):
         specs = get_default_boxd_sandbox_specs()
-        assert specs[0].initial_env.get("LOG_JSON") == "true"
+        assert specs[0].initial_env.get('LOG_JSON') == 'true'
 
 
 class TestBoxdSandboxSpecServiceInjector:


### PR DESCRIPTION
![boxd × OpenHands](https://raw.githubusercontent.com/MichielMAnalytics/OpenHands/assets/boxd-banner.png)

## Summary

Adds `BoxdSandboxService` so OpenHands can run agent conversations inside [boxd](https://boxd.sh) cloud microVMs, alongside the existing Docker / Remote / Process / Local backends.

Each conversation gets a dedicated KVM-isolated VM with the OpenHands agent-server image, two HTTPS subdomain proxies (agent server on port 60000, VS Code on 60001), and `auto_suspend_timeout` for sub-millisecond warm suspend/resume. Selected via `RUNTIME=boxd`.

## What's new

- `BoxdSandboxService` mirrors the `RemoteSandboxService` shape; drives the [boxd Python SDK](https://pypi.org/project/boxd/) async API (`boxd.aio.Compute` + `Box`).
- `BoxdSandboxSpecServiceInjector` provides a default preset spec keyed by the OpenHands agent-server image tag (same image as Docker/Remote).
- Alembic migration `010` creates the `v1_boxd_sandbox` index table.
- `pyproject.toml` adds `boxd>=0.1.2,<1.0.0` as an optional dependency (install with `pip install boxd`).
- `openhands/app_server/sandbox/boxd-runtime.md` is the operator setup guide.
- `openhands/app_server/sandbox/README.md` updated with the backend table.
- Tests: 32 unit tests covering status mapping, lifecycle, user-scoped access, pagination, and security behaviors.

## Why boxd

- Per-VM IPv4 + dedicated KVM isolation (vs. shared-kernel Docker containers).
- Sub-millisecond warm suspend/resume preserves running processes — pause a conversation, return tomorrow, resume with full state.
- Self-hostable (open source), so users with compliance / data-residency requirements can run their own cluster.

## Persistence model

A small SQLAlchemy table (`v1_boxd_sandbox`) indexes sandbox metadata. This mirrors `StoredRemoteSandbox` and is required because the boxd SDK doesn't expose env on the returned `Box` object — we can't recover metadata directly from the VM. The DB is the index; boxd remains the source of truth for live VM status.

## Security model

- `session_api_key` is generated app-side, injected into the VM via `OH_SESSION_API_KEYS_0`, and indexed by SHA-256 hash (via the existing `_hash_session_api_key` helper from `remote_sandbox_service`). The raw key never persists on the OpenHands host.
- `pause_sandbox` clears the stored hash so leaked keys can't be replayed against a suspended VM.
- `delete_sandbox` destroys the VM first, then drops the index row in all paths (success and failure). On destroy failure the row is still dropped so the leaked hash is invalidated.

## Test plan

- [x] Unit tests pass: `pytest tests/unit/app_server/test_boxd_sandbox_service.py tests/unit/app_server/test_boxd_sandbox_spec_service.py` (32 passed)
- [x] `ruff check` clean on all new files + modified `config.py`
- [x] End-to-end smoke test against a real boxd cluster: start → both proxies surface as `agent.oh-<id>.boxd.sh` and `vscode.oh-<id>.boxd.sh`; pause 185ms; resume 295ms; delete drops the row and subsequent `get_sandbox` returns None.

## Notes for maintainers

- `poetry.lock` not regenerated in this PR — the local poetry version was older than the repo's pinned `2.3.3` and produced lockfile churn unrelated to this change. Please regenerate with your CI flow before merge.
- New SQLAlchemy table `v1_boxd_sandbox` follows the naming and migration model of `v1_remote_sandbox`.
- No webhook polling fallback yet (which `RemoteSandboxService` uses for `web_url` on localhost). Documented as a limitation in `boxd-runtime.md`.
- `search_sandboxes` fans out per-row `box.get` lookups with `asyncio.gather`, so a page of N is one round-trip of latency rather than N.