### PR TITLE
Vasco/seed default profile

### DIFF
--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -214,10 +214,23 @@ class SaasSettingsStore(SettingsStore):
         # never moved to the org column.
         if org.llm_profiles:
             kwargs['llm_profiles'] = org.llm_profiles
-        # Pre-migration rows read back as None; Settings.llm_profiles is
-        # non-nullable, so let the default_factory take over.
-        if kwargs.get('llm_profiles') is None:
-            kwargs.pop('llm_profiles', None)
+        # When no profiles exist yet, seed a Default profile from the legacy
+        # LLM config so users (and orgs) upgrading from pre-llm_profiles
+        # settings keep their previous LLM as the active profile instead of
+        # landing on an empty profiles UI (mirrors the OSS FileSettingsStore).
+        # Covers both pre-migration rows (llm_profiles is None) and
+        # already-migrated orgs whose profiles map is empty.
+        if not (kwargs.get('llm_profiles') or {}).get('profiles'):
+            legacy_llm = merged_agent_settings.get('llm')
+            if isinstance(legacy_llm, dict) and legacy_llm.get('model'):
+                kwargs['llm_profiles'] = {
+                    'profiles': {'Default': dict(legacy_llm)},
+                    'active': 'Default',
+                }
+            else:
+                # No legacy LLM to seed; drop a None value so the non-nullable
+                # Settings.llm_profiles falls back to its default_factory.
+                kwargs.pop('llm_profiles', None)
 
         return Settings(**kwargs)
 

--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -22,6 +22,7 @@ from storage.user import User
 from storage.user_settings import UserSettings
 from storage.user_store import UserStore
 
+from openhands.app_server.settings.llm_profiles import LLMProfiles
 from openhands.app_server.settings.settings_models import Settings
 from openhands.app_server.settings.settings_store import SettingsStore
 from openhands.app_server.utils.jsonpatch_compat import (
@@ -220,6 +221,7 @@ class SaasSettingsStore(SettingsStore):
         # landing on an empty profiles UI (mirrors the OSS FileSettingsStore).
         # Covers both pre-migration rows (llm_profiles is None) and
         # already-migrated orgs whose profiles map is empty.
+        seeded_default = False
         if not (kwargs.get('llm_profiles') or {}).get('profiles'):
             legacy_llm = merged_agent_settings.get('llm')
             if isinstance(legacy_llm, dict) and legacy_llm.get('model'):
@@ -227,12 +229,52 @@ class SaasSettingsStore(SettingsStore):
                     'profiles': {'Default': dict(legacy_llm)},
                     'active': 'Default',
                 }
+                seeded_default = True
             else:
                 # No legacy LLM to seed; drop a None value so the non-nullable
                 # Settings.llm_profiles falls back to its default_factory.
                 kwargs.pop('llm_profiles', None)
 
-        return Settings(**kwargs)
+        settings = Settings(**kwargs)
+
+        # The seed above is in-memory only. Persist it onto the org row so the
+        # legacy LLM becomes a real stored profile — otherwise the profiles
+        # management API (server/routes/org_profiles.py, which reads
+        # org.llm_profiles directly) would still see an empty list and the
+        # user's previous model would never land "inside the profiles".
+        if seeded_default:
+            await self._persist_seeded_default_profile(org_id, settings.llm_profiles)
+
+        return settings
+
+    async def _persist_seeded_default_profile(
+        self, org_id: UUID, llm_profiles: LLMProfiles
+    ) -> None:
+        """Backfill the seeded ``Default`` profile onto ``org.llm_profiles``.
+
+        Runs once per org during the pre-llm_profiles → llm_profiles upgrade:
+        ``load()`` seeds the profile in memory, and this writes it back so it
+        becomes a real stored profile that the org-profiles management API can
+        list and mutate. Re-checks emptiness under a row lock so a concurrent
+        ``load()`` doesn't double-seed and so a profile a member just created
+        through the management API is never clobbered.
+        """
+        serialized = llm_profiles.model_dump(
+            mode='json', context={'expose_secrets': True}
+        )
+        async with a_session_maker() as session:
+            result = await session.execute(
+                select(Org).filter(Org.id == org_id).with_for_update()
+            )
+            org = result.scalars().first()
+            if org is None:
+                return
+            # Only seed while the column is still empty — another request may
+            # have populated it between this load() and acquiring the lock.
+            if (org.llm_profiles or {}).get('profiles'):
+                return
+            org.llm_profiles = serialized
+            await session.commit()
 
     async def store(self, item: Settings):
         async with a_session_maker() as session:

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -887,13 +887,13 @@ async def test_store_and_load_llm_profiles_round_trip(
 
 
 @pytest.mark.asyncio
-async def test_load_with_null_llm_profiles_column_uses_default_factory(
+async def test_load_with_null_llm_profiles_column_seeds_default_profile(
     async_session_maker, org_with_multiple_members_fixture
 ):
-    """Rows predating the user.llm_profiles column read back as None.
-    Settings.llm_profiles is non-nullable (default_factory=LLMProfiles), so
-    load() must drop the None and let the factory produce an empty container
-    rather than crashing validation."""
+    """Rows predating the llm_profiles columns read back as None. Rather than
+    presenting an empty profiles UI on upgrade, load() seeds a "Default"
+    profile from the legacy agent_settings.llm config (mirroring the OSS
+    FileSettingsStore behaviour), with that profile marked active."""
     from sqlalchemy import update
     from storage.user import User
 
@@ -923,8 +923,10 @@ async def test_load_with_null_llm_profiles_column_uses_default_factory(
         loaded = await admin_store.load()
 
     assert loaded is not None
-    assert loaded.llm_profiles.profiles == {}
-    assert loaded.llm_profiles.active is None
+    assert set(loaded.llm_profiles.profiles.keys()) == {'Default'}
+    assert loaded.llm_profiles.active == 'Default'
+    default = loaded.llm_profiles.require('Default')
+    assert default.model == 'anthropic/claude-sonnet-4-5-20250929'
 
 
 @pytest.mark.asyncio

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -886,14 +886,28 @@ async def test_store_and_load_llm_profiles_round_trip(
     assert personal.api_key.get_secret_value() == 'personal-key'
 
 
+@pytest.mark.parametrize(
+    'llm_profiles_value',
+    [
+        pytest.param(None, id='pre-migration: llm_profiles is null'),
+        pytest.param(
+            {'profiles': {}, 'active': None},
+            id='already-migrated: profiles dict is empty',
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_load_with_null_llm_profiles_column_seeds_default_profile(
-    async_session_maker, org_with_multiple_members_fixture
+async def test_load_with_null_or_empty_llm_profiles_seeds_default_profile(
+    async_session_maker, org_with_multiple_members_fixture, llm_profiles_value
 ):
-    """Rows predating the llm_profiles columns read back as None. Rather than
-    presenting an empty profiles UI on upgrade, load() seeds a "Default"
-    profile from the legacy agent_settings.llm config (mirroring the OSS
-    FileSettingsStore behaviour), with that profile marked active."""
+    """Seed Default profile from legacy config when no profiles exist.
+
+    Rows predating the llm_profiles column read back as None, and already-
+    migrated orgs may have an empty profiles dict. Rather than presenting an
+    empty profiles UI on upgrade, load() seeds a "Default" profile from the
+    legacy agent_settings.llm config (mirroring the OSS FileSettingsStore
+    behaviour), with that profile marked active.
+    """
     from sqlalchemy import update
     from storage.user import User
 
@@ -911,7 +925,9 @@ async def test_load_with_null_llm_profiles_column_seeds_default_profile(
 
     async with async_session_maker() as session:
         await session.execute(
-            update(User).where(User.id == admin_user_id).values(llm_profiles=None)
+            update(User)
+            .where(User.id == admin_user_id)
+            .values(llm_profiles=llm_profiles_value)
         )
         await session.commit()
 

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -946,6 +946,69 @@ async def test_load_with_null_or_empty_llm_profiles_seeds_default_profile(
 
 
 @pytest.mark.asyncio
+async def test_load_persists_seeded_default_profile_onto_org(
+    async_session_maker, org_with_multiple_members_fixture
+):
+    """The seeded Default profile must be written back to org.llm_profiles.
+
+    The seed is otherwise in-memory only, so the org-profiles management API
+    (which reads org.llm_profiles directly) would still see an empty list.
+    load() backfills it once so the user's last LLM becomes a real stored
+    profile on first use of LLM profiles.
+    """
+    from sqlalchemy import select, update
+    from storage.org import Org
+
+    fixture = org_with_multiple_members_fixture
+    admin_user_id = fixture['admin_user_id']
+    org_id = fixture['org_id']
+    admin_store = SaasSettingsStore(str(admin_user_id))
+
+    seed_settings = _make_settings(
+        model='anthropic/claude-sonnet-4-5-20250929',
+        api_key='seed-key',
+        base_url='https://api.anthropic.com/v1',
+    )
+    with patch('storage.saas_settings_store.a_session_maker', async_session_maker):
+        await admin_store.store(seed_settings)
+
+    # Simulate a pre-migration org: no profiles stored yet.
+    async with async_session_maker() as session:
+        await session.execute(
+            update(Org).where(Org.id == org_id).values(llm_profiles=None)
+        )
+        await session.commit()
+
+    with (
+        patch('storage.saas_settings_store.a_session_maker', async_session_maker),
+        patch('storage.user_store.a_session_maker', async_session_maker),
+        patch('storage.org_store.a_session_maker', async_session_maker),
+    ):
+        await admin_store.load()
+
+    async with async_session_maker() as session:
+        org = (
+            (await session.execute(select(Org).where(Org.id == org_id)))
+            .scalars()
+            .first()
+        )
+
+    assert org.llm_profiles is not None
+    assert set(org.llm_profiles['profiles'].keys()) == {'Default'}
+    assert org.llm_profiles['active'] == 'Default'
+    persisted_default = org.llm_profiles['profiles']['Default']
+    assert persisted_default['model'] == 'anthropic/claude-sonnet-4-5-20250929'
+    assert persisted_default['base_url'] == 'https://api.anthropic.com/v1'
+    # API key from the legacy config must survive the round-trip so the user
+    # doesn't have to re-enter it after the profiles upgrade.
+    assert persisted_default['api_key'] == 'seed-key'
+    assert (
+        org.llm_profiles['profiles']['Default']['model']
+        == 'anthropic/claude-sonnet-4-5-20250929'
+    )
+
+
+@pytest.mark.asyncio
 async def test_llm_profiles_are_encrypted_at_rest(
     async_session_maker, org_with_multiple_members_fixture
 ):


### PR DESCRIPTION
- [x] A human has tested these changes.

## Summary

SaaS orgs upgrading from pre-LLM-profiles settings landed on an empty profiles UI — the LLM they'd been using wasn't carried over.

SaasSettingsStore.load() now seeds a Default profile from the merged org + member effective LLM (model, base_url, api_key) when org.llm_profiles is NULL/empty, and persists it to the column so the org-profiles management API
  (/api/organizations/{org_id}/profiles) sees the same Default the settings path does — not an empty list. The write runs under a SELECT ... FOR UPDATE row lock with an emptiness re-check, so concurrent loads can't double-seed and a profile a member just created via the management API can't be clobbered. Idempotent on later loads.
  
## How to Test
- test_load_with_null_or_empty_llm_profiles_seeds_default_profile — seed surfaces in Settings.llm_profiles for both NULL and empty-dict orgs.
- test_load_persists_seeded_default_profile_onto_org — model, base_url, and api_key all round-trip into org.llm_profiles['profiles']['Default'].

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
