### PR TITLE
fix: redact credentials from PluginSpec.source during serialization

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_models.py
+++ b/openhands/app_server/app_conversation/app_conversation_models.py
@@ -1,9 +1,10 @@
+import re
 from datetime import datetime
 from enum import Enum
 from typing import Any, Literal
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field, SecretStr
+from pydantic import BaseModel, Field, SecretStr, field_serializer
 
 from openhands.agent_server.models import (
     ImageContent,
@@ -41,6 +42,16 @@ class ConversationTrigger(Enum):
     AUTOMATION = 'automation'
 
 
+def _redact_url_credentials(url: str) -> str:
+    """Redact embedded credentials from a URL (https://user:token@host → https://****@host).
+
+    # TODO: replace with `from openhands.sdk.utils.redact import redact_url_credentials`
+    # once the SDK pin is bumped to include OpenHands/software-agent-sdk#2154.
+    """
+    m = re.match(r'^(https?://)([^@/]+)@(.+)$', url)
+    return f'{m.group(1)}****@{m.group(3)}' if m else url
+
+
 class AgentType(Enum):
     """Agent type for conversation."""
 
@@ -59,6 +70,11 @@ class PluginSpec(PluginSource):
         default=None,
         description='User-provided values for plugin input parameters',
     )
+
+    @field_serializer('source')
+    @classmethod
+    def _serialize_source(cls, source: str) -> str:
+        return _redact_url_credentials(source)
 
     @property
     def display_name(self) -> str:

--- a/tests/unit/app_server/test_models.py
+++ b/tests/unit/app_server/test_models.py
@@ -7,6 +7,7 @@ from openhands.app_server.app_conversation.app_conversation_models import (
     AppConversationInfo,
     AppConversationStartRequest,
     AppConversationUpdateRequest,
+    PluginSpec,
 )
 from openhands.app_server.event_callback.event_callback_models import (
     EventCallback,
@@ -98,3 +99,39 @@ def test_app_conversation_update_request_title_field_updates_conversation_info()
         'Title was not updated on AppConversationInfo. '
         "Ensure 'title' is in AppConversationUpdateRequest.model_fields_set."
     )
+
+
+class TestPluginSpecSourceRedaction:
+    """Verify PluginSpec.source credentials are redacted on serialization."""
+
+    def test_model_dump_redacts_credentials(self):
+        spec = PluginSpec(source='https://oauth2:SECRET@gitlab.com/org/repo.git')
+        dumped = spec.model_dump()
+        assert '****' in dumped['source']
+        assert 'SECRET' not in dumped['source']
+
+    def test_model_dump_json_redacts_credentials(self):
+        spec = PluginSpec(source='https://user:pass@github.com/org/repo.git')
+        json_str = spec.model_dump_json()
+        assert 'pass' not in json_str
+        assert '****' in json_str
+
+    def test_source_attribute_retains_raw_value(self):
+        url = 'https://oauth2:SECRET@gitlab.com/org/repo.git'
+        spec = PluginSpec(source=url)
+        assert spec.source == url
+
+    def test_clean_url_passes_through_unchanged(self):
+        url = 'https://github.com/org/repo.git'
+        spec = PluginSpec(source=url)
+        assert spec.model_dump()['source'] == url
+
+    def test_redaction_nested_in_start_request(self):
+        """Credentials stay out of model_dump when PluginSpec is nested."""
+        req = AppConversationStartRequest(
+            plugins=[PluginSpec(source='https://token@github.com/org/repo.git')]
+        )
+        dumped = req.model_dump()
+        plugin_source = dumped['plugins'][0]['source']
+        assert 'token' not in plugin_source
+        assert '****' in plugin_source


### PR DESCRIPTION
HUMAN: 

redact credentials from PluginSpec.source during serialization

- [x] A human has tested these changes.

## Why

`AppConversationStartTask` is persisted to SQL via `task.model_dump()` at `sql_app_conversation_start_task_service.py:246`. When a `PluginSpec.source` contains embedded credentials (e.g. `https://oauth2:token@gitlab.com/org/repo.git`), those credentials are stored in plaintext in the database.

Closes #12959.

## Summary

- Adds a `@field_serializer('source')` on `PluginSpec` that calls `_redact_url_credentials()` at serialization time (`model_dump` / `model_dump_json`), replacing `user:token` with `****`.
- The raw value remains accessible as `plugin_spec.source` at runtime so git clone operations still work.
- Includes a local copy of the redaction regex with a TODO comment to replace it with `from openhands.sdk.utils.redact import redact_url_credentials` once the SDK pin is bumped to include OpenHands/software-agent-sdk#2154.
- 5 new tests: dump redacts, JSON redacts, runtime value intact, clean URL unchanged, nested in `AppConversationStartRequest`.

## How to Test

```python
from openhands.app_server.app_conversation.app_conversation_models import PluginSpec

spec = PluginSpec(source="https://oauth2:SECRET@gitlab.com/org/repo.git")
assert spec.source == "https://oauth2:SECRET@gitlab.com/org/repo.git"  # raw in memory
assert "SECRET" not in spec.model_dump_json()                           # redacted on serialize
```

Or run:

```bash
uv run pytest tests/unit/app_server/test_models.py::TestPluginSpecSourceRedaction -v
```

<!-- HUMAN: Please review this PR. -->
<!-- [ ] I have tested this change -->

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-4ca056b   docker.openhands.dev/openhands/openhands:4ca056b
```