### PR TITLE
feat(saas): seed Default LLM profile from legacy config on profiles upgrade

### DIFF
--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -22,6 +22,7 @@ from storage.user import User
 from storage.user_settings import UserSettings
 from storage.user_store import UserStore
 
+from openhands.app_server.settings.llm_profiles import LLMProfiles
 from openhands.app_server.settings.settings_models import Settings
 from openhands.app_server.settings.settings_store import SettingsStore
 from openhands.app_server.utils.jsonpatch_compat import (
@@ -220,6 +221,7 @@ class SaasSettingsStore(SettingsStore):
         # landing on an empty profiles UI (mirrors the OSS FileSettingsStore).
         # Covers both pre-migration rows (llm_profiles is None) and
         # already-migrated orgs whose profiles map is empty.
+        seeded_default = False
         if not (kwargs.get('llm_profiles') or {}).get('profiles'):
             legacy_llm = merged_agent_settings.get('llm')
             if isinstance(legacy_llm, dict) and legacy_llm.get('model'):
@@ -227,12 +229,63 @@ class SaasSettingsStore(SettingsStore):
                     'profiles': {'Default': dict(legacy_llm)},
                     'active': 'Default',
                 }
+                seeded_default = True
             else:
                 # No legacy LLM to seed; drop a None value so the non-nullable
                 # Settings.llm_profiles falls back to its default_factory.
                 kwargs.pop('llm_profiles', None)
 
-        return Settings(**kwargs)
+        settings = Settings(**kwargs)
+
+        # The seed above is in-memory only. Persist it onto the org row so the
+        # legacy LLM becomes a real stored profile — otherwise the profiles
+        # management API (server/routes/org_profiles.py, which reads
+        # org.llm_profiles directly) would still see an empty list and the
+        # user's previous model would never land "inside the profiles".
+        # Persist is best-effort: a transient DB failure here must not block
+        # returning settings the caller already has in memory.
+        if seeded_default:
+            try:
+                await self._persist_seeded_default_profile(
+                    org_id, settings.llm_profiles
+                )
+            except Exception:
+                logger.warning(
+                    'Failed to persist seeded Default profile for org %s',
+                    org_id,
+                    exc_info=True,
+                )
+
+        return settings
+
+    async def _persist_seeded_default_profile(
+        self, org_id: UUID, llm_profiles: LLMProfiles
+    ) -> None:
+        """Backfill the seeded ``Default`` profile onto ``org.llm_profiles``.
+
+        Runs once per org during the pre-llm_profiles → llm_profiles upgrade:
+        ``load()`` seeds the profile in memory, and this writes it back so it
+        becomes a real stored profile that the org-profiles management API can
+        list and mutate. Re-checks emptiness under a row lock so a concurrent
+        ``load()`` doesn't double-seed and so a profile a member just created
+        through the management API is never clobbered.
+        """
+        serialized = llm_profiles.model_dump(
+            mode='json', context={'expose_secrets': True}
+        )
+        async with a_session_maker() as session:
+            result = await session.execute(
+                select(Org).filter(Org.id == org_id).with_for_update()
+            )
+            org = result.scalars().first()
+            if org is None:
+                return
+            # Only seed while the column is still empty — another request may
+            # have populated it between this load() and acquiring the lock.
+            if (org.llm_profiles or {}).get('profiles'):
+                return
+            org.llm_profiles = serialized
+            await session.commit()
 
     async def store(self, item: Settings):
         async with a_session_maker() as session:

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -946,6 +946,65 @@ async def test_load_with_null_or_empty_llm_profiles_seeds_default_profile(
 
 
 @pytest.mark.asyncio
+async def test_load_persists_seeded_default_profile_onto_org(
+    async_session_maker, org_with_multiple_members_fixture
+):
+    """The seeded Default profile must be written back to org.llm_profiles.
+
+    The seed is otherwise in-memory only, so the org-profiles management API
+    (which reads org.llm_profiles directly) would still see an empty list.
+    load() backfills it once so the user's last LLM becomes a real stored
+    profile on first use of LLM profiles.
+    """
+    from sqlalchemy import select, update
+    from storage.org import Org
+
+    fixture = org_with_multiple_members_fixture
+    admin_user_id = fixture['admin_user_id']
+    org_id = fixture['org_id']
+    admin_store = SaasSettingsStore(str(admin_user_id))
+
+    seed_settings = _make_settings(
+        model='anthropic/claude-sonnet-4-5-20250929',
+        api_key='seed-key',
+        base_url='https://api.anthropic.com/v1',
+    )
+    with patch('storage.saas_settings_store.a_session_maker', async_session_maker):
+        await admin_store.store(seed_settings)
+
+    # Simulate a pre-migration org: no profiles stored yet.
+    async with async_session_maker() as session:
+        await session.execute(
+            update(Org).where(Org.id == org_id).values(llm_profiles=None)
+        )
+        await session.commit()
+
+    with (
+        patch('storage.saas_settings_store.a_session_maker', async_session_maker),
+        patch('storage.user_store.a_session_maker', async_session_maker),
+        patch('storage.org_store.a_session_maker', async_session_maker),
+    ):
+        await admin_store.load()
+
+    async with async_session_maker() as session:
+        org = (
+            (await session.execute(select(Org).where(Org.id == org_id)))
+            .scalars()
+            .first()
+        )
+
+    assert org.llm_profiles is not None
+    assert set(org.llm_profiles['profiles'].keys()) == {'Default'}
+    assert org.llm_profiles['active'] == 'Default'
+    persisted_default = org.llm_profiles['profiles']['Default']
+    assert persisted_default['model'] == 'anthropic/claude-sonnet-4-5-20250929'
+    assert persisted_default['base_url'] == 'https://api.anthropic.com/v1'
+    # API key from the legacy config must survive the round-trip so the user
+    # doesn't have to re-enter it after the profiles upgrade.
+    assert persisted_default['api_key'] == 'seed-key'
+
+
+@pytest.mark.asyncio
 async def test_llm_profiles_are_encrypted_at_rest(
     async_session_maker, org_with_multiple_members_fixture
 ):


### PR DESCRIPTION
- [x] A human has tested these changes.

## Summary

SaaS orgs upgrading from pre-LLM-profiles settings landed on an empty profiles UI — the LLM they'd been using wasn't carried over.

SaasSettingsStore.load() now seeds a Default profile from the merged org + member effective LLM (model, base_url, api_key) when org.llm_profiles is NULL/empty, and persists it to the column so the org-profiles management API
  (/api/organizations/{org_id}/profiles) sees the same Default the settings path does — not an empty list. The write runs under a SELECT ... FOR UPDATE row lock with an emptiness re-check, so concurrent loads can't double-seed and a profile a member just created via the management API can't be clobbered. Idempotent on later loads.
  
## How to Test
- test_load_with_null_or_empty_llm_profiles_seeds_default_profile — seed surfaces in Settings.llm_profiles for both NULL and empty-dict orgs.
- test_load_persists_seeded_default_profile_onto_org — model, base_url, and api_key all round-trip into org.llm_profiles['profiles']['Default'].

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-9d91aa1   docker.openhands.dev/openhands/openhands:9d91aa1
```