### PR TITLE
PLTF-2875: Add promote-to-development workflow for enterprise-server

### DIFF
--- a/.github/workflows/promote-to-development.yml
+++ b/.github/workflows/promote-to-development.yml
@@ -1,0 +1,91 @@
+# Continuously promotes each main build's enterprise-server image to development
+# by bumping the tag in OpenHands/saas-deploy, which ArgoCD syncs.
+#
+# Runs after the "Docker" workflow finishes building + pushing the image for a
+# main commit, so the promoted tag always points at an image that exists. It can
+# also be run manually to re-promote a known-good image tag.
+#
+# This repo is public, so it cannot run the bump action that lives in the
+# private saas-deploy repo directly. Instead it mints a saas-deploy-bot App
+# token and sends a `promote-to-development` repository_dispatch to saas-deploy,
+# whose receiver workflow performs the bump.
+
+name: Promote to development
+
+on:
+  workflow_dispatch:
+    inputs:
+      image-tag:
+        description: "Image tag to promote (defaults to sha-<short SHA> for the selected ref)"
+        required: false
+        type: string
+  workflow_run:
+    workflows: ["Docker"]
+    types: [completed]
+    branches: [main]
+
+# Queue promotions so an earlier main commit deploys before a later one.
+concurrency:
+  group: promote-to-development
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    # Only promote when the Docker build actually succeeded, or when run manually.
+    # The Docker workflow also runs on pull_request, and the workflow_run branches
+    # filter matches the *head* branch — a fork PR from a branch named "main"
+    # would slip through — so additionally require a push event.
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Compute image tag
+        id: tag
+        # Matches docker/metadata-action type=sha (7-char short SHA) emitted by
+        # the docker-image-tags action used in _build-image.yml.
+        env:
+          DISPATCH_IMAGE_TAG: ${{ github.event.inputs['image-tag'] }}
+          SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+        run: |
+          if [ -n "$DISPATCH_IMAGE_TAG" ]; then
+            echo "tag=$DISPATCH_IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=sha-${SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Mint saas-deploy token
+        id: app-token
+        uses: actions/create-github-app-token@7bd03711494f032dfa3be3558f7dc8787b0be333  # v3.1.0
+        with:
+          app-id: ${{ secrets.SAAS_DEPLOY_APP_ID }}
+          private-key: ${{ secrets.SAAS_DEPLOY_APP_PRIVATE_KEY }}
+          owner: OpenHands
+          repositories: saas-deploy
+
+      - name: Dispatch promotion to saas-deploy
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          IMAGE_TAG: ${{ steps.tag.outputs.tag }}
+          SOURCE_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+        run: |
+          gh api /repos/OpenHands/saas-deploy/dispatches \
+            -f event_type=promote-to-development \
+            -F client_payload[release]=openhands \
+            -F client_payload[tag-path]=.openhands.image.tag \
+            -F client_payload[image-tag]="$IMAGE_TAG" \
+            -F client_payload[source-repo]="$GITHUB_REPOSITORY" \
+            -F client_payload[source-sha]="$SOURCE_SHA"
+          echo "Dispatched promote-to-development for openhands ${IMAGE_TAG} (${SOURCE_SHA})."
+
+      - name: Annotate dispatch failure
+        if: ${{ failure() }}
+        env:
+          IMAGE_TAG: ${{ steps.tag.outputs.tag }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          SOURCE_RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          image_tag="${IMAGE_TAG:-sha-${HEAD_SHA::7}}"
+          source="${SOURCE_RUN_URL:-manual workflow_dispatch run}"
+          echo "::error title=Promote to development failed::Failed to dispatch promotion of enterprise-server ${image_tag} (${HEAD_SHA}) to development. Source: ${source}"

--- a/.github/workflows/promote-to-development.yml
+++ b/.github/workflows/promote-to-development.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Mint saas-deploy token
         id: app-token
-        uses: actions/create-github-app-token@7bd03711494f032dfa3be3558f7dc8787b0be333  # v3.1.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           app-id: ${{ secrets.SAAS_DEPLOY_APP_ID }}
           private-key: ${{ secrets.SAAS_DEPLOY_APP_PRIVATE_KEY }}

--- a/.github/workflows/promote-to-development.yml
+++ b/.github/workflows/promote-to-development.yml
@@ -19,6 +19,10 @@ on:
         description: "Image tag to promote (defaults to sha-<short SHA> for the selected ref)"
         required: false
         type: string
+      source-sha:
+        description: "Commit SHA that produced the image (leave blank to use current HEAD)"
+        required: false
+        type: string
   workflow_run:
     workflows: ["Docker"]
     types: [completed]
@@ -68,7 +72,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           IMAGE_TAG: ${{ steps.tag.outputs.tag }}
-          SOURCE_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          SOURCE_SHA: ${{ github.event.inputs['source-sha'] || github.event.workflow_run.head_sha || github.sha }}
         run: |
           gh api /repos/OpenHands/saas-deploy/dispatches \
             -f event_type=promote-to-development \


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:


- [x] A human has tested these changes.

AGENT:

---

## Why

We want every successful `main` build's `enterprise-server` image to land in the development environment automatically. Today the dev tag is bumped by hand in `OpenHands/saas-deploy`.

This repo is public, so it cannot `uses:` the bump action that lives in the private `saas-deploy` repo — GitHub only shares private-repo actions with private repos (a first attempt errored at job setup with `Unable to resolve action openhands/saas-deploy`). So instead of calling the action, this workflow sends a `repository_dispatch` to saas-deploy, where a receiver workflow runs the action.

## Summary

- Adds `.github/workflows/promote-to-development.yml`: after the **Docker** workflow succeeds on a `main` push, compute the `sha-<short>` tag, mint a saas-deploy-bot App token, and POST a `promote-to-development` `repository_dispatch` to `OpenHands/saas-deploy` with `release=openhands`, `tag-path=.openhands.image.tag`, the image tag, and source repo/SHA.
- Also runnable via `workflow_dispatch` to re-promote a known-good tag.

## Issue Number

PLTF-2875

## How to Test

The receiver lives in `OpenHands/saas-deploy` and is already merged to its `main`.

1. Manually run **Promote to development** (`workflow_dispatch`) with `image-tag` set to a real built tag (`sha-<short>`).
2. Confirm this workflow dispatches, the saas-deploy receiver run fires via `repository_dispatch`, and it bumps `.openhands.image.tag` on saas-deploy `main`.
3. Sync the `openhands-development` app in ArgoCD and confirm it goes Healthy on the new image.

### Validated end-to-end ✅ (2026-06-03)

Ran this workflow via `workflow_dispatch` on this branch with `image-tag=sha-73d1d9a` (current `main` HEAD, image confirmed on ghcr):

- **Sender** (this PR) — run [26908859455](https://github.com/OpenHands/OpenHands/actions/runs/26908859455): computed the tag, minted the App token, POSTed the dispatch. All steps green.
- **Receiver** (saas-deploy) — run [26908872522](https://github.com/OpenHands/saas-deploy/actions/runs/26908872522): fired via `repository_dispatch`, validated, and committed `openhands: bump development image to sha-73d1d9a` to saas-deploy `main` as `saas-deploy-bot[bot]` (provenance back to `OpenHands/OpenHands@89a26fb3`).
- **Deploy** — ArgoCD `openhands-development` synced and reports **Healthy** on `sha-73d1d9a`.

The only leg not yet exercised is the `workflow_run` auto-fire (Docker success → this workflow), which can only run once this workflow is on `main`. Merging enables it; the merge commit itself will trigger the first automatic promotion.

## Video/Screenshots

N/A — CI/CD workflow.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- The dispatch route keeps the bump logic and its logs in the private saas-deploy repo; this public workflow reveals only that it sends a tag.
- On merge, every future `main` build auto-promotes to dev; the merge commit triggers the first one.

This PR description was drafted by an AI agent on behalf of the user.
