### PR TITLE
fix: Forgejo/Gitea clone failure when hosted under a subpath

### DIFF
--- a/openhands/app_server/integrations/provider.py
+++ b/openhands/app_server/integrations/provider.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 from collections.abc import Mapping
 from types import MappingProxyType
 from typing import cast
@@ -543,9 +544,10 @@ class ProviderHandler:
         if domain:
             domain = domain.strip()
             domain = domain.replace('https://', '').replace('http://', '')
-            # Remove any trailing path like /api/v3 or /api/v4
-            if '/' in domain:
-                domain = domain.split('/')[0]
+            # Strip a trailing API path (e.g. /api/v3) but preserve any subpath
+            # that is part of the repo URL (e.g. Forgejo under myserver/forgejo).
+            domain = re.sub(r'/api/(?:v\d+|graphql)/?$', '', domain)
+            domain = domain.rstrip('/')
 
         # Try to use token if available, otherwise use public URL
         if self.provider_tokens and provider in self.provider_tokens:

--- a/tests/unit/integrations/test_provider_immutability.py
+++ b/tests/unit/integrations/test_provider_immutability.py
@@ -256,6 +256,54 @@ async def test_azure_devops_pat_git_url_uses_basic_auth():
 
 
 @pytest.mark.asyncio
+async def test_forgejo_subpath_preserved_in_git_url():
+    """A Forgejo/Gitea host under a subpath keeps the subpath in the clone URL."""
+    tokens = MappingProxyType(
+        {
+            ProviderType.FORGEJO: ProviderToken(
+                token=SecretStr('forgejo-token'),
+                host='https://myserver/forgejo',
+            )
+        }
+    )
+    handler = ProviderHandler(provider_tokens=tokens)
+
+    with patch.object(handler, 'verify_repo_provider') as mock_verify:
+        mock_verify.return_value.git_provider = ProviderType.FORGEJO
+        mock_verify.return_value.full_name = 'username/reponame'
+
+        remote_url = await handler.get_authenticated_git_url('username/reponame')
+
+    assert remote_url == (
+        'https://forgejo-token@myserver/forgejo/username/reponame.git'
+    )
+
+
+@pytest.mark.asyncio
+async def test_forgejo_host_api_suffix_stripped():
+    """A host entered with a trailing API path still has that suffix stripped."""
+    tokens = MappingProxyType(
+        {
+            ProviderType.FORGEJO: ProviderToken(
+                token=SecretStr('forgejo-token'),
+                host='https://myserver/forgejo/api/v1',
+            )
+        }
+    )
+    handler = ProviderHandler(provider_tokens=tokens)
+
+    with patch.object(handler, 'verify_repo_provider') as mock_verify:
+        mock_verify.return_value.git_provider = ProviderType.FORGEJO
+        mock_verify.return_value.full_name = 'username/reponame'
+
+        remote_url = await handler.get_authenticated_git_url('username/reponame')
+
+    assert remote_url == (
+        'https://forgejo-token@myserver/forgejo/username/reponame.git'
+    )
+
+
+@pytest.mark.asyncio
 async def test_get_github_organizations_delegates_to_service():
     """Test that get_github_organizations calls get_organizations_from_installations on the GitHub service."""
     tokens = MappingProxyType(


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

Fix for Forgejo/Gitea subpath clone.

- [x] A human has tested these changes.

AGENT:

---

## Why

Forgejo/Gitea instances served under a subpath (e.g. `https://myserver/forgejo`) failed to clone. `get_authenticated_git_url()` normalized the host with `domain.split('/')[0]`, dropping the `/forgejo` subpath and producing a malformed URL (`https://<token>@myserver/owner/repo.git`), causing a silent `repository ... not found` clone failure. The strip was meant to drop an accidental API path, but for Forgejo/Gitea the subpath is part of both the API and git URL.

## Summary

- `provider.py`: strip only a trailing API suffix (`/api/v3`, `/api/v4`, `/api/v1`, `/api/graphql`) instead of everything after the first `/`, preserving genuine subpaths.
- Added two regression tests covering a subpath host and a subpath+API-suffix host.

## Issue Number

Fixes #14927

## How to Test

`poetry run python -m pytest tests/unit/integrations/test_provider_immutability.py -k forgejo`

Both new tests assert the clone URL for a `forgejo` token with `host=https://myserver/forgejo` keeps the subpath: `https://<token>@myserver/forgejo/username/reponame.git`.

## Video/Screenshots

N/A — backend URL-construction fix covered by unit tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Out of scope: the issue also asks that a failed clone surface an error in the UI rather than failing silently. That's a separate subsystem (error propagation from the runtime's git clone) and is not addressed here.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-e1c8462   docker.openhands.dev/openhands/openhands:e1c8462
```