### PR TITLE
fix(frontend): start new LLM profiles on basic settings with blank fields

### DIFF
--- a/frontend/__tests__/routes/llm-settings.test.tsx
+++ b/frontend/__tests__/routes/llm-settings.test.tsx
@@ -252,10 +252,12 @@ async function renderLlmSettingsScreen({
   organizations?: Organization[];
   scope?: "personal" | "org";
   // Profile-enabled scopes land on the Available Models list by default; set
-  // ``view`` to ``"form"`` (the default) to auto-click into the SDK form
-  // so existing form-oriented assertions keep working unchanged, or to
-  // ``"profiles"`` to test the list view itself.
-  view?: "form" | "profiles";
+  // ``view`` to ``"form"`` (the default) to auto-click into the SDK form via
+  // Edit on a seeded active profile — the form then hydrates from the mocked
+  // settings, so existing form-oriented assertions keep working unchanged.
+  // ``"create"`` clicks Add Profile instead (blank create form), and
+  // ``"profiles"`` tests the list view itself.
+  view?: "form" | "create" | "profiles";
 } = {}) {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -283,6 +285,26 @@ async function renderLlmSettingsScreen({
     });
   }
 
+  if (view === "form") {
+    // One active profile to Edit into. Its name matches the model-derived
+    // default for the mocked settings, so auto-profile assertions that
+    // expect the derived name keep working under the edit flow.
+    const seededProfile = {
+      name: "openai_gpt-4o",
+      model: "openai/gpt-4o",
+      base_url: null,
+      api_key_set: false,
+    };
+    vi.mocked(ProfilesService.listProfiles).mockResolvedValue({
+      profiles: [seededProfile],
+      active_profile: seededProfile.name,
+    });
+    vi.mocked(OrgProfilesService.listProfiles).mockResolvedValue({
+      profiles: [seededProfile],
+      active_profile: seededProfile.name,
+    });
+  }
+
   const rendered = render(<LlmSettingsScreen scope={scope} />, {
     wrapper: ({ children }) => (
       <MemoryRouter>
@@ -294,6 +316,11 @@ async function renderLlmSettingsScreen({
   });
 
   if (view === "form") {
+    // Edit the seeded active profile: Add Profile now opens a blank create
+    // form, while these tests exercise the form against persisted settings.
+    await userEvent.click(await screen.findByTestId("profile-menu-trigger"));
+    await userEvent.click(await screen.findByTestId("profile-edit"));
+  } else if (view === "create") {
     await userEvent.click(await screen.findByTestId("add-llm-profile"));
   }
 
@@ -2334,10 +2361,11 @@ describe("LlmSettingsScreen", () => {
         meData: buildOrganizationMember({ org_id: "3", role: "admin" }),
       });
 
-      await userEvent.type(
-        await screen.findByTestId("llm-profile-name-input"),
-        "team-profile",
+      const orgProfileNameInput = await screen.findByTestId(
+        "llm-profile-name-input",
       );
+      await userEvent.clear(orgProfileNameInput);
+      await userEvent.type(orgProfileNameInput, "team-profile");
       await userEvent.type(
         await screen.findByTestId("llm-api-key-input"),
         "test-api-key",
@@ -2375,10 +2403,11 @@ describe("LlmSettingsScreen", () => {
 
       await renderLlmSettingsScreen({ appMode: "oss" });
 
-      await userEvent.type(
-        await screen.findByTestId("llm-profile-name-input"),
-        "my-custom-name",
+      const profileNameInput = await screen.findByTestId(
+        "llm-profile-name-input",
       );
+      await userEvent.clear(profileNameInput);
+      await userEvent.type(profileNameInput, "my-custom-name");
       await userEvent.type(
         await screen.findByTestId("llm-api-key-input"),
         "test-api-key",
@@ -2413,10 +2442,11 @@ describe("LlmSettingsScreen", () => {
 
       await renderLlmSettingsScreen({ appMode: "oss" });
 
-      await userEvent.type(
-        await screen.findByTestId("llm-profile-name-input"),
-        "has space",
+      const profileNameInput = await screen.findByTestId(
+        "llm-profile-name-input",
       );
+      await userEvent.clear(profileNameInput);
+      await userEvent.type(profileNameInput, "has space");
       await userEvent.type(
         await screen.findByTestId("llm-api-key-input"),
         "test-api-key",
@@ -2480,6 +2510,189 @@ describe("LlmSettingsScreen", () => {
       // Activate must NOT run when save already failed — otherwise we'd
       // activate a profile that doesn't exist on the backend.
       expect(ProfilesService.activateProfile).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Add Profile (create flow) ───────────────────────────────────────
+  //
+  // Adding a new profile starts from a clean slate: the form opens on the
+  // basic view with blank fields instead of inheriting the active/org
+  // settings (which previously dropped users with a custom model or base
+  // URL straight into a pre-filled advanced form).
+
+  describe("Add Profile (create flow)", () => {
+    const settingsWithCustomModelAndBaseUrl = () =>
+      buildSettings({
+        llm_model: "litellm_proxy/custom-model",
+        llm_base_url: "https://custom.example/v1",
+        agent_settings: {
+          llm: {
+            model: "litellm_proxy/custom-model",
+            base_url: "https://custom.example/v1",
+          },
+        },
+      });
+
+    it("opens the create form on basic view even when the active settings have a custom model and base URL", async () => {
+      vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+        settingsWithCustomModelAndBaseUrl(),
+      );
+
+      await renderLlmSettingsScreen({ appMode: "oss", view: "create" });
+
+      await screen.findByTestId("llm-settings-form-basic");
+      expect(
+        screen.queryByTestId("llm-settings-form-advanced"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("starts the create form blank instead of pre-filling from the active settings", async () => {
+      vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+        settingsWithCustomModelAndBaseUrl(),
+      );
+
+      await renderLlmSettingsScreen({ appMode: "oss", view: "create" });
+
+      await screen.findByTestId("llm-settings-form-basic");
+      expect(screen.getByTestId("llm-provider-input")).toHaveValue("");
+      expect(screen.getByTestId("llm-model-input")).toHaveValue("");
+      expect(screen.getByTestId("llm-api-key-input")).toHaveValue("");
+
+      await userEvent.click(screen.getByTestId("sdk-section-advanced-toggle"));
+
+      expect(screen.getByTestId("llm-custom-model-input")).toHaveValue("");
+      expect(screen.getByTestId("base-url-input")).toHaveValue("");
+      expect(screen.getByTestId("llm-api-key-input")).toHaveValue("");
+    });
+
+    it("does not preselect the active provider when creating a profile in SaaS mode", async () => {
+      // Default settings use an OpenHands model; previously the create form
+      // inherited the provider selection (hiding the API key input in SaaS).
+      vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+        buildSettings(),
+      );
+
+      await renderLlmSettingsScreen({ appMode: "saas", view: "create" });
+
+      await screen.findByTestId("llm-settings-form-basic");
+      expect(screen.getByTestId("llm-provider-input")).toHaveValue("");
+      expect(screen.getByTestId("llm-api-key-input")).toBeInTheDocument();
+    });
+
+    it("keeps Save disabled in the create form until a model is chosen", async () => {
+      vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+        buildSettings({
+          llm_model: "openai/gpt-4o",
+          agent_settings: { llm: { model: "openai/gpt-4o" } },
+        }),
+      );
+
+      await renderLlmSettingsScreen({ appMode: "oss", view: "create" });
+
+      await screen.findByTestId("llm-settings-form-basic");
+      expect(screen.getByTestId("save-button")).toBeDisabled();
+
+      // Picking a provider alone isn't a model yet.
+      await selectProvider("OpenAI");
+      expect(screen.getByTestId("save-button")).toBeDisabled();
+
+      await selectModel("gpt-4o");
+      await waitFor(() => {
+        expect(screen.getByTestId("save-button")).not.toBeDisabled();
+      });
+    });
+
+    it("saves and activates a profile built from the blank create form", async () => {
+      vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+        buildSettings({
+          llm_model: "openhands/claude-opus-4-5-20251101",
+          agent_settings: {
+            llm: { model: "openhands/claude-opus-4-5-20251101" },
+          },
+        }),
+      );
+      const saveSettingsSpy = vi
+        .spyOn(SettingsService, "saveSettings")
+        .mockResolvedValue(true);
+
+      await renderLlmSettingsScreen({ appMode: "oss", view: "create" });
+
+      await screen.findByTestId("llm-settings-form-basic");
+      await selectProvider("OpenAI");
+      await selectModel("gpt-4o");
+      await userEvent.type(
+        screen.getByTestId("llm-api-key-input"),
+        "new-api-key",
+      );
+      await userEvent.click(screen.getByTestId("save-button"));
+
+      await waitFor(() => {
+        expect(saveSettingsSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            agent_settings_diff: expect.objectContaining({
+              llm: expect.objectContaining({
+                model: "openai/gpt-4o",
+                api_key: "new-api-key",
+              }),
+            }),
+          }),
+        );
+      });
+      await waitFor(() => {
+        expect(ProfilesService.saveProfile).toHaveBeenCalledWith(
+          "openai_gpt-4o",
+          { include_secrets: true },
+        );
+      });
+      await waitFor(() => {
+        expect(ProfilesService.activateProfile).toHaveBeenCalledWith(
+          "openai_gpt-4o",
+        );
+      });
+    });
+
+    it("opens a blank org create form on basic view for admins even when org defaults have custom fields", async () => {
+      vi.spyOn(
+        organizationService,
+        "getOrganizationSettings",
+      ).mockResolvedValue(settingsWithCustomModelAndBaseUrl());
+
+      await renderLlmSettingsScreen({
+        appMode: "saas",
+        scope: "org",
+        organizationId: "3",
+        meData: buildOrganizationMember({ org_id: "3", role: "admin" }),
+        view: "create",
+      });
+
+      await screen.findByTestId("llm-settings-form-basic");
+      expect(
+        screen.queryByTestId("llm-settings-form-advanced"),
+      ).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByTestId("sdk-section-advanced-toggle"));
+
+      expect(screen.getByTestId("llm-custom-model-input")).toHaveValue("");
+      expect(screen.getByTestId("base-url-input")).toHaveValue("");
+    });
+
+    it("still opens the edit form on advanced view with stored values for a profile with custom fields", async () => {
+      vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+        settingsWithCustomModelAndBaseUrl(),
+      );
+
+      await renderLlmSettingsScreen({ appMode: "oss", view: "form" });
+
+      await screen.findByTestId("llm-settings-form-advanced");
+      expect(screen.getByTestId("llm-custom-model-input")).toHaveValue(
+        "litellm_proxy/custom-model",
+      );
+      expect(screen.getByTestId("base-url-input")).toHaveValue(
+        "https://custom.example/v1",
+      );
+      expect(screen.getByTestId("llm-profile-name-input")).toHaveValue(
+        "openai_gpt-4o",
+      );
     });
   });
 });

--- a/frontend/src/components/features/settings/sdk-settings/sdk-section-page.tsx
+++ b/frontend/src/components/features/settings/sdk-settings/sdk-section-page.tsx
@@ -105,6 +105,12 @@ export interface SdkSectionHeaderProps {
   onChange: (key: string, value: string | boolean) => void;
 }
 
+interface SaveDisabledContext {
+  values: SettingsFormValues;
+  dirty: SettingsDirtyState;
+  view: SettingsView;
+}
+
 interface ResolvedSource extends SettingsSourceConfig {
   filteredSchema: SettingsSchema | null;
 }
@@ -133,6 +139,8 @@ export function SdkSectionPage({
   buildPayload,
   onSaveSuccess,
   getInitialView,
+  initialValueOverrides,
+  isSaveDisabled,
   forceShowAdvancedView = false,
   allowAllView = true,
   trailingActions,
@@ -165,6 +173,20 @@ export function SdkSectionPage({
     settings: Settings,
     filteredSchema: SettingsSchema,
   ) => SettingsView;
+  /**
+   * Values merged over the settings-derived initial form state, keyed by
+   * source. Used by create flows that should start from a blank form while
+   * edit flows keep hydrating from the persisted settings. Overridden fields
+   * are not marked dirty — they only change what the form initially shows.
+   */
+  initialValueOverrides?: Partial<
+    Record<SettingsValueSource, Partial<SettingsFormValues>>
+  >;
+  /**
+   * Extra gate on the Save button computed from the unified form state.
+   * Returning true disables Save even when the form is otherwise saveable.
+   */
+  isSaveDisabled?: (context: SaveDisabledContext) => boolean;
   // Extra buttons slotted into the Basic/Advanced/All control strip,
   // after the view toggles. Used by the LLM page to drop a Profiles
   // navigation button into the same row.
@@ -276,7 +298,7 @@ export function SdkSectionPage({
     const result: Partial<Record<SettingsValueSource, SettingsFormValues>> = {};
     for (const src of resolvedSources) {
       if (!src.filteredSchema) return null;
-      result[src.settingsSource] = {
+      const values: SettingsFormValues = {
         ...(result[src.settingsSource] ?? {}),
         ...buildInitialSettingsFormValues(
           settings,
@@ -284,9 +306,18 @@ export function SdkSectionPage({
           src.settingsSource,
         ),
       };
+      const overrides = initialValueOverrides?.[src.settingsSource];
+      if (overrides) {
+        for (const [key, value] of Object.entries(overrides)) {
+          if (value !== undefined) {
+            values[key] = value;
+          }
+        }
+      }
+      result[src.settingsSource] = values;
     }
     return result;
-  }, [settings, resolvedSources]);
+  }, [settings, resolvedSources, initialValueOverrides]);
 
   const initialView = React.useMemo(() => {
     if (!settings) return null;
@@ -466,6 +497,13 @@ export function SdkSectionPage({
 
   const isDirty = Object.keys(flatDirty).length > 0;
 
+  const saveDisabledByCaller =
+    isSaveDisabled?.({
+      values: flatValues,
+      dirty: flatDirty,
+      view,
+    }) ?? false;
+
   return (
     <div data-testid={testId} className="h-full relative">
       <ViewToggle
@@ -526,7 +564,9 @@ export function SdkSectionPage({
             testId="save-button"
             type="button"
             variant="primary"
-            isDisabled={isPending || (!isDirty && !extraDirty)}
+            isDisabled={
+              isPending || saveDisabledByCaller || (!isDirty && !extraDirty)
+            }
             onClick={handleSave}
           >
             {isPending

--- a/frontend/src/routes/llm-settings.tsx
+++ b/frontend/src/routes/llm-settings.tsx
@@ -93,6 +93,8 @@ const isProviderDefaultBaseUrl = (model: string, baseUrl: string) => {
   );
 };
 
+type ProfileFormMode = "create" | "edit";
+
 export function LlmSettingsScreen({
   scope = "personal",
 }: {
@@ -143,6 +145,10 @@ export function LlmSettingsScreen({
   // in handleSaveSuccess. Reset on every form open so a stale name from the
   // previous Add doesn't leak in.
   const [profileName, setProfileName] = React.useState("");
+  // Distinguishes Add Profile (blank create form, opens on basic) from Edit
+  // (form hydrated from the persisted settings). Null when no form is open.
+  const [profileFormMode, setProfileFormMode] =
+    React.useState<ProfileFormMode | null>(null);
   // Snapshotted on form open so we can flag the form dirty when the user
   // edits *only* the name — the SDK section page tracks the LLM fields but
   // not the profile-name input that lives outside its schema.
@@ -165,11 +171,16 @@ export function LlmSettingsScreen({
   const isSaasMode = config?.app_mode === "saas";
 
   React.useEffect(() => {
+    // A freshly opened Add Profile form starts blank — don't let the active
+    // settings re-select a provider underneath it.
+    if (profileFormMode === "create" && !showProfiles) {
+      return;
+    }
     if (settings?.llm_model) {
       const { provider } = extractModelAndProvider(settings.llm_model);
       setSelectedProvider(provider || null);
     }
-  }, [settings?.llm_model]);
+  }, [profileFormMode, settings?.llm_model, showProfiles]);
 
   React.useEffect(() => {
     const checkout = searchParams.get("checkout");
@@ -214,6 +225,14 @@ export function LlmSettingsScreen({
         return "basic";
       }
 
+      // Adding a new profile always starts on the basic view. The schema
+      // inference below looks at the *active/org* settings, so a user whose
+      // current config has a custom model or base URL would otherwise be
+      // dropped straight into the advanced form when creating a profile.
+      if (profileFormMode === "create") {
+        return "basic";
+      }
+
       const schemaView = inferInitialView(currentSettings, filteredSchema);
       if (schemaView !== "basic") {
         return schemaView;
@@ -227,7 +246,7 @@ export function LlmSettingsScreen({
 
       return hasCustomBaseUrl ? "all" : "basic";
     },
-    [initialViewHint, isSaasMode, scope],
+    [initialViewHint, isSaasMode, profileFormMode, scope],
   );
 
   const buildHeader = React.useCallback(
@@ -509,6 +528,7 @@ export function LlmSettingsScreen({
     setProfileName("");
     setInitialProfileName("");
     setInitialViewHint(null);
+    setProfileFormMode(null);
     setShowProfiles(true);
   }, [
     activateProfile,
@@ -525,11 +545,36 @@ export function LlmSettingsScreen({
   ]);
 
   const openForm = (view: SettingsView | null, name = "") => {
+    // Editing is identified by the profile name passed from the profiles
+    // list; Add Profile opens the form with no name and gets a blank
+    // create form instead of one pre-filled from the active settings.
+    const isEdit = Boolean(name);
+    setProfileFormMode(isEdit ? "edit" : "create");
     setProfileName(name);
     setInitialProfileName(name);
     setInitialViewHint(view);
+    if (!isEdit) {
+      setSelectedProvider(null);
+    }
     setShowProfiles(false);
   };
+
+  // Add Profile starts from a clean slate: no inherited model, API key, or
+  // base URL from whatever config happens to be active. Editing keeps the
+  // settings-derived initial values (no overrides).
+  const createProfileInitialValueOverrides = React.useMemo(
+    () =>
+      profileFormMode === "create"
+        ? {
+            agent_settings: {
+              "llm.model": "",
+              "llm.api_key": "",
+              "llm.base_url": "",
+            },
+          }
+        : undefined,
+    [profileFormMode],
+  );
 
   if (isProfilesView) {
     if (isOrgProfileMode) {
@@ -569,6 +614,7 @@ export function LlmSettingsScreen({
       type="button"
       onClick={() => {
         setInitialViewHint(null);
+        setProfileFormMode(null);
         setShowProfiles(true);
       }}
       className="flex items-center gap-2 self-start text-sm text-gray-300 hover:text-white cursor-pointer"
@@ -601,6 +647,17 @@ export function LlmSettingsScreen({
         extraDirty={canManageProfilesForScope}
         onSaveSuccess={handleSaveSuccess}
         getInitialView={getInitialView}
+        initialValueOverrides={createProfileInitialValueOverrides}
+        // A new profile starts blank and can't be saved until a model is
+        // chosen — saving a model-less create form would only churn the
+        // active settings without producing a profile.
+        isSaveDisabled={({ values }) =>
+          profileFormMode === "create" &&
+          !(
+            typeof values["llm.model"] === "string" &&
+            values["llm.model"].trim().length > 0
+          )
+        }
         forceShowAdvancedView
         allowAllView={!isSaasMode}
         testId="llm-settings-screen"

--- a/frontend/src/routes/llm-settings.tsx
+++ b/frontend/src/routes/llm-settings.tsx
@@ -225,10 +225,9 @@ export function LlmSettingsScreen({
         return "basic";
       }
 
-      // Adding a new profile always starts on the basic view. The schema
-      // inference below looks at the *active/org* settings, so a user whose
-      // current config has a custom model or base URL would otherwise be
-      // dropped straight into the advanced form when creating a profile.
+      // Create always starts on basic — the inference below reads the
+      // *active* settings and would otherwise open advanced for users
+      // whose current config has a custom model or base URL.
       if (profileFormMode === "create") {
         return "basic";
       }
@@ -545,9 +544,8 @@ export function LlmSettingsScreen({
   ]);
 
   const openForm = (view: SettingsView | null, name = "") => {
-    // Editing is identified by the profile name passed from the profiles
-    // list; Add Profile opens the form with no name and gets a blank
-    // create form instead of one pre-filled from the active settings.
+    // The profiles list passes a name only when editing; Add Profile
+    // opens a blank create form.
     const isEdit = Boolean(name);
     setProfileFormMode(isEdit ? "edit" : "create");
     setProfileName(name);
@@ -559,9 +557,8 @@ export function LlmSettingsScreen({
     setShowProfiles(false);
   };
 
-  // Add Profile starts from a clean slate: no inherited model, API key, or
-  // base URL from whatever config happens to be active. Editing keeps the
-  // settings-derived initial values (no overrides).
+  // Create starts from a clean slate; editing keeps the settings-derived
+  // initial values (no overrides).
   const createProfileInitialValueOverrides = React.useMemo(
     () =>
       profileFormMode === "create"


### PR DESCRIPTION
HUMAN: Standalone UX fix, successfully verified e2e with unit tests and mock-mode dev server as well as a human click text.

- [x] A human has tested these changes.

## Summary

Creating a new LLM profile currently lands users on the advanced view with the custom model and base URL pre-populated from their active/org settings — confusing on managed installs (fields look "already set") and previously reported by a customer as unexpected. This change makes the **create** flow start on the basic view with blank fields, while leaving the **edit** flow exactly as it is today.

## Changes

- New `profileFormMode` (`create`/`edit`) derived from how the form is opened (Add Profile vs Edit menu).
- Create mode: lands on the basic view; provider/model/API key/custom model/base URL all start blank (placeholders); Save stays disabled until a model is chosen (prevents an untouched blank save from resetting `llm.base_url` via the basic-view payload).
- Edit mode: no behavior change — opens advanced when the profile has custom fields, shows stored values. The existing form tests now enter via the Edit path, pinning that behavior.
- Standalone off main; no dependency on any other open PR.

## Testing

- 7 new create-flow tests + reworked helper so ~57 pre-existing form tests exercise the unchanged edit path: `llm-settings` suite 64/64, settings components 113/113, `npm run lint` clean.
- Manually verified via `npm run dev:mock` with Playwright before/after captures: old flow shows pre-selected provider/model and Save enabled; new flow shows blank basic form, Save disabled, advanced fields empty; edit unchanged.

<img width="1440" height="1000" alt="after-3-create-form-initial" src="https://github.com/user-attachments/assets/9281b635-5179-4d0a-a2bc-98d837e6bcce" />


---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-d371249   docker.openhands.dev/openhands/openhands:d371249
```