### PR TITLE
fix: scope MCP and ACP env vars to the acting org member

### DIFF
--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -25,10 +25,40 @@ from storage.user_store import UserStore
 from openhands.app_server.settings.settings_models import Settings
 from openhands.app_server.settings.settings_store import SettingsStore
 from openhands.app_server.utils.jsonpatch_compat import (
+    WHOLESALE_REPLACEMENT_KEYS,
     deep_merge,
     deep_merge_with_wholesale_keys,
 )
 from openhands.app_server.utils.llm import is_openhands_model
+
+# Agent-settings keys that are private to each org member and must never
+# be written to org-level defaults or broadcast across the org. Today this
+# covers ``mcp_config`` (per-user MCP server set) and ``acp_env`` (per-user
+# ACP environment variables) — both are dict-of-items collections that
+# represent one member's personal configuration, not org-wide defaults.
+MEMBER_PRIVATE_AGENT_KEYS: frozenset[str] = WHOLESALE_REPLACEMENT_KEYS
+
+
+def _split_member_private_keys(
+    agent_settings_diff: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Split an agent_settings dump into (shared, private) halves.
+
+    The shared half is safe to write to ``org.agent_settings`` and to
+    broadcast through ``update_all_members_settings_async``. The private
+    half must be applied only to the acting member's row.
+    """
+    private = {
+        key: agent_settings_diff[key]
+        for key in MEMBER_PRIVATE_AGENT_KEYS
+        if key in agent_settings_diff
+    }
+    shared = {
+        key: value
+        for key, value in agent_settings_diff.items()
+        if key not in MEMBER_PRIVATE_AGENT_KEYS
+    }
+    return shared, private
 
 
 @dataclass
@@ -139,8 +169,16 @@ class SaasSettingsStore(SettingsStore):
                 if (normalized := c.name.lstrip('_')) in Settings.model_fields
             },
         }
+        # Drop member-private keys from the org dump before merging so
+        # legacy values written by older code paths (when mcp_config /
+        # acp_env were broadcast at the org level) can no longer leak
+        # one member's private config to another. Each member's own
+        # ``agent_settings_diff`` still supplies their personal values.
+        org_agent_settings_dump = org_agent_settings.model_dump(mode='json')
+        for private_key in MEMBER_PRIVATE_AGENT_KEYS:
+            org_agent_settings_dump.pop(private_key, None)
         merged_agent_settings = deep_merge(
-            org_agent_settings.model_dump(mode='json'),
+            org_agent_settings_dump,
             member_agent_settings_diff,
         )
         effective_llm_api_key = self._get_effective_llm_api_key(org, org_member)
@@ -244,10 +282,28 @@ class SaasSettingsStore(SettingsStore):
 
             effective_agent_settings_diff = self._get_persisted_agent_settings(item)
 
+            # Keep mcp_config / acp_env scoped to the acting member only.
+            # ``shared_agent_settings_diff`` is the slice safe for org-wide
+            # state; ``private_agent_settings_diff`` is applied below to the
+            # acting member's row only so other members don't inherit one
+            # user's MCP servers (or ACP env vars).
+            shared_agent_settings_diff, private_agent_settings_diff = (
+                _split_member_private_keys(effective_agent_settings_diff)
+            )
+
+            # Strip any pre-existing private keys from the org dump before
+            # merging, so legacy values written by older code paths are
+            # cleaned up on the next save and stop leaking to other members.
+            org_agent_settings_dump = OrgStore.get_agent_settings_from_org(
+                org
+            ).model_dump(mode='json')
+            for private_key in MEMBER_PRIVATE_AGENT_KEYS:
+                org_agent_settings_dump.pop(private_key, None)
+
             # Single assignment so SQLAlchemy tracks the change
             org.agent_settings = deep_merge_with_wholesale_keys(
-                OrgStore.get_agent_settings_from_org(org).model_dump(mode='json'),
-                effective_agent_settings_diff,
+                org_agent_settings_dump,
+                shared_agent_settings_diff,
             )
 
             effective_conversation_diff = item.conversation_settings.model_dump(
@@ -291,7 +347,7 @@ class SaasSettingsStore(SettingsStore):
                 session,
                 org_id,
                 OrgMemberSettingsUpdate(
-                    agent_settings_diff=effective_agent_settings_diff,
+                    agent_settings_diff=shared_agent_settings_diff,
                     conversation_settings_diff=effective_conversation_diff,
                     llm_api_key=(
                         current_member_llm_api_key_raw  # type: ignore[arg-type]
@@ -300,6 +356,15 @@ class SaasSettingsStore(SettingsStore):
                     ),
                 ),
             )
+
+            # Member-private keys (mcp_config, acp_env) live only on the
+            # acting member's row. Use the wholesale-replacement semantics
+            # so deletes stick (APP-1862).
+            if private_agent_settings_diff:
+                org_member.agent_settings_diff = deep_merge_with_wholesale_keys(
+                    dict(org_member.agent_settings_diff),
+                    private_agent_settings_diff,
+                )
 
             if uses_managed_llm_key and current_member_llm_api_key is not None:
                 # Managed/proxy key — store on this member but mark as org-managed

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -575,22 +575,26 @@ async def test_store_keeps_openhands_managed_keys_member_specific(
 
 
 @pytest.mark.asyncio
-async def test_store_saves_mcp_config_in_agent_settings(
+async def test_store_keeps_mcp_config_private_to_acting_member(
     session_maker, async_session_maker, org_with_multiple_members_fixture
 ):
-    """mcp_config now flows through agent_settings / agent_settings_diff,
-    so it is persisted on both the org and all members."""
+    """A member's MCP servers must stay scoped to that member's row.
+
+    After Member 1 saves an mcp_config, no other org member sees those
+    servers on load, and ``org.agent_settings`` carries no mcp_config so
+    new joiners don't inherit them via the org defaults.
+    """
     from sqlalchemy import select
     from storage.org import Org
     from storage.org_member import OrgMember
 
+    # Arrange
     fixture = org_with_multiple_members_fixture
     org_id = fixture['org_id']
     admin_user_id = str(fixture['admin_user_id'])
     member1_user_id = str(fixture['member1_user_id'])
     member2_user_id = str(fixture['member2_user_id'])
 
-    store = SaasSettingsStore(admin_user_id)
     user_mcp_config = {
         'mcpServers': {
             'user1': {'url': 'https://user1-mcp-server.com', 'transport': 'sse'}
@@ -610,14 +614,15 @@ async def test_store_saves_mcp_config_in_agent_settings(
         }
     )
 
+    # Act — Member 1 (admin) saves the mcp_config
+    store = SaasSettingsStore(admin_user_id)
     with patch('storage.saas_settings_store.a_session_maker', async_session_maker):
         await store.store(new_settings)
 
+    # Assert — only the acting member's row carries mcp_config; org and
+    # other members do not.
     with session_maker() as session:
         org = session.execute(select(Org).where(Org.id == org_id)).scalars().first()
-        assert org is not None
-        assert org.agent_settings.get('mcp_config') == user_mcp_config
-
         members = {
             str(m.user_id): m
             for m in session.execute(
@@ -626,18 +631,13 @@ async def test_store_saves_mcp_config_in_agent_settings(
             .scalars()
             .all()
         }
-        assert (
-            members[admin_user_id].agent_settings_diff.get('mcp_config')
-            == user_mcp_config
-        )
-        assert (
-            members[member1_user_id].agent_settings_diff.get('mcp_config')
-            == user_mcp_config
-        )
-        assert (
-            members[member2_user_id].agent_settings_diff.get('mcp_config')
-            == user_mcp_config
-        )
+
+    assert 'mcp_config' not in org.agent_settings
+    assert (
+        members[admin_user_id].agent_settings_diff.get('mcp_config') == user_mcp_config
+    )
+    assert 'mcp_config' not in members[member1_user_id].agent_settings_diff
+    assert 'mcp_config' not in members[member2_user_id].agent_settings_diff
 
 
 @pytest.mark.asyncio
@@ -762,6 +762,60 @@ async def test_store_and_load_mcp_config_via_agent_settings(
         loaded.agent_settings.mcp_config.mcpServers['admin'].url
         == 'https://admin-private-server.com'
     )
+
+
+@pytest.mark.asyncio
+async def test_load_drops_legacy_org_level_mcp_config(
+    session_maker, async_session_maker, org_with_multiple_members_fixture
+):
+    """Legacy org-level mcp_config (from before the fix) must not leak
+    to members on load. Members without their own mcp_config see ``None``
+    even if the org row still carries a stale value in the database.
+    """
+    from sqlalchemy import select
+    from storage.org import Org
+    from storage.user import User
+
+    # Arrange — simulate pre-fix data: org carries an mcp_config that
+    # was broadcast at the org level. member1 has no mcp_config of their
+    # own.
+    fixture = org_with_multiple_members_fixture
+    org_id = fixture['org_id']
+    member1_user_id = str(fixture['member1_user_id'])
+
+    legacy_org_mcp_config = {
+        'mcpServers': {
+            'leaked': {'url': 'https://leaked-server.com', 'transport': 'sse'}
+        },
+    }
+    with session_maker() as session:
+        org = session.execute(select(Org).where(Org.id == org_id)).scalars().first()
+        org.agent_settings = {
+            'agent_kind': 'openhands',
+            'mcp_config': legacy_org_mcp_config,
+        }
+        # Populate the nullable bool defaults that the Settings model
+        # requires non-None when load() rebuilds the Settings object.
+        user = (
+            session.execute(select(User).where(User.id == fixture['member1_user_id']))
+            .scalars()
+            .first()
+        )
+        user.enable_sound_notifications = False
+        session.commit()
+
+    # Act
+    store = SaasSettingsStore(member1_user_id)
+    with (
+        patch('storage.saas_settings_store.a_session_maker', async_session_maker),
+        patch('storage.user_store.a_session_maker', async_session_maker),
+        patch('storage.org_store.a_session_maker', async_session_maker),
+    ):
+        loaded = await store.load()
+
+    # Assert — legacy org mcp_config is not inherited by member1
+    assert loaded is not None
+    assert loaded.agent_settings.mcp_config is None
 
 
 @pytest.mark.asyncio
@@ -946,24 +1000,22 @@ async def test_llm_profiles_are_encrypted_at_rest(
 async def test_store_replaces_mcp_config_on_delete(
     session_maker, async_session_maker, org_with_multiple_members_fixture
 ):
-    """When a server is deleted, mcp_config should be replaced wholesale,
-    not merged (which would resurrect deleted servers).
+    """Deleting a server from a member's mcp_config sticks on the acting
+    member's row and never touches other members' rows.
 
-    This tests the fix for APP-1862: MCP server settings cannot be updated
-    or deleted because deep_merge was resurrecting deleted servers.
+    Combines the APP-1862 wholesale-replacement contract (deletes are not
+    resurrected by deep_merge) with the per-member privacy contract.
     """
     from sqlalchemy import select
-    from storage.org import Org
     from storage.org_member import OrgMember
 
+    # Arrange — Member 1 (admin) starts with 3 MCP servers
     fixture = org_with_multiple_members_fixture
     org_id = fixture['org_id']
     admin_user_id = str(fixture['admin_user_id'])
     member1_user_id = str(fixture['member1_user_id'])
 
     store = SaasSettingsStore(admin_user_id)
-
-    # Step 1: Save 3 MCP servers
     initial_mcp_config = {
         'mcpServers': {
             'server1': {'url': 'https://server1.com', 'transport': 'sse'},
@@ -984,22 +1036,14 @@ async def test_store_replaces_mcp_config_on_delete(
             },
         }
     )
-
     with patch('storage.saas_settings_store.a_session_maker', async_session_maker):
         await store.store(initial_settings)
 
-    # Verify 3 servers are saved
-    with session_maker() as session:
-        org = session.execute(select(Org).where(Org.id == org_id)).scalars().first()
-        assert org is not None
-        assert len(org.agent_settings.get('mcp_config', {}).get('mcpServers', {})) == 3
-
-    # Step 2: Delete one server (save with only 2 servers)
+    # Act — re-save with server3 removed
     updated_mcp_config = {
         'mcpServers': {
             'server1': {'url': 'https://server1.com', 'transport': 'sse'},
             'server2': {'url': 'https://server2.com', 'transport': 'sse'},
-            # server3 is deleted
         },
     }
     updated_settings = DataSettings()
@@ -1015,25 +1059,12 @@ async def test_store_replaces_mcp_config_on_delete(
             },
         }
     )
-
     with patch('storage.saas_settings_store.a_session_maker', async_session_maker):
         await store.store(updated_settings)
 
-    # Step 3: Verify only 2 servers remain (server3 was not resurrected)
+    # Assert — server3 is gone from the acting member; other members were
+    # never touched by either save.
     with session_maker() as session:
-        org = session.execute(select(Org).where(Org.id == org_id)).scalars().first()
-        assert org is not None
-        mcp_servers = org.agent_settings.get('mcp_config', {}).get('mcpServers', {})
-        assert (
-            len(mcp_servers) == 2
-        ), f'Expected 2 servers, got {len(mcp_servers)}: {mcp_servers}'
-        assert 'server1' in mcp_servers
-        assert 'server2' in mcp_servers
-        assert (
-            'server3' not in mcp_servers
-        ), 'Deleted server was resurrected by deep_merge'
-
-        # Also verify member diffs have 2 servers
         members = {
             str(m.user_id): m
             for m in session.execute(
@@ -1042,10 +1073,11 @@ async def test_store_replaces_mcp_config_on_delete(
             .scalars()
             .all()
         }
-        admin_mcp = members[admin_user_id].agent_settings_diff.get('mcp_config', {})
-        assert len(admin_mcp.get('mcpServers', {})) == 2
-        assert 'server3' not in admin_mcp.get('mcpServers', {})
 
-        member1_mcp = members[member1_user_id].agent_settings_diff.get('mcp_config', {})
-        assert len(member1_mcp.get('mcpServers', {})) == 2
-        assert 'server3' not in member1_mcp.get('mcpServers', {})
+    admin_servers = (
+        members[admin_user_id]
+        .agent_settings_diff.get('mcp_config', {})
+        .get('mcpServers', {})
+    )
+    assert set(admin_servers.keys()) == {'server1', 'server2'}
+    assert 'mcp_config' not in members[member1_user_id].agent_settings_diff


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:


- [x] A human has tested these changes.

AGENT:

---

## Why

<!-- Describe problem, motivation, etc.-->

### Summary

When a member of an organization creates an MCP server on `/settings/mcp`, every other member of the same organization sees it. MCP server configuration is supposed to be private to the member that created it.

### Steps to reproduce

1. Create an organization `A` with two members, Member 1 and Member 2.
2. Sign in as Member 1, go to `/settings/mcp`, and add a new MCP server.
3. Sign out and sign in as Member 2.
4. Open `/settings/mcp`.

### Actual behavior

Member 2 sees the MCP server Member 1 created.

### Expected behavior

Each org member's MCP server list is private to that member. Member 2 should see an empty MCP server list until they add their own.

### Root cause

`SaasSettingsStore.store()` in `enterprise/storage/saas_settings_store.py` treats `mcp_config` the same as every other agent setting. On save, the store takes the full effective `agent_settings` dump (which includes `mcp_config`) and:

1. Writes it to `org.agent_settings` via `deep_merge_with_wholesale_keys(...)`. `org.agent_settings` is the default that every member's `load()` deep-merges with their own diff, so Member 1's MCP servers become part of the org defaults Member 2 sees.
2. Calls `OrgMemberStore.update_all_members_settings_async(...)` with the full diff. That helper applies `mcp_config` to every `OrgMember` row in the org, copying Member 1's MCP servers directly onto Member 2's row.

Either fan-out alone is enough to leak; both fired on every save.

`acp_env` (ACP environment variables) is a sibling key in `WHOLESALE_REPLACEMENT_KEYS` with the same per-member semantics and the same leak.

### Scope

- Fixed: per-user `POST /api/v1/settings` write path (the `/settings/mcp` page).
- Out of scope (separate follow-up): the org-defaults endpoint `PATCH /api/organizations/{id}/settings`. An org admin can still write `mcp_config` into `agent_settings_diff` through that route. Worth a separate ticket to harden, since intent there is "org admin sets org-wide defaults" — different threat model.

### Acceptance criteria

- A member's MCP servers (`mcp_config`) and ACP env vars (`acp_env`) are stored only on that member's `org_member` row.
- Other members of the same org see no trace of those values via `load()`.
- `org.agent_settings` carries no `mcp_config` or `acp_env` after a user-side save.
- Pre-existing org-level `mcp_config` left over from before this fix does not leak to members on load (defense for stale data).
- Deleting an MCP server (the APP-1862 contract) still sticks for the acting member; deletes are not resurrected by deep-merge.

## Summary

<!-- 1-3 bullets describing what changed. -->
- `mcp_config` and `acp_env` are now per-member, never written to `org.agent_settings`, never broadcast across the org.
- Splits the effective `agent_settings_diff` into a shared half (LLM/agent/condenser/etc.) and a private half (`mcp_config`, `acp_env`) inside `SaasSettingsStore.store()`. Shared half flows to `org.agent_settings` + `update_all_members_settings_async` as before; private half is applied wholesale to the acting `org_member` only.
- `SaasSettingsStore.load()` strips the private keys from the org dump before deep-merging with the member diff, so pre-fix legacy `org.agent_settings.mcp_config` in the database stops leaking on read.

### Why

Member 1 of an org would add an MCP server on `/settings/mcp` and every other member of the same org would see it. Root cause: the user-settings save path treated `mcp_config` like a shared org setting and fanned it out twice (org row + every member row). See the linked Linear ticket for the full reproduction.

`acp_env` shares the same `WHOLESALE_REPLACEMENT_KEYS` semantics as `mcp_config` and had the same leak — fixed together via a single constant (`MEMBER_PRIVATE_AGENT_KEYS`).

### Files changed

- `enterprise/storage/saas_settings_store.py`
  - New module-level constant `MEMBER_PRIVATE_AGENT_KEYS = WHOLESALE_REPLACEMENT_KEYS` + `_split_member_private_keys()` helper.
  - `store()` splits the diff and writes only the shared half to org-wide state. Private half goes to the acting member only, via `deep_merge_with_wholesale_keys` so deletes stick.
  - `store()` also strips any pre-existing private keys from `org.agent_settings` before the merge, so legacy values are cleaned up on the next save.
  - `load()` strips private keys from the org dump before merging with the member diff.
- `enterprise/tests/unit/test_saas_settings_store.py`
  - Replaced `test_store_saves_mcp_config_in_agent_settings` with `test_store_keeps_mcp_config_private_to_acting_member` — asserts only the acting member's row carries `mcp_config`, org and other members do not.
  - Updated `test_store_replaces_mcp_config_on_delete` to assert both the APP-1862 wholesale-replace-on-delete contract **and** that other members' rows are never touched.
  - New `test_load_drops_legacy_org_level_mcp_config` — pre-seeds `org.agent_settings.mcp_config` (simulating pre-fix data) and asserts the load path does not surface it to a member with no `mcp_config` of their own.

### Out of scope

- The org-defaults endpoint (`PATCH /api/organizations/{org_id}/settings`) still accepts `mcp_config` in `agent_settings_diff` and writes it to the org row. That's a different threat model (admin-intent vs user-intent) and gets its own ticket.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Create an organization `A` with two members, Member 1 and Member 2.
2. Sign in as Member 1, go to `/settings/mcp`, and add a new MCP server.
3. Sign out and sign in as Member 2.
4. Open `/settings/mcp`.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/fc572050-1d0b-4d40-a308-48fe107b8dea

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

### Risk

Low. The fix is scoped to the `SaasSettingsStore` write/read paths; the underlying `OrgMemberStore.update_all_members_settings_async` helper is unchanged so other callers behave identically. Legacy data with `mcp_config` on `org.agent_settings` is silently cleaned up on the next save and ignored on load.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-9d9af70   docker.openhands.dev/openhands/openhands:9d9af70
```