### PR TITLE
fix: preserve SSE MCP server timeouts

### DIFF
--- a/frontend/__tests__/components/features/settings/mcp-settings/mcp-server-form.validation.test.tsx
+++ b/frontend/__tests__/components/features/settings/mcp-settings/mcp-server-form.validation.test.tsx
@@ -107,4 +107,35 @@ describe("MCPServerForm validation", () => {
 
     r2.unmount();
   });
+
+  it("submits timeout for SSE servers", () => {
+    const onSubmit = vi.fn();
+
+    render(
+      <MCPServerForm
+        mode="add"
+        server={{ id: "tmp", type: "sse" }}
+        existingServers={[]}
+        onSubmit={onSubmit}
+        onCancel={noop}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("url-input"), {
+      target: { value: "https://example.com/sse" },
+    });
+    fireEvent.change(screen.getByTestId("timeout-input"), {
+      target: { value: "90" },
+    });
+
+    fireEvent.click(screen.getByTestId("submit-button"));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "sse",
+        url: "https://example.com/sse",
+        timeout: 90,
+      }),
+    );
+  });
 });

--- a/frontend/__tests__/components/features/settings/mcp-settings/mcp-server-list.test.tsx
+++ b/frontend/__tests__/components/features/settings/mcp-settings/mcp-server-list.test.tsx
@@ -129,6 +129,30 @@ describe("MCPServerList", () => {
     expect(screen.getByText(expectedDetails)).toBeInTheDocument();
   });
 
+  it("should display timeout for remote servers", () => {
+    const sseServer = {
+      id: "sse-1",
+      type: "sse" as const,
+      url: "https://example.com/sse",
+      timeout: 90,
+    };
+
+    const mockOnEdit = vi.fn();
+    const mockOnDelete = vi.fn();
+
+    render(
+      <MCPServerList
+        servers={[sseServer]}
+        onEdit={mockOnEdit}
+        onDelete={mockOnDelete}
+      />,
+    );
+
+    expect(
+      screen.getByText("https://example.com/sse (timeout: 90s)"),
+    ).toBeInTheDocument();
+  });
+
   it("should fallback to server name for STDIO servers without command", () => {
     const stdioServer = {
       id: "stdio-2",

--- a/frontend/__tests__/utils/mcp-config.test.ts
+++ b/frontend/__tests__/utils/mcp-config.test.ts
@@ -53,6 +53,26 @@ describe("parseMcpConfig", () => {
     });
   });
 
+  it("should parse timeout for SSE servers", () => {
+    const input = {
+      mcpServers: {
+        "sse-timeout-server": {
+          url: "https://example.com/sse",
+          transport: "sse",
+          timeout: 90,
+        },
+      },
+    };
+
+    const result = parseMcpConfig(input);
+
+    expect(result.sse_servers[0]).toEqual({
+      name: "sse-timeout-server",
+      url: "https://example.com/sse",
+      timeout: 90,
+    });
+  });
+
   it("should preserve server names for shttp servers", () => {
     const input = {
       mcpServers: {
@@ -296,9 +316,9 @@ describe("toSdkMcpConfig", () => {
     expect(result).toHaveProperty("sse");
     expect(result).toHaveProperty("sse_1");
     expect(result).toHaveProperty("sse_2");
-    expect(result?.["sse"].url).toBe("https://example1.com");
-    expect(result?.["sse_1"].url).toBe("https://example2.com");
-    expect(result?.["sse_2"].url).toBe("https://example3.com");
+    expect(result?.sse.url).toBe("https://example1.com");
+    expect(result?.sse_1.url).toBe("https://example2.com");
+    expect(result?.sse_2.url).toBe("https://example3.com");
   });
 
   it("should serialize api_key as an SDK bearer credential", () => {
@@ -318,14 +338,32 @@ describe("toSdkMcpConfig", () => {
 
     const result = toSdkMcpConfig(config);
 
-    expect(result?.["secure"]).toEqual({
+    expect(result?.secure).toEqual({
       url: "https://example.com",
       transport: "sse",
       auth: { strategy: "bearer", value: "my-secret" },
     });
-    expect(result?.["shttp"]).toEqual({
+    expect(result?.shttp).toEqual({
       url: "https://shttp.example",
       auth: { strategy: "bearer", value: "shttp-secret" },
+    });
+  });
+
+  it("should include timeout for sse servers", () => {
+    const config: MCPConfig = {
+      sse_servers: [
+        { name: "sse-timeout", url: "https://example.com/sse", timeout: 90 },
+      ],
+      stdio_servers: [],
+      shttp_servers: [],
+    };
+
+    const result = toSdkMcpConfig(config);
+
+    expect(result?.["sse-timeout"]).toEqual({
+      url: "https://example.com/sse",
+      timeout: 90,
+      transport: "sse",
     });
   });
 
@@ -384,7 +422,7 @@ describe("toSdkMcpConfig", () => {
 
     const result = toSdkMcpConfig(config);
 
-    expect(result?.["timeout"]).toEqual({
+    expect(result?.timeout).toEqual({
       url: "https://example.com",
       timeout: 60,
     });

--- a/frontend/src/components/features/settings/mcp-settings/mcp-server-form.tsx
+++ b/frontend/src/components/features/settings/mcp-settings/mcp-server-form.tsx
@@ -166,12 +166,9 @@ export function MCPServerForm({
       const urlDupError = validateUrlUniqueness(url);
       if (urlDupError) return urlDupError;
 
-      // Validate timeout for SHTTP servers only
-      if (serverType === "shttp") {
-        const timeoutStr = formData.get("timeout")?.toString() || "";
-        const timeoutError = validateTimeout(timeoutStr);
-        if (timeoutError) return timeoutError;
-      }
+      const timeoutStr = formData.get("timeout")?.toString() || "";
+      const timeoutError = validateTimeout(timeoutStr);
+      if (timeoutError) return timeoutError;
 
       return null;
     }
@@ -236,8 +233,7 @@ export function MCPServerForm({
         ...(apiKey && { api_key: apiKey }),
       };
 
-      // Only add timeout for SHTTP servers
-      if (serverType === "shttp" && timeoutStr) {
+      if (timeoutStr) {
         const timeoutValue = parseInt(timeoutStr, 10);
         if (!Number.isNaN(timeoutValue)) {
           serverConfig.timeout = timeoutValue;
@@ -320,20 +316,18 @@ export function MCPServerForm({
             placeholder={t(I18nKey.SETTINGS$MCP_API_KEY_PLACEHOLDER)}
           />
 
-          {serverType === "shttp" && (
-            <SettingsInput
-              testId="timeout-input"
-              name="timeout"
-              type="number"
-              label={t(I18nKey.SETTINGS$MCP_TIMEOUT_LABEL)}
-              className="w-full max-w-[680px]"
-              showOptionalTag
-              defaultValue={server?.timeout?.toString() || ""}
-              placeholder="60"
-              min={1}
-              max={3600}
-            />
-          )}
+          <SettingsInput
+            testId="timeout-input"
+            name="timeout"
+            type="number"
+            label={t(I18nKey.SETTINGS$MCP_TIMEOUT_LABEL)}
+            className="w-full max-w-[680px]"
+            showOptionalTag
+            defaultValue={server?.timeout?.toString() || ""}
+            placeholder="60"
+            min={1}
+            max={3600}
+          />
         </>
       )}
 

--- a/frontend/src/components/features/settings/mcp-settings/mcp-server-list-item.tsx
+++ b/frontend/src/components/features/settings/mcp-settings/mcp-server-list-item.tsx
@@ -53,6 +53,9 @@ export function MCPServerListItem({
       (serverConfig.type === "sse" || serverConfig.type === "shttp") &&
       serverConfig.url
     ) {
+      if (serverConfig.timeout) {
+        return `${serverConfig.url} (timeout: ${serverConfig.timeout}s)`;
+      }
       return serverConfig.url;
     }
     return "";

--- a/frontend/src/hooks/mutation/use-add-mcp-server.ts
+++ b/frontend/src/hooks/mutation/use-add-mcp-server.ts
@@ -46,6 +46,7 @@ export function useAddMcpServer() {
         const sseServer: MCPSSEServer = {
           url: server.url!,
           ...(server.api_key && { api_key: server.api_key }),
+          ...(server.timeout !== undefined && { timeout: server.timeout }),
         };
         newConfig.sse_servers.push(sseServer);
       } else if (server.type === "stdio") {

--- a/frontend/src/hooks/mutation/use-update-mcp-server.ts
+++ b/frontend/src/hooks/mutation/use-update-mcp-server.ts
@@ -53,7 +53,7 @@ function updatedRemoteServer(
     ...(typeof current === "object" ? current : {}),
     url: server.url!,
   };
-  if (server.type === "shttp" && server.timeout !== undefined) {
+  if (server.timeout !== undefined) {
     updated.timeout = server.timeout;
   } else {
     delete updated.timeout;

--- a/frontend/src/routes/mcp-settings.tsx
+++ b/frontend/src/routes/mcp-settings.tsx
@@ -76,6 +76,7 @@ function MCPSettingsScreen() {
       type: "sse" as const,
       url: typeof server === "string" ? server : server.url,
       api_key: typeof server === "object" ? server.api_key : undefined,
+      timeout: typeof server === "object" ? server.timeout : undefined,
     })),
     ...mcpConfig.stdio_servers.map((server, index) => ({
       id: `stdio-${index}`,

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -52,6 +52,7 @@ export type MCPSSEServer = {
   api_key?: string;
   auth?: MCPAuthCredential;
   headers?: Record<string, string>;
+  timeout?: number;
 };
 
 export type MCPStdioServer = {

--- a/frontend/src/utils/mcp-config.ts
+++ b/frontend/src/utils/mcp-config.ts
@@ -270,6 +270,9 @@ export function parseMcpConfig(value: unknown): MCPConfig {
         if (apiKey) server.api_key = apiKey;
         if (auth) server.auth = auth;
         if (headers) server.headers = headers;
+        if (serverConfig.timeout != null) {
+          server.timeout = serverConfig.timeout as number;
+        }
         sseServers.push(server);
       } else {
         const server: MCPSHTTPServer = {
@@ -330,6 +333,7 @@ export function toSdkMcpConfig(
     } else {
       server.url = entry.url;
       Object.assign(server, getRemoteSecretFields(entry));
+      if (entry.timeout != null) server.timeout = entry.timeout;
     }
     server.transport = "sse";
 


### PR DESCRIPTION
HUMAN:

This is a small MCP settings fix. FastMCP remote servers can carry a timeout, but our MCP settings UI only kept that value for Streamable HTTP servers. If someone already had an SSE MCP server with a timeout, opening and saving the settings could drop it. I made SSE use the same timeout path as the other remote MCP server type so slow MCP servers can keep the setting that helps them start reliably.

- [x] A human has tested these changes.

AGENT:

---

## Why

Part of #9805. MCP failures are hard to diagnose when server-level connection settings are not visible or preserved. FastMCP `RemoteMCPServer` supports `timeout` for remote servers, but the frontend only exposed and round-tripped it for `shttp` servers. SSE servers could not set it from the form, and existing SSE timeout values were dropped during parse/save.

## Summary

- Preserve `timeout` on SSE MCP servers in `parseMcpConfig()` and `toSdkMcpConfig()`.
- Show the timeout field for both SSE and SHTTP MCP server forms.
- Persist SSE timeout values through add/update mutations.
- Include timeout in the MCP server list details so users can see when it is configured.
- Add regression coverage for parsing, serialization, form submission, and list rendering.

## Issue Number

Part of #9805

## How to Test

- `cd frontend && npm test -- --run __tests__/utils/mcp-config.test.ts __tests__/components/features/settings/mcp-settings/mcp-server-list.test.tsx __tests__/components/features/settings/mcp-settings/mcp-server-form.validation.test.tsx`
- `cd frontend && npx eslint src/types/settings.ts src/utils/mcp-config.ts src/components/features/settings/mcp-settings/mcp-server-form.tsx src/components/features/settings/mcp-settings/mcp-server-list-item.tsx src/hooks/mutation/use-add-mcp-server.ts src/hooks/mutation/use-update-mcp-server.ts src/routes/mcp-settings.tsx __tests__/utils/mcp-config.test.ts __tests__/components/features/settings/mcp-settings/mcp-server-list.test.tsx __tests__/components/features/settings/mcp-settings/mcp-server-form.validation.test.tsx`
- `cd frontend && npx prettier --check src/types/settings.ts src/utils/mcp-config.ts src/components/features/settings/mcp-settings/mcp-server-form.tsx src/components/features/settings/mcp-settings/mcp-server-list-item.tsx src/hooks/mutation/use-add-mcp-server.ts src/hooks/mutation/use-update-mcp-server.ts src/routes/mcp-settings.tsx __tests__/utils/mcp-config.test.ts __tests__/components/features/settings/mcp-settings/mcp-server-list.test.tsx __tests__/components/features/settings/mcp-settings/mcp-server-form.validation.test.tsx`
- `cd frontend && npm run typecheck:staged`
- `cd frontend && npm run check-translation-completeness`
- `git diff --check`
- Commit hooks: frontend lint-staged/typecheck/translation completeness and backend pre-commit passed.

## Video/Screenshots

N/A, settings serialization/UI behavior covered by focused tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This does not implement the full MCP connection health dashboard from #9805. It closes one confirmed gap in the existing MCP settings owner path: remote SSE server timeout values are now visible and preserved instead of silently dropped.
