### PR TITLE
fix: make a member's settings save private (stop the org-wide broadcast)

### DIFF
--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -9,14 +9,12 @@ from pydantic import SecretStr
 from server.auth.token_manager import TokenManager
 from server.constants import LITE_LLM_API_URL
 from server.logger import logger
-from server.routes.org_models import OrgMemberSettingsUpdate
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 from storage.database import a_session_maker
 from storage.lite_llm_manager import LiteLlmManager, get_openhands_cloud_key_alias
 from storage.org import Org
 from storage.org_member import OrgMember
-from storage.org_member_store import OrgMemberStore
 from storage.org_store import OrgStore
 from storage.user import User
 from storage.user_settings import UserSettings
@@ -41,28 +39,6 @@ from openhands.sdk.llm.utils.openhands_provider import (
 # ACP environment variables) — both are dict-of-items collections that
 # represent one member's personal configuration, not org-wide defaults.
 MEMBER_PRIVATE_AGENT_KEYS: frozenset[str] = WHOLESALE_REPLACEMENT_KEYS
-
-
-def _split_member_private_keys(
-    agent_settings_diff: dict[str, Any],
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Split an agent_settings dump into (shared, private) halves.
-
-    The shared half is safe to write to ``org.agent_settings`` and to
-    broadcast through ``update_all_members_settings_async``. The private
-    half must be applied only to the acting member's row.
-    """
-    private = {
-        key: agent_settings_diff[key]
-        for key in MEMBER_PRIVATE_AGENT_KEYS
-        if key in agent_settings_diff
-    }
-    shared = {
-        key: value
-        for key, value in agent_settings_diff.items()
-        if key not in MEMBER_PRIVATE_AGENT_KEYS
-    }
-    return shared, private
 
 
 @dataclass
@@ -375,54 +351,31 @@ class SaasSettingsStore(SettingsStore):
                 )
 
             effective_agent_settings_diff = self._get_persisted_agent_settings(item)
-
-            # Keep mcp_config / acp_env scoped to the acting member only.
-            # ``shared_agent_settings_diff`` is the slice safe for org-wide
-            # state; ``private_agent_settings_diff`` is applied below to the
-            # acting member's row only so other members don't inherit one
-            # user's MCP servers (or ACP env vars).
-            shared_agent_settings_diff, private_agent_settings_diff = (
-                _split_member_private_keys(effective_agent_settings_diff)
-            )
-
-            # Strip any pre-existing private keys from the org dump before
-            # merging, so legacy values written by older code paths are
-            # cleaned up on the next save and stop leaking to other members.
-            org_agent_settings_dump = OrgStore.get_agent_settings_from_org(
-                org
-            ).model_dump(mode='json')
-            for private_key in MEMBER_PRIVATE_AGENT_KEYS:
-                org_agent_settings_dump.pop(private_key, None)
-
-            # Single assignment so SQLAlchemy tracks the change
-            org.agent_settings = deep_merge_with_wholesale_keys(
-                org_agent_settings_dump,
-                shared_agent_settings_diff,
-            )
-
             effective_conversation_diff = item.conversation_settings.model_dump(
                 mode='json'
             )
-            org.conversation_settings = deep_merge(
-                OrgStore.get_conversation_settings_from_org(org).model_dump(
-                    mode='json'
-                ),
+
+            # A member's personal save writes only their own row. It must not
+            # mutate the org default or other members' rows: org-wide defaults
+            # are set through the dedicated org-defaults path, and members
+            # live-inherit the org default at load() (which merges the org dump
+            # under the member diff), so no org-wide broadcast is needed.
+            org_member.agent_settings_diff = deep_merge_with_wholesale_keys(
+                dict(org_member.agent_settings_diff),
+                effective_agent_settings_diff,
+            )
+            org_member.conversation_settings_diff = deep_merge(
+                dict(org_member.conversation_settings_diff),
                 effective_conversation_diff,
             )
 
+            # Top-level (non-agent/conversation) settings are the user's own.
             kwargs = item.model_dump(context={'expose_secrets': True})
             kwargs.pop('agent_settings', None)
             kwargs.pop('conversation_settings', None)
-
             for key, value in kwargs.items():
                 if hasattr(user, key):
                     setattr(user, key, value)
-                if hasattr(org, key) and key not in {
-                    'llm_api_key',
-                    'agent_settings',
-                    'conversation_settings',
-                }:
-                    setattr(org, key, value)
 
             current_member_llm_api_key = item.agent_settings.llm.api_key
             org_default_llm_api_key = org.llm_api_key
@@ -436,29 +389,6 @@ class SaasSettingsStore(SettingsStore):
                 if current_member_llm_api_key
                 else None
             )
-
-            await OrgMemberStore.update_all_members_settings_async(
-                session,
-                org_id,
-                OrgMemberSettingsUpdate(
-                    agent_settings_diff=shared_agent_settings_diff,
-                    conversation_settings_diff=effective_conversation_diff,
-                    llm_api_key=(
-                        current_member_llm_api_key_raw  # type: ignore[arg-type]
-                        if not uses_managed_llm_key
-                        else None
-                    ),
-                ),
-            )
-
-            # Member-private keys (mcp_config, acp_env) live only on the
-            # acting member's row. Use the wholesale-replacement semantics
-            # so deletes stick (APP-1862).
-            if private_agent_settings_diff:
-                org_member.agent_settings_diff = deep_merge_with_wholesale_keys(
-                    dict(org_member.agent_settings_diff),
-                    private_agent_settings_diff,
-                )
 
             if uses_managed_llm_key and current_member_llm_api_key is not None:
                 # Managed/proxy key — store on this member but mark as org-managed

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -569,10 +569,12 @@ async def test_load_canonicalizes_legacy_litellm_proxy_llm_profiles(
 
 
 @pytest.mark.asyncio
-async def test_store_updates_org_defaults_and_all_members_for_shared_keys(
+async def test_member_save_stays_private_and_does_not_clobber_org_or_members(
     session_maker, async_session_maker, org_with_multiple_members_fixture
 ):
-    """External provider keys should still sync as an org-wide shared snapshot."""
+    """A member's personal save writes only their own row: it must not mutate
+    the org default or other members. Other members keep their own model + key
+    (the old behavior sprayed the saver's external model/key across the org)."""
     from sqlalchemy import select
     from storage.org import Org
     from storage.org_member import OrgMember
@@ -595,9 +597,10 @@ async def test_store_updates_org_defaults_and_all_members_for_shared_keys(
     with session_maker() as session:
         org = session.execute(select(Org).where(Org.id == org_id)).scalars().first()
         assert org is not None
-        assert org.agent_settings['llm']['model'] == 'anthropic/claude-sonnet-4'
-        assert org.agent_settings['llm']['base_url'] == 'https://api.anthropic.com/v1'
-        assert org.conversation_settings['max_iterations'] == 100
+        # The org default is NOT mutated by a member's personal save.
+        assert (org.agent_settings.get('llm') or {}).get(
+            'model'
+        ) != 'anthropic/claude-sonnet-4'
 
         members = {
             str(member.user_id): member
@@ -609,17 +612,23 @@ async def test_store_updates_org_defaults_and_all_members_for_shared_keys(
         }
         assert len(members) == 3
 
-        for member in members.values():
-            assert (
-                member.agent_settings_diff['llm']['model']
-                == 'anthropic/claude-sonnet-4'
-            )
-            assert (
-                member.agent_settings_diff['llm']['base_url']
-                == 'https://api.anthropic.com/v1'
-            )
-            assert member.conversation_settings_diff['max_iterations'] == 100
-            assert decrypt_value(member._llm_api_key) == 'shared-external-api-key'
+        # The acting member got their new settings + their external key.
+        acting = members[str(fixture['admin_user_id'])]
+        assert acting.agent_settings_diff['llm']['model'] == 'anthropic/claude-sonnet-4'
+        assert (
+            acting.agent_settings_diff['llm']['base_url']
+            == 'https://api.anthropic.com/v1'
+        )
+        assert acting.conversation_settings_diff['max_iterations'] == 100
+        assert decrypt_value(acting._llm_api_key) == 'shared-external-api-key'
+
+        # The other members are untouched — model and key unchanged.
+        m1 = members[str(fixture['member1_user_id'])]
+        assert m1.agent_settings_diff['llm']['model'] == 'old-model-v2'
+        assert decrypt_value(m1._llm_api_key) == 'member1-initial-key'
+        m2 = members[str(fixture['member2_user_id'])]
+        assert m2.agent_settings_diff['llm']['model'] == 'old-model-v3'
+        assert decrypt_value(m2._llm_api_key) == 'member2-initial-key'
 
 
 @pytest.mark.asyncio
@@ -657,12 +666,10 @@ async def test_store_keeps_openhands_managed_keys_member_specific(
     with session_maker() as session:
         org = session.execute(select(Org).where(Org.id == org_id)).scalars().first()
         assert org is not None
-        # Settings keeps the public openhands/ provider prefix in persisted data
-        assert (
-            org.agent_settings['llm']['model'] == 'openhands/claude-opus-4-5-20251101'
-        )
-        assert org.agent_settings['llm']['base_url'] == LITE_LLM_API_URL
-        assert org.conversation_settings['max_iterations'] == 75
+        # A member save does not write the org default.
+        assert (org.agent_settings.get('llm') or {}).get(
+            'model'
+        ) != 'openhands/claude-opus-4-5-20251101'
 
         members = {
             str(member.user_id): member
@@ -674,21 +681,22 @@ async def test_store_keeps_openhands_managed_keys_member_specific(
         }
         assert len(members) == 3
 
+        # The acting member got the managed model + their own managed key.
         admin_member = members[admin_user_id]
         assert decrypt_value(admin_member._llm_api_key) == 'admin-managed-api-key'
+        assert (
+            admin_member.agent_settings_diff['llm']['model']
+            == 'openhands/claude-opus-4-5-20251101'
+        )
+        assert admin_member.agent_settings_diff['llm']['base_url'] == LITE_LLM_API_URL
 
+        # Other members keep their OWN model + key — nothing is copied across.
         member1 = members[str(fixture['member1_user_id'])]
         member2 = members[str(fixture['member2_user_id'])]
         assert decrypt_value(member1._llm_api_key) == 'member1-initial-key'
         assert decrypt_value(member2._llm_api_key) == 'member2-initial-key'
-
-        for member in members.values():
-            assert (
-                member.agent_settings_diff['llm']['model']
-                == 'openhands/claude-opus-4-5-20251101'
-            )
-            assert member.agent_settings_diff['llm']['base_url'] == LITE_LLM_API_URL
-            assert member.conversation_settings_diff['max_iterations'] == 75
+        assert member1.agent_settings_diff['llm']['model'] == 'old-model-v2'
+        assert member2.agent_settings_diff['llm']['model'] == 'old-model-v3'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
HUMAN: Goal-3 de-brittle, step 1. Stops a member's personal settings save from clobbering the whole org (the "key spread" gotcha). Backend-only, behavior change to the member-save path; the admin org-defaults path is unchanged. Verified by unit tests; R02 multi-member check pending.

- [ ] A human has tested these changes.

## Problem
Today a member's personal settings save (`SaasSettingsStore.store`) writes the saved settings into **`org.agent_settings`** (the org default) **and** broadcasts them — model, base_url, agent, condenser, and (for non-managed keys) the raw API key — into **every** member's row via `update_all_members_settings_async`. So one member saving overwrites other members' explicit model choices, and a member's BYOK key spreads across the org. This was intentional ("org-wide shared snapshot"), but it breaks the moment members have their own preferences/keys.

## Change
A member's personal save now writes **only their own `OrgMember` row**. It no longer mutates `org.agent_settings`/`org.conversation_settings` or broadcasts to other members. Propagation still works because `load()` merges the org default *under* the member's own diff, so members who haven't overridden continue to track the org default — without overwriting members who have. Org-wide defaults remain set through the dedicated **admin org-defaults path** (`OrgStore._update_org_kwargs`), which is untouched.

## Tests
- `test_member_save_stays_private_and_does_not_clobber_org_or_members`: an admin save leaves the org default and the other two members (each with their own model + key) untouched, while the acting member gets their new settings + key.
- `test_store_keeps_openhands_managed_keys_member_specific`: updated to assert other members keep their own model + managed key (nothing copied).
- Full suites: saas_settings_store 22, org_store/org_profiles/org_member 97 — green.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-1b09105   docker.openhands.dev/openhands/openhands:1b09105
```