### PR TITLE
chore: fix typos in comments, docstrings, and log messages

### DIFF
--- a/enterprise/migrations/versions/018_add_script_results_table.py
+++ b/enterprise/migrations/versions/018_add_script_results_table.py
@@ -1,4 +1,4 @@
-"""Add a table for tracking output from maintainance scripts. These are basically migrations that are not sql centric.
+"""Add a table for tracking output from maintenance scripts. These are basically migrations that are not sql centric.
 Revision ID: 018
 Revises: 017
 Create Date: 2025-03-26 19:45:00.000

--- a/enterprise/server/auth/github_utils.py
+++ b/enterprise/server/auth/github_utils.py
@@ -29,7 +29,7 @@ async def authenticate_github_user_id(auth_user_id: str) -> GitHubUser | None:
 
         return None
     except:  # noqa: E722
-        logger.warning("GitHub user doens't have valid token")
+        logger.warning("GitHub user doesn't have valid token")
         return None
 
 
@@ -46,5 +46,5 @@ async def authenticate_github_user_token(access_token: str):
 
         return None
     except:  # noqa: E722
-        logger.warning("GitHub user doens't have valid token")
+        logger.warning("GitHub user doesn't have valid token")
         return None

--- a/enterprise/storage/gitlab_webhook_store.py
+++ b/enterprise/storage/gitlab_webhook_store.py
@@ -198,7 +198,7 @@ class GitlabWebhookStore:
 
     async def get_webhook_secret(self, webhook_uuid: str, user_id: str) -> str | None:
         """
-        Get's webhook secret given the webhook uuid and admin keycloak user id
+        Gets webhook secret given the webhook uuid and admin keycloak user id
         """
         async with a_session_maker() as session:
             query = (

--- a/enterprise/storage/lite_llm_manager.py
+++ b/enterprise/storage/lite_llm_manager.py
@@ -644,7 +644,7 @@ class LiteLlmManager:
             json=json_data,
         )
 
-        # Team failed to create in litellm - this is an unforseen error state...
+        # Team failed to create in litellm - this is an unforeseen error state...
         if not response.is_success:
             if (
                 response.status_code == 400
@@ -707,7 +707,7 @@ class LiteLlmManager:
             json=json_data,
         )
 
-        # Team failed to update in litellm - this is an unforseen error state...
+        # Team failed to update in litellm - this is an unforeseen error state...
         if not response.is_success:
             logger.error(
                 'error_updating_litellm_team',
@@ -802,7 +802,7 @@ class LiteLlmManager:
                 },
             )
 
-            # User failed to create in litellm - this is an unforseen error state...
+            # User failed to create in litellm - this is an unforeseen error state...
             if not response.is_success:
                 if (
                     response.status_code in (400, 409)
@@ -1088,7 +1088,7 @@ class LiteLlmManager:
             json=json_data,
         )
 
-        # Failed to add user to team - this is an unforseen error state...
+        # Failed to add user to team - this is an unforeseen error state...
         if not response.is_success:
             if (
                 response.status_code == 400
@@ -1183,7 +1183,7 @@ class LiteLlmManager:
             json=json_data,
         )
 
-        # Failed to update user in team - this is an unforseen error state...
+        # Failed to update user in team - this is an unforeseen error state...
         if not response.is_success:
             logger.error(
                 'error_updating_litellm_user_in_team',
@@ -1264,7 +1264,7 @@ class LiteLlmManager:
             f'{LITE_LLM_API_URL}/key/generate',
             json=json_data,
         )
-        # Failed to generate user key for team - this is an unforseen error state...
+        # Failed to generate user key for team - this is an unforeseen error state...
         if not response.is_success:
             logger.error(
                 'error_generate_user_team_key',

--- a/enterprise/sync/install_gitlab_webhooks.py
+++ b/enterprise/sync/install_gitlab_webhooks.py
@@ -119,7 +119,7 @@ class VerifyWebhookStatus:
         Rows with valid conditions with contain (webhook_exists=False, status=WebhookStatus.VERIFIED)
 
         Conditions we check for
-            1. Resoure exists
+            1. Resource exists
                 - user could have deleted resource
             2. User has admin access to resource
                 - user's permissions to install webhook could have changed

--- a/frontend/src/components/features/settings/brand-button.tsx
+++ b/frontend/src/components/features/settings/brand-button.tsx
@@ -27,7 +27,7 @@ export function BrandButton({
       name={name}
       data-testid={testId}
       disabled={isDisabled}
-      // The type is alreadt passed as a prop to the button component
+      // The type is already passed as a prop to the button component
       // eslint-disable-next-line react/button-has-type
       type={type}
       onClick={onClick}

--- a/openhands/app_server/integrations/provider.py
+++ b/openhands/app_server/integrations/provider.py
@@ -62,7 +62,7 @@ class ProviderToken(BaseModel):
             return token_value
         elif isinstance(token_value, dict):
             token_str = token_value.get('token', '')
-            # Override with emtpy string if it was set to None
+            # Override with empty string if it was set to None
             # Cannot pass None to SecretStr
             if token_str is None:
                 token_str = ''  # type: ignore[unreachable]

--- a/openhands/app_server/integrations/service_types.py
+++ b/openhands/app_server/integrations/service_types.py
@@ -175,7 +175,7 @@ class AuthenticationError(ValueError):
 
 
 class UnknownException(ValueError):
-    """Raised when there is an issue with GitHub communcation."""
+    """Raised when there is an issue with GitHub communication."""
 
     pass
 

--- a/openhands/app_server/services/db_session_injector.py
+++ b/openhands/app_server/services/db_session_injector.py
@@ -48,7 +48,7 @@ class DbSessionInjector(BaseModel, Injector[AsyncSession]):
 
     @model_validator(mode='after')
     def fill_empty_fields(self):
-        """Override any defaults with values from legacy enviroment variables"""
+        """Override any defaults with values from legacy environment variables"""
         if self.host is None:
             self.host = os.getenv('DB_HOST')
         if self.port is None:


### PR DESCRIPTION
HUMAN:

- [ ] A human has tested these changes.

AGENT:

---

## Why

Several small typos in comments, docstrings, log warnings, and a migration description were caught by `codespell`. They're harmless but visible — log messages like `"GitHub user doens't have valid token"` show up in production logs, and `unforseen` appears in 6 spots in `lite_llm_manager.py` alone. Fixing them is a free readability win and makes future grep/log-search cleaner.

## Summary

- Fixed 15 typos across 9 files in `openhands/`, `enterprise/`, and `frontend/`
- Comments / docstrings / log messages / migration descriptions only — **no functional or behavioural changes**
- Corrections: `alreadt → already`, `doens't → doesn't` (×2), `Get's → Gets`, `Resoure → Resource`, `emtpy → empty`, `communcation → communication`, `enviroment → environment`, `maintainance → maintenance`, `unforseen → unforeseen` (×6)

## Issue Number

N/A (typo-only chore, no tracking issue).

## How to Test

No runtime behaviour changes, so existing test suite is sufficient. To verify the typos are gone:

```bash
pip install codespell
codespell enterprise/server/auth/github_utils.py \
          enterprise/storage/gitlab_webhook_store.py \
          enterprise/storage/lite_llm_manager.py \
          enterprise/sync/install_gitlab_webhooks.py \
          enterprise/migrations/versions/018_add_script_results_table.py \
          openhands/app_server/integrations/provider.py \
          openhands/app_server/integrations/service_types.py \
          openhands/app_server/services/db_session_injector.py \
          frontend/src/components/features/settings/brand-button.tsx
# expected: no output
```

## Video/Screenshots

N/A — text-only changes inside comments/docstrings/log strings, nothing visible in the UI.

## Type

- [x] Docs / chore

## Notes

- No imports, signatures, or runtime strings that callers depend on were touched.
- Could be a candidate for adding `codespell` to `dev_config/python/.pre-commit-config.yaml` in a follow-up so these don't accumulate again — happy to open a separate PR for that if maintainers want it.