### PR TITLE
feat: PLTF-2968 allow per-deployment resolver macro via OH_RESOLVER_LABEL

### DIFF
--- a/enterprise/integrations/utils.py
+++ b/enterprise/integrations/utils.py
@@ -113,14 +113,24 @@ _jinja_env = Environment(loader=FileSystemLoader(OPENHANDS_RESOLVER_TEMPLATES_DI
 def get_oh_labels(web_host: str) -> tuple[str, str]:
     """Get the OpenHands labels based on the web host.
 
+    An explicit ``OH_RESOLVER_LABEL`` environment variable takes precedence and
+    lets each deployment declare its own trigger macro (issue label + mention)
+    without a code change. When it is unset, the macro is inferred from
+    ``web_host`` for backward compatibility.
+
     Args:
         web_host: The web host string to check
 
     Returns:
         A tuple of (oh_label, inline_oh_label) where:
-        - oh_label is 'openhands-exp' for staging/local hosts, 'openhands' otherwise
-        - inline_oh_label is '@openhands-exp' for staging/local hosts, '@openhands' otherwise
+        - oh_label is OH_RESOLVER_LABEL when set; otherwise 'openhands-exp' for
+          staging/local hosts and 'openhands' for everything else
+        - inline_oh_label is oh_label prefixed with '@'
     """
+    override = os.getenv('OH_RESOLVER_LABEL', '').strip()
+    if override:
+        return override, f'@{override}'
+
     web_host = web_host.strip()
     is_staging_or_local = 'staging' in web_host or 'local' in web_host
     oh_label = 'openhands-exp' if is_staging_or_local else 'openhands'

--- a/enterprise/tests/unit/test_github_view.py
+++ b/enterprise/tests/unit/test_github_view.py
@@ -35,6 +35,27 @@ class TestGithubLabels(TestCase):
         self.assertEqual(oh_label, 'openhands-exp')
         self.assertEqual(inline_oh_label, '@openhands-exp')
 
+    @mock.patch.dict('os.environ', {'OH_RESOLVER_LABEL': 'openhands-dev'})
+    def test_labels_with_override(self):
+        """An explicit OH_RESOLVER_LABEL overrides host inference."""
+        oh_label, inline_oh_label = get_oh_labels('app.all-hands.dev')
+        self.assertEqual(oh_label, 'openhands-dev')
+        self.assertEqual(inline_oh_label, '@openhands-dev')
+
+    @mock.patch.dict('os.environ', {'OH_RESOLVER_LABEL': '  openhands-dev  '})
+    def test_labels_override_is_stripped(self):
+        """The override is trimmed before use."""
+        oh_label, inline_oh_label = get_oh_labels('staging.all-hands.dev')
+        self.assertEqual(oh_label, 'openhands-dev')
+        self.assertEqual(inline_oh_label, '@openhands-dev')
+
+    @mock.patch.dict('os.environ', {'OH_RESOLVER_LABEL': ''})
+    def test_labels_empty_override_falls_back(self):
+        """An empty override falls back to host inference."""
+        oh_label, inline_oh_label = get_oh_labels('staging.all-hands.dev')
+        self.assertEqual(oh_label, 'openhands-exp')
+        self.assertEqual(inline_oh_label, '@openhands-exp')
+
 
 class TestGithubCommentCaseInsensitivity(TestCase):
     @mock.patch('integrations.github.github_view.INLINE_OH_LABEL', '@openhands')


### PR DESCRIPTION
HUMAN:

- [ ] A human has tested these changes.

AGENT:

## Why

The resolver trigger macro (the issue label and `@mention` that fire it) was inferred from `WEB_HOST` by substring matching in `get_oh_labels()`: only hosts containing `staging`/`local` got a distinct macro (`openhands-exp`); everything else fell back to the production `openhands`. So any additional non-production deployment whose host lacked those substrings listened for the same `@openhands` as production and competed with it on shared repos, and standing up a new environment required editing this function each time. An explicit override makes the macro a per-deployment setting, and is safe because it is opt-in — when unset (or empty) the existing host inference is used unchanged.

## Summary

- `get_oh_labels()` now returns `(OH_RESOLVER_LABEL, '@' + OH_RESOLVER_LABEL)` when that env var is set (trimmed); otherwise it falls through to the unchanged `WEB_HOST` inference.
- Added unit cases to `TestGithubLabels` for override-set, override-trimmed, and empty-override-falls-back.

## Issue Number

Closes #14894

## How to Test

```bash
PYTHONPATH=".:$PYTHONPATH" poetry run --project=enterprise pytest -p no:ddtrace ./enterprise/tests/unit/test_github_view.py::TestGithubLabels
```

All cases pass: with `OH_RESOLVER_LABEL` set, `get_oh_labels()` returns the override (e.g. `('openhands-dev', '@openhands-dev')`) regardless of host; unset/empty, staging/local still return `openhands-exp` and other hosts return `openhands`.

## Video/Screenshots

N/A — backend label-resolution logic, no UI surface.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Behavior is unchanged unless `OH_RESOLVER_LABEL` is set, so existing deployments are unaffected. Follow-up (separate, in the deployment config): set `OH_RESOLVER_LABEL` per environment and create the matching GitHub App + issue label so each environment triggers on its own macro instead of the production `@openhands`.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-9329abf   docker.openhands.dev/openhands/openhands:9329abf
```