### PR TITLE
PLTF-2895: add composite index on event_callback (conversation_id, status, event_kind)

### DIFF
--- a/openhands/app_server/app_lifespan/alembic/versions/010.py
+++ b/openhands/app_server/app_lifespan/alembic/versions/010.py
@@ -1,0 +1,42 @@
+"""Add composite index on event_callback for execute_callbacks query
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-06-03
+
+The execute_callbacks query filters on (status, event_kind, conversation_id)
+but none of these columns were indexed, causing full table scans on every
+event dispatch. This index directly covers that query.
+
+CREATE INDEX CONCURRENTLY is used to avoid locking the table during deployment.
+"""
+
+from typing import Sequence
+
+from alembic import op
+
+revision: str = '010'
+down_revision: str | None = '009'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            'ix_event_callback_conversation_id_status_event_kind',
+            'event_callback',
+            ['conversation_id', 'status', 'event_kind'],
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            'ix_event_callback_conversation_id_status_event_kind',
+            table_name='event_callback',
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/openhands/app_server/event_callback/sql_event_callback_service.py
+++ b/openhands/app_server/event_callback/sql_event_callback_service.py
@@ -11,7 +11,7 @@ from typing import AsyncGenerator
 from uuid import UUID, uuid4
 
 from fastapi import Request
-from sqlalchemy import Enum, String, and_, func, select
+from sqlalchemy import Enum, Index, String, and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -47,6 +47,14 @@ _logger = logging.getLogger(__name__)
 
 class StoredEventCallback(Base):
     __tablename__ = 'event_callback'
+    __table_args__ = (
+        Index(
+            'ix_event_callback_conversation_id_status_event_kind',
+            'conversation_id',
+            'status',
+            'event_kind',
+        ),
+    )
 
     id: Mapped[UUID] = mapped_column(primary_key=True)
     conversation_id: Mapped[UUID | None] = mapped_column(nullable=True)


### PR DESCRIPTION
## Problem

INC-95: Production settings page unresponsive, elevated timeouts, high DB utilization.

The `execute_callbacks` method fires on every event dispatch and runs this query:

```sql
SELECT ... FROM event_callback
WHERE status = $1
  AND event_kind = $2
  AND conversation_id = $3
```

The `event_callback` table had **no index on any of these three columns** — the only index was on `created_at`, which this query never uses. Every call was a full table scan.

As the table has grown (~114% more rows over the past 30 days based on `tuples_returned` metrics), each scan has gotten progressively slower. P99 query latency has been rising for weeks and recently crossed the threshold where it causes cascading connection pool exhaustion and user-visible timeouts (P99 reaching 300–400s during peak periods).

## Fix

**`alembic/versions/010.py`** — New migration adding a composite index:
```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS
  ix_event_callback_conversation_id_status_event_kind
  ON event_callback (conversation_id, status, event_kind)
```

`conversation_id` leads the index as the most selective column (UUID per conversation), covering the exact `WHERE` clause in `execute_callbacks`. `CREATE INDEX CONCURRENTLY` is used via Alembic's `autocommit_block()` so the migration builds the index without taking a table lock — safe to deploy while the incident is still active.

**`sql_event_callback_service.py`** — Adds `__table_args__` declaring the same index in the ORM model so future Alembic autogenerate stays in sync.

## Testing

- [ ] Migration runs cleanly against a local PostgreSQL instance
- [ ] `EXPLAIN ANALYZE` on the `execute_callbacks` query shows an index scan instead of a sequential scan after migration

---
_This PR was created by an AI agent (OpenHands) on behalf of the on-call team in response to INC-95._

@erisfully can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c961a9ae-e4a2-46d3-840a-ba4750ce36d3)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-89ab3d5   docker.openhands.dev/openhands/openhands:89ab3d5
```