### PR TITLE
fix: support external Postgres SSL mode

### DIFF
--- a/enterprise/migrations/env.py
+++ b/enterprise/migrations/env.py
@@ -29,6 +29,8 @@ DB_NAME = os.getenv('DB_NAME', 'openhands')
 # too: this keeps every environment on the same driver and lets pg8000-specific
 # migration failures surface before deploy. Set DB_DRIVER='' to use psycopg2.
 DB_DRIVER = os.getenv('DB_DRIVER', 'pg8000')
+DB_SSL_MODE = os.getenv('DB_SSL_MODE') or os.getenv('PGSSLMODE')
+SUPPORTED_DB_SSL_MODES = {'prefer', 'require', 'disable'}
 
 GCP_DB_INSTANCE = os.getenv('GCP_DB_INSTANCE')
 GCP_PROJECT = os.getenv('GCP_PROJECT')
@@ -36,6 +38,37 @@ GCP_REGION = os.getenv('GCP_REGION')
 
 POOL_SIZE = int(os.getenv('DB_POOL_SIZE', '25'))
 MAX_OVERFLOW = int(os.getenv('DB_MAX_OVERFLOW', '10'))
+
+
+def _normalize_db_ssl_mode(db_ssl_mode: str | None) -> str | None:
+    if db_ssl_mode is None:
+        return None
+
+    mode = db_ssl_mode.strip().lower()
+    if not mode or mode == 'prefer':
+        return None
+    if mode not in SUPPORTED_DB_SSL_MODES:
+        raise ValueError(
+            f'Unsupported DB_SSL_MODE "{db_ssl_mode}". '
+            f'Supported values are: {", ".join(sorted(SUPPORTED_DB_SSL_MODES))}.'
+        )
+    return mode
+
+
+def _build_pg8000_connect_args(db_ssl_mode: str | None) -> dict:
+    mode = _normalize_db_ssl_mode(db_ssl_mode)
+    if mode == 'require':
+        return {'ssl_context': True}
+    if mode == 'disable':
+        return {'ssl_context': False}
+    return {}
+
+
+def _build_db_url_query(db_ssl_mode: str | None) -> str:
+    mode = _normalize_db_ssl_mode(db_ssl_mode)
+    if mode:
+        return f'?sslmode={mode}'
+    return ''
 
 
 def get_engine(database_name=DB_NAME):
@@ -63,11 +96,16 @@ def get_engine(database_name=DB_NAME):
     else:
         scheme = f'postgresql+{DB_DRIVER}' if DB_DRIVER else 'postgresql'
         url = f'{scheme}://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{database_name}'
+        if DB_DRIVER != 'pg8000':
+            url += _build_db_url_query(DB_SSL_MODE)
         return create_engine(
             url,
             pool_size=POOL_SIZE,
             max_overflow=MAX_OVERFLOW,
             pool_pre_ping=True,
+            connect_args=(
+                _build_pg8000_connect_args(DB_SSL_MODE) if DB_DRIVER == 'pg8000' else {}
+            ),
         )
 
 

--- a/enterprise/migrations/env.py
+++ b/enterprise/migrations/env.py
@@ -17,6 +17,8 @@ from google.cloud.sql.connector import Connector  # noqa: E402
 from sqlalchemy import create_engine, text  # noqa: E402
 from storage.base import Base  # noqa: E402
 
+from openhands.db.ssl import build_db_url_query, build_pg8000_connect_args  # noqa: E402
+
 target_metadata = Base.metadata
 
 DB_USER = os.getenv('DB_USER', 'postgres')
@@ -30,7 +32,6 @@ DB_NAME = os.getenv('DB_NAME', 'openhands')
 # migration failures surface before deploy. Set DB_DRIVER='' to use psycopg2.
 DB_DRIVER = os.getenv('DB_DRIVER', 'pg8000')
 DB_SSL_MODE = os.getenv('DB_SSL_MODE') or os.getenv('PGSSLMODE')
-SUPPORTED_DB_SSL_MODES = {'prefer', 'require', 'disable'}
 
 GCP_DB_INSTANCE = os.getenv('GCP_DB_INSTANCE')
 GCP_PROJECT = os.getenv('GCP_PROJECT')
@@ -38,37 +39,6 @@ GCP_REGION = os.getenv('GCP_REGION')
 
 POOL_SIZE = int(os.getenv('DB_POOL_SIZE', '25'))
 MAX_OVERFLOW = int(os.getenv('DB_MAX_OVERFLOW', '10'))
-
-
-def _normalize_db_ssl_mode(db_ssl_mode: str | None) -> str | None:
-    if db_ssl_mode is None:
-        return None
-
-    mode = db_ssl_mode.strip().lower()
-    if not mode or mode == 'prefer':
-        return None
-    if mode not in SUPPORTED_DB_SSL_MODES:
-        raise ValueError(
-            f'Unsupported DB_SSL_MODE "{db_ssl_mode}". '
-            f'Supported values are: {", ".join(sorted(SUPPORTED_DB_SSL_MODES))}.'
-        )
-    return mode
-
-
-def _build_pg8000_connect_args(db_ssl_mode: str | None) -> dict:
-    mode = _normalize_db_ssl_mode(db_ssl_mode)
-    if mode == 'require':
-        return {'ssl_context': True}
-    if mode == 'disable':
-        return {'ssl_context': False}
-    return {}
-
-
-def _build_db_url_query(db_ssl_mode: str | None) -> str:
-    mode = _normalize_db_ssl_mode(db_ssl_mode)
-    if mode:
-        return f'?sslmode={mode}'
-    return ''
 
 
 def get_engine(database_name=DB_NAME):
@@ -97,14 +67,14 @@ def get_engine(database_name=DB_NAME):
         scheme = f'postgresql+{DB_DRIVER}' if DB_DRIVER else 'postgresql'
         url = f'{scheme}://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{database_name}'
         if DB_DRIVER != 'pg8000':
-            url += _build_db_url_query(DB_SSL_MODE)
+            url += build_db_url_query(DB_SSL_MODE)
         return create_engine(
             url,
             pool_size=POOL_SIZE,
             max_overflow=MAX_OVERFLOW,
             pool_pre_ping=True,
             connect_args=(
-                _build_pg8000_connect_args(DB_SSL_MODE) if DB_DRIVER == 'pg8000' else {}
+                build_pg8000_connect_args(DB_SSL_MODE) if DB_DRIVER == 'pg8000' else {}
             ),
         )
 

--- a/openhands/app_server/services/db_session_injector.py
+++ b/openhands/app_server/services/db_session_injector.py
@@ -22,6 +22,38 @@ from openhands.app_server.services.injector import Injector, InjectorState
 _logger = logging.getLogger(__name__)
 DB_SESSION_ATTR = 'db_session'
 DB_SESSION_KEEP_OPEN_ATTR = 'db_session_keep_open'
+SUPPORTED_DB_SSL_MODES = {'prefer', 'require', 'disable'}
+
+
+def _normalize_db_ssl_mode(db_ssl_mode: str | None) -> str | None:
+    if db_ssl_mode is None:
+        return None
+
+    mode = db_ssl_mode.strip().lower()
+    if not mode or mode == 'prefer':
+        return None
+    if mode not in SUPPORTED_DB_SSL_MODES:
+        raise ValueError(
+            f'Unsupported DB_SSL_MODE "{db_ssl_mode}". '
+            f'Supported values are: {", ".join(sorted(SUPPORTED_DB_SSL_MODES))}.'
+        )
+    return mode
+
+
+def _build_pg8000_connect_args(db_ssl_mode: str | None) -> dict:
+    mode = _normalize_db_ssl_mode(db_ssl_mode)
+    if mode == 'require':
+        return {'ssl_context': True}
+    if mode == 'disable':
+        return {'ssl_context': False}
+    return {}
+
+
+def _build_asyncpg_connect_args(db_ssl_mode: str | None) -> dict:
+    mode = _normalize_db_ssl_mode(db_ssl_mode)
+    if mode:
+        return {'ssl': mode}
+    return {}
 
 
 class DbSessionInjector(BaseModel, Injector[AsyncSession]):
@@ -38,6 +70,7 @@ class DbSessionInjector(BaseModel, Injector[AsyncSession]):
     gcp_db_instance: str | None = None
     gcp_project: str | None = None
     gcp_region: str | None = None
+    ssl_mode: str | None = None
 
     # Private attrs
     _engine: Engine | None = PrivateAttr(default=None)
@@ -65,6 +98,8 @@ class DbSessionInjector(BaseModel, Injector[AsyncSession]):
             self.gcp_project = os.getenv('GCP_PROJECT')
         if self.gcp_region is None:
             self.gcp_region = os.getenv('GCP_REGION')
+        if self.ssl_mode is None:
+            self.ssl_mode = os.getenv('DB_SSL_MODE') or os.getenv('PGSSLMODE')
         return self
 
     def _create_gcp_db_connection(self):
@@ -189,6 +224,7 @@ class DbSessionInjector(BaseModel, Injector[AsyncSession]):
             if self.host:
                 async_engine = create_async_engine(
                     url,
+                    connect_args=_build_asyncpg_connect_args(self.ssl_mode),
                     pool_size=self.pool_size,
                     max_overflow=self.max_overflow,
                     pool_recycle=self.pool_recycle,
@@ -232,6 +268,7 @@ class DbSessionInjector(BaseModel, Injector[AsyncSession]):
                 url = f'sqlite:///{self.persistence_dir}/openhands.db'
             engine = create_engine(
                 url,
+                connect_args=_build_pg8000_connect_args(self.ssl_mode),
                 pool_size=self.pool_size,
                 max_overflow=self.max_overflow,
                 pool_recycle=self.pool_recycle,

--- a/openhands/app_server/services/db_session_injector.py
+++ b/openhands/app_server/services/db_session_injector.py
@@ -18,42 +18,11 @@ from sqlalchemy.pool import NullPool
 from sqlalchemy.util import await_only
 
 from openhands.app_server.services.injector import Injector, InjectorState
+from openhands.db.ssl import build_asyncpg_connect_args, build_pg8000_connect_args
 
 _logger = logging.getLogger(__name__)
 DB_SESSION_ATTR = 'db_session'
 DB_SESSION_KEEP_OPEN_ATTR = 'db_session_keep_open'
-SUPPORTED_DB_SSL_MODES = {'prefer', 'require', 'disable'}
-
-
-def _normalize_db_ssl_mode(db_ssl_mode: str | None) -> str | None:
-    if db_ssl_mode is None:
-        return None
-
-    mode = db_ssl_mode.strip().lower()
-    if not mode or mode == 'prefer':
-        return None
-    if mode not in SUPPORTED_DB_SSL_MODES:
-        raise ValueError(
-            f'Unsupported DB_SSL_MODE "{db_ssl_mode}". '
-            f'Supported values are: {", ".join(sorted(SUPPORTED_DB_SSL_MODES))}.'
-        )
-    return mode
-
-
-def _build_pg8000_connect_args(db_ssl_mode: str | None) -> dict:
-    mode = _normalize_db_ssl_mode(db_ssl_mode)
-    if mode == 'require':
-        return {'ssl_context': True}
-    if mode == 'disable':
-        return {'ssl_context': False}
-    return {}
-
-
-def _build_asyncpg_connect_args(db_ssl_mode: str | None) -> dict:
-    mode = _normalize_db_ssl_mode(db_ssl_mode)
-    if mode:
-        return {'ssl': mode}
-    return {}
 
 
 class DbSessionInjector(BaseModel, Injector[AsyncSession]):
@@ -224,7 +193,7 @@ class DbSessionInjector(BaseModel, Injector[AsyncSession]):
             if self.host:
                 async_engine = create_async_engine(
                     url,
-                    connect_args=_build_asyncpg_connect_args(self.ssl_mode),
+                    connect_args=build_asyncpg_connect_args(self.ssl_mode),
                     pool_size=self.pool_size,
                     max_overflow=self.max_overflow,
                     pool_recycle=self.pool_recycle,
@@ -268,7 +237,7 @@ class DbSessionInjector(BaseModel, Injector[AsyncSession]):
                 url = f'sqlite:///{self.persistence_dir}/openhands.db'
             engine = create_engine(
                 url,
-                connect_args=_build_pg8000_connect_args(self.ssl_mode),
+                connect_args=build_pg8000_connect_args(self.ssl_mode),
                 pool_size=self.pool_size,
                 max_overflow=self.max_overflow,
                 pool_recycle=self.pool_recycle,

--- a/openhands/db/__init__.py
+++ b/openhands/db/__init__.py
@@ -1,0 +1,1 @@
+"""Shared database helpers."""

--- a/openhands/db/ssl.py
+++ b/openhands/db/ssl.py
@@ -1,0 +1,41 @@
+"""Postgres SSL mode helpers shared by app and migration database setup."""
+
+SUPPORTED_DB_SSL_MODES: frozenset[str] = frozenset({'prefer', 'require', 'disable'})
+
+
+def normalize_db_ssl_mode(db_ssl_mode: str | None) -> str | None:
+    if db_ssl_mode is None:
+        return None
+
+    mode = db_ssl_mode.strip().lower()
+    if not mode or mode == 'prefer':
+        return None
+    if mode not in SUPPORTED_DB_SSL_MODES:
+        raise ValueError(
+            f'Unsupported DB_SSL_MODE "{db_ssl_mode}". '
+            f'Supported values are: {", ".join(sorted(SUPPORTED_DB_SSL_MODES))}.'
+        )
+    return mode
+
+
+def build_pg8000_connect_args(db_ssl_mode: str | None) -> dict[str, bool]:
+    mode = normalize_db_ssl_mode(db_ssl_mode)
+    if mode == 'require':
+        return {'ssl_context': True}
+    if mode == 'disable':
+        return {'ssl_context': False}
+    return {}
+
+
+def build_asyncpg_connect_args(db_ssl_mode: str | None) -> dict[str, str]:
+    mode = normalize_db_ssl_mode(db_ssl_mode)
+    if mode:
+        return {'ssl': mode}
+    return {}
+
+
+def build_db_url_query(db_ssl_mode: str | None) -> str:
+    mode = normalize_db_ssl_mode(db_ssl_mode)
+    if mode:
+        return f'?sslmode={mode}'
+    return ''

--- a/tests/unit/app_server/test_db_session_injector.py
+++ b/tests/unit/app_server/test_db_session_injector.py
@@ -32,6 +32,8 @@ sys.modules['google.cloud.sql.connector'] = MagicMock()
 # Import after mocking to avoid import-time issues
 from openhands.app_server.services.db_session_injector import (  # noqa: E402
     DbSessionInjector,
+    _build_asyncpg_connect_args,
+    _build_pg8000_connect_args,
 )
 
 
@@ -103,6 +105,7 @@ class TestDbSessionInjectorConfiguration:
         assert service.gcp_db_instance is None
         assert service.gcp_project is None
         assert service.gcp_region is None
+        assert service.ssl_mode is None
 
     def test_environment_variable_processing(self, temp_persistence_dir):
         """Test that environment variables are properly processed."""
@@ -112,6 +115,7 @@ class TestDbSessionInjectorConfiguration:
             'DB_NAME': 'env_db',
             'DB_USER': 'env_user',
             'DB_PASS': 'env_password',
+            'DB_SSL_MODE': 'require',
             'GCP_DB_INSTANCE': 'env_instance',
             'GCP_PROJECT': 'env_project',
             'GCP_REGION': 'env_region',
@@ -128,6 +132,7 @@ class TestDbSessionInjectorConfiguration:
             assert service.gcp_db_instance == 'env_instance'
             assert service.gcp_project == 'env_project'
             assert service.gcp_region == 'env_region'
+            assert service.ssl_mode == 'require'
 
     def test_explicit_values_override_env_vars(self, temp_persistence_dir):
         """Test that explicitly provided values override environment variables."""
@@ -203,6 +208,7 @@ class TestDbSessionInjectorConnections:
             assert 'test_db' in url_str
 
             # Verify other parameters
+            assert call_args[1]['connect_args'] == {}
             assert call_args[1]['pool_size'] == 25
             assert call_args[1]['max_overflow'] == 10
             assert call_args[1]['pool_pre_ping']
@@ -235,9 +241,71 @@ class TestDbSessionInjectorConnections:
             assert 'test_db' in url_str
 
             # Verify other parameters
+            assert call_args[1]['connect_args'] == {}
             assert call_args[1]['pool_size'] == 25
             assert call_args[1]['max_overflow'] == 10
             assert call_args[1]['pool_pre_ping']
+
+    def test_postgres_connection_requires_ssl(self, temp_persistence_dir):
+        service = DbSessionInjector(
+            persistence_dir=temp_persistence_dir,
+            host='localhost',
+            port=5432,
+            name='test_db',
+            user='test_user',
+            password=SecretStr('test_password'),
+            ssl_mode='require',
+        )
+
+        with patch(
+            'openhands.app_server.services.db_session_injector.create_engine'
+        ) as mock_create_engine:
+            mock_create_engine.return_value = MagicMock()
+
+            service.get_db_engine()
+
+            assert mock_create_engine.call_args[1]['connect_args'] == {
+                'ssl_context': True
+            }
+
+    @pytest.mark.asyncio
+    async def test_postgres_async_connection_requires_ssl(self, temp_persistence_dir):
+        service = DbSessionInjector(
+            persistence_dir=temp_persistence_dir,
+            host='localhost',
+            port=5432,
+            name='test_db',
+            user='test_user',
+            password=SecretStr('test_password'),
+            ssl_mode='require',
+        )
+
+        with patch(
+            'openhands.app_server.services.db_session_injector.create_async_engine'
+        ) as mock_create_async_engine:
+            mock_create_async_engine.return_value = MagicMock()
+
+            await service.get_async_db_engine()
+
+            assert mock_create_async_engine.call_args[1]['connect_args'] == {
+                'ssl': 'require'
+            }
+
+    def test_build_pg8000_connect_args_for_ssl_modes(self):
+        assert _build_pg8000_connect_args(None) == {}
+        assert _build_pg8000_connect_args('prefer') == {}
+        assert _build_pg8000_connect_args('require') == {'ssl_context': True}
+        assert _build_pg8000_connect_args('disable') == {'ssl_context': False}
+
+    def test_build_asyncpg_connect_args_for_ssl_modes(self):
+        assert _build_asyncpg_connect_args(None) == {}
+        assert _build_asyncpg_connect_args('prefer') == {}
+        assert _build_asyncpg_connect_args('require') == {'ssl': 'require'}
+        assert _build_asyncpg_connect_args('disable') == {'ssl': 'disable'}
+
+    def test_build_connect_args_rejects_unsupported_ssl_mode(self):
+        with pytest.raises(ValueError, match='Unsupported DB_SSL_MODE'):
+            _build_pg8000_connect_args('verify-full')
 
     @patch(
         'openhands.app_server.services.db_session_injector.DbSessionInjector._create_gcp_engine'

--- a/tests/unit/app_server/test_db_session_injector.py
+++ b/tests/unit/app_server/test_db_session_injector.py
@@ -32,8 +32,11 @@ sys.modules['google.cloud.sql.connector'] = MagicMock()
 # Import after mocking to avoid import-time issues
 from openhands.app_server.services.db_session_injector import (  # noqa: E402
     DbSessionInjector,
-    _build_asyncpg_connect_args,
-    _build_pg8000_connect_args,
+)
+from openhands.db.ssl import (  # noqa: E402
+    build_asyncpg_connect_args,
+    build_db_url_query,
+    build_pg8000_connect_args,
 )
 
 
@@ -292,20 +295,26 @@ class TestDbSessionInjectorConnections:
             }
 
     def test_build_pg8000_connect_args_for_ssl_modes(self):
-        assert _build_pg8000_connect_args(None) == {}
-        assert _build_pg8000_connect_args('prefer') == {}
-        assert _build_pg8000_connect_args('require') == {'ssl_context': True}
-        assert _build_pg8000_connect_args('disable') == {'ssl_context': False}
+        assert build_pg8000_connect_args(None) == {}
+        assert build_pg8000_connect_args('prefer') == {}
+        assert build_pg8000_connect_args('require') == {'ssl_context': True}
+        assert build_pg8000_connect_args('disable') == {'ssl_context': False}
 
     def test_build_asyncpg_connect_args_for_ssl_modes(self):
-        assert _build_asyncpg_connect_args(None) == {}
-        assert _build_asyncpg_connect_args('prefer') == {}
-        assert _build_asyncpg_connect_args('require') == {'ssl': 'require'}
-        assert _build_asyncpg_connect_args('disable') == {'ssl': 'disable'}
+        assert build_asyncpg_connect_args(None) == {}
+        assert build_asyncpg_connect_args('prefer') == {}
+        assert build_asyncpg_connect_args('require') == {'ssl': 'require'}
+        assert build_asyncpg_connect_args('disable') == {'ssl': 'disable'}
+
+    def test_build_db_url_query_for_ssl_modes(self):
+        assert build_db_url_query(None) == ''
+        assert build_db_url_query('prefer') == ''
+        assert build_db_url_query('require') == '?sslmode=require'
+        assert build_db_url_query('disable') == '?sslmode=disable'
 
     def test_build_connect_args_rejects_unsupported_ssl_mode(self):
         with pytest.raises(ValueError, match='Unsupported DB_SSL_MODE'):
-            _build_pg8000_connect_args('verify-full')
+            build_pg8000_connect_args('verify-full')
 
     @patch(
         'openhands.app_server.services.db_session_injector.DbSessionInjector._create_gcp_engine'


### PR DESCRIPTION
HUMAN:
This PR adds Postgres SSL-mode support for OpenHands Enterprise external database connections. Successfully validated `sslmode=require` on a real Replicated OHE instance using an external Postgres endpoint on port `5433`; app login and a test conversation passed.

- [x] A human has tested these changes.

## Summary
- Add `DB_SSL_MODE` / `PGSSLMODE` handling to the OpenHands DB session injector.
- Map `require` / `disable` for direct pg8000 and asyncpg connections while preserving default `prefer` behavior.
- Apply the same SSL-mode handling to enterprise Alembic migrations.

## Validation
- `uv run pytest tests/unit/app_server/test_db_session_injector.py`
- `uv run python -m compileall enterprise/migrations/env.py`
- `git diff --check`
- Successfully validated `sslmode=require` on a real Replicated OHE instance using an external Postgres endpoint on port `5433`; app login and a test conversation passed.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-d765b0b   docker.openhands.dev/openhands/openhands:d765b0b
```