### PR TITLE
fix(bitbucket-dc): resolve user via whoami so avatars load with OAuth tokens

### DIFF
--- a/openhands/app_server/integrations/bitbucket_data_center/service/base.py
+++ b/openhands/app_server/integrations/bitbucket_data_center/service/base.py
@@ -1,5 +1,6 @@
 import base64
 from typing import Any
+from urllib.parse import unquote
 
 import httpx
 from pydantic import SecretStr
@@ -214,14 +215,21 @@ class BitbucketDCMixinBase(BaseGitService, HTTPClient):
         return users[0] if users else None
 
     async def _get_authenticated_username(self) -> str | None:
-        """Resolve the authenticated user's username via the whoami servlet.
+        """Resolve the authenticated user's username.
 
         OAuth 2.0 bearer tokens (e.g. the SaaS/Keycloak broker flow) carry no
         username, so the service may be constructed with ``user_id=None``.
-        Bitbucket Data Center has no ``/user`` (myself) REST resource; the
-        applinks whoami servlet returns the username for any user-bound
-        credential. Credentials not tied to a user (e.g. project/repo-scoped
-        HTTP access tokens) yield no username, in which case this returns None.
+        Bitbucket Data Center has no ``/user`` (myself) REST resource, so try
+        two techniques:
+
+        1. The applinks whoami servlet, which returns the username for OAuth
+           credentials. Some servers answer it with 200 and an *empty* body
+           for HTTP access tokens, so an empty response is not an error.
+        2. A cheap REST call, reading the URL-encoded ``X-AUSERNAME`` response
+           header Bitbucket sets on authenticated requests.
+
+        Credentials not tied to a user (e.g. project/repo-scoped HTTP access
+        tokens) yield no username from either, in which case this returns None.
         """
         if not self.BASE_URL:
             return None
@@ -231,9 +239,23 @@ class BitbucketDCMixinBase(BaseGitService, HTTPClient):
             data, _ = await self._make_request(whoami_url)
         except Exception as e:
             logger.warning(f'Bitbucket data center whoami lookup failed: {e}')
-            return None
+            data = None
         if isinstance(data, str) and data.strip():
             return data.strip()
+
+        # Fall back to the X-AUSERNAME header from a cheap REST call.
+        try:
+            _, headers = await self._make_request(
+                f'{self.BASE_URL}/projects', {'limit': '0'}
+            )
+        except Exception as e:
+            logger.warning(f'Bitbucket data center username lookup failed: {e}')
+            return None
+        username = next(
+            (v for k, v in headers.items() if k.lower() == 'x-ausername'), None
+        )
+        if username:
+            return unquote(username)
         return None
 
     async def get_user(self) -> User:
@@ -260,6 +282,17 @@ class BitbucketDCMixinBase(BaseGitService, HTTPClient):
         )
         user_data = self._select_user_data(data.get('values', []), user_id)
         if not user_data:
+            if not self.user_id:
+                # The username was auto-resolved; degrade to the empty user
+                # rather than failing the whole user-info request.
+                logger.warning(f'Bitbucket data center user not found: {user_id}')
+                return User(
+                    id='',
+                    login='',
+                    avatar_url='',
+                    name=None,
+                    email=None,
+                )
             raise AuthenticationError(f'User not found: {user_id}')
 
         avatar = user_data.get('avatarUrl', '')

--- a/openhands/app_server/integrations/bitbucket_data_center/service/base.py
+++ b/openhands/app_server/integrations/bitbucket_data_center/service/base.py
@@ -215,21 +215,13 @@ class BitbucketDCMixinBase(BaseGitService, HTTPClient):
         return users[0] if users else None
 
     async def _get_authenticated_username(self) -> str | None:
-        """Resolve the authenticated user's username.
+        """Resolve the authenticated user's username, or None for credentials
+        not tied to a user (e.g. project/repo-scoped HTTP access tokens).
 
-        OAuth 2.0 bearer tokens (e.g. the SaaS/Keycloak broker flow) carry no
-        username, so the service may be constructed with ``user_id=None``.
         Bitbucket Data Center has no ``/user`` (myself) REST resource, so try
-        two techniques:
-
-        1. The applinks whoami servlet, which returns the username for OAuth
-           credentials. Some servers answer it with 200 and an *empty* body
-           for HTTP access tokens, so an empty response is not an error.
-        2. A cheap REST call, reading the URL-encoded ``X-AUSERNAME`` response
-           header Bitbucket sets on authenticated requests.
-
-        Credentials not tied to a user (e.g. project/repo-scoped HTTP access
-        tokens) yield no username from either, in which case this returns None.
+        the applinks whoami servlet first (some servers answer it with 200 and
+        an *empty* body for HTTP access tokens), then fall back to the
+        URL-encoded ``X-AUSERNAME`` header from a cheap REST call.
         """
         if not self.BASE_URL:
             return None

--- a/openhands/app_server/integrations/bitbucket_data_center/service/base.py
+++ b/openhands/app_server/integrations/bitbucket_data_center/service/base.py
@@ -196,12 +196,55 @@ class BitbucketDCMixinBase(BaseGitService, HTTPClient):
         response, _ = await self._make_request(url)
         return response.get('values', [])
 
+    @staticmethod
+    def _select_user_data(users: list[dict], username: str) -> dict | None:
+        """Pick the user matching ``username`` from a /users?filter= response.
+
+        The filter parameter is a substring match, so the first result is not
+        necessarily the requested user. Match case-insensitively on name,
+        email, and slug, falling back to the first result.
+        """
+        username_folded = username.casefold()
+        for user in users:
+            for key in ('name', 'emailAddress', 'slug'):
+                value = user.get(key)
+                if isinstance(value, str) and value.casefold() == username_folded:
+                    return user
+
+        return users[0] if users else None
+
+    async def _get_authenticated_username(self) -> str | None:
+        """Resolve the authenticated user's username via the whoami servlet.
+
+        OAuth 2.0 bearer tokens (e.g. the SaaS/Keycloak broker flow) carry no
+        username, so the service may be constructed with ``user_id=None``.
+        Bitbucket Data Center has no ``/user`` (myself) REST resource; the
+        applinks whoami servlet returns the username for any user-bound
+        credential. Credentials not tied to a user (e.g. project/repo-scoped
+        HTTP access tokens) yield no username, in which case this returns None.
+        """
+        if not self.BASE_URL:
+            return None
+        base_server_url = self.BASE_URL.rsplit('/rest/api/1.0', 1)[0]
+        whoami_url = f'{base_server_url}/plugins/servlet/applinks/whoami'
+        try:
+            data, _ = await self._make_request(whoami_url)
+        except Exception as e:
+            logger.warning(f'Bitbucket data center whoami lookup failed: {e}')
+            return None
+        if isinstance(data, str) and data.strip():
+            return data.strip()
+        return None
+
     async def get_user(self) -> User:
         """Get the authenticated user's information."""
 
-        if not self.user_id:
-            # HTTP Access tokens (x-token-auth) don't have user info.
-            # For OAuth, the user_id should be set.
+        user_id = self.user_id
+        if not user_id:
+            user_id = await self._get_authenticated_username()
+
+        if not user_id:
+            # Credentials not tied to a user don't have user info.
             return User(
                 id='',
                 login='',
@@ -210,16 +253,15 @@ class BitbucketDCMixinBase(BaseGitService, HTTPClient):
                 email=None,
             )
 
-        # Basic auth - extract username and query users API to get slug
+        # Query the users API with the username to get id, avatar, and email
         users_url = f'{self.BASE_URL}/users'
         data, _ = await self._make_request(
-            users_url, {'filter': self.user_id, 'avatarSize': 64}
+            users_url, {'filter': user_id, 'avatarSize': 64}
         )
-        users = data.get('values', [])
-        if not users:
-            raise AuthenticationError(f'User not found: {self.user_id}')
+        user_data = self._select_user_data(data.get('values', []), user_id)
+        if not user_data:
+            raise AuthenticationError(f'User not found: {user_id}')
 
-        user_data = users[0]
         avatar = user_data.get('avatarUrl', '')
         # Handle relative avatar URLs (Server returns /users/... paths)
         if avatar.startswith('/users'):
@@ -229,8 +271,8 @@ class BitbucketDCMixinBase(BaseGitService, HTTPClient):
         display_name = user_data.get('displayName')
         email = user_data.get('emailAddress')
         return User(
-            id=str(user_data.get('id') or user_data.get('slug') or self.user_id),
-            login=user_data.get('name') or self.user_id,
+            id=str(user_data.get('id') or user_data.get('slug') or user_id),
+            login=user_data.get('name') or user_id,
             avatar_url=avatar,
             name=display_name,
             email=email,

--- a/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc.py
+++ b/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc.py
@@ -156,18 +156,95 @@ async def test_get_user_with_user_id():
 
 
 @pytest.mark.asyncio
-async def test_get_user_without_user_id():
-    # x-token-auth tokens don't have a derivable username, so user_id stays None
+async def test_get_user_without_user_id_resolves_via_whoami():
+    # OAuth bearer tokens (SaaS/Keycloak broker flow) carry no username, so
+    # user_id is None; the user is resolved via the applinks whoami servlet.
     svc = BitbucketDCService(
         token=SecretStr('x-token-auth:mytoken'), base_domain='host.example.com'
     )
+    requested_urls = []
+
+    async def mock_make_request(url, params=None, **kwargs):
+        requested_urls.append(url)
+        if url.endswith('/plugins/servlet/applinks/whoami'):
+            return 'jdoe', {}
+        return {
+            'values': [
+                {
+                    'id': 5,
+                    'slug': 'jdoe',
+                    'name': 'jdoe',
+                    'displayName': 'J Doe',
+                    'emailAddress': 'j@example.com',
+                    'avatarUrl': '/users/jdoe/avatar.png?s=64',
+                }
+            ]
+        }, {}
+
+    with patch.object(svc, '_make_request', side_effect=mock_make_request):
+        user = await svc.get_user()
+
+    assert requested_urls == [
+        'https://host.example.com/plugins/servlet/applinks/whoami',
+        'https://host.example.com/rest/api/1.0/users',
+    ]
+    assert user.id == '5'
+    assert user.login == 'jdoe'
+    assert user.name == 'J Doe'
+    assert user.email == 'j@example.com'
+    assert user.avatar_url == 'https://host.example.com/users/jdoe/avatar.png?s=64'
+
+
+@pytest.mark.asyncio
+async def test_get_user_without_user_id_returns_empty_when_whoami_fails():
+    # Credentials not tied to a user (e.g. project/repo-scoped HTTP access
+    # tokens) fail the whoami lookup; get_user degrades to an empty user.
+    svc = BitbucketDCService(
+        token=SecretStr('x-token-auth:mytoken'), base_domain='host.example.com'
+    )
+    with patch.object(
+        svc, '_make_request', side_effect=Exception('401 Unauthorized')
+    ) as mock_req:
+        user = await svc.get_user()
+
+    assert mock_req.call_count == 1  # only whoami, no /users lookup
+    assert isinstance(user, User)
+    assert user.id == ''
+    assert user.login == ''
+    assert user.avatar_url == ''
+
+
+@pytest.mark.asyncio
+async def test_get_user_without_user_id_or_base_url_skips_requests():
+    svc = BitbucketDCService(token=SecretStr('x-token-auth:mytoken'), base_domain=None)
     with patch.object(svc, '_make_request') as mock_req:
         user = await svc.get_user()
         mock_req.assert_not_called()
 
-    assert isinstance(user, User)
     assert user.id == ''
     assert user.login == ''
+
+
+def test_select_user_data_prefers_exact_match_over_first_result():
+    # /users?filter= is a substring match; the requested user may not be first.
+    users = [
+        {'name': 'jdoe-bot', 'slug': 'jdoe-bot'},
+        {'name': 'JDoe', 'slug': 'jdoe'},
+    ]
+    selected = BitbucketDCService._select_user_data(users, 'jdoe')
+    assert selected is not None
+    assert selected['slug'] == 'jdoe'
+
+
+def test_select_user_data_falls_back_to_first_result():
+    users = [{'name': 'someone-else', 'slug': 'someone-else'}]
+    selected = BitbucketDCService._select_user_data(users, 'jdoe')
+    assert selected is not None
+    assert selected['slug'] == 'someone-else'
+
+
+def test_select_user_data_empty_list_returns_none():
+    assert BitbucketDCService._select_user_data([], 'jdoe') is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc.py
+++ b/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc.py
@@ -196,9 +196,9 @@ async def test_get_user_without_user_id_resolves_via_whoami():
 
 
 @pytest.mark.asyncio
-async def test_get_user_without_user_id_returns_empty_when_whoami_fails():
+async def test_get_user_without_user_id_returns_empty_when_resolution_fails():
     # Credentials not tied to a user (e.g. project/repo-scoped HTTP access
-    # tokens) fail the whoami lookup; get_user degrades to an empty user.
+    # tokens) fail both username lookups; get_user degrades to an empty user.
     svc = BitbucketDCService(
         token=SecretStr('x-token-auth:mytoken'), base_domain='host.example.com'
     )
@@ -207,11 +207,72 @@ async def test_get_user_without_user_id_returns_empty_when_whoami_fails():
     ) as mock_req:
         user = await svc.get_user()
 
-    assert mock_req.call_count == 1  # only whoami, no /users lookup
+    assert mock_req.call_count == 2  # whoami + X-AUSERNAME fallback, no /users
     assert isinstance(user, User)
     assert user.id == ''
     assert user.login == ''
     assert user.avatar_url == ''
+
+
+@pytest.mark.asyncio
+async def test_get_user_falls_back_to_x_ausername_when_whoami_is_empty():
+    # Some Bitbucket DC servers answer whoami with 200 and an empty body for
+    # HTTP access tokens. Fall back to the URL-encoded X-AUSERNAME header
+    # from a cheap REST call. Mirrors a real Bitbucket 8.19 instance where
+    # the user's name differs from the slug.
+    svc = BitbucketDCService(
+        token=SecretStr('x-token-auth:mytoken'), base_domain='host.example.com'
+    )
+
+    async def mock_make_request(url, params=None, **kwargs):
+        if url.endswith('/plugins/servlet/applinks/whoami'):
+            return '', {}
+        if url.endswith('/projects'):
+            return {'values': []}, {'X-AUSERNAME': 'Chris.Bagwell%40example.com'}
+        return {
+            'values': [
+                {
+                    'id': 2,
+                    'slug': 'chris.bagwell_example.com',
+                    'name': 'Chris.Bagwell@example.com',
+                    'displayName': 'Bagwell, Chris',
+                    'emailAddress': 'Chris.Bagwell@example.com',
+                    'avatarUrl': '/users/chris.bagwell_example.com/avatar.png',
+                }
+            ]
+        }, {}
+
+    with patch.object(svc, '_make_request', side_effect=mock_make_request):
+        user = await svc.get_user()
+
+    assert user.id == '2'
+    assert user.login == 'Chris.Bagwell@example.com'
+    assert user.name == 'Bagwell, Chris'
+    assert (
+        user.avatar_url
+        == 'https://host.example.com/users/chris.bagwell_example.com/avatar.png'
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_user_resolved_username_not_found_degrades_to_empty_user():
+    # If the auto-resolved username yields no /users match, degrade to the
+    # empty user instead of raising (explicitly-configured user_id still
+    # raises, covered by test_get_user_raises_when_not_found).
+    svc = BitbucketDCService(
+        token=SecretStr('x-token-auth:mytoken'), base_domain='host.example.com'
+    )
+
+    async def mock_make_request(url, params=None, **kwargs):
+        if url.endswith('/plugins/servlet/applinks/whoami'):
+            return 'ghost-user', {}
+        return {'values': []}, {}
+
+    with patch.object(svc, '_make_request', side_effect=mock_make_request):
+        user = await svc.get_user()
+
+    assert user.id == ''
+    assert user.login == ''
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
HUMAN:
- [x] A human has tested these changes.

In SaaS/enterprise deployments the Bitbucket Data Center provider token is a raw OAuth bearer token from the Keycloak broker with `user_id=None` (the auth-tokens refresh table doesn't store the IdP user id), so `get_user()` early-returned an empty user and the avatar never loads in the UI. Local installs work because `user_id` is derived from `username:token` credentials.

## What

- When `user_id` is unknown, resolve the username via the applinks whoami servlet (Bitbucket DC has no `/user` myself endpoint) — the same technique the enterprise Keycloak userinfo proxy uses — then query `/users?filter=` as before.
- Some servers (observed on Bitbucket 8.19) answer whoami with 200 and an *empty* body for HTTP access tokens, so fall back to the URL-encoded `X-AUSERNAME` response header from a cheap REST call.
- Select from the filter response by case-insensitive name/email/slug match instead of taking the first result (`filter` is a substring match, and name can differ from slug — same lesson as #14711).
- Credentials not tied to a user (project/repo-scoped HTTP access tokens) fail both lookups gracefully and still return the empty user.

## Testing

- New unit tests: whoami resolution (request URLs + relative→absolute avatar rewrite), empty-whoami → `X-AUSERNAME` fallback (modeled on a real 8.19 instance where name ≠ slug), graceful fallback when both lookups fail, no requests when BASE_URL is unset, auto-resolved username with no `/users` match degrades instead of raising, `_select_user_data` match/fallback/empty cases.
- `uv run pytest tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc.py` — 30 passed; ruff/mypy/pre-commit clean.

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-2ab6755   docker.openhands.dev/openhands/openhands:2ab6755
```