### PR TITLE
PLTF-2895: add enterprise migration for event_callback composite index

### DIFF
--- a/enterprise/migrations/versions/117_add_event_callback_composite_index.py
+++ b/enterprise/migrations/versions/117_add_event_callback_composite_index.py
@@ -1,0 +1,50 @@
+"""Add composite index on event_callback for execute_callbacks query
+
+The execute_callbacks query filters on (conversation_id, status, event_kind)
+but none of these columns were indexed, causing full sequential scans on the
+event_callback table for every event dispatch (INC-95). This composite index
+directly covers that query.
+
+The equivalent index is defined for the OSS app_server alembic chain in
+openhands/app_server/app_lifespan/alembic/versions/010.py. That chain is only
+run by OssAppLifespanService; the SaaS deployment applies DB migrations solely
+through this enterprise chain, so the index must also be created here. Both use
+IF NOT EXISTS so they are safe to coexist.
+
+CREATE INDEX CONCURRENTLY is used (inside an autocommit block) to avoid locking
+the table during deployment.
+
+Revision ID: 117
+Revises: 116
+Create Date: 2026-06-04
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = '117'
+down_revision: Union[str, None] = '116'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            'ix_event_callback_conversation_id_status_event_kind',
+            'event_callback',
+            ['conversation_id', 'status', 'event_kind'],
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            'ix_event_callback_conversation_id_status_event_kind',
+            table_name='event_callback',
+            postgresql_concurrently=True,
+            if_exists=True,
+        )


### PR DESCRIPTION
## Problem

The `execute_callbacks` query filters `event_callback` on `(conversation_id, status, event_kind)`, none of which are indexed, causing a **full sequential scan on every event dispatch**.

A previous fix added the index as an **app_server** alembic migration (`openhands/app_server/app_lifespan/alembic/versions/010.py`). That chain is only executed by `OssAppLifespanService.run_alembic()`. The **SaaS deployment** (`saas_server:app`) uses `SaasAppLifespanService` (which runs no migrations) and applies DB migrations solely via the `migrate-db` init container running `alembic upgrade head` on the **enterprise** chain (`enterprise/migrations`, head `116`). The `event_callback` table itself is owned by that enterprise chain (`076_add_v1_tables.py`).

### Verified in staging
Deployed the app_server-only migration to staging and confirmed it does **not** fix the issue:
- `alembic_version` stayed at `116` (no `upgrade 116 -> ...` in `migrate-db` logs)
- index `ix_event_callback_conversation_id_status_event_kind` still **absent**
- `execute_callbacks` query still plans a **Seq Scan** (`Rows Removed by Filter: 2614`)

## Fix

Add the index as enterprise migration `117` (revises `116`) so it runs in the SaaS deployment. Uses `CREATE INDEX CONCURRENTLY` inside an `autocommit_block()` to avoid locking the table. The app_server `010.py` is retained for OSS deployments; both use `IF NOT EXISTS` and are safe to coexist.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-d168400   docker.openhands.dev/openhands/openhands:d168400
```