### PR TITLE
fix(frontend): mark language settings dirty only on selection

### DIFF
--- a/frontend/__tests__/routes/app-settings.test.tsx
+++ b/frontend/__tests__/routes/app-settings.test.tsx
@@ -173,6 +173,23 @@ describe("Form submission", () => {
     expect(submit).toBeDisabled();
   });
 
+  it("should not enable submit when typing in the language field without selecting", async () => {
+    const getSettingsSpy = vi.spyOn(SettingsService, "getSettings");
+    getSettingsSpy.mockResolvedValue(MOCK_DEFAULT_USER_SETTINGS);
+
+    renderAppSettingsScreen();
+
+    const submit = await screen.findByTestId("submit-button");
+    const language = await screen.findByTestId("language-input");
+
+    expect(submit).toBeDisabled();
+
+    await userEvent.click(language);
+    await userEvent.type(language, "Fre");
+
+    expect(submit).toBeDisabled();
+  });
+
   it("should call handleCaptureConsents with true when the analytics switch is toggled", async () => {
     const getSettingsSpy = vi.spyOn(SettingsService, "getSettings");
     getSettingsSpy.mockResolvedValue(MOCK_DEFAULT_USER_SETTINGS);

--- a/frontend/src/components/features/settings/app-settings/language-input.tsx
+++ b/frontend/src/components/features/settings/app-settings/language-input.tsx
@@ -1,3 +1,4 @@
+import type { Key } from "react";
 import { useTranslation } from "react-i18next";
 import { AvailableLanguages } from "#/i18n";
 import { I18nKey } from "#/i18n/declaration";
@@ -16,11 +17,24 @@ export function LanguageInput({
 }: LanguageInputProps) {
   const { t } = useTranslation();
 
+  const handleSelectionChange = (key: Key | null) => {
+    if (key == null) {
+      return;
+    }
+
+    const selectedLanguage = AvailableLanguages.find(
+      (language) => language.value === key,
+    );
+    if (selectedLanguage) {
+      onChange(selectedLanguage.label);
+    }
+  };
+
   return (
     <SettingsDropdownInput
       testId={name}
       name={name}
-      onInputChange={onChange}
+      onSelectionChange={handleSelectionChange}
       label={t(I18nKey.SETTINGS$LANGUAGE)}
       items={AvailableLanguages.map((l) => ({
         key: l.value,


### PR DESCRIPTION

<!-- Keep this PR as draft until it is ready for review. -->
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

## Human testing

This PR fixes the language dropdown on the Application settings page. The Save Changes button now only becomes enabled after a real language is selected, not while the user is typing filter text in the autocomplete.

I added a regression test and ran the app settings test file locally.

- [ ] A human has tested these changes.

---

## Why

On `/settings`, the language dropdown was using `onInputChange` to update dirty state. This meant the handler fired on every keystroke while filtering the dropdown.

For example, typing `Fre` while searching for French did not match a saved language value, so the form was incorrectly marked dirty and Save Changes became enabled before the user selected a language.

The LLM provider selector already uses `onSelectionChange` for this same autocomplete pattern.

## Summary

- Updated `LanguageInput` to use `onSelectionChange` instead of `onInputChange`.
- Mapped the selected key to the language label before updating dirty state.
- Added a regression test to confirm that typing in the language field without selecting an option keeps Save Changes disabled.
- Confirmed existing app settings tests still pass for valid language selection and form submission.

## Issue Number

Fixes #14249

## How to Test

```bash
cd frontend
npm install
npm run test -- __tests__/routes/app-settings.test.tsx
````

Manual check:

1. Open Settings, then Application.
2. Open the language dropdown.
3. Type a few letters without selecting an option.
4. Confirm Save Changes stays disabled.
5. Select a different language.
6. Confirm Save Changes enables.
7. Select the original language again.
8. Confirm Save Changes disables.

## Video or Screenshots

Not included because this is a small UI behavior fix. I can add a short screen recording if reviewers want one.

## Type

* [x] Bug fix
* [ ] Feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Docs or chore

## Notes

There are two other open PRs for this issue, #14307 and #14432. I am happy to close this PR in favor of another approach if maintainers prefer.

This change is frontend only. It does not include backend or config changes.
