### PR TITLE
fix(app-server): respect disabled_skills in conversation skills endpoint

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_router.py
+++ b/openhands/app_server/app_conversation/app_conversation_router.py
@@ -1351,6 +1351,16 @@ async def get_conversation_skills(
                 ctx.agent_server_url,
             )
 
+            # Drop user-disabled skills so the panel matches what the agent
+            # actually loads. The agent context already filters these in
+            # AppConversationServiceBase._load_skills_and_update_agent; without
+            # the same filter here the endpoint advertises skills the agent
+            # does not have.
+            user = await app_conversation_service.user_context.get_user_info()
+            if user.disabled_skills:
+                disabled_set = set(user.disabled_skills)
+                all_skills = [s for s in all_skills if s.name not in disabled_set]
+
         logger.info(
             f'Loaded {len(all_skills)} skills for conversation {conversation_id}: '
             f'{[s.name for s in all_skills]}'

--- a/tests/unit/app_server/test_app_conversation_skills_endpoint.py
+++ b/tests/unit/app_server/test_app_conversation_skills_endpoint.py
@@ -36,6 +36,7 @@ def _make_service_mock(
     conversation_return: AppConversation | None = None,
     skills_return: list[Skill] | None = None,
     raise_on_load: bool = False,
+    disabled_skills: list[str] | None = None,
 ):
     """Create a mock service that passes the isinstance check and returns the desired values."""
     mock_cls = type('AppConversationServiceMock', (MagicMock,), {})
@@ -43,6 +44,11 @@ def _make_service_mock(
 
     service = mock_cls()
     service.user_context = user_context
+    # The skills endpoint reads disabled_skills off the service's user_context
+    # to drop them from the response (mirroring the agent-context filter).
+    user_info = MagicMock()
+    user_info.disabled_skills = disabled_skills
+    user_context.get_user_info = AsyncMock(return_value=user_info)
     service.get_app_conversation = AsyncMock(return_value=conversation_return)
 
     async def _load_skills(*_args, **_kwargs):
@@ -160,6 +166,77 @@ class TestGetConversationSkills:
         assert knowledge_skill_data['type'] == 'knowledge'
         assert knowledge_skill_data['content'] == 'Knowledge skill content'
         assert knowledge_skill_data['triggers'] == ['test', 'help']
+
+    async def test_get_skills_excludes_user_disabled_skills(self):
+        """Test that skills listed in user.disabled_skills are filtered out.
+
+        Arrange: Two skills loaded, one of them in the user's disabled_skills
+        Act: Call get_conversation_skills endpoint
+        Assert: Only the non-disabled skill is returned (mirrors the agent
+            context filter so the panel matches what the agent loads)
+        """
+        # Arrange
+        conversation_id = uuid4()
+        sandbox_id = str(uuid4())
+
+        mock_conversation = AppConversation(
+            id=conversation_id,
+            created_by_user_id='test-user',
+            sandbox_id=sandbox_id,
+            selected_repository='owner/repo',
+            sandbox_status=SandboxStatus.RUNNING,
+        )
+        mock_sandbox = SandboxInfo(
+            id=sandbox_id,
+            created_by_user_id='test-user',
+            status=SandboxStatus.RUNNING,
+            sandbox_spec_id=str(uuid4()),
+            session_api_key='test-api-key',
+            exposed_urls=[
+                ExposedUrl(name=AGENT_SERVER, url='http://localhost:8000', port=8000)
+            ],
+        )
+        mock_sandbox_spec = SandboxSpecInfo(
+            id=str(uuid4()), command=None, working_dir='/workspace'
+        )
+
+        repo_skill = Skill(name='repo_skill', content='kept', trigger=None)
+        disabled_skill = Skill(
+            name='disabled_skill',
+            content='should be filtered',
+            trigger=KeywordTrigger(keywords=['x']),
+        )
+
+        mock_user_context = MagicMock(spec=UserContext)
+        mock_app_conversation_service = _make_service_mock(
+            user_context=mock_user_context,
+            conversation_return=mock_conversation,
+            skills_return=[repo_skill, disabled_skill],
+            disabled_skills=['disabled_skill'],
+        )
+
+        mock_sandbox_service = MagicMock()
+        mock_sandbox_service.get_sandbox = AsyncMock(return_value=mock_sandbox)
+        mock_sandbox_spec_service = MagicMock()
+        mock_sandbox_spec_service.get_sandbox_spec = AsyncMock(
+            return_value=mock_sandbox_spec
+        )
+
+        # Act
+        response = await get_conversation_skills(
+            conversation_id=conversation_id,
+            app_conversation_service=mock_app_conversation_service,
+            sandbox_service=mock_sandbox_service,
+            sandbox_spec_service=mock_sandbox_spec_service,
+        )
+
+        # Assert
+        import json
+
+        assert response.status_code == status.HTTP_200_OK
+        data = json.loads(response.body.decode('utf-8'))
+        names = [s['name'] for s in data['skills']]
+        assert names == ['repo_skill']
 
     async def test_get_skills_returns_404_when_conversation_not_found(self):
         """Test endpoint returns 404 when conversation doesn't exist.


### PR DESCRIPTION
HUMAN:
Fix disabled skills not being filtered out by the conversation skills API.

- [x] A human has tested these changes.

AGENT:
Fixes the conversation skills endpoint (`GET /api/v1/app-conversations/{id}/skills`)
ignoring `disabled_skills`: it returned the full merged set while the agent context
filters them, so the panel advertised skills the agent doesn't have. Applies the same
filter via `app_conversation_service.user_context`. Updated existing tests + added one
asserting disabled skills are excluded.

## Why
The panel endpoint returned skills the agent doesn't actually have, because
`disabled_skills` was only applied to the agent context, not this endpoint.

## Summary
- `get_conversation_skills` now drops `user.disabled_skills`, mirroring
  `_load_skills_and_update_agent`.
- Added/updated unit tests for the disabled-skills filter.

## Issue Number
OpenHands/enterprise#74

## How to Test
1. Disable a skill the agent loads (an AgentSkills name, e.g. `azure-devops`) in user settings.
2. Start a new conversation, open the Available Skills panel → the skill is gone.
   (Unit: `pytest tests/unit/app_server/test_app_conversation_skills_endpoint.py`)

## Type
- [x] Bug fix

## Notes
Part of OpenHands/enterprise#74; the second (design-level) issue in that report — Settings→Skills listing
a different, underscore-named legacy set than the agent loads — is left for maintainer direction.
