### PR TITLE
fix(slack): post final assistant message instead of generated summary

### DIFF
--- a/enterprise/integrations/slack/slack_v1_callback_processor.py
+++ b/enterprise/integrations/slack/slack_v1_callback_processor.py
@@ -1,15 +1,15 @@
 import logging
+from collections.abc import Sequence
 from typing import ClassVar
 from uuid import UUID
 
-import httpx
-from integrations.utils import get_summary_instruction
+from integrations.utils import CONVERSATION_URL
 from integrations.v1_utils import handle_callback_error
 from pydantic import Field
 from slack_sdk import WebClient
 from storage.slack_team_store import SlackTeamStore
 
-from openhands.agent_server.models import AskAgentRequest, AskAgentResponse
+from openhands.agent_server.models import EventSortOrder
 from openhands.app_server.event_callback.event_callback_models import (
     EventCallback,
     EventCallbackProcessor,
@@ -19,15 +19,12 @@ from openhands.app_server.event_callback.event_callback_result_models import (
     EventCallbackResult,
     EventCallbackResultStatus,
 )
-from openhands.app_server.event_callback.util import (
-    ensure_conversation_found,
-    ensure_running_sandbox,
-    get_agent_server_url_from_sandbox,
-)
-from openhands.sdk import Event
+from openhands.sdk import Event, MessageEvent, TextContent
 from openhands.sdk.event import ConversationStateUpdateEvent
 
 _logger = logging.getLogger(__name__)
+
+_FINAL_MESSAGE_SEARCH_LIMIT = 50
 
 
 class SlackV1CallbackProcessor(EventCallbackProcessor):
@@ -54,20 +51,20 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
         # Log ALL terminal states for monitoring (finished, error, stuck)
         _logger.info('[Slack V1] Callback agent state was %s', event)
 
-        # Only request summary when execution has finished successfully
+        # Only post the final assistant message when execution has finished successfully
         if event.value != 'finished':
             return None
 
         try:
-            summary = await self._request_summary(conversation_id)
-            await self._post_summary_to_slack(summary)
+            message = await self._get_final_assistant_message(conversation_id)
+            await self._post_message_to_slack(message)
 
             return EventCallbackResult(
                 status=EventCallbackResultStatus.SUCCESS,
                 event_callback_id=callback.id,
                 event_id=event.id,
                 conversation_id=conversation_id,
-                detail=summary,
+                detail=message,
             )
         except Exception as e:
             await handle_callback_error(
@@ -76,7 +73,7 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
                 service_name='Slack',
                 service_logger=_logger,
                 can_post_error=True,  # Slack always attempts to post errors
-                post_error_func=self._post_summary_to_slack,
+                post_error_func=self._post_message_to_slack,
             )
 
             return EventCallbackResult(
@@ -100,8 +97,8 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
 
         return bot_access_token
 
-    async def _post_summary_to_slack(self, summary: str) -> None:
-        """Post a summary message to the configured Slack channel."""
+    async def _post_message_to_slack(self, message: str) -> None:
+        """Post a message to the configured Slack channel."""
         bot_access_token = await self._get_bot_access_token()
         if not bot_access_token:
             raise RuntimeError('Missing Slack bot access token')
@@ -114,12 +111,12 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
         client = WebClient(token=bot_access_token)
 
         try:
-            # Post the summary as a threaded reply
+            # Post the message as a threaded reply
             # Use markdown_text instead of text to properly render standard Markdown
             # (e.g., **bold**, [link](url)) which is used throughout the codebase
             response = client.chat_postMessage(
                 channel=channel_id,
-                markdown_text=summary,
+                markdown_text=message,
                 thread_ts=thread_ts,
                 unfurl_links=False,
                 unfurl_media=False,
@@ -131,7 +128,7 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
                 )
 
             _logger.info(
-                '[Slack V1] Successfully posted summary to channel %s', channel_id
+                '[Slack V1] Successfully posted message to channel %s', channel_id
             )
 
         except Exception as e:
@@ -139,96 +136,13 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
             raise
 
     # -------------------------------------------------------------------------
-    # Agent / sandbox helpers
+    # Final message lookup
     # -------------------------------------------------------------------------
 
-    async def _ask_question(
-        self,
-        httpx_client: httpx.AsyncClient,
-        agent_server_url: str,
-        conversation_id: UUID,
-        session_api_key: str,
-        message_content: str,
-    ) -> str:
-        """Send a message to the agent server via the V1 API and return response text."""
-        send_message_request = AskAgentRequest(question=message_content)
-
-        url = (
-            f"{agent_server_url.rstrip('/')}"
-            f"/api/conversations/{conversation_id}/ask_agent"
-        )
-        headers = {'X-Session-API-Key': session_api_key}
-        payload = send_message_request.model_dump()
-
-        try:
-            response = await httpx_client.post(
-                url,
-                json=payload,
-                headers=headers,
-                timeout=30.0,
-            )
-            response.raise_for_status()
-
-            agent_response = AskAgentResponse.model_validate(response.json())
-            return agent_response.response
-
-        except httpx.HTTPStatusError as e:
-            error_detail = f'HTTP {e.response.status_code} error'
-            try:
-                error_body = e.response.text
-                if error_body:
-                    error_detail += f': {error_body}'
-            except Exception:  # noqa: BLE001
-                pass
-
-            _logger.error(
-                '[Slack V1] HTTP error sending message to %s: %s. '
-                'Request payload: %s. Response headers: %s',
-                url,
-                error_detail,
-                payload,
-                dict(e.response.headers),
-                exc_info=True,
-            )
-            raise Exception(f'Failed to send message to agent server: {error_detail}')
-
-        except httpx.TimeoutException:
-            error_detail = f'Request timeout after 30 seconds to {url}'
-            _logger.error(
-                '[Slack V1] %s. Request payload: %s',
-                error_detail,
-                payload,
-                exc_info=True,
-            )
-            raise Exception(error_detail)
-
-        except httpx.RequestError as e:
-            error_detail = f'Request error to {url}: {str(e)}'
-            _logger.error(
-                '[Slack V1] %s. Request payload: %s',
-                error_detail,
-                payload,
-                exc_info=True,
-            )
-            raise Exception(error_detail)
-
-    # -------------------------------------------------------------------------
-    # Summary orchestration
-    # -------------------------------------------------------------------------
-
-    async def _request_summary(self, conversation_id: UUID) -> str:
-        """Ask the agent to produce a summary of its work and return the agent response.
-
-        NOTE: This method now returns a string (the agent server's response text)
-        and raises exceptions on errors. The wrapping into EventCallbackResult
-        is handled by __call__.
-        """
+    async def _get_final_assistant_message(self, conversation_id: UUID) -> str:
+        """Return the latest assistant message for a completed Slack run."""
         # Import services within the method to avoid circular imports
-        from openhands.app_server.config import (
-            get_app_conversation_info_service,
-            get_httpx_client,
-            get_sandbox_service,
-        )
+        from openhands.app_server.config import get_event_service
         from openhands.app_server.services.injector import InjectorState
         from openhands.app_server.user.specifiy_user_context import (
             ADMIN,
@@ -239,40 +153,58 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
         state = InjectorState()
         setattr(state, USER_CONTEXT_ATTR, ADMIN)
 
-        async with (
-            get_app_conversation_info_service(state) as app_conversation_info_service,
-            get_sandbox_service(state) as sandbox_service,
-            get_httpx_client(state) as httpx_client,
-        ):
-            # 1. Conversation lookup
-            app_conversation_info = ensure_conversation_found(
-                await app_conversation_info_service.get_app_conversation_info(
-                    conversation_id
-                ),
+        async with get_event_service(state) as event_service:
+            # Finished callbacks are emitted immediately after a run completes, so the
+            # final agent reply should be among the newest MessageEvents. Keep this
+            # bounded to avoid an expensive callback on very long conversations.
+            page = await event_service.search_events(
                 conversation_id,
+                kind__eq='MessageEvent',
+                sort_order=EventSortOrder.TIMESTAMP_DESC,
+                limit=_FINAL_MESSAGE_SEARCH_LIMIT,
             )
 
-            # 2. Sandbox lookup + validation
-            sandbox = ensure_running_sandbox(
-                await sandbox_service.get_sandbox(app_conversation_info.sandbox_id),
-                app_conversation_info.sandbox_id,
+        # EventPage.items is a materialized list, so it is safe to select from it
+        # after the event service context manager has closed.
+        for event in page.items:
+            if not self._is_agent_message_event(event):
+                continue
+            message = self._extract_message_text(event)
+            if message:
+                return message
+
+        return self._get_no_final_message_fallback(conversation_id)
+
+    def _is_agent_message_event(self, event: Event) -> bool:
+        if not isinstance(event, MessageEvent):
+            return False
+
+        return event.source == 'agent'
+
+    def _extract_message_text(self, event: MessageEvent) -> str:
+        llm_message = getattr(event, 'llm_message', None)
+        content = getattr(llm_message, 'content', None)
+        if isinstance(content, str) or not isinstance(content, Sequence):
+            _logger.debug(
+                '[Slack V1] Skipping message event %s because content is not a '
+                'sequence of content blocks',
+                event.id,
             )
+            return ''
 
-            assert (
-                sandbox.session_api_key is not None
-            ), f'No session API key for sandbox: {sandbox.id}'
+        text_parts = []
+        for content_part in content:
+            if not isinstance(content_part, TextContent):
+                continue
+            text = content_part.text.strip()
+            if text:
+                text_parts.append(text)
 
-            # 3. URL + instruction
-            agent_server_url = get_agent_server_url_from_sandbox(sandbox)
+        return '\n\n'.join(text_parts)
 
-            # Prepare message based on agent state
-            message_content = get_summary_instruction()
-
-            # Ask the agent and return the response text
-            return await self._ask_question(
-                httpx_client=httpx_client,
-                agent_server_url=agent_server_url,
-                conversation_id=conversation_id,
-                session_api_key=sandbox.session_api_key,
-                message_content=message_content,
-            )
+    def _get_no_final_message_fallback(self, conversation_id: UUID) -> str:
+        return (
+            'OpenHands finished the run, but no final assistant message was found. '
+            f'[See the conversation]({CONVERSATION_URL.format(conversation_id)}) '
+            'for more information.'
+        )

--- a/enterprise/tests/unit/integrations/slack/test_slack_v1_callback_processor.py
+++ b/enterprise/tests/unit/integrations/slack/test_slack_v1_callback_processor.py
@@ -1,46 +1,50 @@
-"""Tests for the SlackV1CallbackProcessor.
+"""Tests for the SlackV1CallbackProcessor."""
 
-Focuses on high-impact scenarios:
-- Double callback processing (main requirement)
-- Event filtering
-- Error handling for critical failures
-- Successful end-to-end flow
-"""
-
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
-import httpx
 import pytest
 from integrations.slack.slack_v1_callback_processor import (
+    _FINAL_MESSAGE_SEARCH_LIMIT,
     SlackV1CallbackProcessor,
 )
 
-from openhands.app_server.app_conversation.app_conversation_models import (
-    AppConversationInfo,
-)
+from openhands.agent_server.models import EventPage, EventSortOrder
 from openhands.app_server.event_callback.event_callback_models import EventCallback
 from openhands.app_server.event_callback.event_callback_result_models import (
     EventCallbackResultStatus,
 )
-from openhands.app_server.sandbox.sandbox_models import (
-    ExposedUrl,
-    SandboxInfo,
-    SandboxStatus,
-)
+from openhands.sdk import ImageContent, Message, MessageEvent, TextContent
 from openhands.sdk.event import ConversationStateUpdateEvent
 
 
+@asynccontextmanager
+async def _ctx(obj):
+    yield obj
+
+
 def _create_mock_event():
-    """Create a mock event that is not a ConversationStateUpdateEvent."""
     mock_event = MagicMock()
     mock_event.id = uuid4()
     return mock_event
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
+def _make_message_event(
+    role: str,
+    text: str | None = None,
+    *,
+    source: str | None = None,
+    content: list | None = None,
+) -> MessageEvent:
+    message_content = content
+    if message_content is None:
+        message_content = [TextContent(type='text', text=text or '')]
+
+    return MessageEvent(
+        source=source or ('agent' if role == 'assistant' else 'user'),
+        llm_message=Message(role=role, content=message_content),
+    )
 
 
 @pytest.fixture
@@ -69,54 +73,11 @@ def event_callback():
     )
 
 
-@pytest.fixture
-def mock_app_conversation_info():
-    return AppConversationInfo(
-        id=uuid4(),
-        created_by_user_id='test-user-123',
-        sandbox_id=str(uuid4()),
-        title='Test Conversation',
-    )
-
-
-@pytest.fixture
-def mock_sandbox_info():
-    return SandboxInfo(
-        id=str(uuid4()),
-        created_by_user_id='test-user-123',
-        sandbox_spec_id='test-spec-123',
-        status=SandboxStatus.RUNNING,
-        session_api_key='test-session-key',
-        exposed_urls=[
-            ExposedUrl(
-                url='http://localhost:8000',
-                name='AGENT_SERVER',
-                port=8000,
-            )
-        ],
-    )
-
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
-
-
 class TestSlackV1CallbackProcessor:
-    """Test the SlackV1CallbackProcessor class with focus on high-impact scenarios."""
-
-    # -------------------------------------------------------------------------
-    # Event filtering tests (parameterized)
-    # -------------------------------------------------------------------------
-
     @pytest.mark.parametrize(
         'event,expected_result',
         [
-            # Wrong event types should be ignored (use lazy evaluation for mock)
-            pytest.param(
-                None, None, id='wrong_event_type', marks=pytest.mark.wrong_event_type
-            ),
-            # Wrong state values should be ignored
+            pytest.param(_create_mock_event(), None, id='wrong_event_type'),
             (
                 ConversationStateUpdateEvent(key='execution_status', value='running'),
                 None,
@@ -129,155 +90,225 @@ class TestSlackV1CallbackProcessor:
         ],
     )
     async def test_event_filtering(
-        self, slack_callback_processor, event_callback, event, expected_result, request
+        self, slack_callback_processor, event_callback, event, expected_result
     ):
-        """Test that processor correctly filters events."""
-        # Handle the mock event case specially
-        if event is None and 'wrong_event_type' in request.node.name:
-            event = _create_mock_event()
         result = await slack_callback_processor(uuid4(), event_callback, event)
+
         assert result == expected_result
 
-    # -------------------------------------------------------------------------
-    # Double callback processing (main requirement)
-    # -------------------------------------------------------------------------
-
     @patch('storage.slack_team_store.SlackTeamStore.get_instance')
     @patch('integrations.slack.slack_v1_callback_processor.WebClient')
-    @patch.object(SlackV1CallbackProcessor, '_request_summary')
-    async def test_double_callback_processing(
+    @patch('openhands.app_server.config.get_event_service')
+    async def test_successful_flow_posts_final_assistant_message_without_summary_call(
         self,
-        mock_request_summary,
+        mock_get_event_service,
         mock_web_client,
         mock_slack_team_store,
         slack_callback_processor,
         finish_event,
         event_callback,
     ):
-        """Test that processor handles double callback correctly and processes both times."""
         conversation_id = uuid4()
+        final_message = 'I updated the Slack resolver and added tests.'
 
-        # Mock SlackTeamStore (async method)
+        mock_event_service = AsyncMock()
+        mock_event_service.search_events.return_value = EventPage(
+            items=[_make_message_event('assistant', final_message)], next_page_id=None
+        )
+        mock_get_event_service.return_value = _ctx(mock_event_service)
+
         mock_store = MagicMock()
         mock_store.get_team_bot_token = AsyncMock(return_value='xoxb-test-token')
         mock_slack_team_store.return_value = mock_store
 
-        # Mock successful summary generation
-        mock_request_summary.return_value = 'Test summary from agent'
-
-        # Mock Slack WebClient
         mock_slack_client = MagicMock()
         mock_slack_client.chat_postMessage.return_value = {'ok': True}
         mock_web_client.return_value = mock_slack_client
 
-        # First callback
-        result1 = await slack_callback_processor(
-            conversation_id, event_callback, finish_event
-        )
-
-        # Second callback (should not exit, should process again)
-        result2 = await slack_callback_processor(
-            conversation_id, event_callback, finish_event
-        )
-
-        # Verify both callbacks succeeded
-        assert result1 is not None
-        assert result1.status == EventCallbackResultStatus.SUCCESS
-        assert result1.detail == 'Test summary from agent'
-
-        assert result2 is not None
-        assert result2.status == EventCallbackResultStatus.SUCCESS
-        assert result2.detail == 'Test summary from agent'
-
-        # Verify both callbacks triggered summary requests and Slack posts
-        assert mock_request_summary.call_count == 2
-        assert mock_slack_client.chat_postMessage.call_count == 2
-
-    # -------------------------------------------------------------------------
-    # Successful end-to-end flow
-    # -------------------------------------------------------------------------
-
-    @patch('storage.slack_team_store.SlackTeamStore.get_instance')
-    @patch('openhands.app_server.config.get_httpx_client')
-    @patch('openhands.app_server.config.get_sandbox_service')
-    @patch('openhands.app_server.config.get_app_conversation_info_service')
-    @patch('integrations.slack.slack_v1_callback_processor.get_summary_instruction')
-    @patch('integrations.slack.slack_v1_callback_processor.WebClient')
-    async def test_successful_end_to_end_flow(
-        self,
-        mock_web_client,
-        mock_get_summary_instruction,
-        mock_get_app_conversation_info_service,
-        mock_get_sandbox_service,
-        mock_get_httpx_client,
-        mock_slack_team_store,
-        slack_callback_processor,
-        finish_event,
-        event_callback,
-        mock_app_conversation_info,
-        mock_sandbox_info,
-    ):
-        """Test successful end-to-end callback execution."""
-        conversation_id = uuid4()
-
-        # Mock SlackTeamStore (async method)
-        mock_store = MagicMock()
-        mock_store.get_team_bot_token = AsyncMock(return_value='xoxb-test-token')
-        mock_slack_team_store.return_value = mock_store
-
-        # Mock summary instruction
-        mock_get_summary_instruction.return_value = 'Please provide a summary'
-
-        # Mock services
-        mock_app_conversation_info_service = AsyncMock()
-        mock_app_conversation_info_service.get_app_conversation_info.return_value = (
-            mock_app_conversation_info
-        )
-        mock_get_app_conversation_info_service.return_value.__aenter__.return_value = (
-            mock_app_conversation_info_service
-        )
-
-        mock_sandbox_service = AsyncMock()
-        mock_sandbox_service.get_sandbox.return_value = mock_sandbox_info
-        mock_get_sandbox_service.return_value.__aenter__.return_value = (
-            mock_sandbox_service
-        )
-
-        mock_httpx_client = AsyncMock()
-        mock_response = MagicMock()
-        mock_response.json.return_value = {'response': 'Test summary from agent'}
-        mock_response.raise_for_status = MagicMock()
-        mock_httpx_client.post.return_value = mock_response
-        mock_get_httpx_client.return_value.__aenter__.return_value = mock_httpx_client
-
-        # Mock Slack WebClient
-        mock_slack_client = MagicMock()
-        mock_slack_client.chat_postMessage.return_value = {'ok': True}
-        mock_web_client.return_value = mock_slack_client
-
-        # Execute
         result = await slack_callback_processor(
             conversation_id, event_callback, finish_event
         )
 
-        # Verify result
         assert result is not None
         assert result.status == EventCallbackResultStatus.SUCCESS
         assert result.conversation_id == conversation_id
-        assert result.detail == 'Test summary from agent'
+        assert result.detail == final_message
 
-        # Verify Slack posting
+        mock_event_service.search_events.assert_awaited_once_with(
+            conversation_id,
+            kind__eq='MessageEvent',
+            sort_order=EventSortOrder.TIMESTAMP_DESC,
+            limit=_FINAL_MESSAGE_SEARCH_LIMIT,
+        )
         mock_slack_client.chat_postMessage.assert_called_once_with(
             channel='C1234567890',
-            markdown_text='Test summary from agent',
+            markdown_text=final_message,
             thread_ts='1234567890.123456',
             unfurl_links=False,
             unfurl_media=False,
         )
 
-    # -------------------------------------------------------------------------
-    # Error handling tests (parameterized)
-    # -------------------------------------------------------------------------
+    @patch('storage.slack_team_store.SlackTeamStore.get_instance')
+    @patch('integrations.slack.slack_v1_callback_processor.WebClient')
+    @patch.object(SlackV1CallbackProcessor, '_get_final_assistant_message')
+    async def test_double_callback_processing(
+        self,
+        mock_get_final_assistant_message,
+        mock_web_client,
+        mock_slack_team_store,
+        slack_callback_processor,
+        finish_event,
+        event_callback,
+    ):
+        conversation_id = uuid4()
+        mock_get_final_assistant_message.return_value = 'Final assistant message'
+
+        mock_store = MagicMock()
+        mock_store.get_team_bot_token = AsyncMock(return_value='xoxb-test-token')
+        mock_slack_team_store.return_value = mock_store
+
+        mock_slack_client = MagicMock()
+        mock_slack_client.chat_postMessage.return_value = {'ok': True}
+        mock_web_client.return_value = mock_slack_client
+
+        result1 = await slack_callback_processor(
+            conversation_id, event_callback, finish_event
+        )
+        result2 = await slack_callback_processor(
+            conversation_id, event_callback, finish_event
+        )
+
+        assert result1 is not None
+        assert result1.status == EventCallbackResultStatus.SUCCESS
+        assert result1.detail == 'Final assistant message'
+        assert result2 is not None
+        assert result2.status == EventCallbackResultStatus.SUCCESS
+        assert result2.detail == 'Final assistant message'
+        assert mock_get_final_assistant_message.call_count == 2
+        assert mock_slack_client.chat_postMessage.call_count == 2
+
+    async def test_get_final_assistant_message_skips_user_and_empty_messages(
+        self, slack_callback_processor
+    ):
+        conversation_id = uuid4()
+        mock_event_service = AsyncMock()
+        mock_event_service.search_events.return_value = EventPage(
+            items=[
+                _make_message_event('user', 'Most recent user message'),
+                _make_message_event('assistant', '   '),
+                _make_message_event('assistant', 'Older useful assistant message'),
+            ],
+            next_page_id=None,
+        )
+
+        with patch(
+            'openhands.app_server.config.get_event_service',
+            return_value=_ctx(mock_event_service),
+        ):
+            message = await slack_callback_processor._get_final_assistant_message(
+                conversation_id
+            )
+
+        assert message == 'Older useful assistant message'
+
+    async def test_get_final_assistant_message_ignores_assistant_role_from_non_agent_source(
+        self, slack_callback_processor
+    ):
+        conversation_id = uuid4()
+        mock_event_service = AsyncMock()
+        mock_event_service.search_events.return_value = EventPage(
+            items=[
+                _make_message_event(
+                    'assistant',
+                    'Assistant role wins',
+                    source='environment',
+                )
+            ],
+            next_page_id=None,
+        )
+
+        with patch(
+            'openhands.app_server.config.get_event_service',
+            return_value=_ctx(mock_event_service),
+        ):
+            message = await slack_callback_processor._get_final_assistant_message(
+                conversation_id
+            )
+
+        assert 'no final assistant message was found' in message
+        assert f'/conversations/{conversation_id}' in message
+
+    def test_extract_message_text_joins_text_blocks_and_ignores_non_text(
+        self, slack_callback_processor
+    ):
+        event = _make_message_event(
+            'assistant',
+            content=[
+                TextContent(type='text', text='First paragraph'),
+                ImageContent(type='image', image_urls=['https://example.com/a.png']),
+                TextContent(type='text', text='  Second paragraph  '),
+                TextContent(type='text', text='   '),
+            ],
+        )
+
+        message = slack_callback_processor._extract_message_text(event)
+
+        assert message == 'First paragraph\n\nSecond paragraph'
+
+    def test_extract_message_text_logs_and_skips_non_sequence_content(
+        self, slack_callback_processor
+    ):
+        event = MagicMock()
+        event.id = 'event-123'
+        event.llm_message.content = 'plain string content'
+
+        with patch(
+            'integrations.slack.slack_v1_callback_processor._logger'
+        ) as mock_logger:
+            message = slack_callback_processor._extract_message_text(event)
+
+        assert message == ''
+        mock_logger.debug.assert_called_once()
+
+    @patch('storage.slack_team_store.SlackTeamStore.get_instance')
+    @patch('integrations.slack.slack_v1_callback_processor.WebClient')
+    @patch('openhands.app_server.config.get_event_service')
+    async def test_no_assistant_message_posts_fallback(
+        self,
+        mock_get_event_service,
+        mock_web_client,
+        mock_slack_team_store,
+        slack_callback_processor,
+        finish_event,
+        event_callback,
+    ):
+        conversation_id = uuid4()
+        mock_event_service = AsyncMock()
+        mock_event_service.search_events.return_value = EventPage(
+            items=[_make_message_event('user', 'Only user text')], next_page_id=None
+        )
+        mock_get_event_service.return_value = _ctx(mock_event_service)
+
+        mock_store = MagicMock()
+        mock_store.get_team_bot_token = AsyncMock(return_value='xoxb-test-token')
+        mock_slack_team_store.return_value = mock_store
+
+        mock_slack_client = MagicMock()
+        mock_slack_client.chat_postMessage.return_value = {'ok': True}
+        mock_web_client.return_value = mock_slack_client
+
+        result = await slack_callback_processor(
+            conversation_id, event_callback, finish_event
+        )
+
+        assert result is not None
+        assert result.status == EventCallbackResultStatus.SUCCESS
+        assert 'no final assistant message was found' in result.detail
+        assert f'/conversations/{conversation_id}' in result.detail
+        posted_message = mock_slack_client.chat_postMessage.call_args[1][
+            'markdown_text'
+        ]
+        assert posted_message == result.detail
 
     @pytest.mark.parametrize(
         'bot_token,expected_error',
@@ -287,10 +318,10 @@ class TestSlackV1CallbackProcessor:
         ],
     )
     @patch('storage.slack_team_store.SlackTeamStore.get_instance')
-    @patch.object(SlackV1CallbackProcessor, '_request_summary')
+    @patch.object(SlackV1CallbackProcessor, '_get_final_assistant_message')
     async def test_missing_bot_token_scenarios(
         self,
-        mock_request_summary,
+        mock_get_final_assistant_message,
         mock_slack_team_store,
         slack_callback_processor,
         finish_event,
@@ -298,14 +329,10 @@ class TestSlackV1CallbackProcessor:
         bot_token,
         expected_error,
     ):
-        """Test error handling when bot access token is missing or empty."""
-        # Mock SlackTeamStore to return the test token (async method)
+        mock_get_final_assistant_message.return_value = 'Final assistant message'
         mock_store = MagicMock()
         mock_store.get_team_bot_token = AsyncMock(return_value=bot_token)
         mock_slack_team_store.return_value = mock_store
-
-        # Mock successful summary generation
-        mock_request_summary.return_value = 'Test summary'
 
         result = await slack_callback_processor(uuid4(), event_callback, finish_event)
 
@@ -326,10 +353,10 @@ class TestSlackV1CallbackProcessor:
     )
     @patch('storage.slack_team_store.SlackTeamStore.get_instance')
     @patch('integrations.slack.slack_v1_callback_processor.WebClient')
-    @patch.object(SlackV1CallbackProcessor, '_request_summary')
+    @patch.object(SlackV1CallbackProcessor, '_get_final_assistant_message')
     async def test_slack_api_error_scenarios(
         self,
-        mock_request_summary,
+        mock_get_final_assistant_message,
         mock_web_client,
         mock_slack_team_store,
         slack_callback_processor,
@@ -338,16 +365,11 @@ class TestSlackV1CallbackProcessor:
         slack_response,
         expected_error,
     ):
-        """Test error handling for various Slack API errors."""
-        # Mock SlackTeamStore (async method)
+        mock_get_final_assistant_message.return_value = 'Final assistant message'
         mock_store = MagicMock()
         mock_store.get_team_bot_token = AsyncMock(return_value='xoxb-test-token')
         mock_slack_team_store.return_value = mock_store
 
-        # Mock successful summary generation
-        mock_request_summary.return_value = 'Test summary'
-
-        # Mock Slack WebClient with error response
         mock_slack_client = MagicMock()
         mock_slack_client.chat_postMessage.return_value = slack_response
         mock_web_client.return_value = mock_slack_client
@@ -358,149 +380,34 @@ class TestSlackV1CallbackProcessor:
         assert result.status == EventCallbackResultStatus.ERROR
         assert expected_error in result.detail
 
-    @pytest.mark.parametrize(
-        'exception,expected_error_fragment',
-        [
-            (
-                httpx.TimeoutException('Request timeout'),
-                'Request timeout after 30 seconds',
-            ),
-            (
-                httpx.HTTPStatusError(
-                    'Server error',
-                    request=MagicMock(),
-                    response=MagicMock(
-                        status_code=500, text='Internal Server Error', headers={}
-                    ),
-                ),
-                'Failed to send message to agent server',
-            ),
-            (
-                httpx.RequestError('Connection error'),
-                'Request error',
-            ),
-        ],
-    )
     @patch('storage.slack_team_store.SlackTeamStore.get_instance')
-    @patch('openhands.app_server.config.get_httpx_client')
-    @patch('openhands.app_server.config.get_sandbox_service')
-    @patch('openhands.app_server.config.get_app_conversation_info_service')
-    @patch('integrations.slack.slack_v1_callback_processor.get_summary_instruction')
-    async def test_agent_server_error_scenarios(
-        self,
-        mock_get_summary_instruction,
-        mock_get_app_conversation_info_service,
-        mock_get_sandbox_service,
-        mock_get_httpx_client,
-        mock_slack_team_store,
-        slack_callback_processor,
-        finish_event,
-        event_callback,
-        mock_app_conversation_info,
-        mock_sandbox_info,
-        exception,
-        expected_error_fragment,
-    ):
-        """Test error handling for various agent server errors."""
-        conversation_id = uuid4()
-
-        # Mock SlackTeamStore (async method)
-        mock_store = MagicMock()
-        mock_store.get_team_bot_token = AsyncMock(return_value='xoxb-test-token')
-        mock_slack_team_store.return_value = mock_store
-
-        # Mock summary instruction
-        mock_get_summary_instruction.return_value = 'Please provide a summary'
-
-        # Mock services
-        mock_app_conversation_info_service = AsyncMock()
-        mock_app_conversation_info_service.get_app_conversation_info.return_value = (
-            mock_app_conversation_info
-        )
-        mock_get_app_conversation_info_service.return_value.__aenter__.return_value = (
-            mock_app_conversation_info_service
-        )
-
-        mock_sandbox_service = AsyncMock()
-        mock_sandbox_service.get_sandbox.return_value = mock_sandbox_info
-        mock_get_sandbox_service.return_value.__aenter__.return_value = (
-            mock_sandbox_service
-        )
-
-        # Mock HTTP client with the specified exception
-        mock_httpx_client = AsyncMock()
-        mock_httpx_client.post.side_effect = exception
-        mock_get_httpx_client.return_value.__aenter__.return_value = mock_httpx_client
-
-        # Execute
-        result = await slack_callback_processor(
-            conversation_id, event_callback, finish_event
-        )
-
-        # Verify error result
-        assert result is not None
-        assert result.status == EventCallbackResultStatus.ERROR
-        assert expected_error_fragment in result.detail
-
-    @patch('storage.slack_team_store.SlackTeamStore.get_instance')
-    @patch('openhands.app_server.config.get_httpx_client')
-    @patch('openhands.app_server.config.get_sandbox_service')
-    @patch('openhands.app_server.config.get_app_conversation_info_service')
-    @patch('integrations.slack.slack_v1_callback_processor.get_summary_instruction')
     @patch('integrations.slack.slack_v1_callback_processor._logger')
     @patch('integrations.slack.slack_v1_callback_processor.WebClient')
+    @patch.object(SlackV1CallbackProcessor, '_get_final_assistant_message')
     async def test_budget_exceeded_error_logs_info_and_sends_friendly_message(
         self,
+        mock_get_final_assistant_message,
         mock_web_client_cls,
         mock_logger,
-        mock_get_summary_instruction,
-        mock_get_app_conversation_info_service,
-        mock_get_sandbox_service,
-        mock_get_httpx_client,
         mock_slack_team_store,
         slack_callback_processor,
         finish_event,
         event_callback,
-        mock_app_conversation_info,
-        mock_sandbox_info,
     ):
-        """Test that budget exceeded errors are logged at INFO level and user gets friendly message."""
         conversation_id = uuid4()
-
-        # Mock SlackTeamStore
         mock_store = MagicMock()
         mock_store.get_team_bot_token = AsyncMock(return_value='xoxb-test-token')
         mock_slack_team_store.return_value = mock_store
 
-        mock_get_summary_instruction.return_value = 'Please provide a summary'
-
-        # Mock services
-        mock_app_conversation_info_service = AsyncMock()
-        mock_app_conversation_info_service.get_app_conversation_info.return_value = (
-            mock_app_conversation_info
-        )
-        mock_get_app_conversation_info_service.return_value.__aenter__.return_value = (
-            mock_app_conversation_info_service
-        )
-
-        mock_sandbox_service = AsyncMock()
-        mock_sandbox_service.get_sandbox.return_value = mock_sandbox_info
-        mock_get_sandbox_service.return_value.__aenter__.return_value = (
-            mock_sandbox_service
-        )
-
-        # Simulate a budget exceeded error from the agent server
         budget_error_msg = (
             'HTTP 500 error: {"detail":"Internal Server Error",'
             '"exception":"litellm.BadRequestError: Litellm_proxyException - '
             'Budget has been exceeded! Current cost: 12.65, Max budget: 12.62"}'
         )
-        mock_httpx_client = AsyncMock()
-        mock_httpx_client.post.side_effect = Exception(budget_error_msg)
-        mock_get_httpx_client.return_value.__aenter__.return_value = mock_httpx_client
+        mock_get_final_assistant_message.side_effect = Exception(budget_error_msg)
 
-        # Mock Slack WebClient
         mock_slack_client = MagicMock()
+        mock_slack_client.chat_postMessage.return_value = {'ok': True}
         mock_web_client_cls.return_value = mock_slack_client
 
         result = await slack_callback_processor(
@@ -509,21 +416,49 @@ class TestSlackV1CallbackProcessor:
 
         assert result is not None
         assert result.status == EventCallbackResultStatus.ERROR
-
-        # Verify exception was NOT called (budget exceeded uses info instead)
         mock_logger.exception.assert_not_called()
 
-        # Verify budget exceeded info log was called
         info_calls = [str(call) for call in mock_logger.info.call_args_list]
         budget_log_found = any('Budget exceeded' in call for call in info_calls)
         assert budget_log_found, f'Expected budget exceeded log, got: {info_calls}'
 
-        # Verify user-friendly message was posted to Slack
         mock_slack_client.chat_postMessage.assert_called_once()
-        call_kwargs = mock_slack_client.chat_postMessage.call_args[1]
-        posted_message = call_kwargs.get('markdown_text', '')
+        posted_message = mock_slack_client.chat_postMessage.call_args[1][
+            'markdown_text'
+        ]
         assert 'OpenHands encountered an error' in posted_message
         assert 'LLM budget has been exceeded' in posted_message
         assert 'please re-fill' in posted_message
-        # Should NOT contain the raw error message
         assert 'litellm.BadRequestError' not in posted_message
+
+    @patch('integrations.slack.slack_v1_callback_processor.handle_callback_error')
+    @patch.object(SlackV1CallbackProcessor, '_get_final_assistant_message')
+    async def test_event_service_error_uses_shared_callback_error_handler(
+        self,
+        mock_get_final_assistant_message,
+        mock_handle_callback_error,
+        slack_callback_processor,
+        finish_event,
+        event_callback,
+    ):
+        conversation_id = uuid4()
+        error = RuntimeError('event lookup failed')
+        mock_get_final_assistant_message.side_effect = error
+
+        result = await slack_callback_processor(
+            conversation_id, event_callback, finish_event
+        )
+
+        assert result is not None
+        assert result.status == EventCallbackResultStatus.ERROR
+        mock_handle_callback_error.assert_awaited_once()
+        call_kwargs = mock_handle_callback_error.call_args.kwargs
+        assert call_kwargs['error'] is error
+        assert call_kwargs['conversation_id'] == conversation_id
+        assert call_kwargs['service_name'] == 'Slack'
+        assert call_kwargs['can_post_error'] is True
+        assert call_kwargs['post_error_func'].__self__ is slack_callback_processor
+        assert (
+            call_kwargs['post_error_func'].__func__
+            is SlackV1CallbackProcessor._post_message_to_slack
+        )


### PR DESCRIPTION
HUMAN:

This PR updates the Slack V1 completion callback so it posts the agent's final message from the event stream instead of asking the agent to generate a new summary after the run finishes. I verified the callback behavior with unit tests, but I did not test against a staging Slack workspace.

- [ ] A human has tested these changes.

AGENT:

---

## Why

Fixes #13035.

Slack V1 currently asks the agent to generate a new summary when a run finishes. That makes an extra `/ask_agent` LLM call after completion and can post a generated summary instead of the actual final agent reply.

This PR changes Slack V1 completion handling to post the final agent message from the app-server event stream.

## Summary

- Removed the completion-time `AskAgentRequest(get_summary_instruction())` flow, so Slack V1 no longer makes an extra LLM call on `execution_status=finished`.
- Reads the latest `source='agent'` `MessageEvent` through `EventService.search_events` and posts its text content to Slack.
- Keeps `handle_callback_error` for Slack callback failures, preserving friendly budget-exceeded messaging and avoiding raw exception leaks.

## Issue Number

Fixes #13035

## How to Test

```bash
cd enterprise
PYTHONPATH=".:$PYTHONPATH" poetry run pytest tests/unit/integrations/slack/test_slack_v1_callback_processor.py --confcutdir=tests/unit/integrations/slack
```

Also run:

```bash
poetry run pre-commit run --all-files --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml
```

Local validation performed:
- Slack V1 callback unit tests: 18 passed
- Changed-files enterprise pre-commit: passed
- Commit hook pre-commit: passed

No staging Slack workspace was available locally; callback behavior is unit-tested.

## Video/Screenshots

N/A. Backend callback behavior only; no UI changes.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is scoped to `SlackV1CallbackProcessor`; GitHub, GitLab, Jira, and other integrations are untouched.

This PR incorporates the actionable feedback from #13043:
- keeps `handle_callback_error`
- avoids raw exception leakage to Slack
- renames Slack posting from summary terminology to message terminology
- uses `source == 'agent'` for final message selection
- includes fallback messaging with a conversation link

`openhands-agent-server` exposes `/{conversation_id}/agent_final_response`, but using that endpoint from this Slack callback would require reintroducing the sandbox/agent-server URL/session-key path that this fix removes. This PR instead reads the final agent `MessageEvent` through app-server `EventService`, keeping the callback scoped to Slack V1 and avoiding an extra `/ask_agent` LLM call.
