### PR TITLE
ci: pin external third-party actions to commit SHAs + scope Dependabot to composite actions

### DIFF
--- a/.github/actions/docker-image-tags/action.yml
+++ b/.github/actions/docker-image-tags/action.yml
@@ -33,7 +33,7 @@ runs:
   steps:
     - name: Compute tags
       id: meta
-      uses: docker/metadata-action@v6
+      uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
       env:
         # Use the PR head SHA (not the merge SHA) for sha-prefixed tags.
         DOCKER_METADATA_PR_HEAD_SHA: "true"

--- a/.github/actions/docker-merge-manifest/action.yml
+++ b/.github/actions/docker-merge-manifest/action.yml
@@ -13,14 +13,14 @@ runs:
   using: composite
   steps:
     - name: Login to GHCR
-      uses: docker/login-action@v4
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ github.token }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Create multi-arch manifests
       shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,7 +75,10 @@ updates:
           - "*"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/docker-image-tags"
+      - "/.github/actions/docker-merge-manifest"
     schedule:
       interval: "weekly"
     cooldown:

--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -59,13 +59,13 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
         with:
           driver-opts: ${{ inputs.buildx-driver-opts }}
       - name: Compute per-arch tags
@@ -76,7 +76,7 @@ jobs:
           ref-name: ${{ env.RELEVANT_REF_NAME }}
           suffix: -${{ matrix.arch }}
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}

--- a/.github/workflows/enterprise-check-migrations.yml
+++ b/.github/workflows/enterprise-check-migrations.yml
@@ -39,7 +39,7 @@ jobs:
           fi
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         id: find-comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -48,7 +48,7 @@ jobs:
             ⚠️ This PR contains **migrations**
 
       - name: Comment warning on PR
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/npm-publish-ui.yml
+++ b/.github/workflows/npm-publish-ui.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: "openhands-ui/.bun-version"
 

--- a/.github/workflows/pr-review-evaluation.yml
+++ b/.github/workflows/pr-review-evaluation.yml
@@ -28,7 +28,7 @@ jobs:
         steps:
             - name: Download review trace artifact
               id: download-trace
-              uses: dawidd6/action-download-artifact@v21
+              uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
               continue-on-error: true
               with:
                   workflow: pr-review-by-openhands.yml

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
       - name: Install tmux
         run: sudo apt-get update && sudo apt-get install -y tmux
       - name: Setup Node.js
@@ -119,7 +119,7 @@ jobs:
 
       - name: Coverage comment
         id: coverage_comment
-        uses: py-cov-action/python-coverage-comment-action@v3
+        uses: py-cov-action/python-coverage-comment-action@53ff7553078bad69030786e486677315346c2dd2 # v3
         with:
           GITHUB_TOKEN: ${{ github.token }}
           MERGE_COVERAGE_FILES: true

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: 3.12
       - name: Install Poetry
-        uses: snok/install-poetry@v1.4.1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
           virtualenvs-in-project: true
           virtualenvs-path: ~/.virtualenvs

--- a/.github/workflows/tag-image.yml
+++ b/.github/workflows/tag-image.yml
@@ -22,16 +22,16 @@ jobs:
           - ghcr.io/openhands/enterprise-server
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
       - name: Compute tags
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ${{ matrix.image }}
           flavor: latest=auto

--- a/.github/workflows/ui-build.yml
+++ b/.github/workflows/ui-build.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version-file: "openhands-ui/.bun-version"
       - name: Install dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,12 @@ then re-run the command to ensure it passes. Common issues include:
 - Be especially careful with `git reset --hard` after staging files, as it will remove accidentally staged files
 - When remote has new changes, use `git fetch upstream && git rebase upstream/<branch>` on the same branch
 
+## GitHub Actions
+
+- Pin external third-party actions to a full 40-character commit SHA, with the version tag in a trailing comment (e.g. `uses: owner/repo@<sha> # v1.2.3`). Do not use mutable tags (`@v1`) or branches for third-party actions.
+- GitHub-authored (`actions/*`, `github/*`) and first-party (`OpenHands/*`) actions are currently exempt.
+- Dependabot's `github-actions` ecosystem bumps the pinned SHA and the trailing comment under the configured cooldown, so pinning does not block security or version updates.
+
 ## Lockfile Regeneration (Preserve Original Tool Versions)
 
 When regenerating lockfiles (poetry.lock, uv.lock, etc.), you MUST use the same tool version that originally generated the lockfile to avoid unnecessary diff noise. Each lockfile contains a version header indicating which tool version was used.


### PR DESCRIPTION
## Summary

Pin all external third-party GitHub Actions to immutable 40-character commit SHAs and fix Dependabot so those pins stay current automatically. This mirrors the approach proposed for the SDK in OpenHands/software-agent-sdk#2876.

The core risk without pinning: a mutable version tag (`@v4`, `@v2`) can be silently repointed to a different commit by a compromised release, a force-push to the tag, or a renamed release series. Several of the workflows here handle secrets (`GITHUB_TOKEN`, GHCR credentials, PyPI tokens, npm tokens). Mutable tag references in those contexts are a supply-chain exposure.

## What changed

**12 files total:** 8 workflow files, 2 composite actions, `dependabot.yml`, `AGENTS.md`.

### Action pins (workflows)

14 `uses:` lines across 8 workflow files, covering 10 distinct third-party actions, each pinned to the SHA that resolves from its release tag (tag shown in a trailing comment):

| Action | Pinned SHA | Tag |
|--------|-----------|-----|
| `docker/login-action` | `4907a6d` | v4 |
| `docker/setup-buildx-action` | `4d04d5d` | v4 |
| `docker/build-push-action` | `bcafcac` | v7 |
| `docker/metadata-action` | `030e881` | v6 |
| `oven-sh/setup-bun` | `0c5077e` | v2 |
| `snok/install-poetry` | `76e04a9` | v1.4.1 |
| `peter-evans/find-comment` | `b30e6a3` | v4 |
| `peter-evans/create-or-update-comment` | `e8674b0` | v5 |
| `py-cov-action/python-coverage-comment-action` | `53ff755` | v3 |
| `dawidd6/action-download-artifact` | `b6e2e70` | v21 |

### Action pins (composite actions)

`.github/actions/docker-image-tags/action.yml` and `.github/actions/docker-merge-manifest/action.yml` call `docker/*` actions internally. Those 3 references are pinned here too (17 third-party pins in total):

- `docker-image-tags`: `docker/metadata-action` at `030e881` (v6)
- `docker-merge-manifest`: `docker/login-action` at `4907a6d` (v4), `docker/setup-buildx-action` at `8d2750c` (v3)

The composite action keeps `setup-buildx-action` at v3 because that is the version on `main` today. Dependabot's `github-actions` ecosystem never scanned `.github/actions/`, so the workflows were bumped to v4 over time while the composite action stayed at v3. Pinning records that current state faithfully; the Dependabot fix below lets Dependabot harmonise the composite action to v4 on its own schedule under the repo's cooldown, rather than folding an unrelated version bump into this change.

### Dependabot fix

The existing `dependabot.yml` configured the `github-actions` ecosystem with `directory: "/"`. That scans workflow files (and a root `action.yml`) only, not composite actions under `.github/actions/`. Those directories were never bumped automatically, which is why the composite `setup-buildx-action` sits a major version behind the workflows.

Changed `directory` to `directories` and added both composite-action paths:
```
- "/.github/actions/docker-image-tags"
- "/.github/actions/docker-merge-manifest"
```

The 7-day cooldown already configured for the ecosystem is preserved. With this in place, Dependabot will open PRs to update the pinned SHAs and trailing version comments for both composite actions, gated by that cooldown.

### AGENTS.md

Added a "GitHub Actions" policy section: pin external third-party actions to full SHAs with a trailing version comment; `actions/*`, `github/*`, and `OpenHands/*` are currently exempt; Dependabot rotates the pinned SHA under cooldown so pinning does not block updates.

## Scope

**Intentionally not pinned here:** `actions/checkout`, `actions/setup-python`, and other `actions/*` / `github/*` refs. GitHub-authored actions are maintained by GitHub and present a different trust model. First-party `OpenHands/*` refs are also left as-is. Both categories can be addressed in a follow-on if the project decides to extend the policy.

## Validation

Every external third-party `uses:` in the 8 workflow files and 2 composite actions is pinned to a full SHA. Each pinned SHA was resolved from a published release tag of the action and re-verified against the live GitHub API. 16 of the 17 pins resolve to maintainer-signed commits; `snok/install-poetry@v1.4.1` (`76e04a9`) resolves to a published but unsigned release commit, which is still strictly safer pinned than referenced by a mutable tag.

`docker/build-push-action` is held at `bcafcac` (v7.1.0). The `@v7` tag was repointed to v7.2.0 on 2026-05-21, inside the repo's 7-day Dependabot cooldown window, so the pin intentionally did not follow it. Dependabot will propose v7.2.0 once it clears cooldown. This is the pin behaving as intended: a workflow still on the mutable `@v7` tag would have adopted a same-day release automatically.

To verify locally:
```
git diff upstream/main...HEAD -- '.github/workflows/*.yml' '.github/actions/**/*.yml' \
  | grep '^+.*uses:' | grep -v '^+++' | grep -v '@[0-9a-f]\{40\}'
```
That should return nothing. Any third-party `uses:` line not pinned to a full SHA will surface here.
