### PR TITLE
Support pagination for branch search

### DIFF
--- a/openhands/app_server/git/git_router.py
+++ b/openhands/app_server/git/git_router.py
@@ -244,19 +244,11 @@ async def search_branches(
         page = decoded_page_id
 
     if query:
-        if page != 1:
-            # TODO(#13883): Support pagination for branch search after refactoring.
-            # The search_branches method does not support paging in the same way as
-            # get_branches - those should be merged into a single paginated method
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail='Pagination not yet supported for branch search queries. Use empty query to list all branches with pagination.',
-            )
-        # Get search results - we'll handle pagination ourselves
         branches: list[Branch] = await client.search_branches(
             selected_provider=provider,
             repository=repository,
             query=query,
+            page=page,
             per_page=limit + 1,
         )
     else:

--- a/openhands/app_server/integrations/azure_devops/service/branches.py
+++ b/openhands/app_server/integrations/azure_devops/service/branches.py
@@ -140,7 +140,7 @@ class AzureDevOpsBranchesMixin(AzureDevOpsMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
     ) -> list[Branch]:
         """Search for branches within a repository."""
         # Parse repository string: organization/project/repo
@@ -164,6 +164,8 @@ class AzureDevOpsBranchesMixin(AzureDevOpsMixinBase):
         try:
             response, _ = await self._make_request(url)
             branches_data = response.get('value', [])
+            start = max((page - 1) * per_page, 0)
+            end = start + per_page
 
             # Filter branches by query
             filtered_branches = []
@@ -191,10 +193,10 @@ class AzureDevOpsBranchesMixin(AzureDevOpsMixinBase):
                     )
                     filtered_branches.append(branch)
 
-                    if len(filtered_branches) >= per_page:
+                    if len(filtered_branches) >= end:
                         break
 
-            return filtered_branches
+            return filtered_branches[start:end]
         except Exception:
             # Return empty list on error instead of None
             return []

--- a/openhands/app_server/integrations/bitbucket/service/branches.py
+++ b/openhands/app_server/integrations/bitbucket/service/branches.py
@@ -87,7 +87,7 @@ class BitBucketBranchesMixin(BitBucketMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
     ) -> list[Branch]:
         """Search branches by name using Bitbucket API with `q` param."""
         parts = repository.split('/')
@@ -101,6 +101,7 @@ class BitBucketBranchesMixin(BitBucketMixinBase):
         # Bitbucket filtering: name ~ "query"
         params = {
             'pagelen': per_page,
+            'page': page,
             'q': f'name~"{query}"',
             'sort': '-target.date',
         }

--- a/openhands/app_server/integrations/bitbucket_data_center/service/branches.py
+++ b/openhands/app_server/integrations/bitbucket_data_center/service/branches.py
@@ -72,14 +72,16 @@ class BitbucketDCBranchesMixin(BitbucketDCMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
     ) -> list[Branch]:
         """Search branches by name using Bitbucket data center API with `q` param."""
         owner, repo = self._extract_owner_and_repo(repository)
 
         url = f'{self._repo_api_base(owner, repo)}/branches'
+        start = max((page - 1) * per_page, 0)
         params = {
             'limit': per_page,
+            'start': start,
             'filterText': query,
             'orderBy': 'MODIFICATION',
         }

--- a/openhands/app_server/integrations/forgejo/service/branches.py
+++ b/openhands/app_server/integrations/forgejo/service/branches.py
@@ -68,10 +68,12 @@ class ForgejoBranchesMixin(ForgejoMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
     ) -> list[Branch]:  # type: ignore[override]
         all_branches = await self.get_branches(repository)
         lowered = query.lower()
-        return [branch for branch in all_branches if lowered in branch.name.lower()][
-            :per_page
-        ]
+        start = max((page - 1) * per_page, 0)
+        end = start + per_page
+        return [
+            branch for branch in all_branches if lowered in branch.name.lower()
+        ][start:end]

--- a/openhands/app_server/integrations/forgejo/service/branches.py
+++ b/openhands/app_server/integrations/forgejo/service/branches.py
@@ -74,6 +74,6 @@ class ForgejoBranchesMixin(ForgejoMixinBase):
         lowered = query.lower()
         start = max((page - 1) * per_page, 0)
         end = start + per_page
-        return [
-            branch for branch in all_branches if lowered in branch.name.lower()
-        ][start:end]
+        return [branch for branch in all_branches if lowered in branch.name.lower()][
+            start:end
+        ]

--- a/openhands/app_server/integrations/github/queries.py
+++ b/openhands/app_server/integrations/github/queries.py
@@ -129,12 +129,13 @@ query ($threadId: ID!, $page: Int = 50, $after: String) {
 # - query: partial branch name provided by the user
 # - first: pagination size (clamped by caller to GitHub limits)
 search_branches_graphql_query = """
-    query SearchBranches($owner: String!, $name: String!, $query: String!, $perPage: Int!) {
+    query SearchBranches($owner: String!, $name: String!, $query: String!, $perPage: Int!, $after: String) {
         repository(owner: $owner, name: $name) {
             refs(
                 refPrefix: "refs/heads/",
                 query: $query,
                 first: $perPage,
+                after: $after,
                 orderBy: { field: ALPHABETICAL, direction: ASC }
             ) {
                 nodes {
@@ -146,6 +147,10 @@ search_branches_graphql_query = """
                             committedDate
                         }
                     }
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
                 }
             }
         }

--- a/openhands/app_server/integrations/github/service/branches_prs.py
+++ b/openhands/app_server/integrations/github/service/branches_prs.py
@@ -103,7 +103,7 @@ class GitHubBranchesMixin(GitHubMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
     ) -> list[Branch]:
         """Search branches by name using GitHub GraphQL with a partial query."""
         # Require a non-empty query
@@ -124,23 +124,35 @@ class GitHubBranchesMixin(GitHubMixinBase):
             'name': name,
             'query': query or '',
             'perPage': per_page,
+            'after': None,
         }
 
         try:
-            result = await self.execute_graphql_query(
-                search_branches_graphql_query, variables
-            )
+            refs = None
+            for current_page in range(1, max(page, 1) + 1):
+                result = await self.execute_graphql_query(
+                    search_branches_graphql_query, variables.copy()
+                )
+                repo = result.get('data', {}).get('repository')
+                refs = repo.get('refs') if repo else None
+                if not refs:
+                    return []
+                page_info = refs.get('pageInfo') or {}
+                if current_page < page and not page_info.get('hasNextPage'):
+                    return []
+                if not page_info.get('hasNextPage'):
+                    break
+                variables['after'] = page_info.get('endCursor')
         except Exception as e:
             logger.warning(f'Failed to search for branches: {e}')
             # Fallback to empty result on any GraphQL error
             return []
 
-        repo = result.get('data', {}).get('repository')
-        if not repo or not repo.get('refs'):
+        if not refs:
             return []
 
         branches: list[Branch] = []
-        for node in repo['refs'].get('nodes', []):
+        for node in refs.get('nodes', []):
             bname = node.get('name') or ''
             target = node.get('target') or {}
             typename = target.get('__typename')

--- a/openhands/app_server/integrations/gitlab/service/branches.py
+++ b/openhands/app_server/integrations/gitlab/service/branches.py
@@ -88,13 +88,13 @@ class GitLabBranchesMixin(GitLabMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
     ) -> list[Branch]:
         """Search branches using GitLab API which supports `search` param."""
         encoded_name = repository.replace('/', '%2F')
         url = f'{self.BASE_URL}/projects/{encoded_name}/repository/branches'
 
-        params = {'per_page': str(per_page), 'search': query}
+        params = {'per_page': str(per_page), 'page': str(page), 'search': query}
         response, _ = await self._make_request(url, params)
 
         branches: list[Branch] = []

--- a/openhands/app_server/integrations/provider.py
+++ b/openhands/app_server/integrations/provider.py
@@ -327,13 +327,14 @@ class ProviderHandler:
         selected_provider: ProviderType | None,
         repository: str,
         query: str,
+        page: int = 1,
         per_page: int = 30,
     ) -> list[Branch]:
         """Search for branches within a repository using the appropriate provider service."""
         if selected_provider:
             service = self.get_service(selected_provider)
             try:
-                return await service.search_branches(repository, query, per_page)
+                return await service.search_branches(repository, query, page, per_page)
             except Exception as e:
                 logger.warning(
                     f'Error searching branches from selected provider {selected_provider}: {e}'
@@ -344,7 +345,7 @@ class ProviderHandler:
         try:
             repo_details = await self.verify_repo_provider(repository)
             service = self.get_service(repo_details.git_provider)
-            return await service.search_branches(repository, query, per_page)
+            return await service.search_branches(repository, query, page, per_page)
         except Exception as e:
             logger.warning(f'Error searching branches for {repository}: {e}')
             return []

--- a/openhands/app_server/integrations/service_types.py
+++ b/openhands/app_server/integrations/service_types.py
@@ -304,7 +304,7 @@ class GitService(Protocol):
         """Get branches for a repository with pagination"""
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
     ) -> list[Branch]:
         """Search for branches within a repository"""
 

--- a/tests/unit/app_server/test_git_router.py
+++ b/tests/unit/app_server/test_git_router.py
@@ -772,7 +772,45 @@ class TestSearchBranches:
         assert call_kwargs.get('selected_provider') == ProviderType.GITHUB
         assert call_kwargs.get('repository') == 'user/repo'
         assert call_kwargs.get('query') == 'feature'
+        assert call_kwargs.get('page') == 1
         assert call_kwargs.get('per_page') == 11  # limit + 1
+
+    @pytest.mark.asyncio
+    @patch('openhands.app_server.git.git_router.ProviderHandler')
+    async def test_passes_decoded_page_to_branch_search(self, mock_handler_cls):
+        """Test that branch search pagination is passed through to the provider."""
+        # Arrange
+        mock_handler = MagicMock()
+        mock_handler.search_branches = AsyncMock(
+            return_value=[
+                Branch(name='feature-2', commit_sha='def456', protected=False),
+            ]
+        )
+        mock_handler_cls.return_value = mock_handler
+
+        mock_context = _make_mock_user_context(
+            provider_tokens={
+                ProviderType.GITHUB: ProviderToken(user_id='user-123', token='token')
+            },
+            user_id='user-123',
+        )
+
+        # Act
+        result = await search_branches(
+            provider=ProviderType.GITHUB,
+            repository='user/repo',
+            query='feature',
+            page_id=encode_page_id(2),
+            limit=10,
+            user_context=mock_context,
+        )
+
+        # Assert
+        assert [branch.name for branch in result.items] == ['feature-2']
+        assert result.next_page_id is None
+        call_kwargs = mock_handler.search_branches.call_args.kwargs
+        assert call_kwargs.get('page') == 2
+        assert call_kwargs.get('per_page') == 11
 
     def test_returns_403_when_no_provider_tokens(self, test_client):
         """Test that 403 is returned when no provider tokens."""

--- a/tests/unit/integrations/github/test_github_branches.py
+++ b/tests/unit/integrations/github/test_github_branches.py
@@ -129,6 +129,7 @@ async def test_search_branches_github_success_and_variables():
         assert variables['owner'] == 'foo'
         assert variables['name'] == 'bar'
         assert variables['query'] == 'fe'
+        assert variables['after'] is None
         assert 1 <= variables['perPage'] <= 100
 
         assert len(branches) == 2
@@ -143,6 +144,56 @@ async def test_search_branches_github_success_and_variables():
         assert b1.commit_sha == ''
         assert b1.last_push_date is None
         assert b1.protected is False
+
+
+@pytest.mark.asyncio
+async def test_search_branches_github_uses_cursor_for_later_pages():
+    service = GitHubService(token=SecretStr('t'))
+
+    first_page = {
+        'data': {
+            'repository': {
+                'refs': {
+                    'nodes': [
+                        {
+                            'name': 'feature/one',
+                            'target': {'__typename': 'Commit', 'oid': 'aaa111'},
+                            'branchProtectionRule': None,
+                        }
+                    ],
+                    'pageInfo': {'hasNextPage': True, 'endCursor': 'cursor-1'},
+                }
+            }
+        }
+    }
+    second_page = {
+        'data': {
+            'repository': {
+                'refs': {
+                    'nodes': [
+                        {
+                            'name': 'feature/two',
+                            'target': {'__typename': 'Commit', 'oid': 'bbb222'},
+                            'branchProtectionRule': None,
+                        }
+                    ],
+                    'pageInfo': {'hasNextPage': False, 'endCursor': None},
+                }
+            }
+        }
+    }
+
+    exec_mock = AsyncMock(side_effect=[first_page, second_page])
+    with patch.object(service, 'execute_graphql_query', exec_mock):
+        branches = await service.search_branches(
+            'foo/bar', query='feature', page=2, per_page=1
+        )
+
+    assert [branch.name for branch in branches] == ['feature/two']
+    first_variables = exec_mock.call_args_list[0].args[1]
+    second_variables = exec_mock.call_args_list[1].args[1]
+    assert first_variables['after'] is None
+    assert second_variables['after'] == 'cursor-1'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
HUMAN:
This PR threads branch-search pagination through the router and provider services so branch search can return later pages instead of only the first result set. I verified the changed files compile locally, and the GitHub CI checks are now green.

- [x] A human has tested these changes.

## Summary
- pass decoded page ids through the branch search router to provider services
- add provider-level pagination support for branch search where supported
- add GitHub GraphQL cursor pagination for branch search
- add router and GitHub regression tests

Fixes OpenHands/enterprise#22

## Testing
- python3 -m py_compile openhands/app_server/git/git_router.py openhands/app_server/integrations/service_types.py openhands/app_server/integrations/provider.py openhands/app_server/integrations/github/queries.py openhands/app_server/integrations/github/service/branches_prs.py openhands/app_server/integrations/bitbucket/service/branches.py openhands/app_server/integrations/gitlab/service/branches.py openhands/app_server/integrations/bitbucket_data_center/service/branches.py openhands/app_server/integrations/forgejo/service/branches.py openhands/app_server/integrations/azure_devops/service/branches.py tests/unit/app_server/test_git_router.py tests/unit/integrations/github/test_github_branches.py
- Not run: pytest, because this local Python environment is missing pytest and project test dependencies.