### PR TITLE
Cascade-delete sole-org requester on DELETE /api/organizations

### DIFF
--- a/enterprise/server/routes/org_models.py
+++ b/enterprise/server/routes/org_models.py
@@ -80,6 +80,26 @@ class OrgAuthorizationError(OrgDeletionError):
         super().__init__(message)
 
 
+class OrphanedUserError(OrgDeletionError):
+    """Raised when deleting an org would leave OTHER users (not the requester)
+    without any organization.
+
+    A user is "orphaned" when their only ``org_member`` row is for the org being
+    deleted. The deletion path tolerates *the requester themselves* being orphaned
+    (the personal-org self-service case — the requester is consenting to their
+    own deletion by calling ``DELETE``), but refuses to silently destroy the
+    accounts of other members. In that case it raises this error so the org
+    owner can transfer or remove those members first.
+    """
+
+    def __init__(self, user_ids: list[str]):
+        self.user_ids = user_ids
+        super().__init__(
+            f'Cannot delete organization: {len(user_ids)} other user(s) '
+            'would have no remaining organization'
+        )
+
+
 class OrgNotFoundError(Exception):
     """Raised when organization is not found or user doesn't have access."""
 

--- a/enterprise/server/routes/org_models.py
+++ b/enterprise/server/routes/org_models.py
@@ -80,16 +80,6 @@ class OrgAuthorizationError(OrgDeletionError):
         super().__init__(message)
 
 
-class OrphanedUserError(OrgDeletionError):
-    """Raised when deleting an org would leave users without any organization."""
-
-    def __init__(self, user_ids: list[str]):
-        self.user_ids = user_ids
-        super().__init__(
-            f'Cannot delete organization: {len(user_ids)} user(s) would have no remaining organization'
-        )
-
-
 class OrgNotFoundError(Exception):
     """Raised when organization is not found or user doesn't have access."""
 

--- a/enterprise/server/routes/orgs.py
+++ b/enterprise/server/routes/orgs.py
@@ -36,7 +36,6 @@ from server.routes.org_models import (
     OrgPage,
     OrgResponse,
     OrgUpdate,
-    OrphanedUserError,
     RoleNotFoundError,
 )
 from server.services.org_app_settings_service import (
@@ -660,19 +659,6 @@ async def delete_org(
         )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=str(e),
-        )
-    except OrphanedUserError as e:
-        logger.warning(
-            'Cannot delete organization: users would be orphaned',
-            extra={
-                'user_id': user_id,
-                'org_id': str(org_id),
-                'orphaned_users': e.user_ids,
-            },
-        )
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
     except OrgDatabaseError as e:

--- a/enterprise/server/routes/orgs.py
+++ b/enterprise/server/routes/orgs.py
@@ -36,6 +36,7 @@ from server.routes.org_models import (
     OrgPage,
     OrgResponse,
     OrgUpdate,
+    OrphanedUserError,
     RoleNotFoundError,
 )
 from server.services.org_app_settings_service import (
@@ -659,6 +660,19 @@ async def delete_org(
         )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(e),
+        )
+    except OrphanedUserError as e:
+        logger.warning(
+            'Cannot delete organization: other members would be orphaned',
+            extra={
+                'user_id': user_id,
+                'org_id': str(org_id),
+                'orphaned_users': e.user_ids,
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
     except OrgDatabaseError as e:

--- a/enterprise/storage/org_service.py
+++ b/enterprise/storage/org_service.py
@@ -19,6 +19,7 @@ from server.routes.org_models import (
     OrgNameExistsError,
     OrgNotFoundError,
     OrgUpdate,
+    OrphanedUserError,
 )
 from storage.lite_llm_manager import LiteLlmManager
 from storage.org import Org
@@ -799,7 +800,9 @@ class OrgService:
 
         # Step 2: Perform database cascade deletion with LiteLLM cleanup in transaction
         try:
-            deleted_org = await OrgStore.delete_org_cascade(org_id)
+            deleted_org = await OrgStore.delete_org_cascade(
+                org_id, requester_user_id=user_id
+            )
             if not deleted_org:
                 # This shouldn't happen since we verified existence above
                 raise OrgDatabaseError('Organization not found during deletion')
@@ -815,6 +818,11 @@ class OrgService:
 
             return deleted_org
 
+        except OrphanedUserError:
+            # Propagate as-is so the route can return a 400 with the affected
+            # user list. Wrapping into OrgDatabaseError below would mask the
+            # specific failure mode and force a 500.
+            raise
         except Exception as e:
             logger.error(
                 'Organization deletion failed',

--- a/enterprise/storage/org_store.py
+++ b/enterprise/storage/org_store.py
@@ -541,11 +541,12 @@ class OrgStore:
                 )
                 orphaned_user_ids = [str(row[0]) for row in orphaned_result.fetchall()]
 
-                # 3a. Partition orphans into (the requester themselves) and
-                # (everybody else). We will only cascade-delete the requester:
-                # destroying other members' accounts as a side effect of an
-                # org-delete is not consent-respecting, so for any non-requester
-                # orphan we raise and roll back the transaction.
+                # 3a. Split the orphaned users into the requester and
+                # everyone else. Only the requester is cascade-deleted: by
+                # calling DELETE on their own org they've consented to losing
+                # their account. Other members have not consented, so if any
+                # non-requester would be orphaned we raise OrphanedUserError
+                # and let the transaction roll back.
                 other_orphans = [
                     uid for uid in orphaned_user_ids if uid != requester_user_id
                 ]

--- a/enterprise/storage/org_store.py
+++ b/enterprise/storage/org_store.py
@@ -14,6 +14,7 @@ from server.constants import (
 from server.routes.org_models import (
     OrgMemberSettingsUpdate,
     OrgUpdate,
+    OrphanedUserError,
 )
 from sqlalchemy import delete, select, text
 from sqlalchemy.orm import joinedload
@@ -423,15 +424,18 @@ class OrgStore:
             return org
 
     @staticmethod
-    async def delete_org_cascade(org_id: UUID) -> Org | None:
+    async def delete_org_cascade(
+        org_id: UUID, requester_user_id: str | None = None
+    ) -> Org | None:
         """Delete organization and all associated data in cascade, including external LiteLLM cleanup.
 
-        Users that belong to the org being deleted are handled in two ways:
+        Users that belong to the org being deleted are handled in three ways:
 
         * Users with a membership in at least one other org have their
           ``current_org_id`` reassigned to one of those alternative orgs.
-        * Sole-org ("orphaned") users — whose only membership is in the org
-          being deleted — are themselves deleted in the same transaction. The
+        * If the *requester themselves* is the only orphaned user (sole member
+          of the org being deleted — the personal-org self-service case), the
+          requester's user row is cascade-deleted in the same transaction. The
           Keycloak account is left untouched, so on the user's next login
           ``UserStore.create_user`` re-onboards them as a brand-new user. The
           new ``User.id`` and ``Org.id`` are derived from the Keycloak ``sub``
@@ -439,14 +443,25 @@ class OrgStore:
           identity matches the deleted one (``User.id == Org.id ==
           UUID(keycloak.sub)``) and downstream automations that key on
           ``keycloak_user_id`` continue to resolve correctly.
+        * If any orphan is **not** the requester (i.e., a multi-user org where
+          another member has no other org), ``OrphanedUserError`` is raised
+          and the whole transaction is rolled back. The org owner must
+          transfer or remove those members before deletion can proceed —
+          we refuse to silently destroy accounts that did not consent.
 
         Args:
             org_id: UUID of the organization to delete
+            requester_user_id: Keycloak ``sub`` of the user initiating the
+                deletion. Required for the sole-orphan personal-org case;
+                when ``None`` (e.g., internal callers), any orphan triggers
+                ``OrphanedUserError``.
 
         Returns:
             Org: The deleted organization object, or None if not found
 
         Raises:
+            OrphanedUserError: If any non-requester member of the org would be
+                left without any organization by the deletion.
             Exception: If database operations or LiteLLM cleanup fail
         """
         async with a_session_maker() as session:
@@ -524,31 +539,50 @@ class OrgStore:
                     """),
                     {'org_id': str(org_id)},
                 )
-                orphaned_user_ids = [row[0] for row in orphaned_result.fetchall()]
+                orphaned_user_ids = [str(row[0]) for row in orphaned_result.fetchall()]
 
-                # 3a. Cascade-delete orphaned (sole-org) users. Their personal-org
-                # identity is preserved on re-login because UserStore.create_user
-                # derives both User.id and Org.id from the Keycloak ``sub`` claim
-                # (which is stable across logins), so a re-onboarded user receives
-                # the same UUIDs they had before. Downstream systems keyed on
+                # 3a. Partition orphans into (the requester themselves) and
+                # (everybody else). We will only cascade-delete the requester:
+                # destroying other members' accounts as a side effect of an
+                # org-delete is not consent-respecting, so for any non-requester
+                # orphan we raise and roll back the transaction.
+                other_orphans = [
+                    uid for uid in orphaned_user_ids if uid != requester_user_id
+                ]
+                if other_orphans:
+                    raise OrphanedUserError(other_orphans)
+
+                requester_orphan_ids = [
+                    uid for uid in orphaned_user_ids if uid == requester_user_id
+                ]
+
+                # 3b. Cascade-delete the requester if they are a sole-org user
+                # (personal-org self-service path). Their personal-org identity
+                # is preserved on re-login because UserStore.create_user derives
+                # both User.id and Org.id from the Keycloak ``sub`` claim (which
+                # is stable across logins), so a re-onboarded user receives the
+                # same UUIDs they had before. Downstream systems keyed on
                 # ``keycloak_user_id``/``org_id`` continue to resolve correctly.
                 #
-                # We must remove the user row BEFORE deleting the org row, because
-                # ``user.current_org_id`` is a NOT NULL FK to ``org.id``. That in
-                # turn requires releasing other inbound FKs to ``user.id`` first:
-                # ``org_invitation`` and ``org_git_claim`` cascade on ``org.id``
-                # in the DB schema, but the org row still exists at this point,
-                # so we clean those references explicitly here.
-                if orphaned_user_ids:
+                # We must remove the user row BEFORE deleting the org row,
+                # because ``user.current_org_id`` is a NOT NULL FK to
+                # ``org.id``. That in turn requires releasing other inbound
+                # FKs to ``user.id`` first: ``org_invitation`` and
+                # ``org_git_claim`` cascade on ``org.id`` in the DB schema,
+                # but the org row still exists at this point, so we clean
+                # those references explicitly here.
+                if requester_orphan_ids:
                     await session.execute(
                         delete(OrgInvitation).where(
-                            OrgInvitation.inviter_id.in_(orphaned_user_ids)
-                            | OrgInvitation.accepted_by_user_id.in_(orphaned_user_ids)
+                            OrgInvitation.inviter_id.in_(requester_orphan_ids)
+                            | OrgInvitation.accepted_by_user_id.in_(
+                                requester_orphan_ids
+                            )
                         )
                     )
                     await session.execute(
                         delete(OrgGitClaim).where(
-                            OrgGitClaim.claimed_by.in_(orphaned_user_ids)
+                            OrgGitClaim.claimed_by.in_(requester_orphan_ids)
                         )
                     )
                     # All of the orphan's memberships are for the org being
@@ -557,14 +591,14 @@ class OrgStore:
                     # the user_id FK before the user row goes away.
                     await session.execute(
                         delete(OrgMember).where(
-                            OrgMember.user_id.in_(orphaned_user_ids)
+                            OrgMember.user_id.in_(requester_orphan_ids)
                         )
                     )
                     await session.execute(
-                        delete(User).where(User.id.in_(orphaned_user_ids))
+                        delete(User).where(User.id.in_(requester_orphan_ids))
                     )
 
-                # 3b. Batch update: reassign current_org_id to an alternative org
+                # 3c. Batch update: reassign current_org_id to an alternative org
                 # for any remaining users. Orphan rows are gone at this point, so
                 # the subquery is guaranteed to return a non-null org for every
                 # row touched by the UPDATE.

--- a/enterprise/storage/org_store.py
+++ b/enterprise/storage/org_store.py
@@ -472,6 +472,50 @@ class OrgStore:
                 return None
 
             try:
+                # Preflight orphan check — fail fast before any writes.
+                #
+                # The orphan SELECT only reads ``user`` and ``org_member``,
+                # neither of which is modified by the org-data cleanup
+                # below, so we hoist it to the top of the transaction. If
+                # the check fails we raise immediately and the rollback
+                # has essentially no write work to undo.
+                #
+                # Running it inside the transaction (rather than as a
+                # separate pre-flight call before opening the session) is
+                # deliberate: it ensures the orphan computation shares the
+                # same snapshot/locks as the destructive writes below, so
+                # another session cannot create a new orphan between
+                # check-and-act.
+                orphaned_result = await session.execute(
+                    text("""
+                        SELECT u.id
+                        FROM "user" u
+                        WHERE u.current_org_id = :org_id
+                        AND NOT EXISTS (
+                            SELECT 1 FROM org_member om
+                            WHERE om.user_id = u.id AND om.org_id != :org_id
+                        )
+                    """),
+                    {'org_id': str(org_id)},
+                )
+                orphaned_user_ids = [str(row[0]) for row in orphaned_result.fetchall()]
+
+                # Split the orphaned users into the requester and everyone
+                # else. Only the requester is cascade-deleted: by calling
+                # DELETE on their own org they've consented to losing their
+                # account. Other members have not consented, so if any
+                # non-requester would be orphaned we raise OrphanedUserError
+                # and let the transaction roll back.
+                other_orphans = [
+                    uid for uid in orphaned_user_ids if uid != requester_user_id
+                ]
+                if other_orphans:
+                    raise OrphanedUserError(other_orphans)
+
+                requester_orphan_ids = [
+                    uid for uid in orphaned_user_ids if uid == requester_user_id
+                ]
+
                 # 1. Delete conversation data for organization conversations
                 await session.execute(
                     text("""
@@ -525,39 +569,13 @@ class OrgStore:
                     {'org_id': str(org_id)},
                 )
 
-                # 3. Handle users with this as current_org_id BEFORE deleting memberships
-                # Single query to find orphaned users (those with no alternative org)
-                orphaned_result = await session.execute(
-                    text("""
-                        SELECT u.id
-                        FROM "user" u
-                        WHERE u.current_org_id = :org_id
-                        AND NOT EXISTS (
-                            SELECT 1 FROM org_member om
-                            WHERE om.user_id = u.id AND om.org_id != :org_id
-                        )
-                    """),
-                    {'org_id': str(org_id)},
-                )
-                orphaned_user_ids = [str(row[0]) for row in orphaned_result.fetchall()]
+                # 3. Handle users with this as current_org_id BEFORE deleting
+                # memberships. The orphan partition was computed in the
+                # preflight check at the top of this try block;
+                # ``requester_orphan_ids`` is set iff the requester is a
+                # sole-org member of this org.
 
-                # 3a. Split the orphaned users into the requester and
-                # everyone else. Only the requester is cascade-deleted: by
-                # calling DELETE on their own org they've consented to losing
-                # their account. Other members have not consented, so if any
-                # non-requester would be orphaned we raise OrphanedUserError
-                # and let the transaction roll back.
-                other_orphans = [
-                    uid for uid in orphaned_user_ids if uid != requester_user_id
-                ]
-                if other_orphans:
-                    raise OrphanedUserError(other_orphans)
-
-                requester_orphan_ids = [
-                    uid for uid in orphaned_user_ids if uid == requester_user_id
-                ]
-
-                # 3b. Cascade-delete the requester if they are a sole-org user
+                # 3a. Cascade-delete the requester if they are a sole-org user
                 # (personal-org self-service path). Their personal-org identity
                 # is preserved on re-login because UserStore.create_user derives
                 # both User.id and Org.id from the Keycloak ``sub`` claim (which
@@ -599,7 +617,7 @@ class OrgStore:
                         delete(User).where(User.id.in_(requester_orphan_ids))
                     )
 
-                # 3c. Batch update: reassign current_org_id to an alternative org
+                # 3b. Batch update: reassign current_org_id to an alternative org
                 # for any remaining users. Orphan rows are gone at this point, so
                 # the subquery is guaranteed to return a non-null org for every
                 # row touched by the UPDATE.

--- a/enterprise/storage/org_store.py
+++ b/enterprise/storage/org_store.py
@@ -14,13 +14,14 @@ from server.constants import (
 from server.routes.org_models import (
     OrgMemberSettingsUpdate,
     OrgUpdate,
-    OrphanedUserError,
 )
-from sqlalchemy import select, text
+from sqlalchemy import delete, select, text
 from sqlalchemy.orm import joinedload
 from storage.database import a_session_maker
 from storage.lite_llm_manager import LiteLlmManager, get_openhands_cloud_key_alias
 from storage.org import Org
+from storage.org_git_claim import OrgGitClaim
+from storage.org_invitation import OrgInvitation
 from storage.org_member import OrgMember
 from storage.user import User
 from storage.user_settings import UserSettings
@@ -425,6 +426,20 @@ class OrgStore:
     async def delete_org_cascade(org_id: UUID) -> Org | None:
         """Delete organization and all associated data in cascade, including external LiteLLM cleanup.
 
+        Users that belong to the org being deleted are handled in two ways:
+
+        * Users with a membership in at least one other org have their
+          ``current_org_id`` reassigned to one of those alternative orgs.
+        * Sole-org ("orphaned") users — whose only membership is in the org
+          being deleted — are themselves deleted in the same transaction. The
+          Keycloak account is left untouched, so on the user's next login
+          ``UserStore.create_user`` re-onboards them as a brand-new user. The
+          new ``User.id`` and ``Org.id`` are derived from the Keycloak ``sub``
+          claim, which is stable across logins, so the re-created personal-org
+          identity matches the deleted one (``User.id == Org.id ==
+          UUID(keycloak.sub)``) and downstream automations that key on
+          ``keycloak_user_id`` continue to resolve correctly.
+
         Args:
             org_id: UUID of the organization to delete
 
@@ -509,12 +524,50 @@ class OrgStore:
                     """),
                     {'org_id': str(org_id)},
                 )
-                orphaned_users = orphaned_result.fetchall()
+                orphaned_user_ids = [row[0] for row in orphaned_result.fetchall()]
 
-                if orphaned_users:
-                    raise OrphanedUserError([str(row[0]) for row in orphaned_users])
+                # 3a. Cascade-delete orphaned (sole-org) users. Their personal-org
+                # identity is preserved on re-login because UserStore.create_user
+                # derives both User.id and Org.id from the Keycloak ``sub`` claim
+                # (which is stable across logins), so a re-onboarded user receives
+                # the same UUIDs they had before. Downstream systems keyed on
+                # ``keycloak_user_id``/``org_id`` continue to resolve correctly.
+                #
+                # We must remove the user row BEFORE deleting the org row, because
+                # ``user.current_org_id`` is a NOT NULL FK to ``org.id``. That in
+                # turn requires releasing other inbound FKs to ``user.id`` first:
+                # ``org_invitation`` and ``org_git_claim`` cascade on ``org.id``
+                # in the DB schema, but the org row still exists at this point,
+                # so we clean those references explicitly here.
+                if orphaned_user_ids:
+                    await session.execute(
+                        delete(OrgInvitation).where(
+                            OrgInvitation.inviter_id.in_(orphaned_user_ids)
+                            | OrgInvitation.accepted_by_user_id.in_(orphaned_user_ids)
+                        )
+                    )
+                    await session.execute(
+                        delete(OrgGitClaim).where(
+                            OrgGitClaim.claimed_by.in_(orphaned_user_ids)
+                        )
+                    )
+                    # All of the orphan's memberships are for the org being
+                    # deleted (definition of "orphan") and so would be removed
+                    # by step 4 anyway, but we have to release them now to drop
+                    # the user_id FK before the user row goes away.
+                    await session.execute(
+                        delete(OrgMember).where(
+                            OrgMember.user_id.in_(orphaned_user_ids)
+                        )
+                    )
+                    await session.execute(
+                        delete(User).where(User.id.in_(orphaned_user_ids))
+                    )
 
-                # Batch update: reassign current_org_id to an alternative org for all affected users
+                # 3b. Batch update: reassign current_org_id to an alternative org
+                # for any remaining users. Orphan rows are gone at this point, so
+                # the subquery is guaranteed to return a non-null org for every
+                # row touched by the UPDATE.
                 await session.execute(
                     text("""
                         UPDATE "user"

--- a/enterprise/storage/org_store.py
+++ b/enterprise/storage/org_store.py
@@ -486,6 +486,16 @@ class OrgStore:
                 # same snapshot/locks as the destructive writes below, so
                 # another session cannot create a new orphan between
                 # check-and-act.
+                #
+                # No row-level lock (``FOR UPDATE``) is acquired here. A
+                # concurrent session could in principle insert or remove
+                # an ``org_member`` row for the requester between this
+                # read and the ``DELETE User`` write below; we accept
+                # that as an unlikely edge case for the personal-org
+                # self-service path, where the requester is the only
+                # actor with permission to mutate their own memberships.
+                # Promote to ``FOR UPDATE`` if this code starts running
+                # on behalf of multi-actor flows.
                 orphaned_result = await session.execute(
                     text("""
                         SELECT u.id
@@ -590,6 +600,17 @@ class OrgStore:
                 # ``org_git_claim`` cascade on ``org.id`` in the DB schema,
                 # but the org row still exists at this point, so we clean
                 # those references explicitly here.
+                #
+                # FK edges on ``user.id`` cleared before ``DELETE User``:
+                #   * ``org_invitation.inviter_id``
+                #   * ``org_invitation.accepted_by_user_id``
+                #   * ``org_git_claim.claimed_by``
+                #   * ``org_member.user_id``
+                # *** If a future migration adds another table with a
+                # FK to ``user.id`` (e.g. ``user_api_key``, ``audit_log``)
+                # this block MUST be updated to release it, or the
+                # ``DELETE User`` below will raise a runtime FK violation
+                # with no obvious pointer back to this site. ***
                 if requester_orphan_ids:
                     await session.execute(
                         delete(OrgInvitation).where(
@@ -641,14 +662,15 @@ class OrgStore:
                 )
 
                 # 5. Finally delete the organization.
-                # ``AsyncSession.delete`` is a coroutine; without ``await`` it
-                # is a silent no-op (the ORM never flushes the DELETE), which
-                # left the ``org`` row behind even though the route returned
-                # success and the rest of the cascade committed. The next
-                # login then collided on ``org_pkey`` when
-                # ``UserStore.create_user`` tried to INSERT a new ``Org`` row
-                # keyed on the same Keycloak ``sub``. See PR #14617 staging
-                # diagnosis for details.
+                # ``AsyncSession.delete`` is a coroutine; without ``await``
+                # it is a silent no-op — the ORM never flushes the DELETE
+                # and the ``org`` row survives the transaction even though
+                # every preceding step committed. Forgetting the ``await``
+                # here would leave the next sign-in colliding on
+                # ``org_pkey`` in ``UserStore.create_user``, because both
+                # the surviving row and the new row are keyed on the same
+                # stable Keycloak ``sub``. Awaited explicitly to make that
+                # invariant load-bearing rather than incidental.
                 await session.delete(org)
 
                 # 6. Clean up LiteLLM team before committing transaction

--- a/enterprise/storage/org_store.py
+++ b/enterprise/storage/org_store.py
@@ -640,8 +640,16 @@ class OrgStore:
                     {'org_id': str(org_id)},
                 )
 
-                # 5. Finally delete the organization
-                session.delete(org)
+                # 5. Finally delete the organization.
+                # ``AsyncSession.delete`` is a coroutine; without ``await`` it
+                # is a silent no-op (the ORM never flushes the DELETE), which
+                # left the ``org`` row behind even though the route returned
+                # success and the rest of the cascade committed. The next
+                # login then collided on ``org_pkey`` when
+                # ``UserStore.create_user`` tried to INSERT a new ``Org`` row
+                # keyed on the same Keycloak ``sub``. See PR #14617 staging
+                # diagnosis for details.
+                await session.delete(org)
 
                 # 6. Clean up LiteLLM team before committing transaction
                 logger.info(

--- a/enterprise/storage/user_store.py
+++ b/enterprise/storage/user_store.py
@@ -50,7 +50,25 @@ class UserStore:
         user_info: dict,
         role_id: Optional[int] = None,
     ) -> User | None:
-        """Create a new user."""
+        """Create a new user.
+
+        Identity-preservation contract (load-bearing for
+        ``OrgStore.delete_org_cascade``): both ``Org.id`` and ``User.id``
+        are derived from the caller-provided ``user_id`` (the Keycloak
+        ``sub`` claim, stable across logins). This means a user whose
+        personal org was previously cascade-deleted will be re-onboarded
+        here with the **same** ``User.id`` / ``Org.id`` as before,
+        restoring the ``User.id == Org.id == UUID(keycloak.sub)``
+        invariant that downstream lookups keyed on ``keycloak_user_id``
+        depend on.
+
+        If this derivation ever changes (for example, switching to a
+        server-generated UUID), the personal-org self-service recovery
+        path in ``delete_org_cascade`` step 3a will silently break:
+        re-login will succeed but the new IDs will not match the
+        deleted-tenant IDs, breaking any external reference that pinned
+        on the old values.
+        """
         async with a_session_maker() as session:
             # create personal org
             org = Org(

--- a/enterprise/tests/unit/server/routes/test_orgs.py
+++ b/enterprise/tests/unit/server/routes/test_orgs.py
@@ -30,7 +30,6 @@ from server.routes.org_models import (
     OrgNameExistsError,
     OrgNotFoundError,
     OrgUpdate,
-    OrphanedUserError,
     RoleNotFoundError,
 )
 from server.routes.orgs import (
@@ -1484,38 +1483,6 @@ async def test_delete_org_unauthorized(mock_app, mock_owner_role):
 
         # Assert
         assert response.status_code == status.HTTP_403_FORBIDDEN
-
-
-@pytest.mark.asyncio
-async def test_delete_org_orphaned_users(mock_app, mock_owner_role):
-    """
-    GIVEN: Deleting org would leave users without any organization
-    WHEN: DELETE /api/organizations/{org_id} is called
-    THEN: 400 Bad Request error is returned with user count in message
-    """
-    # Arrange
-    org_id = uuid.uuid4()
-    orphaned_user_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
-
-    with (
-        patch(
-            'server.auth.authorization.get_user_org_role',
-            AsyncMock(return_value=mock_owner_role),
-        ),
-        patch(
-            'server.routes.orgs.OrgService.delete_org_with_cleanup',
-            AsyncMock(side_effect=OrphanedUserError(orphaned_user_ids)),
-        ),
-    ):
-        client = TestClient(mock_app)
-
-        # Act
-        response = client.delete(f'/api/organizations/{org_id}')
-
-        # Assert
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert '2 user(s)' in response.json()['detail']
-        assert 'no remaining organization' in response.json()['detail']
 
 
 @pytest.fixture

--- a/enterprise/tests/unit/server/routes/test_orgs.py
+++ b/enterprise/tests/unit/server/routes/test_orgs.py
@@ -30,6 +30,7 @@ from server.routes.org_models import (
     OrgNameExistsError,
     OrgNotFoundError,
     OrgUpdate,
+    OrphanedUserError,
     RoleNotFoundError,
 )
 from server.routes.orgs import (
@@ -1483,6 +1484,44 @@ async def test_delete_org_unauthorized(mock_app, mock_owner_role):
 
         # Assert
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_delete_org_other_members_would_be_orphaned(mock_app, mock_owner_role):
+    """
+    GIVEN: A multi-user org where some members other than the requester would
+           be left without any organization
+    WHEN:  DELETE /api/organizations/{org_id} is called
+    THEN:  400 Bad Request is returned listing the affected member count, and
+           the requester's account is NOT silently destroyed.
+
+    This is the multi-user safeguard: an org owner cannot delete an org if
+    doing so would orphan another member's account. Only the requester
+    themselves may be cascade-deleted as a sole-org user.
+    """
+    # Arrange
+    org_id = uuid.uuid4()
+    orphaned_user_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
+
+    with (
+        patch(
+            'server.auth.authorization.get_user_org_role',
+            AsyncMock(return_value=mock_owner_role),
+        ),
+        patch(
+            'server.routes.orgs.OrgService.delete_org_with_cleanup',
+            AsyncMock(side_effect=OrphanedUserError(orphaned_user_ids)),
+        ),
+    ):
+        client = TestClient(mock_app)
+
+        # Act
+        response = client.delete(f'/api/organizations/{org_id}')
+
+        # Assert
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert '2 other user(s)' in response.json()['detail']
+        assert 'no remaining organization' in response.json()['detail']
 
 
 @pytest.fixture

--- a/enterprise/tests/unit/test_org_store.py
+++ b/enterprise/tests/unit/test_org_store.py
@@ -960,18 +960,39 @@ async def test_get_user_orgs_paginated_ordering(async_session_maker, mock_litell
     assert orgs[2].name == 'Zebra Org'
 
 
+def test_orphaned_user_error_contains_user_ids():
+    """
+    GIVEN: OrphanedUserError is created with a list of user IDs
+    WHEN:  The error message is accessed
+    THEN:  Message includes the count and stores user IDs.
+
+    The error is raised only for orphans OTHER than the requester (so the
+    count refers to "other users"), preserving the safeguard that a
+    multi-user org owner cannot silently destroy other members' accounts.
+    """
+    from server.routes.org_models import OrphanedUserError
+
+    user_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
+    error = OrphanedUserError(user_ids)
+
+    assert error.user_ids == user_ids
+    assert '2 other user(s)' in str(error)
+    assert 'no remaining organization' in str(error)
+
+
 @pytest.mark.asyncio
 @pytest.mark.skip(
     reason='Uses PostgreSQL-specific ::uuid cast syntax not supported by SQLite'
 )
-async def test_delete_org_cascade_sole_org_user_is_deleted(
+async def test_delete_org_cascade_sole_org_requester_is_deleted(
     async_session_maker, mock_litellm_api
 ):
     """
-    GIVEN: A sole-org user (orphan) whose only membership is in the org being deleted
-    WHEN:  delete_org_cascade is called
+    GIVEN: A sole-org user (orphan) whose only membership is in the org being
+           deleted, AND that user is the requester of the deletion
+    WHEN:  delete_org_cascade is called with requester_user_id=the user's id
     THEN:  The user, org, and org_member rows are all removed in the same
-           transaction (no OrphanedUserError is raised).
+           transaction. No OrphanedUserError is raised.
 
     Re-onboarding contract: because UserStore.create_user derives both User.id
     and Org.id from the Keycloak ``sub`` claim (which is stable across logins),
@@ -1008,7 +1029,9 @@ async def test_delete_org_cascade_sole_org_user_is_deleted(
 
     # Act
     with patch('storage.org_store.a_session_maker', async_session_maker):
-        result = await OrgStore.delete_org_cascade(org_id)
+        result = await OrgStore.delete_org_cascade(
+            org_id, requester_user_id=str(user_id)
+        )
 
     # Assert: the deleted org is returned, and the user/org/member rows are gone.
     assert result is not None
@@ -1037,9 +1060,8 @@ async def test_delete_org_cascade_keeps_user_with_alternative_org(
            being deleted
     WHEN:  delete_org_cascade is called on that org
     THEN:  The user row survives with current_org_id reassigned to the
-           remaining org. Only orphan users are deleted.
+           remaining org. No orphan handling is triggered.
     """
-    # Arrange
     deleted_org_id = uuid.uuid4()
     other_org_id = uuid.uuid4()
     user_id = uuid.uuid4()
@@ -1078,17 +1100,97 @@ async def test_delete_org_cascade_keeps_user_with_alternative_org(
         )
         await session.commit()
 
-    # Act
     with patch('storage.org_store.a_session_maker', async_session_maker):
-        result = await OrgStore.delete_org_cascade(deleted_org_id)
+        result = await OrgStore.delete_org_cascade(
+            deleted_org_id, requester_user_id=str(user_id)
+        )
 
-    # Assert
     assert result is not None
     async with async_session_maker() as session:
         assert await session.get(Org, deleted_org_id) is None
         surviving_user = await session.get(User, user_id)
         assert surviving_user is not None
         assert surviving_user.current_org_id == other_org_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip(
+    reason='Uses PostgreSQL-specific ::uuid cast syntax not supported by SQLite'
+)
+async def test_delete_org_cascade_raises_for_non_requester_orphans(
+    async_session_maker, mock_litellm_api
+):
+    """
+    GIVEN: A multi-user org where the requester has another org to fall back
+           on, but a second member's only membership is in this org
+    WHEN:  delete_org_cascade is called with requester_user_id=the requester
+    THEN:  OrphanedUserError is raised listing the OTHER member's id; the
+           whole transaction is rolled back, so org/user/member rows survive.
+
+    This is the multi-user safeguard: an org owner cannot delete an org if
+    doing so would silently destroy another member's account. The owner must
+    first transfer or remove those members.
+    """
+    org_id = uuid.uuid4()
+    other_org_id = uuid.uuid4()
+    requester_id = uuid.uuid4()
+    other_user_id = uuid.uuid4()
+    role_id = 1
+
+    async with async_session_maker() as session:
+        session.add_all(
+            [
+                Role(id=role_id, name='owner', rank=1),
+                Org(id=org_id, name='Shared Org', contact_email='shared@e.com'),
+                Org(
+                    id=other_org_id,
+                    name='Requester Alt Org',
+                    contact_email='alt@e.com',
+                ),
+                # Requester: member of both orgs (NOT orphaned by deleting `org_id`)
+                User(id=requester_id, current_org_id=org_id),
+                OrgMember(
+                    org_id=org_id,
+                    user_id=requester_id,
+                    role_id=role_id,
+                    status='active',
+                    llm_api_key='k1',
+                ),
+                OrgMember(
+                    org_id=other_org_id,
+                    user_id=requester_id,
+                    role_id=role_id,
+                    status='active',
+                    llm_api_key='k2',
+                ),
+                # Other member: sole-org in `org_id` → would be orphaned
+                User(id=other_user_id, current_org_id=org_id),
+                OrgMember(
+                    org_id=org_id,
+                    user_id=other_user_id,
+                    role_id=role_id,
+                    status='active',
+                    llm_api_key='k3',
+                ),
+            ]
+        )
+        await session.commit()
+
+    from server.routes.org_models import OrphanedUserError
+
+    with patch('storage.org_store.a_session_maker', async_session_maker):
+        with pytest.raises(OrphanedUserError) as exc_info:
+            await OrgStore.delete_org_cascade(
+                org_id, requester_user_id=str(requester_id)
+            )
+
+    assert exc_info.value.user_ids == [str(other_user_id)]
+
+    # Transaction rolled back — nothing should have been deleted.
+    async with async_session_maker() as session:
+        assert await session.get(Org, org_id) is not None
+        assert await session.get(User, requester_id) is not None
+        assert await session.get(User, other_user_id) is not None
 
 
 def test_org_deletion_with_invitations_uses_passive_deletes(

--- a/enterprise/tests/unit/test_org_store.py
+++ b/enterprise/tests/unit/test_org_store.py
@@ -960,24 +960,135 @@ async def test_get_user_orgs_paginated_ordering(async_session_maker, mock_litell
     assert orgs[2].name == 'Zebra Org'
 
 
-def test_orphaned_user_error_contains_user_ids():
+@pytest.mark.asyncio
+@pytest.mark.skip(
+    reason='Uses PostgreSQL-specific ::uuid cast syntax not supported by SQLite'
+)
+async def test_delete_org_cascade_sole_org_user_is_deleted(
+    async_session_maker, mock_litellm_api
+):
     """
-    GIVEN: OrphanedUserError is created with a list of user IDs
-    WHEN: The error message is accessed
-    THEN: Message includes the count and stores user IDs
-    """
-    # Arrange
-    from server.routes.org_models import OrphanedUserError
+    GIVEN: A sole-org user (orphan) whose only membership is in the org being deleted
+    WHEN:  delete_org_cascade is called
+    THEN:  The user, org, and org_member rows are all removed in the same
+           transaction (no OrphanedUserError is raised).
 
-    user_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
+    Re-onboarding contract: because UserStore.create_user derives both User.id
+    and Org.id from the Keycloak ``sub`` claim (which is stable across logins),
+    a re-login after this cascade reproduces the same UUIDs the user had
+    before, preserving personal-org identity for downstream lookups keyed on
+    ``keycloak_user_id``. See ``enterprise/storage/user_store.py:create_user``.
+    """
+    # Arrange — personal-org invariant: User.id == Org.id == UUID(keycloak.sub)
+    user_id = uuid.uuid4()
+    org_id = user_id
+    role_id = 1
+
+    async with async_session_maker() as session:
+        session.add_all(
+            [
+                Role(id=role_id, name='owner', rank=1),
+                Org(
+                    id=org_id,
+                    name='Personal Org',
+                    contact_name='Sole Owner',
+                    contact_email='sole@example.com',
+                ),
+                User(id=user_id, current_org_id=org_id),
+                OrgMember(
+                    org_id=org_id,
+                    user_id=user_id,
+                    role_id=role_id,
+                    status='active',
+                    llm_api_key='test-key',
+                ),
+            ]
+        )
+        await session.commit()
 
     # Act
-    error = OrphanedUserError(user_ids)
+    with patch('storage.org_store.a_session_maker', async_session_maker):
+        result = await OrgStore.delete_org_cascade(org_id)
+
+    # Assert: the deleted org is returned, and the user/org/member rows are gone.
+    assert result is not None
+    assert result.id == org_id
+
+    async with async_session_maker() as session:
+        assert await session.get(Org, org_id) is None
+        assert await session.get(User, user_id) is None
+        remaining_members = (
+            (await session.execute(select(OrgMember).filter_by(org_id=org_id)))
+            .scalars()
+            .all()
+        )
+        assert remaining_members == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip(
+    reason='Uses PostgreSQL-specific ::uuid cast syntax not supported by SQLite'
+)
+async def test_delete_org_cascade_keeps_user_with_alternative_org(
+    async_session_maker, mock_litellm_api
+):
+    """
+    GIVEN: A user belonging to two orgs whose current_org_id points at the org
+           being deleted
+    WHEN:  delete_org_cascade is called on that org
+    THEN:  The user row survives with current_org_id reassigned to the
+           remaining org. Only orphan users are deleted.
+    """
+    # Arrange
+    deleted_org_id = uuid.uuid4()
+    other_org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    role_id = 1
+
+    async with async_session_maker() as session:
+        session.add_all(
+            [
+                Role(id=role_id, name='owner', rank=1),
+                Org(
+                    id=deleted_org_id,
+                    name='Org to delete',
+                    contact_email='a@example.com',
+                ),
+                Org(
+                    id=other_org_id,
+                    name='Other Org',
+                    contact_email='b@example.com',
+                ),
+                User(id=user_id, current_org_id=deleted_org_id),
+                OrgMember(
+                    org_id=deleted_org_id,
+                    user_id=user_id,
+                    role_id=role_id,
+                    status='active',
+                    llm_api_key='k1',
+                ),
+                OrgMember(
+                    org_id=other_org_id,
+                    user_id=user_id,
+                    role_id=role_id,
+                    status='active',
+                    llm_api_key='k2',
+                ),
+            ]
+        )
+        await session.commit()
+
+    # Act
+    with patch('storage.org_store.a_session_maker', async_session_maker):
+        result = await OrgStore.delete_org_cascade(deleted_org_id)
 
     # Assert
-    assert error.user_ids == user_ids
-    assert '2 user(s)' in str(error)
-    assert 'no remaining organization' in str(error)
+    assert result is not None
+    async with async_session_maker() as session:
+        assert await session.get(Org, deleted_org_id) is None
+        surviving_user = await session.get(User, user_id)
+        assert surviving_user is not None
+        assert surviving_user.current_org_id == other_org_id
 
 
 def test_org_deletion_with_invitations_uses_passive_deletes(


### PR DESCRIPTION
HUMAN:

## Summary

When an org owner deletes their only org via `DELETE /api/organizations/{id}`, today's behavior raises `OrphanedUserError` → HTTP 400. The user is left in a partially-deleted state with no way to recover without a manual DB intervention.

This PR scopes the cascade so the **requester's own user row** is also deleted in the personal-org self-service case, while **preserving the existing safeguard** for other members of multi-user orgs.

- [x] A human has tested these changes.

### Behavior matrix

| Scenario | Who would be orphaned | Result |
|---|---|---|
| Personal org (sole-member, requester == sole owner) | The requester themselves | **Cascade-delete** the requester. They consent by calling `DELETE`. |
| Multi-user org, all other members have other orgs | Nobody | Existing reassign-`current_org_id` path. |
| Multi-user org, some other members are sole-org here | Other users (not the requester) | **`OrphanedUserError` → HTTP 400** (unchanged from pre-PR). Transaction rolls back; no rows deleted. Owner must transfer/remove those members first. |
| Multi-user org, requester themselves is sole-org here **and** other members would also be orphaned | Requester + others | Still raises (the `others` partition is non-empty). Forces owner to handle the non-consenting accounts first. |

The rule: **an orphan is acceptable only if the sole orphan is the requester.**

## Why this preserves the user's personal-org identity

OpenHands authenticates against Keycloak via OIDC. The OIDC `sub` claim is the user's stable Keycloak identifier — it is generated when the Keycloak user is created and **does not change across logins**. The OpenHands auth callback consumes `sub` directly:

```python
# enterprise/server/routes/auth.py:326-330
user_id = user_info.sub
user = await UserStore.get_user_by_id(user_id)
if not user:
    user = await UserStore.create_user(user_id, user_info_dict)
```

And `UserStore.create_user` (`enterprise/storage/user_store.py:48-89`) derives **both** `Org.id` and `User.id` from that string:

```python
org = Org(id=uuid.UUID(user_id), ...)            # Org.id  = UUID(keycloak.sub)
user = User(id=uuid.UUID(user_id),
            current_org_id=org.id, ...)          # User.id = UUID(keycloak.sub)
```

So after this PR, when the user logs back in their `User.id == Org.id == UUID(keycloak.sub)` invariant is restored, downstream lookups keyed on `keycloak_user_id` resolve to the same org as before, and the UI's `is_personal: true` returns.

## Changes

* `enterprise/storage/org_store.py` — `delete_org_cascade(org_id, requester_user_id=None)`: partition orphans into requester vs. others; raise `OrphanedUserError` for others; cascade-delete the requester (including inbound FK refs from `org_invitation`, `org_git_claim`, `org_member`) when they're the sole orphan. The existing `UPDATE "user" SET current_org_id = …` block runs after orphan handling so the subquery is guaranteed to find a non-NULL alternative.
* `enterprise/storage/org_service.py` — pass `user_id` into the cascade. Add `except OrphanedUserError: raise` **before** the broad `except Exception` so the route's 400 handler is reachable (otherwise the broad except wraps `OrphanedUserError` into `OrgDatabaseError` → 500).
* `enterprise/server/routes/orgs.py` — handler unchanged.
* `enterprise/server/routes/org_models.py` — `OrphanedUserError` only fires for **other** users (not the requester). Message reads "N other user(s) would have no remaining organization".
* Tests:
  * `test_orphaned_user_error_contains_user_ids` — asserts the "other user(s)" wording.
  * `test_delete_org_other_members_would_be_orphaned` — route-level 400 test.
  * `test_delete_org_cascade_sole_org_requester_is_deleted` — sole-org user who IS the requester gets cascade-deleted.
  * `test_delete_org_cascade_keeps_user_with_alternative_org` — multi-org user survives with `current_org_id` reassigned.
  * `test_delete_org_cascade_raises_for_non_requester_orphans` — **new safeguard test**: requester has an alternative org but another member is sole-org; `OrphanedUserError` is raised and the entire transaction is rolled back (org/user/member rows all survive).

### Test execution note

The new `delete_org_cascade` tests are marked `@pytest.mark.skip` on SQLite for the same reason as the existing `test_delete_org_cascade_success`: `delete_org_cascade` contains PG-specific `::uuid` cast syntax and touches the `app_conversation_start_task` table, which is not loaded into the SQLite test schema. They are expected to run in PG-backed CI.

## Behavior change vs. pre-PR

`DELETE /api/organizations/{id}` no longer returns **HTTP 400 "n user(s) would have no remaining organization"** when the requester is the only member being orphaned. Instead, the cascade succeeds and deletes the requester's row in the same transaction; their Keycloak account is unaffected, so a re-login produces a clean fresh-signup state with the same `User.id` / `Org.id`.

Multi-user org behavior is **unchanged**: the safeguard remains in place for other members.

### Suggested release note

> `DELETE /api/organizations/{id}` now permits sole-member owners to delete their own org self-service. On their next sign-in, the user is re-onboarded via the standard new-user flow with the same `User.id` / `Org.id` as before (both derived from the stable Keycloak `sub` claim). The safeguard against deleting orgs that would orphan **other** members is unchanged — the endpoint still returns 400 `OrphanedUserError` in that case.

## What this PR is *not*

This is a user-recovery PR — it makes the self-service recovery path possible so we no longer need a DB-side intervention. It is **not** a fix for the underlying defect that put the user in this state (the breaking `PATCH` with `api_key:null` + managed `base_url`). That fix should still ship as a follow-up; this PR just removes the critical-path blocker.

---

_This PR was opened by an AI agent (OpenHands) on behalf of the user._

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-fbacd33   docker.openhands.dev/openhands/openhands:fbacd33
```