### PR TITLE
fix: clean up LLM Profile auth fields (dedupe variant section + exclude inert auth_type)

### DIFF
--- a/frontend/__tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx
+++ b/frontend/__tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx
@@ -154,7 +154,9 @@ describe("SdkSectionPage", () => {
     );
 
     renderSdkSectionPage({
-      settingsSources: [{ settingsSource: "agent_settings", sectionKeys: ["llm"] }],
+      settingsSources: [
+        { settingsSource: "agent_settings", sectionKeys: ["llm"] },
+      ],
       getInitialView: () => "advanced",
     });
 
@@ -222,7 +224,9 @@ describe("SdkSectionPage", () => {
 
       return (
         <SdkSectionPage
-          settingsSources={[{ settingsSource: "agent_settings", sectionKeys: ["llm"] }]}
+          settingsSources={[
+            { settingsSource: "agent_settings", sectionKeys: ["llm"] },
+          ]}
           header={() => (
             <input
               data-testid="external-state-input"
@@ -236,7 +240,9 @@ describe("SdkSectionPage", () => {
 
     render(<Wrapper />, {
       wrapper: ({ children }) => (
-        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
       ),
     });
 
@@ -247,7 +253,9 @@ describe("SdkSectionPage", () => {
     await userEvent.type(screen.getByTestId("external-state-input"), "a");
 
     await waitFor(() => {
-      expect(screen.getByTestId("sdk-settings-llm.base_url")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("sdk-settings-llm.base_url"),
+      ).toBeInTheDocument();
     });
   });
 
@@ -302,32 +310,46 @@ describe("SdkSectionPage", () => {
     const getSettingsSpy = vi
       .spyOn(SettingsService, "getSettings")
       .mockImplementation(async () => structuredClone(persistedSettings));
-    vi.spyOn(SettingsService, "saveSettings").mockImplementation(async (payload) => {
-      const agentSettings = payload.agent_settings_diff as Record<string, unknown>;
-      const llmSettings = (agentSettings.llm ?? {}) as Record<string, unknown>;
+    vi.spyOn(SettingsService, "saveSettings").mockImplementation(
+      async (payload) => {
+        const agentSettings = payload.agent_settings_diff as Record<
+          string,
+          unknown
+        >;
+        const llmSettings = (agentSettings.llm ?? {}) as Record<
+          string,
+          unknown
+        >;
 
-      persistedSettings = buildSettings({
-        agent_settings_schema: schema,
-        agent_settings: {
-          llm: {
-            endpoint:
-              typeof llmSettings.endpoint === "string"
-                ? llmSettings.endpoint
-                : "https://api.example.com",
+        persistedSettings = buildSettings({
+          agent_settings_schema: schema,
+          agent_settings: {
+            llm: {
+              endpoint:
+                typeof llmSettings.endpoint === "string"
+                  ? llmSettings.endpoint
+                  : "https://api.example.com",
+            },
           },
-        },
-      });
+        });
 
-      return true;
+        return true;
+      },
+    );
+
+    renderSdkSectionPage({
+      settingsSources: [
+        { settingsSource: "agent_settings", sectionKeys: ["llm"] },
+      ],
     });
-
-    renderSdkSectionPage({ settingsSources: [{ settingsSource: "agent_settings", sectionKeys: ["llm"] }] });
 
     await screen.findByTestId("sdk-section-advanced-toggle");
     await userEvent.click(screen.getByTestId("sdk-section-advanced-toggle"));
     await screen.findByTestId("sdk-settings-llm.api_version");
 
-    const endpointInput = await screen.findByTestId("sdk-settings-llm.endpoint");
+    const endpointInput = await screen.findByTestId(
+      "sdk-settings-llm.endpoint",
+    );
     await userEvent.clear(endpointInput);
     await userEvent.type(endpointInput, "https://api.changed.example.com");
     await userEvent.click(screen.getByTestId("save-button"));
@@ -394,32 +416,46 @@ describe("SdkSectionPage", () => {
     const getSettingsSpy = vi
       .spyOn(SettingsService, "getSettings")
       .mockImplementation(async () => structuredClone(persistedSettings));
-    vi.spyOn(SettingsService, "saveSettings").mockImplementation(async (payload) => {
-      const agentSettings = payload.agent_settings_diff as Record<string, unknown>;
-      const llmSettings = (agentSettings.llm ?? {}) as Record<string, unknown>;
+    vi.spyOn(SettingsService, "saveSettings").mockImplementation(
+      async (payload) => {
+        const agentSettings = payload.agent_settings_diff as Record<
+          string,
+          unknown
+        >;
+        const llmSettings = (agentSettings.llm ?? {}) as Record<
+          string,
+          unknown
+        >;
 
-      persistedSettings = buildSettings({
-        agent_settings_schema: schema,
-        agent_settings: {
-          llm: {
-            endpoint:
-              typeof llmSettings.endpoint === "string"
-                ? llmSettings.endpoint
-                : "https://api.example.com",
+        persistedSettings = buildSettings({
+          agent_settings_schema: schema,
+          agent_settings: {
+            llm: {
+              endpoint:
+                typeof llmSettings.endpoint === "string"
+                  ? llmSettings.endpoint
+                  : "https://api.example.com",
+            },
           },
-        },
-      });
+        });
 
-      return true;
+        return true;
+      },
+    );
+
+    renderSdkSectionPage({
+      settingsSources: [
+        { settingsSource: "agent_settings", sectionKeys: ["llm"] },
+      ],
     });
-
-    renderSdkSectionPage({ settingsSources: [{ settingsSource: "agent_settings", sectionKeys: ["llm"] }] });
 
     await screen.findByTestId("sdk-section-all-toggle");
     await userEvent.click(screen.getByTestId("sdk-section-all-toggle"));
     await screen.findByTestId("sdk-settings-llm.timeout");
 
-    const endpointInput = await screen.findByTestId("sdk-settings-llm.endpoint");
+    const endpointInput = await screen.findByTestId(
+      "sdk-settings-llm.endpoint",
+    );
     await userEvent.clear(endpointInput);
     await userEvent.type(endpointInput, "https://api.changed.example.com");
     await userEvent.click(screen.getByTestId("save-button"));
@@ -429,25 +465,32 @@ describe("SdkSectionPage", () => {
     });
 
     await waitFor(() => {
-      expect(screen.queryByTestId("sdk-settings-llm.timeout")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("sdk-settings-llm.timeout"),
+      ).not.toBeInTheDocument();
     });
   });
 
-
-
   it("shows the advanced toggle when it is forced for a critical-only schema", async () => {
-    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(buildSavableSettings());
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSavableSettings(),
+    );
 
     renderSdkSectionPage({
-      settingsSources: [{ settingsSource: "agent_settings", sectionKeys: ["llm"] }],
+      settingsSources: [
+        { settingsSource: "agent_settings", sectionKeys: ["llm"] },
+      ],
       forceShowAdvancedView: true,
     });
 
     await screen.findByTestId("sdk-section-basic-toggle");
-    expect(screen.getByTestId("sdk-section-advanced-toggle")).toBeInTheDocument();
-    expect(screen.queryByTestId("sdk-section-all-toggle")).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("sdk-section-advanced-toggle"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("sdk-section-all-toggle"),
+    ).not.toBeInTheDocument();
   });
-
 
   it("shows the all toggle instead of an empty advanced tier for minor-only schemas", async () => {
     const schema: NonNullable<Settings["agent_settings_schema"]> = {
@@ -498,7 +541,11 @@ describe("SdkSectionPage", () => {
       }),
     );
 
-    renderSdkSectionPage({ settingsSources: [{ settingsSource: "agent_settings", sectionKeys: ["condenser"] }] });
+    renderSdkSectionPage({
+      settingsSources: [
+        { settingsSource: "agent_settings", sectionKeys: ["condenser"] },
+      ],
+    });
 
     await screen.findByTestId("sdk-section-basic-toggle");
     expect(
@@ -559,7 +606,9 @@ describe("SdkSectionPage", () => {
     );
 
     renderSdkSectionPage({
-      settingsSources: [{ settingsSource: "agent_settings", sectionKeys: ["verification"] }],
+      settingsSources: [
+        { settingsSource: "agent_settings", sectionKeys: ["verification"] },
+      ],
       getInitialView: () => "all",
     });
 
@@ -619,7 +668,11 @@ describe("SdkSectionPage", () => {
       }),
     );
 
-    renderSdkSectionPage({ settingsSources: [{ settingsSource: "agent_settings", sectionKeys: ["verification"] }] });
+    renderSdkSectionPage({
+      settingsSources: [
+        { settingsSource: "agent_settings", sectionKeys: ["verification"] },
+      ],
+    });
 
     expect(
       await screen.findByTestId("sdk-settings-verification.critic_enabled"),
@@ -651,7 +704,11 @@ describe("SdkSectionPage", () => {
       "displaySuccessToast",
     );
 
-    renderSdkSectionPage({ settingsSources: [{ settingsSource: "agent_settings", sectionKeys: ["llm"] }] });
+    renderSdkSectionPage({
+      settingsSources: [
+        { settingsSource: "agent_settings", sectionKeys: ["llm"] },
+      ],
+    });
 
     const endpointInput = await screen.findByTestId(
       "sdk-settings-llm.endpoint",
@@ -674,7 +731,11 @@ describe("SdkSectionPage", () => {
     );
     const displayErrorToastSpy = vi.spyOn(ToastHandlers, "displayErrorToast");
 
-    renderSdkSectionPage({ settingsSources: [{ settingsSource: "agent_settings", sectionKeys: ["llm"] }] });
+    renderSdkSectionPage({
+      settingsSources: [
+        { settingsSource: "agent_settings", sectionKeys: ["llm"] },
+      ],
+    });
 
     const endpointInput = await screen.findByTestId(
       "sdk-settings-llm.endpoint",
@@ -694,7 +755,9 @@ describe("SdkSectionPage", () => {
     );
 
     renderSdkSectionPage({
-      settingsSources: [{ settingsSource: "agent_settings", sectionKeys: ["llm"] }],
+      settingsSources: [
+        { settingsSource: "agent_settings", sectionKeys: ["llm"] },
+      ],
       trailingActions: (
         <button type="button" data-testid="trailing-action">
           Extra
@@ -705,9 +768,73 @@ describe("SdkSectionPage", () => {
     // The slot has no view toggles (buildSavableSettings schema has only a
     // critical field), so this also locks the behavior that trailingActions
     // alone is enough to force the strip to render.
+    expect(await screen.findByTestId("trailing-action")).toBeInTheDocument();
+  });
+
+  it("drops duplicate union sections that don't match the source variant", async () => {
+    // SDK agent-settings is a discriminated union: the "llm" key exists under
+    // both the "openhands" and "acp" variants (#14892). A variant-targeted
+    // source must render only its variant's section, not the duplicate.
+    const llmField = (key: string, label: string) => ({
+      key,
+      label,
+      description: null,
+      section: "llm",
+      section_label: "LLM",
+      value_type: "string" as const,
+      default: null,
+      choices: [],
+      depends_on: [],
+      prominence: "critical" as const,
+      secret: false,
+      required: false,
+    });
+    const schema: NonNullable<Settings["agent_settings_schema"]> = {
+      model_name: "AgentSettings",
+      sections: [
+        {
+          key: "llm",
+          label: "LLM",
+          variant: "openhands",
+          fields: [
+            llmField("llm.model", "Model"),
+            llmField("llm.auth_type", "Authentication"),
+          ],
+        },
+        {
+          key: "llm",
+          label: "LLM",
+          variant: "acp",
+          fields: [
+            llmField("llm.model", "Model"),
+            llmField("llm.acp_only", "ACP Only"),
+          ],
+        },
+      ],
+    };
+
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({ agent_settings_schema: schema }),
+    );
+
+    renderSdkSectionPage({
+      settingsSources: [
+        {
+          settingsSource: "agent_settings",
+          sectionKeys: ["llm"],
+          variant: "openhands",
+        },
+      ],
+    });
+
     expect(
-      await screen.findByTestId("trailing-action"),
+      await screen.findByTestId("sdk-settings-llm.auth_type"),
     ).toBeInTheDocument();
+    // openhands fields render exactly once; the acp duplicate is dropped.
+    expect(screen.getAllByTestId("sdk-settings-llm.model")).toHaveLength(1);
+    expect(
+      screen.queryByTestId("sdk-settings-llm.acp_only"),
+    ).not.toBeInTheDocument();
   });
 
   it("allows saving custom payloads when only external state is dirty", async () => {
@@ -717,7 +844,9 @@ describe("SdkSectionPage", () => {
       .mockResolvedValue(true);
 
     renderSdkSectionPage({
-      settingsSources: [{ settingsSource: "agent_settings", sectionKeys: ["llm"] }],
+      settingsSources: [
+        { settingsSource: "agent_settings", sectionKeys: ["llm"] },
+      ],
       extraDirty: true,
       buildPayload: (payload) => ({
         ...payload,

--- a/frontend/src/components/features/settings/sdk-settings/sdk-section-page.tsx
+++ b/frontend/src/components/features/settings/sdk-settings/sdk-section-page.tsx
@@ -96,6 +96,11 @@ export interface SettingsSourceConfig {
   sectionKeys: string[];
   /** Field keys to skip (rendered elsewhere by the caller). */
   excludeKeys?: Set<string>;
+  // The agent variant this page targets. SDK agent-settings is a
+  // discriminated union, so a key like "llm" exists under both the
+  // "openhands" and "acp" variants. When set, only sections matching this
+  // variant (plus shared, untagged ones) render — dropping the duplicate.
+  variant?: string;
 }
 
 export interface SdkSectionHeaderProps {
@@ -227,6 +232,7 @@ export function SdkSectionPage({
           source: s.settingsSource,
           sectionKeys: s.sectionKeys,
           excludeKeys: s.excludeKeys ? Array.from(s.excludeKeys).sort() : null,
+          variant: s.variant ?? null,
         })),
       ),
     [settingsSources],
@@ -239,11 +245,13 @@ export function SdkSectionPage({
       source: SettingsValueSource;
       sectionKeys: string[];
       excludeKeys: string[] | null;
+      variant: string | null;
     }>;
     return parsed.map((p) => ({
       settingsSource: p.source,
       sectionKeys: p.sectionKeys,
       excludeKeys: p.excludeKeys ? new Set(p.excludeKeys) : undefined,
+      variant: p.variant ?? undefined,
     }));
   }, [sourcesSignature]);
 
@@ -273,7 +281,16 @@ export function SdkSectionPage({
         const sectionSet = new Set(src.sectionKeys);
         const filteredSchema: SettingsSchema = {
           ...schema,
-          sections: schema.sections.filter((s) => sectionSet.has(s.key)),
+          // Keep sections matching the requested keys; when the source
+          // targets a variant, drop sections tagged with a different one
+          // (shared/untagged sections always render).
+          sections: schema.sections.filter(
+            (s) =>
+              sectionSet.has(s.key) &&
+              (src.variant == null ||
+                s.variant == null ||
+                s.variant === src.variant),
+          ),
         };
         return { ...src, filteredSchema };
       }),
@@ -543,7 +560,7 @@ export function SdkSectionPage({
           );
           return visibleSections.map((section) => (
             <section
-              key={`${src.settingsSource}:${section.key}`}
+              key={`${src.settingsSource}:${section.key}:${section.variant ?? ""}`}
               className="flex flex-col gap-4"
             >
               <div className="grid gap-4 xl:grid-cols-2">

--- a/frontend/src/routes/llm-settings.tsx
+++ b/frontend/src/routes/llm-settings.tsx
@@ -52,7 +52,14 @@ import { useAppMode } from "#/hooks/use-app-mode";
 import { useMe } from "#/hooks/query/use-me";
 import { usePermission } from "#/hooks/organizations/use-permissions";
 
-const LLM_EXCLUDED_KEYS = new Set(["llm.model", "llm.api_key", "llm.base_url"]);
+// auth_type/subscription_vendor (SDK 1.29.0) are inert in this form and not BYOK-gated; exclude so they don't leak into Basic.
+const LLM_EXCLUDED_KEYS = new Set([
+  "llm.model",
+  "llm.api_key",
+  "llm.base_url",
+  "llm.auth_type",
+  "llm.subscription_vendor",
+]);
 
 const buildModelId = (provider: string | null, model: string | null) => {
   if (!provider || !model) return null;

--- a/frontend/src/routes/llm-settings.tsx
+++ b/frontend/src/routes/llm-settings.tsx
@@ -784,6 +784,9 @@ export function LlmSettingsScreen({
             settingsSource: "agent_settings",
             sectionKeys: ["llm"],
             excludeKeys: LLM_EXCLUDED_KEYS,
+            // The "llm" key exists under both the openhands and acp union
+            // variants; target openhands so the acp duplicate is dropped.
+            variant: "openhands",
           },
         ]}
         header={buildHeader}

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -96,6 +96,9 @@ export type SettingsSectionSchema = {
   key: string;
   label: string;
   fields: SettingsFieldSchema[];
+  // SDK agent-settings is a discriminated union; non-shared sections are
+  // tagged with their variant ("openhands"/"acp"). null/absent = shared.
+  variant?: string | null;
 };
 
 export type SettingsSchema = {


### PR DESCRIPTION
## Why
The LLM Profile settings form showed a **duplicate** "Authentication" (`auth_type`) field; the field was **inert** (clicking did nothing) and **leaked into Basic even when BYOK is disabled**. Both trace to SDK 1.29.0's new `llm.auth_type` field. Closes #14892.

## Summary
- **Variant-aware section filtering** — the SDK agent-settings schema is a discriminated union (`openhands` + `acp`); both emit a section keyed `llm`, and the frontend filtered by key only → rendered both. Now filters by section `variant`, dropping the `acp` duplicate (also fixes the duplicate React key).
- **Exclude `llm.auth_type` + `llm.subscription_vendor`** from the LLM Profile render (`LLM_EXCLUDED_KEYS`) — `auth_type` is inert in this form (not wired; `subscription_vendor`'s `depends_on` can't satisfy the boolean-only FE visibility check) and not BYOK-gated. Excluding restores Basic to model + the (already BYOK-gated) API-Key input in both BYOK on/off modes.

## How to Test
LLM Profile → Basic shows no stray "Authentication" box and no duplicate; the API-Key input shows when BYOK is on and is hidden when BYOK is off. `npm run lint` clean; `sdk-section-page` (incl. new dup-section test) + `llm-settings` vitest green.

## Type
Bug fix

---
HUMAN: Found while QA'ing an OHE release; restores the pre-1.29.0 LLM Profile UX and makes both BYOK modes coherent.

- [x] A human has tested these changes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-c70f7aa   docker.openhands.dev/openhands/openhands:c70f7aa
```
