### PR TITLE
fix: default enterprise injector kinds in the image, not just the chart

### DIFF
--- a/enterprise/Dockerfile
+++ b/enterprise/Dockerfile
@@ -44,6 +44,12 @@ RUN cd /tmp/enterprise && \
 WORKDIR /app
 COPY --chown=openhands:openhands --chmod=770 enterprise .
 
+# Default the enterprise service-injector kinds in the image (overridable via env).
+# Keeping these next to the classes they name means the chart never references an
+# app-internal class path, so a chart/image version skew can't crashloop config load.
+ENV OH_LLM_MODEL_KIND=server.verified_models.litellm_proxy_model_router.LiteLLMProxyModelServiceInjector
+ENV OH_APP_CONVERSATION_INFO_KIND=server.utils.saas_app_conversation_info_injector.SaasAppConversationInfoServiceInjector
+
 USER openhands
 
 # Command will be overridden by Kubernetes deployment template


### PR DESCRIPTION
HUMAN: Image-side skew-proofing for the OHE injector-kind config, so the chart/image mismatch that crashlooped us (the `litellm_proxy_model_router` `ModuleNotFoundError` on every deploy off main) can't recur. It bakes the enterprise injector-kind defaults into the image, next to the classes they name, so the chart no longer has to reference an app-internal class path. Backward-compatible and non-breaking: the OSS image uses a separate Dockerfile (untouched), and the chart still sets these env vars today — a Kubernetes env overrides the image `ENV`, so behavior is unchanged. The follow-up that drops the two lines from `OpenHands-Cloud` `_env.yaml` only lands once an image carrying this is pinned (image-first), and the worst case during that migration is a soft degrade to the default model service — never a crash. Chose the Dockerfile `ENV` over a base `config_from_env` change precisely because it touches zero startup logic, so it can't break OSS or enterprise boot.

- [x] A human has tested these changes.

AGENT:

## Why

The OHE chart (`charts/openhands/templates/_env.yaml`) hard-codes enterprise service-injector class paths as env vars (`OH_LLM_MODEL_KIND`, `OH_APP_CONVERSATION_INFO_KIND`). When the chart points at a class **newer than the pinned enterprise-server image** — exactly what happened when `litellm_proxy_model_router` (#14773) was referenced while the chart pinned a pre-#14773 image — config load does a hard `importlib.import_module` with **no fallback**, so the `openhands`/`integrations`/`mcp` pods crashloop `ModuleNotFoundError`. Chart and image live in separate repos released independently, so this cross-repo skew is easy to introduce and fatal when it happens.

## Summary

- Bake `OH_LLM_MODEL_KIND` + `OH_APP_CONVERSATION_INFO_KIND` defaults into `enterprise/Dockerfile`, next to the classes they name, so the chart never has to reference an app-internal class path → a chart/image skew can't crashloop config load.
- `CONVERSATION_MANAGER_CLASS` is intentionally left out — its consumption path is less clear, so it's a separate investigation.

## How to Test

Build the enterprise image from this branch, deploy it with the chart's `OH_LLM_MODEL_KIND` / `OH_APP_CONVERSATION_INFO_KIND` env vars **absent**, and confirm config load picks up the image `ENV` defaults (pods become Ready, the LiteLLM proxy model service is selected). With the chart env present (current behavior), the k8s env overrides the image `ENV` and nothing changes.

## Type

- [x] Bug fix

## Notes

This is step 1 of a two-step, image-first migration. **Step 2** (separate OpenHands-Cloud PR): drop the two lines from `_env.yaml` once an enterprise-server image carrying this change is pinned. `OpenHands-Cloud#717` (bump the pinned image to a `#14773`-inclusive sha) is the immediate fix that unblocks main today; this PR is the durable layer that prevents the skew class from recurring.
