### PR TITLE
[APP-1961] Support Jira Data Center automation forwarding

### DIFF
--- a/enterprise/integrations/jira_dc/jira_dc_manager.py
+++ b/enterprise/integrations/jira_dc/jira_dc_manager.py
@@ -124,18 +124,26 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
         self, request: Request
     ) -> Tuple[bool, Optional[str], Optional[Dict]]:
         """Verify Jira DC webhook signature."""
+        signature_valid, signature, payload, _ = await self.validate_request_context(
+            request
+        )
+        return signature_valid, signature, payload
+
+    async def validate_request_context(
+        self, request: Request
+    ) -> Tuple[bool, Optional[str], Optional[Dict], Optional[JiraDcWorkspace]]:
+        """Verify Jira DC webhook signature and return the matched workspace."""
         signature_header = request.headers.get('x-hub-signature')
         signature = signature_header.split('=')[1] if signature_header else None
         body = await request.body()
         payload = await request.json()
         workspace_name = ''
+        selfUrl = ''
 
         if payload.get('webhookEvent') == 'comment_created':
             selfUrl = payload.get('comment', {}).get('author', {}).get('self')
         elif payload.get('webhookEvent') == 'jira:issue_updated':
             selfUrl = payload.get('user', {}).get('self')
-        else:
-            workspace_name = ''
 
         parsedUrl = urlparse(selfUrl)
         if parsedUrl.hostname:
@@ -143,30 +151,30 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
 
         if not workspace_name:
             logger.warning('[Jira DC] No workspace name found in webhook payload')
-            return False, None, None
+            return False, None, None, None
 
         if not signature:
             logger.warning('[Jira DC] No signature found in webhook headers')
-            return False, None, None
+            return False, None, None, None
 
         workspace = await self.integration_store.get_workspace_by_name(workspace_name)
 
         if not workspace:
             logger.warning('[Jira DC] Could not identify workspace for webhook')
-            return False, None, None
+            return False, None, None, None
 
         if workspace.status != 'active':
             logger.warning(f'[Jira DC] Workspace {workspace.id} is not active')
-            return False, None, None
+            return False, None, None, None
 
         webhook_secret = self.token_manager.decrypt_text(workspace.webhook_secret)
         digest = hmac.new(webhook_secret.encode(), body, hashlib.sha256).hexdigest()
 
         if hmac.compare_digest(signature, digest):
             logger.info('[Jira DC] Webhook signature verified successfully')
-            return True, signature, payload
+            return True, signature, payload, workspace
 
-        return False, None, None
+        return False, None, None, None
 
     def parse_webhook(self, payload: Dict) -> JobContext | None:
         event_type = payload.get('webhookEvent')

--- a/enterprise/migrations/versions/114_add_org_id_to_jira_dc_workspaces.py
+++ b/enterprise/migrations/versions/114_add_org_id_to_jira_dc_workspaces.py
@@ -1,0 +1,53 @@
+"""add org_id to jira_dc_workspaces
+
+Revision ID: 114
+Revises: 113
+Create Date: 2026-05-22 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '114'
+down_revision: Union[str, None] = '113'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('jira_dc_workspaces', sa.Column('org_id', sa.UUID(), nullable=True))
+    if op.get_bind().dialect.name == 'postgresql':
+        op.execute(
+            sa.text(
+                """
+                UPDATE jira_dc_workspaces AS j
+                SET org_id = u.current_org_id
+                FROM "user" AS u
+                WHERE j.org_id IS NULL
+                  AND j.admin_user_id ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+                  AND u.id = j.admin_user_id::uuid
+                  AND u.current_org_id IS NOT NULL
+                """
+            )
+        )
+    op.create_foreign_key(
+        'fk_jira_dc_workspaces_org_id',
+        'jira_dc_workspaces',
+        'org',
+        ['org_id'],
+        ['id'],
+        ondelete='SET NULL',
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        'fk_jira_dc_workspaces_org_id',
+        'jira_dc_workspaces',
+        type_='foreignkey',
+    )
+    op.drop_column('jira_dc_workspaces', 'org_id')

--- a/enterprise/server/routes/integration/jira_dc.py
+++ b/enterprise/server/routes/integration/jira_dc.py
@@ -520,7 +520,7 @@ async def create_jira_dc_workspace(
                 )
                 # None when the admin left the PAT blank on edit → the store
                 # preserves the existing encrypted token.
-                encrypted_svc_acc_api_key = (
+                updated_encrypted_svc_acc_api_key = (
                     token_manager.encrypt_text(provided_api_key)
                     if provided_api_key
                     else None
@@ -532,7 +532,7 @@ async def create_jira_dc_workspace(
                     org_id=effective_org_id,
                     encrypted_webhook_secret=encrypted_webhook_secret,
                     svc_acc_email=workspace_data.svc_acc_email,
-                    encrypted_svc_acc_api_key=encrypted_svc_acc_api_key,
+                    encrypted_svc_acc_api_key=updated_encrypted_svc_acc_api_key,
                     status='active' if workspace_data.is_active else 'inactive',
                 )
 
@@ -732,7 +732,7 @@ async def jira_dc_callback(request: Request, code: str, state: str):
             # Empty session PAT (admin edited without changing it) → None so the
             # store preserves the existing encrypted token.
             session_api_key = integration_session.get('svc_acc_api_key')
-            encrypted_svc_acc_api_key = (
+            updated_encrypted_svc_acc_api_key = (
                 token_manager.encrypt_text(session_api_key) if session_api_key else None
             )
 
@@ -742,7 +742,7 @@ async def jira_dc_callback(request: Request, code: str, state: str):
                 org_id=org_id,
                 encrypted_webhook_secret=encrypted_webhook_secret,
                 svc_acc_email=integration_session['svc_acc_email'],
-                encrypted_svc_acc_api_key=encrypted_svc_acc_api_key,
+                encrypted_svc_acc_api_key=updated_encrypted_svc_acc_api_key,
                 status='active' if integration_session['is_active'] else 'inactive',
             )
 

--- a/enterprise/server/routes/integration/jira_dc.py
+++ b/enterprise/server/routes/integration/jira_dc.py
@@ -5,6 +5,7 @@ import secrets
 import uuid
 from typing import cast
 from urllib.parse import urlencode, urlparse
+from uuid import UUID
 
 import requests
 from fastapi import (
@@ -19,6 +20,7 @@ from integrations.jira_dc.jira_dc_manager import JiraDcManager
 from integrations.models import Message, SourceType
 from pydantic import BaseModel, Field, field_validator
 from server.auth.constants import (
+    AUTOMATION_EVENT_FORWARDING_ENABLED,
     JIRA_DC_BASE_URL,
     JIRA_DC_CLIENT_ID,
     JIRA_DC_CLIENT_SECRET,
@@ -27,6 +29,7 @@ from server.auth.constants import (
 from server.auth.saas_user_auth import SaasUserAuth
 from server.auth.token_manager import TokenManager
 from server.constants import WEB_HOST
+from server.services.automation_event_service import AutomationEventService
 from storage.redis import get_redis_client
 
 from openhands.app_server.user_auth.user_auth import get_user_auth
@@ -155,6 +158,7 @@ class JiraDcValidateWorkspaceResponse(BaseModel):
 jira_dc_integration_router = APIRouter(prefix='/integration/jira-dc')
 token_manager = TokenManager()
 jira_dc_manager = JiraDcManager(token_manager)
+automation_event_service = AutomationEventService(token_manager)
 redis_client = get_redis_client()
 
 
@@ -262,9 +266,12 @@ async def jira_dc_events(
         )
 
     try:
-        signature_valid, signature, payload = await jira_dc_manager.validate_request(
-            request
-        )
+        (
+            signature_valid,
+            signature,
+            payload,
+            workspace,
+        ) = await jira_dc_manager.validate_request_context(request)
 
         if not signature_valid:
             logger.warning('[Jira DC] Invalid webhook signature')
@@ -278,6 +285,21 @@ async def jira_dc_events(
             return JSONResponse({'success': True})
         else:
             redis_client.setex(key, 120, 1)
+
+        if AUTOMATION_EVENT_FORWARDING_ENABLED and payload and workspace:
+            if workspace.org_id:
+                background_tasks.add_task(
+                    automation_event_service.forward_jira_dc_event,
+                    org_id=workspace.org_id,
+                    payload=payload,
+                    workspace_name=workspace.name,
+                    delivery_id=signature,
+                )
+            else:
+                logger.warning(
+                    '[Jira DC] Workspace %s has no org_id; skipping automation forwarding',
+                    workspace.id,
+                )
 
         # Process the webhook
         message_payload = {'payload': payload}
@@ -373,6 +395,7 @@ async def create_jira_dc_workspace(
         user_auth = cast(SaasUserAuth, await get_user_auth(request))
         user_id = await user_auth.get_user_id()
         user_email = await user_auth.get_user_email()
+        effective_org_id = await user_auth.get_effective_org_id()
 
         if not user_id:
             raise HTTPException(
@@ -412,6 +435,7 @@ async def create_jira_dc_workspace(
             integration_session = {
                 'operation_type': 'workspace_integration',
                 'keycloak_user_id': user_id,
+                'org_id': str(effective_org_id) if effective_org_id else None,
                 'user_email': user_email,
                 'target_workspace': workspace_data.workspace_name,
                 'webhook_secret': resolved_webhook_secret,
@@ -471,6 +495,7 @@ async def create_jira_dc_workspace(
                 workspace = await jira_dc_manager.integration_store.create_workspace(
                     name=workspace_data.workspace_name,
                     admin_user_id=user_id,
+                    org_id=effective_org_id,
                     encrypted_webhook_secret=encrypted_webhook_secret,
                     svc_acc_email=workspace_data.svc_acc_email,
                     encrypted_svc_acc_api_key=encrypted_new_svc_acc_api_key,
@@ -504,6 +529,7 @@ async def create_jira_dc_workspace(
                 # Update workspace details
                 await jira_dc_manager.integration_store.update_workspace(
                     id=workspace.id,
+                    org_id=effective_org_id,
                     encrypted_webhook_secret=encrypted_webhook_secret,
                     svc_acc_email=workspace_data.svc_acc_email,
                     encrypted_svc_acc_api_key=encrypted_svc_acc_api_key,
@@ -671,6 +697,8 @@ async def jira_dc_callback(request: Request, code: str, state: str):
         workspace = await jira_dc_manager.integration_store.get_workspace_by_name(
             target_workspace
         )
+        session_org_id = integration_session.get('org_id')
+        org_id = UUID(session_org_id) if session_org_id else None
         if not workspace:
             # Create new workspace if it doesn't exist
             encrypted_webhook_secret = token_manager.encrypt_text(
@@ -683,6 +711,7 @@ async def jira_dc_callback(request: Request, code: str, state: str):
             await jira_dc_manager.integration_store.create_workspace(
                 name=target_workspace,
                 admin_user_id=integration_session['keycloak_user_id'],
+                org_id=org_id,
                 encrypted_webhook_secret=encrypted_webhook_secret,
                 svc_acc_email=integration_session['svc_acc_email'],
                 encrypted_svc_acc_api_key=encrypted_new_svc_acc_api_key,
@@ -710,6 +739,7 @@ async def jira_dc_callback(request: Request, code: str, state: str):
             # Update workspace details
             await jira_dc_manager.integration_store.update_workspace(
                 id=workspace.id,
+                org_id=org_id,
                 encrypted_webhook_secret=encrypted_webhook_secret,
                 svc_acc_email=integration_session['svc_acc_email'],
                 encrypted_svc_acc_api_key=encrypted_svc_acc_api_key,

--- a/enterprise/server/services/automation_event_service.py
+++ b/enterprise/server/services/automation_event_service.py
@@ -137,6 +137,48 @@ class AutomationEventService:
             )
             # Don't re-raise in background task - just log for debugging
 
+    async def forward_jira_dc_event(
+        self,
+        org_id: UUID,
+        payload: dict[str, Any],
+        workspace_name: str,
+        delivery_id: str | None = None,
+    ) -> None:
+        """
+        Forward a Jira Data Center webhook event to the automation service.
+
+        Jira DC workspaces are configured directly in OpenHands, so the route
+        resolves the OpenHands org from the workspace instead of using the
+        Git-provider owner resolver.
+        """
+        try:
+            event_payload = {
+                'organization': {
+                    'jira_dc_workspace': workspace_name,
+                    'openhands_org_id': str(org_id),
+                },
+                'payload': payload,
+            }
+            await self._send_source_to_automation_service(
+                source='jira_dc',
+                org_id=org_id,
+                payload=event_payload,
+            )
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            logger.error(
+                f'[AutomationEventService] Network error forwarding '
+                f'jira_dc event (org_id={org_id}): {e}',
+                exc_info=True,
+                extra={'delivery_id': delivery_id},
+            )
+        except Exception as e:
+            logger.error(
+                f'[AutomationEventService] Unexpected error forwarding '
+                f'jira_dc event (org_id={org_id}): {e}',
+                exc_info=True,
+                extra={'delivery_id': delivery_id},
+            )
+
     async def _resolve_org_context(
         self, provider: ProviderType, payload: dict[str, Any]
     ) -> OrgContext | None:
@@ -434,6 +476,18 @@ class AutomationEventService:
         org_id: UUID,
         payload: dict[str, Any],
     ) -> None:
+        await self._send_source_to_automation_service(
+            source=provider.value,
+            org_id=org_id,
+            payload=payload,
+        )
+
+    async def _send_source_to_automation_service(
+        self,
+        source: str,
+        org_id: UUID,
+        payload: dict[str, Any],
+    ) -> None:
         """
         Send the normalized payload to the automation service.
 
@@ -441,7 +495,7 @@ class AutomationEventService:
         automation service can verify it came from the OpenHands server.
 
         Args:
-            provider: The Git provider type
+            source: The automation event source
             org_id: The OpenHands organization ID
             payload: The event payload to send
         """
@@ -453,9 +507,9 @@ class AutomationEventService:
 
         # Build endpoint URL. AUTOMATION_SERVICE_URL may include path segments
         # (e.g., https://example.com/api/automation), so we strip trailing slash
-        # and append our path. The provider is included in the URL path.
+        # and append our path. The source is included in the URL path.
         base_url = AUTOMATION_SERVICE_URL.rstrip('/')
-        url = f'{base_url}/v1/events/{org_id}/{provider.value}'
+        url = f'{base_url}/v1/events/{org_id}/{source}'
 
         # Serialize payload to JSON bytes for signing
         payload_bytes = json.dumps(payload, separators=(',', ':')).encode('utf-8')
@@ -483,22 +537,22 @@ class AutomationEventService:
                             body = await resp.text()
                         logger.warning(
                             f'[AutomationEventService] Automation service returned '
-                            f'{resp.status} for {provider.value} org {org_id}: {body}'
+                            f'{resp.status} for {source} org {org_id}: {body}'
                         )
                     else:
                         data = await resp.json()
                         matched = data.get('matched', 0)
                         logger.info(
-                            f'[AutomationEventService] Forwarded {provider.value} '
+                            f'[AutomationEventService] Forwarded {source} '
                             f'event to org {org_id}: {matched} automations matched'
                         )
         except asyncio.TimeoutError:
             logger.warning(
                 f'[AutomationEventService] Timeout ({AUTOMATION_SERVICE_TIMEOUT}s) '
-                f'forwarding {provider.value} event to automation service'
+                f'forwarding {source} event to automation service'
             )
         except aiohttp.ClientError as e:
             logger.warning(
                 f'[AutomationEventService] HTTP error forwarding '
-                f'{provider.value} event to automation service: {e}'
+                f'{source} event to automation service: {e}'
             )

--- a/enterprise/storage/jira_dc_integration_store.py
+++ b/enterprise/storage/jira_dc_integration_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Optional
+from uuid import UUID
 
 from sqlalchemy import select
 from storage.database import a_session_maker
@@ -18,6 +19,7 @@ class JiraDcIntegrationStore:
         self,
         name: str,
         admin_user_id: str,
+        org_id: UUID | None,
         encrypted_webhook_secret: str,
         svc_acc_email: str,
         encrypted_svc_acc_api_key: str,
@@ -29,6 +31,7 @@ class JiraDcIntegrationStore:
             workspace = JiraDcWorkspace(
                 name=name.lower(),
                 admin_user_id=admin_user_id,
+                org_id=org_id,
                 webhook_secret=encrypted_webhook_secret,
                 svc_acc_email=svc_acc_email,
                 svc_acc_api_key=encrypted_svc_acc_api_key,
@@ -43,6 +46,7 @@ class JiraDcIntegrationStore:
     async def update_workspace(
         self,
         id: int,
+        org_id: UUID | None = None,
         encrypted_webhook_secret: Optional[str] = None,
         svc_acc_email: Optional[str] = None,
         encrypted_svc_acc_api_key: Optional[str] = None,
@@ -61,6 +65,9 @@ class JiraDcIntegrationStore:
 
             if encrypted_webhook_secret is not None:
                 workspace.webhook_secret = encrypted_webhook_secret
+
+            if org_id is not None:
+                workspace.org_id = org_id
 
             if svc_acc_email is not None:
                 workspace.svc_acc_email = svc_acc_email

--- a/enterprise/storage/jira_dc_workspace.py
+++ b/enterprise/storage/jira_dc_workspace.py
@@ -1,6 +1,7 @@
 from datetime import datetime
+from uuid import UUID
 
-from sqlalchemy import DateTime, String, text
+from sqlalchemy import DateTime, ForeignKey, String, text
 from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
 
@@ -10,6 +11,9 @@ class JiraDcWorkspace(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String, nullable=False)
+    org_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey('org.id', ondelete='SET NULL'), nullable=True
+    )
     admin_user_id: Mapped[str] = mapped_column(String, nullable=False)
     webhook_secret: Mapped[str] = mapped_column(String, nullable=False)
     svc_acc_email: Mapped[str] = mapped_column(String, nullable=False)

--- a/enterprise/tests/unit/server/routes/test_jira_dc_integration_routes.py
+++ b/enterprise/tests/unit/server/routes/test_jira_dc_integration_routes.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import parse_qs, urlparse
@@ -37,6 +38,7 @@ def mock_jira_dc_manager():
     manager = MagicMock()
     manager.integration_store = AsyncMock()
     manager.validate_request = AsyncMock()
+    manager.validate_request_context = AsyncMock()
     return manager
 
 
@@ -58,6 +60,9 @@ def mock_user_auth():
     auth = AsyncMock(spec=SaasUserAuth)
     auth.get_user_id.return_value = 'test_user_id'
     auth.get_user_email.return_value = 'test@example.com'
+    auth.get_effective_org_id.return_value = uuid.UUID(
+        '00000000-0000-0000-0000-000000000123'
+    )
     return auth
 
 
@@ -66,7 +71,7 @@ def mock_user_auth():
 @patch('server.routes.integration.jira_dc.redis_client', new_callable=MagicMock)
 async def test_jira_dc_events_invalid_signature(mock_redis, mock_manager, mock_request):
     with patch('server.routes.integration.jira_dc.JIRA_DC_WEBHOOKS_ENABLED', True):
-        mock_manager.validate_request.return_value = (False, None, None)
+        mock_manager.validate_request_context.return_value = (False, None, None, None)
         with pytest.raises(HTTPException) as exc_info:
             await jira_dc_events(mock_request, MagicMock())
         assert exc_info.value.status_code == 403
@@ -78,7 +83,12 @@ async def test_jira_dc_events_invalid_signature(mock_redis, mock_manager, mock_r
 @patch('server.routes.integration.jira_dc.redis_client')
 async def test_jira_dc_events_duplicate_request(mock_redis, mock_manager, mock_request):
     with patch('server.routes.integration.jira_dc.JIRA_DC_WEBHOOKS_ENABLED', True):
-        mock_manager.validate_request.return_value = (True, 'sig123', 'payload')
+        mock_manager.validate_request_context.return_value = (
+            True,
+            'sig123',
+            'payload',
+            MagicMock(),
+        )
         mock_redis.exists.return_value = True
         response = await jira_dc_events(mock_request, MagicMock())
         assert response.status_code == 200
@@ -322,6 +332,7 @@ async def test_get_current_workspace_link_found(
         svc_acc_email='svc@test.com',
     )
     mock_workspace.name = 'test-space'
+    mock_workspace.svc_acc_email = 'svc@test.com'
     mock_workspace.created_at = mock_workspace_created_at
     mock_workspace.updated_at = mock_workspace_updated_at
 
@@ -452,10 +463,14 @@ async def test_jira_dc_events_processing_success(
     mock_redis, mock_manager, mock_request
 ):
     with patch('server.routes.integration.jira_dc.JIRA_DC_WEBHOOKS_ENABLED', True):
-        mock_manager.validate_request.return_value = (
+        mock_workspace = MagicMock()
+        mock_workspace.org_id = uuid.UUID('00000000-0000-0000-0000-000000000123')
+        mock_workspace.name = 'jira.company.com'
+        mock_manager.validate_request_context.return_value = (
             True,
             'sig123',
             {'test': 'payload'},
+            mock_workspace,
         )
         mock_redis.exists.return_value = False
 
@@ -470,11 +485,54 @@ async def test_jira_dc_events_processing_success(
 
 
 @pytest.mark.asyncio
+@patch('server.routes.integration.jira_dc.automation_event_service')
+@patch('server.routes.integration.jira_dc.jira_dc_manager', new_callable=AsyncMock)
+@patch('server.routes.integration.jira_dc.redis_client', new_callable=MagicMock)
+async def test_jira_dc_events_forwards_to_automations(
+    mock_redis, mock_manager, mock_automation_service, mock_request
+):
+    org_id = uuid.UUID('00000000-0000-0000-0000-000000000123')
+    payload = {'webhookEvent': 'comment_created'}
+    mock_workspace = MagicMock()
+    mock_workspace.org_id = org_id
+    mock_workspace.name = 'jira.company.com'
+    mock_manager.validate_request_context.return_value = (
+        True,
+        'sig123',
+        payload,
+        mock_workspace,
+    )
+    mock_redis.exists.return_value = False
+
+    with (
+        patch('server.routes.integration.jira_dc.JIRA_DC_WEBHOOKS_ENABLED', True),
+        patch(
+            'server.routes.integration.jira_dc.AUTOMATION_EVENT_FORWARDING_ENABLED',
+            True,
+        ),
+    ):
+        background_tasks = MagicMock()
+        response = await jira_dc_events(mock_request, background_tasks)
+
+    assert response.status_code == 200
+    background_tasks.add_task.assert_any_call(
+        mock_automation_service.forward_jira_dc_event,
+        org_id=org_id,
+        payload=payload,
+        workspace_name='jira.company.com',
+        delivery_id='sig123',
+    )
+    assert background_tasks.add_task.call_count == 2
+
+
+@pytest.mark.asyncio
 @patch('server.routes.integration.jira_dc.jira_dc_manager', new_callable=AsyncMock)
 @patch('server.routes.integration.jira_dc.redis_client', new_callable=MagicMock)
 async def test_jira_dc_events_general_exception(mock_redis, mock_manager, mock_request):
     with patch('server.routes.integration.jira_dc.JIRA_DC_WEBHOOKS_ENABLED', True):
-        mock_manager.validate_request.side_effect = Exception('Unexpected error')
+        mock_manager.validate_request_context.side_effect = Exception(
+            'Unexpected error'
+        )
 
         response = await jira_dc_events(mock_request, MagicMock())
 
@@ -1030,6 +1088,7 @@ async def test_get_current_workspace_link_not_editable(
     )
     # Fix the name attribute to be a string instead of MagicMock
     mock_workspace.name = 'test-space'
+    mock_workspace.svc_acc_email = 'svc@test.com'
 
     mock_manager.integration_store.get_user_by_active_workspace.return_value = mock_user
     mock_manager.integration_store.get_workspace_by_id.return_value = mock_workspace

--- a/enterprise/tests/unit/server/services/test_automation_event_service.py
+++ b/enterprise/tests/unit/server/services/test_automation_event_service.py
@@ -119,11 +119,14 @@ class TestResolveGitOrg:
         mock_redis.get = AsyncMock(return_value=None)  # Cache miss
         mock_redis.setex = AsyncMock()
 
-        with patch(
-            'server.services.automation_event_service.resolve_org_for_repo',
-            new_callable=AsyncMock,
-            return_value=mock_org_git_claim.org_id,
-        ), patch(REDIS_PATCH, return_value=mock_redis):
+        with (
+            patch(
+                'server.services.automation_event_service.resolve_org_for_repo',
+                new_callable=AsyncMock,
+                return_value=mock_org_git_claim.org_id,
+            ),
+            patch(REDIS_PATCH, return_value=mock_redis),
+        ):
             service = create_service(mock_token_manager)
             result = await service._resolve_git_org(ProviderType.GITHUB, 'test-org')
 
@@ -142,10 +145,13 @@ class TestResolveGitOrg:
         mock_redis = AsyncMock()
         mock_redis.get = AsyncMock(return_value=cached_org_id.encode())
 
-        with patch(
-            'server.services.automation_event_service.resolve_org_for_repo',
-            new_callable=AsyncMock,
-        ) as mock_resolver, patch(REDIS_PATCH, return_value=mock_redis):
+        with (
+            patch(
+                'server.services.automation_event_service.resolve_org_for_repo',
+                new_callable=AsyncMock,
+            ) as mock_resolver,
+            patch(REDIS_PATCH, return_value=mock_redis),
+        ):
             service = create_service(mock_token_manager)
             result = await service._resolve_git_org(ProviderType.GITHUB, 'test-org')
 
@@ -164,11 +170,14 @@ class TestResolveGitOrg:
         mock_redis.get = AsyncMock(return_value=None)  # Cache miss
         mock_redis.setex = AsyncMock()
 
-        with patch(
-            'server.services.automation_event_service.resolve_org_for_repo',
-            new_callable=AsyncMock,
-            return_value=None,
-        ), patch(REDIS_PATCH, return_value=mock_redis):
+        with (
+            patch(
+                'server.services.automation_event_service.resolve_org_for_repo',
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(REDIS_PATCH, return_value=mock_redis),
+        ):
             service = create_service(mock_token_manager)
             result = await service._resolve_git_org(
                 ProviderType.GITHUB, 'unclaimed-org'
@@ -191,10 +200,13 @@ class TestResolveGitOrg:
         mock_redis = AsyncMock()
         mock_redis.get = AsyncMock(return_value=b'none')  # Cached negative
 
-        with patch(
-            'server.services.automation_event_service.resolve_org_for_repo',
-            new_callable=AsyncMock,
-        ) as mock_resolver, patch(REDIS_PATCH, return_value=mock_redis):
+        with (
+            patch(
+                'server.services.automation_event_service.resolve_org_for_repo',
+                new_callable=AsyncMock,
+            ) as mock_resolver,
+            patch(REDIS_PATCH, return_value=mock_redis),
+        ):
             service = create_service(mock_token_manager)
             result = await service._resolve_git_org(
                 ProviderType.GITHUB, 'unclaimed-org'
@@ -216,11 +228,14 @@ class TestResolveGitOrg:
         mock_redis.get = AsyncMock(return_value=None)
         mock_redis.setex = AsyncMock()
 
-        with patch(
-            'server.services.automation_event_service.resolve_org_for_repo',
-            new_callable=AsyncMock,
-            return_value=mock_org_git_claim.org_id,
-        ), patch(REDIS_PATCH, return_value=mock_redis):
+        with (
+            patch(
+                'server.services.automation_event_service.resolve_org_for_repo',
+                new_callable=AsyncMock,
+                return_value=mock_org_git_claim.org_id,
+            ),
+            patch(REDIS_PATCH, return_value=mock_redis),
+        ):
             service = create_service(mock_token_manager)
 
             # Call for GitHub
@@ -335,15 +350,19 @@ class TestForwardEvent:
         mock_redis.get = AsyncMock(return_value=None)
         mock_redis.setex = AsyncMock()
 
-        with patch(
-            'server.services.automation_event_service.resolve_org_for_repo',
-            new_callable=AsyncMock,
-            return_value=mock_org_git_claim.org_id,
-        ), patch(REDIS_PATCH, return_value=mock_redis), patch.object(
-            AutomationEventService,
-            '_send_to_automation_service',
-            new_callable=AsyncMock,
-        ) as mock_send:
+        with (
+            patch(
+                'server.services.automation_event_service.resolve_org_for_repo',
+                new_callable=AsyncMock,
+                return_value=mock_org_git_claim.org_id,
+            ),
+            patch(REDIS_PATCH, return_value=mock_redis),
+            patch.object(
+                AutomationEventService,
+                '_send_to_automation_service',
+                new_callable=AsyncMock,
+            ) as mock_send,
+        ):
             service = AutomationEventService(mock_token_manager)
             await service.forward_event(
                 provider=ProviderType.GITHUB,
@@ -383,15 +402,19 @@ class TestForwardEvent:
         mock_redis.get = AsyncMock(return_value=None)
         mock_redis.setex = AsyncMock()
 
-        with patch(
-            'server.services.automation_event_service.resolve_org_for_repo',
-            new_callable=AsyncMock,
-            return_value=None,  # No org claim for personal repo
-        ), patch(REDIS_PATCH, return_value=mock_redis), patch.object(
-            AutomationEventService,
-            '_send_to_automation_service',
-            new_callable=AsyncMock,
-        ) as mock_send:
+        with (
+            patch(
+                'server.services.automation_event_service.resolve_org_for_repo',
+                new_callable=AsyncMock,
+                return_value=None,  # No org claim for personal repo
+            ),
+            patch(REDIS_PATCH, return_value=mock_redis),
+            patch.object(
+                AutomationEventService,
+                '_send_to_automation_service',
+                new_callable=AsyncMock,
+            ) as mock_send,
+        ):
             service = AutomationEventService(mock_token_manager)
             await service.forward_event(
                 provider=ProviderType.GITHUB,
@@ -422,13 +445,14 @@ class TestForwardEvent:
             'sender': {'id': 12345, 'login': 'testuser'},
         }
 
-        with patch(
-            'server.services.automation_event_service.logger'
-        ) as mock_logger, patch.object(
-            AutomationEventService,
-            '_send_to_automation_service',
-            new_callable=AsyncMock,
-        ) as mock_send:
+        with (
+            patch('server.services.automation_event_service.logger') as mock_logger,
+            patch.object(
+                AutomationEventService,
+                '_send_to_automation_service',
+                new_callable=AsyncMock,
+            ) as mock_send,
+        ):
             service = AutomationEventService(mock_token_manager)
             await service.forward_event(
                 provider=ProviderType.GITHUB,
@@ -455,17 +479,20 @@ class TestForwardEvent:
         mock_redis.get = AsyncMock(return_value=None)
         mock_redis.setex = AsyncMock()
 
-        with patch(
-            'server.services.automation_event_service.resolve_org_for_repo',
-            new_callable=AsyncMock,
-            return_value=None,
-        ), patch(REDIS_PATCH, return_value=mock_redis), patch(
-            'server.services.automation_event_service.logger'
-        ) as mock_logger, patch.object(
-            AutomationEventService,
-            '_send_to_automation_service',
-            new_callable=AsyncMock,
-        ) as mock_send:
+        with (
+            patch(
+                'server.services.automation_event_service.resolve_org_for_repo',
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(REDIS_PATCH, return_value=mock_redis),
+            patch('server.services.automation_event_service.logger') as mock_logger,
+            patch.object(
+                AutomationEventService,
+                '_send_to_automation_service',
+                new_callable=AsyncMock,
+            ) as mock_send,
+        ):
             service = AutomationEventService(mock_token_manager)
             await service.forward_event(
                 provider=ProviderType.GITHUB,
@@ -575,12 +602,15 @@ class TestSendToAutomationService:
         mock_session_context.__aenter__ = AsyncMock(return_value=mock_session_instance)
         mock_session_context.__aexit__ = AsyncMock(return_value=None)
 
-        with patch(
-            'server.services.automation_event_service.AUTOMATION_SERVICE_URL',
-            'https://automation.example.com',
-        ), patch(
-            'server.services.automation_event_service.aiohttp.ClientSession',
-            return_value=mock_session_context,
+        with (
+            patch(
+                'server.services.automation_event_service.AUTOMATION_SERVICE_URL',
+                'https://automation.example.com',
+            ),
+            patch(
+                'server.services.automation_event_service.aiohttp.ClientSession',
+                return_value=mock_session_context,
+            ),
         ):
             service = create_service(mock_token_manager)
             await service._send_to_automation_service(
@@ -620,12 +650,15 @@ class TestSendToAutomationService:
         mock_session_context.__aenter__ = AsyncMock(return_value=mock_session_instance)
         mock_session_context.__aexit__ = AsyncMock(return_value=None)
 
-        with patch(
-            'server.services.automation_event_service.AUTOMATION_SERVICE_URL',
-            'https://automation.example.com',
-        ), patch(
-            'server.services.automation_event_service.aiohttp.ClientSession',
-            return_value=mock_session_context,
+        with (
+            patch(
+                'server.services.automation_event_service.AUTOMATION_SERVICE_URL',
+                'https://automation.example.com',
+            ),
+            patch(
+                'server.services.automation_event_service.aiohttp.ClientSession',
+                return_value=mock_session_context,
+            ),
         ):
             service = create_service(mock_token_manager)
 
@@ -637,6 +670,39 @@ class TestSendToAutomationService:
             assert github_url.endswith('/github')
 
     @pytest.mark.asyncio
+    async def test_forward_jira_dc_event_uses_jira_dc_source(self, mock_token_manager):
+        """
+        GIVEN: A Jira DC webhook and resolved OpenHands org
+        WHEN: forward_jira_dc_event is called
+        THEN: The event is forwarded to the jira_dc automation source
+        """
+        org_id = uuid.UUID('12345678-1234-5678-1234-567812345678')
+        payload = {'webhookEvent': 'comment_created'}
+
+        with patch(
+            'server.services.automation_event_service.AutomationEventService._send_source_to_automation_service',
+            new_callable=AsyncMock,
+        ) as mock_send:
+            service = create_service(mock_token_manager)
+            await service.forward_jira_dc_event(
+                org_id=org_id,
+                payload=payload,
+                workspace_name='jira.company.com',
+                delivery_id='sig123',
+            )
+
+            mock_send.assert_awaited_once()
+            assert mock_send.call_args.kwargs['source'] == 'jira_dc'
+            assert mock_send.call_args.kwargs['org_id'] == org_id
+            assert mock_send.call_args.kwargs['payload'] == {
+                'organization': {
+                    'jira_dc_workspace': 'jira.company.com',
+                    'openhands_org_id': str(org_id),
+                },
+                'payload': payload,
+            }
+
+    @pytest.mark.asyncio
     async def test_send_no_url_configured(self, mock_token_manager):
         """
         GIVEN: AUTOMATION_SERVICE_URL is not configured
@@ -646,9 +712,12 @@ class TestSendToAutomationService:
         org_id = uuid.UUID('12345678-1234-5678-1234-567812345678')
         payload = {}
 
-        with patch(
-            'server.services.automation_event_service.AUTOMATION_SERVICE_URL', None
-        ), patch('server.services.automation_event_service.logger') as mock_logger:
+        with (
+            patch(
+                'server.services.automation_event_service.AUTOMATION_SERVICE_URL', None
+            ),
+            patch('server.services.automation_event_service.logger') as mock_logger,
+        ):
             service = create_service(mock_token_manager)
             await service._send_to_automation_service(
                 ProviderType.GITHUB, org_id, payload


### PR DESCRIPTION
## Summary

Adds first-class Jira Data Center webhook forwarding into the automations service path.

- adds migration `114_add_org_id_to_jira_dc_workspaces.py` to persist/backfill `jira_dc_workspaces.org_id`
- stores the OpenHands org on Jira DC workspaces
- forwards verified Jira DC webhook payloads to the built-in `jira_dc` automation source when automation event forwarding is enabled
- keeps the existing resolver/background processing path intact

## Validation

- `env PYTHONPATH=enterprise:. uv run --with python-keycloak --with pytest-asyncio --with aiosqlite --with limits --with coredis pytest enterprise/tests/unit/integrations/jira_dc/test_jira_dc_manager.py enterprise/tests/unit/server/routes/test_jira_dc_integration_routes.py enterprise/tests/unit/server/services/test_automation_event_service.py tests/unit/test_issue_good_first_issue_check_openhands.py -q` -> 152 passed
- `env PYTHONPATH=enterprise:. uv run ruff check --config enterprise/dev_config/python/ruff.toml ...` on affected automations-forwarding files/tests
- `env PYTHONPATH=enterprise:. uv run ruff format --check --config enterprise/dev_config/python/ruff.toml ...` on affected automations-forwarding files/tests
- `env PYTHONPATH=enterprise:. uv run --with types-requests mypy --config-file enterprise/dev_config/python/mypy.ini enterprise/integrations/jira_dc/jira_dc_manager.py enterprise/server/routes/integration/jira_dc.py enterprise/server/services/automation_event_service.py enterprise/storage/jira_dc_integration_store.py enterprise/storage/jira_dc_workspace.py`
- OHE E2E on `replicated-02`: deployed `enterprise-server:sha-2f59489` with `automation:sha-24c8074`; verified `AUTOMATION_SERVICE_URL=http://automation/api/automation` and `AUTOMATION_EVENT_FORWARDING_ENABLED=true`
- OHE E2E on `replicated-02`: Jira DC `comment_created` produced built-in `jira_dc` automation run `17b66b18-8e16-4660-9fa4-5510cc0ca8e7`
- OHE E2E on `replicated-02`: Jira DC `jira:issue_updated` on `KAN-18` produced built-in `jira_dc` automation run `4c17c4b2-e7e1-4c37-a11a-39c06cc49258`

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-987b13c   docker.openhands.dev/openhands/openhands:987b13c
```

---
Linear: APP-1961

_AI-generated metadata update by OpenHands on behalf of ak684._
