### PR TITLE
fix: prevent conversation export overload

### DIFF
--- a/enterprise/storage/redis.py
+++ b/enterprise/storage/redis.py
@@ -1,72 +1,24 @@
-import os
-import threading
-
 from redis import Redis
 from redis import asyncio as aioredis
 from redis import exceptions as redis_exceptions
 
-# Redis configuration
-REDIS_HOST = os.environ.get('REDIS_HOST', 'localhost')
-REDIS_PORT = int(os.environ.get('REDIS_PORT', '6379'))
-REDIS_PASSWORD = os.environ.get('REDIS_PASSWORD', '')
-REDIS_DB = int(os.environ.get('REDIS_DB', '0'))
-REDIS_SOCKET_TIMEOUT = 2
-
-_redis_client: Redis | None = None
-_redis_client_async: aioredis.Redis | None = None
-_redis_lock = threading.Lock()
-
-
-def _get_redis_kwargs():
-    """Return common kwargs for Redis client creation."""
-    return {
-        'host': REDIS_HOST,
-        'port': REDIS_PORT,
-        'password': REDIS_PASSWORD,
-        'db': REDIS_DB,
-        'socket_timeout': REDIS_SOCKET_TIMEOUT,
-    }
-
-
-def get_redis_client() -> Redis:
-    """Get a shared synchronous Redis client, lazily initialized.
-
-    Thread-safe with double-checked locking pattern.
-
-    Returns:
-        A Redis client for synchronous operations.
-    """
-    global _redis_client
-    if _redis_client is None:
-        with _redis_lock:
-            if _redis_client is None:
-                _redis_client = Redis(**_get_redis_kwargs())
-    return _redis_client
-
-
-def get_redis_client_async() -> aioredis.Redis:
-    """Get a shared asynchronous Redis client, lazily initialized.
-
-    Note: This function is synchronous but returns an async client.
-    Thread-safe initialization is handled via a threading lock since
-    asyncio.Lock cannot be used in a sync context.
-
-    Returns:
-        An aioredis client for asynchronous operations.
-    """
-    global _redis_client_async
-    if _redis_client_async is None:
-        with _redis_lock:
-            if _redis_client_async is None:
-                _redis_client_async = aioredis.Redis(**_get_redis_kwargs())
-    return _redis_client_async
-
-
-def get_redis_authed_url():
-    return f'redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}'
-
+from openhands.app_server.utils.redis import (
+    REDIS_DB,
+    REDIS_HOST,
+    REDIS_PASSWORD,
+    REDIS_PORT,
+    REDIS_SOCKET_TIMEOUT,
+    get_redis_authed_url,
+    get_redis_client,
+    get_redis_client_async,
+)
 
 __all__ = [
+    'REDIS_DB',
+    'REDIS_HOST',
+    'REDIS_PASSWORD',
+    'REDIS_PORT',
+    'REDIS_SOCKET_TIMEOUT',
     'Redis',
     'aioredis',
     'get_redis_client',

--- a/openhands/app_server/app_conversation/app_conversation_router.py
+++ b/openhands/app_server/app_conversation/app_conversation_router.py
@@ -13,7 +13,7 @@ from typing import Annotated, Any, AsyncGenerator, Literal
 from uuid import UUID
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse, StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -43,6 +43,9 @@ from openhands.app_server.app_conversation.app_conversation_models import (
 )
 from openhands.app_server.app_conversation.app_conversation_service import (
     AppConversationService,
+    ConversationExportAlreadyRunning,
+    ConversationExportLockUnavailable,
+    ConversationExportTooLarge,
 )
 from openhands.app_server.app_conversation.app_conversation_service_base import (
     AppConversationServiceBase,
@@ -1563,8 +1566,9 @@ async def export_conversation(
         A zip file containing the conversation trajectory
     """
     try:
-        # Get the zip file content
-        zip_content = await app_conversation_service.export_conversation(
+        # Prepare the zip stream before sending headers so lock and validation
+        # errors can still be returned as HTTP status codes.
+        zip_stream = await app_conversation_service.open_conversation_export(
             conversation_id
         )
 
@@ -1591,9 +1595,8 @@ async def export_conversation(
         except Exception:
             logger.exception('analytics:trajectory_downloaded:failed')
 
-        # Return as a downloadable zip file
-        return Response(
-            content=zip_content,
+        return StreamingResponse(
+            zip_stream,
             media_type='application/zip',
             headers={
                 'Content-Disposition': f'attachment; filename="conversation_{conversation_id}.zip"'
@@ -1601,6 +1604,12 @@ async def export_conversation(
         )
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except ConversationExportAlreadyRunning as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except ConversationExportLockUnavailable as e:
+        raise HTTPException(status_code=503, detail=str(e))
+    except ConversationExportTooLarge as e:
+        raise HTTPException(status_code=413, detail=str(e))
     except Exception as e:
         raise HTTPException(
             status_code=500, detail=f'Failed to download trajectory: {str(e)}'

--- a/openhands/app_server/app_conversation/app_conversation_service.py
+++ b/openhands/app_server/app_conversation/app_conversation_service.py
@@ -18,6 +18,18 @@ from openhands.sdk.utils.models import DiscriminatedUnionMixin
 from openhands.sdk.workspace.remote.async_remote_workspace import AsyncRemoteWorkspace
 
 
+class ConversationExportAlreadyRunning(Exception):
+    """Raised when another worker is already exporting the same conversation."""
+
+
+class ConversationExportLockUnavailable(Exception):
+    """Raised when the export lock cannot be checked."""
+
+
+class ConversationExportTooLarge(Exception):
+    """Raised when a conversation exceeds the configured export event limit."""
+
+
 class AppConversationService(ABC):
     """Service for managing conversations running in sandboxes."""
 
@@ -159,6 +171,21 @@ class AppConversationService(ABC):
 
         Returns the zip file as bytes.
         """
+
+    async def open_conversation_export(
+        self, conversation_id: UUID
+    ) -> AsyncGenerator[bytes, None]:
+        """Prepare a streaming conversation trajectory export.
+
+        Implementations may override this to acquire locks or stream zip data.
+        The default preserves compatibility with byte-returning exporters.
+        """
+        content = await self.export_conversation(conversation_id)
+
+        async def stream():
+            yield content
+
+        return stream()
 
 
 class AppConversationServiceInjector(

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -109,6 +109,7 @@ from openhands.app_server.utils.llm_metadata import (
     should_set_litellm_extra_body,
 )
 from openhands.app_server.utils.redis_lock import (
+    LockError,
     RedisLockUnavailable,
     refresh_lock_periodically,
     try_acquire_redis_lock,
@@ -2382,7 +2383,10 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             await self._validate_conversation_export_size(conversation_id)
         except Exception:
             if export_lock:
-                await export_lock.release()
+                try:
+                    await export_lock.release()
+                except LockError:
+                    pass
             raise
 
         refresh_interval = self._conversation_export_lock_refresh_interval()
@@ -2406,7 +2410,13 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 if refresh_task is not None:
                     refresh_task.cancel()
                 if export_lock:
-                    await export_lock.release()
+                    try:
+                        await export_lock.release()
+                    except LockError:
+                        _logger.warning(
+                            'conversation_export:lock_release_failed',
+                            extra={'conversation_id': str(conversation_id)},
+                        )
 
         return stream()
 

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -3,7 +3,7 @@ import importlib.metadata
 import json
 import logging
 import os
-import tempfile
+import time
 import zipfile
 from collections import defaultdict
 from collections.abc import Mapping
@@ -44,6 +44,9 @@ from openhands.app_server.app_conversation.app_conversation_models import (
 from openhands.app_server.app_conversation.app_conversation_service import (
     AppConversationService,
     AppConversationServiceInjector,
+    ConversationExportAlreadyRunning,
+    ConversationExportLockUnavailable,
+    ConversationExportTooLarge,
 )
 from openhands.app_server.app_conversation.app_conversation_service_base import (
     AppConversationServiceBase,
@@ -105,6 +108,10 @@ from openhands.app_server.utils.llm_metadata import (
     get_llm_metadata,
     should_set_litellm_extra_body,
 )
+from openhands.app_server.utils.redis_lock import (
+    RedisLockUnavailable,
+    try_acquire_redis_lock,
+)
 from openhands.sdk import Agent, AgentContext, LocalWorkspace
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.llm import LLM
@@ -114,7 +121,6 @@ from openhands.sdk.secret import LookupSecret, StaticSecret
 from openhands.sdk.settings import ACPAgentSettings
 from openhands.sdk.subagent import get_registered_agent_definitions
 from openhands.sdk.tool.builtins import SwitchLLMTool
-from openhands.sdk.utils.paging import page_iterator
 from openhands.sdk.utils.redact import (
     redact_api_key_literals,
     redact_text_secrets,
@@ -132,6 +138,40 @@ from openhands.tools.preset.planning import (
 
 _conversation_info_type_adapter = TypeAdapter(list[ConversationInfo | None])
 _logger = logging.getLogger(__name__)
+
+_EXPORT_LOCK_KEY_PREFIX = 'app_conversation_export'
+
+
+class _StreamingZipBuffer:
+    """Small non-seekable writer used by zipfile to emit chunks incrementally."""
+
+    def __init__(self):
+        self._chunks: list[bytes] = []
+        self._position = 0
+
+    def write(self, data) -> int:
+        chunk = bytes(data)
+        if chunk:
+            self._chunks.append(chunk)
+            self._position += len(chunk)
+        return len(data)
+
+    def tell(self) -> int:
+        return self._position
+
+    def flush(self):
+        pass
+
+    def writable(self) -> bool:
+        return True
+
+    def seekable(self) -> bool:
+        return False
+
+    def drain(self) -> list[bytes]:
+        chunks = self._chunks
+        self._chunks = []
+        return chunks
 
 
 def _expected_sdk_version() -> str | None:
@@ -181,6 +221,10 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         default_factory=ConversationSecretEnricher
     )
     app_mode: str | None = None
+    export_max_events: int = 10000
+    export_lock_ttl_seconds: int = 3600
+    export_lock_refresh_interval_seconds: int = 30
+    export_lock_required: bool | None = None
 
     async def _get_sandbox_grouping_strategy(self) -> SandboxGroupingStrategy:
         """Get the sandbox grouping strategy from user settings."""
@@ -2246,6 +2290,125 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
 
         return deleted_info or deleted_tasks
 
+    async def _get_conversation_export_info(
+        self, conversation_id: UUID
+    ) -> AppConversationInfo:
+        conversation_info = (
+            await self.app_conversation_info_service.get_app_conversation_info(
+                conversation_id
+            )
+        )
+        if not conversation_info:
+            raise ValueError(f'Conversation not found: {conversation_id}')
+        return conversation_info
+
+    async def _validate_conversation_export_size(self, conversation_id: UUID):
+        if self.export_max_events <= 0:
+            return
+
+        event_count = await self.event_service.count_events(conversation_id)
+        if event_count > self.export_max_events:
+            raise ConversationExportTooLarge(
+                f'Conversation export contains {event_count} events, '
+                f'exceeding the limit of {self.export_max_events}'
+            )
+
+    def _conversation_export_lock_key(self, conversation_id: UUID) -> str:
+        return f'{_EXPORT_LOCK_KEY_PREFIX}:{conversation_id.hex}'
+
+    def _conversation_export_lock_refresh_interval(self) -> int:
+        ttl_seconds = max(1, self.export_lock_ttl_seconds)
+        configured_interval = max(1, self.export_lock_refresh_interval_seconds)
+        return min(configured_interval, max(1, ttl_seconds // 2))
+
+    def _conversation_export_lock_required(self) -> bool:
+        if self.export_lock_required is not None:
+            return self.export_lock_required
+        return (self.app_mode or '').lower() == 'saas'
+
+    async def _stream_conversation_zip(
+        self, conversation_id: UUID, conversation_info: AppConversationInfo
+    ) -> AsyncGenerator[bytes, None]:
+        zip_buffer = _StreamingZipBuffer()
+        with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zipf:
+            zipf.writestr('meta.json', conversation_info.model_dump_json(indent=2))
+            for chunk in zip_buffer.drain():
+                yield chunk
+
+            i = 0
+            async for event in self.event_service.iter_events_for_export(
+                conversation_id
+            ):
+                event_filename = f'event_{i:06d}_{event.id}.json'
+                event_data = event.model_dump(mode='json')
+                event_json = json.dumps(event_data, indent=2)
+                zipf.writestr(event_filename, event_json)
+                for chunk in zip_buffer.drain():
+                    yield chunk
+                i += 1
+
+        for chunk in zip_buffer.drain():
+            yield chunk
+
+    async def open_conversation_export(
+        self, conversation_id: UUID
+    ) -> AsyncGenerator[bytes, None]:
+        """Prepare a locked streaming conversation trajectory export."""
+        conversation_info = await self._get_conversation_export_info(conversation_id)
+        lock_key = self._conversation_export_lock_key(conversation_id)
+        lock_unavailable = False
+        try:
+            export_lock = await try_acquire_redis_lock(
+                lock_key, max(1, self.export_lock_ttl_seconds)
+            )
+        except RedisLockUnavailable as e:
+            if self._conversation_export_lock_required():
+                raise ConversationExportLockUnavailable(
+                    f'Could not acquire export lock for conversation {conversation_id}'
+                ) from e
+            _logger.warning(
+                'conversation_export:lock_unavailable_proceeding_without_lock',
+                extra={'conversation_id': str(conversation_id)},
+            )
+            export_lock = None
+            lock_unavailable = True
+
+        if export_lock is None and not lock_unavailable:
+            raise ConversationExportAlreadyRunning(
+                f'Conversation export already running: {conversation_id}'
+            )
+
+        try:
+            await self._validate_conversation_export_size(conversation_id)
+        except Exception:
+            if export_lock:
+                await export_lock.release()
+            raise
+
+        refresh_interval = self._conversation_export_lock_refresh_interval()
+
+        async def stream():
+            last_refresh = time.monotonic()
+            try:
+                async for chunk in self._stream_conversation_zip(
+                    conversation_id, conversation_info
+                ):
+                    now = time.monotonic()
+                    if export_lock and now - last_refresh >= refresh_interval:
+                        refreshed = await export_lock.refresh()
+                        if not refreshed:
+                            _logger.warning(
+                                'conversation_export:lock_refresh_failed',
+                                extra={'conversation_id': str(conversation_id)},
+                            )
+                        last_refresh = now
+                    yield chunk
+            finally:
+                if export_lock:
+                    await export_lock.release()
+
+        return stream()
+
     async def export_conversation(self, conversation_id: UUID) -> bytes:
         """Download a conversation trajectory as a zip file.
 
@@ -2254,52 +2417,16 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
 
         Returns the zip file as bytes.
         """
-        # Get the conversation info to verify it exists and user has access
-        conversation_info = (
-            await self.app_conversation_info_service.get_app_conversation_info(
-                conversation_id
-            )
-        )
-        if not conversation_info:
-            raise ValueError(f'Conversation not found: {conversation_id}')
+        conversation_info = await self._get_conversation_export_info(conversation_id)
+        await self._validate_conversation_export_size(conversation_id)
 
-        # Create a temporary directory to store files
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # Get all events for this conversation
-            i = 0
-            async for event in page_iterator(
-                self.event_service.search_events, conversation_id=conversation_id
-            ):
-                event_filename = f'event_{i:06d}_{event.id}.json'
-                event_path = os.path.join(temp_dir, event_filename)
+        chunks = []
+        async for chunk in self._stream_conversation_zip(
+            conversation_id, conversation_info
+        ):
+            chunks.append(chunk)
 
-                with open(event_path, 'w', encoding='utf-8') as f:
-                    # Use model_dump with mode='json' to handle UUID serialization
-                    event_data = event.model_dump(mode='json')
-                    json.dump(event_data, f, indent=2)
-                i += 1
-
-            # Create meta.json with conversation info
-            meta_path = os.path.join(temp_dir, 'meta.json')
-            with open(meta_path, 'w', encoding='utf-8') as f:
-                f.write(conversation_info.model_dump_json(indent=2))
-
-            # Create zip file in memory
-            zip_buffer = tempfile.NamedTemporaryFile()
-            with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zipf:
-                # Add all files from temp directory to zip
-                for root, dirs, files in os.walk(temp_dir):
-                    for file in files:
-                        file_path = os.path.join(root, file)
-                        arcname = os.path.relpath(file_path, temp_dir)
-                        zipf.write(file_path, arcname)
-
-            # Read the zip file content
-            zip_buffer.seek(0)
-            zip_content = zip_buffer.read()
-            zip_buffer.close()
-
-            return zip_content
+        return b''.join(chunks)
 
 
 class LiveStatusAppConversationServiceInjector(AppConversationServiceInjector):
@@ -2322,6 +2449,25 @@ class LiveStatusAppConversationServiceInjector(AppConversationServiceInjector):
         description=(
             'A security measure - the time after which git tokens may no longer '
             'be retrieved by a sandboxed conversation.'
+        ),
+    )
+    export_max_events: int = Field(
+        default=10000,
+        description='The maximum number of events allowed in a conversation export',
+    )
+    export_lock_ttl_seconds: int = Field(
+        default=3600,
+        description='Redis lock TTL for a single conversation export',
+    )
+    export_lock_refresh_interval_seconds: int = Field(
+        default=30,
+        description='How often to refresh the Redis lock during a conversation export',
+    )
+    export_lock_required: bool | None = Field(
+        default=None,
+        description=(
+            'Whether Redis export locking is required. Defaults to required in '
+            'SAAS mode and best-effort elsewhere.'
         ),
     )
 
@@ -2408,4 +2554,10 @@ class LiveStatusAppConversationServiceInjector(AppConversationServiceInjector):
                 access_token_hard_timeout=access_token_hard_timeout,
                 conversation_secret_enricher=conversation_secret_enricher,
                 app_mode=app_mode,
+                export_max_events=self.export_max_events,
+                export_lock_ttl_seconds=self.export_lock_ttl_seconds,
+                export_lock_refresh_interval_seconds=(
+                    self.export_lock_refresh_interval_seconds
+                ),
+                export_lock_required=self.export_lock_required,
             )

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -4,7 +4,6 @@ import io
 import json
 import logging
 import os
-import time
 import zipfile
 from collections import defaultdict
 from collections.abc import Mapping
@@ -110,6 +109,7 @@ from openhands.app_server.utils.llm_metadata import (
     should_set_litellm_extra_body,
 )
 from openhands.app_server.utils.redis_lock import (
+    RedisLock,
     RedisLockUnavailable,
     try_acquire_redis_lock,
 )
@@ -173,6 +173,27 @@ class _StreamingZipBuffer(io.RawIOBase):
         chunks = self._chunks
         self._chunks = []
         return chunks
+
+
+async def _refresh_lock_periodically(
+    lock: RedisLock, interval: int, conversation_id: str
+) -> None:
+    """Keep a Redis export lock alive while a streaming response is in flight.
+
+    Runs as a background task (via asyncio.create_task) alongside the streaming
+    generator so the lock TTL is extended without blocking chunk generation.
+    The task is cancelled when the generator's finally-block fires.
+    """
+    try:
+        while True:
+            await asyncio.sleep(interval)
+            if not await lock.refresh():
+                _logger.warning(
+                    'conversation_export:lock_refresh_failed',
+                    extra={'conversation_id': conversation_id},
+                )
+    except asyncio.CancelledError:
+        pass
 
 
 def _expected_sdk_version() -> str | None:
@@ -2391,22 +2412,25 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         refresh_interval = self._conversation_export_lock_refresh_interval()
 
         async def stream():
-            last_refresh = time.monotonic()
+            # Refresh the lock in a background task so the streaming loop stays
+            # simple and lock maintenance doesn't block chunk generation.
+            refresh_task = (
+                asyncio.create_task(
+                    _refresh_lock_periodically(
+                        export_lock, refresh_interval, str(conversation_id)
+                    )
+                )
+                if export_lock
+                else None
+            )
             try:
                 async for chunk in self._stream_conversation_zip(
                     conversation_id, conversation_info
                 ):
-                    now = time.monotonic()
-                    if export_lock and now - last_refresh >= refresh_interval:
-                        refreshed = await export_lock.refresh()
-                        if not refreshed:
-                            _logger.warning(
-                                'conversation_export:lock_refresh_failed',
-                                extra={'conversation_id': str(conversation_id)},
-                            )
-                        last_refresh = now
                     yield chunk
             finally:
+                if refresh_task is not None:
+                    refresh_task.cancel()
                 if export_lock:
                     await export_lock.release()
 

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Any, AsyncGenerator, Sequence, cast
+from typing import Any, AsyncGenerator, BinaryIO, Sequence, cast
 from uuid import UUID, uuid4
 
 import httpx
@@ -2331,7 +2331,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         self, conversation_id: UUID, conversation_info: AppConversationInfo
     ) -> AsyncGenerator[bytes, None]:
         zip_buffer = _StreamingZipBuffer()
-        with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zipf:
+        with zipfile.ZipFile(
+            cast(BinaryIO, zip_buffer), 'w', zipfile.ZIP_DEFLATED
+        ) as zipf:
             zipf.writestr('meta.json', conversation_info.model_dump_json(indent=2))
             for chunk in zip_buffer.drain():
                 yield chunk

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -144,7 +144,13 @@ _EXPORT_LOCK_KEY_PREFIX = 'app_conversation_export'
 
 
 class _StreamingZipBuffer(io.RawIOBase):
-    """Small non-seekable writer used by zipfile to emit chunks incrementally."""
+    """Small non-seekable writer used by zipfile to emit chunks incrementally.
+
+    zipfile.ZipFile only needs write() and tell() from its underlying file
+    object when writing to a non-seekable stream.  Everything else
+    (flush, writable, seekable) is either unused by zipfile or already
+    handled by the io.RawIOBase defaults.
+    """
 
     def __init__(self):
         self._chunks: list[bytes] = []
@@ -159,15 +165,6 @@ class _StreamingZipBuffer(io.RawIOBase):
 
     def tell(self) -> int:
         return self._position
-
-    def flush(self):
-        pass
-
-    def writable(self) -> bool:
-        return True
-
-    def seekable(self) -> bool:
-        return False
 
     def drain(self) -> list[bytes]:
         chunks = self._chunks

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib.metadata
+import io
 import json
 import logging
 import os
@@ -142,7 +143,7 @@ _logger = logging.getLogger(__name__)
 _EXPORT_LOCK_KEY_PREFIX = 'app_conversation_export'
 
 
-class _StreamingZipBuffer:
+class _StreamingZipBuffer(io.RawIOBase):
     """Small non-seekable writer used by zipfile to emit chunks incrementally."""
 
     def __init__(self):

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -109,8 +109,8 @@ from openhands.app_server.utils.llm_metadata import (
     should_set_litellm_extra_body,
 )
 from openhands.app_server.utils.redis_lock import (
-    RedisLock,
     RedisLockUnavailable,
+    refresh_lock_periodically,
     try_acquire_redis_lock,
 )
 from openhands.sdk import Agent, AgentContext, LocalWorkspace
@@ -173,27 +173,6 @@ class _StreamingZipBuffer(io.RawIOBase):
         chunks = self._chunks
         self._chunks = []
         return chunks
-
-
-async def _refresh_lock_periodically(
-    lock: RedisLock, interval: int, conversation_id: str
-) -> None:
-    """Keep a Redis export lock alive while a streaming response is in flight.
-
-    Runs as a background task (via asyncio.create_task) alongside the streaming
-    generator so the lock TTL is extended without blocking chunk generation.
-    The task is cancelled when the generator's finally-block fires.
-    """
-    try:
-        while True:
-            await asyncio.sleep(interval)
-            if not await lock.refresh():
-                _logger.warning(
-                    'conversation_export:lock_refresh_failed',
-                    extra={'conversation_id': conversation_id},
-                )
-    except asyncio.CancelledError:
-        pass
 
 
 def _expected_sdk_version() -> str | None:
@@ -2416,9 +2395,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             # simple and lock maintenance doesn't block chunk generation.
             refresh_task = (
                 asyncio.create_task(
-                    _refresh_lock_periodically(
-                        export_lock, refresh_interval, str(conversation_id)
-                    )
+                    refresh_lock_periodically(export_lock, refresh_interval)
                 )
                 if export_lock
                 else None

--- a/openhands/app_server/event/event_service.py
+++ b/openhands/app_server/event/event_service.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 from abc import ABC, abstractmethod
 from datetime import datetime
+from typing import AsyncGenerator
 from uuid import UUID
 
 from openhands.agent_server.models import EventPage, EventSortOrder
@@ -9,6 +10,7 @@ from openhands.app_server.event_callback.event_callback_models import EventKind
 from openhands.app_server.services.injector import Injector
 from openhands.sdk import Event
 from openhands.sdk.utils.models import DiscriminatedUnionMixin
+from openhands.sdk.utils.paging import page_iterator
 
 _logger = logging.getLogger(__name__)
 
@@ -42,6 +44,18 @@ class EventService(ABC):
         timestamp__lt: datetime | None = None,
     ) -> int:
         """Count events matching the given filters."""
+
+    async def iter_events_for_export(
+        self, conversation_id: UUID
+    ) -> AsyncGenerator[Event, None]:
+        """Iterate all events for a conversation in export order.
+
+        Implementations can override this to avoid paginated searches that reload the
+        full event history for each page.
+        """
+        events = page_iterator(self.search_events, conversation_id=conversation_id)
+        async for event in events:
+            yield event
 
     @abstractmethod
     async def save_event(self, conversation_id: UUID, event: Event):

--- a/openhands/app_server/event/event_service_base.py
+++ b/openhands/app_server/event/event_service_base.py
@@ -1,8 +1,10 @@
 import asyncio
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from typing import AsyncGenerator
 from uuid import UUID
 
 from openhands.agent_server.models import EventPage, EventSortOrder
@@ -17,6 +19,13 @@ from openhands.app_server.event.event_service import EventService
 from openhands.app_server.event_callback.event_callback_models import EventKind
 from openhands.sdk import Event
 from openhands.sdk.utils.paging import page_iterator
+
+
+def _event_load_concurrency() -> int:
+    try:
+        return max(1, int(os.getenv('EVENT_SERVICE_LOAD_EVENT_CONCURRENCY', '10')))
+    except ValueError:
+        return 10
 
 
 @dataclass
@@ -43,6 +52,16 @@ class EventServiceBase(EventService, ABC):
     @abstractmethod
     def _search_paths(self, prefix: Path) -> list[Path]:
         """Search paths."""
+
+    async def _load_events_from_paths(self, paths: list[Path]) -> list[Event | None]:
+        loop = asyncio.get_running_loop()
+        semaphore = asyncio.Semaphore(_event_load_concurrency())
+
+        async def load_event(path: Path) -> Event | None:
+            async with semaphore:
+                return await loop.run_in_executor(None, self._load_event, path)
+
+        return await asyncio.gather(*(load_event(path) for path in paths))
 
     async def get_conversation_path(self, conversation_id: UUID) -> Path:
         """Get a path for a conversation. Ensure user_id is included if possible."""
@@ -87,10 +106,7 @@ class EventServiceBase(EventService, ABC):
         prefix = await self.get_conversation_path(conversation_id)
         paths = await loop.run_in_executor(None, self._search_paths, prefix)
 
-        # Type error: run_in_executor expects a return value, but self._load_event is typed return Event | None.
-        events = await asyncio.gather(
-            *[loop.run_in_executor(None, self._load_event, path) for path in paths]  # type: ignore[arg-type]
-        )
+        events = await self._load_events_from_paths(paths)
         # Convert datetime filters to ISO strings so they can be compared
         # against event.timestamp (which is stored as an ISO 8601 string).
         timestamp_gte_str = timestamp__gte.isoformat() if timestamp__gte else None
@@ -125,6 +141,19 @@ class EventServiceBase(EventService, ABC):
             items = items[:limit]
 
         return EventPage(items=items, next_page_id=next_page_id)
+
+    async def iter_events_for_export(
+        self, conversation_id: UUID
+    ) -> AsyncGenerator[Event, None]:
+        """Iterate all events once in timestamp order for trajectory export."""
+        loop = asyncio.get_running_loop()
+        prefix = await self.get_conversation_path(conversation_id)
+        paths = await loop.run_in_executor(None, self._search_paths, prefix)
+        events = await self._load_events_from_paths(paths)
+        items = [event for event in events if event]
+        items.sort(key=lambda event: event.timestamp)
+        for event in items:
+            yield event
 
     async def count_events(
         self,

--- a/openhands/app_server/utils/redis.py
+++ b/openhands/app_server/utils/redis.py
@@ -1,0 +1,81 @@
+import os
+import threading
+
+from redis import Redis
+from redis import asyncio as aioredis
+from redis import exceptions as redis_exceptions
+
+# Redis configuration
+REDIS_HOST = os.environ.get('REDIS_HOST', 'localhost')
+REDIS_PORT = int(os.environ.get('REDIS_PORT', '6379'))
+REDIS_PASSWORD = os.environ.get('REDIS_PASSWORD', '')
+REDIS_DB = int(os.environ.get('REDIS_DB', '0'))
+REDIS_SOCKET_TIMEOUT = 2
+
+_redis_client: Redis | None = None
+_redis_client_async: aioredis.Redis | None = None
+_redis_lock = threading.Lock()
+
+
+def _get_redis_kwargs():
+    """Return common kwargs for Redis client creation."""
+    return {
+        'host': REDIS_HOST,
+        'port': REDIS_PORT,
+        'password': REDIS_PASSWORD,
+        'db': REDIS_DB,
+        'socket_timeout': REDIS_SOCKET_TIMEOUT,
+    }
+
+
+def get_redis_client() -> Redis:
+    """Get a shared synchronous Redis client, lazily initialized.
+
+    Thread-safe with double-checked locking pattern.
+
+    Returns:
+        A Redis client for synchronous operations.
+    """
+    global _redis_client
+    if _redis_client is None:
+        with _redis_lock:
+            if _redis_client is None:
+                _redis_client = Redis(**_get_redis_kwargs())
+    return _redis_client
+
+
+def get_redis_client_async() -> aioredis.Redis:
+    """Get a shared asynchronous Redis client, lazily initialized.
+
+    Note: This function is synchronous but returns an async client.
+    Thread-safe initialization is handled via a threading lock since
+    asyncio.Lock cannot be used in a sync context.
+
+    Returns:
+        An aioredis client for asynchronous operations.
+    """
+    global _redis_client_async
+    if _redis_client_async is None:
+        with _redis_lock:
+            if _redis_client_async is None:
+                _redis_client_async = aioredis.Redis(**_get_redis_kwargs())
+    return _redis_client_async
+
+
+def get_redis_authed_url():
+    return f'redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}'
+
+
+__all__ = [
+    'REDIS_DB',
+    'REDIS_HOST',
+    'REDIS_PASSWORD',
+    'REDIS_PORT',
+    'REDIS_SOCKET_TIMEOUT',
+    'Redis',
+    'aioredis',
+    'get_redis_client',
+    'get_redis_client_async',
+    'get_redis_authed_url',
+    'redis_exceptions',
+]

--- a/openhands/app_server/utils/redis_lock.py
+++ b/openhands/app_server/utils/redis_lock.py
@@ -1,0 +1,101 @@
+import logging
+import os
+import secrets
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+from redis import asyncio as aioredis
+from redis import exceptions as redis_exceptions
+
+_logger = logging.getLogger(__name__)
+_redis_client_async: aioredis.Redis | None = None
+_redis_lock = threading.Lock()
+
+_RELEASE_SCRIPT = """
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("del", KEYS[1])
+end
+return 0
+"""
+
+_REFRESH_SCRIPT = """
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("expire", KEYS[1], ARGV[2])
+end
+return 0
+"""
+
+
+class RedisLockUnavailable(Exception):
+    """Raised when Redis cannot be used to evaluate a lock."""
+
+
+def _get_redis_client_async():
+    try:
+        from storage.redis import get_redis_client_async
+
+        return get_redis_client_async()
+    except ImportError:
+        pass
+
+    global _redis_client_async
+    if _redis_client_async is None:
+        with _redis_lock:
+            if _redis_client_async is None:
+                _redis_client_async = aioredis.Redis(
+                    host=os.environ.get('REDIS_HOST', 'localhost'),
+                    port=int(os.environ.get('REDIS_PORT', '6379')),
+                    password=os.environ.get('REDIS_PASSWORD', ''),
+                    db=int(os.environ.get('REDIS_DB', '0')),
+                    socket_timeout=2,
+                )
+    return _redis_client_async
+
+
+@dataclass
+class RedisLock:
+    redis: Any
+    key: str
+    token: str
+    ttl_seconds: int
+
+    async def refresh(self) -> bool:
+        try:
+            refreshed = await self.redis.eval(
+                _REFRESH_SCRIPT, 1, self.key, self.token, self.ttl_seconds
+            )
+            return bool(refreshed)
+        except redis_exceptions.RedisError:
+            _logger.warning('redis_lock:refresh_failed', extra={'key': self.key})
+            return False
+
+    async def release(self) -> bool:
+        try:
+            released = await self.redis.eval(
+                _RELEASE_SCRIPT, 1, self.key, self.token
+            )
+            return bool(released)
+        except redis_exceptions.RedisError:
+            _logger.warning('redis_lock:release_failed', extra={'key': self.key})
+            return False
+
+
+async def try_acquire_redis_lock(key: str, ttl_seconds: int) -> RedisLock | None:
+    """Acquire a Redis lock or return None when another holder owns it."""
+    redis = _get_redis_client_async()
+    token = secrets.token_urlsafe(24)
+    try:
+        acquired = await redis.set(key, token, nx=True, ex=ttl_seconds)
+    except redis_exceptions.RedisError as e:
+        raise RedisLockUnavailable from e
+
+    if not acquired:
+        return None
+
+    return RedisLock(
+        redis=redis,
+        key=key,
+        token=token,
+        ttl_seconds=ttl_seconds,
+    )

--- a/openhands/app_server/utils/redis_lock.py
+++ b/openhands/app_server/utils/redis_lock.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 import logging
 import os
@@ -97,3 +98,21 @@ async def try_acquire_redis_lock(key: str, ttl_seconds: int) -> RedisLock | None
         token=token,
         ttl_seconds=ttl_seconds,
     )
+
+
+async def refresh_lock_periodically(lock: RedisLock, interval: int) -> None:
+    """Keep a Redis lock alive by refreshing its TTL every *interval* seconds.
+
+    Intended to run as a background task (via ``asyncio.create_task``) alongside
+    a long-running operation.  Cancel the task when the operation finishes; the
+    caller is responsible for releasing the lock afterwards.
+    """
+    try:
+        while True:
+            await asyncio.sleep(interval)
+            if not await lock.refresh():
+                _logger.warning(
+                    'redis_lock:periodic_refresh_failed', extra={'key': lock.key}
+                )
+    except asyncio.CancelledError:
+        pass

--- a/openhands/app_server/utils/redis_lock.py
+++ b/openhands/app_server/utils/redis_lock.py
@@ -1,3 +1,4 @@
+import importlib
 import logging
 import os
 import secrets
@@ -33,9 +34,8 @@ class RedisLockUnavailable(Exception):
 
 def _get_redis_client_async():
     try:
-        from storage.redis import get_redis_client_async
-
-        return get_redis_client_async()
+        redis_module = importlib.import_module('storage.redis')
+        return redis_module.get_redis_client_async()
     except ImportError:
         pass
 
@@ -72,9 +72,7 @@ class RedisLock:
 
     async def release(self) -> bool:
         try:
-            released = await self.redis.eval(
-                _RELEASE_SCRIPT, 1, self.key, self.token
-            )
+            released = await self.redis.eval(_RELEASE_SCRIPT, 1, self.key, self.token)
             return bool(released)
         except redis_exceptions.RedisError:
             _logger.warning('redis_lock:release_failed', extra={'key': self.key})

--- a/openhands/app_server/utils/redis_lock.py
+++ b/openhands/app_server/utils/redis_lock.py
@@ -1,18 +1,12 @@
 import asyncio
-import importlib
 import logging
-import os
 import secrets
-import threading
 from dataclasses import dataclass
 from typing import Any
 
-from redis import asyncio as aioredis
-from redis import exceptions as redis_exceptions
+from openhands.app_server.utils.redis import get_redis_client_async, redis_exceptions
 
 _logger = logging.getLogger(__name__)
-_redis_client_async: aioredis.Redis | None = None
-_redis_lock = threading.Lock()
 
 _RELEASE_SCRIPT = """
 if redis.call("get", KEYS[1]) == ARGV[1] then
@@ -31,27 +25,6 @@ return 0
 
 class RedisLockUnavailable(Exception):
     """Raised when Redis cannot be used to evaluate a lock."""
-
-
-def _get_redis_client_async():
-    try:
-        redis_module = importlib.import_module('storage.redis')
-        return redis_module.get_redis_client_async()
-    except ImportError:
-        pass
-
-    global _redis_client_async
-    if _redis_client_async is None:
-        with _redis_lock:
-            if _redis_client_async is None:
-                _redis_client_async = aioredis.Redis(
-                    host=os.environ.get('REDIS_HOST', 'localhost'),
-                    port=int(os.environ.get('REDIS_PORT', '6379')),
-                    password=os.environ.get('REDIS_PASSWORD', ''),
-                    db=int(os.environ.get('REDIS_DB', '0')),
-                    socket_timeout=2,
-                )
-    return _redis_client_async
 
 
 @dataclass
@@ -82,7 +55,7 @@ class RedisLock:
 
 async def try_acquire_redis_lock(key: str, ttl_seconds: int) -> RedisLock | None:
     """Acquire a Redis lock or return None when another holder owns it."""
-    redis = _get_redis_client_async()
+    redis = get_redis_client_async()
     token = secrets.token_urlsafe(24)
     try:
         acquired = await redis.set(key, token, nx=True, ex=ttl_seconds)

--- a/openhands/app_server/utils/redis_lock.py
+++ b/openhands/app_server/utils/redis_lock.py
@@ -1,79 +1,39 @@
 import asyncio
 import logging
-import secrets
-from dataclasses import dataclass
-from typing import Any
+
+from redis.asyncio.lock import Lock
+from redis.exceptions import LockError
 
 from openhands.app_server.utils.redis import get_redis_client_async, redis_exceptions
 
 _logger = logging.getLogger(__name__)
 
-_RELEASE_SCRIPT = """
-if redis.call("get", KEYS[1]) == ARGV[1] then
-    return redis.call("del", KEYS[1])
-end
-return 0
-"""
-
-_REFRESH_SCRIPT = """
-if redis.call("get", KEYS[1]) == ARGV[1] then
-    return redis.call("expire", KEYS[1], ARGV[2])
-end
-return 0
-"""
+# Re-export so callers can catch lock errors without importing redis directly.
+__all__ = [
+    'Lock',
+    'LockError',
+    'RedisLockUnavailable',
+    'try_acquire_redis_lock',
+    'refresh_lock_periodically',
+]
 
 
 class RedisLockUnavailable(Exception):
     """Raised when Redis cannot be used to evaluate a lock."""
 
 
-@dataclass
-class RedisLock:
-    redis: Any
-    key: str
-    token: str
-    ttl_seconds: int
-
-    async def refresh(self) -> bool:
-        try:
-            refreshed = await self.redis.eval(
-                _REFRESH_SCRIPT, 1, self.key, self.token, self.ttl_seconds
-            )
-            return bool(refreshed)
-        except redis_exceptions.RedisError:
-            _logger.warning('redis_lock:refresh_failed', extra={'key': self.key})
-            return False
-
-    async def release(self) -> bool:
-        try:
-            released = await self.redis.eval(_RELEASE_SCRIPT, 1, self.key, self.token)
-            return bool(released)
-        except redis_exceptions.RedisError:
-            _logger.warning('redis_lock:release_failed', extra={'key': self.key})
-            return False
-
-
-async def try_acquire_redis_lock(key: str, ttl_seconds: int) -> RedisLock | None:
-    """Acquire a Redis lock or return None when another holder owns it."""
+async def try_acquire_redis_lock(key: str, ttl_seconds: int) -> Lock | None:
+    """Try to acquire a Redis lock; return None if already held by another caller."""
     redis = get_redis_client_async()
-    token = secrets.token_urlsafe(24)
+    lock = redis.lock(key, timeout=ttl_seconds)
     try:
-        acquired = await redis.set(key, token, nx=True, ex=ttl_seconds)
+        acquired = await lock.acquire(blocking=False)
     except redis_exceptions.RedisError as e:
         raise RedisLockUnavailable from e
-
-    if not acquired:
-        return None
-
-    return RedisLock(
-        redis=redis,
-        key=key,
-        token=token,
-        ttl_seconds=ttl_seconds,
-    )
+    return lock if acquired else None
 
 
-async def refresh_lock_periodically(lock: RedisLock, interval: int) -> None:
+async def refresh_lock_periodically(lock: Lock, interval: int) -> None:
     """Keep a Redis lock alive by refreshing its TTL every *interval* seconds.
 
     Intended to run as a background task (via ``asyncio.create_task``) alongside
@@ -83,9 +43,11 @@ async def refresh_lock_periodically(lock: RedisLock, interval: int) -> None:
     try:
         while True:
             await asyncio.sleep(interval)
-            if not await lock.refresh():
+            try:
+                await lock.reacquire()
+            except LockError:
                 _logger.warning(
-                    'redis_lock:periodic_refresh_failed', extra={'key': lock.key}
+                    'redis_lock:periodic_refresh_failed', extra={'key': lock.name}
                 )
     except asyncio.CancelledError:
         pass

--- a/tests/unit/app_server/test_filesystem_event_service.py
+++ b/tests/unit/app_server/test_filesystem_event_service.py
@@ -145,6 +145,29 @@ class TestFilesystemEventServiceSearchEvents:
         assert timestamps == sorted(timestamps, reverse=True)
 
     @pytest.mark.asyncio
+    async def test_iter_events_for_export_returns_all_events_in_timestamp_order(
+        self, service: FilesystemEventService
+    ):
+        """Test export iterator returns all events once in timestamp order."""
+        conversation_id = uuid4()
+        events = []
+
+        for _ in range(3):
+            event = create_token_event()
+            events.append(event)
+            await service.save_event(conversation_id, event)
+            time.sleep(0.01)
+
+        result = [
+            event async for event in service.iter_events_for_export(conversation_id)
+        ]
+
+        assert [event.id for event in result] == [event.id for event in events]
+        assert [event.timestamp for event in result] == sorted(
+            event.timestamp for event in result
+        )
+
+    @pytest.mark.asyncio
     async def test_search_events_returns_event_page(
         self, service: FilesystemEventService
     ):

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -65,16 +65,15 @@ def _async_iter(items):
 
 class _FakeExportLock:
     def __init__(self):
+        self.name = 'fake-lock'
         self.released = False
-        self.refreshed = False
+        self.reacquired = False
 
-    async def refresh(self):
-        self.refreshed = True
-        return True
+    async def reacquire(self):
+        self.reacquired = True
 
     async def release(self):
         self.released = True
-        return True
 
 
 def _build_test_user_agent_settings(user: SimpleNamespace) -> OpenHandsAgentSettings:

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -1,6 +1,5 @@
 """Unit tests for the methods in LiveStatusAppConversationService."""
 
-import builtins
 import io
 import json
 import os
@@ -24,6 +23,11 @@ from openhands.app_server.app_conversation.app_conversation_models import (
     AppConversationStartRequest,
     ConversationTrigger,
 )
+from openhands.app_server.app_conversation.app_conversation_service import (
+    ConversationExportAlreadyRunning,
+    ConversationExportLockUnavailable,
+    ConversationExportTooLarge,
+)
 from openhands.app_server.app_conversation.live_status_app_conversation_service import (
     LiveStatusAppConversationService,
 )
@@ -43,11 +47,34 @@ from openhands.app_server.settings.settings_models import (
     Settings,
 )
 from openhands.app_server.user.user_context import UserContext
+from openhands.app_server.utils.redis_lock import RedisLockUnavailable
 from openhands.sdk import Agent, AgentContext, Event
 from openhands.sdk.llm import LLM
 from openhands.sdk.secret import LookupSecret, StaticSecret
 from openhands.sdk.settings import ConversationSettings, OpenHandsAgentSettings
 from openhands.sdk.workspace.remote.async_remote_workspace import AsyncRemoteWorkspace
+
+
+def _async_iter(items):
+    async def iter_items():
+        for item in items:
+            yield item
+
+    return iter_items()
+
+
+class _FakeExportLock:
+    def __init__(self):
+        self.released = False
+        self.refreshed = False
+
+    async def refresh(self):
+        self.refreshed = True
+        return True
+
+    async def release(self):
+        self.released = True
+        return True
 
 
 def _build_test_user_agent_settings(user: SimpleNamespace) -> OpenHandsAgentSettings:
@@ -1378,10 +1405,7 @@ class TestLiveStatusAppConversationService:
 
     async def test_export_conversation_success(self):
         """Test successful download of conversation trajectory."""
-        # Arrange
         conversation_id = uuid4()
-
-        # Mock conversation info
         mock_conversation_info = Mock(spec=AppConversationInfo)
         mock_conversation_info.id = conversation_id
         mock_conversation_info.title = 'Test Conversation'
@@ -1398,7 +1422,6 @@ class TestLiveStatusAppConversationService:
             return_value=mock_conversation_info
         )
 
-        # Mock events
         mock_event1 = Mock(spec=Event)
         mock_event1.id = uuid4()
         mock_event1.model_dump = Mock(
@@ -1411,64 +1434,52 @@ class TestLiveStatusAppConversationService:
             return_value={'id': str(mock_event2.id), 'type': 'observation'}
         )
 
-        # Mock event service search_events to return paginated results
-        mock_event_page1 = Mock()
-        mock_event_page1.items = [mock_event1]
-        mock_event_page1.next_page_id = 'page2'
-
-        mock_event_page2 = Mock()
-        mock_event_page2.items = [mock_event2]
-        mock_event_page2.next_page_id = None
-
-        self.mock_event_service.search_events = AsyncMock(
-            side_effect=[mock_event_page1, mock_event_page2]
+        self.mock_event_service.count_events = AsyncMock(return_value=2)
+        self.mock_event_service.iter_events_for_export = Mock(
+            return_value=_async_iter([mock_event1, mock_event2])
         )
+        self.mock_event_service.search_events = AsyncMock()
 
-        # Act
         result = await self.service.export_conversation(conversation_id)
 
-        # Assert
         assert result is not None
-        assert isinstance(result, bytes)  # Should be bytes
+        assert isinstance(result, bytes)
 
-        # Verify the zip file contents
         with zipfile.ZipFile(io.BytesIO(result), 'r') as zipf:
             file_list = zipf.namelist()
 
-            # Should contain meta.json and event files
             assert 'meta.json' in file_list
             assert any(
                 f.startswith('event_') and f.endswith('.json') for f in file_list
             )
 
-            # Check meta.json content
             with zipf.open('meta.json') as meta_file:
                 meta_content = meta_file.read().decode('utf-8')
                 assert '"id": "test"' in meta_content
                 assert '"title": "Test Conversation"' in meta_content
 
-            # Check event files
             event_files = [f for f in file_list if f.startswith('event_')]
-            assert len(event_files) == 2  # Should have 2 event files
+            assert len(event_files) == 2
 
-            # Verify event file content
             with zipf.open(event_files[0]) as event_file:
                 event_content = json.loads(event_file.read().decode('utf-8'))
                 assert 'id' in event_content
                 assert 'type' in event_content
 
-        # Verify service calls
         self.mock_app_conversation_info_service.get_app_conversation_info.assert_called_once_with(
             conversation_id
         )
-        assert self.mock_event_service.search_events.call_count == 2
+        self.mock_event_service.count_events.assert_awaited_once_with(conversation_id)
+        self.mock_event_service.iter_events_for_export.assert_called_once_with(
+            conversation_id
+        )
+        self.mock_event_service.search_events.assert_not_called()
         mock_conversation_info.model_dump_json.assert_called_once_with(indent=2)
 
     async def test_export_conversation_writes_utf8_when_platform_default_cannot_encode(
         self,
     ):
         """Test trajectory export writes JSON as UTF-8 regardless of platform default."""
-        # Arrange
         conversation_id = uuid4()
 
         mock_conversation_info = Mock(spec=AppConversationInfo)
@@ -1492,27 +1503,13 @@ class TestLiveStatusAppConversationService:
             }
         )
 
-        mock_event_page = Mock()
-        mock_event_page.items = [mock_event]
-        mock_event_page.next_page_id = None
-        self.mock_event_service.search_events = AsyncMock(return_value=mock_event_page)
+        self.mock_event_service.count_events = AsyncMock(return_value=1)
+        self.mock_event_service.iter_events_for_export = Mock(
+            return_value=_async_iter([mock_event])
+        )
 
-        real_open = builtins.open
+        result = await self.service.export_conversation(conversation_id)
 
-        def cp1252_default_open(file, mode='r', *args, **kwargs):
-            if 'w' in mode and 'encoding' not in kwargs:
-                kwargs['encoding'] = 'cp1252'
-            return real_open(file, mode, *args, **kwargs)
-
-        # Act
-        with patch(
-            'openhands.app_server.app_conversation.live_status_app_conversation_service.open',
-            cp1252_default_open,
-            create=True,
-        ):
-            result = await self.service.export_conversation(conversation_id)
-
-        # Assert
         with zipfile.ZipFile(io.BytesIO(result), 'r') as zipf:
             with zipf.open('meta.json') as meta_file:
                 meta_content = meta_file.read().decode('utf-8')
@@ -1529,31 +1526,29 @@ class TestLiveStatusAppConversationService:
     @pytest.mark.asyncio
     async def test_export_conversation_conversation_not_found(self):
         """Test download when conversation is not found."""
-        # Arrange
         conversation_id = uuid4()
         self.mock_app_conversation_info_service.get_app_conversation_info = AsyncMock(
             return_value=None
         )
+        self.mock_event_service.count_events = AsyncMock()
+        self.mock_event_service.iter_events_for_export = Mock()
 
-        # Act & Assert
         with pytest.raises(
             ValueError, match=f'Conversation not found: {conversation_id}'
         ):
             await self.service.export_conversation(conversation_id)
 
-        # Verify service calls
         self.mock_app_conversation_info_service.get_app_conversation_info.assert_called_once_with(
             conversation_id
         )
-        self.mock_event_service.search_events.assert_not_called()
+        self.mock_event_service.count_events.assert_not_called()
+        self.mock_event_service.iter_events_for_export.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_export_conversation_empty_events(self):
         """Test download with conversation that has no events."""
-        # Arrange
         conversation_id = uuid4()
 
-        # Mock conversation info
         mock_conversation_info = Mock(spec=AppConversationInfo)
         mock_conversation_info.id = conversation_id
         mock_conversation_info.title = 'Empty Conversation'
@@ -1565,48 +1560,36 @@ class TestLiveStatusAppConversationService:
             return_value=mock_conversation_info
         )
 
-        # Mock empty event page
-        mock_event_page = Mock()
-        mock_event_page.items = []
-        mock_event_page.next_page_id = None
+        self.mock_event_service.count_events = AsyncMock(return_value=0)
+        self.mock_event_service.iter_events_for_export = Mock(
+            return_value=_async_iter([])
+        )
 
-        self.mock_event_service.search_events = AsyncMock(return_value=mock_event_page)
-
-        # Act
         result = await self.service.export_conversation(conversation_id)
 
-        # Assert
         assert result is not None
-        assert isinstance(result, bytes)  # Should be bytes
+        assert isinstance(result, bytes)
 
-        # Verify the zip file contents
         with zipfile.ZipFile(io.BytesIO(result), 'r') as zipf:
             file_list = zipf.namelist()
 
-            # Should only contain meta.json (no event files)
             assert 'meta.json' in file_list
             assert len([f for f in file_list if f.startswith('event_')]) == 0
 
-        # Verify service calls
         self.mock_app_conversation_info_service.get_app_conversation_info.assert_called_once_with(
             conversation_id
         )
-        self.mock_event_service.search_events.assert_called_once()
+        self.mock_event_service.count_events.assert_awaited_once_with(conversation_id)
+        self.mock_event_service.iter_events_for_export.assert_called_once_with(
+            conversation_id
+        )
 
     @pytest.mark.asyncio
-    async def test_export_conversation_calls_search_events_with_correct_parameter_name(
+    async def test_export_conversation_calls_iterator_with_conversation_id(
         self,
     ):
-        """Test that export_conversation calls search_events with 'conversation_id' parameter, not 'conversation_id__eq'.
-
-        This test verifies the fix for a bug where page_iterator was called with
-        conversation_id__eq instead of conversation_id, causing a TypeError since
-        the search_events method expects conversation_id as its parameter name.
-        """
-        # Arrange
+        """Test that export_conversation calls the export iterator with conversation_id."""
         conversation_id = uuid4()
-
-        # Mock conversation info
         mock_conversation_info = Mock(spec=AppConversationInfo)
         mock_conversation_info.id = conversation_id
         mock_conversation_info.model_dump_json = Mock(return_value='{}')
@@ -1615,35 +1598,23 @@ class TestLiveStatusAppConversationService:
             return_value=mock_conversation_info
         )
 
-        # Mock empty event page to simplify test
-        mock_event_page = Mock()
-        mock_event_page.items = []
-        mock_event_page.next_page_id = None
+        self.mock_event_service.count_events = AsyncMock(return_value=0)
+        self.mock_event_service.iter_events_for_export = Mock(
+            return_value=_async_iter([])
+        )
+        self.mock_event_service.search_events = AsyncMock()
 
-        self.mock_event_service.search_events = AsyncMock(return_value=mock_event_page)
-
-        # Act
         await self.service.export_conversation(conversation_id)
 
-        # Assert - Verify search_events was called with 'conversation_id', not 'conversation_id__eq'
-        self.mock_event_service.search_events.assert_called()
-        call_kwargs = self.mock_event_service.search_events.call_args[1]
-
-        assert 'conversation_id' in call_kwargs, (
-            "search_events should be called with 'conversation_id' parameter"
+        self.mock_event_service.iter_events_for_export.assert_called_once_with(
+            conversation_id
         )
-        assert 'conversation_id__eq' not in call_kwargs, (
-            "search_events should NOT be called with 'conversation_id__eq' parameter"
-        )
-        assert call_kwargs['conversation_id'] == conversation_id
+        self.mock_event_service.search_events.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_export_conversation_large_pagination(self):
-        """Test download with multiple pages of events."""
-        # Arrange
+    async def test_export_conversation_large_iterator(self):
+        """Test download with many events from one export iterator pass."""
         conversation_id = uuid4()
-
-        # Mock conversation info
         mock_conversation_info = Mock(spec=AppConversationInfo)
         mock_conversation_info.id = conversation_id
         mock_conversation_info.title = 'Large Conversation'
@@ -1655,64 +1626,171 @@ class TestLiveStatusAppConversationService:
             return_value=mock_conversation_info
         )
 
-        # Create multiple pages of events
-        events_per_page = 3
-        total_pages = 4
+        total_events = 12
         all_events = []
 
-        for page_num in range(total_pages):
-            page_events = []
-            for i in range(events_per_page):
-                mock_event = Mock(spec=Event)
-                mock_event.id = uuid4()
-                mock_event.model_dump = Mock(
-                    return_value={
-                        'id': str(mock_event.id),
-                        'type': f'event_page_{page_num}_item_{i}',
-                    }
-                )
-                page_events.append(mock_event)
-                all_events.append(mock_event)
-
-            mock_event_page = Mock()
-            mock_event_page.items = page_events
-            mock_event_page.next_page_id = (
-                f'page{page_num + 1}' if page_num < total_pages - 1 else None
+        for i in range(total_events):
+            mock_event = Mock(spec=Event)
+            mock_event.id = uuid4()
+            mock_event.model_dump = Mock(
+                return_value={
+                    'id': str(mock_event.id),
+                    'type': f'event_{i}',
+                }
             )
+            all_events.append(mock_event)
 
-            if page_num == 0:
-                first_page = mock_event_page
-            elif page_num == 1:
-                second_page = mock_event_page
-            elif page_num == 2:
-                third_page = mock_event_page
-            else:
-                fourth_page = mock_event_page
-
-        self.mock_event_service.search_events = AsyncMock(
-            side_effect=[first_page, second_page, third_page, fourth_page]
+        self.mock_event_service.count_events = AsyncMock(return_value=total_events)
+        self.mock_event_service.iter_events_for_export = Mock(
+            return_value=_async_iter(all_events)
         )
+        self.mock_event_service.search_events = AsyncMock()
 
-        # Act
         result = await self.service.export_conversation(conversation_id)
 
-        # Assert
         assert result is not None
-        assert isinstance(result, bytes)  # Should be bytes
+        assert isinstance(result, bytes)
 
-        # Verify the zip file contents
         with zipfile.ZipFile(io.BytesIO(result), 'r') as zipf:
             file_list = zipf.namelist()
 
-            # Should contain meta.json and all event files
             assert 'meta.json' in file_list
             event_files = [f for f in file_list if f.startswith('event_')]
-            assert (
-                len(event_files) == total_pages * events_per_page
-            )  # Should have all events
+            assert len(event_files) == total_events
 
-        # Verify service calls - should call search_events for each page
-        assert self.mock_event_service.search_events.call_count == total_pages
+        self.mock_event_service.iter_events_for_export.assert_called_once_with(
+            conversation_id
+        )
+        self.mock_event_service.search_events.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_open_conversation_export_streams_with_lock(self):
+        """Test streaming export acquires and releases the conversation export lock."""
+        conversation_id = uuid4()
+        mock_conversation_info = Mock(spec=AppConversationInfo)
+        mock_conversation_info.id = conversation_id
+        mock_conversation_info.model_dump_json = Mock(return_value='{}')
+
+        mock_event = Mock(spec=Event)
+        mock_event.id = uuid4()
+        mock_event.model_dump = Mock(return_value={'id': str(mock_event.id)})
+
+        self.mock_app_conversation_info_service.get_app_conversation_info = AsyncMock(
+            return_value=mock_conversation_info
+        )
+        self.mock_event_service.count_events = AsyncMock(return_value=1)
+        self.mock_event_service.iter_events_for_export = Mock(
+            return_value=_async_iter([mock_event])
+        )
+
+        fake_lock = _FakeExportLock()
+        with patch(
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.try_acquire_redis_lock',
+            new=AsyncMock(return_value=fake_lock),
+        ) as mock_acquire_lock:
+            stream = await self.service.open_conversation_export(conversation_id)
+            result = b''.join([chunk async for chunk in stream])
+
+        assert result
+        assert fake_lock.released is True
+        mock_acquire_lock.assert_awaited_once_with(
+            f'app_conversation_export:{conversation_id.hex}',
+            self.service.export_lock_ttl_seconds,
+        )
+
+    @pytest.mark.asyncio
+    async def test_open_conversation_export_rejects_duplicate_export(self):
+        """Test streaming export rejects duplicate export attempts."""
+        conversation_id = uuid4()
+        mock_conversation_info = Mock(spec=AppConversationInfo)
+        mock_conversation_info.id = conversation_id
+        mock_conversation_info.model_dump_json = Mock(return_value='{}')
+
+        self.mock_app_conversation_info_service.get_app_conversation_info = AsyncMock(
+            return_value=mock_conversation_info
+        )
+
+        with patch(
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.try_acquire_redis_lock',
+            new=AsyncMock(return_value=None),
+        ):
+            with pytest.raises(ConversationExportAlreadyRunning):
+                await self.service.open_conversation_export(conversation_id)
+
+        self.mock_event_service.count_events.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_open_conversation_export_fails_closed_when_lock_unavailable(self):
+        """Test streaming export fails closed when Redis lock cannot be checked."""
+        conversation_id = uuid4()
+        mock_conversation_info = Mock(spec=AppConversationInfo)
+        mock_conversation_info.id = conversation_id
+        mock_conversation_info.model_dump_json = Mock(return_value='{}')
+
+        self.service.export_lock_required = True
+        self.mock_app_conversation_info_service.get_app_conversation_info = AsyncMock(
+            return_value=mock_conversation_info
+        )
+
+        with patch(
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.try_acquire_redis_lock',
+            new=AsyncMock(side_effect=RedisLockUnavailable()),
+        ):
+            with pytest.raises(ConversationExportLockUnavailable):
+                await self.service.open_conversation_export(conversation_id)
+
+        self.mock_event_service.count_events.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_open_conversation_export_proceeds_when_lock_not_required(self):
+        """Test non-SaaS export proceeds without Redis when locking is best effort."""
+        conversation_id = uuid4()
+        mock_conversation_info = Mock(spec=AppConversationInfo)
+        mock_conversation_info.id = conversation_id
+        mock_conversation_info.model_dump_json = Mock(return_value='{}')
+
+        mock_event = Mock(spec=Event)
+        mock_event.id = uuid4()
+        mock_event.model_dump = Mock(return_value={'id': str(mock_event.id)})
+
+        self.service.export_lock_required = False
+        self.mock_app_conversation_info_service.get_app_conversation_info = AsyncMock(
+            return_value=mock_conversation_info
+        )
+        self.mock_event_service.count_events = AsyncMock(return_value=1)
+        self.mock_event_service.iter_events_for_export = Mock(
+            return_value=_async_iter([mock_event])
+        )
+
+        with patch(
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.try_acquire_redis_lock',
+            new=AsyncMock(side_effect=RedisLockUnavailable()),
+        ):
+            stream = await self.service.open_conversation_export(conversation_id)
+            result = b''.join([chunk async for chunk in stream])
+
+        assert result
+        self.mock_event_service.count_events.assert_awaited_once_with(conversation_id)
+
+    @pytest.mark.asyncio
+    async def test_export_conversation_rejects_too_many_events(self):
+        """Test export rejects conversations over the configured event limit."""
+        conversation_id = uuid4()
+        mock_conversation_info = Mock(spec=AppConversationInfo)
+        mock_conversation_info.id = conversation_id
+        mock_conversation_info.model_dump_json = Mock(return_value='{}')
+
+        self.service.export_max_events = 1
+        self.mock_app_conversation_info_service.get_app_conversation_info = AsyncMock(
+            return_value=mock_conversation_info
+        )
+        self.mock_event_service.count_events = AsyncMock(return_value=2)
+        self.mock_event_service.iter_events_for_export = Mock()
+
+        with pytest.raises(ConversationExportTooLarge):
+            await self.service.export_conversation(conversation_id)
+
+        self.mock_event_service.iter_events_for_export.assert_not_called()
 
     @patch(
         'openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace'


### PR DESCRIPTION
Ports the conversation export overload fix from #14896 to `main`.

#14896 was merged into `saas-rel-1.38.0`, but not into `main`. This PR reapplies the same fix on top of current `main` while preserving main-only changes in the conversation service.

## Summary

- Adds a single-pass `iter_events_for_export()` path for export reads.
- Streams conversation zip output instead of building the entire archive through temp files first.
- Adds a Redis-backed per-conversation export lock for SaaS, with best-effort behavior outside SaaS.
- Adds explicit export errors for duplicate exports, Redis lock unavailability, and oversized exports.
- Shares the Redis client helper in `openhands.app_server.utils.redis` while keeping `enterprise.storage.redis` as a compatibility re-export.

## Validation

- `uv run pytest tests/unit/app_server/test_live_status_app_conversation_service.py tests/unit/app_server/test_filesystem_event_service.py tests/unit/app_server/test_app_conversation_router.py`
- `uv run pre-commit run --all-files --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml`
- `cd enterprise && uvx pre-commit==4.2.0 run --all-files --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml`

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-c758983   docker.openhands.dev/openhands/openhands:c758983
```