### PR TITLE
fix: remove org_id from ownership assertion in save_app_conversation_info

### DIFF
--- a/enterprise/server/utils/saas_app_conversation_info_injector.py
+++ b/enterprise/server/utils/saas_app_conversation_info_injector.py
@@ -393,10 +393,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
             saas_result = await self.db_session.execute(saas_query)
             existing_saas_metadata = saas_result.scalar_one_or_none()
 
-            # Only assert on user_id: org_id can legitimately differ from the stored
-            # value whenever it falls back to user.current_org_id (which is mutable),
-            # both on the ADMIN path and on normal requests made after the user switches
-            # orgs. Ownership integrity is enforced by user_id alone.
+            # org_id is not asserted: it falls back to user.current_org_id, which changes when the user switches orgs.
             assert existing_saas_metadata is None or existing_saas_metadata.user_id == user_id_uuid
 
             if not existing_saas_metadata:

--- a/enterprise/server/utils/saas_app_conversation_info_injector.py
+++ b/enterprise/server/utils/saas_app_conversation_info_injector.py
@@ -360,7 +360,6 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         # Get current user_id for SAAS metadata
         # Fall back to info.created_by_user_id for webhook callbacks (which use ADMIN context)
         user_id_str = await self.user_context.get_user_id()
-        is_admin_context = not user_id_str
         if not user_id_str and info.created_by_user_id:
             user_id_str = info.created_by_user_id
         if user_id_str:
@@ -394,17 +393,11 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
             saas_result = await self.db_session.execute(saas_query)
             existing_saas_metadata = saas_result.scalar_one_or_none()
 
-            # On the ADMIN path the user_context carries no org, so org_id was derived
-            # from user.current_org_id which may differ from the org the conversation
-            # was originally created under. Use the existing metadata's org_id so the
-            # assertion below passes and ownership is not accidentally mutated.
-            if is_admin_context and existing_saas_metadata is not None:
-                org_id = existing_saas_metadata.org_id
-
-            assert existing_saas_metadata is None or (
-                existing_saas_metadata.user_id == user_id_uuid
-                and existing_saas_metadata.org_id == org_id
-            )
+            # Only assert on user_id: org_id can legitimately differ from the stored
+            # value whenever it falls back to user.current_org_id (which is mutable),
+            # both on the ADMIN path and on normal requests made after the user switches
+            # orgs. Ownership integrity is enforced by user_id alone.
+            assert existing_saas_metadata is None or existing_saas_metadata.user_id == user_id_uuid
 
             if not existing_saas_metadata:
                 # Create new SAAS metadata with the determined org_id

--- a/enterprise/server/utils/saas_app_conversation_info_injector.py
+++ b/enterprise/server/utils/saas_app_conversation_info_injector.py
@@ -75,7 +75,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         user_id_str = await self.user_context.get_user_id()
         if not user_id_str:
             # Secure default: no user means no access, not "show everything"
-            raise AuthError("User authentication required")
+            raise AuthError('User authentication required')
 
         user_id_uuid = UUID(user_id_str)
         query = query.where(StoredConversationMetadataSaas.user_id == user_id_uuid)
@@ -97,8 +97,8 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         user.current_org_id) when the user is authenticated via SAAS auth,
         otherwise falls back to the user's persisted current_org_id.
         """
-        user_auth = getattr(self.user_context, "user_auth", None)
-        if user_auth is not None and hasattr(user_auth, "get_effective_org_id"):
+        user_auth = getattr(self.user_context, 'user_auth', None)
+        if user_auth is not None and hasattr(user_auth, 'get_effective_org_id'):
             return await user_auth.get_effective_org_id()
         user = await self._get_current_user()
         return user.current_org_id if user else None
@@ -111,7 +111,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
                 StoredConversationMetadata.conversation_id
                 == StoredConversationMetadataSaas.conversation_id,
             )
-            .where(StoredConversationMetadata.conversation_version == "V1")
+            .where(StoredConversationMetadata.conversation_version == 'V1')
         )
         return await self._apply_user_and_org_filter(query)
 
@@ -124,7 +124,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
                 StoredConversationMetadata.conversation_id
                 == StoredConversationMetadataSaas.conversation_id,
             )
-            .where(StoredConversationMetadata.conversation_version == "V1")
+            .where(StoredConversationMetadata.conversation_version == 'V1')
         )
         return await self._apply_user_and_org_filter(query)
 
@@ -226,7 +226,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
                 StoredConversationMetadata.conversation_id
                 == StoredConversationMetadataSaas.conversation_id,
             )
-            .where(StoredConversationMetadata.conversation_version == "V1")
+            .where(StoredConversationMetadata.conversation_version == 'V1')
         )
 
         # Apply user and organization filtering
@@ -261,7 +261,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         conditions: list[ColumnElement[bool]] = []
         if title__contains is not None:
             conditions.append(
-                StoredConversationMetadata.title.like(f"%{title__contains}%")
+                StoredConversationMetadata.title.like(f'%{title__contains}%')
             )
 
         if created_at__gte is not None:
@@ -383,7 +383,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
             # This intentionally trumps the effective org because resolver
             # conversations are authored against a webhook-resolved org,
             # not the caller's session org.
-            resolver_org_id = getattr(self.user_context, "resolver_org_id", None)
+            resolver_org_id = getattr(self.user_context, 'resolver_org_id', None)
             if resolver_org_id is not None:
                 org_id = resolver_org_id
 

--- a/enterprise/server/utils/saas_app_conversation_info_injector.py
+++ b/enterprise/server/utils/saas_app_conversation_info_injector.py
@@ -5,6 +5,11 @@ from typing import AsyncGenerator
 from uuid import UUID
 
 from fastapi import Request
+from sqlalchemy import ColumnElement, func, select
+from storage.stored_conversation_metadata import StoredConversationMetadata
+from storage.stored_conversation_metadata_saas import StoredConversationMetadataSaas
+from storage.user import User
+
 from openhands.app_server.app_conversation.app_conversation_info_service import (
     AppConversationInfoService,
     AppConversationInfoServiceInjector,
@@ -20,11 +25,6 @@ from openhands.app_server.app_conversation.sql_app_conversation_info_service imp
 from openhands.app_server.errors import AuthError
 from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.user.specifiy_user_context import ADMIN
-from sqlalchemy import ColumnElement, func, select
-
-from storage.stored_conversation_metadata import StoredConversationMetadata
-from storage.stored_conversation_metadata_saas import StoredConversationMetadataSaas
-from storage.user import User
 
 
 class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):

--- a/enterprise/server/utils/saas_app_conversation_info_injector.py
+++ b/enterprise/server/utils/saas_app_conversation_info_injector.py
@@ -5,11 +5,6 @@ from typing import AsyncGenerator
 from uuid import UUID
 
 from fastapi import Request
-from sqlalchemy import ColumnElement, func, select
-from storage.stored_conversation_metadata import StoredConversationMetadata
-from storage.stored_conversation_metadata_saas import StoredConversationMetadataSaas
-from storage.user import User
-
 from openhands.app_server.app_conversation.app_conversation_info_service import (
     AppConversationInfoService,
     AppConversationInfoServiceInjector,
@@ -25,6 +20,11 @@ from openhands.app_server.app_conversation.sql_app_conversation_info_service imp
 from openhands.app_server.errors import AuthError
 from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.user.specifiy_user_context import ADMIN
+from sqlalchemy import ColumnElement, func, select
+
+from storage.stored_conversation_metadata import StoredConversationMetadata
+from storage.stored_conversation_metadata_saas import StoredConversationMetadataSaas
+from storage.user import User
 
 
 class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
@@ -394,7 +394,10 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
             existing_saas_metadata = saas_result.scalar_one_or_none()
 
             # org_id is not asserted: it falls back to user.current_org_id, which changes when the user switches orgs.
-            assert existing_saas_metadata is None or existing_saas_metadata.user_id == user_id_uuid
+            assert (
+                existing_saas_metadata is None
+                or existing_saas_metadata.user_id == user_id_uuid
+            )
 
             if not existing_saas_metadata:
                 # Create new SAAS metadata with the determined org_id

--- a/enterprise/server/utils/saas_app_conversation_info_injector.py
+++ b/enterprise/server/utils/saas_app_conversation_info_injector.py
@@ -75,7 +75,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         user_id_str = await self.user_context.get_user_id()
         if not user_id_str:
             # Secure default: no user means no access, not "show everything"
-            raise AuthError('User authentication required')
+            raise AuthError("User authentication required")
 
         user_id_uuid = UUID(user_id_str)
         query = query.where(StoredConversationMetadataSaas.user_id == user_id_uuid)
@@ -97,8 +97,8 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         user.current_org_id) when the user is authenticated via SAAS auth,
         otherwise falls back to the user's persisted current_org_id.
         """
-        user_auth = getattr(self.user_context, 'user_auth', None)
-        if user_auth is not None and hasattr(user_auth, 'get_effective_org_id'):
+        user_auth = getattr(self.user_context, "user_auth", None)
+        if user_auth is not None and hasattr(user_auth, "get_effective_org_id"):
             return await user_auth.get_effective_org_id()
         user = await self._get_current_user()
         return user.current_org_id if user else None
@@ -111,7 +111,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
                 StoredConversationMetadata.conversation_id
                 == StoredConversationMetadataSaas.conversation_id,
             )
-            .where(StoredConversationMetadata.conversation_version == 'V1')
+            .where(StoredConversationMetadata.conversation_version == "V1")
         )
         return await self._apply_user_and_org_filter(query)
 
@@ -124,7 +124,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
                 StoredConversationMetadata.conversation_id
                 == StoredConversationMetadataSaas.conversation_id,
             )
-            .where(StoredConversationMetadata.conversation_version == 'V1')
+            .where(StoredConversationMetadata.conversation_version == "V1")
         )
         return await self._apply_user_and_org_filter(query)
 
@@ -226,7 +226,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
                 StoredConversationMetadata.conversation_id
                 == StoredConversationMetadataSaas.conversation_id,
             )
-            .where(StoredConversationMetadata.conversation_version == 'V1')
+            .where(StoredConversationMetadata.conversation_version == "V1")
         )
 
         # Apply user and organization filtering
@@ -261,7 +261,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         conditions: list[ColumnElement[bool]] = []
         if title__contains is not None:
             conditions.append(
-                StoredConversationMetadata.title.like(f'%{title__contains}%')
+                StoredConversationMetadata.title.like(f"%{title__contains}%")
             )
 
         if created_at__gte is not None:
@@ -360,6 +360,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         # Get current user_id for SAAS metadata
         # Fall back to info.created_by_user_id for webhook callbacks (which use ADMIN context)
         user_id_str = await self.user_context.get_user_id()
+        is_admin_context = not user_id_str
         if not user_id_str and info.created_by_user_id:
             user_id_str = info.created_by_user_id
         if user_id_str:
@@ -382,7 +383,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
             # This intentionally trumps the effective org because resolver
             # conversations are authored against a webhook-resolved org,
             # not the caller's session org.
-            resolver_org_id = getattr(self.user_context, 'resolver_org_id', None)
+            resolver_org_id = getattr(self.user_context, "resolver_org_id", None)
             if resolver_org_id is not None:
                 org_id = resolver_org_id
 
@@ -392,6 +393,14 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
             )
             saas_result = await self.db_session.execute(saas_query)
             existing_saas_metadata = saas_result.scalar_one_or_none()
+
+            # On the ADMIN path the user_context carries no org, so org_id was derived
+            # from user.current_org_id which may differ from the org the conversation
+            # was originally created under. Use the existing metadata's org_id so the
+            # assertion below passes and ownership is not accidentally mutated.
+            if is_admin_context and existing_saas_metadata is not None:
+                org_id = existing_saas_metadata.org_id
+
             assert existing_saas_metadata is None or (
                 existing_saas_metadata.user_id == user_id_uuid
                 and existing_saas_metadata.org_id == org_id


### PR DESCRIPTION
H:
- A human has tested these changes.

<img width="1070" height="741" alt="image" src="https://github.com/user-attachments/assets/de92507c-ad7a-422d-9249-167adc9b57f0" />

AGENT:
*This PR was created by an AI agent (OpenHands) on behalf of the user.*

---

## Why

`org_id` in `save_app_conversation_info` resolves to `user.current_org_id` whenever no `X-Org-Id` header or org-bound API key is present. That value is **mutable** — a user who switches orgs after creating a conversation will have a different `current_org_id`. This causes the ownership assertion to fire on any subsequent save (title update, webhook callback, etc.) even though the caller legitimately owns the conversation.

The previous fix addressed only the ADMIN path (`SetTitleCallbackProcessor`), but the same failure mode exists on the normal authenticated-user path whenever `org_id` falls through to Case 4 (`user.current_org_id`) in `get_effective_org_id`.

`user_id_uuid` is derived from the authenticated identity and is stable across org switches, making it the correct and sufficient ownership guard.

## Summary

- Remove the `org_id` leg from the ownership assertion; keep only the `user_id` check.
- Remove the now-unnecessary `is_admin_context` variable and the `org_id` override block that was patching around the issue on the ADMIN path.
- Add a comment explaining why `org_id` is intentionally excluded from the assertion.

## Issue Number

N/A

## How to Test

1. Create a conversation as a user who belongs to multiple orgs.
2. Switch the user's `current_org_id` to a different org.
3. Trigger any path that calls `save_app_conversation_info` for the original conversation (e.g. a `MessageEvent` so `SetTitleCallbackProcessor` fires, or a direct webhook callback).
4. Before: an `AssertionError` is raised. After: the save succeeds and SAAS metadata ownership is unchanged.

## Video/Screenshots

N/A — server-side logic change with no UI impact.

## Type

- Bug fix

## Notes

The `org_id` is still written correctly on **first creation** of SAAS metadata (the `if not existing_saas_metadata:` block is unchanged). Only the assertion guard for existing records is simplified.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-2a1e099   docker.openhands.dev/openhands/openhands:2a1e099
```