### PR TITLE
Fix amount validation for partial numeric input

### DIFF
--- a/frontend/__tests__/components/features/org/add-credits-modal.test.tsx
+++ b/frontend/__tests__/components/features/org/add-credits-modal.test.tsx
@@ -151,20 +151,6 @@ describe("AddCreditsModal", () => {
       });
     });
 
-    it("should display invalid number error after submitting exponent notation", async () => {
-      const { user } = renderModal();
-      const amountInput = screen.getByTestId("amount-input");
-      const nextButton = screen.getByRole("button", { name: /ORG\$NEXT/i });
-
-      await user.type(amountInput, "1e2");
-      await user.click(nextButton);
-
-      await waitFor(() => {
-        const errorMessage = screen.getByTestId("amount-error");
-        expect(errorMessage).toHaveTextContent("PAYMENT$ERROR_INVALID_NUMBER");
-      });
-    });
-
     it("should display error message after submitting amount below minimum", async () => {
       const { user } = renderModal();
       const amountInput = screen.getByTestId("amount-input");

--- a/frontend/__tests__/components/features/org/add-credits-modal.test.tsx
+++ b/frontend/__tests__/components/features/org/add-credits-modal.test.tsx
@@ -151,6 +151,20 @@ describe("AddCreditsModal", () => {
       });
     });
 
+    it("should display invalid number error after submitting exponent notation", async () => {
+      const { user } = renderModal();
+      const amountInput = screen.getByTestId("amount-input");
+      const nextButton = screen.getByRole("button", { name: /ORG\$NEXT/i });
+
+      await user.type(amountInput, "1e2");
+      await user.click(nextButton);
+
+      await waitFor(() => {
+        const errorMessage = screen.getByTestId("amount-error");
+        expect(errorMessage).toHaveTextContent("PAYMENT$ERROR_INVALID_NUMBER");
+      });
+    });
+
     it("should display error message after submitting amount below minimum", async () => {
       const { user } = renderModal();
       const amountInput = screen.getByTestId("amount-input");

--- a/frontend/__tests__/utils/amount-is-valid.test.ts
+++ b/frontend/__tests__/utils/amount-is-valid.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, test } from "vitest";
 import { amountIsValid } from "#/utils/amount-is-valid";
 
 describe("amountIsValid", () => {
+  describe("passes", () => {
+    test("when an integer amount is within the accepted range", () => {
+      expect(amountIsValid("10")).toBe(true);
+      expect(amountIsValid("25000")).toBe(true);
+    });
+  });
+
   describe("fails", () => {
     test("when the amount is negative", () => {
       expect(amountIsValid("-5")).toBe(false);
@@ -21,6 +28,11 @@ describe("amountIsValid", () => {
       expect(amountIsValid("abc")).toBe(false);
       expect(amountIsValid("1abc")).toBe(false);
       expect(amountIsValid("abc1")).toBe(false);
+    });
+
+    test("when a non-integer numeric value is passed", () => {
+      expect(amountIsValid("10.0")).toBe(false);
+      expect(amountIsValid("10.50")).toBe(false);
     });
 
     test("when an amount less than the minimum is passed", () => {

--- a/frontend/__tests__/utils/amount-is-valid.test.ts
+++ b/frontend/__tests__/utils/amount-is-valid.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, test } from "vitest";
-import { amountIsValid } from "#/utils/amount-is-valid";
+import {
+  amountIsValid,
+  getAmountValidationError,
+} from "#/utils/amount-is-valid";
 
 describe("amountIsValid", () => {
   describe("passes", () => {
     test("when an integer amount is within the accepted range", () => {
       expect(amountIsValid("10")).toBe(true);
       expect(amountIsValid("25000")).toBe(true);
+    });
+
+    test("when a valid amount has surrounding whitespace", () => {
+      expect(amountIsValid(" 10 ")).toBe(true);
     });
   });
 
@@ -28,6 +35,7 @@ describe("amountIsValid", () => {
       expect(amountIsValid("abc")).toBe(false);
       expect(amountIsValid("1abc")).toBe(false);
       expect(amountIsValid("abc1")).toBe(false);
+      expect(amountIsValid("1e2")).toBe(false);
     });
 
     test("when a non-integer numeric value is passed", () => {
@@ -45,6 +53,19 @@ describe("amountIsValid", () => {
       // test assumes the minimum is 25000
       expect(amountIsValid("25001")).toBe(false);
       expect(amountIsValid("25000.01")).toBe(false);
+    });
+  });
+
+  describe("getAmountValidationError", () => {
+    test("returns the matching validation reason", () => {
+      expect(getAmountValidationError("")).toBe("empty");
+      expect(getAmountValidationError("abc")).toBe("invalid");
+      expect(getAmountValidationError("1e2")).toBe("invalid");
+      expect(getAmountValidationError("-5")).toBe("negative");
+      expect(getAmountValidationError("10.50")).toBe("not_integer");
+      expect(getAmountValidationError("9")).toBe("below_minimum");
+      expect(getAmountValidationError("25001")).toBe("above_maximum");
+      expect(getAmountValidationError("10")).toBeNull();
     });
   });
 });

--- a/frontend/src/components/features/org/add-credits-modal.tsx
+++ b/frontend/src/components/features/org/add-credits-modal.tsx
@@ -40,6 +40,8 @@ export function AddCreditsModal({ onClose }: AddCreditsModalProps) {
         return t(I18nKey.PAYMENT$ERROR_MINIMUM_AMOUNT);
       case "above_maximum":
         return t(I18nKey.PAYMENT$ERROR_MAXIMUM_AMOUNT);
+      default:
+        return null;
     }
   };
 

--- a/frontend/src/components/features/org/add-credits-modal.tsx
+++ b/frontend/src/components/features/org/add-credits-modal.tsx
@@ -5,7 +5,12 @@ import { ModalBackdrop } from "#/components/shared/modals/modal-backdrop";
 import { ModalButtonGroup } from "#/components/shared/modals/modal-button-group";
 import { SettingsInput } from "#/components/features/settings/settings-input";
 import { I18nKey } from "#/i18n/declaration";
-import { amountIsValid } from "#/utils/amount-is-valid";
+import {
+  amountIsValid,
+  getAmountValidationError,
+  MAXIMUM_AMOUNT,
+  MINIMUM_AMOUNT,
+} from "#/utils/amount-is-valid";
 
 interface AddCreditsModalProps {
   onClose: () => void;
@@ -19,25 +24,23 @@ export function AddCreditsModal({ onClose }: AddCreditsModalProps) {
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
 
   const getErrorMessage = (value: string): string | null => {
-    if (!value.trim()) return null;
+    const error = getAmountValidationError(value);
 
-    const numValue = parseInt(value, 10);
-    if (Number.isNaN(numValue)) {
-      return t(I18nKey.PAYMENT$ERROR_INVALID_NUMBER);
+    switch (error) {
+      case null:
+      case "empty":
+        return null;
+      case "invalid":
+        return t(I18nKey.PAYMENT$ERROR_INVALID_NUMBER);
+      case "negative":
+        return t(I18nKey.PAYMENT$ERROR_NEGATIVE_AMOUNT);
+      case "not_integer":
+        return t(I18nKey.PAYMENT$ERROR_MUST_BE_WHOLE_NUMBER);
+      case "below_minimum":
+        return t(I18nKey.PAYMENT$ERROR_MINIMUM_AMOUNT);
+      case "above_maximum":
+        return t(I18nKey.PAYMENT$ERROR_MAXIMUM_AMOUNT);
     }
-    if (numValue < 0) {
-      return t(I18nKey.PAYMENT$ERROR_NEGATIVE_AMOUNT);
-    }
-    if (numValue < 10) {
-      return t(I18nKey.PAYMENT$ERROR_MINIMUM_AMOUNT);
-    }
-    if (numValue > 25000) {
-      return t(I18nKey.PAYMENT$ERROR_MAXIMUM_AMOUNT);
-    }
-    if (numValue !== parseFloat(value)) {
-      return t(I18nKey.PAYMENT$ERROR_MUST_BE_WHOLE_NUMBER);
-    }
-    return null;
   };
 
   const formAction = (formData: FormData) => {
@@ -78,8 +81,8 @@ export function AddCreditsModal({ onClose }: AddCreditsModalProps) {
             name="amount"
             label={t(I18nKey.PAYMENT$SPECIFY_AMOUNT_USD)}
             type="number"
-            min={10}
-            max={25000}
+            min={MINIMUM_AMOUNT}
+            max={MAXIMUM_AMOUNT}
             step={1}
             value={inputValue}
             onChange={(value) => handleAmountInputChange(value)}

--- a/frontend/src/components/features/payment/payment-form.tsx
+++ b/frontend/src/components/features/payment/payment-form.tsx
@@ -7,7 +7,11 @@ import MoneyIcon from "#/icons/money.svg?react";
 import { SettingsInput } from "../settings/settings-input";
 import { BrandButton } from "../settings/brand-button";
 import { LoadingSpinner } from "#/components/shared/loading-spinner";
-import { amountIsValid } from "#/utils/amount-is-valid";
+import {
+  amountIsValid,
+  MAXIMUM_AMOUNT,
+  MINIMUM_AMOUNT,
+} from "#/utils/amount-is-valid";
 import { I18nKey } from "#/i18n/declaration";
 import { PoweredByStripeTag } from "./powered-by-stripe-tag";
 
@@ -24,7 +28,7 @@ export function PaymentForm({ isDisabled }: { isDisabled?: boolean }) {
     if (amount?.trim()) {
       if (!amountIsValid(amount)) return;
 
-      const intValue = parseInt(amount, 10);
+      const intValue = Number(amount.trim());
       addBalance({ amount: intValue });
     }
 
@@ -66,8 +70,8 @@ export function PaymentForm({ isDisabled }: { isDisabled?: boolean }) {
           label={t(I18nKey.PAYMENT$ADD_FUNDS)}
           placeholder={t(I18nKey.PAYMENT$SPECIFY_AMOUNT_USD)}
           className="w-[680px]"
-          min={10}
-          max={25000}
+          min={MINIMUM_AMOUNT}
+          max={MAXIMUM_AMOUNT}
           step={1}
           isDisabled={isDisabled}
         />

--- a/frontend/src/utils/amount-is-valid.ts
+++ b/frontend/src/utils/amount-is-valid.ts
@@ -22,6 +22,7 @@ export const getAmountValidationError = (
   const value = Number(trimmedAmount);
   if (!Number.isFinite(value)) return "invalid";
   if (value < 0) return "negative";
+  if (trimmedAmount.includes(".")) return "not_integer";
   if (!Number.isInteger(value)) return "not_integer";
   if (value < MINIMUM_AMOUNT) return "below_minimum";
   if (value > MAXIMUM_AMOUNT) return "above_maximum";
@@ -29,6 +30,5 @@ export const getAmountValidationError = (
   return null;
 };
 
-export const amountIsValid = (amount: string) => {
-  return getAmountValidationError(amount) === null;
-};
+export const amountIsValid = (amount: string) =>
+  getAmountValidationError(amount) === null;

--- a/frontend/src/utils/amount-is-valid.ts
+++ b/frontend/src/utils/amount-is-valid.ts
@@ -1,15 +1,34 @@
-const MINIMUM_AMOUNT = 10;
-const MAXIMUM_AMOUNT = 25_000;
+export const MINIMUM_AMOUNT = 10;
+export const MAXIMUM_AMOUNT = 25_000;
 
-export const amountIsValid = (amount: string) => {
+export type AmountValidationError =
+  | "empty"
+  | "invalid"
+  | "negative"
+  | "not_integer"
+  | "below_minimum"
+  | "above_maximum";
+
+const DECIMAL_AMOUNT_PATTERN = /^-?\d+(?:\.\d+)?$/;
+
+export const getAmountValidationError = (
+  amount: string,
+): AmountValidationError | null => {
   const trimmedAmount = amount.trim();
-  if (!/^\d+$/.test(trimmedAmount)) return false;
+  if (!trimmedAmount) return "empty";
+
+  if (!DECIMAL_AMOUNT_PATTERN.test(trimmedAmount)) return "invalid";
 
   const value = Number(trimmedAmount);
-  if (Number.isNaN(value)) return false;
-  if (value < 0) return false;
-  if (value < MINIMUM_AMOUNT) return false;
-  if (value > MAXIMUM_AMOUNT) return false;
+  if (!Number.isFinite(value)) return "invalid";
+  if (value < 0) return "negative";
+  if (!Number.isInteger(value)) return "not_integer";
+  if (value < MINIMUM_AMOUNT) return "below_minimum";
+  if (value > MAXIMUM_AMOUNT) return "above_maximum";
 
-  return true;
+  return null;
+};
+
+export const amountIsValid = (amount: string) => {
+  return getAmountValidationError(amount) === null;
 };

--- a/frontend/src/utils/amount-is-valid.ts
+++ b/frontend/src/utils/amount-is-valid.ts
@@ -2,12 +2,14 @@ const MINIMUM_AMOUNT = 10;
 const MAXIMUM_AMOUNT = 25_000;
 
 export const amountIsValid = (amount: string) => {
-  const value = parseInt(amount, 10);
+  const trimmedAmount = amount.trim();
+  if (!/^\d+$/.test(trimmedAmount)) return false;
+
+  const value = Number(trimmedAmount);
   if (Number.isNaN(value)) return false;
   if (value < 0) return false;
   if (value < MINIMUM_AMOUNT) return false;
   if (value > MAXIMUM_AMOUNT) return false;
-  if (value !== parseFloat(amount)) return false; // Ensure it's an integer
 
   return true;
 };


### PR DESCRIPTION

HUMAN:

This PR tightens the top-up amount validator so it only accepts full integer dollar amounts. It fixes cases where malformed strings like `1abc` could be partially parsed as numbers, and adds test coverage for valid boundaries plus invalid decimal-form inputs.

- [ ] A human has tested these changes.

## Why

The amount validator used `parseInt` and `parseFloat`, which can accept partial numeric strings. For example, `amountIsValid("1abc")` was expected to return `false` in the existing tests, but the implementation could treat it as a valid parsed number.

This makes payment/top-up validation stricter and prevents malformed amount strings from passing client-side validation.

## Summary

- Require amount input to match a full integer string before parsing
- Use `Number()` after full-string validation instead of partial parsing
- Add tests for valid boundary values and decimal-form invalid values

## Testing

- Ran a targeted Node assertion for the updated validator behavior
- Full frontend Vitest suite was not run locally because the fresh clone did not include `node_modules`

## Issue Number

N/A