### PR TITLE
fix: PLTF-2956 batch_get_sandboxes to gracefully handle runtime API failures

### DIFF
--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -669,7 +669,11 @@ class RemoteSandboxService(SandboxService):
     async def batch_get_sandboxes(
         self, sandbox_ids: list[str]
     ) -> list[SandboxInfo | None]:
-        """Get a batch of sandboxes, returning None for any which were not found."""
+        """Get a batch of sandboxes, returning None for any which were not found.
+
+        Falls back to returning sandboxes with missing/unknown runtime status if the
+        runtime API is unavailable, rather than failing the entire batch request.
+        """
         if not sandbox_ids:
             return []
         query = await self._secure_select()
@@ -679,9 +683,20 @@ class RemoteSandboxService(SandboxService):
             stored_remote_sandbox[0].id: stored_remote_sandbox[0]
             for stored_remote_sandbox in stored_remote_sandboxes
         }
-        runtimes_by_id = await self._get_runtimes_batch(
-            list(stored_remote_sandboxes_by_id)
-        )
+
+        # Gracefully handle runtime API failures by falling back to empty runtimes.
+        # This mirrors the behavior of get_sandbox which falls back to runtime=None.
+        try:
+            runtimes_by_id = await self._get_runtimes_batch(
+                list(stored_remote_sandboxes_by_id)
+            )
+        except Exception:
+            _logger.exception(
+                'Error getting runtimes batch, falling back to empty runtimes',
+                stack_info=True,
+            )
+            runtimes_by_id = {}
+
         results = []
         for sandbox_id in sandbox_ids:
             stored_remote_sandbox = stored_remote_sandboxes_by_id.get(sandbox_id)

--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -11,17 +11,16 @@ from uuid import UUID
 import base62
 import httpx
 from fastapi import Request
-from openhands.agent_server.models import (
-    ConversationInfo,
-    EventPage,
-)
-from openhands.agent_server.utils import utc_now
-from openhands.sdk.utils.paging import page_iterator
 from pydantic import Field
 from sqlalchemy import String, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
 
+from openhands.agent_server.models import (
+    ConversationInfo,
+    EventPage,
+)
+from openhands.agent_server.utils import utc_now
 from openhands.app_server.app_conversation.app_conversation_models import (
     AppConversationInfo,
 )
@@ -49,6 +48,7 @@ from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.user.specifiy_user_context import ADMIN, USER_CONTEXT_ATTR
 from openhands.app_server.user.user_context import UserContext
 from openhands.app_server.utils.sql_utils import Base, UtcDateTime
+from openhands.sdk.utils.paging import page_iterator
 
 _logger = logging.getLogger(__name__)
 polling_task: asyncio.Task | None = None

--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -11,16 +11,17 @@ from uuid import UUID
 import base62
 import httpx
 from fastapi import Request
-from pydantic import Field
-from sqlalchemy import String, func, select
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import Mapped, mapped_column
-
 from openhands.agent_server.models import (
     ConversationInfo,
     EventPage,
 )
 from openhands.agent_server.utils import utc_now
+from openhands.sdk.utils.paging import page_iterator
+from pydantic import Field
+from sqlalchemy import String, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
+
 from openhands.app_server.app_conversation.app_conversation_models import (
     AppConversationInfo,
 )
@@ -48,7 +49,6 @@ from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.user.specifiy_user_context import ADMIN, USER_CONTEXT_ATTR
 from openhands.app_server.user.user_context import UserContext
 from openhands.app_server.utils.sql_utils import Base, UtcDateTime
-from openhands.sdk.utils.paging import page_iterator
 
 _logger = logging.getLogger(__name__)
 polling_task: asyncio.Task | None = None

--- a/tests/unit/app_server/test_remote_sandbox_service.py
+++ b/tests/unit/app_server/test_remote_sandbox_service.py
@@ -1782,9 +1782,7 @@ class TestBatchGetSandboxes:
         mock_result.__iter__ = MagicMock(
             return_value=iter([(stored_sandbox_1,), (stored_sandbox_2,)])
         )
-        remote_sandbox_service.db_session.execute = AsyncMock(
-            return_value=mock_result
-        )
+        remote_sandbox_service.db_session.execute = AsyncMock(return_value=mock_result)
 
         # Mock successful runtime batch response
         remote_sandbox_service._get_runtimes_batch = AsyncMock(
@@ -1833,9 +1831,7 @@ class TestBatchGetSandboxes:
         mock_result.__iter__ = MagicMock(
             return_value=iter([(stored_sandbox_1,), (stored_sandbox_2,)])
         )
-        remote_sandbox_service.db_session.execute = AsyncMock(
-            return_value=mock_result
-        )
+        remote_sandbox_service.db_session.execute = AsyncMock(return_value=mock_result)
 
         # Mock runtime API timeout
         remote_sandbox_service._get_runtimes_batch = AsyncMock(
@@ -1871,9 +1867,7 @@ class TestBatchGetSandboxes:
         # Mock DB query result
         mock_result = MagicMock()
         mock_result.__iter__ = MagicMock(return_value=iter([(stored_sandbox_1,)]))
-        remote_sandbox_service.db_session.execute = AsyncMock(
-            return_value=mock_result
-        )
+        remote_sandbox_service.db_session.execute = AsyncMock(return_value=mock_result)
 
         # Mock runtime API HTTP error
         remote_sandbox_service._get_runtimes_batch = AsyncMock(
@@ -1906,9 +1900,7 @@ class TestBatchGetSandboxes:
         # Mock DB query result
         mock_result = MagicMock()
         mock_result.__iter__ = MagicMock(return_value=iter([(stored_sandbox_1,)]))
-        remote_sandbox_service.db_session.execute = AsyncMock(
-            return_value=mock_result
-        )
+        remote_sandbox_service.db_session.execute = AsyncMock(return_value=mock_result)
 
         # Mock HTTP status error from raise_for_status()
         remote_sandbox_service._get_runtimes_batch = AsyncMock(

--- a/tests/unit/app_server/test_remote_sandbox_service.py
+++ b/tests/unit/app_server/test_remote_sandbox_service.py
@@ -1763,3 +1763,167 @@ class TestPollAgentServersSessionScoping:
             'expected refresh_conversation to open a write session'
         )
         assert tracker.open == 0
+
+
+class TestBatchGetSandboxes:
+    """Test cases for batch_get_sandboxes method."""
+
+    @pytest.mark.asyncio
+    async def test_batch_get_sandboxes_success(self, remote_sandbox_service):
+        """Test successful batch retrieval of sandboxes."""
+        # Setup
+        sandbox_ids = ['sandbox-1', 'sandbox-2']
+        stored_sandbox_1 = create_stored_sandbox(sandbox_id='sandbox-1')
+        stored_sandbox_2 = create_stored_sandbox(sandbox_id='sandbox-2')
+        runtime_1 = create_runtime_data(session_id='sandbox-1', status='running')
+
+        # Mock DB query result
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(
+            return_value=iter([(stored_sandbox_1,), (stored_sandbox_2,)])
+        )
+        remote_sandbox_service.db_session.execute = AsyncMock(
+            return_value=mock_result
+        )
+
+        # Mock successful runtime batch response
+        remote_sandbox_service._get_runtimes_batch = AsyncMock(
+            return_value={'sandbox-1': runtime_1}
+        )
+
+        # Execute
+        results = await remote_sandbox_service.batch_get_sandboxes(sandbox_ids)
+
+        # Verify
+        assert len(results) == 2
+        assert results[0] is not None
+        assert results[0].id == 'sandbox-1'
+        assert results[0].status == SandboxStatus.RUNNING
+        assert results[1] is not None
+        assert results[1].id == 'sandbox-2'
+        # sandbox-2 has no runtime, so it's marked as MISSING
+        assert results[1].status == SandboxStatus.MISSING
+
+    @pytest.mark.asyncio
+    async def test_batch_get_sandboxes_empty_ids(self, remote_sandbox_service):
+        """Test batch retrieval with empty sandbox IDs list."""
+        # Execute
+        results = await remote_sandbox_service.batch_get_sandboxes([])
+
+        # Verify
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_batch_get_sandboxes_graceful_fallback_on_timeout(
+        self, remote_sandbox_service
+    ):
+        """Test that batch_get_sandboxes gracefully handles runtime API timeout.
+
+        This is the key regression test: when the runtime API times out,
+        batch_get_sandboxes should not raise but should return sandboxes
+        with MISSING status (matching the behavior of get_sandbox).
+        """
+        # Setup
+        sandbox_ids = ['sandbox-1', 'sandbox-2']
+        stored_sandbox_1 = create_stored_sandbox(sandbox_id='sandbox-1')
+        stored_sandbox_2 = create_stored_sandbox(sandbox_id='sandbox-2')
+
+        # Mock DB query result
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(
+            return_value=iter([(stored_sandbox_1,), (stored_sandbox_2,)])
+        )
+        remote_sandbox_service.db_session.execute = AsyncMock(
+            return_value=mock_result
+        )
+
+        # Mock runtime API timeout
+        remote_sandbox_service._get_runtimes_batch = AsyncMock(
+            side_effect=httpx.TimeoutException('Request timeout')
+        )
+
+        # Execute - should NOT raise, should gracefully fall back
+        results = await remote_sandbox_service.batch_get_sandboxes(sandbox_ids)
+
+        # Verify - all sandboxes should be returned with MISSING status
+        assert len(results) == 2
+        assert results[0] is not None
+        assert results[0].id == 'sandbox-1'
+        assert results[0].status == SandboxStatus.MISSING
+        assert results[1] is not None
+        assert results[1].id == 'sandbox-2'
+        assert results[1].status == SandboxStatus.MISSING
+
+    @pytest.mark.asyncio
+    async def test_batch_get_sandboxes_graceful_fallback_on_http_error(
+        self, remote_sandbox_service
+    ):
+        """Test that batch_get_sandboxes gracefully handles runtime API HTTP error.
+
+        When the runtime API returns an error (e.g., 500 Internal Server Error),
+        batch_get_sandboxes should not raise but should return sandboxes
+        with MISSING status.
+        """
+        # Setup
+        sandbox_ids = ['sandbox-1']
+        stored_sandbox_1 = create_stored_sandbox(sandbox_id='sandbox-1')
+
+        # Mock DB query result
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter([(stored_sandbox_1,)]))
+        remote_sandbox_service.db_session.execute = AsyncMock(
+            return_value=mock_result
+        )
+
+        # Mock runtime API HTTP error
+        remote_sandbox_service._get_runtimes_batch = AsyncMock(
+            side_effect=httpx.HTTPError('Internal server error')
+        )
+
+        # Execute - should NOT raise, should gracefully fall back
+        results = await remote_sandbox_service.batch_get_sandboxes(sandbox_ids)
+
+        # Verify - sandbox should be returned with MISSING status
+        assert len(results) == 1
+        assert results[0] is not None
+        assert results[0].id == 'sandbox-1'
+        assert results[0].status == SandboxStatus.MISSING
+
+    @pytest.mark.asyncio
+    async def test_batch_get_sandboxes_graceful_fallback_on_raise_for_status(
+        self, remote_sandbox_service
+    ):
+        """Test graceful fallback when raise_for_status() fails in _get_runtimes_batch.
+
+        The _get_runtimes_batch method calls response.raise_for_status().
+        When this raises an httpx.HTTPStatusError, batch_get_sandboxes should
+        catch it and fall back gracefully.
+        """
+        # Setup
+        sandbox_ids = ['sandbox-1']
+        stored_sandbox_1 = create_stored_sandbox(sandbox_id='sandbox-1')
+
+        # Mock DB query result
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter([(stored_sandbox_1,)]))
+        remote_sandbox_service.db_session.execute = AsyncMock(
+            return_value=mock_result
+        )
+
+        # Mock HTTP status error from raise_for_status()
+        remote_sandbox_service._get_runtimes_batch = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                message='500 Internal Server Error',
+                request=MagicMock(),
+                response=MagicMock(status_code=500),
+            )
+        )
+
+        # Execute - should NOT raise, should gracefully fall back
+        results = await remote_sandbox_service.batch_get_sandboxes(sandbox_ids)
+
+        # Verify - sandbox should be returned with MISSING status
+        assert len(results) == 1
+        assert results[0] is not None
+        assert results[0].id == 'sandbox-1'
+        assert results[0].status == SandboxStatus.MISSING


### PR DESCRIPTION
HUMAN: Apply the same guard to batch get sandboxes to handle slow Runtime API calls gracefully that we already have for get sandbox.


- [ ] A human has tested these changes.
AGENT:

---

## Why

When the remote runtime/sandbox API is slow or unreachable, `GET /api/v1/app-conversations` returned HTTP 500 instead of degrading gracefully.

The single-sandbox path (`get_sandbox`) already had graceful degradation. The batch path (`batch_get_sandboxes`) was missing this same guard.

## Summary

- Add try/except around `_get_runtimes_batch` in `batch_get_sandboxes` to catch runtime API failures
- Fall back to empty runtimes dict on any exception
- Add comprehensive unit tests for graceful fallback

## Issue Number

Fixes #14848

## How to Test

Run: `python -m pytest tests/unit/app_server/test_remote_sandbox_service.py::TestBatchGetSandboxes -v`

## Type

- [x] Bug fix

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-ff1182d   docker.openhands.dev/openhands/openhands:ff1182d
```