### PR TITLE
fix: delete LiteLLM user on personal org reset

### DIFF
--- a/enterprise/storage/org_store.py
+++ b/enterprise/storage/org_store.py
@@ -61,6 +61,17 @@ class OrgStore:
     """Store for managing organizations."""
 
     @staticmethod
+    async def _delete_litellm_user_best_effort(user_id: str, org_id: UUID) -> None:
+        """Delete the LiteLLM user record without blocking org deletion."""
+        try:
+            await LiteLlmManager.delete_user(user_id)
+        except Exception as exc:
+            logger.warning(
+                'Failed to delete LiteLLM user during org cascade cleanup',
+                extra={'org_id': str(org_id), 'user_id': user_id, 'error': str(exc)},
+            )
+
+    @staticmethod
     def get_agent_settings_from_org(org: Org) -> AgentSettingsConfig:
         # Route through the shared SDK loader: it applies persisted-settings
         # migrations (incl. the legacy ``agent_kind: 'llm'`` -> ``'openhands'``
@@ -690,6 +701,10 @@ class OrgStore:
                     extra={'org_id': str(org_id)},
                 )
                 await LiteLlmManager.delete_team(str(org_id))
+
+                if requester_orphan_ids:
+                    for user_id in requester_orphan_ids:
+                        await OrgStore._delete_litellm_user_best_effort(user_id, org_id)
 
                 # 7. Commit all changes only if everything succeeded
                 await session.commit()

--- a/enterprise/tests/unit/test_org_store.py
+++ b/enterprise/tests/unit/test_org_store.py
@@ -641,7 +641,13 @@ async def test_delete_org_cascade_success(async_session_maker, mock_litellm_api)
         session.add(expected_org)
         await session.commit()
 
-    with patch('storage.org_store.a_session_maker', async_session_maker):
+    with (
+        patch('storage.org_store.a_session_maker', async_session_maker),
+        patch(
+            'storage.org_store.OrgStore._delete_litellm_user_best_effort',
+            new=AsyncMock(),
+        ) as mock_delete_litellm_user,
+    ):
         # Act
         result = await OrgStore.delete_org_cascade(org_id)
 
@@ -651,6 +657,38 @@ async def test_delete_org_cascade_success(async_session_maker, mock_litellm_api)
     assert result.name == 'Test Organization'
     assert result.contact_name == 'John Doe'
     assert result.contact_email == 'john@example.com'
+    mock_delete_litellm_user.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_litellm_user_best_effort_calls_litellm():
+    user_id = str(uuid.uuid4())
+    org_id = uuid.uuid4()
+
+    with patch(
+        'storage.org_store.LiteLlmManager.delete_user', new=AsyncMock()
+    ) as mock_delete_user:
+        await OrgStore._delete_litellm_user_best_effort(user_id, org_id)
+
+    mock_delete_user.assert_called_once_with(user_id)
+
+
+@pytest.mark.asyncio
+async def test_delete_litellm_user_best_effort_swallows_litellm_failure():
+    user_id = str(uuid.uuid4())
+    org_id = uuid.uuid4()
+
+    with (
+        patch(
+            'storage.org_store.LiteLlmManager.delete_user',
+            new=AsyncMock(side_effect=Exception('LiteLLM API unavailable')),
+        ) as mock_delete_user,
+        patch('storage.org_store.logger.warning') as mock_warning,
+    ):
+        await OrgStore._delete_litellm_user_best_effort(user_id, org_id)
+
+    mock_delete_user.assert_called_once_with(user_id)
+    mock_warning.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -1067,7 +1105,13 @@ async def test_delete_org_cascade_sole_org_requester_is_deleted(
         await session.commit()
 
     # Act
-    with patch('storage.org_store.a_session_maker', async_session_maker):
+    with (
+        patch('storage.org_store.a_session_maker', async_session_maker),
+        patch(
+            'storage.org_store.OrgStore._delete_litellm_user_best_effort',
+            new=AsyncMock(),
+        ) as mock_delete_litellm_user,
+    ):
         result = await OrgStore.delete_org_cascade(
             org_id, requester_user_id=str(user_id)
         )
@@ -1075,6 +1119,7 @@ async def test_delete_org_cascade_sole_org_requester_is_deleted(
     # Assert: the deleted org is returned, and the user/org/member rows are gone.
     assert result is not None
     assert result.id == org_id
+    mock_delete_litellm_user.assert_called_once_with(str(user_id), org_id)
 
     async with async_session_maker() as session:
         assert await session.get(Org, org_id) is None


### PR DESCRIPTION
HUMAN:
This PR fixes the personal-org reset path from #14686. When the requester is the sole user being removed, OpenHands already deletes the local user row and LiteLLM team, but the matching LiteLLM user can remain and block a clean sign-in. The fix adds best-effort LiteLLM user cleanup only for that requester_orphan_ids path; normal org deletion still does not delete LiteLLM users, and LiteLLM cleanup failures are logged without rolling back the OpenHands DB cascade.

- [x] A human has tested these changes.

## Summary

Fixes #14686.

When delete_org_cascade handles the personal-org reset path, OpenHands deletes the requester user row and the LiteLLM team, but the matching LiteLLM user record was left behind. This adds a best-effort LiteLLM user cleanup for that same sole-requester orphan branch so a reset user can sign back in without reattaching to a stale LiteLLM user record.

The cleanup is intentionally scoped to requester_orphan_ids. Regular org deletion paths do not delete LiteLLM users, and a LiteLLM user-delete failure is logged and swallowed so it does not roll back the already-valid OpenHands database cascade.

## Tests

- PYTHONPATH="enterprise:.:$PYTHONPATH" poetry run --project=enterprise pytest enterprise/tests/unit/test_org_store.py -k "delete_litellm_user_best_effort or delete_org_cascade_success"
- poetry run --project=enterprise pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files storage/org_store.py tests/unit/test_org_store.py
- poetry run --project=enterprise pre-commit run --config ../dev_config/python/.pre-commit-config.yaml --files enterprise/storage/org_store.py enterprise/tests/unit/test_org_store.py