### PR TITLE
fix(app_server): only rewrite the host when mapping localhost for Docker

### DIFF
--- a/openhands/app_server/utils/docker_utils.py
+++ b/openhands/app_server/utils/docker_utils.py
@@ -26,7 +26,18 @@ def replace_localhost_hostname_for_docker(
         return url
     parsed = urlparse(url)
     if parsed.hostname == 'localhost':
-        # Replace only the hostname part, preserving port and everything else
-        netloc = parsed.netloc.replace('localhost', replacement, 1)
+        # Rebuild the netloc from its components so that only the host is
+        # changed. A naive str.replace on the raw netloc would corrupt
+        # userinfo that happens to contain 'localhost' (e.g. a password equal
+        # to 'localhost') and would miss a differently-cased host such as
+        # 'LOCALHOST', which urlparse normalizes when exposing parsed.hostname.
+        netloc = replacement
+        if parsed.port is not None:
+            netloc = f'{netloc}:{parsed.port}'
+        if parsed.username is not None:
+            userinfo = parsed.username
+            if parsed.password is not None:
+                userinfo = f'{userinfo}:{parsed.password}'
+            netloc = f'{userinfo}@{netloc}'
         return urlunparse(parsed._replace(netloc=netloc))
     return url

--- a/tests/unit/app_server/test_docker_utils.py
+++ b/tests/unit/app_server/test_docker_utils.py
@@ -295,3 +295,45 @@ class TestReplaceLocalhostHostnameForDocker:
         # Only hostname should be different
         assert original_parsed.hostname == 'localhost'
         assert result_parsed.hostname == 'host.docker.internal'
+
+    @patch(
+        'openhands.app_server.utils.docker_utils.is_running_in_docker',
+        return_value=True,
+    )
+    def test_userinfo_containing_localhost_is_not_replaced(self, mock_is_docker):
+        """Credentials that contain the literal string 'localhost' must not be
+        rewritten; only the host component should change.
+
+        Replacing the first occurrence of 'localhost' in the raw netloc corrupts
+        the userinfo (e.g. a password equal to 'localhost') and leaves the actual
+        host untouched.
+        """
+        from urllib.parse import urlparse
+
+        result = replace_localhost_hostname_for_docker(
+            'http://user:localhost@localhost:8080/path'
+        )
+        assert result == 'http://user:localhost@host.docker.internal:8080/path'
+
+        parsed = urlparse(result)
+        assert parsed.username == 'user'
+        assert parsed.password == 'localhost'
+        assert parsed.hostname == 'host.docker.internal'
+        assert parsed.port == 8080
+
+        # A username equal to 'localhost' must also be preserved.
+        result = replace_localhost_hostname_for_docker(
+            'http://localhost:pass@localhost:8080/path'
+        )
+        assert result == 'http://localhost:pass@host.docker.internal:8080/path'
+
+    @patch(
+        'openhands.app_server.utils.docker_utils.is_running_in_docker',
+        return_value=True,
+    )
+    def test_uppercase_localhost_host_is_replaced(self, mock_is_docker):
+        """An uppercase 'LOCALHOST' host matches parsed.hostname (which urlparse
+        lowercases) and so must actually be replaced, not silently left as-is.
+        """
+        result = replace_localhost_hostname_for_docker('http://LOCALHOST:8080/path')
+        assert result == 'http://host.docker.internal:8080/path'


### PR DESCRIPTION
HUMAN:
This fixes a small URL rewriting bug in the app server Docker path. I checked the helper against userinfo and uppercase-host cases because the old implementation replaced the first literal `localhost` in the raw netloc instead of replacing only the parsed host.

- [x] A human has tested these changes.

## What

`replace_localhost_hostname_for_docker` (in `openhands/app_server/utils/docker_utils.py`) rewrites a `localhost` URL to `host.docker.internal` when running inside a container. It did this with `parsed.netloc.replace('localhost', replacement, 1)` on the raw netloc, which breaks in two cases:

1. If the userinfo contains the literal string `localhost` (e.g. a password that is exactly `localhost`), the first occurrence replaced is in the credentials, not the host. The credentials get mangled and the actual host is left as `localhost`, so the resulting URL is unusable from inside the container.
2. A host with different casing such as `LOCALHOST` passes the `parsed.hostname == 'localhost'` check (urlparse lowercases `hostname`) but is never replaced, because `str.replace` is case-sensitive. The host is silently left unchanged.

The function is used to build agent-server URLs throughout `app_server` (sandbox services, event callbacks, conversation router), some of which carry credentials in the userinfo, so a corrupted netloc means a failed connection.

## Fix

Rebuild the netloc from the parsed components — keep `username`/`password` verbatim, substitute only the host, and preserve the port — instead of doing a positional string replace on the whole netloc. This is the same `urlparse` the guard already relies on, so the host is always replaced when it matches and userinfo is never touched.

## Tests

Added two regression tests to `tests/unit/app_server/test_docker_utils.py`:
- userinfo containing `localhost` (both as password and as username) is preserved and only the host changes;
- an uppercase `LOCALHOST` host is actually replaced.

Both fail on `main` and pass with this change; the existing 13 tests in the file still pass. `ruff` and `ruff-format` (0.12.5) and `mypy` are clean on the touched files.
