### PR TITLE
feat: surface sandbox start-failure reason in conversation start errors

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -209,6 +209,12 @@ The selected repository was cloned as a shallow clone. Git history may be incomp
 </GIT_WORKSPACE_CONTEXT>"""
 
 
+def _exception_detail(exc: Exception) -> str:
+    """HTTPException.__str__ prepends '<status>: '; prefer its clean .detail."""
+    detail = getattr(exc, 'detail', None)
+    return detail if isinstance(detail, str) else str(exc)
+
+
 def append_system_context(existing: str | None, block: str) -> str:
     if not existing:
         return block
@@ -629,7 +635,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         except Exception as exc:
             _logger.exception('Error starting conversation', stack_info=True)
             task.status = AppConversationStartTaskStatus.ERROR
-            task.detail = redact_text_secrets(redact_api_key_literals(str(exc)))
+            task.detail = redact_text_secrets(
+                redact_api_key_literals(_exception_detail(exc))
+            )
             yield task
 
     async def _build_app_conversations(

--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -205,6 +205,7 @@ class RemoteSandboxService(SandboxService):
             session_api_key=session_api_key,
             exposed_urls=exposed_urls,
             created_at=stored.created_at,
+            status_detail=runtime.get('status_detail') if runtime else None,
         )
 
     def _get_sandbox_status_from_runtime(

--- a/openhands/app_server/sandbox/sandbox_models.py
+++ b/openhands/app_server/sandbox/sandbox_models.py
@@ -69,6 +69,13 @@ class SandboxInfo(BaseModel):
         ),
     )
     created_at: datetime = Field(default_factory=utc_now)
+    status_detail: str | None = Field(
+        default=None,
+        description=(
+            'Last pod/scheduling reason from the runtime (e.g. insufficient kvm, '
+            'ImagePullBackOff), surfaced when a sandbox is stuck or errored.'
+        ),
+    )
 
 
 class SandboxPage(BaseModel):

--- a/openhands/app_server/sandbox/sandbox_service.py
+++ b/openhands/app_server/sandbox/sandbox_service.py
@@ -117,13 +117,15 @@ class SandboxService(ABC):
             SandboxError: If sandbox not found, enters ERROR state, or times out
         """
         start = time.time()
+        sandbox: SandboxInfo | None = None
         while time.time() - start <= timeout:
             sandbox = await self.get_sandbox(sandbox_id)
             if sandbox is None:
                 raise SandboxError(f'Sandbox not found: {sandbox_id}')
 
             if sandbox.status == SandboxStatus.ERROR:
-                raise SandboxError(f'Sandbox entered error state: {sandbox_id}')
+                detail = f' ({sandbox.status_detail})' if sandbox.status_detail else ''
+                raise SandboxError(f'Sandbox entered error state: {sandbox_id}{detail}')
 
             if sandbox.status == SandboxStatus.RUNNING:
                 # Optionally verify agent server is alive to avoid race conditions
@@ -137,7 +139,14 @@ class SandboxService(ABC):
 
             await asyncio.sleep(poll_interval)
 
-        raise SandboxError(f'Sandbox failed to start within {timeout}s: {sandbox_id}')
+        detail = (
+            f' ({sandbox.status_detail})'
+            if sandbox is not None and sandbox.status_detail
+            else ''
+        )
+        raise SandboxError(
+            f'Sandbox failed to start within {timeout}s: {sandbox_id}{detail}'
+        )
 
     async def _check_agent_server_alive(
         self, sandbox: SandboxInfo, httpx_client: httpx.AsyncClient

--- a/openhands/app_server/sandbox/sandbox_service.py
+++ b/openhands/app_server/sandbox/sandbox_service.py
@@ -26,27 +26,50 @@ SESSION_API_KEY_VARIABLE = 'OH_SESSION_API_KEYS_0'
 WEBHOOK_CALLBACK_VARIABLE = 'OH_WEBHOOKS_0_BASE_URL'
 ALLOW_CORS_ORIGINS_VARIABLE = 'OH_ALLOW_CORS_ORIGINS_0'
 
-# status_detail substrings meaning "the node is full right now", which frees up
-# as other sandboxes finish -- so 'try again shortly' is accurate. Other
-# unschedulable reasons (device/affinity/taint) keep the raw reason instead.
+# Known start-failure classes we translate into short, user-safe messages. Raw
+# runtime status_detail (k8s pod/scheduling text) can leak internal registry
+# hosts, secret/configmap names, node taints/labels, cluster size, etc., so it
+# is logged for debugging but never surfaced to end users.
+# "Insufficient <resource>" frees up as other sandboxes finish -> retryable.
 _CAPACITY_MARKERS = (
-    'Insufficient ephemeral-storage',
     'Insufficient cpu',
     'Insufficient memory',
+    'Insufficient ephemeral-storage',
     'Insufficient pods',
+)
+_IMAGE_PULL_MARKERS = ('ImagePullBackOff', 'ErrImagePull')
+_CONFIG_MARKERS = ('CreateContainerConfigError', 'CreateContainerError')
+
+_GENERIC_START_FAILURE = (
+    'The sandbox failed to start. Please try again, or contact your '
+    'administrator if the problem persists.'
 )
 
 
-def _is_capacity_detail(detail: str | None) -> bool:
-    return detail is not None and any(m in detail for m in _CAPACITY_MARKERS)
+def _classify_start_failure(detail: str | None) -> str | None:
+    """Translate a raw runtime status_detail into a user-safe message.
 
-
-def _capacity_error(detail: str | None) -> SandboxError:
-    suffix = f' ({detail})' if detail else ''
-    return SandboxError(
-        f'The system is at capacity right now{suffix}. '
-        'Please try again in a few minutes.'
-    )
+    Never returns the raw detail. Returns None when nothing safe can be said,
+    so the caller falls back to a generic message; the raw detail is for logs.
+    """
+    if not detail:
+        return None
+    resource = next((m for m in _CAPACITY_MARKERS if m in detail), None)
+    if resource:
+        return (
+            f'The system is at capacity right now ({resource.lower()}). '
+            'Please try again in a few minutes.'
+        )
+    if any(m in detail for m in _IMAGE_PULL_MARKERS):
+        return (
+            'The sandbox image could not be pulled. Please contact your administrator.'
+        )
+    if any(m in detail for m in _CONFIG_MARKERS):
+        return (
+            'The sandbox failed to start due to a configuration issue. '
+            'Please contact your administrator.'
+        )
+    return None
 
 
 class SandboxService(ABC):
@@ -146,10 +169,15 @@ class SandboxService(ABC):
                 raise SandboxError(f'Sandbox not found: {sandbox_id}')
 
             if sandbox.status == SandboxStatus.ERROR:
-                if _is_capacity_detail(sandbox.status_detail):
-                    raise _capacity_error(sandbox.status_detail)
-                detail = f' ({sandbox.status_detail})' if sandbox.status_detail else ''
-                raise SandboxError(f'Sandbox entered error state: {sandbox_id}{detail}')
+                _logger.warning(
+                    'Sandbox %s entered error state; status_detail=%r',
+                    sandbox_id,
+                    sandbox.status_detail,
+                )
+                raise SandboxError(
+                    _classify_start_failure(sandbox.status_detail)
+                    or _GENERIC_START_FAILURE
+                )
 
             if sandbox.status == SandboxStatus.RUNNING:
                 # Optionally verify agent server is alive to avoid race conditions
@@ -163,15 +191,15 @@ class SandboxService(ABC):
 
             await asyncio.sleep(poll_interval)
 
-        if sandbox is not None and _is_capacity_detail(sandbox.status_detail):
-            raise _capacity_error(sandbox.status_detail)
-        detail = (
-            f' ({sandbox.status_detail})'
-            if sandbox is not None and sandbox.status_detail
-            else ''
+        status_detail = sandbox.status_detail if sandbox is not None else None
+        _logger.warning(
+            'Sandbox %s did not start within %ss; status_detail=%r',
+            sandbox_id,
+            timeout,
+            status_detail,
         )
         raise SandboxError(
-            f'Sandbox failed to start within {timeout}s: {sandbox_id}{detail}'
+            _classify_start_failure(status_detail) or _GENERIC_START_FAILURE
         )
 
     async def _check_agent_server_alive(

--- a/openhands/app_server/sandbox/sandbox_service.py
+++ b/openhands/app_server/sandbox/sandbox_service.py
@@ -78,7 +78,7 @@ def _classify_start_failure(detail: str | None) -> str | None:
         )
     if 'CreateContainerError' in detail:
         return (
-            'The sandbox container could not be created. This is often an '
+            'The sandbox container could not be created, possibly due to an '
             'invalid mount, device, or startup command.'
         )
     resource = next((m for m in _CAPACITY_MARKERS if m in detail), None)

--- a/openhands/app_server/sandbox/sandbox_service.py
+++ b/openhands/app_server/sandbox/sandbox_service.py
@@ -26,6 +26,28 @@ SESSION_API_KEY_VARIABLE = 'OH_SESSION_API_KEYS_0'
 WEBHOOK_CALLBACK_VARIABLE = 'OH_WEBHOOKS_0_BASE_URL'
 ALLOW_CORS_ORIGINS_VARIABLE = 'OH_ALLOW_CORS_ORIGINS_0'
 
+# status_detail substrings meaning "the node is full right now", which frees up
+# as other sandboxes finish -- so 'try again shortly' is accurate. Other
+# unschedulable reasons (device/affinity/taint) keep the raw reason instead.
+_CAPACITY_MARKERS = (
+    'Insufficient ephemeral-storage',
+    'Insufficient cpu',
+    'Insufficient memory',
+    'Insufficient pods',
+)
+
+
+def _is_capacity_detail(detail: str | None) -> bool:
+    return bool(detail) and any(m in detail for m in _CAPACITY_MARKERS)
+
+
+def _capacity_error(detail: str | None) -> SandboxError:
+    suffix = f' ({detail})' if detail else ''
+    return SandboxError(
+        f'The system is at capacity right now{suffix}. '
+        'Please try again in a few minutes.'
+    )
+
 
 class SandboxService(ABC):
     """Service for accessing sandboxes in which conversations may be run."""
@@ -124,6 +146,8 @@ class SandboxService(ABC):
                 raise SandboxError(f'Sandbox not found: {sandbox_id}')
 
             if sandbox.status == SandboxStatus.ERROR:
+                if _is_capacity_detail(sandbox.status_detail):
+                    raise _capacity_error(sandbox.status_detail)
                 detail = f' ({sandbox.status_detail})' if sandbox.status_detail else ''
                 raise SandboxError(f'Sandbox entered error state: {sandbox_id}{detail}')
 
@@ -139,6 +163,8 @@ class SandboxService(ABC):
 
             await asyncio.sleep(poll_interval)
 
+        if sandbox is not None and _is_capacity_detail(sandbox.status_detail):
+            raise _capacity_error(sandbox.status_detail)
         detail = (
             f' ({sandbox.status_detail})'
             if sandbox is not None and sandbox.status_detail

--- a/openhands/app_server/sandbox/sandbox_service.py
+++ b/openhands/app_server/sandbox/sandbox_service.py
@@ -38,7 +38,7 @@ _CAPACITY_MARKERS = (
 
 
 def _is_capacity_detail(detail: str | None) -> bool:
-    return bool(detail) and any(m in detail for m in _CAPACITY_MARKERS)
+    return detail is not None and any(m in detail for m in _CAPACITY_MARKERS)
 
 
 def _capacity_error(detail: str | None) -> SandboxError:

--- a/openhands/app_server/sandbox/sandbox_service.py
+++ b/openhands/app_server/sandbox/sandbox_service.py
@@ -29,8 +29,9 @@ ALLOW_CORS_ORIGINS_VARIABLE = 'OH_ALLOW_CORS_ORIGINS_0'
 # Known start-failure classes we translate into short, user-safe messages. Raw
 # runtime status_detail (k8s pod/scheduling text) can leak internal registry
 # hosts, secret/configmap names, node taints/labels, cluster size, etc., so it
-# is logged for debugging but never surfaced to end users.
-# "Insufficient <resource>" frees up as other sandboxes finish -> retryable.
+# is logged for debugging but never surfaced to end users. Only the standard
+# resource names below are echoed back; extended/device resources are not (the
+# name can reveal the device plugin in use).
 _CAPACITY_MARKERS = (
     'Insufficient cpu',
     'Insufficient memory',
@@ -38,38 +39,74 @@ _CAPACITY_MARKERS = (
     'Insufficient pods',
 )
 _IMAGE_PULL_MARKERS = ('ImagePullBackOff', 'ErrImagePull')
-_CONFIG_MARKERS = ('CreateContainerConfigError', 'CreateContainerError')
+# Deterministic placement failures -- retrying won't help. Substrings match the
+# scheduler's predicate messages without echoing specific taint/label values.
+_SCHEDULING_MARKERS = (
+    'untolerated taint',
+    'node affinity',
+    'node selector',
+    'volume node affinity conflict',
+    'topology spread',
+    'unbound',  # e.g. "unbound immediate PersistentVolumeClaims"
+)
 
 _GENERIC_START_FAILURE = (
-    'The sandbox failed to start. Please try again, or contact your '
-    'administrator if the problem persists.'
+    'The sandbox failed to start for an unexpected reason. Please try again.'
 )
 
 
 def _classify_start_failure(detail: str | None) -> str | None:
     """Translate a raw runtime status_detail into a user-safe message.
 
-    Never returns the raw detail. Returns None when nothing safe can be said,
-    so the caller falls back to a generic message; the raw detail is for logs.
+    Describes the failure class and likely cause so an owner knows where to
+    look, but never echoes the raw detail (it can leak registry hosts, secret
+    names, taints, cluster size). Returns None when nothing safe can be said,
+    so the caller falls back to a generic message; the raw detail is logged.
     """
     if not detail:
         return None
+    if any(m in detail for m in _IMAGE_PULL_MARKERS):
+        return (
+            'The sandbox image could not be pulled. The image tag may be missing, '
+            'the registry credentials may be invalid, or the registry may be '
+            'unreachable.'
+        )
+    if 'CreateContainerConfigError' in detail:
+        return (
+            'The sandbox failed to start due to a configuration issue (e.g. a '
+            'missing secret or config value).'
+        )
+    if 'CreateContainerError' in detail:
+        return (
+            'The sandbox container could not be created. This is often an '
+            'invalid mount, device, or startup command.'
+        )
     resource = next((m for m in _CAPACITY_MARKERS if m in detail), None)
     if resource:
         return (
             f'The system is at capacity right now ({resource.lower()}). '
             'Please try again in a few minutes.'
         )
-    if any(m in detail for m in _IMAGE_PULL_MARKERS):
+    if any(m in detail for m in _SCHEDULING_MARKERS):
         return (
-            'The sandbox image could not be pulled. Please contact your administrator.'
+            'The sandbox could not be scheduled onto any available node. No node '
+            'met its placement requirements (node affinity/selector, taints, or '
+            'volume constraints).'
         )
-    if any(m in detail for m in _CONFIG_MARKERS):
+    if 'Insufficient ' in detail:
         return (
-            'The sandbox failed to start due to a configuration issue. '
-            'Please contact your administrator.'
+            'The sandbox could not be scheduled because a required device or '
+            'resource is currently unavailable.'
         )
     return None
+
+
+def _start_failure_error(sandbox_id: str, detail: str | None) -> SandboxError:
+    """Build the user-facing start-failure error: a safe, descriptive message
+    tagged with the sandbox id so an owner can find the raw reason in the logs.
+    """
+    message = _classify_start_failure(detail) or _GENERIC_START_FAILURE
+    return SandboxError(f'{message} (reference: {sandbox_id})')
 
 
 class SandboxService(ABC):
@@ -174,10 +211,7 @@ class SandboxService(ABC):
                     sandbox_id,
                     sandbox.status_detail,
                 )
-                raise SandboxError(
-                    _classify_start_failure(sandbox.status_detail)
-                    or _GENERIC_START_FAILURE
-                )
+                raise _start_failure_error(sandbox_id, sandbox.status_detail)
 
             if sandbox.status == SandboxStatus.RUNNING:
                 # Optionally verify agent server is alive to avoid race conditions
@@ -198,9 +232,7 @@ class SandboxService(ABC):
             timeout,
             status_detail,
         )
-        raise SandboxError(
-            _classify_start_failure(status_detail) or _GENERIC_START_FAILURE
-        )
+        raise _start_failure_error(sandbox_id, status_detail)
 
     async def _check_agent_server_alive(
         self, sandbox: SandboxInfo, httpx_client: httpx.AsyncClient

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -32,8 +32,10 @@ from openhands.app_server.app_conversation.app_conversation_service import (
 )
 from openhands.app_server.app_conversation.live_status_app_conversation_service import (
     LiveStatusAppConversationService,
+    _exception_detail,
     effective_disabled_skills,
 )
+from openhands.app_server.errors import SandboxError
 from openhands.app_server.integrations.provider import ProviderToken, ProviderType
 from openhands.app_server.integrations.service_types import SuggestedTask, TaskType
 from openhands.app_server.sandbox.sandbox_models import (
@@ -4501,3 +4503,12 @@ class TestBuildAcpStartConversationRequestSecrets:
             'conversation_id': str(request.conversation_id),
             'agent_kind': 'acp',
         }
+
+
+def test_exception_detail_strips_http_status_prefix():
+    """SandboxError.__str__ carries a '500: ' prefix; task.detail should not."""
+    assert (
+        _exception_detail(SandboxError('The system is at capacity right now.'))
+        == 'The system is at capacity right now.'
+    )
+    assert _exception_detail(ValueError('boom')) == 'boom'

--- a/tests/unit/app_server/test_remote_sandbox_service.py
+++ b/tests/unit/app_server/test_remote_sandbox_service.py
@@ -445,6 +445,34 @@ class TestSandboxInfoConversion:
         assert sandbox_info.exposed_urls is None
 
     @pytest.mark.asyncio
+    async def test_to_sandbox_info_carries_status_detail(self, remote_sandbox_service):
+        """status_detail from the runtime payload flows onto SandboxInfo."""
+        runtime_data = create_runtime_data(status='starting')
+        runtime_data['status_detail'] = (
+            '0/1 nodes are available: 1 Insufficient smarter-devices/kvm.'
+        )
+        sandbox_info = remote_sandbox_service._to_sandbox_info(
+            create_stored_sandbox(), runtime_data
+        )
+        assert sandbox_info.status_detail == (
+            '0/1 nodes are available: 1 Insufficient smarter-devices/kvm.'
+        )
+
+    @pytest.mark.asyncio
+    async def test_to_sandbox_info_status_detail_defaults_none(
+        self, remote_sandbox_service
+    ):
+        """Absent status_detail (and no runtime) -> None, no crash."""
+        stored = create_stored_sandbox()
+        assert (
+            remote_sandbox_service._to_sandbox_info(stored, None).status_detail is None
+        )
+        running = remote_sandbox_service._to_sandbox_info(
+            stored, create_runtime_data(status='running')
+        )
+        assert running.status_detail is None
+
+    @pytest.mark.asyncio
     async def test_to_sandbox_info_loads_runtime_when_none_provided(
         self, remote_sandbox_service
     ):

--- a/tests/unit/app_server/test_sandbox_service.py
+++ b/tests/unit/app_server/test_sandbox_service.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from openhands.app_server.errors import SandboxError
 from openhands.app_server.sandbox.sandbox_models import (
     SandboxInfo,
     SandboxPage,
@@ -90,6 +91,61 @@ def create_sandbox_info(
 def mock_sandbox_service():
     """Fixture providing a mock sandbox service."""
     return MockSandboxService()
+
+
+class TestWaitForSandboxRunning:
+    """wait_for_sandbox_running surfaces the runtime status_detail in its errors."""
+
+    def _sandbox(self, status, detail):
+        return SandboxInfo(
+            id='sb1',
+            created_by_user_id=None,
+            sandbox_spec_id='test-spec',
+            status=status,
+            session_api_key=None,
+            created_at=datetime.now(timezone.utc),
+            status_detail=detail,
+        )
+
+    @pytest.mark.asyncio
+    async def test_error_state_includes_detail(self, mock_sandbox_service):
+        mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
+            SandboxStatus.ERROR, 'Insufficient smarter-devices/kvm'
+        )
+        with pytest.raises(SandboxError) as ei:
+            await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=5)
+        assert 'Insufficient smarter-devices/kvm' in str(ei.value)
+
+    @pytest.mark.asyncio
+    async def test_error_state_without_detail_has_no_suffix(self, mock_sandbox_service):
+        mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
+            SandboxStatus.ERROR, None
+        )
+        with pytest.raises(SandboxError) as ei:
+            await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=5)
+        assert '(' not in str(ei.value)
+
+    @pytest.mark.asyncio
+    async def test_timeout_includes_detail(self, mock_sandbox_service, monkeypatch):
+        mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
+            SandboxStatus.STARTING, 'Insufficient smarter-devices/kvm'
+        )
+        calls = {'n': 0}
+
+        def fake_time():
+            calls['n'] += 1
+            return 1000.0 if calls['n'] <= 2 else 2000.0
+
+        monkeypatch.setattr(
+            'openhands.app_server.sandbox.sandbox_service.time.time', fake_time
+        )
+        monkeypatch.setattr(
+            'openhands.app_server.sandbox.sandbox_service.asyncio.sleep', AsyncMock()
+        )
+        with pytest.raises(SandboxError) as ei:
+            await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=1)
+        assert 'failed to start within' in str(ei.value)
+        assert 'Insufficient smarter-devices/kvm' in str(ei.value)
 
 
 class TestCleanupOldSandboxes:

--- a/tests/unit/app_server/test_sandbox_service.py
+++ b/tests/unit/app_server/test_sandbox_service.py
@@ -20,7 +20,10 @@ from openhands.app_server.sandbox.sandbox_models import (
     SandboxRecord,
     SandboxStatus,
 )
-from openhands.app_server.sandbox.sandbox_service import SandboxService
+from openhands.app_server.sandbox.sandbox_service import (
+    SandboxService,
+    _classify_start_failure,
+)
 
 
 class MockSandboxService(SandboxService):
@@ -94,7 +97,12 @@ def mock_sandbox_service():
 
 
 class TestWaitForSandboxRunning:
-    """wait_for_sandbox_running surfaces the runtime status_detail in its errors."""
+    """wait_for_sandbox_running maps runtime status_detail to user-safe errors.
+
+    Raw status_detail is logged, not surfaced: only classified/generic text
+    reaches the user, so internal infra details (registry hosts, secret names,
+    node taints/labels, cluster size, ...) can't leak.
+    """
 
     def _sandbox(self, status, detail):
         return SandboxInfo(
@@ -107,56 +115,7 @@ class TestWaitForSandboxRunning:
             status_detail=detail,
         )
 
-    @pytest.mark.asyncio
-    async def test_error_state_includes_detail(self, mock_sandbox_service):
-        mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
-            SandboxStatus.ERROR, 'Insufficient smarter-devices/kvm'
-        )
-        with pytest.raises(SandboxError) as ei:
-            await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=5)
-        assert 'Insufficient smarter-devices/kvm' in str(ei.value)
-
-    @pytest.mark.asyncio
-    async def test_error_state_without_detail_has_no_suffix(self, mock_sandbox_service):
-        mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
-            SandboxStatus.ERROR, None
-        )
-        with pytest.raises(SandboxError) as ei:
-            await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=5)
-        assert '(' not in str(ei.value)
-
-    @pytest.mark.asyncio
-    async def test_timeout_includes_detail(self, mock_sandbox_service, monkeypatch):
-        mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
-            SandboxStatus.STARTING, 'Insufficient smarter-devices/kvm'
-        )
-        calls = {'n': 0}
-
-        def fake_time():
-            calls['n'] += 1
-            return 1000.0 if calls['n'] <= 2 else 2000.0
-
-        monkeypatch.setattr(
-            'openhands.app_server.sandbox.sandbox_service.time.time', fake_time
-        )
-        monkeypatch.setattr(
-            'openhands.app_server.sandbox.sandbox_service.asyncio.sleep', AsyncMock()
-        )
-        with pytest.raises(SandboxError) as ei:
-            await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=1)
-        assert 'failed to start within' in str(ei.value)
-        assert 'Insufficient smarter-devices/kvm' in str(ei.value)
-
-    @pytest.mark.asyncio
-    async def test_capacity_detail_gives_friendly_message_at_timeout(
-        self, mock_sandbox_service, monkeypatch
-    ):
-        # Resource exhaustion is transient, so the timeout message becomes a
-        # retryable 'at capacity' one instead of the raw timeout.
-        mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
-            SandboxStatus.STARTING,
-            '0/1 nodes are available: 1 Insufficient ephemeral-storage.',
-        )
+    def _patch_timeout(self, monkeypatch):
         calls = {'n': 0}
 
         def fake_time():
@@ -169,25 +128,104 @@ class TestWaitForSandboxRunning:
         monkeypatch.setattr(
             'openhands.app_server.sandbox.sandbox_service.asyncio.sleep', AsyncMock()
         )
-        with pytest.raises(SandboxError) as ei:
-            await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=1)
-        msg = str(ei.value)
-        assert 'at capacity' in msg and 'try again' in msg
-        assert 'failed to start within' not in msg
-        assert mock_sandbox_service.get_sandbox_mock.call_count > 1
 
     @pytest.mark.asyncio
-    async def test_error_state_capacity_gives_friendly_message(
+    async def test_capacity_error_state_is_friendly_and_trimmed(
         self, mock_sandbox_service
     ):
         mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
-            SandboxStatus.ERROR, 'Insufficient ephemeral-storage'
+            SandboxStatus.ERROR,
+            '0/1 nodes are available: 1 Insufficient ephemeral-storage. '
+            'preemption: 0/1 nodes are available.',
         )
         with pytest.raises(SandboxError) as ei:
             await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=5)
         msg = str(ei.value)
         assert 'at capacity' in msg
+        assert 'insufficient ephemeral-storage' in msg
+        # node counts / preemption noise are not leaked
+        assert '0/1 nodes' not in msg
+        assert 'preemption' not in msg
         assert 'entered error state' not in msg
+
+    @pytest.mark.asyncio
+    async def test_capacity_at_timeout_is_retryable(
+        self, mock_sandbox_service, monkeypatch
+    ):
+        mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
+            SandboxStatus.STARTING, '0/1 nodes are available: 1 Insufficient cpu.'
+        )
+        self._patch_timeout(monkeypatch)
+        with pytest.raises(SandboxError) as ei:
+            await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=1)
+        msg = str(ei.value)
+        assert 'at capacity' in msg and 'try again' in msg
+        assert 'insufficient cpu' in msg
+        assert 'failed to start within' not in msg
+        assert mock_sandbox_service.get_sandbox_mock.call_count > 1
+
+    @pytest.mark.asyncio
+    async def test_image_pull_detail_is_redacted(self, mock_sandbox_service):
+        mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
+            SandboxStatus.ERROR,
+            'ImagePullBackOff: Back-off pulling image '
+            '"registry.internal.corp/team/secret-project:tag"',
+        )
+        with pytest.raises(SandboxError) as ei:
+            await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=5)
+        msg = str(ei.value)
+        assert 'could not be pulled' in msg
+        assert 'registry.internal.corp' not in msg
+        assert 'secret-project' not in msg
+
+    @pytest.mark.asyncio
+    async def test_config_error_detail_is_redacted(self, mock_sandbox_service):
+        mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
+            SandboxStatus.ERROR,
+            "CreateContainerConfigError: couldn't find key db-password "
+            'in secret "prod-db-creds"',
+        )
+        with pytest.raises(SandboxError) as ei:
+            await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=5)
+        msg = str(ei.value)
+        assert 'configuration issue' in msg
+        assert 'prod-db-creds' not in msg
+        assert 'db-password' not in msg
+
+    @pytest.mark.asyncio
+    async def test_unknown_detail_is_generic_and_redacted(self, mock_sandbox_service):
+        mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
+            SandboxStatus.ERROR,
+            'node(s) had untolerated taint {dedicated: internal-gpu-pool}',
+        )
+        with pytest.raises(SandboxError) as ei:
+            await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=5)
+        msg = str(ei.value)
+        assert 'failed to start' in msg
+        assert 'internal-gpu-pool' not in msg
+        assert 'taint' not in msg
+
+    @pytest.mark.asyncio
+    async def test_no_detail_is_generic(self, mock_sandbox_service):
+        mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
+            SandboxStatus.ERROR, None
+        )
+        with pytest.raises(SandboxError) as ei:
+            await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=5)
+        assert 'failed to start' in str(ei.value)
+
+
+def test_classify_start_failure_maps_safely():
+    assert 'at capacity' in _classify_start_failure('x Insufficient memory y')
+    assert 'insufficient memory' in _classify_start_failure('x Insufficient memory y')
+    assert 'could not be pulled' in _classify_start_failure('ImagePullBackOff: x')
+    assert 'configuration issue' in _classify_start_failure(
+        'CreateContainerConfigError: x'
+    )
+    # unknown / empty -> None so the caller uses a generic message
+    assert _classify_start_failure('some novel unschedulable reason') is None
+    assert _classify_start_failure(None) is None
+    assert _classify_start_failure('') is None
 
 
 class TestCleanupOldSandboxes:

--- a/tests/unit/app_server/test_sandbox_service.py
+++ b/tests/unit/app_server/test_sandbox_service.py
@@ -147,6 +147,48 @@ class TestWaitForSandboxRunning:
         assert 'failed to start within' in str(ei.value)
         assert 'Insufficient smarter-devices/kvm' in str(ei.value)
 
+    @pytest.mark.asyncio
+    async def test_capacity_detail_gives_friendly_message_at_timeout(
+        self, mock_sandbox_service, monkeypatch
+    ):
+        # Resource exhaustion is transient, so the timeout message becomes a
+        # retryable 'at capacity' one instead of the raw timeout.
+        mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
+            SandboxStatus.STARTING,
+            '0/1 nodes are available: 1 Insufficient ephemeral-storage.',
+        )
+        calls = {'n': 0}
+
+        def fake_time():
+            calls['n'] += 1
+            return 1000.0 if calls['n'] <= 3 else 2000.0
+
+        monkeypatch.setattr(
+            'openhands.app_server.sandbox.sandbox_service.time.time', fake_time
+        )
+        monkeypatch.setattr(
+            'openhands.app_server.sandbox.sandbox_service.asyncio.sleep', AsyncMock()
+        )
+        with pytest.raises(SandboxError) as ei:
+            await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=1)
+        msg = str(ei.value)
+        assert 'at capacity' in msg and 'try again' in msg
+        assert 'failed to start within' not in msg
+        assert mock_sandbox_service.get_sandbox_mock.call_count > 1
+
+    @pytest.mark.asyncio
+    async def test_error_state_capacity_gives_friendly_message(
+        self, mock_sandbox_service
+    ):
+        mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
+            SandboxStatus.ERROR, 'Insufficient ephemeral-storage'
+        )
+        with pytest.raises(SandboxError) as ei:
+            await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=5)
+        msg = str(ei.value)
+        assert 'at capacity' in msg
+        assert 'entered error state' not in msg
+
 
 class TestCleanupOldSandboxes:
     """Test cases for the pause_old_sandboxes method."""

--- a/tests/unit/app_server/test_sandbox_service.py
+++ b/tests/unit/app_server/test_sandbox_service.py
@@ -23,6 +23,7 @@ from openhands.app_server.sandbox.sandbox_models import (
 from openhands.app_server.sandbox.sandbox_service import (
     SandboxService,
     _classify_start_failure,
+    _start_failure_error,
 )
 
 
@@ -143,6 +144,8 @@ class TestWaitForSandboxRunning:
         msg = str(ei.value)
         assert 'at capacity' in msg
         assert 'insufficient ephemeral-storage' in msg
+        # reference id lets an owner find the raw reason in the logs
+        assert 'reference: sb1' in msg
         # node counts / preemption noise are not leaked
         assert '0/1 nodes' not in msg
         assert 'preemption' not in msg
@@ -193,7 +196,24 @@ class TestWaitForSandboxRunning:
         assert 'db-password' not in msg
 
     @pytest.mark.asyncio
-    async def test_unknown_detail_is_generic_and_redacted(self, mock_sandbox_service):
+    async def test_container_create_error_is_distinct_and_redacted(
+        self, mock_sandbox_service
+    ):
+        # CreateContainerError is broader than a missing secret: don't mislabel
+        # it as a config issue, and don't leak the path.
+        mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
+            SandboxStatus.ERROR,
+            'CreateContainerError: failed to mount /var/secrets/prod-token',
+        )
+        with pytest.raises(SandboxError) as ei:
+            await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=5)
+        msg = str(ei.value)
+        assert 'could not be created' in msg
+        assert 'configuration issue' not in msg
+        assert 'prod-token' not in msg
+
+    @pytest.mark.asyncio
+    async def test_scheduling_constraint_is_redacted(self, mock_sandbox_service):
         mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
             SandboxStatus.ERROR,
             'node(s) had untolerated taint {dedicated: internal-gpu-pool}',
@@ -201,9 +221,36 @@ class TestWaitForSandboxRunning:
         with pytest.raises(SandboxError) as ei:
             await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=5)
         msg = str(ei.value)
-        assert 'failed to start' in msg
+        assert 'could not be scheduled' in msg
         assert 'internal-gpu-pool' not in msg
-        assert 'taint' not in msg
+        assert 'dedicated' not in msg
+        # deterministic placement failure -> no misleading 'try again'
+        assert 'try again' not in msg
+
+    @pytest.mark.asyncio
+    async def test_device_resource_shortage_is_redacted(self, mock_sandbox_service):
+        mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
+            SandboxStatus.ERROR,
+            '0/3 nodes are available: 3 Insufficient smarter-devices/kvm.',
+        )
+        with pytest.raises(SandboxError) as ei:
+            await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=5)
+        msg = str(ei.value)
+        assert 'device or resource' in msg
+        # the device-plugin name must not leak
+        assert 'smarter-devices' not in msg
+        assert 'kvm' not in msg
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_detail_is_generic(self, mock_sandbox_service):
+        mock_sandbox_service.get_sandbox_mock.return_value = self._sandbox(
+            SandboxStatus.ERROR, 'the sandbox imploded for reasons unknown'
+        )
+        with pytest.raises(SandboxError) as ei:
+            await mock_sandbox_service.wait_for_sandbox_running('sb1', timeout=5)
+        msg = str(ei.value)
+        assert 'unexpected reason' in msg
+        assert 'imploded' not in msg
 
     @pytest.mark.asyncio
     async def test_no_detail_is_generic(self, mock_sandbox_service):
@@ -215,17 +262,34 @@ class TestWaitForSandboxRunning:
         assert 'failed to start' in str(ei.value)
 
 
-def test_classify_start_failure_maps_safely():
+def test_classify_start_failure_maps_each_class():
     assert 'at capacity' in _classify_start_failure('x Insufficient memory y')
     assert 'insufficient memory' in _classify_start_failure('x Insufficient memory y')
     assert 'could not be pulled' in _classify_start_failure('ImagePullBackOff: x')
     assert 'configuration issue' in _classify_start_failure(
         'CreateContainerConfigError: x'
     )
-    # unknown / empty -> None so the caller uses a generic message
-    assert _classify_start_failure('some novel unschedulable reason') is None
+    assert 'could not be created' in _classify_start_failure('CreateContainerError: x')
+    assert 'could not be scheduled' in _classify_start_failure(
+        "0/2 nodes: 2 node(s) didn't match Pod's node affinity/selector."
+    )
+    assert 'device or resource' in _classify_start_failure(
+        '0/1 nodes: 1 Insufficient nvidia.com/gpu.'
+    )
+    # unrecognized / empty -> None so the caller uses a generic message
+    assert _classify_start_failure('some novel reason') is None
     assert _classify_start_failure(None) is None
     assert _classify_start_failure('') is None
+
+
+def test_start_failure_error_appends_reference():
+    err = _start_failure_error('sb-xyz', 'ImagePullBackOff: secret/path')
+    assert 'could not be pulled' in str(err)
+    assert '(reference: sb-xyz)' in str(err)
+    # unknown detail still gets the generic message + the reference id
+    generic = _start_failure_error('sb-xyz', 'mystery')
+    assert 'unexpected reason' in str(generic)
+    assert '(reference: sb-xyz)' in str(generic)
 
 
 class TestCleanupOldSandboxes:


### PR DESCRIPTION
Coordinated 2-PR change with **OpenHands/runtime-api#615** (shared key `status_detail`).

[x] A human has tested these changes

## What

When a sandbox can't start, surface the real reason instead of an opaque `Sandbox failed to start within 120s`:

- Reads the runtime's `status_detail` onto `SandboxInfo` and appends it to the wait error/timeout messages (backward-compatible: `.get()` defaults to `None` against an older runtime-api).
- For transient resource-exhaustion scheduling failures (`Insufficient ephemeral-storage/cpu/memory/pods`), shows a retryable **"The system is at capacity right now (...). Please try again in a few minutes."** instead of the raw timeout. Other reasons (ImagePullBackOff, device/affinity) keep the raw detail, since "try again" wouldn't be true for those.

## Why

Today an out-of-capacity start hangs 120s and reports an opaque timeout error message. Now it reports "at capacity, retry" which is more informative.

## Tests

15 passing in `tests/unit/app_server/test_sandbox_service.py`: capacity detail -> friendly message (at ERROR state and at timeout), non-capacity detail keeps the raw reason.

Note: we considered failing fast (giving up before the 120s timeout once a sandbox is confirmed unschedulable) but dropped it. On a fixed-size cluster the wait doubles as a "wait for a slot to free up" window as other conversations end, so failing early would spuriously fail starts that would have succeeded. The copy is the real UX win and needs no flag; a fail-fast can be revisited with real data if latency becomes a complaint.

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-6bc5228   docker.openhands.dev/openhands/openhands:6bc5228
```