### PR TITLE
fix: seed system_message_suffix from saved user agent_context

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1592,6 +1592,16 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             else:
                 effective_suffix = PLANNING_AGENT_INSTRUCTION
 
+        # Fallback: when the per-conversation request carried no suffix
+        # (the GUI never sets one), seed from the user's saved global
+        # agent_context.system_message_suffix so always-on user
+        # preferences reach every conversation, in-repo and no-repo.
+        if not effective_suffix:
+            _saved_ctx = getattr(user.agent_settings, 'agent_context', None)
+            _saved_suffix = getattr(_saved_ctx, 'system_message_suffix', None)
+            if _saved_suffix:
+                effective_suffix = _saved_suffix
+
         # --- web host context -----------------------------------------------
         # Add WEB_HOST to agent context if available
         if self.web_url:

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1582,25 +1582,19 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             user, llm_model, conversation_id
         )
 
-        # --- system_message_suffix (planning-agent prefix) ------------------
-        effective_suffix = system_message_suffix
+        # --- system_message_suffix (user suffix + planning-agent prefix) ------
+        saved_agent_context = getattr(user.agent_settings, 'agent_context', None)
+        saved_system_message_suffix = getattr(
+            saved_agent_context, 'system_message_suffix', None
+        )
+        base_suffix = system_message_suffix or saved_system_message_suffix
+
+        effective_suffix = base_suffix
         if agent_type == AgentType.PLAN:
-            if system_message_suffix:
-                effective_suffix = (
-                    f'{PLANNING_AGENT_INSTRUCTION}\n\n{system_message_suffix}'
-                )
+            if base_suffix:
+                effective_suffix = f'{PLANNING_AGENT_INSTRUCTION}\n\n{base_suffix}'
             else:
                 effective_suffix = PLANNING_AGENT_INSTRUCTION
-
-        # Fallback: when the per-conversation request carried no suffix
-        # (the GUI never sets one), seed from the user's saved global
-        # agent_context.system_message_suffix so always-on user
-        # preferences reach every conversation, in-repo and no-repo.
-        if not effective_suffix:
-            _saved_ctx = getattr(user.agent_settings, 'agent_context', None)
-            _saved_suffix = getattr(_saved_ctx, 'system_message_suffix', None)
-            if _saved_suffix:
-                effective_suffix = _saved_suffix
 
         # --- web host context -----------------------------------------------
         # Add WEB_HOST to agent context if available

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -24,6 +24,7 @@ from openhands.app_server.app_conversation.app_conversation_models import (
     ConversationTrigger,
 )
 from openhands.app_server.app_conversation.live_status_app_conversation_service import (
+    PLANNING_AGENT_INSTRUCTION,
     LiveStatusAppConversationService,
 )
 from openhands.app_server.integrations.provider import ProviderToken, ProviderType
@@ -1045,6 +1046,49 @@ class TestLiveStatusAppConversationService:
                 f'saved suffix missing for repo={selected_repository!r}'
             )
             assert '<HOST>' in suffix
+
+    @patch(
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.get_planning_tools',
+        return_value=[],
+    )
+    @pytest.mark.asyncio
+    async def test_build_start_conversation_request_plan_seeds_saved_suffix(
+        self, _mock_tools
+    ):
+        """Planning conversations keep their prompt boundary and saved suffix."""
+        from openhands.sdk import AgentContext
+
+        saved_suffix = '<USER_PREFERENCES>Prefer concise plans.</USER_PREFERENCES>'
+        self.mock_user.agent_settings = _build_test_user_agent_settings(
+            self.mock_user
+        ).model_copy(
+            update={'agent_context': AgentContext(system_message_suffix=saved_suffix)}
+        )
+        self.mock_user_context.get_user_info.return_value = self.mock_user
+
+        self.service._setup_secrets_for_git_providers = AsyncMock(return_value={})
+        self.service._configure_llm_and_mcp = AsyncMock(
+            return_value=(LLM(model='gpt-4', api_key=SecretStr('test-key')), None)
+        )
+
+        result = await self.service._build_start_conversation_request_for_user(
+            sandbox=self.mock_sandbox,
+            conversation_id=uuid4(),
+            initial_message=None,
+            system_message_suffix=None,
+            git_provider=ProviderType.GITHUB,
+            working_dir='/test/dir',
+            agent_type=AgentType.PLAN,
+            llm_model='gpt-4',
+            remote_workspace=None,
+            selected_repository=None,
+        )
+        suffix = result.agent.agent_context.system_message_suffix
+        assert PLANNING_AGENT_INSTRUCTION in suffix
+        assert saved_suffix in suffix
+        assert '<HOST>' in suffix
+        assert suffix.index(PLANNING_AGENT_INSTRUCTION) < suffix.index(saved_suffix)
+        assert suffix.index(saved_suffix) < suffix.index('<HOST>')
 
     @patch(
         'openhands.app_server.app_conversation.live_status_app_conversation_service.get_default_tools',

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -1001,6 +1001,91 @@ class TestLiveStatusAppConversationService:
         )
 
     @patch(
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.get_default_tools',
+        return_value=[],
+    )
+    @pytest.mark.asyncio
+    async def test_build_start_conversation_request_seeds_saved_suffix(
+        self, _mock_tools
+    ):
+        """A GUI conversation (no per-request suffix) must still receive the
+        user's saved ``agent_context.system_message_suffix``, both in-repo and
+        no-repo. Regression for the global-preferences drop (sibling of the
+        ``_configure_llm`` fix in #14451)."""
+        from openhands.sdk import AgentContext
+
+        saved_suffix = '<USER_PREFERENCES>British English.</USER_PREFERENCES>'
+        self.mock_user.agent_settings = _build_test_user_agent_settings(
+            self.mock_user
+        ).model_copy(
+            update={'agent_context': AgentContext(system_message_suffix=saved_suffix)}
+        )
+        self.mock_user_context.get_user_info.return_value = self.mock_user
+
+        self.service._setup_secrets_for_git_providers = AsyncMock(return_value={})
+        self.service._configure_llm_and_mcp = AsyncMock(
+            return_value=(LLM(model='gpt-4', api_key=SecretStr('test-key')), None)
+        )
+
+        for selected_repository in ('test/repo', None):
+            result = await self.service._build_start_conversation_request_for_user(
+                sandbox=self.mock_sandbox,
+                conversation_id=uuid4(),
+                initial_message=None,
+                system_message_suffix=None,
+                git_provider=ProviderType.GITHUB,
+                working_dir='/test/dir',
+                agent_type=AgentType.DEFAULT,
+                llm_model='gpt-4',
+                remote_workspace=None,
+                selected_repository=selected_repository,
+            )
+            suffix = result.agent.agent_context.system_message_suffix
+            assert saved_suffix in suffix, (
+                f'saved suffix missing for repo={selected_repository!r}'
+            )
+            assert '<HOST>' in suffix
+
+    @patch(
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.get_default_tools',
+        return_value=[],
+    )
+    @pytest.mark.asyncio
+    async def test_build_start_conversation_request_per_request_suffix_wins(
+        self, _mock_tools
+    ):
+        """An explicit per-request suffix takes precedence over the saved one."""
+        from openhands.sdk import AgentContext
+
+        self.mock_user.agent_settings = _build_test_user_agent_settings(
+            self.mock_user
+        ).model_copy(
+            update={'agent_context': AgentContext(system_message_suffix='SAVED')}
+        )
+        self.mock_user_context.get_user_info.return_value = self.mock_user
+
+        self.service._setup_secrets_for_git_providers = AsyncMock(return_value={})
+        self.service._configure_llm_and_mcp = AsyncMock(
+            return_value=(LLM(model='gpt-4', api_key=SecretStr('test-key')), None)
+        )
+
+        result = await self.service._build_start_conversation_request_for_user(
+            sandbox=self.mock_sandbox,
+            conversation_id=uuid4(),
+            initial_message=None,
+            system_message_suffix='PER_REQUEST',
+            git_provider=ProviderType.GITHUB,
+            working_dir='/test/dir',
+            agent_type=AgentType.DEFAULT,
+            llm_model='gpt-4',
+            remote_workspace=None,
+            selected_repository=None,
+        )
+        suffix = result.agent.agent_context.system_message_suffix
+        assert 'PER_REQUEST' in suffix
+        assert 'SAVED' not in suffix
+
+    @patch(
         'openhands.app_server.app_conversation.live_status_app_conversation_service.get_registered_agent_definitions'
     )
     @patch(


### PR DESCRIPTION
HUMAN:

Tested on my self-hosted `main` fleet: with a saved global suffix, new
conversations now receive it in both no-repo and in-repo cases (confirmed by
reading the rendered `agent_context`, and behaviourally — the agent follows the
preferences). An explicit per-request suffix still takes precedence.

- [x] A human has tested these changes.

AGENT:

## Why

A user's saved global system-prompt instructions
(`agent_settings.agent_context.system_message_suffix`, set in Settings / `settings.json`,
visible in `/api/v1/settings`) never reach conversations started from the WebUI.

`LiveStatusAppConversationService._build_start_conversation_request_for_user` builds
`effective_suffix` purely from the **per-request** `system_message_suffix`, then appends
the `<HOST>` block and constructs a fresh `AgentContext(system_message_suffix=effective_suffix)`.
The GUI "new conversation" path never sets a per-request suffix (only the enterprise
resolver/integration views do), so the saved suffix is silently discarded — global
preferences (writing style, language, disclosure rules) are ignored, in-repo and no-repo.

Same class of bug as the LLM-settings drop fixed in OpenHands/OpenHands#14451 (`_configure_llm`); the WebUI
side of the long-standing "global user preferences don't apply" problem (related: OpenHands/software-agent-sdk#4252,
SDK OpenHands/OpenHands#2417). A maintainer confirmed an always-on user suffix is intended and regressed in V1.

## Summary

- When the per-conversation request carries no suffix, seed from the user's saved
  `agent_settings.agent_context.system_message_suffix` before composing planning-agent
  instructions and appending `<HOST>`.
- An explicit per-request suffix still wins (unchanged for the resolver/integration paths).
- Adds three regression tests (no-repo + in-repo seeding; planning seeding; per-request precedence).

```python
saved_agent_context = getattr(user.agent_settings, 'agent_context', None)
saved_system_message_suffix = getattr(
    saved_agent_context, 'system_message_suffix', None
)
base_suffix = system_message_suffix or saved_system_message_suffix
```

## Issue Number

Related: OpenHands/software-agent-sdk#4252, OpenHands/OpenHands#14451 (sibling fix).

## How to Test

Unit:
```
poetry run pytest tests/unit/app_server/test_live_status_app_conversation_service.py \
  -k "seeds_saved_suffix or per_request_suffix_wins or integration"
```

End-to-end (self-hosted `:main`):
1. Set `agent_settings.agent_context.system_message_suffix` in `settings.json`; restart.
2. Start a no-repo and an in-repo conversation from the GUI.
3. Read the agent-server `GET /api/conversations/<id>` and confirm
   `agent.agent_context.system_message_suffix` contains your saved text (plus the `<HOST>`
   block) in both cases. Before this change it was only `<HOST>`; after, the full suffix
   is present and the agent follows it.

## Video/Screenshots

n/a (server-side; verified by reading the rendered `agent_context` as above).


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

_AI disclosure: this PR description was updated by an AI agent (OpenHands) on behalf of @openhands to reflect the latest commit._
