### PR TITLE
fix: bump agent-server to 1.28.0

### DIFF
--- a/openhands/app_server/sandbox/sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/sandbox_spec_service.py
@@ -13,7 +13,7 @@ from openhands.sdk.utils.models import DiscriminatedUnionMixin
 
 # The version of the agent server to use for deployments.
 # Typically this will be the same as the values from the pyproject.toml
-AGENT_SERVER_IMAGE = 'ghcr.io/openhands/agent-server:1.27.1-python'
+AGENT_SERVER_IMAGE = 'ghcr.io/openhands/agent-server:1.28.0-python'
 
 
 class SandboxSpecService(ABC):


### PR DESCRIPTION
HUMAN: Bumps the pinned agent-server image from 1.27.1-python to 1.28.0-python so the OHE 1.38.0 release ships the SDK team's standard v1.28.0 release (carries the Gemini cache_control fix #3586 plus post-1.27.0 main) instead of the one-off 1.27.1 cherry-pick. Keeps the app's sandbox pin coherent with the chart-side agent-server tags.

- [x] A human has tested these changes.

## Summary
- `AGENT_SERVER_IMAGE`: `ghcr.io/openhands/agent-server:1.27.1-python` → `1.28.0-python`
- SDK release: https://github.com/OpenHands/software-agent-sdk/releases/tag/v1.28.0

## Testing
- `docker manifest inspect ghcr.io/openhands/agent-server:1.28.0-python` succeeds
- v1.28.0 release workflows green on software-agent-sdk

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-4be2806   docker.openhands.dev/openhands/openhands:4be2806
```