### PR TITLE
Fix CVE-2026-41238: Update dompurify to 3.4.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8852,13 +8852,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "engines": {
-        "node": ">=20"
-      },
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -129,6 +129,6 @@
     ]
   },
   "overrides": {
-    "dompurify": "3.3.2"
+    "dompurify": "3.4.0"
   }
 }


### PR DESCRIPTION
HUMAN: Addresses CVE and Dependabot alerts.

- [x] A human has tested these change

---

Security fix for CVE-2026-41238.

This PR updates the frontend dompurify override and package lock entry from 3.3.2 to 3.4.0.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@aivong-openhands can click here to [continue refining the PR](https://app.all-hands.dev/conversations/11fba18f-4b74-4232-a45e-69e5f18b813a)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-4d40328   docker.openhands.dev/openhands/openhands:4d40328
```