### PR TITLE
ci: add label-triggered OpenHands QA workflow

### DIFF
--- a/.github/workflows/qa-changes-by-openhands.yml
+++ b/.github/workflows/qa-changes-by-openhands.yml
@@ -1,0 +1,41 @@
+---
+# Automated QA validation of PR changes using OpenHands.
+#
+# This workflow runs only when the `qa-this` label is added to a same-repo PR.
+# Unlike code review, the QA agent executes the changed code and posts a
+# functional verification report.
+name: QA Changes by OpenHands
+
+on:
+    pull_request:
+        types: [labeled]
+
+permissions:
+    contents: read
+    pull-requests: write
+    issues: write
+
+jobs:
+    qa-changes:
+        # Only run for same-repo PRs (secrets are not available to forks), and
+        # only when explicitly triggered by the `qa-this` label.
+        if: |
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            github.event.label.name == 'qa-this'
+        concurrency:
+            group: qa-changes-${{ github.event.pull_request.number }}
+            cancel-in-progress: true
+        runs-on: ubuntu-24.04
+        timeout-minutes: 30
+        steps:
+            - name: Run QA Changes
+              uses: OpenHands/extensions/plugins/qa-changes@main
+              with:
+                  llm-model: litellm_proxy/openai/gpt-5.5
+                  llm-base-url: https://llm-proxy.app.all-hands.dev
+                  max-budget: '10.0'
+                  timeout-minutes: '30'
+                  max-iterations: '500'
+                  llm-api-key: ${{ secrets.LLM_API_KEY }}
+                  github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC || github.token }}
+                  lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}


### PR DESCRIPTION
HUMAN:
This PR adds a label-only repo-only QA workflow, modeled by the workflow in use on agent-sdk repo.

Note: the workflow has been tested on agent-sdk and it works just fine, that's why we are bringing it here.

- [x] A human has tested these changes.

AGENT:

## Summary

- Add a `QA Changes by OpenHands` workflow adapted from the OpenHands QA Changes plugin.
- Trigger it only when the `qa-this` label is added to a same-repo PR.
- Use the OpenHands LLM proxy and the bot token fallback already used by other workflows in this repo.

## Validation

- Parsed `.github/workflows/qa-changes-by-openhands.yml` with PyYAML from an existing project environment.

## Notes

Created the `qa-this` repository label with orange color `FF8C00` and description `Trigger OpenHands QA validation`.

This PR was created by an AI agent (OpenHands) on behalf of the user.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e948c79b-6548-44f4-b8af-ab71970dc27d)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-21cbf2b   docker.openhands.dev/openhands/openhands:21cbf2b
```