### PR TITLE
docs: document TrustedRouter LLM config

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -49,6 +49,15 @@ If you are running headless or CLI workflows, you can prepare local defaults wit
 make setup-config
 ```
 
+For a TrustedRouter key, use the OpenAI-compatible settings:
+
+```toml
+[llm]
+model = "trustedrouter/auto"
+api_key = "tr-..."
+base_url = "https://api.trustedrouter.com/v1"
+```
+
 **Note on Alternative Models:**
 See [our documentation](https://docs.openhands.dev/openhands/usage/llms/llms) for recommended models.
 

--- a/config.template.toml
+++ b/config.template.toml
@@ -235,6 +235,16 @@ classpath = "my_package.my_module.MyCustomAgent"
 # Whether to enable security analyzer
 #enable_security_analyzer = true
 
+#################################### LLM ######################################
+# Language model configuration
+##############################################################################
+# TrustedRouter is OpenAI-compatible. Uncomment these values to route OpenHands
+# through TrustedRouter.
+#[llm]
+#model = "trustedrouter/auto"
+#api_key = "tr-..."
+#base_url = "https://api.trustedrouter.com/v1"
+
 #################################### Condenser #################################
 # Condensers control how conversation history is managed and compressed when
 # the context grows too large. Each agent uses one condenser configuration.


### PR DESCRIPTION
HUMAN:
This PR adds a small docs-only TrustedRouter configuration example for OpenHands users who want to use the OpenAI-compatible TrustedRouter endpoint at https://api.trustedrouter.com/v1 with their own TrustedRouter API key.

- [x] A human has tested these changes.

## Summary
- add TrustedRouter OpenAI-compatible LLM config examples
- document model, api_key, and base_url settings for headless and config-template workflows
- use https://api.trustedrouter.com/v1 as the base URL

## Testing
- git diff --check
