### PR TITLE
fix(enterprise): litellm_proxy/ → openhands/ on settings load

### DIFF
--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -197,6 +197,14 @@ class SaasSettingsStore(SettingsStore):
                 f'No effective LLM API key found for user {self.user_id} '
                 f'in org {org_id} (org key and member key are both unset)'
             )
+        # Canonicalize legacy litellm_proxy/ → openhands/ on the merged LLM
+        # config so the UI shows the public provider prefix. The canonical
+        # form persists on the next settings save (matches SDK read-time
+        # migration in LLMProfileStore and Settings.from_persisted).
+        llm_dict = merged_agent_settings.get('llm')
+        if isinstance(llm_dict, dict):
+            merged_agent_settings['llm'] = canonicalize_openhands_llm_payload(llm_dict)
+
         kwargs['agent_settings'] = merged_agent_settings
         org_conversation = OrgStore.get_conversation_settings_from_org(org)
         member_conversation_diff = dict(org_member.conversation_settings_diff)

--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -197,10 +197,9 @@ class SaasSettingsStore(SettingsStore):
                 f'No effective LLM API key found for user {self.user_id} '
                 f'in org {org_id} (org key and member key are both unset)'
             )
-        # Canonicalize legacy litellm_proxy/ → openhands/ on the merged LLM
-        # config so the UI shows the public provider prefix. The canonical
-        # form persists on the next settings save (matches SDK read-time
-        # migration in LLMProfileStore and Settings.from_persisted).
+        # Canonicalize legacy managed OpenHands LLM payloads before Settings
+        # validation so current settings and seeded profiles use the public
+        # openhands/ prefix.
         llm_dict = merged_agent_settings.get('llm')
         if isinstance(llm_dict, dict):
             merged_agent_settings['llm'] = canonicalize_openhands_llm_payload(llm_dict)

--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -31,6 +31,9 @@ from openhands.app_server.utils.jsonpatch_compat import (
     deep_merge_with_wholesale_keys,
 )
 from openhands.app_server.utils.llm import is_openhands_model
+from openhands.sdk.llm.utils.openhands_provider import (
+    canonicalize_openhands_llm_payload,
+)
 
 # Agent-settings keys that are private to each org member and must never
 # be written to org-level defaults or broadcast across the org. Today this
@@ -214,7 +217,16 @@ class SaasSettingsStore(SettingsStore):
         # the org has none — handles older personal accounts whose profiles
         # never moved to the org column.
         if org.llm_profiles:
-            kwargs['llm_profiles'] = org.llm_profiles
+            profiles_data = dict(org.llm_profiles)
+            raw_profiles = profiles_data.get('profiles')
+            if isinstance(raw_profiles, dict):
+                profiles_data['profiles'] = {
+                    name: canonicalize_openhands_llm_payload(prof)
+                    if isinstance(prof, dict)
+                    else prof
+                    for name, prof in raw_profiles.items()
+                }
+            kwargs['llm_profiles'] = profiles_data
         # When no profiles exist yet, seed a Default profile from the legacy
         # LLM config so users (and orgs) upgrading from pre-llm_profiles
         # settings keep their previous LLM as the active profile instead of

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -496,6 +496,65 @@ async def test_load_canonicalizes_legacy_litellm_proxy_active_llm(
 
 
 @pytest.mark.asyncio
+async def test_load_canonicalizes_legacy_litellm_proxy_llm_profiles(
+    async_session_maker, org_with_multiple_members_fixture
+):
+    from sqlalchemy import update
+    from storage.org import Org
+    from storage.user import User
+
+    fixture = org_with_multiple_members_fixture
+    admin_user_id = fixture['admin_user_id']
+    org_id = fixture['org_id']
+
+    async with async_session_maker() as session:
+        await session.execute(
+            update(Org)
+            .where(Org.id == org_id)
+            .values(
+                llm_profiles={
+                    'profiles': {
+                        'legacy': {
+                            'model': 'litellm_proxy/claude-opus-4-8',
+                            'base_url': LITE_LLM_API_URL,
+                        },
+                        'custom': {
+                            'model': 'litellm_proxy/custom-alias',
+                            'base_url': LITE_LLM_API_URL,
+                        },
+                    },
+                    'active': 'legacy',
+                }
+            )
+        )
+        await session.execute(
+            update(User)
+            .where(User.id == admin_user_id)
+            .values(enable_sound_notifications=False)
+        )
+        await session.commit()
+
+    store = SaasSettingsStore(str(admin_user_id))
+    with (
+        patch('storage.saas_settings_store.a_session_maker', async_session_maker),
+        patch('storage.user_store.a_session_maker', async_session_maker),
+        patch('storage.org_store.a_session_maker', async_session_maker),
+    ):
+        loaded = await store.load()
+
+    assert loaded is not None
+    assert loaded.llm_profiles.active == 'legacy'
+
+    legacy = loaded.llm_profiles.require('legacy')
+    assert legacy.model == 'openhands/claude-opus-4-8'
+    assert legacy.base_url is None
+
+    custom = loaded.llm_profiles.require('custom')
+    assert custom.model == 'litellm_proxy/custom-alias'
+    assert custom.base_url == LITE_LLM_API_URL
+
+
+@pytest.mark.asyncio
 async def test_store_updates_org_defaults_and_all_members_for_shared_keys(
     session_maker, async_session_maker, org_with_multiple_members_fixture
 ):

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -451,6 +451,51 @@ def org_with_multiple_members_fixture(session_maker):
 
 
 @pytest.mark.asyncio
+async def test_load_canonicalizes_legacy_litellm_proxy_active_llm(
+    async_session_maker, org_with_multiple_members_fixture
+):
+    from sqlalchemy import update
+    from storage.org_member import OrgMember
+    from storage.user import User
+
+    fixture = org_with_multiple_members_fixture
+    admin_user_id = fixture['admin_user_id']
+    org_id = fixture['org_id']
+
+    async with async_session_maker() as session:
+        await session.execute(
+            update(OrgMember)
+            .where(OrgMember.org_id == org_id, OrgMember.user_id == admin_user_id)
+            .values(
+                agent_settings_diff={
+                    'llm': {
+                        'model': 'litellm_proxy/claude-opus-4-8',
+                        'base_url': LITE_LLM_API_URL,
+                    },
+                }
+            )
+        )
+        await session.execute(
+            update(User)
+            .where(User.id == admin_user_id)
+            .values(enable_sound_notifications=False)
+        )
+        await session.commit()
+
+    store = SaasSettingsStore(str(admin_user_id))
+    with (
+        patch('storage.saas_settings_store.a_session_maker', async_session_maker),
+        patch('storage.user_store.a_session_maker', async_session_maker),
+        patch('storage.org_store.a_session_maker', async_session_maker),
+    ):
+        loaded = await store.load()
+
+    assert loaded is not None
+    assert loaded.agent_settings.llm.model == 'openhands/claude-opus-4-8'
+    assert loaded.agent_settings.llm.base_url is None
+
+
+@pytest.mark.asyncio
 async def test_store_updates_org_defaults_and_all_members_for_shared_keys(
     session_maker, async_session_maker, org_with_multiple_members_fixture
 ):


### PR DESCRIPTION
HUMAN:
Follow-up to #14725 — adds read-time canonicalization of legacy `litellm_proxy/` model names in enterprise settings.

- [x] A human has tested these changes

AGENT:

## What

Adds `canonicalize_openhands_llm_payload` calls in `SaasSettingsStore.load()` on:
1. `merged_agent_settings['llm']` — before passing to `Settings()`
2. Each profile in `org.llm_profiles` — when loaded from DB

This matches the SDK read-time migration pattern already used in `LLMProfileStore.list_summaries()` and the `Settings` schema v3→v4 migration.

## Why

PR #14725 cleaned up the reverse-mapping in org response paths and the frontend, but existing DB rows with `litellm_proxy/` + proxy base_url still load as-is through the enterprise settings store. Users see `litellm_proxy/` in the UI instead of `openhands/`.

## How it works

`canonicalize_openhands_llm_payload` (SDK 1.28.0) converts `litellm_proxy/<model>` + OpenHands proxy base_url → `openhands/<model>` (base_url stripped). Only verified model names are migrated; custom LiteLLM proxy configs are left untouched.

The canonical form persists on the next settings save — lazy one-time migration, no Alembic needed.

cc @enyst
