### PR TITLE
Skip personal-org automation dispatch while personal workspaces are hidden

### DIFF
--- a/enterprise/server/services/automation_event_service.py
+++ b/enterprise/server/services/automation_event_service.py
@@ -212,14 +212,25 @@ class AutomationEventService:
         # Try to resolve via OrgGitClaim
         org_id = await self._resolve_git_org(provider, git_org_name)
 
-        # Fallback for personal repos (owner_type indicates individual user)
+        # Fallback for personal repos (owner_type indicates individual user).
+        # Skipped while personal workspaces are hidden: dispatching there
+        # would run automations (and spend) in a workspace the owner can no
+        # longer see. The default-org fallback below routes the event to the
+        # visible org instead; unhiding restores the personal routing.
         if not org_id and owner_type == 'User':
-            org_id = await self._resolve_personal_org(provider, owner_id)
-            if org_id:
+            if get_default_org_config().hide_personal_workspaces:
                 logger.info(
-                    f'[AutomationEventService] Resolved personal repo owner '
-                    f'{git_org_name} to personal org {org_id} ({provider.value})'
+                    f'[AutomationEventService] Personal workspaces are hidden; '
+                    f'skipping personal-org resolution for {git_org_name} '
+                    f'({provider.value})'
                 )
+            else:
+                org_id = await self._resolve_personal_org(provider, owner_id)
+                if org_id:
+                    logger.info(
+                        f'[AutomationEventService] Resolved personal repo owner '
+                        f'{git_org_name} to personal org {org_id} ({provider.value})'
+                    )
 
         # Fallback for single-org installs with a bootstrapped default org:
         # route unclaimed repos there instead of dropping the event. Claims

--- a/enterprise/tests/unit/server/services/test_automation_event_service.py
+++ b/enterprise/tests/unit/server/services/test_automation_event_service.py
@@ -1131,3 +1131,112 @@ class TestResolveDefaultOrgFallback:
             assert context is not None
             assert context.org_id == org.id
             assert context.git_org == 'PROJ'
+
+
+class TestPersonalOrgSkippedWhenPersonalWorkspacesHidden:
+    """Personal-repo events skip personal-org dispatch while hiding is on.
+
+    Dispatching would run automations (and spend) in a workspace the owner
+    can no longer see; the default-org fallback picks the event up instead.
+    """
+
+    @pytest.mark.asyncio
+    async def test_personal_repo_skips_personal_org_when_hiding_on(
+        self, mock_token_manager, github_user_payload, monkeypatch
+    ):
+        monkeypatch.setenv('HIDE_PERSONAL_WORKSPACES', 'true')
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.setex = AsyncMock()
+
+        with (
+            patch(
+                'server.services.automation_event_service.resolve_org_for_repo',
+                new_callable=AsyncMock,
+                return_value=None,  # No claim
+            ),
+            patch(
+                'server.services.automation_event_service.OrgStore'
+            ) as mock_org_store,
+            patch(REDIS_PATCH, return_value=mock_redis),
+        ):
+            # No default org configured either: the event should drop without
+            # ever consulting the personal-org resolution.
+            monkeypatch.delenv('OPENHANDS_DEFAULT_ORG_ENABLED', raising=False)
+            mock_org_store.get_default_org = AsyncMock()
+            service = create_service(mock_token_manager)
+            with patch.object(
+                service, '_resolve_personal_org', new_callable=AsyncMock
+            ) as mock_personal:
+                context = await service._resolve_org_context(
+                    ProviderType.GITHUB, github_user_payload
+                )
+
+            assert context is None
+            mock_personal.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_personal_repo_routes_to_default_org_when_hiding_on(
+        self, mock_token_manager, github_user_payload, monkeypatch
+    ):
+        monkeypatch.setenv('HIDE_PERSONAL_WORKSPACES', 'true')
+        monkeypatch.setenv('OPENHANDS_DEFAULT_ORG_ENABLED', 'true')
+        org = MagicMock()
+        org.id = uuid.UUID('87654321-4321-8765-4321-876543218765')
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.setex = AsyncMock()
+
+        with (
+            patch(
+                'server.services.automation_event_service.resolve_org_for_repo',
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                'server.services.automation_event_service.OrgStore'
+            ) as mock_org_store,
+            patch(REDIS_PATCH, return_value=mock_redis),
+        ):
+            mock_org_store.get_default_org = AsyncMock(return_value=org)
+            mock_org_store.count_team_orgs = AsyncMock(return_value=1)
+            service = create_service(mock_token_manager)
+            context = await service._resolve_org_context(
+                ProviderType.GITHUB, github_user_payload
+            )
+
+            assert context is not None
+            assert context.org_id == org.id
+
+    @pytest.mark.asyncio
+    async def test_personal_repo_resolves_personal_org_when_hiding_off(
+        self, mock_token_manager, github_user_payload, monkeypatch
+    ):
+        monkeypatch.delenv('HIDE_PERSONAL_WORKSPACES', raising=False)
+        personal_org_id = uuid.uuid4()
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.setex = AsyncMock()
+
+        with (
+            patch(
+                'server.services.automation_event_service.resolve_org_for_repo',
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(REDIS_PATCH, return_value=mock_redis),
+        ):
+            service = create_service(mock_token_manager)
+            with patch.object(
+                service,
+                '_resolve_personal_org',
+                new_callable=AsyncMock,
+                return_value=personal_org_id,
+            ) as mock_personal:
+                context = await service._resolve_org_context(
+                    ProviderType.GITHUB, github_user_payload
+                )
+
+            mock_personal.assert_awaited_once()
+            assert context is not None
+            assert context.org_id == personal_org_id


### PR DESCRIPTION
## Summary

Webhook events from personal repos resolve to the owner's *personal org* in the automation forwarding path. With `hide_personal_workspaces` on (now the default for org-enabled OHE installs), those automations kept dispatching runs — burning LLM spend — into a workspace the owner can no longer see.

The personal-org fallback in `_resolve_org_context` now skips while hiding is on. Because the default-org fallback sits right below it in the resolution chain (claim → personal → default org), the event **routes to the visible default org instead of dispatching invisibly or being dropped** — which is also where the user's attention now lives.

Design notes:
- **Stateless skip, not stateful pause** — no automation rows are mutated, so turning the hide option off restores personal routing immediately, matching how hiding treats all other personal-workspace data.
- Claims and team-org routing are unaffected; the skip only touches the `owner_type == 'User'` personal fallback.
- Reads the same `HIDE_PERSONAL_WORKSPACES` env the bootstrap, web client, and the personal-API-key guard (#14756) already use.

Known residual, deliberately out of scope: *scheduled* automations created in a personal workspace before hiding still run on their cron inside the automation service, which doesn't see this env. Covering those needs a small change in the automation repo (skip when `org_id == user_id` and the env is set) plus chart env wiring — worth doing only if a brownfield customer actually has scheduled personal automations.

Context: brownfield-only exposure (personal automations predating org-only mode); fresh installs have none. Companion to #14756.

## Testing

- 3 new tests in `enterprise/tests/unit/server/services/test_automation_event_service.py`: hiding on + no default org → personal resolution never consulted, event drops; hiding on + default org → event routes to the default org; hiding off → personal routing unchanged. 38/38 passing.
- Enterprise ruff lint/format clean.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-7d94f0f   docker.openhands.dev/openhands/openhands:7d94f0f
```