### PR TITLE
fix: seek temp file before read; delete DB record after remote stop

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -425,6 +425,7 @@ class AppConversationServiceBase(AppConversationService, ABC):
             if download_result.success:
                 _logger.info('Preserving existing pre-commit hook')
                 # an existing pre-commit hook exists
+                temp_file.seek(0)
                 if 'This hook was installed by OpenHands' not in temp_file.read():
                     # Move the existing hook to pre-commit.local
                     command = (

--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -417,10 +417,14 @@ class AppConversationServiceBase(AppConversationService, ABC):
         if pre_commit_command_result.exit_code:
             return
 
-        # Check if there's an existing pre-commit hook
-        with tempfile.TemporaryFile(mode='w+t') as temp_file:
+        # Check if there's an existing pre-commit hook.
+        # NamedTemporaryFile gives file_download a real filesystem path to
+        # write into; TemporaryFile only gives an fd-backed object whose
+        # str() is not a valid path and would silently cause the download to
+        # fail, leaving the hook check unreachable.
+        with tempfile.NamedTemporaryFile(mode='w+t', suffix='.hook', delete=True) as temp_file:
             download_result = await workspace.file_download(
-                PRE_COMMIT_HOOK, str(temp_file)
+                PRE_COMMIT_HOOK, temp_file.name
             )
             if download_result.success:
                 _logger.info('Preserving existing pre-commit hook')

--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -605,9 +605,6 @@ class RemoteSandboxService(SandboxService):
             stored_sandbox = await self._get_stored_sandbox(sandbox_id)
             if not stored_sandbox:
                 return False
-            # Deleting the record also removes the session_api_key_hash,
-            # which invalidates any leaked session keys.
-            await self.db_session.delete(stored_sandbox)
             runtime_data = await self._get_runtime(sandbox_id)
             response = await self._send_runtime_api_request(
                 'POST',
@@ -616,6 +613,12 @@ class RemoteSandboxService(SandboxService):
             )
             if response.status_code != 404:
                 response.raise_for_status()
+            # Delete the record only after the remote stop succeeds, so that
+            # a failed API call does not leave the sandbox running without a
+            # DB record (unrecoverable inconsistent state).
+            # Deleting the record also removes the session_api_key_hash,
+            # which invalidates any leaked session keys.
+            await self.db_session.delete(stored_sandbox)
             return True
         except httpx.HTTPError as e:
             _logger.error(f'Error deleting sandbox {sandbox_id}: {e}')


### PR DESCRIPTION
HUMAN: Found two logic bugs via code review:
1. `TemporaryFile` was passed as a path to `file_download` via `str(temp_file)`, which gives an object repr like `<_io.TextIOWrapper name=3 ...>` — not a valid path. The download always silently failed, making the entire pre-commit hook preservation block unreachable. Fixed by switching to `NamedTemporaryFile` and passing `temp_file.name`.
2. In `delete_sandbox`, the DB record was deleted *before* the remote `/stop` API call. If the API raised, the sandbox kept running with no DB record — unrecoverable state. Fixed by moving the delete after the API call succeeds.

- [ ] A human has tested these changes.

---

## Summary

Two logic bugs found during code review.

---

### Bug 1 — `app_conversation_service_base.py`: `TemporaryFile` path is never valid

```python
# Before (broken)
with tempfile.TemporaryFile(mode='w+t') as temp_file:
    download_result = await workspace.file_download(
        PRE_COMMIT_HOOK, str(temp_file)   # str(TemporaryFile) → '<_io.TextIOWrapper name=3 ...>'
    )
    if download_result.success:           # always False — download fails silently
        if 'This hook was installed by OpenHands' not in temp_file.read():
```

`str(TemporaryFile)` returns the object repr like `<_io.TextIOWrapper name=3 mode='w+t' encoding='UTF-8'>`, which is not a valid filesystem path. `file_download` always fails, `download_result.success` is always `False`, and the entire pre-commit hook preservation block is **unreachable** — the hook is always overwritten.

```python
# After (fixed)
with tempfile.NamedTemporaryFile(mode='w+t', suffix='.hook', delete=True) as temp_file:
    download_result = await workspace.file_download(
        PRE_COMMIT_HOOK, temp_file.name   # real filesystem path
    )
    if download_result.success:
        temp_file.seek(0)                 # reset pointer after file_download writes
        if 'This hook was installed by OpenHands' not in temp_file.read():
```

Also adds `seek(0)` before `read()` since `file_download` leaves the file pointer at the end.

---

### Bug 2 — `remote_sandbox_service.py`: DB record deleted before remote API call

```python
# Before: delete DB → call /stop API (if API fails, DB record is already gone)
await self.db_session.delete(stored_sandbox)
response = await self._send_runtime_api_request('POST', '/stop', ...)
response.raise_for_status()

# After: call /stop API → delete DB only on success
response = await self._send_runtime_api_request('POST', '/stop', ...)
response.raise_for_status()
await self.db_session.delete(stored_sandbox)
```

If the `/stop` request raised an `httpx.HTTPError`, the DB record was already deleted but the runtime was still running — an unrecoverable inconsistent state. Moving `db_session.delete()` after `raise_for_status()` ensures both operations succeed or the DB record is preserved for retry.

## Testing

- [ ] Existing pre-commit hook is correctly preserved when it does **not** contain `This hook was installed by OpenHands`
- [ ] Existing hook installed by OpenHands is **not** moved to `.local`
- [ ] Sandbox DB record is preserved when the remote `/stop` API returns an HTTP error