### PR TITLE
feat: make the first signed-in user the default org owner, track the org by is_default flag

### DIFF
--- a/enterprise/migrations/versions/119_add_is_default_to_org.py
+++ b/enterprise/migrations/versions/119_add_is_default_to_org.py
@@ -1,0 +1,48 @@
+"""Add is_default flag to org for default-org bootstrap keying
+
+The OHE default-org bootstrap previously located its org by configured name,
+so renaming the org (in KOTS or in-app) silently forked a second org. The
+bootstrap now marks the org it creates (or adopts) with is_default and looks
+it up by that flag, making the org freely renameable.
+
+A partial unique index guarantees at most one default org per install.
+
+Revision ID: 119
+Revises: 118
+Create Date: 2026-06-10
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '119'
+down_revision: Union[str, None] = '118'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'org',
+        sa.Column(
+            'is_default',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.create_index(
+        'uq_org_is_default',
+        'org',
+        ['is_default'],
+        unique=True,
+        postgresql_where=sa.text('is_default'),
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('uq_org_is_default', table_name='org', if_exists=True)
+    op.drop_column('org', 'is_default')

--- a/enterprise/server/services/automation_event_service.py
+++ b/enterprise/server/services/automation_event_service.py
@@ -34,10 +34,7 @@ from server.auth.constants import (
     AUTOMATION_WEBHOOK_SECRET,
 )
 from server.auth.token_manager import TokenManager
-from storage.default_org_service import (
-    get_default_org_config,
-    is_personal_workspace_org,
-)
+from storage.default_org_service import get_default_org_config
 from storage.org_store import OrgStore
 from storage.redis import get_redis_client_async
 
@@ -244,16 +241,16 @@ class AutomationEventService:
     ) -> UUID | None:
         """Resolve unclaimed events to the bootstrapped default org.
 
-        Applies only when a default org is configured (OPENHANDS_DEFAULT_ORG_*)
+        Applies only when the default org is enabled (OPENHANDS_DEFAULT_ORG_*)
         and exactly one team org exists in the install — the default org
-        itself (with zero team orgs the default org has not been created yet,
-        so nothing resolves). The moment a second team org exists the
-        fallback switches off (within the cache TTL) and routing reverts to
-        explicit claims, so events can never cross org boundaries in
-        multi-org installs.
+        itself, located by its is_default flag (with zero team orgs the
+        default org has not been created yet, so nothing resolves). The
+        moment a second team org exists the fallback switches off (within
+        the cache TTL) and routing reverts to explicit claims, so events can
+        never cross org boundaries in multi-org installs.
         """
         config = get_default_org_config()
-        if not (config.enabled and config.org_name):
+        if not config.enabled:
             return None
 
         cached = await self._get_cached_value(DEFAULT_ORG_FALLBACK_CACHE_KEY)
@@ -261,9 +258,8 @@ class AutomationEventService:
             return None if cached == 'none' else UUID(cached)
 
         org_id: UUID | None = None
-        org = await OrgStore.get_org_by_name(config.org_name)
-        is_personal = org is not None and is_personal_workspace_org(org)
-        if org and not is_personal and await OrgStore.count_team_orgs() == 1:
+        org = await OrgStore.get_default_org()
+        if org and await OrgStore.count_team_orgs() == 1:
             org_id = org.id
 
         await self._set_cached_value(

--- a/enterprise/storage/default_org_service.py
+++ b/enterprise/storage/default_org_service.py
@@ -1,16 +1,14 @@
-"""Bootstrap a configured default OpenHands organization for OHE installs."""
+"""Bootstrap a default OpenHands organization for OHE installs."""
 
 import os
-import re
 from dataclasses import dataclass
 from enum import Enum
 from uuid import UUID
 
 from pydantic import SecretStr
-from server.constants import ROLE_MEMBER, ROLE_OWNER
+from server.constants import ROLE_MEMBER
 from server.routes.org_models import OrgNameExistsError
 from storage.org import Org
-from storage.org_member import OrgMember
 from storage.org_member_store import OrgMemberStore
 from storage.org_service import OrgService
 from storage.org_store import OrgStore
@@ -21,14 +19,14 @@ from storage.user_store import UserStore
 from openhands.app_server.utils.logger import openhands_logger as logger
 
 _TRUTHY_VALUES = {'1', 'true', 'yes', 'on'}
-_EMAIL_SPLIT_RE = re.compile(r'[\s,;]+')
+
+DEFAULT_ORG_NAME = 'Enterprise Org'
 
 
 class MembershipOutcome(Enum):
     """Result of ensuring a user's membership in the default org."""
 
     ADDED = 'added'
-    PROMOTED = 'promoted'
     UNCHANGED = 'unchanged'
 
 
@@ -36,7 +34,6 @@ class MembershipOutcome(Enum):
 class DefaultOrgConfig:
     enabled: bool
     org_name: str
-    owner_emails: frozenset[str]
     auto_add_users: bool
     hide_personal_workspaces: bool
 
@@ -53,30 +50,20 @@ def _env_truthy(name: str, *aliases: str, default: str = 'false') -> bool:
     return _env_value(name, *aliases, default=default).strip().lower() in _TRUTHY_VALUES
 
 
-def _parse_owner_emails(raw_value: str) -> frozenset[str]:
-    return frozenset(
-        token.strip().lower()
-        for token in _EMAIL_SPLIT_RE.split(raw_value)
-        if token.strip()
-    )
-
-
 def get_default_org_config() -> DefaultOrgConfig:
     return DefaultOrgConfig(
         enabled=_env_truthy(
             'OPENHANDS_DEFAULT_ORG_ENABLED',
             'OH_DEFAULT_ORG_ENABLED',
         ),
+        # Only used as the initial name when the org is first created; owners
+        # can rename it in the app afterwards (the org is tracked by its
+        # is_default flag, not its name).
         org_name=_env_value(
             'OPENHANDS_DEFAULT_ORG_NAME',
             'OH_DEFAULT_ORG_NAME',
-        ).strip(),
-        owner_emails=_parse_owner_emails(
-            _env_value(
-                'OPENHANDS_DEFAULT_ORG_OWNER_EMAILS',
-                'OH_DEFAULT_ORG_OWNER_EMAILS',
-            )
-        ),
+        ).strip()
+        or DEFAULT_ORG_NAME,
         auto_add_users=_env_truthy(
             'OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS',
             'OH_DEFAULT_ORG_AUTO_ADD_USERS',
@@ -94,7 +81,14 @@ def is_personal_workspace_org(org: Org) -> bool:
 
 
 class DefaultOrgBootstrapService:
-    """Apply additive default organization membership rules on user login."""
+    """Apply additive default organization membership rules on user login.
+
+    The first user to sign in after the feature is enabled creates the
+    default org and becomes its owner. The org is tracked by the is_default
+    flag, so it can be freely renamed in the app; ownership and membership
+    are likewise managed in the app afterwards (this service never demotes
+    or removes anyone).
+    """
 
     @staticmethod
     async def apply_for_user(user: User, is_new_user: bool) -> User:
@@ -102,49 +96,32 @@ class DefaultOrgBootstrapService:
         if not config.enabled:
             return user
 
-        if not config.org_name:
-            logger.warning('default_org_bootstrap:missing_org_name')
-            return user
-
-        if not config.owner_emails:
-            logger.warning(
-                'default_org_bootstrap:missing_owner_emails',
-                extra={'org_name': config.org_name},
-            )
-            return user
-
         user_email = (user.email or '').strip().lower()
         if not user_email:
             logger.warning(
                 'default_org_bootstrap:user_missing_email',
-                extra={'user_id': str(user.id), 'org_name': config.org_name},
+                extra={'user_id': str(user.id)},
             )
             return user
 
-        is_configured_owner = user_email in config.owner_emails
         org, org_created_by_user = await DefaultOrgBootstrapService._get_or_create_org(
             config=config,
             current_user=user,
-            current_user_is_owner=is_configured_owner,
         )
 
         if not org:
-            logger.info(
-                'default_org_bootstrap:pending_owner_login',
-                extra={'user_id': str(user.id), 'org_name': config.org_name},
-            )
             return user
 
         outcome = await DefaultOrgBootstrapService._ensure_membership(
             org=org,
             user=user,
-            is_configured_owner=is_configured_owner,
             auto_add_users=config.auto_add_users,
         )
 
         # Move the user into the default org on their first join (signup,
-        # first auto-add, or owner-created org); never on later logins, so a
-        # deliberate switch back to the personal workspace sticks.
+        # first auto-add, or having just created the org); never on later
+        # logins, so a deliberate switch back to the personal workspace
+        # sticks.
         should_set_current_org = outcome is MembershipOutcome.ADDED or (
             (is_new_user or org_created_by_user)
             and await OrgMemberStore.get_org_member(org.id, user.id) is not None
@@ -159,8 +136,7 @@ class DefaultOrgBootstrapService:
             and user.current_org_id == user.id
         ):
             should_set_current_org = (
-                outcome is MembershipOutcome.PROMOTED
-                or await OrgMemberStore.get_org_member(org.id, user.id) is not None
+                await OrgMemberStore.get_org_member(org.id, user.id) is not None
             )
 
         if should_set_current_org:
@@ -182,98 +158,91 @@ class DefaultOrgBootstrapService:
     async def _get_or_create_org(
         config: DefaultOrgConfig,
         current_user: User,
-        current_user_is_owner: bool,
     ) -> tuple[Org | None, bool]:
         """Find or lazily create the default org.
 
         Returns (org, created_by_current_user) where the flag is True only
         when the org was created in this call with the current user as its
-        owner — not on adoption, race recovery, or creation under a
-        different configured owner.
+        owner — not on adoption or race recovery.
         """
-        org = await OrgStore.get_org_by_name(config.org_name)
+        org = await OrgStore.get_default_org()
         if org:
-            if DefaultOrgBootstrapService._is_personal_workspace_org(org):
-                logger.warning(
-                    'default_org_bootstrap:refusing_personal_workspace_org',
-                    extra={'org_id': str(org.id), 'org_name': org.name},
-                )
-                return None, False
-
-            logger.info(
-                'default_org_bootstrap:adopting_existing_org',
-                extra={'org_id': str(org.id), 'org_name': org.name},
-            )
             return org, False
 
-        owner_user = current_user if current_user_is_owner else None
-        if owner_user is None:
-            owner_user = await DefaultOrgBootstrapService._find_existing_owner_user(
-                config.owner_emails
+        # An install can predate the is_default flag (an org bootstrapped by
+        # an earlier name-keyed version). Team orgs cannot be created by
+        # users on OHE installs, so a sole team org is the default org:
+        # adopt it instead of creating a duplicate.
+        team_orgs = await OrgStore.list_team_orgs(limit=2)
+        if len(team_orgs) == 1:
+            adopted = await OrgStore.mark_org_as_default(team_orgs[0].id)
+            if adopted is None:
+                # A concurrent login flagged an org first; use that one.
+                return await OrgStore.get_default_org(), False
+            logger.info(
+                'default_org_bootstrap:adopting_existing_org',
+                extra={'org_id': str(adopted.id), 'org_name': adopted.name},
             )
-
-        if owner_user is None:
+            return adopted, False
+        if len(team_orgs) > 1:
+            logger.warning(
+                'default_org_bootstrap:ambiguous_existing_orgs',
+                extra={'team_org_count': len(team_orgs)},
+            )
             return None, False
 
-        owner_email = (owner_user.email or '').strip().lower()
+        # No team org exists yet: the current user is the first one through
+        # the door — create the org with them as its owner.
+        user_email = (current_user.email or '').strip().lower()
         try:
             created_org = await OrgService.create_org_with_owner(
                 name=config.org_name,
-                contact_name=owner_email or 'Default organization owner',
-                contact_email=owner_email,
-                user_id=str(owner_user.id),
+                contact_name=user_email or 'Default organization owner',
+                contact_email=user_email,
+                user_id=str(current_user.id),
             )
-            return created_org, owner_user.id == current_user.id
         except OrgNameExistsError:
-            # A concurrent login may have created the org after our first lookup.
+            # A concurrent login may have created the org after our lookup.
+            org = await OrgStore.get_default_org()
+            if org:
+                return org, False
             org = await OrgStore.get_org_by_name(config.org_name)
-            if org and DefaultOrgBootstrapService._is_personal_workspace_org(org):
-                logger.warning(
-                    'default_org_bootstrap:refusing_personal_workspace_org',
-                    extra={'org_id': str(org.id), 'org_name': org.name},
-                )
-                return None, False
-            return org, False
+            if org and not is_personal_workspace_org(org):
+                return await OrgStore.mark_org_as_default(org.id), False
+            return None, False
 
-    @staticmethod
-    def _is_personal_workspace_org(org: Org) -> bool:
-        return is_personal_workspace_org(org)
-
-    @staticmethod
-    async def _find_existing_owner_user(owner_emails: frozenset[str]) -> User | None:
-        for owner_email in sorted(owner_emails):
-            owner_user = await UserStore.get_user_by_email(owner_email)
-            if owner_user:
-                return owner_user
-        return None
+        flagged_org = await OrgStore.mark_org_as_default(created_org.id)
+        if flagged_org is None:
+            # Another org got flagged concurrently; defer to it.
+            return await OrgStore.get_default_org(), False
+        logger.info(
+            'default_org_bootstrap:org_created',
+            extra={
+                'org_id': str(flagged_org.id),
+                'org_name': flagged_org.name,
+                'owner_user_id': str(current_user.id),
+            },
+        )
+        return flagged_org, True
 
     @staticmethod
     async def _ensure_membership(
         org: Org,
         user: User,
-        is_configured_owner: bool,
         auto_add_users: bool,
     ) -> MembershipOutcome:
         membership = await OrgMemberStore.get_org_member(org.id, user.id)
-        desired_role_name = ROLE_OWNER if is_configured_owner else ROLE_MEMBER
-
         if membership:
-            if is_configured_owner:
-                return await DefaultOrgBootstrapService._promote_to_owner_if_needed(
-                    org_id=org.id,
-                    user_id=user.id,
-                    membership=membership,
-                )
             return MembershipOutcome.UNCHANGED
 
-        if not is_configured_owner and not auto_add_users:
+        if not auto_add_users:
             return MembershipOutcome.UNCHANGED
 
-        role = await RoleStore.get_role_by_name(desired_role_name)
+        role = await RoleStore.get_role_by_name(ROLE_MEMBER)
         if not role:
             logger.error(
                 'default_org_bootstrap:role_not_found',
-                extra={'role': desired_role_name, 'org_id': str(org.id)},
+                extra={'role': ROLE_MEMBER, 'org_id': str(org.id)},
             )
             return MembershipOutcome.UNCHANGED
 
@@ -296,7 +265,7 @@ class DefaultOrgBootstrapService:
             extra={
                 'user_id': str(user.id),
                 'org_id': str(org.id),
-                'role': desired_role_name,
+                'role': ROLE_MEMBER,
             },
         )
         return MembershipOutcome.ADDED
@@ -309,33 +278,3 @@ class DefaultOrgBootstrapService:
         if isinstance(llm_api_key, SecretStr):
             return llm_api_key.get_secret_value()
         return llm_api_key or ''
-
-    @staticmethod
-    async def _promote_to_owner_if_needed(
-        org_id: UUID,
-        user_id: UUID,
-        membership: OrgMember,
-    ) -> MembershipOutcome:
-        current_role = await RoleStore.get_role_by_id(membership.role_id)
-        if current_role and current_role.name == ROLE_OWNER:
-            return MembershipOutcome.UNCHANGED
-
-        owner_role = await RoleStore.get_role_by_name(ROLE_OWNER)
-        if not owner_role:
-            logger.error(
-                'default_org_bootstrap:role_not_found',
-                extra={'role': ROLE_OWNER, 'org_id': str(org_id)},
-            )
-            return MembershipOutcome.UNCHANGED
-
-        await OrgMemberStore.update_user_role_in_org(
-            org_id=org_id,
-            user_id=user_id,
-            role_id=owner_role.id,
-            status='active',
-        )
-        logger.info(
-            'default_org_bootstrap:member_promoted_to_owner',
-            extra={'user_id': str(user_id), 'org_id': str(org_id)},
-        )
-        return MembershipOutcome.PROMOTED

--- a/enterprise/storage/org.py
+++ b/enterprise/storage/org.py
@@ -70,6 +70,9 @@ class Org(Base):
     llm_profiles: Mapped[dict[str, Any] | None] = mapped_column(
         EncryptedJSON, nullable=True
     )
+    # Marks the bootstrapped default org on OHE installs; a partial unique
+    # index allows at most one default org per install.
+    is_default: Mapped[bool] = mapped_column(nullable=False, default=False)
 
     # Relationships
     org_members: Mapped[list['OrgMember']] = relationship(

--- a/enterprise/storage/org_store.py
+++ b/enterprise/storage/org_store.py
@@ -17,6 +17,7 @@ from server.routes.org_models import (
     OrphanedUserError,
 )
 from sqlalchemy import delete, func, select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 from storage.database import a_session_maker
 from storage.lite_llm_manager import LiteLlmManager, get_openhands_cloud_key_alias
@@ -170,6 +171,46 @@ class OrgStore:
             result = await session.execute(select(Org).filter(Org.name == name))
             org = result.scalars().first()
         return await OrgStore._validate_org_version(org)
+
+    @staticmethod
+    async def get_default_org() -> Org | None:
+        """Get the org flagged as the install's bootstrapped default org."""
+        async with a_session_maker() as session:
+            result = await session.execute(select(Org).filter(Org.is_default))
+            org = result.scalars().first()
+        return await OrgStore._validate_org_version(org)
+
+    @staticmethod
+    async def mark_org_as_default(org_id: UUID) -> Org | None:
+        """Flag an org as the install's default org.
+
+        Returns the org on success (or if already flagged). Returns None if
+        the org does not exist or another org is already flagged (the partial
+        unique index allows at most one default org).
+        """
+        async with a_session_maker() as session:
+            result = await session.execute(select(Org).filter(Org.id == org_id))
+            org = result.scalars().first()
+            if not org:
+                return None
+            if not org.is_default:
+                org.is_default = True
+                try:
+                    await session.commit()
+                except IntegrityError:
+                    await session.rollback()
+                    return None
+        return org
+
+    @staticmethod
+    async def list_team_orgs(limit: int | None = None) -> list[Org]:
+        """List orgs that are not personal workspaces (see count_team_orgs)."""
+        async with a_session_maker() as session:
+            stmt = select(Org).where(~select(User.id).where(User.id == Org.id).exists())
+            if limit is not None:
+                stmt = stmt.limit(limit)
+            result = await session.execute(stmt)
+            return list(result.scalars().all())
 
     @staticmethod
     async def count_team_orgs() -> int:

--- a/enterprise/tests/unit/server/services/test_automation_event_service.py
+++ b/enterprise/tests/unit/server/services/test_automation_event_service.py
@@ -990,7 +990,6 @@ class TestResolveDefaultOrgFallback:
         THEN: The default org id is returned and cached
         """
         monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
-        monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'AcmeOrg')
         org = self._team_org()
         mock_redis = AsyncMock()
         mock_redis.get = AsyncMock(return_value=None)
@@ -1002,7 +1001,7 @@ class TestResolveDefaultOrgFallback:
             ) as mock_org_store,
             patch(REDIS_PATCH, return_value=mock_redis),
         ):
-            mock_org_store.get_org_by_name = AsyncMock(return_value=org)
+            mock_org_store.get_default_org = AsyncMock(return_value=org)
             mock_org_store.count_team_orgs = AsyncMock(return_value=1)
             service = create_service(mock_token_manager)
             result = await service._resolve_default_org_fallback(
@@ -1030,14 +1029,14 @@ class TestResolveDefaultOrgFallback:
             ) as mock_org_store,
             patch(REDIS_PATCH, return_value=mock_redis),
         ):
-            mock_org_store.get_org_by_name = AsyncMock()
+            mock_org_store.get_default_org = AsyncMock()
             service = create_service(mock_token_manager)
             result = await service._resolve_default_org_fallback(
                 ProviderType.BITBUCKET_DATA_CENTER, 'proj'
             )
 
             assert result is None
-            mock_org_store.get_org_by_name.assert_not_called()
+            mock_org_store.get_default_org.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_fallback_off_with_multiple_team_orgs(
@@ -1049,7 +1048,6 @@ class TestResolveDefaultOrgFallback:
         THEN: None is returned (multi-org installs require explicit claims)
         """
         monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
-        monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'AcmeOrg')
         org = self._team_org()
         mock_redis = AsyncMock()
         mock_redis.get = AsyncMock(return_value=None)
@@ -1061,7 +1059,7 @@ class TestResolveDefaultOrgFallback:
             ) as mock_org_store,
             patch(REDIS_PATCH, return_value=mock_redis),
         ):
-            mock_org_store.get_org_by_name = AsyncMock(return_value=org)
+            mock_org_store.get_default_org = AsyncMock(return_value=org)
             mock_org_store.count_team_orgs = AsyncMock(return_value=2)
             service = create_service(mock_token_manager)
             result = await service._resolve_default_org_fallback(
@@ -1078,7 +1076,6 @@ class TestResolveDefaultOrgFallback:
         THEN: The cached org id is returned without DB lookups
         """
         monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
-        monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'AcmeOrg')
         cached_id = '87654321-4321-8765-4321-876543218765'
         mock_redis = AsyncMock()
         mock_redis.get = AsyncMock(return_value=cached_id.encode())
@@ -1089,14 +1086,14 @@ class TestResolveDefaultOrgFallback:
             ) as mock_org_store,
             patch(REDIS_PATCH, return_value=mock_redis),
         ):
-            mock_org_store.get_org_by_name = AsyncMock()
+            mock_org_store.get_default_org = AsyncMock()
             service = create_service(mock_token_manager)
             result = await service._resolve_default_org_fallback(
                 ProviderType.BITBUCKET_DATA_CENTER, 'proj'
             )
 
             assert result == uuid.UUID(cached_id)
-            mock_org_store.get_org_by_name.assert_not_called()
+            mock_org_store.get_default_org.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_unclaimed_bitbucket_dc_event_routes_to_default_org(
@@ -1108,7 +1105,6 @@ class TestResolveDefaultOrgFallback:
         THEN: The event resolves to the default org instead of being dropped
         """
         monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
-        monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'AcmeOrg')
         org = self._team_org()
         mock_redis = AsyncMock()
         mock_redis.get = AsyncMock(return_value=None)
@@ -1125,7 +1121,7 @@ class TestResolveDefaultOrgFallback:
             ) as mock_org_store,
             patch(REDIS_PATCH, return_value=mock_redis),
         ):
-            mock_org_store.get_org_by_name = AsyncMock(return_value=org)
+            mock_org_store.get_default_org = AsyncMock(return_value=org)
             mock_org_store.count_team_orgs = AsyncMock(return_value=1)
             service = create_service(mock_token_manager)
             context = await service._resolve_org_context(

--- a/enterprise/tests/unit/test_default_org_service.py
+++ b/enterprise/tests/unit/test_default_org_service.py
@@ -4,7 +4,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from pydantic import SecretStr
+from server.routes.org_models import OrgNameExistsError
 from storage.default_org_service import (
+    DEFAULT_ORG_NAME,
     DefaultOrgBootstrapService,
     get_default_org_config,
 )
@@ -26,33 +28,30 @@ def _user(email: str) -> User:
     return User(id=user_id, email=email, current_org_id=user_id)
 
 
-def _org(name: str = 'Acme') -> Org:
+def _org(name: str = DEFAULT_ORG_NAME) -> Org:
     return Org(id=uuid.uuid4(), name=name)
 
 
-def _personal_org() -> Org:
-    org_id = uuid.uuid4()
-    return Org(id=org_id, name=f'user_{org_id}_org')
-
-
-def test_default_org_config_accepts_one_as_truthy(monkeypatch):
+def test_default_org_config_defaults_org_name(monkeypatch):
     monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', '1')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'Acme')
-    monkeypatch.setenv(
-        'OPENHANDS_DEFAULT_ORG_OWNER_EMAILS',
-        'Owner@Example.com, second@example.com\nthird@example.com',
-    )
+    monkeypatch.delenv('OPENHANDS_DEFAULT_ORG_NAME', raising=False)
     monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS', 'true')
 
     config = get_default_org_config()
 
     assert config.enabled is True
-    assert config.org_name == 'Acme'
-    assert config.owner_emails == frozenset(
-        {'owner@example.com', 'second@example.com', 'third@example.com'}
-    )
+    assert config.org_name == DEFAULT_ORG_NAME
     assert config.auto_add_users is True
     assert config.hide_personal_workspaces is False
+
+
+def test_default_org_config_allows_org_name_override(monkeypatch):
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', '1')
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'Acme')
+
+    config = get_default_org_config()
+
+    assert config.org_name == 'Acme'
 
 
 def test_default_org_config_reads_hide_personal_workspaces(monkeypatch):
@@ -69,7 +68,7 @@ async def test_disabled_default_org_does_nothing(monkeypatch):
     user = _user('member@example.com')
 
     with patch(
-        'storage.default_org_service.OrgStore.get_org_by_name',
+        'storage.default_org_service.OrgStore.get_default_org',
         new_callable=AsyncMock,
     ) as mock_get_org:
         result = await DefaultOrgBootstrapService.apply_for_user(
@@ -82,23 +81,202 @@ async def test_disabled_default_org_does_nothing(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_non_owner_waits_when_no_configured_owner_exists(monkeypatch):
+async def test_first_user_creates_default_org_and_becomes_owner(monkeypatch):
     monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'Acme')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_OWNER_EMAILS', 'owner@example.com')
+    monkeypatch.delenv('OPENHANDS_DEFAULT_ORG_NAME', raising=False)
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS', 'true')
+    user = _user('first@example.com')
+    org = _org()
+    owner_membership = SimpleNamespace(role_id=1)
+    updated_user = _user('first@example.com')
+    updated_user.id = user.id
+    updated_user.current_org_id = org.id
+
+    with (
+        patch(
+            'storage.default_org_service.OrgStore.get_default_org',
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            'storage.default_org_service.OrgStore.list_team_orgs',
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            'storage.default_org_service.OrgService.create_org_with_owner',
+            new_callable=AsyncMock,
+            return_value=org,
+        ) as mock_create_org,
+        patch(
+            'storage.default_org_service.OrgStore.mark_org_as_default',
+            new_callable=AsyncMock,
+            return_value=org,
+        ) as mock_mark_default,
+        patch(
+            'storage.default_org_service.OrgMemberStore.get_org_member',
+            new_callable=AsyncMock,
+            return_value=owner_membership,
+        ),
+        patch(
+            'storage.default_org_service.UserStore.update_current_org',
+            new_callable=AsyncMock,
+            return_value=updated_user,
+        ) as mock_update_current_org,
+        patch(
+            'storage.default_org_service.UserStore.get_user_by_id',
+            new_callable=AsyncMock,
+            return_value=updated_user,
+        ),
+    ):
+        result = await DefaultOrgBootstrapService.apply_for_user(
+            user,
+            is_new_user=True,
+        )
+
+    mock_create_org.assert_awaited_once_with(
+        name=DEFAULT_ORG_NAME,
+        contact_name='first@example.com',
+        contact_email='first@example.com',
+        user_id=str(user.id),
+    )
+    mock_mark_default.assert_awaited_once_with(org.id)
+    mock_update_current_org.assert_awaited_once_with(str(user.id), org.id)
+    assert result.current_org_id == org.id
+
+
+@pytest.mark.asyncio
+async def test_first_user_creates_org_even_with_auto_add_disabled(monkeypatch):
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS', 'false')
+    user = _user('first@example.com')
+    org = _org()
+    owner_membership = SimpleNamespace(role_id=1)
+
+    with (
+        patch(
+            'storage.default_org_service.OrgStore.get_default_org',
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            'storage.default_org_service.OrgStore.list_team_orgs',
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            'storage.default_org_service.OrgService.create_org_with_owner',
+            new_callable=AsyncMock,
+            return_value=org,
+        ) as mock_create_org,
+        patch(
+            'storage.default_org_service.OrgStore.mark_org_as_default',
+            new_callable=AsyncMock,
+            return_value=org,
+        ),
+        patch(
+            'storage.default_org_service.OrgMemberStore.get_org_member',
+            new_callable=AsyncMock,
+            return_value=owner_membership,
+        ),
+        patch(
+            'storage.default_org_service.UserStore.update_current_org',
+            new_callable=AsyncMock,
+            return_value=user,
+        ) as mock_update_current_org,
+        patch(
+            'storage.default_org_service.UserStore.get_user_by_id',
+            new_callable=AsyncMock,
+            return_value=user,
+        ),
+    ):
+        await DefaultOrgBootstrapService.apply_for_user(user, is_new_user=False)
+
+    # Auto-add gates *other* users; the creating user always owns the org.
+    mock_create_org.assert_awaited_once()
+    mock_update_current_org.assert_awaited_once_with(str(user.id), org.id)
+
+
+@pytest.mark.asyncio
+async def test_sole_existing_team_org_is_adopted(monkeypatch):
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS', 'true')
+    member = _user('member@example.com')
+    org = _org('Acme')
+
+    with (
+        patch(
+            'storage.default_org_service.OrgStore.get_default_org',
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            'storage.default_org_service.OrgStore.list_team_orgs',
+            new_callable=AsyncMock,
+            return_value=[org],
+        ),
+        patch(
+            'storage.default_org_service.OrgStore.mark_org_as_default',
+            new_callable=AsyncMock,
+            return_value=org,
+        ) as mock_mark_default,
+        patch(
+            'storage.default_org_service.OrgService.create_org_with_owner',
+            new_callable=AsyncMock,
+        ) as mock_create_org,
+        patch(
+            'storage.default_org_service.OrgMemberStore.get_org_member',
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            'storage.default_org_service.RoleStore.get_role_by_name',
+            new_callable=AsyncMock,
+            return_value=Role(id=3, name='member', rank=3),
+        ),
+        patch(
+            'storage.default_org_service.OrgService.create_litellm_integration',
+            new_callable=AsyncMock,
+            return_value=_settings(),
+        ),
+        patch(
+            'storage.default_org_service.OrgMemberStore.add_user_to_org',
+            new_callable=AsyncMock,
+        ) as mock_add_member,
+        patch(
+            'storage.default_org_service.UserStore.update_current_org',
+            new_callable=AsyncMock,
+            return_value=member,
+        ),
+        patch(
+            'storage.default_org_service.UserStore.get_user_by_id',
+            new_callable=AsyncMock,
+            return_value=member,
+        ),
+    ):
+        await DefaultOrgBootstrapService.apply_for_user(member, is_new_user=False)
+
+    mock_mark_default.assert_awaited_once_with(org.id)
+    mock_create_org.assert_not_called()
+    mock_add_member.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_multiple_unflagged_team_orgs_skip_bootstrap(monkeypatch):
+    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
     monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS', 'true')
     user = _user('member@example.com')
 
     with (
         patch(
-            'storage.default_org_service.OrgStore.get_org_by_name',
+            'storage.default_org_service.OrgStore.get_default_org',
             new_callable=AsyncMock,
             return_value=None,
         ),
         patch(
-            'storage.default_org_service.UserStore.get_user_by_email',
+            'storage.default_org_service.OrgStore.list_team_orgs',
             new_callable=AsyncMock,
-            return_value=None,
+            return_value=[_org('A'), _org('B')],
         ),
         patch(
             'storage.default_org_service.OrgService.create_org_with_owner',
@@ -120,93 +298,66 @@ async def test_non_owner_waits_when_no_configured_owner_exists(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_first_configured_owner_creates_default_org_and_switches_new_user(
-    monkeypatch,
-):
+async def test_concurrent_creation_race_adopts_winner(monkeypatch):
     monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'Acme')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_OWNER_EMAILS', 'owner@example.com')
     monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS', 'true')
-    user = _user('owner@example.com')
+    user = _user('second@example.com')
     org = _org()
-    owner_membership = SimpleNamespace(role_id=1)
-    updated_user = _user('owner@example.com')
-    updated_user.id = user.id
-    updated_user.current_org_id = org.id
+    existing_membership = SimpleNamespace(role_id=3)
 
     with (
         patch(
-            'storage.default_org_service.OrgStore.get_org_by_name',
+            'storage.default_org_service.OrgStore.get_default_org',
             new_callable=AsyncMock,
-            return_value=None,
+            # First lookup misses; after the create collides, the winner's
+            # flagged org is found.
+            side_effect=[None, org],
+        ),
+        patch(
+            'storage.default_org_service.OrgStore.list_team_orgs',
+            new_callable=AsyncMock,
+            return_value=[],
         ),
         patch(
             'storage.default_org_service.OrgService.create_org_with_owner',
             new_callable=AsyncMock,
-            return_value=org,
-        ) as mock_create_org,
+            side_effect=OrgNameExistsError('exists'),
+        ),
         patch(
             'storage.default_org_service.OrgMemberStore.get_org_member',
             new_callable=AsyncMock,
-            side_effect=[owner_membership, owner_membership],
-        ),
-        patch(
-            'storage.default_org_service.RoleStore.get_role_by_id',
-            new_callable=AsyncMock,
-            return_value=Role(id=1, name='owner', rank=1),
+            return_value=existing_membership,
         ),
         patch(
             'storage.default_org_service.UserStore.update_current_org',
             new_callable=AsyncMock,
-            return_value=updated_user,
         ) as mock_update_current_org,
         patch(
             'storage.default_org_service.UserStore.get_user_by_id',
             new_callable=AsyncMock,
-            return_value=updated_user,
+            return_value=user,
         ),
     ):
-        result = await DefaultOrgBootstrapService.apply_for_user(
-            user,
-            is_new_user=True,
-        )
+        await DefaultOrgBootstrapService.apply_for_user(user, is_new_user=False)
 
-    mock_create_org.assert_awaited_once_with(
-        name='Acme',
-        contact_name='owner@example.com',
-        contact_email='owner@example.com',
-        user_id=str(user.id),
-    )
-    mock_update_current_org.assert_awaited_once_with(str(user.id), org.id)
-    assert result.current_org_id == org.id
+    # The loser of the race is already a member (or treated as existing);
+    # no new org is created and no workspace move is forced.
+    mock_update_current_org.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_existing_owner_user_can_create_org_for_member_auto_join(monkeypatch):
+async def test_existing_user_auto_added_is_moved_into_default_org(monkeypatch):
     monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'Acme')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_OWNER_EMAILS', 'owner@example.com')
     monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS', 'true')
     member = _user('member@example.com')
-    owner = _user('owner@example.com')
     org = _org()
 
     with (
         patch(
-            'storage.default_org_service.OrgStore.get_org_by_name',
-            new_callable=AsyncMock,
-            return_value=None,
-        ),
-        patch(
-            'storage.default_org_service.UserStore.get_user_by_email',
-            new_callable=AsyncMock,
-            return_value=owner,
-        ),
-        patch(
-            'storage.default_org_service.OrgService.create_org_with_owner',
+            'storage.default_org_service.OrgStore.get_default_org',
             new_callable=AsyncMock,
             return_value=org,
-        ) as mock_create_org,
+        ),
         patch(
             'storage.default_org_service.OrgMemberStore.get_org_member',
             new_callable=AsyncMock,
@@ -239,12 +390,6 @@ async def test_existing_owner_user_can_create_org_for_member_auto_join(monkeypat
     ):
         await DefaultOrgBootstrapService.apply_for_user(member, is_new_user=False)
 
-    mock_create_org.assert_awaited_once_with(
-        name='Acme',
-        contact_name='owner@example.com',
-        contact_email='owner@example.com',
-        user_id=str(owner.id),
-    )
     mock_add_member.assert_awaited_once_with(
         org_id=org.id,
         user_id=member.id,
@@ -258,40 +403,23 @@ async def test_existing_owner_user_can_create_org_for_member_auto_join(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_configured_owner_is_promoted_without_demoting_others(monkeypatch):
+async def test_auto_add_disabled_leaves_later_users_alone(monkeypatch):
     monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'Acme')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_OWNER_EMAILS', 'owner@example.com')
     monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS', 'false')
-    user = _user('owner@example.com')
+    user = _user('member@example.com')
     org = _org()
-    existing_membership = SimpleNamespace(role_id=3)
 
     with (
         patch(
-            'storage.default_org_service.OrgStore.get_org_by_name',
+            'storage.default_org_service.OrgStore.get_default_org',
             new_callable=AsyncMock,
             return_value=org,
         ),
         patch(
             'storage.default_org_service.OrgMemberStore.get_org_member',
             new_callable=AsyncMock,
-            return_value=existing_membership,
+            return_value=None,
         ),
-        patch(
-            'storage.default_org_service.RoleStore.get_role_by_id',
-            new_callable=AsyncMock,
-            return_value=Role(id=3, name='member', rank=3),
-        ),
-        patch(
-            'storage.default_org_service.RoleStore.get_role_by_name',
-            new_callable=AsyncMock,
-            return_value=Role(id=1, name='owner', rank=1),
-        ),
-        patch(
-            'storage.default_org_service.OrgMemberStore.update_user_role_in_org',
-            new_callable=AsyncMock,
-        ) as mock_update_role,
         patch(
             'storage.default_org_service.OrgMemberStore.add_user_to_org',
             new_callable=AsyncMock,
@@ -306,76 +434,19 @@ async def test_configured_owner_is_promoted_without_demoting_others(monkeypatch)
             return_value=user,
         ),
     ):
-        await DefaultOrgBootstrapService.apply_for_user(user, is_new_user=False)
+        result = await DefaultOrgBootstrapService.apply_for_user(
+            user,
+            is_new_user=False,
+        )
 
-    mock_update_role.assert_awaited_once_with(
-        org_id=org.id,
-        user_id=user.id,
-        role_id=1,
-        status='active',
-    )
+    assert result is user
     mock_add_member.assert_not_called()
-    # Promotion means the user was already a member; their workspace choice
-    # is preserved.
     mock_update_current_org.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_existing_user_auto_added_is_moved_into_default_org(monkeypatch):
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'Acme')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_OWNER_EMAILS', 'owner@example.com')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS', 'true')
-    member = _user('member@example.com')
-    org = _org()
-
-    with (
-        patch(
-            'storage.default_org_service.OrgStore.get_org_by_name',
-            new_callable=AsyncMock,
-            return_value=org,
-        ),
-        patch(
-            'storage.default_org_service.OrgMemberStore.get_org_member',
-            new_callable=AsyncMock,
-            return_value=None,
-        ),
-        patch(
-            'storage.default_org_service.RoleStore.get_role_by_name',
-            new_callable=AsyncMock,
-            return_value=Role(id=3, name='member', rank=3),
-        ),
-        patch(
-            'storage.default_org_service.OrgService.create_litellm_integration',
-            new_callable=AsyncMock,
-            return_value=_settings(),
-        ),
-        patch(
-            'storage.default_org_service.OrgMemberStore.add_user_to_org',
-            new_callable=AsyncMock,
-        ) as mock_add_member,
-        patch(
-            'storage.default_org_service.UserStore.update_current_org',
-            new_callable=AsyncMock,
-            return_value=member,
-        ) as mock_update_current_org,
-        patch(
-            'storage.default_org_service.UserStore.get_user_by_id',
-            new_callable=AsyncMock,
-            return_value=member,
-        ),
-    ):
-        await DefaultOrgBootstrapService.apply_for_user(member, is_new_user=False)
-
-    mock_add_member.assert_awaited_once()
-    mock_update_current_org.assert_awaited_once_with(str(member.id), org.id)
 
 
 @pytest.mark.asyncio
 async def test_existing_member_login_keeps_current_workspace(monkeypatch):
     monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'Acme')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_OWNER_EMAILS', 'owner@example.com')
     monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS', 'true')
     member = _user('member@example.com')
     org = _org()
@@ -383,7 +454,7 @@ async def test_existing_member_login_keeps_current_workspace(monkeypatch):
 
     with (
         patch(
-            'storage.default_org_service.OrgStore.get_org_by_name',
+            'storage.default_org_service.OrgStore.get_default_org',
             new_callable=AsyncMock,
             return_value=org,
         ),
@@ -416,58 +487,8 @@ async def test_existing_member_login_keeps_current_workspace(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_existing_owner_creating_org_is_moved_into_it(monkeypatch):
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'Acme')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_OWNER_EMAILS', 'owner@example.com')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS', 'false')
-    owner = _user('owner@example.com')
-    org = _org()
-    owner_membership = SimpleNamespace(role_id=1)
-
-    with (
-        patch(
-            'storage.default_org_service.OrgStore.get_org_by_name',
-            new_callable=AsyncMock,
-            return_value=None,
-        ),
-        patch(
-            'storage.default_org_service.OrgService.create_org_with_owner',
-            new_callable=AsyncMock,
-            return_value=org,
-        ),
-        patch(
-            'storage.default_org_service.OrgMemberStore.get_org_member',
-            new_callable=AsyncMock,
-            return_value=owner_membership,
-        ),
-        patch(
-            'storage.default_org_service.RoleStore.get_role_by_id',
-            new_callable=AsyncMock,
-            return_value=Role(id=1, name='owner', rank=1),
-        ),
-        patch(
-            'storage.default_org_service.UserStore.update_current_org',
-            new_callable=AsyncMock,
-            return_value=owner,
-        ) as mock_update_current_org,
-        patch(
-            'storage.default_org_service.UserStore.get_user_by_id',
-            new_callable=AsyncMock,
-            return_value=owner,
-        ),
-    ):
-        await DefaultOrgBootstrapService.apply_for_user(owner, is_new_user=False)
-
-    # The configured owner just bootstrapped the org by logging in; land them in it.
-    mock_update_current_org.assert_awaited_once_with(str(owner.id), org.id)
-
-
-@pytest.mark.asyncio
 async def test_hide_personal_workspaces_moves_member_parked_on_personal(monkeypatch):
     monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'Acme')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_OWNER_EMAILS', 'owner@example.com')
     monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS', 'true')
     monkeypatch.setenv('HIDE_PERSONAL_WORKSPACES', 'true')
     # _user() parks the user on their personal org (current_org_id == id)
@@ -477,7 +498,7 @@ async def test_hide_personal_workspaces_moves_member_parked_on_personal(monkeypa
 
     with (
         patch(
-            'storage.default_org_service.OrgStore.get_org_by_name',
+            'storage.default_org_service.OrgStore.get_default_org',
             new_callable=AsyncMock,
             return_value=org,
         ),
@@ -509,8 +530,6 @@ async def test_hide_personal_workspaces_does_not_move_user_in_another_team_org(
     monkeypatch,
 ):
     monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'Acme')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_OWNER_EMAILS', 'owner@example.com')
     monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS', 'true')
     monkeypatch.setenv('HIDE_PERSONAL_WORKSPACES', 'true')
     member = _user('member@example.com')
@@ -521,7 +540,7 @@ async def test_hide_personal_workspaces_does_not_move_user_in_another_team_org(
 
     with (
         patch(
-            'storage.default_org_service.OrgStore.get_org_by_name',
+            'storage.default_org_service.OrgStore.get_default_org',
             new_callable=AsyncMock,
             return_value=org,
         ),
@@ -548,8 +567,6 @@ async def test_hide_personal_workspaces_does_not_move_user_in_another_team_org(
 @pytest.mark.asyncio
 async def test_hide_personal_workspaces_leaves_non_member_on_personal(monkeypatch):
     monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', 'Acme')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_OWNER_EMAILS', 'owner@example.com')
     monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS', 'false')
     monkeypatch.setenv('HIDE_PERSONAL_WORKSPACES', 'true')
     member = _user('member@example.com')
@@ -557,7 +574,7 @@ async def test_hide_personal_workspaces_leaves_non_member_on_personal(monkeypatc
 
     with (
         patch(
-            'storage.default_org_service.OrgStore.get_org_by_name',
+            'storage.default_org_service.OrgStore.get_default_org',
             new_callable=AsyncMock,
             return_value=org,
         ),
@@ -581,37 +598,3 @@ async def test_hide_personal_workspaces_leaves_non_member_on_personal(monkeypatc
     # Not a member of the default org (auto-add off): never strand the user
     # with zero workspaces — they stay on personal and the UI keeps showing it.
     mock_update_current_org.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_existing_personal_workspace_org_is_not_adopted(monkeypatch):
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
-    personal_org = _personal_org()
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_NAME', personal_org.name)
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_OWNER_EMAILS', 'owner@example.com')
-    monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_AUTO_ADD_USERS', 'true')
-    user = _user('owner@example.com')
-
-    with (
-        patch(
-            'storage.default_org_service.OrgStore.get_org_by_name',
-            new_callable=AsyncMock,
-            return_value=personal_org,
-        ),
-        patch(
-            'storage.default_org_service.OrgMemberStore.get_org_member',
-            new_callable=AsyncMock,
-        ) as mock_get_member,
-        patch(
-            'storage.default_org_service.OrgService.create_org_with_owner',
-            new_callable=AsyncMock,
-        ) as mock_create_org,
-    ):
-        result = await DefaultOrgBootstrapService.apply_for_user(
-            user,
-            is_new_user=True,
-        )
-
-    assert result is user
-    mock_get_member.assert_not_called()
-    mock_create_org.assert_not_called()


### PR DESCRIPTION
HUMAN: Reworks the (cut but unreleased) default-org bootstrap before customers see it: instead of KOTS-configured owner emails and org name, the first user to sign in after enabling creates the org ("Enterprise Org") and becomes its owner; renaming and role management happen in the app. The org is now keyed by a new is_default flag instead of its name, which also fixes a latent bug where renaming the org in-app would fork a second org on the next login. Pairs with OpenHands-Cloud#701; intended to be cherry-picked into the 1.39.0 release so the old UX never ships. Successfully tested end-to-end on a real OHE instance (Replicated embedded-cluster, R02): migration 119 applied via the migrate-db init container, the first sign-in created the org with the signing-in user as owner and moved them into it, an in-app rename followed by re-login did not fork a second org, and enabling hide-personal-workspaces afterwards behaved correctly. Bootstrap logs showed exactly one org_created across all logins. Also covered by unit tests.

- [x] A human has tested these changes.

## Summary

Simplifies the OHE default-org bootstrap contract (follows up on the KOTS default org work, pairs with OpenHands-Cloud PR removing the corresponding config fields):

- **First user to sign in becomes the owner.** The configured owner-email list is gone; the first user to sign in after enabling the default org creates it and owns it. Ownership is then managed in the app (owners can promote other members to owner/admin, and another owner can demote the first one if needed).
- **The org is tracked by a new `org.is_default` flag, not by name.** Migration 119 adds the column with a partial unique index (at most one default org per install). Name-keying meant any rename — in KOTS *or in the app* — silently forked a second org on the next login; flag-keying makes the org freely renameable, which the in-app rename path requires.
- **Default name is `Enterprise Org`** when `OPENHANDS_DEFAULT_ORG_NAME` is unset; the env var remains as an optional override for the initial name only.
- **Adoption safety net:** if no flagged org exists but a sole team org does (bootstrapped by the earlier name-keyed version), it is adopted instead of duplicated. Users cannot create team orgs on OHE installs, so a sole team org is unambiguous; with multiple unflagged team orgs the bootstrap logs and skips.
- **Automation fallback** (`_resolve_default_org_fallback`) resolves by the same flag instead of the configured name.
- `OPENHANDS_DEFAULT_ORG_OWNER_EMAILS` is no longer read.

Auto-add and hide-personal-workspaces behavior is unchanged: auto-add gates later users only (the creating user always owns the org), and members parked on a personal workspace are still moved on login when personal workspaces are hidden.

## Why now

The default-org feature is in the cut-but-unreleased 1.39.0, so no install has bootstrapped under the name-keyed scheme yet. Landing this before release means the rename-forks-an-org gotcha, the owner-email sync disclaimers, and the silently-dead state when a configured owner never signs in are never shipped.

## Testing

- `enterprise/tests/unit/test_default_org_service.py` rewritten for the new behavior (first-user-creates-and-owns, sole-team-org adoption, multi-org skip, creation race, auto-add gating, hide-personal-workspaces cases): 50 tests pass together with the updated automation-service tests.
- `scripts/check_enterprise_migration_integrity.py` passes.
- Ruff check/format clean with the enterprise config.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-867943c   docker.openhands.dev/openhands/openhands:867943c
```

