### PR TITLE
fix(process-sandbox): use loopback for child agent server health checks

### DIFF
--- a/openhands/app_server/sandbox/process_sandbox_service.py
+++ b/openhands/app_server/sandbox/process_sandbox_service.py
@@ -38,9 +38,6 @@ from openhands.app_server.sandbox.sandbox_service import (
 from openhands.app_server.sandbox.sandbox_spec_models import SandboxSpecInfo
 from openhands.app_server.sandbox.sandbox_spec_service import SandboxSpecService
 from openhands.app_server.services.injector import InjectorState
-from openhands.app_server.utils.docker_utils import (
-    replace_localhost_hostname_for_docker,
-)
 
 _logger = logging.getLogger(__name__)
 
@@ -106,6 +103,10 @@ class ProcessSandboxService(SandboxService):
         os.makedirs(sandbox_dir, exist_ok=True)
         return sandbox_dir
 
+    def _agent_server_url(self, port: int) -> str:
+        """Return the loopback URL for the child agent server process."""
+        return f'http://127.0.0.1:{port}'
+
     async def _start_agent_process(
         self,
         sandbox_id: str,
@@ -162,14 +163,10 @@ class ProcessSandboxService(SandboxService):
         start_time = time.time()
         while time.time() - start_time < timeout:
             try:
-                url = replace_localhost_hostname_for_docker(
-                    f'http://localhost:{port}/alive'
-                )
+                url = f'{self._agent_server_url(port)}{self.health_check_path}'
                 response = await self.httpx_client.get(url, timeout=5.0)
-                if response.status_code == 200:
-                    data = response.json()
-                    if data.get('status') == 'ok':
-                        return True
+                if response.is_success:
+                    return True
             except Exception:
                 pass
             await asyncio.sleep(1)
@@ -204,15 +201,16 @@ class ProcessSandboxService(SandboxService):
         if status == SandboxStatus.RUNNING:
             # Check if server is actually responding
             try:
-                url = replace_localhost_hostname_for_docker(
-                    f'http://localhost:{process_info.port}{self.health_check_path}'
+                url = (
+                    f'{self._agent_server_url(process_info.port)}'
+                    f'{self.health_check_path}'
                 )
                 response = await self.httpx_client.get(url, timeout=5.0)
-                if response.status_code == 200:
+                if response.is_success:
                     exposed_urls = [
                         ExposedUrl(
                             name=AGENT_SERVER,
-                            url=f'http://localhost:{process_info.port}',
+                            url=self._agent_server_url(process_info.port),
                             port=process_info.port,
                         ),
                     ]

--- a/tests/unit/app_server/test_process_sandbox_service.py
+++ b/tests/unit/app_server/test_process_sandbox_service.py
@@ -90,12 +90,31 @@ class TestProcessSandboxService:
         """Test waiting for server to be ready - success case."""
         # Mock successful response
         mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {'status': 'ok'}
+        mock_response.is_success = True
         process_sandbox_service.httpx_client.get.return_value = mock_response
 
         result = await process_sandbox_service._wait_for_server_ready(9000, timeout=1)
         assert result is True
+        process_sandbox_service.httpx_client.get.assert_awaited_once_with(
+            'http://127.0.0.1:9000/alive', timeout=5.0
+        )
+
+    @pytest.mark.asyncio
+    async def test_wait_for_server_ready_uses_configured_health_check_path(
+        self, process_sandbox_service
+    ):
+        """Test waiting for server readiness uses the configured health check."""
+        process_sandbox_service.health_check_path = '/health'
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        process_sandbox_service.httpx_client.get.return_value = mock_response
+
+        result = await process_sandbox_service._wait_for_server_ready(9000, timeout=1)
+
+        assert result is True
+        process_sandbox_service.httpx_client.get.assert_awaited_once_with(
+            'http://127.0.0.1:9000/health', timeout=5.0
+        )
 
     @pytest.mark.asyncio
     async def test_wait_for_server_ready_timeout(self, process_sandbox_service):
@@ -208,7 +227,7 @@ class TestProcessSandboxService:
 
             # Mock successful health check response
             mock_response = MagicMock()
-            mock_response.status_code = 200
+            mock_response.is_success = True
             process_sandbox_service.httpx_client.get.return_value = mock_response
 
             # Execute with custom sandbox_id
@@ -287,6 +306,42 @@ class TestProcessSandboxService:
         assert status == SandboxStatus.MISSING
 
     @pytest.mark.asyncio
+    async def test_process_to_sandbox_info_success_uses_loopback_url(
+        self, process_sandbox_service
+    ):
+        """Test process sandbox info keeps child process URLs on loopback."""
+        with patch.object(
+            process_sandbox_service,
+            '_get_process_status',
+            return_value=SandboxStatus.RUNNING,
+        ):
+            mock_response = MagicMock()
+            mock_response.is_success = True
+            process_sandbox_service.httpx_client.get.return_value = mock_response
+
+            process_info = ProcessInfo(
+                pid=1234,
+                port=9000,
+                user_id='test-user-id',
+                working_dir='/tmp/test',
+                session_api_key='test-key',
+                created_at=datetime.now(),
+                sandbox_spec_id='test-spec',
+            )
+
+            sandbox_info = await process_sandbox_service._process_to_sandbox_info(
+                'test-sandbox', process_info
+            )
+
+            assert sandbox_info.status == SandboxStatus.RUNNING
+            assert sandbox_info.session_api_key == 'test-key'
+            assert sandbox_info.exposed_urls is not None
+            assert sandbox_info.exposed_urls[0].url == 'http://127.0.0.1:9000'
+            process_sandbox_service.httpx_client.get.assert_awaited_once_with(
+                'http://127.0.0.1:9000/alive', timeout=5.0
+            )
+
+    @pytest.mark.asyncio
     async def test_process_to_sandbox_info_error_status(self, process_sandbox_service):
         """Test converting process info to sandbox info when server is not responding."""
         # Mock a process that's running but server is not responding
@@ -297,7 +352,7 @@ class TestProcessSandboxService:
         ):
             # Mock httpx client to return error response
             mock_response = MagicMock()
-            mock_response.status_code = 500
+            mock_response.is_success = False
             process_sandbox_service.httpx_client.get.return_value = mock_response
 
             process_info = ProcessInfo(
@@ -358,7 +413,9 @@ class TestProcessSandboxServiceInjector:
         """Test default configuration values."""
         injector = ProcessSandboxServiceInjector()
 
-        assert injector.base_working_dir == '/tmp/openhands-sandboxes'
+        assert injector.base_working_dir == os.path.join(
+            tempfile.gettempdir(), 'openhands-sandboxes'
+        )
         assert injector.base_port == 8000
         assert injector.health_check_path == '/alive'
         assert injector.agent_server_module == 'openhands.agent_server'


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

This PR fixes process sandbox startup readiness by keeping child agent server health checks on the container-local loopback address instead of using the Docker hostname rewrite path. I verified the focused process sandbox unit tests and Python pre-commit checks pass locally.

- [ ] A human has tested these changes.

AGENT:

---

## Why

Process sandbox mode starts the agent server as a child process in the same container. Its readiness checks and exposed agent server URL should therefore use the container-local loopback address.

Before this change, the process sandbox reused the Docker hostname rewrite path, which can turn `localhost` into `host.docker.internal` when OpenHands itself runs in Docker. That is correct for cross-container Docker sandbox access, but wrong for a child process in process sandbox mode, and can make startup fail with `Agent Server Failed to start properly` even when the agent server has started.

## Summary

- Use `127.0.0.1` for process sandbox child agent server health checks and exposed URLs.
- Honor the configured `health_check_path` during process sandbox readiness checks instead of hardcoding `/alive`.
- Add focused unit coverage for loopback URLs, configured health-check paths, and platform-safe tempdir defaults.

## Issue Number

Fixes #14499

## How to Test

poetry run pytest tests/unit/app_server/test_process_sandbox_service.py

poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files openhands/app_server/sandbox/process_sandbox_service.py tests/unit/app_server/test_process_sandbox_service.py

Both commands pass locally.

## Video/Screenshots

Not applicable. This is a backend process sandbox readiness fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This change is scoped to process sandbox behavior. Docker sandbox still uses the existing hostname rewrite path.