### PR TITLE
Clarify Jira DC repository access prompt

### DIFF
--- a/enterprise/integrations/jira_dc/jira_dc_manager.py
+++ b/enterprise/integrations/jira_dc/jira_dc_manager.py
@@ -24,6 +24,7 @@ from integrations.utils import (
     get_account_not_linked_message,
     get_session_expired_message,
     get_user_not_found_message,
+    infer_repo_from_message,
     markdown_to_jira_markup,
 )
 from jinja2 import Environment, FileSystemLoader
@@ -444,6 +445,7 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
             )
 
             target_str = f'{jira_dc_view.job_context.issue_description}\n{jira_dc_view.job_context.user_msg}'
+            mentioned_repos = infer_repo_from_message(target_str)
 
             # Try to infer repository from issue description
             match, repos = filter_potential_repos_by_user_msg(target_str, user_repos)
@@ -455,7 +457,17 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
                 return True
             else:
                 # No clear match - send repository selection comment
-                await self._send_repo_selection_comment(jira_dc_view)
+                matched_repos = [
+                    repo
+                    for repo in user_repos
+                    if any(
+                        mentioned_repo.lower() in repo.full_name.lower()
+                        for mentioned_repo in mentioned_repos
+                    )
+                ]
+                await self._send_repo_selection_comment(
+                    jira_dc_view, mentioned_repos, matched_repos
+                )
                 return False
 
         except Exception as e:
@@ -830,13 +842,35 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
         except Exception as e:
             logger.error(f'[Jira DC] Failed to send error comment: {str(e)}')
 
-    async def _send_repo_selection_comment(self, jira_dc_view: JiraDcViewInterface):
+    async def _send_repo_selection_comment(
+        self,
+        jira_dc_view: JiraDcViewInterface,
+        mentioned_repos: list[str] | None = None,
+        matched_repos: list[Repository] | None = None,
+    ):
         """Send a comment with repository options for the user to choose."""
         try:
-            comment_msg = (
-                'I need to know which repository to work with. '
-                'Please add it to your issue description or send a followup comment.'
-            )
+            mentioned_repos = mentioned_repos or []
+            matched_repo_names = [repo.full_name for repo in matched_repos or []]
+            if not mentioned_repos:
+                comment_msg = (
+                    'Could not determine which repository to use. '
+                    'Please mention the repository (e.g., owner/repo) in the issue '
+                    'description or comment.'
+                )
+            elif len(matched_repo_names) > 1:
+                comment_msg = (
+                    f'Multiple repositories found: {", ".join(matched_repo_names)}. '
+                    'Please specify exactly one repository in the issue description '
+                    'or comment.'
+                )
+            else:
+                comment_msg = (
+                    f'Could not access any of the mentioned repositories: '
+                    f'{", ".join(mentioned_repos)}. '
+                    'Please ensure your OpenHands account has access to the '
+                    'repository and it exists.'
+                )
 
             service_account = resolve_jira_dc_service_account(
                 jira_dc_view.jira_dc_workspace, self.token_manager

--- a/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_manager.py
+++ b/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_manager.py
@@ -904,7 +904,7 @@ class TestIsJobRequested:
 
             assert result is False
             jira_dc_manager._send_repo_selection_comment.assert_called_once_with(
-                mock_view
+                mock_view, [], []
             )
 
     @pytest.mark.asyncio
@@ -1448,7 +1448,33 @@ class TestSendRepoSelectionComment:
 
         jira_dc_manager.send_message.assert_called_once()
         call_args = jira_dc_manager.send_message.call_args[0]
-        assert 'which repository to work with' in call_args[0]
+        assert 'Could not determine which repository to use' in call_args[0]
+
+    @pytest.mark.asyncio
+    async def test_send_repo_selection_comment_repo_inaccessible(
+        self, jira_dc_manager, sample_jira_dc_workspace
+    ):
+        """Test repository selection comment when mentioned repos are inaccessible."""
+        mock_view = MagicMock(spec=JiraDcViewInterface)
+        mock_view.jira_dc_workspace = sample_jira_dc_workspace
+        mock_view.job_context = MagicMock()
+        mock_view.job_context.issue_key = 'PROJ-123'
+        mock_view.job_context.base_api_url = 'https://jira.company.com'
+
+        jira_dc_manager.send_message = AsyncMock()
+        jira_dc_manager.token_manager.decrypt_text.return_value = 'decrypted_key'
+
+        await jira_dc_manager._send_repo_selection_comment(
+            mock_view, ['company/repo'], []
+        )
+
+        jira_dc_manager.send_message.assert_called_once()
+        call_args = jira_dc_manager.send_message.call_args[0]
+        assert (
+            'Could not access any of the mentioned repositories: company/repo'
+            in call_args[0]
+        )
+        assert 'OpenHands account has access' in call_args[0]
 
     @pytest.mark.asyncio
     async def test_send_repo_selection_comment_send_fails(


### PR DESCRIPTION
HUMAN:
This copy update comes from R02 Jira DC shim testing: the non-installer account link and webhook delivery worked, but the linked user did not have access to the repo already named on the issue, so OpenHands asked only for a repo name.

- [x] A human has tested the underlying Jira DC flow on R02; this PR only updates the fallback copy.

AGENT:

## Why

When Jira DC cannot infer a usable repository from the issue/comment, the fallback comment should distinguish between missing repo context, inaccessible mentioned repositories, and ambiguous repository matches. Jira Cloud already handles these cases more precisely, so this brings Jira DC closer to the Jira Cloud behavior while clarifying that repo access is checked through the linked OpenHands account.

## Summary

- Split the Jira DC repository-selection fallback into Jira Cloud-style cases for missing, inaccessible, and ambiguous repositories.
- Include the mentioned repository name when the invoking OpenHands user cannot access it.
- Add focused Jira DC manager unit coverage for the inaccessible-repository message.

## How to Test

- `python3 -m py_compile enterprise/integrations/jira_dc/jira_dc_manager.py enterprise/tests/unit/integrations/jira_dc/test_jira_dc_manager.py`
- `uv run ruff check enterprise/integrations/jira_dc/jira_dc_manager.py enterprise/tests/unit/integrations/jira_dc/test_jira_dc_manager.py`
- `PYTHONPATH=enterprise:. uv run --with python-keycloak --with limits --with coredis pytest enterprise/tests/unit/integrations/jira_dc/test_jira_dc_manager.py -q`

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-0276397   docker.openhands.dev/openhands/openhands:0276397
```