### PR TITLE
fix: avoid decrypting org_member.llm_api_key when not set

### DIFF
--- a/enterprise/server/routes/org_models.py
+++ b/enterprise/server/routes/org_models.py
@@ -532,9 +532,7 @@ class MeResponse(BaseModel):
         # Only access member.llm_api_key when has_custom_llm_api_key is True
         # to avoid decryption errors when the key is not set
         llm_api_key = (
-            cls._mask_key(member.llm_api_key)
-            if member.has_custom_llm_api_key
-            else None
+            cls._mask_key(member.llm_api_key) if member.has_custom_llm_api_key else ''
         )
         return cls(
             org_id=str(member.org_id),

--- a/enterprise/server/routes/org_models.py
+++ b/enterprise/server/routes/org_models.py
@@ -529,12 +529,19 @@ class MeResponse(BaseModel):
         email: str,
     ) -> 'MeResponse':
         """Create a MeResponse from an OrgMember, Role, and user email."""
+        # Only access member.llm_api_key when has_custom_llm_api_key is True
+        # to avoid decryption errors when the key is not set
+        llm_api_key = (
+            cls._mask_key(member.llm_api_key)
+            if member.has_custom_llm_api_key
+            else None
+        )
         return cls(
             org_id=str(member.org_id),
             user_id=str(member.user_id),
             email=email,
             role=role.name,
-            llm_api_key=cls._mask_key(member.llm_api_key),
+            llm_api_key=llm_api_key,
             llm_api_key_for_byor=cls._mask_key(member.llm_api_key_for_byor) or None,
             agent_settings_diff=dict(member.agent_settings_diff or {}),
             conversation_settings_diff=dict(member.conversation_settings_diff or {}),

--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -127,7 +127,10 @@ class SaasSettingsStore(SettingsStore):
     ) -> SecretStr | None:
         if org_member.has_custom_llm_api_key:
             return org_member.llm_api_key
-        return org.llm_api_key or org_member.llm_api_key
+        # When has_custom_llm_api_key is False, only return org-level key
+        # Don't fall back to org_member.llm_api_key as it may not be set
+        # and accessing it would trigger decryption of an empty/null value
+        return org.llm_api_key
 
     @staticmethod
     def _get_persisted_agent_settings(item: Settings) -> dict[str, Any]:

--- a/enterprise/tests/unit/server/routes/test_org_models.py
+++ b/enterprise/tests/unit/server/routes/test_org_models.py
@@ -1,0 +1,102 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for enterprise.server.routes.org_models."""
+
+from unittest.mock import MagicMock, PropertyMock
+from uuid import uuid4
+
+import pytest
+
+from server.auth.authorization import RoleName
+from server.routes.org_models import MeResponse
+from storage.org_member import OrgMember
+
+
+class TestMeResponseFromOrgMember:
+    """Tests for MeResponse.from_org_member() - regression tests for GitHub #14898."""
+
+    def test_from_org_member_with_custom_llm_api_key(self):
+        """When has_custom_llm_api_key is True, member's API key is masked and returned."""
+        member = MagicMock(spec=OrgMember)
+        member.org_id = uuid4()
+        member.user_id = uuid4()
+        member.agent_settings_diff = {}
+        member.conversation_settings_diff = {}
+        member.status = 'active'
+        member.has_custom_llm_api_key = True
+        type(member).llm_api_key = PropertyMock(return_value='sk-test-secret123')
+        type(member).llm_api_key_for_byor = PropertyMock(return_value=None)
+
+        role = MagicMock()
+        role.name = RoleName.MEMBER
+
+        result = MeResponse.from_org_member(member, role, 'test@example.com')
+
+        assert result.llm_api_key == '****t123'
+        assert result.role == RoleName.MEMBER
+        assert result.email == 'test@example.com'
+
+    def test_from_org_member_without_custom_llm_api_key_returns_empty_string(self):
+        """When has_custom_llm_api_key is False, returns '' without accessing member.llm_api_key.
+
+        This is a regression test for GitHub #14898 - when has_custom_llm_api_key is False,
+        the code must NOT try to access member.llm_api_key because it will attempt
+        decryption which fails on empty/null stored values.
+        """
+        member = MagicMock(spec=OrgMember)
+        member.org_id = uuid4()
+        member.user_id = uuid4()
+        member.agent_settings_diff = {}
+        member.conversation_settings_diff = {}
+        member.status = 'active'
+        member.has_custom_llm_api_key = False
+
+        # Set llm_api_key to raise an error if accessed - this verifies we don't access it
+        # when has_custom_llm_api_key is False
+        def raise_on_access():
+            raise AssertionError(
+                'member.llm_api_key should not be accessed when has_custom_llm_api_key is False'
+            )
+
+        type(member).llm_api_key = PropertyMock(side_effect=raise_on_access)
+        type(member).llm_api_key_for_byor = PropertyMock(return_value=None)
+
+        role = MagicMock()
+        role.name = RoleName.MEMBER
+
+        result = MeResponse.from_org_member(member, role, 'test@example.com')
+
+        # Must return empty string when has_custom_llm_api_key is False
+        assert result.llm_api_key == ''
+        assert result.role == RoleName.MEMBER
+        assert result.email == 'test@example.com'
+
+    def test_from_org_member_with_llm_api_key_for_byor(self):
+        """BYOR key is masked and included when present."""
+        member = MagicMock(spec=OrgMember)
+        member.org_id = uuid4()
+        member.user_id = uuid4()
+        member.agent_settings_diff = {}
+        member.conversation_settings_diff = {}
+        member.status = 'active'
+        member.has_custom_llm_api_key = True
+        type(member).llm_api_key = PropertyMock(return_value='sk-member-key')
+        type(member).llm_api_key_for_byor = PropertyMock(return_value='sk-byor-key')
+
+        role = MagicMock()
+        role.name = RoleName.ADMIN
+
+        result = MeResponse.from_org_member(member, role, 'admin@example.com')
+
+        assert result.llm_api_key == '****-key'
+        assert result.llm_api_key_for_byor == '****-key'

--- a/enterprise/tests/unit/server/routes/test_org_models.py
+++ b/enterprise/tests/unit/server/routes/test_org_models.py
@@ -15,8 +15,6 @@
 from unittest.mock import MagicMock, PropertyMock
 from uuid import uuid4
 
-import pytest
-
 from server.auth.authorization import RoleName
 from server.routes.org_models import MeResponse
 from storage.org_member import OrgMember

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -2,9 +2,10 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
+from pydantic import SecretStr
+
 from openhands.app_server.settings.settings_models import Settings
 from openhands.app_server.settings.settings_models import Settings as DataSettings
-from pydantic import SecretStr
 
 
 def _agent_value(settings: Settings, key: str):
@@ -474,7 +475,6 @@ async def test_load_canonicalizes_legacy_litellm_proxy_active_llm(
     async_session_maker, org_with_multiple_members_fixture
 ):
     from sqlalchemy import update
-
     from storage.org_member import OrgMember
     from storage.user import User
 
@@ -520,7 +520,6 @@ async def test_load_canonicalizes_legacy_litellm_proxy_llm_profiles(
     async_session_maker, org_with_multiple_members_fixture
 ):
     from sqlalchemy import update
-
     from storage.org import Org
     from storage.user import User
 
@@ -581,7 +580,6 @@ async def test_store_updates_org_defaults_and_all_members_for_shared_keys(
 ):
     """External provider keys should still sync as an org-wide shared snapshot."""
     from sqlalchemy import select
-
     from storage.org import Org
     from storage.org_member import OrgMember
 
@@ -636,7 +634,6 @@ async def test_store_keeps_openhands_managed_keys_member_specific(
 ):
     """Managed OpenHands keys should not be copied from one member to everyone else."""
     from sqlalchemy import select
-
     from storage.org import Org
     from storage.org_member import OrgMember
 
@@ -711,7 +708,6 @@ async def test_store_keeps_mcp_config_private_to_acting_member(
     new joiners don't inherit them via the org defaults.
     """
     from sqlalchemy import select
-
     from storage.org import Org
     from storage.org_member import OrgMember
 
@@ -900,7 +896,6 @@ async def test_load_drops_legacy_org_level_mcp_config(
     even if the org row still carries a stale value in the database.
     """
     from sqlalchemy import select
-
     from storage.org import Org
     from storage.user import User
 
@@ -1037,7 +1032,6 @@ async def test_load_with_null_or_empty_llm_profiles_seeds_default_profile(
     behaviour), with that profile marked active.
     """
     from sqlalchemy import update
-
     from storage.user import User
 
     fixture = org_with_multiple_members_fixture
@@ -1086,7 +1080,6 @@ async def test_load_persists_seeded_default_profile_onto_org(
     profile on first use of LLM profiles.
     """
     from sqlalchemy import select, update
-
     from storage.org import Org
 
     fixture = org_with_multiple_members_fixture
@@ -1144,7 +1137,6 @@ async def test_llm_profiles_are_encrypted_at_rest(
     org_member already enforce on _llm_api_key."""
     from openhands.sdk.llm import LLM
     from sqlalchemy import select, text
-
     from storage.user import User
 
     fixture = org_with_multiple_members_fixture
@@ -1214,7 +1206,6 @@ async def test_store_replaces_mcp_config_on_delete(
     resurrected by deep_merge) with the per-member privacy contract.
     """
     from sqlalchemy import select
-
     from storage.org_member import OrgMember
 
     # Arrange — Member 1 (admin) starts with 3 MCP servers
@@ -1297,7 +1288,6 @@ class TestGetEffectiveLlmApiKey:
     def test_returns_member_key_when_has_custom_is_true(self):
         """When has_custom_llm_api_key is True, returns member's LLM API key."""
         from pydantic import SecretStr
-
         from storage.saas_settings_store import SaasSettingsStore
 
         org = MagicMock()
@@ -1321,7 +1311,6 @@ class TestGetEffectiveLlmApiKey:
         caused decryption errors when the member had no custom key set (empty/null stored value).
         """
         from pydantic import SecretStr
-
         from storage.saas_settings_store import SaasSettingsStore
 
         org = MagicMock()

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -1,5 +1,5 @@
 import uuid
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 from pydantic import SecretStr
@@ -1135,10 +1135,9 @@ async def test_llm_profiles_are_encrypted_at_rest(
     a JSON dict — profile api_keys would otherwise leak in DB dumps,
     replicas, and backups. Mirrors the encryption invariant org and
     org_member already enforce on _llm_api_key."""
+    from openhands.sdk.llm import LLM
     from sqlalchemy import select, text
     from storage.user import User
-
-    from openhands.sdk.llm import LLM
 
     fixture = org_with_multiple_members_fixture
     admin_user_id = fixture['admin_user_id']
@@ -1289,7 +1288,6 @@ class TestGetEffectiveLlmApiKey:
     def test_returns_member_key_when_has_custom_is_true(self):
         """When has_custom_llm_api_key is True, returns member's LLM API key."""
         from pydantic import SecretStr
-
         from storage.saas_settings_store import SaasSettingsStore
 
         org = MagicMock()
@@ -1303,7 +1301,9 @@ class TestGetEffectiveLlmApiKey:
 
         assert result == SecretStr('member-api-key')
 
-    def test_returns_org_key_and_does_not_access_member_key_when_has_custom_is_false(self):
+    def test_returns_org_key_and_does_not_access_member_key_when_has_custom_is_false(
+        self,
+    ):
         """When has_custom_llm_api_key is False, returns org key without accessing member key.
 
         This is a regression test for GitHub #14898. Previously, the code would fall back
@@ -1311,7 +1311,6 @@ class TestGetEffectiveLlmApiKey:
         caused decryption errors when the member had no custom key set (empty/null stored value).
         """
         from pydantic import SecretStr
-
         from storage.saas_settings_store import SaasSettingsStore
 
         org = MagicMock()
@@ -1342,7 +1341,9 @@ class TestGetEffectiveLlmApiKey:
 
         member = MagicMock()
         member.has_custom_llm_api_key = False
-        type(member).llm_api_key = PropertyMock(side_effect=AssertionError('should not be accessed'))
+        type(member).llm_api_key = PropertyMock(
+            side_effect=AssertionError('should not be accessed')
+        )
 
         result = SaasSettingsStore._get_effective_llm_api_key(org, member)
 

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -1281,3 +1281,69 @@ async def test_store_replaces_mcp_config_on_delete(
     )
     assert set(admin_servers.keys()) == {'server1', 'server2'}
     assert 'mcp_config' not in members[member1_user_id].agent_settings_diff
+
+
+class TestGetEffectiveLlmApiKey:
+    """Regression tests for SaasSettingsStore._get_effective_llm_api_key() - GitHub #14898."""
+
+    def test_returns_member_key_when_has_custom_is_true(self):
+        """When has_custom_llm_api_key is True, returns member's LLM API key."""
+        from pydantic import SecretStr
+
+        from storage.saas_settings_store import SaasSettingsStore
+
+        org = MagicMock()
+        org.llm_api_key = SecretStr('org-api-key')
+
+        member = MagicMock()
+        member.has_custom_llm_api_key = True
+        member.llm_api_key = SecretStr('member-api-key')
+
+        result = SaasSettingsStore._get_effective_llm_api_key(org, member)
+
+        assert result == SecretStr('member-api-key')
+
+    def test_returns_org_key_and_does_not_access_member_key_when_has_custom_is_false(self):
+        """When has_custom_llm_api_key is False, returns org key without accessing member key.
+
+        This is a regression test for GitHub #14898. Previously, the code would fall back
+        to org_member.llm_api_key even when has_custom_llm_api_key was False, which
+        caused decryption errors when the member had no custom key set (empty/null stored value).
+        """
+        from pydantic import SecretStr
+
+        from storage.saas_settings_store import SaasSettingsStore
+
+        org = MagicMock()
+        org.llm_api_key = SecretStr('org-api-key')
+
+        member = MagicMock()
+        member.has_custom_llm_api_key = False
+
+        # Set llm_api_key to raise an error if accessed - this verifies we don't access it
+        def raise_on_access():
+            raise AssertionError(
+                'member.llm_api_key should not be accessed when has_custom_llm_api_key is False'
+            )
+
+        type(member).llm_api_key = PropertyMock(side_effect=raise_on_access)
+
+        result = SaasSettingsStore._get_effective_llm_api_key(org, member)
+
+        # Must return org key when has_custom_llm_api_key is False
+        assert result == SecretStr('org-api-key')
+
+    def test_returns_org_key_when_member_has_custom_false_and_org_has_no_key(self):
+        """When has_custom_llm_api_key is False but org has no key, returns None."""
+        from storage.saas_settings_store import SaasSettingsStore
+
+        org = MagicMock()
+        org.llm_api_key = None
+
+        member = MagicMock()
+        member.has_custom_llm_api_key = False
+        type(member).llm_api_key = PropertyMock(side_effect=AssertionError('should not be accessed'))
+
+        result = SaasSettingsStore._get_effective_llm_api_key(org, member)
+
+        assert result is None

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -2,10 +2,9 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
-from pydantic import SecretStr
-
 from openhands.app_server.settings.settings_models import Settings
 from openhands.app_server.settings.settings_models import Settings as DataSettings
+from pydantic import SecretStr
 
 
 def _agent_value(settings: Settings, key: str):
@@ -475,6 +474,7 @@ async def test_load_canonicalizes_legacy_litellm_proxy_active_llm(
     async_session_maker, org_with_multiple_members_fixture
 ):
     from sqlalchemy import update
+
     from storage.org_member import OrgMember
     from storage.user import User
 
@@ -520,6 +520,7 @@ async def test_load_canonicalizes_legacy_litellm_proxy_llm_profiles(
     async_session_maker, org_with_multiple_members_fixture
 ):
     from sqlalchemy import update
+
     from storage.org import Org
     from storage.user import User
 
@@ -580,6 +581,7 @@ async def test_store_updates_org_defaults_and_all_members_for_shared_keys(
 ):
     """External provider keys should still sync as an org-wide shared snapshot."""
     from sqlalchemy import select
+
     from storage.org import Org
     from storage.org_member import OrgMember
 
@@ -634,6 +636,7 @@ async def test_store_keeps_openhands_managed_keys_member_specific(
 ):
     """Managed OpenHands keys should not be copied from one member to everyone else."""
     from sqlalchemy import select
+
     from storage.org import Org
     from storage.org_member import OrgMember
 
@@ -708,6 +711,7 @@ async def test_store_keeps_mcp_config_private_to_acting_member(
     new joiners don't inherit them via the org defaults.
     """
     from sqlalchemy import select
+
     from storage.org import Org
     from storage.org_member import OrgMember
 
@@ -896,6 +900,7 @@ async def test_load_drops_legacy_org_level_mcp_config(
     even if the org row still carries a stale value in the database.
     """
     from sqlalchemy import select
+
     from storage.org import Org
     from storage.user import User
 
@@ -1032,6 +1037,7 @@ async def test_load_with_null_or_empty_llm_profiles_seeds_default_profile(
     behaviour), with that profile marked active.
     """
     from sqlalchemy import update
+
     from storage.user import User
 
     fixture = org_with_multiple_members_fixture
@@ -1080,6 +1086,7 @@ async def test_load_persists_seeded_default_profile_onto_org(
     profile on first use of LLM profiles.
     """
     from sqlalchemy import select, update
+
     from storage.org import Org
 
     fixture = org_with_multiple_members_fixture
@@ -1137,6 +1144,7 @@ async def test_llm_profiles_are_encrypted_at_rest(
     org_member already enforce on _llm_api_key."""
     from openhands.sdk.llm import LLM
     from sqlalchemy import select, text
+
     from storage.user import User
 
     fixture = org_with_multiple_members_fixture
@@ -1206,6 +1214,7 @@ async def test_store_replaces_mcp_config_on_delete(
     resurrected by deep_merge) with the per-member privacy contract.
     """
     from sqlalchemy import select
+
     from storage.org_member import OrgMember
 
     # Arrange — Member 1 (admin) starts with 3 MCP servers
@@ -1288,6 +1297,7 @@ class TestGetEffectiveLlmApiKey:
     def test_returns_member_key_when_has_custom_is_true(self):
         """When has_custom_llm_api_key is True, returns member's LLM API key."""
         from pydantic import SecretStr
+
         from storage.saas_settings_store import SaasSettingsStore
 
         org = MagicMock()
@@ -1311,6 +1321,7 @@ class TestGetEffectiveLlmApiKey:
         caused decryption errors when the member had no custom key set (empty/null stored value).
         """
         from pydantic import SecretStr
+
         from storage.saas_settings_store import SaasSettingsStore
 
         org = MagicMock()

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -1135,9 +1135,10 @@ async def test_llm_profiles_are_encrypted_at_rest(
     a JSON dict — profile api_keys would otherwise leak in DB dumps,
     replicas, and backups. Mirrors the encryption invariant org and
     org_member already enforce on _llm_api_key."""
-    from openhands.sdk.llm import LLM
     from sqlalchemy import select, text
     from storage.user import User
+
+    from openhands.sdk.llm import LLM
 
     fixture = org_with_multiple_members_fixture
     admin_user_id = fixture['admin_user_id']


### PR DESCRIPTION
HUMAN: I am a hooman and I solemnly swear this is a small correction of behavior which will enable me to test OHE deployments more easily while not being anything untoward. Go in peace.

- [x] A human has tested these changes.

## Why

When `has_custom_llm_api_key` is False, the code was still trying to access `org_member.llm_api_key` which always attempts decryption. If the stored value is empty or null, decryption fails, causing 500 errors on `/api/v1/settings`, `/api/v1/app-conversations/search`, and `/api/organizations/{org_id}/me`.

## Summary

- `MeResponse.from_org_member()`: Only access `member.llm_api_key` when `has_custom_llm_api_key` is True
- `SaasSettingsStore._get_effective_llm_api_key()`: Do not fall back to `org_member.llm_api_key` when `has_custom_llm_api_key` is False

## Issue Number

N/A - hotfix discovered during OHE deployment testing

## How to Test

1. Set up an org with users who have `has_custom_llm_api_key = False` (default for new users)
2. Ensure the user has no custom LLM API key set (empty/null in DB)
3. Call any of the affected endpoints and verify they return 200 instead of 500:
   - `GET /api/v1/settings`
   - `GET /api/v1/app-conversations/search`
   - `GET /api/organizations/{org_id}/me`
4. Verify the `llm_api_key` field in the response is empty string (not an error)

## Video/Screenshots

N/A - backend-only fix

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Regression tests have been added in:
- `enterprise/tests/unit/server/routes/test_org_models.py`
- `enterprise/tests/unit/test_saas_settings_store.py`

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-fb536ae   docker.openhands.dev/openhands/openhands:fb536ae
```