### PR TITLE
feat(enterprise): make rate limits configurable via env vars

### DIFF
--- a/enterprise/server/auth/saas_user_auth.py
+++ b/enterprise/server/auth/saas_user_auth.py
@@ -23,6 +23,7 @@ from server.auth.cookie_chunking import read_chunked_cookie
 from server.auth.token_manager import TokenManager
 from server.logger import logger
 from server.rate_limit import RateLimiter, create_redis_rate_limiter
+from server.utils.rate_limit_utils import RATE_LIMIT_AUTH_WINDOWS
 from sqlalchemy import delete, select
 from storage.api_key_store import ApiKeyStore
 from storage.auth_tokens import AuthTokens
@@ -49,7 +50,7 @@ from openhands.app_server.user_auth.user_auth import AuthType, UserAuth
 token_manager = TokenManager()
 
 
-rate_limiter: RateLimiter = create_redis_rate_limiter('10/second; 100/minute')
+rate_limiter: RateLimiter = create_redis_rate_limiter(RATE_LIMIT_AUTH_WINDOWS)
 
 
 @dataclass

--- a/enterprise/server/routes/auth.py
+++ b/enterprise/server/routes/auth.py
@@ -51,7 +51,11 @@ from server.services.org_invitation_service import (
     UserAlreadyMemberError,
 )
 from server.utils.conversation_utils import get_session_api_key, get_user_id
-from server.utils.rate_limit_utils import check_rate_limit_by_user_id
+from server.utils.rate_limit_utils import (
+    RATE_LIMIT_AUTH_VERIFY_EMAIL_IP_SECONDS,
+    RATE_LIMIT_AUTH_VERIFY_EMAIL_USER_SECONDS,
+    check_rate_limit_by_user_id,
+)
 from server.utils.url_utils import get_cookie_domain, get_cookie_samesite, get_web_url
 from sqlalchemy import select
 from storage.database import a_session_maker
@@ -399,16 +403,17 @@ async def keycloak_callback(
         # Import locally to avoid circular import with email.py
         from server.routes.email import verify_email
 
-        # Rate limit verification emails during auth flow (60 seconds per user)
-        # This is separate from the manual resend rate limit which uses 30 seconds
+        # Rate limit verification emails during auth flow (defaults: 60s per user,
+        # 120s per IP; configurable via RATE_LIMIT_AUTH_VERIFY_EMAIL_* env vars).
+        # This is separate from the manual resend limit (RATE_LIMIT_EMAIL_RESEND_*).
         rate_limited = False
         try:
             await check_rate_limit_by_user_id(
                 request=request,
                 key_prefix='auth_verify_email',
                 user_id=user_id,
-                user_rate_limit_seconds=60,
-                ip_rate_limit_seconds=120,
+                user_rate_limit_seconds=RATE_LIMIT_AUTH_VERIFY_EMAIL_USER_SECONDS,
+                ip_rate_limit_seconds=RATE_LIMIT_AUTH_VERIFY_EMAIL_IP_SECONDS,
             )
             await verify_email(request=request, user_id=user_id, is_auth_flow=True)
         except HTTPException as e:

--- a/enterprise/server/routes/email.py
+++ b/enterprise/server/routes/email.py
@@ -9,7 +9,11 @@ from server.auth.keycloak_manager import get_keycloak_admin
 from server.auth.saas_user_auth import SaasUserAuth
 from server.constants import IS_LOCAL_ENV
 from server.routes.auth import set_response_cookie
-from server.utils.rate_limit_utils import check_rate_limit_by_user_id
+from server.utils.rate_limit_utils import (
+    RATE_LIMIT_EMAIL_RESEND_IP_SECONDS,
+    RATE_LIMIT_EMAIL_RESEND_USER_SECONDS,
+    check_rate_limit_by_user_id,
+)
 from server.utils.url_utils import get_web_url
 from storage.user_store import UserStore
 
@@ -130,14 +134,15 @@ async def resend_email_verification(
             detail='user_id is required in request body or user must be authenticated',
         )
 
-    # Check rate limit (uses user_id if available, otherwise falls back to IP)
-    # Use 30 seconds for user-based rate limiting to match frontend cooldown
+    # Check rate limit (uses user_id if available, otherwise falls back to IP).
+    # Defaults: 30s per user (matches frontend cooldown), 60s per IP (more
+    # lenient); configurable via RATE_LIMIT_EMAIL_RESEND_* env vars.
     await check_rate_limit_by_user_id(
         request=request,
         key_prefix='email_resend',
         user_id=user_id,
-        user_rate_limit_seconds=30,
-        ip_rate_limit_seconds=60,  # 1 minute for IP-based limiting (more lenient)
+        user_rate_limit_seconds=RATE_LIMIT_EMAIL_RESEND_USER_SECONDS,
+        ip_rate_limit_seconds=RATE_LIMIT_EMAIL_RESEND_IP_SECONDS,
     )
 
     # Get is_auth_flow from body if provided, default to False

--- a/enterprise/server/routes/org_invitations.py
+++ b/enterprise/server/routes/org_invitations.py
@@ -19,7 +19,10 @@ from server.routes.org_invitation_models import (
     UserAlreadyMemberError,
 )
 from server.services.org_invitation_service import OrgInvitationService
-from server.utils.rate_limit_utils import check_rate_limit_by_user_id
+from server.utils.rate_limit_utils import (
+    RATE_LIMIT_ORG_INVITATION_USER_SECONDS,
+    check_rate_limit_by_user_id,
+)
 from storage.org_store import OrgStore
 from storage.role_store import RoleStore
 
@@ -78,12 +81,14 @@ async def create_invitation(
         HTTPException 403: User lacks permission to invite
         HTTPException 429: Rate limit exceeded
     """
-    # Rate limit: 10 invitations per minute per user (6 seconds between requests)
+    # Rate limit invitation creation per user (default: 6s between requests, i.e.
+    # 10 invitations per minute; configurable via
+    # RATE_LIMIT_ORG_INVITATION_USER_SECONDS).
     await check_rate_limit_by_user_id(
         request=request,
         key_prefix='org_invitation_create',
         user_id=user_id,
-        user_rate_limit_seconds=6,
+        user_rate_limit_seconds=RATE_LIMIT_ORG_INVITATION_USER_SECONDS,
     )
 
     try:

--- a/enterprise/server/utils/rate_limit_utils.py
+++ b/enterprise/server/utils/rate_limit_utils.py
@@ -1,11 +1,51 @@
+import os
+
 from fastapi import HTTPException, Request, status
 from storage.redis import get_redis_client_async
 
 from openhands.app_server.utils.logger import openhands_logger as logger
 
-# Rate limiting constants
-RATE_LIMIT_USER_SECONDS = 120  # 2 minutes per user_id
-RATE_LIMIT_IP_SECONDS = 300  # 5 minutes per IP address
+# Rate limiting configuration.
+#
+# Every rate limit below is configurable via an environment variable, falling
+# back to the default when the variable is unset.
+
+# Per-user request limiter for authenticated API requests (see
+# server.auth.saas_user_auth). Value is a `limits`-style window string, where
+# multiple windows are separated by ';', e.g. "10/second; 100/minute".
+RATE_LIMIT_AUTH_WINDOWS = os.environ.get(
+    'RATE_LIMIT_AUTH_WINDOWS', '10/second; 100/minute'
+)
+
+# Generic fallback windows used by check_rate_limit_by_user_id when a caller does
+# not pass its own values.
+RATE_LIMIT_USER_SECONDS = int(
+    os.environ.get('RATE_LIMIT_USER_SECONDS', '120')
+)  # 2 minutes per user_id
+RATE_LIMIT_IP_SECONDS = int(
+    os.environ.get('RATE_LIMIT_IP_SECONDS', '300')
+)  # 5 minutes per IP address
+
+# Email verification during the auth flow (server.routes.auth).
+RATE_LIMIT_AUTH_VERIFY_EMAIL_USER_SECONDS = int(
+    os.environ.get('RATE_LIMIT_AUTH_VERIFY_EMAIL_USER_SECONDS', '60')
+)
+RATE_LIMIT_AUTH_VERIFY_EMAIL_IP_SECONDS = int(
+    os.environ.get('RATE_LIMIT_AUTH_VERIFY_EMAIL_IP_SECONDS', '120')
+)
+
+# Manual verification email resend (server.routes.email).
+RATE_LIMIT_EMAIL_RESEND_USER_SECONDS = int(
+    os.environ.get('RATE_LIMIT_EMAIL_RESEND_USER_SECONDS', '30')
+)
+RATE_LIMIT_EMAIL_RESEND_IP_SECONDS = int(
+    os.environ.get('RATE_LIMIT_EMAIL_RESEND_IP_SECONDS', '60')
+)
+
+# Organization invitation creation (server.routes.org_invitations).
+RATE_LIMIT_ORG_INVITATION_USER_SECONDS = int(
+    os.environ.get('RATE_LIMIT_ORG_INVITATION_USER_SECONDS', '6')
+)
 
 
 async def check_rate_limit_by_user_id(

--- a/enterprise/tests/unit/server/test_rate_limit_utils.py
+++ b/enterprise/tests/unit/server/test_rate_limit_utils.py
@@ -1,3 +1,4 @@
+import importlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -268,3 +269,57 @@ async def test_rate_limit_different_users_have_separate_limits(
             True,
             RATE_LIMIT_USER_SECONDS,
         ) in call_args_list
+
+
+class TestRateLimitEnvConfiguration:
+    """Rate limit windows are read from environment variables at import time,
+    with a default value for each when the variable is unset."""
+
+    @pytest.mark.parametrize(
+        'const_name,expected_default',
+        [
+            ('RATE_LIMIT_AUTH_WINDOWS', '10/second; 100/minute'),
+            ('RATE_LIMIT_USER_SECONDS', 120),
+            ('RATE_LIMIT_IP_SECONDS', 300),
+            ('RATE_LIMIT_AUTH_VERIFY_EMAIL_USER_SECONDS', 60),
+            ('RATE_LIMIT_AUTH_VERIFY_EMAIL_IP_SECONDS', 120),
+            ('RATE_LIMIT_EMAIL_RESEND_USER_SECONDS', 30),
+            ('RATE_LIMIT_EMAIL_RESEND_IP_SECONDS', 60),
+            ('RATE_LIMIT_ORG_INVITATION_USER_SECONDS', 6),
+        ],
+    )
+    def test_default_values(self, const_name, expected_default):
+        import server.utils.rate_limit_utils as rate_limit_utils
+
+        assert getattr(rate_limit_utils, const_name) == expected_default
+
+    def test_environment_variables_override_defaults(self, monkeypatch):
+        import server.utils.rate_limit_utils as rate_limit_utils
+
+        overrides = {
+            'RATE_LIMIT_AUTH_WINDOWS': '5/second; 50/minute',
+            'RATE_LIMIT_USER_SECONDS': '11',
+            'RATE_LIMIT_IP_SECONDS': '22',
+            'RATE_LIMIT_AUTH_VERIFY_EMAIL_USER_SECONDS': '33',
+            'RATE_LIMIT_AUTH_VERIFY_EMAIL_IP_SECONDS': '44',
+            'RATE_LIMIT_EMAIL_RESEND_USER_SECONDS': '55',
+            'RATE_LIMIT_EMAIL_RESEND_IP_SECONDS': '66',
+            'RATE_LIMIT_ORG_INVITATION_USER_SECONDS': '77',
+        }
+        for key, value in overrides.items():
+            monkeypatch.setenv(key, value)
+
+        try:
+            importlib.reload(rate_limit_utils)
+            assert rate_limit_utils.RATE_LIMIT_AUTH_WINDOWS == '5/second; 50/minute'
+            assert rate_limit_utils.RATE_LIMIT_USER_SECONDS == 11
+            assert rate_limit_utils.RATE_LIMIT_IP_SECONDS == 22
+            assert rate_limit_utils.RATE_LIMIT_AUTH_VERIFY_EMAIL_USER_SECONDS == 33
+            assert rate_limit_utils.RATE_LIMIT_AUTH_VERIFY_EMAIL_IP_SECONDS == 44
+            assert rate_limit_utils.RATE_LIMIT_EMAIL_RESEND_USER_SECONDS == 55
+            assert rate_limit_utils.RATE_LIMIT_EMAIL_RESEND_IP_SECONDS == 66
+            assert rate_limit_utils.RATE_LIMIT_ORG_INVITATION_USER_SECONDS == 77
+        finally:
+            # Restore module-level defaults so other tests are unaffected.
+            monkeypatch.undo()
+            importlib.reload(rate_limit_utils)


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:


- [x] A human has tested these changes.

AGENT:

---

## Why

The Redis-backed rate limits in the enterprise server were hardcoded. A customer needs to tune these limits for their deployment, which isn't possible today without a code change.

This makes every rate limit configurable via an environment variable. Defaults are set to the current values, so behavior is unchanged unless a variable is explicitly set.

## Summary

- Centralized all rate-limit windows in `rate_limit_utils.py`, each read from an env var that defaults to the previous hardcoded value.
- Pointed the per-user auth limiter (`saas_user_auth.py`) and the per-route limits in `auth.py`, `email.py`, and `org_invitations.py` at those constants.

## Issue Number

## How to Test

From the `enterprise` directory, run the rate-limit unit tests:

`pytest tests/unit/server/test_rate_limit.py tests/unit/server/test_rate_limit_utils.py`

There's a new test that reloads the module under a patched environment and asserts both the defaults and the overrides. To sanity-check by hand, set something like `RATE_LIMIT_AUTH_WINDOWS="5/second; 50/minute"` and confirm the limiter picks it up. With nothing set, the defaults match today's values.

I ran the unit tests and verified the env overrides manually, but I haven't exercised the limits against a running server.

## Video/Screenshots

N/A, server-side config change with no UI.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is a no-op until an env var is set, since every default equals the current value.

I deliberately left the RFC 8628 device-polling interval in `oauth_device.py` alone. It's a protocol-mandated value, not an operational knob.

New env vars (all default to today's values):

- `RATE_LIMIT_AUTH_WINDOWS` (`10/second; 100/minute`)
- `RATE_LIMIT_USER_SECONDS` (`120`), `RATE_LIMIT_IP_SECONDS` (`300`)
- `RATE_LIMIT_AUTH_VERIFY_EMAIL_USER_SECONDS` (`60`), `RATE_LIMIT_AUTH_VERIFY_EMAIL_IP_SECONDS` (`120`)
- `RATE_LIMIT_EMAIL_RESEND_USER_SECONDS` (`30`), `RATE_LIMIT_EMAIL_RESEND_IP_SECONDS` (`60`)
- `RATE_LIMIT_ORG_INVITATION_USER_SECONDS` (`6`)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-6b80bde   docker.openhands.dev/openhands/openhands:6b80bde
```