### PR TITLE
feat(acp): snapshot ACP agent spec at conversation creation (#1015)

### DIFF
--- a/enterprise/migrations/versions/118_add_acp_agent_settings_snapshot.py
+++ b/enterprise/migrations/versions/118_add_acp_agent_settings_snapshot.py
@@ -1,0 +1,36 @@
+"""Add acp_agent_settings_snapshot column to conversation_metadata table.
+
+Stores a secret-free snapshot of the ACP agent spec, frozen at conversation
+creation, so a later edit to the user's global agent settings cannot silently
+re-target an in-flight ACP conversation when its recycled sandbox is rebuilt
+(agent-canvas#1015). Provider credentials and other secrets are NOT persisted
+here — they are re-resolved from the live encrypted vault on every build
+(agent-canvas#1016) — so a plain JSON column is sufficient. NULL for non-ACP
+conversations and for ACP conversations created before this column landed.
+
+Revision ID: 118
+Revises: 117
+Create Date: 2026-06-05
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '118'
+down_revision: Union[str, None] = '117'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'conversation_metadata',
+        sa.Column('acp_agent_settings_snapshot', sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('conversation_metadata', 'acp_agent_settings_snapshot')

--- a/enterprise/tests/unit/storage/test_saas_sql_app_conversation_info_service.py
+++ b/enterprise/tests/unit/storage/test_saas_sql_app_conversation_info_service.py
@@ -281,6 +281,7 @@ class TestSaasSQLAppConversationInfoService:
         stored_metadata.public = None
         stored_metadata.tags = {}
         stored_metadata.agent_kind = None
+        stored_metadata.acp_agent_settings_snapshot = None
 
         saas_metadata = MagicMock(spec=StoredConversationMetadataSaas)
         saas_metadata.user_id = UUID('a1111111-1111-1111-1111-111111111111')

--- a/openhands/app_server/app_conversation/app_conversation_models.py
+++ b/openhands/app_server/app_conversation/app_conversation_models.py
@@ -23,6 +23,7 @@ from openhands.app_server.settings.settings_models import SandboxGroupingStrateg
 from openhands.sdk.conversation import ConversationExecutionStatus
 from openhands.sdk.llm import MetricsSnapshot
 from openhands.sdk.plugin import PluginSource
+from openhands.sdk.settings import ACPAgentSettings
 
 __all__ = ['SandboxGroupingStrategy']
 
@@ -103,6 +104,23 @@ class AppConversationInfo(BaseModel):
     pr_number: list[int] = Field(default_factory=list)
     llm_model: str | None = None
     agent_kind: str = 'openhands'
+
+    # Conversation-scoped snapshot of the ACP agent spec, frozen at creation.
+    # The cloud backend rebuilds the ACP agent from the user's *global* settings
+    # whenever a recycled sandbox is restarted (#14640); re-resolving from live
+    # settings lets a settings edit between create and resume silently re-target
+    # an in-flight conversation (e.g. Claude Code -> Codex). Pinning the spec
+    # here makes the agent identity conversation-scoped, mirroring how the
+    # regular agent rides the agent-server's meta.json snapshot (#1015).
+    # Secret-bearing fields are stripped before persisting — provider creds,
+    # acp_env, mcp_config and agent_context are re-resolved from the live
+    # encrypted vault on every build, so nothing secret persists at rest (#1016).
+    # Internal: persisted via the explicit SQL mapping and read back by
+    # attribute on resume; excluded from serialization so it neither bloats
+    # conversation-list responses nor leaks the spec into the public API.
+    acp_agent_settings_snapshot: ACPAgentSettings | None = Field(
+        default=None, exclude=True
+    )
 
     metrics: MetricsSnapshot | None = None
 

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -138,6 +138,80 @@ _ACP_RESUME_MESSAGE_MAX_CHARS = 8_000  # per message turn
 _ACP_RESUME_TOOL_MAX_CHARS = 2_000  # per tool event
 
 
+# --- ACP agent-spec snapshot (#1015) ---------------------------------------
+# The cloud backend rebuilds the ACP agent from the user's *global* settings
+# whenever a recycled sandbox is restarted (#14640). Re-resolving from live
+# settings lets a settings edit between create and resume silently re-target an
+# in-flight conversation (e.g. Claude Code -> Codex, or a model swap). We freeze
+# the agent spec onto the conversation at creation and rebuild from it on
+# resume, mirroring how the regular agent rides the agent-server's meta.json
+# snapshot. Secrets are never frozen: provider creds, acp_env, mcp_config and
+# agent_context are re-resolved from the live encrypted vault on every build so
+# nothing secret persists at rest in the conversation_metadata JSON column,
+# which dumps with expose_secrets (#1016).
+
+
+def _snapshot_acp_settings(settings: ACPAgentSettings) -> ACPAgentSettings:
+    """Return a secret-free, conversation-scoped copy of an ACP agent spec.
+
+    Clears every secret-bearing field (LLM credentials, ``acp_env``,
+    ``mcp_config``, ``agent_context``) so the snapshot can be persisted to the
+    plain ``conversation_metadata`` JSON column without leaking secrets at rest.
+    The identity fields that must stay stable across a resume — ``acp_server``,
+    ``acp_model``, ``acp_session_mode``, ``acp_command``/``acp_args``, timeouts
+    and the metrics ``llm.model`` — are preserved verbatim.
+    """
+    return settings.model_copy(
+        update={
+            'llm': settings.llm.model_copy(
+                update={
+                    'api_key': None,
+                    'base_url': None,
+                    'aws_access_key_id': None,
+                    'aws_secret_access_key': None,
+                    'aws_session_token': None,
+                }
+            ),
+            'acp_env': {},
+            'mcp_config': None,
+            'agent_context': None,
+        }
+    )
+
+
+def _restore_acp_settings(
+    snapshot: ACPAgentSettings, live: ACPAgentSettings
+) -> ACPAgentSettings:
+    """Rebuild effective ACP settings from a frozen snapshot + live secrets.
+
+    The snapshot pins the agent identity; the secret-bearing fields it dropped
+    are re-attached from the user's current (live) settings — i.e. from the
+    encrypted vault — so credentials stay fresh and are never read from the
+    at-rest snapshot. Provider credentials (``llm.api_key``/``base_url``) are
+    only re-attached when the live provider still matches the snapshot's: after
+    a mid-conversation provider switch the live key belongs to a *different*
+    provider, so injecting it under the snapshot provider's env var would be
+    wrong. In that case the subprocess falls back to its ambient/materialised
+    auth rather than receiving a mismatched key. (Per-provider credential
+    storage that removes this limitation is tracked by #1022.)
+    """
+    update: dict[str, object] = {
+        'acp_env': dict(live.acp_env),
+        'mcp_config': live.mcp_config,
+    }
+    if live.acp_server == snapshot.acp_server:
+        update['llm'] = snapshot.llm.model_copy(
+            update={
+                'api_key': live.llm.api_key,
+                'base_url': live.llm.base_url,
+                'aws_access_key_id': live.llm.aws_access_key_id,
+                'aws_secret_access_key': live.llm.aws_secret_access_key,
+                'aws_session_token': live.llm.aws_session_token,
+            }
+        )
+    return snapshot.model_copy(update=update)
+
+
 def _truncate_keep_head(text: str, max_chars: int) -> str:
     """Truncate to at most max_chars, keeping the start."""
     if max_chars <= 0:
@@ -559,6 +633,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             # the same agent back through the AgentBase discriminator.
             request_agent = start_conversation_request.agent
             tags: dict[str, str] = {}
+            acp_agent_settings_snapshot: ACPAgentSettings | None = None
             if request_agent.agent_kind == 'acp':
                 llm_model = None
                 agent_kind = 'acp'
@@ -568,6 +643,21 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 acp_user = await self.user_context.get_user_info()
                 if isinstance(acp_user.agent_settings, ACPAgentSettings):
                     tags['acp_server'] = acp_user.agent_settings.acp_server
+                    # Freeze the ACP agent spec onto the conversation at
+                    # creation so a later global-settings edit can't re-target
+                    # it when a recycled sandbox is rebuilt (#1015). On resume
+                    # the row already carries a snapshot; preserve it, since the
+                    # merge below would otherwise overwrite the frozen spec with
+                    # a fresh one resolved from (possibly changed) live settings.
+                    existing = await self.app_conversation_info_service.get_app_conversation_info(  # noqa: E501
+                        info.id
+                    )
+                    acp_agent_settings_snapshot = (
+                        existing.acp_agent_settings_snapshot
+                        if existing is not None
+                        and existing.acp_agent_settings_snapshot is not None
+                        else _snapshot_acp_settings(acp_user.agent_settings)
+                    )
             else:
                 llm_model = request_agent.llm.model
                 agent_kind = 'openhands'
@@ -580,6 +670,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 llm_model=llm_model,
                 agent_kind=agent_kind,
                 tags=tags,
+                acp_agent_settings_snapshot=acp_agent_settings_snapshot,
                 # Git parameters
                 selected_repository=request.selected_repository,
                 selected_branch=request.selected_branch,
@@ -1956,8 +2047,28 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             initial_message = resume_result
 
         # --- build the ACP agent ------------------------------------------
-        acp_settings = user.agent_settings  # already verified to be ACPAgentSettings
-        assert isinstance(acp_settings, ACPAgentSettings)
+        live_settings = user.agent_settings  # already verified to be ACPAgentSettings
+        assert isinstance(live_settings, ACPAgentSettings)
+
+        # Use the conversation-scoped spec snapshot frozen at creation, if one
+        # exists, instead of the live (mutable, global) settings. This keeps the
+        # agent identity stable when a recycled sandbox is rebuilt (#14640): a
+        # settings edit between create and resume can no longer silently switch
+        # an in-flight conversation's provider or model. Secret-bearing fields
+        # were stripped from the snapshot and are re-attached here from the live
+        # vault. Falls back to live settings on a fresh conversation, or for ACP
+        # conversations created before snapshotting landed.
+        existing_info = (
+            await self.app_conversation_info_service.get_app_conversation_info(  # noqa: E501
+                conversation_id
+            )
+        )
+        snapshot = existing_info.acp_agent_settings_snapshot if existing_info else None
+        acp_settings = (
+            _restore_acp_settings(snapshot, live_settings)
+            if snapshot is not None
+            else live_settings
+        )
 
         # acp_settings.create_agent() folds provider creds into agent_context.secrets
         # (sdk#3464). Pass SecretSource objects verbatim — the SDK resolves them

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -58,6 +58,7 @@ from openhands.app_server.utils.sql_utils import (
 from openhands.sdk import ConversationStats
 from openhands.sdk.event import ConversationStateUpdateEvent
 from openhands.sdk.llm import MetricsSnapshot, TokenUsage
+from openhands.sdk.settings import ACPAgentSettings
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +115,17 @@ class StoredConversationMetadata(Base):
     # Tags for conversation metadata (e.g., automation context, skills used)
     tags: Mapped[dict[str, str] | None] = mapped_column(
         create_json_type_decorator(dict[str, str]), nullable=True
+    )
+
+    # Snapshot of the ACP agent spec, frozen at conversation creation so a later
+    # edit to the user's global agent settings can't silently re-target an
+    # in-flight conversation when its sandbox is recycled and rebuilt (#1015).
+    # Secret-bearing fields are stripped before persisting (provider creds etc.
+    # are re-resolved from the live encrypted vault on every build), so this
+    # plain JSON column never holds secrets at rest (#1016). NULL for non-ACP
+    # conversations and for ACP conversations created before this column landed.
+    acp_agent_settings_snapshot: Mapped[ACPAgentSettings | None] = mapped_column(
+        create_json_type_decorator(ACPAgentSettings | None), nullable=True
     )
 
 
@@ -381,6 +393,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             ),
             public=info.public,
             tags=info.tags if info.tags else None,
+            acp_agent_settings_snapshot=info.acp_agent_settings_snapshot,
         )
 
         await self.db_session.merge(stored)
@@ -570,6 +583,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             sub_conversation_ids=sub_conversation_ids or [],
             public=stored.public,
             tags=stored.tags or {},
+            acp_agent_settings_snapshot=stored.acp_agent_settings_snapshot,
             created_at=created_at,
             updated_at=updated_at,
         )

--- a/openhands/app_server/app_lifespan/alembic/versions/011.py
+++ b/openhands/app_server/app_lifespan/alembic/versions/011.py
@@ -1,0 +1,35 @@
+"""Add acp_agent_settings_snapshot column to conversation_metadata table
+
+Revision ID: 011
+Revises: 010
+Create Date: 2026-06-05
+
+Stores a secret-free snapshot of the ACP agent spec, frozen at conversation
+creation, so a later edit to the user's global agent settings cannot silently
+re-target an in-flight ACP conversation when its recycled sandbox is rebuilt
+(agent-canvas#1015). Provider credentials and other secrets are NOT persisted
+here — they are re-resolved from the live encrypted vault on every build
+(agent-canvas#1016) — so a plain JSON column is sufficient. NULL for non-ACP
+conversations and for ACP conversations created before this column landed.
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '011'
+down_revision: str | None = '010'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'conversation_metadata',
+        sa.Column('acp_agent_settings_snapshot', sa.JSON, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('conversation_metadata', 'acp_agent_settings_snapshot')

--- a/openhands/app_server/utils/sql_utils.py
+++ b/openhands/app_server/utils/sql_utils.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 from enum import Enum
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from pydantic import SecretStr, TypeAdapter
 from sqlalchemy import JSON, DateTime, String, TypeDecorator
@@ -22,8 +22,13 @@ class Base(DeclarativeBase):
 T = TypeVar('T', bound=Enum)
 
 
-def create_json_type_decorator(object_type: type):
-    """Create a decorator for a particular type. Introduced because SQLAlchemy could not process lists of enum values."""
+def create_json_type_decorator(object_type: Any):
+    """Create a decorator for a particular type. Introduced because SQLAlchemy could not process lists of enum values.
+
+    ``object_type`` accepts anything ``pydantic.TypeAdapter`` understands —
+    concrete classes, generic aliases (``list[int]``) and unions
+    (``Model | None``).
+    """
     type_adapter: TypeAdapter = TypeAdapter(object_type)
 
     class JsonTypeDecorator(TypeDecorator):

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -1715,6 +1715,115 @@ class TestLiveStatusAppConversationService:
         assert saved_info.id == conversation_id
 
     @pytest.mark.asyncio
+    @patch(
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace'
+    )
+    @patch(
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.ConversationInfo'
+    )
+    async def test_start_app_conversation_persists_acp_spec_snapshot(
+        self, mock_conversation_info_class, mock_remote_workspace_class
+    ):
+        """A fresh ACP conversation freezes a secret-free spec snapshot (#1015)."""
+        from openhands.sdk.settings import ACPAgentSettings
+
+        conversation_id = uuid4()
+
+        acp_user = _TestUserInfo(
+            id='test_user_123',
+            llm_model='',
+            llm_base_url=None,
+            llm_api_key=None,
+            sandbox_grouping_strategy=SandboxGroupingStrategy.ADD_TO_ANY,
+            confirmation_mode=False,
+            security_analyzer=None,
+            search_api_key=None,
+            mcp_config=None,
+            disabled_skills=[],
+        )
+        acp_user.agent_settings = ACPAgentSettings(
+            acp_server='claude-code',
+            acp_model='claude-opus-4-6',
+            llm=LLM(
+                model='claude-sonnet-4-5',
+                api_key=SecretStr('sk-ui-key'),
+                usage_id='acp',
+            ),
+        )
+        self.mock_user_context.get_user_id = AsyncMock(return_value='test_user_123')
+        self.mock_user_context.get_user_info = AsyncMock(return_value=acp_user)
+
+        # Fresh conversation: no persisted snapshot yet -> the service freezes one.
+        self.mock_app_conversation_info_service.get_app_conversation_info = AsyncMock(
+            return_value=None
+        )
+        self.mock_app_conversation_info_service.save_app_conversation_info = AsyncMock()
+
+        mock_sandbox_spec = Mock(spec=SandboxSpecInfo)
+        mock_sandbox_spec.working_dir = '/test/workspace'
+        self.mock_sandbox.sandbox_spec_id = str(uuid4())
+        self.mock_sandbox.id = str(uuid4())
+        self.mock_sandbox.session_api_key = 'test_session_key'
+        self.mock_sandbox.exposed_urls = [
+            ExposedUrl(name=AGENT_SERVER, url='http://agent-server:8000', port=60000)
+        ]
+        self.mock_sandbox_service.get_sandbox = AsyncMock(
+            return_value=self.mock_sandbox
+        )
+        self.mock_sandbox_spec_service.get_sandbox_spec = AsyncMock(
+            return_value=mock_sandbox_spec
+        )
+        mock_remote_workspace_class.return_value = Mock()
+
+        async def mock_wait_for_sandbox(task):
+            task.sandbox_id = self.mock_sandbox.id
+            yield task
+
+        async def mock_run_setup_scripts(task, sandbox, workspace, agent_server_url):
+            yield task
+
+        self.service._wait_for_sandbox_start = mock_wait_for_sandbox
+        self.service.run_setup_scripts = mock_run_setup_scripts
+        self.service._seed_sandbox_profiles = AsyncMock()
+
+        # Only the built request's agent_kind matters; the build itself is mocked.
+        mock_start_request = Mock(spec=StartConversationRequest)
+        mock_start_request.agent = SimpleNamespace(agent_kind='acp')
+        mock_start_request.model_dump.return_value = {'test': 'data'}
+        self.service._build_start_conversation_request_for_user = AsyncMock(
+            return_value=mock_start_request
+        )
+
+        mock_conversation_info = Mock()
+        mock_conversation_info.id = conversation_id
+        mock_conversation_info_class.model_validate.return_value = (
+            mock_conversation_info
+        )
+
+        mock_response = Mock()
+        mock_response.json.return_value = {'id': str(conversation_id)}
+        mock_response.raise_for_status = Mock()
+        self.mock_httpx_client.post = AsyncMock(return_value=mock_response)
+        self.mock_event_callback_service.save_event_callback = AsyncMock()
+
+        async for _ in self.service._start_app_conversation(
+            AppConversationStartRequest()
+        ):
+            pass
+
+        self.mock_app_conversation_info_service.save_app_conversation_info.assert_called_once()  # noqa: E501
+        saved_info = self.mock_app_conversation_info_service.save_app_conversation_info.call_args[
+            0
+        ][0]
+        assert saved_info.agent_kind == 'acp'
+        snap = saved_info.acp_agent_settings_snapshot
+        assert snap is not None
+        assert snap.acp_server == 'claude-code'
+        assert snap.acp_model == 'claude-opus-4-6'
+        # Credentials are never frozen into the at-rest snapshot (#1016).
+        assert snap.llm.api_key is None
+
+    @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_with_custom_remote_servers(self):
         """Test _configure_llm_and_mcp merges custom remote servers."""
         from fastmcp.mcp_config import MCPConfig, RemoteMCPServer
@@ -3290,6 +3399,11 @@ class TestBuildAcpStartConversationRequestSecrets:
         service.event_service.search_events = AsyncMock(
             return_value=EventPage(items=[], next_page_id=None)
         )
+        # No persisted spec snapshot for a fresh conversation, so the build uses
+        # the live settings (see TestAcpAgentSettingsSnapshot for the resume path).
+        service.app_conversation_info_service.get_app_conversation_info = AsyncMock(
+            return_value=None
+        )
         sandbox = Mock(spec=SandboxInfo)
         return service._build_acp_start_conversation_request(
             sandbox=sandbox,
@@ -3664,6 +3778,9 @@ class TestSynthesizeAcpResumeInitialMessage:
         service.user_context.get_user_info = AsyncMock(return_value=user)
         service.user_context.get_user_email = AsyncMock(return_value=None)
         service._setup_secrets_for_git_providers = AsyncMock(return_value={})
+        service.app_conversation_info_service.get_app_conversation_info = AsyncMock(
+            return_value=None
+        )
 
         import tempfile
 
@@ -3720,6 +3837,9 @@ class TestSynthesizeAcpResumeInitialMessage:
         service.user_context.get_user_info = AsyncMock(return_value=user)
         service.user_context.get_user_email = AsyncMock(return_value=None)
         service._setup_secrets_for_git_providers = AsyncMock(return_value={})
+        service.app_conversation_info_service.get_app_conversation_info = AsyncMock(
+            return_value=None
+        )
 
         import tempfile
 
@@ -4132,3 +4252,219 @@ class TestSynthesizeAcpResumeInitialMessage:
         # Failure details at the end must appear
         assert 'AssertionError' in text
         assert '1 failed, 20 passed' in text
+
+
+class TestAcpAgentSettingsSnapshot:
+    """ACP agent-spec snapshot at creation + restore on resume (#1015).
+
+    The cloud backend rebuilds the ACP agent from the user's *global* settings
+    whenever a recycled sandbox is restarted. These tests pin the behaviour that
+    a settings edit between create and resume can no longer silently re-target an
+    in-flight conversation, while keeping credentials out of the at-rest snapshot
+    (#1016).
+    """
+
+    @pytest.fixture
+    def service(self):
+        return LiveStatusAppConversationService(
+            init_git_in_empty_workspace=True,
+            user_context=Mock(spec=UserContext),
+            app_conversation_info_service=Mock(),
+            app_conversation_start_task_service=Mock(),
+            event_callback_service=Mock(),
+            event_service=Mock(),
+            sandbox_service=Mock(),
+            sandbox_spec_service=Mock(),
+            jwt_service=Mock(),
+            pending_message_service=Mock(),
+            sandbox_startup_timeout=30,
+            sandbox_startup_poll_frequency=1,
+            max_num_conversations_per_sandbox=20,
+            httpx_client=Mock(),
+            web_url=None,
+            openhands_provider_base_url=None,
+            access_token_hard_timeout=None,
+            app_mode='test',
+        )
+
+    def _acp_settings(self, acp_server='claude-code', acp_model=None, api_key=None):
+        from openhands.sdk.settings import ACPAgentSettings
+
+        return ACPAgentSettings(
+            acp_server=acp_server,  # type: ignore[arg-type]
+            acp_model=acp_model,
+            llm=LLM(
+                model='claude-sonnet-4-5',
+                api_key=SecretStr(api_key) if api_key else None,
+                usage_id='acp',
+            ),
+        )
+
+    def _make_user(self, settings):
+        user = _TestUserInfo(
+            id='u1',
+            llm_model='',
+            llm_base_url=None,
+            llm_api_key=None,
+            sandbox_grouping_strategy=SandboxGroupingStrategy.ADD_TO_ANY,
+            confirmation_mode=False,
+            security_analyzer=None,
+            search_api_key=None,
+            mcp_config=None,
+            disabled_skills=[],
+        )
+        user.agent_settings = settings
+        return user
+
+    async def _build(self, service, user, existing_snapshot, tmp_path):
+        from openhands.agent_server.models import EventPage
+
+        service.user_context.get_user_info = AsyncMock(return_value=user)
+        service.user_context.get_user_email = AsyncMock(return_value=None)
+        service._setup_secrets_for_git_providers = AsyncMock(return_value={})
+        service.event_service.search_events = AsyncMock(
+            return_value=EventPage(items=[], next_page_id=None)
+        )
+        existing_info = (
+            AppConversationInfo(
+                id=uuid4(),
+                created_by_user_id='u1',
+                sandbox_id='sandbox_1',
+                agent_kind='acp',
+                acp_agent_settings_snapshot=existing_snapshot,
+            )
+            if existing_snapshot is not None
+            else None
+        )
+        service.app_conversation_info_service.get_app_conversation_info = AsyncMock(
+            return_value=existing_info
+        )
+        return await service._build_acp_start_conversation_request(
+            sandbox=Mock(spec=SandboxInfo),
+            conversation_id=uuid4(),
+            initial_message=None,
+            working_dir=str(tmp_path),
+        )
+
+    # --- _snapshot_acp_settings ------------------------------------------------
+
+    def test_snapshot_strips_all_secrets(self):
+        """No credential survives into the persisted (expose_secrets) snapshot."""
+        from openhands.app_server.app_conversation.live_status_app_conversation_service import (  # noqa: E501
+            _snapshot_acp_settings,
+        )
+        from openhands.sdk.context import AgentContext
+        from openhands.sdk.secret import StaticSecret
+        from openhands.sdk.settings import ACPAgentSettings
+
+        settings = ACPAgentSettings(
+            acp_server='claude-code',
+            acp_model='claude-opus-4-6',
+            llm=LLM(
+                model='claude-sonnet-4-5',
+                api_key=SecretStr('sk-secret-key'),
+                aws_secret_access_key=SecretStr('aws-secret'),
+                usage_id='acp',
+            ),
+            acp_env={'EXTRA_TOKEN': 'env-secret'},
+            agent_context=AgentContext(
+                secrets={'PANEL': StaticSecret(value=SecretStr('panel-secret'))}
+            ),
+        )
+
+        snap = _snapshot_acp_settings(settings)
+
+        # Identity preserved
+        assert snap.acp_server == 'claude-code'
+        assert snap.acp_model == 'claude-opus-4-6'
+        assert snap.llm.model == 'claude-sonnet-4-5'
+        # Secrets cleared
+        assert snap.llm.api_key is None
+        assert snap.llm.aws_secret_access_key is None
+        assert snap.acp_env == {}
+        assert snap.agent_context is None
+
+        # Even an expose_secrets dump (how the JSON column persists) is clean.
+        from pydantic import TypeAdapter
+
+        blob = json.dumps(
+            TypeAdapter(ACPAgentSettings).dump_python(
+                snap, mode='json', context={'expose_secrets': True}
+            )
+        )
+        for secret in ('sk-secret-key', 'aws-secret', 'env-secret', 'panel-secret'):
+            assert secret not in blob
+
+    # --- _restore_acp_settings -------------------------------------------------
+
+    def test_restore_reattaches_live_creds_same_provider(self):
+        from openhands.app_server.app_conversation.live_status_app_conversation_service import (  # noqa: E501
+            _restore_acp_settings,
+            _snapshot_acp_settings,
+        )
+
+        snap = _snapshot_acp_settings(
+            self._acp_settings(acp_server='claude-code', acp_model='claude-opus-4-6')
+        )
+        live = self._acp_settings(acp_server='claude-code', api_key='sk-live-key')
+
+        effective = _restore_acp_settings(snap, live)
+
+        assert effective.acp_server == 'claude-code'
+        assert effective.acp_model == 'claude-opus-4-6'
+        assert effective.llm.api_key.get_secret_value() == 'sk-live-key'
+
+    def test_restore_refuses_mismatched_cred_on_provider_switch(self):
+        from openhands.app_server.app_conversation.live_status_app_conversation_service import (  # noqa: E501
+            _restore_acp_settings,
+            _snapshot_acp_settings,
+        )
+
+        snap = _snapshot_acp_settings(self._acp_settings(acp_server='claude-code'))
+        # User switched their global default to Codex (with a Codex key).
+        live = self._acp_settings(acp_server='codex', api_key='sk-codex-key')
+
+        effective = _restore_acp_settings(snap, live)
+
+        # Snapshot provider wins; the mismatched live key is NOT injected.
+        assert effective.acp_server == 'claude-code'
+        assert effective.llm.api_key is None
+
+    # --- resume race via _build_acp_start_conversation_request -----------------
+
+    @pytest.mark.asyncio
+    async def test_create_uses_live_settings(self, service, tmp_path):
+        """No snapshot yet -> the agent is built from the live settings."""
+        user = self._make_user(
+            self._acp_settings(acp_server='claude-code', acp_model='claude-opus-4-6')
+        )
+        req = await self._build(
+            service, user, existing_snapshot=None, tmp_path=tmp_path
+        )
+        assert req.agent.acp_model == 'claude-opus-4-6'
+
+    @pytest.mark.asyncio
+    async def test_resume_uses_snapshot_not_live_settings(self, service, tmp_path):
+        """Snapshot present + live settings changed -> snapshot identity wins."""
+        from openhands.app_server.app_conversation.live_status_app_conversation_service import (  # noqa: E501
+            _snapshot_acp_settings,
+        )
+
+        # Conversation was created on Claude Code / opus...
+        snapshot = _snapshot_acp_settings(
+            self._acp_settings(acp_server='claude-code', acp_model='claude-opus-4-6')
+        )
+        # ...but the user has since switched their global default to Codex.
+        live = self._acp_settings(
+            acp_server='codex', acp_model='gpt-5.2-codex', api_key='sk-codex-key'
+        )
+        user = self._make_user(live)
+
+        req = await self._build(
+            service, user, existing_snapshot=snapshot, tmp_path=tmp_path
+        )
+
+        # The resumed agent stays Claude Code / opus, not Codex.
+        assert req.agent.acp_model == 'claude-opus-4-6'
+        joined_cmd = ' '.join(req.agent.acp_command)
+        assert 'codex' not in joined_cmd.lower()

--- a/tests/unit/app_server/test_sql_app_conversation_info_service.py
+++ b/tests/unit/app_server/test_sql_app_conversation_info_service.py
@@ -1270,3 +1270,51 @@ class TestFixTimezone:
         aware_dt = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
         result = service._fix_timezone(aware_dt)
         assert result == aware_dt
+
+
+class TestAcpAgentSettingsSnapshotPersistence:
+    """The ACP agent-spec snapshot column round-trips and never holds secrets.
+
+    Covers agent-canvas#1015 (conversation-scoped spec) and #1016 (the spec is
+    persisted to a plain JSON column, so it must carry no credentials at rest).
+    """
+
+    def _acp_snapshot(self):
+        from openhands.sdk.llm import LLM
+        from openhands.sdk.settings import ACPAgentSettings
+
+        # A spec as it would be stored: secret-free (the live service strips
+        # creds via _snapshot_acp_settings before persisting).
+        return ACPAgentSettings(
+            acp_server='claude-code',
+            acp_model='claude-opus-4-6',
+            llm=LLM(model='claude-sonnet-4-5', usage_id='acp'),
+        )
+
+    @pytest.mark.asyncio
+    async def test_snapshot_round_trips(self, service):
+        info = AppConversationInfo(
+            id=uuid4(),
+            created_by_user_id='u1',
+            sandbox_id='sandbox_1',
+            agent_kind='acp',
+            acp_agent_settings_snapshot=self._acp_snapshot(),
+        )
+
+        await service.save_app_conversation_info(info)
+        retrieved = await service.get_app_conversation_info(info.id)
+
+        assert retrieved is not None
+        snap = retrieved.acp_agent_settings_snapshot
+        assert snap is not None
+        assert snap.acp_server == 'claude-code'
+        assert snap.acp_model == 'claude-opus-4-6'
+        assert snap.llm.model == 'claude-sonnet-4-5'
+
+    @pytest.mark.asyncio
+    async def test_non_acp_snapshot_is_null(self, service, sample_conversation_info):
+        await service.save_app_conversation_info(sample_conversation_info)
+        retrieved = await service.get_app_conversation_info(sample_conversation_info.id)
+
+        assert retrieved is not None
+        assert retrieved.acp_agent_settings_snapshot is None


### PR DESCRIPTION
## What

Freeze a **secret-free `ACPAgentSettings` snapshot** onto the conversation at creation, and rebuild the ACP agent from it on resume — instead of re-resolving the user's *live, mutable, global* `agent_settings` on every build.

Part of [agent-canvas#988](https://github.com/OpenHands/OpenHands/issues/15746). Implements [#1015](https://github.com/OpenHands/OpenHands/issues/15738) and upholds [#1016](https://github.com/OpenHands/agent-canvas/issues/2118).

## Why

The backend already builds an `ACPAgent` from the persisted `user.agent_settings`. But when a recycled sandbox is rebuilt, the cloud backend re-runs the ACP conversation-start path (#14640) and **re-resolves the agent from live settings**. So a settings edit *between* create and resume silently re-targets an in-flight conversation:

- start a conversation on **Claude Code / opus**, sandbox gets recycled, meanwhile the user switches their global default to **Codex** → the resumed conversation silently becomes Codex.

The regular agent avoids this: its resolved `Agent` is snapshotted into the agent-server's `meta.json` at creation and rebuilt from there, never re-resolved. ACP's session storage is gone after a recycle (hence the bootstrap-prompt resume in OpenHands/OpenHands#14640), so the spec must be pinned in the app's own durable store. This PR does exactly that.

## How

- `AppConversationInfo.acp_agent_settings_snapshot` — internal field (`exclude=True`; persisted via the explicit SQL mapping, read by attribute on resume, never serialized into list/API responses).
- New JSON column `acp_agent_settings_snapshot` on `conversation_metadata` (+ `save` / `_to_info` mapping). The cloud `SaasSQLAppConversationInfoService` inherits the patched base `save`/`_to_info`, so no enterprise code change is needed — only the migration.
- Migrations: **app_server alembic `011`** (OSS) and **enterprise alembic `118`** (cloud) — `conversation_metadata` is migrated by both.
- `_snapshot_acp_settings(settings)` — freezes the agent **identity** (`acp_server`, `acp_model`, `acp_session_mode`, `acp_command`/`acp_args`, timeouts, metrics `llm.model`) and **strips every secret-bearing field**.
- `_restore_acp_settings(snapshot, live)` — on resume, restores the frozen spec and re-attaches secrets **from the live encrypted vault**, re-injecting provider creds only when `live.acp_server == snapshot.acp_server` (so a provider switch can't inject a mismatched key; the subprocess falls back to ambient/materialised auth).

## Credentials are never persisted at rest (#1016)

Per-provider credential injection already landed in **#14620**: SDK 1.25.0's `ACPAgentSettings.create_agent()` folds `llm.api_key` into `agent_context.secrets`, which rides the cipher-protected `request.secrets` → `state.secret_registry` channel — credentials never touch the app DB. This PR preserves that by construction: `conversation_metadata` is a plain JSON column whose `TypeDecorator` dumps with `expose_secrets=True`, so the snapshot **must** be secret-free. `_snapshot_acp_settings` clears `llm` creds (`api_key`/`base_url`/`aws_*`), `acp_env`, `mcp_config` and `agent_context`; those are re-resolved from the live vault on every build. A test asserts no secret survives even an `expose_secrets` dump.

## Tests

- `_snapshot_acp_settings` strips all secrets (incl. expose-secrets dump is clean).
- `_restore_acp_settings` re-attaches live creds on a provider match; refuses a mismatched key after a provider switch.
- Resume race: snapshot present + live settings switched to Codex → the resumed agent stays Claude Code / opus.
- Fresh create uses live settings; `_start_app_conversation` persists a secret-free snapshot.
- SQL round-trip of the snapshot column; non-ACP conversations store `NULL`.

## Scope notes

- This is the snapshot half (#1015), the foundation OpenHands/agent-canvas#2118's credential injection builds on. The credential-injection / at-rest-encryption tasks of OpenHands/agent-canvas#2118 already merged in OpenHands/OpenHands#14620 — this PR ensures they aren't regressed.
- OpenHands/agent-canvas#2118's remaining "bump the cloud sandbox image pin to a post-ACP build" is a deploy-config change (separate from this backend PR).
- Per-provider credential storage (so a provider switch resumes with the right key) is tracked by [#1022](https://github.com/OpenHands/agent-canvas/issues/2113).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-3faf293   docker.openhands.dev/openhands/openhands:3faf293
```