### PR TITLE
fix: self-heal stale LiteLLM user on re-onboarding

### DIFF
--- a/enterprise/storage/lite_llm_manager.py
+++ b/enterprise/storage/lite_llm_manager.py
@@ -200,19 +200,28 @@ class LiteLlmManager:
                 )
 
                 if create_user:
-                    # create_user is reached only when onboarding a brand-new
-                    # OpenHands user, so a pre-existing LiteLLM record here is a
-                    # stale orphan from a prior teardown (e.g. an account reset
-                    # that dropped the user + org team but left the LiteLLM user).
-                    # Reset it so _create_user rebuilds a clean record instead of
-                    # re-attaching an inconsistent one LiteLLM later fails to
-                    # deserialize — same multi-install trade-off as the key reset.
+                    # create_user is True only when no OpenHands User row exists,
+                    # so a pre-existing LiteLLM record under this id is a stale
+                    # orphan (e.g. from an account reset). Reset it so _create_user
+                    # rebuilds a clean record rather than re-attaching it. Best-
+                    # effort: a failed reset must not block onboarding — _create_user
+                    # below still tolerates a surviving record (409).
                     if await LiteLlmManager._user_exists(client, keycloak_user_id):
                         logger.info(
                             'LiteLlmManager:create_entries:reset_stale_litellm_user',
                             extra={'org_id': org_id, 'user_id': keycloak_user_id},
                         )
-                        await LiteLlmManager._delete_user(client, keycloak_user_id)
+                        try:
+                            await LiteLlmManager._delete_user(client, keycloak_user_id)
+                        except Exception as exc:
+                            logger.warning(
+                                'LiteLlmManager:create_entries:reset_stale_litellm_user_failed',
+                                extra={
+                                    'org_id': org_id,
+                                    'user_id': keycloak_user_id,
+                                    'error': str(exc),
+                                },
+                            )
 
                     user_created = await LiteLlmManager._create_user(
                         client, keycloak_user_info.get('email'), keycloak_user_id

--- a/enterprise/storage/lite_llm_manager.py
+++ b/enterprise/storage/lite_llm_manager.py
@@ -200,6 +200,20 @@ class LiteLlmManager:
                 )
 
                 if create_user:
+                    # create_user is reached only when onboarding a brand-new
+                    # OpenHands user, so a pre-existing LiteLLM record here is a
+                    # stale orphan from a prior teardown (e.g. an account reset
+                    # that dropped the user + org team but left the LiteLLM user).
+                    # Reset it so _create_user rebuilds a clean record instead of
+                    # re-attaching an inconsistent one LiteLLM later fails to
+                    # deserialize — same multi-install trade-off as the key reset.
+                    if await LiteLlmManager._user_exists(client, keycloak_user_id):
+                        logger.info(
+                            'LiteLlmManager:create_entries:reset_stale_litellm_user',
+                            extra={'org_id': org_id, 'user_id': keycloak_user_id},
+                        )
+                        await LiteLlmManager._delete_user(client, keycloak_user_id)
+
                     user_created = await LiteLlmManager._create_user(
                         client, keycloak_user_info.get('email'), keycloak_user_id
                     )
@@ -1049,6 +1063,13 @@ class LiteLlmManager:
         )
 
         if not response.is_success:
+            if response.status_code == 404:
+                # User doesn't exist - delete is idempotent (mirrors _delete_team).
+                logger.info(
+                    'LiteLlmManager:_delete_user:already_deleted_or_missing',
+                    extra={'user_id': keycloak_user_id},
+                )
+                return
             logger.error(
                 'error_deleting_litellm_user',
                 extra={

--- a/enterprise/tests/unit/test_lite_llm_manager.py
+++ b/enterprise/tests/unit/test_lite_llm_manager.py
@@ -620,6 +620,146 @@ class TestLiteLlmManager:
             assert exc_info.value.response.status_code == 500
 
     @pytest.mark.asyncio
+    async def test_create_entries_resets_stale_litellm_user(self, mock_settings):
+        """Onboarding a brand-new user must reset a pre-existing LiteLLM record.
+
+        A surviving LiteLLM user under the same id is a stale orphan from a
+        prior teardown (e.g. an account reset), so create_entries deletes it
+        before _create_user rebuilds a clean record.
+        """
+        mock_token_manager = MagicMock()
+        mock_token_manager.return_value.get_user_info_from_user_id = AsyncMock(
+            return_value={'email': 'test@example.com'}
+        )
+
+        mock_client = AsyncMock()
+        mock_client_class = MagicMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        with (
+            patch.dict(os.environ, {'LOCAL_DEPLOYMENT': ''}),
+            patch('storage.lite_llm_manager.LITE_LLM_API_KEY', 'test-key'),
+            patch('storage.lite_llm_manager.LITE_LLM_API_URL', 'http://test.com'),
+            patch('storage.lite_llm_manager.TokenManager', mock_token_manager),
+            patch('httpx.AsyncClient', mock_client_class),
+            patch.object(LiteLlmManager, '_get_team', new=AsyncMock(return_value=None)),
+            patch.object(LiteLlmManager, '_create_team', new=AsyncMock()),
+            patch.object(
+                LiteLlmManager,
+                '_team_alias_for_org',
+                new=AsyncMock(return_value='Personal Workspace'),
+            ),
+            # Pre-check sees the orphan; post-create verify sees the clean user.
+            patch.object(
+                LiteLlmManager, '_user_exists', new=AsyncMock(return_value=True)
+            ),
+            patch.object(LiteLlmManager, '_delete_user', new=AsyncMock()) as mock_del,
+            patch.object(
+                LiteLlmManager, '_create_user', new=AsyncMock(return_value=True)
+            ) as mock_create,
+            patch.object(LiteLlmManager, '_add_user_to_team', new=AsyncMock()),
+            patch.object(LiteLlmManager, '_delete_key_by_alias', new=AsyncMock()),
+            patch.object(
+                LiteLlmManager, '_generate_key', new=AsyncMock(return_value='new-key')
+            ),
+        ):
+            result = await LiteLlmManager.create_entries(
+                'test-user-id', 'test-user-id', mock_settings, create_user=True
+            )
+
+        assert result is not None
+        mock_del.assert_awaited_once_with(mock_client, 'test-user-id')
+        mock_create.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_create_entries_skips_reset_for_fresh_litellm_user(
+        self, mock_settings
+    ):
+        """A genuinely new user (no LiteLLM record) is created without a delete."""
+        mock_token_manager = MagicMock()
+        mock_token_manager.return_value.get_user_info_from_user_id = AsyncMock(
+            return_value={'email': 'test@example.com'}
+        )
+
+        mock_client = AsyncMock()
+        mock_client_class = MagicMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        with (
+            patch.dict(os.environ, {'LOCAL_DEPLOYMENT': ''}),
+            patch('storage.lite_llm_manager.LITE_LLM_API_KEY', 'test-key'),
+            patch('storage.lite_llm_manager.LITE_LLM_API_URL', 'http://test.com'),
+            patch('storage.lite_llm_manager.TokenManager', mock_token_manager),
+            patch('httpx.AsyncClient', mock_client_class),
+            patch.object(LiteLlmManager, '_get_team', new=AsyncMock(return_value=None)),
+            patch.object(LiteLlmManager, '_create_team', new=AsyncMock()),
+            patch.object(
+                LiteLlmManager,
+                '_team_alias_for_org',
+                new=AsyncMock(return_value='Personal Workspace'),
+            ),
+            # Pre-check: absent; post-create verify: present.
+            patch.object(
+                LiteLlmManager,
+                '_user_exists',
+                new=AsyncMock(side_effect=[False, True]),
+            ),
+            patch.object(LiteLlmManager, '_delete_user', new=AsyncMock()) as mock_del,
+            patch.object(
+                LiteLlmManager, '_create_user', new=AsyncMock(return_value=True)
+            ) as mock_create,
+            patch.object(LiteLlmManager, '_add_user_to_team', new=AsyncMock()),
+            patch.object(LiteLlmManager, '_delete_key_by_alias', new=AsyncMock()),
+            patch.object(
+                LiteLlmManager, '_generate_key', new=AsyncMock(return_value='new-key')
+            ),
+        ):
+            result = await LiteLlmManager.create_entries(
+                'test-user-id', 'test-user-id', mock_settings, create_user=True
+            )
+
+        assert result is not None
+        mock_del.assert_not_awaited()
+        mock_create.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch('storage.lite_llm_manager.LITE_LLM_API_URL', 'http://test.com')
+    @patch('storage.lite_llm_manager.LITE_LLM_API_KEY', 'test-key')
+    async def test_delete_user_idempotent_on_404(self, mock_http_client):
+        """_delete_user treats 404 as success (mirrors _delete_team)."""
+        response = MagicMock()
+        response.is_success = False
+        response.status_code = 404
+        response.text = 'User not found'
+        response.raise_for_status = MagicMock(
+            side_effect=AssertionError('should not raise on 404')
+        )
+        mock_http_client.post.return_value = response
+
+        # Must not raise.
+        await LiteLlmManager._delete_user(mock_http_client, 'missing-user')
+        response.raise_for_status.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch('storage.lite_llm_manager.LITE_LLM_API_URL', 'http://test.com')
+    @patch('storage.lite_llm_manager.LITE_LLM_API_KEY', 'test-key')
+    async def test_delete_user_raises_on_server_error(self, mock_http_client):
+        """_delete_user still surfaces non-404 failures."""
+        response = MagicMock()
+        response.is_success = False
+        response.status_code = 500
+        response.text = 'Internal server error'
+        response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                message='500', request=MagicMock(), response=response
+            )
+        )
+        mock_http_client.post.return_value = response
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await LiteLlmManager._delete_user(mock_http_client, 'test-user-id')
+
+    @pytest.mark.asyncio
     async def test_migrate_entries_missing_config(self, mock_user_settings):
         """Test migrate_entries when LiteLLM config is missing."""
         with patch.dict(os.environ, {'LITE_LLM_API_KEY': '', 'LITE_LLM_API_URL': ''}):

--- a/enterprise/tests/unit/test_lite_llm_manager.py
+++ b/enterprise/tests/unit/test_lite_llm_manager.py
@@ -723,6 +723,127 @@ class TestLiteLlmManager:
         mock_create.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_create_entries_reset_failure_does_not_block_onboarding(
+        self, mock_settings
+    ):
+        """A failed stale-user reset must not block onboarding (best-effort).
+
+        If _delete_user raises (e.g. a transient 5xx from the proxy),
+        create_entries swallows it and still calls _create_user, which
+        tolerates the surviving record via its 409 handling.
+        """
+        mock_token_manager = MagicMock()
+        mock_token_manager.return_value.get_user_info_from_user_id = AsyncMock(
+            return_value={'email': 'test@example.com'}
+        )
+
+        mock_client = AsyncMock()
+        mock_client_class = MagicMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        with (
+            patch.dict(os.environ, {'LOCAL_DEPLOYMENT': ''}),
+            patch('storage.lite_llm_manager.LITE_LLM_API_KEY', 'test-key'),
+            patch('storage.lite_llm_manager.LITE_LLM_API_URL', 'http://test.com'),
+            patch('storage.lite_llm_manager.TokenManager', mock_token_manager),
+            patch('httpx.AsyncClient', mock_client_class),
+            patch.object(LiteLlmManager, '_get_team', new=AsyncMock(return_value=None)),
+            patch.object(LiteLlmManager, '_create_team', new=AsyncMock()),
+            patch.object(
+                LiteLlmManager,
+                '_team_alias_for_org',
+                new=AsyncMock(return_value='Personal Workspace'),
+            ),
+            patch.object(
+                LiteLlmManager, '_user_exists', new=AsyncMock(return_value=True)
+            ),
+            patch.object(
+                LiteLlmManager,
+                '_delete_user',
+                new=AsyncMock(
+                    side_effect=httpx.HTTPStatusError(
+                        '500', request=MagicMock(), response=MagicMock()
+                    )
+                ),
+            ) as mock_del,
+            patch.object(
+                LiteLlmManager, '_create_user', new=AsyncMock(return_value=True)
+            ) as mock_create,
+            patch.object(LiteLlmManager, '_add_user_to_team', new=AsyncMock()),
+            patch.object(LiteLlmManager, '_delete_key_by_alias', new=AsyncMock()),
+            patch.object(
+                LiteLlmManager, '_generate_key', new=AsyncMock(return_value='new-key')
+            ),
+        ):
+            result = await LiteLlmManager.create_entries(
+                'test-user-id', 'test-user-id', mock_settings, create_user=True
+            )
+
+        assert result is not None
+        mock_del.assert_awaited_once()
+        mock_create.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_create_entries_resets_stale_user_via_http(
+        self, mock_settings, mock_response
+    ):
+        """Drive the real create_entries body over a mocked HTTP client.
+
+        Unlike the method-mocked tests above, this exercises the actual
+        _user_exists / _delete_user / _create_user bodies and asserts that
+        POST /user/delete fires for the orphan before POST /user/new.
+        """
+        mock_404 = MagicMock()
+        mock_404.status_code = 404
+        mock_404.is_success = False
+        mock_404.raise_for_status.side_effect = httpx.HTTPStatusError(
+            message='Not Found', request=MagicMock(), response=mock_404
+        )
+
+        # _user_exists: orphan present on the pre-check and after recreate.
+        mock_user_exists = MagicMock()
+        mock_user_exists.is_success = True
+        mock_user_exists.json.return_value = {'user_info': {'user_id': 'test-user-id'}}
+
+        mock_token_manager = MagicMock()
+        mock_token_manager.return_value.get_user_info_from_user_id = AsyncMock(
+            return_value={'email': 'test@example.com'}
+        )
+
+        mock_client = AsyncMock()
+        # GET: _get_team (404) -> _user_exists pre-check -> _user_exists verify
+        mock_client.get.side_effect = [mock_404, mock_user_exists, mock_user_exists]
+        mock_client.post.return_value = mock_response
+
+        mock_client_class = MagicMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        with (
+            patch.dict(os.environ, {'LOCAL_DEPLOYMENT': ''}),
+            patch('storage.lite_llm_manager.LITE_LLM_API_KEY', 'test-key'),
+            patch('storage.lite_llm_manager.LITE_LLM_API_URL', 'http://test.com'),
+            patch('storage.lite_llm_manager.TokenManager', mock_token_manager),
+            patch('httpx.AsyncClient', mock_client_class),
+            patch.object(
+                LiteLlmManager,
+                '_team_alias_for_org',
+                new=AsyncMock(return_value='Personal Workspace'),
+            ),
+        ):
+            result = await LiteLlmManager.create_entries(
+                'test-user-id', 'test-user-id', mock_settings, create_user=True
+            )
+
+        assert result is not None
+        post_urls = [call.args[0] for call in mock_client.post.call_args_list]
+        delete_idx = next(i for i, u in enumerate(post_urls) if '/user/delete' in u)
+        new_idx = next(i for i, u in enumerate(post_urls) if '/user/new' in u)
+        # The orphan is deleted before the clean record is created.
+        assert delete_idx < new_idx
+        delete_call = mock_client.post.call_args_list[delete_idx]
+        assert delete_call.kwargs['json'] == {'user_ids': ['test-user-id']}
+
+    @pytest.mark.asyncio
     @patch('storage.lite_llm_manager.LITE_LLM_API_URL', 'http://test.com')
     @patch('storage.lite_llm_manager.LITE_LLM_API_KEY', 'test-key')
     async def test_delete_user_idempotent_on_404(self, mock_http_client):


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

prevents new orphans from a clean reset


- [x] A human has tested these changes.

AGENT:

Implemented by an agent. Behavior is verified end-to-end over the real `create_entries` body (see **Evidence**), not just method mocks.

---

## Why

After an account reset (the customer-facing `reset_account.sh` → `OrgStore.delete_org_cascade`), the OpenHands `User`/`Org`, the LiteLLM team, and the team-scoped keys are all cleaned up — but the LiteLLM **user** record could be left behind. On the next sign-in, `LiteLlmManager.create_entries` re-onboards the user, `_create_user` swallows the `409 User already exists`, and the dangling record is re-attached to the freshly recreated team. LiteLLM then fails to deserialize it (`CacheCodec.deserialize: validation failed for LiteLLM_UserTable`, "missing `user_id`") on every chat request.

#14700 added a best-effort `delete_user` on the reset path. That prevents *new* orphans from a clean reset, but it does **not** heal installs that are already broken (e.g. the AMD escalation in #14686), nor orphans from any other source, because the re-onboarding path still trusts a pre-existing LiteLLM record instead of reconciling it. This PR closes that gap at the re-onboarding layer, which is robust regardless of how the orphan was created.

I confirmed against the LiteLLM proxy source that `/user/new` 409s cleanly with no partial mutation, and that neither `/user/delete` nor `/user/update` purges the proxy cache — so delete-then-recreate is the only reliable reconciliation (`update` cannot clear a corrupt cached record).

## Summary

- `create_entries`: when onboarding a brand-new user (`create_user=True`) and a LiteLLM record already exists under that id, delete it before `_create_user` rebuilds a clean record. `create_user` is reached only when no OpenHands `User` row exists (`auth.py`), so a pre-existing LiteLLM user there is unambiguously a stale orphan. Mirrors the managed-key reset directly below it (and shares its multi-install trade-off).
- The reset is **best-effort**: a transient failure from `_delete_user` is logged and swallowed so it cannot hard-block onboarding — `_create_user` still tolerates a surviving record via its existing 409 handling.
- `_delete_user`: treat `404` as success (idempotent), mirroring `_delete_team`, so both this reset and the #14700 reset path stop logging spurious errors when the user is already gone.

## Issue Number

Fixes #14686

## How to Test

Unit tests:

```bash
cd enterprise
python3 -m pytest tests/unit/test_lite_llm_manager.py tests/unit/test_org_store.py -q
```

New cases: stale user is reset (`_delete_user` then `_create_user`) — both as a method-level assertion and end-to-end over a mocked HTTP client that asserts the real `POST /user/delete` precedes `POST /user/new`; a genuinely new user is created without a delete; a failed reset does not block onboarding; `_delete_user` is idempotent on 404 and still raises on 500.

Manual (staging): create a personal-org user → run `reset_account.sh` → sign back in → confirm no `LiteLLM_UserTable` deserialize warnings and that a fresh LiteLLM user/key is provisioned.

## Evidence

`test_create_entries_resets_stale_user_via_http` drives the real `create_entries` body over a mocked HTTP client (exercising the actual `_user_exists` / `_delete_user` / `_create_user` code paths) and asserts `POST /user/delete` fires before `POST /user/new`. Captured INFO log from that run shows the heal end-to-end:

```
create_entries:start                      org_id=test-user-id user_id=test-user-id
create_entries:no_existing_team           (team was deleted on the prior reset)
create_entries:reset_stale_litellm_user   (orphan user deleted)
_generate_key:key_created                 key_alias="OpenHands Cloud - user test-user-id - org test-user-id"
```

(A cluster run against the live LiteLLM proxy is the remaining human check; the agent has no cluster access.)

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **Already-corrupt cache:** because LiteLLM invalidates no cache on delete/update, a record already corrupt in the live proxy cache (the current AMD state) still needs a proxy restart / TTL expiry to clear. This PR guarantees a valid DB record going forward; the documented `/user/delete` + restart workaround is still required to clear an existing corrupt cache entry. A fully durable cache-heal would need an upstream LiteLLM cache-invalidation patch.
- The issue also proposed adding `delete_user` to `downgrade_entries`; that path intentionally *keeps* the user on the default team and is dead code (removable post-2026-02-15), so it is intentionally **not** changed here. The new `create_entries` self-heal also covers any orphan that path would leave.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-597b8ef   docker.openhands.dev/openhands/openhands:597b8ef
```