### PR TITLE
fix(app_server): use live title when stored title is default placeholder

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -538,13 +538,34 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 conversation_url += f'/api/conversations/{app_conversation_info.id.hex}'
             session_api_key = sandbox.session_api_key
 
+        payload = app_conversation_info.model_dump()
+        live_title = getattr(conversation_info, 'title', None) if conversation_info else None
+        stored_title = payload.get('title')
+        if (
+            live_title
+            and isinstance(live_title, str)
+            and self._is_default_generated_title(
+                stored_title, app_conversation_info.id.hex
+            )
+        ):
+            payload['title'] = live_title
+
         return AppConversation(
-            **app_conversation_info.model_dump(),
+            **payload,
             sandbox_status=sandbox_status,
             execution_status=execution_status,
             conversation_url=conversation_url,
             session_api_key=session_api_key,
         )
+
+    @staticmethod
+    def _is_default_generated_title(title: str | None, conversation_id_hex: str) -> bool:
+        if not title:
+            return True
+        return title in {
+            f'Conversation {conversation_id_hex[:5]}',
+            f'Conversation {conversation_id_hex}',
+        }
 
     def _get_sandbox_id_to_conversation_ids(
         self, stored_conversations: Sequence[AppConversationInfo | None]

--- a/openhands/app_server/event_callback/webhook_router.py
+++ b/openhands/app_server/event_callback/webhook_router.py
@@ -226,14 +226,25 @@ def detect_automation_trigger(
     return None
 
 
+def _is_default_generated_title(title: str | None, conversation_id_hex: str) -> bool:
+    if not title:
+        return True
+    return title in {
+        f'Conversation {conversation_id_hex[:5]}',
+        f'Conversation {conversation_id_hex}',
+    }
+
+
 async def valid_sandbox(
     request: Request,
     session_api_key: str = Depends(
         APIKeyHeader(name='X-Session-API-Key', auto_error=False)
     ),
 ) -> SandboxInfo:
-    """Use a session api key for validation, and get a sandbox. Subsequent actions
-    are executed in the context of the owner of the sandbox"""
+    """Use a session API key for validation, and get a sandbox.
+
+    Subsequent actions are executed in the context of the owner of the sandbox.
+    """
     if not session_api_key:
         raise HTTPException(
             status.HTTP_401_UNAUTHORIZED, detail='X-Session-API-Key header is required'
@@ -346,9 +357,17 @@ async def on_conversation_update(
         agent_kind = 'openhands'
         llm_model = agent.llm.model
 
+    resolved_title = existing.title or f'Conversation {conversation_info.id.hex}'
+    if (
+        isinstance(conversation_info.title, str)
+        and conversation_info.title
+        and _is_default_generated_title(existing.title, conversation_info.id.hex)
+    ):
+        resolved_title = conversation_info.title
+
     app_conversation_info = AppConversationInfo(
         id=conversation_info.id,
-        title=existing.title or f'Conversation {conversation_info.id.hex}',
+        title=resolved_title,
         sandbox_id=sandbox_info.id,
         created_by_user_id=sandbox_info.created_by_user_id,
         llm_model=llm_model,
@@ -457,9 +476,11 @@ async def get_secret(
     access_token: str = Depends(APIKeyHeader(name='X-Access-Token', auto_error=False)),
     jwt_service: JwtService = jwt_dependency,
 ) -> Response:
-    """Given an access token, retrieve a user secret. The access token
-    is limited by user and provider type, and may include a timeout, limiting
-    the damage in the event that a token is ever leaked"""
+    """Given an access token, retrieve a user secret.
+
+    The access token is limited by user and provider type, and may include a
+    timeout, limiting the damage in the event that a token is ever leaked.
+    """
     try:
         payload = jwt_service.verify_jws_token(access_token)
         user_id = payload['user_id']
@@ -493,7 +514,7 @@ async def _run_callbacks_in_bg_and_close(
     user_id: str | None,
     events: list[Event],
 ):
-    """Run all callbacks and close the session"""
+    """Run all callbacks and close the session."""
     state = InjectorState()
     setattr(state, USER_CONTEXT_ATTR, SpecifyUserContext(user_id=user_id))
 

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3146,6 +3146,64 @@ class TestAgentKindConversationUrl:
             'http://localhost:8000/api/conversations/11111111111111111111111111111111'
         )
 
+    def test_build_conversation_prefers_live_title_over_default_placeholder(self):
+        from types import SimpleNamespace
+        from uuid import UUID
+
+        from openhands.app_server.app_conversation.app_conversation_models import (
+            AppConversationInfo,
+        )
+        from openhands.app_server.sandbox.sandbox_models import SandboxStatus
+
+        service = LiveStatusAppConversationService.__new__(
+            LiveStatusAppConversationService
+        )
+
+        info = AppConversationInfo(
+            id=UUID('22222222-2222-2222-2222-222222222222'),
+            created_by_user_id=None,
+            sandbox_id='sandbox-a',
+            title='Conversation 22222',
+        )
+        live_info = SimpleNamespace(
+            execution_status=None,
+            title='Fix auth regression in login flow',
+        )
+
+        result = service._build_conversation(info, None, live_info)
+
+        assert result is not None
+        assert result.sandbox_status == SandboxStatus.MISSING
+        assert result.title == 'Fix auth regression in login flow'
+
+    def test_build_conversation_keeps_non_default_stored_title(self):
+        from types import SimpleNamespace
+        from uuid import UUID
+
+        from openhands.app_server.app_conversation.app_conversation_models import (
+            AppConversationInfo,
+        )
+
+        service = LiveStatusAppConversationService.__new__(
+            LiveStatusAppConversationService
+        )
+
+        info = AppConversationInfo(
+            id=UUID('33333333-3333-3333-3333-333333333333'),
+            created_by_user_id=None,
+            sandbox_id='sandbox-a',
+            title='Ship production-ready OAuth fix',
+        )
+        live_info = SimpleNamespace(
+            execution_status=None,
+            title='Interim generated title',
+        )
+
+        result = service._build_conversation(info, None, live_info)
+
+        assert result is not None
+        assert result.title == 'Ship production-ready OAuth fix'
+
 
 class TestBuildAcpStartConversationRequestSecrets:
     """Tests for user-secret injection in ``_build_acp_start_conversation_request``.

--- a/tests/unit/app_server/test_webhook_router_auto_title.py
+++ b/tests/unit/app_server/test_webhook_router_auto_title.py
@@ -455,3 +455,73 @@ class TestOnConversationUpdateAutoTitle:
 
         # Verify order: conversation saved first, then callback registered
         assert operation_order == ['save_conversation', 'save_callback']
+
+    @pytest.mark.asyncio
+    async def test_persists_live_title_when_existing_title_is_default_placeholder(
+        self,
+        async_session,
+        app_conversation_info_service,
+        sandbox_info,
+        mock_conversation_info,
+    ):
+        conversation_id = mock_conversation_info.id
+        mock_conversation_info.title = 'Fix the authentication bug in login.py'
+
+        existing_conv = AppConversationInfo(
+            id=conversation_id,
+            title=f'Conversation {conversation_id.hex[:5]}',
+            sandbox_id='sandbox_123',
+            created_by_user_id='user_123',
+        )
+
+        with patch(
+            'openhands.app_server.event_callback.webhook_router.valid_conversation',
+            return_value=existing_conv,
+        ):
+            result = await on_conversation_update(
+                conversation_info=mock_conversation_info,
+                sandbox_info=sandbox_info,
+                app_conversation_info_service=app_conversation_info_service,
+            )
+
+        assert isinstance(result, Success)
+        saved = await app_conversation_info_service.get_app_conversation_info(
+            conversation_id
+        )
+        assert saved is not None
+        assert saved.title == 'Fix the authentication bug in login.py'
+
+    @pytest.mark.asyncio
+    async def test_preserves_existing_custom_title_over_live_generated_title(
+        self,
+        async_session,
+        app_conversation_info_service,
+        sandbox_info,
+        mock_conversation_info,
+    ):
+        conversation_id = mock_conversation_info.id
+        mock_conversation_info.title = 'Interim generated title'
+
+        existing_conv = AppConversationInfo(
+            id=conversation_id,
+            title='My custom conversation title',
+            sandbox_id='sandbox_123',
+            created_by_user_id='user_123',
+        )
+
+        with patch(
+            'openhands.app_server.event_callback.webhook_router.valid_conversation',
+            return_value=existing_conv,
+        ):
+            result = await on_conversation_update(
+                conversation_info=mock_conversation_info,
+                sandbox_info=sandbox_info,
+                app_conversation_info_service=app_conversation_info_service,
+            )
+
+        assert isinstance(result, Success)
+        saved = await app_conversation_info_service.get_app_conversation_info(
+            conversation_id
+        )
+        assert saved is not None
+        assert saved.title == 'My custom conversation title'


### PR DESCRIPTION
## Summary

Fixes API-triggered conversations that remain stuck with default titles like `Conversation abc12` in the UI.

This now fixes the bug in two places:
- persist the live title from webhook conversation updates when the stored title is still a generated placeholder
- keep a response-level fallback in `AppConversation` building so the UI still shows the live title even before persistence catches up

## Why this fixes the bug

The underlying problem is a race between default placeholder creation and later title generation.

Previously:
- the app server stored a default placeholder title early
- webhook updates continued to preserve that stored placeholder instead of replacing it with `conversation_info.title`
- `_build_conversation` also preferred the stored placeholder over the live title

That meant API-created conversations could keep a default title in the interface indefinitely.

With this change:
- webhook updates persist the generated title as soon as it is present and the stored title is still default
- manually customized stored titles are preserved
- the live-status response still falls back to the live title if persistence has not happened yet

## Duplicate check

Before implementing this fix, I checked open PRs for this area/topic:
- `repo:OpenHands/OpenHands "generate_title" is:pr is:open` → no matches
- `repo:OpenHands/OpenHands "ConversationTrigger.REMOTE_API_KEY" "title" is:pr is:open` → no matches

So this is not duplicating an active PR for this specific bug.

## Changes

- `openhands/app_server/event_callback/webhook_router.py`
  - persist `conversation_info.title` when the existing stored title is still a generated default placeholder
  - preserve existing custom titles
  - clean up touched docstrings so the file passes lint cleanly
- `openhands/app_server/app_conversation/live_status_app_conversation_service.py`
  - resolve title from live conversation info when stored title is still a generated default placeholder
- Added regression tests:
  - `test_persists_live_title_when_existing_title_is_default_placeholder`
  - `test_preserves_existing_custom_title_over_live_generated_title`
  - `test_build_conversation_prefers_live_title_over_default_placeholder`
  - `test_build_conversation_keeps_non_default_stored_title`

## Validation

- `uv run pytest tests/unit/app_server/test_webhook_router_auto_title.py tests/unit/app_server/test_live_status_app_conversation_service.py -k "persists_live_title_when_existing_title_is_default_placeholder or preserves_existing_custom_title_over_live_generated_title or build_conversation_prefers_live_title_over_default_placeholder or build_conversation_keeps_non_default_stored_title or test_build_conversation_url_uses_unified_path"`
- `uv run ruff check openhands/app_server/event_callback/webhook_router.py tests/unit/app_server/test_webhook_router_auto_title.py openhands/app_server/app_conversation/live_status_app_conversation_service.py tests/unit/app_server/test_live_status_app_conversation_service.py`

## Related issue

- Addresses #13125