### PR TITLE
fix: stop the connection-error banner from flashing on transient websocket drops

### DIFF
--- a/frontend/__tests__/conversation-websocket-handler.test.tsx
+++ b/frontend/__tests__/conversation-websocket-handler.test.tsx
@@ -40,6 +40,7 @@ import {
   ConversationWebSocketProvider,
   useConversationWebSocket,
   CONNECTION_ERROR_GRACE_MS,
+  CONNECTION_ERROR_MESSAGE,
 } from "#/contexts/conversation-websocket-context";
 import { conversationWebSocketTestSetup } from "./helpers/msw-websocket-setup";
 import { useEventStore } from "#/stores/use-event-store";
@@ -98,6 +99,10 @@ function renderWithWebSocketContext(
   conversationId = "test-conversation-default",
   conversationUrl = "http://localhost:3000/api/conversations/test-conversation-default",
   sessionApiKey: string | null = null,
+  extraProps: {
+    subConversations?: { id: string; conversation_url: string }[];
+    subConversationIds?: string[];
+  } = {},
 ) {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -117,6 +122,9 @@ function renderWithWebSocketContext(
                 conversationId={conversationId}
                 conversationUrl={conversationUrl}
                 sessionApiKey={sessionApiKey}
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                subConversations={extraProps.subConversations as any}
+                subConversationIds={extraProps.subConversationIds}
               >
                 {children}
               </ConversationWebSocketProvider>
@@ -715,18 +723,96 @@ describe("Conversation WebSocket Handler", () => {
       await waitFor(
         () => {
           expect(useErrorMessageStore.getState().errorMessage).toBe(
-            "Failed to connect to server",
+            CONNECTION_ERROR_MESSAGE,
           );
         },
         { timeout: CONNECTION_ERROR_GRACE_MS + 3000 },
       );
     }, 15000);
 
+    it("should keep the connection banner when the planning socket is active while main stays down", async () => {
+      // Invariant: the banner is owned by the main socket. A planning-socket
+      // message/reconnect must NOT clear a main-connection outage banner
+      // while the main socket is still down during an active run.
+      useV1ConversationStateStore.setState({
+        execution_status: V1ExecutionStatus.RUNNING,
+      });
+
+      const mainId = "main-conv-banner";
+      const subId = "planning-conv-banner";
+      let mainAttempts = 0;
+
+      mswServer.use(
+        http.get(
+          `http://localhost:3000/api/conversations/${mainId}/events/count`,
+          () => HttpResponse.json(0),
+        ),
+        http.get(
+          `http://localhost:3000/api/conversations/${subId}/events/count`,
+          () => HttpResponse.json(0),
+        ),
+        wsLink.addEventListener("connection", (conn) => {
+          const isMain = String(conn.client.url).includes(mainId);
+          if (isMain) {
+            mainAttempts += 1;
+            if (mainAttempts === 1) {
+              // Open once, then drop and never reopen.
+              setTimeout(() => conn.client.close(1006, "Outage"), 50);
+            } else {
+              conn.client.close(1006, "Outage");
+            }
+          } else {
+            // Planning socket stays up and emits a non-error event after the
+            // banner would have appeared — this used to clear it.
+            setTimeout(() => {
+              conn.client.send(
+                JSON.stringify(
+                  createMockMessageEvent({ id: "planning-msg-1" }),
+                ),
+              );
+            }, CONNECTION_ERROR_GRACE_MS + 800);
+          }
+        }),
+      );
+
+      renderWithWebSocketContext(
+        <ErrorMessageStoreComponent />,
+        mainId,
+        `http://localhost:3000/api/conversations/${mainId}`,
+        null,
+        {
+          subConversations: [
+            {
+              id: subId,
+              conversation_url: `http://localhost:3000/api/conversations/${subId}`,
+            },
+          ],
+          subConversationIds: [subId],
+        },
+      );
+
+      // Banner appears after the grace window (main down + agent running).
+      await waitFor(
+        () =>
+          expect(useErrorMessageStore.getState().errorMessage).toBe(
+            CONNECTION_ERROR_MESSAGE,
+          ),
+        { timeout: CONNECTION_ERROR_GRACE_MS + 3000 },
+      );
+
+      // The planning socket's event fires (~grace + 800ms); the main-socket
+      // banner must still be present afterwards.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1500);
+      });
+      expect(useErrorMessageStore.getState().errorMessage).toBe(
+        CONNECTION_ERROR_MESSAGE,
+      );
+    }, 15000);
+
     it("should clear the connection banner when the socket reconnects", async () => {
       // A surfaced connection banner is cleared once the socket reconnects.
-      useErrorMessageStore
-        .getState()
-        .setErrorMessage("Failed to connect to server");
+      useErrorMessageStore.getState().setErrorMessage(CONNECTION_ERROR_MESSAGE);
 
       mswServer.use(
         wsLink.addEventListener("connection", () => {

--- a/frontend/__tests__/conversation-websocket-handler.test.tsx
+++ b/frontend/__tests__/conversation-websocket-handler.test.tsx
@@ -17,6 +17,8 @@ import { useOptimisticUserMessageStore } from "#/stores/optimistic-user-message-
 import { useBrowserStore } from "#/stores/browser-store";
 import { useCommandStore } from "#/stores/command-store";
 import { useErrorMessageStore } from "#/stores/error-message-store";
+import { useV1ConversationStateStore } from "#/stores/v1-conversation-state-store";
+import { V1ExecutionStatus } from "#/types/v1/core/base/common";
 import {
   createMockMessageEvent,
   createMockUserMessageEvent,
@@ -37,6 +39,7 @@ import {
 import {
   ConversationWebSocketProvider,
   useConversationWebSocket,
+  CONNECTION_ERROR_GRACE_MS,
 } from "#/contexts/conversation-websocket-context";
 import { conversationWebSocketTestSetup } from "./helpers/msw-websocket-setup";
 import { useEventStore } from "#/stores/use-event-store";
@@ -76,6 +79,7 @@ afterEach(() => {
   // Reset stores to prevent state leakage between tests
   useErrorMessageStore.getState().removeErrorMessage();
   useEventStore.getState().clearEvents();
+  useV1ConversationStateStore.getState().reset();
 });
 
 afterAll(async () => {
@@ -591,9 +595,10 @@ describe("Conversation WebSocket Handler", () => {
       expect(currentError).not.toBe("STATUS$ERROR_LLM_OUT_OF_CREDITS");
     });
 
-    it("should set error message store on WebSocket connection errors", async () => {
-      // Simulate a connect-then-fail sequence (the MSW server auto-connects by default).
-      // This should surface an error message because the app has previously connected.
+    it("should not flash a connection banner on an idle transient disconnect", async () => {
+      // Idle (no running agent): a dropped socket self-heals on reconnect, so
+      // it must NOT flash the red banner. Regression test for the over-eager
+      // "Failed to connect to server" message.
       mswServer.use(
         wsLink.addEventListener("connection", ({ client }) => {
           setTimeout(() => {
@@ -602,7 +607,6 @@ describe("Conversation WebSocket Handler", () => {
         }),
       );
 
-      // Render components that use both WebSocket and error message store
       renderWithWebSocketContext(
         <>
           <ErrorMessageStoreComponent />
@@ -610,37 +614,39 @@ describe("Conversation WebSocket Handler", () => {
         </>,
       );
 
-      // Initially should show "none"
       expect(screen.getByTestId("error-message")).toHaveTextContent("none");
 
-      // Wait for disconnect
       await waitFor(() => {
         expect(screen.getByTestId("connection-state")).toHaveTextContent(
           "CLOSED",
         );
       });
 
-      await waitFor(() => {
-        expect(screen.getByTestId("error-message")).not.toHaveTextContent(
-          "none",
-        );
-      });
+      // No agent running -> the banner never appears (it's gated on a running
+      // agent), and crucially it is NOT set synchronously on the drop.
+      expect(screen.getByTestId("error-message")).toHaveTextContent("none");
+      expect(useErrorMessageStore.getState().errorMessage).toBeNull();
     });
 
-    it("should set error message store on WebSocket disconnect with error", async () => {
-      // Set up MSW to connect first, then disconnect with error
-      mswServer.use(
-        wsLink.addEventListener("connection", ({ client, server }) => {
-          server.connect();
+    it("should not flash a connection banner when a transient drop reconnects during an active run", async () => {
+      // Agent running, but the drop recovers within the grace window: the
+      // pending banner is cancelled by the reconnect, so it never appears.
+      useV1ConversationStateStore.setState({
+        execution_status: V1ExecutionStatus.RUNNING,
+      });
 
-          // Simulate disconnect with error after a short delay
-          setTimeout(() => {
-            client.close(1006, "Unexpected disconnect");
-          }, 100);
+      let connectionAttempt = 0;
+      mswServer.use(
+        wsLink.addEventListener("connection", ({ client }) => {
+          connectionAttempt += 1;
+          if (connectionAttempt === 1) {
+            setTimeout(() => {
+              client.close(1006, "Transient drop");
+            }, 50);
+          }
         }),
       );
 
-      // Render components that use both WebSocket and error message store
       renderWithWebSocketContext(
         <>
           <ErrorMessageStoreComponent />
@@ -648,81 +654,103 @@ describe("Conversation WebSocket Handler", () => {
         </>,
       );
 
-      // Initially should show "none"
-      expect(screen.getByTestId("error-message")).toHaveTextContent("none");
+      // First drop
+      await waitFor(() => {
+        expect(screen.getByTestId("connection-state")).toHaveTextContent(
+          "CLOSED",
+        );
+      });
 
-      // Wait for connection to be established first
+      // Reconnect (within the grace window) cancels the pending banner, so it
+      // never appears.
+      await waitFor(
+        () => {
+          expect(screen.getByTestId("connection-state")).toHaveTextContent(
+            "OPEN",
+          );
+        },
+        { timeout: 5000 },
+      );
+      expect(useErrorMessageStore.getState().errorMessage).toBeNull();
+    }, 10000);
+
+    it("should show a connection banner when the agent is running and the socket stays down", async () => {
+      // Agent running and the socket fails to recover: after the grace window
+      // we surface the banner because live updates are genuinely stalled.
+      useV1ConversationStateStore.setState({
+        execution_status: V1ExecutionStatus.RUNNING,
+      });
+
+      let connectionAttempt = 0;
+      mswServer.use(
+        wsLink.addEventListener("connection", ({ client }) => {
+          connectionAttempt += 1;
+          if (connectionAttempt === 1) {
+            // Open once, then drop after the app has marked us connected.
+            setTimeout(() => {
+              client.close(1006, "Outage");
+            }, 50);
+          } else {
+            // Reconnect attempts fail to open (close before the open registers).
+            client.close(1006, "Outage");
+          }
+        }),
+      );
+
+      renderWithWebSocketContext(
+        <>
+          <ErrorMessageStoreComponent />
+          <ConnectionStatusComponent />
+        </>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("connection-state")).toHaveTextContent(
+          "CLOSED",
+        );
+      });
+
+      // Banner appears only after the grace window elapses.
+      expect(useErrorMessageStore.getState().errorMessage).toBeNull();
+      await waitFor(
+        () => {
+          expect(useErrorMessageStore.getState().errorMessage).toBe(
+            "Failed to connect to server",
+          );
+        },
+        { timeout: CONNECTION_ERROR_GRACE_MS + 3000 },
+      );
+    }, 15000);
+
+    it("should clear the connection banner when the socket reconnects", async () => {
+      // A surfaced connection banner is cleared once the socket reconnects.
+      useErrorMessageStore
+        .getState()
+        .setErrorMessage("Failed to connect to server");
+
+      mswServer.use(
+        wsLink.addEventListener("connection", () => {
+          // Stay connected.
+        }),
+      );
+
+      renderWithWebSocketContext(
+        <>
+          <ErrorMessageStoreComponent />
+          <ConnectionStatusComponent />
+        </>,
+      );
+
       await waitFor(() => {
         expect(screen.getByTestId("connection-state")).toHaveTextContent(
           "OPEN",
         );
       });
 
-      // Wait for disconnect and error message to be set
+      // onOpen clears the banner on a successful connection.
       await waitFor(() => {
-        expect(screen.getByTestId("connection-state")).toHaveTextContent(
-          "CLOSED",
-        );
+        expect(useErrorMessageStore.getState().errorMessage).toBeNull();
       });
-
-      // Should set error message on unexpected disconnect
-      await waitFor(() => {
-        expect(screen.getByTestId("error-message")).not.toHaveTextContent(
-          "none",
-        );
-      });
-    });
-
-    it("should clear error message store when connection is restored", async () => {
-      let connectionAttempt = 0;
-
-      // Fail once (after connect), then allow reconnection to stay open.
-      mswServer.use(
-        wsLink.addEventListener("connection", ({ client }) => {
-          connectionAttempt += 1;
-
-          if (connectionAttempt === 1) {
-            setTimeout(() => {
-              client.close(1006, "Initial connection failed");
-            }, 50);
-          }
-        }),
-      );
-
-      // Render components that use both WebSocket and error message store
-      renderWithWebSocketContext(
-        <>
-          <ErrorMessageStoreComponent />
-          <ConnectionStatusComponent />
-        </>,
-      );
-
-      // Initially should show "none"
-      expect(screen.getByTestId("error-message")).toHaveTextContent("none");
-
-      // Wait for first failure
-      await waitFor(() => {
-        expect(screen.getByTestId("connection-state")).toHaveTextContent(
-          "CLOSED",
-        );
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("error-message")).not.toHaveTextContent(
-          "none",
-        );
-      });
-
-      // Wait for reconnect to happen and verify error clears on successful connection
-      await waitFor(
-        () => {
-          expect(screen.getByTestId("connection-state")).toHaveTextContent(
-            "OPEN",
-          );
-          expect(screen.getByTestId("error-message")).toHaveTextContent("none");
-        },
-        { timeout: 5000 },
-      );
     });
 
     it("should clear error message when a successful event is received after a ConversationErrorEvent", async () => {

--- a/frontend/src/contexts/conversation-websocket-context.tsx
+++ b/frontend/src/contexts/conversation-websocket-context.tsx
@@ -16,6 +16,7 @@ import { updateConversationLlmModelInCache } from "#/hooks/mutation/conversation
 import { useErrorMessageStore } from "#/stores/error-message-store";
 import { useOptimisticUserMessageStore } from "#/stores/optimistic-user-message-store";
 import { useV1ConversationStateStore } from "#/stores/v1-conversation-state-store";
+import { V1ExecutionStatus } from "#/types/v1/core/base/common";
 import { useCommandStore } from "#/stores/command-store";
 import { useBrowserStore } from "#/stores/browser-store";
 import {
@@ -77,6 +78,11 @@ const ConversationWebSocketContext = createContext<
   ConversationWebSocketContextType | undefined
 >(undefined);
 
+// Wait this long after the main socket drops before showing the connection
+// banner. Transient drops reconnect (with full event replay) within a few
+// seconds, so this lets normal churn self-heal silently.
+export const CONNECTION_ERROR_GRACE_MS = 5000;
+
 export function ConversationWebSocketProvider({
   children,
   conversationId,
@@ -101,7 +107,11 @@ export function ConversationWebSocketProvider({
   // Track if we've ever successfully connected for each connection
   // Don't show errors until after first successful connection
   const hasConnectedRefMain = React.useRef(false);
-  const hasConnectedRefPlanning = React.useRef(false);
+
+  // Pending grace-window timer before the connection banner is shown.
+  const connectionErrorTimerRef = React.useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
 
   const queryClient = useQueryClient();
   const { addEvent } = useEventStore();
@@ -327,14 +337,18 @@ export function ConversationWebSocketProvider({
     [isLoadingHistoryMain, isLoadingHistoryPlanning],
   );
 
-  // Reset hasConnected flags and history loading state when conversation changes
+  // Reset history loading state when conversation changes
   useEffect(() => {
-    hasConnectedRefPlanning.current = false;
     setIsLoadingHistoryMain(true);
     setExpectedEventCountMain(null);
     receivedEventCountRefMain.current = 0;
     // Reset the tracked event ref when conversation changes
     latestPlanningFileEventRef.current = null;
+    // Drop any pending connection banner from the previous conversation.
+    if (connectionErrorTimerRef.current) {
+      clearTimeout(connectionErrorTimerRef.current);
+      connectionErrorTimerRef.current = null;
+    }
   }, [conversationId]);
 
   const { data: preloadedEvents, isFetched: isHistoryFetched } =
@@ -749,6 +763,11 @@ export function ConversationWebSocketProvider({
       onOpen: async () => {
         setMainConnectionState("OPEN");
         hasConnectedRefMain.current = true; // Mark that we've successfully connected
+        // A reconnect cancels any pending connection banner before it shows.
+        if (connectionErrorTimerRef.current) {
+          clearTimeout(connectionErrorTimerRef.current);
+          connectionErrorTimerRef.current = null;
+        }
         removeErrorMessage(); // Clear any previous error messages on successful connection
 
         // Fetch expected event count for history loading detection
@@ -778,9 +797,21 @@ export function ConversationWebSocketProvider({
       },
       onError: () => {
         setMainConnectionState("CLOSED");
-        // Only show error message if we've previously connected successfully
-        if (hasConnectedRefMain.current) {
-          setErrorMessage("Failed to connect to server");
+        // Don't flash on transient reconnect churn. Only surface a banner if
+        // we'd previously connected, the drop persists past the grace window,
+        // and the agent is actively running (idle drops self-heal silently
+        // and still show in the status indicator). onOpen cancels this first.
+        if (hasConnectedRefMain.current && !connectionErrorTimerRef.current) {
+          connectionErrorTimerRef.current = setTimeout(() => {
+            connectionErrorTimerRef.current = null;
+            const isRunning =
+              useV1ConversationStateStore.getState().execution_status ===
+              V1ExecutionStatus.RUNNING;
+            // Don't clobber a more specific error (e.g. budget/credit).
+            if (isRunning && !useErrorMessageStore.getState().errorMessage) {
+              setErrorMessage("Failed to connect to server");
+            }
+          }, CONNECTION_ERROR_GRACE_MS);
         }
       },
       onMessage: handleMainMessage,
@@ -812,7 +843,6 @@ export function ConversationWebSocketProvider({
       reconnect: { enabled: true },
       onOpen: async () => {
         setPlanningConnectionState("OPEN");
-        hasConnectedRefPlanning.current = true; // Mark that we've successfully connected
         removeErrorMessage(); // Clear any previous error messages on successful connection
 
         // Fetch expected event count for history loading detection
@@ -845,16 +875,13 @@ export function ConversationWebSocketProvider({
       },
       onError: () => {
         setPlanningConnectionState("CLOSED");
-        // Only show error message if we've previously connected successfully
-        if (hasConnectedRefPlanning.current) {
-          setErrorMessage("Failed to connect to server");
-        }
+        // Connection banner tracks the main socket only; planning churn is
+        // secondary and shouldn't raise a "failed to connect" error on its own.
       },
       onMessage: handlePlanningMessage,
     };
   }, [
     handlePlanningMessage,
-    setErrorMessage,
     removeErrorMessage,
     sessionApiKey,
     subConversations,
@@ -979,6 +1006,17 @@ export function ConversationWebSocketProvider({
       updateState();
     }
   }, [planningAgentSocket, planningAgentWsUrl]);
+
+  // Clear any pending connection-error timer on unmount.
+  useEffect(
+    () => () => {
+      if (connectionErrorTimerRef.current) {
+        clearTimeout(connectionErrorTimerRef.current);
+        connectionErrorTimerRef.current = null;
+      }
+    },
+    [],
+  );
 
   const contextValue = useMemo(
     () => ({ connectionState, sendMessage, isLoadingHistory }),

--- a/frontend/src/contexts/conversation-websocket-context.tsx
+++ b/frontend/src/contexts/conversation-websocket-context.tsx
@@ -83,6 +83,11 @@ const ConversationWebSocketContext = createContext<
 // seconds, so this lets normal churn self-heal silently.
 export const CONNECTION_ERROR_GRACE_MS = 5000;
 
+// The connection banner is owned by the main socket: only its onError sets it
+// and only its onOpen clears it. Other producers (planning socket, non-error
+// events) must not erase it while the main connection is still down.
+export const CONNECTION_ERROR_MESSAGE = "Failed to connect to server";
+
 export function ConversationWebSocketProvider({
   children,
   conversationId,
@@ -161,6 +166,12 @@ export function ConversationWebSocketProvider({
       // Budget errors persist until agent proves LLM is working
       if (isBudgetError && !isAgentEvent) {
         return; // Keep budget error visible
+      }
+
+      // The connection banner is cleared only by the main socket reconnect, so
+      // a (possibly planning-socket) event must not erase it while down.
+      if (currentError === CONNECTION_ERROR_MESSAGE) {
+        return;
       }
 
       removeErrorMessage();
@@ -809,7 +820,7 @@ export function ConversationWebSocketProvider({
               V1ExecutionStatus.RUNNING;
             // Don't clobber a more specific error (e.g. budget/credit).
             if (isRunning && !useErrorMessageStore.getState().errorMessage) {
-              setErrorMessage("Failed to connect to server");
+              setErrorMessage(CONNECTION_ERROR_MESSAGE);
             }
           }, CONNECTION_ERROR_GRACE_MS);
         }
@@ -843,7 +854,13 @@ export function ConversationWebSocketProvider({
       reconnect: { enabled: true },
       onOpen: async () => {
         setPlanningConnectionState("OPEN");
-        removeErrorMessage(); // Clear any previous error messages on successful connection
+        // Clear prior errors, but never the main socket's connection banner.
+        if (
+          useErrorMessageStore.getState().errorMessage !==
+          CONNECTION_ERROR_MESSAGE
+        ) {
+          removeErrorMessage();
+        }
 
         // Fetch expected event count for history loading detection
         if (


### PR DESCRIPTION
HUMAN: The red "failed to connect" banner flashes too eagerly — it pops on transient/benign websocket reconnects (idle socket timeouts, backgrounded-tab reaps, brief network blips) even when the user isn't doing anything, then clears itself a few seconds later. It makes the UI feel broken when nothing actually is.

## Problem
The banner (`"Failed to connect to server"`) was set **immediately** on the first abnormal websocket close, in both the main and planning socket `onError` handlers in `conversation-websocket-context.tsx`, with no debounce or grace period. Because the socket auto-reconnects on a fixed ~3s delay, every benign drop produced a visible flash: drop → red banner instantly → ~3s later reconnect → banner cleared. The only existing guard (`hasConnectedRef`) merely suppressed it before the *first* connect, not the steady-state reconnect churn that causes the flashing.

## Fix
Gate the banner on **intent/state** rather than raw socket state. It now appears only when:
- the agent is **actively running** (`execution_status === RUNNING`), **and**
- the **main** socket stays down past a short grace window (5s) — a successful reconnect cancels the pending banner before it ever shows.

This is safe because the connection self-heals: both sockets reconnect with `resend_all=true`, so the full event history is replayed and de-duplicated on reconnect — a transient drop loses nothing. A genuinely closed socket still surfaces in the passive status indicator (`agent-status.tsx`), and the send path already shows a real error when a message can't be delivered. Planning-socket churn no longer raises a connection banner on its own (the banner tracks the main connection).

## Behavior
- Idle user, transient drop → **no banner** (self-heals silently; only the status indicator reflects it).
- Active run, transient drop that reconnects within the grace window → **no banner**.
- Active run, socket genuinely stays down → banner appears after the grace window, and auto-clears on reconnect.

## Tests
Updated `conversation-websocket-handler.test.tsx`:
- no flash on an idle transient disconnect
- no flash when a transient drop reconnects during an active run
- banner *does* appear when the agent is running and the socket stays down
- banner clears on reconnect

`npm run lint` and the websocket + error-banner test files pass locally.

- [ ] A human has tested these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-b623744   docker.openhands.dev/openhands/openhands:b623744
```