### PR TITLE
[APP-1957] Scope resolver runtime auth to resolved org

### DIFF
--- a/enterprise/integrations/resolver_context.py
+++ b/enterprise/integrations/resolver_context.py
@@ -22,6 +22,11 @@ class ResolverUserContext(UserContext):
         self.saas_user_auth = saas_user_auth
         self.resolver_org_id = resolver_org_id
         self._provider_handler: ProviderHandler | None = None
+        set_effective_org_id_override = getattr(
+            type(self.saas_user_auth), 'set_effective_org_id_override', None
+        )
+        if resolver_org_id is not None and callable(set_effective_org_id_override):
+            set_effective_org_id_override(self.saas_user_auth, resolver_org_id)
 
     async def get_user_id(self) -> str | None:
         return await self.saas_user_auth.get_user_id()

--- a/enterprise/integrations/resolver_context.py
+++ b/enterprise/integrations/resolver_context.py
@@ -22,6 +22,8 @@ class ResolverUserContext(UserContext):
         self.saas_user_auth = saas_user_auth
         self.resolver_org_id = resolver_org_id
         self._provider_handler: ProviderHandler | None = None
+        # SaasUserAuth supports this resolver override; other UserAuth
+        # implementations may not, so keep the call defensive.
         set_effective_org_id_override = getattr(
             type(self.saas_user_auth), 'set_effective_org_id_override', None
         )

--- a/enterprise/server/auth/saas_user_auth.py
+++ b/enterprise/server/auth/saas_user_auth.py
@@ -100,6 +100,10 @@ class SaasUserAuth(UserAuth):
     def set_effective_org_id_override(self, org_id: UUID | None) -> None:
         """Set a trusted server-side org override and clear org-scoped caches."""
         self.effective_org_id_override = org_id
+        self._clear_org_scoped_caches()
+
+    def _clear_org_scoped_caches(self) -> None:
+        """Clear cached data that depends on the effective organization."""
         self._effective_org_id = None
         self._effective_org_id_resolved = False
         self.settings_store = None
@@ -112,6 +116,56 @@ class SaasUserAuth(UserAuth):
         self._role = None
         self._permissions = None
         self._org_info_loaded = False
+
+    async def _resolve_and_verify_override_org(self) -> UUID | None:
+        """Verify and return the trusted resolver org override, if present."""
+        if self.effective_org_id_override is None:
+            return None
+
+        # Import locally to avoid a circular import via authorization.py.
+        from fastapi import status
+        from storage.org_member_store import OrgMemberStore
+
+        override_org_id = self.effective_org_id_override
+        if self.api_key_org_id is not None and self.api_key_org_id != override_org_id:
+            logger.warning(
+                'effective_org_id_override_api_key_mismatch',
+                extra={
+                    'user_id': self.user_id,
+                    'api_key_org_id': str(self.api_key_org_id),
+                    'effective_org_id_override': str(override_org_id),
+                },
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail='API key is not authorized for this organization',
+            )
+        try:
+            user_uuid = UUID(self.user_id)
+        except ValueError as exc:
+            logger.error(
+                'effective_org_id_override_invalid_user_id',
+                extra={'user_id': self.user_id},
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail='User is not a member of the requested organization',
+            ) from exc
+
+        member = await OrgMemberStore.get_org_member(override_org_id, user_uuid)
+        if member is None:
+            logger.warning(
+                'effective_org_id_override_not_a_member',
+                extra={
+                    'user_id': self.user_id,
+                    'effective_org_id_override': str(override_org_id),
+                },
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail='User is not a member of the requested organization',
+            )
+        return override_org_id
 
     async def get_effective_org_id(self) -> UUID | None:
         """Resolve the effective organization ID for this request.
@@ -137,58 +191,12 @@ class SaasUserAuth(UserAuth):
         if self._effective_org_id_resolved:
             return self._effective_org_id
 
-        # Import locally to avoid a circular import via authorization.py.
         from fastapi import status
         from storage.org_member_store import OrgMemberStore
 
-        if self.effective_org_id_override is not None:
-            if (
-                self.api_key_org_id is not None
-                and self.api_key_org_id != self.effective_org_id_override
-            ):
-                logger.warning(
-                    'effective_org_id_override_api_key_mismatch',
-                    extra={
-                        'user_id': self.user_id,
-                        'api_key_org_id': str(self.api_key_org_id),
-                        'effective_org_id_override': str(
-                            self.effective_org_id_override
-                        ),
-                    },
-                )
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail='API key is not authorized for this organization',
-                )
-            try:
-                user_uuid = UUID(self.user_id)
-            except ValueError as exc:
-                logger.error(
-                    'effective_org_id_override_invalid_user_id',
-                    extra={'user_id': self.user_id},
-                )
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail='User is not a member of the requested organization',
-                ) from exc
-            member = await OrgMemberStore.get_org_member(
-                self.effective_org_id_override, user_uuid
-            )
-            if member is None:
-                logger.warning(
-                    'effective_org_id_override_not_a_member',
-                    extra={
-                        'user_id': self.user_id,
-                        'effective_org_id_override': str(
-                            self.effective_org_id_override
-                        ),
-                    },
-                )
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail='User is not a member of the requested organization',
-                )
-            self._effective_org_id = self.effective_org_id_override
+        override_org_id = await self._resolve_and_verify_override_org()
+        if override_org_id is not None:
+            self._effective_org_id = override_org_id
             self._effective_org_id_resolved = True
             return self._effective_org_id
 

--- a/enterprise/server/auth/saas_user_auth.py
+++ b/enterprise/server/auth/saas_user_auth.py
@@ -80,6 +80,9 @@ class SaasUserAuth(UserAuth):
     # Per-request `X-Org-Id` header (raw, unvalidated); see
     # `enterprise/server/auth/org_context.py` for resolution rules.
     _x_org_id_header: str | None = None
+    # Trusted server-side override used by background resolver contexts after
+    # they have already resolved and membership-checked the target org.
+    effective_org_id_override: UUID | None = None
     # Cached result of `get_effective_org_id()`. The `_resolved` flag is
     # needed to distinguish "not yet computed" from "computed and None".
     _effective_org_id: UUID | None = None
@@ -94,18 +97,35 @@ class SaasUserAuth(UserAuth):
         """
         return self.api_key_org_id
 
+    def set_effective_org_id_override(self, org_id: UUID | None) -> None:
+        """Set a trusted server-side org override and clear org-scoped caches."""
+        self.effective_org_id_override = org_id
+        self._effective_org_id = None
+        self._effective_org_id_resolved = False
+        self.settings_store = None
+        self.secrets_store = None
+        self._settings = None
+        self._secrets = None
+        self.provider_tokens = None
+        self._org_id = None
+        self._org_name = None
+        self._role = None
+        self._permissions = None
+        self._org_info_loaded = False
+
     async def get_effective_org_id(self) -> UUID | None:
         """Resolve the effective organization ID for this request.
 
         Precedence (highest first):
 
-        1. ``api_key_org_id`` — if the request is authenticated with an
+        1. ``effective_org_id_override`` — trusted server-side resolver context.
+        2. ``api_key_org_id`` — if the request is authenticated with an
            org-bound API key, that org wins. If the caller also sent an
            ``X-Org-Id`` header that disagrees, raise 403.
-        2. ``X-Org-Id`` header — explicit, per-request override. The
+        3. ``X-Org-Id`` header — explicit, per-request override. The
            authenticated user must be a member of that org or we raise
            403. Malformed UUIDs raise 400.
-        3. ``user.current_org_id`` — server-side default.
+        4. ``user.current_org_id`` — server-side default.
 
         The resolved value is cached on the auth instance for the rest
         of the request, so callers can invoke this freely.
@@ -120,6 +140,57 @@ class SaasUserAuth(UserAuth):
         # Import locally to avoid a circular import via authorization.py.
         from fastapi import status
         from storage.org_member_store import OrgMemberStore
+
+        if self.effective_org_id_override is not None:
+            if (
+                self.api_key_org_id is not None
+                and self.api_key_org_id != self.effective_org_id_override
+            ):
+                logger.warning(
+                    'effective_org_id_override_api_key_mismatch',
+                    extra={
+                        'user_id': self.user_id,
+                        'api_key_org_id': str(self.api_key_org_id),
+                        'effective_org_id_override': str(
+                            self.effective_org_id_override
+                        ),
+                    },
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail='API key is not authorized for this organization',
+                )
+            try:
+                user_uuid = UUID(self.user_id)
+            except ValueError as exc:
+                logger.error(
+                    'effective_org_id_override_invalid_user_id',
+                    extra={'user_id': self.user_id},
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail='User is not a member of the requested organization',
+                ) from exc
+            member = await OrgMemberStore.get_org_member(
+                self.effective_org_id_override, user_uuid
+            )
+            if member is None:
+                logger.warning(
+                    'effective_org_id_override_not_a_member',
+                    extra={
+                        'user_id': self.user_id,
+                        'effective_org_id_override': str(
+                            self.effective_org_id_override
+                        ),
+                    },
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail='User is not a member of the requested organization',
+                )
+            self._effective_org_id = self.effective_org_id_override
+            self._effective_org_id_resolved = True
+            return self._effective_org_id
 
         header_value = self._x_org_id_header
         requested: UUID | None = None

--- a/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_view.py
+++ b/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_view.py
@@ -1,6 +1,7 @@
 """Tests for the Jira DC view factory's conversation-creation strategy."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
 
 import pytest
 from integrations.jira_dc.jira_dc_view import (
@@ -8,6 +9,7 @@ from integrations.jira_dc.jira_dc_view import (
     JiraDcFactory,
     JiraDcNewConversationView,
 )
+from openhands.app_server.integrations.service_types import ProviderType, Repository
 
 
 @pytest.mark.asyncio
@@ -46,3 +48,41 @@ async def test_factory_always_creates_new_conversation(
     # A fresh view starts with no conversation id (assigned at creation time).
     assert view.conversation_id == ''
     assert view.selected_repo is None
+
+
+@pytest.mark.asyncio
+async def test_new_conversation_resolves_org_from_selected_repo_claim(
+    new_conversation_view,
+):
+    """Jira DC @mentions use the shared repo-claim org routing path."""
+    resolved_org_id = UUID('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+    new_conversation_view.saas_user_auth.get_provider_tokens.return_value = {
+        ProviderType.GITHUB: MagicMock()
+    }
+    repository = Repository(
+        id='1',
+        full_name='company/repo1',
+        stargazers_count=0,
+        git_provider=ProviderType.GITHUB,
+        is_public=False,
+    )
+
+    with (
+        patch('integrations.jira_dc.jira_dc_view.ProviderHandler') as handler_cls,
+        patch(
+            'integrations.jira_dc.jira_dc_view.resolve_org_for_repo',
+            new=AsyncMock(return_value=resolved_org_id),
+        ) as resolve_org,
+    ):
+        handler = MagicMock()
+        handler.verify_repo_provider = AsyncMock(return_value=repository)
+        handler_cls.return_value = handler
+
+        result = await new_conversation_view._get_resolved_org_id()
+
+    assert result == resolved_org_id
+    resolve_org.assert_awaited_once_with(
+        provider=ProviderType.GITHUB.value,
+        full_repo_name='company/repo1',
+        keycloak_user_id='test_keycloak_id',
+    )

--- a/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_view.py
+++ b/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_view.py
@@ -9,6 +9,7 @@ from integrations.jira_dc.jira_dc_view import (
     JiraDcFactory,
     JiraDcNewConversationView,
 )
+
 from openhands.app_server.integrations.service_types import ProviderType, Repository
 
 

--- a/enterprise/tests/unit/integrations/test_resolver_context.py
+++ b/enterprise/tests/unit/integrations/test_resolver_context.py
@@ -5,6 +5,7 @@ This test focuses on testing the actual ResolverUserContext implementation.
 
 from types import MappingProxyType
 from unittest.mock import AsyncMock
+from uuid import UUID
 
 import pytest
 from pydantic import SecretStr
@@ -45,13 +46,29 @@ def test_resolver_org_id_defaults_to_none(mock_saas_user_auth):
 
 def test_resolver_org_id_can_be_set_via_constructor(mock_saas_user_auth):
     """Test that resolver_org_id can be set via constructor for org routing."""
-    from uuid import UUID
-
     org_id = UUID('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
     ctx = ResolverUserContext(
         saas_user_auth=mock_saas_user_auth, resolver_org_id=org_id
     )
     assert ctx.resolver_org_id == org_id
+
+
+def test_resolver_org_id_scopes_saas_auth_when_supported():
+    """Resolver orgs should scope runtime settings, secrets, and API keys."""
+
+    class FakeSaasUserAuth:
+        def __init__(self):
+            self.effective_org_id_override = None
+
+        def set_effective_org_id_override(self, org_id):
+            self.effective_org_id_override = org_id
+
+    org_id = UUID('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+    auth = FakeSaasUserAuth()
+
+    ResolverUserContext(saas_user_auth=auth, resolver_org_id=org_id)
+
+    assert auth.effective_org_id_override == org_id
 
 
 def create_custom_secret(value: str, description: str = 'Test secret') -> CustomSecret:

--- a/enterprise/tests/unit/server/auth/test_saas_user_auth_effective_org.py
+++ b/enterprise/tests/unit/server/auth/test_saas_user_auth_effective_org.py
@@ -150,6 +150,88 @@ class TestGetEffectiveOrgId:
         assert effective == other_org_id
 
     @pytest.mark.asyncio
+    async def test_server_side_override_wins_when_user_is_member(
+        self, async_session_maker, user_id, org_id, other_org_id
+    ):
+        await _seed_minimal(async_session_maker, user_id, org_id, other_org_id)
+        user_auth = SaasUserAuth(
+            user_id=user_id,
+            refresh_token=SecretStr('mock'),
+            effective_org_id_override=other_org_id,
+        )
+        with _stores_patched(async_session_maker)[2]:
+            effective = await user_auth.get_effective_org_id()
+
+        assert effective == other_org_id
+
+    @pytest.mark.asyncio
+    async def test_server_side_override_with_non_member_org_raises_403(
+        self, async_session_maker, user_id, org_id, other_org_id
+    ):
+        await _seed_minimal(async_session_maker, user_id, org_id)
+        user_auth = SaasUserAuth(
+            user_id=user_id,
+            refresh_token=SecretStr('mock'),
+            effective_org_id_override=other_org_id,
+        )
+        with _stores_patched(async_session_maker)[2]:
+            with pytest.raises(HTTPException) as exc_info:
+                await user_auth.get_effective_org_id()
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_server_side_override_api_key_org_mismatch_raises_403(
+        self, user_id, org_id, other_org_id
+    ):
+        user_auth = SaasUserAuth(
+            user_id=user_id,
+            refresh_token=SecretStr('mock'),
+            api_key_org_id=org_id,
+            effective_org_id_override=other_org_id,
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await user_auth.get_effective_org_id()
+
+        assert exc_info.value.status_code == 403
+
+    def test_set_effective_org_id_override_clears_org_scoped_caches(
+        self, user_id, org_id
+    ):
+        user_auth = SaasUserAuth(
+            user_id=user_id,
+            refresh_token=SecretStr('mock'),
+        )
+        user_auth._effective_org_id = uuid.uuid4()
+        user_auth._effective_org_id_resolved = True
+        user_auth.settings_store = object()
+        user_auth.secrets_store = object()
+        user_auth._settings = object()
+        user_auth._secrets = object()
+        user_auth.provider_tokens = {}
+        user_auth._org_id = 'old-org'
+        user_auth._org_name = 'Old Org'
+        user_auth._role = 'member'
+        user_auth._permissions = ['read']
+        user_auth._org_info_loaded = True
+
+        user_auth.set_effective_org_id_override(org_id)
+
+        assert user_auth.effective_org_id_override == org_id
+        assert user_auth._effective_org_id is None
+        assert user_auth._effective_org_id_resolved is False
+        assert user_auth.settings_store is None
+        assert user_auth.secrets_store is None
+        assert user_auth._settings is None
+        assert user_auth._secrets is None
+        assert user_auth.provider_tokens is None
+        assert user_auth._org_id is None
+        assert user_auth._org_name is None
+        assert user_auth._role is None
+        assert user_auth._permissions is None
+        assert user_auth._org_info_loaded is False
+
+    @pytest.mark.asyncio
     async def test_header_with_non_member_org_raises_403(
         self, async_session_maker, user_id, org_id, other_org_id
     ):


### PR DESCRIPTION
HUMAN:
This PR makes resolver-started conversations use the org resolved from repo claims for runtime auth, so settings, secrets, provider tokens, org info, and generated system API keys match the conversation org instead of falling back to the user's default org.

- [x] A human has tested these changes.

## Summary

Scopes resolver runtime auth to the org resolved from repo-claim routing.

- when a resolver integration sets `resolver_org_id`, apply it to the underlying SaaS auth object
- make `SaasUserAuth.get_effective_org_id()` honor that trusted server-side resolver override after verifying membership
- clear org-scoped caches when the override is applied so settings, secrets, provider tokens, org info, and generated API keys are loaded from the resolved org
- adds coverage for the generic resolver context, effective-org precedence, and Jira DC's selected-repo org claim path

## Validation

Successfully tested on a real OHE instance with Jira Data Center. What was real end-to-end:

- A real Jira comment was created in Jira.
- Jira delivered the webhook to OpenHands.
- OpenHands accepted and processed the webhook.
- Jira DC repo inference selected `alona6-group/alona6-project`.
- The repo claim resolved to the test OpenHands org.
- OpenHands created the conversation under that claimed org.
- Runtime auth used that org too, proven by the system API key being created under the claimed org.

Also verified the public org/claim API setup path on R02:

- `POST /api/organizations` returned `201` and the org appeared in `GET /api/organizations`.
- `POST /api/organizations/{org_id}/git-claims` returned `201`, the claim appeared in `GET /git-claims`, and `DELETE /git-claims/{claim_id}` returned `200`.

Local checks:

- `env PYTHONPATH=enterprise:. uv run --with python-keycloak --with pytest-asyncio --with aiosqlite --with limits --with coredis pytest enterprise/tests/unit/integrations/test_resolver_context.py enterprise/tests/unit/server/auth/test_saas_user_auth_effective_org.py enterprise/tests/unit/integrations/jira_dc/test_jira_dc_view.py` -> 32 passed
- `env PYTHONPATH=enterprise:. uv run ruff check enterprise/integrations/resolver_context.py enterprise/server/auth/saas_user_auth.py enterprise/tests/unit/integrations/test_resolver_context.py enterprise/tests/unit/server/auth/test_saas_user_auth_effective_org.py enterprise/tests/unit/integrations/jira_dc/test_jira_dc_view.py` -> all checks passed

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-4bca098   docker.openhands.dev/openhands/openhands:4bca098
```

---
Linear: APP-1957

_AI-generated metadata update by OpenHands on behalf of ak684._
