### PR TITLE
test(frontend): add V1 pending message queue coverage

### DIFF
--- a/frontend/__tests__/conversation-websocket-handler.test.tsx
+++ b/frontend/__tests__/conversation-websocket-handler.test.tsx
@@ -38,6 +38,7 @@ import {
   ConversationWebSocketProvider,
   useConversationWebSocket,
 } from "#/contexts/conversation-websocket-context";
+import PendingMessageService from "#/api/pending-message-service/pending-message-service.api";
 import { conversationWebSocketTestSetup } from "./helpers/msw-websocket-setup";
 import { useEventStore } from "#/stores/use-event-store";
 import { isV1Event } from "#/types/v1/type-guards";
@@ -891,6 +892,123 @@ describe("Conversation WebSocket Handler", () => {
 
   // 7. Message Sending Tests
   describe("Message Sending", () => {
+    it("should queue user messages through PendingMessageService when the WebSocket is not connected", async () => {
+      const conversationId = "test-conversation-queued";
+      const queueMessageSpy = vi
+        .spyOn(PendingMessageService, "queueMessage")
+        .mockResolvedValue({
+          id: "pending-message-1",
+          queued: true,
+          position: 1,
+        });
+
+      let sendMessageFn: typeof useConversationWebSocket extends () => infer R
+        ? R extends { sendMessage: infer S }
+          ? S
+          : null
+        : null = null;
+
+      function TestComponent() {
+        const context = useConversationWebSocket();
+
+        React.useEffect(() => {
+          if (context?.sendMessage) {
+            sendMessageFn = context.sendMessage;
+          }
+        }, [context?.sendMessage]);
+
+        return (
+          <div>
+            <div data-testid="connection-state">
+              {context?.connectionState || "NOT_AVAILABLE"}
+            </div>
+          </div>
+        );
+      }
+
+      renderWithWebSocketContext(<TestComponent />, conversationId, "");
+
+      await waitFor(() => {
+        expect(sendMessageFn).not.toBeNull();
+      });
+
+      let sendResult: Awaited<ReturnType<NonNullable<typeof sendMessageFn>>>;
+
+      await act(async () => {
+        sendResult = await sendMessageFn!({
+          role: "user",
+          content: [{ type: "text", text: "Queue me while disconnected" }],
+        });
+      });
+
+      expect(sendResult!).toEqual({ queued: true });
+      expect(queueMessageSpy).toHaveBeenCalledWith(conversationId, {
+        role: "user",
+        content: [{ type: "text", text: "Queue me while disconnected" }],
+      });
+
+      queueMessageSpy.mockRestore();
+    });
+
+    it("should surface queueing errors when PendingMessageService fails", async () => {
+      const conversationId = "test-conversation-queue-error";
+      const queueError = new Error("Failed to queue message for delivery");
+      const queueMessageSpy = vi
+        .spyOn(PendingMessageService, "queueMessage")
+        .mockRejectedValue(queueError);
+
+      let sendMessageFn: typeof useConversationWebSocket extends () => infer R
+        ? R extends { sendMessage: infer S }
+          ? S
+          : null
+        : null = null;
+
+      function TestComponent() {
+        const context = useConversationWebSocket();
+
+        React.useEffect(() => {
+          if (context?.sendMessage) {
+            sendMessageFn = context.sendMessage;
+          }
+        }, [context?.sendMessage]);
+
+        return (
+          <div>
+            <div data-testid="connection-state">
+              {context?.connectionState || "NOT_AVAILABLE"}
+            </div>
+            <ErrorMessageStoreComponent />
+          </div>
+        );
+      }
+
+      renderWithWebSocketContext(<TestComponent />, conversationId, "");
+
+      await waitFor(() => {
+        expect(sendMessageFn).not.toBeNull();
+      });
+
+      await expect(
+        sendMessageFn!({
+          role: "user",
+          content: [{ type: "text", text: "This one should fail" }],
+        }),
+      ).rejects.toThrow("Failed to queue message for delivery");
+
+      await waitFor(() => {
+        expect(screen.getByTestId("error-message")).toHaveTextContent(
+          "Failed to queue message for delivery",
+        );
+      });
+
+      expect(queueMessageSpy).toHaveBeenCalledWith(conversationId, {
+        role: "user",
+        content: [{ type: "text", text: "This one should fail" }],
+      });
+
+      queueMessageSpy.mockRestore();
+    });
+
     it("should send user actions through WebSocket when connected", async () => {
       // Arrange
       const conversationId = "test-conversation-send";


### PR DESCRIPTION
HUMAN:

This PR adds targeted frontend coverage for the V1 pending-message fallback path. It verifies that disconnected `sendMessage` calls queue through `PendingMessageService` and that queueing failures surface correctly to both the caller and the frontend error store.

- [ ] A human has tested these changes.

AGENT:

---

## Why

V1 conversations already fall back to `PendingMessageService` when the WebSocket
is unavailable, but the frontend WebSocket handler test suite did not clearly
cover that disconnected queueing path or its error-handling behavior.

## Summary

- add a V1 test that verifies disconnected `sendMessage` calls queue through
  `PendingMessageService`
- add a V1 test that verifies queueing failures surface both to the caller and
  to the frontend error message store
- keep the change scoped to frontend test coverage only

## Issue Number

Closes #12279

## How to Test

Run:

```bash
/Users/sreytouch/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node \
  /Users/sreytouch/Desktop/ReactJs/OpenHands/frontend/node_modules/vitest/vitest.mjs \
  run __tests__/conversation-websocket-handler.test.tsx \
  -t "queue user messages through PendingMessageService|surface queueing errors when PendingMessageService fails"
```

Expected result:

- 2 tests pass for the V1 queue fallback scenarios

## Video/Screenshots

Not applicable. This PR adds automated frontend test coverage only.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- This PR adds targeted coverage for the current V1 queue fallback path.
- Scope note: upstream `main` already implements the server-side pending-message queueing the issue described; this PR adds the frontend test coverage that validates the V1 disconnected-queueing behavior (both the successful-queue and error-surfacing paths). I've set this to `Closes #12279` to tie the work to the issue, and maintainers should feel free to keep the issue open if they consider the original scope broader.
