### PR TITLE
fix: recover conversation metadata save race

### DIFF
--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -34,6 +34,7 @@ from sqlalchemy import (
     select,
 )
 from sqlalchemy.engine import CursorResult
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -383,8 +384,22 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             tags=info.tags if info.tags else None,
         )
 
-        await self.db_session.merge(stored)
-        await self.db_session.commit()
+        try:
+            await self.db_session.merge(stored)
+            await self.db_session.commit()
+        except IntegrityError:
+            await self.db_session.rollback()
+            existing = await self.db_session.get(
+                StoredConversationMetadata, stored.conversation_id
+            )
+            if existing is None:
+                raise
+
+            for column in StoredConversationMetadata.__table__.columns:
+                if column.primary_key:
+                    continue
+                setattr(existing, column.name, getattr(stored, column.name))
+            await self.db_session.commit()
         return info
 
     async def update_conversation_statistics(
@@ -575,8 +590,10 @@ class SQLAppConversationInfoService(AppConversationInfoService):
         )
 
     def _fix_timezone(self, value: datetime | None) -> datetime:
-        """Sqlite does not store timezones - and since we can't update the existing models
-        we assume UTC if the timezone is missing. Returns current UTC time if value is None.
+        """Sqlite does not store timezones.
+
+        Since we can't update the existing models, we assume UTC if the timezone is
+        missing. Returns current UTC time if value is None.
         """
         if value is None:
             # Fallback for legacy data: use current time to match model defaults.

--- a/tests/unit/app_server/test_sql_app_conversation_info_service.py
+++ b/tests/unit/app_server/test_sql_app_conversation_info_service.py
@@ -10,6 +10,7 @@ from typing import AsyncGenerator
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
@@ -20,6 +21,7 @@ from openhands.app_server.app_conversation.app_conversation_models import (
 )
 from openhands.app_server.app_conversation.sql_app_conversation_info_service import (
     SQLAppConversationInfoService,
+    StoredConversationMetadata,
 )
 from openhands.app_server.integrations.service_types import ProviderType
 from openhands.app_server.user.specifiy_user_context import SpecifyUserContext
@@ -559,6 +561,54 @@ class TestSQLAppConversationInfoService:
 
         # Verify other fields remain unchanged
         assert retrieved_info.sandbox_id == sample_conversation_info.sandbox_id
+
+    @pytest.mark.asyncio
+    async def test_save_recovers_from_concurrent_insert(
+        self,
+        async_engine,
+        service: SQLAppConversationInfoService,
+        sample_conversation_info: AppConversationInfo,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        original_commit = service.db_session.commit
+        commit_count = 0
+
+        async def commit_with_race():
+            nonlocal commit_count
+            commit_count += 1
+            if commit_count == 1:
+                session_maker = async_sessionmaker(
+                    async_engine, class_=AsyncSession, expire_on_commit=False
+                )
+                async with session_maker() as racing_session:
+                    racing_session.add(
+                        StoredConversationMetadata(
+                            conversation_id=str(sample_conversation_info.id),
+                            conversation_version='V1',
+                            sandbox_id='webhook_sandbox',
+                            title='Webhook Title',
+                            pr_number=[],
+                        )
+                    )
+                    await racing_session.commit()
+                raise IntegrityError('insert conversation_metadata', {}, Exception())
+
+            await original_commit()
+
+        monkeypatch.setattr(service.db_session, 'commit', commit_with_race)
+
+        await service.save_app_conversation_info(sample_conversation_info)
+
+        retrieved_info = await service.get_app_conversation_info(
+            sample_conversation_info.id
+        )
+        assert retrieved_info is not None
+        assert retrieved_info.title == sample_conversation_info.title
+        assert retrieved_info.sandbox_id == sample_conversation_info.sandbox_id
+        assert retrieved_info.selected_repository == (
+            sample_conversation_info.selected_repository
+        )
+        assert commit_count == 2
 
     @pytest.mark.asyncio
     async def test_search_with_invalid_page_id(


### PR DESCRIPTION
﻿## Summary
- recover from a duplicate-key race when conversation metadata is inserted by a concurrent startup/webhook writer
- after rolling back the failed insert, update the row that already exists for the same conversation id
- add a regression test for the concurrent insert path

## To verify
- `uv run pytest tests/unit/app_server/test_sql_app_conversation_info_service.py -q --basetemp .tmp/pytest-sql-conversation-info`
- `uv run ruff check openhands/app_server/app_conversation/sql_app_conversation_info_service.py tests/unit/app_server/test_sql_app_conversation_info_service.py`
- `python -m py_compile openhands/app_server/app_conversation/sql_app_conversation_info_service.py tests/unit/app_server/test_sql_app_conversation_info_service.py`
- `git diff --check`

Fixes OpenHands/enterprise#26
