### PR TITLE
Simplify event callback execution filters

### DIFF
--- a/enterprise/integrations/bitbucket/bitbucket_v1_callback_processor.py
+++ b/enterprise/integrations/bitbucket/bitbucket_v1_callback_processor.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, ClassVar
 from uuid import UUID
 
 import httpx
@@ -11,6 +11,7 @@ from openhands.agent_server.models import AskAgentRequest, AskAgentResponse
 from openhands.app_server.event_callback.event_callback_models import (
     EventCallback,
     EventCallbackProcessor,
+    EventKind,
 )
 from openhands.app_server.event_callback.event_callback_result_models import (
     EventCallbackResult,
@@ -33,6 +34,8 @@ class BitbucketV1CallbackProcessor(EventCallbackProcessor):
     Posts a summary comment back to the originating PR when the agent
     finishes successfully. Mirrors :class:`GitlabV1CallbackProcessor`.
     """
+
+    event_kind: ClassVar[EventKind] = 'ConversationStateUpdateEvent'
 
     bitbucket_view_data: dict[str, Any] = Field(default_factory=dict)
     should_request_summary: bool = Field(default=True)

--- a/enterprise/integrations/bitbucket_data_center/bitbucket_dc_v1_callback_processor.py
+++ b/enterprise/integrations/bitbucket_data_center/bitbucket_dc_v1_callback_processor.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, ClassVar
 from uuid import UUID
 
 import httpx
@@ -11,6 +11,7 @@ from openhands.agent_server.models import AskAgentRequest, AskAgentResponse
 from openhands.app_server.event_callback.event_callback_models import (
     EventCallback,
     EventCallbackProcessor,
+    EventKind,
 )
 from openhands.app_server.event_callback.event_callback_result_models import (
     EventCallbackResult,
@@ -33,6 +34,8 @@ class BitbucketDCV1CallbackProcessor(EventCallbackProcessor):
     Posts a summary comment back to the originating PR when the agent
     finishes successfully. Mirrors :class:`BitbucketV1CallbackProcessor`.
     """
+
+    event_kind: ClassVar[EventKind] = 'ConversationStateUpdateEvent'
 
     bitbucket_dc_view_data: dict[str, Any] = Field(default_factory=dict)
     should_request_summary: bool = Field(default=True)

--- a/enterprise/integrations/github/github_v1_callback_processor.py
+++ b/enterprise/integrations/github/github_v1_callback_processor.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, ClassVar
 from uuid import UUID
 
 import httpx
@@ -13,6 +13,7 @@ from openhands.agent_server.models import AskAgentRequest, AskAgentResponse
 from openhands.app_server.event_callback.event_callback_models import (
     EventCallback,
     EventCallbackProcessor,
+    EventKind,
 )
 from openhands.app_server.event_callback.event_callback_result_models import (
     EventCallbackResult,
@@ -31,6 +32,8 @@ _logger = logging.getLogger(__name__)
 
 class GithubV1CallbackProcessor(EventCallbackProcessor):
     """Callback processor for GitHub V1 integrations."""
+
+    event_kind: ClassVar[EventKind] = 'ConversationStateUpdateEvent'
 
     github_view_data: dict[str, Any] = Field(default_factory=dict)
     should_request_summary: bool = Field(default=True)

--- a/enterprise/integrations/gitlab/gitlab_v1_callback_processor.py
+++ b/enterprise/integrations/gitlab/gitlab_v1_callback_processor.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, ClassVar
 from uuid import UUID
 
 import httpx
@@ -11,6 +11,7 @@ from openhands.agent_server.models import AskAgentRequest, AskAgentResponse
 from openhands.app_server.event_callback.event_callback_models import (
     EventCallback,
     EventCallbackProcessor,
+    EventKind,
 )
 from openhands.app_server.event_callback.event_callback_result_models import (
     EventCallbackResult,
@@ -29,6 +30,8 @@ _logger = logging.getLogger(__name__)
 
 class GitlabV1CallbackProcessor(EventCallbackProcessor):
     """Callback processor for GitLab V1 integrations."""
+
+    event_kind: ClassVar[EventKind] = 'ConversationStateUpdateEvent'
 
     gitlab_view_data: dict[str, Any] = Field(default_factory=dict)
     should_request_summary: bool = Field(default=True)

--- a/enterprise/integrations/jira/jira_v1_callback_processor.py
+++ b/enterprise/integrations/jira/jira_v1_callback_processor.py
@@ -1,4 +1,5 @@
 import logging
+from typing import ClassVar
 from uuid import UUID
 
 import httpx
@@ -9,6 +10,7 @@ from openhands.agent_server.models import AskAgentRequest, AskAgentResponse
 from openhands.app_server.event_callback.event_callback_models import (
     EventCallback,
     EventCallbackProcessor,
+    EventKind,
 )
 from openhands.app_server.event_callback.event_callback_result_models import (
     EventCallbackResult,
@@ -30,6 +32,8 @@ JIRA_CLOUD_API_URL = 'https://api.atlassian.com/ex/jira'
 
 class JiraV1CallbackProcessor(EventCallbackProcessor):
     """Callback processor for Jira V1 integrations."""
+
+    event_kind: ClassVar[EventKind] = 'ConversationStateUpdateEvent'
 
     should_request_summary: bool = Field(default=True)
     svc_acc_email: str

--- a/enterprise/integrations/jira_dc/jira_dc_v1_callback_processor.py
+++ b/enterprise/integrations/jira_dc/jira_dc_v1_callback_processor.py
@@ -5,6 +5,7 @@ summaries back to Jira DC issues when the agent finishes work.
 """
 
 import logging
+from typing import ClassVar
 from uuid import UUID
 
 import httpx
@@ -15,6 +16,7 @@ from openhands.agent_server.models import AskAgentRequest, AskAgentResponse
 from openhands.app_server.event_callback.event_callback_models import (
     EventCallback,
     EventCallbackProcessor,
+    EventKind,
 )
 from openhands.app_server.event_callback.event_callback_result_models import (
     EventCallbackResult,
@@ -34,6 +36,8 @@ _logger = logging.getLogger(__name__)
 
 class JiraDcV1CallbackProcessor(EventCallbackProcessor):
     """Callback processor for Jira Data Center V1 integrations."""
+
+    event_kind: ClassVar[EventKind] = 'ConversationStateUpdateEvent'
 
     should_request_summary: bool = Field(default=True)
     issue_key: str

--- a/enterprise/integrations/slack/slack_v1_callback_processor.py
+++ b/enterprise/integrations/slack/slack_v1_callback_processor.py
@@ -1,4 +1,5 @@
 import logging
+from typing import ClassVar
 from uuid import UUID
 
 import httpx
@@ -12,6 +13,7 @@ from openhands.agent_server.models import AskAgentRequest, AskAgentResponse
 from openhands.app_server.event_callback.event_callback_models import (
     EventCallback,
     EventCallbackProcessor,
+    EventKind,
 )
 from openhands.app_server.event_callback.event_callback_result_models import (
     EventCallbackResult,
@@ -30,6 +32,8 @@ _logger = logging.getLogger(__name__)
 
 class SlackV1CallbackProcessor(EventCallbackProcessor):
     """Callback processor for Slack V1 integrations."""
+
+    event_kind: ClassVar[EventKind] = 'ConversationStateUpdateEvent'
 
     slack_view_data: dict[str, str | None] = Field(default_factory=dict)
 

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -415,6 +415,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 await self.event_callback_service.save_event_callback(
                     EventCallback(
                         conversation_id=info.id,
+                        event_kind=processor.get_event_kind(),
                         processor=processor,
                     )
                 )

--- a/openhands/app_server/event_callback/event_callback_models.py
+++ b/openhands/app_server/event_callback/event_callback_models.py
@@ -5,7 +5,7 @@ import logging
 from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, ClassVar, Literal
 from uuid import UUID, uuid4
 
 from pydantic import Field
@@ -38,6 +38,12 @@ class EventCallbackStatus(Enum):
 
 
 class EventCallbackProcessor(DiscriminatedUnionMixin, ABC):
+    event_kind: ClassVar[EventKind] = 'MessageEvent'
+
+    @classmethod
+    def get_event_kind(cls) -> EventKind:
+        return cls.event_kind
+
     @abstractmethod
     async def __call__(
         self,
@@ -71,18 +77,13 @@ class LoggingCallbackProcessor(EventCallbackProcessor):
 
 
 class CreateEventCallbackRequest(OpenHandsModel):
-    conversation_id: OpenHandsUUID | None = Field(
-        default=None,
-        description=(
-            'Optional filter on the conversation to which this callback applies'
-        ),
+    conversation_id: OpenHandsUUID = Field(
+        description='Conversation to which this callback applies',
     )
     processor: EventCallbackProcessor
-    event_kind: EventKind | None = Field(
-        default=None,
-        description=(
-            'Optional filter on the type of events to which this callback applies'
-        ),
+    event_kind: EventKind = Field(
+        default='MessageEvent',
+        description='Type of event to which this callback applies',
     )
 
 

--- a/openhands/app_server/event_callback/set_title_callback_processor.py
+++ b/openhands/app_server/event_callback/set_title_callback_processor.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from typing import ClassVar
 from uuid import UUID
 
 import httpx
@@ -11,6 +12,7 @@ from openhands.app_server.event_callback.event_callback_models import (
     EventCallback,
     EventCallbackProcessor,
     EventCallbackStatus,
+    EventKind,
 )
 from openhands.app_server.event_callback.event_callback_result_models import (
     EventCallbackResult,
@@ -79,6 +81,8 @@ async def _poll_for_title(
 
 class SetTitleCallbackProcessor(EventCallbackProcessor):
     """Callback processor which sets conversation titles."""
+
+    event_kind: ClassVar[EventKind] = 'MessageEvent'
 
     async def __call__(
         self,

--- a/openhands/app_server/event_callback/sql_event_callback_service.py
+++ b/openhands/app_server/event_callback/sql_event_callback_service.py
@@ -11,7 +11,7 @@ from typing import AsyncGenerator
 from uuid import UUID, uuid4
 
 from fastapi import Request
-from sqlalchemy import Enum, String, and_, func, or_, select
+from sqlalchemy import Enum, String, and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -201,18 +201,8 @@ class SQLEventCallbackService(EventCallbackService):
         query = (
             select(StoredEventCallback)
             .where(StoredEventCallback.status == EventCallbackStatus.ACTIVE)
-            .where(
-                or_(
-                    StoredEventCallback.event_kind == event.kind,
-                    StoredEventCallback.event_kind.is_(None),
-                )
-            )
-            .where(
-                or_(
-                    StoredEventCallback.conversation_id == conversation_id,
-                    StoredEventCallback.conversation_id.is_(None),
-                )
-            )
+            .where(StoredEventCallback.event_kind == event.kind)
+            .where(StoredEventCallback.conversation_id == conversation_id)
         )
         result = await self.db_session.execute(query)
         stored_callbacks = result.scalars().all()

--- a/openhands/app_server/event_callback/webhook_router.py
+++ b/openhands/app_server/event_callback/webhook_router.py
@@ -383,6 +383,7 @@ async def on_conversation_update(
             await event_callback_service.save_event_callback(
                 EventCallback(
                     conversation_id=conversation_info.id,
+                    event_kind=SetTitleCallbackProcessor.get_event_kind(),
                     processor=SetTitleCallbackProcessor(),
                 )
             )

--- a/tests/unit/app_server/test_sql_event_callback_service.py
+++ b/tests/unit/app_server/test_sql_event_callback_service.py
@@ -10,6 +10,8 @@ from typing import AsyncGenerator
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
@@ -17,12 +19,16 @@ from openhands.app_server.event_callback.event_callback_models import (
     CreateEventCallbackRequest,
     EventCallback,
     EventCallbackProcessor,
+    EventCallbackStatus,
     LoggingCallbackProcessor,
 )
 from openhands.app_server.event_callback.sql_event_callback_service import (
     SQLEventCallbackService,
+    StoredEventCallback,
+    StoredEventCallbackResult,
 )
 from openhands.app_server.utils.sql_utils import Base
+from openhands.sdk import Message, MessageEvent, TextContent
 
 
 @pytest.fixture
@@ -267,31 +273,38 @@ class TestSQLEventCallbackService:
         assert len(next_result.items) == 2
         assert next_result.next_page_id is None
 
-    async def test_search_callbacks_with_null_filters(
-        self,
-        service: SQLEventCallbackService,
-        sample_processor: EventCallbackProcessor,
+    def test_event_callback_request_requires_conversation_id(
+        self, sample_processor: EventCallbackProcessor
     ):
-        """Test searching callbacks with null conversation_id and event_kind."""
-        # Create callbacks with null values
-        callback1_request = CreateEventCallbackRequest(
-            conversation_id=None,
-            processor=sample_processor,
-            event_kind=None,
-        )
-        callback2_request = CreateEventCallbackRequest(
+        """Callbacks must be scoped to a concrete conversation."""
+        with pytest.raises(ValidationError):
+            CreateEventCallbackRequest(
+                conversation_id=None,
+                processor=sample_processor,
+                event_kind='MessageEvent',
+            )
+
+    def test_event_callback_request_rejects_null_event_kind(
+        self, sample_processor: EventCallbackProcessor
+    ):
+        """Callbacks must be scoped to a concrete event kind."""
+        with pytest.raises(ValidationError):
+            CreateEventCallbackRequest(
+                conversation_id=uuid4(),
+                processor=sample_processor,
+                event_kind=None,
+            )
+
+    def test_event_callback_request_defaults_event_kind_to_message_event(
+        self, sample_processor: EventCallbackProcessor
+    ):
+        """MessageEvent is the default callback event kind."""
+        callback_request = CreateEventCallbackRequest(
             conversation_id=uuid4(),
             processor=sample_processor,
-            event_kind='ActionEvent',
         )
 
-        await service.create_event_callback(callback1_request)
-        await service.create_event_callback(callback2_request)
-
-        # Search should return both callbacks
-        result = await service.search_event_callbacks()
-
-        assert len(result.items) == 2
+        assert callback_request.event_kind == 'MessageEvent'
 
     async def test_callback_timestamps(
         self,
@@ -372,6 +385,89 @@ class TestSQLEventCallbackService:
         assert len(result.items) == 2
         assert result.items[0].id == callback2.id
         assert result.items[1].id == callback1.id
+
+    async def test_execute_callbacks_runs_conversation_specific_callback(
+        self,
+        service: SQLEventCallbackService,
+        sample_processor: EventCallbackProcessor,
+    ):
+        """Test executing callbacks for the matching conversation."""
+        conversation_id = uuid4()
+        callback = await service.create_event_callback(
+            CreateEventCallbackRequest(
+                conversation_id=conversation_id,
+                processor=sample_processor,
+                event_kind='MessageEvent',
+            )
+        )
+        event = MessageEvent(
+            source='user',
+            llm_message=Message(role='user', content=[TextContent(text='hi')]),
+        )
+
+        await service.execute_callbacks(conversation_id, event)
+
+        result = await service.db_session.execute(select(StoredEventCallbackResult))
+        callback_results = result.scalars().all()
+        assert len(callback_results) == 1
+        assert callback_results[0].event_callback_id == callback.id
+        assert callback_results[0].conversation_id == conversation_id
+
+    async def test_execute_callbacks_ignores_legacy_null_conversation_callback(
+        self,
+        service: SQLEventCallbackService,
+        sample_processor: EventCallbackProcessor,
+    ):
+        """Legacy callbacks without a conversation_id should not execute globally."""
+        conversation_id = uuid4()
+        service.db_session.add(
+            StoredEventCallback(
+                id=uuid4(),
+                conversation_id=None,
+                status=EventCallbackStatus.ACTIVE,
+                processor=sample_processor,
+                event_kind='MessageEvent',
+            )
+        )
+        await service.db_session.commit()
+        event = MessageEvent(
+            source='user',
+            llm_message=Message(role='user', content=[TextContent(text='hi')]),
+        )
+
+        await service.execute_callbacks(conversation_id, event)
+
+        result = await service.db_session.execute(select(StoredEventCallbackResult))
+        callback_results = result.scalars().all()
+        assert callback_results == []
+
+    async def test_execute_callbacks_ignores_legacy_null_event_kind_callback(
+        self,
+        service: SQLEventCallbackService,
+        sample_processor: EventCallbackProcessor,
+    ):
+        """Legacy callbacks without an event_kind should not execute as event wildcards."""
+        conversation_id = uuid4()
+        service.db_session.add(
+            StoredEventCallback(
+                id=uuid4(),
+                conversation_id=conversation_id,
+                status=EventCallbackStatus.ACTIVE,
+                processor=sample_processor,
+                event_kind=None,
+            )
+        )
+        await service.db_session.commit()
+        event = MessageEvent(
+            source='user',
+            llm_message=Message(role='user', content=[TextContent(text='hi')]),
+        )
+
+        await service.execute_callbacks(conversation_id, event)
+
+        result = await service.db_session.execute(select(StoredEventCallbackResult))
+        callback_results = result.scalars().all()
+        assert callback_results == []
 
     async def test_save_event_callback_new(
         self,
@@ -498,34 +594,24 @@ class TestSQLEventCallbackService:
         time_diff = now - saved_utc
         assert time_diff.total_seconds() < 60
 
-    async def test_save_event_callback_with_null_values(
+    def test_event_callback_rejects_null_values(
         self,
-        service: SQLEventCallbackService,
         sample_processor: EventCallbackProcessor,
     ):
-        """Test saving a callback with null conversation_id and event_kind."""
-        # Create a callback with null values
-        callback = EventCallback(
-            conversation_id=None,
-            processor=sample_processor,
-            event_kind=None,
-        )
+        """EventCallback should not allow null conversation_id or event_kind."""
+        with pytest.raises(ValidationError):
+            EventCallback(
+                conversation_id=None,
+                processor=sample_processor,
+                event_kind='MessageEvent',
+            )
 
-        # Save the callback
-        saved_callback = await service.save_event_callback(callback)
-
-        # Verify the callback was saved correctly
-        assert saved_callback.id == callback.id
-        assert saved_callback.conversation_id is None
-        assert saved_callback.event_kind is None
-        assert saved_callback.processor == sample_processor
-
-        # Commit and verify persistence
-        await service.db_session.commit()
-        retrieved_callback = await service.get_event_callback(callback.id)
-        assert retrieved_callback is not None
-        assert retrieved_callback.conversation_id is None
-        assert retrieved_callback.event_kind is None
+        with pytest.raises(ValidationError):
+            EventCallback(
+                conversation_id=uuid4(),
+                processor=sample_processor,
+                event_kind=None,
+            )
 
     async def test_save_event_callback_preserves_created_at(
         self,

--- a/tests/unit/app_server/test_webhook_router_auto_title.py
+++ b/tests/unit/app_server/test_webhook_router_auto_title.py
@@ -174,6 +174,7 @@ class TestOnConversationUpdateAutoTitle:
         assert len(saved_callbacks) == 1
         callback = saved_callbacks[0]
         assert callback.conversation_id == conversation_id
+        assert callback.event_kind == 'MessageEvent'
         assert isinstance(callback.processor, SetTitleCallbackProcessor)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
HUMAN: Slightly reduce flexibility of our event callback queries to hopefully increase efficiency and decrease DB load.

- [ ] A human has tested these changes

## Summary

- Remove `event_kind IS NULL` and `conversation_id IS NULL` wildcard matching from `SQLEventCallbackService.execute_callbacks()`.
- Tighten `CreateEventCallbackRequest` / `EventCallback` so new callbacks require concrete `conversation_id` and non-null `event_kind`.
- Add `EventCallbackProcessor.get_event_kind()` and use it when registering startup processors.
- Register enterprise V1 integration processors for `ConversationStateUpdateEvent` and title callbacks for `MessageEvent`.
- Add tests for exact callback execution, model validation, and ignored legacy null conversation/event-kind rows.

Closes #14556

## Context

The callback execution query is on a hot event path and previously expanded each lookup with null wildcard branches. Callback processors already handle specific event types, so registrations now declare the event kind they actually handle and execution uses exact matching.

The DB columns remain nullable in this PR for backwards compatibility with existing rows; legacy null rows simply do not match execution anymore. A later migration can clean them up and add `NOT NULL` constraints/indexes if desired.

## Testing

- `OPENHANDS_SUPPRESS_BANNER=1 uv run python -m pytest tests/unit/app_server/test_sql_event_callback_service.py tests/unit/app_server/test_webhook_router_auto_title.py tests/unit/app_server/test_set_title_callback_processor.py -q`
- `OPENHANDS_SUPPRESS_BANNER=1 uv run ruff check openhands/app_server/event_callback/event_callback_models.py openhands/app_server/event_callback/sql_event_callback_service.py openhands/app_server/app_conversation/live_status_app_conversation_service.py openhands/app_server/event_callback/webhook_router.py tests/unit/app_server/test_sql_event_callback_service.py tests/unit/app_server/test_webhook_router_auto_title.py tests/unit/app_server/test_set_title_callback_processor.py enterprise/integrations/bitbucket/bitbucket_v1_callback_processor.py enterprise/integrations/bitbucket_data_center/bitbucket_dc_v1_callback_processor.py enterprise/integrations/github/github_v1_callback_processor.py enterprise/integrations/gitlab/gitlab_v1_callback_processor.py enterprise/integrations/jira/jira_v1_callback_processor.py enterprise/integrations/jira_dc/jira_dc_v1_callback_processor.py enterprise/integrations/slack/slack_v1_callback_processor.py`
- `cd enterprise && python3 -m pre_commit run --all-files --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml`

---

_This PR was updated by an AI agent (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-ed55b0b   docker.openhands.dev/openhands/openhands:ed55b0b
```