### PR TITLE
test: cover live status LLM option preservation

### DIFF
--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -678,6 +678,35 @@ class TestLiveStatusAppConversationService:
         assert llm.extended_thinking_budget is None
 
     @pytest.mark.asyncio
+    async def test_configure_llm_and_mcp_preserves_user_llm_options(self):
+        self.mock_user.agent_settings = Settings(
+            agent_settings={
+                'llm': {
+                    'model': 'anthropic/claude-opus-4-7',
+                    'api_key': 'test-key',
+                    'base_url': 'https://sdk-llm.example.com',
+                    'drop_params': False,
+                    'extended_thinking_budget': 12345,
+                    'max_output_tokens': 2048,
+                    'reasoning_effort': None,
+                }
+            }
+        ).agent_settings
+        self.mock_user_context.get_mcp_api_key.return_value = None
+
+        llm, _ = await self.service._configure_llm_and_mcp(
+            self.mock_user, None, self.conversation_id
+        )
+
+        assert llm.model == 'anthropic/claude-opus-4-7'
+        assert llm.base_url == 'https://sdk-llm.example.com'
+        assert llm.drop_params is False
+        assert llm.extended_thinking_budget == 12345
+        assert llm.max_output_tokens == 2048
+        assert llm.reasoning_effort is None
+        assert llm.usage_id == 'agent'
+
+    @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_openhands_model_uses_user_base_url(
         self,
     ):


### PR DESCRIPTION
HUMAN: This keeps live-status agent runs from silently dropping the user's existing non-default LLM options when the run overrides model/base_url. The regression test covers reasoning, output-limit, and provider option fields because those are the settings that are painful to lose during a live run. - [ ] A human has tested these changes.  ## Summary - preserve the user's existing LLM settings when live-status conversations override model/base_url for the agent run - continue setting usage_id to agent for runtime lookup - add a regression test covering non-default LLM options such as reasoning_effort, extended_thinking_budget, max_output_tokens, and drop_params  Fixes #14450  ## Test plan - `python -m pytest tests/unit/app_server/test_live_status_app_conversation_service.py -q -k configure_llm_and_mcp` - `python -m ruff check openhands/app_server/app_conversation/live_status_app_conversation_service.py tests/unit/app_server/test_live_status_app_conversation_service.py` - `python -m ruff format --check openhands/app_server/app_conversation/live_status_app_conversation_service.py tests/unit/app_server/test_live_status_app_conversation_service.py` - `python -m py_compile openhands/app_server/app_conversation/live_status_app_conversation_service.py tests/unit/app_server/test_live_status_app_conversation_service.py` - `git diff --check`  Note: the repository pre-commit hook could not complete on this Windows machine. The default cache hit `PermissionError` in `C:\Users\He\.cache\pre-commit`; using a repo-local cache progressed further but pip hit Windows long-path limits while installing hook dependencies. 