### PR TITLE
ci: add 7-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       # put packages in their own group if they have a history of breaking the build or needing to be reverted
@@ -29,6 +31,8 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       docusaurus:
@@ -51,6 +55,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       docusaurus:
@@ -72,6 +78,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
 
   - package-ecosystem: "docker"
@@ -79,4 +87,6 @@ updates:
       - "containers/*"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- add a 7-day Dependabot cooldown to the existing update entries
- delay version-update PR creation long enough for early supply-chain issues to surface
- keep the current schedules and grouping rules unchanged

## Testing
- not run (configuration-only change)

_This PR was created by an AI agent (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-acf2ea3   docker.openhands.dev/openhands/openhands:acf2ea3
```