### PR TITLE
feat: add JungleGrid external execution service scaffold

### DIFF
--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -37,6 +37,10 @@ from openhands.app_server.event_callback.event_callback_service import (
     EventCallbackService,
     EventCallbackServiceInjector,
 )
+from openhands.app_server.external_execution.external_execution_service import (
+    ExternalExecutionService,
+    ExternalExecutionServiceInjector,
+)
 from openhands.app_server.file_store.files import FileStore
 from openhands.app_server.file_store.local import LocalFileStore
 from openhands.app_server.pending_messages.pending_message_service import (
@@ -217,6 +221,7 @@ class AppServerConfig(OpenHandsModel):
     llm_model: LLMModelServiceInjector | None = None
     event: EventServiceInjector | None = None
     event_callback: EventCallbackServiceInjector | None = None
+    external_execution: ExternalExecutionServiceInjector | None = None
     sandbox: SandboxServiceInjector | None = None
     sandbox_spec: SandboxSpecServiceInjector | None = None
     app_conversation_info: AppConversationInfoServiceInjector | None = None
@@ -261,6 +266,9 @@ def config_from_env() -> AppServerConfig:
     )
     from openhands.app_server.event_callback.sql_event_callback_service import (
         SQLEventCallbackServiceInjector,
+    )
+    from openhands.app_server.external_execution.junglegrid_service import (
+        JungleGridExecutionServiceInjector,
     )
     from openhands.app_server.sandbox.docker_sandbox_service import (
         DockerSandboxServiceInjector,
@@ -330,6 +338,24 @@ def config_from_env() -> AppServerConfig:
 
     if config.event_callback is None:
         config.event_callback = SQLEventCallbackServiceInjector()
+
+    if config.external_execution is None:
+        junglegrid_api_key = os.getenv('JUNGLEGRID_API_KEY') or os.getenv(
+            'JUNGLE_GRID_API_KEY'
+        )
+        junglegrid_base_url = (
+            os.getenv('JUNGLEGRID_API_BASE')
+            or os.getenv('JUNGLEGRID_BASE_URL')
+            or os.getenv('JUNGLE_GRID_API_URL')
+            or 'https://api.junglegrid.dev'
+        ).rstrip('/')
+        if junglegrid_api_key:
+            config.external_execution = JungleGridExecutionServiceInjector(
+                api_key=SecretStr(junglegrid_api_key),
+                base_url=junglegrid_base_url,
+                workspace_id=os.getenv('JUNGLEGRID_WORKSPACE_ID')
+                or os.getenv('JUNGLEGRID_PROJECT_ID'),
+            )
 
     if config.sandbox is None:
         # Legacy fallback
@@ -451,6 +477,15 @@ def get_event_callback_service(
     return injector.context(state, request)
 
 
+def get_external_execution_service(
+    state: InjectorState, request: Request | None = None
+) -> AsyncContextManager[ExternalExecutionService] | None:
+    injector = get_global_config().external_execution
+    if injector is None:
+        return None
+    return injector.context(state, request)
+
+
 def get_sandbox_service(
     state: InjectorState, request: Request | None = None
 ) -> AsyncContextManager[SandboxService]:
@@ -535,6 +570,13 @@ def depends_event_service():
 def depends_event_callback_service():
     injector = get_global_config().event_callback
     assert injector is not None
+    return Depends(injector.depends)
+
+
+def depends_external_execution_service():
+    injector = get_global_config().external_execution
+    if injector is None:
+        return None
     return Depends(injector.depends)
 
 

--- a/openhands/app_server/external_execution/__init__.py
+++ b/openhands/app_server/external_execution/__init__.py
@@ -1,0 +1,1 @@
+"""Optional external execution backends for app-server workflows."""

--- a/openhands/app_server/external_execution/external_execution_service.py
+++ b/openhands/app_server/external_execution/external_execution_service.py
@@ -1,0 +1,58 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+from openhands.app_server.services.injector import Injector
+from openhands.sdk.utils.models import DiscriminatedUnionMixin
+
+
+class ExternalExecutionService(ABC):
+    """Async external execution backend for durable, long-running work.
+
+    This is intentionally separate from SandboxService. Sandboxes provide an
+    interactive OpenHands agent-server environment; external execution is for
+    submitting durable jobs and polling their logs/artifacts over time.
+    """
+
+    @abstractmethod
+    async def estimate_job(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Estimate cost/resources for a job payload."""
+
+    @abstractmethod
+    async def submit_job(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Submit a job and return provider metadata including a job id."""
+
+    @abstractmethod
+    async def get_job(self, job_id: str) -> dict[str, Any]:
+        """Return provider metadata for a submitted job."""
+
+    @abstractmethod
+    async def get_job_status(self, job_id: str) -> dict[str, Any]:
+        """Return provider status metadata for a submitted job."""
+
+    @abstractmethod
+    async def get_job_logs(
+        self, job_id: str, limit: int | None = None, cursor: str | int | None = None
+    ) -> dict[str, Any]:
+        """Return or page through provider logs for a submitted job."""
+
+    @abstractmethod
+    async def cancel_job(
+        self, job_id: str, reason: str | None = None
+    ) -> dict[str, Any]:
+        """Cancel a submitted job."""
+
+    @abstractmethod
+    async def list_artifacts(self, job_id: str) -> dict[str, Any]:
+        """List artifacts produced by a submitted job."""
+
+    @abstractmethod
+    async def get_artifact_download_url(
+        self, job_id: str, artifact_id: str
+    ) -> dict[str, Any]:
+        """Return a provider download URL for an artifact."""
+
+
+class ExternalExecutionServiceInjector(
+    DiscriminatedUnionMixin, Injector[ExternalExecutionService], ABC
+):
+    pass

--- a/openhands/app_server/external_execution/junglegrid_client.py
+++ b/openhands/app_server/external_execution/junglegrid_client.py
@@ -1,0 +1,197 @@
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+from pydantic import SecretStr
+
+
+class JungleGridApiError(RuntimeError):
+    """Raised when the Jungle Grid API returns an error response."""
+
+    def __init__(self, status_code: int, code: str, message: str) -> None:
+        self.status_code = status_code
+        self.code = code
+        super().__init__(message)
+
+
+@dataclass
+class JungleGridClient:
+    """Async client boundary for the Jungle Grid API.
+
+    Route details mirror the official Jungle Grid MCP server's REST API.
+    """
+
+    base_url: str
+    api_key: SecretStr
+    httpx_client: httpx.AsyncClient
+    workspace_id: str | None = None
+
+    def __post_init__(self) -> None:
+        self.base_url = self.base_url.rstrip('/')
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            'Accept': 'application/json',
+            'Authorization': f'Bearer {self.api_key.get_secret_value()}',
+            'Content-Type': 'application/json',
+        }
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {}
+        if json is not None:
+            kwargs['json'] = json
+        response = await self.httpx_client.request(
+            method,
+            f'{self.base_url}{path}',
+            headers=self._headers(),
+            **kwargs,
+        )
+        if response.status_code == 204:
+            return {}
+
+        data = self._read_json(response)
+        if response.is_error:
+            raise self._api_error(response.status_code, data)
+
+        unwrapped = self._unwrap_mcp_envelope(data)
+        if isinstance(unwrapped, dict):
+            return unwrapped
+        return {'data': unwrapped}
+
+    def _read_json(self, response: httpx.Response) -> Any:
+        if not response.content:
+            return {}
+        try:
+            return response.json()
+        except ValueError:
+            if response.is_error:
+                return {}
+            raise JungleGridApiError(
+                502,
+                'INVALID_API_RESPONSE',
+                'Jungle Grid API returned an invalid JSON response.',
+            )
+
+    def _api_error(self, status_code: int, data: Any) -> JungleGridApiError:
+        parsed = self._parse_api_error(data)
+        return JungleGridApiError(
+            status_code,
+            parsed.get('code') or self._status_code_to_error_code(status_code),
+            parsed.get('message') or self._status_code_to_message(status_code),
+        )
+
+    def _parse_api_error(self, data: Any) -> dict[str, str | None]:
+        if not isinstance(data, dict):
+            return {'code': None, 'message': None}
+        nested = data.get('error')
+        if isinstance(nested, dict):
+            return {
+                'code': self._clean_string(nested.get('code')),
+                'message': self._clean_string(nested.get('message')),
+            }
+        return {
+            'code': self._clean_string(data.get('code')),
+            'message': self._clean_string(data.get('message')),
+        }
+
+    def _unwrap_mcp_envelope(self, data: Any) -> Any:
+        if isinstance(data, dict) and data.get('ok') is True and 'data' in data:
+            return data['data']
+        return data
+
+    def _clean_string(self, value: Any) -> str | None:
+        if not isinstance(value, str):
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+    def _status_code_to_error_code(self, status_code: int) -> str:
+        if status_code == 401:
+            return 'UNAUTHORIZED'
+        if status_code == 403:
+            return 'FORBIDDEN'
+        if status_code == 404:
+            return 'NOT_FOUND'
+        if status_code == 429:
+            return 'RATE_LIMITED'
+        if status_code >= 500:
+            return 'UPSTREAM_ERROR'
+        return 'API_ERROR'
+
+    def _status_code_to_message(self, status_code: int) -> str:
+        if status_code == 401:
+            return 'Authentication is required or the token is invalid.'
+        if status_code == 403:
+            return 'The token is not authorized for this Jungle Grid action.'
+        if status_code == 404:
+            return 'The requested Jungle Grid resource was not found.'
+        if status_code == 429:
+            return 'Jungle Grid API rate limit exceeded.'
+        if status_code >= 500:
+            return 'Jungle Grid API is temporarily unavailable.'
+        return f'Jungle Grid API request failed with status {status_code}.'
+
+    async def estimate_job(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._request('POST', '/v1/mcp/jobs/estimate', json=payload)
+
+    async def submit_job(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._request('POST', '/v1/mcp/jobs', json=payload)
+
+    async def get_job(self, job_id: str) -> dict[str, Any]:
+        return await self._request('GET', f'/v1/mcp/jobs/{self._path(job_id)}')
+
+    async def get_job_status(self, job_id: str) -> dict[str, Any]:
+        return await self.get_job(job_id)
+
+    async def get_job_logs(
+        self, job_id: str, limit: int | None = None, cursor: str | int | None = None
+    ) -> dict[str, Any]:
+        params = {}
+        if limit is not None:
+            params['limit'] = str(limit)
+        if cursor is not None and str(cursor).strip():
+            params['cursor'] = str(cursor).strip()
+        suffix = f'?{httpx.QueryParams(params)}' if params else ''
+        return await self._request(
+            'GET',
+            f'/v1/mcp/jobs/{self._path(job_id)}/logs{suffix}',
+        )
+
+    async def cancel_job(
+        self, job_id: str, reason: str | None = None
+    ) -> dict[str, Any]:
+        return await self._request(
+            'POST',
+            f'/v1/mcp/jobs/{self._path(job_id)}/cancel',
+            json={
+                'reason': reason.strip()
+                if reason and reason.strip()
+                else 'Cancelled via OpenHands'
+            },
+        )
+
+    async def list_artifacts(self, job_id: str) -> dict[str, Any]:
+        return await self._request(
+            'GET',
+            f'/v1/mcp/jobs/{self._path(job_id)}/artifacts',
+        )
+
+    async def get_artifact_download_url(
+        self, job_id: str, artifact_id: str
+    ) -> dict[str, Any]:
+        return await self._request(
+            'POST',
+            f'/v1/mcp/jobs/{self._path(job_id)}'
+            + f'/artifacts/{self._path(artifact_id)}'
+            + '/download',
+        )
+
+    def _path(self, value: str) -> str:
+        return quote(value, safe='')

--- a/openhands/app_server/external_execution/junglegrid_service.py
+++ b/openhands/app_server/external_execution/junglegrid_service.py
@@ -1,0 +1,80 @@
+from dataclasses import dataclass
+from typing import Any, AsyncGenerator
+
+from fastapi import Request
+from pydantic import Field, SecretStr
+
+from openhands.app_server.external_execution.external_execution_service import (
+    ExternalExecutionService,
+    ExternalExecutionServiceInjector,
+)
+from openhands.app_server.external_execution.junglegrid_client import JungleGridClient
+from openhands.app_server.services.injector import InjectorState
+
+
+@dataclass
+class JungleGridExecutionService(ExternalExecutionService):
+    """Jungle Grid external execution adapter.
+
+    This service is async-first: callers submit work, receive provider metadata
+    such as a job id, and poll status/logs/artifacts without blocking OpenHands'
+    default local, Docker, process, or remote sandbox behavior.
+    """
+
+    client: JungleGridClient
+
+    async def estimate_job(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self.client.estimate_job(payload)
+
+    async def submit_job(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self.client.submit_job(payload)
+
+    async def get_job(self, job_id: str) -> dict[str, Any]:
+        return await self.client.get_job(job_id)
+
+    async def get_job_status(self, job_id: str) -> dict[str, Any]:
+        return await self.client.get_job_status(job_id)
+
+    async def get_job_logs(
+        self, job_id: str, limit: int | None = None, cursor: str | int | None = None
+    ) -> dict[str, Any]:
+        return await self.client.get_job_logs(job_id, limit=limit, cursor=cursor)
+
+    async def cancel_job(
+        self, job_id: str, reason: str | None = None
+    ) -> dict[str, Any]:
+        return await self.client.cancel_job(job_id, reason=reason)
+
+    async def list_artifacts(self, job_id: str) -> dict[str, Any]:
+        return await self.client.list_artifacts(job_id)
+
+    async def get_artifact_download_url(
+        self, job_id: str, artifact_id: str
+    ) -> dict[str, Any]:
+        return await self.client.get_artifact_download_url(job_id, artifact_id)
+
+
+class JungleGridExecutionServiceInjector(ExternalExecutionServiceInjector):
+    """Dependency injector for Jungle Grid external execution."""
+
+    api_key: SecretStr = Field(description='Jungle Grid API key')
+    base_url: str = Field(description='Jungle Grid API base URL')
+    workspace_id: str | None = Field(
+        default=None,
+        description='Optional Jungle Grid workspace or project identifier',
+    )
+
+    async def inject(
+        self, state: InjectorState, request: Request | None = None
+    ) -> AsyncGenerator[ExternalExecutionService, None]:
+        from openhands.app_server.config import get_httpx_client
+
+        async with get_httpx_client(state, request) as httpx_client:
+            yield JungleGridExecutionService(
+                client=JungleGridClient(
+                    base_url=self.base_url,
+                    api_key=self.api_key,
+                    workspace_id=self.workspace_id,
+                    httpx_client=httpx_client,
+                )
+            )

--- a/tests/unit/app_server/test_junglegrid_external_execution.py
+++ b/tests/unit/app_server/test_junglegrid_external_execution.py
@@ -1,0 +1,247 @@
+import os
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+from pydantic import SecretStr
+
+from openhands.app_server.external_execution.junglegrid_client import (
+    JungleGridApiError,
+    JungleGridClient,
+)
+
+
+def _clean_env() -> dict[str, str]:
+    env = {}
+    for key in ['PATH', 'HOME', 'PYTHONPATH', 'VIRTUAL_ENV', 'TMPDIR', 'TMP', 'TEMP']:
+        if key in os.environ:
+            env[key] = os.environ[key]
+    return env
+
+
+def test_junglegrid_external_execution_disabled_without_env():
+    from openhands.app_server.config import config_from_env
+
+    with patch.dict(os.environ, _clean_env(), clear=True):
+        config = config_from_env()
+
+    assert config.external_execution is None
+
+
+def test_junglegrid_external_execution_enabled_from_env():
+    from openhands.app_server.config import config_from_env
+    from openhands.app_server.external_execution.junglegrid_service import (
+        JungleGridExecutionServiceInjector,
+    )
+
+    env = _clean_env()
+    env['JUNGLEGRID_API_KEY'] = 'jg_test_key'
+    env['JUNGLEGRID_API_BASE'] = 'https://api.junglegrid.example/'
+    env['JUNGLEGRID_WORKSPACE_ID'] = 'workspace-123'
+
+    with patch.dict(os.environ, env, clear=True):
+        config = config_from_env()
+
+    assert isinstance(config.external_execution, JungleGridExecutionServiceInjector)
+    assert config.external_execution.api_key.get_secret_value() == 'jg_test_key'
+    assert config.external_execution.base_url == 'https://api.junglegrid.example'
+    assert config.external_execution.workspace_id == 'workspace-123'
+
+
+@pytest.mark.parametrize(
+    ('method_name', 'args', 'expected_method', 'expected_path', 'expected_body'),
+    [
+        (
+            'estimate_job',
+            ({'workload_type': 'batch'},),
+            'POST',
+            '/v1/mcp/jobs/estimate',
+            {'workload_type': 'batch'},
+        ),
+        (
+            'submit_job',
+            ({'name': 'tests', 'workload_type': 'batch', 'image': 'python:3.12'},),
+            'POST',
+            '/v1/mcp/jobs',
+            {'name': 'tests', 'workload_type': 'batch', 'image': 'python:3.12'},
+        ),
+        ('get_job', ('job 123',), 'GET', '/v1/mcp/jobs/job%20123', None),
+        ('get_job_status', ('job 123',), 'GET', '/v1/mcp/jobs/job%20123', None),
+        (
+            'get_job_logs',
+            ('job 123',),
+            'GET',
+            '/v1/mcp/jobs/job%20123/logs',
+            None,
+        ),
+        (
+            'cancel_job',
+            ('job 123',),
+            'POST',
+            '/v1/mcp/jobs/job%20123/cancel',
+            {'reason': 'Cancelled via OpenHands'},
+        ),
+        (
+            'list_artifacts',
+            ('job 123',),
+            'GET',
+            '/v1/mcp/jobs/job%20123/artifacts',
+            None,
+        ),
+        (
+            'get_artifact_download_url',
+            ('job 123', 'artifact 456'),
+            'POST',
+            '/v1/mcp/jobs/job%20123/artifacts/artifact%20456/download',
+            None,
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_junglegrid_client_methods_call_documented_endpoints(
+    method_name, args, expected_method, expected_path, expected_body
+):
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={'ok': True, 'data': {'status': 'ok'}})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler)
+    ) as httpx_client:
+        client = JungleGridClient(
+            base_url='https://api.junglegrid.example/',
+            api_key=SecretStr('jg_test_key'),
+            httpx_client=httpx_client,
+        )
+
+        result = await getattr(client, method_name)(*args)
+
+    assert result == {'status': 'ok'}
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.method == expected_method
+    assert request.url == httpx.URL(f'https://api.junglegrid.example{expected_path}')
+    assert request.headers['Accept'] == 'application/json'
+    assert request.headers['Authorization'] == 'Bearer jg_test_key'
+    assert request.headers['Content-Type'] == 'application/json'
+    if expected_body is None:
+        assert request.content == b''
+    else:
+        assert _request_json(request) == expected_body
+
+
+@pytest.mark.asyncio
+async def test_junglegrid_client_get_job_logs_supports_pagination():
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={'items': []})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler)
+    ) as httpx_client:
+        client = JungleGridClient(
+            base_url='https://api.junglegrid.example',
+            api_key=SecretStr('jg_test_key'),
+            httpx_client=httpx_client,
+        )
+
+        assert await client.get_job_logs('job 123', limit=50, cursor='cursor-1') == {
+            'items': []
+        }
+
+    assert requests[0].url == httpx.URL(
+        'https://api.junglegrid.example/v1/mcp/jobs/job%20123/logs'
+        '?limit=50&cursor=cursor-1'
+    )
+
+
+@pytest.mark.asyncio
+async def test_junglegrid_client_cancel_job_accepts_reason():
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={'status': 'cancelled'})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler)
+    ) as httpx_client:
+        client = JungleGridClient(
+            base_url='https://api.junglegrid.example',
+            api_key=SecretStr('jg_test_key'),
+            httpx_client=httpx_client,
+        )
+
+        await client.cancel_job('job-123', reason='user requested')
+
+    assert _request_json(requests[0]) == {'reason': 'user requested'}
+
+
+@pytest.mark.asyncio
+async def test_junglegrid_client_raises_structured_api_errors():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            403,
+            json={
+                'error': {
+                    'code': 'FORBIDDEN',
+                    'message': 'api key missing jobs:read scope',
+                }
+            },
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler)
+    ) as httpx_client:
+        client = JungleGridClient(
+            base_url='https://api.junglegrid.example',
+            api_key=SecretStr('jg_test_key'),
+            httpx_client=httpx_client,
+        )
+
+        with pytest.raises(JungleGridApiError) as exc_info:
+            await client.get_job('job-123')
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.code == 'FORBIDDEN'
+    assert str(exc_info.value) == 'api key missing jobs:read scope'
+
+
+def test_junglegrid_external_execution_supports_legacy_env_aliases():
+    from openhands.app_server.config import config_from_env
+    from openhands.app_server.external_execution.junglegrid_service import (
+        JungleGridExecutionServiceInjector,
+    )
+
+    env = _clean_env()
+    env['JUNGLE_GRID_API_KEY'] = 'jg_test_key'
+    env['JUNGLE_GRID_API_URL'] = 'https://api.junglegrid.example/'
+
+    with patch.dict(os.environ, env, clear=True):
+        config = config_from_env()
+
+    assert isinstance(config.external_execution, JungleGridExecutionServiceInjector)
+    assert config.external_execution.api_key.get_secret_value() == 'jg_test_key'
+    assert config.external_execution.base_url == 'https://api.junglegrid.example'
+
+
+def test_junglegrid_external_execution_uses_documented_default_base_url():
+    from openhands.app_server.config import config_from_env
+
+    env = _clean_env()
+    env['JUNGLEGRID_API_KEY'] = 'jg_test_key'
+
+    with patch.dict(os.environ, env, clear=True):
+        config = config_from_env()
+
+    assert config.external_execution is not None
+    assert config.external_execution.base_url == 'https://api.junglegrid.dev'
+
+
+def _request_json(request: httpx.Request) -> Any:
+    return httpx.Response(200, request=request, content=request.content).json()


### PR DESCRIPTION
HUMAN:

This PR adds a JungleGrid external execution backend so OpenHands can estimate and submit durable JungleGrid jobs, then poll status, logs, cancellation, and artifact download URLs through the documented JungleGrid MCP REST API. I also live-tested the read-only estimate call with a demo key and removed an unsupported list-jobs endpoint after the API returned 405.

- [x] A human has tested these changes.

AGENT:

---

## Why

Refs OpenHands/software-agent-sdk#4254.

This adds a production-wired JungleGrid external execution backend for durable job-style work. It keeps the integration separate from `SandboxService`, so existing local, Docker, process, and remote sandbox behavior is unchanged.

The REST client mirrors the official Jungle Grid MCP server contract: bearer auth, default hosted API base, `/v1/mcp/jobs` endpoints, MCP envelope unwrapping, structured API errors, paginated logs, cancellation reason support, artifact listing, and signed artifact download URL creation.

## Summary

- Add an `ExternalExecutionService` abstraction and JungleGrid implementation.
- Enable JungleGrid from env with documented aliases: `JUNGLEGRID_API_KEY` / `JUNGLE_GRID_API_KEY`, `JUNGLEGRID_API_BASE`, `JUNGLEGRID_BASE_URL`, or `JUNGLE_GRID_API_URL`.
- Wire estimate, submit, get job/status, logs, cancel, list artifacts, and artifact download URL calls to JungleGrid REST endpoints.
- Add focused tests for configuration, endpoint mapping, auth headers, request bodies, response envelope unwrapping, log pagination, cancellation reasons, and structured API errors.

## Issue Number

Refs OpenHands/software-agent-sdk#4254

## How to Test

```bash
PATH=/home/invinc/code/OpenHands/.venv/bin:$PATH poetry run pytest tests/unit/app_server/test_junglegrid_external_execution.py -q
PRE_COMMIT_HOME=/tmp/pre-commit-cache PATH=/home/invinc/code/OpenHands/.venv/bin:$PATH poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files openhands/app_server/config.py openhands/app_server/external_execution/external_execution_service.py openhands/app_server/external_execution/junglegrid_client.py openhands/app_server/external_execution/junglegrid_service.py tests/unit/app_server/test_junglegrid_external_execution.py
```

Observed locally:

```text
15 passed in 24.77s
pre-commit targeted files: Passed
```

Live read-only smoke test with a demo key:

```text
estimate_job: OK
estimate_available=True
estimate_cost_usd=0.25
```

`make install-pre-commit-hooks` was attempted first as required, but the full Poetry dependency install hit a PyPI/network timeout and then a local `.venv` embedded pip wheel error while replacing packages. The targeted test and targeted backend pre-commit check passed afterward.

## Video/Screenshots

N/A, backend service integration only.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The submitted API key was used only for read-only live smoke testing because it was exposed in chat and should be rotated before use outside this demo. No paid compute job was submitted.