### PR TITLE
PLTF-2895: event_callback index — use plain CREATE INDEX

### DIFF
--- a/enterprise/migrations/versions/117_add_event_callback_composite_index.py
+++ b/enterprise/migrations/versions/117_add_event_callback_composite_index.py
@@ -5,14 +5,18 @@ but none of these columns were indexed, causing full sequential scans on the
 event_callback table for every event dispatch (INC-95). This composite index
 directly covers that query.
 
-The equivalent index is defined for the OSS app_server alembic chain in
-openhands/app_server/app_lifespan/alembic/versions/010.py. That chain is only
-run by OssAppLifespanService; the SaaS deployment applies DB migrations solely
-through this enterprise chain, so the index must also be created here. Both use
-IF NOT EXISTS so they are safe to coexist.
+Implementation note: this migration runs through the enterprise alembic harness
+(migrations/env.py), which acquires a session-level pg_advisory_lock on the
+migration connection before opening the migration transaction. That pre-opened
+transaction makes alembic's autocommit_block() (required for CREATE INDEX
+CONCURRENTLY) raise an AssertionError, so a CONCURRENTLY build is not possible
+here. event_callback is small, so a plain transactional CREATE INDEX completes
+in well under a second; the brief lock on writes during the build is acceptable
+and is consistent with every other migration in this chain.
 
-CREATE INDEX CONCURRENTLY is used (inside an autocommit block) to avoid locking
-the table during deployment.
+The OSS app_server chain creates the equivalent index in
+openhands/app_server/app_lifespan/alembic/versions/010.py. Both use IF NOT
+EXISTS so they are safe to coexist across deployment modes.
 
 Revision ID: 117
 Revises: 116
@@ -30,21 +34,17 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    with op.get_context().autocommit_block():
-        op.create_index(
-            'ix_event_callback_conversation_id_status_event_kind',
-            'event_callback',
-            ['conversation_id', 'status', 'event_kind'],
-            postgresql_concurrently=True,
-            if_not_exists=True,
-        )
+    op.create_index(
+        'ix_event_callback_conversation_id_status_event_kind',
+        'event_callback',
+        ['conversation_id', 'status', 'event_kind'],
+        if_not_exists=True,
+    )
 
 
 def downgrade() -> None:
-    with op.get_context().autocommit_block():
-        op.drop_index(
-            'ix_event_callback_conversation_id_status_event_kind',
-            table_name='event_callback',
-            postgresql_concurrently=True,
-            if_exists=True,
-        )
+    op.drop_index(
+        'ix_event_callback_conversation_id_status_event_kind',
+        table_name='event_callback',
+        if_exists=True,
+    )


### PR DESCRIPTION
- [x] A human has tested this

---

## Problem

The enterprise migration `117_add_event_callback_composite_index.py` (merged in 904e9cf) used `CREATE INDEX CONCURRENTLY` via `op.get_context().autocommit_block()`. **It crashes the `migrate-db` init container in staging**, blocking the deploy.

### Root cause (verified in staging)
The enterprise migration harness (`enterprise/migrations/env.py`) runs:
```python
connection.execute(text('SELECT pg_advisory_lock(...)'))   # opens a tx on the connection
with context.begin_transaction():
    context.run_migrations()
```
The advisory-lock statement opens a transaction that alembic does not own, so `autocommit_block()` raises an `AssertionError`; the transaction then aborts (`25P02 current transaction is aborted`) and the migration exits 1 (CrashLoopBackOff). Reproduced directly against the staging DB:
- `autocommit_block()` + CONCURRENTLY → `AssertionError` / failure
- plain transactional `CREATE INDEX` → success
- `alembic_version` stayed at `116`, no partial/invalid index left behind

## Fix

Drop `CONCURRENTLY`/`autocommit_block()` and create the index transactionally, like every other migration in this chain. `event_callback` is small (~2.6k rows in staging), so the build is sub-second and the brief write-lock during deploy is acceptable — and far better than the ongoing seq scans. `117` was never successfully applied anywhere (`alembic_version` is still `116`), so editing it in place is safe. The OSS app_server `010.py` is unchanged; both use `IF NOT EXISTS`.

## Verified in staging (PR build `sha-0c372034`, deployed without merging)

  | Check | Before (broken `117`, `CONCURRENTLY`) | After (this PR) |
  |---|---|---|
  | `migrate-db` init container | CrashLoopBackOff (`AssertionError` in `autocommit_block`) | `Running upgrade 116 -> 117` → completed cleanly |
  | `alembic_version` | `116` | `117` |
  | `ix_event_callback_conversation_id_status_event_kind` | absent | present & valid (`indisvalid=t`, `indisready=t`) |
  | `execute_callbacks` query plan | Seq Scan — `buffers=58`, 2614 rows removed by filter | Index Scan — `buffers=1`, 0 rows filtered |
  | Planner choice on the index | n/a | chosen by default planner (no `enable_seqscan=off` needed) |

The composite index is created and the `execute_callbacks` query now uses it.

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-34ce61a   docker.openhands.dev/openhands/openhands:34ce61a
```
