### PR TITLE
feat: support sandbox specs in conversation start

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_models.py
+++ b/openhands/app_server/app_conversation/app_conversation_models.py
@@ -3,7 +3,13 @@ from enum import Enum
 from typing import Any, Literal
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field, SecretStr, computed_field
+from pydantic import (
+    BaseModel,
+    Field,
+    SecretStr,
+    computed_field,
+    model_validator,
+)
 
 from openhands.agent_server.models import (
     ImageContent,
@@ -194,7 +200,14 @@ class AppConversationStartRequest(OpenHandsModel):
     from the app server copies these from the user info.
     """
 
-    sandbox_id: str | None = Field(default=None)
+    sandbox_id: str | None = Field(
+        default=None,
+        description='ID of an existing sandbox to use. Mutually exclusive with sandbox_spec_id.',
+    )
+    sandbox_spec_id: str | None = Field(
+        default=None,
+        description='Image/spec ID for creating a new sandbox. Mutually exclusive with sandbox_id.',
+    )
     conversation_id: UUID | None = Field(default=None)
     initial_message: SendMessageRequest | None = None
     system_message_suffix: str | None = None
@@ -234,6 +247,12 @@ class AppConversationStartRequest(OpenHandsModel):
             'Warning: Providing a secret that already exists will silently override it.'
         ),
     )
+
+    @model_validator(mode='after')
+    def validate_sandbox_params(self) -> 'AppConversationStartRequest':
+        if self.sandbox_id and self.sandbox_spec_id:
+            raise ValueError('Cannot specify both sandbox_id and sandbox_spec_id')
+        return self
 
 
 class AppConversationUpdateRequest(BaseModel):

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -847,8 +847,13 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         """Wait for sandbox to start and return info."""
         # Get or create the sandbox
         if not task.request.sandbox_id:
-            # First try to find a running sandbox for the current user
-            sandbox = await self._find_running_sandbox_for_user()
+            requested_sandbox_spec_id = task.request.sandbox_spec_id
+            # First try to find a running sandbox for the current user. Requests
+            # for a custom sandbox spec need a new sandbox; otherwise grouping
+            # could attach the conversation to a sandbox running a different image.
+            sandbox = None
+            if requested_sandbox_spec_id is None:
+                sandbox = await self._find_running_sandbox_for_user()
             if sandbox is None:
                 # No running sandbox found, start a new one
 
@@ -860,7 +865,8 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 )
 
                 sandbox = await self.sandbox_service.start_sandbox(
-                    sandbox_id=sandbox_id_str
+                    sandbox_id=sandbox_id_str,
+                    sandbox_spec_id=requested_sandbox_spec_id,
                 )
             task.sandbox_id = sandbox.id
         else:

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -21,6 +21,7 @@ from openhands.app_server.app_conversation.app_conversation_models import (
     AgentType,
     AppConversationInfo,
     AppConversationStartRequest,
+    AppConversationStartTask,
     ConversationTrigger,
 )
 from openhands.app_server.app_conversation.app_conversation_service import (
@@ -238,6 +239,37 @@ class TestLiveStatusAppConversationService:
         # Default mock for hooks loading - returns None (no hooks found)
         # Tests that specifically test hooks loading can override this mock
         self.service._load_hooks_from_workspace = AsyncMock(return_value=None)
+
+    @pytest.mark.asyncio
+    async def test_wait_for_sandbox_start_uses_requested_sandbox_spec(self):
+        conversation_id = uuid4()
+        request = AppConversationStartRequest(
+            conversation_id=conversation_id,
+            sandbox_spec_id='custom-image:latest',
+        )
+        task = AppConversationStartTask(
+            created_by_user_id='test_user_123',
+            request=request,
+        )
+        sandbox = SandboxInfo(
+            id='custom-sandbox',
+            created_by_user_id='test_user_123',
+            sandbox_spec_id='custom-image:latest',
+            status=SandboxStatus.RUNNING,
+            session_api_key='session-key',
+        )
+        self.service._find_running_sandbox_for_user = AsyncMock()
+        self.mock_sandbox_service.start_sandbox = AsyncMock(return_value=sandbox)
+
+        async for updated_task in self.service._wait_for_sandbox_start(task):
+            assert updated_task.sandbox_id == 'custom-sandbox'
+            break
+
+        self.service._find_running_sandbox_for_user.assert_not_called()
+        self.mock_sandbox_service.start_sandbox.assert_awaited_once_with(
+            sandbox_id=conversation_id.hex,
+            sandbox_spec_id='custom-image:latest',
+        )
 
     @pytest.mark.asyncio
     async def test_seed_sandbox_profiles_upserts_resolved_keys_and_prunes(self):

--- a/tests/unit/app_server/test_models.py
+++ b/tests/unit/app_server/test_models.py
@@ -46,6 +46,21 @@ async def test_app_conversation_start_request_polymorphism():
     assert result.detail == 'Live long and prosper!'
 
 
+def test_app_conversation_start_request_accepts_sandbox_spec_id():
+    req = AppConversationStartRequest(sandbox_spec_id='custom-image:latest')
+
+    assert req.sandbox_spec_id == 'custom-image:latest'
+    assert req.model_dump()['sandbox_spec_id'] == 'custom-image:latest'
+
+
+def test_app_conversation_start_request_rejects_sandbox_id_with_sandbox_spec_id():
+    with pytest.raises(ValueError, match='Cannot specify both sandbox_id'):
+        AppConversationStartRequest(
+            sandbox_id='existing-sandbox',
+            sandbox_spec_id='custom-image:latest',
+        )
+
+
 def test_app_conversation_update_request_includes_title_field():
     """Test that AppConversationUpdateRequest supports updating the title field.
 


### PR DESCRIPTION
HUMAN:

I wanted this to stay pretty small: if someone starts a conversation and asks for a specific sandbox spec, that choice should actually make it all the way to sandbox startup. Before this, the lower sandbox layer already knew how to accept a `sandbox_spec_id`, but the conversation-start API did not pass it through. I also added the guard that you can choose either an existing sandbox or a sandbox spec, not both, so we do not accidentally attach a custom-image request to the wrong running sandbox.

- [x] A human has tested these changes.

AGENT:

---

## Why

Conversation start requests could not select a custom sandbox image/spec, even though the sandbox service layer already accepts `sandbox_spec_id`. This completes the API-to-service path for custom sandbox specs and prevents custom-spec requests from being attached to an existing sandbox running a different image.

## Summary

- Add `sandbox_spec_id` to `AppConversationStartRequest` and validate it is mutually exclusive with `sandbox_id`.
- Pass `sandbox_spec_id` through to `sandbox_service.start_sandbox()` when creating a sandbox.
- Skip generic running-sandbox reuse for custom spec requests so the selected image is honored.

## Issue Number

Fixes OpenHands/enterprise#33

## How to Test

- `uv run --python 3.12 --group test pytest tests/unit/app_server/test_models.py::test_app_conversation_start_request_accepts_sandbox_spec_id tests/unit/app_server/test_models.py::test_app_conversation_start_request_rejects_sandbox_id_with_sandbox_spec_id tests/unit/app_server/test_live_status_app_conversation_service.py::TestLiveStatusAppConversationService::test_wait_for_sandbox_start_uses_requested_sandbox_spec -q`
- `uv run --python 3.12 ruff format --check openhands/app_server/app_conversation/app_conversation_models.py openhands/app_server/app_conversation/live_status_app_conversation_service.py tests/unit/app_server/test_models.py tests/unit/app_server/test_live_status_app_conversation_service.py`
- `uv run --python 3.12 ruff check openhands/app_server/app_conversation/app_conversation_models.py openhands/app_server/app_conversation/live_status_app_conversation_service.py tests/unit/app_server/test_models.py tests/unit/app_server/test_live_status_app_conversation_service.py`
- `uv run --python 3.12 pre-commit run --config ./dev_config/python/.pre-commit-config.yaml`

## Video/Screenshots

N/A, backend API/service change covered by unit tests.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The selected sandbox spec is the single API input; existing sandbox services remain the source of truth for resolving that spec to the actual runtime image/config.
