### PR TITLE
Update default agent server image to 1.23.1

### DIFF
--- a/openhands/app_server/sandbox/sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/sandbox_spec_service.py
@@ -13,7 +13,7 @@ from openhands.sdk.utils.models import DiscriminatedUnionMixin
 
 # The version of the agent server to use for deployments.
 # Typically this will be the same as the values from the pyproject.toml
-AGENT_SERVER_IMAGE = 'ghcr.io/openhands/agent-server:1.22.1-python'
+AGENT_SERVER_IMAGE = 'ghcr.io/openhands/agent-server:1.23.1-python'
 
 
 class SandboxSpecService(ABC):


### PR DESCRIPTION
## Summary
- update the default deployed agent-server image from `1.22.1-python` to `1.23.1-python`
- align the sandbox default image with the existing `openhands-agent-server==1.23.1` / `openhands-sdk==1.23.1` package pins
- ensure deployments that derive `AGENT_SERVER_IMAGE_TAG` from `sandbox_spec_service.py` pick up the Laminar `set_trace_user_id` support

## Validation
- `docker manifest inspect ghcr.io/openhands/agent-server:1.23.1-python`
- `poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files openhands/app_server/sandbox/sandbox_spec_service.py`
- `poetry run pytest tests/unit/app_server/test_agent_server_env_override.py`

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1e1eb43e-a404-4c95-9f48-f24bf07313fa)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-7462246   docker.openhands.dev/openhands/openhands:7462246
```