### PR TITLE
fix: retry conversation metadata save races

### DIFF
--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -34,6 +34,7 @@ from sqlalchemy import (
     select,
 )
 from sqlalchemy.engine import CursorResult
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -383,8 +384,17 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             tags=info.tags if info.tags else None,
         )
 
-        await self.db_session.merge(stored)
-        await self.db_session.commit()
+        try:
+            await self.db_session.merge(stored)
+            await self.db_session.commit()
+        except IntegrityError:
+            logger.warning(
+                'Retrying conversation metadata save after integrity error',
+                exc_info=True,
+            )
+            await self.db_session.rollback()
+            await self.db_session.merge(stored)
+            await self.db_session.commit()
         return info
 
     async def update_conversation_statistics(

--- a/tests/unit/app_server/test_sql_app_conversation_info_service.py
+++ b/tests/unit/app_server/test_sql_app_conversation_info_service.py
@@ -10,6 +10,7 @@ from typing import AsyncGenerator
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
@@ -559,6 +560,51 @@ class TestSQLAppConversationInfoService:
 
         # Verify other fields remain unchanged
         assert retrieved_info.sandbox_id == sample_conversation_info.sandbox_id
+
+    @pytest.mark.asyncio
+    async def test_save_retries_after_metadata_insert_race(
+        self,
+        service: SQLAppConversationInfoService,
+        sample_conversation_info: AppConversationInfo,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        original_commit = service.db_session.commit
+        original_rollback = service.db_session.rollback
+        commit_calls = 0
+        rollback_calls = 0
+
+        async def commit_once_with_integrity_error():
+            nonlocal commit_calls
+            commit_calls += 1
+            if commit_calls == 1:
+                raise IntegrityError(
+                    'insert conversation_metadata',
+                    {},
+                    Exception('duplicate key value violates unique constraint'),
+                )
+            await original_commit()
+
+        async def track_rollback():
+            nonlocal rollback_calls
+            rollback_calls += 1
+            await original_rollback()
+
+        monkeypatch.setattr(
+            service.db_session, 'commit', commit_once_with_integrity_error
+        )
+        monkeypatch.setattr(service.db_session, 'rollback', track_rollback)
+
+        saved_info = await service.save_app_conversation_info(sample_conversation_info)
+
+        assert saved_info.id == sample_conversation_info.id
+        assert commit_calls == 2
+        assert rollback_calls == 1
+
+        retrieved_info = await service.get_app_conversation_info(
+            sample_conversation_info.id
+        )
+        assert retrieved_info is not None
+        assert retrieved_info.title == sample_conversation_info.title
 
     @pytest.mark.asyncio
     async def test_search_with_invalid_page_id(


### PR DESCRIPTION
HUMAN: This fixes a real insert race between conversation startup and webhook metadata writes. If another writer inserts the row between merge's lookup and commit, this retries the same merge once after rollback; unrelated integrity errors still propagate instead of being hidden. - [ ] A human has tested these changes.  Fixes OpenHands/enterprise#26.  Conversation startup and webhook updates can both write `conversation_metadata` for the same conversation. `merge()` handles normal updates, but it can still lose the race when another writer inserts the row between merge's lookup and commit. In that case the commit raises an `IntegrityError`, leaving the resolver conversation started but metadata persistence failed.  This patch makes `save_app_conversation_info()` recover from that insert race by rolling back and retrying the same merge once. If the integrity error is unrelated, the retry will still fail and propagate instead of silently hiding it.  ## To verify  - `.venv\Scripts\python -m pytest tests\unit\app_server\test_sql_app_conversation_info_service.py -q` - `.venv\Scripts\python -m ruff check openhands\app_server\app_conversation\sql_app_conversation_info_service.py tests\unit\app_server\test_sql_app_conversation_info_service.py` - `.venv\Scripts\python -m ruff format --check openhands\app_server\app_conversation\sql_app_conversation_info_service.py tests\unit\app_server\test_sql_app_conversation_info_service.py` - `.venv\Scripts\python -m py_compile openhands\app_server\app_conversation\sql_app_conversation_info_service.py tests\unit\app_server\test_sql_app_conversation_info_service.py` - `git diff --check origin/main...HEAD`  The local pre-commit hook is still blocked by a machine cache permission issue:  `PermissionError: [Errno 13] Permission denied: 'C:\Users\He\.cache\pre-commit\...\.pre-commit-hooks.yaml'` 