### PR TITLE
fix(app-server): recover conversation metadata save race

### DIFF
--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -34,6 +34,7 @@ from sqlalchemy import (
     select,
 )
 from sqlalchemy.engine import CursorResult
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -383,8 +384,17 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             tags=info.tags if info.tags else None,
         )
 
-        await self.db_session.merge(stored)
-        await self.db_session.commit()
+        try:
+            await self.db_session.merge(stored)
+            await self.db_session.commit()
+        except IntegrityError:
+            await self.db_session.rollback()
+            logger.info(
+                'Recovering conversation metadata save after integrity race for %s',
+                stored.conversation_id,
+            )
+            await self.db_session.merge(stored)
+            await self.db_session.commit()
         return info
 
     async def update_conversation_statistics(

--- a/tests/unit/app_server/test_sql_app_conversation_info_service.py
+++ b/tests/unit/app_server/test_sql_app_conversation_info_service.py
@@ -10,6 +10,7 @@ from typing import AsyncGenerator
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
@@ -165,6 +166,53 @@ class TestSQLAppConversationInfoService:
         assert retrieved_info.trigger == sample_conversation_info.trigger
         assert retrieved_info.pr_number == sample_conversation_info.pr_number
         assert retrieved_info.llm_model == sample_conversation_info.llm_model
+
+    @pytest.mark.asyncio
+    async def test_save_recovers_from_integrity_race(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        service: SQLAppConversationInfoService,
+        sample_conversation_info: AppConversationInfo,
+    ):
+        """A concurrent startup/webhook writer can win the insert race.
+
+        The losing writer should roll back and re-merge instead of surfacing a
+        duplicate-key failure that hides an otherwise running conversation.
+        """
+        original_commit = service.db_session.commit
+        original_rollback = service.db_session.rollback
+        calls = {'commit': 0, 'rollback': 0}
+
+        async def flaky_commit():
+            calls['commit'] += 1
+            if calls['commit'] == 1:
+                raise IntegrityError(
+                    'INSERT INTO conversation_metadata ...',
+                    {},
+                    Exception(
+                        'duplicate key value violates unique constraint '
+                        '"conversation_metadata_pkey"'
+                    ),
+                )
+            await original_commit()
+
+        async def tracking_rollback():
+            calls['rollback'] += 1
+            await original_rollback()
+
+        monkeypatch.setattr(service.db_session, 'commit', flaky_commit)
+        monkeypatch.setattr(service.db_session, 'rollback', tracking_rollback)
+
+        saved_info = await service.save_app_conversation_info(sample_conversation_info)
+
+        assert saved_info.id == sample_conversation_info.id
+        assert calls == {'commit': 2, 'rollback': 1}
+        retrieved_info = await service.get_app_conversation_info(
+            sample_conversation_info.id
+        )
+        assert retrieved_info is not None
+        assert retrieved_info.id == sample_conversation_info.id
+        assert retrieved_info.title == sample_conversation_info.title
 
     @pytest.mark.asyncio
     async def test_get_nonexistent_conversation_info(


### PR DESCRIPTION
Fixes OpenHands/enterprise#26.

HUMAN:
This PR makes app-server conversation metadata saves recover from a startup/webhook duplicate-key race by rolling back the losing transaction and re-merging the same conversation info. I tested the targeted SQL metadata service path and nearby webhook/router paths locally.

- [x] A human has tested these changes.

## Summary
- recover `conversation_metadata` saves when a concurrent startup/webhook writer wins the insert race
- roll back the failed transaction and re-merge the same `AppConversationInfo` instead of surfacing the duplicate-key failure
- add regression coverage for the integrity-race retry path

## Validation
- `uv run --python 3.12 pytest tests/unit/app_server/test_sql_app_conversation_info_service.py -q`
- `uv run --python 3.12 pytest tests/unit/app_server/test_webhook_router_acp.py tests/unit/app_server/test_app_conversation_router.py -q`
- `uv run --python 3.12 ruff check openhands/app_server/app_conversation/sql_app_conversation_info_service.py tests/unit/app_server/test_sql_app_conversation_info_service.py`
- `uv run --python 3.12 ruff format --check openhands/app_server/app_conversation/sql_app_conversation_info_service.py tests/unit/app_server/test_sql_app_conversation_info_service.py`
- `uv run --python 3.12 pre-commit run --config ./dev_config/python/.pre-commit-config.yaml`
- `git diff --check`

## Changelog
App-server conversation metadata saves now recover from startup/webhook duplicate-key races instead of hiding otherwise running conversations.