### PR TITLE
[APP-1959] Add connection-scoped Bitbucket DC webhooks

### DIFF
--- a/enterprise/integrations/bitbucket_data_center/bitbucket_dc_manager.py
+++ b/enterprise/integrations/bitbucket_data_center/bitbucket_dc_manager.py
@@ -68,9 +68,11 @@ class BitbucketDCManager(Manager[BitbucketDCViewType]):
     async def _commenter_has_write_access(
         self, message: Message, installer_user_id: str
     ) -> bool:
-        """Use the installer's Bitbucket DC token to check whether the
-        commenter has ``REPO_WRITE``/``REPO_ADMIN`` permission on the PR's
-        repository — mirrors the Cloud manager's installer-scoped check.
+        """Check commenter permissions using the installer's Bitbucket DC token.
+
+        The check confirms whether the commenter has ``REPO_WRITE`` or
+        ``REPO_ADMIN`` permission on the PR's repository, mirroring the Cloud
+        manager's installer-scoped check.
         """
         from integrations.bitbucket_data_center.bitbucket_dc_service import (
             SaaSBitbucketDCService,
@@ -172,8 +174,7 @@ class BitbucketDCManager(Manager[BitbucketDCViewType]):
         installer_user_id: str,
         mentioner_slug: str | None,
     ) -> None:
-        """Reply to the triggering comment asking an unenrolled mentioner to
-        sign up, mirroring ``GithubManager._send_user_not_found_message``.
+        """Ask an unenrolled mentioner to sign up in a PR reply.
 
         The mentioner has no OHE account, so there is no token to post as
         them; the reply goes out under the installer's BBDC token (the
@@ -200,9 +201,11 @@ class BitbucketDCManager(Manager[BitbucketDCViewType]):
             return
 
         project_key, repo_slug = self._extract_repo_identity(message)
-        installer_user_id = await self.webhook_store.get_webhook_user_id(
-            project_key=project_key, repo_slug=repo_slug
-        )
+        installer_user_id = message.message.get('installer_user_id')
+        if not installer_user_id:
+            installer_user_id = await self.webhook_store.get_webhook_user_id(
+                project_key=project_key, repo_slug=repo_slug
+            )
         if not installer_user_id:
             logger.warning(
                 f'[Bitbucket DC] No installer recorded for '

--- a/enterprise/server/routes/integration/bitbucket_dc.py
+++ b/enterprise/server/routes/integration/bitbucket_dc.py
@@ -59,7 +59,12 @@ BITBUCKET_DC_WEBHOOK_EVENTS = [
     'pr:comment:edited',
     'pr:comment:deleted',
 ]
-BITBUCKET_DC_WEBHOOK_URL = f'{HOST_URL}/integration/bitbucket-dc/events'
+BITBUCKET_DC_LEGACY_WEBHOOK_URL = f'{HOST_URL}/integration/bitbucket-dc/events'
+BITBUCKET_DC_WEBHOOK_URL = BITBUCKET_DC_LEGACY_WEBHOOK_URL
+
+
+def bitbucket_dc_webhook_url(connection_id: int) -> str:
+    return f'{HOST_URL}/integration/bitbucket-dc/connections/{connection_id}/events'
 
 
 class BitbucketDCResourceIdentifier(BaseModel):
@@ -73,8 +78,10 @@ class BitbucketDCResourceWithWebhookStatus(BaseModel):
     name: str
     full_name: str
     type: str = 'repository'
+    connection_id: int | None
     webhook_enrolled: bool
     webhook_id: str | None
+    webhook_url: str | None
     webhook_secret_set: bool
     installed_by_user_id: str | None
     last_synced: str | None
@@ -93,6 +100,7 @@ class BitbucketDCWebhookEnrollmentResult(BaseModel):
     repo_slug: str
     success: bool
     error: str | None
+    connection_id: int | None
     webhook_url: str | None
     webhook_secret: str | None
     webhook_name: str
@@ -121,6 +129,8 @@ class BitbucketDCWebhookInstallationResult(BaseModel):
     success: bool
     error: str | None
     webhook_id: str | None
+    connection_id: int | None = None
+    webhook_url: str | None = None
 
 
 def _normalize_dc_resource(
@@ -161,6 +171,7 @@ async def _get_or_create_dc_webhook(
     project_key: str,
     repo_slug: str,
     webhook_secret: str,
+    webhook_url: str,
 ) -> str | None:
     """Idempotent webhook (re)installation against BBDC.
 
@@ -173,7 +184,7 @@ async def _get_or_create_dc_webhook(
         webhook_exists,
         webhook_id,
     ) = await bitbucket_dc_service.check_webhook_exists_on_repository(
-        project_key, repo_slug, BITBUCKET_DC_WEBHOOK_URL
+        project_key, repo_slug, webhook_url
     )
     if webhook_exists and webhook_id:
         return await bitbucket_dc_service.update_repository_webhook(
@@ -181,7 +192,24 @@ async def _get_or_create_dc_webhook(
             repo_slug=repo_slug,
             webhook_id=webhook_id,
             name=BITBUCKET_DC_WEBHOOK_NAME,
-            webhook_url=BITBUCKET_DC_WEBHOOK_URL,
+            webhook_url=webhook_url,
+            webhook_secret=webhook_secret,
+            events=BITBUCKET_DC_WEBHOOK_EVENTS,
+        )
+
+    (
+        legacy_webhook_exists,
+        legacy_webhook_id,
+    ) = await bitbucket_dc_service.check_webhook_exists_on_repository(
+        project_key, repo_slug, BITBUCKET_DC_LEGACY_WEBHOOK_URL
+    )
+    if legacy_webhook_exists and legacy_webhook_id:
+        return await bitbucket_dc_service.update_repository_webhook(
+            owner=project_key,
+            repo_slug=repo_slug,
+            webhook_id=legacy_webhook_id,
+            name=BITBUCKET_DC_WEBHOOK_NAME,
+            webhook_url=webhook_url,
             webhook_secret=webhook_secret,
             events=BITBUCKET_DC_WEBHOOK_EVENTS,
         )
@@ -190,10 +218,30 @@ async def _get_or_create_dc_webhook(
         owner=project_key,
         repo_slug=repo_slug,
         name=BITBUCKET_DC_WEBHOOK_NAME,
-        webhook_url=BITBUCKET_DC_WEBHOOK_URL,
+        webhook_url=webhook_url,
         webhook_secret=webhook_secret,
         events=BITBUCKET_DC_WEBHOOK_EVENTS,
     )
+
+
+async def _find_existing_dc_webhook_id(
+    bitbucket_dc_service: SaaSBitbucketDCService,
+    project_key: str,
+    repo_slug: str,
+    webhook_urls: list[str],
+) -> str | None:
+    for webhook_url in webhook_urls:
+        if not webhook_url:
+            continue
+        (
+            webhook_exists,
+            webhook_id,
+        ) = await bitbucket_dc_service.check_webhook_exists_on_repository(
+            project_key, repo_slug, webhook_url
+        )
+        if webhook_exists and webhook_id:
+            return webhook_id
+    return None
 
 
 def _extract_repo_identity(payload_data: dict) -> tuple[str, str]:
@@ -233,8 +281,9 @@ async def verify_bitbucket_dc_signature(
     *,
     signature_header: str | None,
     body: bytes,
-    project_key: str,
-    repo_slug: str,
+    project_key: str = '',
+    repo_slug: str = '',
+    webhook_secret: str | None = None,
 ) -> None:
     """Verify ``X-Hub-Signature`` against the per-repository secret.
 
@@ -244,15 +293,15 @@ async def verify_bitbucket_dc_signature(
     per-installation UUID header on DC, so we look up the secret by the
     ``(project_key, repo_slug)`` carried in the payload.
     """
-    if not project_key or not repo_slug:
+    if webhook_secret is None and (not project_key or not repo_slug):
         raise HTTPException(
             status_code=403,
             detail='Missing repository identity in payload',
         )
 
     if IS_LOCAL_DEPLOYMENT:
-        webhook_secret: str | None = 'localdeploymentwebhooktesttoken'
-    else:
+        webhook_secret = webhook_secret or 'localdeploymentwebhooktesttoken'
+    elif webhook_secret is None:
         webhook_secret = await webhook_store.get_webhook_secret(
             project_key=project_key, repo_slug=repo_slug
         )
@@ -311,8 +360,12 @@ async def get_bitbucket_dc_resources(
                     repo_slug=repo_slug,
                     name=repo_slug,
                     full_name=f'{project_key}/{repo_slug}',
+                    connection_id=webhook.id if webhook else None,
                     webhook_enrolled=bool(webhook and webhook.webhook_secret),
                     webhook_id=webhook.webhook_id if webhook else None,
+                    webhook_url=(
+                        bitbucket_dc_webhook_url(webhook.id) if webhook else None
+                    ),
                     webhook_secret_set=bool(webhook and webhook.webhook_secret),
                     installed_by_user_id=webhook.user_id if webhook else None,
                     last_synced=(
@@ -352,19 +405,21 @@ async def enroll_bitbucket_dc_webhook(
     webhook_secret = secrets.token_urlsafe(32)
 
     try:
-        await webhook_store.upsert_webhook_enrollment(
+        webhook = await webhook_store.upsert_webhook_enrollment(
             project_key=project_key,
             repo_slug=repo_slug,
             user_id=user_id,
             webhook_secret=webhook_secret,
         )
+        webhook_url = bitbucket_dc_webhook_url(webhook.id)
 
         return BitbucketDCWebhookEnrollmentResult(
             project_key=project_key,
             repo_slug=repo_slug,
             success=True,
             error=None,
-            webhook_url=BITBUCKET_DC_WEBHOOK_URL,
+            connection_id=webhook.id,
+            webhook_url=webhook_url,
             webhook_secret=webhook_secret,
             webhook_name=BITBUCKET_DC_WEBHOOK_NAME,
             events=BITBUCKET_DC_WEBHOOK_EVENTS,
@@ -449,9 +504,19 @@ async def reinstall_bitbucket_dc_webhook(
 
     try:
         await _ensure_dc_admin_access(bitbucket_dc_service, project_key, repo_slug)
+        webhook = await webhook_store.ensure_webhook_enrollment(
+            project_key=project_key,
+            repo_slug=repo_slug,
+            user_id=user_id,
+        )
         webhook_secret = secrets.token_urlsafe(32)
+        webhook_url = bitbucket_dc_webhook_url(webhook.id)
         webhook_id = await _get_or_create_dc_webhook(
-            bitbucket_dc_service, project_key, repo_slug, webhook_secret
+            bitbucket_dc_service,
+            project_key,
+            repo_slug,
+            webhook_secret,
+            webhook_url,
         )
         if not webhook_id:
             raise HTTPException(
@@ -488,6 +553,8 @@ async def reinstall_bitbucket_dc_webhook(
             success=True,
             error=None,
             webhook_id=webhook_id,
+            connection_id=webhook.id,
+            webhook_url=webhook_url,
         )
 
     except HTTPException:
@@ -519,11 +586,14 @@ async def uninstall_bitbucket_dc_webhook(
     try:
         await _ensure_dc_admin_access(bitbucket_dc_service, project_key, repo_slug)
         webhook = await webhook_store.get_webhook_by_repo(project_key, repo_slug)
-        (
-            provider_exists,
-            provider_id,
-        ) = await bitbucket_dc_service.check_webhook_exists_on_repository(
-            project_key, repo_slug, BITBUCKET_DC_WEBHOOK_URL
+        provider_id = await _find_existing_dc_webhook_id(
+            bitbucket_dc_service,
+            project_key,
+            repo_slug,
+            [
+                bitbucket_dc_webhook_url(webhook.id) if webhook else '',
+                BITBUCKET_DC_LEGACY_WEBHOOK_URL,
+            ],
         )
         db_id = webhook.webhook_id if webhook else None
         webhook_id = provider_id or db_id
@@ -531,11 +601,16 @@ async def uninstall_bitbucket_dc_webhook(
             await bitbucket_dc_service.delete_repository_webhook(
                 project_key, repo_slug, provider_id
             )
-        elif provider_exists:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail='Failed to locate Bitbucket DC webhook id',
-            )
+        elif db_id:
+            try:
+                await bitbucket_dc_service.delete_repository_webhook(
+                    project_key, repo_slug, db_id
+                )
+            except Exception as e:
+                logger.warning(
+                    f'[Bitbucket DC] Stored webhook id {db_id} for '
+                    f'{project_key}/{repo_slug} could not be deleted: {e}'
+                )
 
         await webhook_store.delete_webhook_by_repo(
             project_key=project_key,
@@ -558,6 +633,8 @@ async def uninstall_bitbucket_dc_webhook(
             success=True,
             error=None,
             webhook_id=webhook_id,
+            connection_id=webhook.id if webhook else None,
+            webhook_url=bitbucket_dc_webhook_url(webhook.id) if webhook else None,
         )
 
     except HTTPException:
@@ -570,13 +647,13 @@ async def uninstall_bitbucket_dc_webhook(
         )
 
 
-@bitbucket_dc_integration_router.post('/bitbucket-dc/events')
-async def bitbucket_dc_events(
+async def _handle_bitbucket_dc_event(
     request: Request,
     background_tasks: BackgroundTasks,
-    x_hub_signature: str | None = Header(None),
-    x_event_key: str | None = Header(None),
-    x_request_id: str | None = Header(None),
+    x_hub_signature: str | None,
+    x_event_key: str | None,
+    x_request_id: str | None,
+    connection_id: int | None = None,
 ):
     try:
         body = await request.body()
@@ -594,12 +671,41 @@ async def bitbucket_dc_events(
         payload_data = _normalize_bitbucket_dc_event_payload(payload_data, x_event_key)
 
         project_key, repo_slug = _extract_repo_identity(payload_data)
-        await verify_bitbucket_dc_signature(
-            signature_header=x_hub_signature,
-            body=body,
-            project_key=project_key,
-            repo_slug=repo_slug,
-        )
+        installer_user_id: str | None = None
+        if connection_id is not None:
+            webhook = await webhook_store.get_webhook_by_id(connection_id)
+            if not webhook:
+                raise HTTPException(
+                    status_code=403,
+                    detail='No webhook found for connection',
+                )
+            if (
+                project_key
+                and repo_slug
+                and (
+                    webhook.project_key != project_key
+                    or webhook.repo_slug != repo_slug
+                )
+            ):
+                raise HTTPException(
+                    status_code=403,
+                    detail='Webhook connection does not match payload repository',
+                )
+            project_key = project_key or webhook.project_key
+            repo_slug = repo_slug or webhook.repo_slug
+            installer_user_id = webhook.user_id
+            await verify_bitbucket_dc_signature(
+                signature_header=x_hub_signature,
+                body=body,
+                webhook_secret=webhook.webhook_secret,
+            )
+        else:
+            await verify_bitbucket_dc_signature(
+                signature_header=x_hub_signature,
+                body=body,
+                project_key=project_key,
+                repo_slug=repo_slug,
+            )
 
         pr_id = (payload_data.get('pullRequest') or {}).get('id')
         comment_id = (payload_data.get('comment') or {}).get('id')
@@ -634,6 +740,8 @@ async def bitbucket_dc_events(
                 'payload': payload_data,
                 'event_key': x_event_key,
                 'installation_id': installation_id,
+                'connection_id': connection_id,
+                'installer_user_id': installer_user_id,
             },
         )
         await bitbucket_dc_manager.receive_message(message)
@@ -656,3 +764,39 @@ async def bitbucket_dc_events(
             status_code=400,
             content={'error': 'Invalid payload.', 'error_type': type(e).__name__},
         )
+
+
+@bitbucket_dc_integration_router.post('/bitbucket-dc/connections/{connection_id}/events')
+async def bitbucket_dc_connection_events(
+    connection_id: int,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    x_hub_signature: str | None = Header(None),
+    x_event_key: str | None = Header(None),
+    x_request_id: str | None = Header(None),
+):
+    return await _handle_bitbucket_dc_event(
+        request=request,
+        background_tasks=background_tasks,
+        x_hub_signature=x_hub_signature,
+        x_event_key=x_event_key,
+        x_request_id=x_request_id,
+        connection_id=connection_id,
+    )
+
+
+@bitbucket_dc_integration_router.post('/bitbucket-dc/events')
+async def bitbucket_dc_events(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    x_hub_signature: str | None = Header(None),
+    x_event_key: str | None = Header(None),
+    x_request_id: str | None = Header(None),
+):
+    return await _handle_bitbucket_dc_event(
+        request=request,
+        background_tasks=background_tasks,
+        x_hub_signature=x_hub_signature,
+        x_event_key=x_event_key,
+        x_request_id=x_request_id,
+    )

--- a/enterprise/server/routes/integration/bitbucket_dc.py
+++ b/enterprise/server/routes/integration/bitbucket_dc.py
@@ -33,38 +33,38 @@ from openhands.app_server.config_api.config_models import AppMode
 from openhands.app_server.integrations.provider import ProviderType
 from openhands.app_server.utils.logger import openhands_logger as logger
 
-bitbucket_dc_integration_router = APIRouter(prefix='/integration')
+bitbucket_dc_integration_router = APIRouter(prefix="/integration")
 
 webhook_store = BitbucketDCWebhookStore()
 token_manager = TokenManager()
 bitbucket_dc_manager = BitbucketDCManager(token_manager)
 automation_event_service = AutomationEventService(token_manager)
 
-BITBUCKET_DC_WEBHOOK_NAME = 'OpenHands Resolver'
+BITBUCKET_DC_WEBHOOK_NAME = "OpenHands Resolver"
 BITBUCKET_DC_WEBHOOK_EVENTS = [
-    'repo:refs_changed',
-    'repo:comment:added',
-    'repo:comment:edited',
-    'repo:comment:deleted',
-    'pr:opened',
-    'pr:from_ref_updated',
-    'pr:modified',
-    'pr:reviewer:approved',
-    'pr:reviewer:unapproved',
-    'pr:reviewer:needs_work',
-    'pr:merged',
-    'pr:declined',
-    'pr:deleted',
-    'pr:comment:added',
-    'pr:comment:edited',
-    'pr:comment:deleted',
+    "repo:refs_changed",
+    "repo:comment:added",
+    "repo:comment:edited",
+    "repo:comment:deleted",
+    "pr:opened",
+    "pr:from_ref_updated",
+    "pr:modified",
+    "pr:reviewer:approved",
+    "pr:reviewer:unapproved",
+    "pr:reviewer:needs_work",
+    "pr:merged",
+    "pr:declined",
+    "pr:deleted",
+    "pr:comment:added",
+    "pr:comment:edited",
+    "pr:comment:deleted",
 ]
-BITBUCKET_DC_LEGACY_WEBHOOK_URL = f'{HOST_URL}/integration/bitbucket-dc/events'
+BITBUCKET_DC_LEGACY_WEBHOOK_URL = f"{HOST_URL}/integration/bitbucket-dc/events"
 BITBUCKET_DC_WEBHOOK_URL = BITBUCKET_DC_LEGACY_WEBHOOK_URL
 
 
 def bitbucket_dc_webhook_url(connection_id: int) -> str:
-    return f'{HOST_URL}/integration/bitbucket-dc/connections/{connection_id}/events'
+    return f"{HOST_URL}/integration/bitbucket-dc/connections/{connection_id}/events"
 
 
 class BitbucketDCResourceIdentifier(BaseModel):
@@ -77,7 +77,7 @@ class BitbucketDCResourceWithWebhookStatus(BaseModel):
     repo_slug: str
     name: str
     full_name: str
-    type: str = 'repository'
+    type: str = "repository"
     connection_id: int | None
     webhook_enrolled: bool
     webhook_id: str | None
@@ -141,7 +141,7 @@ def _normalize_dc_resource(
     if not project_key or not repo_slug:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail='project_key and repo_slug are required',
+            detail="project_key and repo_slug are required",
         )
     return project_key, repo_slug
 
@@ -162,7 +162,7 @@ async def _ensure_dc_admin_access(
     if not await bitbucket_dc_service.user_has_admin_access(project_key, repo_slug):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail='User does not have admin access to this repository',
+            detail="User does not have admin access to this repository",
         )
 
 
@@ -251,14 +251,14 @@ def _extract_repo_identity(payload_data: dict) -> tuple[str, str]:
     ``pullRequest.toRef.repository``; for repo-level events it lives at
     the top level under ``repository``.
     """
-    pull_request = payload_data.get('pullRequest') or {}
+    pull_request = payload_data.get("pullRequest") or {}
     repository = (
-        (pull_request.get('toRef') or {}).get('repository')
-        or payload_data.get('repository')
+        (pull_request.get("toRef") or {}).get("repository")
+        or payload_data.get("repository")
         or {}
     )
-    project = repository.get('project') or {}
-    return project.get('key') or '', repository.get('slug') or ''
+    project = repository.get("project") or {}
+    return project.get("key") or "", repository.get("slug") or ""
 
 
 def _normalize_bitbucket_dc_event_payload(
@@ -271,9 +271,9 @@ def _normalize_bitbucket_dc_event_payload(
     deliveries, in the JSON payload. Some tests and proxies only preserve the
     header, so normalize the payload before forwarding it internally.
     """
-    if event_key and not payload_data.get('eventKey'):
+    if event_key and not payload_data.get("eventKey"):
         payload_data = dict(payload_data)
-        payload_data['eventKey'] = event_key
+        payload_data["eventKey"] = event_key
     return payload_data
 
 
@@ -281,8 +281,8 @@ async def verify_bitbucket_dc_signature(
     *,
     signature_header: str | None,
     body: bytes,
-    project_key: str = '',
-    repo_slug: str = '',
+    project_key: str = "",
+    repo_slug: str = "",
     webhook_secret: str | None = None,
 ) -> None:
     """Verify ``X-Hub-Signature`` against the per-repository secret.
@@ -296,11 +296,11 @@ async def verify_bitbucket_dc_signature(
     if webhook_secret is None and (not project_key or not repo_slug):
         raise HTTPException(
             status_code=403,
-            detail='Missing repository identity in payload',
+            detail="Missing repository identity in payload",
         )
 
     if IS_LOCAL_DEPLOYMENT:
-        webhook_secret = webhook_secret or 'localdeploymentwebhooktesttoken'
+        webhook_secret = webhook_secret or "localdeploymentwebhooktesttoken"
     elif webhook_secret is None:
         webhook_secret = await webhook_store.get_webhook_secret(
             project_key=project_key, repo_slug=repo_slug
@@ -309,26 +309,26 @@ async def verify_bitbucket_dc_signature(
     if not webhook_secret:
         raise HTTPException(
             status_code=403,
-            detail='No webhook secret found for repository',
+            detail="No webhook secret found for repository",
         )
 
     if IS_LOCAL_DEPLOYMENT and signature_header in (
         None,
-        'localdeploymentwebhooktesttoken',
+        "localdeploymentwebhooktesttoken",
     ):
         return
 
     if not signature_header:
-        raise HTTPException(status_code=403, detail='Missing X-Hub-Signature header')
+        raise HTTPException(status_code=403, detail="Missing X-Hub-Signature header")
 
     expected = (
-        'sha256=' + hmac.new(webhook_secret.encode(), body, hashlib.sha256).hexdigest()
+        "sha256=" + hmac.new(webhook_secret.encode(), body, hashlib.sha256).hexdigest()
     )
     if not hmac.compare_digest(expected, signature_header):
         raise HTTPException(status_code=403, detail="Request signatures didn't match!")
 
 
-@bitbucket_dc_integration_router.get('/bitbucket-dc/resources')
+@bitbucket_dc_integration_router.get("/bitbucket-dc/resources")
 async def get_bitbucket_dc_resources(
     user_id: str = Depends(require_permission(Permission.MANAGE_INTEGRATIONS)),
 ) -> BitbucketDCResourcesResponse:
@@ -336,15 +336,15 @@ async def get_bitbucket_dc_resources(
     try:
         bitbucket_dc_service = SaaSBitbucketDCService(external_auth_id=user_id)
         repositories = await bitbucket_dc_service.get_all_repositories(
-            sort='updated', app_mode=AppMode.SAAS
+            sort="updated", app_mode=AppMode.SAAS
         )
 
         repo_identities: list[tuple[str, str]] = []
         for repo in repositories:
-            parts = repo.full_name.split('/', 1)
+            parts = repo.full_name.split("/", 1)
             if len(parts) != 2:
                 logger.warning(
-                    f'[Bitbucket DC] Skipping repo with unexpected full_name: {repo.full_name}'
+                    f"[Bitbucket DC] Skipping repo with unexpected full_name: {repo.full_name}"
                 )
                 continue
             repo_identities.append((parts[0], parts[1]))
@@ -359,7 +359,7 @@ async def get_bitbucket_dc_resources(
                     project_key=project_key,
                     repo_slug=repo_slug,
                     name=repo_slug,
-                    full_name=f'{project_key}/{repo_slug}',
+                    full_name=f"{project_key}/{repo_slug}",
                     connection_id=webhook.id if webhook else None,
                     webhook_enrolled=bool(webhook and webhook.webhook_secret),
                     webhook_id=webhook.webhook_id if webhook else None,
@@ -381,14 +381,14 @@ async def get_bitbucket_dc_resources(
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception(f'Error retrieving Bitbucket DC resources: {e}')
+        logger.exception(f"Error retrieving Bitbucket DC resources: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail='Failed to retrieve Bitbucket DC resources',
+            detail="Failed to retrieve Bitbucket DC resources",
         )
 
 
-@bitbucket_dc_integration_router.post('/bitbucket-dc/enroll-webhook')
+@bitbucket_dc_integration_router.post("/bitbucket-dc/enroll-webhook")
 async def enroll_bitbucket_dc_webhook(
     body: EnrollBitbucketDCWebhookRequest,
     user_id: str = Depends(require_permission(Permission.MANAGE_INTEGRATIONS)),
@@ -399,7 +399,7 @@ async def enroll_bitbucket_dc_webhook(
     if not project_key or not repo_slug:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail='project_key and repo_slug are required',
+            detail="project_key and repo_slug are required",
         )
 
     webhook_secret = secrets.token_urlsafe(32)
@@ -426,14 +426,14 @@ async def enroll_bitbucket_dc_webhook(
         )
 
     except Exception as e:
-        logger.exception(f'Error enrolling Bitbucket DC webhook: {e}')
+        logger.exception(f"Error enrolling Bitbucket DC webhook: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail='Failed to enroll Bitbucket DC webhook',
+            detail="Failed to enroll Bitbucket DC webhook",
         )
 
 
-@bitbucket_dc_integration_router.patch('/bitbucket-dc/webhook-id')
+@bitbucket_dc_integration_router.patch("/bitbucket-dc/webhook-id")
 async def update_bitbucket_dc_webhook_id(
     body: UpdateBitbucketDCWebhookIdRequest,
     user_id: str = Depends(require_permission(Permission.MANAGE_INTEGRATIONS)),
@@ -445,7 +445,7 @@ async def update_bitbucket_dc_webhook_id(
     if not project_key or not repo_slug or not webhook_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail='project_key, repo_slug, and webhook_id are required',
+            detail="project_key, repo_slug, and webhook_id are required",
         )
 
     try:
@@ -457,16 +457,16 @@ async def update_bitbucket_dc_webhook_id(
         if not updated:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail='Bitbucket DC webhook enrollment not found',
+                detail="Bitbucket DC webhook enrollment not found",
             )
 
         logger.info(
-            '[Bitbucket DC] Webhook id recorded',
+            "[Bitbucket DC] Webhook id recorded",
             extra={
-                'user_id': user_id,
-                'project_key': project_key,
-                'repo_slug': repo_slug,
-                'webhook_id': webhook_id,
+                "user_id": user_id,
+                "project_key": project_key,
+                "repo_slug": repo_slug,
+                "webhook_id": webhook_id,
             },
         )
         return BitbucketDCWebhookIdUpdateResult(
@@ -479,14 +479,14 @@ async def update_bitbucket_dc_webhook_id(
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception(f'Error updating Bitbucket DC webhook id: {e}')
+        logger.exception(f"Error updating Bitbucket DC webhook id: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail='Failed to update Bitbucket DC webhook id',
+            detail="Failed to update Bitbucket DC webhook id",
         )
 
 
-@bitbucket_dc_integration_router.post('/bitbucket-dc/reinstall-webhook')
+@bitbucket_dc_integration_router.post("/bitbucket-dc/reinstall-webhook")
 async def reinstall_bitbucket_dc_webhook(
     body: BitbucketDCWebhookRequest,
     user_id: str = Depends(require_permission(Permission.MANAGE_INTEGRATIONS)),
@@ -521,7 +521,7 @@ async def reinstall_bitbucket_dc_webhook(
         if not webhook_id:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail='Failed to install Bitbucket DC webhook',
+                detail="Failed to install Bitbucket DC webhook",
             )
 
         await webhook_store.upsert_webhook_enrollment(
@@ -538,12 +538,12 @@ async def reinstall_bitbucket_dc_webhook(
         # (BBDC's API is the authoritative auth boundary), so the audit
         # trail lives here.
         logger.info(
-            '[Bitbucket DC] Webhook installed',
+            "[Bitbucket DC] Webhook installed",
             extra={
-                'user_id': user_id,
-                'project_key': project_key,
-                'repo_slug': repo_slug,
-                'webhook_id': webhook_id,
+                "user_id": user_id,
+                "project_key": project_key,
+                "repo_slug": repo_slug,
+                "webhook_id": webhook_id,
             },
         )
 
@@ -560,14 +560,14 @@ async def reinstall_bitbucket_dc_webhook(
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception(f'Error installing Bitbucket DC webhook: {e}')
+        logger.exception(f"Error installing Bitbucket DC webhook: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail='Failed to install Bitbucket DC webhook',
+            detail="Failed to install Bitbucket DC webhook",
         )
 
 
-@bitbucket_dc_integration_router.post('/bitbucket-dc/uninstall-webhook')
+@bitbucket_dc_integration_router.post("/bitbucket-dc/uninstall-webhook")
 async def uninstall_bitbucket_dc_webhook(
     body: BitbucketDCWebhookRequest,
     user_id: str = Depends(require_permission(Permission.MANAGE_INTEGRATIONS)),
@@ -591,7 +591,7 @@ async def uninstall_bitbucket_dc_webhook(
             project_key,
             repo_slug,
             [
-                bitbucket_dc_webhook_url(webhook.id) if webhook else '',
+                bitbucket_dc_webhook_url(webhook.id) if webhook else "",
                 BITBUCKET_DC_LEGACY_WEBHOOK_URL,
             ],
         )
@@ -608,8 +608,8 @@ async def uninstall_bitbucket_dc_webhook(
                 )
             except Exception as e:
                 logger.warning(
-                    f'[Bitbucket DC] Stored webhook id {db_id} for '
-                    f'{project_key}/{repo_slug} could not be deleted: {e}'
+                    f"[Bitbucket DC] Stored webhook id {db_id} for "
+                    f"{project_key}/{repo_slug} could not be deleted: {e}"
                 )
 
         await webhook_store.delete_webhook_by_repo(
@@ -618,12 +618,12 @@ async def uninstall_bitbucket_dc_webhook(
         )
 
         logger.info(
-            '[Bitbucket DC] Webhook uninstalled',
+            "[Bitbucket DC] Webhook uninstalled",
             extra={
-                'user_id': user_id,
-                'project_key': project_key,
-                'repo_slug': repo_slug,
-                'webhook_id': webhook_id,
+                "user_id": user_id,
+                "project_key": project_key,
+                "repo_slug": repo_slug,
+                "webhook_id": webhook_id,
             },
         )
 
@@ -640,10 +640,10 @@ async def uninstall_bitbucket_dc_webhook(
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception(f'Error uninstalling Bitbucket DC webhook: {e}')
+        logger.exception(f"Error uninstalling Bitbucket DC webhook: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail='Failed to uninstall Bitbucket DC webhook',
+            detail="Failed to uninstall Bitbucket DC webhook",
         )
 
 
@@ -662,10 +662,10 @@ async def _handle_bitbucket_dc_event(
         # DC sends a ``diagnostics:ping`` event when the admin clicks the
         # "Test connection" button on the webhook configuration page; it
         # carries no repository payload, so accept it as a no-op.
-        if x_event_key == 'diagnostics:ping':
+        if x_event_key == "diagnostics:ping":
             return JSONResponse(
                 status_code=200,
-                content={'message': 'Bitbucket DC ping acknowledged.'},
+                content={"message": "Bitbucket DC ping acknowledged."},
             )
 
         payload_data = _normalize_bitbucket_dc_event_payload(payload_data, x_event_key)
@@ -677,19 +677,18 @@ async def _handle_bitbucket_dc_event(
             if not webhook:
                 raise HTTPException(
                     status_code=403,
-                    detail='No webhook found for connection',
+                    detail="No webhook found for connection",
                 )
             if (
                 project_key
                 and repo_slug
                 and (
-                    webhook.project_key != project_key
-                    or webhook.repo_slug != repo_slug
+                    webhook.project_key != project_key or webhook.repo_slug != repo_slug
                 )
             ):
                 raise HTTPException(
                     status_code=403,
-                    detail='Webhook connection does not match payload repository',
+                    detail="Webhook connection does not match payload repository",
                 )
             project_key = project_key or webhook.project_key
             repo_slug = repo_slug or webhook.repo_slug
@@ -707,25 +706,25 @@ async def _handle_bitbucket_dc_event(
                 repo_slug=repo_slug,
             )
 
-        pr_id = (payload_data.get('pullRequest') or {}).get('id')
-        comment_id = (payload_data.get('comment') or {}).get('id')
+        pr_id = (payload_data.get("pullRequest") or {}).get("id")
+        comment_id = (payload_data.get("comment") or {}).get("id")
 
         if x_request_id:
-            dedup_key = f'bbdc:{x_event_key}:{pr_id}:{comment_id}:{x_request_id}'
+            dedup_key = f"bbdc:{x_event_key}:{pr_id}:{comment_id}:{x_request_id}"
         else:
             dedup_hash = hashlib.sha256(body).hexdigest()
-            dedup_key = f'bbdc:msg:{dedup_hash}'
+            dedup_key = f"bbdc:msg:{dedup_hash}"
 
         redis = get_redis_client_async()
         created = await redis.set(dedup_key, 1, nx=True, ex=60)
         if not created:
-            logger.info('bitbucket_dc_is_duplicate')
+            logger.info("bitbucket_dc_is_duplicate")
             return JSONResponse(
                 status_code=200,
-                content={'message': 'Duplicate Bitbucket DC event ignored.'},
+                content={"message": "Duplicate Bitbucket DC event ignored."},
             )
 
-        installation_id = f'{project_key}/{repo_slug}'
+        installation_id = f"{project_key}/{repo_slug}"
         if AUTOMATION_EVENT_FORWARDING_ENABLED:
             background_tasks.add_task(
                 automation_event_service.forward_event,
@@ -737,11 +736,11 @@ async def _handle_bitbucket_dc_event(
         message = Message(
             source=SourceType.BITBUCKET_DATA_CENTER,
             message={
-                'payload': payload_data,
-                'event_key': x_event_key,
-                'installation_id': installation_id,
-                'connection_id': connection_id,
-                'installer_user_id': installer_user_id,
+                "payload": payload_data,
+                "event_key": x_event_key,
+                "installation_id": installation_id,
+                "connection_id": connection_id,
+                "installer_user_id": installer_user_id,
             },
         )
         await bitbucket_dc_manager.receive_message(message)
@@ -749,24 +748,26 @@ async def _handle_bitbucket_dc_event(
         return JSONResponse(
             status_code=200,
             content={
-                'message': 'Bitbucket DC events endpoint reached successfully.',
+                "message": "Bitbucket DC events endpoint reached successfully.",
             },
         )
 
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception(f'Error processing Bitbucket DC event: {e}')
+        logger.exception(f"Error processing Bitbucket DC event: {e}")
         # Surface the exception class name so admins reading DC's webhook
         # delivery UI can correlate with server logs without leaking a full
         # message (which may contain sensitive payload fragments).
         return JSONResponse(
             status_code=400,
-            content={'error': 'Invalid payload.', 'error_type': type(e).__name__},
+            content={"error": "Invalid payload.", "error_type": type(e).__name__},
         )
 
 
-@bitbucket_dc_integration_router.post('/bitbucket-dc/connections/{connection_id}/events')
+@bitbucket_dc_integration_router.post(
+    "/bitbucket-dc/connections/{connection_id}/events"
+)
 async def bitbucket_dc_connection_events(
     connection_id: int,
     request: Request,
@@ -785,7 +786,7 @@ async def bitbucket_dc_connection_events(
     )
 
 
-@bitbucket_dc_integration_router.post('/bitbucket-dc/events')
+@bitbucket_dc_integration_router.post("/bitbucket-dc/events")
 async def bitbucket_dc_events(
     request: Request,
     background_tasks: BackgroundTasks,

--- a/enterprise/server/routes/integration/bitbucket_dc.py
+++ b/enterprise/server/routes/integration/bitbucket_dc.py
@@ -33,38 +33,38 @@ from openhands.app_server.config_api.config_models import AppMode
 from openhands.app_server.integrations.provider import ProviderType
 from openhands.app_server.utils.logger import openhands_logger as logger
 
-bitbucket_dc_integration_router = APIRouter(prefix="/integration")
+bitbucket_dc_integration_router = APIRouter(prefix='/integration')
 
 webhook_store = BitbucketDCWebhookStore()
 token_manager = TokenManager()
 bitbucket_dc_manager = BitbucketDCManager(token_manager)
 automation_event_service = AutomationEventService(token_manager)
 
-BITBUCKET_DC_WEBHOOK_NAME = "OpenHands Resolver"
+BITBUCKET_DC_WEBHOOK_NAME = 'OpenHands Resolver'
 BITBUCKET_DC_WEBHOOK_EVENTS = [
-    "repo:refs_changed",
-    "repo:comment:added",
-    "repo:comment:edited",
-    "repo:comment:deleted",
-    "pr:opened",
-    "pr:from_ref_updated",
-    "pr:modified",
-    "pr:reviewer:approved",
-    "pr:reviewer:unapproved",
-    "pr:reviewer:needs_work",
-    "pr:merged",
-    "pr:declined",
-    "pr:deleted",
-    "pr:comment:added",
-    "pr:comment:edited",
-    "pr:comment:deleted",
+    'repo:refs_changed',
+    'repo:comment:added',
+    'repo:comment:edited',
+    'repo:comment:deleted',
+    'pr:opened',
+    'pr:from_ref_updated',
+    'pr:modified',
+    'pr:reviewer:approved',
+    'pr:reviewer:unapproved',
+    'pr:reviewer:needs_work',
+    'pr:merged',
+    'pr:declined',
+    'pr:deleted',
+    'pr:comment:added',
+    'pr:comment:edited',
+    'pr:comment:deleted',
 ]
-BITBUCKET_DC_LEGACY_WEBHOOK_URL = f"{HOST_URL}/integration/bitbucket-dc/events"
+BITBUCKET_DC_LEGACY_WEBHOOK_URL = f'{HOST_URL}/integration/bitbucket-dc/events'
 BITBUCKET_DC_WEBHOOK_URL = BITBUCKET_DC_LEGACY_WEBHOOK_URL
 
 
 def bitbucket_dc_webhook_url(connection_id: int) -> str:
-    return f"{HOST_URL}/integration/bitbucket-dc/connections/{connection_id}/events"
+    return f'{HOST_URL}/integration/bitbucket-dc/connections/{connection_id}/events'
 
 
 class BitbucketDCResourceIdentifier(BaseModel):
@@ -77,7 +77,7 @@ class BitbucketDCResourceWithWebhookStatus(BaseModel):
     repo_slug: str
     name: str
     full_name: str
-    type: str = "repository"
+    type: str = 'repository'
     connection_id: int | None
     webhook_enrolled: bool
     webhook_id: str | None
@@ -141,7 +141,7 @@ def _normalize_dc_resource(
     if not project_key or not repo_slug:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="project_key and repo_slug are required",
+            detail='project_key and repo_slug are required',
         )
     return project_key, repo_slug
 
@@ -162,7 +162,7 @@ async def _ensure_dc_admin_access(
     if not await bitbucket_dc_service.user_has_admin_access(project_key, repo_slug):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="User does not have admin access to this repository",
+            detail='User does not have admin access to this repository',
         )
 
 
@@ -251,14 +251,14 @@ def _extract_repo_identity(payload_data: dict) -> tuple[str, str]:
     ``pullRequest.toRef.repository``; for repo-level events it lives at
     the top level under ``repository``.
     """
-    pull_request = payload_data.get("pullRequest") or {}
+    pull_request = payload_data.get('pullRequest') or {}
     repository = (
-        (pull_request.get("toRef") or {}).get("repository")
-        or payload_data.get("repository")
+        (pull_request.get('toRef') or {}).get('repository')
+        or payload_data.get('repository')
         or {}
     )
-    project = repository.get("project") or {}
-    return project.get("key") or "", repository.get("slug") or ""
+    project = repository.get('project') or {}
+    return project.get('key') or '', repository.get('slug') or ''
 
 
 def _normalize_bitbucket_dc_event_payload(
@@ -271,9 +271,9 @@ def _normalize_bitbucket_dc_event_payload(
     deliveries, in the JSON payload. Some tests and proxies only preserve the
     header, so normalize the payload before forwarding it internally.
     """
-    if event_key and not payload_data.get("eventKey"):
+    if event_key and not payload_data.get('eventKey'):
         payload_data = dict(payload_data)
-        payload_data["eventKey"] = event_key
+        payload_data['eventKey'] = event_key
     return payload_data
 
 
@@ -281,8 +281,8 @@ async def verify_bitbucket_dc_signature(
     *,
     signature_header: str | None,
     body: bytes,
-    project_key: str = "",
-    repo_slug: str = "",
+    project_key: str = '',
+    repo_slug: str = '',
     webhook_secret: str | None = None,
 ) -> None:
     """Verify ``X-Hub-Signature`` against the per-repository secret.
@@ -296,11 +296,11 @@ async def verify_bitbucket_dc_signature(
     if webhook_secret is None and (not project_key or not repo_slug):
         raise HTTPException(
             status_code=403,
-            detail="Missing repository identity in payload",
+            detail='Missing repository identity in payload',
         )
 
     if IS_LOCAL_DEPLOYMENT:
-        webhook_secret = webhook_secret or "localdeploymentwebhooktesttoken"
+        webhook_secret = webhook_secret or 'localdeploymentwebhooktesttoken'
     elif webhook_secret is None:
         webhook_secret = await webhook_store.get_webhook_secret(
             project_key=project_key, repo_slug=repo_slug
@@ -309,26 +309,26 @@ async def verify_bitbucket_dc_signature(
     if not webhook_secret:
         raise HTTPException(
             status_code=403,
-            detail="No webhook secret found for repository",
+            detail='No webhook secret found for repository',
         )
 
     if IS_LOCAL_DEPLOYMENT and signature_header in (
         None,
-        "localdeploymentwebhooktesttoken",
+        'localdeploymentwebhooktesttoken',
     ):
         return
 
     if not signature_header:
-        raise HTTPException(status_code=403, detail="Missing X-Hub-Signature header")
+        raise HTTPException(status_code=403, detail='Missing X-Hub-Signature header')
 
     expected = (
-        "sha256=" + hmac.new(webhook_secret.encode(), body, hashlib.sha256).hexdigest()
+        'sha256=' + hmac.new(webhook_secret.encode(), body, hashlib.sha256).hexdigest()
     )
     if not hmac.compare_digest(expected, signature_header):
         raise HTTPException(status_code=403, detail="Request signatures didn't match!")
 
 
-@bitbucket_dc_integration_router.get("/bitbucket-dc/resources")
+@bitbucket_dc_integration_router.get('/bitbucket-dc/resources')
 async def get_bitbucket_dc_resources(
     user_id: str = Depends(require_permission(Permission.MANAGE_INTEGRATIONS)),
 ) -> BitbucketDCResourcesResponse:
@@ -336,15 +336,15 @@ async def get_bitbucket_dc_resources(
     try:
         bitbucket_dc_service = SaaSBitbucketDCService(external_auth_id=user_id)
         repositories = await bitbucket_dc_service.get_all_repositories(
-            sort="updated", app_mode=AppMode.SAAS
+            sort='updated', app_mode=AppMode.SAAS
         )
 
         repo_identities: list[tuple[str, str]] = []
         for repo in repositories:
-            parts = repo.full_name.split("/", 1)
+            parts = repo.full_name.split('/', 1)
             if len(parts) != 2:
                 logger.warning(
-                    f"[Bitbucket DC] Skipping repo with unexpected full_name: {repo.full_name}"
+                    f'[Bitbucket DC] Skipping repo with unexpected full_name: {repo.full_name}'
                 )
                 continue
             repo_identities.append((parts[0], parts[1]))
@@ -359,7 +359,7 @@ async def get_bitbucket_dc_resources(
                     project_key=project_key,
                     repo_slug=repo_slug,
                     name=repo_slug,
-                    full_name=f"{project_key}/{repo_slug}",
+                    full_name=f'{project_key}/{repo_slug}',
                     connection_id=webhook.id if webhook else None,
                     webhook_enrolled=bool(webhook and webhook.webhook_secret),
                     webhook_id=webhook.webhook_id if webhook else None,
@@ -381,14 +381,14 @@ async def get_bitbucket_dc_resources(
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception(f"Error retrieving Bitbucket DC resources: {e}")
+        logger.exception(f'Error retrieving Bitbucket DC resources: {e}')
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to retrieve Bitbucket DC resources",
+            detail='Failed to retrieve Bitbucket DC resources',
         )
 
 
-@bitbucket_dc_integration_router.post("/bitbucket-dc/enroll-webhook")
+@bitbucket_dc_integration_router.post('/bitbucket-dc/enroll-webhook')
 async def enroll_bitbucket_dc_webhook(
     body: EnrollBitbucketDCWebhookRequest,
     user_id: str = Depends(require_permission(Permission.MANAGE_INTEGRATIONS)),
@@ -399,7 +399,7 @@ async def enroll_bitbucket_dc_webhook(
     if not project_key or not repo_slug:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="project_key and repo_slug are required",
+            detail='project_key and repo_slug are required',
         )
 
     webhook_secret = secrets.token_urlsafe(32)
@@ -426,14 +426,14 @@ async def enroll_bitbucket_dc_webhook(
         )
 
     except Exception as e:
-        logger.exception(f"Error enrolling Bitbucket DC webhook: {e}")
+        logger.exception(f'Error enrolling Bitbucket DC webhook: {e}')
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to enroll Bitbucket DC webhook",
+            detail='Failed to enroll Bitbucket DC webhook',
         )
 
 
-@bitbucket_dc_integration_router.patch("/bitbucket-dc/webhook-id")
+@bitbucket_dc_integration_router.patch('/bitbucket-dc/webhook-id')
 async def update_bitbucket_dc_webhook_id(
     body: UpdateBitbucketDCWebhookIdRequest,
     user_id: str = Depends(require_permission(Permission.MANAGE_INTEGRATIONS)),
@@ -445,7 +445,7 @@ async def update_bitbucket_dc_webhook_id(
     if not project_key or not repo_slug or not webhook_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="project_key, repo_slug, and webhook_id are required",
+            detail='project_key, repo_slug, and webhook_id are required',
         )
 
     try:
@@ -457,16 +457,16 @@ async def update_bitbucket_dc_webhook_id(
         if not updated:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail="Bitbucket DC webhook enrollment not found",
+                detail='Bitbucket DC webhook enrollment not found',
             )
 
         logger.info(
-            "[Bitbucket DC] Webhook id recorded",
+            '[Bitbucket DC] Webhook id recorded',
             extra={
-                "user_id": user_id,
-                "project_key": project_key,
-                "repo_slug": repo_slug,
-                "webhook_id": webhook_id,
+                'user_id': user_id,
+                'project_key': project_key,
+                'repo_slug': repo_slug,
+                'webhook_id': webhook_id,
             },
         )
         return BitbucketDCWebhookIdUpdateResult(
@@ -479,14 +479,14 @@ async def update_bitbucket_dc_webhook_id(
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception(f"Error updating Bitbucket DC webhook id: {e}")
+        logger.exception(f'Error updating Bitbucket DC webhook id: {e}')
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to update Bitbucket DC webhook id",
+            detail='Failed to update Bitbucket DC webhook id',
         )
 
 
-@bitbucket_dc_integration_router.post("/bitbucket-dc/reinstall-webhook")
+@bitbucket_dc_integration_router.post('/bitbucket-dc/reinstall-webhook')
 async def reinstall_bitbucket_dc_webhook(
     body: BitbucketDCWebhookRequest,
     user_id: str = Depends(require_permission(Permission.MANAGE_INTEGRATIONS)),
@@ -521,7 +521,7 @@ async def reinstall_bitbucket_dc_webhook(
         if not webhook_id:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to install Bitbucket DC webhook",
+                detail='Failed to install Bitbucket DC webhook',
             )
 
         await webhook_store.upsert_webhook_enrollment(
@@ -538,12 +538,12 @@ async def reinstall_bitbucket_dc_webhook(
         # (BBDC's API is the authoritative auth boundary), so the audit
         # trail lives here.
         logger.info(
-            "[Bitbucket DC] Webhook installed",
+            '[Bitbucket DC] Webhook installed',
             extra={
-                "user_id": user_id,
-                "project_key": project_key,
-                "repo_slug": repo_slug,
-                "webhook_id": webhook_id,
+                'user_id': user_id,
+                'project_key': project_key,
+                'repo_slug': repo_slug,
+                'webhook_id': webhook_id,
             },
         )
 
@@ -560,14 +560,14 @@ async def reinstall_bitbucket_dc_webhook(
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception(f"Error installing Bitbucket DC webhook: {e}")
+        logger.exception(f'Error installing Bitbucket DC webhook: {e}')
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to install Bitbucket DC webhook",
+            detail='Failed to install Bitbucket DC webhook',
         )
 
 
-@bitbucket_dc_integration_router.post("/bitbucket-dc/uninstall-webhook")
+@bitbucket_dc_integration_router.post('/bitbucket-dc/uninstall-webhook')
 async def uninstall_bitbucket_dc_webhook(
     body: BitbucketDCWebhookRequest,
     user_id: str = Depends(require_permission(Permission.MANAGE_INTEGRATIONS)),
@@ -591,7 +591,7 @@ async def uninstall_bitbucket_dc_webhook(
             project_key,
             repo_slug,
             [
-                bitbucket_dc_webhook_url(webhook.id) if webhook else "",
+                bitbucket_dc_webhook_url(webhook.id) if webhook else '',
                 BITBUCKET_DC_LEGACY_WEBHOOK_URL,
             ],
         )
@@ -608,8 +608,8 @@ async def uninstall_bitbucket_dc_webhook(
                 )
             except Exception as e:
                 logger.warning(
-                    f"[Bitbucket DC] Stored webhook id {db_id} for "
-                    f"{project_key}/{repo_slug} could not be deleted: {e}"
+                    f'[Bitbucket DC] Stored webhook id {db_id} for '
+                    f'{project_key}/{repo_slug} could not be deleted: {e}'
                 )
 
         await webhook_store.delete_webhook_by_repo(
@@ -618,12 +618,12 @@ async def uninstall_bitbucket_dc_webhook(
         )
 
         logger.info(
-            "[Bitbucket DC] Webhook uninstalled",
+            '[Bitbucket DC] Webhook uninstalled',
             extra={
-                "user_id": user_id,
-                "project_key": project_key,
-                "repo_slug": repo_slug,
-                "webhook_id": webhook_id,
+                'user_id': user_id,
+                'project_key': project_key,
+                'repo_slug': repo_slug,
+                'webhook_id': webhook_id,
             },
         )
 
@@ -640,10 +640,10 @@ async def uninstall_bitbucket_dc_webhook(
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception(f"Error uninstalling Bitbucket DC webhook: {e}")
+        logger.exception(f'Error uninstalling Bitbucket DC webhook: {e}')
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to uninstall Bitbucket DC webhook",
+            detail='Failed to uninstall Bitbucket DC webhook',
         )
 
 
@@ -662,10 +662,10 @@ async def _handle_bitbucket_dc_event(
         # DC sends a ``diagnostics:ping`` event when the admin clicks the
         # "Test connection" button on the webhook configuration page; it
         # carries no repository payload, so accept it as a no-op.
-        if x_event_key == "diagnostics:ping":
+        if x_event_key == 'diagnostics:ping':
             return JSONResponse(
                 status_code=200,
-                content={"message": "Bitbucket DC ping acknowledged."},
+                content={'message': 'Bitbucket DC ping acknowledged.'},
             )
 
         payload_data = _normalize_bitbucket_dc_event_payload(payload_data, x_event_key)
@@ -677,7 +677,7 @@ async def _handle_bitbucket_dc_event(
             if not webhook:
                 raise HTTPException(
                     status_code=403,
-                    detail="No webhook found for connection",
+                    detail='No webhook found for connection',
                 )
             if (
                 project_key
@@ -688,7 +688,7 @@ async def _handle_bitbucket_dc_event(
             ):
                 raise HTTPException(
                     status_code=403,
-                    detail="Webhook connection does not match payload repository",
+                    detail='Webhook connection does not match payload repository',
                 )
             project_key = project_key or webhook.project_key
             repo_slug = repo_slug or webhook.repo_slug
@@ -706,25 +706,25 @@ async def _handle_bitbucket_dc_event(
                 repo_slug=repo_slug,
             )
 
-        pr_id = (payload_data.get("pullRequest") or {}).get("id")
-        comment_id = (payload_data.get("comment") or {}).get("id")
+        pr_id = (payload_data.get('pullRequest') or {}).get('id')
+        comment_id = (payload_data.get('comment') or {}).get('id')
 
         if x_request_id:
-            dedup_key = f"bbdc:{x_event_key}:{pr_id}:{comment_id}:{x_request_id}"
+            dedup_key = f'bbdc:{x_event_key}:{pr_id}:{comment_id}:{x_request_id}'
         else:
             dedup_hash = hashlib.sha256(body).hexdigest()
-            dedup_key = f"bbdc:msg:{dedup_hash}"
+            dedup_key = f'bbdc:msg:{dedup_hash}'
 
         redis = get_redis_client_async()
         created = await redis.set(dedup_key, 1, nx=True, ex=60)
         if not created:
-            logger.info("bitbucket_dc_is_duplicate")
+            logger.info('bitbucket_dc_is_duplicate')
             return JSONResponse(
                 status_code=200,
-                content={"message": "Duplicate Bitbucket DC event ignored."},
+                content={'message': 'Duplicate Bitbucket DC event ignored.'},
             )
 
-        installation_id = f"{project_key}/{repo_slug}"
+        installation_id = f'{project_key}/{repo_slug}'
         if AUTOMATION_EVENT_FORWARDING_ENABLED:
             background_tasks.add_task(
                 automation_event_service.forward_event,
@@ -736,11 +736,11 @@ async def _handle_bitbucket_dc_event(
         message = Message(
             source=SourceType.BITBUCKET_DATA_CENTER,
             message={
-                "payload": payload_data,
-                "event_key": x_event_key,
-                "installation_id": installation_id,
-                "connection_id": connection_id,
-                "installer_user_id": installer_user_id,
+                'payload': payload_data,
+                'event_key': x_event_key,
+                'installation_id': installation_id,
+                'connection_id': connection_id,
+                'installer_user_id': installer_user_id,
             },
         )
         await bitbucket_dc_manager.receive_message(message)
@@ -748,25 +748,25 @@ async def _handle_bitbucket_dc_event(
         return JSONResponse(
             status_code=200,
             content={
-                "message": "Bitbucket DC events endpoint reached successfully.",
+                'message': 'Bitbucket DC events endpoint reached successfully.',
             },
         )
 
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception(f"Error processing Bitbucket DC event: {e}")
+        logger.exception(f'Error processing Bitbucket DC event: {e}')
         # Surface the exception class name so admins reading DC's webhook
         # delivery UI can correlate with server logs without leaking a full
         # message (which may contain sensitive payload fragments).
         return JSONResponse(
             status_code=400,
-            content={"error": "Invalid payload.", "error_type": type(e).__name__},
+            content={'error': 'Invalid payload.', 'error_type': type(e).__name__},
         )
 
 
 @bitbucket_dc_integration_router.post(
-    "/bitbucket-dc/connections/{connection_id}/events"
+    '/bitbucket-dc/connections/{connection_id}/events'
 )
 async def bitbucket_dc_connection_events(
     connection_id: int,
@@ -786,7 +786,7 @@ async def bitbucket_dc_connection_events(
     )
 
 
-@bitbucket_dc_integration_router.post("/bitbucket-dc/events")
+@bitbucket_dc_integration_router.post('/bitbucket-dc/events')
 async def bitbucket_dc_events(
     request: Request,
     background_tasks: BackgroundTasks,

--- a/enterprise/server/routes/integration/bitbucket_dc.py
+++ b/enterprise/server/routes/integration/bitbucket_dc.py
@@ -59,8 +59,6 @@ BITBUCKET_DC_WEBHOOK_EVENTS = [
     'pr:comment:edited',
     'pr:comment:deleted',
 ]
-BITBUCKET_DC_LEGACY_WEBHOOK_URL = f'{HOST_URL}/integration/bitbucket-dc/events'
-BITBUCKET_DC_WEBHOOK_URL = BITBUCKET_DC_LEGACY_WEBHOOK_URL
 
 
 def bitbucket_dc_webhook_url(connection_id: int) -> str:
@@ -197,23 +195,6 @@ async def _get_or_create_dc_webhook(
             events=BITBUCKET_DC_WEBHOOK_EVENTS,
         )
 
-    (
-        legacy_webhook_exists,
-        legacy_webhook_id,
-    ) = await bitbucket_dc_service.check_webhook_exists_on_repository(
-        project_key, repo_slug, BITBUCKET_DC_LEGACY_WEBHOOK_URL
-    )
-    if legacy_webhook_exists and legacy_webhook_id:
-        return await bitbucket_dc_service.update_repository_webhook(
-            owner=project_key,
-            repo_slug=repo_slug,
-            webhook_id=legacy_webhook_id,
-            name=BITBUCKET_DC_WEBHOOK_NAME,
-            webhook_url=webhook_url,
-            webhook_secret=webhook_secret,
-            events=BITBUCKET_DC_WEBHOOK_EVENTS,
-        )
-
     return await bitbucket_dc_service.create_repository_webhook(
         owner=project_key,
         repo_slug=repo_slug,
@@ -228,19 +209,18 @@ async def _find_existing_dc_webhook_id(
     bitbucket_dc_service: SaaSBitbucketDCService,
     project_key: str,
     repo_slug: str,
-    webhook_urls: list[str],
+    webhook_url: str,
 ) -> str | None:
-    for webhook_url in webhook_urls:
-        if not webhook_url:
-            continue
-        (
-            webhook_exists,
-            webhook_id,
-        ) = await bitbucket_dc_service.check_webhook_exists_on_repository(
-            project_key, repo_slug, webhook_url
-        )
-        if webhook_exists and webhook_id:
-            return webhook_id
+    if not webhook_url:
+        return None
+    (
+        webhook_exists,
+        webhook_id,
+    ) = await bitbucket_dc_service.check_webhook_exists_on_repository(
+        project_key, repo_slug, webhook_url
+    )
+    if webhook_exists and webhook_id:
+        return webhook_id
     return None
 
 
@@ -281,35 +261,21 @@ async def verify_bitbucket_dc_signature(
     *,
     signature_header: str | None,
     body: bytes,
-    project_key: str = '',
-    repo_slug: str = '',
     webhook_secret: str | None = None,
 ) -> None:
-    """Verify ``X-Hub-Signature`` against the per-repository secret.
+    """Verify ``X-Hub-Signature`` against the connection-scoped secret.
 
     Bitbucket Data Center signs each webhook delivery with HMAC-SHA256 of
     the request body using the secret configured on the repository's
-    webhook. The header has the form ``sha256=<hex>``. There is no
-    per-installation UUID header on DC, so we look up the secret by the
-    ``(project_key, repo_slug)`` carried in the payload.
+    webhook. The header has the form ``sha256=<hex>``.
     """
-    if webhook_secret is None and (not project_key or not repo_slug):
-        raise HTTPException(
-            status_code=403,
-            detail='Missing repository identity in payload',
-        )
-
     if IS_LOCAL_DEPLOYMENT:
         webhook_secret = webhook_secret or 'localdeploymentwebhooktesttoken'
-    elif webhook_secret is None:
-        webhook_secret = await webhook_store.get_webhook_secret(
-            project_key=project_key, repo_slug=repo_slug
-        )
 
     if not webhook_secret:
         raise HTTPException(
             status_code=403,
-            detail='No webhook secret found for repository',
+            detail='No webhook secret found for connection',
         )
 
     if IS_LOCAL_DEPLOYMENT and signature_header in (
@@ -590,10 +556,7 @@ async def uninstall_bitbucket_dc_webhook(
             bitbucket_dc_service,
             project_key,
             repo_slug,
-            [
-                bitbucket_dc_webhook_url(webhook.id) if webhook else '',
-                BITBUCKET_DC_LEGACY_WEBHOOK_URL,
-            ],
+            bitbucket_dc_webhook_url(webhook.id) if webhook else '',
         )
         db_id = webhook.webhook_id if webhook else None
         webhook_id = provider_id or db_id
@@ -653,7 +616,7 @@ async def _handle_bitbucket_dc_event(
     x_hub_signature: str | None,
     x_event_key: str | None,
     x_request_id: str | None,
-    connection_id: int | None = None,
+    connection_id: int,
 ):
     try:
         body = await request.body()
@@ -671,40 +634,29 @@ async def _handle_bitbucket_dc_event(
         payload_data = _normalize_bitbucket_dc_event_payload(payload_data, x_event_key)
 
         project_key, repo_slug = _extract_repo_identity(payload_data)
-        installer_user_id: str | None = None
-        if connection_id is not None:
-            webhook = await webhook_store.get_webhook_by_id(connection_id)
-            if not webhook:
-                raise HTTPException(
-                    status_code=403,
-                    detail='No webhook found for connection',
-                )
-            if (
-                project_key
-                and repo_slug
-                and (
-                    webhook.project_key != project_key or webhook.repo_slug != repo_slug
-                )
-            ):
-                raise HTTPException(
-                    status_code=403,
-                    detail='Webhook connection does not match payload repository',
-                )
-            project_key = project_key or webhook.project_key
-            repo_slug = repo_slug or webhook.repo_slug
-            installer_user_id = webhook.user_id
-            await verify_bitbucket_dc_signature(
-                signature_header=x_hub_signature,
-                body=body,
-                webhook_secret=webhook.webhook_secret,
+        webhook = await webhook_store.get_webhook_by_id(connection_id)
+        if not webhook:
+            raise HTTPException(
+                status_code=403,
+                detail='No webhook found for connection',
             )
-        else:
-            await verify_bitbucket_dc_signature(
-                signature_header=x_hub_signature,
-                body=body,
-                project_key=project_key,
-                repo_slug=repo_slug,
+        if (
+            project_key
+            and repo_slug
+            and (webhook.project_key != project_key or webhook.repo_slug != repo_slug)
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail='Webhook connection does not match payload repository',
             )
+        project_key = project_key or webhook.project_key
+        repo_slug = repo_slug or webhook.repo_slug
+        installer_user_id: str | None = webhook.user_id
+        await verify_bitbucket_dc_signature(
+            signature_header=x_hub_signature,
+            body=body,
+            webhook_secret=webhook.webhook_secret,
+        )
 
         pr_id = (payload_data.get('pullRequest') or {}).get('id')
         comment_id = (payload_data.get('comment') or {}).get('id')
@@ -783,21 +735,4 @@ async def bitbucket_dc_connection_events(
         x_event_key=x_event_key,
         x_request_id=x_request_id,
         connection_id=connection_id,
-    )
-
-
-@bitbucket_dc_integration_router.post('/bitbucket-dc/events')
-async def bitbucket_dc_events(
-    request: Request,
-    background_tasks: BackgroundTasks,
-    x_hub_signature: str | None = Header(None),
-    x_event_key: str | None = Header(None),
-    x_request_id: str | None = Header(None),
-):
-    return await _handle_bitbucket_dc_event(
-        request=request,
-        background_tasks=background_tasks,
-        x_hub_signature=x_hub_signature,
-        x_event_key=x_event_key,
-        x_request_id=x_request_id,
     )

--- a/enterprise/storage/bitbucket_dc_webhook_store.py
+++ b/enterprise/storage/bitbucket_dc_webhook_store.py
@@ -32,6 +32,16 @@ class BitbucketDCWebhookStore:
             webhook = result.scalars().first()
             return webhook.webhook_secret if webhook else None
 
+    async def get_webhook_by_id(self, webhook_id: int) -> BitbucketDCWebhook | None:
+        async with a_session_maker() as session:
+            query = (
+                select(BitbucketDCWebhook)
+                .where(BitbucketDCWebhook.id == webhook_id)
+                .limit(1)
+            )
+            result = await session.execute(query)
+            return result.scalars().first()
+
     async def get_webhook_user_id(self, project_key: str, repo_slug: str) -> str | None:
         async with a_session_maker() as session:
             query = (
@@ -44,6 +54,45 @@ class BitbucketDCWebhookStore:
             )
             result = await session.execute(query)
             return result.scalar_one_or_none()
+
+    async def ensure_webhook_enrollment(
+        self,
+        *,
+        project_key: str,
+        repo_slug: str,
+        user_id: str,
+    ) -> BitbucketDCWebhook:
+        """Ensure a local row exists so its id can be used in webhook URLs.
+
+        This intentionally does not rotate an existing secret. Automatic
+        reinstall first needs a stable row id to build the provider webhook URL;
+        the active secret is updated only after the Bitbucket-side write
+        succeeds.
+        """
+        async with a_session_maker() as session:
+            async with session.begin():
+                query = (
+                    select(BitbucketDCWebhook)
+                    .where(
+                        BitbucketDCWebhook.project_key == project_key,
+                        BitbucketDCWebhook.repo_slug == repo_slug,
+                    )
+                    .limit(1)
+                )
+                result = await session.execute(query)
+                webhook = result.scalars().first()
+
+                if not webhook:
+                    webhook = BitbucketDCWebhook(
+                        project_key=project_key,
+                        repo_slug=repo_slug,
+                        user_id=user_id,
+                        webhook_secret=None,
+                    )
+                    session.add(webhook)
+
+            await session.refresh(webhook)
+            return webhook
 
     async def get_webhook_by_repo(
         self, project_key: str, repo_slug: str

--- a/enterprise/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_webhook.py
+++ b/enterprise/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_webhook.py
@@ -20,8 +20,8 @@ from server.routes.integration.bitbucket_dc import (
 from openhands.app_server.integrations.service_types import ProviderType, Repository
 
 
-def _signed(body: bytes, secret: str = "shared-secret") -> str:
-    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+def _signed(body: bytes, secret: str = 'shared-secret') -> str:
+    return 'sha256=' + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
 
 def _request_with_body(body: bytes) -> MagicMock:
@@ -33,50 +33,50 @@ def _request_with_body(body: bytes) -> MagicMock:
 def _pr_comment_body() -> bytes:
     return json.dumps(
         {
-            "pullRequest": {
-                "id": 1,
-                "toRef": {
-                    "repository": {
-                        "slug": "myrepo",
-                        "project": {"key": "PROJ"},
+            'pullRequest': {
+                'id': 1,
+                'toRef': {
+                    'repository': {
+                        'slug': 'myrepo',
+                        'project': {'key': 'PROJ'},
                     }
                 },
             },
-            "comment": {"id": 99, "text": "Hey @openhands"},
+            'comment': {'id': 99, 'text': 'Hey @openhands'},
         }
     ).encode()
 
 
 def test_bitbucket_dc_webhook_events_cover_automation_sources():
     assert {
-        "repo:refs_changed",
-        "repo:comment:added",
-        "repo:comment:edited",
-        "repo:comment:deleted",
-        "pr:opened",
-        "pr:from_ref_updated",
-        "pr:modified",
-        "pr:reviewer:approved",
-        "pr:reviewer:unapproved",
-        "pr:reviewer:needs_work",
-        "pr:merged",
-        "pr:declined",
-        "pr:deleted",
-        "pr:comment:added",
-        "pr:comment:edited",
-        "pr:comment:deleted",
+        'repo:refs_changed',
+        'repo:comment:added',
+        'repo:comment:edited',
+        'repo:comment:deleted',
+        'pr:opened',
+        'pr:from_ref_updated',
+        'pr:modified',
+        'pr:reviewer:approved',
+        'pr:reviewer:unapproved',
+        'pr:reviewer:needs_work',
+        'pr:merged',
+        'pr:declined',
+        'pr:deleted',
+        'pr:comment:added',
+        'pr:comment:edited',
+        'pr:comment:deleted',
     }.issubset(set(BITBUCKET_DC_WEBHOOK_EVENTS))
 
 
 @pytest.mark.asyncio
-@patch("server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT", False)
-@patch("server.routes.integration.bitbucket_dc.webhook_store")
-@patch("server.routes.integration.bitbucket_dc.bitbucket_dc_manager")
-@patch("server.routes.integration.bitbucket_dc.get_redis_client_async")
+@patch('server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT', False)
+@patch('server.routes.integration.bitbucket_dc.webhook_store')
+@patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
+@patch('server.routes.integration.bitbucket_dc.get_redis_client_async')
 async def test_signature_verification_rejects_bad_signature_with_403(
     mock_get_redis_client_async, mock_manager, mock_store
 ):
-    mock_store.get_webhook_secret = AsyncMock(return_value="shared-secret")
+    mock_store.get_webhook_secret = AsyncMock(return_value='shared-secret')
     mock_manager.receive_message = AsyncMock()
     mock_get_redis_client_async.return_value = AsyncMock()
 
@@ -86,9 +86,9 @@ async def test_signature_verification_rejects_bad_signature_with_403(
         await bitbucket_dc_events(
             request=_request_with_body(body),
             background_tasks=MagicMock(),
-            x_hub_signature="sha256=deadbeef",
-            x_event_key="pr:comment:added",
-            x_request_id="req-1",
+            x_hub_signature='sha256=deadbeef',
+            x_event_key='pr:comment:added',
+            x_request_id='req-1',
         )
 
     assert exc.value.status_code == 403
@@ -96,26 +96,26 @@ async def test_signature_verification_rejects_bad_signature_with_403(
 
 
 @pytest.mark.asyncio
-@patch("server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT", False)
-@patch("server.routes.integration.bitbucket_dc.webhook_store")
-@patch("server.routes.integration.bitbucket_dc.bitbucket_dc_manager")
-@patch("server.routes.integration.bitbucket_dc.get_redis_client_async")
+@patch('server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT', False)
+@patch('server.routes.integration.bitbucket_dc.webhook_store')
+@patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
+@patch('server.routes.integration.bitbucket_dc.get_redis_client_async')
 async def test_missing_repo_identity_rejected_with_403(
     mock_get_redis_client_async, mock_manager, mock_store
 ):
-    mock_store.get_webhook_secret = AsyncMock(return_value="shared-secret")
+    mock_store.get_webhook_secret = AsyncMock(return_value='shared-secret')
     mock_manager.receive_message = AsyncMock()
     mock_get_redis_client_async.return_value = AsyncMock()
 
-    body = json.dumps({"pullRequest": {"id": 1}}).encode()
+    body = json.dumps({'pullRequest': {'id': 1}}).encode()
 
     with pytest.raises(HTTPException) as exc:
         await bitbucket_dc_events(
             request=_request_with_body(body),
             background_tasks=MagicMock(),
             x_hub_signature=_signed(body),
-            x_event_key="pr:comment:added",
-            x_request_id="req-1",
+            x_event_key='pr:comment:added',
+            x_request_id='req-1',
         )
 
     assert exc.value.status_code == 403
@@ -123,14 +123,14 @@ async def test_missing_repo_identity_rejected_with_403(
 
 
 @pytest.mark.asyncio
-@patch("server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT", False)
-@patch("server.routes.integration.bitbucket_dc.webhook_store")
-@patch("server.routes.integration.bitbucket_dc.bitbucket_dc_manager")
-@patch("server.routes.integration.bitbucket_dc.get_redis_client_async")
+@patch('server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT', False)
+@patch('server.routes.integration.bitbucket_dc.webhook_store')
+@patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
+@patch('server.routes.integration.bitbucket_dc.get_redis_client_async')
 async def test_duplicate_event_returns_200_and_skips_dispatch(
     mock_get_redis_client_async, mock_manager, mock_store
 ):
-    mock_store.get_webhook_secret = AsyncMock(return_value="shared-secret")
+    mock_store.get_webhook_secret = AsyncMock(return_value='shared-secret')
     mock_manager.receive_message = AsyncMock()
     redis = AsyncMock()
     redis.set = AsyncMock(return_value=False)  # duplicate
@@ -142,24 +142,24 @@ async def test_duplicate_event_returns_200_and_skips_dispatch(
         request=_request_with_body(body),
         background_tasks=MagicMock(),
         x_hub_signature=_signed(body),
-        x_event_key="pr:comment:added",
-        x_request_id="req-1",
+        x_event_key='pr:comment:added',
+        x_request_id='req-1',
     )
 
     mock_manager.receive_message.assert_not_called()
     assert response.status_code == 200
-    assert json.loads(response.body)["message"].startswith("Duplicate")
+    assert json.loads(response.body)['message'].startswith('Duplicate')
 
 
 @pytest.mark.asyncio
-@patch("server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT", False)
-@patch("server.routes.integration.bitbucket_dc.webhook_store")
-@patch("server.routes.integration.bitbucket_dc.bitbucket_dc_manager")
-@patch("server.routes.integration.bitbucket_dc.get_redis_client_async")
+@patch('server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT', False)
+@patch('server.routes.integration.bitbucket_dc.webhook_store')
+@patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
+@patch('server.routes.integration.bitbucket_dc.get_redis_client_async')
 async def test_valid_pr_comment_event_dispatches_to_manager_and_returns_200(
     mock_get_redis_client_async, mock_manager, mock_store
 ):
-    mock_store.get_webhook_secret = AsyncMock(return_value="shared-secret")
+    mock_store.get_webhook_secret = AsyncMock(return_value='shared-secret')
     mock_manager.receive_message = AsyncMock()
     redis = AsyncMock()
     redis.set = AsyncMock(return_value=True)
@@ -171,31 +171,31 @@ async def test_valid_pr_comment_event_dispatches_to_manager_and_returns_200(
         request=_request_with_body(body),
         background_tasks=MagicMock(),
         x_hub_signature=_signed(body),
-        x_event_key="pr:comment:added",
-        x_request_id="req-1",
+        x_event_key='pr:comment:added',
+        x_request_id='req-1',
     )
 
     mock_manager.receive_message.assert_awaited_once()
     dispatched = mock_manager.receive_message.call_args.args[0]
-    assert dispatched.source.value == "bitbucket_data_center"
-    assert dispatched.message["event_key"] == "pr:comment:added"
-    assert dispatched.message["installation_id"] == "PROJ/myrepo"
+    assert dispatched.source.value == 'bitbucket_data_center'
+    assert dispatched.message['event_key'] == 'pr:comment:added'
+    assert dispatched.message['installation_id'] == 'PROJ/myrepo'
     assert response.status_code == 200
 
 
 @pytest.mark.asyncio
-@patch("server.routes.integration.bitbucket_dc.automation_event_service")
-@patch("server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT", False)
-@patch("server.routes.integration.bitbucket_dc.webhook_store")
-@patch("server.routes.integration.bitbucket_dc.bitbucket_dc_manager")
-@patch("server.routes.integration.bitbucket_dc.get_redis_client_async")
+@patch('server.routes.integration.bitbucket_dc.automation_event_service')
+@patch('server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT', False)
+@patch('server.routes.integration.bitbucket_dc.webhook_store')
+@patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
+@patch('server.routes.integration.bitbucket_dc.get_redis_client_async')
 async def test_valid_event_forwards_to_automations_when_enabled(
     mock_get_redis_client_async,
     mock_manager,
     mock_store,
     mock_automation_service,
 ):
-    mock_store.get_webhook_secret = AsyncMock(return_value="shared-secret")
+    mock_store.get_webhook_secret = AsyncMock(return_value='shared-secret')
     mock_manager.receive_message = AsyncMock()
     redis = AsyncMock()
     redis.set = AsyncMock(return_value=True)
@@ -205,15 +205,15 @@ async def test_valid_event_forwards_to_automations_when_enabled(
     background_tasks = MagicMock()
 
     with patch(
-        "server.routes.integration.bitbucket_dc.AUTOMATION_EVENT_FORWARDING_ENABLED",
+        'server.routes.integration.bitbucket_dc.AUTOMATION_EVENT_FORWARDING_ENABLED',
         True,
     ):
         response = await bitbucket_dc_events(
             request=_request_with_body(body),
             background_tasks=background_tasks,
             x_hub_signature=_signed(body),
-            x_event_key="pr:opened",
-            x_request_id="req-1",
+            x_event_key='pr:opened',
+            x_request_id='req-1',
         )
 
     assert response.status_code == 200
@@ -222,24 +222,24 @@ async def test_valid_event_forwards_to_automations_when_enabled(
         provider=ProviderType.BITBUCKET_DATA_CENTER,
         payload={
             **json.loads(body),
-            "eventKey": "pr:opened",
+            'eventKey': 'pr:opened',
         },
-        installation_id="PROJ/myrepo",
+        installation_id='PROJ/myrepo',
     )
     mock_manager.receive_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-@patch("server.routes.integration.bitbucket_dc.bitbucket_dc_manager")
+@patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
 async def test_diagnostics_ping_returns_200_without_dispatch(mock_manager):
     mock_manager.receive_message = AsyncMock()
 
     response = await bitbucket_dc_events(
-        request=_request_with_body(b"{}"),
+        request=_request_with_body(b'{}'),
         background_tasks=MagicMock(),
         x_hub_signature=None,
-        x_event_key="diagnostics:ping",
-        x_request_id="ping-1",
+        x_event_key='diagnostics:ping',
+        x_request_id='ping-1',
     )
 
     mock_manager.receive_message.assert_not_called()
@@ -247,8 +247,8 @@ async def test_diagnostics_ping_returns_200_without_dispatch(mock_manager):
 
 
 @pytest.mark.asyncio
-@patch("server.routes.integration.bitbucket_dc.webhook_store")
-@patch("server.routes.integration.bitbucket_dc.SaaSBitbucketDCService")
+@patch('server.routes.integration.bitbucket_dc.webhook_store')
+@patch('server.routes.integration.bitbucket_dc.SaaSBitbucketDCService')
 async def test_get_bitbucket_dc_resources_returns_repo_enrollment_status(
     mock_service_cls, mock_store
 ):
@@ -256,8 +256,8 @@ async def test_get_bitbucket_dc_resources_returns_repo_enrollment_status(
     service.get_all_repositories = AsyncMock(
         return_value=[
             Repository(
-                id="1",
-                full_name="PROJ/myrepo",
+                id='1',
+                full_name='PROJ/myrepo',
                 git_provider=ProviderType.BITBUCKET_DATA_CENTER,
                 is_public=False,
             )
@@ -266,37 +266,37 @@ async def test_get_bitbucket_dc_resources_returns_repo_enrollment_status(
     mock_service_cls.return_value = service
 
     webhook = MagicMock()
-    webhook.project_key = "PROJ"
-    webhook.repo_slug = "myrepo"
-    webhook.webhook_secret = "shared-secret"
-    webhook.webhook_id = "42"
+    webhook.project_key = 'PROJ'
+    webhook.repo_slug = 'myrepo'
+    webhook.webhook_secret = 'shared-secret'
+    webhook.webhook_id = '42'
     webhook.id = 7
-    webhook.user_id = "kc-installer"
+    webhook.user_id = 'kc-installer'
     webhook.last_synced = None
     mock_store.get_webhooks_by_repos = AsyncMock(
-        return_value={("PROJ", "myrepo"): webhook}
+        return_value={('PROJ', 'myrepo'): webhook}
     )
 
-    response = await get_bitbucket_dc_resources(user_id="kc-viewer")
+    response = await get_bitbucket_dc_resources(user_id='kc-viewer')
 
-    mock_service_cls.assert_called_once_with(external_auth_id="kc-viewer")
-    mock_store.get_webhooks_by_repos.assert_awaited_once_with([("PROJ", "myrepo")])
+    mock_service_cls.assert_called_once_with(external_auth_id='kc-viewer')
+    mock_store.get_webhooks_by_repos.assert_awaited_once_with([('PROJ', 'myrepo')])
     assert len(response.resources) == 1
     resource = response.resources[0]
-    assert resource.project_key == "PROJ"
-    assert resource.repo_slug == "myrepo"
+    assert resource.project_key == 'PROJ'
+    assert resource.repo_slug == 'myrepo'
     assert resource.connection_id == 7
     assert resource.webhook_enrolled is True
-    assert resource.webhook_id == "42"
+    assert resource.webhook_id == '42'
     assert resource.webhook_url.endswith(
-        "/integration/bitbucket-dc/connections/7/events"
+        '/integration/bitbucket-dc/connections/7/events'
     )
-    assert resource.installed_by_user_id == "kc-installer"
+    assert resource.installed_by_user_id == 'kc-installer'
 
 
 @pytest.mark.asyncio
-@patch("server.routes.integration.bitbucket_dc.secrets.token_urlsafe")
-@patch("server.routes.integration.bitbucket_dc.webhook_store")
+@patch('server.routes.integration.bitbucket_dc.secrets.token_urlsafe')
+@patch('server.routes.integration.bitbucket_dc.webhook_store')
 async def test_enroll_bitbucket_dc_webhook_generates_secret_and_stores_row(
     mock_store, mock_token_urlsafe
 ):
@@ -305,7 +305,7 @@ async def test_enroll_bitbucket_dc_webhook_generates_secret_and_stores_row(
         EnrollBitbucketDCWebhookRequest,
     )
 
-    mock_token_urlsafe.return_value = "generated-secret"
+    mock_token_urlsafe.return_value = 'generated-secret'
     webhook = MagicMock()
     webhook.id = 123
     mock_store.upsert_webhook_enrollment = AsyncMock(return_value=webhook)
@@ -313,32 +313,32 @@ async def test_enroll_bitbucket_dc_webhook_generates_secret_and_stores_row(
     response = await enroll_bitbucket_dc_webhook(
         body=EnrollBitbucketDCWebhookRequest(
             resource=BitbucketDCResourceIdentifier(
-                project_key="PROJ",
-                repo_slug="myrepo",
+                project_key='PROJ',
+                repo_slug='myrepo',
             )
         ),
-        user_id="kc-installer",
+        user_id='kc-installer',
     )
 
     mock_store.upsert_webhook_enrollment.assert_awaited_once_with(
-        project_key="PROJ",
-        repo_slug="myrepo",
-        user_id="kc-installer",
-        webhook_secret="generated-secret",
+        project_key='PROJ',
+        repo_slug='myrepo',
+        user_id='kc-installer',
+        webhook_secret='generated-secret',
     )
     assert response.success is True
     assert response.connection_id == 123
-    assert response.webhook_secret == "generated-secret"
+    assert response.webhook_secret == 'generated-secret'
     assert response.webhook_url.endswith(
-        "/integration/bitbucket-dc/connections/123/events"
+        '/integration/bitbucket-dc/connections/123/events'
     )
     assert response.events == BITBUCKET_DC_WEBHOOK_EVENTS
 
 
 @pytest.mark.asyncio
-@patch("server.routes.integration.bitbucket_dc.secrets.token_urlsafe")
-@patch("server.routes.integration.bitbucket_dc.webhook_store")
-@patch("server.routes.integration.bitbucket_dc.SaaSBitbucketDCService")
+@patch('server.routes.integration.bitbucket_dc.secrets.token_urlsafe')
+@patch('server.routes.integration.bitbucket_dc.webhook_store')
+@patch('server.routes.integration.bitbucket_dc.SaaSBitbucketDCService')
 async def test_reinstall_bitbucket_dc_webhook_installs_connection_scoped_url(
     mock_service_cls, mock_store, mock_token_urlsafe
 ):
@@ -347,7 +347,7 @@ async def test_reinstall_bitbucket_dc_webhook_installs_connection_scoped_url(
         BitbucketDCWebhookRequest,
     )
 
-    mock_token_urlsafe.return_value = "generated-secret"
+    mock_token_urlsafe.return_value = 'generated-secret'
     webhook = MagicMock()
     webhook.id = 123
     mock_store.ensure_webhook_enrollment = AsyncMock(return_value=webhook)
@@ -358,58 +358,58 @@ async def test_reinstall_bitbucket_dc_webhook_installs_connection_scoped_url(
     service.check_webhook_exists_on_repository = AsyncMock(
         side_effect=[(False, None), (False, None)]
     )
-    service.create_repository_webhook = AsyncMock(return_value="101")
+    service.create_repository_webhook = AsyncMock(return_value='101')
     mock_service_cls.return_value = service
 
     response = await reinstall_bitbucket_dc_webhook(
         body=BitbucketDCWebhookRequest(
             resource=BitbucketDCResourceIdentifier(
-                project_key="PROJ",
-                repo_slug="myrepo",
+                project_key='PROJ',
+                repo_slug='myrepo',
             )
         ),
-        user_id="kc-installer",
+        user_id='kc-installer',
     )
 
     mock_store.ensure_webhook_enrollment.assert_awaited_once_with(
-        project_key="PROJ",
-        repo_slug="myrepo",
-        user_id="kc-installer",
+        project_key='PROJ',
+        repo_slug='myrepo',
+        user_id='kc-installer',
     )
     service.create_repository_webhook.assert_awaited_once()
     create_kwargs = service.create_repository_webhook.await_args.kwargs
-    assert create_kwargs["webhook_url"].endswith(
-        "/integration/bitbucket-dc/connections/123/events"
+    assert create_kwargs['webhook_url'].endswith(
+        '/integration/bitbucket-dc/connections/123/events'
     )
     mock_store.upsert_webhook_enrollment.assert_awaited_once_with(
-        project_key="PROJ",
-        repo_slug="myrepo",
-        user_id="kc-installer",
-        webhook_id="101",
-        webhook_secret="generated-secret",
+        project_key='PROJ',
+        repo_slug='myrepo',
+        user_id='kc-installer',
+        webhook_id='101',
+        webhook_secret='generated-secret',
     )
     assert response.success is True
-    assert response.webhook_id == "101"
+    assert response.webhook_id == '101'
     assert response.connection_id == 123
     assert response.webhook_url.endswith(
-        "/integration/bitbucket-dc/connections/123/events"
+        '/integration/bitbucket-dc/connections/123/events'
     )
 
 
 @pytest.mark.asyncio
-@patch("server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT", False)
-@patch("server.routes.integration.bitbucket_dc.webhook_store")
-@patch("server.routes.integration.bitbucket_dc.bitbucket_dc_manager")
-@patch("server.routes.integration.bitbucket_dc.get_redis_client_async")
+@patch('server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT', False)
+@patch('server.routes.integration.bitbucket_dc.webhook_store')
+@patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
+@patch('server.routes.integration.bitbucket_dc.get_redis_client_async')
 async def test_connection_event_verifies_with_connection_secret_and_dispatches_installer(
     mock_get_redis_client_async, mock_manager, mock_store
 ):
     webhook = MagicMock()
     webhook.id = 123
-    webhook.project_key = "PROJ"
-    webhook.repo_slug = "myrepo"
-    webhook.webhook_secret = "shared-secret"
-    webhook.user_id = "kc-installer"
+    webhook.project_key = 'PROJ'
+    webhook.repo_slug = 'myrepo'
+    webhook.webhook_secret = 'shared-secret'
+    webhook.user_id = 'kc-installer'
     mock_store.get_webhook_by_id = AsyncMock(return_value=webhook)
     mock_manager.receive_message = AsyncMock()
     redis = AsyncMock()
@@ -423,33 +423,33 @@ async def test_connection_event_verifies_with_connection_secret_and_dispatches_i
         request=_request_with_body(body),
         background_tasks=MagicMock(),
         x_hub_signature=_signed(body),
-        x_event_key="pr:comment:added",
-        x_request_id="req-1",
+        x_event_key='pr:comment:added',
+        x_request_id='req-1',
     )
 
     mock_store.get_webhook_by_id.assert_awaited_once_with(123)
     mock_manager.receive_message.assert_awaited_once()
     dispatched = mock_manager.receive_message.call_args.args[0]
-    assert dispatched.message["connection_id"] == 123
-    assert dispatched.message["installer_user_id"] == "kc-installer"
-    assert dispatched.message["installation_id"] == "PROJ/myrepo"
+    assert dispatched.message['connection_id'] == 123
+    assert dispatched.message['installer_user_id'] == 'kc-installer'
+    assert dispatched.message['installation_id'] == 'PROJ/myrepo'
     assert response.status_code == 200
 
 
 @pytest.mark.asyncio
-@patch("server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT", False)
-@patch("server.routes.integration.bitbucket_dc.webhook_store")
-@patch("server.routes.integration.bitbucket_dc.bitbucket_dc_manager")
-@patch("server.routes.integration.bitbucket_dc.get_redis_client_async")
+@patch('server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT', False)
+@patch('server.routes.integration.bitbucket_dc.webhook_store')
+@patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
+@patch('server.routes.integration.bitbucket_dc.get_redis_client_async')
 async def test_connection_event_rejects_payload_for_different_repository(
     mock_get_redis_client_async, mock_manager, mock_store
 ):
     webhook = MagicMock()
     webhook.id = 123
-    webhook.project_key = "OTHER"
-    webhook.repo_slug = "repo"
-    webhook.webhook_secret = "shared-secret"
-    webhook.user_id = "kc-installer"
+    webhook.project_key = 'OTHER'
+    webhook.repo_slug = 'repo'
+    webhook.webhook_secret = 'shared-secret'
+    webhook.user_id = 'kc-installer'
     mock_store.get_webhook_by_id = AsyncMock(return_value=webhook)
     mock_manager.receive_message = AsyncMock()
     mock_get_redis_client_async.return_value = AsyncMock()
@@ -462,8 +462,8 @@ async def test_connection_event_rejects_payload_for_different_repository(
             request=_request_with_body(body),
             background_tasks=MagicMock(),
             x_hub_signature=_signed(body),
-            x_event_key="pr:comment:added",
-            x_request_id="req-1",
+            x_event_key='pr:comment:added',
+            x_request_id='req-1',
         )
 
     assert exc.value.status_code == 403
@@ -471,7 +471,7 @@ async def test_connection_event_rejects_payload_for_different_repository(
 
 
 @pytest.mark.asyncio
-@patch("server.routes.integration.bitbucket_dc.webhook_store")
+@patch('server.routes.integration.bitbucket_dc.webhook_store')
 async def test_update_bitbucket_dc_webhook_id_records_webhook_id(mock_store):
     from server.routes.integration.bitbucket_dc import (
         BitbucketDCResourceIdentifier,
@@ -483,17 +483,17 @@ async def test_update_bitbucket_dc_webhook_id_records_webhook_id(mock_store):
     response = await update_bitbucket_dc_webhook_id(
         body=UpdateBitbucketDCWebhookIdRequest(
             resource=BitbucketDCResourceIdentifier(
-                project_key="PROJ",
-                repo_slug="myrepo",
+                project_key='PROJ',
+                repo_slug='myrepo',
             ),
-            webhook_id="42",
+            webhook_id='42',
         ),
-        user_id="kc-installer",
+        user_id='kc-installer',
     )
 
     mock_store.update_webhook_id.assert_awaited_once_with(
-        project_key="PROJ",
-        repo_slug="myrepo",
-        webhook_id="42",
+        project_key='PROJ',
+        repo_slug='myrepo',
+        webhook_id='42',
     )
     assert response.success is True

--- a/enterprise/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_webhook.py
+++ b/enterprise/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_webhook.py
@@ -10,7 +10,6 @@ from fastapi import HTTPException
 from server.routes.integration.bitbucket_dc import (
     BITBUCKET_DC_WEBHOOK_EVENTS,
     bitbucket_dc_connection_events,
-    bitbucket_dc_events,
     enroll_bitbucket_dc_webhook,
     get_bitbucket_dc_resources,
     reinstall_bitbucket_dc_webhook,
@@ -47,6 +46,23 @@ def _pr_comment_body() -> bytes:
     ).encode()
 
 
+def _webhook(
+    *,
+    webhook_id: int = 123,
+    project_key: str = 'PROJ',
+    repo_slug: str = 'myrepo',
+    webhook_secret: str = 'shared-secret',
+    user_id: str = 'kc-installer',
+) -> MagicMock:
+    webhook = MagicMock()
+    webhook.id = webhook_id
+    webhook.project_key = project_key
+    webhook.repo_slug = repo_slug
+    webhook.webhook_secret = webhook_secret
+    webhook.user_id = user_id
+    return webhook
+
+
 def test_bitbucket_dc_webhook_events_cover_automation_sources():
     assert {
         'repo:refs_changed',
@@ -76,14 +92,15 @@ def test_bitbucket_dc_webhook_events_cover_automation_sources():
 async def test_signature_verification_rejects_bad_signature_with_403(
     mock_get_redis_client_async, mock_manager, mock_store
 ):
-    mock_store.get_webhook_secret = AsyncMock(return_value='shared-secret')
+    mock_store.get_webhook_by_id = AsyncMock(return_value=_webhook())
     mock_manager.receive_message = AsyncMock()
     mock_get_redis_client_async.return_value = AsyncMock()
 
     body = _pr_comment_body()
 
     with pytest.raises(HTTPException) as exc:
-        await bitbucket_dc_events(
+        await bitbucket_dc_connection_events(
+            connection_id=123,
             request=_request_with_body(body),
             background_tasks=MagicMock(),
             x_hub_signature='sha256=deadbeef',
@@ -100,26 +117,35 @@ async def test_signature_verification_rejects_bad_signature_with_403(
 @patch('server.routes.integration.bitbucket_dc.webhook_store')
 @patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
 @patch('server.routes.integration.bitbucket_dc.get_redis_client_async')
-async def test_missing_repo_identity_rejected_with_403(
+async def test_connection_event_uses_connection_repository_when_payload_identity_missing(
     mock_get_redis_client_async, mock_manager, mock_store
 ):
-    mock_store.get_webhook_secret = AsyncMock(return_value='shared-secret')
+    mock_store.get_webhook_by_id = AsyncMock(return_value=_webhook())
     mock_manager.receive_message = AsyncMock()
-    mock_get_redis_client_async.return_value = AsyncMock()
+    redis = AsyncMock()
+    redis.set = AsyncMock(return_value=True)
+    mock_get_redis_client_async.return_value = redis
 
-    body = json.dumps({'pullRequest': {'id': 1}}).encode()
+    body = json.dumps(
+        {
+            'pullRequest': {'id': 1},
+            'comment': {'id': 99, 'text': 'Hey @openhands'},
+        }
+    ).encode()
 
-    with pytest.raises(HTTPException) as exc:
-        await bitbucket_dc_events(
-            request=_request_with_body(body),
-            background_tasks=MagicMock(),
-            x_hub_signature=_signed(body),
-            x_event_key='pr:comment:added',
-            x_request_id='req-1',
-        )
+    response = await bitbucket_dc_connection_events(
+        connection_id=123,
+        request=_request_with_body(body),
+        background_tasks=MagicMock(),
+        x_hub_signature=_signed(body),
+        x_event_key='pr:comment:added',
+        x_request_id='req-1',
+    )
 
-    assert exc.value.status_code == 403
-    mock_manager.receive_message.assert_not_called()
+    mock_manager.receive_message.assert_awaited_once()
+    dispatched = mock_manager.receive_message.call_args.args[0]
+    assert dispatched.message['installation_id'] == 'PROJ/myrepo'
+    assert response.status_code == 200
 
 
 @pytest.mark.asyncio
@@ -130,7 +156,7 @@ async def test_missing_repo_identity_rejected_with_403(
 async def test_duplicate_event_returns_200_and_skips_dispatch(
     mock_get_redis_client_async, mock_manager, mock_store
 ):
-    mock_store.get_webhook_secret = AsyncMock(return_value='shared-secret')
+    mock_store.get_webhook_by_id = AsyncMock(return_value=_webhook())
     mock_manager.receive_message = AsyncMock()
     redis = AsyncMock()
     redis.set = AsyncMock(return_value=False)  # duplicate
@@ -138,7 +164,8 @@ async def test_duplicate_event_returns_200_and_skips_dispatch(
 
     body = _pr_comment_body()
 
-    response = await bitbucket_dc_events(
+    response = await bitbucket_dc_connection_events(
+        connection_id=123,
         request=_request_with_body(body),
         background_tasks=MagicMock(),
         x_hub_signature=_signed(body),
@@ -159,7 +186,7 @@ async def test_duplicate_event_returns_200_and_skips_dispatch(
 async def test_valid_pr_comment_event_dispatches_to_manager_and_returns_200(
     mock_get_redis_client_async, mock_manager, mock_store
 ):
-    mock_store.get_webhook_secret = AsyncMock(return_value='shared-secret')
+    mock_store.get_webhook_by_id = AsyncMock(return_value=_webhook())
     mock_manager.receive_message = AsyncMock()
     redis = AsyncMock()
     redis.set = AsyncMock(return_value=True)
@@ -167,7 +194,8 @@ async def test_valid_pr_comment_event_dispatches_to_manager_and_returns_200(
 
     body = _pr_comment_body()
 
-    response = await bitbucket_dc_events(
+    response = await bitbucket_dc_connection_events(
+        connection_id=123,
         request=_request_with_body(body),
         background_tasks=MagicMock(),
         x_hub_signature=_signed(body),
@@ -195,7 +223,7 @@ async def test_valid_event_forwards_to_automations_when_enabled(
     mock_store,
     mock_automation_service,
 ):
-    mock_store.get_webhook_secret = AsyncMock(return_value='shared-secret')
+    mock_store.get_webhook_by_id = AsyncMock(return_value=_webhook())
     mock_manager.receive_message = AsyncMock()
     redis = AsyncMock()
     redis.set = AsyncMock(return_value=True)
@@ -208,7 +236,8 @@ async def test_valid_event_forwards_to_automations_when_enabled(
         'server.routes.integration.bitbucket_dc.AUTOMATION_EVENT_FORWARDING_ENABLED',
         True,
     ):
-        response = await bitbucket_dc_events(
+        response = await bitbucket_dc_connection_events(
+            connection_id=123,
             request=_request_with_body(body),
             background_tasks=background_tasks,
             x_hub_signature=_signed(body),
@@ -234,7 +263,8 @@ async def test_valid_event_forwards_to_automations_when_enabled(
 async def test_diagnostics_ping_returns_200_without_dispatch(mock_manager):
     mock_manager.receive_message = AsyncMock()
 
-    response = await bitbucket_dc_events(
+    response = await bitbucket_dc_connection_events(
+        connection_id=123,
         request=_request_with_body(b'{}'),
         background_tasks=MagicMock(),
         x_hub_signature=None,
@@ -355,9 +385,7 @@ async def test_reinstall_bitbucket_dc_webhook_installs_connection_scoped_url(
 
     service = MagicMock()
     service.user_has_admin_access = AsyncMock(return_value=True)
-    service.check_webhook_exists_on_repository = AsyncMock(
-        side_effect=[(False, None), (False, None)]
-    )
+    service.check_webhook_exists_on_repository = AsyncMock(return_value=(False, None))
     service.create_repository_webhook = AsyncMock(return_value='101')
     mock_service_cls.return_value = service
 
@@ -377,6 +405,11 @@ async def test_reinstall_bitbucket_dc_webhook_installs_connection_scoped_url(
         user_id='kc-installer',
     )
     service.create_repository_webhook.assert_awaited_once()
+    service.check_webhook_exists_on_repository.assert_awaited_once_with(
+        'PROJ',
+        'myrepo',
+        'https://app.all-hands.dev/integration/bitbucket-dc/connections/123/events',
+    )
     create_kwargs = service.create_repository_webhook.await_args.kwargs
     assert create_kwargs['webhook_url'].endswith(
         '/integration/bitbucket-dc/connections/123/events'

--- a/enterprise/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_webhook.py
+++ b/enterprise/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_webhook.py
@@ -9,9 +9,11 @@ import pytest
 from fastapi import HTTPException
 from server.routes.integration.bitbucket_dc import (
     BITBUCKET_DC_WEBHOOK_EVENTS,
+    bitbucket_dc_connection_events,
     bitbucket_dc_events,
     enroll_bitbucket_dc_webhook,
     get_bitbucket_dc_resources,
+    reinstall_bitbucket_dc_webhook,
     update_bitbucket_dc_webhook_id,
 )
 
@@ -268,6 +270,7 @@ async def test_get_bitbucket_dc_resources_returns_repo_enrollment_status(
     webhook.repo_slug = 'myrepo'
     webhook.webhook_secret = 'shared-secret'
     webhook.webhook_id = '42'
+    webhook.id = 7
     webhook.user_id = 'kc-installer'
     webhook.last_synced = None
     mock_store.get_webhooks_by_repos = AsyncMock(
@@ -282,8 +285,10 @@ async def test_get_bitbucket_dc_resources_returns_repo_enrollment_status(
     resource = response.resources[0]
     assert resource.project_key == 'PROJ'
     assert resource.repo_slug == 'myrepo'
+    assert resource.connection_id == 7
     assert resource.webhook_enrolled is True
     assert resource.webhook_id == '42'
+    assert resource.webhook_url.endswith('/integration/bitbucket-dc/connections/7/events')
     assert resource.installed_by_user_id == 'kc-installer'
 
 
@@ -299,7 +304,9 @@ async def test_enroll_bitbucket_dc_webhook_generates_secret_and_stores_row(
     )
 
     mock_token_urlsafe.return_value = 'generated-secret'
-    mock_store.upsert_webhook_enrollment = AsyncMock()
+    webhook = MagicMock()
+    webhook.id = 123
+    mock_store.upsert_webhook_enrollment = AsyncMock(return_value=webhook)
 
     response = await enroll_bitbucket_dc_webhook(
         body=EnrollBitbucketDCWebhookRequest(
@@ -318,9 +325,147 @@ async def test_enroll_bitbucket_dc_webhook_generates_secret_and_stores_row(
         webhook_secret='generated-secret',
     )
     assert response.success is True
+    assert response.connection_id == 123
     assert response.webhook_secret == 'generated-secret'
-    assert response.webhook_url.endswith('/integration/bitbucket-dc/events')
+    assert response.webhook_url.endswith(
+        '/integration/bitbucket-dc/connections/123/events'
+    )
     assert response.events == BITBUCKET_DC_WEBHOOK_EVENTS
+
+
+@pytest.mark.asyncio
+@patch('server.routes.integration.bitbucket_dc.secrets.token_urlsafe')
+@patch('server.routes.integration.bitbucket_dc.webhook_store')
+@patch('server.routes.integration.bitbucket_dc.SaaSBitbucketDCService')
+async def test_reinstall_bitbucket_dc_webhook_installs_connection_scoped_url(
+    mock_service_cls, mock_store, mock_token_urlsafe
+):
+    from server.routes.integration.bitbucket_dc import (
+        BitbucketDCResourceIdentifier,
+        BitbucketDCWebhookRequest,
+    )
+
+    mock_token_urlsafe.return_value = 'generated-secret'
+    webhook = MagicMock()
+    webhook.id = 123
+    mock_store.ensure_webhook_enrollment = AsyncMock(return_value=webhook)
+    mock_store.upsert_webhook_enrollment = AsyncMock()
+
+    service = MagicMock()
+    service.user_has_admin_access = AsyncMock(return_value=True)
+    service.check_webhook_exists_on_repository = AsyncMock(
+        side_effect=[(False, None), (False, None)]
+    )
+    service.create_repository_webhook = AsyncMock(return_value='101')
+    mock_service_cls.return_value = service
+
+    response = await reinstall_bitbucket_dc_webhook(
+        body=BitbucketDCWebhookRequest(
+            resource=BitbucketDCResourceIdentifier(
+                project_key='PROJ',
+                repo_slug='myrepo',
+            )
+        ),
+        user_id='kc-installer',
+    )
+
+    mock_store.ensure_webhook_enrollment.assert_awaited_once_with(
+        project_key='PROJ',
+        repo_slug='myrepo',
+        user_id='kc-installer',
+    )
+    service.create_repository_webhook.assert_awaited_once()
+    create_kwargs = service.create_repository_webhook.await_args.kwargs
+    assert create_kwargs['webhook_url'].endswith(
+        '/integration/bitbucket-dc/connections/123/events'
+    )
+    mock_store.upsert_webhook_enrollment.assert_awaited_once_with(
+        project_key='PROJ',
+        repo_slug='myrepo',
+        user_id='kc-installer',
+        webhook_id='101',
+        webhook_secret='generated-secret',
+    )
+    assert response.success is True
+    assert response.webhook_id == '101'
+    assert response.connection_id == 123
+    assert response.webhook_url.endswith(
+        '/integration/bitbucket-dc/connections/123/events'
+    )
+
+
+@pytest.mark.asyncio
+@patch('server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT', False)
+@patch('server.routes.integration.bitbucket_dc.webhook_store')
+@patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
+@patch('server.routes.integration.bitbucket_dc.get_redis_client_async')
+async def test_connection_event_verifies_with_connection_secret_and_dispatches_installer(
+    mock_get_redis_client_async, mock_manager, mock_store
+):
+    webhook = MagicMock()
+    webhook.id = 123
+    webhook.project_key = 'PROJ'
+    webhook.repo_slug = 'myrepo'
+    webhook.webhook_secret = 'shared-secret'
+    webhook.user_id = 'kc-installer'
+    mock_store.get_webhook_by_id = AsyncMock(return_value=webhook)
+    mock_manager.receive_message = AsyncMock()
+    redis = AsyncMock()
+    redis.set = AsyncMock(return_value=True)
+    mock_get_redis_client_async.return_value = redis
+
+    body = _pr_comment_body()
+
+    response = await bitbucket_dc_connection_events(
+        connection_id=123,
+        request=_request_with_body(body),
+        background_tasks=MagicMock(),
+        x_hub_signature=_signed(body),
+        x_event_key='pr:comment:added',
+        x_request_id='req-1',
+    )
+
+    mock_store.get_webhook_by_id.assert_awaited_once_with(123)
+    mock_manager.receive_message.assert_awaited_once()
+    dispatched = mock_manager.receive_message.call_args.args[0]
+    assert dispatched.message['connection_id'] == 123
+    assert dispatched.message['installer_user_id'] == 'kc-installer'
+    assert dispatched.message['installation_id'] == 'PROJ/myrepo'
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+@patch('server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT', False)
+@patch('server.routes.integration.bitbucket_dc.webhook_store')
+@patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
+@patch('server.routes.integration.bitbucket_dc.get_redis_client_async')
+async def test_connection_event_rejects_payload_for_different_repository(
+    mock_get_redis_client_async, mock_manager, mock_store
+):
+    webhook = MagicMock()
+    webhook.id = 123
+    webhook.project_key = 'OTHER'
+    webhook.repo_slug = 'repo'
+    webhook.webhook_secret = 'shared-secret'
+    webhook.user_id = 'kc-installer'
+    mock_store.get_webhook_by_id = AsyncMock(return_value=webhook)
+    mock_manager.receive_message = AsyncMock()
+    mock_get_redis_client_async.return_value = AsyncMock()
+
+    body = _pr_comment_body()
+
+    with pytest.raises(HTTPException) as exc:
+        await bitbucket_dc_connection_events(
+            connection_id=123,
+            request=_request_with_body(body),
+            background_tasks=MagicMock(),
+            x_hub_signature=_signed(body),
+            x_event_key='pr:comment:added',
+            x_request_id='req-1',
+        )
+
+    assert exc.value.status_code == 403
+    mock_manager.receive_message.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/enterprise/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_webhook.py
+++ b/enterprise/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_webhook.py
@@ -20,8 +20,8 @@ from server.routes.integration.bitbucket_dc import (
 from openhands.app_server.integrations.service_types import ProviderType, Repository
 
 
-def _signed(body: bytes, secret: str = 'shared-secret') -> str:
-    return 'sha256=' + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+def _signed(body: bytes, secret: str = "shared-secret") -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
 
 def _request_with_body(body: bytes) -> MagicMock:
@@ -33,50 +33,50 @@ def _request_with_body(body: bytes) -> MagicMock:
 def _pr_comment_body() -> bytes:
     return json.dumps(
         {
-            'pullRequest': {
-                'id': 1,
-                'toRef': {
-                    'repository': {
-                        'slug': 'myrepo',
-                        'project': {'key': 'PROJ'},
+            "pullRequest": {
+                "id": 1,
+                "toRef": {
+                    "repository": {
+                        "slug": "myrepo",
+                        "project": {"key": "PROJ"},
                     }
                 },
             },
-            'comment': {'id': 99, 'text': 'Hey @openhands'},
+            "comment": {"id": 99, "text": "Hey @openhands"},
         }
     ).encode()
 
 
 def test_bitbucket_dc_webhook_events_cover_automation_sources():
     assert {
-        'repo:refs_changed',
-        'repo:comment:added',
-        'repo:comment:edited',
-        'repo:comment:deleted',
-        'pr:opened',
-        'pr:from_ref_updated',
-        'pr:modified',
-        'pr:reviewer:approved',
-        'pr:reviewer:unapproved',
-        'pr:reviewer:needs_work',
-        'pr:merged',
-        'pr:declined',
-        'pr:deleted',
-        'pr:comment:added',
-        'pr:comment:edited',
-        'pr:comment:deleted',
+        "repo:refs_changed",
+        "repo:comment:added",
+        "repo:comment:edited",
+        "repo:comment:deleted",
+        "pr:opened",
+        "pr:from_ref_updated",
+        "pr:modified",
+        "pr:reviewer:approved",
+        "pr:reviewer:unapproved",
+        "pr:reviewer:needs_work",
+        "pr:merged",
+        "pr:declined",
+        "pr:deleted",
+        "pr:comment:added",
+        "pr:comment:edited",
+        "pr:comment:deleted",
     }.issubset(set(BITBUCKET_DC_WEBHOOK_EVENTS))
 
 
 @pytest.mark.asyncio
-@patch('server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT', False)
-@patch('server.routes.integration.bitbucket_dc.webhook_store')
-@patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
-@patch('server.routes.integration.bitbucket_dc.get_redis_client_async')
+@patch("server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT", False)
+@patch("server.routes.integration.bitbucket_dc.webhook_store")
+@patch("server.routes.integration.bitbucket_dc.bitbucket_dc_manager")
+@patch("server.routes.integration.bitbucket_dc.get_redis_client_async")
 async def test_signature_verification_rejects_bad_signature_with_403(
     mock_get_redis_client_async, mock_manager, mock_store
 ):
-    mock_store.get_webhook_secret = AsyncMock(return_value='shared-secret')
+    mock_store.get_webhook_secret = AsyncMock(return_value="shared-secret")
     mock_manager.receive_message = AsyncMock()
     mock_get_redis_client_async.return_value = AsyncMock()
 
@@ -86,9 +86,9 @@ async def test_signature_verification_rejects_bad_signature_with_403(
         await bitbucket_dc_events(
             request=_request_with_body(body),
             background_tasks=MagicMock(),
-            x_hub_signature='sha256=deadbeef',
-            x_event_key='pr:comment:added',
-            x_request_id='req-1',
+            x_hub_signature="sha256=deadbeef",
+            x_event_key="pr:comment:added",
+            x_request_id="req-1",
         )
 
     assert exc.value.status_code == 403
@@ -96,26 +96,26 @@ async def test_signature_verification_rejects_bad_signature_with_403(
 
 
 @pytest.mark.asyncio
-@patch('server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT', False)
-@patch('server.routes.integration.bitbucket_dc.webhook_store')
-@patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
-@patch('server.routes.integration.bitbucket_dc.get_redis_client_async')
+@patch("server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT", False)
+@patch("server.routes.integration.bitbucket_dc.webhook_store")
+@patch("server.routes.integration.bitbucket_dc.bitbucket_dc_manager")
+@patch("server.routes.integration.bitbucket_dc.get_redis_client_async")
 async def test_missing_repo_identity_rejected_with_403(
     mock_get_redis_client_async, mock_manager, mock_store
 ):
-    mock_store.get_webhook_secret = AsyncMock(return_value='shared-secret')
+    mock_store.get_webhook_secret = AsyncMock(return_value="shared-secret")
     mock_manager.receive_message = AsyncMock()
     mock_get_redis_client_async.return_value = AsyncMock()
 
-    body = json.dumps({'pullRequest': {'id': 1}}).encode()
+    body = json.dumps({"pullRequest": {"id": 1}}).encode()
 
     with pytest.raises(HTTPException) as exc:
         await bitbucket_dc_events(
             request=_request_with_body(body),
             background_tasks=MagicMock(),
             x_hub_signature=_signed(body),
-            x_event_key='pr:comment:added',
-            x_request_id='req-1',
+            x_event_key="pr:comment:added",
+            x_request_id="req-1",
         )
 
     assert exc.value.status_code == 403
@@ -123,14 +123,14 @@ async def test_missing_repo_identity_rejected_with_403(
 
 
 @pytest.mark.asyncio
-@patch('server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT', False)
-@patch('server.routes.integration.bitbucket_dc.webhook_store')
-@patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
-@patch('server.routes.integration.bitbucket_dc.get_redis_client_async')
+@patch("server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT", False)
+@patch("server.routes.integration.bitbucket_dc.webhook_store")
+@patch("server.routes.integration.bitbucket_dc.bitbucket_dc_manager")
+@patch("server.routes.integration.bitbucket_dc.get_redis_client_async")
 async def test_duplicate_event_returns_200_and_skips_dispatch(
     mock_get_redis_client_async, mock_manager, mock_store
 ):
-    mock_store.get_webhook_secret = AsyncMock(return_value='shared-secret')
+    mock_store.get_webhook_secret = AsyncMock(return_value="shared-secret")
     mock_manager.receive_message = AsyncMock()
     redis = AsyncMock()
     redis.set = AsyncMock(return_value=False)  # duplicate
@@ -142,24 +142,24 @@ async def test_duplicate_event_returns_200_and_skips_dispatch(
         request=_request_with_body(body),
         background_tasks=MagicMock(),
         x_hub_signature=_signed(body),
-        x_event_key='pr:comment:added',
-        x_request_id='req-1',
+        x_event_key="pr:comment:added",
+        x_request_id="req-1",
     )
 
     mock_manager.receive_message.assert_not_called()
     assert response.status_code == 200
-    assert json.loads(response.body)['message'].startswith('Duplicate')
+    assert json.loads(response.body)["message"].startswith("Duplicate")
 
 
 @pytest.mark.asyncio
-@patch('server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT', False)
-@patch('server.routes.integration.bitbucket_dc.webhook_store')
-@patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
-@patch('server.routes.integration.bitbucket_dc.get_redis_client_async')
+@patch("server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT", False)
+@patch("server.routes.integration.bitbucket_dc.webhook_store")
+@patch("server.routes.integration.bitbucket_dc.bitbucket_dc_manager")
+@patch("server.routes.integration.bitbucket_dc.get_redis_client_async")
 async def test_valid_pr_comment_event_dispatches_to_manager_and_returns_200(
     mock_get_redis_client_async, mock_manager, mock_store
 ):
-    mock_store.get_webhook_secret = AsyncMock(return_value='shared-secret')
+    mock_store.get_webhook_secret = AsyncMock(return_value="shared-secret")
     mock_manager.receive_message = AsyncMock()
     redis = AsyncMock()
     redis.set = AsyncMock(return_value=True)
@@ -171,31 +171,31 @@ async def test_valid_pr_comment_event_dispatches_to_manager_and_returns_200(
         request=_request_with_body(body),
         background_tasks=MagicMock(),
         x_hub_signature=_signed(body),
-        x_event_key='pr:comment:added',
-        x_request_id='req-1',
+        x_event_key="pr:comment:added",
+        x_request_id="req-1",
     )
 
     mock_manager.receive_message.assert_awaited_once()
     dispatched = mock_manager.receive_message.call_args.args[0]
-    assert dispatched.source.value == 'bitbucket_data_center'
-    assert dispatched.message['event_key'] == 'pr:comment:added'
-    assert dispatched.message['installation_id'] == 'PROJ/myrepo'
+    assert dispatched.source.value == "bitbucket_data_center"
+    assert dispatched.message["event_key"] == "pr:comment:added"
+    assert dispatched.message["installation_id"] == "PROJ/myrepo"
     assert response.status_code == 200
 
 
 @pytest.mark.asyncio
-@patch('server.routes.integration.bitbucket_dc.automation_event_service')
-@patch('server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT', False)
-@patch('server.routes.integration.bitbucket_dc.webhook_store')
-@patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
-@patch('server.routes.integration.bitbucket_dc.get_redis_client_async')
+@patch("server.routes.integration.bitbucket_dc.automation_event_service")
+@patch("server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT", False)
+@patch("server.routes.integration.bitbucket_dc.webhook_store")
+@patch("server.routes.integration.bitbucket_dc.bitbucket_dc_manager")
+@patch("server.routes.integration.bitbucket_dc.get_redis_client_async")
 async def test_valid_event_forwards_to_automations_when_enabled(
     mock_get_redis_client_async,
     mock_manager,
     mock_store,
     mock_automation_service,
 ):
-    mock_store.get_webhook_secret = AsyncMock(return_value='shared-secret')
+    mock_store.get_webhook_secret = AsyncMock(return_value="shared-secret")
     mock_manager.receive_message = AsyncMock()
     redis = AsyncMock()
     redis.set = AsyncMock(return_value=True)
@@ -205,15 +205,15 @@ async def test_valid_event_forwards_to_automations_when_enabled(
     background_tasks = MagicMock()
 
     with patch(
-        'server.routes.integration.bitbucket_dc.AUTOMATION_EVENT_FORWARDING_ENABLED',
+        "server.routes.integration.bitbucket_dc.AUTOMATION_EVENT_FORWARDING_ENABLED",
         True,
     ):
         response = await bitbucket_dc_events(
             request=_request_with_body(body),
             background_tasks=background_tasks,
             x_hub_signature=_signed(body),
-            x_event_key='pr:opened',
-            x_request_id='req-1',
+            x_event_key="pr:opened",
+            x_request_id="req-1",
         )
 
     assert response.status_code == 200
@@ -222,24 +222,24 @@ async def test_valid_event_forwards_to_automations_when_enabled(
         provider=ProviderType.BITBUCKET_DATA_CENTER,
         payload={
             **json.loads(body),
-            'eventKey': 'pr:opened',
+            "eventKey": "pr:opened",
         },
-        installation_id='PROJ/myrepo',
+        installation_id="PROJ/myrepo",
     )
     mock_manager.receive_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-@patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
+@patch("server.routes.integration.bitbucket_dc.bitbucket_dc_manager")
 async def test_diagnostics_ping_returns_200_without_dispatch(mock_manager):
     mock_manager.receive_message = AsyncMock()
 
     response = await bitbucket_dc_events(
-        request=_request_with_body(b'{}'),
+        request=_request_with_body(b"{}"),
         background_tasks=MagicMock(),
         x_hub_signature=None,
-        x_event_key='diagnostics:ping',
-        x_request_id='ping-1',
+        x_event_key="diagnostics:ping",
+        x_request_id="ping-1",
     )
 
     mock_manager.receive_message.assert_not_called()
@@ -247,8 +247,8 @@ async def test_diagnostics_ping_returns_200_without_dispatch(mock_manager):
 
 
 @pytest.mark.asyncio
-@patch('server.routes.integration.bitbucket_dc.webhook_store')
-@patch('server.routes.integration.bitbucket_dc.SaaSBitbucketDCService')
+@patch("server.routes.integration.bitbucket_dc.webhook_store")
+@patch("server.routes.integration.bitbucket_dc.SaaSBitbucketDCService")
 async def test_get_bitbucket_dc_resources_returns_repo_enrollment_status(
     mock_service_cls, mock_store
 ):
@@ -256,8 +256,8 @@ async def test_get_bitbucket_dc_resources_returns_repo_enrollment_status(
     service.get_all_repositories = AsyncMock(
         return_value=[
             Repository(
-                id='1',
-                full_name='PROJ/myrepo',
+                id="1",
+                full_name="PROJ/myrepo",
                 git_provider=ProviderType.BITBUCKET_DATA_CENTER,
                 is_public=False,
             )
@@ -266,35 +266,37 @@ async def test_get_bitbucket_dc_resources_returns_repo_enrollment_status(
     mock_service_cls.return_value = service
 
     webhook = MagicMock()
-    webhook.project_key = 'PROJ'
-    webhook.repo_slug = 'myrepo'
-    webhook.webhook_secret = 'shared-secret'
-    webhook.webhook_id = '42'
+    webhook.project_key = "PROJ"
+    webhook.repo_slug = "myrepo"
+    webhook.webhook_secret = "shared-secret"
+    webhook.webhook_id = "42"
     webhook.id = 7
-    webhook.user_id = 'kc-installer'
+    webhook.user_id = "kc-installer"
     webhook.last_synced = None
     mock_store.get_webhooks_by_repos = AsyncMock(
-        return_value={('PROJ', 'myrepo'): webhook}
+        return_value={("PROJ", "myrepo"): webhook}
     )
 
-    response = await get_bitbucket_dc_resources(user_id='kc-viewer')
+    response = await get_bitbucket_dc_resources(user_id="kc-viewer")
 
-    mock_service_cls.assert_called_once_with(external_auth_id='kc-viewer')
-    mock_store.get_webhooks_by_repos.assert_awaited_once_with([('PROJ', 'myrepo')])
+    mock_service_cls.assert_called_once_with(external_auth_id="kc-viewer")
+    mock_store.get_webhooks_by_repos.assert_awaited_once_with([("PROJ", "myrepo")])
     assert len(response.resources) == 1
     resource = response.resources[0]
-    assert resource.project_key == 'PROJ'
-    assert resource.repo_slug == 'myrepo'
+    assert resource.project_key == "PROJ"
+    assert resource.repo_slug == "myrepo"
     assert resource.connection_id == 7
     assert resource.webhook_enrolled is True
-    assert resource.webhook_id == '42'
-    assert resource.webhook_url.endswith('/integration/bitbucket-dc/connections/7/events')
-    assert resource.installed_by_user_id == 'kc-installer'
+    assert resource.webhook_id == "42"
+    assert resource.webhook_url.endswith(
+        "/integration/bitbucket-dc/connections/7/events"
+    )
+    assert resource.installed_by_user_id == "kc-installer"
 
 
 @pytest.mark.asyncio
-@patch('server.routes.integration.bitbucket_dc.secrets.token_urlsafe')
-@patch('server.routes.integration.bitbucket_dc.webhook_store')
+@patch("server.routes.integration.bitbucket_dc.secrets.token_urlsafe")
+@patch("server.routes.integration.bitbucket_dc.webhook_store")
 async def test_enroll_bitbucket_dc_webhook_generates_secret_and_stores_row(
     mock_store, mock_token_urlsafe
 ):
@@ -303,7 +305,7 @@ async def test_enroll_bitbucket_dc_webhook_generates_secret_and_stores_row(
         EnrollBitbucketDCWebhookRequest,
     )
 
-    mock_token_urlsafe.return_value = 'generated-secret'
+    mock_token_urlsafe.return_value = "generated-secret"
     webhook = MagicMock()
     webhook.id = 123
     mock_store.upsert_webhook_enrollment = AsyncMock(return_value=webhook)
@@ -311,32 +313,32 @@ async def test_enroll_bitbucket_dc_webhook_generates_secret_and_stores_row(
     response = await enroll_bitbucket_dc_webhook(
         body=EnrollBitbucketDCWebhookRequest(
             resource=BitbucketDCResourceIdentifier(
-                project_key='PROJ',
-                repo_slug='myrepo',
+                project_key="PROJ",
+                repo_slug="myrepo",
             )
         ),
-        user_id='kc-installer',
+        user_id="kc-installer",
     )
 
     mock_store.upsert_webhook_enrollment.assert_awaited_once_with(
-        project_key='PROJ',
-        repo_slug='myrepo',
-        user_id='kc-installer',
-        webhook_secret='generated-secret',
+        project_key="PROJ",
+        repo_slug="myrepo",
+        user_id="kc-installer",
+        webhook_secret="generated-secret",
     )
     assert response.success is True
     assert response.connection_id == 123
-    assert response.webhook_secret == 'generated-secret'
+    assert response.webhook_secret == "generated-secret"
     assert response.webhook_url.endswith(
-        '/integration/bitbucket-dc/connections/123/events'
+        "/integration/bitbucket-dc/connections/123/events"
     )
     assert response.events == BITBUCKET_DC_WEBHOOK_EVENTS
 
 
 @pytest.mark.asyncio
-@patch('server.routes.integration.bitbucket_dc.secrets.token_urlsafe')
-@patch('server.routes.integration.bitbucket_dc.webhook_store')
-@patch('server.routes.integration.bitbucket_dc.SaaSBitbucketDCService')
+@patch("server.routes.integration.bitbucket_dc.secrets.token_urlsafe")
+@patch("server.routes.integration.bitbucket_dc.webhook_store")
+@patch("server.routes.integration.bitbucket_dc.SaaSBitbucketDCService")
 async def test_reinstall_bitbucket_dc_webhook_installs_connection_scoped_url(
     mock_service_cls, mock_store, mock_token_urlsafe
 ):
@@ -345,7 +347,7 @@ async def test_reinstall_bitbucket_dc_webhook_installs_connection_scoped_url(
         BitbucketDCWebhookRequest,
     )
 
-    mock_token_urlsafe.return_value = 'generated-secret'
+    mock_token_urlsafe.return_value = "generated-secret"
     webhook = MagicMock()
     webhook.id = 123
     mock_store.ensure_webhook_enrollment = AsyncMock(return_value=webhook)
@@ -356,58 +358,58 @@ async def test_reinstall_bitbucket_dc_webhook_installs_connection_scoped_url(
     service.check_webhook_exists_on_repository = AsyncMock(
         side_effect=[(False, None), (False, None)]
     )
-    service.create_repository_webhook = AsyncMock(return_value='101')
+    service.create_repository_webhook = AsyncMock(return_value="101")
     mock_service_cls.return_value = service
 
     response = await reinstall_bitbucket_dc_webhook(
         body=BitbucketDCWebhookRequest(
             resource=BitbucketDCResourceIdentifier(
-                project_key='PROJ',
-                repo_slug='myrepo',
+                project_key="PROJ",
+                repo_slug="myrepo",
             )
         ),
-        user_id='kc-installer',
+        user_id="kc-installer",
     )
 
     mock_store.ensure_webhook_enrollment.assert_awaited_once_with(
-        project_key='PROJ',
-        repo_slug='myrepo',
-        user_id='kc-installer',
+        project_key="PROJ",
+        repo_slug="myrepo",
+        user_id="kc-installer",
     )
     service.create_repository_webhook.assert_awaited_once()
     create_kwargs = service.create_repository_webhook.await_args.kwargs
-    assert create_kwargs['webhook_url'].endswith(
-        '/integration/bitbucket-dc/connections/123/events'
+    assert create_kwargs["webhook_url"].endswith(
+        "/integration/bitbucket-dc/connections/123/events"
     )
     mock_store.upsert_webhook_enrollment.assert_awaited_once_with(
-        project_key='PROJ',
-        repo_slug='myrepo',
-        user_id='kc-installer',
-        webhook_id='101',
-        webhook_secret='generated-secret',
+        project_key="PROJ",
+        repo_slug="myrepo",
+        user_id="kc-installer",
+        webhook_id="101",
+        webhook_secret="generated-secret",
     )
     assert response.success is True
-    assert response.webhook_id == '101'
+    assert response.webhook_id == "101"
     assert response.connection_id == 123
     assert response.webhook_url.endswith(
-        '/integration/bitbucket-dc/connections/123/events'
+        "/integration/bitbucket-dc/connections/123/events"
     )
 
 
 @pytest.mark.asyncio
-@patch('server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT', False)
-@patch('server.routes.integration.bitbucket_dc.webhook_store')
-@patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
-@patch('server.routes.integration.bitbucket_dc.get_redis_client_async')
+@patch("server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT", False)
+@patch("server.routes.integration.bitbucket_dc.webhook_store")
+@patch("server.routes.integration.bitbucket_dc.bitbucket_dc_manager")
+@patch("server.routes.integration.bitbucket_dc.get_redis_client_async")
 async def test_connection_event_verifies_with_connection_secret_and_dispatches_installer(
     mock_get_redis_client_async, mock_manager, mock_store
 ):
     webhook = MagicMock()
     webhook.id = 123
-    webhook.project_key = 'PROJ'
-    webhook.repo_slug = 'myrepo'
-    webhook.webhook_secret = 'shared-secret'
-    webhook.user_id = 'kc-installer'
+    webhook.project_key = "PROJ"
+    webhook.repo_slug = "myrepo"
+    webhook.webhook_secret = "shared-secret"
+    webhook.user_id = "kc-installer"
     mock_store.get_webhook_by_id = AsyncMock(return_value=webhook)
     mock_manager.receive_message = AsyncMock()
     redis = AsyncMock()
@@ -421,33 +423,33 @@ async def test_connection_event_verifies_with_connection_secret_and_dispatches_i
         request=_request_with_body(body),
         background_tasks=MagicMock(),
         x_hub_signature=_signed(body),
-        x_event_key='pr:comment:added',
-        x_request_id='req-1',
+        x_event_key="pr:comment:added",
+        x_request_id="req-1",
     )
 
     mock_store.get_webhook_by_id.assert_awaited_once_with(123)
     mock_manager.receive_message.assert_awaited_once()
     dispatched = mock_manager.receive_message.call_args.args[0]
-    assert dispatched.message['connection_id'] == 123
-    assert dispatched.message['installer_user_id'] == 'kc-installer'
-    assert dispatched.message['installation_id'] == 'PROJ/myrepo'
+    assert dispatched.message["connection_id"] == 123
+    assert dispatched.message["installer_user_id"] == "kc-installer"
+    assert dispatched.message["installation_id"] == "PROJ/myrepo"
     assert response.status_code == 200
 
 
 @pytest.mark.asyncio
-@patch('server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT', False)
-@patch('server.routes.integration.bitbucket_dc.webhook_store')
-@patch('server.routes.integration.bitbucket_dc.bitbucket_dc_manager')
-@patch('server.routes.integration.bitbucket_dc.get_redis_client_async')
+@patch("server.routes.integration.bitbucket_dc.IS_LOCAL_DEPLOYMENT", False)
+@patch("server.routes.integration.bitbucket_dc.webhook_store")
+@patch("server.routes.integration.bitbucket_dc.bitbucket_dc_manager")
+@patch("server.routes.integration.bitbucket_dc.get_redis_client_async")
 async def test_connection_event_rejects_payload_for_different_repository(
     mock_get_redis_client_async, mock_manager, mock_store
 ):
     webhook = MagicMock()
     webhook.id = 123
-    webhook.project_key = 'OTHER'
-    webhook.repo_slug = 'repo'
-    webhook.webhook_secret = 'shared-secret'
-    webhook.user_id = 'kc-installer'
+    webhook.project_key = "OTHER"
+    webhook.repo_slug = "repo"
+    webhook.webhook_secret = "shared-secret"
+    webhook.user_id = "kc-installer"
     mock_store.get_webhook_by_id = AsyncMock(return_value=webhook)
     mock_manager.receive_message = AsyncMock()
     mock_get_redis_client_async.return_value = AsyncMock()
@@ -460,8 +462,8 @@ async def test_connection_event_rejects_payload_for_different_repository(
             request=_request_with_body(body),
             background_tasks=MagicMock(),
             x_hub_signature=_signed(body),
-            x_event_key='pr:comment:added',
-            x_request_id='req-1',
+            x_event_key="pr:comment:added",
+            x_request_id="req-1",
         )
 
     assert exc.value.status_code == 403
@@ -469,7 +471,7 @@ async def test_connection_event_rejects_payload_for_different_repository(
 
 
 @pytest.mark.asyncio
-@patch('server.routes.integration.bitbucket_dc.webhook_store')
+@patch("server.routes.integration.bitbucket_dc.webhook_store")
 async def test_update_bitbucket_dc_webhook_id_records_webhook_id(mock_store):
     from server.routes.integration.bitbucket_dc import (
         BitbucketDCResourceIdentifier,
@@ -481,17 +483,17 @@ async def test_update_bitbucket_dc_webhook_id_records_webhook_id(mock_store):
     response = await update_bitbucket_dc_webhook_id(
         body=UpdateBitbucketDCWebhookIdRequest(
             resource=BitbucketDCResourceIdentifier(
-                project_key='PROJ',
-                repo_slug='myrepo',
+                project_key="PROJ",
+                repo_slug="myrepo",
             ),
-            webhook_id='42',
+            webhook_id="42",
         ),
-        user_id='kc-installer',
+        user_id="kc-installer",
     )
 
     mock_store.update_webhook_id.assert_awaited_once_with(
-        project_key='PROJ',
-        repo_slug='myrepo',
-        webhook_id='42',
+        project_key="PROJ",
+        repo_slug="myrepo",
+        webhook_id="42",
     )
     assert response.success is True

--- a/enterprise/tests/unit/storage/test_bitbucket_dc_webhook_store.py
+++ b/enterprise/tests/unit/storage/test_bitbucket_dc_webhook_store.py
@@ -79,6 +79,22 @@ async def test_get_webhook_secret_returns_none_when_repo_not_registered(webhook_
 
 
 @pytest.mark.asyncio
+async def test_get_webhook_by_id_returns_matching_row(webhook_store, sample_webhook):
+    webhook = await webhook_store.get_webhook_by_id(sample_webhook.id)
+
+    assert webhook is not None
+    assert webhook.project_key == 'PROJ'
+    assert webhook.repo_slug == 'myrepo'
+
+
+@pytest.mark.asyncio
+async def test_get_webhook_by_id_returns_none_when_absent(webhook_store):
+    webhook = await webhook_store.get_webhook_by_id(999)
+
+    assert webhook is None
+
+
+@pytest.mark.asyncio
 async def test_get_webhook_user_id_returns_installer_keycloak_id(
     webhook_store, sample_webhook
 ):
@@ -98,6 +114,36 @@ async def test_get_webhooks_by_repos_returns_matching_webhooks(
 
     assert list(webhook_map.keys()) == [('PROJ', 'myrepo')]
     assert webhook_map[('PROJ', 'myrepo')].webhook_secret == 'shared-secret'
+
+
+@pytest.mark.asyncio
+async def test_ensure_webhook_enrollment_creates_placeholder_row(webhook_store):
+    webhook = await webhook_store.ensure_webhook_enrollment(
+        project_key='PROJ',
+        repo_slug='newrepo',
+        user_id='kc-user',
+    )
+
+    assert webhook.id is not None
+    assert webhook.project_key == 'PROJ'
+    assert webhook.repo_slug == 'newrepo'
+    assert webhook.user_id == 'kc-user'
+    assert webhook.webhook_secret is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_webhook_enrollment_preserves_existing_secret(
+    webhook_store, sample_webhook
+):
+    webhook = await webhook_store.ensure_webhook_enrollment(
+        project_key='PROJ',
+        repo_slug='myrepo',
+        user_id='kc-new-user',
+    )
+
+    assert webhook.id == sample_webhook.id
+    assert webhook.user_id == 'kc-installer'
+    assert webhook.webhook_secret == 'shared-secret'
 
 
 @pytest.mark.asyncio

--- a/frontend/__tests__/components/features/settings/bitbucket-dc-webhook-manager.test.tsx
+++ b/frontend/__tests__/components/features/settings/bitbucket-dc-webhook-manager.test.tsx
@@ -19,8 +19,10 @@ const mockResources: BitbucketDCResource[] = [
     name: "myrepo",
     full_name: "PROJ/myrepo",
     type: "repository",
+    connection_id: null,
     webhook_enrolled: false,
     webhook_id: null,
+    webhook_url: null,
     webhook_secret_set: false,
     installed_by_user_id: null,
     last_synced: null,
@@ -31,8 +33,11 @@ const mockResources: BitbucketDCResource[] = [
     name: "platform",
     full_name: "OPS/platform",
     type: "repository",
+    connection_id: 7,
     webhook_enrolled: true,
     webhook_id: "42",
+    webhook_url:
+      "https://example.com/integration/bitbucket-dc/connections/7/events",
     webhook_secret_set: true,
     installed_by_user_id: "kc-bot",
     last_synced: "2026-01-01T00:00:00",
@@ -99,6 +104,9 @@ describe("BitbucketDCWebhookManager", () => {
         success: true,
         error: null,
         webhook_id: "101",
+        connection_id: 8,
+        webhook_url:
+          "https://example.com/integration/bitbucket-dc/connections/8/events",
       });
 
     renderComponent();
@@ -127,6 +135,9 @@ describe("BitbucketDCWebhookManager", () => {
         success: true,
         error: null,
         webhook_id: "42",
+        connection_id: 7,
+        webhook_url:
+          "https://example.com/integration/bitbucket-dc/connections/7/events",
       });
 
     renderComponent();

--- a/frontend/src/api/integration-service/integration-service.types.ts
+++ b/frontend/src/api/integration-service/integration-service.types.ts
@@ -34,8 +34,10 @@ export interface BitbucketDCResource {
   name: string;
   full_name: string;
   type: "repository";
+  connection_id: number | null;
   webhook_enrolled: boolean;
   webhook_id: string | null;
+  webhook_url: string | null;
   webhook_secret_set: boolean;
   installed_by_user_id: string | null;
   last_synced: string | null;
@@ -59,6 +61,7 @@ export interface BitbucketDCWebhookEnrollmentResult {
   repo_slug: string;
   success: boolean;
   error: string | null;
+  connection_id: number | null;
   webhook_url: string | null;
   webhook_secret: string | null;
   webhook_name: string;
@@ -87,4 +90,6 @@ export interface BitbucketDCWebhookInstallationResult {
   success: boolean;
   error: string | null;
   webhook_id: string | null;
+  connection_id: number | null;
+  webhook_url: string | null;
 }


### PR DESCRIPTION
## Why
Bitbucket Data Center webhook deliveries should be scoped to a stable OpenHands connection id instead of relying on `(project_key, repo_slug)` extracted from the payload. This gives us a cleaner path to future multi-instance Bitbucket DC support and removes ambiguity from newly generated webhook URLs.

## Summary
- Generate Bitbucket DC webhook URLs as `/integration/bitbucket-dc/connections/{id}/events` for both manual enrollment and automatic reinstall.
- Verify connection-scoped deliveries against the webhook row selected by the URL id, and reject payloads for a different repository.
- Remove the old global `/integration/bitbucket-dc/events` route and the legacy webhook URL lookup/update path.
- Carry the installer user id from the webhook row into resolver processing.
- Return `connection_id` and `webhook_url` in BBDC resource/webhook responses and update frontend types/tests.

## How to Test
- `uv run ruff check --config enterprise/dev_config/python/ruff.toml enterprise/server/routes/integration/bitbucket_dc.py enterprise/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_webhook.py`
- `PYTHONPATH=enterprise:. uv run --with python-keycloak --with limits --with coredis --with aiosqlite pytest enterprise/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_webhook.py enterprise/tests/unit/storage/test_bitbucket_dc_webhook_store.py tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_resolver.py`
- `cd frontend && npm run typecheck:staged`
- `cd frontend && npm test -- bitbucket-dc-webhook-manager`

## Notes
Bitbucket Data Center webhook enrollment has not launched publicly for OHE, so this intentionally ships the connection-scoped route as the only delivery path before there are public consumers. Existing internal/test webhooks that still point at `/integration/bitbucket-dc/events` must be reinstalled through the OpenHands UI or updated manually to the connection-scoped URL.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-254a4d4   docker.openhands.dev/openhands/openhands:254a4d4
```

---
Linear: APP-1959

_AI-generated metadata update by OpenHands on behalf of ak684._
