### PR TITLE
Seed Default LLM profile from legacy config on first load in SaaS

### DIFF
--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -214,10 +214,23 @@ class SaasSettingsStore(SettingsStore):
         # never moved to the org column.
         if org.llm_profiles:
             kwargs['llm_profiles'] = org.llm_profiles
-        # Pre-migration rows read back as None; Settings.llm_profiles is
-        # non-nullable, so let the default_factory take over.
-        if kwargs.get('llm_profiles') is None:
-            kwargs.pop('llm_profiles', None)
+        # When no profiles exist yet, seed a Default profile from the legacy
+        # LLM config so users (and orgs) upgrading from pre-llm_profiles
+        # settings keep their previous LLM as the active profile instead of
+        # landing on an empty profiles UI (mirrors the OSS FileSettingsStore).
+        # Covers both pre-migration rows (llm_profiles is None) and
+        # already-migrated orgs whose profiles map is empty.
+        if not (kwargs.get('llm_profiles') or {}).get('profiles'):
+            legacy_llm = merged_agent_settings.get('llm')
+            if isinstance(legacy_llm, dict) and legacy_llm.get('model'):
+                kwargs['llm_profiles'] = {
+                    'profiles': {'Default': dict(legacy_llm)},
+                    'active': 'Default',
+                }
+            else:
+                # No legacy LLM to seed; drop a None value so the non-nullable
+                # Settings.llm_profiles falls back to its default_factory.
+                kwargs.pop('llm_profiles', None)
 
         return Settings(**kwargs)
 

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -887,13 +887,13 @@ async def test_store_and_load_llm_profiles_round_trip(
 
 
 @pytest.mark.asyncio
-async def test_load_with_null_llm_profiles_column_uses_default_factory(
+async def test_load_with_null_llm_profiles_column_seeds_default_profile(
     async_session_maker, org_with_multiple_members_fixture
 ):
-    """Rows predating the user.llm_profiles column read back as None.
-    Settings.llm_profiles is non-nullable (default_factory=LLMProfiles), so
-    load() must drop the None and let the factory produce an empty container
-    rather than crashing validation."""
+    """Rows predating the llm_profiles columns read back as None. Rather than
+    presenting an empty profiles UI on upgrade, load() seeds a "Default"
+    profile from the legacy agent_settings.llm config (mirroring the OSS
+    FileSettingsStore behaviour), with that profile marked active."""
     from sqlalchemy import update
     from storage.user import User
 
@@ -923,8 +923,10 @@ async def test_load_with_null_llm_profiles_column_uses_default_factory(
         loaded = await admin_store.load()
 
     assert loaded is not None
-    assert loaded.llm_profiles.profiles == {}
-    assert loaded.llm_profiles.active is None
+    assert set(loaded.llm_profiles.profiles.keys()) == {'Default'}
+    assert loaded.llm_profiles.active == 'Default'
+    default = loaded.llm_profiles.require('Default')
+    assert default.model == 'anthropic/claude-sonnet-4-5-20250929'
 
 
 @pytest.mark.asyncio

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -886,14 +886,28 @@ async def test_store_and_load_llm_profiles_round_trip(
     assert personal.api_key.get_secret_value() == 'personal-key'
 
 
+@pytest.mark.parametrize(
+    'llm_profiles_value',
+    [
+        pytest.param(None, id='pre-migration: llm_profiles is null'),
+        pytest.param(
+            {'profiles': {}, 'active': None},
+            id='already-migrated: profiles dict is empty',
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_load_with_null_llm_profiles_column_seeds_default_profile(
-    async_session_maker, org_with_multiple_members_fixture
+async def test_load_with_null_or_empty_llm_profiles_seeds_default_profile(
+    async_session_maker, org_with_multiple_members_fixture, llm_profiles_value
 ):
-    """Rows predating the llm_profiles columns read back as None. Rather than
-    presenting an empty profiles UI on upgrade, load() seeds a "Default"
-    profile from the legacy agent_settings.llm config (mirroring the OSS
-    FileSettingsStore behaviour), with that profile marked active."""
+    """Seed Default profile from legacy config when no profiles exist.
+
+    Rows predating the llm_profiles column read back as None, and already-
+    migrated orgs may have an empty profiles dict. Rather than presenting an
+    empty profiles UI on upgrade, load() seeds a "Default" profile from the
+    legacy agent_settings.llm config (mirroring the OSS FileSettingsStore
+    behaviour), with that profile marked active.
+    """
     from sqlalchemy import update
     from storage.user import User
 
@@ -911,7 +925,9 @@ async def test_load_with_null_llm_profiles_column_seeds_default_profile(
 
     async with async_session_maker() as session:
         await session.execute(
-            update(User).where(User.id == admin_user_id).values(llm_profiles=None)
+            update(User)
+            .where(User.id == admin_user_id)
+            .values(llm_profiles=llm_profiles_value)
         )
         await session.commit()
 


### PR DESCRIPTION
## Summary
  
  In OSS, FileSettingsStore.load() seeds a Default LLM profile from the legacy single-LLM config when no llm_profiles exist, so users upgrading to LLM profiles keep their previous
  LLM as the active profile. The SaaS SaasSettingsStore.load() did not do this — it dropped a null llm_profiles and let the default factory produce an empty container, leaving
  upgrading users with an empty profiles UI.
  
  This change mirrors the OSS behavior in SaaS: when no profiles exist, load() seeds a Default profile from the effective (org + member merged) LLM config and marks it active. It
  covers both pre-migration rows (llm_profiles is null) and already-migrated orgs whose profiles map is empty. Existing non-empty profiles are left untouched, and the non-nullable
  fallback to the default factory is preserved when there is no legacy LLM to seed.
  
  Tests: repurposed the prior null-column test to assert the Default profile is seeded and active; existing round-trip and encryption-at-rest tests confirm real profiles are not
  clobbered and seeded keys are encrypted.

