### PR TITLE
Fix WebSocket user messages triggering agent run

### DIFF
--- a/frontend/__tests__/conversation-websocket-handler.test.tsx
+++ b/frontend/__tests__/conversation-websocket-handler.test.tsx
@@ -1110,10 +1110,12 @@ describe("Conversation WebSocket Handler", () => {
       expect(receivedMessages[0]).toEqual({
         role: "user",
         content: [{ type: "text", text: "Message 1" }],
+        run: true,
       });
       expect(receivedMessages[1]).toEqual({
         role: "user",
         content: [{ type: "text", text: "Message 2" }],
+        run: true,
       });
     });
   });

--- a/frontend/src/contexts/conversation-websocket-context.tsx
+++ b/frontend/src/contexts/conversation-websocket-context.tsx
@@ -910,7 +910,7 @@ export function ConversationWebSocketProvider({
 
       try {
         // Send message through WebSocket as JSON
-        currentSocket.send(JSON.stringify(message));
+        currentSocket.send(JSON.stringify({ ...message, run: true }));
         return { queued: false };
       } catch (error) {
         const errorMessage =


### PR DESCRIPTION
HUMAN:

This PR keeps user follow-up messages from getting stuck after a conversation is idle by making the WebSocket send path request an agent run, just like the REST/pending-message paths already do.

- [ ] A human has tested these changes.

AGENT:

---

## Why

Closes OpenHands/enterprise#28.

When the frontend sends a user message over the direct agent-server WebSocket, it currently sends only `role` and `content`. The agent-server event endpoint defaults `run` to false, so a follow-up message can be persisted without restarting the agent loop after a conversation is already idle or finished.

The REST and pending-message paths already request a run, so this aligns the connected WebSocket path with those message delivery paths.

## Summary

- Add `run: true` to user messages sent through the connected conversation WebSocket.
- Tighten the WebSocket message-sending test to assert that sent payloads include `run: true`.

## Issue Number

OpenHands/enterprise#28

## How to Test

I ran:

```bash
cd frontend
npm run test -- __tests__/conversation-websocket-handler.test.tsx
npm run typecheck
npx prettier --check src/contexts/conversation-websocket-context.tsx __tests__/conversation-websocket-handler.test.tsx
npx eslint src/contexts/conversation-websocket-context.tsx
```

The commit hook also ran frontend lint-staged checks, staged typecheck, translation completeness, and backend pre-commit checks successfully.

Note: `make install-pre-commit-hooks` could not run before editing because this machine's default Python is outside the repository's required `>=3.12,<3.14` range.

## Video/Screenshots

N/A, logic-only WebSocket payload fix covered by tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This intentionally keeps the change narrow to the connected WebSocket path used for user messages. Existing queued/pending-message delivery already sends `run: true` when it forwards pending messages to the agent server.
