### PR TITLE
fix(resolver): use literal placeholders in branch/PR naming instructions

### DIFF
--- a/openhands/app_server/integrations/templates/resolver/jira/jira_instructions.j2
+++ b/openhands/app_server/integrations/templates/resolver/jira/jira_instructions.j2
@@ -5,9 +5,9 @@ Follow these instructions carefully:
 1.  Thoroughly analyze the issue description and Acceptance Criteria before writing any code.
 2.  If requirements are ambiguous or conflicting, request clarification from the user.
 3.  When creating branches and pull requests, adhere strictly to the following naming conventions using the issue key:
-    *   Branch: `{{ issue_key }}-{{ description_in_kebab_case }}`
+    *   Branch: `<ISSUE-KEY>-<short-description-in-kebab-case>`
         *   Example: `FRE-24-improve-form-validations`
-    *   PR Title: `[{{ issue_key }}] {{ pr_title }}`
+    *   PR Title: `[<ISSUE-KEY>] <title>`
         *   Example: `[FRE-24] Improve form validations`
 4.  If the repository already contains a style guides and PR templates, respect those.
 5.  Write clean, maintainable code that meets the requirements outlined in the issue.

--- a/openhands/app_server/integrations/templates/resolver/jira_dc/jira_dc_instructions.j2
+++ b/openhands/app_server/integrations/templates/resolver/jira_dc/jira_dc_instructions.j2
@@ -5,9 +5,9 @@ Follow these instructions carefully:
 1.  Thoroughly analyze the issue description and Acceptance Criteria before writing any code.
 2.  If requirements are ambiguous or conflicting, request clarification from the user.
 3.  When creating branches and pull requests, adhere strictly to the following naming conventions using the issue key:
-    *   Branch: `{{ issue_key }}-{{ description_in_kebab_case }}`
+    *   Branch: `<ISSUE-KEY>-<short-description-in-kebab-case>`
         *   Example: `FRE-24-improve-form-validations`
-    *   PR Title: `[{{ issue_key }}] {{ pr_title }}`
+    *   PR Title: `[<ISSUE-KEY>] <title>`
         *   Example: `[FRE-24] Improve form validations`
 4.  If the repository already contains a style guides and PR templates, respect those.
 5.  Write clean, maintainable code that meets the requirements outlined in the issue.

--- a/openhands/app_server/integrations/templates/resolver/linear/linear_instructions.j2
+++ b/openhands/app_server/integrations/templates/resolver/linear/linear_instructions.j2
@@ -5,9 +5,9 @@ Follow these instructions carefully:
 1.  Thoroughly analyze the issue description and Acceptance Criteria before writing any code.
 2.  If requirements are ambiguous or conflicting, request clarification from the user.
 3.  When creating branches and pull requests, adhere strictly to the following naming conventions using the issue key:
-    *   Branch: `{{ issue_key }}-{{ description_in_kebab_case }}`
+    *   Branch: `<ISSUE-KEY>-<short-description-in-kebab-case>`
         *   Example: `FRE-24-improve-form-validations`
-    *   PR Title: `[{{ issue_key }}] {{ pr_title }}`
+    *   PR Title: `[<ISSUE-KEY>] <title>`
         *   Example: `[FRE-24] Improve form validations`
 4.  If the repository already contains a style guides and PR templates, respect those.
 5.  Write clean, maintainable code that meets the requirements outlined in the issue.


### PR DESCRIPTION
## What

The Jira, Jira DC, and Linear resolver instruction templates wrote the branch/PR naming convention with Jinja placeholders (`{{ issue_key }}`, `{{ description_in_kebab_case }}`, `{{ pr_title }}`), but the views render these `*_instructions.j2` templates with **no context** (`instructions_template.render()` with no args). So the placeholders rendered as empty strings and the agent's system message actually read:

```
*   Branch: `-`
*   PR Title: `[] `
```

This replaces the placeholders with literal illustrative text so the convention reads correctly regardless of render context — mirroring the GitHub resolver, which uses literal examples (e.g. `` `openhands/` as a prefix ``) rather than unfilled template variables.

```
*   Branch: `<ISSUE-KEY>-<short-description-in-kebab-case>`
*   PR Title: `[<ISSUE-KEY>] <title>`
```

## Scope

- Behavior-neutral / cosmetic — the agent already gets the real issue key from the user message; only the convention examples in the system message were degraded.
- Pre-existing and shared across all three project-management integrations (the templates are byte-identical copies).

## Noticed but not addressed here

`linear_instructions.j2` still opens with "You have been assigned an issue from **Jira**" (copy-paste leftover) — left for a separate follow-up to keep this focused.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-a8aaf4e   docker.openhands.dev/openhands/openhands:a8aaf4e
```