### PR TITLE
feat(acp): enable ACP UI by default

### DIFF
--- a/enterprise/server/config.py
+++ b/enterprise/server/config.py
@@ -74,6 +74,7 @@ class SaaSServerConfig(ServerConfig):
     enable_jira_dc = ENABLE_JIRA_DC
     enable_linear = ENABLE_LINEAR
     enable_onboarding = os.environ.get('OH_ENABLE_ONBOARDING', 'false') == 'true'
+    enable_acp = os.environ.get('ENABLE_ACP', 'true') != 'false'
 
     app_slug: None | str = None
 
@@ -169,6 +170,7 @@ class SaaSServerConfig(ServerConfig):
                 'ENABLE_LINEAR': self.enable_linear,
                 'DEPLOYMENT_MODE': DEPLOYMENT_MODE,
                 'ENABLE_ONBOARDING': self.enable_onboarding,
+                'ENABLE_ACP': self.enable_acp,
             },
             'PROVIDERS_CONFIGURED': providers_configured,
         }

--- a/enterprise/server/config.py
+++ b/enterprise/server/config.py
@@ -74,7 +74,7 @@ class SaaSServerConfig(ServerConfig):
     enable_jira_dc = ENABLE_JIRA_DC
     enable_linear = ENABLE_LINEAR
     enable_onboarding = os.environ.get('OH_ENABLE_ONBOARDING', 'false') == 'true'
-    enable_acp = os.environ.get('ENABLE_ACP', 'true') != 'false'
+    enable_acp = True
 
     app_slug: None | str = None
 

--- a/openhands/app_server/web_client/default_web_client_config_injector.py
+++ b/openhands/app_server/web_client/default_web_client_config_injector.py
@@ -175,7 +175,7 @@ def _get_feature_flags() -> WebClientFeatureFlags:
         hide_integrations_page=os.getenv('HIDE_INTEGRATIONS_PAGE', 'false') == 'true',
         hide_personal_workspaces=os.getenv('HIDE_PERSONAL_WORKSPACES', 'false')
         == 'true',
-        enable_acp=os.getenv('ENABLE_ACP', 'false') == 'true',
+        enable_acp=os.getenv('ENABLE_ACP', 'true') != 'false',
         enable_onboarding=os.getenv('OH_ENABLE_ONBOARDING', 'false') == 'true',
     )
 

--- a/openhands/app_server/web_client/default_web_client_config_injector.py
+++ b/openhands/app_server/web_client/default_web_client_config_injector.py
@@ -175,7 +175,7 @@ def _get_feature_flags() -> WebClientFeatureFlags:
         hide_integrations_page=os.getenv('HIDE_INTEGRATIONS_PAGE', 'false') == 'true',
         hide_personal_workspaces=os.getenv('HIDE_PERSONAL_WORKSPACES', 'false')
         == 'true',
-        enable_acp=os.getenv('ENABLE_ACP', 'true') != 'false',
+        enable_acp=True,
         enable_onboarding=os.getenv('OH_ENABLE_ONBOARDING', 'false') == 'true',
     )
 

--- a/openhands/app_server/web_client/web_client_models.py
+++ b/openhands/app_server/web_client/web_client_models.py
@@ -26,7 +26,7 @@ class WebClientFeatureFlags(BaseModel):
     # workspace users see. UI-level only — the orgs API still returns
     # personal orgs, and disabling the flag restores them.
     hide_personal_workspaces: bool = False
-    enable_acp: bool = False
+    enable_acp: bool = True
     deployment_mode: DeploymentMode | None = None
     enable_onboarding: bool = False
 


### PR DESCRIPTION
## Summary

Default `ENABLE_ACP` to `true` so the ACP agent selection UI is visible without explicit env-var opt-in. Can be suppressed per-deployment with `ENABLE_ACP=false`.

## Why

Needed to validate ACP agents on a Cloud Canvas feature env (agent-canvas#1290). The feature env doesn't set `ENABLE_ACP=true`, so `isAcpEnabled` was always `false` and the ACP UI was invisible.

## How to Test

Deploy to a feature env (no `ENABLE_ACP` env var) — the Agent Settings page should show the ACP agent picker.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-de288e6   docker.openhands.dev/openhands/openhands:de288e6
```