### PR TITLE
feat: PLTF-2956 parallelize GitHub GraphQL queries in get_suggested_tasks

### DIFF
--- a/openhands/app_server/integrations/github/service/features.py
+++ b/openhands/app_server/integrations/github/service/features.py
@@ -1,3 +1,6 @@
+import asyncio
+from typing import Any
+
 from openhands.app_server.integrations.github.queries import (
     suggested_task_issue_graphql_query,
     suggested_task_pr_graphql_query,
@@ -23,95 +26,113 @@ class GitHubFeaturesMixin(GitHubMixinBase):
         - PRs authored by the user.
         - Issues assigned to the user.
 
-        Note: Queries are split to avoid timeout issues.
+        Note: Queries are run concurrently for better performance.
         """
         # Get user info to use in queries
         user = await self.get_user()
         login = user.login
         tasks: list[SuggestedTask] = []
-        variables = {'login': login}
+        variables: dict[str, str] = {'login': login}
 
-        try:
-            pr_response = await self.execute_graphql_query(
-                suggested_task_pr_graphql_query, variables
+        # Execute both GraphQL queries concurrently
+        results: tuple[Any, Any] = await asyncio.gather(
+            self.execute_graphql_query(suggested_task_pr_graphql_query, variables),
+            self.execute_graphql_query(suggested_task_issue_graphql_query, variables),
+            return_exceptions=True,
+        )
+        pr_response: Any = results[0]
+        issue_response: Any = results[1]
+
+        # Process PR response
+        if isinstance(pr_response, Exception):
+            logger.info(
+                f'Error fetching suggested task for PRs: {pr_response}',
+                extra={
+                    'signal': 'github_suggested_tasks',
+                    'user_id': self.external_auth_id,
+                },
             )
-            pr_data = pr_response['data']['user']
+        else:
+            try:
+                pr_data = pr_response['data']['user']
 
-            # Process pull requests
-            for pr in pr_data['pullRequests']['nodes']:
-                repo_name = pr['repository']['nameWithOwner']
+                # Process pull requests
+                for pr in pr_data['pullRequests']['nodes']:
+                    repo_name = pr['repository']['nameWithOwner']
 
-                # Start with default task type
-                task_type = TaskType.OPEN_PR
+                    # Start with default task type
+                    task_type = TaskType.OPEN_PR
 
-                # Check for specific states
-                if pr['mergeable'] == 'CONFLICTING':
-                    task_type = TaskType.MERGE_CONFLICTS
-                elif (
-                    pr['commits']['nodes']
-                    and pr['commits']['nodes'][0]['commit']['statusCheckRollup']
-                    and pr['commits']['nodes'][0]['commit']['statusCheckRollup'][
-                        'state'
-                    ]
-                    == 'FAILURE'
-                ):
-                    task_type = TaskType.FAILING_CHECKS
-                elif any(
-                    review['state'] in ['CHANGES_REQUESTED', 'COMMENTED']
-                    for review in pr['reviews']['nodes']
-                ):
-                    task_type = TaskType.UNRESOLVED_COMMENTS
+                    # Check for specific states
+                    if pr['mergeable'] == 'CONFLICTING':
+                        task_type = TaskType.MERGE_CONFLICTS
+                    elif (
+                        pr['commits']['nodes']
+                        and pr['commits']['nodes'][0]['commit']['statusCheckRollup']
+                        and pr['commits']['nodes'][0]['commit']['statusCheckRollup'][
+                            'state'
+                        ]
+                        == 'FAILURE'
+                    ):
+                        task_type = TaskType.FAILING_CHECKS
+                    elif any(
+                        review['state'] in ['CHANGES_REQUESTED', 'COMMENTED']
+                        for review in pr['reviews']['nodes']
+                    ):
+                        task_type = TaskType.UNRESOLVED_COMMENTS
 
-                # Only add the task if it's not OPEN_PR
-                if task_type != TaskType.OPEN_PR:
+                    # Only add the task if it's not OPEN_PR
+                    if task_type != TaskType.OPEN_PR:
+                        tasks.append(
+                            SuggestedTask(
+                                git_provider=ProviderType.GITHUB,
+                                task_type=task_type,
+                                repo=repo_name,
+                                issue_number=pr['number'],
+                                title=pr['title'],
+                            )
+                        )
+            except Exception as e:
+                logger.info(
+                    f'Error processing PR response: {e}',
+                    extra={
+                        'signal': 'github_suggested_tasks',
+                        'user_id': self.external_auth_id,
+                    },
+                )
+
+        # Process issue response
+        if isinstance(issue_response, Exception):
+            logger.info(
+                f'Error fetching suggested task for issues: {issue_response}',
+                extra={
+                    'signal': 'github_suggested_tasks',
+                    'user_id': self.external_auth_id,
+                },
+            )
+        else:
+            try:
+                issue_data = issue_response['data']['user']
+
+                # Process issues
+                for issue in issue_data['issues']['nodes']:
+                    repo_name = issue['repository']['nameWithOwner']
                     tasks.append(
                         SuggestedTask(
                             git_provider=ProviderType.GITHUB,
-                            task_type=task_type,
+                            task_type=TaskType.OPEN_ISSUE,
                             repo=repo_name,
-                            issue_number=pr['number'],
-                            title=pr['title'],
+                            issue_number=issue['number'],
+                            title=issue['title'],
                         )
                     )
-
-        except Exception as e:
-            logger.info(
-                f'Error fetching suggested task for PRs: {e}',
-                extra={
-                    'signal': 'github_suggested_tasks',
-                    'user_id': self.external_auth_id,
-                },
-            )
-
-        try:
-            # Execute issue query
-            issue_response = await self.execute_graphql_query(
-                suggested_task_issue_graphql_query, variables
-            )
-            issue_data = issue_response['data']['user']
-
-            # Process issues
-            for issue in issue_data['issues']['nodes']:
-                repo_name = issue['repository']['nameWithOwner']
-                tasks.append(
-                    SuggestedTask(
-                        git_provider=ProviderType.GITHUB,
-                        task_type=TaskType.OPEN_ISSUE,
-                        repo=repo_name,
-                        issue_number=issue['number'],
-                        title=issue['title'],
-                    )
+            except Exception as e:
+                logger.info(
+                    f'Error processing issue response: {e}',
+                    extra={
+                        'signal': 'github_suggested_tasks',
+                        'user_id': self.external_auth_id,
+                    },
                 )
-
-            return tasks
-
-        except Exception as e:
-            logger.info(
-                f'Error fetching suggested task for issues: {e}',
-                extra={
-                    'signal': 'github_suggested_tasks',
-                    'user_id': self.external_auth_id,
-                },
-            )
 
         return tasks

--- a/tests/unit/integrations/github/test_suggested_tasks.py
+++ b/tests/unit/integrations/github/test_suggested_tasks.py
@@ -1,8 +1,12 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, call
 
 import pytest
 
 from openhands.app_server.integrations.github.github_service import GitHubService
+from openhands.app_server.integrations.github.queries import (
+    suggested_task_issue_graphql_query,
+    suggested_task_pr_graphql_query,
+)
 from openhands.app_server.integrations.service_types import TaskType, User
 
 
@@ -16,8 +20,8 @@ async def test_get_suggested_tasks():
         name='Test User',
     )
 
-    # Mock GraphQL response
-    mock_graphql_response = {
+    # Mock PR GraphQL response
+    mock_pr_graphql_response = {
         'data': {
             'user': {
                 'pullRequests': {
@@ -66,6 +70,14 @@ async def test_get_suggested_tasks():
                         },
                     ]
                 },
+            }
+        }
+    }
+
+    # Mock issue GraphQL response
+    mock_issue_graphql_response = {
+        'data': {
+            'user': {
                 'issues': {
                     'nodes': [
                         {
@@ -87,10 +99,20 @@ async def test_get_suggested_tasks():
     # Create service instance with mocked methods
     service = GitHubService()
     service.get_user = AsyncMock(return_value=mock_user)
-    service.execute_graphql_query = AsyncMock(return_value=mock_graphql_response)
+    service.execute_graphql_query = AsyncMock(
+        side_effect=[mock_pr_graphql_response, mock_issue_graphql_response]
+    )
 
     # Call the function
     tasks = await service.get_suggested_tasks()
+
+    # Verify both GraphQL queries were called
+    assert service.execute_graphql_query.call_count == 2
+    expected_calls = [
+        call(suggested_task_pr_graphql_query, {'login': 'test-user'}),
+        call(suggested_task_issue_graphql_query, {'login': 'test-user'}),
+    ]
+    service.execute_graphql_query.assert_has_calls(expected_calls)
 
     # Verify the results
     assert len(tasks) == 5  # Should have 5 tasks total
@@ -122,3 +144,98 @@ async def test_get_suggested_tasks():
     commented_pr = next(t for t in tasks if t.task_type == TaskType.UNRESOLVED_COMMENTS)
     assert commented_pr.issue_number == 4
     assert commented_pr.title == 'PR with comments'
+
+
+@pytest.mark.asyncio
+async def test_get_suggested_tasks_pr_query_fails():
+    """Test that issues are still returned when PR query fails."""
+    mock_user = User(
+        id='1',
+        login='test-user',
+        avatar_url='https://example.com/avatar.jpg',
+        name='Test User',
+    )
+
+    # Mock issue response only
+    mock_issue_graphql_response = {
+        'data': {
+            'user': {
+                'issues': {
+                    'nodes': [
+                        {
+                            'number': 1,
+                            'title': 'Assigned issue',
+                            'repository': {'nameWithOwner': 'test-org/repo'},
+                        },
+                    ]
+                },
+            }
+        }
+    }
+
+    service = GitHubService()
+    service.get_user = AsyncMock(return_value=mock_user)
+    service.execute_graphql_query = AsyncMock(
+        side_effect=[
+            Exception('PR query failed'),  # PR query fails
+            mock_issue_graphql_response,  # Issue query succeeds
+        ]
+    )
+
+    # Call the function - should not raise despite PR query failure
+    tasks = await service.get_suggested_tasks()
+
+    # Verify we still get the issue task
+    assert len(tasks) == 1
+    assert tasks[0].task_type == TaskType.OPEN_ISSUE
+    assert tasks[0].issue_number == 1
+
+
+@pytest.mark.asyncio
+async def test_get_suggested_tasks_issue_query_fails():
+    """Test that PRs are still returned when issue query fails."""
+    mock_user = User(
+        id='1',
+        login='test-user',
+        avatar_url='https://example.com/avatar.jpg',
+        name='Test User',
+    )
+
+    # Mock PR response only
+    mock_pr_graphql_response = {
+        'data': {
+            'user': {
+                'pullRequests': {
+                    'nodes': [
+                        {
+                            'number': 1,
+                            'title': 'PR with conflicts',
+                            'repository': {'nameWithOwner': 'test-org/repo'},
+                            'mergeable': 'CONFLICTING',
+                            'commits': {
+                                'nodes': [{'commit': {'statusCheckRollup': None}}]
+                            },
+                            'reviews': {'nodes': []},
+                        },
+                    ]
+                },
+            }
+        }
+    }
+
+    service = GitHubService()
+    service.get_user = AsyncMock(return_value=mock_user)
+    service.execute_graphql_query = AsyncMock(
+        side_effect=[
+            mock_pr_graphql_response,  # PR query succeeds
+            Exception('Issue query failed'),  # Issue query fails
+        ]
+    )
+
+    # Call the function - should not raise despite issue query failure
+    tasks = await service.get_suggested_tasks()
+
+    # Verify we still get the PR task
+    assert len(tasks) == 1
+    assert tasks[0].task_type == TaskType.MERGE_CONFLICTS
+    assert tasks[0].issue_number == 1


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN: Get suggested tasks still loads for me during testing.


- [x] A human has tested these changes.

AGENT:

---

## Why

The `GET /api/v1/git/suggested-tasks/search` endpoint had high latency dominated by sequential GitHub API calls. The two GraphQL queries (PRs authored by the user + issues assigned to the user) were being awaited sequentially, adding one full GraphQL round-trip to every request.

## Summary

- Use `asyncio.gather` to run both GitHub GraphQL queries concurrently instead of sequentially
- Both queries are independent (both keyed on `user.login`), so they can safely run in parallel
- Preserve independent error handling by using `return_exceptions=True` — if one query fails, the other still returns results
- This change cuts roughly one GraphQL round-trip off every request, significantly reducing p95 latency

## Issue Number

Fixes #14817

## How to Test

1. Set up a GitHub integration and authenticated user
2. Monitor the `/api/v1/git/suggested-tasks/search` endpoint latency
3. Verify that suggested tasks (PRs with conflicts/checks/comments + assigned issues) are still returned correctly
4. Verify that if one query fails, the other still returns results (independent error handling)

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. You added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The same pattern likely exists in sibling provider implementations (gitlab, bitbucket, azure_devops, forgejo). This PR focuses only on GitHub as specified in the issue.

@aivong-openhands can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f05b5e36-7ca8-432a-a066-62a25df356c5)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-765151a   docker.openhands.dev/openhands/openhands:765151a
```