### PR TITLE
fix: forward ALLOW_INSECURE_GIT_ACCESS to agent server

### DIFF
--- a/openhands/app_server/sandbox/sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/sandbox_spec_service.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 from abc import ABC, abstractmethod
 
+
 from openhands.agent_server import env_parser
 from openhands.app_server.errors import SandboxError
 from openhands.app_server.sandbox.sandbox_spec_models import (
@@ -73,6 +74,10 @@ def get_agent_server_image() -> str:
 # These are typically configuration variables that affect the agent's behavior
 AUTO_FORWARD_PREFIXES = ('LLM_', 'LMNR_')
 
+# Exact environment variables that should be auto-forwarded to agent-server.
+# These are OpenHands runtime flags that do not share a common prefix.
+AUTO_FORWARD_EXACT_VARS = ('ALLOW_INSECURE_GIT_ACCESS',)
+
 
 def get_agent_server_env() -> dict[str, str]:
     """Get environment variables to be injected into agent server sandbox environments.
@@ -80,7 +85,8 @@ def get_agent_server_env() -> dict[str, str]:
     This function combines two sources of environment variables:
 
     1. **Auto-forwarded variables**: Environment variables with certain prefixes
-       (e.g., LLM_*, LMNR_*) are automatically forwarded to the agent-server container.
+       (e.g., LLM_*, LMNR_*) and selected exact OpenHands runtime flags
+       are automatically forwarded to the agent-server container.
        This ensures that LLM configuration like timeouts and retry settings
        work correctly in the two-container V1 architecture, as well as
        Laminar monitoring/analytics configuration.
@@ -97,6 +103,7 @@ def get_agent_server_env() -> dict[str, str]:
         # Auto-forwarding (no action needed):
         export LLM_TIMEOUT=3600
         export LLM_NUM_RETRIES=10
+        export ALLOW_INSECURE_GIT_ACCESS=true
         # These will automatically be available in the agent-server
 
         # Auto-forwarding for Laminar:
@@ -122,7 +129,9 @@ def get_agent_server_env() -> dict[str, str]:
 
     # Step 1: Auto-forward environment variables with recognized prefixes
     for key, value in os.environ.items():
-        if any(key.startswith(prefix) for prefix in AUTO_FORWARD_PREFIXES):
+        if key in AUTO_FORWARD_EXACT_VARS or any(
+            key.startswith(prefix) for prefix in AUTO_FORWARD_PREFIXES
+        ):
             result[key] = value
 
     # Step 2: Apply explicit overrides from OH_AGENT_SERVER_ENV

--- a/openhands/app_server/sandbox/sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/sandbox_spec_service.py
@@ -1,8 +1,6 @@
 import asyncio
 import os
 from abc import ABC, abstractmethod
-
-
 from openhands.agent_server import env_parser
 from openhands.app_server.errors import SandboxError
 from openhands.app_server.sandbox.sandbox_spec_models import (

--- a/openhands/app_server/sandbox/sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/sandbox_spec_service.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 from abc import ABC, abstractmethod
+
 from openhands.agent_server import env_parser
 from openhands.app_server.errors import SandboxError
 from openhands.app_server.sandbox.sandbox_spec_models import (

--- a/tests/unit/app_server/test_agent_server_env_override.py
+++ b/tests/unit/app_server/test_agent_server_env_override.py
@@ -194,6 +194,19 @@ class TestLLMAutoForwarding:
         """Test that LLM_ is in the auto-forward prefixes."""
         assert 'LLM_' in AUTO_FORWARD_PREFIXES
 
+    def test_allow_insecure_git_access_auto_forwarded(self):
+        """Test that ALLOW_INSECURE_GIT_ACCESS is automatically forwarded."""
+        env_vars = {
+            'ALLOW_INSECURE_GIT_ACCESS': 'true',
+            'OTHER_VAR': 'should_not_be_included',
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            result = get_agent_server_env()
+
+        assert result['ALLOW_INSECURE_GIT_ACCESS'] == 'true'
+        assert 'OTHER_VAR' not in result
+
     def test_llm_timeout_auto_forwarded(self):
         """Test that LLM_TIMEOUT is automatically forwarded."""
         env_vars = {


### PR DESCRIPTION
Fixes #14523

HUMAN:
I traced the environment propagation path from `get_agent_server_env()` to the agent-server sandbox environment. This PR adds a narrow exact allowlist for `ALLOW_INSECURE_GIT_ACCESS` so it is forwarded without exposing arbitrary host environment variables.

- [x] A human has tested these changes.

## Summary

Fixes environment variable forwarding for `ALLOW_INSECURE_GIT_ACCESS`.

Previously, `get_agent_server_env()` only auto-forwarded environment variables with recognized prefixes such as `LLM_` and `LMNR_`. As a result, `ALLOW_INSECURE_GIT_ACCESS=true` was not propagated into the agent-server sandbox environment, even though the git provider logic expects this environment variable to be available.

This PR adds an exact allowlist for selected OpenHands runtime flags and forwards `ALLOW_INSECURE_GIT_ACCESS` without forwarding arbitrary host environment variables.

## Changes

- Added `AUTO_FORWARD_EXACT_VARS`
- Auto-forward `ALLOW_INSECURE_GIT_ACCESS` to the agent-server environment
- Updated the `get_agent_server_env()` docstring
- Added unit test coverage for exact env var forwarding

## Test Plan

- `git diff --check` passed
- `python -m py_compile openhands/app_server/sandbox/sandbox_spec_service.py` passed
- Targeted pytest was not run locally because `pytest` is not installed in my current environment
