### PR TITLE
feat(enterprise): enforce org conversation expiration

### DIFF
--- a/enterprise/run_maintenance_tasks.py
+++ b/enterprise/run_maintenance_tasks.py
@@ -7,6 +7,12 @@ from storage.maintenance_task import (
     MaintenanceTask,
     MaintenanceTaskStatus,
 )
+from storage.org import Org
+
+CONVERSATION_EXPIRATION_PROCESSOR = (
+    'server.maintenance_task_processor.conversation_expiration_processor.'
+    'ConversationExpirationProcessor'
+)
 
 NUM_RETRIES = 3
 RETRY_DELAY = 60
@@ -15,9 +21,48 @@ RETRY_DELAY = 60
 async def main():
     try:
         set_stale_task_error()
+        with session_maker() as session:
+            enqueue_conversation_expiration_task(session)
+            session.commit()
         await run_tasks()
     except Exception as e:
         logger.info(f'Error running maintenance tasks: {e}')
+
+
+def enqueue_conversation_expiration_task(session) -> bool:
+    has_enabled_policy = (
+        session.query(Org.id)
+        .filter(
+            Org.conversation_expiration.isnot(None),
+            Org.conversation_expiration > 0,
+        )
+        .first()
+        is not None
+    )
+    if not has_enabled_policy:
+        return False
+
+    active_task = (
+        session.query(MaintenanceTask.id)
+        .filter(
+            MaintenanceTask.processor_type == CONVERSATION_EXPIRATION_PROCESSOR,
+            MaintenanceTask.status.in_(
+                [MaintenanceTaskStatus.PENDING, MaintenanceTaskStatus.WORKING]
+            ),
+        )
+        .first()
+    )
+    if active_task:
+        return False
+
+    session.add(
+        MaintenanceTask(
+            status=MaintenanceTaskStatus.PENDING,
+            processor_type=CONVERSATION_EXPIRATION_PROCESSOR,
+            processor_json='{}',
+        )
+    )
+    return True
 
 
 def set_stale_task_error():

--- a/enterprise/server/maintenance_task_processor/conversation_expiration_processor.py
+++ b/enterprise/server/maintenance_task_processor/conversation_expiration_processor.py
@@ -1,0 +1,93 @@
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from storage.database import a_session_maker
+from storage.maintenance_task import MaintenanceTask, MaintenanceTaskProcessor
+from storage.org import Org
+from storage.stored_conversation_metadata import StoredConversationMetadata
+from storage.stored_conversation_metadata_saas import StoredConversationMetadataSaas
+
+from openhands.app_server.app_conversation.sql_app_conversation_start_task_service import (
+    StoredAppConversationStartTask,
+)
+
+
+class ConversationExpirationProcessor(MaintenanceTaskProcessor):
+    """Delete conversations older than each org's conversation_expiration setting."""
+
+    async def __call__(self, task: MaintenanceTask) -> dict:
+        orgs_processed = 0
+        deleted_conversations = 0
+        deleted_start_tasks = 0
+
+        async with a_session_maker() as session:
+            orgs = (
+                await session.scalars(
+                    select(Org).where(
+                        Org.conversation_expiration.is_not(None),
+                        Org.conversation_expiration > 0,
+                    )
+                )
+            ).all()
+
+            for org in orgs:
+                orgs_processed += 1
+                threshold = datetime.now(UTC) - timedelta(
+                    days=org.conversation_expiration
+                )
+                expired_conversation_ids = list(
+                    await session.scalars(
+                        select(StoredConversationMetadata.conversation_id)
+                        .join(
+                            StoredConversationMetadataSaas,
+                            StoredConversationMetadata.conversation_id
+                            == StoredConversationMetadataSaas.conversation_id,
+                        )
+                        .where(
+                            StoredConversationMetadataSaas.org_id == org.id,
+                            StoredConversationMetadata.conversation_version == 'V1',
+                            StoredConversationMetadata.last_updated_at < threshold,
+                        )
+                    )
+                )
+
+                if not expired_conversation_ids:
+                    continue
+
+                expired_conversation_uuids = [
+                    UUID(conversation_id)
+                    for conversation_id in expired_conversation_ids
+                ]
+                start_task_result = await session.execute(
+                    delete(StoredAppConversationStartTask).where(
+                        StoredAppConversationStartTask.app_conversation_id.in_(
+                            expired_conversation_uuids
+                        )
+                    )
+                )
+                deleted_start_tasks += start_task_result.rowcount or 0
+
+                await session.execute(
+                    delete(StoredConversationMetadataSaas).where(
+                        StoredConversationMetadataSaas.conversation_id.in_(
+                            expired_conversation_ids
+                        )
+                    )
+                )
+                metadata_result = await session.execute(
+                    delete(StoredConversationMetadata).where(
+                        StoredConversationMetadata.conversation_id.in_(
+                            expired_conversation_ids
+                        )
+                    )
+                )
+                deleted_conversations += metadata_result.rowcount or 0
+
+            await session.commit()
+
+        return {
+            'orgs_processed': orgs_processed,
+            'deleted_conversations': deleted_conversations,
+            'deleted_start_tasks': deleted_start_tasks,
+        }

--- a/enterprise/tests/unit/test_conversation_expiration_processor.py
+++ b/enterprise/tests/unit/test_conversation_expiration_processor.py
@@ -1,0 +1,224 @@
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+from server.maintenance_task_processor.conversation_expiration_processor import (
+    ConversationExpirationProcessor,
+)
+from sqlalchemy import select
+from storage.maintenance_task import MaintenanceTask
+from storage.org import Org
+from storage.stored_conversation_metadata import StoredConversationMetadata
+from storage.stored_conversation_metadata_saas import StoredConversationMetadataSaas
+
+from openhands.app_server.app_conversation.app_conversation_models import (
+    AppConversationStartRequest,
+    AppConversationStartTaskStatus,
+)
+from openhands.app_server.app_conversation.sql_app_conversation_start_task_service import (
+    StoredAppConversationStartTask,
+)
+
+
+@asynccontextmanager
+async def _session_context(async_session_maker):
+    async with async_session_maker() as session:
+        yield session
+
+
+@pytest.mark.asyncio
+async def test_processor_deletes_only_expired_conversations_for_org_policy(
+    async_session_maker, monkeypatch
+):
+    processor = ConversationExpirationProcessor()
+    now = datetime.now(timezone.utc)
+    expired_conversation_id = uuid4()
+    active_conversation_id = uuid4()
+    disabled_policy_conversation_id = uuid4()
+    org_with_policy = uuid4()
+    org_without_policy = uuid4()
+    user_id = uuid4()
+
+    async with async_session_maker() as session:
+        session.add_all(
+            [
+                Org(
+                    id=org_with_policy,
+                    name='retention-enabled',
+                    conversation_expiration=30,
+                ),
+                Org(
+                    id=org_without_policy,
+                    name='retention-disabled',
+                    conversation_expiration=None,
+                ),
+                StoredConversationMetadata(
+                    conversation_id=str(expired_conversation_id),
+                    conversation_version='V1',
+                    last_updated_at=now - timedelta(days=31),
+                    created_at=now - timedelta(days=40),
+                    title='expired',
+                ),
+                StoredConversationMetadataSaas(
+                    conversation_id=str(expired_conversation_id),
+                    user_id=user_id,
+                    org_id=org_with_policy,
+                ),
+                StoredAppConversationStartTask(
+                    id=uuid4(),
+                    created_by_user_id=str(user_id),
+                    status=AppConversationStartTaskStatus.WORKING,
+                    app_conversation_id=expired_conversation_id,
+                    request=AppConversationStartRequest(),
+                ),
+                StoredConversationMetadata(
+                    conversation_id=str(active_conversation_id),
+                    conversation_version='V1',
+                    last_updated_at=now - timedelta(days=29),
+                    created_at=now - timedelta(days=40),
+                    title='active',
+                ),
+                StoredConversationMetadataSaas(
+                    conversation_id=str(active_conversation_id),
+                    user_id=user_id,
+                    org_id=org_with_policy,
+                ),
+                StoredAppConversationStartTask(
+                    id=uuid4(),
+                    created_by_user_id=str(user_id),
+                    status=AppConversationStartTaskStatus.WORKING,
+                    app_conversation_id=active_conversation_id,
+                    request=AppConversationStartRequest(),
+                ),
+                StoredConversationMetadata(
+                    conversation_id=str(disabled_policy_conversation_id),
+                    conversation_version='V1',
+                    last_updated_at=now - timedelta(days=365),
+                    created_at=now - timedelta(days=400),
+                    title='disabled-policy',
+                ),
+                StoredConversationMetadataSaas(
+                    conversation_id=str(disabled_policy_conversation_id),
+                    user_id=user_id,
+                    org_id=org_without_policy,
+                ),
+            ]
+        )
+        await session.commit()
+
+    monkeypatch.setattr(
+        'server.maintenance_task_processor.conversation_expiration_processor.a_session_maker',
+        lambda: _session_context(async_session_maker),
+    )
+
+    result = await processor(MaintenanceTask(id=1))
+
+    assert result == {
+        'orgs_processed': 1,
+        'deleted_conversations': 1,
+        'deleted_start_tasks': 1,
+    }
+
+    async with async_session_maker() as session:
+        remaining_conversation_ids = set(
+            await session.scalars(select(StoredConversationMetadata.conversation_id))
+        )
+        remaining_saas_ids = set(
+            await session.scalars(
+                select(StoredConversationMetadataSaas.conversation_id)
+            )
+        )
+        remaining_start_task_ids = set(
+            await session.scalars(
+                select(StoredAppConversationStartTask.app_conversation_id)
+            )
+        )
+
+    assert str(expired_conversation_id) not in remaining_conversation_ids
+    assert str(expired_conversation_id) not in remaining_saas_ids
+    assert expired_conversation_id not in remaining_start_task_ids
+    assert str(active_conversation_id) in remaining_conversation_ids
+    assert str(disabled_policy_conversation_id) in remaining_conversation_ids
+
+
+@pytest.mark.asyncio
+async def test_processor_ignores_orgs_with_non_positive_expiration(
+    async_session_maker, monkeypatch
+):
+    processor = ConversationExpirationProcessor()
+
+    async with async_session_maker() as session:
+        session.add_all(
+            [
+                Org(id=uuid4(), name='zero-retention', conversation_expiration=0),
+                Org(id=uuid4(), name='negative-retention', conversation_expiration=-1),
+            ]
+        )
+        await session.commit()
+
+    monkeypatch.setattr(
+        'server.maintenance_task_processor.conversation_expiration_processor.a_session_maker',
+        lambda: _session_context(async_session_maker),
+    )
+
+    result = await processor(MaintenanceTask(id=1))
+
+    assert result == {
+        'orgs_processed': 0,
+        'deleted_conversations': 0,
+        'deleted_start_tasks': 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_processor_ignores_legacy_non_v1_conversations(
+    async_session_maker, monkeypatch
+):
+    processor = ConversationExpirationProcessor()
+    now = datetime.now(timezone.utc)
+    org_id = uuid4()
+    user_id = uuid4()
+
+    async with async_session_maker() as session:
+        session.add_all(
+            [
+                Org(
+                    id=org_id,
+                    name='retention-enabled',
+                    conversation_expiration=30,
+                ),
+                StoredConversationMetadata(
+                    conversation_id='legacy-conversation-id',
+                    conversation_version='V0',
+                    last_updated_at=now - timedelta(days=365),
+                    created_at=now - timedelta(days=400),
+                    title='legacy',
+                ),
+                StoredConversationMetadataSaas(
+                    conversation_id='legacy-conversation-id',
+                    user_id=user_id,
+                    org_id=org_id,
+                ),
+            ]
+        )
+        await session.commit()
+
+    monkeypatch.setattr(
+        'server.maintenance_task_processor.conversation_expiration_processor.a_session_maker',
+        lambda: _session_context(async_session_maker),
+    )
+
+    result = await processor(MaintenanceTask(id=1))
+
+    assert result == {
+        'orgs_processed': 1,
+        'deleted_conversations': 0,
+        'deleted_start_tasks': 0,
+    }
+    async with async_session_maker() as session:
+        remaining_conversation_ids = set(
+            await session.scalars(select(StoredConversationMetadata.conversation_id))
+        )
+
+    assert 'legacy-conversation-id' in remaining_conversation_ids

--- a/enterprise/tests/unit/test_run_maintenance_tasks.py
+++ b/enterprise/tests/unit/test_run_maintenance_tasks.py
@@ -19,6 +19,7 @@ sys.modules['storage.database'] = mock_db
 
 # Import after mocking
 from run_maintenance_tasks import (  # noqa: E402
+    enqueue_conversation_expiration_task,
     main,
     next_task,
     run_tasks,
@@ -28,6 +29,12 @@ from storage.maintenance_task import (  # noqa: E402
     MaintenanceTask,
     MaintenanceTaskProcessor,
     MaintenanceTaskStatus,
+)
+from storage.org import Org  # noqa: E402
+
+CONVERSATION_EXPIRATION_PROCESSOR = (
+    'server.maintenance_task_processor.conversation_expiration_processor.'
+    'ConversationExpirationProcessor'
 )
 
 
@@ -41,6 +48,46 @@ class MockMaintenanceTaskProcessor(MaintenanceTaskProcessor):
 
 class TestRunMaintenanceTasks:
     """Tests for the run_maintenance_tasks.py module."""
+
+    def test_enqueue_conversation_expiration_task_when_policy_enabled(
+        self, session_maker
+    ):
+        """Create one expiration maintenance task when an org enables retention."""
+        with session_maker() as session:
+            session.add(Org(name='retention-enabled', conversation_expiration=30))
+            session.commit()
+
+        with session_maker() as session:
+            created = enqueue_conversation_expiration_task(session)
+            session.commit()
+
+        assert created is True
+        with session_maker() as session:
+            task = session.query(MaintenanceTask).one()
+            assert task.status == MaintenanceTaskStatus.PENDING
+            assert task.processor_type == CONVERSATION_EXPIRATION_PROCESSOR
+            assert task.processor_json == '{}'
+
+    def test_enqueue_conversation_expiration_task_is_idempotent(self, session_maker):
+        """Do not enqueue duplicate expiration work while a task is pending."""
+        with session_maker() as session:
+            session.add(Org(name='retention-enabled', conversation_expiration=30))
+            session.add(
+                MaintenanceTask(
+                    status=MaintenanceTaskStatus.PENDING,
+                    processor_type=CONVERSATION_EXPIRATION_PROCESSOR,
+                    processor_json='{}',
+                )
+            )
+            session.commit()
+
+        with session_maker() as session:
+            created = enqueue_conversation_expiration_task(session)
+            session.commit()
+
+        assert created is False
+        with session_maker() as session:
+            assert session.query(MaintenanceTask).count() == 1
 
     def test_set_stale_task_error(self, session_maker):
         """Test that stale tasks are marked as error."""


### PR DESCRIPTION
## Summary
- enqueue daily conversation-expiration maintenance work when any org has conversation_expiration configured
- add a maintenance processor that deletes expired V1 conversation metadata, SaaS mappings, and start tasks per org policy
- cover enqueue idempotency and processor retention behavior with unit tests

Fixes #12656

## Tests
- PYTHONPATH=".:$PYTHONPATH" poetry run --project=enterprise pytest --forked -q enterprise/tests/unit/test_run_maintenance_tasks.py enterprise/tests/unit/test_conversation_expiration_processor.py --confcutdir=enterprise/tests/unit
- PYTHONPATH=".:$PYTHONPATH" poetry run --project=enterprise pre-commit run --config enterprise/dev_config/python/.pre-commit-config.yaml --files enterprise/run_maintenance_tasks.py enterprise/server/maintenance_task_processor/conversation_expiration_processor.py enterprise/tests/unit/test_conversation_expiration_processor.py enterprise/tests/unit/test_run_maintenance_tasks.py