### PR TITLE
test: pin SDK to main (ab886d3) for OHE 1.38.1 validation [do not merge]

### DIFF
--- a/containers/dev/compose.yml
+++ b/containers/dev/compose.yml
@@ -13,7 +13,7 @@ services:
       - DOCKER_HOST_ADDR=host.docker.internal
       #
       - AGENT_SERVER_IMAGE_REPOSITORY=${AGENT_SERVER_IMAGE_REPOSITORY:-ghcr.io/openhands/agent-server}
-      - AGENT_SERVER_IMAGE_TAG=${AGENT_SERVER_IMAGE_TAG:-1.28.0-python}
+      - AGENT_SERVER_IMAGE_TAG=${AGENT_SERVER_IMAGE_TAG:-ab886d3-python}
       - SANDBOX_USER_ID=${SANDBOX_USER_ID:-1234}
       - WORKSPACE_MOUNT_PATH=${WORKSPACE_BASE:-$PWD/workspace}
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: openhands-app-${DATE:-}
     environment:
       - AGENT_SERVER_IMAGE_REPOSITORY=${AGENT_SERVER_IMAGE_REPOSITORY:-ghcr.io/openhands/agent-server}
-      - AGENT_SERVER_IMAGE_TAG=${AGENT_SERVER_IMAGE_TAG:-1.28.0-python}
+      - AGENT_SERVER_IMAGE_TAG=${AGENT_SERVER_IMAGE_TAG:-ab886d3-python}
       #- SANDBOX_USER_ID=${SANDBOX_USER_ID:-1234} # enable this only if you want a specific non-root sandbox user but you will have to manually adjust permissions of ~/.openhands for this user
       - WORKSPACE_MOUNT_PATH=${WORKSPACE_BASE:-$PWD/workspace}
     ports:

--- a/openhands/app_server/sandbox/sandbox_spec_service.py
+++ b/openhands/app_server/sandbox/sandbox_spec_service.py
@@ -13,7 +13,7 @@ from openhands.sdk.utils.models import DiscriminatedUnionMixin
 
 # The version of the agent server to use for deployments.
 # Typically this will be the same as the values from the pyproject.toml
-AGENT_SERVER_IMAGE = 'ghcr.io/openhands/agent-server:1.28.0-python'
+AGENT_SERVER_IMAGE = 'ghcr.io/openhands/agent-server:ab886d3-python'
 
 
 class SandboxSpecService(ABC):


### PR DESCRIPTION
## What

Pins `openhands-sdk`/`-agent-server`/`-tools` to **software-agent-sdk main `ab886d3`** (git ref) and sets `AGENT_SERVER_IMAGE` to `ghcr.io/openhands/agent-server:ab886d3-python` so the enterprise image is byte-coherent with the SDK-main agent-server runtime. Lock files (uv/poetry/enterprise) regenerated against the git source.

## Why

Validation vehicle for the OHE **1.38.1** patch release — lets us pin this PR's auto-built `enterprise-server:sha-<head>` image in the OpenHands-Cloud release branch and test latest-SDK-main end-to-end on a Replicated instance **without merging or cutting an SDK release**.

## Status: DO NOT MERGE

- `check-package-versions` is expected to fail on the git `rev` pin — that is a **merge gate, not a build gate**; the `sha-<head>` image still publishes for OHE pinning.
- Unmerged on purpose; this exists only to produce a testable image.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-e6f59e0   docker.openhands.dev/openhands/openhands:e6f59e0
```