### PR TITLE
feat(enterprise): cap automation-minted API keys to org member (Phase 2 of #14912)

### DIFF
--- a/enterprise/server/auth/authorization.py
+++ b/enterprise/server/auth/authorization.py
@@ -99,6 +99,106 @@ class RoleName(str, Enum):
     MEMBER = 'member'
 
 
+# Privilege ordering, most-privileged first. Used to "cap" the effective role
+# carried by an API key down to the lesser of (the user's real org role, the
+# cap requested when the key was minted). Capping can only *reduce* privilege,
+# never grant more than the user already has, so it is always safe.
+_ROLE_PRIVILEGE_ORDER: tuple[RoleName, ...] = (
+    RoleName.OWNER,
+    RoleName.ADMIN,
+    RoleName.MEMBER,
+)
+
+
+def _role_privilege_index(role_name: str) -> int:
+    """Return the privilege index of a role (lower index = more privileged).
+
+    Unknown role names sort as least-privileged so that an unrecognized value
+    can never accidentally *grant* privilege when used as a cap.
+    """
+    try:
+        return _ROLE_PRIVILEGE_ORDER.index(RoleName(role_name))
+    except ValueError:
+        return len(_ROLE_PRIVILEGE_ORDER)
+
+
+# Reserved, OpenHands-owned scope namespace that maps an API key to an org
+# role. Unlike third-party scopes (which OpenHands stores opaquely and never
+# interprets), this namespace is interpreted by OpenHands itself: a key
+# carrying ``openhands:role:member`` is treated as if its bearer had at most
+# the ``member`` role, regardless of the owner's actual (possibly higher) role.
+# This is the bridge from the Phase 1 opaque-scope foundation to the concrete
+# org role/permission system that already exists today.
+ROLE_CAP_SCOPE_PREFIX = 'openhands:role:'
+
+
+def make_role_cap_scope(role_name: str) -> str:
+    """Build the reserved role-cap scope string for a role (e.g. ``member``)."""
+    return f'{ROLE_CAP_SCOPE_PREFIX}{role_name}'
+
+
+def role_cap_from_scopes(scopes: list[str] | None) -> str | None:
+    """Extract the effective role cap from an API key's scope list.
+
+    Returns the *least privileged* role named by any ``openhands:role:<role>``
+    scope (so multiple caps combine to the most restrictive), or ``None`` when
+    the key carries no role-cap scope (i.e. it is uncapped). The reserved
+    ``full`` sentinel and all non-role scopes are ignored.
+    """
+    if not scopes:
+        return None
+    cap: str | None = None
+    for scope in scopes:
+        if not scope.startswith(ROLE_CAP_SCOPE_PREFIX):
+            continue
+        role_name = scope[len(ROLE_CAP_SCOPE_PREFIX) :].strip()
+        if not role_name:
+            continue
+        if cap is None or _role_privilege_index(role_name) > _role_privilege_index(cap):
+            cap = role_name
+    return cap
+
+
+def apply_role_cap(role_name: str | None, scopes: list[str] | None) -> str | None:
+    """Cap a real org role down to the role permitted by the key's scopes.
+
+    The effective role is the *least privileged* of the user's actual role and
+    the role cap carried by the API key. Returns ``role_name`` unchanged when
+    the key is uncapped or the cap would not reduce privilege (capping never
+    escalates). ``None`` in/``None`` out (non-member users stay non-members).
+    """
+    if role_name is None:
+        return None
+    cap = role_cap_from_scopes(scopes)
+    if cap is None:
+        return role_name
+    if _role_privilege_index(cap) > _role_privilege_index(role_name):
+        return cap
+    return role_name
+
+
+def effective_role_permissions(
+    role_name: str | None, scopes: list[str] | None
+) -> frozenset[Permission]:
+    """Permissions for a role after applying any API-key role cap."""
+    effective = apply_role_cap(role_name, scopes)
+    if effective is None:
+        return frozenset()
+    return get_role_permissions(effective)
+
+
+async def get_api_key_scopes_from_request(request: Request) -> list[str] | None:
+    """Get the scopes carried by the API key used to authenticate ``request``.
+
+    Returns ``None`` when the request is not authenticated via an API key
+    (e.g. cookie auth) or the auth backend does not expose scopes.
+    """
+    user_auth = getattr(request.state, 'user_auth', None)
+    if user_auth and hasattr(user_auth, 'get_api_key_scopes'):
+        return user_auth.get_api_key_scopes()
+    return None
+
+
 # Permission mappings for each role
 ROLE_PERMISSIONS: dict[RoleName, frozenset[Permission]] = {
     RoleName.OWNER: frozenset(
@@ -230,6 +330,17 @@ def has_permission(user_role: Role, permission: Permission) -> bool:
     return permission in permissions
 
 
+def has_permission_for_role(role_name: str | None, permission: Permission) -> bool:
+    """Check if a role (by name) has a permission.
+
+    Accepts a role *name* rather than a ``Role`` object so callers can pass an
+    effective (possibly API-key-capped) role name. ``None`` has no permissions.
+    """
+    if role_name is None:
+        return False
+    return permission in get_role_permissions(role_name)
+
+
 async def get_api_key_org_id_from_request(request: Request) -> UUID | None:
     """Get the org_id bound to the API key used for authentication.
 
@@ -321,13 +432,21 @@ def require_permission(permission: Permission):
                 detail='User is not a member of this organization',
             )
 
-        if not has_permission(user_role, permission):
+        # Cap the effective role down to whatever the authenticating API key is
+        # scoped to (e.g. an automation key minted as ``openhands:role:member``
+        # never gets owner/admin powers, even when its owner is an org owner).
+        # Cookie auth and uncapped keys leave the real role unchanged.
+        api_key_scopes = await get_api_key_scopes_from_request(request)
+        effective_role_name = apply_role_cap(user_role.name, api_key_scopes)
+
+        if not has_permission_for_role(effective_role_name, permission):
             logger.warning(
                 'Insufficient permissions',
                 extra={
                     'user_id': user_id,
                     'org_id': str(org_id),
                     'user_role': user_role.name,
+                    'effective_role': effective_role_name,
                     'required_permission': permission.value,
                 },
             )
@@ -389,11 +508,21 @@ async def require_financial_data_access(
                 detail='API key is not authorized for this organization',
             )
 
+    # Honor any API-key role cap so a reduced-privilege key (e.g. an automation
+    # key capped to ``member``) cannot read financial data even when its owner
+    # holds an admin/owner role or an @openhands.dev email. ``key_allows_admin``
+    # is True for cookie auth and uncapped keys, and for keys capped at
+    # admin/owner; it is False once the cap drops below admin.
+    api_key_scopes = await get_api_key_scopes_from_request(request)
+    key_allows_admin = (
+        apply_role_cap(RoleName.ADMIN.value, api_key_scopes) == RoleName.ADMIN.value
+    )
+
     # Check if user has @openhands.dev email
     user_auth = await get_user_auth(request)
     user_email = await user_auth.get_user_email()
 
-    if user_email and user_email.endswith('@openhands.dev'):
+    if key_allows_admin and user_email and user_email.endswith('@openhands.dev'):
         logger.debug(
             'Financial data access granted via @openhands.dev email',
             extra={'user_id': user_id, 'org_id': str(org_id)},
@@ -413,7 +542,9 @@ async def require_financial_data_access(
             detail='User is not a member of this organization',
         )
 
-    if user_role.name not in (RoleName.OWNER.value, RoleName.ADMIN.value):
+    effective_role_name = apply_role_cap(user_role.name, api_key_scopes)
+
+    if effective_role_name not in (RoleName.OWNER.value, RoleName.ADMIN.value):
         logger.warning(
             'Financial data access denied - insufficient role',
             extra={

--- a/enterprise/server/auth/saas_user_auth.py
+++ b/enterprise/server/auth/saas_user_auth.py
@@ -15,6 +15,7 @@ from server.auth.auth_error import (
     NoCredentialsError,
 )
 from server.auth.authorization import (
+    apply_role_cap,
     get_role_permissions,
     get_user_org_role,
 )
@@ -608,16 +609,27 @@ class SaasUserAuth(UserAuth):
             role = await get_user_org_role(self.user_id, effective_org_id)
             role_name = role.name if role else None
 
-            # Get permissions for the role
+            # Cap the effective role/permissions down to whatever the API key
+            # used for this request is scoped to. A request authenticated with
+            # an automation key minted as ``openhands:role:member`` therefore
+            # reports member-level permissions here even when the owning user is
+            # an org owner. Cookie auth and uncapped keys are unaffected. This is
+            # the surface the issue calls out: validating such a key via
+            # /users/me must not return the owner's full permission set.
+            effective_role_name = apply_role_cap(role_name, self.api_key_scopes)
+
+            # Get permissions for the effective (capped) role
             permissions: list[str] = []
-            if role_name:
-                role_permissions = get_role_permissions(role_name)
+            if effective_role_name:
+                role_permissions = get_role_permissions(effective_role_name)
                 permissions = [p.value for p in role_permissions]
 
-            # Cache the results
+            # Cache the results. Report the effective (capped) role so that the
+            # reported role and permissions stay consistent for API-key callers;
+            # for cookie/uncapped auth this equals the real role.
             self._org_id = str(effective_org_id)
             self._org_name = org.name
-            self._role = role_name
+            self._role = effective_role_name
             self._permissions = permissions
 
             return {

--- a/enterprise/server/routes/service.py
+++ b/enterprise/server/routes/service.py
@@ -13,6 +13,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Header, HTTPException, status
 from pydantic import BaseModel, field_validator
+from server.auth.authorization import RoleName, make_role_cap_scope
 from storage.api_key_store import ApiKeyStore
 from storage.org_member_store import OrgMemberStore
 from storage.user_store import UserStore
@@ -22,6 +23,14 @@ from openhands.app_server.utils.logger import openhands_logger as logger
 # Environment variable for the service API key
 AUTOMATIONS_SERVICE_KEY = os.getenv('AUTOMATIONS_SERVICE_KEY', '').strip()
 
+# Default role cap for keys minted through this internal service endpoint.
+# Automation runs should act with org *member* privileges, not the (possibly
+# org-owner) minting user's full authority — so a leaked or misbehaving
+# automation key cannot manage members, billing, org settings, or org claims.
+# Callers may override via the request ``role`` field (including ``null`` for an
+# uncapped key) but can never exceed the user's real org role.
+DEFAULT_SERVICE_KEY_ROLE = RoleName.MEMBER.value
+
 service_router = APIRouter(prefix='/api/service', tags=['Service'])
 
 
@@ -29,6 +38,11 @@ class CreateUserApiKeyRequest(BaseModel):
     """Request model for creating an API key on behalf of a user."""
 
     name: str  # Required - used to identify the key
+    # Role to cap the minted key to. Defaults to ``member`` (least privilege for
+    # automations). Pass an explicit ``null`` to mint an uncapped key. The cap
+    # only ever *reduces* privilege — it can never grant more than the user's
+    # actual org role.
+    role: str | None = DEFAULT_SERVICE_KEY_ROLE
 
     @field_validator('name')
     @classmethod
@@ -36,6 +50,17 @@ class CreateUserApiKeyRequest(BaseModel):
         if not v or not v.strip():
             raise ValueError('name is required and cannot be empty')
         return v.strip()
+
+    @field_validator('role')
+    @classmethod
+    def validate_role(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        v = v.strip()
+        valid = {r.value for r in RoleName}
+        if v not in valid:
+            raise ValueError(f'role must be one of {sorted(valid)} or null')
+        return v
 
 
 class CreateUserApiKeyResponse(BaseModel):
@@ -45,6 +70,9 @@ class CreateUserApiKeyResponse(BaseModel):
     user_id: str
     org_id: str
     name: str
+    # Effective role cap applied to the key (``None`` if uncapped). Lets the
+    # caller confirm the reduced-privilege level it actually received.
+    role: str | None = None
 
 
 class ServiceInfoResponse(BaseModel):
@@ -170,14 +198,19 @@ async def get_or_create_api_key_for_user(
             detail=f'User {user_id} is not a member of org {org_id}',
         )
 
-    # Get or create the system API key
+    # Get or create the system API key. By default the key is capped to the
+    # ``member`` role so automation runs never inherit the minting user's
+    # owner/admin authority (the reduced-privilege guarantee). A ``null`` role
+    # mints an uncapped key.
     api_key_store = ApiKeyStore.get_instance()
+    scopes = [make_role_cap_scope(request.role)] if request.role else None
 
     try:
         api_key = await api_key_store.get_or_create_system_api_key(
             user_id=user_id,
             org_id=org_id,
             name=request.name,
+            scopes=scopes,
         )
     except Exception as e:
         logger.exception(
@@ -208,6 +241,7 @@ async def get_or_create_api_key_for_user(
         user_id=user_id,
         org_id=str(org_id),
         name=request.name,
+        role=request.role,
     )
 
 

--- a/enterprise/storage/api_key_store.py
+++ b/enterprise/storage/api_key_store.py
@@ -99,6 +99,29 @@ class ApiKeyStore:
         scopes = list(result.scalars().all())
         return scopes if scopes else [FULL_SCOPE]
 
+    @staticmethod
+    async def _ensure_scope_rows(
+        session: AsyncSession, api_key_id: int, scopes: list[str]
+    ) -> None:
+        """Idempotently add any missing scope rows to an existing key.
+
+        Additive only — it never removes scopes a key already has. This lets an
+        internal caller *tighten* an already-existing system key by attaching a
+        scope (e.g. a ``openhands:role:member`` cap) so the reduced-privilege
+        guarantee also covers keys minted before scopes existed. Enforcement
+        combines role-cap scopes to the least-privileged one, so adding a cap can
+        only narrow, never widen, the key's effective role.
+        """
+        if not scopes:
+            return
+        result = await session.execute(
+            select(ApiKeyScope.scope).filter(ApiKeyScope.api_key_id == api_key_id)
+        )
+        existing = set(result.scalars().all())
+        for scope in scopes:
+            if scope not in existing:
+                session.add(ApiKeyScope(api_key_id=api_key_id, scope=scope))
+
     async def create_api_key(
         self,
         user_id: str,
@@ -176,10 +199,13 @@ class ApiKeyStore:
             user_id: The ID of the user to create the key for
             org_id: The organization ID to associate the key with
             name: Required name for the key (will be prefixed with __SYSTEM__:)
-            scopes: Optional opaque, namespaced scope strings attached only when
-                a *new* key is minted. Omitted/empty means the implicit ``full``
-                scope (no behavior change). Scopes of an already-existing,
-                non-expired key are left untouched.
+            scopes: Optional opaque, namespaced scope strings. For a *new* key
+                they are attached at creation. For an already-existing,
+                non-expired key they are reconciled **additively** (missing rows
+                are added; nothing is removed) so an internal caller can tighten
+                an existing key — e.g. attach a ``openhands:role:member`` cap.
+                Omitted/empty means the implicit ``full`` scope (no behavior
+                change).
 
         Returns:
             The API key (existing or newly created)
@@ -220,7 +246,8 @@ class ApiKeyStore:
                         await session.delete(existing_key)
                         await session.commit()
                     else:
-                        # Key exists and is not expired, return it
+                        # Key exists and is not expired, return it (tightening
+                        # any requested scopes onto it first).
                         logger.debug(
                             'Returning existing system API key',
                             extra={
@@ -229,9 +256,14 @@ class ApiKeyStore:
                                 'key_name': system_key_name,
                             },
                         )
+                        await self._ensure_scope_rows(
+                            session, existing_key.id, normalized_scopes
+                        )
+                        await session.commit()
                         return existing_key.key
                 else:
-                    # Key exists and has no expiration, return it
+                    # Key exists and has no expiration, return it (tightening
+                    # any requested scopes onto it first).
                     logger.debug(
                         'Returning existing system API key',
                         extra={
@@ -240,6 +272,10 @@ class ApiKeyStore:
                             'key_name': system_key_name,
                         },
                     )
+                    await self._ensure_scope_rows(
+                        session, existing_key.id, normalized_scopes
+                    )
+                    await session.commit()
                     return existing_key.key
 
         # Create new key (no expiration)

--- a/enterprise/tests/unit/routes/test_service.py
+++ b/enterprise/tests/unit/routes/test_service.py
@@ -60,6 +60,26 @@ class TestCreateUserApiKeyRequest:
             name='automation',
         )
         assert request.name == 'automation'
+        # Defaults to the least-privileged ``member`` role cap.
+        assert request.role == 'member'
+
+    def test_role_defaults_to_member(self):
+        """Role defaults to member when omitted."""
+        assert CreateUserApiKeyRequest(name='automation').role == 'member'
+
+    def test_role_can_be_overridden(self):
+        """A valid role override is accepted and normalized."""
+        assert CreateUserApiKeyRequest(name='a', role='admin').role == 'admin'
+        assert CreateUserApiKeyRequest(name='a', role='  owner ').role == 'owner'
+
+    def test_role_can_be_null_for_uncapped_key(self):
+        """An explicit null role mints an uncapped key."""
+        assert CreateUserApiKeyRequest(name='a', role=None).role is None
+
+    def test_invalid_role_fails(self):
+        """An unrecognized role value is rejected."""
+        with pytest.raises(ValueError):
+            CreateUserApiKeyRequest(name='a', role='superuser')
 
     def test_name_is_required(self):
         """Test that name field is required."""
@@ -184,12 +204,57 @@ class TestGetOrCreateApiKeyForUser:
         assert response.user_id == valid_user_id
         assert response.org_id == str(valid_org_id)
         assert response.name == 'automation'
+        # Defaults to a member-capped key (least privilege for automations).
+        assert response.role == 'member'
 
-        # Verify the store was called with correct arguments
+        # Verify the store was called with correct arguments, including the
+        # default ``member`` role cap expressed as a reserved scope.
         mock_api_key_store.get_or_create_system_api_key.assert_called_once_with(
             user_id=valid_user_id,
             org_id=valid_org_id,
             name='automation',
+            scopes=['openhands:role:member'],
+        )
+
+    @pytest.mark.asyncio
+    async def test_null_role_mints_uncapped_key(self, valid_user_id, valid_org_id):
+        """An explicit null role passes no scopes (uncapped, full key)."""
+        mock_user = MagicMock()
+        mock_org_member = MagicMock()
+        mock_api_key_store = MagicMock()
+        mock_api_key_store.get_or_create_system_api_key = AsyncMock(
+            return_value='sk-oh-uncapped'
+        )
+        request = CreateUserApiKeyRequest(name='automation', role=None)
+
+        with patch('server.routes.service.AUTOMATIONS_SERVICE_KEY', 'test-key'):
+            with patch(
+                'server.routes.service.UserStore.get_user_by_id', new_callable=AsyncMock
+            ) as mock_get_user:
+                with patch(
+                    'server.routes.service.OrgMemberStore.get_org_member',
+                    new_callable=AsyncMock,
+                ) as mock_get_member:
+                    with patch(
+                        'server.routes.service.ApiKeyStore.get_instance'
+                    ) as mock_get_store:
+                        mock_get_user.return_value = mock_user
+                        mock_get_member.return_value = mock_org_member
+                        mock_get_store.return_value = mock_api_key_store
+
+                        response = await get_or_create_api_key_for_user(
+                            user_id=valid_user_id,
+                            org_id=valid_org_id,
+                            request=request,
+                            x_service_api_key='test-key',
+                        )
+
+        assert response.role is None
+        mock_api_key_store.get_or_create_system_api_key.assert_called_once_with(
+            user_id=valid_user_id,
+            org_id=valid_org_id,
+            name='automation',
+            scopes=None,
         )
 
     @pytest.mark.asyncio

--- a/enterprise/tests/unit/test_authorization.py
+++ b/enterprise/tests/unit/test_authorization.py
@@ -10,14 +10,20 @@ from uuid import uuid4
 import pytest
 from fastapi import HTTPException
 from server.auth.authorization import (
+    ROLE_CAP_SCOPE_PREFIX,
     ROLE_PERMISSIONS,
     Permission,
     RoleName,
+    apply_role_cap,
+    effective_role_permissions,
     get_api_key_org_id_from_request,
     get_role_permissions,
     get_user_org_role,
     has_permission,
+    has_permission_for_role,
+    make_role_cap_scope,
     require_permission,
+    role_cap_from_scopes,
 )
 
 # =============================================================================
@@ -449,11 +455,14 @@ class TestGetUserOrgRole:
 # =============================================================================
 
 
-def _create_mock_request(api_key_org_id=None):
-    """Helper to create a mock request with optional api_key_org_id."""
+def _create_mock_request(api_key_org_id=None, api_key_scopes=None):
+    """Helper to create a mock request with optional api_key_org_id/scopes."""
     mock_request = MagicMock()
     mock_user_auth = MagicMock()
     mock_user_auth.get_api_key_org_id.return_value = api_key_org_id
+    # Default to None (uncapped / non-API-key auth) so existing tests keep their
+    # behavior; the role-cap tests pass an explicit scope list.
+    mock_user_auth.get_api_key_scopes.return_value = api_key_scopes
     mock_request.state.user_auth = mock_user_auth
     return mock_request
 
@@ -1019,12 +1028,16 @@ class TestGetApiKeyOrgIdFromRequest:
 # =============================================================================
 
 
-def _create_mock_request_with_email(api_key_org_id=None, user_email='user@example.com'):
+def _create_mock_request_with_email(
+    api_key_org_id=None, user_email='user@example.com', api_key_scopes=None
+):
     """Helper to create a mock request with optional api_key_org_id and email."""
     mock_request = MagicMock()
     mock_user_auth = MagicMock()
     # get_api_key_org_id is sync, not async
     mock_user_auth.get_api_key_org_id.return_value = api_key_org_id
+    # get_api_key_scopes is sync; default None (cookie / uncapped auth)
+    mock_user_auth.get_api_key_scopes.return_value = api_key_scopes
     # get_user_email is async
     mock_user_auth.get_user_email = AsyncMock(return_value=user_email)
     mock_request.state.user_auth = mock_user_auth
@@ -1243,3 +1256,164 @@ class TestRequireFinancialDataAccess:
 
         assert exc_info.value.status_code == 403
         assert 'API key is not authorized' in exc_info.value.detail
+
+
+# =============================================================================
+# Tests for the API-key role-cap mechanism (Phase 2 of #14912)
+# =============================================================================
+
+
+class TestRoleCapHelpers:
+    """Unit tests for the role-cap scope helpers."""
+
+    def test_make_role_cap_scope(self):
+        assert make_role_cap_scope('member') == f'{ROLE_CAP_SCOPE_PREFIX}member'
+        assert make_role_cap_scope('owner') == 'openhands:role:owner'
+
+    def test_role_cap_from_scopes_none_or_empty(self):
+        assert role_cap_from_scopes(None) is None
+        assert role_cap_from_scopes([]) is None
+
+    def test_role_cap_from_scopes_ignores_non_role_scopes(self):
+        assert role_cap_from_scopes(['full', 'automation:kv:read:org']) is None
+
+    def test_role_cap_from_scopes_extracts_role(self):
+        assert role_cap_from_scopes([make_role_cap_scope('member')]) == 'member'
+
+    def test_role_cap_from_scopes_picks_least_privileged(self):
+        scopes = [make_role_cap_scope('owner'), make_role_cap_scope('member')]
+        assert role_cap_from_scopes(scopes) == 'member'
+
+    def test_apply_role_cap_uncapped_returns_actual(self):
+        assert apply_role_cap('owner', None) == 'owner'
+        assert apply_role_cap('owner', ['automation:kv:read:org']) == 'owner'
+
+    def test_apply_role_cap_reduces_owner_to_member(self):
+        assert apply_role_cap('owner', [make_role_cap_scope('member')]) == 'member'
+
+    def test_apply_role_cap_never_escalates(self):
+        assert apply_role_cap('member', [make_role_cap_scope('owner')]) == 'member'
+
+    def test_apply_role_cap_none_role(self):
+        assert apply_role_cap(None, [make_role_cap_scope('member')]) is None
+
+    def test_effective_role_permissions_capped(self):
+        capped = effective_role_permissions('owner', [make_role_cap_scope('member')])
+        assert capped == ROLE_PERMISSIONS[RoleName.MEMBER]
+        assert Permission.DELETE_ORGANIZATION not in capped
+        assert Permission.VIEW_BILLING not in capped
+        assert Permission.MANAGE_SECRETS in capped
+
+    def test_has_permission_for_role(self):
+        assert has_permission_for_role('owner', Permission.DELETE_ORGANIZATION)
+        assert not has_permission_for_role('member', Permission.DELETE_ORGANIZATION)
+        assert not has_permission_for_role(None, Permission.MANAGE_SECRETS)
+
+
+class TestRequirePermissionRoleCap:
+    """require_permission honors the API-key role cap."""
+
+    @pytest.mark.asyncio
+    async def test_member_capped_key_denied_owner_only_permission(self):
+        user_id = str(uuid4())
+        org_id = uuid4()
+        mock_request = _create_mock_request(
+            api_key_scopes=[make_role_cap_scope('member')]
+        )
+        owner_role = MagicMock()
+        owner_role.name = 'owner'
+        with patch(
+            'server.auth.authorization.get_user_org_role',
+            AsyncMock(return_value=owner_role),
+        ):
+            permission_checker = require_permission(Permission.DELETE_ORGANIZATION)
+            with pytest.raises(HTTPException) as exc_info:
+                await permission_checker(
+                    request=mock_request, org_id=org_id, user_id=user_id
+                )
+            assert exc_info.value.status_code == 403
+            assert 'delete_organization' in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_member_capped_key_allowed_member_permission(self):
+        user_id = str(uuid4())
+        org_id = uuid4()
+        mock_request = _create_mock_request(
+            api_key_scopes=[make_role_cap_scope('member')]
+        )
+        owner_role = MagicMock()
+        owner_role.name = 'owner'
+        with patch(
+            'server.auth.authorization.get_user_org_role',
+            AsyncMock(return_value=owner_role),
+        ):
+            permission_checker = require_permission(Permission.MANAGE_SECRETS)
+            result = await permission_checker(
+                request=mock_request, org_id=org_id, user_id=user_id
+            )
+            assert result == user_id
+
+    @pytest.mark.asyncio
+    async def test_uncapped_owner_key_allowed_owner_permission(self):
+        user_id = str(uuid4())
+        org_id = uuid4()
+        mock_request = _create_mock_request(api_key_scopes=['full'])
+        owner_role = MagicMock()
+        owner_role.name = 'owner'
+        with patch(
+            'server.auth.authorization.get_user_org_role',
+            AsyncMock(return_value=owner_role),
+        ):
+            permission_checker = require_permission(Permission.DELETE_ORGANIZATION)
+            result = await permission_checker(
+                request=mock_request, org_id=org_id, user_id=user_id
+            )
+            assert result == user_id
+
+
+class TestRequireFinancialDataAccessRoleCap:
+    """require_financial_data_access honors the API-key role cap."""
+
+    @pytest.mark.asyncio
+    async def test_member_capped_key_denied_even_for_owner(self):
+        from server.auth.authorization import require_financial_data_access
+
+        user_id = str(uuid4())
+        org_id = uuid4()
+        mock_request = _create_mock_request_with_email(
+            user_email='user@company.com',
+            api_key_scopes=[make_role_cap_scope('member')],
+        )
+        owner_role = MagicMock()
+        owner_role.name = 'owner'
+        with patch(
+            'server.auth.authorization.get_user_org_role',
+            AsyncMock(return_value=owner_role),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await require_financial_data_access(
+                    request=mock_request, org_id=org_id, user_id=user_id
+                )
+            assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_member_capped_key_denied_even_with_openhands_email(self):
+        from server.auth.authorization import require_financial_data_access
+
+        user_id = str(uuid4())
+        org_id = uuid4()
+        mock_request = _create_mock_request_with_email(
+            user_email='admin@openhands.dev',
+            api_key_scopes=[make_role_cap_scope('member')],
+        )
+        member_role = MagicMock()
+        member_role.name = 'member'
+        with patch(
+            'server.auth.authorization.get_user_org_role',
+            AsyncMock(return_value=member_role),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await require_financial_data_access(
+                    request=mock_request, org_id=org_id, user_id=user_id
+                )
+            assert exc_info.value.status_code == 403

--- a/enterprise/tests/unit/test_saas_user_auth.py
+++ b/enterprise/tests/unit/test_saas_user_auth.py
@@ -1316,3 +1316,82 @@ class TestOpenHandsApiKey:
             assert result is not None
             assert 'OPENHANDS_API_KEY' in result.custom_secrets
             assert len(result.custom_secrets) == 1
+
+
+class TestGetOrgInfoRoleCap:
+    """get_org_info caps reported role/permissions to the API key's scope."""
+
+    @pytest.mark.asyncio
+    async def test_member_capped_key_reports_member_permissions_for_owner(self):
+        """An owner authenticating with a member-capped key reports member perms."""
+        from server.auth.authorization import ROLE_PERMISSIONS, RoleName
+
+        org_id = uuid.uuid4()
+        user_auth = SaasUserAuth(
+            user_id='owner-user',
+            refresh_token=SecretStr('refresh_token'),
+            api_key_scopes=['openhands:role:member'],
+        )
+        user_auth.get_effective_org_id = AsyncMock(return_value=org_id)
+
+        mock_org = MagicMock()
+        mock_org.name = 'Acme'
+        owner_role = MagicMock()
+        owner_role.name = 'owner'
+
+        with (
+            patch(
+                'server.auth.saas_user_auth.OrgStore.get_org_by_id',
+                AsyncMock(return_value=mock_org),
+            ),
+            patch(
+                'server.auth.saas_user_auth.get_user_org_role',
+                AsyncMock(return_value=owner_role),
+            ),
+        ):
+            info = await user_auth.get_org_info()
+
+        assert info is not None
+        # Reported role and permissions are capped to member.
+        assert info['role'] == 'member'
+        expected = {p.value for p in ROLE_PERMISSIONS[RoleName.MEMBER]}
+        assert set(info['permissions']) == expected
+        # Owner-only permissions are absent.
+        assert 'delete_organization' not in info['permissions']
+        assert 'view_billing' not in info['permissions']
+
+    @pytest.mark.asyncio
+    async def test_uncapped_owner_key_reports_owner_permissions(self):
+        """Without a cap, an owner key reports full owner perms (no change)."""
+        from server.auth.authorization import ROLE_PERMISSIONS, RoleName
+
+        org_id = uuid.uuid4()
+        user_auth = SaasUserAuth(
+            user_id='owner-user',
+            refresh_token=SecretStr('refresh_token'),
+            api_key_scopes=['full'],
+        )
+        user_auth.get_effective_org_id = AsyncMock(return_value=org_id)
+
+        mock_org = MagicMock()
+        mock_org.name = 'Acme'
+        owner_role = MagicMock()
+        owner_role.name = 'owner'
+
+        with (
+            patch(
+                'server.auth.saas_user_auth.OrgStore.get_org_by_id',
+                AsyncMock(return_value=mock_org),
+            ),
+            patch(
+                'server.auth.saas_user_auth.get_user_org_role',
+                AsyncMock(return_value=owner_role),
+            ),
+        ):
+            info = await user_auth.get_org_info()
+
+        assert info is not None
+        assert info['role'] == 'owner'
+        expected = {p.value for p in ROLE_PERMISSIONS[RoleName.OWNER]}
+        assert set(info['permissions']) == expected
+        assert 'delete_organization' in info['permissions']


### PR DESCRIPTION
## Summary

Implements **Phase 2** of OpenHands/enterprise#38, **stacked on Phase 1** (#14913, branch `scoped-api-credentials-foundation` — this PR targets that branch, not `main`).

Phase 1 gave API keys an opaque, namespaced `scopes` list but enforced nothing. Phase 2 uses that foundation to fix the **most immediate over‑privilege problem**: an API key minted for an **OpenHands automation run** today inherits the *minting user's full org authority*. When that user is an **org owner**, the automation can do anything the owner can — manage members, billing, org settings, org claims — even though it only needs member‑level access. This PR caps those keys to **org member** by default.

## The fix: a role‑cap scope tied to the existing role/permission system

Today permissions come purely from the user's **org role** (`require_permission` → `get_user_org_role` → `ROLE_PERMISSIONS`; same for `/api/v1/users/me`); the API key plays no part. We introduce a reserved, **OpenHands‑interpreted** scope:

```
openhands:role:<role>     e.g. openhands:role:member
```

A request authenticated by a key carrying this scope has its **effective role capped** to the *lesser* of (the user's real role, the cap). Capping can **only reduce** privilege — requesting a cap above your real role is a no‑op — so there is **no escalation path**. Unlike third‑party scopes (which OpenHands stores opaquely and never interprets), the `openhands:` namespace is reserved and interpreted by OpenHands itself, consistent with the existing reserved `full` sentinel.

`member` vs `owner` is exactly the blast‑radius reduction the issue describes: a capped key keeps member capabilities (secrets, MCP, integrations, app settings, manage automations, view settings) but loses owner/admin‑only powers (billing/credits, member management, org rename/delete, org‑claim management, financial data).

## What changed

- **`server/auth/authorization.py`**
  - Role privilege ordering + `ROLE_CAP_SCOPE_PREFIX` / `make_role_cap_scope` / `role_cap_from_scopes` / `apply_role_cap` / `effective_role_permissions` / `has_permission_for_role` / `get_api_key_scopes_from_request`.
  - `require_permission` checks the **capped** effective role.
  - `require_financial_data_access` honors the cap **and** suppresses the `@openhands.dev` email bypass for capped keys.
- **`server/auth/saas_user_auth.py`** — `get_org_info` caps the `role`/`permissions` returned by `/api/v1/users/me`, so validating a reduced key no longer reports the owner's full permission set (the exact symptom called out in the issue).
- **`server/routes/service.py`** — the automations‑only service endpoint (`POST /api/service/users/{user_id}/orgs/{org_id}/api-keys`, used by the automation service to mint the key injected into a run) now **defaults to a `member` cap**, accepts an optional `role` (any valid role, or `null` to mint an uncapped key — never exceeds the user's real role), and echoes the effective `role` in the response.
- **`storage/api_key_store.py`** — `get_or_create_system_api_key` now **idempotently, additively** reconciles requested scopes onto an *already‑existing* system key, so the cap also covers automation keys minted before scopes existed. Additive‑only means it can tighten but never broaden a key.

## Behavior change to flag

Keys minted through the automations service endpoint now default to **member**. This is intentional least‑privilege for automations. Automations that genuinely need more can pass an explicit higher `role` (or `null`). Because OpenHands core auth doesn't *enforce* opaque third‑party scopes, this only affects role‑based permission checks — and capping strictly removes privilege, so it cannot break a flow that was already within member scope.

## Testing

- `authorization`: cap parsing/least‑privileged combination/no‑escalation; `require_permission` denies owner‑only perms but allows member perms for a member‑capped owner key; uncapped key unchanged; `require_financial_data_access` denied for a member‑capped owner key and for an `@openhands.dev` user with a capped key.
- `saas_user_auth`: `/users/me` reports member perms for a member‑capped owner; full owner perms when uncapped.
- `service`: request defaults to `member`, override + `null` accepted, invalid role rejected; endpoint passes the right scopes and echoes the role.
- Full affected suites pass locally: `test_authorization.py` (70), `test_service.py` (21), `test_saas_user_auth.py` (52), `test_api_key_store.py` (27) → **170 passed**. `ruff check` + `ruff format` clean.

## Follow‑ups (not in this PR)
- Phase 3: scope manifest (`/.well-known/openhands-scopes`) + generic consent UI + `min_role_rank` grant‑time gate.
- Update the automation service (separate repo) to surface/choose the role cap explicitly if desired; the default already secures runs without changes there.

Related: OpenHands/enterprise#38 · Stacked on OpenHands/OpenHands#14913

---
_This PR was created by an AI agent (OpenHands) on behalf of the maintainer._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e7e2f1a0-6c3d-4b26-884d-1fbf3966f131)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-051984a   docker.openhands.dev/openhands/openhands:051984a
```