### PR TITLE
Fix CVE-2026-41305: Update postcss to 8.5.10

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14249,9 +14249,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -14266,7 +14266,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -129,6 +129,7 @@
     ]
   },
   "overrides": {
-    "dompurify": "3.4.0"
+    "dompurify": "3.4.0",
+    "postcss": "8.5.10"
   }
 }

--- a/openhands-ui/bun.lock
+++ b/openhands-ui/bun.lock
@@ -36,10 +36,13 @@
         "react": ">=19.1.0",
         "react-dom": ">=19.1.0",
         "tailwind-merge": "^3.3.1",
-        "react": ">=19.1.0",
+        "tailwind-scrollbar": "^4.0.2",
         "tailwindcss": "^4.1.10",
       },
     },
+  },
+  "overrides": {
+    "postcss": "8.5.10",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.3", "", {}, "sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA=="],
@@ -802,7 +805,7 @@
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 

--- a/openhands-ui/package.json
+++ b/openhands-ui/package.json
@@ -76,7 +76,6 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.10",
     "tailwind-scrollbar": "^4.0.2"
-
   },
   "dependencies": {
     "@floating-ui/react": "^0.27.12",
@@ -99,5 +98,8 @@
     "bun": ">=1.2.0",
     "node": ">=22.0.0",
     "npm": ">=10.0.0"
+  },
+  "overrides": {
+    "postcss": "8.5.10"
   }
 }


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

Security fix for CVE-2026-41305 affecting the transitive `postcss` dependency.

## Summary

- Added `postcss` `8.5.10` overrides in the frontend npm package and OpenHands UI Bun package.
- Regenerated `frontend/package-lock.json` and `openhands-ui/bun.lock` so locked `postcss` resolves to `8.5.10`.

## Issue Number

N/A

## How to Test

- `cd frontend && npx --yes -p npm@10.5.0 npm run lint:fix`
- `cd frontend && npx --yes -p npm@10.5.0 npm run build`
- `cd openhands-ui && npx --yes bun@1.2.17 run build`

## Video/Screenshots

N/A - dependency-only security update.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR was created by an AI agent (OpenHands) on behalf of the user.

@aivong-openhands can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6ceb384a-109e-4441-8d8d-3dc630ccabbf)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-4a180d6   docker.openhands.dev/openhands/openhands:4a180d6
```