### PR TITLE
fix: drop wholesale key when its update value is None

### DIFF
--- a/openhands/app_server/utils/jsonpatch_compat.py
+++ b/openhands/app_server/utils/jsonpatch_compat.py
@@ -52,6 +52,9 @@ def deep_merge_with_wholesale_keys(
 
     result = deep_merge(base, updates)
     for key in wholesale_keys:
-        if key in updates:
+        # A None update means "remove the key" (deep_merge already popped it), so
+        # only re-apply a wholesale value when one was actually provided —
+        # otherwise we'd resurrect the key with a None value.
+        if key in updates and updates[key] is not None:
             result[key] = updates[key]
     return result

--- a/tests/unit/app_server/utils/test_jsonpatch_compat.py
+++ b/tests/unit/app_server/utils/test_jsonpatch_compat.py
@@ -129,6 +129,24 @@ class TestDeepMergeWithWholesaleKeys:
 
         assert result['mcp_config']['mcpServers'] == {}
 
+    def test_wholesale_key_none_deletes(self):
+        """A None value for a wholesale key should remove it, not leave None.
+
+        deep_merge documents None as "remove the key", so passing
+        ``mcp_config: None`` to clear it must drop the key entirely rather than
+        re-adding it with a None value.
+        """
+        base = {
+            'llm': {'model': 'gpt-4'},
+            'mcp_config': {'mcpServers': {'server1': {'url': 'https://s1.com'}}},
+        }
+        updates = {'mcp_config': None}
+
+        result = deep_merge_with_wholesale_keys(base, updates)
+
+        assert 'mcp_config' not in result
+        assert result == {'llm': {'model': 'gpt-4'}}
+
     def test_custom_wholesale_keys(self):
         """Should support custom wholesale keys via parameter."""
         base = {'custom_dict': {'a': 1, 'b': 2, 'c': 3}}


### PR DESCRIPTION
## Why

`deep_merge` documents a `None` update value as "remove the corresponding key", and it does pop the key. But `deep_merge_with_wholesale_keys` then re-applied the wholesale value unconditionally:

```python
result = deep_merge(base, updates)
for key in wholesale_keys:
    if key in updates:
        result[key] = updates[key]
```

So passing `{"mcp_config": None}` to clear it ended up putting `{"mcp_config": None}` back into the result instead of removing the key — the wholesale path silently disagreed with `deep_merge`'s own delete semantics.

## Summary

- Skip re-applying a wholesale key when its update value is `None`, so the wholesale path honours the same "None deletes" rule (`deep_merge` has already popped it).
- Add a regression test: `mcp_config: None` now removes the key rather than leaving it set to `None`.

## Testing

```
pytest tests/unit/app_server/utils/test_jsonpatch_compat.py
```

12 passed (the new case fails before the change and passes after). `ruff check` and `ruff format --check` are clean on both files.
