### PR TITLE
fix: API key CORS header handling

### DIFF
--- a/enterprise/server/middleware.py
+++ b/enterprise/server/middleware.py
@@ -15,6 +15,7 @@ from server.auth.gitlab_sync import schedule_gitlab_repo_sync
 from server.auth.saas_user_auth import SaasUserAuth, token_manager
 from server.routes.auth import set_response_cookie
 from server.utils.url_utils import get_cookie_domain, get_cookie_samesite
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from openhands.app_server.user_auth.user_auth import AuthType, UserAuth, get_user_auth
 from openhands.app_server.utils.logger import openhands_logger as logger
@@ -229,6 +230,26 @@ _CREDENTIALLESS_PATH_PREFIXES = (
 )
 
 
+class _OriginStrippingApp:
+    """Hide Origin from inner middleware after outer CORS classifies the request."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope['type'] != 'http':
+            await self.app(scope, receive, send)
+            return
+
+        inner_scope = dict(scope)
+        inner_scope['headers'] = tuple(
+            (name, value)
+            for name, value in scope['headers']
+            if name.lower() != b'origin'
+        )
+        await self.app(inner_scope, receive, send)
+
+
 class ApiKeyAwareCORSMiddleware:
     """CORS dispatcher that loosens the policy for credential-less requests.
 
@@ -244,9 +265,9 @@ class ApiKeyAwareCORSMiddleware:
     credentials enabled.
     """
 
-    def __init__(self, app, allow_origins):
+    def __init__(self, app: ASGIApp, allow_origins: list[str]) -> None:
         self._permissive = CORSMiddleware(
-            app,
+            _OriginStrippingApp(app),
             allow_origins=['*'],
             allow_credentials=False,
             allow_methods=['*'],
@@ -260,14 +281,14 @@ class ApiKeyAwareCORSMiddleware:
             allow_headers=['*'],
         )
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope['type'] == 'http' and self._is_credentialless(scope):
             await self._permissive(scope, receive, send)
         else:
             await self._strict(scope, receive, send)
 
     @staticmethod
-    def _is_credentialless(scope) -> bool:
+    def _is_credentialless(scope: Scope) -> bool:
         path = scope.get('path', '')
         if any(path.startswith(prefix) for prefix in _CREDENTIALLESS_PATH_PREFIXES):
             return True

--- a/enterprise/tests/unit/test_api_key_aware_cors_middleware.py
+++ b/enterprise/tests/unit/test_api_key_aware_cors_middleware.py
@@ -14,16 +14,20 @@ non-allowlisted origin should be accepted with an API key and rejected
 without one.
 """
 
+import logging
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from server.middleware import ApiKeyAwareCORSMiddleware
 
+from openhands.app_server.middleware import LocalhostCORSMiddleware
+
 ALLOWED_ORIGIN = 'https://app.all-hands.dev'
-FOREIGN_ORIGIN = 'http://localhost:3000'
+FOREIGN_ORIGIN = 'https://client.example.com'
 
 
-def _build_client() -> TestClient:
+def _build_client(with_inner_cors: bool = False) -> TestClient:
     app = FastAPI()
 
     @app.get('/api/v1/settings')
@@ -33,6 +37,9 @@ def _build_client() -> TestClient:
     @app.post('/oauth/device/authorize')
     def authorize():
         return {'device_code': 'd', 'user_code': 'u'}
+
+    if with_inner_cors:
+        app.add_middleware(LocalhostCORSMiddleware)
 
     app.add_middleware(
         ApiKeyAwareCORSMiddleware,
@@ -106,6 +113,27 @@ class TestApiKeyAwareCORSMiddleware:
         assert 'access-control-allow-credentials' not in {
             k.lower() for k in response.headers
         }
+
+    def test_bearer_request_does_not_inherit_inner_cors_headers_or_warnings(
+        self, caplog
+    ):
+        client = _build_client(with_inner_cors=True)
+
+        with caplog.at_level(logging.WARNING, logger='openhands.app_server.middleware'):
+            response = client.get(
+                '/api/v1/settings',
+                headers={
+                    'Origin': FOREIGN_ORIGIN,
+                    'Authorization': 'Bearer test-api-key',
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.headers.get('access-control-allow-origin') == '*'
+        assert 'access-control-allow-credentials' not in {
+            k.lower() for k in response.headers
+        }
+        assert 'No CORS origins configured' not in caplog.text
 
     @pytest.mark.parametrize(
         'auth_header',


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

API-key CORS requests can be classified by the SaaS API-key-aware CORS middleware, then still pass through inner app CORS middleware. For actual API-key requests, the inner middleware can add credentialed CORS headers and emit noisy CORS warnings before the outer middleware writes its wildcard API-key response headers.

API-key responses should keep the credentialless contract: wildcard origin, no credentials header, and no inner-app CORS warning for the same already-classified request.

## Summary

- Added an internal ASGI wrapper for the API-key/credentialless path that hides the `Origin` header from inner middleware after the outer CORS middleware has classified the request.
- Kept strict credentialed/cookie CORS behavior unchanged.
- Added regression coverage for a stacked inner CORS middleware scenario using a generic test origin.

## Issue Number

N/A

## How to Test

- `cd enterprise && poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files server/middleware.py tests/unit/test_api_key_aware_cors_middleware.py --show-diff-on-failure`
- `cd enterprise && PYTHONPATH=".:$PYTHONPATH" poetry run pytest tests/unit/test_api_key_aware_cors_middleware.py -q`

## Video/Screenshots

N/A — backend middleware change covered by unit tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR intentionally avoids including production log payloads, customer identifiers, or user data. It uses only generic test values.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6f16ddf9-7eaf-433c-99ee-0433d1ade998)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-8d29769   docker.openhands.dev/openhands/openhands:8d29769
```

## Issue

Fixes #14847.