### PR TITLE
fix(mcp): store remote MCP API keys as redacted Authorization headers

### DIFF
--- a/frontend/__tests__/utils/mcp-config.test.ts
+++ b/frontend/__tests__/utils/mcp-config.test.ts
@@ -223,13 +223,17 @@ describe("toSdkMcpConfig", () => {
     expect(result?.mcpServers["sse_2"].url).toBe("https://example3.com");
   });
 
-  it("should include api_key as auth field", () => {
+  it("should serialize api_key as an Authorization bearer header", () => {
+    // The SDK only redacts/encrypts ``headers`` (and ``env``), not ``auth`` —
+    // writing the key to ``auth`` would persist it in plaintext.
     const config: MCPConfig = {
       sse_servers: [
         { name: "secure", url: "https://example.com", api_key: "my-secret" },
       ],
       stdio_servers: [],
-      shttp_servers: [],
+      shttp_servers: [
+        { name: "shttp", url: "https://shttp.example", api_key: "shttp-secret" },
+      ],
     };
 
     const result = toSdkMcpConfig(config);
@@ -237,7 +241,52 @@ describe("toSdkMcpConfig", () => {
     expect(result?.mcpServers["secure"]).toEqual({
       url: "https://example.com",
       transport: "sse",
-      auth: "my-secret",
+      headers: { Authorization: "Bearer my-secret" },
+    });
+    expect(result?.mcpServers["shttp"]).toEqual({
+      url: "https://shttp.example",
+      headers: { Authorization: "Bearer shttp-secret" },
+    });
+  });
+
+  it("round-trips persisted Authorization headers back to api_key fields", () => {
+    const persisted = {
+      mcpServers: {
+        shttp: {
+          url: "https://shttp.example",
+          headers: { Authorization: "Bearer shttp-secret" },
+        },
+      },
+    };
+
+    const parsed = parseMcpConfig(persisted);
+
+    expect(parsed.shttp_servers).toEqual([
+      { name: "shttp", url: "https://shttp.example", api_key: "shttp-secret" },
+    ]);
+  });
+
+  it("migrates legacy auth credentials to Authorization headers on re-serialize", () => {
+    const persisted = {
+      mcpServers: {
+        sse: {
+          url: "https://example.com",
+          transport: "sse",
+          auth: "legacy-secret",
+        },
+      },
+    };
+
+    const written = toSdkMcpConfig(parseMcpConfig(persisted));
+
+    expect(written).toEqual({
+      mcpServers: {
+        sse: {
+          url: "https://example.com",
+          transport: "sse",
+          headers: { Authorization: "Bearer legacy-secret" },
+        },
+      },
     });
   });
 

--- a/frontend/src/utils/mcp-config.ts
+++ b/frontend/src/utils/mcp-config.ts
@@ -15,6 +15,53 @@ const EMPTY_MCP_CONFIG: MCPConfig = {
 type SdkMcpServerConfig = Record<string, SettingsValue>;
 type SdkMcpConfig = { mcpServers: Record<string, SdkMcpServerConfig> };
 
+function apiKeyFromAuthorizationHeader(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    return value
+      .map(apiKeyFromAuthorizationHeader)
+      .find((apiKey) => apiKey !== undefined);
+  }
+
+  if (typeof value !== "string" || value.length === 0) return undefined;
+  const bearer = value.match(/^Bearer\s+(.+)$/i);
+  return bearer ? bearer[1] : value;
+}
+
+/**
+ * Recover a remote server's API key from either the canonical
+ * ``headers.Authorization`` bearer token or the legacy ``auth`` field (kept
+ * for back-compat with settings persisted before the header migration).
+ */
+function apiKeyFromServerConfig(
+  serverConfig: Record<string, unknown>,
+): string | undefined {
+  const { headers } = serverConfig;
+  const authorization =
+    headers && typeof headers === "object"
+      ? ((headers as Record<string, unknown>).Authorization ??
+        (headers as Record<string, unknown>).authorization)
+      : undefined;
+  const headerApiKey = apiKeyFromAuthorizationHeader(authorization);
+  if (headerApiKey) return headerApiKey;
+
+  const { auth } = serverConfig;
+  return typeof auth === "string" && auth !== "oauth" ? auth : undefined;
+}
+
+/**
+ * Serialize an API key as an ``Authorization`` bearer header. The SDK only
+ * redacts/encrypts ``headers`` (and ``env``), not ``auth``, so a key written
+ * to ``auth`` would persist in plaintext — write the header form instead.
+ */
+function getAuthorizationHeaders(apiKey: string | undefined) {
+  if (!apiKey) return {};
+  return {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  };
+}
+
 /**
  * Generate a unique name for an MCP server, avoiding collisions with existing names.
  * Only adds a suffix if there's an actual collision.
@@ -64,9 +111,7 @@ export function parseMcpConfig(value: unknown): MCPConfig {
 
     if (url) {
       const transport = serverConfig.transport as string | undefined;
-      const auth = serverConfig.auth as string | undefined;
-      const apiKey =
-        typeof auth === "string" && auth !== "oauth" ? auth : undefined;
+      const apiKey = apiKeyFromServerConfig(serverConfig);
 
       if (transport === "sse") {
         const server: MCPSSEServer = {
@@ -124,7 +169,7 @@ export function toSdkMcpConfig(config: MCPConfig): SdkMcpConfig | null {
       server.url = entry;
     } else {
       server.url = entry.url;
-      if (entry.api_key) server.auth = entry.api_key;
+      Object.assign(server, getAuthorizationHeaders(entry.api_key));
     }
     server.transport = "sse";
 
@@ -142,7 +187,7 @@ export function toSdkMcpConfig(config: MCPConfig): SdkMcpConfig | null {
       server.url = entry;
     } else {
       server.url = entry.url;
-      if (entry.api_key) server.auth = entry.api_key;
+      Object.assign(server, getAuthorizationHeaders(entry.api_key));
       if (entry.timeout != null) server.timeout = entry.timeout;
     }
 


### PR DESCRIPTION
HUMAN:

Reviewed and approved — ports the agent-canvas #1164 fix to OpenHands; remote MCP API keys are now redacted at rest.

- [x] A human has tested these changes.

AGENT:

Verified with the SDK serializer directly: an `ACPAgentSettings`/`OpenHandsAgentSettings` whose `mcp_config` carries the key as `auth` leaks it (`'SECRET' in model_dump_json()` → True), while the `headers.Authorization` form this PR writes is redacted (`<redacted>`). Frontend unit tests: 26/26 pass.

---

## Why

Remote (SSE / SHTTP) MCP server API keys were serialized into `mcp_config` as a bare `auth: <key>` field. The SDK's `mcp_config` secret serializer only redacts/encrypts `env` and `headers` — **not** `auth` — so the key was persisted and round-tripped in **plaintext** (in settings storage and in redacted GET responses). Older SDKs also didn't forward `auth` to ACP subprocesses (only `headers` was translated).

This is the same bug agent-canvas hit and fixed in OpenHands/agent-canvas#1164. It affects both the OpenHands agent and (once MCP is un-gated for ACP, OpenHands/software-agent-sdk#3705 / PR #14613) ACP agents.

## Summary

- `toSdkMcpConfig` now writes remote API keys as `headers: { Authorization: "Bearer <key>" }` instead of `auth: <key>`, so the SDK redacts/encrypts them and the ACP forwarding path picks them up.
- `parseMcpConfig` reads the key from `headers.Authorization` **or** the legacy `auth` field, so existing persisted settings keep working and migrate to the header form on the next save.
- Updated/added unit tests: serialize-as-header, header→`api_key` round-trip, and legacy-`auth`→header migration.

## Issue Number

Relates to OpenHands/software-agent-sdk#3705 (ACP MCP forwarding foundation)

## How to Test

```sh
cd frontend
npx vitest run __tests__/utils/mcp-config.test.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-473f035   docker.openhands.dev/openhands/openhands:473f035
```