### PR TITLE
fix: don't switch LLM profile before the conversation UUID exists (avoids 422)

### DIFF
--- a/frontend/__tests__/components/features/chat/switch-profile-button.test.tsx
+++ b/frontend/__tests__/components/features/chat/switch-profile-button.test.tsx
@@ -13,6 +13,7 @@ import type { LlmProfileSummary } from "#/api/settings-service/profiles-service.
 const mockUseLlmProfiles = vi.hoisted(() => vi.fn());
 const mockUseActiveConversation = vi.hoisted(() => vi.fn());
 const mockSwitchAndLog = vi.hoisted(() => vi.fn());
+const mockConversationId = vi.hoisted(() => ({ value: "conv-1" }));
 const mockModelStore = vi.hoisted(() => ({
   activeProfileByConversation: {} as Record<string, string>,
 }));
@@ -34,7 +35,7 @@ vi.mock("#/hooks/mutation/use-switch-llm-profile-and-log", () => ({
 }));
 
 vi.mock("#/hooks/use-conversation-id", () => ({
-  useConversationId: () => ({ conversationId: "conv-1" }),
+  useConversationId: () => ({ conversationId: mockConversationId.value }),
 }));
 
 vi.mock("#/stores/model-store", () => ({
@@ -102,6 +103,7 @@ const setupHooks = (
 describe("SwitchProfileButton", () => {
   beforeEach(() => {
     mockSwitchAndLog.mockReset();
+    mockConversationId.value = "conv-1";
   });
 
   afterEach(() => {
@@ -203,6 +205,13 @@ describe("SwitchProfileButton", () => {
     await user.click(screen.getByTestId("switch-profile-button"));
     await user.click(screen.getByTestId("switch-profile-option-default"));
     expect(mockSwitchAndLog).toHaveBeenCalledWith("conv-1", "default");
+  });
+
+  it("is disabled while the conversation id is still the `task-` placeholder", () => {
+    mockConversationId.value = "task-abc-123";
+    setupHooks({ conversationModel: "openai/gpt-5" });
+    renderButton();
+    expect(screen.getByTestId("switch-profile-button")).toBeDisabled();
   });
 
   it("does not call switchAndLog when the already-active profile is selected", async () => {

--- a/frontend/__tests__/hooks/mutation/use-switch-llm-profile-and-log.test.ts
+++ b/frontend/__tests__/hooks/mutation/use-switch-llm-profile-and-log.test.ts
@@ -52,6 +52,17 @@ describe("useSwitchLlmProfileAndLog", () => {
     );
   });
 
+  it("no-ops for a `task-` placeholder id (no call, no error toast) during startup", async () => {
+    const { result } = renderTestHook();
+    act(() => result.current.switchAndLog("task-abc-123", "gpt-5"));
+    // Give any pending mutation a tick to fire (it shouldn't).
+    await new Promise((r) => {
+      setTimeout(r, 0);
+    });
+    expect(mockSwitchProfile).not.toHaveBeenCalled();
+    expect(mockDisplayErrorToast).not.toHaveBeenCalled();
+  });
+
   it("records a switch entry on success, anchored to the latest rendered v1 event", async () => {
     useEventStore.setState({
       events: [],

--- a/frontend/src/components/features/chat/switch-profile-button.tsx
+++ b/frontend/src/components/features/chat/switch-profile-button.tsx
@@ -25,6 +25,10 @@ export function SwitchProfileButton() {
   const profiles = data?.profiles ?? [];
   const conversationModel = conversation?.llm_model ?? null;
 
+  // Still starting: the id is the placeholder `task-<uuid>`, not the real
+  // conversation UUID yet, so a switch can't be persisted (would 422).
+  const isStarting = conversationId.startsWith("task-");
+
   // Resolve the active profile, most-authoritative source first:
   //   1. A switch the user made this session (recorded by name, so it's exact
   //      even when several profiles share a model string, e.g. SaaS managed
@@ -77,7 +81,7 @@ export function SwitchProfileButton() {
       <button
         type="button"
         onClick={handleClick}
-        disabled={isPending}
+        disabled={isPending || isStarting}
         data-testid="switch-profile-button"
         title={activeProfileModel ?? undefined}
         aria-haspopup="menu"

--- a/frontend/src/hooks/mutation/use-switch-llm-profile-and-log.ts
+++ b/frontend/src/hooks/mutation/use-switch-llm-profile-and-log.ts
@@ -17,6 +17,11 @@ export function useSwitchLlmProfileAndLog() {
   // Stable identity so the /model interceptor's outer useCallback doesn't bust each render.
   const switchAndLog = useCallback(
     (conversationId: string, profileName: string) => {
+      // During chat startup the id is the placeholder `task-<uuid>` (the real
+      // conversation UUID doesn't exist yet); the switch endpoint types its
+      // path param as a UUID and would 422. No-op until the UUID is live.
+      if (conversationId.startsWith("task-")) return;
+
       const last = getRenderedV1Events(useEventStore.getState().uiEvents).at(
         -1,
       );


### PR DESCRIPTION
HUMAN: Please click-test in a live OHE/SaaS install. Start a brand-new conversation and, in the first couple of seconds (while the URL still shows `.../conversations/task-...`), open the LLM-profile switcher and try to switch — and also try the `/model <name>` slash command. Before this fix that fired a `422` and surfaced a "failed to switch" toast; after it, the control is disabled during startup and the switch is a no-op until the real conversation UUID exists. Confirm switching still works normally once the conversation is live.

## Root cause

During the first seconds of a conversation the route param is still the placeholder `task-<uuid>` (set in `use-create-conversation.ts` as `conversation_id: \`task-${startTask.id}\``) — the real conversation UUID doesn't exist yet. Switching the LLM profile in that window fires `POST /api/v1/app-conversations/task-<uuid>/switch_profile`, which FastAPI rejects with **422** because the path param is typed `conversation_id: UUID` and `task-<uuid>` isn't a UUID. The user sees a "failed to switch" toast on the first try during startup; once the real UUID exists the same switch works. The message-send path is independent and unaffected.

The backend typing is correct, so this is a frontend-only fix.

## Fix

- Guard the shared switch path (`use-switch-llm-profile-and-log.ts` → `switchAndLog`) so it short-circuits — no network call, no error toast — when `conversationId.startsWith("task-")`. This covers **both** entry points: the `SwitchProfileButton` and the `/model <name>` slash command (`use-model-interceptor.ts`).
- Additionally disable `SwitchProfileButton` while the conversation is still in the `task-` startup phase, for clearer UX (previously only `isPending` disabled it).

No backend changes.

## Tests

- `use-switch-llm-profile-and-log.test.ts`: new case asserting a `task-` id no-ops (no `switchProfile` call, no error toast).
- `switch-profile-button.test.tsx`: new case asserting the button is disabled while the id is the `task-` placeholder.
- All targeted vitest pass; `npm run lint` clean (0 errors).

- [x] A human has tested these changes.

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-e5ff72b   docker.openhands.dev/openhands/openhands:e5ff72b
```