### PR TITLE
fix(frontend): only mark language dirty on selection

### DIFF
--- a/frontend/__tests__/routes/app-settings.test.tsx
+++ b/frontend/__tests__/routes/app-settings.test.tsx
@@ -173,6 +173,23 @@ describe("Form submission", () => {
     expect(submit).toBeDisabled();
   });
 
+  it("should not enable the submit button when filtering languages without selecting", async () => {
+    const getSettingsSpy = vi.spyOn(SettingsService, "getSettings");
+    getSettingsSpy.mockResolvedValue(MOCK_DEFAULT_USER_SETTINGS);
+
+    renderAppSettingsScreen();
+
+    const submit = await screen.findByTestId("submit-button");
+    expect(submit).toBeDisabled();
+
+    const language = await screen.findByTestId("language-input");
+    await userEvent.click(language);
+    await userEvent.clear(language);
+    await userEvent.type(language, "Nor");
+
+    expect(submit).toBeDisabled();
+  });
+
   it("should call handleCaptureConsents with true when the analytics switch is toggled", async () => {
     const getSettingsSpy = vi.spyOn(SettingsService, "getSettings");
     getSettingsSpy.mockResolvedValue(MOCK_DEFAULT_USER_SETTINGS);

--- a/frontend/src/components/features/settings/app-settings/language-input.tsx
+++ b/frontend/src/components/features/settings/app-settings/language-input.tsx
@@ -20,7 +20,11 @@ export function LanguageInput({
     <SettingsDropdownInput
       testId={name}
       name={name}
-      onInputChange={onChange}
+      onSelectionChange={(key) => {
+        if (key) {
+          onChange(key.toString());
+        }
+      }}
       label={t(I18nKey.SETTINGS$LANGUAGE)}
       items={AvailableLanguages.map((l) => ({
         key: l.value,

--- a/frontend/src/routes/app-settings.tsx
+++ b/frontend/src/routes/app-settings.tsx
@@ -140,14 +140,7 @@ function AppSettingsScreen() {
   };
 
   const checkIfLanguageInputHasChanged = (value: string) => {
-    const selectedLanguage = AvailableLanguages.find(
-      ({ label: langValue }) => langValue === value,
-    )?.label;
-    const currentLanguage = AvailableLanguages.find(
-      ({ value: langValue }) => langValue === settings?.language,
-    )?.label;
-
-    setLanguageInputHasChanged(selectedLanguage !== currentLanguage);
+    setLanguageInputHasChanged(value !== settings?.language);
   };
 
   const checkIfAnalyticsSwitchHasChanged = (checked: boolean) => {


### PR DESCRIPTION
HUMAN: 
The save changes button stays disabled until a new language is actually selected
- [x] A human has tested these changes.
## Summary
- update the language settings dropdown to mark changes only after a committed selection
- compare the selected language key against the current settings language
- add a regression test for filtering languages without selecting an option

Fixes #14249

## Tests
- npm test -- __tests__/routes/app-settings.test.tsx
- npm run typecheck
- npx prettier --check src/components/features/settings/app-settings/language-input.tsx src/routes/app-settings.tsx __tests__/routes/app-settings.test.tsx
- npx eslint src/components/features/settings/app-settings/language-input.tsx src/routes/app-settings.tsx __tests__/routes/app-settings.test.tsx