### PR TITLE
PLTF-2899: await SaaS get_user_id() in Slack repo-inference log

### DIFF
--- a/enterprise/integrations/slack/slack_manager.py
+++ b/enterprise/integrations/slack/slack_manager.py
@@ -604,7 +604,8 @@ class SlackManager(Manager[SlackViewInterface]):
             return False
 
         inferred_repo = inferred_repos[0]
-        user_id = await slack_view.saas_user_auth.get_user_id()
+        user_id: str | None = await slack_view.saas_user_auth.get_user_id()
+        # Fixes #14655
         logger.info(
             f'[Slack] Verifying inferred repo "{inferred_repo}" '
             f'for user {user.slack_display_name} (id={user_id})'

--- a/enterprise/integrations/slack/slack_manager.py
+++ b/enterprise/integrations/slack/slack_manager.py
@@ -604,9 +604,10 @@ class SlackManager(Manager[SlackViewInterface]):
             return False
 
         inferred_repo = inferred_repos[0]
+        user_id = await slack_view.saas_user_auth.get_user_id()
         logger.info(
             f'[Slack] Verifying inferred repo "{inferred_repo}" '
-            f'for user {user.slack_display_name} (id={slack_view.saas_user_auth.get_user_id()})'
+            f'for user {user.slack_display_name} (id={user_id})'
         )
 
         try:


### PR DESCRIPTION
## Why

`SaasUserAuth.get_user_id()` is `async`, but in the Slack repo-inference path it was called **without `await`** inside a log f-string. That logged a coroutine object instead of the id and emitted `RuntimeWarning: coroutine 'SaasUserAuth.get_user_id' was never awaited` on every Slack repo-verification.

Fixes #14655.

## Summary

- `await` `get_user_id()` into a local before formatting the log line in `_try_verify_inferred_repo` (`enterprise/integrations/slack/slack_manager.py`).

## Issue Number

#14655

## How to Test

- Trigger a Slack message that infers a single repo and confirm the `[Slack] Verifying inferred repo ...` log line shows a real user id and no `coroutine ... was never awaited` RuntimeWarning is emitted.

## Type

- [x] Bug fix

## Notes

- The other half of #14655 (partial Slack payloads logged as `slack_error_no_view`) already has good diagnostics at `slack_types.py` `from_payload` (it logs `has_team_id`/`has_channel_id`/`has_user_id` and `payload_keys`). This PR intentionally scopes to the concrete un-awaited-coroutine bug; deciding whether certain partial payloads should be silently ignored vs. surfaced is left for follow-up on the issue.

---
_This was created by an AI assistant._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-6dd2efc   docker.openhands.dev/openhands/openhands:6dd2efc
```