### PR TITLE
fix(acp): route provider creds via agent_context.secrets, not acp_env

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1593,16 +1593,20 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
     ) -> StartConversationRequest:
         """Build a StartConversationRequest for ACP agent conversations.
 
-        Unlike the LLM path, ACP agents run as separate subprocesses; we pass
-        credentials via environment variables rather than injecting an LLM object.
+        Unlike the LLM path, ACP agents run as separate subprocesses; the
+        provider credentials reach the subprocess as environment variables
+        rather than via an injected LLM object.
 
-        User secrets (Secrets panel + git provider tokens) flow through two
-        complementary channels: they're rendered into the ACP prompt as a
-        ``<CUSTOM_SECRETS>`` block via ``AgentContext.secrets`` (so the agent
-        knows the names) and also pre-exported as environment variables on
-        the ACP subprocess via ``acp_env`` (so plain CLI commands like
-        ``gh`` / ``aws`` / ``git`` pick them up from env without the agent
-        having to manually export them).
+        Both the provider credentials (the UI-saved ``llm.api_key`` /
+        ``base_url``, keyed by the provider's env-var names) and user secrets
+        (Secrets panel + git provider tokens) flow through the single
+        ``AgentContext.secrets`` channel: their names are rendered into the
+        ACP prompt as a ``<CUSTOM_SECRETS>`` block, and the SDK's
+        ``ACPAgent._start_acp_server`` gap-fills the values into the subprocess
+        env at launch. Routing the provider creds this way keeps them on the
+        cipher-protected ``request.secrets`` boundary instead of the
+        deprecated, persist-unsafe ``acp_env`` channel (software-agent-sdk
+        #3464; OpenHands/agent-canvas#1039).
 
         Args:
             sandbox: Sandbox information
@@ -1640,19 +1644,36 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         acp_settings = user.agent_settings  # already verified to be ACPAgentSettings
         assert isinstance(acp_settings, ACPAgentSettings)
 
-        # Pass user secrets via AgentContext. The SDK renders them as a
-        # <CUSTOM_SECRETS> block in the ACP prompt (so the agent knows the
-        # names) and ``ACPAgent._start_acp_server`` gap-fills any that
-        # aren't already in ``acp_env`` into the subprocess env at launch
-        # time — preserving the ``acp_env > provider env > secrets``
-        # precedence end-to-end. We pass ``SecretSource`` objects through
-        # verbatim; resolving them here (with ``source.get_value()``) would
-        # eagerly hit the auth service for every ``LookupSecret`` on every
-        # conversation start, from the wrong process.
+        # Route the ACP provider credentials (the UI-saved ``llm.api_key`` /
+        # ``base_url``) through the cipher-protected ``agent_context.secrets``
+        # channel — keyed by the provider's expected env-var names — instead
+        # of ``acp_env``. ``acp_env`` is a parallel, persist-unsafe credential
+        # channel the SDK has deprecated (software-agent-sdk #3464). Provider
+        # creds override a same-named Secrets-panel entry, preserving the prior
+        # ``provider env > panel secret`` priority. See
+        # OpenHands/agent-canvas#1039.
+        provider_env = acp_settings.resolve_provider_env()
+        for env_name, env_value in provider_env.items():
+            secrets[env_name] = StaticSecret(value=SecretStr(env_value))
+
+        # Pass secrets via AgentContext. The SDK renders the names as a
+        # <CUSTOM_SECRETS> block in the ACP prompt and
+        # ``ACPAgent._start_acp_server`` gap-fills any not already in the
+        # subprocess env at launch time, delivering the provider creds. We
+        # pass ``SecretSource`` objects verbatim; resolving them here (with
+        # ``source.get_value()``) would eagerly hit the auth service for every
+        # ``LookupSecret`` on every conversation start, from the wrong process.
         agent_context = AgentContext(secrets=secrets) if secrets else None
-        settings_update = (
-            {'agent_context': agent_context} if agent_context is not None else {}
-        )
+        settings_update: dict[str, object] = {}
+        if agent_context is not None:
+            settings_update['agent_context'] = agent_context
+        # Strip the provider creds off the (dummy) ACP ``llm`` so
+        # ``create_agent()`` does not re-fold them into ``acp_env`` via
+        # ``resolve_provider_env``.
+        if provider_env:
+            settings_update['llm'] = acp_settings.llm.model_copy(
+                update={'api_key': None, 'base_url': None}
+            )
         acp_agent = acp_settings.model_copy(update=settings_update).create_agent()
 
         sdk_plugins: list[PluginSource] | None = None

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3337,10 +3337,14 @@ class TestBuildAcpStartConversationRequestSecrets:
         assert request.agent.acp_env.get('MY_TOKEN') == 'explicit-override'
 
     @pytest.mark.asyncio
-    async def test_provider_env_in_acp_env_secrets_in_agent_context(
-        self, service, tmp_path
-    ):
-        """LLM credentials land in acp_env; panel secrets in agent_context."""
+    async def test_provider_env_in_agent_context_not_acp_env(self, service, tmp_path):
+        """LLM credentials land in agent_context.secrets, never acp_env.
+
+        The provider cred (from ``llm.api_key``) overrides a same-named
+        Secrets-panel entry, preserving the prior ``provider env > panel``
+        priority — now expressed within the single ``agent_context.secrets``
+        channel rather than across ``acp_env`` vs ``agent_context``.
+        """
         user = self._make_acp_user(acp_server='claude-code', api_key='sk-ui-key')
         panel_secret = StaticSecret(value=SecretStr('sk-from-secrets-panel'))
         service._setup_secrets_for_git_providers = AsyncMock(
@@ -3349,10 +3353,13 @@ class TestBuildAcpStartConversationRequestSecrets:
 
         request = await self._call_build(service, user, tmp_path)
 
-        assert request.agent.acp_env.get('ANTHROPIC_API_KEY') == 'sk-ui-key'
+        # Provider creds no longer ride acp_env.
+        assert request.agent.acp_env.get('ANTHROPIC_API_KEY') is None
         assert request.agent.agent_context is not None
+        # Provider env wins over the same-named panel secret.
         assert (
-            request.agent.agent_context.secrets.get('ANTHROPIC_API_KEY') is panel_secret
+            request.agent.agent_context.secrets.get('ANTHROPIC_API_KEY').get_value()
+            == 'sk-ui-key'
         )
 
     @pytest.mark.asyncio
@@ -3367,12 +3374,13 @@ class TestBuildAcpStartConversationRequestSecrets:
 
     @pytest.mark.asyncio
     async def test_acp_env_overrides_provider_env(self, service, tmp_path):
-        """Explicit acp_env entries take priority over auto-generated provider_env.
+        """Explicit acp_env entries take priority over the provider cred.
 
         When a user sets ANTHROPIC_API_KEY explicitly in acp_env, it must win
-        over the same key the SDK derives from the UI-saved LLM credentials.
-        This exercises the merge priority:
-          acp_env > provider_env > agent_context.secrets
+        over the key the SDK derives from the UI-saved LLM credentials. The
+        provider cred now rides ``agent_context.secrets`` (not ``acp_env``);
+        the SDK's launch-time precedence is ``acp_env > agent_context.secrets``,
+        so the explicit ``acp_env`` entry still wins.
         """
         user = self._make_acp_user(
             acp_server='claude-code',
@@ -3383,8 +3391,16 @@ class TestBuildAcpStartConversationRequestSecrets:
 
         request = await self._call_build(service, user, tmp_path)
 
-        # acp_env must win; the UI-saved key must NOT overwrite it
+        # The user's explicit acp_env entry is preserved verbatim; the provider
+        # cred is NOT folded into acp_env.
         assert request.agent.acp_env.get('ANTHROPIC_API_KEY') == 'sk-explicit-override'
+        # The provider cred lands in agent_context.secrets; the SDK gap-fill
+        # then defers to the higher-precedence acp_env entry at launch.
+        assert request.agent.agent_context is not None
+        assert (
+            request.agent.agent_context.secrets.get('ANTHROPIC_API_KEY').get_value()
+            == 'sk-ui-key'
+        )
 
     @pytest.mark.asyncio
     async def test_secrets_forwarded_via_agent_context(self, service, tmp_path):
@@ -3416,11 +3432,9 @@ class TestBuildAcpStartConversationRequestSecrets:
         """Provider env (from ``llm.api_key``) keeps priority over panel secrets.
 
         If a user has both a UI-saved Claude Code LLM key AND a same-named
-        ``ANTHROPIC_API_KEY`` in the Secrets panel, the LLM-saved one ends
-        up driving the subprocess: ``acp_env`` carries it (via the SDK's
-        ``resolve_acp_env`` → ``resolve_provider_env``), and the SDK's
-        subprocess-launch gap-fill skips ``agent_context.secrets`` keys
-        already present in env.
+        ``ANTHROPIC_API_KEY`` in the Secrets panel, the LLM-saved one wins.
+        Both now ride ``agent_context.secrets`` (not ``acp_env``); the provider
+        cred is folded in last so it overrides the panel entry of the same name.
         """
         user = self._make_acp_user(acp_server='claude-code', api_key='sk-ui-key')
         panel_secret = StaticSecret(value=SecretStr('sk-from-secrets-panel'))
@@ -3430,14 +3444,13 @@ class TestBuildAcpStartConversationRequestSecrets:
 
         request = await self._call_build(service, user, tmp_path)
 
-        # llm.api_key-derived provider env wins in acp_env.
-        assert request.agent.acp_env.get('ANTHROPIC_API_KEY') == 'sk-ui-key'
-        # The panel secret is still forwarded in agent_context.secrets; the
-        # SDK's gap-fill will see ANTHROPIC_API_KEY already in env and skip
-        # it, preserving the priority.
+        # Provider creds no longer ride acp_env.
+        assert request.agent.acp_env.get('ANTHROPIC_API_KEY') is None
+        # The provider cred overrides the same-named panel secret.
         assert request.agent.agent_context is not None
         assert (
-            request.agent.agent_context.secrets.get('ANTHROPIC_API_KEY') is panel_secret
+            request.agent.agent_context.secrets.get('ANTHROPIC_API_KEY').get_value()
+            == 'sk-ui-key'
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
HUMAN:
ACP agents were leaking provider API keys/base-URL through `acp_env`, a
credential channel that gets redacted to `**********` when SaaS settings are
persisted (so cloud-injected creds were silently dropped). This routes those
creds through `agent_context.secrets` instead — the same encrypted channel
every other secret uses — and stops feeding them to `acp_env`. Behaviour for
users is unchanged; it just moves the creds onto the safe channel. Part of the
ACP-on-cloud work (OpenHands/OpenHands#15722).

- [x] A human has tested these changes.

---

## Problem
ACP provider credentials (the UI-saved `llm.api_key` / `base_url`) reached the subprocess by being folded into **`acp_env`** inside the SDK's `create_agent()` (`resolve_acp_env` → `resolve_provider_env`). `acp_env` is a parallel, partly-unmasked, **persist-unsafe** credential channel the SDK has deprecated (OpenHands/software-agent-sdk#3464): SaaS settings stores dump `agent_settings` without cipher context, redacting `acp_env` to `**********` at persist and silently dropping cloud-injected creds.

## What this does
In `_build_acp_start_conversation_request`, route the ACP provider creds through **`agent_context.secrets`** instead of `acp_env`:
- Fold `acp_settings.resolve_provider_env()` (api key + base url, keyed by `api_key_env_var` / `base_url_env_var`) into the `secrets` dict as `StaticSecret`s, so they ride the encrypted `request.secrets` boundary like every other secret and the SDK gap-fills them into the subprocess env at launch.
- **Strip** the creds off the dummy ACP `llm` (`api_key=None`, `base_url=None`) so `create_agent()` no longer re-folds them into `acp_env`.
- Provider creds are folded in **last** so they override a same-named Secrets-panel entry — preserving the prior `provider env > panel secret` priority, now expressed within the single `agent_context.secrets` channel.
- A user's **explicit `acp_env`** entry still wins at the SDK's launch-time `acp_env > agent_context.secrets` precedence. The user-managed `acp_env` settings **field is untouched** (its editor / merge / member-private plumbing stays).

## Why it works on the pinned SDK
v1.23.1 already injects `agent_context.secrets` into the ACP subprocess env, so this is a **client-side reroute that works today** — no SDK release wait. (#3464, which removes the SDK-side `llm.api_key`→`acp_env` fold, is not yet in a release; stripping `llm` here makes the behavior correct regardless.)

## Validation
- `TestBuildAcpStartConversationRequestSecrets` — **9/9 pass** against a fresh venv on the pinned `openhands-sdk==1.23.1`.
- `ruff check` / `ruff format` clean.

## Context
Toward the registry-only end-state in OpenHands/OpenHands#15722 (remove the `acp_env` channel); part of epic OpenHands/OpenHands#15746, follows SDK #3464. Pairs with agent-canvas#1050 (stop forwarding `acp_env`) and a benchmarks change (route eval creds off `acp_env`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-df165de   docker.openhands.dev/openhands/openhands:df165de
```
