### PR TITLE
fix: Fix CVE-2026-49458: Update dompurify to 3.4.6

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8854,9 +8854,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.6.tgz",
+      "integrity": "sha512-+7gzEI8trIIQkVCvQ3ucGtNfH3nOmDgVTzc62rAAOlMxLth78pwpPoZCPc7CyRzAQF89MqcfPdEWkDwnjgqktg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -129,6 +129,6 @@
     ]
   },
   "overrides": {
-    "dompurify": "3.4.0"
+    "dompurify": "3.4.6"
   }
 }


### PR DESCRIPTION
Human: Tested this locally

<img width="885" height="773" alt="Screenshot 2026-06-23 at 10 01 27 AM" src="https://github.com/user-attachments/assets/be42c491-d13a-43c7-9697-f526ec236c90" />


## Security Fix: CVE-2026-49458

### Summary
Updates `dompurify` from **3.4.0** to **3.4.6** to address the security vulnerability [CVE-2026-49458](https://nvd.nist.gov/vuln/detail/CVE-2026-49458).

### Changes
- Updated `dompurify` version in `frontend/package.json` from `3.4.0` to `3.4.6`
- Regenerated `frontend/package-lock.json` to reflect the updated dependency

### Impact
This is a direct dependency update in the frontend package. No API or functionality changes are expected.

---
_This PR was created by an AI agent (OpenHands) to remediate a security vulnerability._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-61392b4   docker.openhands.dev/openhands/openhands:61392b4
```