### PR TITLE
fix(tests): use cross-platform process sandbox temp path

### DIFF
--- a/tests/unit/app_server/test_process_sandbox_service.py
+++ b/tests/unit/app_server/test_process_sandbox_service.py
@@ -358,7 +358,9 @@ class TestProcessSandboxServiceInjector:
         """Test default configuration values."""
         injector = ProcessSandboxServiceInjector()
 
-        assert injector.base_working_dir == '/tmp/openhands-sandboxes'
+        assert injector.base_working_dir == os.path.join(
+            tempfile.gettempdir(), 'openhands-sandboxes'
+        )
         assert injector.base_port == 8000
         assert injector.health_check_path == '/alive'
         assert injector.agent_server_module == 'openhands.agent_server'


### PR DESCRIPTION
HUMAN:

Tested the cross-platform path construction on Windows. It resolves to the system temporary directory as expected.

- [x] A human has tested these changes.

AGENT:

---

## Why

PR #14261 changed the process sandbox working directory from a hard-coded `/tmp` path to a cross-platform temporary directory. However, the corresponding unit test still expects the old Unix-specific path, causing it to fail on Windows.

## Summary

- Update the process sandbox injector test to use `tempfile.gettempdir()`.
- Keep the test expectation consistent with the production implementation.
- Improve cross-platform test compatibility.

## Issue Number

N/A

## How to Test

```bash
poetry run pytest tests/unit/app_server/test_process_sandbox_service.py::TestProcessSandboxServiceInjector::test_default_values
