### PR TITLE
Fix CVE-2026-44492: Update axios to 1.16.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
         "@uidotdev/usehooks": "^2.4.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
-        "axios": "1.15.2",
+        "axios": "1.16.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "downshift": "^9.3.0",
@@ -7672,12 +7672,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "@uidotdev/usehooks": "^2.4.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
-    "axios": "1.15.2",
+    "axios": "1.16.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "downshift": "^9.3.0",


### PR DESCRIPTION
Human: Tested this

<img width="898" height="260" alt="Screenshot 2026-06-03 at 2 05 51 PM" src="https://github.com/user-attachments/assets/0628b8f0-2c70-43f0-89e2-8ac4bf502ba4" />

## Security Fix: CVE-2026-44492

### Summary
Updates the `axios` package from version `1.15.2` to `1.16.0` to address security vulnerability CVE-2026-44492.

### Changes
- Updated `axios` direct dependency in `frontend/package.json` from `1.15.2` to `1.16.0`
- Regenerated `frontend/package-lock.json` to reflect the updated dependency

### Details
- **CVE**: CVE-2026-44492
- **Package**: axios
- **Previous Version**: 1.15.2
- **Fixed Version**: 1.16.0
- **Dependency Type**: Direct (frontend)

---
_This PR was created by an AI agent (OpenHands) to remediate a security vulnerability._

@mamoodi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bc622acd-3577-4c1d-b177-b0a6025eb60d)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-adb58fc   docker.openhands.dev/openhands/openhands:adb58fc
```