### PR TITLE
Fix conversation metadata startup race

### DIFF
--- a/enterprise/server/utils/saas_app_conversation_info_injector.py
+++ b/enterprise/server/utils/saas_app_conversation_info_injector.py
@@ -1,5 +1,6 @@
 """Enterprise injector for SQLAppConversationInfoService with SAAS filtering."""
 
+import logging
 from datetime import datetime
 from typing import AsyncGenerator
 from uuid import UUID
@@ -25,6 +26,8 @@ from openhands.app_server.app_conversation.sql_app_conversation_info_service imp
 from openhands.app_server.errors import AuthError
 from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.user.specifiy_user_context import ADMIN
+
+logger = logging.getLogger(__name__)
 
 
 class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
@@ -392,12 +395,26 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
             )
             saas_result = await self.db_session.execute(saas_query)
             existing_saas_metadata = saas_result.scalar_one_or_none()
-            assert existing_saas_metadata is None or (
-                existing_saas_metadata.user_id == user_id_uuid
-                and existing_saas_metadata.org_id == org_id
-            )
 
-            if not existing_saas_metadata:
+            if existing_saas_metadata:
+                if existing_saas_metadata.user_id != user_id_uuid:
+                    raise AuthError('Conversation belongs to a different user')
+
+                if existing_saas_metadata.org_id != org_id:
+                    if resolver_org_id is not None:
+                        existing_saas_metadata.org_id = resolver_org_id
+                    else:
+                        logger.warning(
+                            'Preserving existing conversation SAAS org metadata '
+                            'during conflicting save',
+                            extra={
+                                'conversation_id': str(info.id),
+                                'existing_org_id': str(existing_saas_metadata.org_id),
+                                'requested_org_id': str(org_id),
+                                'user_id': str(user_id_uuid),
+                            },
+                        )
+            else:
                 # Create new SAAS metadata with the determined org_id
                 saas_metadata = StoredConversationMetadataSaas(
                     conversation_id=str(info.id),

--- a/enterprise/tests/unit/storage/test_saas_sql_app_conversation_info_service.py
+++ b/enterprise/tests/unit/storage/test_saas_sql_app_conversation_info_service.py
@@ -1420,3 +1420,95 @@ class TestResolverOrgIdRouting:
 
         assert saas_metadata is not None
         assert saas_metadata.org_id == ORG1_ID
+        assert saas_metadata.user_id == USER1_ID
+
+    @pytest.mark.asyncio
+    async def test_resolver_save_repairs_webhook_org_race(
+        self,
+        async_session_with_users: AsyncSession,
+    ):
+        """Resolver context is authoritative if a webhook saved current org first."""
+        from storage.stored_conversation_metadata_saas import (
+            StoredConversationMetadataSaas,
+        )
+
+        from enterprise.integrations.resolver_context import ResolverUserContext
+
+        conv_id = uuid4()
+        conv_info = AppConversationInfo(
+            id=conv_id,
+            created_by_user_id=str(USER1_ID),
+            sandbox_id='sandbox_webhook_first',
+            title='Webhook First Conversation',
+        )
+
+        webhook_service = SaasSQLAppConversationInfoService(
+            db_session=async_session_with_users,
+            user_context=SpecifyUserContext(user_id=None),
+        )
+        await webhook_service.save_app_conversation_info(conv_info)
+
+        resolver_context = MagicMock(spec=ResolverUserContext)
+        resolver_context.get_user_id = AsyncMock(return_value=str(USER1_ID))
+        resolver_context.resolver_org_id = ORG2_ID
+        resolver_service = SaasSQLAppConversationInfoService(
+            db_session=async_session_with_users,
+            user_context=resolver_context,
+        )
+
+        await resolver_service.save_app_conversation_info(conv_info)
+
+        result = await async_session_with_users.execute(
+            select(StoredConversationMetadataSaas).where(
+                StoredConversationMetadataSaas.conversation_id == str(conv_id)
+            )
+        )
+        saas_metadata = result.scalar_one_or_none()
+        assert saas_metadata is not None
+        assert saas_metadata.user_id == USER1_ID
+        assert saas_metadata.org_id == ORG2_ID
+
+    @pytest.mark.asyncio
+    async def test_webhook_save_preserves_existing_resolver_org(
+        self,
+        async_session_with_users: AsyncSession,
+    ):
+        """A later webhook save must not downgrade resolver-routed metadata."""
+        from storage.stored_conversation_metadata_saas import (
+            StoredConversationMetadataSaas,
+        )
+
+        from enterprise.integrations.resolver_context import ResolverUserContext
+
+        resolver_context = MagicMock(spec=ResolverUserContext)
+        resolver_context.get_user_id = AsyncMock(return_value=str(USER1_ID))
+        resolver_context.resolver_org_id = ORG2_ID
+        resolver_service = SaasSQLAppConversationInfoService(
+            db_session=async_session_with_users,
+            user_context=resolver_context,
+        )
+
+        conv_id = uuid4()
+        conv_info = AppConversationInfo(
+            id=conv_id,
+            created_by_user_id=str(USER1_ID),
+            sandbox_id='sandbox_resolver_first',
+            title='Resolver First Conversation',
+        )
+        await resolver_service.save_app_conversation_info(conv_info)
+
+        webhook_service = SaasSQLAppConversationInfoService(
+            db_session=async_session_with_users,
+            user_context=SpecifyUserContext(user_id=None),
+        )
+        await webhook_service.save_app_conversation_info(conv_info)
+
+        result = await async_session_with_users.execute(
+            select(StoredConversationMetadataSaas).where(
+                StoredConversationMetadataSaas.conversation_id == str(conv_id)
+            )
+        )
+        saas_metadata = result.scalar_one_or_none()
+        assert saas_metadata is not None
+        assert saas_metadata.user_id == USER1_ID
+        assert saas_metadata.org_id == ORG2_ID

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -34,6 +34,7 @@ from sqlalchemy import (
     select,
 )
 from sqlalchemy.engine import CursorResult
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -344,13 +345,13 @@ class SQLAppConversationInfoService(AppConversationInfoService):
 
         return results
 
-    async def save_app_conversation_info(
+    def _to_stored_metadata(
         self, info: AppConversationInfo
-    ) -> AppConversationInfo:
+    ) -> StoredConversationMetadata:
         metrics = info.metrics or MetricsSnapshot()
         usage = metrics.accumulated_token_usage or TokenUsage()
 
-        stored = StoredConversationMetadata(
+        return StoredConversationMetadata(
             conversation_id=str(info.id),
             selected_repository=info.selected_repository,
             selected_branch=info.selected_branch,
@@ -383,8 +384,62 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             tags=info.tags if info.tags else None,
         )
 
-        await self.db_session.merge(stored)
+    @staticmethod
+    def _looks_like_duplicate_metadata_error(error: IntegrityError) -> bool:
+        orig = getattr(error, 'orig', None)
+        constraint_name = getattr(orig, 'constraint_name', None)
+        if constraint_name is None:
+            constraint_name = getattr(
+                getattr(orig, 'diag', None), 'constraint_name', None
+            )
+        if constraint_name == 'conversation_metadata_pkey':
+            return True
+        if getattr(orig, 'pgcode', None) == '23505':
+            return True
+        if getattr(orig, 'sqlstate', None) == '23505':
+            return True
+
+        message = str(error).lower()
+        return 'conversation_metadata' in message and (
+            'duplicate' in message or 'unique' in message
+        )
+
+    async def _update_existing_metadata_after_duplicate(
+        self, stored: StoredConversationMetadata
+    ) -> bool:
+        result = await self.db_session.execute(
+            select(StoredConversationMetadata).where(
+                StoredConversationMetadata.conversation_id == stored.conversation_id
+            )
+        )
+        existing = result.scalar_one_or_none()
+        if existing is None:
+            return False
+
+        # Last writer wins is acceptable for this startup race: both writers are
+        # saving metadata for the same newly created conversation, and the later
+        # state is at least as complete as the row inserted by the concurrent save.
+        for column in StoredConversationMetadata.__table__.columns:
+            if column.name == 'conversation_id':
+                continue
+            setattr(existing, column.name, getattr(stored, column.name))
         await self.db_session.commit()
+        return True
+
+    async def save_app_conversation_info(
+        self, info: AppConversationInfo
+    ) -> AppConversationInfo:
+        stored = self._to_stored_metadata(info)
+
+        try:
+            await self.db_session.merge(stored)
+            await self.db_session.commit()
+        except IntegrityError as error:
+            await self.db_session.rollback()
+            if not self._looks_like_duplicate_metadata_error(error):
+                raise
+            if not await self._update_existing_metadata_after_duplicate(stored):
+                raise
         return info
 
     async def update_conversation_statistics(
@@ -575,8 +630,10 @@ class SQLAppConversationInfoService(AppConversationInfoService):
         )
 
     def _fix_timezone(self, value: datetime | None) -> datetime:
-        """Sqlite does not store timezones - and since we can't update the existing models
-        we assume UTC if the timezone is missing. Returns current UTC time if value is None.
+        """Ensure a datetime has timezone information.
+
+        Sqlite does not store timezones, so assume UTC if the timezone is missing.
+        Returns current UTC time if value is None.
         """
         if value is None:
             # Fallback for legacy data: use current time to match model defaults.

--- a/tests/unit/app_server/test_sql_app_conversation_info_service.py
+++ b/tests/unit/app_server/test_sql_app_conversation_info_service.py
@@ -5,11 +5,14 @@ focusing on basic CRUD operations, search functionality, filtering, pagination,
 and batch operations using SQLite as a mock database.
 """
 
+import asyncio
 from datetime import datetime, timezone
-from typing import AsyncGenerator
+from typing import AsyncGenerator, cast
+from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
@@ -165,6 +168,114 @@ class TestSQLAppConversationInfoService:
         assert retrieved_info.trigger == sample_conversation_info.trigger
         assert retrieved_info.pr_number == sample_conversation_info.pr_number
         assert retrieved_info.llm_model == sample_conversation_info.llm_model
+
+    @pytest.mark.asyncio
+    async def test_concurrent_saves_recover_from_duplicate_key_race(
+        self,
+        sample_conversation_info: AppConversationInfo,
+    ):
+        """Two concurrent writers can both miss a row before one insert wins."""
+
+        class ScalarResult:
+            def __init__(self, row):
+                self.row = row
+
+            def scalar_one_or_none(self):
+                return self.row
+
+        class RaceyConversationMetadataTable:
+            def __init__(self, conversation_id: str):
+                self.conversation_id = conversation_id
+                self.rows = {}
+                self.merge_count = 0
+                self.all_writers_ready = asyncio.Event()
+                self.unique_index_lock = asyncio.Lock()
+                self.duplicate_errors = 0
+                self.recovery_selects = 0
+
+            async def wait_until_both_writers_have_selected_no_row(self):
+                self.merge_count += 1
+                if self.merge_count == 2:
+                    self.all_writers_ready.set()
+                await self.all_writers_ready.wait()
+
+        def make_db_session_mock(insert_delay: float) -> Mock:
+            session = Mock(spec=AsyncSession)
+            pending_insert = None
+
+            async def merge(stored):
+                nonlocal pending_insert
+                pending_insert = stored
+                await table.wait_until_both_writers_have_selected_no_row()
+
+            async def commit():
+                nonlocal pending_insert
+                if pending_insert is None:
+                    return
+
+                stored = pending_insert
+                pending_insert = None
+                await asyncio.sleep(insert_delay)
+
+                async with table.unique_index_lock:
+                    if stored.conversation_id in table.rows:
+                        table.duplicate_errors += 1
+                        raise IntegrityError(
+                            'INSERT INTO conversation_metadata',
+                            {},
+                            Exception(
+                                'duplicate key value violates unique constraint '
+                                '"conversation_metadata_pkey"'
+                            ),
+                        )
+                    table.rows[stored.conversation_id] = stored
+
+            async def rollback():
+                nonlocal pending_insert
+                pending_insert = None
+
+            async def execute(_query):
+                table.recovery_selects += 1
+                await asyncio.sleep(0)
+                return ScalarResult(table.rows.get(table.conversation_id))
+
+            session.merge = AsyncMock(side_effect=merge)
+            session.commit = AsyncMock(side_effect=commit)
+            session.rollback = AsyncMock(side_effect=rollback)
+            session.execute = AsyncMock(side_effect=execute)
+            return session
+
+        conversation_id = str(sample_conversation_info.id)
+        table = RaceyConversationMetadataTable(conversation_id)
+        webhook_session = make_db_session_mock(insert_delay=0.01)
+        live_status_session = make_db_session_mock(insert_delay=0.05)
+        webhook_service = SQLAppConversationInfoService(
+            db_session=cast(AsyncSession, webhook_session),
+            user_context=SpecifyUserContext(user_id='test_user'),
+        )
+        live_status_service = SQLAppConversationInfoService(
+            db_session=cast(AsyncSession, live_status_session),
+            user_context=SpecifyUserContext(user_id='test_user'),
+        )
+
+        webhook_info = sample_conversation_info.model_copy(
+            deep=True, update={'title': 'metadata from webhook'}
+        )
+        live_status_info = sample_conversation_info.model_copy(
+            deep=True, update={'title': 'metadata from live status'}
+        )
+
+        await asyncio.gather(
+            webhook_service.save_app_conversation_info(webhook_info),
+            live_status_service.save_app_conversation_info(live_status_info),
+        )
+
+        assert table.merge_count == 2
+        assert table.duplicate_errors == 1
+        assert table.recovery_selects == 1
+        webhook_session.rollback.assert_not_awaited()
+        live_status_session.rollback.assert_awaited_once()
+        assert table.rows[conversation_id].title == live_status_info.title
 
     @pytest.mark.asyncio
     async def test_get_nonexistent_conversation_info(


### PR DESCRIPTION
## Summary

Fixes OpenHands/enterprise#26.

This makes conversation metadata saves resilient to the startup race where the agent-server webhook and `LiveStatusAppConversationService._start_app_conversation()` both try to persist metadata for the same conversation.

Changes:
- Recover from duplicate-key `conversation_metadata` races by rolling back and updating the row that the concurrent writer inserted.
- Make SaaS conversation metadata saves tolerate resolver/webhook org ordering:
  - resolver org context repairs an earlier webhook/current-org save
  - later webhook/current-org saves preserve existing resolver-routed org metadata
  - different-user conflicts raise `AuthError` instead of an assertion
- Add regression coverage for the duplicate-key race and the two resolver/webhook org ordering cases.

The base regression test keeps production service logic intact and mocks only the async DB-session calls the service makes (`merge`, `commit`, `rollback`, and `execute`). Those DB-call side effects model two concurrent PostgreSQL sessions sharing one table: both writers reach the stale no-row insert decision, the faster webhook-style commit wins the unique index, and the slower live-status commit receives the same `conversation_metadata_pkey` duplicate-key error seen in production before recovering.

## Tests

- `poetry run pytest tests/unit/app_server/test_sql_app_conversation_info_service.py::TestSQLAppConversationInfoService::test_concurrent_saves_recover_from_duplicate_key_race -q`
- `poetry run pytest tests/unit/app_server/test_sql_app_conversation_info_service.py -q`
- `cd enterprise && poetry run pytest tests/unit/storage/test_saas_sql_app_conversation_info_service.py -q`
- `poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml`

_This PR was updated by an AI agent (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-8c7396a   docker.openhands.dev/openhands/openhands:8c7396a
```