### PR TITLE
feat(acp): persist current_model_id on conversations

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -362,7 +362,16 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             request_agent = start_conversation_request.agent
             tags: dict[str, str] = {}
             if request_agent.agent_kind == 'acp':
-                llm_model = None
+                # ACP agents don't expose the active LLM via ``request_agent.llm``
+                # (the SDK uses a placeholder LLM whose ``model`` is the
+                # "acp-managed" sentinel — see ``ACPAgent._make_dummy_llm``).
+                # The real model comes back on the agent-server response as
+                # ``info.current_model_id``, lifted from
+                # ``ACPAgent.current_model_id`` which the SDK populates from
+                # the UNSTABLE ``models.currentModelId`` field on the ACP
+                # session response. ``getattr`` keeps us forward-compatible
+                # with older SDK builds that predate the field.
+                llm_model = getattr(info, 'current_model_id', None)
                 agent_kind = 'acp'
                 # Persist the active ACP provider key so the conversation UI
                 # can resolve a brand label ("Claude Code", "Codex", …) via

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -365,13 +365,17 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 # ACP agents don't expose the active LLM via ``request_agent.llm``
                 # (the SDK uses a placeholder LLM whose ``model`` is the
                 # "acp-managed" sentinel — see ``ACPAgent._make_dummy_llm``).
-                # The real model comes back on the agent-server response as
-                # ``info.current_model_id``, lifted from
-                # ``ACPAgent.current_model_id`` which the SDK populates from
-                # the UNSTABLE ``models.currentModelId`` field on the ACP
-                # session response. ``getattr`` keeps us forward-compatible
-                # with older SDK builds that predate the field.
-                llm_model = getattr(info, 'current_model_id', None)
+                # The real model comes back on the agent-server response.
+                # Prefer ``current_model_name`` (the resolved human-readable
+                # value, e.g. "Default (recommended)" rather than "default"
+                # for claude-agent-acp); fall back to ``current_model_id``
+                # for SDK builds that have one but not the other; finally
+                # ``None`` for older builds that have neither. ``getattr``
+                # keeps the app_server forward- and backward-compatible
+                # with whatever SDK version the agent-server is running.
+                llm_model = getattr(info, 'current_model_name', None) or getattr(
+                    info, 'current_model_id', None
+                )
                 agent_kind = 'acp'
                 # Persist the active ACP provider key so the conversation UI
                 # can resolve a brand label ("Claude Code", "Codex", …) via


### PR DESCRIPTION
## Why

ACP conversations were created with `llm_model = None` in the app_server — there was no upstream signal of which model the ACP harness was actually using. As a result, every ACP conversation came back from the API as:

```json
{ "agent_kind": "acp", "llm_model": null, ... }
```

…even for Claude Code / Codex / Gemini CLI sessions where the underlying model is well-defined. The web chip then has nothing useful to show.

This change reads the model the SDK now exposes (via the companion PR) and persists it like any other conversation's `llm_model`. The frontend chip [already displays this](https://github.com/OpenHands/OpenHands/blob/main/frontend/src/utils/agent-display-label.ts) — no UI change required.

## Summary

- One line change in `live_status_app_conversation_service.py`: replace `llm_model = None` (hard-coded for the ACP branch) with `llm_model = getattr(info, 'current_model_id', None)`.
- `getattr` keeps the app_server forward-compatible with older SDK builds — degrades to today's `None` behavior if the SDK doesn't surface the field yet.

## Issue Number

None — follow-up to chip-UX work in #14505 / #14510.

## How to Test

After the SDK PR (OpenHands/software-agent-sdk#3347) merges and a new SDK release pins through here, locally:

```bash
# Bump the SDK pin in pyproject.toml to the new release, then
poetry lock && poetry install
ENABLE_ACP=true poetry run python -m uvicorn openhands.server.listen:app --host 127.0.0.1 --port 3000
cd frontend && VITE_BACKEND_HOST=127.0.0.1:3000 npm run dev
```

1. Start a Claude Code (ACP) conversation. The chip should now show the actual model (e.g. `Claude Opus 4.1`) next to the Claude brand mark, instead of just "Claude Code".
2. Verify via API: `curl http://localhost:3001/api/v1/app-conversations/search?limit=5 | jq '.items[] | select(.agent_kind=="acp") | .llm_model'` — should return a non-null string for new ACP convs.
3. Existing ACP conversations created before this change keep `llm_model: null` (no migration here, by design).

## Video/Screenshots

To attach after the SDK is bumped — UI difference is the chip text on ACP conversations gaining the underlying model.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **Depends on** OpenHands/software-agent-sdk#3347 (adds `ConversationInfo.current_model_id`) and an SDK release that includes it. Marking this PR as **draft** until the SDK pin can be bumped.
- The model surfaces via the ACP protocol's UNSTABLE `models.currentModelId` field. All three known ACP providers (Claude Code, Codex, Gemini CLI) implement it today; older / custom servers will leave the field `None` and the chip falls back to the provider brand — same as today's behavior.
- Existing ACP conversations are left as-is. A backfill would require re-querying the agent-server for each running conversation; not worth it for a cosmetic chip improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-392bb5f   docker.openhands.dev/openhands/openhands:392bb5f
```