### PR TITLE
feat: move existing users into the default org when first auto-added

### DIFF
--- a/enterprise/storage/default_org_service.py
+++ b/enterprise/storage/default_org_service.py
@@ -3,6 +3,7 @@
 import os
 import re
 from dataclasses import dataclass
+from enum import Enum
 from uuid import UUID
 
 from pydantic import SecretStr
@@ -21,6 +22,14 @@ from openhands.app_server.utils.logger import openhands_logger as logger
 
 _TRUTHY_VALUES = {'1', 'true', 'yes', 'on'}
 _EMAIL_SPLIT_RE = re.compile(r'[\s,;]+')
+
+
+class MembershipOutcome(Enum):
+    """Result of ensuring a user's membership in the default org."""
+
+    ADDED = 'added'
+    PROMOTED = 'promoted'
+    UNCHANGED = 'unchanged'
 
 
 @dataclass(frozen=True)
@@ -103,7 +112,7 @@ class DefaultOrgBootstrapService:
             return user
 
         is_configured_owner = user_email in config.owner_emails
-        org = await DefaultOrgBootstrapService._get_or_create_org(
+        org, org_created_by_user = await DefaultOrgBootstrapService._get_or_create_org(
             config=config,
             current_user=user,
             current_user_is_owner=is_configured_owner,
@@ -116,19 +125,32 @@ class DefaultOrgBootstrapService:
             )
             return user
 
-        await DefaultOrgBootstrapService._ensure_membership(
+        outcome = await DefaultOrgBootstrapService._ensure_membership(
             org=org,
             user=user,
             is_configured_owner=is_configured_owner,
             auto_add_users=config.auto_add_users,
         )
 
-        if is_new_user and await OrgMemberStore.get_org_member(org.id, user.id):
+        # Move the user into the default org when they first join it: on
+        # signup, on first auto-add of an existing user, or when they just
+        # created the org as its configured owner. Joining is a one-time
+        # event, so this never re-fires on later logins — a user who
+        # deliberately switches back to their personal workspace stays there.
+        should_set_current_org = outcome is MembershipOutcome.ADDED or (
+            (is_new_user or org_created_by_user)
+            and await OrgMemberStore.get_org_member(org.id, user.id) is not None
+        )
+        if should_set_current_org:
             updated_user = await UserStore.update_current_org(str(user.id), org.id)
             if updated_user:
                 logger.info(
-                    'default_org_bootstrap:set_new_user_current_org',
-                    extra={'user_id': str(user.id), 'org_id': str(org.id)},
+                    'default_org_bootstrap:set_current_org',
+                    extra={
+                        'user_id': str(user.id),
+                        'org_id': str(org.id),
+                        'is_new_user': is_new_user,
+                    },
                 )
                 return await UserStore.get_user_by_id(str(user.id)) or updated_user
 
@@ -139,7 +161,14 @@ class DefaultOrgBootstrapService:
         config: DefaultOrgConfig,
         current_user: User,
         current_user_is_owner: bool,
-    ) -> Org | None:
+    ) -> tuple[Org | None, bool]:
+        """Find or lazily create the default org.
+
+        Returns (org, created_by_current_user) where the flag is True only
+        when the org was created in this call with the current user as its
+        owner — not on adoption, race recovery, or creation under a
+        different configured owner.
+        """
         org = await OrgStore.get_org_by_name(config.org_name)
         if org:
             if DefaultOrgBootstrapService._is_personal_workspace_org(org):
@@ -147,13 +176,13 @@ class DefaultOrgBootstrapService:
                     'default_org_bootstrap:refusing_personal_workspace_org',
                     extra={'org_id': str(org.id), 'org_name': org.name},
                 )
-                return None
+                return None, False
 
             logger.info(
                 'default_org_bootstrap:adopting_existing_org',
                 extra={'org_id': str(org.id), 'org_name': org.name},
             )
-            return org
+            return org, False
 
         owner_user = current_user if current_user_is_owner else None
         if owner_user is None:
@@ -162,16 +191,17 @@ class DefaultOrgBootstrapService:
             )
 
         if owner_user is None:
-            return None
+            return None, False
 
         owner_email = (owner_user.email or '').strip().lower()
         try:
-            return await OrgService.create_org_with_owner(
+            created_org = await OrgService.create_org_with_owner(
                 name=config.org_name,
                 contact_name=owner_email or 'Default organization owner',
                 contact_email=owner_email,
                 user_id=str(owner_user.id),
             )
+            return created_org, owner_user.id == current_user.id
         except OrgNameExistsError:
             # A concurrent login may have created the org after our first lookup.
             org = await OrgStore.get_org_by_name(config.org_name)
@@ -180,8 +210,8 @@ class DefaultOrgBootstrapService:
                     'default_org_bootstrap:refusing_personal_workspace_org',
                     extra={'org_id': str(org.id), 'org_name': org.name},
                 )
-                return None
-            return org
+                return None, False
+            return org, False
 
     @staticmethod
     def _is_personal_workspace_org(org: Org) -> bool:
@@ -201,7 +231,7 @@ class DefaultOrgBootstrapService:
         user: User,
         is_configured_owner: bool,
         auto_add_users: bool,
-    ) -> bool:
+    ) -> MembershipOutcome:
         membership = await OrgMemberStore.get_org_member(org.id, user.id)
         desired_role_name = ROLE_OWNER if is_configured_owner else ROLE_MEMBER
 
@@ -212,10 +242,10 @@ class DefaultOrgBootstrapService:
                     user_id=user.id,
                     membership=membership,
                 )
-            return False
+            return MembershipOutcome.UNCHANGED
 
         if not is_configured_owner and not auto_add_users:
-            return False
+            return MembershipOutcome.UNCHANGED
 
         role = await RoleStore.get_role_by_name(desired_role_name)
         if not role:
@@ -223,7 +253,7 @@ class DefaultOrgBootstrapService:
                 'default_org_bootstrap:role_not_found',
                 extra={'role': desired_role_name, 'org_id': str(org.id)},
             )
-            return False
+            return MembershipOutcome.UNCHANGED
 
         llm_api_key = await DefaultOrgBootstrapService._create_member_litellm_api_key(
             org_id=org.id,
@@ -247,7 +277,7 @@ class DefaultOrgBootstrapService:
                 'role': desired_role_name,
             },
         )
-        return True
+        return MembershipOutcome.ADDED
 
     @staticmethod
     async def _create_member_litellm_api_key(org_id: UUID, user_id: UUID) -> str:
@@ -263,10 +293,10 @@ class DefaultOrgBootstrapService:
         org_id: UUID,
         user_id: UUID,
         membership: OrgMember,
-    ) -> bool:
+    ) -> MembershipOutcome:
         current_role = await RoleStore.get_role_by_id(membership.role_id)
         if current_role and current_role.name == ROLE_OWNER:
-            return False
+            return MembershipOutcome.UNCHANGED
 
         owner_role = await RoleStore.get_role_by_name(ROLE_OWNER)
         if not owner_role:
@@ -274,7 +304,7 @@ class DefaultOrgBootstrapService:
                 'default_org_bootstrap:role_not_found',
                 extra={'role': ROLE_OWNER, 'org_id': str(org_id)},
             )
-            return False
+            return MembershipOutcome.UNCHANGED
 
         await OrgMemberStore.update_user_role_in_org(
             org_id=org_id,
@@ -286,4 +316,4 @@ class DefaultOrgBootstrapService:
             'default_org_bootstrap:member_promoted_to_owner',
             extra={'user_id': str(user_id), 'org_id': str(org_id)},
         )
-        return True
+        return MembershipOutcome.PROMOTED

--- a/enterprise/storage/default_org_service.py
+++ b/enterprise/storage/default_org_service.py
@@ -132,11 +132,9 @@ class DefaultOrgBootstrapService:
             auto_add_users=config.auto_add_users,
         )
 
-        # Move the user into the default org when they first join it: on
-        # signup, on first auto-add of an existing user, or when they just
-        # created the org as its configured owner. Joining is a one-time
-        # event, so this never re-fires on later logins — a user who
-        # deliberately switches back to their personal workspace stays there.
+        # Move the user into the default org on their first join (signup,
+        # first auto-add, or owner-created org); never on later logins, so a
+        # deliberate switch back to the personal workspace sticks.
         should_set_current_org = outcome is MembershipOutcome.ADDED or (
             (is_new_user or org_created_by_user)
             and await OrgMemberStore.get_org_member(org.id, user.id) is not None

--- a/enterprise/tests/unit/test_default_org_service.py
+++ b/enterprise/tests/unit/test_default_org_service.py
@@ -218,6 +218,11 @@ async def test_existing_owner_user_can_create_org_for_member_auto_join(monkeypat
             new_callable=AsyncMock,
         ) as mock_add_member,
         patch(
+            'storage.default_org_service.UserStore.update_current_org',
+            new_callable=AsyncMock,
+            return_value=member,
+        ) as mock_update_current_org,
+        patch(
             'storage.default_org_service.UserStore.get_user_by_id',
             new_callable=AsyncMock,
             return_value=member,
@@ -240,6 +245,7 @@ async def test_existing_owner_user_can_create_org_for_member_auto_join(monkeypat
         agent_settings_diff={},
         conversation_settings_diff={},
     )
+    mock_update_current_org.assert_awaited_once_with(str(member.id), org.id)
 
 
 @pytest.mark.asyncio
@@ -282,6 +288,10 @@ async def test_configured_owner_is_promoted_without_demoting_others(monkeypatch)
             new_callable=AsyncMock,
         ) as mock_add_member,
         patch(
+            'storage.default_org_service.UserStore.update_current_org',
+            new_callable=AsyncMock,
+        ) as mock_update_current_org,
+        patch(
             'storage.default_org_service.UserStore.get_user_by_id',
             new_callable=AsyncMock,
             return_value=user,
@@ -296,6 +306,152 @@ async def test_configured_owner_is_promoted_without_demoting_others(monkeypatch)
         status='active',
     )
     mock_add_member.assert_not_called()
+    # Promotion means the user was already a member; their workspace choice
+    # is preserved.
+    mock_update_current_org.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_existing_user_auto_added_is_moved_into_default_org(monkeypatch):
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'Acme')
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_OWNER_EMAILS', 'owner@example.com')
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS', 'true')
+    member = _user('member@example.com')
+    org = _org()
+
+    with (
+        patch(
+            'storage.default_org_service.OrgStore.get_org_by_name',
+            new_callable=AsyncMock,
+            return_value=org,
+        ),
+        patch(
+            'storage.default_org_service.OrgMemberStore.get_org_member',
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            'storage.default_org_service.RoleStore.get_role_by_name',
+            new_callable=AsyncMock,
+            return_value=Role(id=3, name='member', rank=3),
+        ),
+        patch(
+            'storage.default_org_service.OrgService.create_litellm_integration',
+            new_callable=AsyncMock,
+            return_value=_settings(),
+        ),
+        patch(
+            'storage.default_org_service.OrgMemberStore.add_user_to_org',
+            new_callable=AsyncMock,
+        ) as mock_add_member,
+        patch(
+            'storage.default_org_service.UserStore.update_current_org',
+            new_callable=AsyncMock,
+            return_value=member,
+        ) as mock_update_current_org,
+        patch(
+            'storage.default_org_service.UserStore.get_user_by_id',
+            new_callable=AsyncMock,
+            return_value=member,
+        ),
+    ):
+        await DefaultOrgBootstrapService.apply_for_user(member, is_new_user=False)
+
+    mock_add_member.assert_awaited_once()
+    mock_update_current_org.assert_awaited_once_with(str(member.id), org.id)
+
+
+@pytest.mark.asyncio
+async def test_existing_member_login_keeps_current_workspace(monkeypatch):
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'Acme')
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_OWNER_EMAILS', 'owner@example.com')
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS', 'true')
+    member = _user('member@example.com')
+    org = _org()
+    existing_membership = SimpleNamespace(role_id=3)
+
+    with (
+        patch(
+            'storage.default_org_service.OrgStore.get_org_by_name',
+            new_callable=AsyncMock,
+            return_value=org,
+        ),
+        patch(
+            'storage.default_org_service.OrgMemberStore.get_org_member',
+            new_callable=AsyncMock,
+            return_value=existing_membership,
+        ),
+        patch(
+            'storage.default_org_service.OrgMemberStore.add_user_to_org',
+            new_callable=AsyncMock,
+        ) as mock_add_member,
+        patch(
+            'storage.default_org_service.UserStore.update_current_org',
+            new_callable=AsyncMock,
+        ) as mock_update_current_org,
+        patch(
+            'storage.default_org_service.UserStore.get_user_by_id',
+            new_callable=AsyncMock,
+            return_value=member,
+        ),
+    ):
+        await DefaultOrgBootstrapService.apply_for_user(member, is_new_user=False)
+
+    # Already a member: the one-time move happened in the past; the user's
+    # current workspace choice (e.g. a deliberate switch back to personal)
+    # is preserved on later logins.
+    mock_add_member.assert_not_called()
+    mock_update_current_org.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_existing_owner_creating_org_is_moved_into_it(monkeypatch):
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'Acme')
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_OWNER_EMAILS', 'owner@example.com')
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS', 'false')
+    owner = _user('owner@example.com')
+    org = _org()
+    owner_membership = SimpleNamespace(role_id=1)
+
+    with (
+        patch(
+            'storage.default_org_service.OrgStore.get_org_by_name',
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            'storage.default_org_service.OrgService.create_org_with_owner',
+            new_callable=AsyncMock,
+            return_value=org,
+        ),
+        patch(
+            'storage.default_org_service.OrgMemberStore.get_org_member',
+            new_callable=AsyncMock,
+            return_value=owner_membership,
+        ),
+        patch(
+            'storage.default_org_service.RoleStore.get_role_by_id',
+            new_callable=AsyncMock,
+            return_value=Role(id=1, name='owner', rank=1),
+        ),
+        patch(
+            'storage.default_org_service.UserStore.update_current_org',
+            new_callable=AsyncMock,
+            return_value=owner,
+        ) as mock_update_current_org,
+        patch(
+            'storage.default_org_service.UserStore.get_user_by_id',
+            new_callable=AsyncMock,
+            return_value=owner,
+        ),
+    ):
+        await DefaultOrgBootstrapService.apply_for_user(owner, is_new_user=False)
+
+    # The configured owner just bootstrapped the org by logging in; land them in it.
+    mock_update_current_org.assert_awaited_once_with(str(owner.id), org.id)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
HUMAN: On OHE installs that bootstrap a default org, existing users were added as members but stayed parked in their personal workspace until they manually switched. This moves the switch to membership-creation time, so everyone (new users, existing users on first auto-add, and the configured owner) lands in the default org on the sign-in where they first join it. Validated on a real Replicated install (R03): owner bootstrap and a fresh GitLab signup both landed in the default org.

- [x] A human has tested these changes.

## Summary

The OHE default-org bootstrap (#14713) only switched `current_org_id` for brand-new users; existing users were added as members but stayed parked in their personal workspace until they manually switched. This PR moves the switch to **membership-creation time**, so every user — new or pre-existing — lands in the default organization on the sign-in where they first join it:

- on signup (unchanged behavior),
- on the first auto-add of an existing user (new),
- when the configured owner bootstraps the org by logging in (new).

Joining is a one-time event, so the move never re-fires on later logins: a user who deliberately switches back to their personal workspace stays there. Promoting an already-member configured owner does not move them.

This also means resolver conversations (Jira DC / Bitbucket DC / GitHub / GitLab webhooks) and the automations UI route to the default org for everyone after their next sign-in, since both fall back to the user's `current_org_id`.

## Implementation

- `_ensure_membership` now returns a `MembershipOutcome` (ADDED / PROMOTED / UNCHANGED) instead of a bool.
- `_get_or_create_org` reports whether the org was created in this call with the current user as owner (false on adoption, race recovery, or creation under a different configured owner).
- The KOTS help-text change matching this behavior is in the companion OpenHands-Cloud PR.

## Testing

- `enterprise/tests/unit/test_default_org_service.py`: existing tests updated, plus new coverage for existing-user auto-add (moved), already-member login (not moved), and owner-creates-org (moved). 10/10 passing.

Part of the org-only mode work for OHE (stacked under the hide-personal-workspaces PR).

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-1811b34   docker.openhands.dev/openhands/openhands:1811b34
```