### PR TITLE
Fix OpenHands LLM key access for credited orgs

### DIFF
--- a/enterprise/storage/org.py
+++ b/enterprise/storage/org.py
@@ -64,6 +64,8 @@ class Org(Base):
     max_budget_per_task: Mapped[float | None] = mapped_column(nullable=True)
     v1_enabled: Mapped[bool | None] = mapped_column(nullable=True)
     conversation_expiration: Mapped[int | None] = mapped_column(nullable=True)
+    # Source of truth for BYOR/OpenHands LLM key export entitlement.
+    # Set by completed billing sessions or when positive org credits are detected.
     byor_export_enabled: Mapped[bool] = mapped_column(nullable=False, default=False)
     sandbox_grouping_strategy: Mapped[str | None] = mapped_column(String, nullable=True)
     # Encrypted column for LLM profiles (contains API keys)

--- a/enterprise/storage/org_service.py
+++ b/enterprise/storage/org_service.py
@@ -859,7 +859,11 @@ class OrgService:
             return True
 
         credits = await OrgService.get_org_credits(user_id, org_id)
-        return credits is not None and credits > 0
+        if credits is None or credits <= 0:
+            return False
+
+        org = await OrgStore.enable_byor_export(org_id)
+        return bool(org and org.byor_export_enabled)
 
     @staticmethod
     async def switch_org(user_id: str, org_id: UUID) -> Org:

--- a/enterprise/storage/org_service.py
+++ b/enterprise/storage/org_service.py
@@ -855,7 +855,11 @@ class OrgService:
         if not org:
             return False
 
-        return org.byor_export_enabled
+        if org.byor_export_enabled:
+            return True
+
+        credits = await OrgService.get_org_credits(user_id, org_id)
+        return credits is not None and credits > 0
 
     @staticmethod
     async def switch_org(user_id: str, org_id: UUID) -> Org:

--- a/enterprise/storage/org_service.py
+++ b/enterprise/storage/org_service.py
@@ -858,6 +858,9 @@ class OrgService:
         if org.byor_export_enabled:
             return True
 
+        if await OrgStore.has_completed_billing_session(org_id):
+            return False
+
         credits = await OrgService.get_org_credits(user_id, org_id)
         return credits is not None and credits > 0
 

--- a/enterprise/storage/org_service.py
+++ b/enterprise/storage/org_service.py
@@ -858,9 +858,6 @@ class OrgService:
         if org.byor_export_enabled:
             return True
 
-        if await OrgStore.has_completed_billing_session(org_id):
-            return False
-
         credits = await OrgService.get_org_credits(user_id, org_id)
         return credits is not None and credits > 0
 

--- a/enterprise/storage/org_store.py
+++ b/enterprise/storage/org_store.py
@@ -18,7 +18,6 @@ from server.routes.org_models import (
 )
 from sqlalchemy import delete, select, text
 from sqlalchemy.orm import joinedload
-from storage.billing_session import BillingSession
 from storage.database import a_session_maker
 from storage.lite_llm_manager import LiteLlmManager, get_openhands_cloud_key_alias
 from storage.org import Org
@@ -116,20 +115,6 @@ class OrgStore:
             result = await session.execute(select(Org).filter(Org.id == org_id))
             org = result.scalars().first()
         return await OrgStore._validate_org_version(org)
-
-    @staticmethod
-    async def has_completed_billing_session(org_id: UUID) -> bool:
-        """Check whether an organization has completed Stripe billing."""
-        async with a_session_maker() as session:
-            result = await session.execute(
-                select(BillingSession.id)
-                .filter(
-                    BillingSession.org_id == org_id,
-                    BillingSession.status == 'completed',
-                )
-                .limit(1)
-            )
-            return result.scalar_one_or_none() is not None
 
     @staticmethod
     async def get_orgs_by_ids(org_ids: list[UUID]) -> list[Org]:

--- a/enterprise/storage/org_store.py
+++ b/enterprise/storage/org_store.py
@@ -117,6 +117,14 @@ class OrgStore:
         return await OrgStore._validate_org_version(org)
 
     @staticmethod
+    async def enable_byor_export(org_id: UUID) -> Org | None:
+        """Persist BYOR export enablement for an organization."""
+        return await OrgStore._update_org_kwargs(
+            org_id,
+            {'byor_export_enabled': True},
+        )
+
+    @staticmethod
     async def get_orgs_by_ids(org_ids: list[UUID]) -> list[Org]:
         """Get multiple organizations by IDs in a single query.
 

--- a/enterprise/storage/org_store.py
+++ b/enterprise/storage/org_store.py
@@ -18,6 +18,7 @@ from server.routes.org_models import (
 )
 from sqlalchemy import delete, select, text
 from sqlalchemy.orm import joinedload
+from storage.billing_session import BillingSession
 from storage.database import a_session_maker
 from storage.lite_llm_manager import LiteLlmManager, get_openhands_cloud_key_alias
 from storage.org import Org
@@ -115,6 +116,20 @@ class OrgStore:
             result = await session.execute(select(Org).filter(Org.id == org_id))
             org = result.scalars().first()
         return await OrgStore._validate_org_version(org)
+
+    @staticmethod
+    async def has_completed_billing_session(org_id: UUID) -> bool:
+        """Check whether an organization has completed Stripe billing."""
+        async with a_session_maker() as session:
+            result = await session.execute(
+                select(BillingSession.id)
+                .filter(
+                    BillingSession.org_id == org_id,
+                    BillingSession.status == 'completed',
+                )
+                .limit(1)
+            )
+            return result.scalar_one_or_none() is not None
 
     @staticmethod
     async def get_orgs_by_ids(org_ids: list[UUID]) -> list[Org]:

--- a/enterprise/tests/unit/test_org_service.py
+++ b/enterprise/tests/unit/test_org_service.py
@@ -1900,18 +1900,23 @@ async def test_check_byor_export_enabled_returns_true_when_enabled():
             new_callable=AsyncMock,
             return_value=mock_org,
         ),
+        patch(
+            'storage.org_service.OrgService.get_org_credits',
+            new_callable=AsyncMock,
+        ) as mock_get_credits,
     ):
         # Act
         result = await OrgService.check_byor_export_enabled(user_id)
 
         # Assert
         assert result is True
+        mock_get_credits.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_check_byor_export_enabled_returns_false_when_disabled():
+async def test_check_byor_export_enabled_returns_false_when_disabled_without_credits():
     """
-    GIVEN: User has current_org with byor_export_enabled=False
+    GIVEN: User has current_org with byor_export_enabled=False and no credits
     WHEN: check_byor_export_enabled is called
     THEN: Returns False
     """
@@ -1935,12 +1940,57 @@ async def test_check_byor_export_enabled_returns_false_when_disabled():
             new_callable=AsyncMock,
             return_value=mock_org,
         ),
+        patch(
+            'storage.org_service.OrgService.get_org_credits',
+            AsyncMock(return_value=0),
+        ) as mock_get_credits,
     ):
         # Act
         result = await OrgService.check_byor_export_enabled(user_id)
 
         # Assert
         assert result is False
+        mock_get_credits.assert_called_once_with(user_id, org_id)
+
+
+@pytest.mark.asyncio
+async def test_check_byor_export_enabled_returns_true_when_disabled_with_credits():
+    """
+    GIVEN: User has current_org with byor_export_enabled=False and credits
+    WHEN: check_byor_export_enabled is called
+    THEN: Returns True
+    """
+    # Arrange
+    user_id = 'test-user-123'
+    org_id = uuid.uuid4()
+
+    mock_user = MagicMock()
+    mock_user.current_org_id = org_id
+
+    mock_org = MagicMock()
+    mock_org.byor_export_enabled = False
+
+    with (
+        patch(
+            'storage.org_service.UserStore.get_user_by_id',
+            AsyncMock(return_value=mock_user),
+        ),
+        patch(
+            'storage.org_service.OrgStore.get_org_by_id',
+            new_callable=AsyncMock,
+            return_value=mock_org,
+        ),
+        patch(
+            'storage.org_service.OrgService.get_org_credits',
+            AsyncMock(return_value=25.0),
+        ) as mock_get_credits,
+    ):
+        # Act
+        result = await OrgService.check_byor_export_enabled(user_id)
+
+        # Assert
+        assert result is True
+        mock_get_credits.assert_called_once_with(user_id, org_id)
 
 
 @pytest.mark.asyncio

--- a/enterprise/tests/unit/test_org_service.py
+++ b/enterprise/tests/unit/test_org_service.py
@@ -1901,10 +1901,6 @@ async def test_check_byor_export_enabled_returns_true_when_enabled():
             return_value=mock_org,
         ),
         patch(
-            'storage.org_service.OrgStore.has_completed_billing_session',
-            new_callable=AsyncMock,
-        ) as mock_has_completed_billing,
-        patch(
             'storage.org_service.OrgService.get_org_credits',
             new_callable=AsyncMock,
         ) as mock_get_credits,
@@ -1914,7 +1910,6 @@ async def test_check_byor_export_enabled_returns_true_when_enabled():
 
         # Assert
         assert result is True
-        mock_has_completed_billing.assert_not_called()
         mock_get_credits.assert_not_called()
 
 
@@ -1946,10 +1941,6 @@ async def test_check_byor_export_enabled_returns_false_when_disabled_without_cre
             return_value=mock_org,
         ),
         patch(
-            'storage.org_service.OrgStore.has_completed_billing_session',
-            AsyncMock(return_value=False),
-        ) as mock_has_completed_billing,
-        patch(
             'storage.org_service.OrgService.get_org_credits',
             AsyncMock(return_value=0),
         ) as mock_get_credits,
@@ -1959,14 +1950,13 @@ async def test_check_byor_export_enabled_returns_false_when_disabled_without_cre
 
         # Assert
         assert result is False
-        mock_has_completed_billing.assert_called_once_with(org_id)
         mock_get_credits.assert_called_once_with(user_id, org_id)
 
 
 @pytest.mark.asyncio
-async def test_check_byor_export_enabled_returns_true_when_credited_without_billing():
+async def test_check_byor_export_enabled_returns_true_when_disabled_with_credits():
     """
-    GIVEN: User has current_org with byor_export_enabled=False, credits, and no completed billing
+    GIVEN: User has current_org with byor_export_enabled=False and credits
     WHEN: check_byor_export_enabled is called
     THEN: Returns True
     """
@@ -1991,10 +1981,6 @@ async def test_check_byor_export_enabled_returns_true_when_credited_without_bill
             return_value=mock_org,
         ),
         patch(
-            'storage.org_service.OrgStore.has_completed_billing_session',
-            AsyncMock(return_value=False),
-        ) as mock_has_completed_billing,
-        patch(
             'storage.org_service.OrgService.get_org_credits',
             AsyncMock(return_value=25.0),
         ) as mock_get_credits,
@@ -2004,53 +1990,7 @@ async def test_check_byor_export_enabled_returns_true_when_credited_without_bill
 
         # Assert
         assert result is True
-        mock_has_completed_billing.assert_called_once_with(org_id)
         mock_get_credits.assert_called_once_with(user_id, org_id)
-
-
-@pytest.mark.asyncio
-async def test_check_byor_export_enabled_returns_false_when_disabled_after_billing():
-    """
-    GIVEN: User has current_org with byor_export_enabled=False, completed billing, and credits
-    WHEN: check_byor_export_enabled is called
-    THEN: Returns False
-    """
-    # Arrange
-    user_id = 'test-user-123'
-    org_id = uuid.uuid4()
-
-    mock_user = MagicMock()
-    mock_user.current_org_id = org_id
-
-    mock_org = MagicMock()
-    mock_org.byor_export_enabled = False
-
-    with (
-        patch(
-            'storage.org_service.UserStore.get_user_by_id',
-            AsyncMock(return_value=mock_user),
-        ),
-        patch(
-            'storage.org_service.OrgStore.get_org_by_id',
-            new_callable=AsyncMock,
-            return_value=mock_org,
-        ),
-        patch(
-            'storage.org_service.OrgStore.has_completed_billing_session',
-            AsyncMock(return_value=True),
-        ) as mock_has_completed_billing,
-        patch(
-            'storage.org_service.OrgService.get_org_credits',
-            new_callable=AsyncMock,
-        ) as mock_get_credits,
-    ):
-        # Act
-        result = await OrgService.check_byor_export_enabled(user_id)
-
-        # Assert
-        assert result is False
-        mock_has_completed_billing.assert_called_once_with(org_id)
-        mock_get_credits.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/enterprise/tests/unit/test_org_service.py
+++ b/enterprise/tests/unit/test_org_service.py
@@ -1904,6 +1904,10 @@ async def test_check_byor_export_enabled_returns_true_when_enabled():
             'storage.org_service.OrgService.get_org_credits',
             new_callable=AsyncMock,
         ) as mock_get_credits,
+        patch(
+            'storage.org_service.OrgStore.enable_byor_export',
+            new_callable=AsyncMock,
+        ) as mock_enable_byor_export,
     ):
         # Act
         result = await OrgService.check_byor_export_enabled(user_id)
@@ -1911,6 +1915,7 @@ async def test_check_byor_export_enabled_returns_true_when_enabled():
         # Assert
         assert result is True
         mock_get_credits.assert_not_called()
+        mock_enable_byor_export.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1944,6 +1949,10 @@ async def test_check_byor_export_enabled_returns_false_when_disabled_without_cre
             'storage.org_service.OrgService.get_org_credits',
             AsyncMock(return_value=0),
         ) as mock_get_credits,
+        patch(
+            'storage.org_service.OrgStore.enable_byor_export',
+            new_callable=AsyncMock,
+        ) as mock_enable_byor_export,
     ):
         # Act
         result = await OrgService.check_byor_export_enabled(user_id)
@@ -1951,14 +1960,15 @@ async def test_check_byor_export_enabled_returns_false_when_disabled_without_cre
         # Assert
         assert result is False
         mock_get_credits.assert_called_once_with(user_id, org_id)
+        mock_enable_byor_export.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_check_byor_export_enabled_returns_true_when_disabled_with_credits():
+async def test_check_byor_export_enabled_sets_flag_when_disabled_with_credits():
     """
     GIVEN: User has current_org with byor_export_enabled=False and credits
     WHEN: check_byor_export_enabled is called
-    THEN: Returns True
+    THEN: Persists byor_export_enabled=True and returns True
     """
     # Arrange
     user_id = 'test-user-123'
@@ -1969,6 +1979,8 @@ async def test_check_byor_export_enabled_returns_true_when_disabled_with_credits
 
     mock_org = MagicMock()
     mock_org.byor_export_enabled = False
+    enabled_org = MagicMock()
+    enabled_org.byor_export_enabled = True
 
     with (
         patch(
@@ -1984,6 +1996,10 @@ async def test_check_byor_export_enabled_returns_true_when_disabled_with_credits
             'storage.org_service.OrgService.get_org_credits',
             AsyncMock(return_value=25.0),
         ) as mock_get_credits,
+        patch(
+            'storage.org_service.OrgStore.enable_byor_export',
+            AsyncMock(return_value=enabled_org),
+        ) as mock_enable_byor_export,
     ):
         # Act
         result = await OrgService.check_byor_export_enabled(user_id)
@@ -1991,6 +2007,7 @@ async def test_check_byor_export_enabled_returns_true_when_disabled_with_credits
         # Assert
         assert result is True
         mock_get_credits.assert_called_once_with(user_id, org_id)
+        mock_enable_byor_export.assert_called_once_with(org_id)
 
 
 @pytest.mark.asyncio

--- a/enterprise/tests/unit/test_org_service.py
+++ b/enterprise/tests/unit/test_org_service.py
@@ -1901,6 +1901,10 @@ async def test_check_byor_export_enabled_returns_true_when_enabled():
             return_value=mock_org,
         ),
         patch(
+            'storage.org_service.OrgStore.has_completed_billing_session',
+            new_callable=AsyncMock,
+        ) as mock_has_completed_billing,
+        patch(
             'storage.org_service.OrgService.get_org_credits',
             new_callable=AsyncMock,
         ) as mock_get_credits,
@@ -1910,6 +1914,7 @@ async def test_check_byor_export_enabled_returns_true_when_enabled():
 
         # Assert
         assert result is True
+        mock_has_completed_billing.assert_not_called()
         mock_get_credits.assert_not_called()
 
 
@@ -1941,6 +1946,10 @@ async def test_check_byor_export_enabled_returns_false_when_disabled_without_cre
             return_value=mock_org,
         ),
         patch(
+            'storage.org_service.OrgStore.has_completed_billing_session',
+            AsyncMock(return_value=False),
+        ) as mock_has_completed_billing,
+        patch(
             'storage.org_service.OrgService.get_org_credits',
             AsyncMock(return_value=0),
         ) as mock_get_credits,
@@ -1950,13 +1959,14 @@ async def test_check_byor_export_enabled_returns_false_when_disabled_without_cre
 
         # Assert
         assert result is False
+        mock_has_completed_billing.assert_called_once_with(org_id)
         mock_get_credits.assert_called_once_with(user_id, org_id)
 
 
 @pytest.mark.asyncio
-async def test_check_byor_export_enabled_returns_true_when_disabled_with_credits():
+async def test_check_byor_export_enabled_returns_true_when_credited_without_billing():
     """
-    GIVEN: User has current_org with byor_export_enabled=False and credits
+    GIVEN: User has current_org with byor_export_enabled=False, credits, and no completed billing
     WHEN: check_byor_export_enabled is called
     THEN: Returns True
     """
@@ -1981,6 +1991,10 @@ async def test_check_byor_export_enabled_returns_true_when_disabled_with_credits
             return_value=mock_org,
         ),
         patch(
+            'storage.org_service.OrgStore.has_completed_billing_session',
+            AsyncMock(return_value=False),
+        ) as mock_has_completed_billing,
+        patch(
             'storage.org_service.OrgService.get_org_credits',
             AsyncMock(return_value=25.0),
         ) as mock_get_credits,
@@ -1990,7 +2004,53 @@ async def test_check_byor_export_enabled_returns_true_when_disabled_with_credits
 
         # Assert
         assert result is True
+        mock_has_completed_billing.assert_called_once_with(org_id)
         mock_get_credits.assert_called_once_with(user_id, org_id)
+
+
+@pytest.mark.asyncio
+async def test_check_byor_export_enabled_returns_false_when_disabled_after_billing():
+    """
+    GIVEN: User has current_org with byor_export_enabled=False, completed billing, and credits
+    WHEN: check_byor_export_enabled is called
+    THEN: Returns False
+    """
+    # Arrange
+    user_id = 'test-user-123'
+    org_id = uuid.uuid4()
+
+    mock_user = MagicMock()
+    mock_user.current_org_id = org_id
+
+    mock_org = MagicMock()
+    mock_org.byor_export_enabled = False
+
+    with (
+        patch(
+            'storage.org_service.UserStore.get_user_by_id',
+            AsyncMock(return_value=mock_user),
+        ),
+        patch(
+            'storage.org_service.OrgStore.get_org_by_id',
+            new_callable=AsyncMock,
+            return_value=mock_org,
+        ),
+        patch(
+            'storage.org_service.OrgStore.has_completed_billing_session',
+            AsyncMock(return_value=True),
+        ) as mock_has_completed_billing,
+        patch(
+            'storage.org_service.OrgService.get_org_credits',
+            new_callable=AsyncMock,
+        ) as mock_get_credits,
+    ):
+        # Act
+        result = await OrgService.check_byor_export_enabled(user_id)
+
+        # Assert
+        assert result is False
+        mock_has_completed_billing.assert_called_once_with(org_id)
+        mock_get_credits.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/enterprise/tests/unit/test_org_store.py
+++ b/enterprise/tests/unit/test_org_store.py
@@ -77,6 +77,28 @@ async def test_get_org_by_id_not_found(async_session_maker):
 
 
 @pytest.mark.asyncio
+async def test_enable_byor_export_persists_flag(async_session_maker):
+    async with async_session_maker() as session:
+        org = Org(name=f'test-org-{uuid.uuid4()}')
+        session.add(org)
+        await session.commit()
+        await session.refresh(org)
+        org_id = org.id
+        assert org.byor_export_enabled is False
+
+    with patch('storage.org_store.a_session_maker', async_session_maker):
+        updated_org = await OrgStore.enable_byor_export(org_id)
+
+    assert updated_org is not None
+    assert updated_org.byor_export_enabled is True
+
+    async with async_session_maker() as session:
+        persisted_org = await session.get(Org, org_id)
+        assert persisted_org is not None
+        assert persisted_org.byor_export_enabled is True
+
+
+@pytest.mark.asyncio
 async def test_list_orgs(async_session_maker, mock_litellm_api):
     # Test listing all orgs
     async with async_session_maker() as session:


### PR DESCRIPTION
HUMAN:
This PR proposes a quick implementation for the behavior: if a user already has credits, allow the creation of an OpenHands LLM API key from the UI.

In my understanding, the current check is supposed to help with abuse from new accounts. If an account has credits, this PR proposes to treat it as legimate.

- [ ] A human has tested these changes.

AGENT:

---

## Why

Organizations can receive OpenHands credits without having completed a Stripe payment. BYOR/OpenHands LLM key export was gated only by the completed-payment-backed `byor_export_enabled` flag, so credited users could still be blocked from creating an OpenHands LLM API key.

## Summary

- Allow BYOR/OpenHands LLM key export when the org already has a positive LiteLLM credit balance, even if the billing-history flag is false.
- Preserve the existing `byor_export_enabled` short-circuit for orgs that already unlocked key export through billing.
- Add focused OrgService tests for enabled, no-credit, and credited-org paths.

## Issue Number

N/A

## How to Test

- `cd enterprise && PYTHONPATH=".:..:$PYTHONPATH" poetry run pytest tests/unit/test_org_service.py -k "check_byor_export_enabled" --confcutdir=tests/unit -q`
- `cd enterprise && PYTHONPATH=".:..:$PYTHONPATH" poetry run pytest tests/unit/server/routes/test_api_keys.py::TestGetLlmApiKeyForByor tests/unit/server/routes/test_api_keys.py::TestCheckByorPermitted --confcutdir=tests/unit -q`
- `cd enterprise && poetry run pre-commit run --files storage/org_service.py tests/unit/test_org_service.py --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml`

## Video/Screenshots

Not applicable; backend entitlement fix covered by unit tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR was created by an AI agent (OpenHands) on behalf of the user.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6281a0f5-a070-41b3-a77f-5882a2222ca9)

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-8745223   docker.openhands.dev/openhands/openhands:8745223
```