### PR TITLE
fix: allow self-hosted BYOR key export

### DIFF
--- a/enterprise/storage/org_service.py
+++ b/enterprise/storage/org_service.py
@@ -8,6 +8,7 @@ from uuid import UUID, uuid4
 from uuid import UUID as parse_uuid
 
 from server.constants import (
+    DEPLOYMENT_MODE,
     ORG_SETTINGS_VERSION,
     get_default_llm_base_url,
     get_default_llm_model,
@@ -845,6 +846,9 @@ class OrgService:
         Returns:
             bool: True if BYOR export is enabled, False otherwise.
         """
+        if DEPLOYMENT_MODE == 'self_hosted':
+            return True
+
         if org_id is None:
             user = await UserStore.get_user_by_id(user_id)
             if not user or not user.current_org_id:

--- a/enterprise/tests/unit/test_org_service.py
+++ b/enterprise/tests/unit/test_org_service.py
@@ -1874,6 +1874,26 @@ async def test_update_org_with_permissions_only_non_llm_fields(
 
 
 @pytest.mark.asyncio
+async def test_check_byor_export_enabled_allows_self_hosted_deployments():
+    with (
+        patch('storage.org_service.DEPLOYMENT_MODE', 'self_hosted'),
+        patch(
+            'storage.org_service.UserStore.get_user_by_id',
+            new_callable=AsyncMock,
+        ) as get_user_by_id_mock,
+        patch(
+            'storage.org_service.OrgStore.get_org_by_id',
+            new_callable=AsyncMock,
+        ) as get_org_by_id_mock,
+    ):
+        result = await OrgService.check_byor_export_enabled('test-user-123')
+
+    assert result is True
+    get_user_by_id_mock.assert_not_awaited()
+    get_org_by_id_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_check_byor_export_enabled_returns_true_when_enabled():
     """
     GIVEN: User has current_org with byor_export_enabled=True


### PR DESCRIPTION
HUMAN:
This is a narrow self-hosted Enterprise fix: BYOR key export should not depend on the SaaS credit flag when the deployment is not using the cloud billing path. The cloud path still uses the existing per-org `byor_export_enabled` setting.

- [ ] A human has tested these changes.

## Summary

Self-hosted Enterprise installs do not use the SaaS credit gate, but the BYOR LLM key endpoints still checked `org.byor_export_enabled`. That leaves self-hosted orgs stuck behind the "Purchase credits" path because nothing in a billing-disabled deployment flips that flag.

This changes `OrgService.check_byor_export_enabled()` to allow BYOR export when `DEPLOYMENT_MODE == 'self_hosted'`. The cloud path still uses the existing per-org `byor_export_enabled` flag.

Fixes #14610.

## To verify

Ran locally on Windows after rebasing onto current `origin/main`:

```powershell
python -m py_compile enterprise\storage\org_service.py enterprise\tests\unit\test_org_service.py
git diff --check origin/main..HEAD
$env:PYTHONPATH=(Resolve-Path .\enterprise).Path; python -m pytest enterprise\tests\unit\test_org_service.py -q -k check_byor_export_enabled --basetemp .tmp\pytest-14610 -p no:cacheprovider
$env:PYTHONPATH=(Resolve-Path .\enterprise).Path; python -m pytest enterprise\tests\unit\test_org_service.py -q --basetemp .tmp\pytest-14610-full -p no:cacheprovider
```

Results:
- BYOR-focused tests: `6 passed, 48 deselected`
- Full `test_org_service.py`: `54 passed`
- `py_compile` and `git diff --check`: passed

Note: I installed the declared enterprise dependency `python-keycloak==5.3.1` locally so the enterprise unit tests could import `server.auth.token_manager`.

I also checked `python -m ruff check enterprise\storage\org_service.py enterprise\tests\unit\test_org_service.py`; it reports existing full-file docstring style issues unrelated to this patch, so I left that broader cleanup out of scope.