### PR TITLE
fix: Ignore OpenHands bot GitHub resolver events

### DIFF
--- a/enterprise/integrations/github/github_manager.py
+++ b/enterprise/integrations/github/github_manager.py
@@ -42,6 +42,12 @@ from openhands.app_server.types import (
 )
 from openhands.app_server.utils.logger import openhands_logger as logger
 
+IGNORED_GITHUB_EVENT_SENDERS = frozenset(
+    {
+        'openhands-ai[bot]',
+    }
+)
+
 
 class GithubManager(Manager[GithubViewType]):
     def __init__(
@@ -123,6 +129,13 @@ class GithubManager(Manager[GithubViewType]):
 
             return False
 
+    def _get_ignored_sender_login(self, message: Message) -> str | None:
+        payload = message.message.get('payload', {})
+        login = payload.get('sender', {}).get('login')
+        if login and login.lower() in IGNORED_GITHUB_EVENT_SENDERS:
+            return login
+        return None
+
     def _get_issue_number_from_payload(self, message: Message) -> int | None:
         """Extract issue/PR number from a GitHub webhook payload.
 
@@ -196,6 +209,11 @@ class GithubManager(Manager[GithubViewType]):
     async def is_job_requested(self, message: Message) -> bool:
         self._confirm_incoming_source_type(message)
 
+        ignored_sender = self._get_ignored_sender_login(message)
+        if ignored_sender:
+            logger.info('[GitHub] Ignoring event from %s', ignored_sender)
+            return False
+
         installation_id = message.message['installation']
         payload = message.message.get('payload', {})
         repo_obj = payload.get('repository')
@@ -236,6 +254,12 @@ class GithubManager(Manager[GithubViewType]):
 
     async def receive_message(self, message: Message):
         self._confirm_incoming_source_type(message)
+
+        ignored_sender = self._get_ignored_sender_login(message)
+        if ignored_sender:
+            logger.info('[GitHub] Ignoring event from %s', ignored_sender)
+            return
+
         try:
             await self.data_collector.process_payload(message)
         except Exception:

--- a/enterprise/tests/unit/integrations/github/test_github_manager.py
+++ b/enterprise/tests/unit/integrations/github/test_github_manager.py
@@ -7,6 +7,7 @@ Covers:
 - All supported trigger types: labeled issues, issue comments, PR comments, inline PR comments
 """
 
+from copy import deepcopy
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -315,6 +316,63 @@ class TestGithubManagerUserNotFound:
         assert '@testuser' in comment_text
         assert "haven't created an OpenHands account" in comment_text
         assert 'sign up' in comment_text.lower()
+
+    @pytest.mark.asyncio
+    @patch('integrations.github.github_manager.Auth')
+    @patch('integrations.github.github_manager.GithubIntegration')
+    async def test_is_job_requested_ignores_openhands_bot_sender(
+        self,
+        mock_github_integration,
+        mock_auth,
+        mock_token_manager,
+        mock_data_collector,
+        github_issue_message,
+    ):
+        """Test that bot-authored comments from the OpenHands GitHub App do not start jobs."""
+        github_issue_message = deepcopy(github_issue_message)
+        github_issue_message.message['payload']['sender'] = {
+            'id': 188912522,
+            'login': 'openhands-ai[bot]',
+        }
+        github_issue_message.message['payload']['comment']['body'] = (
+            'Documented upstream changes in @openhands/extensions.'
+        )
+
+        manager = GithubManager(mock_token_manager, mock_data_collector)
+        manager._user_has_write_access_to_repo = MagicMock(return_value=True)
+
+        assert await manager.is_job_requested(github_issue_message) is False
+        manager._user_has_write_access_to_repo.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch('integrations.github.github_manager.Auth')
+    @patch('integrations.github.github_manager.GithubIntegration')
+    async def test_receive_message_ignores_openhands_bot_sender_before_processing(
+        self,
+        mock_github_integration,
+        mock_auth,
+        mock_token_manager,
+        mock_data_collector,
+        github_issue_message,
+    ):
+        """Test that ignored bot events are dropped before collection or account lookup."""
+        github_issue_message = deepcopy(github_issue_message)
+        github_issue_message.message['payload']['sender'] = {
+            'id': 188912522,
+            'login': 'openhands-ai[bot]',
+        }
+        github_issue_message.message['payload']['comment']['body'] = (
+            'Documented upstream changes in @openhands/extensions.'
+        )
+
+        manager = GithubManager(mock_token_manager, mock_data_collector)
+        manager.is_job_requested = AsyncMock(return_value=True)
+
+        await manager.receive_message(github_issue_message)
+
+        mock_data_collector.process_payload.assert_not_awaited()
+        manager.is_job_requested.assert_not_awaited()
+        mock_token_manager.get_user_id_from_idp_user_id.assert_not_called()
 
     @patch('integrations.github.github_manager.Auth')
     @patch('integrations.github.github_manager.GithubIntegration')


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:


- [ ] A human has tested these changes.

AGENT:

_This PR was created by an AI agent (OpenHands) on behalf of the user._

---

## Why

GitHub resolver summaries can mention repositories such as `@openhands/extensions`. The current GitHub trigger detection treats that text as an `@openhands` invocation, so the OpenHands GitHub App bot's own summary comment can be re-ingested as a new resolver request. Because `openhands-ai[bot]` is not linked to a Keycloak user, the resolver posts a misleading account creation message immediately after the real summary.

## Summary

- Add a small GitHub resolver sender blacklist with `openhands-ai[bot]`.
- Drop ignored sender events before payload collection, permission checks, account lookup, or job startup.
- Also guard `is_job_requested()` directly so callers cannot accidentally start jobs for ignored senders.
- Add focused tests for both direct job-request checks and full `receive_message()` processing.

## Issue Number

APP-2305

## How to Test

Validation run:

```bash
cd enterprise
PYTHONPATH=".:$PYTHONPATH" poetry run pytest \
  tests/unit/integrations/github/test_github_manager.py \
  --confcutdir=tests/unit/integrations -q

poetry run pre-commit run --show-diff-on-failure \
  --config ./dev_config/python/.pre-commit-config.yaml \
  --files integrations/github/github_manager.py \
          tests/unit/integrations/github/test_github_manager.py
```

Results:

- `15 passed`
- targeted pre-commit passed

## Video/Screenshots

N/A — backend resolver filtering only.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This intentionally uses a conservative blacklist instead of broad bot detection because some automation accounts may appear as normal GitHub users. The immediate production issue is the OpenHands GitHub App sender `openhands-ai[bot]`.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/daac7803-c8b9-4151-9839-8bea68ae99d9)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-058bfb0   docker.openhands.dev/openhands/openhands:058bfb0
```