### PR TITLE
docs(skills): fix typo in OpenHands docs URL in add_agent.md

### DIFF
--- a/skills/add_agent.md
+++ b/skills/add_agent.md
@@ -36,5 +36,5 @@ When creating a new microagent:
 
 For detailed information, see:
 
-- [Microagents Overview](https://docs.OpenHnads.dev/usage/prompting/microagents-overview)
+- [Microagents Overview](https://docs.OpenHands.dev/usage/prompting/microagents-overview)
 - [Example GitHub Skill](https://github.com/OpenHands/OpenHands/blob/main/skills/github.md)


### PR DESCRIPTION
## HUMAN:
This PR fixes a one-character typo in a documentation URL in `skills/add_agent.md`. The URL was `docs.OpenHnads.dev` (with 'a' and 'n' transposed in the subdomain) which does not resolve; the correct URL is `docs.OpenHands.dev`. The fix is a single character change: `OpenHnads` -> `OpenHands`. The URL was independently verified to return 200 (correct) vs NXDOMAIN (broken). No code, no config, no tests touched.

## Summary

`skills/add_agent.md` links to `https://docs.OpenHnads.dev/usage/prompting/microagents-overview` — the subdomain has the letters 'a' and 'n' transposed ("OpenHnads" instead of "OpenHands"). The correct URL is `https://docs.OpenHands.dev/usage/prompting/microagents-overview`.

## Verification

- Old URL: `docs.OpenHnads.dev` does not resolve (NXDOMAIN).
- New URL: 200.

## Diff

```diff
-- [Microagents Overview](https://docs.OpenHnads.dev/usage/prompting/microagents-overview)
++ [Microagents Overview](https://docs.OpenHands.dev/usage/prompting/microagents-overview)
```