### PR TITLE
ROUGH DRAFT: Support OHE managed LiteLLM model catalog

### DIFF
--- a/enterprise/server/constants.py
+++ b/enterprise/server/constants.py
@@ -1,6 +1,10 @@
 import os
 import re
 
+from openhands.app_server.utils.managed_litellm_models import (
+    get_managed_litellm_model_aliases,
+)
+
 # Get the host from environment variable
 HOST = os.getenv('WEB_HOST', 'app.all-hands.dev').strip()
 
@@ -139,6 +143,9 @@ def get_default_litellm_model():
     """Construct proxy for litellm model based on user settings if not set explicitly."""
     if LITELLM_DEFAULT_MODEL:
         return LITELLM_DEFAULT_MODEL
+    managed_models = get_managed_litellm_model_aliases()
+    if managed_models:
+        return build_litellm_proxy_model_path(managed_models[0])
     model = PERSONAL_WORKSPACE_VERSION_TO_MODEL[PERSONAL_WORKSPACE_VERSION]
     return build_litellm_proxy_model_path(model)
 

--- a/enterprise/tests/unit/server/test_constants.py
+++ b/enterprise/tests/unit/server/test_constants.py
@@ -103,3 +103,44 @@ class TestDeploymentModeInConfig:
             assert 'FEATURE_FLAGS' in config
             assert 'DEPLOYMENT_MODE' in config['FEATURE_FLAGS']
             assert config['FEATURE_FLAGS']['DEPLOYMENT_MODE'] == 'self_hosted'
+
+
+class TestDefaultLiteLLMModel:
+    """Tests for deployment-default LiteLLM model selection."""
+
+    def test_managed_litellm_models_first_entry_is_default(self):
+        """KOTS-managed model routes use the first entry as the deployment default."""
+        import importlib
+
+        with patch.dict(
+            'os.environ',
+            {
+                'OPENHANDS_MANAGED_LITELLM_MODELS': 'sonnet=anthropic-target, opus',
+                'LITELLM_DEFAULT_MODEL': '',
+            },
+        ):
+            import server.constants as constants_module
+
+            importlib.reload(constants_module)
+
+            assert constants_module.get_default_litellm_model() == 'litellm_proxy/sonnet'
+
+    def test_explicit_litellm_default_model_takes_precedence(self):
+        """Existing explicit default-model deployments keep their configured default."""
+        import importlib
+
+        with patch.dict(
+            'os.environ',
+            {
+                'OPENHANDS_MANAGED_LITELLM_MODELS': 'sonnet, opus',
+                'LITELLM_DEFAULT_MODEL': 'litellm_proxy/manual-default',
+            },
+        ):
+            import server.constants as constants_module
+
+            importlib.reload(constants_module)
+
+            assert (
+                constants_module.get_default_litellm_model()
+                == 'litellm_proxy/manual-default'
+            )

--- a/openhands/app_server/config_api/default_llm_model_service.py
+++ b/openhands/app_server/config_api/default_llm_model_service.py
@@ -43,6 +43,7 @@ _VERIFIED_MODEL_SET: set[str] = {
 def _to_llm_models(models_response: ModelsResponse) -> list[LLMModel]:
     """Convert raw model strings into ``LLMModel`` objects with verified flags."""
     results: list[LLMModel] = []
+    verified_openhands_models = set(models_response.verified_models)
     for model_name in models_response.models:
         parts = model_name.split('/', 1)
         if len(parts) == 2:
@@ -54,7 +55,8 @@ def _to_llm_models(models_response: ModelsResponse) -> list[LLMModel]:
             LLMModel(
                 provider=provider,
                 name=name,
-                verified=model_name in _VERIFIED_MODEL_SET,
+                verified=model_name in _VERIFIED_MODEL_SET
+                or (provider == 'openhands' and name in verified_openhands_models),
             )
         )
     return results

--- a/openhands/app_server/utils/llm.py
+++ b/openhands/app_server/utils/llm.py
@@ -33,6 +33,10 @@ from openhands.sdk.llm.utils.verified_models import (
     VERIFIED_OPENHANDS_MODELS as _SDK_OPENHANDS,
 )
 
+from openhands.app_server.utils.managed_litellm_models import (  # noqa: E402
+    get_managed_openhands_models,
+)
+
 # Build the ``openhands/…`` model list from the SDK.
 OPENHANDS_MODELS: list[str] = [f'openhands/{m}' for m in _SDK_OPENHANDS]
 
@@ -220,6 +224,9 @@ def get_openhands_models(
     Returns:
         A list such as ``["openhands/claude-opus-4-6", ...]``.
     """
+    managed_models = get_managed_openhands_models()
+    if managed_models:
+        return managed_models
     return verified_models if verified_models else OPENHANDS_MODELS
 
 

--- a/openhands/app_server/utils/managed_litellm_models.py
+++ b/openhands/app_server/utils/managed_litellm_models.py
@@ -1,0 +1,50 @@
+import os
+import re
+
+
+MANAGED_LITELLM_MODELS_ENV = 'OPENHANDS_MANAGED_LITELLM_MODELS'
+_MODEL_ENTRY_SPLIT_RE = re.compile(r'[,\n\r]+')
+
+
+def parse_managed_litellm_model_aliases(raw_value: str | None) -> list[str]:
+    """Parse operator-configured LiteLLM model entries into route aliases.
+
+    The raw value comes from OHE/KOTS and accepts comma or newline separated
+    entries. Each entry may be either ``model-id`` or ``alias=model-id``. The
+    alias is the stable LiteLLM route name surfaced in OpenHands as
+    ``openhands/<alias>``.
+    """
+    if not raw_value:
+        return []
+
+    aliases: list[str] = []
+    seen: set[str] = set()
+    for raw_entry in _MODEL_ENTRY_SPLIT_RE.split(raw_value):
+        entry = raw_entry.strip()
+        if not entry:
+            continue
+
+        if '=' in entry:
+            alias, model_id = (part.strip() for part in entry.split('=', 1))
+            if not alias or not model_id:
+                continue
+        else:
+            alias = entry
+
+        alias = alias.removeprefix('openhands/').removeprefix('litellm_proxy/')
+        if not alias or alias in seen:
+            continue
+        aliases.append(alias)
+        seen.add(alias)
+
+    return aliases
+
+
+def get_managed_litellm_model_aliases() -> list[str]:
+    return parse_managed_litellm_model_aliases(
+        os.getenv(MANAGED_LITELLM_MODELS_ENV)
+    )
+
+
+def get_managed_openhands_models() -> list[str]:
+    return [f'openhands/{alias}' for alias in get_managed_litellm_model_aliases()]

--- a/tests/unit/app_server/test_llm_model_service.py
+++ b/tests/unit/app_server/test_llm_model_service.py
@@ -35,6 +35,23 @@ class TestDefaultLLMModelServiceSearchModels:
         assert 'openhands' in providers
 
     @pytest.mark.asyncio
+    async def test_managed_openhands_models_are_verified(self, monkeypatch):
+        monkeypatch.setenv(
+            'OPENHANDS_MANAGED_LITELLM_MODELS',
+            'sonnet=provider-model, meta-llama/Llama-3.1-70B-Instruct',
+        )
+
+        service = DefaultLLMModelService()
+        result = await service.search_llm_models(
+            provider_eq='openhands',
+            limit=10000,
+        )
+
+        models = {m.name: m for m in result.items}
+        assert models['sonnet'].verified is True
+        assert models['meta-llama/Llama-3.1-70B-Instruct'].verified is True
+
+    @pytest.mark.asyncio
     async def test_includes_clarifai_models(self):
         service = DefaultLLMModelService()
         result = await service.search_llm_models(limit=10000)

--- a/tests/unit/utils/test_llm_utils.py
+++ b/tests/unit/utils/test_llm_utils.py
@@ -7,6 +7,9 @@ from openhands.app_server.utils.llm import (
     get_provider_api_base,
     is_openhands_model,
 )
+from openhands.app_server.utils.managed_litellm_models import (
+    parse_managed_litellm_model_aliases,
+)
 
 
 class TestIsOpenhandsModel:
@@ -123,6 +126,47 @@ class TestDeriveVerifiedModels:
         assert _derive_verified_models(models) == [
             'claude-opus-4-5-20251101',
             'gpt-5',
+        ]
+
+
+class TestParseManagedLitellmModelAliases:
+    """Tests for OHE/KOTS managed LiteLLM model list parsing."""
+
+    def test_accepts_commas_newlines_and_aliases(self):
+        raw = """
+        sonnet=us.anthropic.claude-sonnet-4-5-20250929-v1:0,
+        opus=us.anthropic.claude-opus-4-5-20251101-v1:0
+        qwen3-coder-480b
+        """
+
+        assert parse_managed_litellm_model_aliases(raw) == [
+            'sonnet',
+            'opus',
+            'qwen3-coder-480b',
+        ]
+
+    def test_plain_model_ids_are_used_as_aliases(self):
+        assert parse_managed_litellm_model_aliases(
+            'qwen3-coder-480b, meta-llama/Llama-3.1-70B-Instruct'
+        ) == [
+            'qwen3-coder-480b',
+            'meta-llama/Llama-3.1-70B-Instruct',
+        ]
+
+    def test_dedupes_and_normalizes_prefixes(self):
+        assert parse_managed_litellm_model_aliases(
+            'openhands/sonnet, litellm_proxy/sonnet, opus='
+        ) == ['sonnet']
+
+    def test_managed_models_override_verified_openhands_models(self, monkeypatch):
+        monkeypatch.setenv(
+            'OPENHANDS_MANAGED_LITELLM_MODELS',
+            'sonnet=us.anthropic.claude-sonnet-4-5-20250929-v1:0, opus',
+        )
+
+        assert llm_utils.get_openhands_models(['openhands/db-model']) == [
+            'openhands/sonnet',
+            'openhands/opus',
         ]
 
 


### PR DESCRIPTION
Draft checkpoint for the OHE managed multi-model work.

Stack layer 1/3.

This layer adds backend support for `OPENHANDS_MANAGED_LITELLM_MODELS` and surfaces those models as managed OpenHands/LiteLLM options.

Notes before marking ready:
- Pair with the OpenHands-Cloud KOTS plumbing PR.
- Confirm upgrade compatibility aliases are preserved in the chart/KOTS layer for legacy Bedrock/custom/Azure route names.
- Re-run focused backend/frontend model catalog tests after final stack cleanup.

Validation from the working branch so far:
- Focused app-server LLM tests passed locally.
- Focused frontend model selector/OHE mode tests passed locally.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-df745a7   docker.openhands.dev/openhands/openhands:df745a7
```