### PR TITLE
fix: renumber duplicate migration 122 → 123 (drop is_paused)

### DIFF
--- a/enterprise/migrations/versions/123_drop_is_paused_from_v1_remote_sandbox.py
+++ b/enterprise/migrations/versions/123_drop_is_paused_from_v1_remote_sandbox.py
@@ -6,8 +6,8 @@ explicit app-level pause/resume calls update it, so externally terminated or
 expired sandboxes remain is_paused=False forever. Concurrency counting now
 uses the runtime /list endpoint as the source of truth instead.
 
-Revision ID: 122
-Revises: 121
+Revision ID: 123
+Revises: 122
 Create Date: 2026-06-05
 """
 
@@ -16,8 +16,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = '122'
-down_revision: Union[str, None] = '121'
+revision: str = '123'
+down_revision: Union[str, None] = '122'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

- [x] A human has tested these changes.

AGENT:

---

## Why

A merge conflict caused two Alembic migrations to be assigned the same revision ID `122`:
- `122_add_oauth_tokens_to_jira_dc_users` (down_revision: `121`)
- `122_drop_is_paused_from_v1_remote_sandbox` (down_revision: `121`)

This breaks Alembic's linear migration chain and would cause failures when running migrations.

## Summary

- Renamed `122_drop_is_paused_from_v1_remote_sandbox.py` → `123_drop_is_paused_from_v1_remote_sandbox.py`
- Updated `revision` from `'122'` → `'123'` inside the file
- Updated `down_revision` from `'121'` → `'122'` so it chains correctly after the Jira DC migration

Resulting chain: `121` → `122` (`add_oauth_tokens_to_jira_dc_users`) → `123` (`drop_is_paused_from_v1_remote_sandbox`)

## Issue Number

N/A

## How to Test

Run the enterprise migration integrity check — it should no longer report duplicate revision IDs.

## Type

- [x] Bug fix

_This PR was created by an AI agent (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-29dbf42   docker.openhands.dev/openhands/openhands:29dbf42
```