### PR TITLE
Fix CVE-2026-39373: Update jwcrypto to 1.5.7

### DIFF
--- a/enterprise/poetry.lock
+++ b/enterprise/poetry.lock
@@ -4590,19 +4590,19 @@ files = [
 
 [[package]]
 name = "jwcrypto"
-version = "1.5.6"
+version = "1.5.7"
 description = "Implementation of JOSE Web standards"
 optional = false
-python-versions = ">= 3.8"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "jwcrypto-1.5.6-py3-none-any.whl", hash = "sha256:150d2b0ebbdb8f40b77f543fb44ffd2baeff48788be71f67f03566692fd55789"},
-    {file = "jwcrypto-1.5.6.tar.gz", hash = "sha256:771a87762a0c081ae6166958a954f80848820b2ab066937dc8b8379d65b1b039"},
+    {file = "jwcrypto-1.5.7-py3-none-any.whl", hash = "sha256:729463fefe28b6de5cf1ebfda3e94f1a1b41d2799148ef98a01cb9678ebe2bb0"},
+    {file = "jwcrypto-1.5.7.tar.gz", hash = "sha256:70204d7cca406eda8c82352e3c41ba2d946610dafd19e54403f0a1f4f18633c6"},
 ]
 
 [package.dependencies]
 cryptography = ">=3.4"
-typing-extensions = ">=4.5.0"
+typing_extensions = ">=4.5.0"
 
 [[package]]
 name = "keyring"


### PR DESCRIPTION
## Summary

Addresses **CVE-2026-39373** in the `jwcrypto` package by upgrading it from `1.5.6` to `1.5.7` (the latest available version on PyPI at the time of this change) in `enterprise/poetry.lock`.

## Details

- **Package:** `jwcrypto`
- **Previous version:** `1.5.6`
- **New version:** `1.5.7`
- **CVE:** CVE-2026-39373
- **Dependency type:** Transitive — pulled in via `python-keycloak` (declared in `enterprise/pyproject.toml`).

Because `jwcrypto` is a transitive dependency, no manifest file (`pyproject.toml`) needed to be edited. The upgrade was performed via:

```bash
cd enterprise
poetry update jwcrypto --lock
```

The lockfile was regenerated with Poetry `2.3.3` — the same version that originally produced `enterprise/poetry.lock` — to keep the diff minimal.

> Note: The advisory does not list an official "fixed version" yet. We upgraded to the latest available release (`1.5.7`); if a future jwcrypto release explicitly remediates this CVE, a follow-up bump will be straightforward.

## Files changed

- `enterprise/poetry.lock` — `jwcrypto` version bumped from `1.5.6` → `1.5.7`.

---
_This PR was created by an AI agent (OpenHands) on behalf of the maintainers as part of automated CVE remediation._

@aivong-openhands can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c7312018-0c45-416a-8f55-911589fecda2)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-d5e31a4   docker.openhands.dev/openhands/openhands:d5e31a4
```