### PR TITLE
fix: preserve LLM base URL on basic saves

### DIFF
--- a/frontend/__tests__/routes/llm-settings.test.tsx
+++ b/frontend/__tests__/routes/llm-settings.test.tsx
@@ -859,7 +859,7 @@ describe("LlmSettingsScreen", () => {
     });
   });
 
-  it("resets hidden advanced and all settings back to defaults when saving basic view", async () => {
+  it("preserves the existing base URL when saving basic view without changing the model", async () => {
     const schema = structuredClone(
       MOCK_DEFAULT_USER_SETTINGS.agent_settings_schema!,
     );
@@ -945,7 +945,6 @@ describe("LlmSettingsScreen", () => {
           agent_settings_diff: expect.objectContaining({
             llm: expect.objectContaining({
               api_key: "test-api-key",
-              base_url: "https://schema.default/v1",
               timeout: 30,
             }),
           }),
@@ -957,6 +956,11 @@ describe("LlmSettingsScreen", () => {
       string,
       unknown
     >;
+    const llmPayload = getPayloadAgentSettings(payload).llm as Record<
+      string,
+      unknown
+    >;
+    expect(llmPayload).not.toHaveProperty("base_url");
     expect(getPayloadAgentSettings(payload)).not.toHaveProperty("agent");
   });
 
@@ -1254,7 +1258,7 @@ describe("LlmSettingsScreen", () => {
     });
   });
 
-  it("does not clear the hidden search API key on SaaS org settings when saving basic view", async () => {
+  it("does not clear hidden search API key or existing base URL on SaaS org settings when saving basic view", async () => {
     let persistedSettings = buildSettingsWithAdvancedToggle({
       llm_model: "openai/gpt-4o",
       llm_base_url: "https://custom.example/v1",
@@ -1316,7 +1320,6 @@ describe("LlmSettingsScreen", () => {
             agent_settings_diff: expect.objectContaining({
               llm: expect.objectContaining({
                 api_key: "test-api-key",
-                base_url: null,
               }),
             }),
           }),
@@ -1327,6 +1330,10 @@ describe("LlmSettingsScreen", () => {
     const payload = saveOrganizationSettingsSpy.mock.calls[0]?.at(0) as {
       settings: Record<string, unknown>;
     };
+    const llmPayload = (
+      payload.settings.agent_settings_diff as Record<string, unknown>
+    ).llm as Record<string, unknown>;
+    expect(llmPayload).not.toHaveProperty("base_url");
     expect(payload.settings).not.toHaveProperty("search_api_key");
 
     await waitFor(() => {
@@ -1352,7 +1359,7 @@ describe("LlmSettingsScreen", () => {
     });
   });
 
-  it("returns to the profiles list after save and re-enters the form in basic view even when a stale legacy base URL lingers on refetch", async () => {
+  it("keeps an existing custom base URL when saving basic view without a model change", async () => {
     let persistedSettings = buildSettingsWithAdvancedToggle({
       llm_base_url: "https://stale.example/v1",
       agent_settings: {
@@ -1409,12 +1416,21 @@ describe("LlmSettingsScreen", () => {
           agent_settings_diff: expect.objectContaining({
             llm: expect.objectContaining({
               api_key: "test-api-key",
-              base_url: null,
             }),
           }),
         }),
       );
     });
+
+    const payload = saveSettingsSpy.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    const llmPayload = getPayloadAgentSettings(payload).llm as Record<
+      string,
+      unknown
+    >;
+    expect(llmPayload).not.toHaveProperty("base_url");
 
     await waitFor(() => {
       expect(getSettingsSpy).toHaveBeenCalledTimes(2);
@@ -1428,14 +1444,13 @@ describe("LlmSettingsScreen", () => {
       ).not.toBeInTheDocument();
     });
 
-    // Re-entering the form must not get bumped into advanced by the
-    // stale legacy base_url on refetch.
+    // Re-entering the form reflects the still-custom base_url instead of
+    // silently clearing it during the previous save.
     await userEvent.click(screen.getByTestId("add-llm-profile"));
     await waitFor(() => {
-      expect(screen.getByTestId("llm-settings-form-basic")).toBeInTheDocument();
       expect(
-        screen.queryByTestId("llm-settings-form-advanced"),
-      ).not.toBeInTheDocument();
+        screen.getByTestId("llm-settings-form-advanced"),
+      ).toBeInTheDocument();
     });
   });
 

--- a/frontend/__tests__/routes/llm-settings.test.tsx
+++ b/frontend/__tests__/routes/llm-settings.test.tsx
@@ -1444,13 +1444,22 @@ describe("LlmSettingsScreen", () => {
       ).not.toBeInTheDocument();
     });
 
-    // Re-entering the form reflects the still-custom base_url instead of
-    // silently clearing it during the previous save.
+    // The persisted settings still carry the custom base_url instead of
+    // being silently cleared during the previous save.
+    expect(
+      (persistedSettings.agent_settings?.llm as Record<string, SettingsValue>)
+        ?.base_url,
+    ).toBe("https://stale.example/v1");
+
+    // Re-entering via Add Profile starts a blank create form on the basic
+    // view regardless of stored values; the preserved base_url shows when
+    // editing the existing configuration instead.
     await userEvent.click(screen.getByTestId("add-llm-profile"));
     await waitFor(() => {
+      expect(screen.getByTestId("llm-settings-form-basic")).toBeInTheDocument();
       expect(
-        screen.getByTestId("llm-settings-form-advanced"),
-      ).toBeInTheDocument();
+        screen.queryByTestId("llm-settings-form-advanced"),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/routes/llm-settings.tsx
+++ b/frontend/src/routes/llm-settings.tsx
@@ -445,7 +445,7 @@ export function LlmSettingsScreen({
         agentSettings.llm = llm;
       }
 
-      if (context.view === "basic") {
+      if (context.view === "basic" && llm.model !== undefined) {
         llm.base_url = getSchemaFieldDefaultValue(schema, "llm.base_url");
         agentSettings.llm = llm;
       }


### PR DESCRIPTION
HUMAN:

This keeps a Basic settings save from wiping a custom LLM base URL unless the user actually changes the model.

- [ ] A human has tested these changes.

AGENT:

Implemented with Codex; focused route tests, lint, formatting, and typecheck passed locally.

---

## Why

Fixes #14749.

The LLM settings form currently resets `llm.base_url` whenever the Basic view is saved, even if the user did not change the model. Because the profile form can save with only external state dirty, simply saving a profile from Basic can send `base_url: null` or the schema default and overwrite a manually edited `settings.json` custom endpoint.

## Summary

- Only reset `llm.base_url` from the Basic view when the model is part of the save payload.
- Keep the existing behavior for Basic model changes: choosing a different model still clears the previous custom endpoint.
- Update LLM settings route tests so Basic saves without a model change preserve the existing custom base URL.

## Issue Number

Fixes #14749

## How to Test

- `npm ci --prefer-offline`
- `npm test -- __tests__/routes/llm-settings.test.tsx`
- `npx prettier --check src/routes/llm-settings.tsx __tests__/routes/llm-settings.test.tsx`
- `npx eslint src/routes/llm-settings.tsx __tests__/routes/llm-settings.test.tsx`
- `npm run typecheck`
- `git diff --check`

## Video/Screenshots

N/A. The changed behavior is covered by the route tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The first dependency install attempt hit an npm `ECONNRESET`; retrying with `--prefer-offline` succeeded. No production dependencies were changed.
