### PR TITLE
fix: PLTF-2956 log level from warning to error for automation service forwarding failures

### DIFF
--- a/enterprise/server/services/automation_event_service.py
+++ b/enterprise/server/services/automation_event_service.py
@@ -617,12 +617,12 @@ class AutomationEventService:
                             f'event to org {org_id}: {matched} automations matched'
                         )
         except asyncio.TimeoutError:
-            logger.warning(
+            logger.error(
                 f'[AutomationEventService] Timeout ({AUTOMATION_SERVICE_TIMEOUT}s) '
                 f'forwarding {source} event to automation service'
             )
         except aiohttp.ClientError as e:
-            logger.warning(
+            logger.error(
                 f'[AutomationEventService] HTTP error forwarding '
                 f'{source} event to automation service: {e}'
             )

--- a/enterprise/tests/unit/server/services/test_automation_event_service.py
+++ b/enterprise/tests/unit/server/services/test_automation_event_service.py
@@ -862,7 +862,9 @@ class TestSendToAutomationService:
             raise asyncio.TimeoutError('Connection timed out')
 
         mock_post_context = MagicMock()
-        mock_post_context.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError('Connection timed out'))
+        mock_post_context.__aenter__ = AsyncMock(
+            side_effect=asyncio.TimeoutError('Connection timed out')
+        )
         mock_post_context.__aexit__ = AsyncMock(return_value=None)
 
         mock_session_instance = MagicMock()
@@ -890,9 +892,10 @@ class TestSendToAutomationService:
 
             mock_logger.error.assert_called()
             assert 'Timeout' in str(mock_logger.error.call_args)
-            assert 'never delivered' in str(mock_logger.error.call_args).lower() or 'timeout' in str(
-                mock_logger.error.call_args
-            ).lower()
+            assert (
+                'never delivered' in str(mock_logger.error.call_args).lower()
+                or 'timeout' in str(mock_logger.error.call_args).lower()
+            )
 
     @pytest.mark.asyncio
     async def test_send_client_error_logs_error(self, mock_token_manager):
@@ -911,7 +914,9 @@ class TestSendToAutomationService:
 
         # Create a mock that raises ClientError when used as async context manager
         mock_post_context = MagicMock()
-        mock_post_context.__aenter__ = AsyncMock(side_effect=aiohttp.ClientError('Connection refused'))
+        mock_post_context.__aenter__ = AsyncMock(
+            side_effect=aiohttp.ClientError('Connection refused')
+        )
         mock_post_context.__aexit__ = AsyncMock(return_value=None)
 
         mock_session_instance.post = MagicMock(return_value=mock_post_context)

--- a/enterprise/tests/unit/server/services/test_automation_event_service.py
+++ b/enterprise/tests/unit/server/services/test_automation_event_service.py
@@ -841,6 +841,104 @@ class TestSendToAutomationService:
             mock_logger.warning.assert_called()
             assert 'not configured' in str(mock_logger.warning.call_args)
 
+    @pytest.mark.asyncio
+    async def test_send_timeout_logs_error(self, mock_token_manager):
+        """
+        GIVEN: AUTOMATION_SERVICE_URL is configured
+        WHEN: _send_to_automation_service times out
+        THEN: Error is logged (not warning) since the event was never delivered
+        """
+        import asyncio
+
+        org_id = uuid.UUID('12345678-1234-5678-1234-567812345678')
+        payload = {'test': 'data'}
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={'matched': 2})
+
+        # Create a mock post that raises TimeoutError within the async context
+        async def raise_timeout(*args, **kwargs):
+            raise asyncio.TimeoutError('Connection timed out')
+
+        mock_post_context = MagicMock()
+        mock_post_context.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError('Connection timed out'))
+        mock_post_context.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session_instance = MagicMock()
+        mock_session_instance.post = MagicMock(return_value=mock_post_context)
+
+        mock_session_context = MagicMock()
+        mock_session_context.__aenter__ = AsyncMock(return_value=mock_session_instance)
+        mock_session_context.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                'server.services.automation_event_service.AUTOMATION_SERVICE_URL',
+                'https://automation.example.com',
+            ),
+            patch(
+                'server.services.automation_event_service.aiohttp.ClientSession',
+                return_value=mock_session_context,
+            ),
+            patch('server.services.automation_event_service.logger') as mock_logger,
+        ):
+            service = create_service(mock_token_manager)
+            await service._send_to_automation_service(
+                ProviderType.GITHUB, org_id, payload
+            )
+
+            mock_logger.error.assert_called()
+            assert 'Timeout' in str(mock_logger.error.call_args)
+            assert 'never delivered' in str(mock_logger.error.call_args).lower() or 'timeout' in str(
+                mock_logger.error.call_args
+            ).lower()
+
+    @pytest.mark.asyncio
+    async def test_send_client_error_logs_error(self, mock_token_manager):
+        """
+        GIVEN: AUTOMATION_SERVICE_URL is configured
+        WHEN: _send_to_automation_service fails with HTTP error
+        THEN: Error is logged (not warning) since the event was not delivered
+        """
+        import aiohttp
+
+        org_id = uuid.UUID('12345678-1234-5678-1234-567812345678')
+        payload = {'test': 'data'}
+
+        mock_session_instance = MagicMock()
+        mock_session_instance.post = MagicMock()
+
+        # Create a mock that raises ClientError when used as async context manager
+        mock_post_context = MagicMock()
+        mock_post_context.__aenter__ = AsyncMock(side_effect=aiohttp.ClientError('Connection refused'))
+        mock_post_context.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session_instance.post = MagicMock(return_value=mock_post_context)
+
+        mock_session_context = MagicMock()
+        mock_session_context.__aenter__ = AsyncMock(return_value=mock_session_instance)
+        mock_session_context.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                'server.services.automation_event_service.AUTOMATION_SERVICE_URL',
+                'https://automation.example.com',
+            ),
+            patch(
+                'server.services.automation_event_service.aiohttp.ClientSession',
+                return_value=mock_session_context,
+            ),
+            patch('server.services.automation_event_service.logger') as mock_logger,
+        ):
+            service = create_service(mock_token_manager)
+            await service._send_to_automation_service(
+                ProviderType.GITHUB, org_id, payload
+            )
+
+            mock_logger.error.assert_called()
+            assert 'HTTP error' in str(mock_logger.error.call_args)
+
 
 class TestSignPayload:
     """Tests for _sign_payload method."""


### PR DESCRIPTION
HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

When forwarding an event to the automation service times out or fails with an HTTP error, the event was **never delivered**. The user triggered a Git provider action and nothing downstream processed it. No retry, no fallback. This is a hard failure with user-visible impact, not a degraded-but-recoverable condition.

## Summary

- Change log level from `warning` to `error` for `asyncio.TimeoutError` in `_send_source_to_automation_service`
- Change log level from `warning` to `error` for `aiohttp.ClientError` in `_send_source_to_automation_service`
- Add unit tests to verify the correct log level (error) is used for both exception cases

Logging convention applied:
- `warning` = degraded but recoverable (retrying, falling back)
- `error` = operation failed, user impact, no recovery

## Issue Number

Fixes #14816

## How to Test

Run the unit tests:
```bash
cd enterprise
PYTHONPATH=".:$PYTHONPATH" poetry run pytest tests/unit/server/services/test_automation_event_service.py::TestSendToAutomationService -v
```

All 6 tests should pass, including the 2 new tests:
- `test_send_timeout_logs_error`
- `test_send_client_error_logs_error`

## Type

- [x] Bug fix

@aivong-openhands can click here to [continue refining the PR](https://app.all-hands.dev/conversations/11ba071c-7c07-42a6-b4a8-2c3c68c9db43)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-fcad2b2   docker.openhands.dev/openhands/openhands:fcad2b2
```