### PR TITLE
[APP-1955] Support Bitbucket Data Center org claims

### DIFF
--- a/enterprise/server/routes/org_models.py
+++ b/enterprise/server/routes/org_models.py
@@ -607,7 +607,7 @@ class OrgAppSettingsUpdate(BaseModel):
         return v
 
 
-VALID_GIT_PROVIDERS = {'github', 'gitlab', 'bitbucket'}
+VALID_GIT_PROVIDERS = {'github', 'gitlab', 'bitbucket', 'bitbucket_data_center'}
 
 
 class GitOrgClaimRequest(BaseModel):

--- a/enterprise/server/routes/users_v1.py
+++ b/enterprise/server/routes/users_v1.py
@@ -133,6 +133,8 @@ async def get_current_user_git_organizations(
         orgs = await client.get_gitlab_groups()
     elif provider == ProviderType.BITBUCKET:
         orgs = await client.get_bitbucket_workspaces()
+    elif provider == ProviderType.BITBUCKET_DATA_CENTER:
+        orgs = await client.get_bitbucket_dc_projects()
     else:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/enterprise/tests/unit/server/routes/test_org_git_claims.py
+++ b/enterprise/tests/unit/server/routes/test_org_git_claims.py
@@ -348,7 +348,7 @@ class TestGitOrgClaimRequestValidation:
         """Each supported provider is accepted and normalized to lowercase."""
         from server.routes.org_models import GitOrgClaimRequest
 
-        for provider in ['github', 'GitLab', 'BITBUCKET']:
+        for provider in ['github', 'GitLab', 'BITBUCKET', 'BITBUCKET_DATA_CENTER']:
             req = GitOrgClaimRequest(provider=provider, git_organization='test-org')
             assert req.provider == provider.lower().strip()
 

--- a/enterprise/tests/unit/test_user_git_organizations.py
+++ b/enterprise/tests/unit/test_user_git_organizations.py
@@ -84,8 +84,13 @@ async def test_raises_400_when_provider_unsupported():
             'get_installations',
             ['my-workspace'],
         ),
+        (
+            ProviderType.BITBUCKET_DATA_CENTER,
+            'get_installations',
+            ['PROJ'],
+        ),
     ],
-    ids=['github', 'gitlab', 'bitbucket'],
+    ids=['github', 'gitlab', 'bitbucket', 'bitbucket_data_center'],
 )
 async def test_returns_organizations_for_supported_provider(
     provider, service_method, service_return

--- a/frontend/__tests__/components/features/org/git-conversation-routing.test.tsx
+++ b/frontend/__tests__/components/features/org/git-conversation-routing.test.tsx
@@ -54,12 +54,12 @@ describe("GitConversationRouting", () => {
   it("should render organizations from API data", () => {
     renderWithProviders(<GitConversationRouting />);
 
-    expect(
-      screen.getByTestId("org-row-github:openhands"),
-    ).toHaveTextContent("github/OpenHands");
-    expect(
-      screen.getByTestId("org-row-github:acmeco"),
-    ).toHaveTextContent("github/AcmeCo");
+    expect(screen.getByTestId("org-row-github:openhands")).toHaveTextContent(
+      "GitHub/OpenHands",
+    );
+    expect(screen.getByTestId("org-row-github:acmeco")).toHaveTextContent(
+      "GitHub/AcmeCo",
+    );
   });
 
   it("should show claimed org with 'Claimed' label", () => {
@@ -72,9 +72,9 @@ describe("GitConversationRouting", () => {
   it("should show unclaimed orgs with 'Claim' label", () => {
     renderWithProviders(<GitConversationRouting />);
 
-    expect(
-      screen.getByTestId("claim-button-github:acmeco"),
-    ).toHaveTextContent("ORG$CLAIM");
+    expect(screen.getByTestId("claim-button-github:acmeco")).toHaveTextContent(
+      "ORG$CLAIM",
+    );
   });
 
   it("should call claim mutation when clicking claim on unclaimed org", async () => {
@@ -100,5 +100,4 @@ describe("GitConversationRouting", () => {
       expect.objectContaining({ onSettled: expect.any(Function) }),
     );
   });
-
 });

--- a/frontend/__tests__/components/features/org/git-org-row.test.tsx
+++ b/frontend/__tests__/components/features/org/git-org-row.test.tsx
@@ -43,4 +43,24 @@ describe("GitOrgRow", () => {
     // Assert
     expect(screen.getByTestId("claim-button-1")).toBeInTheDocument();
   });
+
+  it("renders a readable Bitbucket Data Center provider label", () => {
+    // Arrange & Act
+    renderWithProviders(
+      <GitOrgRow
+        org={createOrg({
+          provider: "bitbucket_data_center",
+          name: "PROJ",
+        })}
+        isLast={false}
+        onClaim={vi.fn()}
+        onDisconnect={vi.fn()}
+      />,
+    );
+
+    // Assert
+    expect(screen.getByTestId("org-row-1")).toHaveTextContent(
+      "Bitbucket Data Center/PROJ",
+    );
+  });
 });

--- a/frontend/__tests__/hooks/use-git-conversation-routing.test.ts
+++ b/frontend/__tests__/hooks/use-git-conversation-routing.test.ts
@@ -89,9 +89,7 @@ describe("useGitConversationRouting", () => {
 
     expect(result.current.orgs).toHaveLength(2);
 
-    const claimedOrg = result.current.orgs.find(
-      (o) => o.name === "OpenHands",
-    );
+    const claimedOrg = result.current.orgs.find((o) => o.name === "OpenHands");
     expect(claimedOrg).toMatchObject({
       id: "github:openhands",
       claimId: "claim-1",
@@ -99,9 +97,7 @@ describe("useGitConversationRouting", () => {
       status: "claimed",
     });
 
-    const unclaimedOrg = result.current.orgs.find(
-      (o) => o.name === "AcmeCo",
-    );
+    const unclaimedOrg = result.current.orgs.find((o) => o.name === "AcmeCo");
     expect(unclaimedOrg).toMatchObject({
       id: "github:acmeco",
       claimId: null,
@@ -134,6 +130,35 @@ describe("useGitConversationRouting", () => {
       status: "claimed",
       claimId: "claim-1",
       name: "All-Hands-AI",
+    });
+  });
+
+  it("supports Bitbucket Data Center projects", () => {
+    setupMocks({
+      userOrgs: {
+        provider: "bitbucket_data_center",
+        organizations: ["PROJ"],
+      },
+      claims: [
+        {
+          id: "claim-1",
+          org_id: "org-1",
+          provider: "bitbucket_data_center",
+          git_organization: "proj",
+          claimed_by: "user-1",
+          claimed_at: "2026-01-01T00:00:00",
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useGitConversationRouting());
+
+    expect(result.current.orgs[0]).toMatchObject({
+      id: "bitbucket_data_center:proj",
+      claimId: "claim-1",
+      provider: "bitbucket_data_center",
+      name: "PROJ",
+      status: "claimed",
     });
   });
 
@@ -200,10 +225,7 @@ describe("useGitConversationRouting", () => {
     setupMocks();
 
     mockClaimMutate.mockImplementation(
-      (
-        _args: unknown,
-        options: { onSettled?: () => void },
-      ) => {
+      (_args: unknown, options: { onSettled?: () => void }) => {
         options?.onSettled?.();
       },
     );

--- a/frontend/src/components/features/org/git-org-row.tsx
+++ b/frontend/src/components/features/org/git-org-row.tsx
@@ -1,6 +1,7 @@
-import { cn } from "#/utils/utils";
+import { cn, getProviderName } from "#/utils/utils";
 import { Text } from "#/ui/typography";
 import type { GitOrg } from "#/types/org";
+import type { Provider } from "#/types/settings";
 import { ClaimButton } from "./claim-button";
 
 interface GitOrgRowProps {
@@ -25,7 +26,9 @@ export function GitOrgRow({
       )}
     >
       <span className="text-sm font-normal leading-5">
-        <Text className="text-[#8c8c8c]">{org.provider}/</Text>
+        <Text className="text-[#8c8c8c]">
+          {getProviderName(org.provider.toLowerCase() as Provider)}/
+        </Text>
         <Text className="text-[#fafafa]">{org.name}</Text>
       </span>
       <ClaimButton org={org} onClaim={onClaim} onDisconnect={onDisconnect} />


### PR DESCRIPTION
## Summary

[x] A human has tested these changes.

Enables Bitbucket Data Center projects to be claimed for org-level resolver routing.

- accepts bitbucket_data_center in org git-claim validation
- returns Bitbucket Data Center projects from /api/v1/users/git-organizations so admins can claim them through the existing org routing UI
- renders a readable Bitbucket Data Center provider label in the org-claims table
- adds focused backend and frontend coverage for the BBDC provider path

## Validation

- env PYTHONPATH=enterprise:. uv run --with python-keycloak --with pytest-asyncio --with aiosqlite --with limits --with coredis pytest enterprise/tests/unit/server/routes/test_org_git_claims.py enterprise/tests/unit/test_user_git_organizations.py -q -> 27 passed
- env PYTHONPATH=enterprise:. uv run ruff check --config enterprise/dev_config/python/ruff.toml enterprise/server/routes/org_models.py enterprise/server/routes/users_v1.py enterprise/tests/unit/server/routes/test_org_git_claims.py enterprise/tests/unit/test_user_git_organizations.py -> passed
- npm test -- __tests__/hooks/use-git-conversation-routing.test.ts __tests__/components/features/org/git-org-row.test.tsx __tests__/components/features/org/git-conversation-routing.test.tsx -> 18 passed
- R01 OHE overlay validation: created bitbucket_data_center claim for project AIV through /api/organizations/{org_id}/git-claims, resolved bitbucket_data_center/AIV to the claimed org with membership validation, deleted the claim through the API, and verified /api/v1/users/git-organizations returns provider bitbucket_data_center with projects AIV and DEM.
- R01 live Bitbucket DC webhook validation: created a temporary org through /api/organizations using cookie auth, claimed AIV through the org claims API, posted a real @openhands PR comment on AIV/test#7, and verified logs routed bitbucket_data_center/aiv to the temporary org before creating conversation 9fd5d841-bf7d-49d1-90e4-1a30a42399c1.
- R01 runtime-org validation: verified conversation_metadata_saas.org_id for 9fd5d841-bf7d-49d1-90e4-1a30a42399c1 matched the claimed org, and verified __SYSTEM__:OPENHANDS_API_KEY plus MCP_API_KEY rows were generated under that same org without printing key values.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-b18a095   docker.openhands.dev/openhands/openhands:b18a095
```

---
Linear: APP-1955

_AI-generated metadata update by OpenHands on behalf of ak684._
