### PR TITLE
fix(enterprise): allow BYOR export when self-hosted

### DIFF
--- a/enterprise/storage/org_service.py
+++ b/enterprise/storage/org_service.py
@@ -8,6 +8,7 @@ from uuid import UUID, uuid4
 from uuid import UUID as parse_uuid
 
 from server.constants import (
+    DEPLOYMENT_MODE,
     ORG_SETTINGS_VERSION,
     get_default_llm_base_url,
     get_default_llm_model,
@@ -845,6 +846,9 @@ class OrgService:
         Returns:
             bool: True if BYOR export is enabled, False otherwise.
         """
+        if DEPLOYMENT_MODE == 'self_hosted':
+            return True
+
         if org_id is None:
             user = await UserStore.get_user_by_id(user_id)
             if not user or not user.current_org_id:

--- a/enterprise/tests/unit/test_org_service.py
+++ b/enterprise/tests/unit/test_org_service.py
@@ -1874,6 +1874,97 @@ async def test_update_org_with_permissions_only_non_llm_fields(
 
 
 @pytest.mark.asyncio
+async def test_check_byor_export_enabled_returns_true_for_self_hosted():
+    user_id = 'test-user-123'
+
+    with (
+        patch('storage.org_service.DEPLOYMENT_MODE', 'self_hosted'),
+        patch(
+            'storage.org_service.UserStore.get_user_by_id',
+            new_callable=AsyncMock,
+        ) as mock_get_user,
+        patch(
+            'storage.org_service.OrgStore.get_org_by_id',
+            new_callable=AsyncMock,
+        ) as mock_get_org,
+        patch(
+            'storage.org_service.OrgService.get_org_credits',
+            new_callable=AsyncMock,
+        ) as mock_get_credits,
+        patch(
+            'storage.org_service.OrgStore.enable_byor_export',
+            new_callable=AsyncMock,
+        ) as mock_enable_byor_export,
+    ):
+        result = await OrgService.check_byor_export_enabled(user_id)
+
+        assert result is True
+        mock_get_user.assert_not_called()
+        mock_get_org.assert_not_called()
+        mock_get_credits.assert_not_called()
+        mock_enable_byor_export.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_check_byor_export_enabled_returns_true_for_self_hosted_with_org_id():
+    user_id = 'test-user-123'
+    org_id = uuid.uuid4()
+
+    with (
+        patch('storage.org_service.DEPLOYMENT_MODE', 'self_hosted'),
+        patch(
+            'storage.org_service.UserStore.get_user_by_id',
+            new_callable=AsyncMock,
+        ) as mock_get_user,
+        patch(
+            'storage.org_service.OrgStore.get_org_by_id',
+            new_callable=AsyncMock,
+        ) as mock_get_org,
+        patch(
+            'storage.org_service.OrgService.get_org_credits',
+            new_callable=AsyncMock,
+        ) as mock_get_credits,
+        patch(
+            'storage.org_service.OrgStore.enable_byor_export',
+            new_callable=AsyncMock,
+        ) as mock_enable_byor_export,
+    ):
+        result = await OrgService.check_byor_export_enabled(user_id, org_id)
+
+        assert result is True
+        mock_get_user.assert_not_called()
+        mock_get_org.assert_not_called()
+        mock_get_credits.assert_not_called()
+        mock_enable_byor_export.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_check_byor_export_enabled_uses_existing_gate_for_cloud():
+    user_id = 'test-user-123'
+    org_id = uuid.uuid4()
+
+    mock_user = MagicMock()
+    mock_user.current_org_id = org_id
+
+    with (
+        patch('storage.org_service.DEPLOYMENT_MODE', 'cloud'),
+        patch(
+            'storage.org_service.UserStore.get_user_by_id',
+            AsyncMock(return_value=mock_user),
+        ) as mock_get_user,
+        patch(
+            'storage.org_service.OrgStore.get_org_by_id',
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        result = await OrgService.check_byor_export_enabled(user_id)
+
+        assert result is False
+        mock_get_user.assert_awaited_once_with(user_id)
+
+
+@pytest.mark.asyncio
 async def test_check_byor_export_enabled_returns_true_when_enabled():
     """
     GIVEN: User has current_org with byor_export_enabled=True


### PR DESCRIPTION
HUMAN:
This fixes the self-hosted BYOR key export gate so deployments without billing do not hit the cloud credits paywall.

- [ ] A human has tested these changes.

## Summary
- allow `OrgService.check_byor_export_enabled` to short-circuit for `self_hosted` deployments
- keep the existing credits/enablement gate unchanged for cloud deployments
- add regression coverage for self-hosted calls with and without an explicit org id, plus a cloud fallback check

Fixes #14610

## Tests
- `PYTHONPATH=".:$PYTHONPATH" poetry run pytest tests/unit/test_org_service.py -k 'check_byor_export_enabled' -q`
- `git diff --check`

## Notes
- `make install-pre-commit-hooks` stopped during dependency install because the repository lock file is reported as out of sync with `pyproject.toml`.
- `poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files enterprise/storage/org_service.py enterprise/tests/unit/test_org_service.py` could not initialize the local mypy hook because the hook created a Python 3.11 environment while `openhands-sdk==1.28.0` requires Python >=3.12.
