### PR TITLE
fix: distinguish stopped sandboxes from archived conversations

### DIFF
--- a/frontend/src/api/sandbox-service/sandbox-service.types.ts
+++ b/frontend/src/api/sandbox-service/sandbox-service.types.ts
@@ -6,6 +6,7 @@ export type V1SandboxStatus =
   | "STARTING"
   | "RUNNING"
   | "PAUSED"
+  | "STOPPED"
   | "ERROR";
 
 export interface V1ExposedUrl {

--- a/frontend/src/components/features/chat/archived-banner.tsx
+++ b/frontend/src/components/features/chat/archived-banner.tsx
@@ -1,7 +1,13 @@
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
 
-export function ArchivedBanner() {
+interface ArchivedBannerProps {
+  messageKey?: I18nKey;
+}
+
+export function ArchivedBanner({
+  messageKey = I18nKey.CONVERSATION$ARCHIVED_READ_ONLY,
+}: ArchivedBannerProps) {
   const { t } = useTranslation();
 
   return (
@@ -9,9 +15,7 @@ export function ArchivedBanner() {
       data-testid="archived-banner"
       className="flex items-center justify-center px-4 py-3 rounded-lg bg-neutral-700 border border-neutral-600"
     >
-      <span className="text-sm text-neutral-300">
-        {t(I18nKey.CONVERSATION$ARCHIVED_READ_ONLY)}
-      </span>
+      <span className="text-sm text-neutral-300">{t(messageKey)}</span>
     </div>
   );
 }

--- a/frontend/src/components/features/controls/server-status.tsx
+++ b/frontend/src/components/features/controls/server-status.tsx
@@ -25,7 +25,8 @@ export function ServerStatus({
 
   const isStartingStatus =
     curAgentState === AgentState.LOADING || curAgentState === AgentState.INIT;
-  const isStopStatus = sandboxStatus === "MISSING";
+  const isStopStatus =
+    sandboxStatus === "MISSING" || sandboxStatus === "STOPPED";
 
   const statusColor = getStatusColor({
     isPausing,

--- a/frontend/src/components/features/conversation/archived-conversation-view.tsx
+++ b/frontend/src/components/features/conversation/archived-conversation-view.tsx
@@ -16,7 +16,13 @@ import { ConversationNameWithStatus } from "./conversation-name-with-status";
  * Similar to the shared conversation view, it only shows the conversation
  * events without the VS Code tab, Planner, Terminal, and other interactive elements.
  */
-export function ArchivedConversationView() {
+interface ArchivedConversationViewProps {
+  reason?: "archived" | "stopped";
+}
+
+export function ArchivedConversationView({
+  reason = "archived",
+}: ArchivedConversationViewProps) {
   const { t } = useTranslation();
   const conversationWebSocket = useConversationWebSocket();
   const { v1FullEvents } = useFilteredEvents();
@@ -53,7 +59,13 @@ export function ArchivedConversationView() {
 
       {/* Archived banner */}
       <div className="px-3 md:px-0 py-2">
-        <ArchivedBanner />
+        <ArchivedBanner
+          messageKey={
+            reason === "stopped"
+              ? I18nKey.CHAT_INTERFACE$AGENT_STOPPED_MESSAGE
+              : I18nKey.CONVERSATION$ARCHIVED_READ_ONLY
+          }
+        />
       </div>
 
       {/* Chat panel - read-only */}

--- a/frontend/src/components/features/conversation/conversation-name-with-status.tsx
+++ b/frontend/src/components/features/conversation/conversation-name-with-status.tsx
@@ -25,7 +25,9 @@ export function ConversationNameWithStatus() {
 
   const isStartingStatus =
     curAgentState === AgentState.LOADING || curAgentState === AgentState.INIT;
-  const isStopStatus = conversation?.sandbox_status === "MISSING";
+  const isStopStatus =
+    conversation?.sandbox_status === "MISSING" ||
+    conversation?.sandbox_status === "STOPPED";
 
   const statusColor = getStatusColor({
     isPausing: false,
@@ -67,7 +69,7 @@ export function ConversationNameWithStatus() {
               : undefined
           }
           onStartServer={
-            conversation?.sandbox_status === "MISSING"
+            conversation?.sandbox_status === "PAUSED"
               ? handleStartServer
               : undefined
           }

--- a/frontend/src/components/features/home/recent-conversations/sandbox-status-indicator.tsx
+++ b/frontend/src/components/features/home/recent-conversations/sandbox-status-indicator.tsx
@@ -17,6 +17,8 @@ const getSandboxStatusLabel = (status: V1SandboxStatus): string => {
       return "COMMON$STARTING";
     case "PAUSED":
       return "COMMON$PAUSED";
+    case "STOPPED":
+      return "COMMON$STOPPED";
     case "MISSING":
       return "COMMON$ARCHIVED";
     default:
@@ -36,7 +38,8 @@ export function SandboxStatusIndicator({
       case "STARTING":
         return "bg-[#FFD43B]"; // Busy/starting - yellow
       case "PAUSED":
-        return "bg-[#A3A3A3]"; // Paused - grey
+      case "STOPPED":
+        return "bg-[#A3A3A3]"; // Inactive - grey
       case "MISSING":
         return "bg-[#A3A3A3]"; // Missing - grey (archived)
       default:

--- a/frontend/src/hooks/use-agent-state.test.tsx
+++ b/frontend/src/hooks/use-agent-state.test.tsx
@@ -98,4 +98,18 @@ describe("useAgentState", () => {
     expect(result.current.curAgentState).toBe(AgentState.STOPPED);
     expect(result.current.isArchived).toBe(true);
   });
+
+  it("returns STOPPED state without isArchived for stopped sandboxes", () => {
+    mockUseActiveConversation.mockReturnValue({
+      data: {
+        execution_status: V1ExecutionStatus.FINISHED,
+        sandbox_status: "STOPPED",
+      },
+    } as ReturnType<typeof useActiveConversation>);
+
+    const { result } = renderHook(() => useAgentState());
+
+    expect(result.current.curAgentState).toBe(AgentState.STOPPED);
+    expect(result.current.isArchived).toBe(false);
+  });
 });

--- a/frontend/src/hooks/use-agent-state.ts
+++ b/frontend/src/hooks/use-agent-state.ts
@@ -12,9 +12,9 @@ function mapV1StatusToV0State(
   status: V1ExecutionStatus | null,
   sandboxStatus: V1SandboxStatus | undefined,
 ): AgentState {
-  // For archived conversations (sandbox MISSING), return STOPPED to avoid loading states
-  // The conversation is read-only and won't resume, so we should not show "starting" indicators
-  if (sandboxStatus === "MISSING") {
+  // For unavailable conversations, return STOPPED to avoid loading states.
+  // STOPPED is not archived; it means the runtime was stopped.
+  if (sandboxStatus === "MISSING" || sandboxStatus === "STOPPED") {
     return AgentState.STOPPED;
   }
 
@@ -52,7 +52,7 @@ export interface UseAgentStateResult {
  * Unified hook that returns the current agent state
  * - For V0 conversations: Returns state from useAgentStore
  * - For V1 conversations: Returns mapped state from useV1ConversationStateStore
- * - For archived conversations (sandbox MISSING): Returns STOPPED state
+ * - For unavailable conversations (sandbox MISSING/STOPPED): Returns STOPPED state
  */
 export function useAgentState(): UseAgentStateResult {
   const liveExecutionStatus = useV1ConversationStateStore(

--- a/frontend/src/routes/conversation.tsx
+++ b/frontend/src/routes/conversation.tsx
@@ -91,18 +91,20 @@ function AppContent() {
     }
   }, [conversation, isFetched, isAuthed, navigate, t]);
 
-  // Check if this is an archived conversation (sandbox no longer exists)
+  // MISSING means the sandbox no longer exists; STOPPED means the runtime was
+  // intentionally stopped. Both are read-only, but only MISSING is archived.
   const isArchived = conversation?.sandbox_status === "MISSING";
+  const isStopped = conversation?.sandbox_status === "STOPPED";
 
-  // For archived conversations, show a simplified read-only view
-  // similar to the shared conversation view
-  if (isArchived) {
+  if (isArchived || isStopped) {
     return (
       <WebSocketProviderWrapper conversationId={conversationId}>
         <ConversationSubscriptionsProvider>
           <EventHandler>
             <div data-testid="app-route" className="flex flex-col h-full gap-3">
-              <ArchivedConversationView />
+              <ArchivedConversationView
+                reason={isStopped ? "stopped" : "archived"}
+              />
             </div>
           </EventHandler>
         </ConversationSubscriptionsProvider>

--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -61,7 +61,7 @@ polling_task: asyncio.Task | None = None
 STATUS_MAPPING = {
     'running': SandboxStatus.RUNNING,
     'paused': SandboxStatus.PAUSED,
-    'stopped': SandboxStatus.MISSING,
+    'stopped': SandboxStatus.STOPPED,
     'starting': SandboxStatus.STARTING,
     'error': SandboxStatus.ERROR,
 }

--- a/openhands/app_server/sandbox/sandbox_models.py
+++ b/openhands/app_server/sandbox/sandbox_models.py
@@ -10,6 +10,7 @@ class SandboxStatus(Enum):
     STARTING = 'STARTING'
     RUNNING = 'RUNNING'
     PAUSED = 'PAUSED'
+    STOPPED = 'STOPPED'
     ERROR = 'ERROR'
     MISSING = 'MISSING'
     """Missing - possibly deleted"""

--- a/tests/unit/app_server/test_remote_sandbox_service.py
+++ b/tests/unit/app_server/test_remote_sandbox_service.py
@@ -232,7 +232,7 @@ class TestStatusMapping:
         test_cases = [
             ('running', SandboxStatus.RUNNING),
             ('paused', SandboxStatus.PAUSED),
-            ('stopped', SandboxStatus.MISSING),
+            ('stopped', SandboxStatus.STOPPED),
             ('starting', SandboxStatus.STARTING),
             ('error', SandboxStatus.ERROR),
         ]


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

Runtime API reports stopped runtimes as `stopped`, but the app server mapped that state to `SandboxStatus.MISSING`, causing the frontend to display stopped conversations as archived. Stopped sandboxes should not be labeled archived unless the sandbox is actually missing/archived.

## Summary

- Add a distinct `STOPPED` sandbox status and map runtime-api `stopped` to it instead of `MISSING`.
- Keep stopped conversations read-only but show stopped copy rather than archived copy.
- Add frontend status handling and test coverage for stopped sandboxes.

## Issue Number

Closes #14739

## How to Test

- `cd frontend && npm run lint:fix && npm run build`
- `cd frontend && npm run test -- src/hooks/use-agent-state.test.tsx`
- `poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml`

## Video/Screenshots

Not captured; this is a status-mapping and label fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Created by an AI agent (OpenHands) on behalf of the user. Companion Agent Canvas PR updates that frontend to understand `STOPPED` once emitted by the cloud API.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-d6be30f   docker.openhands.dev/openhands/openhands:d6be30f
```