### PR TITLE
[APP-1956] BBDC: optionally post comments/reactions as a bot service account

### DIFF
--- a/enterprise/integrations/bitbucket_data_center/bitbucket_dc_manager.py
+++ b/enterprise/integrations/bitbucket_data_center/bitbucket_dc_manager.py
@@ -22,6 +22,7 @@ from integrations.utils import (
 from integrations.v1_utils import get_saas_user_auth
 from jinja2 import Environment, FileSystemLoader
 from pydantic import SecretStr
+from server.auth.constants import BITBUCKET_DATA_CENTER_BOT_TOKEN
 from server.auth.token_manager import TokenManager
 from storage.bitbucket_dc_webhook_store import BitbucketDCWebhookStore
 
@@ -93,6 +94,30 @@ class BitbucketDCManager(Manager[BitbucketDCViewType]):
             )
             return False
 
+    def _posting_service(self, fallback_external_auth_id: str):
+        """Build the Bitbucket DC service used to POST comments/reactions.
+
+        When a bot service-account token is configured
+        (``BITBUCKET_DATA_CENTER_BOT_TOKEN``), every outbound comment and
+        reaction is posted as that bot -- mirroring the GitHub App's
+        ``openhands[bot]`` identity -- instead of as the @-mentioning user or
+        the webhook installer. Otherwise we fall back to the per-user/installer
+        OAuth token (``fallback_external_auth_id``).
+
+        This affects only who *posts*. The resolver job itself always runs with
+        the invoking user's own token (see ``start_job``); the bot token is
+        never used to create conversations or touch the repo.
+        """
+        from integrations.bitbucket_data_center.bitbucket_dc_service import (
+            SaaSBitbucketDCService,
+        )
+
+        if BITBUCKET_DATA_CENTER_BOT_TOKEN:
+            return SaaSBitbucketDCService(
+                token=SecretStr(BITBUCKET_DATA_CENTER_BOT_TOKEN)
+            )
+        return SaaSBitbucketDCService(external_auth_id=fallback_external_auth_id)
+
     async def _add_eyes_reaction(
         self,
         message: Message,
@@ -121,12 +146,8 @@ class BitbucketDCManager(Manager[BitbucketDCViewType]):
         if comment_id is None or pr_id is None:
             return
 
-        from integrations.bitbucket_data_center.bitbucket_dc_service import (
-            SaaSBitbucketDCService,
-        )
-
         try:
-            service = SaaSBitbucketDCService(external_auth_id=reacting_user_id)
+            service = self._posting_service(reacting_user_id)
             await service.add_comment_reaction(
                 owner=project_key,
                 repo_slug=repo_slug,
@@ -287,12 +308,8 @@ class BitbucketDCManager(Manager[BitbucketDCViewType]):
     async def send_message(
         self, message: str, bitbucket_view: ResolverViewInterface
     ) -> None:
-        from integrations.bitbucket_data_center.bitbucket_dc_service import (
-            SaaSBitbucketDCService,
-        )
-
-        bitbucket_service = SaaSBitbucketDCService(
-            external_auth_id=bitbucket_view.user_info.keycloak_user_id
+        bitbucket_service = self._posting_service(
+            bitbucket_view.user_info.keycloak_user_id
         )
 
         if isinstance(bitbucket_view, BitbucketDCInlinePRComment):

--- a/enterprise/integrations/bitbucket_data_center/bitbucket_dc_manager.py
+++ b/enterprise/integrations/bitbucket_data_center/bitbucket_dc_manager.py
@@ -113,9 +113,14 @@ class BitbucketDCManager(Manager[BitbucketDCViewType]):
         )
 
         if BITBUCKET_DATA_CENTER_BOT_TOKEN:
-            return SaaSBitbucketDCService(
-                token=SecretStr(BITBUCKET_DATA_CENTER_BOT_TOKEN)
-            )
+            # BBDC HTTP access tokens authenticate via Bearer. The service's
+            # ``token=`` constructor arg rewrites a colon-less token to
+            # ``x-token-auth:<token>`` (a Bitbucket *Cloud* convention) and
+            # sends it as HTTP Basic, which Data Center rejects with 401. Set
+            # the raw token directly so ``_get_headers`` uses Bearer.
+            service = SaaSBitbucketDCService()
+            service.token = SecretStr(BITBUCKET_DATA_CENTER_BOT_TOKEN)
+            return service
         return SaaSBitbucketDCService(external_auth_id=fallback_external_auth_id)
 
     async def _add_eyes_reaction(

--- a/enterprise/server/auth/constants.py
+++ b/enterprise/server/auth/constants.py
@@ -49,6 +49,15 @@ BITBUCKET_DATA_CENTER_CLIENT_SECRET = os.getenv(
     'BITBUCKET_DATA_CENTER_CLIENT_SECRET', ''
 ).strip()
 BITBUCKET_DATA_CENTER_HOST = os.getenv('BITBUCKET_DATA_CENTER_HOST', '').strip()
+# Optional HTTP access token for a dedicated bot service account. When set,
+# OpenHands posts all Bitbucket Data Center comments/reactions as this bot
+# (mirroring the GitHub App's openhands[bot] identity) instead of as the
+# per-repo webhook installer or the @-mentioning user. Only the posting
+# identity changes -- the resolver job still runs with the invoking user's
+# own token.
+BITBUCKET_DATA_CENTER_BOT_TOKEN = os.getenv(
+    'BITBUCKET_DATA_CENTER_BOT_TOKEN', ''
+).strip()
 BITBUCKET_DATA_CENTER_TOKEN_URL = (
     f'https://{BITBUCKET_DATA_CENTER_HOST}/rest/oauth2/latest/token'
 )

--- a/enterprise/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_manager.py
+++ b/enterprise/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_manager.py
@@ -314,12 +314,14 @@ def test_posting_service_uses_bot_token_when_set():
     ), patch(
         'integrations.bitbucket_data_center.bitbucket_dc_service.SaaSBitbucketDCService'
     ) as service_cls:
-        manager._posting_service('kc-alice')
+        svc = manager._posting_service('kc-alice')
 
-    service_cls.assert_called_once()
-    kwargs = service_cls.call_args.kwargs
-    assert 'external_auth_id' not in kwargs
-    assert kwargs['token'].get_secret_value() == 'bot-pat-123'
+    # Built with no per-user auth; the raw bot token is set directly so the
+    # service sends Bearer. NOT via external_auth_id, and NOT via the token=
+    # constructor arg (which would downgrade it to x-token-auth HTTP Basic,
+    # rejected by Bitbucket Data Center).
+    assert 'external_auth_id' not in service_cls.call_args.kwargs
+    assert svc.token.get_secret_value() == 'bot-pat-123'
 
 
 def test_posting_service_falls_back_to_user_token_when_bot_unset():

--- a/enterprise/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_manager.py
+++ b/enterprise/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_manager.py
@@ -300,3 +300,40 @@ async def test_send_message_uses_view_user_info_keycloak_id():
         await manager.send_message('Done', _pr_comment_view())
 
     service_cls.assert_called_once_with(external_auth_id='kc-alice')
+
+
+def test_posting_service_uses_bot_token_when_set():
+    """With BITBUCKET_DATA_CENTER_BOT_TOKEN set, the posting service auths as
+    the bot (token=...) and does NOT fall back to the per-user token.
+    """
+    manager = BitbucketDCManager(AsyncMock())
+
+    with patch(
+        'integrations.bitbucket_data_center.bitbucket_dc_manager.BITBUCKET_DATA_CENTER_BOT_TOKEN',
+        'bot-pat-123',
+    ), patch(
+        'integrations.bitbucket_data_center.bitbucket_dc_service.SaaSBitbucketDCService'
+    ) as service_cls:
+        manager._posting_service('kc-alice')
+
+    service_cls.assert_called_once()
+    kwargs = service_cls.call_args.kwargs
+    assert 'external_auth_id' not in kwargs
+    assert kwargs['token'].get_secret_value() == 'bot-pat-123'
+
+
+def test_posting_service_falls_back_to_user_token_when_bot_unset():
+    """Without a bot token, the posting service uses the per-user/installer
+    OAuth token (current behavior).
+    """
+    manager = BitbucketDCManager(AsyncMock())
+
+    with patch(
+        'integrations.bitbucket_data_center.bitbucket_dc_manager.BITBUCKET_DATA_CENTER_BOT_TOKEN',
+        '',
+    ), patch(
+        'integrations.bitbucket_data_center.bitbucket_dc_service.SaaSBitbucketDCService'
+    ) as service_cls:
+        manager._posting_service('kc-alice')
+
+    service_cls.assert_called_once_with(external_auth_id='kc-alice')


### PR DESCRIPTION
## What

Adds an optional `BITBUCKET_DATA_CENTER_BOT_TOKEN` env var (an HTTP access token for a dedicated bot user account). When set, **all** of OpenHands' Bitbucket Data Center comments and reactions — the sign-up reply, the "I'm on it" reply, the 👀 reaction, and result replies — are posted as that bot, mirroring the GitHub App's `openhands[bot]` identity, instead of as the @-mentioning user or the per-repo webhook installer.

When the token is unset, behavior is unchanged.

## Why

BBDC has no app/bot identity like GitHub Apps (where OpenHands posts as `openhands[bot]` via an installation token). Today every BBDC comment is authored by a real user's OAuth token — replies come from the @-mentioning user (a self-reply), and the sign-up message for an unenrolled user comes from the webhook installer. A dedicated bot service account gives the closest BBDC parallel: one uniform bot identity for everything OpenHands says.

**Only the posting identity changes.** The resolver job still runs with the invoking user's own token (`start_job` is untouched), so commits and PRs stay attributed to the human. The bot token is never used to create conversations or touch the repo.

## How

A single `_posting_service()` helper picks the credential and is used at the two outbound call-sites (`send_message`, `_add_eyes_reaction`); the sign-up reply flows through `send_message`, so it's covered too. The permission check (`_commenter_has_write_access`) deliberately keeps using the installer's token.

When the bot token is set, the helper builds the BBDC service and sets the **raw token directly** so `_get_headers` sends `Authorization: Bearer <token>`. It deliberately does **not** use the service's `token=` constructor arg: that rewrites a colon-less token to `x-token-auth:<token>` and sends it as HTTP **Basic** (a Bitbucket *Cloud* convention), which Bitbucket Data Center rejects with `401 Invalid bitbucket_data_center token`. BBDC HTTP access tokens authenticate via Bearer (verified against a live instance: Bearer → 201, x-token-auth Basic → 401).

## Setup (operator)

Create a dedicated BBDC user (e.g. `openhands-bot`), grant it access to the relevant projects/repos, mint an **HTTP access token** for it, and set `BITBUCKET_DATA_CENTER_BOT_TOKEN`. (Wired through KOTS config in the OpenHands-Cloud chart in companion PR OpenHands/OpenHands-Cloud#649.)

## Testing

Successfully tested end to end on an OHE instance and a bitbucket data center instance:

<img width="1674" height="932" alt="Screenshot 2026-05-21 at 1 55 11 PM" src="https://github.com/user-attachments/assets/b97ef1cb-cd89-441c-bfad-3575bf0524d7" />

https://github.com/user-attachments/assets/a2e808ed-f5fd-45d8-9751-d9f322741083



- `enterprise/tests/unit/integrations/bitbucket_data_center/` — passing, including new coverage that the posting service uses the bot token (raw, Bearer) when set and falls back to the per-user token when unset.
- ruff check + format clean against the pinned `v0.4.1` config.
- Verified live on a self-hosted Replicated install: unenrolled mention → sign-up reply posted by `openhands-bot`; enrolled mention → "I'm on it" + 👀 by `openhands-bot`; job still runs as the invoking user.

---
Linear: APP-1956

_AI-generated metadata update by OpenHands on behalf of ak684._
