### PR TITLE
fix(enterprise): inherit org agent_kind in org⊕member settings overlay

### DIFF
--- a/enterprise/storage/org_store.py
+++ b/enterprise/storage/org_store.py
@@ -56,6 +56,14 @@ _ORG_SETTINGS_FIELDS = {
     if (normalized := column.name.lstrip('_')) not in _ORG_SETTINGS_EXCLUDED_FIELDS
 }
 
+# Member-diff keys safe to overlay onto a *different* org variant (see
+# ``constrain_member_diff_to_org_kind``). ``llm`` and ``mcp_config`` are the
+# only fields shared by both variants with a compatible shape. ``agent_context``
+# is excluded on purpose: it is non-null on OpenHands but nullable on ACP, so
+# carrying it across variants reproduces the #14674 500. Fail-closed allowlist:
+# a future shared-but-type-divergent field is dropped, not forwarded.
+_CROSS_VARIANT_OVERLAY_KEYS: frozenset[str] = frozenset({'llm', 'mcp_config'})
+
 
 class OrgStore:
     """Store for managing organizations."""
@@ -68,6 +76,37 @@ class OrgStore:
         # ``ACPAgentSettings``, not coerced into the OpenHands shape — that
         # coercion 500s on ACP's nullable ``agent_context``.
         return _load_persisted_agent_settings(dict(org.agent_settings))
+
+    @staticmethod
+    def constrain_member_diff_to_org_kind(
+        org_agent_settings: AgentSettingsConfig,
+        member_agent_settings_diff: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Constrain a member's agent-settings diff to the org's variant.
+
+        The agent variant (``agent_kind``) is an org-level choice; in the
+        org⊕member overlay a member inherits it rather than owning it. A member
+        diff whose kind diverges from the org's would otherwise mix variants
+        into an invalid mongrel — e.g. ACP org (``agent_context: None``) +
+        ``agent_kind: 'openhands'`` validates as ``OpenHandsAgentSettings`` with
+        ``agent_context=None`` → the #14674 500 (#14678). So a divergent diff is
+        reduced to the cross-variant-safe fields
+        (:data:`_CROSS_VARIANT_OVERLAY_KEYS`); a matching/absent kind passes
+        through unchanged.
+
+        Deliberately *not* the "replace on kind change" rule of the self-edit
+        path (:meth:`_merge_and_validate_settings`, ``Settings.update``): there
+        the user owns the switch; here a sparse diff must not replace the org's
+        variant.
+        """
+        member_kind = member_agent_settings_diff.get('agent_kind')
+        if member_kind is None or member_kind == org_agent_settings.agent_kind:
+            return member_agent_settings_diff
+        return {
+            key: value
+            for key, value in member_agent_settings_diff.items()
+            if key in _CROSS_VARIANT_OVERLAY_KEYS
+        }
 
     @staticmethod
     def get_conversation_settings_from_org(org: Org) -> ConversationSettings:

--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -178,6 +178,14 @@ class SaasSettingsStore(SettingsStore):
         org_agent_settings_dump = org_agent_settings.model_dump(mode='json')
         for private_key in MEMBER_PRIVATE_AGENT_KEYS:
             org_agent_settings_dump.pop(private_key, None)
+        # The agent variant is an org-level choice; a member inherits it. Strip
+        # a divergent ``agent_kind`` (and its variant-specific fields) from the
+        # member diff before merging so the overlay can't mix variants into an
+        # invalid mongrel (#14678 / the #14674 500 reached via this door).
+        member_agent_settings_diff = OrgStore.constrain_member_diff_to_org_kind(
+            org_agent_settings,
+            member_agent_settings_diff,
+        )
         merged_agent_settings = deep_merge(
             org_agent_settings_dump,
             member_agent_settings_diff,
@@ -369,17 +377,25 @@ class SaasSettingsStore(SettingsStore):
             # Strip any pre-existing private keys from the org dump before
             # merging, so legacy values written by older code paths are
             # cleaned up on the next save and stop leaking to other members.
-            org_agent_settings_dump = OrgStore.get_agent_settings_from_org(
-                org
-            ).model_dump(mode='json')
+            org_agent_settings = OrgStore.get_agent_settings_from_org(org)
+            org_agent_settings_dump = org_agent_settings.model_dump(mode='json')
             for private_key in MEMBER_PRIVATE_AGENT_KEYS:
                 org_agent_settings_dump.pop(private_key, None)
 
-            # Single assignment so SQLAlchemy tracks the change
-            org.agent_settings = deep_merge_with_wholesale_keys(
-                org_agent_settings_dump,
-                shared_agent_settings_diff,
-            )
+            # Single assignment so SQLAlchemy tracks the change.
+            # ``shared_agent_settings_diff`` is a complete variant dump (``item``
+            # is fully validated), so on a variant switch, deep-merging it onto
+            # the outgoing variant strands the old keys in ``org.agent_settings``
+            # (a persisted cross-variant mongrel — #14678). Write the new variant
+            # fresh on a kind change; same-variant keeps the merge for its
+            # wholesale-key (mcp_config) semantics.
+            if item.agent_settings.agent_kind != org_agent_settings.agent_kind:
+                org.agent_settings = shared_agent_settings_diff
+            else:
+                org.agent_settings = deep_merge_with_wholesale_keys(
+                    org_agent_settings_dump,
+                    shared_agent_settings_diff,
+                )
 
             effective_conversation_diff = item.conversation_settings.model_dump(
                 mode='json'

--- a/enterprise/storage/user_store.py
+++ b/enterprise/storage/user_store.py
@@ -1031,6 +1031,14 @@ class UserStore:
 
         member_agent_settings_diff = dict(org_member.agent_settings_diff)
         org_agent_settings = OrgStore.get_agent_settings_from_org(org)
+        # The agent variant is an org-level choice; a member inherits it. Strip
+        # a divergent ``agent_kind`` (and its variant-specific fields) from the
+        # member diff before overlaying so a member whose diff diverges from the
+        # org's kind can't mint a cross-variant mongrel here (#14678).
+        member_agent_settings_diff = OrgStore.constrain_member_diff_to_org_kind(
+            org_agent_settings,
+            member_agent_settings_diff,
+        )
         agent_settings = {
             **org_agent_settings.model_dump(mode='json'),
             **member_agent_settings_diff,

--- a/enterprise/tests/unit/test_org_store.py
+++ b/enterprise/tests/unit/test_org_store.py
@@ -198,6 +198,61 @@ def test_merge_and_validate_settings_switches_variant_without_mongrel():
     assert merged.acp_server == 'claude-code'
 
 
+def test_constrain_member_diff_drops_divergent_openhands_diff_on_acp_org():
+    """#14678: an ACP org overlaid with an OpenHands member diff must not mix
+    variants. The discriminator and OpenHands-only fields are dropped (the
+    member inherits the org's ACP kind); only cross-variant fields survive.
+
+    Without this, deep-merging ``{'agent_kind': 'openhands'}`` onto an ACP org
+    dump (``agent_context: None``) validates as ``OpenHandsAgentSettings`` with
+    ``agent_context=None`` — the #14674 500, reached via the overlay door.
+    """
+    org_acp = ACPAgentSettings(acp_server='claude-code')
+    member_diff = {
+        'agent_kind': 'openhands',
+        'agent_context': None,
+        'agent': 'CodeActAgent',
+        'llm': {'model': 'gpt-4o'},
+        'mcp_config': {'mcpServers': {'s': {'url': 'http://m', 'transport': 'sse'}}},
+    }
+
+    constrained = OrgStore.constrain_member_diff_to_org_kind(org_acp, member_diff)
+
+    assert constrained == {
+        'llm': {'model': 'gpt-4o'},
+        'mcp_config': {'mcpServers': {'s': {'url': 'http://m', 'transport': 'sse'}}},
+    }
+
+
+def test_constrain_member_diff_drops_divergent_acp_diff_on_openhands_org():
+    """Reverse direction: an OpenHands org overlaid with an ACP member diff
+    drops ``agent_kind`` and the ACP-only fields, so the OpenHands variant
+    survives intact (the silent-drop path in #14678)."""
+    org_oh = OpenHandsAgentSettings()
+    member_diff = {
+        'agent_kind': 'acp',
+        'acp_server': 'codex',
+        'acp_command': ['npx', 'foo'],
+        'llm': {'model': 'sonnet'},
+    }
+
+    constrained = OrgStore.constrain_member_diff_to_org_kind(org_oh, member_diff)
+
+    assert constrained == {'llm': {'model': 'sonnet'}}
+
+
+def test_constrain_member_diff_passes_matching_kind_through_unchanged():
+    """A member diff that matches (or omits) the org's kind is returned as-is,
+    so same-variant overrides (incl. variant-specific fields) still apply."""
+    org_acp = ACPAgentSettings(acp_server='claude-code')
+
+    matching = {'agent_kind': 'acp', 'acp_server': 'codex', 'llm': {'model': 'x'}}
+    assert OrgStore.constrain_member_diff_to_org_kind(org_acp, matching) is matching
+
+    no_kind = {'llm': {'model': 'y'}}
+    assert OrgStore.constrain_member_diff_to_org_kind(org_acp, no_kind) is no_kind
+
+
 @pytest.mark.asyncio
 async def test_update_org_not_found(async_session_maker):
     # Test updating org that doesn't exist

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -1158,3 +1158,183 @@ async def test_store_replaces_mcp_config_on_delete(
     )
     assert set(admin_servers.keys()) == {'server1', 'server2'}
     assert 'mcp_config' not in members[member1_user_id].agent_settings_diff
+
+
+@pytest.fixture
+def acp_org_with_divergent_member_fixture(session_maker):
+    """An org on the ACP variant whose member's stored diff diverges to the
+    OpenHands kind — the latent #14678 overlay state."""
+    from storage.org import Org
+    from storage.org_member import OrgMember
+    from storage.role import Role
+    from storage.user import User
+
+    from openhands.sdk.settings import ACPAgentSettings
+
+    org_id = uuid.UUID('6694c7b6-f959-4b81-92e9-b09c206f5081')
+    member_user_id = uuid.UUID('6694c7b6-f959-4b81-92e9-b09c206f5082')
+
+    with session_maker() as session:
+        session.add(Role(id=20, name='member', rank=3))
+        session.add(
+            Org(
+                id=org_id,
+                name='acp-org',
+                org_version=1,
+                enable_proactive_conversation_starters=True,
+                # Org is on the ACP variant (agent_context is null for ACP).
+                agent_settings=ACPAgentSettings(acp_server='claude-code').model_dump(
+                    mode='json'
+                ),
+                conversation_settings={},
+                # Non-empty so load() does not take the seed-default profile
+                # write path.
+                llm_profiles={
+                    'profiles': {'Default': {'model': 'anthropic/claude-sonnet-4'}},
+                    'active': 'Default',
+                },
+            )
+        )
+        session.add(
+            User(
+                id=member_user_id,
+                current_org_id=org_id,
+                user_consents_to_analytics=True,
+                enable_sound_notifications=False,
+            )
+        )
+        session.add(
+            OrgMember(
+                org_id=org_id,
+                user_id=member_user_id,
+                role_id=20,
+                llm_api_key='member-key',
+                has_custom_llm_api_key=True,
+                # Diff diverges from the org's ACP kind; no agent_context, so the
+                # deep_merge keeps the org's null one -> the #14674 500 shape.
+                agent_settings_diff={
+                    'agent_kind': 'openhands',
+                    'agent': 'CodeActAgent',
+                    'llm': {'model': 'member-model', 'base_url': 'http://member.url'},
+                },
+                conversation_settings_diff={},
+                status='active',
+            )
+        )
+        session.commit()
+
+    return {'org_id': org_id, 'member_user_id': member_user_id}
+
+
+@pytest.mark.asyncio
+async def test_load_inherits_org_acp_kind_for_divergent_openhands_member_diff(
+    async_session_maker, acp_org_with_divergent_member_fixture
+):
+    """#14678: SaasSettingsStore.load() overlaying an OpenHands member diff onto
+    an ACP org must inherit the org's ACP kind instead of 500'ing (the #14674
+    failure reached through the overlay door)."""
+    from storage.saas_settings_store import SaasSettingsStore
+
+    fixture = acp_org_with_divergent_member_fixture
+    store = SaasSettingsStore(str(fixture['member_user_id']))
+
+    with (
+        patch('storage.saas_settings_store.a_session_maker', async_session_maker),
+        patch('storage.user_store.a_session_maker', async_session_maker),
+        patch('storage.org_store.a_session_maker', async_session_maker),
+    ):
+        settings = await store.load()
+
+    assert settings is not None
+    # Member inherits the org's ACP variant; no cross-variant mongrel.
+    assert settings.agent_settings.agent_kind == 'acp'
+    assert settings.agent_settings.acp_server == 'claude-code'
+    # The genuinely-shared llm override still rides through the overlay.
+    assert settings.agent_settings.llm.model == 'member-model'
+
+
+@pytest.mark.asyncio
+async def test_store_variant_switch_persists_clean_org_settings(
+    session_maker, async_session_maker
+):
+    """#14678: when a member's save switches the org's variant, org.agent_settings
+    is rewritten as the new variant's clean dump rather than a deep-merge that
+    strands the outgoing variant's keys (a persisted cross-variant mongrel)."""
+    from sqlalchemy import select
+    from storage.org import Org
+    from storage.org_member import OrgMember
+    from storage.role import Role
+    from storage.saas_settings_store import SaasSettingsStore
+    from storage.user import User
+
+    from openhands.sdk.settings import ACPAgentSettings
+
+    org_id = uuid.UUID('7794c7b6-f959-4b81-92e9-b09c206f5081')
+    member_user_id = uuid.UUID('7794c7b6-f959-4b81-92e9-b09c206f5082')
+
+    with session_maker() as session:
+        session.add(Role(id=30, name='member', rank=3))
+        session.add(
+            Org(
+                id=org_id,
+                name='acp-org-2',
+                org_version=1,
+                enable_proactive_conversation_starters=True,
+                agent_settings=ACPAgentSettings(
+                    acp_server='claude-code', acp_command=['npx', 'foo']
+                ).model_dump(mode='json'),
+                conversation_settings={},
+            )
+        )
+        session.add(
+            User(
+                id=member_user_id,
+                current_org_id=org_id,
+                user_consents_to_analytics=True,
+            )
+        )
+        session.add(
+            OrgMember(
+                org_id=org_id,
+                user_id=member_user_id,
+                role_id=30,
+                llm_api_key='member-key',
+                has_custom_llm_api_key=True,
+                agent_settings_diff={'agent_kind': 'acp', 'acp_server': 'claude-code'},
+                conversation_settings_diff={},
+                status='active',
+            )
+        )
+        session.commit()
+
+    # Member saves an OpenHands (BYOR, non-managed) settings -> variant switch.
+    store = SaasSettingsStore(str(member_user_id))
+    new_settings = _make_settings(
+        model='anthropic/claude-sonnet-4',
+        base_url='https://api.anthropic.com/v1',
+        api_key='member-byor-key',
+    )
+
+    with patch('storage.saas_settings_store.a_session_maker', async_session_maker):
+        await store.store(new_settings)
+
+    with session_maker() as session:
+        org = session.execute(select(Org).where(Org.id == org_id)).scalars().first()
+        member = (
+            session.execute(
+                select(OrgMember).where(OrgMember.user_id == member_user_id)
+            )
+            .scalars()
+            .first()
+        )
+
+    # org.agent_settings is a clean OpenHands variant: no stranded ACP keys.
+    assert org.agent_settings['agent_kind'] == 'openhands'
+    assert 'acp_server' not in org.agent_settings
+    assert 'acp_command' not in org.agent_settings
+    # And it round-trips through the loader as the OpenHands variant.
+    from storage.org_store import OrgStore
+
+    assert OrgStore.get_agent_settings_from_org(org).agent_kind == 'openhands'
+    # The broadcast leaves the acting member's stored diff openhands too.
+    assert member.agent_settings_diff['agent_kind'] == 'openhands'

--- a/enterprise/tests/unit/test_user_store.py
+++ b/enterprise/tests/unit/test_user_store.py
@@ -1020,6 +1020,72 @@ def test_create_user_settings_from_entities_with_org_fallback():
     assert result.search_api_key == 'search-key'
 
 
+def test_create_user_settings_from_entities_inherits_org_acp_kind():
+    """#14678: an ACP org overlaid with a member's OpenHands diff must inherit
+    the org's ACP variant, not mint a cross-variant mongrel.
+
+    Before the fix, ``{**acp_org_dump, **openhands_member_diff}`` yielded
+    ``agent_kind: 'openhands'`` with ``agent_context: None`` — the latent
+    #14674 500 (it surfaces when this UserSettings is later loaded as Settings).
+    """
+    from openhands.sdk.settings import ACPAgentSettings, validate_agent_settings
+
+    user_id = str(uuid.uuid4())
+
+    org_member = MagicMock()
+    org_member.llm_api_key = SecretStr('member-key')
+    # Member diff diverges from the org's ACP variant.
+    org_member.agent_settings_diff = {
+        'agent_kind': 'openhands',
+        'agent_context': None,
+        'agent': 'CodeActAgent',
+        'llm': {'model': 'member-model', 'base_url': 'https://member.api.com'},
+    }
+    org_member.conversation_settings_diff = {}
+
+    user = MagicMock()
+    user.accepted_tos = None
+    user.enable_sound_notifications = True
+    user.language = 'en'
+    user.user_consents_to_analytics = True
+    user.email = 'test@example.com'
+    user.email_verified = True
+    user.git_user_name = None
+    user.git_user_email = None
+
+    org = MagicMock()
+    org.remote_runtime_resource_factor = 1.0
+    org.billing_margin = 0.0
+    org.enable_proactive_conversation_starters = True
+    org.sandbox_base_container_image = None
+    org.sandbox_runtime_container_image = None
+    org.org_version = 1
+    org.agent_settings = ACPAgentSettings(acp_server='claude-code').model_dump(
+        mode='json'
+    )
+    org.conversation_settings = {}
+    org.search_api_key = None
+    org.sandbox_api_key = None
+    org.max_budget_per_task = None
+    org.v1_enabled = True
+
+    result = UserStore._create_user_settings_from_entities(
+        user_id, org_member, user, org
+    )
+
+    # Member inherits the org's ACP kind; OpenHands-only fields are dropped.
+    assert result.agent_settings['agent_kind'] == 'acp'
+    assert result.agent_settings['acp_server'] == 'claude-code'
+    assert 'agent' not in result.agent_settings
+    # The genuinely-shared llm override still rides through.
+    assert result.agent_settings['llm']['model'] == 'member-model'
+    # The merged result validates as the ACP variant without a 500 (it would
+    # raise on the OpenHands variant's non-null agent_context if it mongreled).
+    assert isinstance(
+        validate_agent_settings(result.agent_settings), ACPAgentSettings
+    )
+
+
 # --- Tests for Redis lock functions (mocked) ---
 
 


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:


- [ ] A human has tested these changes.

AGENT:

Tested via the regression tests below (unit + DB-backed integration over `load()`/`store()`/the `user_store` overlay). Not manually exercised in a running app — this is a latent (not-observed) defect, reproduced and fixed at the unit level.

## Why

The org⊕member **effective-settings overlay** merges a member's `agent_settings_diff` onto the org's resolved `agent_settings` without normalizing `agent_kind`. A member diff whose kind diverges from the org's mixes variants into an invalid mongrel — the same `agent_context=None` 500 as #14674 (`Input should be a valid dictionary or instance of AgentContext`), reached through a different door. Latent today (no prod occurrences), but "close the door before someone walks through it."

This resolves the ownership question the issue raised as **no**: the agent variant is an org-level choice a member *inherits*, not a per-member decision (org variant is owned by the org-defaults write path / `Settings.update`). So `apply_agent_settings_diff`'s "replace on kind change" rule (#14675 / SDK#3534) is deliberately **not** applied to the read overlays.

## Summary

- Add `OrgStore.constrain_member_diff_to_org_kind` + `_CROSS_VARIANT_OVERLAY_KEYS = {llm, mcp_config}` (fail-closed allowlist; `agent_context` excluded — it's non-null on OpenHands, nullable on ACP, which is the 500 vector).
- `SaasSettingsStore.load()` and `UserStore._create_user_settings_from_entities` (the read overlays that actually 500): strip a divergent `agent_kind` from the member diff so the member inherits the org's variant and keeps only cross-variant-safe fields.
- `SaasSettingsStore.store()` (the member-authoritative variant-switch write path — must keep switching working, so *not* normalized to the org's old kind): on a kind change, write the new variant's clean dump instead of deep-merging onto the outgoing variant, so `org.agent_settings` never persists a cross-variant mongrel.
- Regression tests for ACP-org + OpenHands-member-diff (and the reverse) at all three sites.

## Issue Number

Closes #14678 (latent redux of #14674; complements #14675).

## How to Test

```bash
cd enterprise
python3 -m pytest \
  tests/unit/test_org_store.py \
  tests/unit/test_user_store.py \
  tests/unit/test_saas_settings_store.py -q
```

Key cases: `test_constrain_member_diff_*` (org_store), `test_create_user_settings_from_entities_inherits_org_acp_kind` (user_store), `test_load_inherits_org_acp_kind_for_divergent_openhands_member_diff` and `test_store_variant_switch_persists_clean_org_settings` (saas_settings_store). The `load()` test 500s before this change and inherits `agent_kind: 'acp'` after.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-a94dd01   docker.openhands.dev/openhands/openhands:a94dd01
```