### PR TITLE
fix: prevent agent_context=null from corrupting org settings and causing 500s

### DIFF
--- a/enterprise/server/routes/org_models.py
+++ b/enterprise/server/routes/org_models.py
@@ -262,6 +262,21 @@ class OrgUpdate(BaseModel):
 
     def _normalize_agent_settings_diff(self) -> None:
         """Normalize nested LLM settings inside ``agent_settings_diff``."""
+        if self.agent_settings_diff is None:
+            return
+
+        # Strip an explicit ``agent_context: null`` for non-ACP variants.  The
+        # field is non-nullable in ``OpenHandsAgentSettings``; a null value in
+        # the diff would propagate into the stored JSON and cause a
+        # ValidationError on every subsequent read.
+        target_kind = self.agent_settings_diff.get('agent_kind', 'openhands')
+        if (
+            target_kind != 'acp'
+            and 'agent_context' in self.agent_settings_diff
+            and self.agent_settings_diff['agent_context'] is None
+        ):
+            self.agent_settings_diff.pop('agent_context')
+
         llm_diff = self._get_agent_llm_diff()
         if llm_diff is None:
             return

--- a/enterprise/tests/unit/server/routes/test_org_defaults_settings.py
+++ b/enterprise/tests/unit/server/routes/test_org_defaults_settings.py
@@ -213,3 +213,72 @@ def test_from_org_keeps_custom_base_url_that_is_not_provider_default():
         == 'https://company-proxy.internal/anthropic'
     )
     assert response.search_api_key == '****1234'
+
+
+def test_from_org_strips_null_agent_context_without_500():
+    """GIVEN: An org row with ``agent_context: null`` persisted for an OpenHands
+        variant (the exact shape behind the /api/organizations 500s reported in
+        the incident at 05:46 UTC).
+    WHEN: ``OrgDefaultsSettingsResponse.from_org`` serializes the org.
+    THEN: It loads successfully instead of raising a Pydantic ValidationError —
+        the null is silently dropped and the field default is used instead.
+    """
+    org = MagicMock(spec=Org)
+    org.agent_settings = {
+        'agent_kind': 'openhands',
+        'agent_context': None,
+        'llm': {'model': 'anthropic/claude-sonnet-4-5'},
+    }
+    org.conversation_settings = {}
+    org.llm_api_key = None
+    org.search_api_key = None
+
+    response = OrgDefaultsSettingsResponse.from_org(org)
+
+    assert response.agent_settings.agent_kind == 'openhands'
+    assert response.agent_settings.llm.model == 'anthropic/claude-sonnet-4-5'
+
+
+def test_org_update_strips_null_agent_context_for_openhands_variant():
+    """``OrgUpdate.agent_settings_diff`` with ``agent_context: null`` must be
+    stripped during normalisation for OpenHands variants.
+
+    ``OpenHandsAgentSettings.agent_context`` is non-nullable; a null value in
+    the diff would propagate via deep-merge into the stored JSON column and
+    cause a ValidationError on every subsequent read.  The model validator must
+    remove the key before the diff reaches ``_merge_and_validate_settings``.
+    """
+    update = OrgUpdate.model_validate(
+        {
+            'agent_settings_diff': {
+                'agent_context': None,
+                'llm': {'model': 'anthropic/claude-sonnet-4-5'},
+            }
+        }
+    )
+
+    assert update.agent_settings_diff is not None
+    assert 'agent_context' not in update.agent_settings_diff
+
+
+def test_org_update_preserves_null_agent_context_for_acp_variant():
+    """``OrgUpdate.agent_settings_diff`` must preserve ``agent_context: null``
+    when ``agent_kind: 'acp'`` is explicitly set.
+
+    ``ACPAgentSettings.agent_context`` is nullable, so null is a valid and
+    meaningful value for ACP diffs.
+    """
+    update = OrgUpdate.model_validate(
+        {
+            'agent_settings_diff': {
+                'agent_kind': 'acp',
+                'agent_context': None,
+                'acp_server': 'claude-code',
+            }
+        }
+    )
+
+    assert update.agent_settings_diff is not None
+    assert update.agent_settings_diff.get('agent_context') is None
+    # Key must be present (not accidentally dropped together with agent_kind stripping)
+    assert 'agent_context' in update.agent_settings_diff

--- a/openhands/app_server/settings/settings_models.py
+++ b/openhands/app_server/settings/settings_models.py
@@ -75,10 +75,26 @@ def _load_persisted_agent_settings(
     ``LLMAgentSettings``. Doing it here keeps every read on the canonical
     ``{openhands, acp}`` variants, without the cross-variant coercion that 500'd
     ACP settings (``agent_kind: 'acp'`` is left untouched).
+
+    Defensively strips an explicit ``agent_context: null`` for non-ACP variants.
+    ``OpenHandsAgentSettings`` requires ``agent_context`` to be a dict or
+    ``AgentContext`` instance — never ``None``.  Clients that persist
+    ``agent_context=null`` (e.g. older code paths or buggy writes) would
+    otherwise surface as HTTP 500 on every subsequent read.  Dropping the key
+    lets the field default take over, restoring a valid state without losing any
+    real configuration.  ACP settings legitimately carry ``agent_context=None``
+    (the field is nullable there), so they are left untouched.
     """
     payload = data or {}
     if isinstance(payload, dict) and payload.get('agent_kind') == 'llm':
         payload = {**payload, 'agent_kind': 'openhands'}
+    if (
+        isinstance(payload, dict)
+        and payload.get('agent_kind', 'openhands') != 'acp'
+        and 'agent_context' in payload
+        and payload['agent_context'] is None
+    ):
+        payload = {k: v for k, v in payload.items() if k != 'agent_context'}
     return validate_agent_settings(payload)
 
 
@@ -216,10 +232,24 @@ class Settings(BaseModel):
                     _coerce_value(value) if not isinstance(value, dict) else value
                 )
 
+            # Strip an explicit ``agent_context: null`` for non-ACP variants.
+            # The field is non-nullable in ``OpenHandsAgentSettings``, so null
+            # is never a valid write.  Removing the key here also prevents
+            # ``deep_merge`` from treating it as a "delete this key" tombstone,
+            # which would silently wipe a valid existing ``agent_context`` from
+            # org settings.
+            new_kind = coerced.get('agent_kind')
+            target_kind = new_kind or self.agent_settings.agent_kind
+            if (
+                target_kind != 'acp'
+                and 'agent_context' in coerced
+                and coerced['agent_context'] is None
+            ):
+                coerced.pop('agent_context')
+
             replace_mcp_config = 'mcp_config' in agent_update
             mcp_config = coerced.pop('mcp_config', None) if replace_mcp_config else None
 
-            new_kind = coerced.get('agent_kind')
             current_kind = self.agent_settings.agent_kind
 
             if new_kind and new_kind != current_kind:

--- a/tests/unit/app_server/test_settings_agent_kind_switch.py
+++ b/tests/unit/app_server/test_settings_agent_kind_switch.py
@@ -144,3 +144,75 @@ def test_loader_preserves_acp_variant_without_coercion():
 
     assert loaded.agent_kind == 'acp'
     assert loaded.agent_context is None
+
+
+def test_loader_strips_null_agent_context_for_openhands_variant():
+    """Persisted ``agent_context: null`` for OpenHands settings must not 500.
+
+    ``OpenHandsAgentSettings`` requires ``agent_context`` to be a dict or
+    ``AgentContext`` instance — ``None`` is invalid.  Buggy writes or legacy
+    code paths that stored ``agent_context=null`` would otherwise cause a
+    Pydantic ``ValidationError`` (HTTP 500) on every subsequent read of the
+    organisation's settings.  The loader must silently drop the null and let
+    the field default take over.
+    """
+    loaded = _load_persisted_agent_settings(
+        {
+            'agent_kind': 'openhands',
+            'agent_context': None,
+            'llm': {'model': 'anthropic/claude-sonnet-4-5'},
+        }
+    )
+
+    assert loaded.agent_kind == 'openhands'
+
+
+def test_loader_strips_null_agent_context_when_agent_kind_absent():
+    """``agent_context: null`` is stripped even when ``agent_kind`` is absent.
+
+    Persisted rows that pre-date the ``agent_kind`` field default to the
+    ``openhands`` variant.  The loader must strip null ``agent_context`` for
+    those rows too.
+    """
+    loaded = _load_persisted_agent_settings(
+        {
+            'agent_context': None,
+            'llm': {'model': 'anthropic/claude-sonnet-4-5'},
+        }
+    )
+
+    assert loaded.agent_kind == 'openhands'
+
+
+def test_loader_preserves_null_agent_context_for_acp_variant():
+    """``agent_context: null`` must be preserved for ACP settings.
+
+    ``ACPAgentSettings.agent_context`` is nullable by design — stripping it
+    would change the semantics of ACP configurations.
+    """
+    loaded = _load_persisted_agent_settings(
+        {
+            'agent_kind': 'acp',
+            'agent_context': None,
+            'acp_server': 'claude-code',
+            'llm': {'model': 'litellm_proxy/anthropic/claude-sonnet-4'},
+        }
+    )
+
+    assert loaded.agent_kind == 'acp'
+    assert loaded.agent_context is None
+
+
+def test_update_strips_null_agent_context_from_openhands_diff():
+    """``agent_settings_diff`` with ``agent_context: null`` must not corrupt
+    org settings.
+
+    ``deep_merge`` treats ``None`` values as "delete this key", so sending
+    ``agent_context: null`` in the diff would silently remove a valid existing
+    ``agent_context`` from org settings.  The fix must strip the key before
+    the merge to preserve the existing value.
+    """
+    s = Settings()
+    # Should not raise even though OpenHands settings reject agent_context=None
+    s.update({'agent_settings_diff': {'agent_context': None}})
+    assert s.agent_settings.agent_kind == 'openhands'


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

H:


- [ ] A human has tested these changes.

AGENT:

---

## Why

Datadog reported HTTP 500s on `GET /api/organizations`, `GET /api/v1/settings`, and `GET /api/v1/settings/profiles` for affected orgs. Root cause: a write-read validation asymmetry where `POST /api/v1/settings` (and the enterprise org-update route) accepted `agent_context=null` in the payload without validation, storing it in the `org.agent_settings` JSON column. On every subsequent read, `_load_persisted_agent_settings` called `validate_agent_settings({agent_context: None, ...})`, which Pydantic rejects for `OpenHandsAgentSettings` (the field is non-nullable there), producing the 500.

## Summary

- **Read path (defensive repair):** `_load_persisted_agent_settings` now strips an explicit `agent_context: null` key from non-ACP payloads before calling `validate_agent_settings`. This restores a valid in-memory state for already-corrupted rows without any DB migration. ACP rows are untouched (`ACPAgentSettings.agent_context` is nullable by design).
- **Write path (preventive guards, two call-sites):** `Settings.update()` and `OrgUpdate._normalize_agent_settings_diff()` both strip `agent_context: null` from incoming diffs for non-ACP variants before deep-merging. This also prevents `deep_merge` from treating `null` as a "delete-this-key" tombstone that would silently wipe a valid existing `agent_context` from org settings.
- **Tests:** Five new regression tests covering the loader strip, `Settings.update`, `OrgDefaultsSettingsResponse.from_org`, and `OrgUpdate` normalization for both OpenHands and ACP variants.

## Issue Number

N/A — Datadog incident fix.

## How to Test

```bash
# Backend unit tests
poetry run pytest tests/unit/app_server/test_settings_agent_kind_switch.py -v

# Enterprise tests
cd enterprise && PYTHONPATH=.:PYTHONPATH poetry run pytest tests/unit/server/routes/test_org_defaults_settings.py -v
```

To verify the 500 is fixed end-to-end: create an org, directly set `agent_context: null` in the DB row (or use a client that sends `agent_settings_diff: {agent_context: null}`), then call `GET /api/organizations` — should return 200 instead of 500.

## Type

- [x] Bug fix

## Notes

This does **not** require a database migration. The read-path fix handles already-corrupted rows transparently on each read. Separately, a one-off DB query to null-coalesce `agent_settings->agent_context` back to the field default would clean up the stored data, but that is out of scope for this code PR.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-003af2b   docker.openhands.dev/openhands/openhands:003af2b
```