### PR TITLE
PLTF-2899: store GitHub PR timestamps as naive UTC (asyncpg DataError)

### DIFF
--- a/enterprise/integrations/github/data_collector.py
+++ b/enterprise/integrations/github/data_collector.py
@@ -658,6 +658,8 @@ class GitHubDataCollector:
         # Extract timestamps. Example: "closed_at":"2025-06-19T21:19:36Z".
         # Both are normalized to naive UTC so they can be bound to the naive
         # TIMESTAMP columns on openhands_prs (see _github_ts_to_naive_utc).
+        # Previously created_at was passed as a raw string; it is now
+        # consistently a naive-UTC datetime like closed_at.
         closed_at = _github_ts_to_naive_utc(pr_data.get('closed_at'))
         created_at = _github_ts_to_naive_utc(pr_data.get('created_at'))
 

--- a/enterprise/integrations/github/data_collector.py
+++ b/enterprise/integrations/github/data_collector.py
@@ -2,7 +2,7 @@ import base64
 import json
 import os
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
@@ -26,6 +26,25 @@ from openhands.app_server.integrations.service_types import ProviderType
 from openhands.app_server.utils.logger import openhands_logger as logger
 
 file_store = get_global_config().file_store
+
+
+def _github_ts_to_naive_utc(value: str | None) -> datetime | None:
+    """Normalize a GitHub ISO-8601 timestamp to a naive UTC datetime.
+
+    GitHub sends timestamps like ``"2025-06-19T21:19:36Z"``. Parsing the
+    trailing ``Z`` produces a timezone-aware datetime, which asyncpg refuses to
+    bind to the ``TIMESTAMP WITHOUT TIME ZONE`` columns on ``openhands_prs``
+    (``DataError: can't subtract offset-naive and offset-aware datetimes``).
+    Converting to UTC and dropping ``tzinfo`` keeps the stored value consistent
+    with how naive UTC timestamps are already persisted on that table.
+    """
+    if not value:
+        return None
+    return (
+        datetime.fromisoformat(value.replace('Z', '+00:00'))
+        .astimezone(timezone.utc)
+        .replace(tzinfo=None)
+    )
 
 
 COLLECT_GITHUB_INTERACTIONS = (
@@ -636,12 +655,11 @@ class GitHubDataCollector:
         num_deletions = pr_data.get('deletions', 0)
         merged = pr_data.get('merged', False)
 
-        # Extract closed_at timestamp
-        # Example: "closed_at":"2025-06-19T21:19:36Z"
-        closed_at_str = pr_data.get('closed_at')
-        created_at = pr_data.get('created_at')
-
-        closed_at = datetime.fromisoformat(closed_at_str.replace('Z', '+00:00'))
+        # Extract timestamps. Example: "closed_at":"2025-06-19T21:19:36Z".
+        # Both are normalized to naive UTC so they can be bound to the naive
+        # TIMESTAMP columns on openhands_prs (see _github_ts_to_naive_utc).
+        closed_at = _github_ts_to_naive_utc(pr_data.get('closed_at'))
+        created_at = _github_ts_to_naive_utc(pr_data.get('created_at'))
 
         # Determine status based on whether it was merged
         status = PRStatus.MERGED if merged else PRStatus.CLOSED

--- a/enterprise/tests/unit/integrations/github/test_data_collector_timestamps.py
+++ b/enterprise/tests/unit/integrations/github/test_data_collector_timestamps.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+
+import pytest
+from integrations.github.data_collector import _github_ts_to_naive_utc
+
+
+def test_z_suffix_parsed_as_naive_utc():
+    result = _github_ts_to_naive_utc('2025-06-19T21:19:36Z')
+    # Must be naive (tzinfo stripped) so it can bind to a
+    # TIMESTAMP WITHOUT TIME ZONE column via asyncpg.
+    assert result == datetime(2025, 6, 19, 21, 19, 36)
+    assert result.tzinfo is None
+
+
+def test_non_utc_offset_converted_to_utc():
+    # 21:19:36+02:00 == 19:19:36 UTC
+    result = _github_ts_to_naive_utc('2025-06-19T21:19:36+02:00')
+    assert result == datetime(2025, 6, 19, 19, 19, 36)
+    assert result.tzinfo is None
+
+
+@pytest.mark.parametrize('value', [None, ''])
+def test_missing_values_return_none(value):
+    assert _github_ts_to_naive_utc(value) is None


### PR DESCRIPTION
## Why

Every `closed`/`merged` GitHub PR webhook fails to record in `openhands_prs`. GitHub timestamps like `"2025-06-19T21:19:36Z"` are parsed into **timezone-aware** datetimes (`fromisoformat` on the `+00:00` form), but the `closed_at`/`created_at` columns are mapped as bare `DateTime` (`TIMESTAMP WITHOUT TIME ZONE`). asyncpg refuses to bind a tz-aware datetime to a naive column and raises `DataError: can't subtract offset-naive and offset-aware datetimes`. In production this fires continuously (~7/min) and PR analytics tracking has effectively not recorded closed/merged PRs.

Fixes #14654.

## Summary

- Add `_github_ts_to_naive_utc()` in `data_collector.py` that converts a GitHub ISO-8601 timestamp to a **naive UTC** datetime (and returns `None` for missing values).
- Use it for both `closed_at` and `created_at` (previously `closed_at` was tz-aware and `created_at` was passed through as a raw string — now both are consistent naive-UTC datetimes).
- Add unit tests for the normalizer.

No DB migration required: the values are normalized to naive UTC to match the existing `TIMESTAMP WITHOUT TIME ZONE` columns and how data is already stored.

## Issue Number

#14654

## How to Test

- `cd enterprise && uv run pytest tests/unit/integrations/github/test_data_collector_timestamps.py`
- Or send a `pull_request` webhook with `action: closed` (merged or not) through the GitHub integration and confirm `_track_closed_or_merged_pr` → `insert_pr` no longer raises `DataError` and the row is written.

## Type

- [x] Bug fix

## Notes

- Alternative considered: make the columns `DateTime(timezone=True)` (matches `storage/proactive_convos.py`) — rejected for this PR because it requires an Alembic migration and column-type change in prod; normalizing in code is the lower-risk fix and keeps stored values consistent with existing rows.

---
_This was created by an AI assistant._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-1fabfa7   docker.openhands.dev/openhands/openhands:1fabfa7
```