### PR TITLE
Fix App tab detection for exposed worker URLs

### DIFF
--- a/frontend/src/api/sandbox-service/sandbox-service.api.ts
+++ b/frontend/src/api/sandbox-service/sandbox-service.api.ts
@@ -2,7 +2,10 @@
 // This file contains API methods for /api/v1/sandboxes endpoints.
 
 import { openHands } from "../open-hands-axios";
-import type { V1SandboxInfo } from "./sandbox-service.types";
+import type {
+  V1SandboxInfo,
+  V1WebHostStatusResponse,
+} from "./sandbox-service.types";
 
 export class SandboxService {
   /**
@@ -46,6 +49,20 @@ export class SandboxService {
     ids.forEach((id) => params.append("id", id));
     const { data } = await openHands.get<(V1SandboxInfo | null)[]>(
       `/api/v1/sandboxes?${params.toString()}`,
+    );
+    return data;
+  }
+
+  /**
+   * Check whether an exposed sandbox worker URL is serving a web app
+   */
+  static async getWebHostStatus(
+    sandboxId: string,
+    url: string,
+  ): Promise<V1WebHostStatusResponse> {
+    const { data } = await openHands.get<V1WebHostStatusResponse>(
+      `/api/v1/sandboxes/${sandboxId}/web-host-status`,
+      { params: { url } },
     );
     return data;
   }

--- a/frontend/src/api/sandbox-service/sandbox-service.types.ts
+++ b/frontend/src/api/sandbox-service/sandbox-service.types.ts
@@ -22,3 +22,7 @@ export interface V1SandboxInfo {
   exposed_urls: V1ExposedUrl[] | null;
   created_at: string;
 }
+
+export interface V1WebHostStatusResponse {
+  reachable: boolean;
+}

--- a/frontend/src/hooks/query/use-unified-active-host.ts
+++ b/frontend/src/hooks/query/use-unified-active-host.ts
@@ -1,6 +1,6 @@
 import { useQueries, useQuery } from "@tanstack/react-query";
-import axios from "axios";
 import React from "react";
+import { SandboxService } from "#/api/sandbox-service/sandbox-service.api";
 import { useConversationId } from "#/hooks/use-conversation-id";
 import { useRuntimeIsReady } from "#/hooks/use-runtime-is-ready";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
@@ -49,16 +49,22 @@ export const useUnifiedActiveHost = () => {
   // Poll all hosts to find which one is active
   const apps = useQueries({
     queries: data.hosts.map((host) => ({
-      queryKey: [conversationId, "unified", "hosts", host],
+      queryKey: [conversationId, "unified", "hosts", sandboxId, host],
       queryFn: async () => {
+        if (!sandboxId) {
+          return "";
+        }
+
         try {
-          await axios.get(host);
-          return host;
+          const status = await SandboxService.getWebHostStatus(sandboxId, host);
+          return status.reachable ? host : "";
         } catch (e) {
           return "";
         }
       },
+      enabled: !!sandboxId,
       refetchInterval: 3000,
+      retry: false,
       meta: {
         disableToast: true,
       },

--- a/openhands/app_server/sandbox/sandbox_models.py
+++ b/openhands/app_server/sandbox/sandbox_models.py
@@ -61,6 +61,12 @@ class SandboxPage(BaseModel):
     next_page_id: str | None = None
 
 
+class WebHostStatusResponse(BaseModel):
+    """Reachability status for a sandbox exposed web host."""
+
+    reachable: bool
+
+
 class SecretNameItem(BaseModel):
     """A secret's name and optional description (value NOT included)."""
 

--- a/openhands/app_server/sandbox/sandbox_router.py
+++ b/openhands/app_server/sandbox/sandbox_router.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Annotated, cast
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.security import APIKeyHeader
 
@@ -13,6 +14,7 @@ from openhands.app_server.sandbox.sandbox_models import (
     SandboxPage,
     SecretNameItem,
     SecretNamesResponse,
+    WebHostStatusResponse,
 )
 from openhands.app_server.sandbox.sandbox_service import (
     SandboxService,
@@ -67,6 +69,53 @@ async def batch_get_sandboxes(
         )
     sandboxes = await sandbox_service.batch_get_sandboxes(id)
     return sandboxes
+
+
+def _normalize_exposed_url(url: str) -> str:
+    return url.rstrip('/')
+
+
+def _is_allowed_worker_url(sandbox: SandboxInfo, url: str) -> bool:
+    """Only allow probing worker URLs already exposed for this sandbox."""
+    requested_url = _normalize_exposed_url(url)
+    return any(
+        exposed_url.name.startswith('WORKER_')
+        and _normalize_exposed_url(exposed_url.url) == requested_url
+        for exposed_url in sandbox.exposed_urls or []
+    )
+
+
+async def _probe_web_host(url: str) -> bool:
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=httpx.Timeout(2.5),
+        ) as client:
+            async with client.stream('GET', url) as response:
+                return 200 <= response.status_code < 400
+    except httpx.HTTPError as exc:
+        _logger.debug('Web host probe failed for %s: %s', url, exc)
+        return False
+
+
+@router.get('/{sandbox_id}/web-host-status')
+async def get_web_host_status(
+    sandbox_id: str,
+    url: Annotated[str, Query()],
+    sandbox_service: SandboxService = sandbox_service_dependency,
+) -> WebHostStatusResponse:
+    """Check whether an exposed sandbox worker URL is serving a web app."""
+    sandbox = await sandbox_service.get_sandbox(sandbox_id)
+    if sandbox is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+
+    if not _is_allowed_worker_url(sandbox, url):
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail='URL is not an exposed worker URL for this sandbox',
+        )
+
+    return WebHostStatusResponse(reachable=await _probe_web_host(url))
 
 
 # Write Methods

--- a/tests/unit/app_server/test_sandbox_web_host_status_router.py
+++ b/tests/unit/app_server/test_sandbox_web_host_status_router.py
@@ -1,0 +1,101 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException, status
+
+from openhands.app_server.sandbox.sandbox_models import (
+    ExposedUrl,
+    SandboxInfo,
+    SandboxStatus,
+)
+from openhands.app_server.sandbox.sandbox_router import (
+    _is_allowed_worker_url,
+    get_web_host_status,
+)
+
+SANDBOX_ID = 'sb-test-123'
+WORKER_URL = 'https://work-1-runtime.example.com/'
+
+
+def _make_sandbox_info() -> SandboxInfo:
+    return SandboxInfo(
+        id=SANDBOX_ID,
+        created_by_user_id='test-user-id',
+        sandbox_spec_id='test-spec',
+        status=SandboxStatus.RUNNING,
+        session_api_key='session-key',
+        exposed_urls=[
+            ExposedUrl(name='WORKER_1', url=WORKER_URL, port=12000),
+            ExposedUrl(
+                name='VSCODE',
+                url='https://vscode-runtime.example.com/',
+                port=12001,
+            ),
+        ],
+    )
+
+
+def test_allows_only_registered_worker_urls():
+    sandbox = _make_sandbox_info()
+
+    assert _is_allowed_worker_url(sandbox, WORKER_URL)
+    assert _is_allowed_worker_url(sandbox, WORKER_URL.rstrip('/'))
+    assert not _is_allowed_worker_url(sandbox, 'https://vscode-runtime.example.com/')
+    assert not _is_allowed_worker_url(sandbox, 'https://metadata.google.internal/')
+
+
+@pytest.mark.asyncio
+async def test_web_host_status_returns_probe_result_for_worker_url():
+    sandbox_service = AsyncMock()
+    sandbox_service.get_sandbox = AsyncMock(return_value=_make_sandbox_info())
+
+    with patch(
+        'openhands.app_server.sandbox.sandbox_router._probe_web_host',
+        AsyncMock(return_value=True),
+    ) as mock_probe:
+        response = await get_web_host_status(
+            sandbox_id=SANDBOX_ID,
+            url=WORKER_URL,
+            sandbox_service=sandbox_service,
+        )
+
+    assert response.reachable is True
+    sandbox_service.get_sandbox.assert_awaited_once_with(SANDBOX_ID)
+    mock_probe.assert_awaited_once_with(WORKER_URL)
+
+
+@pytest.mark.asyncio
+async def test_web_host_status_rejects_unregistered_urls():
+    sandbox_service = AsyncMock()
+    sandbox_service.get_sandbox = AsyncMock(return_value=_make_sandbox_info())
+
+    with (
+        patch(
+            'openhands.app_server.sandbox.sandbox_router._probe_web_host',
+            AsyncMock(return_value=True),
+        ) as mock_probe,
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await get_web_host_status(
+            sandbox_id=SANDBOX_ID,
+            url='https://metadata.google.internal/',
+            sandbox_service=sandbox_service,
+        )
+
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+    mock_probe.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_web_host_status_returns_404_for_missing_sandbox():
+    sandbox_service = AsyncMock()
+    sandbox_service.get_sandbox = AsyncMock(return_value=None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_web_host_status(
+            sandbox_id=SANDBOX_ID,
+            url=WORKER_URL,
+            sandbox_service=sandbox_service,
+        )
+
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
## Summary

App tab host detection currently probes exposed worker URLs directly from the browser. That makes detection depend on the served application permitting cross-origin requests, so a reachable app can still be reported as not running when it does not emit CORS headers.

This change moves the reachability probe behind a sandbox-scoped same-origin API endpoint:

- adds `GET /api/v1/sandboxes/{sandbox_id}/web-host-status?url=...`
- only allows probing URLs already registered as `WORKER_*` exposed URLs for that sandbox
- updates the App tab detector to call that endpoint instead of directly fetching the worker URL from the browser
- adds unit coverage for allowed worker URLs, rejected unregistered URLs, and missing sandboxes

## Validation

- `uv run pytest tests/unit/app_server/test_sandbox_web_host_status_router.py`
- `uv run ruff check openhands/app_server/sandbox/sandbox_router.py openhands/app_server/sandbox/sandbox_models.py tests/unit/app_server/test_sandbox_web_host_status_router.py`
- `npm --prefix frontend run typecheck:staged`
- `cd frontend && npx eslint src/hooks/query/use-unified-active-host.ts src/api/sandbox-service/sandbox-service.api.ts src/api/sandbox-service/sandbox-service.types.ts`
- pre-commit hooks run during commit: frontend lint/typecheck/translation check, backend ruff/ruff-format/mypy

## Manual Verification

Validated on a replicated test instance by hotpatching the App-tab-era image. A running app without CORS headers was detected through the new same-origin probe and rendered in the App tab iframe. A second exposed worker URL with no app returned `reachable: false`.
