### PR TITLE
fix: include user skill dirs in skills search

### DIFF
--- a/openhands/app_server/user/skills_router.py
+++ b/openhands/app_server/user/skills_router.py
@@ -13,7 +13,12 @@ router = APIRouter(prefix='/skills', tags=['Skills'], dependencies=get_dependenc
 
 # skills/ is at the repo root, two levels above the openhands package __file__
 GLOBAL_SKILLS_DIR = Path(openhands.__file__).parent.parent / 'skills'
-USER_SKILLS_DIR = Path.home() / '.openhands' / 'microagents'
+USER_SKILLS_DIRS = (
+    Path.home() / '.agents' / 'skills',
+    Path.home() / '.openhands' / 'skills',
+    Path.home() / '.openhands' / 'skills' / 'installed',
+    Path.home() / '.openhands' / 'microagents',
+)
 
 
 class SkillInfo(BaseModel):
@@ -131,10 +136,11 @@ async def search_skills(
         logger.warning(f'Failed to load global skills: {e}')
 
     # Load user-level skills
-    try:
-        skills.extend(_load_skills_from_dir(USER_SKILLS_DIR, 'user'))
-    except Exception as e:
-        logger.warning(f'Failed to load user skills: {e}')
+    for user_skills_dir in USER_SKILLS_DIRS:
+        try:
+            skills.extend(_load_skills_from_dir(user_skills_dir, 'user'))
+        except Exception as e:
+            logger.warning(f'Failed to load user skills from {user_skills_dir}: {e}')
 
     # Sort by source (global first), then by name
     skills.sort(key=lambda s: (s.source, s.name))

--- a/tests/unit/server/routes/test_skills_api.py
+++ b/tests/unit/server/routes/test_skills_api.py
@@ -117,8 +117,8 @@ async def test_skills_search_returns_skills(test_client, tmp_path):
     with (
         patch('openhands.app_server.user.skills_router.GLOBAL_SKILLS_DIR', global_dir),
         patch(
-            'openhands.app_server.user.skills_router.USER_SKILLS_DIR',
-            tmp_path / 'nonexistent',
+            'openhands.app_server.user.skills_router.USER_SKILLS_DIRS',
+            (tmp_path / 'nonexistent',),
         ),
     ):
         response = test_client.get('/api/v1/skills/search')
@@ -157,8 +157,8 @@ async def test_skills_search_handles_missing_dirs(test_client, tmp_path):
             tmp_path / 'no_such_dir',
         ),
         patch(
-            'openhands.app_server.user.skills_router.USER_SKILLS_DIR',
-            tmp_path / 'also_missing',
+            'openhands.app_server.user.skills_router.USER_SKILLS_DIRS',
+            (tmp_path / 'also_missing',),
         ),
     ):
         response = test_client.get('/api/v1/skills/search')
@@ -181,7 +181,7 @@ async def test_skills_search_sorted_by_source_then_name(test_client, tmp_path):
 
     with (
         patch('openhands.app_server.user.skills_router.GLOBAL_SKILLS_DIR', global_dir),
-        patch('openhands.app_server.user.skills_router.USER_SKILLS_DIR', user_dir),
+        patch('openhands.app_server.user.skills_router.USER_SKILLS_DIRS', (user_dir,)),
     ):
         response = test_client.get('/api/v1/skills/search')
 
@@ -210,8 +210,8 @@ async def test_skills_search_pagination(test_client, tmp_path):
     with (
         patch('openhands.app_server.user.skills_router.GLOBAL_SKILLS_DIR', global_dir),
         patch(
-            'openhands.app_server.user.skills_router.USER_SKILLS_DIR',
-            tmp_path / 'nonexistent',
+            'openhands.app_server.user.skills_router.USER_SKILLS_DIRS',
+            (tmp_path / 'nonexistent',),
         ),
     ):
         # First page with limit=2
@@ -233,6 +233,38 @@ async def test_skills_search_pagination(test_client, tmp_path):
         assert len(data['items']) == 1
         assert data['items'][0]['name'] == 'skill_c'
         assert data['next_page_id'] is None
+
+
+@pytest.mark.asyncio
+async def test_skills_search_reads_all_user_skill_dirs(test_client, tmp_path):
+    global_dir = tmp_path / 'global'
+    user_dirs = (
+        tmp_path / '.agents' / 'skills',
+        tmp_path / '.openhands' / 'skills',
+        tmp_path / '.openhands' / 'skills' / 'installed',
+        tmp_path / '.openhands' / 'microagents',
+    )
+
+    _write_skill_file(user_dirs[0], 'agent_skill')
+    _write_skill_file(user_dirs[1], 'openhands_skill')
+    _write_skill_file(user_dirs[2], 'installed_skill')
+    _write_skill_file(user_dirs[3], 'microagent_skill')
+
+    with (
+        patch('openhands.app_server.user.skills_router.GLOBAL_SKILLS_DIR', global_dir),
+        patch('openhands.app_server.user.skills_router.USER_SKILLS_DIRS', user_dirs),
+    ):
+        response = test_client.get('/api/v1/skills/search')
+
+    assert response.status_code == 200
+    skills = response.json()['items']
+    assert {skill['name'] for skill in skills} == {
+        'agent_skill',
+        'openhands_skill',
+        'installed_skill',
+        'microagent_skill',
+    }
+    assert {skill['source'] for skill in skills} == {'user'}
 
 
 def test_global_skills_dir_points_to_repo_root():


### PR DESCRIPTION
HUMAN:
This is deliberately scoped to the app-server skills search endpoint. It makes the WebUI skill list look in the same user-level skill locations discussed in OpenHands/software-agent-sdk#4252 while leaving the Docker / agent-server runtime visibility path as a separate follow-up.

- [ ] A human has tested these changes.

## Summary

- include the documented user skill locations in `/api/v1/skills/search`
- keep the legacy `~/.openhands/microagents` lookup for compatibility
- add a route-level regression test that covers all user skill directories

## Notes

Refs OpenHands/software-agent-sdk#4252. This only fixes the app-server skills search endpoint so user skills in `~/.agents/skills`, `~/.openhands/skills`, and `~/.openhands/skills/installed` are visible to the WebUI list. The Docker / agent-server runtime visibility path is separate and may still need a follow-up change.

## To verify

```bash
python -m pytest tests/unit/server/routes/test_skills_api.py -q
python -m ruff check openhands/app_server/user/skills_router.py tests/unit/server/routes/test_skills_api.py
git diff --check
python -m py_compile openhands/app_server/user/skills_router.py tests/unit/server/routes/test_skills_api.py
```
