### PR TITLE
docs(enterprise/sync): align Resend README env vars with required_vars guard (fixes #14543)

### DIFF
--- a/enterprise/sync/README.md
+++ b/enterprise/sync/README.md
@@ -17,7 +17,9 @@ The service is configured using environment variables:
 |----------|-------------|---------|
 | `RESEND_API_KEY` | Resend API key | (required) |
 | `RESEND_AUDIENCE_ID` | Resend audience ID | (required) |
-| `KEYCLOAK_REALM` | Keycloak realm | `all-hands` |
+| `KEYCLOAK_SERVER_URL` | URL of the Keycloak server | (required) |
+| `KEYCLOAK_REALM_NAME` | Keycloak realm name | (required) |
+| `KEYCLOAK_ADMIN_PASSWORD` | Keycloak admin password | (required) |
 | `BATCH_SIZE` | Number of users to process in each batch | `100` |
 | `MAX_RETRIES` | Maximum number of retries for API calls | `3` |
 | `INITIAL_BACKOFF_SECONDS` | Initial backoff time for retries | `1` |


### PR DESCRIPTION
HUMAN: Aligns the Resend sync README with the script's actual required_vars guard. The README documented KEYCLOAK_REALM (with a default value) but the script reads KEYCLOAK_REALM_NAME and sys.exit(1)s if it is unset, along with two other Keycloak variables the README never listed. Pure docs change, no code touched.

- [ ] A human has tested these changes.

---

The Resend sync README documented `KEYCLOAK_REALM` (default `all-hands`) but the script's required_vars guard at `enterprise/sync/resend_keycloak.py:411-417` actually reads `KEYCLOAK_REALM_NAME` and `sys.exit(1)`s when it (and two other Keycloak variables) are not set. An operator following the README literally would get a failed script run with `KEYCLOAK_REALM_NAME environment variable is not set`.

## What changed

\`enterprise/sync/README.md\` configuration table — 1 file, +3/-1 line:

- **Replaced** \`KEYCLOAK_REALM\` (wrong name, listed as optional with default) with \`KEYCLOAK_REALM_NAME\` (required, no default — matches what the script actually reads at line 50).
- **Added** \`KEYCLOAK_SERVER_URL\` as required (script line 49 + line 414 guard).
- **Added** \`KEYCLOAK_ADMIN_PASSWORD\` as required (script line 53 + line 416 guard).

\`RESEND_API_KEY\` and \`RESEND_AUDIENCE_ID\` were already correctly listed as required and unchanged.

## Verification

Compared \`enterprise/sync/resend_keycloak.py:411-417\`:

\`\`\`python
required_vars = {
    'RESEND_API_KEY': RESEND_API_KEY,
    'RESEND_AUDIENCE_ID': RESEND_AUDIENCE_ID,
    'KEYCLOAK_SERVER_URL': KEYCLOAK_SERVER_URL,
    'KEYCLOAK_REALM_NAME': KEYCLOAK_REALM_NAME,
    'KEYCLOAK_ADMIN_PASSWORD': KEYCLOAK_ADMIN_PASSWORD,
}
\`\`\`

After the patch, every key in \`required_vars\` appears in the README table as \`(required)\`.

This matches the **Proposed Repair** option in #14543 (script is the source of truth, README aligns to it).

Fixes #14543