### PR TITLE
fix: clear stale git changes on context change

### DIFF
--- a/frontend/__tests__/hooks/query/use-unified-get-git-changes.test.tsx
+++ b/frontend/__tests__/hooks/query/use-unified-get-git-changes.test.tsx
@@ -1,0 +1,96 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useUnifiedGetGitChanges } from "#/hooks/query/use-unified-get-git-changes";
+
+const mocks = vi.hoisted(() => ({
+  conversationId: "conversation-1",
+  conversation: {
+    conversation_url: "http://runtime-1.test",
+    session_api_key: "key-1",
+    selected_repository: null as string | null,
+  },
+  runtimeIsReady: true,
+  settings: {
+    sandbox_grouping_strategy: "NO_GROUPING",
+  },
+  getGitChanges: vi.fn(),
+}));
+
+vi.mock("#/hooks/use-conversation-id", () => ({
+  useConversationId: () => ({ conversationId: mocks.conversationId }),
+}));
+
+vi.mock("#/hooks/query/use-active-conversation", () => ({
+  useActiveConversation: () => ({ data: mocks.conversation }),
+}));
+
+vi.mock("#/hooks/use-runtime-is-ready", () => ({
+  useRuntimeIsReady: () => mocks.runtimeIsReady,
+}));
+
+vi.mock("#/hooks/query/use-settings", () => ({
+  useSettings: () => ({ data: mocks.settings }),
+}));
+
+vi.mock("#/api/git-service/v1-git-service.api", () => ({
+  default: {
+    getGitChanges: mocks.getGitChanges,
+  },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useUnifiedGetGitChanges", () => {
+  beforeEach(() => {
+    mocks.conversationId = "conversation-1";
+    mocks.conversation = {
+      conversation_url: "http://runtime-1.test",
+      session_api_key: "key-1",
+      selected_repository: null,
+    };
+    mocks.runtimeIsReady = true;
+    mocks.getGitChanges.mockResolvedValue([{ path: "old.ts", status: "M" }]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("clears ordered changes when the conversation context changes", async () => {
+    const { result, rerender } = renderHook(() => useUnifiedGetGitChanges(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ path: "old.ts", status: "M" }]);
+    });
+
+    mocks.conversationId = "conversation-2";
+    mocks.conversation = {
+      conversation_url: "http://runtime-2.test",
+      session_api_key: "key-2",
+      selected_repository: "owner/new-repo",
+    };
+    mocks.runtimeIsReady = false;
+
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([]);
+    });
+  });
+});

--- a/frontend/src/hooks/query/use-unified-get-git-changes.ts
+++ b/frontend/src/hooks/query/use-unified-get-git-changes.ts
@@ -63,6 +63,11 @@ export const useUnifiedGetGitChanges = () => {
     },
   });
 
+  React.useEffect(() => {
+    setOrderedChanges([]);
+    previousDataRef.current = null;
+  }, [conversationId, conversationUrl, sessionApiKey, gitPath]);
+
   // Latest changes should be on top
   React.useEffect(() => {
     if (!result.isFetching && result.isSuccess && result.data) {


### PR DESCRIPTION
HUMAN:

This one is about avoiding a really confusing UI moment. The Changes tab keeps a local ordered copy of the files so new files can stay at the top, but that copy was surviving after the conversation or git path changed. So you could switch context and still briefly see diffs from the previous conversation while the new runtime was loading. I kept the fix scoped to that local state: when the query context changes, clear the old ordered changes and let the current context load fresh.

- [x] A human has tested these changes.

AGENT:

---

## Why

The Changes tab keeps a local `orderedChanges` copy so newly discovered files can stay at the top. That local state was not reset when the conversation/runtime/git path changed, so switching to another conversation or repository could briefly keep showing stale diffs from the previous context, especially while the new runtime is not ready or before the next query succeeds.

## Summary

- Reset `orderedChanges` and its previous-data ref whenever the git changes query context changes.
- Add a hook regression test that switches conversation context with the runtime disabled and verifies old changes are cleared.

## Issue Number

Addresses OpenHands/enterprise#72

## How to Test

- `cd frontend && npm ci --cache /tmp/openhands-npm-cache`
- `cd frontend && npm test -- --run __tests__/hooks/query/use-unified-get-git-changes.test.tsx`
- `cd frontend && npm run lint:fix`
- `cd frontend && npx prettier --check __tests__/hooks/query/use-unified-get-git-changes.test.tsx src/hooks/query/use-unified-get-git-changes.ts`
- `cd frontend && npm run build`
- `uv run --python 3.12 pre-commit run --config ./dev_config/python/.pre-commit-config.yaml`

## Video/Screenshots

N/A, hook state regression covered by unit test.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This does not attempt to solve the full cross-repo git metadata update flow from OpenHands/enterprise#72. It closes the OpenHands frontend stale-state gap so the tab does not show previous-context changes while waiting for the current context to load.
