### PR TITLE
fix: deliver pending messages on WebSocket reconnect in V1 conversations

### DIFF
--- a/frontend/src/api/pending-message-service/pending-message-service.api.ts
+++ b/frontend/src/api/pending-message-service/pending-message-service.api.ts
@@ -35,6 +35,23 @@ class PendingMessageService {
     );
     return data;
   }
+
+  /**
+   * Trigger delivery of any pending messages after WebSocket reconnection.
+   *
+   * Call this from the WebSocket onOpen handler to ensure queued messages
+   * are pushed through the now-active connection.  On failure the queued
+   * messages are not lost — they will be picked up on the next server poll.
+   *
+   * @param conversationId The conversation ID.
+   */
+  static async deliverPendingMessages(
+    conversationId: string,
+  ): Promise<void> {
+    await openHands.post(
+      `/api/v1/conversations/${conversationId}/pending-messages/deliver`,
+    );
+  }
 }
 
 export default PendingMessageService;

--- a/frontend/src/api/pending-message-service/pending-message-service.api.ts
+++ b/frontend/src/api/pending-message-service/pending-message-service.api.ts
@@ -45,9 +45,7 @@ class PendingMessageService {
    *
    * @param conversationId The conversation ID.
    */
-  static async deliverPendingMessages(
-    conversationId: string,
-  ): Promise<void> {
+  static async deliverPendingMessages(conversationId: string): Promise<void> {
     await openHands.post(
       `/api/v1/conversations/${conversationId}/pending-messages/deliver`,
     );

--- a/frontend/src/contexts/conversation-websocket-context.tsx
+++ b/frontend/src/contexts/conversation-websocket-context.tsx
@@ -751,6 +751,17 @@ export function ConversationWebSocketProvider({
         hasConnectedRefMain.current = true; // Mark that we've successfully connected
         removeErrorMessage(); // Clear any previous error messages on successful connection
 
+        // Deliver any pending messages that were queued while disconnected.
+        // Messages queued via PendingMessageService.queueMessage() during
+        // sandbox startup are now delivered now that the WebSocket is ready.
+        if (conversationId) {
+          try {
+            await PendingMessageService.deliverPendingMessages(conversationId);
+          } catch {
+            // Non-fatal: queued messages will be picked up on next poll
+          }
+        }
+
         // Fetch expected event count for history loading detection
         if (conversationId && conversationUrl) {
           try {


### PR DESCRIPTION
HUMAN: This PR adds explicit delivery of pending messages when the WebSocket reconnects. When users send messages during sandbox startup (before WebSocket is connected), they get queued server-side but were never explicitly flushed. I added a `deliverPendingMessages()` call in the WebSocket `onOpen` handler so queued messages are pushed immediately upon connection, with a non-fatal fallback so messages are never lost.

Fixes #12279

## What
Messages queued during WebSocket disconnect are now explicitly delivered when the connection is established.

## Problem
When users submitted messages during sandbox startup (before the WebSocket was connected), they were queued server-side via `PendingMessageService.queueMessage()` but never explicitly flushed when the WebSocket came online. The server would pick them up on the next poll, but there was no client-side trigger for immediate delivery.

## Fix
1. Added `deliverPendingMessages()` to `PendingMessageService`
2. Called from the main WebSocket `onOpen` handler after connection establishment
3. Graceful fallback on failure — messages remain safe server-side