### PR TITLE
Block personal-workspace API keys while personal workspaces are hidden

### DIFF
--- a/enterprise/server/auth/saas_user_auth.py
+++ b/enterprise/server/auth/saas_user_auth.py
@@ -218,6 +218,31 @@ class SaasUserAuth(UserAuth):
 
         # Case 1: API key binds the org.
         if self.api_key_org_id is not None:
+            # When personal workspaces are hidden, a key bound to one would
+            # silently operate in a workspace its owner can no longer see.
+            # Fail loudly instead; unhiding restores the key, matching how
+            # hiding treats all other personal-workspace data.
+            from storage.default_org_service import get_default_org_config
+
+            if (
+                str(self.api_key_org_id) == self.user_id
+                and get_default_org_config().hide_personal_workspaces
+            ):
+                logger.warning(
+                    'api_key_personal_workspace_hidden',
+                    extra={
+                        'user_id': self.user_id,
+                        'api_key_id': self.api_key_id,
+                    },
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=(
+                        'This API key belongs to your personal workspace, '
+                        'which is hidden on this instance. Create a new API '
+                        'key in your organization and use that instead.'
+                    ),
+                )
             if requested is not None and requested != self.api_key_org_id:
                 logger.warning(
                     'x_org_id_api_key_mismatch',

--- a/enterprise/tests/unit/server/auth/test_saas_user_auth_effective_org.py
+++ b/enterprise/tests/unit/server/auth/test_saas_user_auth_effective_org.py
@@ -338,3 +338,53 @@ class TestGetEffectiveOrgId:
         second = await user_auth.get_effective_org_id()
         assert first == second == other_org_id
         assert user_auth._effective_org_id_resolved is True
+
+
+class TestPersonalApiKeyWhenPersonalWorkspacesHidden:
+    """API keys bound to a personal workspace fail loudly while hiding is on.
+
+    A personal-bound key would otherwise keep operating in a workspace its
+    owner can no longer see. Unhiding restores the key, matching how hiding
+    treats all other personal-workspace data.
+    """
+
+    @pytest.mark.asyncio
+    async def test_personal_key_blocked_when_hiding_on(self, user_id, monkeypatch):
+        monkeypatch.setenv('HIDE_PERSONAL_WORKSPACES', 'true')
+        user_auth = SaasUserAuth(
+            user_id=user_id,
+            refresh_token=SecretStr('mock'),
+            api_key_org_id=uuid.UUID(user_id),
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await user_auth.get_effective_org_id()
+
+        assert exc_info.value.status_code == 403
+        assert 'personal workspace' in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_personal_key_allowed_when_hiding_off(self, user_id, monkeypatch):
+        monkeypatch.delenv('HIDE_PERSONAL_WORKSPACES', raising=False)
+        user_auth = SaasUserAuth(
+            user_id=user_id,
+            refresh_token=SecretStr('mock'),
+            api_key_org_id=uuid.UUID(user_id),
+        )
+
+        effective = await user_auth.get_effective_org_id()
+
+        assert effective == uuid.UUID(user_id)
+
+    @pytest.mark.asyncio
+    async def test_org_key_unaffected_by_hiding(self, user_id, org_id, monkeypatch):
+        monkeypatch.setenv('HIDE_PERSONAL_WORKSPACES', 'true')
+        user_auth = SaasUserAuth(
+            user_id=user_id,
+            refresh_token=SecretStr('mock'),
+            api_key_org_id=org_id,
+        )
+
+        effective = await user_auth.get_effective_org_id()
+
+        assert effective == org_id


### PR DESCRIPTION
## Summary

With `hide_personal_workspaces` on (now the default for org-enabled OHE installs), an API key that was minted in a personal workspace keeps authenticating — every call it makes lands in a workspace its owner can no longer see. A user's old CLI/CI integration keeps creating conversations invisibly, with no feedback that anything is wrong. Silent invisible activity is the worst failure mode available; this PR makes it fail loudly instead.

`get_effective_org_id` (the choke point every org-scoped operation passes through) now rejects personal-bound API keys with a clear 403 while hiding is on:

> This API key belongs to your personal workspace, which is hidden on this instance. Create a new API key in your organization and use that instead.

Design notes:
- **Stateless skip, not stateful mutation** — nothing is revoked or modified. Turning the hide option off restores the key immediately, matching how hiding treats all other personal-workspace data (conversations, secrets, automations).
- Keys bound to team orgs are unaffected; cookie/session auth is unaffected.
- The check reads the same `HIDE_PERSONAL_WORKSPACES` env the bootstrap and web client already use.

Context: this only affects brownfield installs (personal-workspace usage predating org-only mode) — fresh installs have no personal-bound keys to block. Part of gracefully supporting the hidden-personal-workspaces state; companion PR skips automation dispatch for hidden personal orgs.

## Testing

- 3 new tests in `enterprise/tests/unit/server/auth/test_saas_user_auth_effective_org.py` (personal key blocked when hiding on; allowed when off; team-org key unaffected) — 15/15 passing.
- Enterprise ruff lint/format clean.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-778b5a5   docker.openhands.dev/openhands/openhands:778b5a5
```