### PR TITLE
Fix Slack message for critic API key startup errors

### DIFF
--- a/enterprise/integrations/slack/slack_manager.py
+++ b/enterprise/integrations/slack/slack_manager.py
@@ -58,6 +58,17 @@ SLACK_USER_MSG_KEY_PREFIX = 'slack_user_msg'
 SLACK_USER_MSG_EXPIRATION = 300
 
 
+def _get_v1_start_error_message(error: RuntimeError, username: str) -> str | None:
+    """Map known V1 conversation startup failures to user-facing Slack messages."""
+    detail = str(error)
+    if 'agent.critic' in detail and 'api_key must be non-empty' in detail:
+        return (
+            f'@{username} please set a valid LLM API key for your critic agent in '
+            f'[OpenHands Cloud]({HOST_URL}) before starting a job.'
+        )
+    return None
+
+
 class SlackManager(Manager[SlackViewInterface]):
     def __init__(self, token_manager):
         self.token_manager = token_manager
@@ -738,6 +749,18 @@ class SlackManager(Manager[SlackViewInterface]):
 
             except StartingConvoException as e:
                 msg_info = str(e)
+
+            except RuntimeError as e:
+                msg_info = _get_v1_start_error_message(
+                    e, user_info.slack_display_name
+                )
+                if msg_info is None:
+                    raise
+                logger.warning(
+                    '[Slack] V1 conversation validation error for user %s: %s',
+                    user_info.slack_display_name,
+                    str(e),
+                )
 
             await self.send_message(msg_info, slack_view)
 

--- a/enterprise/tests/unit/test_slack_integration.py
+++ b/enterprise/tests/unit/test_slack_integration.py
@@ -67,6 +67,52 @@ def slack_new_conversation_view(mock_slack_user, mock_user_auth):
     )
 
 
+
+class TestStartJob:
+    """Test Slack job startup error handling."""
+
+    @pytest.mark.asyncio
+    async def test_start_job_shows_critic_api_key_error(
+        self, slack_manager, slack_new_conversation_view
+    ):
+        """Surface critic API key validation failures with a user-friendly message."""
+        slack_new_conversation_view.selected_repo = 'OpenHands/OpenHands'
+        slack_new_conversation_view.create_or_update_conversation = AsyncMock(
+            side_effect=RuntimeError(
+                'Failed to start V1 conversation: 1 validation error for '
+                'ConversationInfo\nagent.critic.api_key\n'
+                '  Value error, api_key must be non-empty '
+                '[type=value_error, input_value=None, input_type=NoneType]'
+            )
+        )
+        slack_manager.send_message = AsyncMock()
+
+        await slack_manager.start_job(slack_new_conversation_view)
+
+        slack_manager.send_message.assert_called_once()
+        sent_message = slack_manager.send_message.call_args[0][0]
+        assert 'critic agent' in sent_message
+        assert 'LLM API key' in sent_message
+
+    @pytest.mark.asyncio
+    async def test_start_job_keeps_generic_message_for_unknown_runtime_error(
+        self, slack_manager, slack_new_conversation_view
+    ):
+        """Keep the generic fallback for unrelated runtime failures."""
+        slack_new_conversation_view.selected_repo = 'OpenHands/OpenHands'
+        slack_new_conversation_view.create_or_update_conversation = AsyncMock(
+            side_effect=RuntimeError('boom')
+        )
+        slack_manager.send_message = AsyncMock()
+
+        await slack_manager.start_job(slack_new_conversation_view)
+
+        slack_manager.send_message.assert_called_once_with(
+            'Uh oh! There was an unexpected error starting the job :(',
+            slack_new_conversation_view,
+        )
+
+
 @pytest.mark.parametrize(
     'message,expected',
     [


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Slack jobs currently fall back to the generic unexpected-error message when V1 conversation startup fails with a nested critic API key validation error. That hides the actual action the user needs to take and makes issue #14480 harder to diagnose.

## Summary

- detect the specific V1 startup `RuntimeError` detail for nested `agent.critic` API key validation failures
- surface a Slack-specific, actionable message telling the user to configure the critic agent's LLM API key
- add regression tests for both the critic-specific message and the generic fallback path

## Issue Number

Closes #14480

## How to Test

- `cd enterprise && PYTHONPATH=".:..:$PYTHONPATH" poetry run pytest tests/unit/test_slack_integration.py`
- `cd /workspace/project/OpenHands && poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files enterprise/integrations/slack/slack_manager.py enterprise/tests/unit/test_slack_integration.py`

## Video/Screenshots

- Not applicable; this is backend Slack error-handling only.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- I investigated the current installed `openhands-sdk` / `openhands-agent-server` path as well. In the locally pinned versions, missing or empty `LLM.api_key` already normalizes to `None`, and critic construction is skipped when the main LLM key is absent. This fix therefore maps the runtime failure coming back from V1 startup without adding an early blanket key check that could break local-model or non-key-auth setups.
- This PR description was created by an AI agent (OpenHands) on behalf of the user.


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/12fc5419-c3d5-421b-b14e-4c5c9377efe7)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-410f628   docker.openhands.dev/openhands/openhands:410f628
```