### PR TITLE
fix: keep language filter from dirtying settings

### DIFF
--- a/frontend/__tests__/routes/app-settings.test.tsx
+++ b/frontend/__tests__/routes/app-settings.test.tsx
@@ -173,6 +173,24 @@ describe("Form submission", () => {
     expect(submit).toBeDisabled();
   });
 
+  it("should not mark language as changed while filtering options", async () => {
+    const getSettingsSpy = vi.spyOn(SettingsService, "getSettings");
+    getSettingsSpy.mockResolvedValue(MOCK_DEFAULT_USER_SETTINGS);
+
+    renderAppSettingsScreen();
+
+    const submit = await screen.findByTestId("submit-button");
+    expect(submit).toBeDisabled();
+
+    const language = await screen.findByTestId("language-input");
+    await userEvent.click(language);
+    await userEvent.clear(language);
+    await userEvent.type(language, "Nor");
+
+    expect(language).toHaveValue("Nor");
+    expect(submit).toBeDisabled();
+  });
+
   it("should call handleCaptureConsents with true when the analytics switch is toggled", async () => {
     const getSettingsSpy = vi.spyOn(SettingsService, "getSettings");
     getSettingsSpy.mockResolvedValue(MOCK_DEFAULT_USER_SETTINGS);

--- a/frontend/src/components/features/settings/app-settings/language-input.tsx
+++ b/frontend/src/components/features/settings/app-settings/language-input.tsx
@@ -20,7 +20,11 @@ export function LanguageInput({
     <SettingsDropdownInput
       testId={name}
       name={name}
-      onInputChange={onChange}
+      onSelectionChange={(key) => {
+        if (key !== null) {
+          onChange(String(key));
+        }
+      }}
       label={t(I18nKey.SETTINGS$LANGUAGE)}
       items={AvailableLanguages.map((l) => ({
         key: l.value,

--- a/frontend/src/routes/app-settings.tsx
+++ b/frontend/src/routes/app-settings.tsx
@@ -140,14 +140,7 @@ function AppSettingsScreen() {
   };
 
   const checkIfLanguageInputHasChanged = (value: string) => {
-    const selectedLanguage = AvailableLanguages.find(
-      ({ label: langValue }) => langValue === value,
-    )?.label;
-    const currentLanguage = AvailableLanguages.find(
-      ({ value: langValue }) => langValue === settings?.language,
-    )?.label;
-
-    setLanguageInputHasChanged(selectedLanguage !== currentLanguage);
+    setLanguageInputHasChanged(value !== settings?.language);
   };
 
   const checkIfAnalyticsSwitchHasChanged = (checked: boolean) => {


### PR DESCRIPTION
HUMAN:

This fixes the settings language dropdown so typing into the autocomplete filter does not enable Save; only selecting a real language changes the form state.

- [ ] A human has tested these changes.

AGENT:

Implemented and verified with targeted automated tests, typecheck, lint, formatting check, and frontend build.

---

## Why

Fixes #14249.

The settings language dropdown was using `onInputChange` to mark the form dirty. That callback fires while the user is only typing to filter options, so partial text such as `Nor` made the Save button enable even when no language was selected.

## Summary

- Move the language dirty-state update to `onSelectionChange`, so filtering text does not count as a settings change.
- Compare selected language keys against the saved language code instead of comparing labels.
- Add a regression test for typing into the language filter without selecting an option.

## Issue Number

#14249

## How to Test

From `frontend/`:

```bash
npm run test -- __tests__/routes/app-settings.test.tsx
npm run typecheck
npx eslint src/components/features/settings/app-settings/language-input.tsx src/routes/app-settings.tsx __tests__/routes/app-settings.test.tsx
npx prettier --check src/components/features/settings/app-settings/language-input.tsx src/routes/app-settings.tsx __tests__/routes/app-settings.test.tsx
npm run build
```

Also ran:

```bash
git diff --check
```

## Video/Screenshots

Not included. The regression is covered by the new settings route test.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

`npm ci` reported existing dependency audit warnings. I did not run `npm audit fix` because that would be unrelated dependency churn.
