### PR TITLE
fix: log error level for failed GitHub payload processing (#14814)

### DIFF
--- a/enterprise/integrations/github/github_manager.py
+++ b/enterprise/integrations/github/github_manager.py
@@ -263,7 +263,7 @@ class GithubManager(Manager[GithubViewType]):
         try:
             await self.data_collector.process_payload(message)
         except Exception:
-            logger.warning(
+            logger.error(
                 '[Github]: Error processing payload for gh interaction', exc_info=True
             )
 


### PR DESCRIPTION
HUMAN:


- [x] A human has tested these changes.

AGENT:

---

## Why

A failed GitHub webhook payload-processing operation is logged at `warning` when it should be `error`. The log message itself is literally titled "Error", but the level is `warning`, so it falls below the threshold our error monitoring alerts on.

The operation fails entirely -- `data_collector.process_payload()` raises and the PR/interaction data is never persisted. There is no retry or fallback. The dominant root cause is a database connection timeout, i.e. a hard failure with user-visible impact.

## Summary

- Changed `logger.warning` to `logger.error` in `GithubManager.receive_message` for failed payload processing in `enterprise/integrations/github/github_manager.py`
- Aligns with the project's logging convention: `warning` = degraded but recoverable, `error` = operation failed with user impact

## Issue Number

OpenHands/enterprise#31

## How to Test

1. Set up the enterprise development environment
2. Simulate a GitHub webhook payload processing failure (e.g., database connection timeout)
3. Verify the log output shows `ERROR` level instead of `WARNING` for the `[Github]: Error processing payload for gh interaction` message

## Video/Screenshots

N/A -- this is a one-line log level change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is one of three related log-level fixes. Once corrected, error monitoring can rely on `status:error` and drop the warning-level special cases.
