### PR TITLE
PLTF-2875: Add promote-to-development sender

### DIFF
--- a/.github/workflows/promote-to-development.yml
+++ b/.github/workflows/promote-to-development.yml
@@ -1,0 +1,86 @@
+# Promotes each successful main build's enterprise-server image to the
+# development environment by dispatching to OpenHands/saas-deploy, which runs
+# the bump. Runs after the Docker workflow succeeds on main; can also be run
+# manually (from main) to re-promote a known-good image tag.
+
+name: Promote to development
+
+on:
+  workflow_dispatch:
+    inputs:
+      image-tag:
+        description: "Image tag to promote (defaults to sha-<short SHA> for the selected ref)"
+        required: false
+        type: string
+  workflow_run:
+    workflows: ["Docker"]
+    types: [completed]
+    branches: [main]
+
+# Queue promotions so an earlier main commit deploys before a later one.
+concurrency:
+  group: promote-to-development
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    # Only promote when the Docker build actually succeeded, or when run manually.
+    # The Docker workflow also runs on pull_request, and the workflow_run branches
+    # filter matches the *head* branch — a fork PR from a branch named "main"
+    # would slip through — so additionally require a push event.
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: dev-deploy
+    permissions:
+      contents: read
+    steps:
+      - name: Compute image tag
+        id: tag
+        # Matches docker/metadata-action type=sha (7-char short SHA) emitted by
+        # the docker-image-tags action used in _build-image.yml.
+        env:
+          DISPATCH_IMAGE_TAG: ${{ github.event.inputs['image-tag'] }}
+          SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+        run: |
+          if [ -n "$DISPATCH_IMAGE_TAG" ]; then
+            echo "tag=$DISPATCH_IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=sha-${SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Mint token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ secrets.SAAS_DEPLOY_DISPATCHER_APP_ID }}
+          private-key: ${{ secrets.SAAS_DEPLOY_DISPATCHER_APP_PRIVATE_KEY }}
+          owner: OpenHands
+          repositories: saas-deploy
+          permission-contents: write
+
+      - name: Dispatch promotion to saas-deploy
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          IMAGE_TAG: ${{ steps.tag.outputs.tag }}
+          SOURCE_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+        run: |
+          gh api /repos/OpenHands/saas-deploy/dispatches \
+            -f event_type=promote-to-development \
+            -F client_payload[release]=openhands \
+            -F client_payload[tag-path]=.openhands.image.tag \
+            -F client_payload[image-tag]="$IMAGE_TAG" \
+            -F client_payload[source-repo]="$GITHUB_REPOSITORY" \
+            -F client_payload[source-sha]="$SOURCE_SHA"
+          echo "Dispatched promote-to-development for openhands ${IMAGE_TAG} (${SOURCE_SHA})."
+
+      - name: Annotate dispatch failure
+        if: ${{ failure() }}
+        env:
+          IMAGE_TAG: ${{ steps.tag.outputs.tag }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          SOURCE_RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          image_tag="${IMAGE_TAG:-sha-${HEAD_SHA::7}}"
+          source="${SOURCE_RUN_URL:-manual workflow_dispatch run}"
+          echo "::error title=Promote to development failed::Failed to dispatch promotion of enterprise-server ${image_tag} (${HEAD_SHA}) to development. Source: ${source}"


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

Promote each successful `main` build's `enterprise-server` image to the development environment automatically, instead of bumping the tag by hand in `OpenHands/saas-deploy`.

Because this repo is public, it can't `uses:` the bump action that lives in the private `saas-deploy` repo, so it dispatches an event and a receiver there performs the bump. The dispatch credential is gated to a `main`-restricted Environment and is intentionally minimal in scope.

## Summary

- Adds `.github/workflows/promote-to-development.yml`: after the **Docker** workflow succeeds on a `main` push, mint a token, compute the `sha-<short>` tag, and POST a `promote-to-development` `repository_dispatch` to `OpenHands/saas-deploy`.
- Runs under the `dev-deploy` Environment (restricted to `main`); the minted token is down-scoped to `contents: write`.
- Also runnable via `workflow_dispatch` (from `main`) to re-promote a known-good tag.

## Issue Number

PLTF-2875

## How to Test

Depends on the saas-deploy receiver (OpenHands/saas-deploy#10) being on `main`, and the `dev-deploy` Environment + its secrets being configured (done).

Because `dev-deploy` is restricted to `main`, the credential is unreadable on any other ref — so this workflow can only run from `main`. After merge:

1. Manually run **Promote to development** (`workflow_dispatch`) with `image-tag` set to a real built tag, or push to `main` and let the Docker build trigger it.
2. Confirm the saas-deploy receiver run fires and bumps `.openhands.image.tag`.
3. Sync the openhands development app in ArgoCD and confirm it's healthy on the new image.

## Video/Screenshots

N/A — CI/CD workflow.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The `dev-deploy` branch restriction is what makes this safe to run from a public repo: it prevents non-`main` refs from reading the deploy credential, so the workflow can't be exercised from a feature branch — including before this merges.
- On merge, every future `main` build auto-promotes to dev; the merge commit triggers the first one.

This PR description was drafted by an AI agent on behalf of the user.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-6e67bc1   docker.openhands.dev/openhands/openhands:6e67bc1
```