### PR TITLE
fix(frontend): preserve chat input text when server send fails

### DIFF
--- a/frontend/src/components/features/chat/custom-chat-input.tsx
+++ b/frontend/src/components/features/chat/custom-chat-input.tsx
@@ -16,7 +16,7 @@ export interface CustomChatInputProps {
   isNewConversationPending?: boolean;
   showButton?: boolean;
   sandboxStatus?: V1SandboxStatus | null;
-  onSubmit: (message: string) => void;
+  onSubmit: (message: string) => Promise<void> | void;
   onFocus?: () => void;
   onBlur?: () => void;
   onFilesPaste?: (files: File[]) => void;

--- a/frontend/src/components/features/chat/interactive-chat-box.tsx
+++ b/frontend/src/components/features/chat/interactive-chat-box.tsx
@@ -14,7 +14,7 @@ import { useSubConversationTaskPolling } from "#/hooks/query/use-sub-conversatio
 import { isTaskPolling } from "#/utils/utils";
 
 interface InteractiveChatBoxProps {
-  onSubmit: (message: string, images: File[], files: File[]) => void;
+  onSubmit: (message: string, images: File[], files: File[]) => Promise<void>;
   disabled?: boolean;
 }
 
@@ -140,8 +140,8 @@ export function InteractiveChatBox({
   };
 
   const conversationId = conversation?.id ?? null;
-  const submitWithFiles = (message: string) => {
-    onSubmit(message, images, files);
+  const submitWithFiles = async (message: string): Promise<void> => {
+    await onSubmit(message, images, files);
     clearAllFiles();
   };
   const handleAfterModel = useBtwInterceptor(conversationId, submitWithFiles);

--- a/frontend/src/hooks/chat/use-btw-interceptor.ts
+++ b/frontend/src/hooks/chat/use-btw-interceptor.ts
@@ -12,19 +12,18 @@ const BTW_PREFIX = `${BTW_COMMAND} `;
  */
 export const useBtwInterceptor = (
   conversationId: string | null | undefined,
-  onSubmit: (message: string) => void,
+  onSubmit: (message: string) => Promise<void> | void,
 ) => {
   const addPending = useBtwStore((s) => s.addPending);
   const resolve = useBtwStore((s) => s.resolve);
   const fail = useBtwStore((s) => s.fail);
 
   return useCallback(
-    (message: string) => {
+    (message: string): Promise<void> | void => {
       const trimmed = message.trim();
       const isBtw = trimmed === BTW_COMMAND || trimmed.startsWith(BTW_PREFIX);
       if (!conversationId || !isBtw) {
-        onSubmit(message);
-        return;
+        return onSubmit(message);
       }
       const question = trimmed.slice(BTW_COMMAND.length).trim();
       if (!question) return;

--- a/frontend/src/hooks/chat/use-chat-submission.ts
+++ b/frontend/src/hooks/chat/use-chat-submission.ts
@@ -11,11 +11,11 @@ export const useChatSubmission = (
   chatInputRef: React.RefObject<HTMLDivElement | null>,
   fileInputRef: React.RefObject<HTMLInputElement | null>,
   smartResize: () => void,
-  onSubmit: (message: string) => void,
+  onSubmit: (message: string) => Promise<void> | void,
   resetManualResize?: () => void,
 ) => {
   // Send button click handler
-  const handleSubmit = useCallback(() => {
+  const handleSubmit = useCallback(async () => {
     const message = chatInputRef.current?.innerText || "";
     const trimmedMessage = message.trim();
 
@@ -23,17 +23,22 @@ export const useChatSubmission = (
       return;
     }
 
-    onSubmit(message);
+    try {
+      await onSubmit(message);
 
-    // Clear the input
-    clearTextContent(chatInputRef.current);
-    clearFileInput(fileInputRef.current);
+      // Clear the input only after a successful send so the user's text is
+      // preserved if the network call fails (e.g. "Failed to connect to server").
+      clearTextContent(chatInputRef.current);
+      clearFileInput(fileInputRef.current);
 
-    // Reset height and show suggestions again
-    smartResize();
+      // Reset height and show suggestions again
+      smartResize();
 
-    // Reset manual resize state for next message
-    resetManualResize?.();
+      // Reset manual resize state for next message
+      resetManualResize?.();
+    } catch {
+      // Send failed — leave the input intact so the user doesn't lose their message.
+    }
   }, [chatInputRef, fileInputRef, smartResize, onSubmit, resetManualResize]);
 
   // Handle stop button click

--- a/frontend/src/hooks/chat/use-model-interceptor.ts
+++ b/frontend/src/hooks/chat/use-model-interceptor.ts
@@ -21,7 +21,7 @@ const MODEL_PREFIX = `${MODEL_COMMAND} `;
  */
 export const useModelInterceptor = (
   conversationId: string | null | undefined,
-  onSubmit: (message: string) => void,
+  onSubmit: (message: string) => Promise<void> | void,
 ) => {
   const showProfiles = useModelStore((s) => s.show);
   const queryClient = useQueryClient();
@@ -29,13 +29,12 @@ export const useModelInterceptor = (
   const { t } = useTranslation();
 
   return useCallback(
-    (message: string) => {
+    (message: string): Promise<void> | void => {
       const trimmed = message.trim();
       const isModel =
         trimmed === MODEL_COMMAND || trimmed.startsWith(MODEL_PREFIX);
       if (!conversationId || !isModel) {
-        onSubmit(message);
-        return;
+        return onSubmit(message);
       }
 
       const arg = trimmed.slice(MODEL_COMMAND.length).trim();


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

H:

- [ ] A human has tested these changes.

AGENT: Fix authored by OpenHands AI agent on behalf of the user.

---

## Why

When a user hits Enter and the WebSocket/REST send fails (e.g. "Failed to connect to server"), the chat input was immediately cleared regardless of whether the send succeeded. The user's carefully typed message was permanently lost.

This happened because `handleSubmit` in `useChatSubmission` called `onSubmit(message)` as a synchronous fire-and-forget call and then unconditionally called `clearTextContent()` right after — before the async network operation could resolve or reject.

## Summary

- Made `handleSubmit` in `useChatSubmission` `async`; the input is now cleared only inside a `try` block **after** `await onSubmit` resolves successfully.
- Made `submitWithFiles` in `InteractiveChatBox` `async` so it properly awaits the send before clearing files.
- Updated `useBtwInterceptor` and `useModelInterceptor` to `return` the promise on passthrough calls, completing the async chain.
- Updated `onSubmit` type signatures in `CustomChatInputProps` and `InteractiveChatBoxProps` to `Promise<void> | void`.

## Issue Number

N/A

## How to Test

1. Open a conversation.
2. Type a long message.
3. Disconnect your network (e.g. DevTools → Network → Offline).
4. Hit Enter.
5. **Before fix:** input is cleared immediately; error banner appears; message is gone forever.
6. **After fix:** input stays intact; error banner appears; reconnect and retry without retyping.

## Video/Screenshots

Tested via code-path analysis.

## Type

- [x] Bug fix

## Notes

- Happy path also slightly improved: input clears at the same instant the optimistic message appears, eliminating a brief DOM flash.
- `() => Promise<void>` is assignable to `() => void` in TypeScript, so `ChatInputContainer` and `ChatInputRow` required no changes.

_This PR was created by an OpenHands AI agent on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-f2fd3c1   docker.openhands.dev/openhands/openhands:f2fd3c1
```