### PR TITLE
fix: show raw llm_model on OpenHands conversation chip

### DIFF
--- a/frontend/__tests__/components/features/conversation/conversation-name.test.tsx
+++ b/frontend/__tests__/components/features/conversation/conversation-name.test.tsx
@@ -296,7 +296,7 @@ describe("ConversationName", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("should render the OpenHands brand when an llm_model is set", () => {
+  it("should render the raw llm_model when set", () => {
     useActiveConversationMock.mockReturnValue({
       data: {
         conversation_id: "test-conversation-id",
@@ -310,8 +310,7 @@ describe("ConversationName", () => {
 
     const model = screen.getByTestId("conversation-name-llm-model");
     expect(model).toBeInTheDocument();
-    // Visible chip is the harness brand; raw model is preserved on hover.
-    expect(model).toHaveTextContent("OpenHands");
+    expect(model).toHaveTextContent("openai/gpt-4o");
     expect(model).toHaveAttribute("title", "openai/gpt-4o");
     expect(model.querySelector("svg")).toBeInTheDocument();
   });

--- a/frontend/__tests__/components/features/home/recent-conversation.test.tsx
+++ b/frontend/__tests__/components/features/home/recent-conversation.test.tsx
@@ -54,7 +54,7 @@ const renderRecentConversation = (conversation: V1AppConversation) =>
   );
 
 describe("RecentConversation - llm_model", () => {
-  it("should render the OpenHands brand label when llm_model is provided", () => {
+  it("should render the raw llm_model when provided", () => {
     renderRecentConversation({
       ...baseConversation,
       llm_model: "anthropic/claude-sonnet-4-20250514",
@@ -62,8 +62,7 @@ describe("RecentConversation - llm_model", () => {
 
     const model = screen.getByTestId("recent-conversation-llm-model");
     expect(model).toBeInTheDocument();
-    // Visible label is the harness brand; raw model is preserved on hover.
-    expect(model).toHaveTextContent("OpenHands");
+    expect(model).toHaveTextContent("anthropic/claude-sonnet-4-20250514");
     expect(model).toHaveAttribute(
       "title",
       "anthropic/claude-sonnet-4-20250514",
@@ -72,7 +71,7 @@ describe("RecentConversation - llm_model", () => {
 
     const textSpan = model.querySelector("span.truncate");
     expect(textSpan).toBeInTheDocument();
-    expect(textSpan).toHaveTextContent("OpenHands");
+    expect(textSpan).toHaveTextContent("anthropic/claude-sonnet-4-20250514");
   });
 
   it("should render plain 'ACP' for ACP-agent conversations", () => {

--- a/frontend/src/utils/agent-display-label.ts
+++ b/frontend/src/utils/agent-display-label.ts
@@ -17,8 +17,9 @@ export const ACP_SERVER_TAG = "acp_server";
  *   "Gemini CLI", …) looked up via the SDK registry that the server exposes
  *   at ``/api/v1/web-client/config``. Falls back to plain "ACP" when the
  *   provider key is unknown (custom commands, or registry not yet loaded).
- * - OpenHands conversations show the harness brand "OpenHands" — the raw
- *   ``llm_model`` is preserved on hover via the ``title`` attribute.
+ * - OpenHands conversations show the raw ``llm_model`` string verbatim
+ *   (e.g. ``"anthropic/claude-sonnet-4-5-20250929"``), matching the
+ *   pre-ACP behavior of the model chip.
  */
 export function agentDisplayLabel(
   agentKind: AgentKind | undefined,
@@ -34,6 +35,5 @@ export function agentDisplayLabel(
     }
     return "ACP";
   }
-  if (llmModel) return "OpenHands";
-  return null;
+  return llmModel ?? null;
 }


### PR DESCRIPTION
## Summary

- The conversation model chip showed every OpenHands conversation as the literal string `"OpenHands"` regardless of `llm_model` — a regression introduced in #14401 (commit `9aa772b9`), which added `agentDisplayLabel(...)` to render ACP provider brands but also rewrote the OpenHands branch to a hard-coded harness label.
- This restores the pre-#14401 behavior for the OpenHands agent branch: the chip displays the raw `llm_model` string (e.g. `anthropic/claude-sonnet-4-5-20250929`). ACP behavior is unchanged — ACP conversations still resolve to provider brand (`Claude Code`, `Codex`, `Gemini CLI`, …) and fall back to `"ACP"`.
- The sidebar tooltip (`ConversationCardFooter`, `title={llmModel}`) is also fixed as a side effect — it now shows the underlying model rather than `"OpenHands"`.

The harness-brand-vs-model conflation in the chip is a separate design question (the chip uses a `CircuitIcon` and the `*-llm-model` test-ids — it was originally a model indicator). We'll address that as a follow-up.

## Test plan

- [x] `npm test` passes for the three touched component test files (56 tests)
- [x] `npm run lint` passes (pre-existing warnings only)
- [ ] Eyeball the model chip in the sidebar, the home page Recent Conversations, and an open conversation header for an OpenHands+Anthropic conversation (should now show `anthropic/...` instead of `OpenHands`)
- [ ] Eyeball an ACP (Claude Code) conversation (chip should still show `Claude Code`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-e46f38a   docker.openhands.dev/openhands/openhands:e46f38a
```