### PR TITLE
fix: bump agent-server to 1.27.1 for Gemini cache fix

### DIFF
--- a/openhands/app_server/sandbox/sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/sandbox_spec_service.py
@@ -13,7 +13,7 @@ from openhands.sdk.utils.models import DiscriminatedUnionMixin
 
 # The version of the agent server to use for deployments.
 # Typically this will be the same as the values from the pyproject.toml
-AGENT_SERVER_IMAGE = 'ghcr.io/openhands/agent-server:1.27.0-python'
+AGENT_SERVER_IMAGE = 'ghcr.io/openhands/agent-server:1.27.1-python'
 
 
 class SandboxSpecService(ABC):


### PR DESCRIPTION
HUMAN: Bumps the pinned agent-server image from 1.27.0-python to 1.27.1-python. v1.27.1 is a one-commit patch release: v1.27.0 plus agent-sdk #3586 (don't emit explicit cache_control markers for Gemini), cherry-picked so OHE installs get the Gemini prompt-caching fix without the rest of post-1.27.0 main. Needed for the OpenHands Enterprise 1.39.0 release.

- [x] A human has tested these changes.

## Summary
- `AGENT_SERVER_IMAGE`: `ghcr.io/openhands/agent-server:1.27.0-python` → `1.27.1-python`
- agent-sdk release: https://github.com/OpenHands/software-agent-sdk/releases/tag/v1.27.1 (image verified present in ghcr)

## Testing
- `docker manifest inspect ghcr.io/openhands/agent-server:1.27.1-python` succeeds
- v1.27.1 release workflows (PyPI, agent-server images, binaries, eval) all green

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-5bf29f5   docker.openhands.dev/openhands/openhands:5bf29f5
```