### PR TITLE
fix: Add SaaS migration for sandbox pause state

### DIFF
--- a/enterprise/migrations/versions/121_add_is_paused_to_v1_remote_sandbox.py
+++ b/enterprise/migrations/versions/121_add_is_paused_to_v1_remote_sandbox.py
@@ -1,0 +1,37 @@
+"""Add is_paused to v1_remote_sandbox.
+
+The OpenHands app-server RemoteSandboxService stores pause state on
+v1_remote_sandbox and queries it during concurrency-limit checks. Enterprise
+migrations create the table separately from the OSS app-lifespan migrations, so
+SaaS deployments need this column in the enterprise migration chain as well.
+
+Revision ID: 121
+Revises: 120
+Create Date: 2026-06-15
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '121'
+down_revision: Union[str, None] = '120'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'v1_remote_sandbox',
+        sa.Column(
+            'is_paused',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('v1_remote_sandbox', 'is_paused')


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:


- [ ] A human has tested these changes.

AGENT:

_This PR was created by an AI agent (OpenHands) on behalf of the user._

---

## Why

OpenHands app-server migration `openhands/app_server/app_lifespan/alembic/versions/011.py` added `v1_remote_sandbox.is_paused` for local/OSS deployments, and `RemoteSandboxService` now queries that column during concurrency-limit checks.

SaaS/enterprise deployments use the enterprise Alembic migration chain under `enterprise/migrations/versions/`, which creates and migrates `v1_remote_sandbox` separately. That chain did not include the `is_paused` column, causing SaaS conversation startup to fail with:

```text
UndefinedColumnError: column v1_remote_sandbox.is_paused does not exist
```

PR which introduced bug https://github.com/OpenHands/OpenHands/pull/14168

## Summary

- Add enterprise migration `121_add_is_paused_to_v1_remote_sandbox.py`.
- Add non-null `v1_remote_sandbox.is_paused` with default `false`, matching the local app-server migration behavior.
- Include downgrade support for removing the column.

## Issue Number

N/A

## How to Test

Validation run:

```bash
cd enterprise
python3 -m py_compile migrations/versions/121_add_is_paused_to_v1_remote_sandbox.py
poetry run pre-commit run --show-diff-on-failure \
  --config ./dev_config/python/.pre-commit-config.yaml \
  --files migrations/versions/121_add_is_paused_to_v1_remote_sandbox.py
poetry run alembic heads
poetry run alembic history -r 118:head
```

Results:

- Pre-commit passed.
- Alembic head is `121`.
- History shows `120 -> 121 (head), Add is_paused to v1_remote_sandbox.`

## Video/Screenshots

N/A — database migration only.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This migration mirrors the `is_paused` schema addition that already exists in the local app-server Alembic migration chain, but applies it to the SaaS/enterprise migration path.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/daac7803-c8b9-4151-9839-8bea68ae99d9)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-05cb00d   docker.openhands.dev/openhands/openhands:05cb00d
```