### PR TITLE
fix(acp): sanitize agent-server error body in switch_acp_model proxy

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_router.py
+++ b/openhands/app_server/app_conversation/app_conversation_router.py
@@ -829,7 +829,7 @@ async def switch_conversation_acp_model(
         if e.response.status_code in (400, 409, 504):
             raise HTTPException(
                 status_code=e.response.status_code,
-                detail=e.response.text,
+                detail=f'Agent server error: {e.response.status_code}',
             )
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,


### PR DESCRIPTION
HUMAN: 

 sanitize agent-server error body in switch_acp_model proxy

- [x] A human has tested these changes.

AGENT:

## Summary

- Stops forwarding the agent-server's raw error body (`detail=e.response.text`) to external callers in the `switch_acp_model` proxy endpoint
- For upstream 400/409/504 the status code is still surfaced directly (it carries the actionable semantics: not-ACP / no-session / timeout), but the detail is now the sanitized `Agent server error: {status_code}` used everywhere else in this router

## Why

Follow-up to @VascoSch92's review on #14744 (https://github.com/OpenHands/OpenHands/pull/14744#pullrequestreview-4475126619): this line was the only place in the entire router that forwarded a raw upstream body into a client-facing `HTTPException`. Every other handler logs the raw body and returns a sanitized detail. The raw body is still available in the server logs via the existing `logger.error` call.

## How to Test

- Trigger an ACP model switch against a non-ACP conversation (400) or before the first message (409): the response status is unchanged, but the detail is now `Agent server error: <code>` instead of the raw agent-server body

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-27e8b24   docker.openhands.dev/openhands/openhands:27e8b24
```