### PR TITLE
feat(enterprise): scoped API credentials foundation (Phase 1 of #14912)

### DIFF
--- a/enterprise/migrations/versions/125_create_api_key_scopes_table.py
+++ b/enterprise/migrations/versions/125_create_api_key_scopes_table.py
@@ -1,0 +1,51 @@
+"""Create api_key_scopes table.
+
+Phase 1 foundation for scoped (reduced-privilege) API credentials.
+
+Stores opaque, namespaced scope strings attached to an API key. A key with no
+rows here is treated as carrying the implicit ``full`` scope, so existing keys
+keep their current behavior (no behavior change on rollout).
+
+Revision ID: 125
+Revises: 124
+Create Date: 2026-06-20 00:00:00.000000
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '125'
+down_revision: str | None = '124'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'api_key_scopes',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('api_key_id', sa.Integer(), nullable=False),
+        sa.Column('scope', sa.String(length=255), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['api_key_id'],
+            ['api_keys.id'],
+            ondelete='CASCADE',
+        ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('api_key_id', 'scope', name='uq_api_key_scopes_key_scope'),
+    )
+    op.create_index(
+        op.f('ix_api_key_scopes_api_key_id'),
+        'api_key_scopes',
+        ['api_key_id'],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f('ix_api_key_scopes_api_key_id'), table_name='api_key_scopes'
+    )
+    op.drop_table('api_key_scopes')

--- a/enterprise/server/auth/saas_user_auth.py
+++ b/enterprise/server/auth/saas_user_auth.py
@@ -72,6 +72,10 @@ class SaasUserAuth(UserAuth):
     api_key_org_id: UUID | None = None  # Org bound to the API key used for auth
     api_key_id: int | None = None
     api_key_name: str | None = None
+    # Opaque, namespaced scope strings carried by the API/session key used for
+    # auth. None when not authenticated via an API key (e.g. cookie auth).
+    # ``[FULL_SCOPE]`` for keys without explicit scopes (legacy/back-compat).
+    api_key_scopes: list[str] | None = None
     # Organization context fields - populated lazily via get_org_info()
     _org_id: str | None = None
     _org_name: str | None = None
@@ -97,6 +101,16 @@ class SaasUserAuth(UserAuth):
             (cookie auth or legacy API keys without org binding).
         """
         return self.api_key_org_id
+
+    def get_api_key_scopes(self) -> list[str] | None:
+        """Get the opaque scope strings carried by the API key used for auth.
+
+        Returns:
+            The scope list when authenticated via an API/session key
+            (``[FULL_SCOPE]`` for keys without explicit scopes), or None for
+            non-API-key auth such as cookie sessions.
+        """
+        return self.api_key_scopes
 
     def set_effective_org_id_override(self, org_id: UUID | None) -> None:
         """Set a trusted server-side org override and clear org-scoped caches."""
@@ -696,6 +710,7 @@ async def saas_user_auth_from_bearer(request: Request) -> SaasUserAuth | None:
             api_key_org_id=validation_result.org_id,
             api_key_id=validation_result.key_id,
             api_key_name=validation_result.key_name,
+            api_key_scopes=validation_result.scopes,
         )
     except Exception as exc:
         raise BearerTokenError from exc

--- a/enterprise/server/models/user_models.py
+++ b/enterprise/server/models/user_models.py
@@ -17,6 +17,11 @@ class SaasUserInfo(UserInfo):
     org_name: str | None = None
     role: str | None = None
     permissions: list[str] | None = None
+    # Opaque, namespaced scope strings carried by the API/session key used for
+    # this request. None for non-API-key (e.g. cookie) auth. Resource servers
+    # use this to enforce reduced-privilege credentials; OpenHands does not
+    # interpret the strings.
+    api_key_scopes: list[str] | None = None
 
 
 class GitOrganizationsResponse(BaseModel):

--- a/enterprise/server/routes/users_v1.py
+++ b/enterprise/server/routes/users_v1.py
@@ -90,6 +90,12 @@ async def get_current_user_saas(
     if org_info:
         user_info_data.update(org_info)
 
+    # Surface the scopes carried by the API/session key (if any) so resource
+    # servers can enforce reduced-privilege credentials.
+    api_key_scopes = _get_api_key_scopes_from_context(user_context)
+    if api_key_scopes is not None:
+        user_info_data['api_key_scopes'] = api_key_scopes
+
     user_info = SaasUserInfo(**user_info_data)
 
     if expose_secrets:
@@ -155,6 +161,22 @@ async def _get_org_info_from_context(user_context: UserContext) -> dict | None:
         user_auth = user_context.user_auth
         if isinstance(user_auth, SaasUserAuth):
             return await user_auth.get_org_info()
+    return None
+
+
+def _get_api_key_scopes_from_context(
+    user_context: UserContext,
+) -> list[str] | None:
+    """Extract the API key scopes from the user context if available.
+
+    Returns the scope list when the request authenticated via an API/session
+    key (``[FULL_SCOPE]`` for keys without explicit scopes), or None for
+    non-API-key auth such as cookie sessions.
+    """
+    if isinstance(user_context, AuthUserContext):
+        user_auth = user_context.user_auth
+        if isinstance(user_auth, SaasUserAuth):
+            return user_auth.get_api_key_scopes()
     return None
 
 

--- a/enterprise/storage/api_key.py
+++ b/enterprise/storage/api_key.py
@@ -11,9 +11,7 @@ if TYPE_CHECKING:
 
 
 class ApiKey(Base):
-    """
-    Represents an API key for a user.
-    """
+    """Represents an API key for a user."""
 
     __tablename__ = 'api_keys'
 
@@ -32,3 +30,36 @@ class ApiKey(Base):
 
     # Relationships
     org: Mapped['Org | None'] = relationship('Org', back_populates='api_keys')
+    scopes: Mapped[list['ApiKeyScope']] = relationship(
+        'ApiKeyScope',
+        back_populates='api_key',
+        cascade='all, delete-orphan',
+        # Rely on the DB-level ``ON DELETE CASCADE`` (see migration) rather than
+        # loading children on parent delete, which would trigger blocking lazy
+        # IO under the async session.
+        passive_deletes=True,
+    )
+
+
+class ApiKeyScope(Base):
+    """An opaque, namespaced scope string attached to an API key.
+
+    OpenHands does not interpret scope strings; it stores them, returns them at
+    validation time, and leaves all semantic enforcement to the resource server
+    that owns the namespace (e.g. ``automation:kv:read:org``). A key with no
+    scope rows is treated as carrying the implicit ``full`` scope, preserving
+    backwards compatibility with keys minted before scopes existed.
+    """
+
+    __tablename__ = 'api_key_scopes'
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    api_key_id: Mapped[int] = mapped_column(
+        ForeignKey('api_keys.id', ondelete='CASCADE'),
+        nullable=False,
+        index=True,
+    )
+    scope: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    # Relationships
+    api_key: Mapped['ApiKey'] = relationship('ApiKey', back_populates='scopes')

--- a/enterprise/storage/api_key_store.py
+++ b/enterprise/storage/api_key_store.py
@@ -2,16 +2,23 @@ from __future__ import annotations
 
 import secrets
 import string
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from uuid import UUID
 
 from sqlalchemy import select, update
-from storage.api_key import ApiKey
+from sqlalchemy.ext.asyncio import AsyncSession
+from storage.api_key import ApiKey, ApiKeyScope
 from storage.database import a_session_maker
 from storage.user_store import UserStore
 
 from openhands.app_server.utils.logger import openhands_logger as logger
+
+# Implicit scope carried by keys that have no explicit scope rows. Storing no
+# rows (rather than a literal "full" row) keeps legacy keys unchanged and lets
+# `full` remain a reserved, OpenHands-owned sentinel rather than a grantable
+# namespaced scope.
+FULL_SCOPE = 'full'
 
 
 @dataclass
@@ -22,6 +29,10 @@ class ApiKeyValidationResult:
     org_id: UUID | None  # None for legacy API keys without org binding
     key_id: int
     key_name: str | None
+    # Opaque, namespaced scope strings attached to the key. Defaults to
+    # ``[FULL_SCOPE]`` for keys without explicit scopes (legacy + back-compat).
+    # OpenHands does not interpret these; resource servers enforce them.
+    scopes: list[str] = field(default_factory=lambda: [FULL_SCOPE])
 
 
 @dataclass
@@ -50,12 +61,51 @@ class ApiKeyStore:
         """
         return f'{cls.SYSTEM_KEY_NAME_PREFIX}{name}'
 
+    @staticmethod
+    def _normalize_scopes(scopes: list[str] | None) -> list[str]:
+        """Normalize a requested scope list into rows to persist.
+
+        - ``None`` or empty -> ``[]`` (no rows; key carries the implicit
+          ``full`` scope, preserving legacy behavior).
+        - The reserved ``full`` sentinel is dropped: a fully-privileged key is
+          represented by the *absence* of scope rows, not by a ``full`` row.
+        - Duplicates are removed while preserving order.
+        """
+        if not scopes:
+            return []
+        normalized: list[str] = []
+        for raw in scopes:
+            scope = raw.strip()
+            if not scope or scope == FULL_SCOPE:
+                continue
+            if scope not in normalized:
+                normalized.append(scope)
+        return normalized
+
+    @staticmethod
+    async def _add_scope_rows(
+        session: AsyncSession, api_key_id: int, scopes: list[str]
+    ) -> None:
+        """Persist normalized scope rows for a key within an open session."""
+        for scope in scopes:
+            session.add(ApiKeyScope(api_key_id=api_key_id, scope=scope))
+
+    @staticmethod
+    async def _load_scopes(session: AsyncSession, api_key_id: int) -> list[str]:
+        """Load scope strings for a key, defaulting to ``[FULL_SCOPE]``."""
+        result = await session.execute(
+            select(ApiKeyScope.scope).filter(ApiKeyScope.api_key_id == api_key_id)
+        )
+        scopes = list(result.scalars().all())
+        return scopes if scopes else [FULL_SCOPE]
+
     async def create_api_key(
         self,
         user_id: str,
         name: str | None = None,
         expires_at: datetime | None = None,
         org_id: UUID | None = None,
+        scopes: list[str] | None = None,
     ) -> str:
         """Create a new API key for a user.
 
@@ -68,6 +118,10 @@ class ApiKeyStore:
                 to the user's persisted ``current_org_id``. Callers in
                 request context should pass the effective org id (see
                 ``SaasUserAuth.get_effective_org_id``).
+            scopes: Optional opaque, namespaced scope strings to attach to the
+                key. When omitted/empty the key carries the implicit ``full``
+                scope (no behavior change). OpenHands stores these verbatim and
+                does not interpret them; resource servers enforce meaning.
 
         Returns:
             The generated API key
@@ -83,6 +137,8 @@ class ApiKeyStore:
         if expires_at is not None and expires_at.tzinfo is not None:
             expires_at = expires_at.replace(tzinfo=None)
 
+        normalized_scopes = self._normalize_scopes(scopes)
+
         async with a_session_maker() as session:
             key_record = ApiKey(
                 key=api_key,
@@ -92,6 +148,8 @@ class ApiKeyStore:
                 expires_at=expires_at,
             )
             session.add(key_record)
+            await session.flush()
+            await self._add_scope_rows(session, key_record.id, normalized_scopes)
             await session.commit()
 
         return api_key
@@ -101,6 +159,7 @@ class ApiKeyStore:
         user_id: str,
         org_id: UUID,
         name: str,
+        scopes: list[str] | None = None,
     ) -> str:
         """Get or create a system API key for a user on behalf of an internal service.
 
@@ -117,12 +176,17 @@ class ApiKeyStore:
             user_id: The ID of the user to create the key for
             org_id: The organization ID to associate the key with
             name: Required name for the key (will be prefixed with __SYSTEM__:)
+            scopes: Optional opaque, namespaced scope strings attached only when
+                a *new* key is minted. Omitted/empty means the implicit ``full``
+                scope (no behavior change). Scopes of an already-existing,
+                non-expired key are left untouched.
 
         Returns:
             The API key (existing or newly created)
         """
         # Create system key name with prefix
         system_key_name = self.make_system_key_name(name)
+        normalized_scopes = self._normalize_scopes(scopes)
 
         async with a_session_maker() as session:
             # Check if key already exists for this user/org/name
@@ -190,6 +254,8 @@ class ApiKeyStore:
                 expires_at=None,  # System keys never expire
             )
             session.add(key_record)
+            await session.flush()
+            await self._add_scope_rows(session, key_record.id, normalized_scopes)
             await session.commit()
 
         logger.info(
@@ -235,6 +301,8 @@ class ApiKeyStore:
                 .where(ApiKey.id == key_record.id)
                 .values(last_used_at=now.replace(tzinfo=None))
             )
+
+            scopes = await self._load_scopes(session, key_record.id)
             await session.commit()
 
             return ApiKeyValidationResult(
@@ -242,6 +310,7 @@ class ApiKeyStore:
                 org_id=key_record.org_id,
                 key_id=key_record.id,
                 key_name=key_record.name,
+                scopes=scopes,
             )
 
     async def delete_api_key(self, api_key: str) -> bool:

--- a/enterprise/tests/unit/test_api_key_store.py
+++ b/enterprise/tests/unit/test_api_key_store.py
@@ -4,8 +4,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy import select
-from storage.api_key import ApiKey
-from storage.api_key_store import ApiKeyStore, ApiKeyValidationResult
+from storage.api_key import ApiKey, ApiKeyScope
+from storage.api_key_store import (
+    FULL_SCOPE,
+    ApiKeyStore,
+    ApiKeyValidationResult,
+)
 
 
 @pytest.fixture
@@ -593,3 +597,125 @@ async def test_delete_api_key_by_name_not_found(api_key_store, async_session_mak
 
     # Verify
     assert result is False
+
+
+class TestApiKeyScopes:
+    """Tests for the Phase 1 scoped-credentials foundation."""
+
+    def test_normalize_scopes_empty(self, api_key_store):
+        """None/empty means no rows (implicit full scope)."""
+        assert api_key_store._normalize_scopes(None) == []
+        assert api_key_store._normalize_scopes([]) == []
+
+    def test_normalize_scopes_drops_full_sentinel(self, api_key_store):
+        """The reserved ``full`` sentinel is never stored as a row."""
+        assert api_key_store._normalize_scopes([FULL_SCOPE]) == []
+        assert api_key_store._normalize_scopes(
+            ['automation:kv:read:org', FULL_SCOPE]
+        ) == ['automation:kv:read:org']
+
+    def test_normalize_scopes_strips_and_dedupes(self, api_key_store):
+        """Whitespace is trimmed, blanks dropped, order-preserving dedupe."""
+        assert api_key_store._normalize_scopes(
+            ['  a:b ', 'a:b', '', '  ', 'c:d']
+        ) == ['a:b', 'c:d']
+
+    @pytest.mark.asyncio
+    async def test_create_api_key_with_scopes(
+        self, api_key_store, async_session_maker
+    ):
+        """Scopes passed at creation are persisted and returned on validation."""
+        user_id = str(uuid.uuid4())
+        org_id = uuid.uuid4()
+        scopes = ['automation:kv:read:org', 'automation:kv:write:org']
+
+        with patch('storage.api_key_store.a_session_maker', async_session_maker):
+            api_key = await api_key_store.create_api_key(
+                user_id, name='scoped', org_id=org_id, scopes=scopes
+            )
+            result = await api_key_store.validate_api_key(api_key)
+
+        assert isinstance(result, ApiKeyValidationResult)
+        assert sorted(result.scopes) == sorted(scopes)
+
+        # Rows exist in api_key_scopes
+        async with async_session_maker() as session:
+            key = (
+                await session.execute(select(ApiKey).filter(ApiKey.key == api_key))
+            ).scalars().first()
+            rows = (
+                await session.execute(
+                    select(ApiKeyScope.scope).filter(
+                        ApiKeyScope.api_key_id == key.id
+                    )
+                )
+            ).scalars().all()
+        assert sorted(rows) == sorted(scopes)
+
+    @pytest.mark.asyncio
+    async def test_create_api_key_without_scopes_defaults_to_full(
+        self, api_key_store, async_session_maker
+    ):
+        """A key without scopes carries implicit full scope and stores no rows."""
+        user_id = str(uuid.uuid4())
+        org_id = uuid.uuid4()
+
+        with patch('storage.api_key_store.a_session_maker', async_session_maker):
+            api_key = await api_key_store.create_api_key(
+                user_id, name='plain', org_id=org_id
+            )
+            result = await api_key_store.validate_api_key(api_key)
+
+        assert result.scopes == [FULL_SCOPE]
+
+        async with async_session_maker() as session:
+            key = (
+                await session.execute(select(ApiKey).filter(ApiKey.key == api_key))
+            ).scalars().first()
+            rows = (
+                await session.execute(
+                    select(ApiKeyScope).filter(ApiKeyScope.api_key_id == key.id)
+                )
+            ).scalars().all()
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_validate_legacy_key_returns_full_scope(
+        self, api_key_store, async_session_maker
+    ):
+        """A pre-existing key with no scope rows validates as full scope."""
+        api_key_value = 'legacy-key-no-scopes'
+        async with async_session_maker() as session:
+            session.add(
+                ApiKey(
+                    key=api_key_value,
+                    user_id=str(uuid.uuid4()),
+                    org_id=uuid.uuid4(),
+                    name='legacy',
+                    expires_at=None,
+                )
+            )
+            await session.commit()
+
+        with patch('storage.api_key_store.a_session_maker', async_session_maker):
+            result = await api_key_store.validate_api_key(api_key_value)
+
+        assert result is not None
+        assert result.scopes == [FULL_SCOPE]
+
+    @pytest.mark.asyncio
+    async def test_system_key_with_scopes(
+        self, api_key_store, async_session_maker
+    ):
+        """System (session) keys can be minted with reduced scopes."""
+        user_id = str(uuid.uuid4())
+        org_id = uuid.uuid4()
+        scopes = ['automation:kv:read:org']
+
+        with patch('storage.api_key_store.a_session_maker', async_session_maker):
+            api_key = await api_key_store.get_or_create_system_api_key(
+                user_id=user_id, org_id=org_id, name='sandbox', scopes=scopes
+            )
+            result = await api_key_store.validate_api_key(api_key)
+
+        assert result.scopes == scopes


### PR DESCRIPTION
## Summary

Implements **Phase 1** of OpenHands/enterprise#38 — an opaque, namespaced **scope** foundation for API and session keys. This is the *pure foundation* step: it adds the data model and surfaces scopes on validation, with **no behavior change** for any existing key.

Today every API key / session key is a full‑identity bearer credential: `validate_api_key()` resolves only the owning `user_id`/`org_id`, and `/api/v1/users/me` returns the owner's complete role‑based `permissions`. There is no way to mint a key with *fewer* rights than its owner. This PR lays the groundwork to fix that.

## What changed

- **New `api_key_scopes` table** (`migration 125`) + `ApiKeyScope` model — `api_key_id` FK (`ON DELETE CASCADE`) + opaque `scope` text, unique per `(api_key_id, scope)`.
- **`ApiKeyStore`**
  - `create_api_key(...)` and `get_or_create_system_api_key(...)` accept an optional `scopes` list and persist scope rows.
  - `validate_api_key(...)` now returns `scopes` on `ApiKeyValidationResult`.
  - A key with **no scope rows** resolves to the implicit `['full']` scope, so **legacy keys and all current callers are unchanged**. The reserved `full` sentinel is never stored as a row (full = absence of scopes).
- **`SaasUserAuth`** carries `api_key_scopes` (populated from bearer/session‑key validation) with a `get_api_key_scopes()` accessor.
- **`/api/v1/users/me`** surfaces `api_key_scopes` so resource servers (e.g. the Automation service, which already enforces via `/users/me`) can act on reduced‑privilege credentials. The field is `None` for cookie (non‑API‑key) auth.

## Design notes

- **Opaque & namespaced** — OpenHands stores scope strings like `automation:kv:read:org` verbatim and does **not** interpret them. This is the OAuth authorization‑server / resource‑server split from the issue: OpenHands mints + returns scopes; resource servers enforce meaning.
- **No grant‑time gate / consent UI here.** Per the issue's phasing, enforcement (`min_role_rank`, "can't grant what you lack"), the scope manifest, and consent UI are deliberately **out of scope** for Phase 1 and are left as follow‑ups (Phases 2–4).
- `passive_deletes=True` on the relationship relies on the DB‑level `ON DELETE CASCADE` (correct for Postgres) and avoids blocking lazy IO under the async session.

## Testing

- Added `TestApiKeyScopes` to `tests/unit/test_api_key_store.py`: scope normalization (strip/dedupe/drop‑`full`), create‑with‑scopes round‑trips through `validate`, create‑without‑scopes defaults to `['full']`, legacy keys (no rows) validate as `['full']`, and system/session keys can be minted with reduced scopes.
- `pytest` for all affected areas passes locally (api key store + storage + routes + saas auth + users_v1): **86 passed**. `ruff` clean on changed code.

## Follow-ups (not in this PR)
- Phase 2: mint sandbox/session keys with reduced scopes.
- Phase 3: scope manifest (`/.well-known/openhands-scopes`) + generic consent UI + `min_role_rank` grant‑time gate.
- Phase 4 (optional): dynamic registration.
- Consumer: `OpenHands/automation#201` org‑scoped KV tokens.

Related: OpenHands/enterprise#38

---
_This PR was created by an AI agent (OpenHands) on behalf of the maintainer._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2d91a2d0-7f85-496f-a9bc-84578273e8e8)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-628324d   docker.openhands.dev/openhands/openhands:628324d
```