### PR TITLE
fix(frontend): treat managed openhands base URLs as provider defaults in view inference

### DIFF
--- a/frontend/__tests__/routes/llm-settings.test.tsx
+++ b/frontend/__tests__/routes/llm-settings.test.tsx
@@ -396,7 +396,60 @@ describe("LlmSettingsScreen", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("opens advanced view when an OpenHands model has a custom base URL", async () => {
+  it("opens basic view when an OpenHands managed model has a server-filled base URL", async () => {
+    // Managed openhands/* profiles always come back with a base_url — the
+    // backend fills it with the managed LiteLLM endpoint on save. That must
+    // not be mistaken for a user customization that opens advanced/all.
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettingsWithAdvancedToggle({
+        llm_model: "openhands/claude-opus-4-5-20251101",
+        llm_base_url: "http://openhands-litellm:4000",
+        agent_settings: {
+          llm: {
+            model: "openhands/claude-opus-4-5-20251101",
+            base_url: "http://openhands-litellm:4000",
+          },
+        },
+      }),
+    );
+
+    await renderLlmSettingsScreen({ appMode: "oss" });
+
+    await screen.findByTestId("llm-settings-form-basic");
+    expect(
+      screen.queryByTestId("llm-settings-form-advanced"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens basic view when editing an org-scope OpenHands managed profile with a server-filled base URL", async () => {
+    // Org scope is not covered by the personal-SaaS first-mount-basic rule,
+    // so this exercises the base-URL inference path directly.
+    vi.spyOn(organizationService, "getOrganizationSettings").mockResolvedValue(
+      buildSettingsWithAdvancedToggle({
+        llm_model: "openhands/claude-opus-4-5-20251101",
+        llm_base_url: "http://openhands-litellm:4000",
+        agent_settings: {
+          llm: {
+            model: "openhands/claude-opus-4-5-20251101",
+            base_url: "http://openhands-litellm:4000",
+          },
+        },
+      }),
+    );
+
+    await renderLlmSettingsScreen({ appMode: "saas", scope: "org" });
+
+    await screen.findByTestId("llm-settings-form-basic");
+    expect(
+      screen.queryByTestId("llm-settings-form-advanced"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens basic view even when an OpenHands model has a non-managed base URL", async () => {
+    // Accepted edge case: the server owns base_url for openhands/* models,
+    // so editing always starts on basic — even if the stored URL was set
+    // deliberately in advanced mode. The value is preserved and the
+    // advanced view remains one click away.
     vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
       buildSettingsWithAdvancedToggle({
         llm_model: "openhands/claude-opus-4-5-20251101",
@@ -412,10 +465,10 @@ describe("LlmSettingsScreen", () => {
 
     await renderLlmSettingsScreen({ appMode: "oss" });
 
-    await screen.findByTestId("llm-settings-form-advanced");
-    expect(screen.getByTestId("base-url-input")).toHaveValue(
-      "https://custom.example/v1",
-    );
+    await screen.findByTestId("llm-settings-form-basic");
+    expect(
+      screen.queryByTestId("llm-settings-form-advanced"),
+    ).not.toBeInTheDocument();
   });
 
   it("treats a litellm_proxy model with the managed proxy URL as an explicit custom endpoint", async () => {
@@ -1360,10 +1413,14 @@ describe("LlmSettingsScreen", () => {
   });
 
   it("keeps an existing custom base URL when saving basic view without a model change", async () => {
+    // Use a non-managed model: openhands/* models treat any base_url as
+    // server-owned, which would keep this scenario from opening advanced.
     let persistedSettings = buildSettingsWithAdvancedToggle({
+      llm_model: "openai/gpt-4o",
       llm_base_url: "https://stale.example/v1",
       agent_settings: {
         llm: {
+          model: "openai/gpt-4o",
           base_url: "https://stale.example/v1",
         },
       },

--- a/frontend/src/routes/llm-settings.tsx
+++ b/frontend/src/routes/llm-settings.tsx
@@ -78,13 +78,10 @@ const normalizeBaseUrl = (baseUrl: string) => {
 };
 
 const isProviderDefaultBaseUrl = (model: string, baseUrl: string) => {
-  // Managed openhands/* models always carry a server-owned base_url: the
-  // backend auto-fills it with the managed LiteLLM endpoint on save (see
-  // resolve_llm_base_url in openhands/app_server/utils/llm.py). Whatever
-  // value is stored, the user didn't customize it, so it never warrants
-  // opening the advanced view. Accepted edge case: someone who deliberately
-  // paired an openhands/* model with a custom base_url lands on basic when
-  // editing — their values are preserved and Advanced is one click away.
+  // For openhands/* models, base_url is server-owned (auto-filled on save) —
+  // never treat it as user customization that warrants the advanced view.
+  // Accepted edge case: a deliberately customized base_url on an openhands/*
+  // model also lands on basic; values are preserved, Advanced is a click away.
   if (model.startsWith("openhands/")) {
     return true;
   }

--- a/frontend/src/routes/llm-settings.tsx
+++ b/frontend/src/routes/llm-settings.tsx
@@ -78,6 +78,17 @@ const normalizeBaseUrl = (baseUrl: string) => {
 };
 
 const isProviderDefaultBaseUrl = (model: string, baseUrl: string) => {
+  // Managed openhands/* models always carry a server-owned base_url: the
+  // backend auto-fills it with the managed LiteLLM endpoint on save (see
+  // resolve_llm_base_url in openhands/app_server/utils/llm.py). Whatever
+  // value is stored, the user didn't customize it, so it never warrants
+  // opening the advanced view. Accepted edge case: someone who deliberately
+  // paired an openhands/* model with a custom base_url lands on basic when
+  // editing — their values are preserved and Advanced is one click away.
+  if (model.startsWith("openhands/")) {
+    return true;
+  }
+
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
   const { provider } = extractModelAndProvider(model);
 


### PR DESCRIPTION
HUMAN: Follow-up to #14782 (now merged). Verified by unit tests including regression guards that fail without the fix.

- [ ] A human has tested these changes.

## Summary

On managed installs, every profile using an `openhands/<model>` carries a server-managed `base_url` (the backend auto-fills `LITE_LLM_API_URL` on save — see `resolve_llm_base_url`). The edit-view inference treated any unrecognized base URL as user customization, so editing **any** managed-model profile landed on the advanced/all view. This teaches `isProviderDefaultBaseUrl` that for `openhands/*` models the base URL is a provider default by construction.

## Changes

- `isProviderDefaultBaseUrl` returns true for models with the `openhands/` prefix — the server owns and auto-fills the value, so its presence is not evidence of user customization.
- Accepted edge case (documented in code): a user who deliberately paired an `openhands/*` model with a custom base URL in advanced mode now lands on basic when editing; their values are preserved and the advanced view remains one click away.
- Non-managed models are unaffected: custom base URLs on `openai/*`, `litellm_proxy/*`, etc. still open advanced (existing tests pass unchanged).

## Testing

- New: OSS-mode and SaaS org-scope tests assert managed model + in-cluster litellm URL lands on basic (both fail without the source fix).
- Flipped: the prior "openhands model + custom base URL opens advanced" test asserted the accepted edge case and now documents the trade-off.
- Suite 66/66; `npm run lint` clean.

## Design note: why `openhands/*` but not `litellm_proxy/*`

The two prefixes look similar but signal different intent. `openhands/<model>` is the app's managed provider: the user picks a model from the dropdown and the server fills `base_url` behind the scenes — its presence says nothing about user intent. `litellm_proxy/<model>` is an explicit transport prefix the user typed themselves (advanced/BYO configuration), so a base URL alongside it — even one pointing at the managed proxy — reflects deliberate setup and still opens the advanced view. The existing test pinning that behavior is unchanged.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-ada307c   docker.openhands.dev/openhands/openhands:ada307c
```