### PR TITLE
fix(app_server): preserve user LLM settings for DeepSeek via model_copy

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1215,6 +1215,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             base_url=base_url,
             api_key=user.agent_settings.llm.api_key,
             usage_id='agent',
+            timeout=user.agent_settings.llm.timeout,
         )
 
     async def _add_system_mcp_servers(

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1210,12 +1210,13 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             provider_base_url=self.openhands_provider_base_url,
         )
 
-        return LLM(
-            model=model,
-            base_url=base_url,
-            api_key=user.agent_settings.llm.api_key,
-            usage_id='agent',
-            timeout=user.agent_settings.llm.timeout,
+        user_llm = user.agent_settings.llm
+        return user_llm.model_copy(
+            update={
+                'model': model,
+                'base_url': base_url,
+                'usage_id': 'agent',
+            }
         )
 
     async def _add_system_mcp_servers(

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -637,13 +637,17 @@ class TestLiveStatusAppConversationService:
         assert llm.base_url == 'https://sdk-llm.example.com'
 
     @pytest.mark.asyncio
-    async def test_configure_llm_and_mcp_uses_user_llm_timeout(self):
-        """User-configured LLM timeout should override the SDK default (300s)."""
+    async def test_configure_llm_and_mcp_preserves_deepseek_llm_settings(self):
+        """DeepSeek user settings should survive _configure_llm via model_copy."""
         self.mock_user.agent_settings = Settings(
             agent_settings={
                 'llm': {
-                    'model': 'ollama/qwen3',
+                    'model': 'deepseek/deepseek-chat',
+                    'base_url': 'https://api.deepseek.com/v1',
                     'timeout': 3600,
+                    'reasoning_effort': 'none',
+                    'enable_encrypted_reasoning': False,
+                    'litellm_extra_body': {'thinking': {'type': 'disabled'}},
                 }
             }
         ).agent_settings
@@ -653,7 +657,37 @@ class TestLiveStatusAppConversationService:
             self.mock_user, None, self.conversation_id
         )
 
+        assert llm.model == 'deepseek/deepseek-chat'
+        assert llm.base_url == 'https://api.deepseek.com/v1'
         assert llm.timeout == 3600
+        assert llm.reasoning_effort == 'none'
+        assert llm.enable_encrypted_reasoning is False
+        assert llm.litellm_extra_body == {'thinking': {'type': 'disabled'}}
+        assert llm.usage_id == 'agent'
+
+    @pytest.mark.asyncio
+    async def test_configure_llm_and_mcp_overrides_model_and_base_url_only(self):
+        """Conversation model override should not discard other user LLM fields."""
+        self.mock_user.agent_settings = Settings(
+            agent_settings={
+                'llm': {
+                    'model': 'deepseek/deepseek-chat',
+                    'base_url': 'https://api.deepseek.com/v1',
+                    'timeout': 1800,
+                    'num_retries': 8,
+                }
+            }
+        ).agent_settings
+        self.mock_user_context.get_mcp_api_key.return_value = None
+
+        llm, _ = await self.service._configure_llm_and_mcp(
+            self.mock_user, 'deepseek/deepseek-reasoner', self.conversation_id
+        )
+
+        assert llm.model == 'deepseek/deepseek-reasoner'
+        assert llm.base_url == 'https://api.deepseek.com/v1'
+        assert llm.timeout == 1800
+        assert llm.num_retries == 8
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_openhands_model_uses_user_base_url(

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -637,6 +637,25 @@ class TestLiveStatusAppConversationService:
         assert llm.base_url == 'https://sdk-llm.example.com'
 
     @pytest.mark.asyncio
+    async def test_configure_llm_and_mcp_uses_user_llm_timeout(self):
+        """User-configured LLM timeout should override the SDK default (300s)."""
+        self.mock_user.agent_settings = Settings(
+            agent_settings={
+                'llm': {
+                    'model': 'ollama/qwen3',
+                    'timeout': 3600,
+                }
+            }
+        ).agent_settings
+        self.mock_user_context.get_mcp_api_key.return_value = None
+
+        llm, _ = await self.service._configure_llm_and_mcp(
+            self.mock_user, None, self.conversation_id
+        )
+
+        assert llm.timeout == 3600
+
+    @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_openhands_model_uses_user_base_url(
         self,
     ):


### PR DESCRIPTION
## Summary
- Fix `_configure_llm` discarding user Settings when starting conversations
- Use `model_copy()` to forward timeout, reasoning_effort, litellm_extra_body, enable_encrypted_reasoning, num_retries, and other LLM fields
- Add DeepSeek-focused unit tests for settings preservation and per-conversation model override

## Root cause
`_configure_llm` rebuilt `LLM(...)` with only model/base_url/api_key, so SDK defaults (e.g. timeout=300s, reasoning_effort=high) overrode user-configured DeepSeek settings.

## DeepSeek impact
- Fixes long-request timeout (#14682)
- Preserves `reasoning_effort: none` and `litellm_extra_body: {thinking: disabled}` needed for DeepSeek V4 compatibility (#14177)

Fixes OpenHands/software-agent-sdk#4255
Related to OpenHands/software-agent-sdk#4249