### PR TITLE
fix(acp): route provider creds via agent_context.secrets (clean, no workaround)

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1593,18 +1593,11 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
     ) -> StartConversationRequest:
         """Build a StartConversationRequest for ACP agent conversations.
 
-        Unlike the LLM path, ACP agents run as separate subprocesses; the
-        provider credentials reach the subprocess as environment variables
-        rather than via an injected LLM object.
-
-        Both the provider credentials (the UI-saved ``llm.api_key`` /
-        ``base_url``) and user secrets (Secrets panel + git provider tokens)
-        flow through the single ``AgentContext.secrets`` channel — the
-        cipher-protected channel that rides the encrypted ``request.secrets``
-        boundary. ``ACPAgentSettings.create_agent()`` folds the provider creds
-        (keyed by the provider's env-var names) into ``agent_context.secrets``
-        (software-agent-sdk #3464), and the SDK gap-fills the values into the
-        subprocess env at launch.
+        Provider creds (``llm.api_key`` / ``base_url``) and user secrets both
+        flow through ``AgentContext.secrets``. ``acp_settings.create_agent()``
+        folds the provider creds (keyed by env-var name, sdk#3464) into
+        ``agent_context.secrets``; the SDK gap-fills them into the subprocess
+        env at launch.
 
         Args:
             sandbox: Sandbox information
@@ -1642,14 +1635,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         acp_settings = user.agent_settings  # already verified to be ACPAgentSettings
         assert isinstance(acp_settings, ACPAgentSettings)
 
-        # Pass user secrets via AgentContext and let create_agent() fold the
-        # ACP provider creds (llm.api_key / base_url) into agent_context.secrets
-        # — keyed by the provider's env-var names (software-agent-sdk #3464).
-        # The SDK renders names as a <CUSTOM_SECRETS> block in the ACP prompt
-        # and gap-fills values into the subprocess env at launch. We pass
-        # ``SecretSource`` objects verbatim; resolving them here would eagerly
-        # hit the auth service for every LookupSecret on every conversation
-        # start, from the wrong process.
+        # acp_settings.create_agent() folds provider creds into agent_context.secrets
+        # (sdk#3464). Pass SecretSource objects verbatim — the SDK resolves them
+        # at subprocess launch, not here, to avoid eager LookupSecret calls.
         agent_context = AgentContext(secrets=secrets) if secrets else None
         settings_update = (
             {'agent_context': agent_context} if agent_context is not None else {}

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1598,15 +1598,13 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         rather than via an injected LLM object.
 
         Both the provider credentials (the UI-saved ``llm.api_key`` /
-        ``base_url``, keyed by the provider's env-var names) and user secrets
-        (Secrets panel + git provider tokens) flow through the single
-        ``AgentContext.secrets`` channel: their names are rendered into the
-        ACP prompt as a ``<CUSTOM_SECRETS>`` block, and the SDK's
-        ``ACPAgent._start_acp_server`` gap-fills the values into the subprocess
-        env at launch. Routing the provider creds this way keeps them on the
-        cipher-protected ``request.secrets`` boundary instead of the
-        deprecated, persist-unsafe ``acp_env`` channel (software-agent-sdk
-        #3464; OpenHands/agent-canvas#1039).
+        ``base_url``) and user secrets (Secrets panel + git provider tokens)
+        flow through the single ``AgentContext.secrets`` channel — the
+        cipher-protected channel that rides the encrypted ``request.secrets``
+        boundary. ``ACPAgentSettings.create_agent()`` folds the provider creds
+        (keyed by the provider's env-var names) into ``agent_context.secrets``
+        (software-agent-sdk #3464), and the SDK gap-fills the values into the
+        subprocess env at launch.
 
         Args:
             sandbox: Sandbox information
@@ -1644,36 +1642,18 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         acp_settings = user.agent_settings  # already verified to be ACPAgentSettings
         assert isinstance(acp_settings, ACPAgentSettings)
 
-        # Route the ACP provider credentials (the UI-saved ``llm.api_key`` /
-        # ``base_url``) through the cipher-protected ``agent_context.secrets``
-        # channel — keyed by the provider's expected env-var names — instead
-        # of ``acp_env``. ``acp_env`` is a parallel, persist-unsafe credential
-        # channel the SDK has deprecated (software-agent-sdk #3464). Provider
-        # creds override a same-named Secrets-panel entry, preserving the prior
-        # ``provider env > panel secret`` priority. See
-        # OpenHands/agent-canvas#1039.
-        provider_env = acp_settings.resolve_provider_env()
-        for env_name, env_value in provider_env.items():
-            secrets[env_name] = StaticSecret(value=SecretStr(env_value))
-
-        # Pass secrets via AgentContext. The SDK renders the names as a
-        # <CUSTOM_SECRETS> block in the ACP prompt and
-        # ``ACPAgent._start_acp_server`` gap-fills any not already in the
-        # subprocess env at launch time, delivering the provider creds. We
-        # pass ``SecretSource`` objects verbatim; resolving them here (with
-        # ``source.get_value()``) would eagerly hit the auth service for every
-        # ``LookupSecret`` on every conversation start, from the wrong process.
+        # Pass user secrets via AgentContext and let create_agent() fold the
+        # ACP provider creds (llm.api_key / base_url) into agent_context.secrets
+        # — keyed by the provider's env-var names (software-agent-sdk #3464).
+        # The SDK renders names as a <CUSTOM_SECRETS> block in the ACP prompt
+        # and gap-fills values into the subprocess env at launch. We pass
+        # ``SecretSource`` objects verbatim; resolving them here would eagerly
+        # hit the auth service for every LookupSecret on every conversation
+        # start, from the wrong process.
         agent_context = AgentContext(secrets=secrets) if secrets else None
-        settings_update: dict[str, object] = {}
-        if agent_context is not None:
-            settings_update['agent_context'] = agent_context
-        # Strip the provider creds off the (dummy) ACP ``llm`` so
-        # ``create_agent()`` does not re-fold them into ``acp_env`` via
-        # ``resolve_provider_env``.
-        if provider_env:
-            settings_update['llm'] = acp_settings.llm.model_copy(
-                update={'api_key': None, 'base_url': None}
-            )
+        settings_update = (
+            {'agent_context': agent_context} if agent_context is not None else {}
+        )
         acp_agent = acp_settings.model_copy(update=settings_update).create_agent()
 
         sdk_plugins: list[PluginSource] | None = None

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3347,21 +3347,14 @@ class TestBuildAcpStartConversationRequestSecrets:
 
     @pytest.mark.asyncio
     async def test_provider_env_in_agent_context_not_acp_env(self, service, tmp_path):
-        """LLM credentials land in agent_context.secrets, never acp_env.
-
-        create_agent() folds the provider cred (from ``llm.api_key``) into
-        agent_context.secrets. When no conflicting panel secret exists the
-        provider cred is the only entry for that name.
-        """
+        """Provider cred lands in agent_context.secrets, not acp_env."""
         user = self._make_acp_user(acp_server='claude-code', api_key='sk-ui-key')
         service._setup_secrets_for_git_providers = AsyncMock(return_value={})
 
         request = await self._call_build(service, user, tmp_path)
 
-        # Provider creds no longer ride acp_env.
         assert request.agent.acp_env.get('ANTHROPIC_API_KEY') is None
         assert request.agent.agent_context is not None
-        # Provider cred lands in agent_context.secrets.
         assert (
             request.agent.agent_context.secrets.get('ANTHROPIC_API_KEY').get_value()
             == 'sk-ui-key'
@@ -3379,14 +3372,7 @@ class TestBuildAcpStartConversationRequestSecrets:
 
     @pytest.mark.asyncio
     async def test_acp_env_overrides_provider_env(self, service, tmp_path):
-        """Explicit acp_env entries take priority over the provider cred.
-
-        When a user sets ANTHROPIC_API_KEY explicitly in acp_env, it must win
-        over the key the SDK derives from the UI-saved LLM credentials. The
-        provider cred now rides ``agent_context.secrets`` (not ``acp_env``);
-        the SDK's launch-time precedence is ``acp_env > agent_context.secrets``,
-        so the explicit ``acp_env`` entry still wins.
-        """
+        """Explicit acp_env entry beats the provider cred (acp_env > agent_context.secrets at launch)."""
         user = self._make_acp_user(
             acp_server='claude-code',
             acp_env={'ANTHROPIC_API_KEY': 'sk-explicit-override'},
@@ -3396,11 +3382,8 @@ class TestBuildAcpStartConversationRequestSecrets:
 
         request = await self._call_build(service, user, tmp_path)
 
-        # The user's explicit acp_env entry is preserved verbatim; the provider
-        # cred is NOT folded into acp_env.
         assert request.agent.acp_env.get('ANTHROPIC_API_KEY') == 'sk-explicit-override'
-        # The provider cred lands in agent_context.secrets; the SDK gap-fill
-        # then defers to the higher-precedence acp_env entry at launch.
+        # Provider cred still lands in agent_context.secrets; acp_env wins at launch.
         assert request.agent.agent_context is not None
         assert (
             request.agent.agent_context.secrets.get('ANTHROPIC_API_KEY').get_value()
@@ -3409,15 +3392,7 @@ class TestBuildAcpStartConversationRequestSecrets:
 
     @pytest.mark.asyncio
     async def test_secrets_forwarded_via_agent_context(self, service, tmp_path):
-        """Panel secrets flow through ``agent_context.secrets`` only.
-
-        The SDK's ``ACPAgent._start_acp_server`` gap-fills ``agent_context.secrets``
-        into the subprocess env at launch time. Pre-resolving here would
-        eagerly hit external auth services (e.g. ``LookupSecret``) on every
-        conversation start from the wrong process, so we forward the
-        ``SecretSource`` objects untouched and let the SDK resolve them
-        at the right boundary.
-        """
+        """Panel secrets flow through agent_context.secrets; not pre-resolved into acp_env."""
         gh_secret = StaticSecret(value=SecretStr('ghp_test123'))
         user = self._make_acp_user()
         service._setup_secrets_for_git_providers = AsyncMock(
@@ -3426,9 +3401,7 @@ class TestBuildAcpStartConversationRequestSecrets:
 
         request = await self._call_build(service, user, tmp_path)
 
-        # NOT pre-resolved into acp_env — the SDK does that at subprocess start.
         assert request.agent.acp_env.get('GH_TOKEN') is None
-        # Surfaced as a SecretSource in agent_context.
         assert request.agent.agent_context is not None
         assert request.agent.agent_context.secrets.get('GH_TOKEN') is gh_secret
 
@@ -3436,12 +3409,10 @@ class TestBuildAcpStartConversationRequestSecrets:
     async def test_panel_secret_overrides_provider_env_when_conflicting(
         self, service, tmp_path
     ):
-        """Explicitly-set panel secret wins over the provider-derived cred.
+        """Panel secret beats provider-derived cred when both name the same key.
 
-        The SDK merges as ``{**provider_secrets, **existing}`` so an explicit
-        panel entry for the same key name overrides the auto-derived provider
-        cred. This lets users override the LLM-settings key via the Secrets
-        panel when they need to.
+        SDK merge order: {**provider_secrets, **existing} → existing (panel) wins.
+        Priority is now panel > provider, reversed from the old workaround.
         """
         user = self._make_acp_user(acp_server='claude-code', api_key='sk-ui-key')
         panel_secret = StaticSecret(value=SecretStr('sk-from-secrets-panel'))
@@ -3451,9 +3422,7 @@ class TestBuildAcpStartConversationRequestSecrets:
 
         request = await self._call_build(service, user, tmp_path)
 
-        # Provider creds no longer ride acp_env.
         assert request.agent.acp_env.get('ANTHROPIC_API_KEY') is None
-        # The explicit panel entry wins over the provider-derived cred.
         assert request.agent.agent_context is not None
         assert (
             request.agent.agent_context.secrets.get('ANTHROPIC_API_KEY').get_value()

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3224,6 +3224,15 @@ class TestBuildAcpStartConversationRequestSecrets:
     Covers issue #14167: secrets from the Secrets panel and git provider
     tokens must be available to ACP subprocesses as environment variables,
     mirroring how they flow into the regular OpenHands sandbox.
+
+    The provider-credential cases below assert the **post-#3464 contract**:
+    ``create_agent()`` routes the ACP provider creds (``llm.api_key`` /
+    ``base_url``) onto ``agent_context.secrets``, NOT ``acp_env``. They
+    therefore FAIL while ``openhands-sdk`` is pinned to a release *before*
+    software-agent-sdk #3464 (which still folds the creds into ``acp_env``) and
+    only pass once the pin is bumped past it — this is the intended merge gate
+    for this PR. See OpenHands/agent-canvas#1039 and the interim workaround in
+    OpenHands#14620.
     """
 
     @pytest.fixture
@@ -3340,23 +3349,19 @@ class TestBuildAcpStartConversationRequestSecrets:
     async def test_provider_env_in_agent_context_not_acp_env(self, service, tmp_path):
         """LLM credentials land in agent_context.secrets, never acp_env.
 
-        The provider cred (from ``llm.api_key``) overrides a same-named
-        Secrets-panel entry, preserving the prior ``provider env > panel``
-        priority — now expressed within the single ``agent_context.secrets``
-        channel rather than across ``acp_env`` vs ``agent_context``.
+        create_agent() folds the provider cred (from ``llm.api_key``) into
+        agent_context.secrets. When no conflicting panel secret exists the
+        provider cred is the only entry for that name.
         """
         user = self._make_acp_user(acp_server='claude-code', api_key='sk-ui-key')
-        panel_secret = StaticSecret(value=SecretStr('sk-from-secrets-panel'))
-        service._setup_secrets_for_git_providers = AsyncMock(
-            return_value={'ANTHROPIC_API_KEY': panel_secret}
-        )
+        service._setup_secrets_for_git_providers = AsyncMock(return_value={})
 
         request = await self._call_build(service, user, tmp_path)
 
         # Provider creds no longer ride acp_env.
         assert request.agent.acp_env.get('ANTHROPIC_API_KEY') is None
         assert request.agent.agent_context is not None
-        # Provider env wins over the same-named panel secret.
+        # Provider cred lands in agent_context.secrets.
         assert (
             request.agent.agent_context.secrets.get('ANTHROPIC_API_KEY').get_value()
             == 'sk-ui-key'
@@ -3428,13 +3433,15 @@ class TestBuildAcpStartConversationRequestSecrets:
         assert request.agent.agent_context.secrets.get('GH_TOKEN') is gh_secret
 
     @pytest.mark.asyncio
-    async def test_panel_secret_does_not_override_provider_env(self, service, tmp_path):
-        """Provider env (from ``llm.api_key``) keeps priority over panel secrets.
+    async def test_panel_secret_overrides_provider_env_when_conflicting(
+        self, service, tmp_path
+    ):
+        """Explicitly-set panel secret wins over the provider-derived cred.
 
-        If a user has both a UI-saved Claude Code LLM key AND a same-named
-        ``ANTHROPIC_API_KEY`` in the Secrets panel, the LLM-saved one wins.
-        Both now ride ``agent_context.secrets`` (not ``acp_env``); the provider
-        cred is folded in last so it overrides the panel entry of the same name.
+        The SDK merges as ``{**provider_secrets, **existing}`` so an explicit
+        panel entry for the same key name overrides the auto-derived provider
+        cred. This lets users override the LLM-settings key via the Secrets
+        panel when they need to.
         """
         user = self._make_acp_user(acp_server='claude-code', api_key='sk-ui-key')
         panel_secret = StaticSecret(value=SecretStr('sk-from-secrets-panel'))
@@ -3446,11 +3453,11 @@ class TestBuildAcpStartConversationRequestSecrets:
 
         # Provider creds no longer ride acp_env.
         assert request.agent.acp_env.get('ANTHROPIC_API_KEY') is None
-        # The provider cred overrides the same-named panel secret.
+        # The explicit panel entry wins over the provider-derived cred.
         assert request.agent.agent_context is not None
         assert (
             request.agent.agent_context.secrets.get('ANTHROPIC_API_KEY').get_value()
-            == 'sk-ui-key'
+            == 'sk-from-secrets-panel'
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
✅ **`openhands-sdk` is now pinned to v1.25.0, which includes software-agent-sdk#3464. CI should be green.**

- [ ] A human has tested these changes.

---

## What this is
The **clean end-state** for keeping ACP provider credentials off the deprecated, persist-unsafe `acp_env` channel. With `openhands-sdk` v1.25.0 (includes #3464), `ACPAgentSettings.create_agent()` folds the provider creds (`llm.api_key` / `base_url`) onto `agent_context.secrets` itself — so OpenHands needs **no client-side workaround**.

The production builder (`_build_acp_start_conversation_request`) is **unchanged from `main`**: it already passes `agent_context` and calls `create_agent()`. This PR only:
- updates the docstrings/comments to describe the post-#3464 routing, and
- flips the three provider-cred tests to the post-#3464 contract (creds on `agent_context.secrets`, never `acp_env`).

## Context
Toward the registry-only end-state in OpenHands/OpenHands#15722 (remove the `acp_env` channel); follows software-agent-sdk#3464. Pairs with agent-canvas#1050 and benchmarks#734.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-262065d   docker.openhands.dev/openhands/openhands:262065d
```