### PR TITLE
fix: repair git pagination boundaries

### DIFF
--- a/openhands/app_server/git/git_router.py
+++ b/openhands/app_server/git/git_router.py
@@ -46,6 +46,13 @@ router = APIRouter(
 user_context_dependency = depends_user_context()
 
 
+def _repositories_have_next_page(repos: list[Repository], limit: int) -> bool:
+    link_headers = [repo.link_header for repo in repos if repo.link_header is not None]
+    if link_headers:
+        return any('rel="next"' in link_header for link_header in link_headers)
+    return len(repos) >= limit
+
+
 @router.get('/installations/search')
 async def search_user_installations(
     provider: ProviderType,
@@ -154,6 +161,12 @@ async def search_repositories(
 
     # If query is provided, use search; otherwise get user's repositories
     if query:
+        if page != 1:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail='Pagination not yet supported for repository search queries.',
+            )
+
         # Parse sort_order into sort and order components (if provided)
         if sort_order:
             search_sort, order = sort_order.value.rsplit('-', 1)
@@ -164,11 +177,13 @@ async def search_repositories(
         repos: list[Repository] = await client.search_repositories(
             selected_provider=provider,
             query=query,
-            per_page=limit + 1,
+            per_page=limit,
             sort=search_sort,
             order=order,
             app_mode=get_global_config().app_mode,
         )
+        repos = repos[:limit]
+        next_page_id = None
     else:
         if sort_order:
             # TODO: This is a temporary state until we refactor the underlying API.
@@ -185,14 +200,13 @@ async def search_repositories(
             app_mode=get_global_config().app_mode,
             selected_provider=provider,
             page=page,
-            per_page=limit + 1,
+            per_page=limit,
             installation_id=installation_id,
         )
-
-    next_page_id = None
-    if len(repos) > limit:
-        repos = repos[:-1]
-        next_page_id = encode_page_id(page + 1)
+        next_page_id = None
+        if _repositories_have_next_page(repos, limit):
+            next_page_id = encode_page_id(page + 1)
+        repos = repos[:limit]
 
     return RepositoryPage(items=repos, next_page_id=next_page_id)
 
@@ -252,26 +266,26 @@ async def search_branches(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail='Pagination not yet supported for branch search queries. Use empty query to list all branches with pagination.',
             )
-        # Get search results - we'll handle pagination ourselves
         branches: list[Branch] = await client.search_branches(
             selected_provider=provider,
             repository=repository,
             query=query,
-            per_page=limit + 1,
+            per_page=limit,
         )
+        branches = branches[:limit]
+        next_page_id = None
     else:
         current_page = await client.get_branches(
             repository=repository,
             specified_provider=provider,
             page=page,
-            per_page=limit + 1,
+            per_page=limit,
         )
         branches = current_page.branches
-
-    next_page_id = None
-    if len(branches) > limit:
-        branches = branches[:-1]
-        next_page_id = encode_page_id(page + 1)
+        next_page_id = None
+        if current_page.has_next_page:
+            next_page_id = encode_page_id(page + 1)
+        branches = branches[:limit]
 
     return BranchPage(items=branches, next_page_id=next_page_id)
 

--- a/tests/unit/app_server/test_git_router.py
+++ b/tests/unit/app_server/test_git_router.py
@@ -7,7 +7,7 @@ focusing on pagination and error handling.
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import FastAPI, status
+from fastapi import FastAPI, HTTPException, status
 from fastapi.testclient import TestClient
 
 from openhands.app_server.git.git_models import SortOrder
@@ -21,6 +21,7 @@ from openhands.app_server.git.git_router import (
 from openhands.app_server.integrations.provider import ProviderToken
 from openhands.app_server.integrations.service_types import (
     Branch,
+    PaginatedBranchesResponse,
     ProviderType,
     Repository,
     SuggestedTask,
@@ -330,8 +331,7 @@ class TestSearchRepositories:
         assert call_kwargs.get('sort') == 'stars'
         assert call_kwargs.get('order') == 'desc'
 
-        # Verify per_page is limit + 1
-        assert call_kwargs.get('per_page') == 11
+        assert call_kwargs.get('per_page') == 10
 
         # Verify results are returned
         assert len(result.items) == 2
@@ -408,16 +408,13 @@ class TestSearchRepositories:
         """Test that pagination works correctly across multiple pages.
 
         Note: This endpoint uses page-based pagination (passing page number to provider),
-        not offset-based pagination like installations. The provider returns limit+1 items,
-        and we check if there are more to determine next_page_id.
+        not offset-based pagination like installations. The router must not request
+        limit+1 items because that shifts every provider page boundary.
         """
         # Arrange
         mock_handler = MagicMock()
 
         # We'll set up the mock to return different data based on the page parameter
-        # First call (page=1): return 3 items (limit+1), meaning there's a next page
-        # Second call (page=2): return 3 items, meaning there's a next page
-        # Third call (page=3): return 2 items, meaning it's the last page
         def mock_get_repositories(**kwargs):
             page = kwargs.get('page', 1)
             if page == 1:
@@ -427,8 +424,9 @@ class TestSearchRepositories:
                         full_name=f'user/repo{i}',
                         git_provider=ProviderType.GITHUB,
                         is_public=True,
+                        link_header='<https://api.github.com/user/repos?page=2>; rel="next"',
                     )
-                    for i in range(1, 4)  # 3 items = limit+1
+                    for i in range(1, 3)
                 ]
             elif page == 2:
                 return [
@@ -437,8 +435,9 @@ class TestSearchRepositories:
                         full_name=f'user/repo{i}',
                         git_provider=ProviderType.GITHUB,
                         is_public=True,
+                        link_header='',
                     )
-                    for i in range(4, 7)  # 3 items = limit+1
+                    for i in range(3, 5)
                 ]
             else:
                 return [
@@ -448,7 +447,7 @@ class TestSearchRepositories:
                         git_provider=ProviderType.GITHUB,
                         is_public=True,
                     )
-                    for i in range(7, 9)  # 2 items < limit+1 = last page
+                    for i in range(5, 7)
                 ]
 
         mock_handler.get_repositories = AsyncMock(side_effect=mock_get_repositories)
@@ -472,11 +471,12 @@ class TestSearchRepositories:
             user_context=mock_context,
         )
 
-        # Assert - First page returns 2 items (truncated from limit+1=3), with next_page_id
+        # Assert - First page returns 2 items with next_page_id from provider link metadata
         assert len(result_page1.items) == 2
         assert result_page1.items[0].id == '1'
         assert result_page1.items[1].id == '2'
         assert result_page1.next_page_id == encode_page_id(2)
+        assert mock_handler.get_repositories.call_args.kwargs['per_page'] == 2
 
         # Act - Second page (page=2)
         result_page2 = await search_repositories(
@@ -491,10 +491,9 @@ class TestSearchRepositories:
 
         # Assert - Second page returns next 2 items
         assert len(result_page2.items) == 2
-        assert result_page2.items[0].id == '4'
-        assert result_page2.items[1].id == '5'
-        # next_page_id = page + 1 = 2 + 1 = 3, encoded as base64 = 'Mw'
-        assert result_page2.next_page_id == encode_page_id(3)
+        assert result_page2.items[0].id == '3'
+        assert result_page2.items[1].id == '4'
+        assert result_page2.next_page_id is None
 
     @pytest.mark.asyncio
     @patch('openhands.app_server.git.git_router.ProviderHandler')
@@ -579,12 +578,6 @@ class TestSearchRepositories:
                     git_provider=ProviderType.GITHUB,
                     is_public=True,
                 ),
-                Repository(
-                    id='3',
-                    full_name='user/repo3',
-                    git_provider=ProviderType.GITHUB,
-                    is_public=True,
-                ),
             ]
         )
         mock_handler_cls.return_value = mock_handler
@@ -621,7 +614,32 @@ class TestSearchRepositories:
                 is_public=True,
             ),
         ]
-        assert result.next_page_id == encode_page_id(2)
+        assert result.next_page_id is None
+
+    @pytest.mark.asyncio
+    @patch('openhands.app_server.git.git_router.ProviderHandler')
+    async def test_rejects_repository_search_followup_page(self, mock_handler_cls):
+        """Repository search does not accept next_page_id until provider paging exists."""
+        mock_handler_cls.return_value = MagicMock()
+
+        mock_context = _make_mock_user_context(
+            provider_tokens={
+                ProviderType.GITHUB: ProviderToken(user_id='user-123', token='token')
+            },
+            user_id='user-123',
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await search_repositories(
+                provider=ProviderType.GITHUB,
+                query='test',
+                page_id=encode_page_id(2),
+                limit=5,
+                sort_order=SortOrder.STAR_DESC,
+                user_context=mock_context,
+            )
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
 
     @pytest.mark.asyncio
     @patch('openhands.app_server.git.git_router.ProviderHandler')
@@ -712,7 +730,6 @@ class TestSearchBranches:
             return_value=[
                 Branch(name='main', commit_sha='abc123', protected=False),
                 Branch(name='develop', commit_sha='def456', protected=False),
-                Branch(name='feature-branch', commit_sha='ghi789', protected=False),
             ]
         )
         mock_handler_cls.return_value = mock_handler
@@ -738,7 +755,7 @@ class TestSearchBranches:
         assert len(result.items) == 2
         assert result.items[0].name == 'main'
         assert result.items[1].name == 'develop'
-        assert result.next_page_id == encode_page_id(2)
+        assert result.next_page_id is None
 
     @pytest.mark.asyncio
     @patch('openhands.app_server.git.git_router.ProviderHandler')
@@ -772,7 +789,45 @@ class TestSearchBranches:
         assert call_kwargs.get('selected_provider') == ProviderType.GITHUB
         assert call_kwargs.get('repository') == 'user/repo'
         assert call_kwargs.get('query') == 'feature'
-        assert call_kwargs.get('per_page') == 11  # limit + 1
+        assert call_kwargs.get('per_page') == 10
+
+    @pytest.mark.asyncio
+    @patch('openhands.app_server.git.git_router.ProviderHandler')
+    async def test_returns_paginated_branch_listing(self, mock_handler_cls):
+        """Empty branch query uses provider pagination metadata."""
+        mock_handler = MagicMock()
+        mock_handler.get_branches = AsyncMock(
+            return_value=PaginatedBranchesResponse(
+                branches=[
+                    Branch(name='main', commit_sha='abc123', protected=False),
+                    Branch(name='develop', commit_sha='def456', protected=False),
+                ],
+                has_next_page=True,
+                current_page=1,
+                per_page=2,
+            )
+        )
+        mock_handler_cls.return_value = mock_handler
+
+        mock_context = _make_mock_user_context(
+            provider_tokens={
+                ProviderType.GITHUB: ProviderToken(user_id='user-123', token='token')
+            },
+            user_id='user-123',
+        )
+
+        result = await search_branches(
+            provider=ProviderType.GITHUB,
+            repository='user/repo',
+            query='',
+            page_id=None,
+            limit=2,
+            user_context=mock_context,
+        )
+
+        assert [branch.name for branch in result.items] == ['main', 'develop']
+        assert result.next_page_id == encode_page_id(2)
+        assert mock_handler.get_branches.call_args.kwargs['per_page'] == 2
 
     def test_returns_403_when_no_provider_tokens(self, test_client):
         """Test that 403 is returned when no provider tokens."""


### PR DESCRIPTION
HUMAN:

This fixes a backend pagination bug in the V1 git endpoints. I validated it with targeted unit tests on Windows; I did not do browser/manual UI testing.

- [ ] A human has tested these changes.

AGENT:

Codex assisted with issue triage, patching, and validation.

---

## Why

The V1 git router used `limit + 1` against provider APIs that already use page-number pagination. With a limit of 30, page 1 requested 31 repositories and displayed 30; page 2 requested the next provider page of 31, so the 31st repository was never returned to the UI. The branch listing path had the same boundary issue.

The query-search paths had a different pagination problem: they advertised a `next_page_id` even though provider-level search pagination is not wired through these router methods yet. Following the advertised page either repeated the first repository search page or hit the existing branch-search 400.

## Summary

- Request exactly `limit` items from provider page-number repository and branch listing APIs.
- Use repository link metadata and branch `has_next_page` metadata to decide whether to emit `next_page_id`.
- Stop advertising follow-up pages for query search paths until provider-level search pagination exists.
- Reject explicit repository-search follow-up page requests instead of returning another copy of page 1.
- Update git router unit tests so they no longer encode the lost-boundary-item behavior.

## Issue Number

Fixes OpenHands/enterprise#73

## How to Test

- `python -m py_compile openhands\app_server\git\git_router.py tests\unit\app_server\test_git_router.py`
- `python -m pytest tests\unit\app_server\test_git_router.py -q`
- `python -m ruff check openhands\app_server\git\git_router.py tests\unit\app_server\test_git_router.py`
- `python -m ruff format --check openhands\app_server\git\git_router.py tests\unit\app_server\test_git_router.py`
- `git diff --check`

## Video/Screenshots

N/A, backend pagination fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This intentionally keeps repository query search and branch query search single-page for now. A real paginated search path should be added at the provider layer later instead of simulated in the router.
