### PR TITLE
fix(logger): remove dead aifc pre-import block (alternative to #14592)

### DIFF
--- a/openhands/app_server/utils/logger.py
+++ b/openhands/app_server/utils/logger.py
@@ -20,15 +20,6 @@ from openhands.sdk.utils.redact import (
     redact_url_params,
 )
 
-# Suppress deprecation warnings from dependencies before they're imported
-# aifc was removed in Python 3.13 but speech_recognition still references it
-with warnings.catch_warnings():
-    warnings.simplefilter('ignore')
-    import aifc
-
-    # Stop the linter from deleting the import
-    _AIFC = aifc.__name__
-
 warnings.filterwarnings('ignore', category=SyntaxWarning, module=r'pydub\.utils')
 
 LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO').upper()

--- a/openhands/app_server/utils/logger.py
+++ b/openhands/app_server/utils/logger.py
@@ -20,9 +20,6 @@ from openhands.sdk.utils.redact import (
     redact_url_params,
 )
 
-# Defensive: pydub is absent from the poetry-built image but present
-# in uv.lock via openhands-aci, so the filter is a no-op today but matters
-# under the uv-based install path.
 warnings.filterwarnings('ignore', category=SyntaxWarning, module=r'pydub\.utils')
 
 LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO').upper()

--- a/openhands/app_server/utils/logger.py
+++ b/openhands/app_server/utils/logger.py
@@ -20,6 +20,9 @@ from openhands.sdk.utils.redact import (
     redact_url_params,
 )
 
+# Defensive: pydub is absent from the poetry-built image but present
+# in uv.lock via openhands-aci, so the filter is a no-op today but matters
+# under the uv-based install path.
 warnings.filterwarnings('ignore', category=SyntaxWarning, module=r'pydub\.utils')
 
 LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO').upper()


### PR DESCRIPTION
## Summary

Alternative fix for #14591 (`ModuleNotFoundError: No module named 'aifc'` on `openhands serve`). Deletes the dead pre-import block at the top of `openhands/app_server/utils/logger.py` instead of papering over it by shipping the `standard-aifc` backport.

## Why this and not #14592

#14592 adds `standard-aifc; python_version >= '3.13'` to `pyproject.toml` + regenerates `poetry.lock`. That makes the existing block work, but the block itself is dead code in the published image, so we'd be shipping a backport solely to feed a no-op pre-import. Evidence below.

The block was added in #12579 ("Cleaner Logs") to pre-import `aifc` under a `catch_warnings()` so that a later import of `speech_recognition` would not emit a `DeprecationWarning` on Python 3.12. Two things have changed since:

1. The published image base moved from `python:3.12.10-slim` to `python:3.13.7-slim-trixie` (#11114), and `aifc` was removed from the stdlib in 3.13.
2. `speech_recognition`, `standard-aifc`, `audioop-lts`, and `pydub` are not (and have not been) in `poetry.lock`. So nothing in the published image transitively imports `aifc` — there's no `DeprecationWarning` left to suppress.

Verified against the exact image SHA reported in #14591 (`sha256:7b5ff43040d1e249b7a2d1c84637dfb16bf69e8efe8a6970be169d00303d21dd`):

```text
$ docker run --rm --entrypoint /app/.venv/bin/python ...:latest -c "
> import importlib.util
> for m in ('aifc','speech_recognition','standard_aifc','audioop','audioop_lts','pydub'):
>     print(m, '->', 'FOUND' if importlib.util.find_spec(m) else 'missing')"
aifc -> missing
speech_recognition -> missing
standard_aifc -> missing
audioop -> missing
audioop_lts -> missing
pydub -> missing
```

`aifc` is also referenced **nowhere else** under `openhands/`:

```text
$ grep -rn 'import aifc\|from aifc\|aifc\.' openhands/
openhands/app_server/utils/logger.py:27:    import aifc
openhands/app_server/utils/logger.py:30:    _AIFC = aifc.__name__
```

…both of which this PR removes. So there is no caller that depends on `aifc` being importable.

Side note: the block was also only ever half-effective on 3.12 — it suppressed the `aifc` DeprecationWarning from `speech_recognition/__init__.py:7` but not the `audioop` one from line 8. So even its original goal was incomplete.

## Verification

Patched the file inside a container of the same published image SHA and imported the actual uvicorn entrypoint (`Cmd: ["uvicorn","openhands.server.listen:app",...]`):

```text
$ docker run --rm -d --name oh_verify --entrypoint sleep ...:latest 300
$ docker cp openhands/app_server/utils/logger.py oh_verify:/app/openhands/app_server/utils/logger.py
$ docker exec oh_verify /app/.venv/bin/python -c \
>   'import openhands.server.listen; print(openhands.server.listen.app)'
08:32:47 - openhands:INFO: server_config.py:49 - Using config class None
08:32:48 - openhands:INFO: mcp_router.py:59 - Tavily API key not configured, skipping Tavily MCP proxy
<fastapi.applications.FastAPI object at 0x779c67a446e0>
```

Plus:

- `python -m py_compile openhands/app_server/utils/logger.py` — OK.
- Confirmed `sys` and `warnings` imports are still used elsewhere in the file (so no unused-import lint regressions).

## Tradeoff vs. alternatives

I considered four fixes for #14591:

| Fix | Pros | Cons |
|---|---|---|
| **A.** `if sys.version_info < (3, 13):` guard around the block | Minimal diff, preserves original intent on 3.12 | Keeps a partial-suppression block for a dependency that isn't installed |
| **B.** `try/except ModuleNotFoundError:` around the block | Robust across Python versions and both lockfiles | Hides import errors more broadly than needed |
| **C.** Delete the block *(this PR)* | Matches reality on disk; smallest surface area; removes a misleading comment that caused this debugging detour | If `speech_recognition` is ever re-introduced, 3.12 logs gain back the warnings the block was *trying* to suppress |
| **D.** Add `standard-aifc; python_version >= '3.13'` *(approach in #14592)* | No code change | Ships a backport solely to feed a no-op pre-import |

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-50b9e0e   docker.openhands.dev/openhands/openhands:50b9e0e
```