### PR TITLE
ci: stop using pytest --forked so coverage is captured

### DIFF
--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -57,7 +57,13 @@ jobs:
       - name: Build Environment
         run: make build
       - name: Run Unit Tests
-        run: PYTHONPATH=".:$PYTHONPATH" poetry run pytest --forked -n auto -s ./tests/unit --cov=openhands --cov-branch
+        # NOTE: do not add `--forked` here. pytest-forked runs each test in an
+        # os.fork() child that exits via os._exit(), so coverage collected in
+        # the child is never written back. That silently undercounts coverage
+        # (multiprocessing concurrency does not recover it). `-n auto` already
+        # provides process-level parallelism/isolation across xdist workers,
+        # and pytest-cov correctly combines per-worker coverage.
+        run: PYTHONPATH=".:$PYTHONPATH" poetry run pytest -n auto -s ./tests/unit --cov=openhands --cov-branch
         env:
           COVERAGE_FILE: ".coverage.${{ matrix.python_version }}"
       - name: Store coverage file
@@ -89,7 +95,12 @@ jobs:
         run: poetry install --with dev,test
       - name: Run Unit Tests
         # Use base working directory for coverage paths to line up.
-        run: PYTHONPATH=".:$PYTHONPATH" poetry run --project=enterprise pytest --forked -n auto -s -p no:ddtrace -p no:ddtrace.pytest_bdd -p no:ddtrace.pytest_benchmark ./enterprise/tests/unit --cov=enterprise --cov-branch
+        # NOTE: do not add `--forked` here. pytest-forked runs each test in an
+        # os.fork() child that exits via os._exit(), so coverage collected in
+        # the child is never written back, silently undercounting coverage.
+        # `-n auto` already provides process-level parallelism/isolation across
+        # xdist workers, and pytest-cov correctly combines per-worker coverage.
+        run: PYTHONPATH=".:$PYTHONPATH" poetry run --project=enterprise pytest -n auto -s -p no:ddtrace -p no:ddtrace.pytest_bdd -p no:ddtrace.pytest_benchmark ./enterprise/tests/unit --cov=enterprise --cov-branch
         env:
           COVERAGE_FILE: ".coverage.enterprise.${{ matrix.python_version }}"
       - name: Store coverage file


### PR DESCRIPTION
## Problem

The PR coverage badges report **far lower** numbers than reality. Both the core and enterprise unit-test jobs run pytest with `--forked`:

```
pytest --forked -n auto ... --cov=...
```

`pytest-forked` runs **each test in an `os.fork()` child** that terminates with `os._exit()`. Because `os._exit()` skips `atexit` handlers, the coverage data collected inside the forked child is **never written back** to the parent. The parent process only records import-time / collection-time lines, so test-body execution is invisible to coverage.

This silently undercounts coverage. It's most visible on the enterprise tree — well-tested modules report a small fraction of their true coverage, which is why a recent enterprise PR showed a `~48%` PR-coverage badge and files like `user_models.py` at `0%` despite being fully exercised by committed tests.

## Root cause (verified locally)

Running the **same** enterprise tests two ways:

| Run mode | `enterprise/storage/api_key_store.py` |
|---|---|
| `--forked -n auto` (current CI) | **25%** |
| `-n auto` (this PR) | **87%** |

I also confirmed that adding `concurrency = ["multiprocessing", ...]` does **not** help — pytest-forked's raw `os.fork()` + `os._exit()` children are not captured by coverage's multiprocessing support. Removing `--forked` is the fix that actually works.

## Fix

Drop `--forked` from both unit-test jobs while keeping `-n auto`:

- `pytest-xdist` (`-n auto`) already runs tests across multiple worker processes, providing parallelism and process-level isolation between workers.
- `pytest-cov` correctly collects and combines per-worker coverage, so the captured numbers reflect reality.

No test code changes — this only affects how the suite is executed in CI.

## Risk / validation

`--forked` additionally forced **per-test** process isolation. The vast majority of tests don't rely on that, but if any test mutates global state in a way that contaminates siblings in the same worker, it could surface here. CI on this PR is the validation: if a small number of tests need isolation they can be marked (e.g. a dedicated serial group) rather than forking the entire suite and losing all coverage signal. Opened as **draft** so maintainers can review the trade-off and watch CI.

## Expected effect

- The "whole project" and "PR diff" coverage numbers should jump substantially (the enterprise tree in particular), reflecting coverage that already exists.

---
_This PR was created by an AI agent (OpenHands) on behalf of the maintainer._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2d91a2d0-7f85-496f-a9bc-84578273e8e8)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-a5c89bd   docker.openhands.dev/openhands/openhands:a5c89bd
```