### PR TITLE
Fix Bitbucket DC userinfo lookup

### DIFF
--- a/enterprise/server/routes/bitbucket_dc_proxy.py
+++ b/enterprise/server/routes/bitbucket_dc_proxy.py
@@ -10,6 +10,17 @@ router = APIRouter(prefix='/bitbucket-dc-proxy')
 BITBUCKET_DC_TIMEOUT = 10  # seconds
 
 
+def _select_user_data(users: list[dict], username: str) -> dict | None:
+    username_folded = username.casefold()
+    for user in users:
+        for key in ('name', 'emailAddress', 'slug'):
+            value = user.get(key)
+            if isinstance(value, str) and value.casefold() == username_folded:
+                return user
+
+    return users[0] if users else None
+
+
 # Bitbucket Data Center is not an OIDC provider, so keycloak
 # can't retrieve user info from it directly.
 # This endpoint proxies requests to bitbucket data center to get user info
@@ -42,8 +53,9 @@ async def userinfo(request: Request):
 
         # Step 2: get user details
         user_resp = await client.get(
-            f'{bitbucket_base_url}/rest/api/latest/users/{username}',
+            f'{bitbucket_base_url}/rest/api/latest/users',
             headers=headers,
+            params={'filter': username},
             timeout=BITBUCKET_DC_TIMEOUT,
         )
         if user_resp.status_code != 200:
@@ -51,7 +63,12 @@ async def userinfo(request: Request):
                 {'error': f'bitbucket_error: {user_resp.status_code}'},
                 status_code=user_resp.status_code,
             )
-        user_data = user_resp.json()
+        user_data = _select_user_data(user_resp.json().get('values', []), username)
+        if not user_data:
+            return JSONResponse(
+                {'error': f'user_not_found: {username}'},
+                status_code=404,
+            )
 
     return JSONResponse(
         {

--- a/enterprise/tests/unit/server/routes/test_bitbucket_dc_proxy.py
+++ b/enterprise/tests/unit/server/routes/test_bitbucket_dc_proxy.py
@@ -93,6 +93,30 @@ def test_user_details_non_200(client):
     assert response.json() == {'error': 'bitbucket_error: 404'}
 
 
+def test_user_details_empty_search_results(client):
+    whoami_resp = MagicMock()
+    whoami_resp.status_code = 200
+    whoami_resp.text = 'testuser'
+
+    user_resp = MagicMock()
+    user_resp.status_code = 200
+    user_resp.json.return_value = {'values': []}
+
+    with patch('server.routes.bitbucket_dc_proxy.httpx.AsyncClient') as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[whoami_resp, user_resp])
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        response = client.get(
+            '/bitbucket-dc-proxy/oauth2/userinfo',
+            headers={'Authorization': 'Bearer some_token'},
+        )
+
+    assert response.status_code == 404
+    assert response.json() == {'error': 'user_not_found: testuser'}
+
+
 def test_happy_path_full_user_data(client):
     whoami_resp = MagicMock()
     whoami_resp.status_code = 200
@@ -101,10 +125,14 @@ def test_happy_path_full_user_data(client):
     user_resp = MagicMock()
     user_resp.status_code = 200
     user_resp.json.return_value = {
-        'id': 42,
-        'name': 'jsmith',
-        'displayName': 'John Smith',
-        'emailAddress': 'john@example.com',
+        'values': [
+            {
+                'id': 42,
+                'name': 'jsmith',
+                'displayName': 'John Smith',
+                'emailAddress': 'john@example.com',
+            }
+        ]
     }
 
     with patch('server.routes.bitbucket_dc_proxy.httpx.AsyncClient') as mock_client_cls:
@@ -132,8 +160,9 @@ def test_happy_path_full_user_data(client):
                 timeout=10,
             ),
             call(
-                'https://bitbucket.test/rest/api/latest/users/jsmith',
+                'https://bitbucket.test/rest/api/latest/users',
                 headers={'Authorization': 'Bearer some_token'},
+                params={'filter': 'jsmith'},
                 timeout=10,
             ),
         ]
@@ -148,9 +177,13 @@ def test_happy_path_missing_id_falls_back_to_username(client):
     user_resp = MagicMock()
     user_resp.status_code = 200
     user_resp.json.return_value = {
-        'name': 'jsmith',
-        'displayName': 'John Smith',
-        'emailAddress': 'john@example.com',
+        'values': [
+            {
+                'name': 'jsmith',
+                'displayName': 'John Smith',
+                'emailAddress': 'john@example.com',
+            }
+        ]
     }
 
     with patch('server.routes.bitbucket_dc_proxy.httpx.AsyncClient') as mock_client_cls:
@@ -174,8 +207,69 @@ def test_happy_path_missing_id_falls_back_to_username(client):
                 timeout=10,
             ),
             call(
-                'https://bitbucket.test/rest/api/latest/users/jsmith',
+                'https://bitbucket.test/rest/api/latest/users',
                 headers={'Authorization': 'Bearer some_token'},
+                params={'filter': 'jsmith'},
+                timeout=10,
+            ),
+        ]
+    )
+
+
+def test_happy_path_login_name_can_differ_from_slug(client):
+    whoami_resp = MagicMock()
+    whoami_resp.status_code = 200
+    whoami_resp.text = 'Jane.Doe@example.com'
+
+    user_resp = MagicMock()
+    user_resp.status_code = 200
+    user_resp.json.return_value = {
+        'values': [
+            {
+                'id': 1,
+                'name': 'other@example.com',
+                'displayName': 'Other User',
+                'emailAddress': 'other@example.com',
+                'slug': 'other',
+            },
+            {
+                'id': 2,
+                'name': 'Jane.Doe@example.com',
+                'displayName': 'Doe, Jane',
+                'emailAddress': 'Jane.Doe@example.com',
+                'slug': 'jane.doe_example.com',
+            },
+        ]
+    }
+
+    with patch('server.routes.bitbucket_dc_proxy.httpx.AsyncClient') as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[whoami_resp, user_resp])
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        response = client.get(
+            '/bitbucket-dc-proxy/oauth2/userinfo',
+            headers={'Authorization': 'Bearer some_token'},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data['sub'] == '2'
+    assert data['preferred_username'] == 'Jane.Doe@example.com'
+    assert data['name'] == 'Doe, Jane'
+    assert data['email'] == 'Jane.Doe@example.com'
+    mock_client.get.assert_has_calls(
+        [
+            call(
+                'https://bitbucket.test/plugins/servlet/applinks/whoami',
+                headers={'Authorization': 'Bearer some_token'},
+                timeout=10,
+            ),
+            call(
+                'https://bitbucket.test/rest/api/latest/users',
+                headers={'Authorization': 'Bearer some_token'},
+                params={'filter': 'Jane.Doe@example.com'},
                 timeout=10,
             ),
         ]


### PR DESCRIPTION
HUMAN:
This PR fixes Bitbucket Data Center login for instances where `whoami` returns a username/email that is not the same as the user slug. It now looks up the authenticated user through Bitbucket's filtered users endpoint and adds tests for the mismatched name/slug case.

- [ ] A human has tested these changes.

## Summary
- Resolve Bitbucket Data Center user details via `/rest/api/latest/users?filter=<username>` instead of assuming the `whoami` value is a user path slug.
- Select an exact match by `name`, `emailAddress`, or `slug` when Bitbucket returns multiple filtered users.
- Add route tests for empty search results and login names that differ from slugs.

## Why
Some Bitbucket Data Center instances return a login/name from `whoami` that is not accepted by `/rest/api/latest/users/<slug>`. That made Keycloak's user profile endpoint receive a 404 during OAuth login even though the OAuth token was valid.

## Validation
- `poetry run pytest tests/unit/server/routes/test_bitbucket_dc_proxy.py`
- `uv run ruff check enterprise/server/routes/bitbucket_dc_proxy.py enterprise/tests/unit/server/routes/test_bitbucket_dc_proxy.py`

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-b592d02   docker.openhands.dev/openhands/openhands:b592d02
```