### PR TITLE
test: cover execute_bash without security risk

### DIFF
--- a/tests/unit/llm/test_fn_call_converter_security_risk.py
+++ b/tests/unit/llm/test_fn_call_converter_security_risk.py
@@ -1,0 +1,41 @@
+from openhands.sdk.llm.mixins.fn_call_converter import (
+    convert_non_fncall_messages_to_fncall_messages,
+)
+
+
+def test_execute_bash_alias_does_not_require_security_risk():
+    tools = [
+        {
+            'type': 'function',
+            'function': {
+                'name': 'terminal',
+                'description': 'Execute a shell command.',
+                'parameters': {
+                    'type': 'object',
+                    'properties': {
+                        'command': {'type': 'string'},
+                        'security_risk': {
+                            'type': 'string',
+                            'enum': ['LOW', 'MEDIUM', 'HIGH', 'UNKNOWN'],
+                        },
+                    },
+                    'required': ['command', 'security_risk'],
+                },
+            },
+        }
+    ]
+    messages = [
+        {'role': 'user', 'content': 'List the current directory.'},
+        {
+            'role': 'assistant',
+            'content': '<function=execute_bash>\n'
+            '<parameter=command>ls</parameter>\n'
+            '</function>',
+        },
+    ]
+
+    converted = convert_non_fncall_messages_to_fncall_messages(messages, tools)
+
+    tool_call = converted[1]['tool_calls'][0]
+    assert tool_call['function']['name'] == 'terminal'
+    assert tool_call['function']['arguments'] == '{"command": "ls"}'


### PR DESCRIPTION
## Summary
- Add regression coverage for legacy `execute_bash` tool-call alias conversion when `security_risk` is omitted.
- Verifies the call maps to the current `terminal` tool and preserves the command arguments without raising a missing-parameter error.

Fixes OpenHands/software-agent-sdk#4248

## Verification
- `OPENHANDS_SUPPRESS_BANNER=1 uv run pytest tests/unit/llm/test_fn_call_converter_security_risk.py -q`
- `PATH="$PWD/.venv/bin:$PATH" pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files tests/unit/llm/test_fn_call_converter_security_risk.py`

Note: `make install-pre-commit-hooks` initially failed under the system Python 3.9; rerunning with `.venv/bin` first got past the Python check but Poetry hit a transient virtualenv embedded-pip uninstall path error for `tree-sitter-language-pack`. The focused pytest and required Python pre-commit command both passed afterward.