### PR TITLE
fix(acp): surface acp_server on cloud conversations so the model picker renders

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_models.py
+++ b/openhands/app_server/app_conversation/app_conversation_models.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Any, Literal
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field, SecretStr, field_serializer
+from pydantic import BaseModel, Field, SecretStr, computed_field, field_serializer
 
 from openhands.agent_server.models import (
     ImageContent,
@@ -26,6 +26,12 @@ from openhands.sdk.llm import MetricsSnapshot
 from openhands.sdk.plugin import PluginSource
 
 __all__ = ['SandboxGroupingStrategy']
+
+# Canonical conversation-tag key under which the active ACP provider key
+# ('claude-code', 'codex', 'gemini-cli') is stored. Lowercase-alphanumeric to satisfy
+# the SDK tag-key validator (^[a-z0-9]+$); mirrors agent-canvas' ACP_SERVER_TAG_KEY.
+# The typed ``AppConversationInfo.acp_server`` field is a projection of this tag.
+ACP_SERVER_TAG_KEY = 'acpserver'
 
 
 class ConversationTrigger(Enum):
@@ -132,6 +138,22 @@ class AppConversationInfo(BaseModel):
 
     created_at: datetime = Field(default_factory=utc_now)
     updated_at: datetime = Field(default_factory=utc_now)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def acp_server(self) -> str | None:
+        """Active ACP provider key ('claude-code', 'codex', 'gemini-cli'), else None.
+
+        A typed projection of the ``acpserver`` tag (the same key agent-canvas
+        reads) so the conversation UI can resolve a provider brand label without
+        a dedicated column. Riding the tag keeps a single source of truth that
+        round-trips through the DB ``tags`` column for free. Gated on
+        ``agent_kind`` so a stray tag never reports a provider for an OpenHands
+        conversation.
+        """
+        if self.agent_kind != 'acp':
+            return None
+        return self.tags.get(ACP_SERVER_TAG_KEY)
 
 
 class AppConversationSortOrder(Enum):

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -25,6 +25,7 @@ from openhands.app_server.app_conversation.app_conversation_info_service import 
     AppConversationInfoService,
 )
 from openhands.app_server.app_conversation.app_conversation_models import (
+    ACP_SERVER_TAG_KEY,
     AgentType,
     AppConversation,
     AppConversationInfo,
@@ -381,9 +382,10 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 # Persist the active ACP provider key so the conversation UI
                 # can resolve a brand label ("Claude Code", "Codex", …) via
                 # the SDK registry without keeping a per-conversation column.
+                # Surfaced to the UI as the projected ``acp_server`` field.
                 acp_user = await self.user_context.get_user_info()
                 if isinstance(acp_user.agent_settings, ACPAgentSettings):
-                    tags['acp_server'] = acp_user.agent_settings.acp_server
+                    tags[ACP_SERVER_TAG_KEY] = acp_user.agent_settings.acp_server
             else:
                 llm_model = request_agent.llm.model
                 agent_kind = 'openhands'

--- a/tests/unit/app_server/test_models.py
+++ b/tests/unit/app_server/test_models.py
@@ -4,6 +4,8 @@ from uuid import UUID, uuid4
 import pytest
 
 from openhands.app_server.app_conversation.app_conversation_models import (
+    ACP_SERVER_TAG_KEY,
+    AppConversation,
     AppConversationInfo,
     AppConversationStartRequest,
     AppConversationUpdateRequest,
@@ -99,6 +101,58 @@ def test_app_conversation_update_request_title_field_updates_conversation_info()
         'Title was not updated on AppConversationInfo. '
         "Ensure 'title' is in AppConversationUpdateRequest.model_fields_set."
     )
+
+
+class TestAcpServerProjection:
+    """``AppConversationInfo.acp_server`` projects the ``acpserver`` tag.
+
+    The conversation UI on the cloud backend reads this top-level field to
+    resolve a provider brand label and render the model picker.
+    """
+
+    def _acp_info(self, **overrides) -> AppConversationInfo:
+        kwargs: dict = {
+            'created_by_user_id': 'u',
+            'sandbox_id': 'sb',
+            'agent_kind': 'acp',
+            'tags': {ACP_SERVER_TAG_KEY: 'codex'},
+        }
+        kwargs.update(overrides)
+        return AppConversationInfo(**kwargs)
+
+    def test_projects_provider_key_from_tag(self):
+        assert self._acp_info().acp_server == 'codex'
+
+    def test_serialized_into_json_for_the_canvas(self):
+        info = self._acp_info()
+        assert info.model_dump()['acp_server'] == 'codex'
+        assert info.model_dump_json().find('"acp_server":"codex"') != -1
+
+    def test_survives_db_roundtrip_via_tags_only(self):
+        # The list endpoint rebuilds info from stored columns; ``tags`` is the
+        # only carrier, so re-deriving from it alone must still yield the key.
+        info = self._acp_info()
+        restored = AppConversationInfo(
+            created_by_user_id=None,
+            sandbox_id='sb',
+            agent_kind='acp',
+            tags=info.tags,
+        )
+        assert restored.acp_server == 'codex'
+
+    def test_survives_app_conversation_build(self):
+        # ``_build_conversation`` does ``AppConversation(**info.model_dump())``.
+        info = self._acp_info()
+        conv = AppConversation(**info.model_dump())
+        assert conv.acp_server == 'codex'
+
+    def test_none_for_openhands_even_with_stray_tag(self):
+        info = self._acp_info(agent_kind='openhands')
+        assert info.acp_server is None
+
+    def test_none_when_tag_absent(self):
+        info = self._acp_info(tags={})
+        assert info.acp_server is None
 
 
 class TestPluginSpecSourceRedaction:

--- a/tests/unit/app_server/test_webhook_router_acp.py
+++ b/tests/unit/app_server/test_webhook_router_acp.py
@@ -17,6 +17,7 @@ from sqlalchemy.pool import StaticPool
 
 from openhands.agent_server.models import ConversationInfo, Success
 from openhands.app_server.app_conversation.app_conversation_models import (
+    ACP_SERVER_TAG_KEY,
     AppConversationInfo,
 )
 from openhands.app_server.app_conversation.sql_app_conversation_info_service import (
@@ -183,12 +184,13 @@ async def test_acp_conversation_sets_agent_kind(async_session, service, sandbox_
 async def test_acp_server_tag_preserved_on_webhook_update(
     async_session, service, sandbox_record
 ):
-    """``tags['acp_server']`` set during creation must survive a webhook update.
+    """The ``acpserver`` tag set during creation must survive a webhook update.
 
-    The live-status service stamps the active ACP provider key into
-    ``tags['acp_server']`` when the conversation is first stored. Subsequent
-    webhook updates merge incoming tags onto existing ones, so the provider
-    key must still be present after a state-change webhook fires.
+    The live-status service stamps the active ACP provider key into the
+    ``acpserver`` tag when the conversation is first stored. Subsequent webhook
+    updates merge incoming tags onto existing ones, so the provider key — and
+    the ``acp_server`` field projected from it — must still be present after a
+    state-change webhook fires.
     """
     acp_info = _make_acp_conversation_info(acp_command=['my-acp'])
     conversation_id = acp_info.id
@@ -198,7 +200,8 @@ async def test_acp_server_tag_preserved_on_webhook_update(
         title='Test',
         sandbox_id=sandbox_record.id,
         created_by_user_id=sandbox_record.created_by_user_id,
-        tags={'acp_server': 'claude-code'},
+        agent_kind='acp',
+        tags={ACP_SERVER_TAG_KEY: 'claude-code'},
     )
 
     with patch(
@@ -213,7 +216,9 @@ async def test_acp_server_tag_preserved_on_webhook_update(
 
     saved = await service.get_app_conversation_info(conversation_id)
     assert saved is not None
-    assert saved.tags.get('acp_server') == 'claude-code'
+    assert saved.tags.get(ACP_SERVER_TAG_KEY) == 'claude-code'
+    # The projected field is what the conversation UI reads on the cloud backend.
+    assert saved.acp_server == 'claude-code'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

surface acp_server on cloud conversations so the model picker renders


- [x] A human has tested these changes.

AGENT:

---

## Why

The ACP model picker is missing when the canvas is connected to a cloud/SaaS backend — the user sees only the current model label (e.g. `gpt-5.5/medium`) and a settings link, with no switchable model list.

The canvas reads a **top-level** `acp_server` field off the `GET /api/v1/app-conversations` JSON to look up the provider's `available_models` and render the picker. The Python `AppConversationInfo` model never declared that field, so cloud-backend conversations always saw `acp_server: undefined` → no provider found → empty model list → picker hidden.

The provider key *was* already being persisted — in the `tags` column — but under the key `acp_server` (underscore), which violates the SDK tag-key validator (`^[a-z0-9]+$`). The canonical key used by the canvas and SDK is `acpserver`.

Fixes #14796.

## Summary

- Expose `acp_server` on `AppConversationInfo` as a **`@computed_field` projection of the `acpserver` tag** (the contract the canvas `AppConversation` type already documents: *"Populated from `info.tags.acpserver`"*). Gated on `agent_kind == 'acp'` so a stray tag never reports a provider for an OpenHands conversation.
- Stamp the provider key under the canonical `acpserver` tag key (was the invalid `acp_server`), via a shared `ACP_SERVER_TAG_KEY` constant.

**Why a computed field rather than a stored field + dual-written tag:** the broken list endpoint rebuilds conversations from the DB via `_to_info`, which only repopulates declared columns. A plain `acp_server` field with no SQL column would be silently `None` on exactly that endpoint — but `_to_info` already round-trips `tags`. Projecting from the tag keeps a single source of truth, survives the DB round-trip and webhook tag-merges for free, needs **no migration**, and unifies the representation with the direct agent-server path.

## Issue Number

#14796

## How to Test

Automated (run against the pinned `openhands-sdk==1.28.0`):

```bash
uv sync --frozen
uv run pytest tests/unit/app_server/test_models.py tests/unit/app_server/test_webhook_router_acp.py -q
```

- `TestAcpServerProjection` covers: projection from the tag, JSON serialization, DB-round-trip-via-tags-only, the `AppConversation(**info.model_dump())` build path, and `None` for non-ACP / absent-tag.
- `test_acp_server_tag_preserved_on_webhook_update` now asserts both the canonical `acpserver` tag and the projected `acp_server` field survive a webhook update.

Manual: with an ACP provider selected, start a conversation on the cloud backend and confirm `GET /api/v1/app-conversations` returns `acp_server` (e.g. `"codex"`) and the canvas renders the switchable model picker.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No DB migration. The companion client-side fallback in agent-canvas (`use-chat-input-model-state.ts`, falls back to `settings.agent_settings.acp_server`) can remain as defence-in-depth; with this change the live conversation's own `acp_server` is authoritative so mid-conversation model switches are attributed to the session rather than the home/settings context.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-a6be359   docker.openhands.dev/openhands/openhands:a6be359
```