### PR TITLE
fix: forward insecure git access env to sandboxes

### DIFF
--- a/openhands/app_server/sandbox/sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/sandbox_spec_service.py
@@ -76,6 +76,9 @@ def is_custom_agent_server_image() -> bool:
     return bool(tag) and tag != AGENT_SERVER_IMAGE.rsplit(':', 1)[-1]
 
 
+# Exact environment variables that should be auto-forwarded to agent-server.
+AUTO_FORWARD_VARIABLES = ('ALLOW_INSECURE_GIT_ACCESS',)
+
 # Prefixes for environment variables that should be auto-forwarded to agent-server
 # These are typically configuration variables that affect the agent's behavior
 AUTO_FORWARD_PREFIXES = ('LLM_', 'LMNR_')
@@ -86,11 +89,12 @@ def get_agent_server_env() -> dict[str, str]:
 
     This function combines two sources of environment variables:
 
-    1. **Auto-forwarded variables**: Environment variables with certain prefixes
-       (e.g., LLM_*, LMNR_*) are automatically forwarded to the agent-server container.
+    1. **Auto-forwarded variables**: Selected variables and variables with certain
+       prefixes (e.g., ALLOW_INSECURE_GIT_ACCESS, LLM_*, LMNR_*) are automatically
+       forwarded to the agent-server container.
        This ensures that LLM configuration like timeouts and retry settings
        work correctly in the two-container V1 architecture, as well as
-       Laminar monitoring/analytics configuration.
+       Laminar monitoring/analytics configuration and git access flags.
 
     2. **Explicit overrides via OH_AGENT_SERVER_ENV**: A JSON string that allows
        setting arbitrary environment variables in the agent-server container.
@@ -127,12 +131,17 @@ def get_agent_server_env() -> dict[str, str]:
     """
     result: dict[str, str] = {}
 
-    # Step 1: Auto-forward environment variables with recognized prefixes
+    # Step 1: Auto-forward selected exact environment variables.
+    for key in AUTO_FORWARD_VARIABLES:
+        if key in os.environ:
+            result[key] = os.environ[key]
+
+    # Step 2: Auto-forward environment variables with recognized prefixes
     for key, value in os.environ.items():
         if any(key.startswith(prefix) for prefix in AUTO_FORWARD_PREFIXES):
             result[key] = value
 
-    # Step 2: Apply explicit overrides from OH_AGENT_SERVER_ENV
+    # Step 3: Apply explicit overrides from OH_AGENT_SERVER_ENV
     # These take precedence over auto-forwarded variables
     explicit_env = env_parser.from_env(dict[str, str], 'OH_AGENT_SERVER_ENV')
     result.update(explicit_env)

--- a/tests/unit/app_server/test_agent_server_env_override.py
+++ b/tests/unit/app_server/test_agent_server_env_override.py
@@ -27,6 +27,7 @@ from openhands.app_server.sandbox.remote_sandbox_spec_service import (
 )
 from openhands.app_server.sandbox.sandbox_spec_service import (
     AUTO_FORWARD_PREFIXES,
+    AUTO_FORWARD_VARIABLES,
     get_agent_server_env,
 )
 
@@ -295,6 +296,33 @@ class TestLLMAutoForwarding:
             assert 'Llm_Timeout' not in result
 
 
+class TestExactAutoForwarding:
+    """Test cases for exact auto-forwarded environment variables."""
+
+    def test_auto_forward_variables_contains_insecure_git_access(self):
+        assert 'ALLOW_INSECURE_GIT_ACCESS' in AUTO_FORWARD_VARIABLES
+
+    def test_allow_insecure_git_access_auto_forwarded(self):
+        env_vars = {
+            'ALLOW_INSECURE_GIT_ACCESS': 'true',
+            'OTHER_VAR': 'should_not_be_included',
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            result = get_agent_server_env()
+            assert result == {'ALLOW_INSECURE_GIT_ACCESS': 'true'}
+
+    def test_explicit_override_takes_precedence_over_exact_forward(self):
+        env_vars = {
+            'ALLOW_INSECURE_GIT_ACCESS': 'false',
+            'OH_AGENT_SERVER_ENV': '{"ALLOW_INSECURE_GIT_ACCESS": "true"}',
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            result = get_agent_server_env()
+            assert result['ALLOW_INSECURE_GIT_ACCESS'] == 'true'
+
+
 class TestLMNRAutoForwarding:
     """Test cases for automatic forwarding of LMNR_* environment variables."""
 
@@ -359,6 +387,19 @@ class TestLMNRAutoForwarding:
 
 class TestDockerSandboxSpecEnvironmentOverride:
     """Test environment variable override integration in Docker sandbox specs."""
+
+    def test_docker_specs_include_insecure_git_access_env(self):
+        """Test that the insecure git access flag reaches Docker sandbox specs."""
+        env_vars = {
+            'ALLOW_INSECURE_GIT_ACCESS': 'true',
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            specs = get_default_docker_sandbox_specs()
+
+            assert len(specs) == 1
+            spec = specs[0]
+            assert spec.initial_env['ALLOW_INSECURE_GIT_ACCESS'] == 'true'
 
     def test_docker_specs_include_agent_server_env(self):
         """Test that Docker sandbox specs include agent server environment variables."""


### PR DESCRIPTION
HUMAN: This fixes self-hosted agent-server sandboxes dropping `ALLOW_INSECURE_GIT_ACCESS` even when the parent process explicitly enables it. The forwarding remains narrow: only the existing allowlisted prefixes plus this explicit OpenHands env flag are copied automatically; arbitrary env forwarding still requires `OH_AGENT_SERVER_ENV`.

- [ ] A human has tested these changes.

Refs #14523.

## Summary
- auto-forward `ALLOW_INSECURE_GIT_ACCESS` into agent-server sandbox specs alongside the existing `LLM_` and `LMNR_` forwarding
- keep arbitrary env forwarding explicit via `OH_AGENT_SERVER_ENV`
- add coverage for exact env forwarding and the Docker sandbox spec environment

## Validation
- `uv run pytest tests\unit\app_server\test_agent_server_env_override.py::TestExactAutoForwarding tests\unit\app_server\test_agent_server_env_override.py::TestDockerSandboxSpecEnvironmentOverride::test_docker_specs_include_insecure_git_access_env -q`
- `uv run ruff check openhands\app_server\sandbox\sandbox_spec_service.py tests\unit\app_server\test_agent_server_env_override.py`
- `python -m py_compile openhands\app_server\sandbox\sandbox_spec_service.py tests\unit\app_server\test_agent_server_env_override.py`
- `git diff --check`

Note: I also ran the full `tests\unit\app_server\test_agent_server_env_override.py` on Windows. It reached 43 passed / 2 failed; the failures are the existing case-sensitivity expectations for `LLM_` and `LMNR_` env names on Windows, where `os.environ` is case-insensitive. The new exact-forwarding tests pass.