### PR TITLE
Require human context at the top of PR descriptions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,12 @@
 
 <!-- AI/LLM agents: be concise and specific. Do not check the box below. -->
 
+HUMAN:
+
+
 - [ ] A human has tested these changes.
+
+AGENT:
 
 ---
 

--- a/.github/workflows/pr-readiness-confirm.yml
+++ b/.github/workflows/pr-readiness-confirm.yml
@@ -2,11 +2,11 @@
 name: PR Readiness Confirmation
 
 on:
-  # Trigger when a PR is opened (non-draft) or converted from draft to ready.
+  # Trigger when a PR is opened, edited while ready for review, or converted from draft.
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, edited, ready_for_review]
   pull_request_target:
-    types: [opened, ready_for_review]
+    types: [opened, edited, ready_for_review]
 
   # Daily check for stale unconfirmed PRs.
   schedule:
@@ -14,13 +14,121 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
+  # ── Require a short human-written summary on ready-for-review PRs ──
+  check-human-context:
+    if: |
+      github.event_name != 'schedule' &&
+      github.event.pull_request.draft == false &&
+      (
+        (
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        ) ||
+        (
+          github.event_name == 'pull_request_target' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        )
+      )
+    concurrency:
+      group: pr-human-context-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Validate HUMAN section
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const reminderMarker = '<!-- pr-human-context-required -->';
+            const pr = context.payload.pull_request;
+            const issueNumber = pr.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const body = pr.body || '';
+
+            const extractHumanSection = (text) => {
+              const match = text.match(
+                /(?:^|\n)HUMAN:\s*\n([\s\S]*?)(?=\n(?:- )?\[[ xX]\] A human has tested these changes\.)/
+              );
+              if (!match) {
+                return '';
+              }
+              return match[1].replace(/<!--[\s\S]*?-->/g, '').trim();
+            };
+
+            const humanSection = extractHumanSection(body);
+            const hasHumanText = humanSection
+              .split(/\r?\n/)
+              .some((line) => line.trim().length > 0);
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: issueNumber,
+            });
+            const existingReminder = comments.find((comment) =>
+              comment.body.includes(reminderMarker)
+            );
+
+            if (hasHumanText) {
+              if (existingReminder) {
+                await github.rest.issues.deleteComment({
+                  owner,
+                  repo,
+                  comment_id: existingReminder.id,
+                });
+              }
+
+              const reactions = await github.paginate(
+                github.rest.reactions.listForIssue,
+                {
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                }
+              );
+              const botAlreadyReacted = reactions.some(
+                (reaction) =>
+                  reaction.user?.login === 'github-actions[bot]' &&
+                  reaction.content === '+1'
+              );
+
+              if (!botAlreadyReacted) {
+                await github.rest.reactions.createForIssue({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  content: '+1',
+                });
+              }
+
+              return;
+            }
+
+            if (!existingReminder) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body: [
+                  reminderMarker,
+                  '👋 Thanks for opening this PR!',
+                  '',
+                  'Before review, please add a short note in the `HUMAN:` section at the top of the PR description telling maintainers, in your own words, what this PR does.',
+                  '',
+                  'Please put that note between `HUMAN:` and the `- [ ] A human has tested these changes.` checkbox.',
+                ].join('\n'),
+              });
+            }
+
   # ── Post a confirmation request when a PR becomes ready for review ──
   ask-confirmation:
     if: |
       github.event_name != 'schedule' &&
+      github.event.action != 'edited' &&
       github.event.pull_request.draft == false &&
       (
         (

--- a/.github/workflows/pr-readiness-confirm.yml
+++ b/.github/workflows/pr-readiness-confirm.yml
@@ -43,16 +43,29 @@ jobs:
         with:
           script: |
             const reminderMarker = '<!-- pr-human-context-required -->';
+            const humanTestedCheckboxText = 'A human has tested these changes.';
             const pr = context.payload.pull_request;
             const issueNumber = pr.number;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const body = pr.body || '';
 
+            const escapeRegex = (text) =>
+              text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const humanSectionPattern = new RegExp(
+              `(?:^|\\n)HUMAN:\\s*\\n([\\s\\S]*?)(?=\\n(?:- )?\\[[ xX]\\] ${escapeRegex(humanTestedCheckboxText)})`
+            );
+            const warnOnly = async (label, operation) => {
+              try {
+                return await operation();
+              } catch (error) {
+                core.warning(`${label}: ${error.message}`);
+                return null;
+              }
+            };
+
             const extractHumanSection = (text) => {
-              const match = text.match(
-                /(?:^|\n)HUMAN:\s*\n([\s\S]*?)(?=\n(?:- )?\[[ xX]\] A human has tested these changes\.)/
-              );
+              const match = text.match(humanSectionPattern);
               if (!match) {
                 return '';
               }
@@ -64,32 +77,41 @@ jobs:
               .split(/\r?\n/)
               .some((line) => line.trim().length > 0);
 
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number: issueNumber,
-            });
+            const comments = await warnOnly('Failed to list PR comments', () =>
+              github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: issueNumber,
+              })
+            );
+            if (!comments) {
+              return;
+            }
             const existingReminder = comments.find((comment) =>
               comment.body.includes(reminderMarker)
             );
 
             if (hasHumanText) {
               if (existingReminder) {
-                await github.rest.issues.deleteComment({
-                  owner,
-                  repo,
-                  comment_id: existingReminder.id,
-                });
+                await warnOnly('Failed to delete HUMAN reminder comment', () =>
+                  github.rest.issues.deleteComment({
+                    owner,
+                    repo,
+                    comment_id: existingReminder.id,
+                  })
+                );
               }
 
-              const reactions = await github.paginate(
-                github.rest.reactions.listForIssue,
-                {
+              const reactions = await warnOnly('Failed to list PR reactions', () =>
+                github.paginate(github.rest.reactions.listForIssue, {
                   owner,
                   repo,
                   issue_number: issueNumber,
-                }
+                })
               );
+              if (!reactions) {
+                return;
+              }
               const botAlreadyReacted = reactions.some(
                 (reaction) =>
                   reaction.user?.login === 'github-actions[bot]' &&
@@ -97,31 +119,35 @@ jobs:
               );
 
               if (!botAlreadyReacted) {
-                await github.rest.reactions.createForIssue({
-                  owner,
-                  repo,
-                  issue_number: issueNumber,
-                  content: '+1',
-                });
+                await warnOnly('Failed to add HUMAN thumbs up reaction', () =>
+                  github.rest.reactions.createForIssue({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    content: '+1',
+                  })
+                );
               }
 
               return;
             }
 
             if (!existingReminder) {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: issueNumber,
-                body: [
-                  reminderMarker,
-                  '👋 Thanks for opening this PR!',
-                  '',
-                  'Before review, please add a short note in the `HUMAN:` section at the top of the PR description telling maintainers, in your own words, what this PR does.',
-                  '',
-                  'Please put that note between `HUMAN:` and the `- [ ] A human has tested these changes.` checkbox.',
-                ].join('\n'),
-              });
+              await warnOnly('Failed to create HUMAN reminder comment', () =>
+                github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  body: [
+                    reminderMarker,
+                    '👋 Thanks for opening this PR!',
+                    '',
+                    'Before review, please add a short note in the `HUMAN:` section at the top of the PR description telling maintainers, in your own words, what this PR does.',
+                    '',
+                    `Please put that note between \`HUMAN:\` and the \`- [ ] ${humanTestedCheckboxText}\` checkbox.`,
+                  ].join('\n'),
+                })
+              );
             }
 
   # ── Post a confirmation request when a PR becomes ready for review ──

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,6 +279,9 @@ Each integration follows a consistent pattern with service classes, storage mode
 ## Template for Github Pull Request
 
 If you are starting a pull request (PR), please follow the template in `.github/pull_request_template.md`.
+- The PR template now starts with a `HUMAN:` section, the human-tested checkbox, and an `AGENT:` section.
+- `.github/workflows/pr-readiness-confirm.yml` checks non-draft PRs for non-empty text between `HUMAN:` and the human-tested checkbox; if present it adds a 👍 reaction, and if absent it posts a reminder comment.
+
 
 ## Implementation Details
 


### PR DESCRIPTION
HUMAN:
Added HUMAN section and tested it.

- [ ] A human has tested these changes.

AGENT:

## Why

We want PR authors to tell maintainers, in their own words, what the PR does. The current template has a human-tested checkbox, and the current readiness workflow comments only for first-time contributors confirming that a PR is ready for review.

## Summary

- add explicit `HUMAN:` / `AGENT:` sections at the top of the PR template, keeping the existing human-tested checkbox in place
- update `pr-readiness-confirm.yml` to check every non-draft PR for non-empty text between `HUMAN:` and the checkbox
- post a reminder comment when that human section is blank, and add a 👍 reaction (plus remove any prior reminder) when it is filled in

## Issue Number

N/A

## How to Test

1. Open `.github/pull_request_template.md` and confirm the top now reads `HUMAN:`, then the existing human-tested checkbox, then `AGENT:`.
2. Open `.github/workflows/pr-readiness-confirm.yml` and confirm it now listens to `opened`, `edited`, and `ready_for_review`.
3. Confirm the new `check-human-context` job:
   - checks non-draft PRs regardless of author association
   - looks for non-empty text between `HUMAN:` and `- [ ] A human has tested these changes.`
   - posts a reminder comment if that section is blank
   - adds a 👍 reaction and removes any prior reminder comment if that section is later filled in
4. Run `poetry run pre-commit run --files .github/pull_request_template.md .github/workflows/pr-readiness-confirm.yml AGENTS.md --config ./dev_config/python/.pre-commit-config.yaml`.

## Video/Screenshots

N/A

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- The workflow uses the default workflow token with `issues: write` so it can add a 👍 reaction on PRs whose `HUMAN:` block is filled in.
- I also recorded the new PR-template/workflow behavior in `AGENTS.md` for future sessions.

_This PR description was created by an AI agent (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fcc8d8b4-bb15-41cf-83ca-a2639ab9a813)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-1fe4b98   docker.openhands.dev/openhands/openhands:1fe4b98
```