### PR TITLE
feat: explicit OH_DEPLOYMENT_MODE flag; gate cloud-account CTA to enterprise cloud

### DIFF
--- a/enterprise/server/constants.py
+++ b/enterprise/server/constants.py
@@ -19,8 +19,7 @@ IS_FEATURE_ENV = (
 IS_LOCAL_ENV = bool(HOST == 'localhost')
 
 
-# _is_all_hands_managed_domain() can be removed/replaced when a self-hosted specific
-# env var is created (e.g is_self_hosted` or `deployment_mode`)
+# Explicit OH_DEPLOYMENT_MODE wins; _is_all_hands_managed_domain() is the host fallback.
 def _is_all_hands_managed_domain(host: str) -> bool:
     """Check if the host is an All-Hands managed domain."""
     return (
@@ -32,12 +31,14 @@ def _is_all_hands_managed_domain(host: str) -> bool:
 
 
 def _get_deployment_mode() -> str:
-    """Determine deployment mode based on WEB_HOST.
+    """Determine deployment mode.
 
-    Returns:
-        'cloud' for All-Hands managed infrastructure (app.all-hands.dev, etc.)
-        'self_hosted' for enterprise self-hosted deployments (customer domains)
+    Honors an explicit OH_DEPLOYMENT_MODE ('cloud' | 'self_hosted'); otherwise
+    infers from WEB_HOST (managed domain -> 'cloud', else 'self_hosted').
     """
+    explicit = os.getenv('OH_DEPLOYMENT_MODE', '').strip().lower()
+    if explicit in ('cloud', 'self_hosted'):
+        return explicit
     if _is_all_hands_managed_domain(HOST):
         return 'cloud'
     return 'self_hosted'

--- a/enterprise/tests/unit/server/test_constants.py
+++ b/enterprise/tests/unit/server/test_constants.py
@@ -8,6 +8,11 @@ import pytest
 class TestDeploymentMode:
     """Tests for _get_deployment_mode() and _is_all_hands_managed_domain() functions."""
 
+    @pytest.fixture(autouse=True)
+    def _no_explicit_mode(self, monkeypatch):
+        """Host-heuristic tests must ignore any ambient OH_DEPLOYMENT_MODE."""
+        monkeypatch.delenv('OH_DEPLOYMENT_MODE', raising=False)
+
     @pytest.mark.parametrize(
         'web_host,expected_mode',
         [
@@ -33,6 +38,34 @@ class TestDeploymentMode:
         """Test that DEPLOYMENT_MODE is correctly determined based on WEB_HOST."""
         with patch.dict('os.environ', {'WEB_HOST': web_host}):
             # Need to reimport to pick up the mocked environment variable
+            import importlib
+
+            import server.constants as constants_module
+
+            importlib.reload(constants_module)
+
+            assert constants_module.DEPLOYMENT_MODE == expected_mode
+
+    @pytest.mark.parametrize(
+        'flag,web_host,expected_mode',
+        [
+            # Explicit flag wins over the host heuristic
+            ('self_hosted', 'app.all-hands.dev', 'self_hosted'),
+            ('cloud', 'openhands.acme.com', 'cloud'),
+            # Case/whitespace tolerant
+            ('  Self_Hosted ', 'app.all-hands.dev', 'self_hosted'),
+            # Invalid/empty values fall back to the host heuristic
+            ('bogus', 'app.all-hands.dev', 'cloud'),
+            ('', 'openhands.acme.com', 'self_hosted'),
+        ],
+    )
+    def test_explicit_deployment_mode_overrides_host(
+        self, flag: str, web_host: str, expected_mode: str
+    ):
+        """OH_DEPLOYMENT_MODE takes precedence; invalid values fall back to WEB_HOST."""
+        with patch.dict(
+            'os.environ', {'OH_DEPLOYMENT_MODE': flag, 'WEB_HOST': web_host}
+        ):
             import importlib
 
             import server.constants as constants_module

--- a/frontend/src/components/shared/modals/settings/model-selector.tsx
+++ b/frontend/src/components/shared/modals/settings/model-selector.tsx
@@ -13,6 +13,7 @@ import { HelpLink } from "#/ui/help-link";
 import { PRODUCT_URL } from "#/utils/constants";
 import { useSearchProviders } from "#/hooks/query/use-search-providers";
 import { useProviderModels } from "#/hooks/query/use-provider-models";
+import { useAppMode } from "#/hooks/use-app-mode";
 
 interface ModelSelectorProps {
   isDisabled?: boolean;
@@ -46,6 +47,8 @@ export function ModelSelector({
     isLoading: isLoadingModels,
     error: modelsError,
   } = useProviderModels(selectedProvider);
+  // The OpenHands-account CTA points at the cloud product; only show it there.
+  const { isEnterpriseCloud } = useAppMode();
 
   const verifiedProviders = React.useMemo(
     () => providers.filter((p) => p.verified),
@@ -159,7 +162,7 @@ export function ModelSelector({
         </Autocomplete>
       </fieldset>
 
-      {selectedProvider === "openhands" && (
+      {selectedProvider === "openhands" && isEnterpriseCloud && (
         <HelpLink
           testId="openhands-account-help"
           text={t(I18nKey.SETTINGS$NEED_OPENHANDS_ACCOUNT)}

--- a/openhands/app_server/web_client/web_client_deployment_mode.py
+++ b/openhands/app_server/web_client/web_client_deployment_mode.py
@@ -4,15 +4,18 @@ from typing import Literal
 DeploymentMode = Literal['cloud', 'self_hosted']
 
 
-# This can be removed / replaced when a DeploymentMode (or similar) env var is created.
+# Honors an explicit OH_DEPLOYMENT_MODE; the OH_WEB_HOST/WEB_HOST heuristic is the fallback.
 def get_deployment_mode() -> DeploymentMode | None:
-    """Get deployment mode based on OH_WEB_HOST environment variable.
+    """Get deployment mode.
 
-    Returns:
-        'cloud' for All-Hands managed infrastructure (app.all-hands.dev, etc.)
-        'self_hosted' for enterprise self-hosted deployments (customer domains)
-        None if WEB_HOST is not set
+    Honors an explicit OH_DEPLOYMENT_MODE ('cloud' | 'self_hosted'); otherwise
+    infers from OH_WEB_HOST/WEB_HOST (managed domain -> 'cloud'), or None if unset.
     """
+    explicit = os.getenv('OH_DEPLOYMENT_MODE', '').strip().lower()
+    if explicit == 'cloud':
+        return 'cloud'
+    if explicit == 'self_hosted':
+        return 'self_hosted'
     web_host = os.getenv('OH_WEB_HOST', os.getenv('WEB_HOST', '')).strip()
     if not web_host:
         return None

--- a/tests/unit/app_server/test_web_client_deployment_mode.py
+++ b/tests/unit/app_server/test_web_client_deployment_mode.py
@@ -12,6 +12,12 @@ from openhands.app_server.web_client.web_client_deployment_mode import (
 class TestGetDeploymentMode:
     """Tests for get_deployment_mode() function."""
 
+    @pytest.fixture(autouse=True)
+    def _hermetic_env(self, monkeypatch):
+        """Each test fully controls deployment-mode env; ignore ambient values."""
+        for var in ('OH_DEPLOYMENT_MODE', 'OH_WEB_HOST', 'WEB_HOST'):
+            monkeypatch.delenv(var, raising=False)
+
     @pytest.mark.parametrize(
         'web_host,expected',
         [
@@ -79,3 +85,26 @@ class TestGetDeploymentMode:
                 del os.environ['OH_WEB_HOST']
             result = get_deployment_mode()
             assert result == 'self_hosted'
+
+    @pytest.mark.parametrize(
+        'flag,web_host,expected',
+        [
+            # Explicit flag wins over the host heuristic
+            ('self_hosted', 'app.all-hands.dev', 'self_hosted'),
+            ('cloud', 'customer.example.com', 'cloud'),
+            # Case/whitespace tolerant
+            (' Cloud ', 'customer.example.com', 'cloud'),
+            # Invalid value falls back to the host chain
+            ('bogus', 'app.all-hands.dev', 'cloud'),
+        ],
+    )
+    def test_explicit_deployment_mode_overrides_host(
+        self, flag: str, web_host: str, expected: str
+    ):
+        """OH_DEPLOYMENT_MODE takes precedence; invalid values fall back to WEB_HOST."""
+        with patch.dict(
+            'os.environ',
+            {'OH_DEPLOYMENT_MODE': flag, 'WEB_HOST': web_host},
+            clear=False,
+        ):
+            assert get_deployment_mode() == expected


### PR DESCRIPTION
## What

OHE runs in `app_mode=saas`, so the cloud-vs-self-hosted distinction lives in `deployment_mode`, **not** `isSaasMode`. `deployment_mode` was inferred from `WEB_HOST` (`*.all-hands.dev` / `*.openhands.ai` ⇒ cloud), which mislabels self-hosted OHE installs that sit under an All-Hands domain (e.g. our test VMs) as `cloud`.

This makes the signal explicit and reliable:

- Honor an explicit **`OH_DEPLOYMENT_MODE`** (`cloud` | `self_hosted`) in both resolvers — `enterprise/server/constants.py` and `openhands/app_server/web_client/web_client_deployment_mode.py` — taking precedence over the host heuristic. When unset/invalid, behavior is byte-for-byte identical to today, so **cloud SaaS is unaffected**.
- Gate the "Need an OpenHands Account?" CTA in the model selector (links to `app.all-hands.dev`) on `useAppMode().isEnterpriseCloud`, so it shows on cloud but not on self-hosted OHE.

Chart side (setting `OH_DEPLOYMENT_MODE=self_hosted` on OHE deployments) is the companion PR: OpenHands/OpenHands-Cloud#713.

**Deliberately scoped:** only the genuinely cloud-only CTA changes. The many shared `app_mode==='saas'` conditionals are correct for both cloud and OHE and are left untouched; future cloud-only-vs-self-hosted gating can key on this same flag, case by case.

## Test

- `enterprise/tests/unit/server/test_constants.py` — 28 passed (added explicit-override precedence, invalid-fallback, case/whitespace cases)
- `tests/unit/app_server/test_web_client_deployment_mode.py` — 21 passed (same)
- frontend — lint/tsc clean, `model-selector` + `llm-settings` vitest 79 passed

Based on `main` and independent of the LLM-settings stack: the frontend edit is in regions disjoint from #14774, so it composes in either merge order (verified — clean rebase onto main, no conflict).

HUMAN: Local unit/lint/typecheck/render checks pass; R02 self-hosted click-test pending.

- [x] A human has tested these changes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-454cb0a   docker.openhands.dev/openhands/openhands:454cb0a
```