### PR TITLE
fix: update Bitbucket skill token guidance

### DIFF
--- a/skills/bitbucket.md
+++ b/skills/bitbucket.md
@@ -9,7 +9,9 @@ triggers:
 ---
 
 You have access to an environment variable, `BITBUCKET_TOKEN`, which allows you to interact with
-the Bitbucket API.
+the Bitbucket API. For Bitbucket Cloud API tokens, `BITBUCKET_TOKEN` must be in
+the `email:api_token` format. The API token must be a scoped Atlassian API token
+with at least the `read:user:bitbucket` scope.
 
 <IMPORTANT>
 You can use `curl` with the `BITBUCKET_TOKEN` to interact with Bitbucket's API.
@@ -17,7 +19,7 @@ ALWAYS use the Bitbucket API for operations instead of a web browser.
 ALWAYS use the `create_bitbucket_pr` tool to open a pull request
 </IMPORTANT>
 
-If you encounter authentication issues when pushing to Bitbucket (such as password prompts or permission errors), the old token may have expired. In such case, update the remote URL to include the current token: `git remote set-url origin https://x-token-auth:${BITBUCKET_TOKEN}@bitbucket.org/username/repo.git`
+If you encounter authentication issues when pushing to Bitbucket (such as password prompts or permission errors), the old token may have expired or the token may not be in the required `email:api_token` format. In that case, create a scoped Atlassian API token, store it in `BITBUCKET_TOKEN` as `email:api_token`, URL-encode the email and token, and update the remote URL with encoded credentials: `git remote set-url origin https://<url_encoded_email>:<url_encoded_api_token>@bitbucket.org/username/repo.git`.
 
 Here are some instructions for pushing, but ONLY do this if the user asks you to:
 * NEVER push directly to the `main` or `master` branch

--- a/tests/unit/server/routes/test_skills_api.py
+++ b/tests/unit/server/routes/test_skills_api.py
@@ -267,3 +267,15 @@ def test_global_skills_dir_points_to_repo_root():
         f'Expected skill file not found: {expected_skill}. '
         f'GLOBAL_SKILLS_DIR may be pointing to wrong location.'
     )
+
+
+def test_bitbucket_skill_documents_api_token_auth_format():
+    """Bitbucket skill guidance should match the API-token flow from settings."""
+    from openhands.app_server.user.skills_router import GLOBAL_SKILLS_DIR
+
+    bitbucket_skill = GLOBAL_SKILLS_DIR / 'bitbucket.md'
+    content = bitbucket_skill.read_text()
+
+    assert 'email:api_token' in content
+    assert 'https://${BITBUCKET_TOKEN}@bitbucket.org' not in content
+    assert 'https://x-token-auth:${BITBUCKET_TOKEN}@bitbucket.org' not in content


### PR DESCRIPTION
HUMAN:

- [ ] A human has tested these changes.

AGENT:

---

## Why

Bitbucket Cloud API tokens now need to be supplied as `email:api_token`. The app UI and backend were updated in #14363, but the bundled Bitbucket skill still told agents to use the stale raw `x-token-auth:${BITBUCKET_TOKEN}` git remote shape. That can make agent-driven Bitbucket operations fail even after the provider fix.

## Summary

- Update `skills/bitbucket.md` to document the required `email:api_token` format and `read:user:bitbucket` scope.
- Replace stale `x-token-auth:${BITBUCKET_TOKEN}` remote guidance with URL-encoded email/token credentials.
- Add a regression test so the Bitbucket skill cannot silently drift back to stale token guidance.

## Issue Number

Fixes #14304

## How to Test

- `poetry run pytest tests/unit/server/routes/test_skills_api.py::test_bitbucket_skill_documents_api_token_auth_format -q`
- `poetry run pytest tests/unit/server/routes/test_skills_api.py -q`
- `poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files skills/bitbucket.md tests/unit/server/routes/test_skills_api.py`

## Video/Screenshots

N/A. Markdown skill guidance and regression test only.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

#14363 fixed the main Bitbucket provider/API-token flow. This PR closes the remaining agent-skill guidance gap so agent instructions match the fixed provider behavior.
