### PR TITLE
APP-2218: add indexes on conversation_metadata_saas (user_id, org_id)

### DIFF
--- a/enterprise/migrations/versions/118_add_conversation_metadata_saas_indexes.py
+++ b/enterprise/migrations/versions/118_add_conversation_metadata_saas_indexes.py
@@ -1,0 +1,58 @@
+"""Add indexes on conversation_metadata_saas for user_id / org_id lookups
+
+conversation_metadata_saas only had the conversation_id primary-key index, so
+every query filtering by user_id or org_id did a full table scan — the
+2nd-heaviest sequential-scan table in prod (~680K seq scans, ~42B rows read
+since mid-December).
+
+Indexes added (matched to the actual query paths):
+  - (user_id, org_id): the conversation-listing path filters by user_id and
+    optionally org_id; the leftmost prefix also serves the user_id-only delete.
+  - (org_id): org-admin paths select/delete by org_id alone.
+
+Plain CREATE INDEX (not CONCURRENTLY): the enterprise migration harness runs
+inside a transaction with an advisory lock, where alembic's autocommit_block
+fails (see migration 117). conversation_metadata_saas is small (~124K rows /
+12MB), so the build is sub-second and the brief write lock is acceptable.
+
+Revision ID: 118
+Revises: 117
+Create Date: 2026-06-04
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = '118'
+down_revision: Union[str, None] = '117'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        'ix_conversation_metadata_saas_user_id_org_id',
+        'conversation_metadata_saas',
+        ['user_id', 'org_id'],
+        if_not_exists=True,
+    )
+    op.create_index(
+        'ix_conversation_metadata_saas_org_id',
+        'conversation_metadata_saas',
+        ['org_id'],
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        'ix_conversation_metadata_saas_org_id',
+        table_name='conversation_metadata_saas',
+        if_exists=True,
+    )
+    op.drop_index(
+        'ix_conversation_metadata_saas_user_id_org_id',
+        table_name='conversation_metadata_saas',
+        if_exists=True,
+    )

--- a/enterprise/storage/stored_conversation_metadata_saas.py
+++ b/enterprise/storage/stored_conversation_metadata_saas.py
@@ -28,9 +28,7 @@ class StoredConversationMetadataSaas(Base):
         #   (user_id, org_id): conversation listing filters by user_id and
         #     optionally org_id; the prefix also serves user_id-only deletes.
         #   (org_id): org-admin paths select/delete by org_id alone.
-        Index(
-            'ix_conversation_metadata_saas_user_id_org_id', 'user_id', 'org_id'
-        ),
+        Index('ix_conversation_metadata_saas_user_id_org_id', 'user_id', 'org_id'),
         Index('ix_conversation_metadata_saas_org_id', 'org_id'),
     )
 

--- a/enterprise/storage/stored_conversation_metadata_saas.py
+++ b/enterprise/storage/stored_conversation_metadata_saas.py
@@ -8,7 +8,7 @@ containing only the conversation_id, user_id, and org_id.
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import ForeignKey, String
+from sqlalchemy import ForeignKey, Index, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from storage.base import Base
 
@@ -21,6 +21,18 @@ class StoredConversationMetadataSaas(Base):
     """SaaS conversation metadata model containing user and org associations."""
 
     __tablename__ = 'conversation_metadata_saas'
+    __table_args__ = (
+        # The only pre-existing index was the conversation_id PK, so every query
+        # filtering by user_id or org_id did a full table scan (~680K seq scans /
+        # ~42B rows read in prod). These cover those paths:
+        #   (user_id, org_id): conversation listing filters by user_id and
+        #     optionally org_id; the prefix also serves user_id-only deletes.
+        #   (org_id): org-admin paths select/delete by org_id alone.
+        Index(
+            'ix_conversation_metadata_saas_user_id_org_id', 'user_id', 'org_id'
+        ),
+        Index('ix_conversation_metadata_saas_org_id', 'org_id'),
+    )
 
     conversation_id: Mapped[str] = mapped_column(String, primary_key=True)
     user_id: Mapped[UUID] = mapped_column(ForeignKey('user.id'), nullable=False)


### PR DESCRIPTION
Closes #14631

## Problem
`conversation_metadata_saas` only has the `conversation_id` primary-key index, so every query filtering by `user_id` or `org_id` does a full table scan — one of the heaviest sequential-scan tables in prod (~680K seq scans, ~42B rows read).

## The unindexed query paths
Table is `(conversation_id PK, user_id, org_id)`. Seq scans come from:
- conversation listing — `saas_app_conversation_info_injector.py` filters `user_id == ?` and optionally `org_id == ?`
- `user_store.py` — `DELETE … WHERE user_id = ?`
- `org_store.py` — `SELECT/DELETE … WHERE org_id = ?`

## Fix
Migration `118` (revises `117`) adds two indexes matched to those paths, and declares them on the model:
- **`(user_id, org_id)`** — listing path (`user_id` always, `org_id` optional) + `user_id`-only delete via prefix
- **`(org_id)`** — org-admin paths filtering by `org_id` alone

Plain `CREATE INDEX` (not `CONCURRENTLY`): the enterprise harness runs migrations on pg8000 inside a transaction with an advisory lock, where alembic's `autocommit_block` fails (see #14651). At ~124K rows / 12 MB the build is sub-second.

_Generated by an AI assistant._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-93b38cc   docker.openhands.dev/openhands/openhands:93b38cc
```