### PR TITLE
fix(frontend): avoid dirty language filter input

### DIFF
--- a/frontend/__tests__/routes/app-settings.test.tsx
+++ b/frontend/__tests__/routes/app-settings.test.tsx
@@ -173,6 +173,25 @@ describe("Form submission", () => {
     expect(submit).toBeDisabled();
   });
 
+  it("should keep the submit button disabled while filtering languages without selecting one", async () => {
+    const getSettingsSpy = vi.spyOn(SettingsService, "getSettings");
+    getSettingsSpy.mockResolvedValue(MOCK_DEFAULT_USER_SETTINGS);
+
+    const user = userEvent.setup();
+    renderAppSettingsScreen();
+
+    const language = await screen.findByTestId("language-input");
+    const submit = await screen.findByTestId("submit-button");
+
+    expect(language).toHaveValue("English");
+    expect(submit).toBeDisabled();
+
+    await user.click(language);
+    await user.keyboard("Nor");
+
+    expect(submit).toBeDisabled();
+  });
+
   it("should call handleCaptureConsents with true when the analytics switch is toggled", async () => {
     const getSettingsSpy = vi.spyOn(SettingsService, "getSettings");
     getSettingsSpy.mockResolvedValue(MOCK_DEFAULT_USER_SETTINGS);

--- a/frontend/src/components/features/settings/app-settings/language-input.tsx
+++ b/frontend/src/components/features/settings/app-settings/language-input.tsx
@@ -1,3 +1,4 @@
+import type { Key } from "react";
 import { useTranslation } from "react-i18next";
 import { AvailableLanguages } from "#/i18n";
 import { I18nKey } from "#/i18n/declaration";
@@ -15,12 +16,18 @@ export function LanguageInput({
   name,
 }: LanguageInputProps) {
   const { t } = useTranslation();
+  const handleSelectionChange = (key: Key | null) => {
+    const language = AvailableLanguages.find((l) => l.value === key);
+    if (language) {
+      onChange(language.label);
+    }
+  };
 
   return (
     <SettingsDropdownInput
       testId={name}
       name={name}
-      onInputChange={onChange}
+      onSelectionChange={handleSelectionChange}
       label={t(I18nKey.SETTINGS$LANGUAGE)}
       items={AvailableLanguages.map((l) => ({
         key: l.value,


### PR DESCRIPTION
HUMAN:
This keeps the app settings form from treating language dropdown filter text as a saved setting change. Save Changes should stay disabled while someone only types to filter languages, and only become dirty after an actual language option is selected.

- [x] A human has tested these changes.

## Summary
- mark the language setting dirty only when a language option is selected
- keep autocomplete filter typing from enabling Save Changes without a real setting change
- add a regression test for filtering the language dropdown without selecting a new language

Fixes #14249

## Changelog
Users can filter the language dropdown without the app settings form being marked dirty until they actually select a language.

## Testing
- `npm run test -- __tests__/routes/app-settings.test.tsx`
- `npm run lint:fix`
- `npx prettier --check __tests__/routes/app-settings.test.tsx src/components/features/settings/app-settings/language-input.tsx`
- `npm run typecheck`
- `npm run build`