### PR TITLE
fix: Use final response endpoint for resolver callbacks

### DIFF
--- a/enterprise/integrations/github/github_v1_callback_processor.py
+++ b/enterprise/integrations/github/github_v1_callback_processor.py
@@ -4,12 +4,10 @@ from uuid import UUID
 
 import httpx
 from github import Auth, Github, GithubException, GithubIntegration
-from integrations.utils import get_summary_instruction
 from integrations.v1_utils import handle_callback_error
 from pydantic import Field
 from server.auth.constants import GITHUB_APP_CLIENT_ID, GITHUB_APP_PRIVATE_KEY
 
-from openhands.agent_server.models import AskAgentRequest, AskAgentResponse
 from openhands.app_server.event_callback.event_callback_models import (
     EventCallback,
     EventCallbackProcessor,
@@ -56,12 +54,12 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
         # Log ALL terminal states for monitoring (finished, error, stuck)
         _logger.info('[GitHub V1] Callback agent state was %s', event)
 
-        # Only request summary when execution has finished successfully
+        # Only post the final response when execution has finished successfully
         if event.value != 'finished':
             return None
 
         _logger.info(
-            '[GitHub V1] Should request summary: %s', self.should_request_summary
+            '[GitHub V1] Should post final response: %s', self.should_request_summary
         )
 
         if not self.should_request_summary:
@@ -70,20 +68,20 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
         self.should_request_summary = False
 
         try:
-            _logger.info(f'[GitHub V1] Requesting summary {conversation_id}')
-            summary = await self._request_summary(conversation_id)
+            _logger.info(f'[GitHub V1] Fetching final response {conversation_id}')
+            final_response = await self._request_final_response(conversation_id)
             _logger.info(
-                f'[GitHub V1] Posting summary {conversation_id}',
-                extra={'summary': summary},
+                f'[GitHub V1] Posting final response {conversation_id}',
+                extra={'final_response': final_response},
             )
-            await self._post_summary_to_github(summary)
+            await self._post_summary_to_github(final_response)
 
             return EventCallbackResult(
                 status=EventCallbackResultStatus.SUCCESS,
                 event_callback_id=callback.id,
                 event_id=event.id,
                 conversation_id=conversation_id,
-                detail=summary,
+                detail=final_response,
             )
         except Exception as e:
             # Check if we have installation ID and credentials before posting
@@ -131,7 +129,7 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
         return token_data.token
 
     async def _post_summary_to_github(self, summary: str) -> None:
-        """Post a summary comment to the configured GitHub issue."""
+        """Post a resolver response comment to the configured GitHub issue."""
         installation_token = self._get_installation_access_token()
 
         if not installation_token:
@@ -169,35 +167,36 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
     # Agent / sandbox helpers
     # -------------------------------------------------------------------------
 
-    async def _ask_question(
+    async def _get_final_response(
         self,
         httpx_client: httpx.AsyncClient,
         agent_server_url: str,
         conversation_id: UUID,
         session_api_key: str,
-        message_content: str,
     ) -> str:
-        """Send a message to the agent server via the V1 API and return response text."""
-        send_message_request = AskAgentRequest(question=message_content)
-
+        """Fetch the agent's final response from the V1 API."""
         url = (
             f'{agent_server_url.rstrip("/")}'
-            f'/api/conversations/{conversation_id}/ask_agent'
+            f'/api/conversations/{conversation_id}/agent_final_response'
         )
         headers = {'X-Session-API-Key': session_api_key}
-        payload = send_message_request.model_dump()
 
         try:
-            response = await httpx_client.post(
+            response = await httpx_client.get(
                 url,
-                json=payload,
                 headers=headers,
                 timeout=30.0,
             )
             response.raise_for_status()
 
-            agent_response = AskAgentResponse.model_validate(response.json())
-            return agent_response.response
+            payload = response.json()
+            if not isinstance(payload, dict):
+                raise RuntimeError('Invalid agent final response payload')
+
+            final_response = str(payload.get('response') or '').strip()
+            if not final_response:
+                raise RuntimeError('Agent final response was empty')
+            return final_response
 
         except httpx.HTTPStatusError as e:
             error_detail = f'HTTP {e.response.status_code} error'
@@ -209,47 +208,33 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
                 pass
 
             _logger.error(
-                '[GitHub V1] HTTP error sending message to %s: %s. '
-                'Request payload: %s. Response headers: %s',
+                '[GitHub V1] HTTP error fetching final response from %s: %s. '
+                'Response headers: %s',
                 url,
                 error_detail,
-                payload,
                 dict(e.response.headers),
                 exc_info=True,
             )
-            raise Exception(f'Failed to send message to agent server: {error_detail}')
+            raise Exception(
+                f'Failed to fetch final response from agent server: {error_detail}'
+            )
 
         except httpx.TimeoutException:
             error_detail = f'Request timeout after 30 seconds to {url}'
-            _logger.error(
-                '[GitHub V1] %s. Request payload: %s',
-                error_detail,
-                payload,
-                exc_info=True,
-            )
+            _logger.error('[GitHub V1] %s', error_detail, exc_info=True)
             raise Exception(error_detail)
 
         except httpx.RequestError as e:
             error_detail = f'Request error to {url}: {str(e)}'
-            _logger.error(
-                '[GitHub V1] %s. Request payload: %s',
-                error_detail,
-                payload,
-                exc_info=True,
-            )
+            _logger.error('[GitHub V1] %s', error_detail, exc_info=True)
             raise Exception(error_detail)
 
     # -------------------------------------------------------------------------
-    # Summary orchestration
+    # Final response orchestration
     # -------------------------------------------------------------------------
 
-    async def _request_summary(self, conversation_id: UUID) -> str:
-        """Ask the agent to produce a summary of its work and return the agent response.
-
-        NOTE: This method now returns a string (the agent server's response text)
-        and raises exceptions on errors. The wrapping into EventCallbackResult
-        is handled by __call__.
-        """
+    async def _request_final_response(self, conversation_id: UUID) -> str:
+        """Return the agent's final response without asking the LLM to summarize."""
         # Import services within the method to avoid circular imports
         from openhands.app_server.config import (
             get_app_conversation_info_service,
@@ -289,18 +274,12 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
                 f'No session API key for sandbox: {sandbox.id}'
             )
 
-            # 3. URL + instruction
-            agent_server_url = get_agent_server_url_from_sandbox(sandbox)
+            # 3. URL
             agent_server_url = get_agent_server_url_from_sandbox(sandbox)
 
-            # Prepare message based on agent state
-            message_content = get_summary_instruction()
-
-            # Ask the agent and return the response text
-            return await self._ask_question(
+            return await self._get_final_response(
                 httpx_client=httpx_client,
                 agent_server_url=agent_server_url,
                 conversation_id=conversation_id,
                 session_api_key=sandbox.session_api_key,
-                message_content=message_content,
             )

--- a/enterprise/integrations/github/github_v1_callback_processor.py
+++ b/enterprise/integrations/github/github_v1_callback_processor.py
@@ -274,12 +274,9 @@ class GithubV1CallbackProcessor(EventCallbackProcessor):
                 f'No session API key for sandbox: {sandbox.id}'
             )
 
-            # 3. URL
-            agent_server_url = get_agent_server_url_from_sandbox(sandbox)
-
             return await self._get_final_response(
                 httpx_client=httpx_client,
-                agent_server_url=agent_server_url,
+                agent_server_url=get_agent_server_url_from_sandbox(sandbox),
                 conversation_id=conversation_id,
                 session_api_key=sandbox.session_api_key,
             )

--- a/enterprise/integrations/slack/slack_v1_callback_processor.py
+++ b/enterprise/integrations/slack/slack_v1_callback_processor.py
@@ -3,13 +3,11 @@ from typing import ClassVar
 from uuid import UUID
 
 import httpx
-from integrations.utils import get_summary_instruction
 from integrations.v1_utils import handle_callback_error
 from pydantic import Field
 from slack_sdk import WebClient
 from storage.slack_team_store import SlackTeamStore
 
-from openhands.agent_server.models import AskAgentRequest, AskAgentResponse
 from openhands.app_server.event_callback.event_callback_models import (
     EventCallback,
     EventCallbackProcessor,
@@ -54,20 +52,25 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
         # Log ALL terminal states for monitoring (finished, error, stuck)
         _logger.info('[Slack V1] Callback agent state was %s', event)
 
-        # Only request summary when execution has finished successfully
+        # Only post the final response when execution has finished successfully
         if event.value != 'finished':
             return None
 
         try:
-            summary = await self._request_summary(conversation_id)
-            await self._post_summary_to_slack(summary)
+            _logger.info(f'[Slack V1] Fetching final response {conversation_id}')
+            final_response = await self._request_final_response(conversation_id)
+            _logger.info(
+                f'[Slack V1] Posting final response {conversation_id}',
+                extra={'final_response': final_response},
+            )
+            await self._post_summary_to_slack(final_response)
 
             return EventCallbackResult(
                 status=EventCallbackResultStatus.SUCCESS,
                 event_callback_id=callback.id,
                 event_id=event.id,
                 conversation_id=conversation_id,
-                detail=summary,
+                detail=final_response,
             )
         except Exception as e:
             await handle_callback_error(
@@ -101,7 +104,7 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
         return bot_access_token
 
     async def _post_summary_to_slack(self, summary: str) -> None:
-        """Post a summary message to the configured Slack channel."""
+        """Post a resolver response message to the configured Slack channel."""
         bot_access_token = await self._get_bot_access_token()
         if not bot_access_token:
             raise RuntimeError('Missing Slack bot access token')
@@ -114,9 +117,9 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
         client = WebClient(token=bot_access_token)
 
         try:
-            # Post the summary as a threaded reply
+            # Post the response as a threaded reply.
             # Use markdown_text instead of text to properly render standard Markdown
-            # (e.g., **bold**, [link](url)) which is used throughout the codebase
+            # (e.g., **bold**, [link](url)) which is used throughout the codebase.
             response = client.chat_postMessage(
                 channel=channel_id,
                 markdown_text=summary,
@@ -131,7 +134,8 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
                 )
 
             _logger.info(
-                '[Slack V1] Successfully posted summary to channel %s', channel_id
+                '[Slack V1] Successfully posted final response to channel %s',
+                channel_id,
             )
 
         except Exception as e:
@@ -142,35 +146,36 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
     # Agent / sandbox helpers
     # -------------------------------------------------------------------------
 
-    async def _ask_question(
+    async def _get_final_response(
         self,
         httpx_client: httpx.AsyncClient,
         agent_server_url: str,
         conversation_id: UUID,
         session_api_key: str,
-        message_content: str,
     ) -> str:
-        """Send a message to the agent server via the V1 API and return response text."""
-        send_message_request = AskAgentRequest(question=message_content)
-
+        """Fetch the agent's final response from the V1 API."""
         url = (
             f'{agent_server_url.rstrip("/")}'
-            f'/api/conversations/{conversation_id}/ask_agent'
+            f'/api/conversations/{conversation_id}/agent_final_response'
         )
         headers = {'X-Session-API-Key': session_api_key}
-        payload = send_message_request.model_dump()
 
         try:
-            response = await httpx_client.post(
+            response = await httpx_client.get(
                 url,
-                json=payload,
                 headers=headers,
                 timeout=30.0,
             )
             response.raise_for_status()
 
-            agent_response = AskAgentResponse.model_validate(response.json())
-            return agent_response.response
+            payload = response.json()
+            if not isinstance(payload, dict):
+                raise RuntimeError('Invalid agent final response payload')
+
+            final_response = str(payload.get('response') or '').strip()
+            if not final_response:
+                raise RuntimeError('Agent final response was empty')
+            return final_response
 
         except httpx.HTTPStatusError as e:
             error_detail = f'HTTP {e.response.status_code} error'
@@ -182,47 +187,33 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
                 pass
 
             _logger.error(
-                '[Slack V1] HTTP error sending message to %s: %s. '
-                'Request payload: %s. Response headers: %s',
+                '[Slack V1] HTTP error fetching final response from %s: %s. '
+                'Response headers: %s',
                 url,
                 error_detail,
-                payload,
                 dict(e.response.headers),
                 exc_info=True,
             )
-            raise Exception(f'Failed to send message to agent server: {error_detail}')
+            raise Exception(
+                f'Failed to fetch final response from agent server: {error_detail}'
+            )
 
         except httpx.TimeoutException:
             error_detail = f'Request timeout after 30 seconds to {url}'
-            _logger.error(
-                '[Slack V1] %s. Request payload: %s',
-                error_detail,
-                payload,
-                exc_info=True,
-            )
+            _logger.error('[Slack V1] %s', error_detail, exc_info=True)
             raise Exception(error_detail)
 
         except httpx.RequestError as e:
             error_detail = f'Request error to {url}: {str(e)}'
-            _logger.error(
-                '[Slack V1] %s. Request payload: %s',
-                error_detail,
-                payload,
-                exc_info=True,
-            )
+            _logger.error('[Slack V1] %s', error_detail, exc_info=True)
             raise Exception(error_detail)
 
     # -------------------------------------------------------------------------
-    # Summary orchestration
+    # Final response orchestration
     # -------------------------------------------------------------------------
 
-    async def _request_summary(self, conversation_id: UUID) -> str:
-        """Ask the agent to produce a summary of its work and return the agent response.
-
-        NOTE: This method now returns a string (the agent server's response text)
-        and raises exceptions on errors. The wrapping into EventCallbackResult
-        is handled by __call__.
-        """
+    async def _request_final_response(self, conversation_id: UUID) -> str:
+        """Return the agent's final response without asking the LLM to summarize."""
         # Import services within the method to avoid circular imports
         from openhands.app_server.config import (
             get_app_conversation_info_service,
@@ -262,17 +253,12 @@ class SlackV1CallbackProcessor(EventCallbackProcessor):
                 f'No session API key for sandbox: {sandbox.id}'
             )
 
-            # 3. URL + instruction
+            # 3. URL
             agent_server_url = get_agent_server_url_from_sandbox(sandbox)
 
-            # Prepare message based on agent state
-            message_content = get_summary_instruction()
-
-            # Ask the agent and return the response text
-            return await self._ask_question(
+            return await self._get_final_response(
                 httpx_client=httpx_client,
                 agent_server_url=agent_server_url,
                 conversation_id=conversation_id,
                 session_api_key=sandbox.session_api_key,
-                message_content=message_content,
             )

--- a/enterprise/tests/unit/integrations/github/test_github_v1_callback_processor.py
+++ b/enterprise/tests/unit/integrations/github/test_github_v1_callback_processor.py
@@ -3,7 +3,7 @@ Tests for the GithubV1CallbackProcessor.
 
 Covers:
 - Event filtering
-- Successful summary + GitHub posting
+- Successful final response + GitHub posting
 - Inline PR comments
 - Error conditions (missing IDs/credentials, conversation/sandbox issues)
 - Agent server HTTP/timeout errors
@@ -152,7 +152,7 @@ async def _setup_happy_path_services(
     mock_response = MagicMock()
     mock_response.json.return_value = {'response': agent_response_text}
     mock_response.raise_for_status.return_value = None
-    mock_httpx_client.post.return_value = mock_response
+    mock_httpx_client.get.return_value = mock_response
     mock_get_httpx_client.return_value.__aenter__.return_value = mock_httpx_client
 
     return mock_httpx_client
@@ -211,7 +211,6 @@ class TestGithubV1CallbackProcessor:
     @patch('openhands.app_server.config.get_app_conversation_info_service')
     @patch('openhands.app_server.config.get_sandbox_service')
     @patch('openhands.app_server.config.get_httpx_client')
-    @patch('integrations.github.github_v1_callback_processor.get_summary_instruction')
     @patch('integrations.github.github_v1_callback_processor.Auth')
     @patch('integrations.github.github_v1_callback_processor.GithubIntegration')
     @patch('integrations.github.github_v1_callback_processor.Github')
@@ -220,7 +219,6 @@ class TestGithubV1CallbackProcessor:
         mock_github,
         mock_github_integration,
         mock_auth,
-        mock_get_summary_instruction,
         mock_get_httpx_client,
         mock_get_sandbox_service,
         mock_get_app_conversation_info_service,
@@ -240,8 +238,6 @@ class TestGithubV1CallbackProcessor:
             mock_app_conversation_info,
             mock_sandbox_info,
         )
-
-        mock_get_summary_instruction.return_value = 'Please provide a summary'
 
         # Auth.AppAuth and Auth.Token mock
         mock_app_auth_instance = MagicMock()
@@ -288,12 +284,12 @@ class TestGithubV1CallbackProcessor:
         mock_repo.get_issue.assert_called_once_with(number=42)
         mock_issue.create_comment.assert_called_once_with('Test summary from agent')
 
-        mock_httpx_client.post.assert_called_once()
-        url_arg, kwargs = mock_httpx_client.post.call_args
+        mock_httpx_client.get.assert_called_once()
+        url_arg, kwargs = mock_httpx_client.get.call_args
         url = url_arg[0] if url_arg else kwargs['url']
-        assert 'ask_agent' in url
+        assert 'agent_final_response' in url
         assert kwargs['headers']['X-Session-API-Key'] == 'test_api_key'
-        assert kwargs['json']['question'] == 'Please provide a summary'
+        assert 'json' not in kwargs
 
     @patch(
         'integrations.github.github_v1_callback_processor.GITHUB_APP_CLIENT_ID',
@@ -306,14 +302,12 @@ class TestGithubV1CallbackProcessor:
     @patch('openhands.app_server.config.get_app_conversation_info_service')
     @patch('openhands.app_server.config.get_sandbox_service')
     @patch('openhands.app_server.config.get_httpx_client')
-    @patch('integrations.github.github_v1_callback_processor.get_summary_instruction')
     @patch('integrations.github.github_v1_callback_processor.GithubIntegration')
     @patch('integrations.github.github_v1_callback_processor.Github')
     async def test_successful_inline_pr_comment(
         self,
         mock_github,
         mock_github_integration,
-        mock_get_summary_instruction,
         mock_get_httpx_client,
         mock_get_sandbox_service,
         mock_get_app_conversation_info_service,
@@ -332,8 +326,6 @@ class TestGithubV1CallbackProcessor:
             mock_app_conversation_info,
             mock_sandbox_info,
         )
-
-        mock_get_summary_instruction.return_value = 'Please provide a summary'
 
         mock_token_data = MagicMock()
         mock_token_data.token = 'test_access_token'
@@ -366,7 +358,6 @@ class TestGithubV1CallbackProcessor:
     # Error paths
     # ------------------------------------------------------------------ #
 
-    @patch('integrations.github.github_v1_callback_processor.get_summary_instruction')
     @patch('openhands.app_server.config.get_httpx_client')
     @patch('openhands.app_server.config.get_sandbox_service')
     @patch('openhands.app_server.config.get_app_conversation_info_service')
@@ -375,7 +366,6 @@ class TestGithubV1CallbackProcessor:
         mock_get_app_conversation_info_service,
         mock_get_sandbox_service,
         mock_get_httpx_client,
-        mock_get_summary_instruction,
         conversation_state_update_event,
         event_callback,
         mock_app_conversation_info,
@@ -393,8 +383,6 @@ class TestGithubV1CallbackProcessor:
             mock_app_conversation_info,
             mock_sandbox_info,
         )
-
-        mock_get_summary_instruction.return_value = 'Please provide a summary'
 
         result = await processor(
             conversation_id=conversation_id,
@@ -414,7 +402,6 @@ class TestGithubV1CallbackProcessor:
         'integrations.github.github_v1_callback_processor.GITHUB_APP_PRIVATE_KEY',
         '',
     )
-    @patch('integrations.github.github_v1_callback_processor.get_summary_instruction')
     @patch('openhands.app_server.config.get_httpx_client')
     @patch('openhands.app_server.config.get_sandbox_service')
     @patch('openhands.app_server.config.get_app_conversation_info_service')
@@ -423,7 +410,6 @@ class TestGithubV1CallbackProcessor:
         mock_get_app_conversation_info_service,
         mock_get_sandbox_service,
         mock_get_httpx_client,
-        mock_get_summary_instruction,
         github_callback_processor,
         conversation_state_update_event,
         event_callback,
@@ -439,8 +425,6 @@ class TestGithubV1CallbackProcessor:
             mock_app_conversation_info,
             mock_sandbox_info,
         )
-
-        mock_get_summary_instruction.return_value = 'Please provide a summary'
 
         result = await github_callback_processor(
             conversation_id=conversation_id,
@@ -515,10 +499,8 @@ class TestGithubV1CallbackProcessor:
     @patch('openhands.app_server.config.get_app_conversation_info_service')
     @patch('openhands.app_server.config.get_sandbox_service')
     @patch('openhands.app_server.config.get_httpx_client')
-    @patch('integrations.github.github_v1_callback_processor.get_summary_instruction')
     async def test_agent_server_http_error(
         self,
-        mock_get_summary_instruction,
         mock_get_httpx_client,
         mock_get_sandbox_service,
         mock_get_app_conversation_info_service,
@@ -539,8 +521,6 @@ class TestGithubV1CallbackProcessor:
             mock_sandbox_info,
         )
 
-        mock_get_summary_instruction.return_value = 'Please provide a summary'
-
         mock_httpx_client = mock_get_httpx_client.return_value.__aenter__.return_value
         mock_response = MagicMock()
         mock_response.status_code = 500
@@ -549,7 +529,7 @@ class TestGithubV1CallbackProcessor:
         mock_error = httpx.HTTPStatusError(
             'HTTP 500 error', request=MagicMock(), response=mock_response
         )
-        mock_httpx_client.post.side_effect = mock_error
+        mock_httpx_client.get.side_effect = mock_error
 
         result = await github_callback_processor(
             conversation_id=conversation_id,
@@ -559,7 +539,7 @@ class TestGithubV1CallbackProcessor:
 
         assert result is not None
         assert result.status == EventCallbackResultStatus.ERROR
-        assert 'Failed to send message to agent server' in result.detail
+        assert 'Failed to fetch final response from agent server' in result.detail
 
     @patch(
         'integrations.github.github_v1_callback_processor.GITHUB_APP_CLIENT_ID',
@@ -572,10 +552,8 @@ class TestGithubV1CallbackProcessor:
     @patch('openhands.app_server.config.get_app_conversation_info_service')
     @patch('openhands.app_server.config.get_sandbox_service')
     @patch('openhands.app_server.config.get_httpx_client')
-    @patch('integrations.github.github_v1_callback_processor.get_summary_instruction')
     async def test_agent_server_timeout(
         self,
-        mock_get_summary_instruction,
         mock_get_httpx_client,
         mock_get_sandbox_service,
         mock_get_app_conversation_info_service,
@@ -595,10 +573,8 @@ class TestGithubV1CallbackProcessor:
             mock_sandbox_info,
         )
 
-        mock_get_summary_instruction.return_value = 'Please provide a summary'
-
         mock_httpx_client = mock_get_httpx_client.return_value.__aenter__.return_value
-        mock_httpx_client.post.side_effect = httpx.TimeoutException('Request timeout')
+        mock_httpx_client.get.side_effect = httpx.TimeoutException('Request timeout')
 
         result = await github_callback_processor(
             conversation_id=conversation_id,
@@ -772,7 +748,6 @@ class TestGithubV1CallbackProcessor:
         'integrations.github.github_v1_callback_processor.GITHUB_APP_PRIVATE_KEY',
         'test_private_key',
     )
-    @patch('integrations.github.github_v1_callback_processor.get_summary_instruction')
     @patch('openhands.app_server.config.get_httpx_client')
     @patch('openhands.app_server.config.get_sandbox_service')
     @patch('openhands.app_server.config.get_app_conversation_info_service')
@@ -781,7 +756,6 @@ class TestGithubV1CallbackProcessor:
         mock_get_app_conversation_info_service,
         mock_get_sandbox_service,
         mock_get_httpx_client,
-        mock_get_summary_instruction,
         github_callback_processor,
         conversation_state_update_event,
         event_callback,
@@ -798,8 +772,7 @@ class TestGithubV1CallbackProcessor:
             mock_app_conversation_info,
             mock_sandbox_info,
         )
-        mock_httpx_client.post.side_effect = Exception('Simulated agent server error')
-        mock_get_summary_instruction.return_value = 'Please provide a summary'
+        mock_httpx_client.get.side_effect = Exception('Simulated agent server error')
 
         with (
             patch(
@@ -848,7 +821,6 @@ class TestGithubV1CallbackProcessor:
         'integrations.github.github_v1_callback_processor.GITHUB_APP_PRIVATE_KEY',
         'test_private_key',
     )
-    @patch('integrations.github.github_v1_callback_processor.get_summary_instruction')
     @patch('openhands.app_server.config.get_httpx_client')
     @patch('openhands.app_server.config.get_sandbox_service')
     @patch('openhands.app_server.config.get_app_conversation_info_service')
@@ -859,7 +831,6 @@ class TestGithubV1CallbackProcessor:
         mock_get_app_conversation_info_service,
         mock_get_sandbox_service,
         mock_get_httpx_client,
-        mock_get_summary_instruction,
         github_callback_processor,
         conversation_state_update_event,
         event_callback,
@@ -882,8 +853,7 @@ class TestGithubV1CallbackProcessor:
             '"exception":"litellm.BadRequestError: Litellm_proxyException - '
             'Budget has been exceeded! Current cost: 12.65, Max budget: 12.62"}'
         )
-        mock_httpx_client.post.side_effect = Exception(budget_error_msg)
-        mock_get_summary_instruction.return_value = 'Please provide a summary'
+        mock_httpx_client.get.side_effect = Exception(budget_error_msg)
 
         with (
             patch(

--- a/enterprise/tests/unit/integrations/slack/test_slack_v1_callback_processor.py
+++ b/enterprise/tests/unit/integrations/slack/test_slack_v1_callback_processor.py
@@ -144,10 +144,10 @@ class TestSlackV1CallbackProcessor:
 
     @patch('storage.slack_team_store.SlackTeamStore.get_instance')
     @patch('integrations.slack.slack_v1_callback_processor.WebClient')
-    @patch.object(SlackV1CallbackProcessor, '_request_summary')
+    @patch.object(SlackV1CallbackProcessor, '_request_final_response')
     async def test_double_callback_processing(
         self,
-        mock_request_summary,
+        mock_request_final_response,
         mock_web_client,
         mock_slack_team_store,
         slack_callback_processor,
@@ -162,8 +162,8 @@ class TestSlackV1CallbackProcessor:
         mock_store.get_team_bot_token = AsyncMock(return_value='xoxb-test-token')
         mock_slack_team_store.return_value = mock_store
 
-        # Mock successful summary generation
-        mock_request_summary.return_value = 'Test summary from agent'
+        # Mock successful final response retrieval
+        mock_request_final_response.return_value = 'Test summary from agent'
 
         # Mock Slack WebClient
         mock_slack_client = MagicMock()
@@ -189,8 +189,8 @@ class TestSlackV1CallbackProcessor:
         assert result2.status == EventCallbackResultStatus.SUCCESS
         assert result2.detail == 'Test summary from agent'
 
-        # Verify both callbacks triggered summary requests and Slack posts
-        assert mock_request_summary.call_count == 2
+        # Verify both callbacks fetched final responses and posted to Slack
+        assert mock_request_final_response.call_count == 2
         assert mock_slack_client.chat_postMessage.call_count == 2
 
     # -------------------------------------------------------------------------
@@ -201,12 +201,10 @@ class TestSlackV1CallbackProcessor:
     @patch('openhands.app_server.config.get_httpx_client')
     @patch('openhands.app_server.config.get_sandbox_service')
     @patch('openhands.app_server.config.get_app_conversation_info_service')
-    @patch('integrations.slack.slack_v1_callback_processor.get_summary_instruction')
     @patch('integrations.slack.slack_v1_callback_processor.WebClient')
     async def test_successful_end_to_end_flow(
         self,
         mock_web_client,
-        mock_get_summary_instruction,
         mock_get_app_conversation_info_service,
         mock_get_sandbox_service,
         mock_get_httpx_client,
@@ -224,9 +222,6 @@ class TestSlackV1CallbackProcessor:
         mock_store = MagicMock()
         mock_store.get_team_bot_token = AsyncMock(return_value='xoxb-test-token')
         mock_slack_team_store.return_value = mock_store
-
-        # Mock summary instruction
-        mock_get_summary_instruction.return_value = 'Please provide a summary'
 
         # Mock services
         mock_app_conversation_info_service = AsyncMock()
@@ -247,7 +242,7 @@ class TestSlackV1CallbackProcessor:
         mock_response = MagicMock()
         mock_response.json.return_value = {'response': 'Test summary from agent'}
         mock_response.raise_for_status = MagicMock()
-        mock_httpx_client.post.return_value = mock_response
+        mock_httpx_client.get.return_value = mock_response
         mock_get_httpx_client.return_value.__aenter__.return_value = mock_httpx_client
 
         # Mock Slack WebClient
@@ -274,6 +269,12 @@ class TestSlackV1CallbackProcessor:
             unfurl_links=False,
             unfurl_media=False,
         )
+        mock_httpx_client.get.assert_called_once()
+        url_arg, kwargs = mock_httpx_client.get.call_args
+        url = url_arg[0] if url_arg else kwargs['url']
+        assert 'agent_final_response' in url
+        assert kwargs['headers']['X-Session-API-Key'] == 'test-session-key'
+        assert 'json' not in kwargs
 
     # -------------------------------------------------------------------------
     # Error handling tests (parameterized)
@@ -287,10 +288,10 @@ class TestSlackV1CallbackProcessor:
         ],
     )
     @patch('storage.slack_team_store.SlackTeamStore.get_instance')
-    @patch.object(SlackV1CallbackProcessor, '_request_summary')
+    @patch.object(SlackV1CallbackProcessor, '_request_final_response')
     async def test_missing_bot_token_scenarios(
         self,
-        mock_request_summary,
+        mock_request_final_response,
         mock_slack_team_store,
         slack_callback_processor,
         finish_event,
@@ -304,8 +305,8 @@ class TestSlackV1CallbackProcessor:
         mock_store.get_team_bot_token = AsyncMock(return_value=bot_token)
         mock_slack_team_store.return_value = mock_store
 
-        # Mock successful summary generation
-        mock_request_summary.return_value = 'Test summary'
+        # Mock successful final response retrieval
+        mock_request_final_response.return_value = 'Test summary'
 
         result = await slack_callback_processor(uuid4(), event_callback, finish_event)
 
@@ -326,10 +327,10 @@ class TestSlackV1CallbackProcessor:
     )
     @patch('storage.slack_team_store.SlackTeamStore.get_instance')
     @patch('integrations.slack.slack_v1_callback_processor.WebClient')
-    @patch.object(SlackV1CallbackProcessor, '_request_summary')
+    @patch.object(SlackV1CallbackProcessor, '_request_final_response')
     async def test_slack_api_error_scenarios(
         self,
-        mock_request_summary,
+        mock_request_final_response,
         mock_web_client,
         mock_slack_team_store,
         slack_callback_processor,
@@ -344,8 +345,8 @@ class TestSlackV1CallbackProcessor:
         mock_store.get_team_bot_token = AsyncMock(return_value='xoxb-test-token')
         mock_slack_team_store.return_value = mock_store
 
-        # Mock successful summary generation
-        mock_request_summary.return_value = 'Test summary'
+        # Mock successful final response retrieval
+        mock_request_final_response.return_value = 'Test summary'
 
         # Mock Slack WebClient with error response
         mock_slack_client = MagicMock()
@@ -373,7 +374,7 @@ class TestSlackV1CallbackProcessor:
                         status_code=500, text='Internal Server Error', headers={}
                     ),
                 ),
-                'Failed to send message to agent server',
+                'Failed to fetch final response from agent server',
             ),
             (
                 httpx.RequestError('Connection error'),
@@ -385,10 +386,8 @@ class TestSlackV1CallbackProcessor:
     @patch('openhands.app_server.config.get_httpx_client')
     @patch('openhands.app_server.config.get_sandbox_service')
     @patch('openhands.app_server.config.get_app_conversation_info_service')
-    @patch('integrations.slack.slack_v1_callback_processor.get_summary_instruction')
     async def test_agent_server_error_scenarios(
         self,
-        mock_get_summary_instruction,
         mock_get_app_conversation_info_service,
         mock_get_sandbox_service,
         mock_get_httpx_client,
@@ -409,9 +408,6 @@ class TestSlackV1CallbackProcessor:
         mock_store.get_team_bot_token = AsyncMock(return_value='xoxb-test-token')
         mock_slack_team_store.return_value = mock_store
 
-        # Mock summary instruction
-        mock_get_summary_instruction.return_value = 'Please provide a summary'
-
         # Mock services
         mock_app_conversation_info_service = AsyncMock()
         mock_app_conversation_info_service.get_app_conversation_info.return_value = (
@@ -429,7 +425,7 @@ class TestSlackV1CallbackProcessor:
 
         # Mock HTTP client with the specified exception
         mock_httpx_client = AsyncMock()
-        mock_httpx_client.post.side_effect = exception
+        mock_httpx_client.get.side_effect = exception
         mock_get_httpx_client.return_value.__aenter__.return_value = mock_httpx_client
 
         # Execute
@@ -446,14 +442,12 @@ class TestSlackV1CallbackProcessor:
     @patch('openhands.app_server.config.get_httpx_client')
     @patch('openhands.app_server.config.get_sandbox_service')
     @patch('openhands.app_server.config.get_app_conversation_info_service')
-    @patch('integrations.slack.slack_v1_callback_processor.get_summary_instruction')
     @patch('integrations.slack.slack_v1_callback_processor._logger')
     @patch('integrations.slack.slack_v1_callback_processor.WebClient')
     async def test_budget_exceeded_error_logs_info_and_sends_friendly_message(
         self,
         mock_web_client_cls,
         mock_logger,
-        mock_get_summary_instruction,
         mock_get_app_conversation_info_service,
         mock_get_sandbox_service,
         mock_get_httpx_client,
@@ -471,8 +465,6 @@ class TestSlackV1CallbackProcessor:
         mock_store = MagicMock()
         mock_store.get_team_bot_token = AsyncMock(return_value='xoxb-test-token')
         mock_slack_team_store.return_value = mock_store
-
-        mock_get_summary_instruction.return_value = 'Please provide a summary'
 
         # Mock services
         mock_app_conversation_info_service = AsyncMock()
@@ -496,7 +488,7 @@ class TestSlackV1CallbackProcessor:
             'Budget has been exceeded! Current cost: 12.65, Max budget: 12.62"}'
         )
         mock_httpx_client = AsyncMock()
-        mock_httpx_client.post.side_effect = Exception(budget_error_msg)
+        mock_httpx_client.get.side_effect = Exception(budget_error_msg)
         mock_get_httpx_client.return_value.__aenter__.return_value = mock_httpx_client
 
         # Mock Slack WebClient


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:


- [x] A human has tested these changes.

AGENT:

_This PR was created by an AI agent (OpenHands) on behalf of the user._

---

## Why

Slack and GitHub resolver callbacks currently call `ask_agent` to ask the LLM to summarize the full trajectory before posting back to the originating thread/issue. That can be slow and flaky, and it can be less useful than posting the agent's actual final response.

## Summary

- Replace Slack and GitHub V1 resolver callback summary generation with `GET /api/conversations/{conversation_id}/agent_final_response`.
- Post the returned final response directly to Slack/GitHub instead of sending a summary prompt to `ask_agent`.
- Update Slack/GitHub callback tests to assert `agent_final_response` usage and remove `ask_agent` request expectations.

## Issue Number

APP-2305

## How to Test

Automated validation run:

```bash
cd enterprise
PYTHONPATH=".:$PYTHONPATH" poetry run pytest \
  tests/unit/integrations/github/test_github_v1_callback_processor.py \
  tests/unit/integrations/slack/test_slack_v1_callback_processor.py \
  --confcutdir=tests/unit/integrations -q
```

Result: `34 passed`

Targeted pre-commit run:

```bash
cd enterprise
poetry run pre-commit run --show-diff-on-failure \
  --config ./dev_config/python/.pre-commit-config.yaml \
  --files integrations/github/github_v1_callback_processor.py \
          integrations/slack/slack_v1_callback_processor.py \
          tests/unit/integrations/github/test_github_v1_callback_processor.py \
          tests/unit/integrations/slack/test_slack_v1_callback_processor.py
```

Result: all hooks passed.

## Video/Screenshots

N/A — backend integration callback behavior covered by unit tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The existing `should_request_summary` field/name is preserved for compatibility with existing serialized callback processor payloads, but its behavior now gates final response posting rather than summary generation.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/daac7803-c8b9-4151-9839-8bea68ae99d9)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-07cf7bf   docker.openhands.dev/openhands/openhands:07cf7bf
```