### PR TITLE
fix(deps): bump postcss to 8.5.15 to fix XSS (GHSA-qx2v-qp2m-jg93)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13658,9 +13658,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -14249,9 +14249,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -14268,7 +14268,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
HUMAN:


- [x] A human has tested these changes.

AGENT:

---

## Why

Dependabot alert [#453](https://github.com/OpenHands/OpenHands/security/dependabot/453) flags transitive dependency `postcss` 8.5.6 in `frontend/package-lock.json` for [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) (CVE-2026-41305, medium): XSS via unescaped `</style>` in PostCSS's CSS stringify output. Patched in 8.5.10.

Dependabot couldn't auto-fix it because it tried to update the parent packages (`@react-router/dev`, `vite`, `vitest`), which have conflicting requirements. But postcss isn't pinned by any of them — they all accept `^8.x` — so a lockfile-only bump of postcss itself resolves the alert without touching the parents.

## Summary

- Bump `postcss` 8.5.6 → 8.5.15 in `frontend/package-lock.json` (all dependents dedupe to this single install)
- Bump `nanoid` 3.3.11 → 3.3.12, required by postcss 8.5.15 (it declares `nanoid: ^3.3.12`)

## Issue Number

N/A (Dependabot alert 453)

## How to Test

```
cd frontend
npm ci
npm ls postcss   # shows 8.5.15 everywhere
npm run build
```

Verified locally: clean install and production build both pass.

## Video/Screenshots

N/A — dependency-only change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

`npm audit` reports other pre-existing advisories unrelated to this alert; left out of scope to keep this a minimal security fix.

_This was created by an AI assistant._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-8dddc12   docker.openhands.dev/openhands/openhands:8dddc12
```