### PR TITLE
fix: duplicate Slack no-repository selections

### DIFF
--- a/enterprise/integrations/slack/slack_manager.py
+++ b/enterprise/integrations/slack/slack_manager.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import httpx
 from integrations.manager import Manager
 from integrations.models import Message, SourceType
 from integrations.slack.slack_errors import SlackError, SlackErrorCode
@@ -54,6 +55,8 @@ authorize_url_generator = AuthorizeUrlGenerator(
 
 # Key prefix for storing user messages in Redis during repo selection flow
 SLACK_USER_MSG_KEY_PREFIX = 'slack_user_msg'
+# Key prefix for deduplicating Slack repo selection form submissions
+SLACK_FORM_INTERACTION_KEY_PREFIX = 'slack_form_interaction'
 # Expiration time for stored user messages (5 minutes)
 # Arbitrary timeout based on typical user attention span; may be tuned based on feedback
 SLACK_USER_MSG_EXPIRATION = 300
@@ -201,6 +204,98 @@ class SlackManager(Manager[SlackViewInterface]):
             raise SlackError(
                 SlackErrorCode.REDIS_RETRIEVE_FAILED,
                 log_context={'message_ts': message_ts, 'thread_ts': thread_ts},
+            )
+
+    async def _claim_form_interaction(
+        self, team_id: str, channel_id: str, message_ts: str, thread_ts: str | None
+    ) -> bool:
+        """Atomically claim a repo selection form interaction.
+
+        Slack can deliver multiple button click payloads when a user clicks the
+        form repeatedly. Only the first interaction for an original Slack message
+        should start a conversation.
+        """
+        key = (
+            f'{SLACK_FORM_INTERACTION_KEY_PREFIX}:'
+            f'{team_id}:{channel_id}:{message_ts}:{thread_ts}'
+        )
+        try:
+            redis = get_redis_client_async()
+            claimed = await redis.set(
+                key,
+                'processing',
+                ex=SLACK_USER_MSG_EXPIRATION,
+                nx=True,
+            )
+            if claimed:
+                logger.info(
+                    'slack_form_interaction_claimed',
+                    extra={
+                        'message_ts': message_ts,
+                        'thread_ts': thread_ts,
+                        'key': key,
+                    },
+                )
+                return True
+
+            logger.info(
+                'slack_form_interaction_already_claimed',
+                extra={
+                    'message_ts': message_ts,
+                    'thread_ts': thread_ts,
+                    'key': key,
+                },
+            )
+            return False
+        except Exception as e:
+            logger.error(
+                'slack_claim_form_interaction_failed',
+                extra={
+                    'message_ts': message_ts,
+                    'thread_ts': thread_ts,
+                    'key': key,
+                    'error': str(e),
+                },
+            )
+            raise SlackError(
+                SlackErrorCode.REDIS_STORE_FAILED,
+                log_context={'message_ts': message_ts, 'thread_ts': thread_ts},
+            )
+
+    async def _replace_repo_selection_form(
+        self, response_url: str | None, selected_repository: str | None
+    ) -> None:
+        """Replace the interactive repo selector with a non-interactive status."""
+        if not response_url:
+            return
+
+        selected_text = (
+            'No repository selected'
+            if selected_repository is None
+            else f'Repository selected: `{selected_repository}`'
+        )
+        message = {
+            'replace_original': True,
+            'text': f'{selected_text}. Starting conversation...',
+            'blocks': [
+                {
+                    'type': 'section',
+                    'text': {
+                        'type': 'mrkdwn',
+                        'text': f':white_check_mark: {selected_text}. Starting conversation...',
+                    },
+                }
+            ],
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.post(response_url, json=message)
+                response.raise_for_status()
+        except Exception as e:
+            logger.warning(
+                'slack_replace_repo_selection_form_failed',
+                extra={'error': str(e)},
             )
 
     async def _search_repositories(
@@ -418,6 +513,7 @@ class SlackManager(Manager[SlackViewInterface]):
         slack_user_id = slack_payload['user']['id']
         channel_id = slack_payload['container']['channel_id']
         team_id = slack_payload['team']['id']
+        response_url = slack_payload.get('response_url')
 
         # Parse the action to extract message_ts, thread_ts, and selected value
         parsed = self._parse_form_action(action)
@@ -444,6 +540,17 @@ class SlackManager(Manager[SlackViewInterface]):
 
         # Convert "-" (No Repository) to None
         selected_repository = None if selected_value == '-' else selected_value
+
+        try:
+            if not await self._claim_form_interaction(
+                team_id, channel_id, message_ts, thread_ts
+            ):
+                return
+        except SlackError as e:
+            await self.handle_slack_error(payload, e)
+            return
+
+        await self._replace_repo_selection_form(response_url, selected_repository)
 
         # Retrieve the original user message from Redis
         try:
@@ -677,6 +784,7 @@ class SlackManager(Manager[SlackViewInterface]):
             3. Otherwise shows the repo selection form
 
         Args:
+            message: Incoming Slack message.
             slack_view: Must be a SlackViewType (authenticated view that can start jobs)
 
         Returns:

--- a/enterprise/tests/unit/test_slack_integration.py
+++ b/enterprise/tests/unit/test_slack_integration.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import BackgroundTasks
 from integrations.slack.slack_manager import (
+    SLACK_FORM_INTERACTION_KEY_PREFIX,
     SLACK_USER_MSG_EXPIRATION,
     SLACK_USER_MSG_KEY_PREFIX,
     SlackManager,
@@ -235,6 +236,62 @@ class TestRepoVerificationHandling:
             assert call_args.message['selected_repo'] is None
             assert call_args.message['message_ts'] == '1234567890.123456'
             assert call_args.message['thread_ts'] is None
+
+    @pytest.mark.asyncio
+    @patch('integrations.slack.slack_manager.get_redis_client_async')
+    async def test_duplicate_no_repository_click_is_ignored(
+        self,
+        mock_get_redis_client_async,
+        slack_manager,
+    ):
+        """Test repeated "No Repository" clicks only process the first interaction."""
+        mock_redis = AsyncMock()
+        mock_redis.set = AsyncMock(side_effect=[True, None])
+        stored_msg = json.dumps({'text': 'Hello, help me with code', 'user': 'U123'})
+        mock_redis.get = AsyncMock(return_value=stored_msg)
+        mock_get_redis_client_async.return_value = mock_redis
+
+        button_payload = {
+            'type': 'block_actions',
+            'actions': [
+                {
+                    'action_id': 'no_repository:1234567890.123456:None',
+                    'type': 'button',
+                    'value': '-',
+                }
+            ],
+            'user': {'id': 'U123'},
+            'container': {'channel_id': 'C123'},
+            'team': {'id': 'T123'},
+            'response_url': 'https://hooks.slack.com/actions/test',
+        }
+
+        with (
+            patch.object(
+                slack_manager, 'receive_message', new_callable=AsyncMock
+            ) as mock_receive,
+            patch.object(
+                slack_manager, '_replace_repo_selection_form', new_callable=AsyncMock
+            ) as mock_replace_form,
+        ):
+            await slack_manager.receive_form_interaction(button_payload)
+            await slack_manager.receive_form_interaction(button_payload)
+
+            mock_receive.assert_called_once()
+            mock_replace_form.assert_awaited_once_with(
+                'https://hooks.slack.com/actions/test', None
+            )
+
+        expected_claim_key = (
+            f'{SLACK_FORM_INTERACTION_KEY_PREFIX}:T123:C123:1234567890.123456:None'
+        )
+        mock_redis.set.assert_any_call(
+            expected_claim_key,
+            'processing',
+            ex=SLACK_USER_MSG_EXPIRATION,
+            nx=True,
+        )
+        mock_redis.get.assert_called_once()
 
     @patch('integrations.slack.slack_manager.get_redis_client_async')
     @patch('integrations.slack.slack_manager.ProviderHandler')


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

<img width="1280" height="822" alt="image" src="https://github.com/user-attachments/assets/2c561d46-2d36-40d3-aa50-84ee93ec22c8" />


- [x] A human has tested these changes.

AGENT:

This PR was created by an AI agent (OpenHands) on behalf of the user.

---

## Why

Clicking the Slack repository selector's "No Repository" button multiple times could enqueue multiple form interactions and create duplicate OpenHands conversations for the same Slack prompt.

## Summary

- Adds an atomic Redis `SET NX` claim for Slack repository selection form submissions, scoped by team/channel/message/thread.
- Replaces the interactive Slack selector using the interaction `response_url` after the first successful selection so the form is no longer clickable.
- Adds a regression test that verifies duplicate "No Repository" clicks only process once and only replace the form once.

## Issue Number

APP-2299

## How to Test

Automated validation run:

```bash
python -m py_compile enterprise/integrations/slack/slack_manager.py enterprise/tests/unit/test_slack_integration.py
poetry run pre-commit run --files enterprise/integrations/slack/slack_manager.py enterprise/tests/unit/test_slack_integration.py --show-diff-on-failure --config enterprise/dev_config/python/.pre-commit-config.yaml
```

Result: passed.

I also attempted the targeted enterprise pytest command, but this sandbox's enterprise Poetry environment did not have `pytest` installed (`Command not found: pytest`).

## Video/Screenshots

Not captured; this change is backend Slack interaction handling.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Slack behavior was checked against official Slack documentation:
- Slack block actions payloads can include `response_url`: https://api.slack.com/reference/interaction-payloads/block-actions
- Slack interaction handling supports updating the source interactive message by posting to `response_url` with `replace_original: true`: https://api.slack.com/interactivity/handling

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b5d7b285-c9d5-45e8-977b-42cfa0758273)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-040fdaf   docker.openhands.dev/openhands/openhands:040fdaf
```