### PR TITLE
docs: use installable netcat package on Linux

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -78,7 +78,7 @@ This guide covers Ubuntu/Debian. For other distributions, adapt the package mana
 sudo apt update
 
 # Install system dependencies
-sudo apt install -y build-essential curl netcat software-properties-common
+sudo apt install -y build-essential curl netcat-openbsd software-properties-common
 
 # Install Python 3.12
 # Ubuntu 24.04+ and Debian 13+ ship with Python 3.12 — skip the PPA step if


### PR DESCRIPTION
HUMAN:
This PR updates the Linux setup docs to install `netcat-openbsd`, which provides the `nc` command OpenHands expects on Ubuntu/Debian.
- [ ] A human has tested these changes.

## Summary
- Update the Linux setup command to install `netcat-openbsd` instead of the ambiguous `netcat` package.
- Match the setup docs with the repo troubleshooting note for the `nc` binary.

## Validation
- `brew install poetry`
- `make install-pre-commit-hooks`
- `poetry run pre-commit run --files Development.md --config ./dev_config/python/.pre-commit-config.yaml`
- `git diff --check`
- `git show --stat --check --oneline HEAD`