### PR TITLE
fix: support paginated branch search

### DIFF
--- a/openhands/app_server/git/git_router.py
+++ b/openhands/app_server/git/git_router.py
@@ -20,7 +20,6 @@ from openhands.app_server.git.git_models import (
 )
 from openhands.app_server.integrations.provider import ProviderHandler
 from openhands.app_server.integrations.service_types import (
-    Branch,
     ProviderType,
     Repository,
     SuggestedTask,

--- a/openhands/app_server/git/git_router.py
+++ b/openhands/app_server/git/git_router.py
@@ -244,21 +244,16 @@ async def search_branches(
         page = decoded_page_id
 
     if query:
-        if page != 1:
-            # TODO(#13883): Support pagination for branch search after refactoring.
-            # The search_branches method does not support paging in the same way as
-            # get_branches - those should be merged into a single paginated method
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail='Pagination not yet supported for branch search queries. Use empty query to list all branches with pagination.',
-            )
-        # Get search results - we'll handle pagination ourselves
-        branches: list[Branch] = await client.search_branches(
+        search_page = await client.search_branches(
             selected_provider=provider,
             repository=repository,
             query=query,
-            per_page=limit + 1,
+            page=page,
+            per_page=limit,
         )
+        branches = search_page.branches
+        next_page_id = encode_page_id(page + 1) if search_page.has_next_page else None
+        return BranchPage(items=branches, next_page_id=next_page_id)
     else:
         current_page = await client.get_branches(
             repository=repository,

--- a/openhands/app_server/integrations/azure_devops/service/branches.py
+++ b/openhands/app_server/integrations/azure_devops/service/branches.py
@@ -140,8 +140,8 @@ class AzureDevOpsBranchesMixin(AzureDevOpsMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
-    ) -> list[Branch]:
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
+    ) -> PaginatedBranchesResponse:
         """Search for branches within a repository."""
         # Parse repository string: organization/project/repo
         parts = repository.split('/')
@@ -191,10 +191,19 @@ class AzureDevOpsBranchesMixin(AzureDevOpsMixinBase):
                     )
                     filtered_branches.append(branch)
 
-                    if len(filtered_branches) >= per_page:
-                        break
-
-            return filtered_branches
+            start_idx = max((page - 1) * per_page, 0)
+            end_idx = start_idx + per_page
+            return PaginatedBranchesResponse(
+                branches=filtered_branches[start_idx:end_idx],
+                has_next_page=end_idx < len(filtered_branches),
+                current_page=page,
+                per_page=per_page,
+                total_count=len(filtered_branches),
+            )
         except Exception:
-            # Return empty list on error instead of None
-            return []
+            return PaginatedBranchesResponse(
+                branches=[],
+                has_next_page=False,
+                current_page=page,
+                per_page=per_page,
+            )

--- a/openhands/app_server/integrations/bitbucket/service/branches.py
+++ b/openhands/app_server/integrations/bitbucket/service/branches.py
@@ -87,8 +87,8 @@ class BitBucketBranchesMixin(BitBucketMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
-    ) -> list[Branch]:
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
+    ) -> PaginatedBranchesResponse:
         """Search branches by name using Bitbucket API with `q` param."""
         parts = repository.split('/')
         if len(parts) < 2:
@@ -101,6 +101,7 @@ class BitBucketBranchesMixin(BitBucketMixinBase):
         # Bitbucket filtering: name ~ "query"
         params = {
             'pagelen': per_page,
+            'page': page,
             'q': f'name~"{query}"',
             'sort': '-target.date',
         }
@@ -116,4 +117,10 @@ class BitBucketBranchesMixin(BitBucketMixinBase):
                     last_push_date=branch.get('target', {}).get('date', None),
                 )
             )
-        return branches
+        return PaginatedBranchesResponse(
+            branches=branches,
+            has_next_page=response.get('next') is not None,
+            current_page=page,
+            per_page=per_page,
+            total_count=response.get('size'),
+        )

--- a/openhands/app_server/integrations/bitbucket_data_center/service/branches.py
+++ b/openhands/app_server/integrations/bitbucket_data_center/service/branches.py
@@ -72,21 +72,31 @@ class BitbucketDCBranchesMixin(BitbucketDCMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
-    ) -> list[Branch]:
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
+    ) -> PaginatedBranchesResponse:
         """Search branches by name using Bitbucket data center API with `q` param."""
         owner, repo = self._extract_owner_and_repo(repository)
 
         url = f'{self._repo_api_base(owner, repo)}/branches'
+        start = max((page - 1) * per_page, 0)
         params = {
             'limit': per_page,
+            'start': start,
             'filterText': query,
             'orderBy': 'MODIFICATION',
         }
 
         response, _ = await self._make_request(url, params)
 
-        return [self._parse_branch(branch) for branch in response.get('values', [])]
+        return PaginatedBranchesResponse(
+            branches=[
+                self._parse_branch(branch) for branch in response.get('values', [])
+            ],
+            has_next_page=not response.get('isLastPage', True),
+            current_page=page,
+            per_page=per_page,
+            total_count=response.get('size'),
+        )
 
     def _parse_branch(self, branch: dict) -> Branch:
         """Normalize Bitbucket branch representations across Cloud and Server."""

--- a/openhands/app_server/integrations/forgejo/service/branches.py
+++ b/openhands/app_server/integrations/forgejo/service/branches.py
@@ -68,10 +68,19 @@ class ForgejoBranchesMixin(ForgejoMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
-    ) -> list[Branch]:  # type: ignore[override]
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
+    ) -> PaginatedBranchesResponse:  # type: ignore[override]
         all_branches = await self.get_branches(repository)
         lowered = query.lower()
-        return [branch for branch in all_branches if lowered in branch.name.lower()][
-            :per_page
+        matching_branches = [
+            branch for branch in all_branches if lowered in branch.name.lower()
         ]
+        start = max((page - 1) * per_page, 0)
+        end = start + per_page
+        return PaginatedBranchesResponse(
+            branches=matching_branches[start:end],
+            has_next_page=end < len(matching_branches),
+            current_page=page,
+            per_page=per_page,
+            total_count=len(matching_branches),
+        )

--- a/openhands/app_server/integrations/github/queries.py
+++ b/openhands/app_server/integrations/github/queries.py
@@ -129,12 +129,13 @@ query ($threadId: ID!, $page: Int = 50, $after: String) {
 # - query: partial branch name provided by the user
 # - first: pagination size (clamped by caller to GitHub limits)
 search_branches_graphql_query = """
-    query SearchBranches($owner: String!, $name: String!, $query: String!, $perPage: Int!) {
+    query SearchBranches($owner: String!, $name: String!, $query: String!, $perPage: Int!, $after: String) {
         repository(owner: $owner, name: $name) {
             refs(
                 refPrefix: "refs/heads/",
                 query: $query,
                 first: $perPage,
+                after: $after,
                 orderBy: { field: ALPHABETICAL, direction: ASC }
             ) {
                 nodes {
@@ -146,6 +147,10 @@ search_branches_graphql_query = """
                             committedDate
                         }
                     }
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
                 }
             }
         }

--- a/openhands/app_server/integrations/github/service/branches_prs.py
+++ b/openhands/app_server/integrations/github/service/branches_prs.py
@@ -103,12 +103,17 @@ class GitHubBranchesMixin(GitHubMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
-    ) -> list[Branch]:
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
+    ) -> PaginatedBranchesResponse:
         """Search branches by name using GitHub GraphQL with a partial query."""
         # Require a non-empty query
         if not query:
-            return []
+            return PaginatedBranchesResponse(
+                branches=[],
+                has_next_page=False,
+                current_page=page,
+                per_page=per_page,
+            )
 
         # Clamp per_page to GitHub GraphQL limits
         per_page = min(max(per_page, 1), 100)
@@ -116,31 +121,65 @@ class GitHubBranchesMixin(GitHubMixinBase):
         # Extract owner and repo name from the repository string
         parts = repository.split('/')
         if len(parts) < 2:
-            return []
+            return PaginatedBranchesResponse(
+                branches=[],
+                has_next_page=False,
+                current_page=page,
+                per_page=per_page,
+            )
         owner, name = parts[-2], parts[-1]
 
-        variables = {
-            'owner': owner,
-            'name': name,
-            'query': query or '',
-            'perPage': per_page,
-        }
-
+        requested_page = max(page, 1)
+        after = None
+        result = None
         try:
-            result = await self.execute_graphql_query(
-                search_branches_graphql_query, variables
-            )
+            for current_page in range(1, requested_page + 1):
+                variables = {
+                    'owner': owner,
+                    'name': name,
+                    'query': query or '',
+                    'perPage': per_page,
+                    'after': after,
+                }
+                result = await self.execute_graphql_query(
+                    search_branches_graphql_query, variables
+                )
+                refs = result.get('data', {}).get('repository', {}).get('refs')
+                if not refs:
+                    break
+                page_info = refs.get('pageInfo') or {}
+                if current_page < requested_page and not page_info.get(
+                    'hasNextPage', False
+                ):
+                    return PaginatedBranchesResponse(
+                        branches=[],
+                        has_next_page=False,
+                        current_page=requested_page,
+                        per_page=per_page,
+                    )
+                after = page_info.get('endCursor')
         except Exception as e:
             logger.warning(f'Failed to search for branches: {e}')
             # Fallback to empty result on any GraphQL error
-            return []
+            return PaginatedBranchesResponse(
+                branches=[],
+                has_next_page=False,
+                current_page=requested_page,
+                per_page=per_page,
+            )
 
-        repo = result.get('data', {}).get('repository')
+        repo = result.get('data', {}).get('repository') if result else None
         if not repo or not repo.get('refs'):
-            return []
+            return PaginatedBranchesResponse(
+                branches=[],
+                has_next_page=False,
+                current_page=requested_page,
+                per_page=per_page,
+            )
 
         branches: list[Branch] = []
-        for node in repo['refs'].get('nodes', []):
+        refs = repo['refs']
+        for node in refs.get('nodes', []):
             bname = node.get('name') or ''
             target = node.get('target') or {}
             typename = target.get('__typename')
@@ -161,4 +200,10 @@ class GitHubBranchesMixin(GitHubMixinBase):
                 )
             )
 
-        return branches
+        page_info = refs.get('pageInfo') or {}
+        return PaginatedBranchesResponse(
+            branches=branches,
+            has_next_page=page_info.get('hasNextPage', False),
+            current_page=requested_page,
+            per_page=per_page,
+        )

--- a/openhands/app_server/integrations/gitlab/service/branches.py
+++ b/openhands/app_server/integrations/gitlab/service/branches.py
@@ -88,14 +88,14 @@ class GitLabBranchesMixin(GitLabMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
-    ) -> list[Branch]:
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
+    ) -> PaginatedBranchesResponse:
         """Search branches using GitLab API which supports `search` param."""
         encoded_name = repository.replace('/', '%2F')
         url = f'{self.BASE_URL}/projects/{encoded_name}/repository/branches'
 
-        params = {'per_page': str(per_page), 'search': query}
-        response, _ = await self._make_request(url, params)
+        params = {'per_page': str(per_page), 'page': str(page), 'search': query}
+        response, headers = await self._make_request(url, params)
 
         branches: list[Branch] = []
         for branch_data in response:
@@ -107,4 +107,17 @@ class GitLabBranchesMixin(GitLabMixinBase):
                     last_push_date=branch_data.get('commit', {}).get('committed_date'),
                 )
             )
-        return branches
+        total_count = None
+        if 'X-Total' in headers:
+            try:
+                total_count = int(headers['X-Total'])
+            except (ValueError, TypeError):
+                pass
+
+        return PaginatedBranchesResponse(
+            branches=branches,
+            has_next_page='rel="next"' in headers.get('Link', ''),
+            current_page=page,
+            per_page=per_page,
+            total_count=total_count,
+        )

--- a/openhands/app_server/integrations/provider.py
+++ b/openhands/app_server/integrations/provider.py
@@ -30,7 +30,6 @@ from openhands.app_server.integrations.gitlab.constants import GITLAB_HOST
 from openhands.app_server.integrations.gitlab.gitlab_service import GitLabServiceImpl
 from openhands.app_server.integrations.service_types import (
     AuthenticationError,
-    Branch,
     GitService,
     InstallationsService,
     PaginatedBranchesResponse,

--- a/openhands/app_server/integrations/provider.py
+++ b/openhands/app_server/integrations/provider.py
@@ -327,27 +327,38 @@ class ProviderHandler:
         selected_provider: ProviderType | None,
         repository: str,
         query: str,
+        page: int = 1,
         per_page: int = 30,
-    ) -> list[Branch]:
+    ) -> PaginatedBranchesResponse:
         """Search for branches within a repository using the appropriate provider service."""
         if selected_provider:
             service = self.get_service(selected_provider)
             try:
-                return await service.search_branches(repository, query, per_page)
+                return await service.search_branches(repository, query, page, per_page)
             except Exception as e:
                 logger.warning(
                     f'Error searching branches from selected provider {selected_provider}: {e}'
                 )
-                return []
+                return PaginatedBranchesResponse(
+                    branches=[],
+                    has_next_page=False,
+                    current_page=page,
+                    per_page=per_page,
+                )
 
         # If provider not specified, determine provider by verifying repository access
         try:
             repo_details = await self.verify_repo_provider(repository)
             service = self.get_service(repo_details.git_provider)
-            return await service.search_branches(repository, query, per_page)
+            return await service.search_branches(repository, query, page, per_page)
         except Exception as e:
             logger.warning(f'Error searching branches for {repository}: {e}')
-            return []
+            return PaginatedBranchesResponse(
+                branches=[],
+                has_next_page=False,
+                current_page=page,
+                per_page=per_page,
+            )
 
     async def search_repositories(
         self,

--- a/openhands/app_server/integrations/service_types.py
+++ b/openhands/app_server/integrations/service_types.py
@@ -304,9 +304,9 @@ class GitService(Protocol):
         """Get branches for a repository with pagination"""
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
-    ) -> list[Branch]:
-        """Search for branches within a repository"""
+        self, repository: str, query: str, page: int = 1, per_page: int = 30
+    ) -> PaginatedBranchesResponse:
+        """Search for branches within a repository with pagination"""
 
     async def get_pr_details(self, repository: str, pr_number: int) -> dict:
         """Get detailed information about a specific pull request/merge request

--- a/tests/unit/app_server/test_git_router.py
+++ b/tests/unit/app_server/test_git_router.py
@@ -21,6 +21,7 @@ from openhands.app_server.git.git_router import (
 from openhands.app_server.integrations.provider import ProviderToken
 from openhands.app_server.integrations.service_types import (
     Branch,
+    PaginatedBranchesResponse,
     ProviderType,
     Repository,
     SuggestedTask,
@@ -709,11 +710,15 @@ class TestSearchBranches:
         # Arrange
         mock_handler = MagicMock()
         mock_handler.search_branches = AsyncMock(
-            return_value=[
-                Branch(name='main', commit_sha='abc123', protected=False),
-                Branch(name='develop', commit_sha='def456', protected=False),
-                Branch(name='feature-branch', commit_sha='ghi789', protected=False),
-            ]
+            return_value=PaginatedBranchesResponse(
+                branches=[
+                    Branch(name='main', commit_sha='abc123', protected=False),
+                    Branch(name='develop', commit_sha='def456', protected=False),
+                ],
+                has_next_page=True,
+                current_page=1,
+                per_page=2,
+            )
         )
         mock_handler_cls.return_value = mock_handler
 
@@ -742,11 +747,61 @@ class TestSearchBranches:
 
     @pytest.mark.asyncio
     @patch('openhands.app_server.git.git_router.ProviderHandler')
+    async def test_returns_paginated_branch_search_page(self, mock_handler_cls):
+        """Test that branch search supports page_id pagination."""
+        # Arrange
+        mock_handler = MagicMock()
+        mock_handler.search_branches = AsyncMock(
+            return_value=PaginatedBranchesResponse(
+                branches=[
+                    Branch(name='feature-branch', commit_sha='ghi789', protected=False),
+                ],
+                has_next_page=False,
+                current_page=2,
+                per_page=2,
+            )
+        )
+        mock_handler_cls.return_value = mock_handler
+
+        mock_context = _make_mock_user_context(
+            provider_tokens={
+                ProviderType.GITHUB: ProviderToken(user_id='user-123', token='token')
+            },
+            user_id='user-123',
+        )
+
+        # Act
+        result = await search_branches(
+            provider=ProviderType.GITHUB,
+            repository='user/repo',
+            query='feature',
+            page_id=encode_page_id(2),
+            limit=2,
+            user_context=mock_context,
+        )
+
+        # Assert
+        assert len(result.items) == 1
+        assert result.items[0].name == 'feature-branch'
+        assert result.next_page_id is None
+        call_kwargs = mock_handler.search_branches.call_args.kwargs
+        assert call_kwargs.get('page') == 2
+        assert call_kwargs.get('per_page') == 2
+
+    @pytest.mark.asyncio
+    @patch('openhands.app_server.git.git_router.ProviderHandler')
     async def test_passes_parameters_to_provider(self, mock_handler_cls):
         """Test that all parameters are passed through to the provider."""
         # Arrange
         mock_handler = MagicMock()
-        mock_handler.search_branches = AsyncMock(return_value=[])
+        mock_handler.search_branches = AsyncMock(
+            return_value=PaginatedBranchesResponse(
+                branches=[],
+                has_next_page=False,
+                current_page=1,
+                per_page=10,
+            )
+        )
         mock_handler_cls.return_value = mock_handler
 
         mock_context = _make_mock_user_context(
@@ -772,7 +827,8 @@ class TestSearchBranches:
         assert call_kwargs.get('selected_provider') == ProviderType.GITHUB
         assert call_kwargs.get('repository') == 'user/repo'
         assert call_kwargs.get('query') == 'feature'
-        assert call_kwargs.get('per_page') == 11  # limit + 1
+        assert call_kwargs.get('page') == 1
+        assert call_kwargs.get('per_page') == 10
 
     def test_returns_403_when_no_provider_tokens(self, test_client):
         """Test that 403 is returned when no provider tokens."""

--- a/tests/unit/integrations/bitbucket/test_bitbucket_branches.py
+++ b/tests/unit/integrations/bitbucket/test_bitbucket_branches.py
@@ -69,17 +69,23 @@ async def test_search_branches_bitbucket_filters_by_name_contains():
     }
 
     with patch.object(service, '_make_request', return_value=(mock_response, {})) as m:
-        branches = await service.search_branches('w/r', query='bugfix', per_page=15)
+        result = await service.search_branches(
+            'w/r', query='bugfix', page=2, per_page=15
+        )
 
         args, kwargs = m.call_args
         url = args[0]
         params = args[1]
         assert 'refs/branches' in url
         assert params['pagelen'] == 15
+        assert params['page'] == 2
         assert params['q'] == 'name~"bugfix"'
         assert params['sort'] == '-target.date'
 
-        assert branches == [
+        assert isinstance(result, PaginatedBranchesResponse)
+        assert result.current_page == 2
+        assert result.per_page == 15
+        assert result.branches == [
             Branch(
                 name='bugfix/issue-1',
                 commit_sha='hhh',

--- a/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_branches.py
+++ b/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_branches.py
@@ -112,16 +112,21 @@ async def test_search_branches_uses_filter_text():
     with patch.object(
         svc, '_make_request', return_value=(mock_response, {})
     ) as mock_req:
-        branches = await svc.search_branches(
-            'PROJ/myrepo', query='my-thing', per_page=15
+        result = await svc.search_branches(
+            'PROJ/myrepo', query='my-thing', page=2, per_page=15
         )
 
     call_url, call_params = mock_req.call_args[0]
     assert 'filterText' in call_params
     assert call_params['filterText'] == 'my-thing'
+    assert call_params['limit'] == 15
+    assert call_params['start'] == 15
     assert 'q' not in call_params
-    assert len(branches) == 1
-    assert branches[0].name == 'feature/my-thing'
+    assert isinstance(result, PaginatedBranchesResponse)
+    assert result.current_page == 2
+    assert result.per_page == 15
+    assert len(result.branches) == 1
+    assert result.branches[0].name == 'feature/my-thing'
 
 
 # ── get_branches (all pages via _fetch_paginated_data) ───────────────────────

--- a/tests/unit/integrations/github/test_github_branches.py
+++ b/tests/unit/integrations/github/test_github_branches.py
@@ -112,7 +112,11 @@ async def test_search_branches_github_success_and_variables():
                             },
                             'branchProtectionRule': None,
                         },
-                    ]
+                    ],
+                    'pageInfo': {
+                        'hasNextPage': True,
+                        'endCursor': 'cursor-1',
+                    },
                 }
             }
         }
@@ -120,7 +124,7 @@ async def test_search_branches_github_success_and_variables():
 
     exec_mock = AsyncMock(return_value=graphql_result)
     with patch.object(service, 'execute_graphql_query', exec_mock) as mock_exec:
-        branches = await service.search_branches('foo/bar', query='fe', per_page=999)
+        result = await service.search_branches('foo/bar', query='fe', per_page=999)
 
         # per_page should be clamped to <= 100 when passed to GraphQL variables
         args, kwargs = mock_exec.call_args
@@ -130,7 +134,11 @@ async def test_search_branches_github_success_and_variables():
         assert variables['name'] == 'bar'
         assert variables['query'] == 'fe'
         assert 1 <= variables['perPage'] <= 100
+        assert variables['after'] is None
 
+        assert isinstance(result, PaginatedBranchesResponse)
+        assert result.has_next_page is True
+        branches = result.branches
         assert len(branches) == 2
         b0, b1 = branches
         assert b0.name == 'feature/bar'
@@ -150,15 +158,71 @@ async def test_search_branches_github_edge_cases():
     service = GitHubService(token=SecretStr('t'))
 
     # Empty query should return [] without issuing a GraphQL call
-    branches = await service.search_branches('foo/bar', query='')
-    assert branches == []
+    result = await service.search_branches('foo/bar', query='')
+    assert result.branches == []
 
     # Invalid repository string should return [] without calling GraphQL
     exec_mock = AsyncMock()
     with patch.object(service, 'execute_graphql_query', exec_mock):
-        branches = await service.search_branches('invalidrepo', query='q')
-        assert branches == []
+        result = await service.search_branches('invalidrepo', query='q')
+        assert result.branches == []
         exec_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_search_branches_github_uses_cursor_for_requested_page():
+    service = GitHubService(token=SecretStr('t'))
+
+    first_page = {
+        'data': {
+            'repository': {
+                'refs': {
+                    'nodes': [],
+                    'pageInfo': {
+                        'hasNextPage': True,
+                        'endCursor': 'cursor-1',
+                    },
+                }
+            }
+        }
+    }
+    second_page = {
+        'data': {
+            'repository': {
+                'refs': {
+                    'nodes': [
+                        {
+                            'name': 'feature/second',
+                            'target': {
+                                '__typename': 'Commit',
+                                'oid': 'bbb222',
+                                'committedDate': '2024-01-06T10:00:00Z',
+                            },
+                            'branchProtectionRule': None,
+                        }
+                    ],
+                    'pageInfo': {
+                        'hasNextPage': False,
+                        'endCursor': None,
+                    },
+                }
+            }
+        }
+    }
+
+    exec_mock = AsyncMock(side_effect=[first_page, second_page])
+    with patch.object(service, 'execute_graphql_query', exec_mock):
+        result = await service.search_branches(
+            'foo/bar', query='feature', page=2, per_page=1
+        )
+
+    assert result.current_page == 2
+    assert result.has_next_page is False
+    assert [branch.name for branch in result.branches] == ['feature/second']
+    first_call = exec_mock.call_args_list[0].args[1]
+    second_call = exec_mock.call_args_list[1].args[1]
+    assert first_call['after'] is None
+    assert second_call['after'] == 'cursor-1'
 
 
 @pytest.mark.asyncio
@@ -167,5 +231,5 @@ async def test_search_branches_github_graphql_error_returns_empty():
 
     exec_mock = AsyncMock(side_effect=Exception('Boom'))
     with patch.object(service, 'execute_graphql_query', exec_mock):
-        branches = await service.search_branches('foo/bar', query='q')
-        assert branches == []
+        result = await service.search_branches('foo/bar', query='q')
+        assert result.branches == []

--- a/tests/unit/integrations/gitlab/test_gitlab_branches.py
+++ b/tests/unit/integrations/gitlab/test_gitlab_branches.py
@@ -95,8 +95,8 @@ async def test_search_branches_gitlab_uses_search_param():
     ]
 
     with patch.object(service, '_make_request', return_value=(mock_response, {})) as m:
-        branches = await service.search_branches(
-            'group/repo', query='feat', per_page=50
+        result = await service.search_branches(
+            'group/repo', query='feat', page=2, per_page=50
         )
 
         # Verify parameters
@@ -105,8 +105,13 @@ async def test_search_branches_gitlab_uses_search_param():
         params = args[1]
         assert 'repository/branches' in url
         assert params['per_page'] == '50'
+        assert params['page'] == '2'
         assert params['search'] == 'feat'
 
+        assert isinstance(result, PaginatedBranchesResponse)
+        assert result.current_page == 2
+        assert result.per_page == 50
+        branches = result.branches
         assert len(branches) == 2
         assert branches[0] == Branch(
             name='feat/new',


### PR DESCRIPTION
HUMAN:
This updates branch search to paginate like regular branch listing, so passing page_id with a search query returns the requested search page instead of a 400.
- [ ] A human has tested these changes.

## Summary
- adds pagination to branch search responses instead of rejecting page_id when a query is present
- passes page/per_page through the provider branch search contract
- uses native provider pagination where available and cursor/client-side pagination where needed

Fixes OpenHands/enterprise#22

## Testing
- python3 -m compileall -q openhands/app_server/git/git_router.py openhands/app_server/integrations/provider.py openhands/app_server/integrations/service_types.py openhands/app_server/integrations/github/service/branches_prs.py openhands/app_server/integrations/gitlab/service/branches.py openhands/app_server/integrations/bitbucket/service/branches.py openhands/app_server/integrations/bitbucket_data_center/service/branches.py openhands/app_server/integrations/forgejo/service/branches.py openhands/app_server/integrations/azure_devops/service/branches.py tests/unit/app_server/test_git_router.py tests/unit/integrations/github/test_github_branches.py tests/unit/integrations/gitlab/test_gitlab_branches.py tests/unit/integrations/bitbucket/test_bitbucket_branches.py tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_branches.py
- git diff --check

Note: targeted pytest collection could not run in this local checkout because required project dependencies are missing (for example, openhands.agent_server and litellm).