### PR TITLE
fix: harden git identity setup for cloud runtimes

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -50,6 +50,30 @@ PRE_COMMIT_HOOK = '.git/hooks/pre-commit'
 PRE_COMMIT_LOCAL = '.git/hooks/pre-commit.local'
 
 
+def _build_git_config_global_command(config_key: str, value: str) -> str:
+    quoted_config_key = shlex.quote(config_key)
+    quoted_value = shlex.quote(value)
+    return ' '.join(
+        [
+            f'git config --global {quoted_config_key} {quoted_value};',
+            'config_exit_code=$?;',
+            'if [ $config_exit_code -eq 0 ]; then',
+            'passwd_home=$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6 || true);',
+            'if [ -n "$passwd_home" ] && [ "$passwd_home" != "$HOME" ]; then',
+            'mkdir -p "$passwd_home" &&',
+            f'git config --file "$passwd_home/.gitconfig" {quoted_config_key} {quoted_value};',
+            'config_exit_code=$?;',
+            'fi;',
+            'fi;',
+            'if [ $config_exit_code -eq 0 ]; then',
+            f'test "$(git config --global --get {quoted_config_key})" = {quoted_value};',
+            'config_exit_code=$?;',
+            'fi;',
+            'exit $config_exit_code',
+        ]
+    )
+
+
 def get_project_dir(
     working_dir: str,
     selected_repository: str | None = None,
@@ -295,7 +319,9 @@ class AppConversationServiceBase(AppConversationService, ABC):
             user_info = await self.user_context.get_user_info()
 
             if user_info.git_user_name:
-                cmd = f'git config --global user.name "{user_info.git_user_name}"'
+                cmd = _build_git_config_global_command(
+                    'user.name', user_info.git_user_name
+                )
                 result = await workspace.execute_command(cmd, workspace.working_dir)
                 if result.exit_code:
                     _logger.warning(f'Git config user.name failed: {result.stderr}')
@@ -305,7 +331,9 @@ class AppConversationServiceBase(AppConversationService, ABC):
                     )
 
             if user_info.git_user_email:
-                cmd = f'git config --global user.email "{user_info.git_user_email}"'
+                cmd = _build_git_config_global_command(
+                    'user.email', user_info.git_user_email
+                )
                 result = await workspace.execute_command(cmd, workspace.working_dir)
                 if result.exit_code:
                     _logger.warning(f'Git config user.email failed: {result.stderr}')

--- a/tests/unit/app_server/test_app_conversation_service_base.py
+++ b/tests/unit/app_server/test_app_conversation_service_base.py
@@ -15,6 +15,7 @@ import pytest
 from openhands.app_server.app_conversation.app_conversation_models import AgentType
 from openhands.app_server.app_conversation.app_conversation_service_base import (
     AppConversationServiceBase,
+    _build_git_config_global_command,
 )
 from openhands.app_server.integrations.service_types import ProviderType
 from openhands.app_server.sandbox.sandbox_models import SandboxInfo, SandboxStatus
@@ -728,6 +729,16 @@ async def test_set_security_analyzer_logs_warning_on_failure():
 # =============================================================================
 
 
+def test_build_git_config_global_command_quotes_and_verifies_value():
+    """Test git config commands quote values and verify the written setting."""
+    command = _build_git_config_global_command('user.name', 'Jane "Danger" $HOME')
+
+    assert 'git config --global user.name \'Jane "Danger" $HOME\'' in command
+    assert 'git config --file "$passwd_home/.gitconfig" user.name' in command
+    assert 'git config --global --get user.name' in command
+    assert 'exit $config_exit_code' in command
+
+
 def _create_service_with_mock_user_context(
     user_info: MockUserInfo, bind_methods: tuple[str, ...] | None = None
 ) -> tuple:
@@ -910,12 +921,14 @@ async def test_configure_git_user_settings_both_name_and_email(mock_workspace):
 
     # Check git config user.name call
     mock_workspace.execute_command.assert_any_call(
-        'git config --global user.name "Test User"', '/workspace/project'
+        _build_git_config_global_command('user.name', 'Test User'),
+        '/workspace/project',
     )
 
     # Check git config user.email call
     mock_workspace.execute_command.assert_any_call(
-        'git config --global user.email "test@example.com"', '/workspace/project'
+        _build_git_config_global_command('user.email', 'test@example.com'),
+        '/workspace/project',
     )
 
 
@@ -930,7 +943,8 @@ async def test_configure_git_user_settings_only_name(mock_workspace):
     # Verify only user.name was configured
     assert mock_workspace.execute_command.call_count == 1
     mock_workspace.execute_command.assert_called_once_with(
-        'git config --global user.name "Test User"', '/workspace/project'
+        _build_git_config_global_command('user.name', 'Test User'),
+        '/workspace/project',
     )
 
 
@@ -945,7 +959,8 @@ async def test_configure_git_user_settings_only_email(mock_workspace):
     # Verify only user.email was configured
     assert mock_workspace.execute_command.call_count == 1
     mock_workspace.execute_command.assert_called_once_with(
-        'git config --global user.email "test@example.com"', '/workspace/project'
+        _build_git_config_global_command('user.email', 'test@example.com'),
+        '/workspace/project',
     )
 
 
@@ -1047,7 +1062,29 @@ async def test_configure_git_user_settings_special_characters_in_name(mock_works
 
     # Verify the name is passed with special characters
     mock_workspace.execute_command.assert_any_call(
-        'git config --global user.name "Test O\'Brien"', '/workspace/project'
+        _build_git_config_global_command('user.name', "Test O'Brien"),
+        '/workspace/project',
+    )
+
+
+@pytest.mark.asyncio
+async def test_configure_git_user_settings_shell_quotes_values(mock_workspace):
+    """Test git user settings are shell-quoted before remote execution."""
+    user_info = MockUserInfo(
+        git_user_name='Jane "Danger" $HOME',
+        git_user_email='jane+"danger"@example.com',
+    )
+    service, _ = _create_service_with_mock_user_context(user_info)
+
+    await service._configure_git_user_settings(mock_workspace)
+
+    mock_workspace.execute_command.assert_any_call(
+        _build_git_config_global_command('user.name', 'Jane "Danger" $HOME'),
+        '/workspace/project',
+    )
+    mock_workspace.execute_command.assert_any_call(
+        _build_git_config_global_command('user.email', 'jane+"danger"@example.com'),
+        '/workspace/project',
     )
 
 


### PR DESCRIPTION
﻿<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

This PR makes Git identity setup in cloud runtimes more robust by safely applying the Git name/email configured in Settings, including cases where the runtime setup shell and interactive shell use different home directories.

- [x] A human has tested these changes.

AGENT:

---

## Why

Cloud runtimes can miss git identity setup when configured Settings values contain shell-sensitive characters or when the setup shell `$HOME` differs from the passwd-entry home used by interactive shells. This makes `git config --global user.name` / `user.email` unreliable for commits in some runtime paths.

## Summary

- Shell-quote configured Git name/email before executing remote `git config` commands.
- Also write the setting to the passwd-entry home `.gitconfig` when it differs from `$HOME`.
- Verify the written global value and add unit coverage for quoting/verification behavior.

## Issue Number

Fixes #14696

## How to Test

- `python -X utf8 -m py_compile openhands/app_server/app_conversation/app_conversation_service_base.py tests/unit/app_server/test_app_conversation_service_base.py`
- `git diff --check`
- CI: Python Tests on Linux (3.12), Enterprise Python Unit Tests (3.12), Lint python, Lint enterprise python, and Lint frontend passed on PR #14765.

## Video/Screenshots

N/A — backend runtime setup change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Local `make install-pre-commit-hooks` and `poetry run pytest ...` could not be run in this Windows environment because `make` and `poetry` are unavailable. The available syntax and whitespace checks pass, and the relevant GitHub CI checks pass.
