### PR TITLE
fix: retry conversation metadata save after duplicate key

### DIFF
--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -34,6 +34,7 @@ from sqlalchemy import (
     select,
 )
 from sqlalchemy.engine import CursorResult
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -383,8 +384,18 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             tags=info.tags if info.tags else None,
         )
 
-        await self.db_session.merge(stored)
-        await self.db_session.commit()
+        try:
+            await self.db_session.merge(stored)
+            await self.db_session.commit()
+        except IntegrityError:
+            logger.warning(
+                'Conversation metadata save hit duplicate key for %s; retrying as update',
+                info.id,
+                exc_info=True,
+            )
+            await self.db_session.rollback()
+            await self.db_session.merge(stored)
+            await self.db_session.commit()
         return info
 
     async def update_conversation_statistics(

--- a/tests/unit/app_server/test_sql_app_conversation_info_service.py
+++ b/tests/unit/app_server/test_sql_app_conversation_info_service.py
@@ -10,6 +10,7 @@ from typing import AsyncGenerator
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
@@ -559,6 +560,35 @@ class TestSQLAppConversationInfoService:
 
         # Verify other fields remain unchanged
         assert retrieved_info.sandbox_id == sample_conversation_info.sandbox_id
+
+    @pytest.mark.asyncio
+    async def test_save_conversation_info_retries_after_integrity_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        service: SQLAppConversationInfoService,
+        sample_conversation_info: AppConversationInfo,
+    ):
+        """Duplicate-key races during startup should not drop metadata saves."""
+        original_commit = service.db_session.commit
+        calls = 0
+
+        async def flaky_commit():
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise IntegrityError('insert conversation_metadata', {}, Exception())
+            await original_commit()
+
+        monkeypatch.setattr(service.db_session, 'commit', flaky_commit)
+
+        await service.save_app_conversation_info(sample_conversation_info)
+
+        retrieved_info = await service.get_app_conversation_info(
+            sample_conversation_info.id
+        )
+        assert calls == 2
+        assert retrieved_info is not None
+        assert retrieved_info.title == sample_conversation_info.title
 
     @pytest.mark.asyncio
     async def test_search_with_invalid_page_id(


### PR DESCRIPTION
HUMAN:

This PR makes conversation metadata persistence safer when resolver startup and webhook updates race to save the same conversation. It retries the SQL save after a duplicate-key integrity error so a running resolver conversation is not lost from the visible conversation list.

- [ ] A human has tested these changes.

AGENT:

---

## Why

Fixes OpenHands/enterprise#26. Resolver startup can race with webhook persistence for the same conversation metadata row. If the concurrent writer wins first, the second save can hit a duplicate-key `IntegrityError`, causing metadata persistence to fail and started conversations to be hidden from the conversation list.

## Summary

- Catches `IntegrityError` during SQL conversation metadata save, rolls back, and retries the save as an idempotent merge/update.
- Adds a regression test covering retry behavior after a duplicate-key style integrity failure.

## Issue Number

Fixes OpenHands/enterprise#26

## How to Test

- `uv run pytest tests/unit/app_server/test_sql_app_conversation_info_service.py -q`
- `uv run ruff check openhands/app_server/app_conversation/sql_app_conversation_info_service.py tests/unit/app_server/test_sql_app_conversation_info_service.py`

## Video/Screenshots

Not applicable; backend persistence race fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This keeps the existing `merge` behavior, but makes the save path resilient when an insert/update race is observed at commit time.