### PR TITLE
fix: write trajectory exports as utf-8

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -2110,7 +2110,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 event_filename = f'event_{i:06d}_{event.id}.json'
                 event_path = os.path.join(temp_dir, event_filename)
 
-                with open(event_path, 'w') as f:
+                with open(event_path, 'w', encoding='utf-8') as f:
                     # Use model_dump with mode='json' to handle UUID serialization
                     event_data = event.model_dump(mode='json')
                     json.dump(event_data, f, indent=2)
@@ -2118,7 +2118,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
 
             # Create meta.json with conversation info
             meta_path = os.path.join(temp_dir, 'meta.json')
-            with open(meta_path, 'w') as f:
+            with open(meta_path, 'w', encoding='utf-8') as f:
                 f.write(conversation_info.model_dump_json(indent=2))
 
             # Create zip file in memory

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -1,5 +1,6 @@
 """Unit tests for the methods in LiveStatusAppConversationService."""
 
+import builtins
 import io
 import json
 import os
@@ -1462,6 +1463,68 @@ class TestLiveStatusAppConversationService:
         )
         assert self.mock_event_service.search_events.call_count == 2
         mock_conversation_info.model_dump_json.assert_called_once_with(indent=2)
+
+    async def test_export_conversation_writes_utf8_when_platform_default_cannot_encode(
+        self,
+    ):
+        """Test trajectory export writes JSON as UTF-8 regardless of platform default."""
+        # Arrange
+        conversation_id = uuid4()
+
+        mock_conversation_info = Mock(spec=AppConversationInfo)
+        mock_conversation_info.id = conversation_id
+        mock_conversation_info.title = 'Café 🔐'
+        mock_conversation_info.model_dump_json = Mock(
+            return_value='{"id": "test", "title": "Café 🔐"}'
+        )
+
+        self.mock_app_conversation_info_service.get_app_conversation_info = AsyncMock(
+            return_value=mock_conversation_info
+        )
+
+        mock_event = Mock(spec=Event)
+        mock_event.id = uuid4()
+        mock_event.model_dump = Mock(
+            return_value={
+                'id': str(mock_event.id),
+                'type': 'observation',
+                'message': 'résumé 🔐',
+            }
+        )
+
+        mock_event_page = Mock()
+        mock_event_page.items = [mock_event]
+        mock_event_page.next_page_id = None
+        self.mock_event_service.search_events = AsyncMock(return_value=mock_event_page)
+
+        real_open = builtins.open
+
+        def cp1252_default_open(file, mode='r', *args, **kwargs):
+            if 'w' in mode and 'encoding' not in kwargs:
+                kwargs['encoding'] = 'cp1252'
+            return real_open(file, mode, *args, **kwargs)
+
+        # Act
+        with patch(
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.open',
+            cp1252_default_open,
+            create=True,
+        ):
+            result = await self.service.export_conversation(conversation_id)
+
+        # Assert
+        with zipfile.ZipFile(io.BytesIO(result), 'r') as zipf:
+            with zipf.open('meta.json') as meta_file:
+                meta_content = meta_file.read().decode('utf-8')
+                assert '"title": "Café 🔐"' in meta_content
+
+            event_files = [
+                name for name in zipf.namelist() if name.startswith('event_')
+            ]
+            assert len(event_files) == 1
+            with zipf.open(event_files[0]) as event_file:
+                event_content = json.loads(event_file.read().decode('utf-8'))
+                assert event_content['message'] == 'résumé 🔐'
 
     @pytest.mark.asyncio
     async def test_export_conversation_conversation_not_found(self):


### PR DESCRIPTION
HUMAN:
This PR makes trajectory exports explicitly write event and metadata JSON as UTF-8, so conversations with non-ASCII content export consistently on platforms whose default encoding is not UTF-8. The change is limited to the export write boundary and covered by a regression test that simulates a non-UTF-8 platform default.

- [x] A human has tested these changes.

## Summary

- Write trajectory export `event_*.json` files and `meta.json` with explicit UTF-8 encoding.
- Add a regression test that simulates a non-UTF-8 platform default encoding and verifies exported metadata and event payloads decode as UTF-8.

## Why

`export_conversation()` writes JSON files before zipping the trajectory. Without an explicit encoding, Python uses the platform default. On Windows-style defaults such as `cp1252`, metadata or event payloads containing non-ASCII characters can fail to write or produce inconsistent export bytes.

The exported trajectory is already consumed as UTF-8 by existing tests and clients, so the write boundary should use the same encoding explicitly.

## Edge cases covered

- Non-ASCII conversation metadata.
- Non-ASCII event payloads.
- Platform defaults that cannot encode emoji.
- Existing empty-events export behavior.
- Existing paginated event export behavior.
- Existing conversation-not-found behavior.
- Existing zip layout and filenames.
- Existing JSON schema and API response type.

## Validation

- `uv run --group test pytest tests/unit/app_server/test_live_status_app_conversation_service.py -q`
- `uv run ruff format --check openhands/app_server/app_conversation/live_status_app_conversation_service.py tests/unit/app_server/test_live_status_app_conversation_service.py`
- `uv run ruff check openhands/app_server/app_conversation/live_status_app_conversation_service.py tests/unit/app_server/test_live_status_app_conversation_service.py`
- `git diff --check`
