### PR TITLE
fix: Fix CVE-2026-41691: Update i18next-http-backend to 3.0.5

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,7 @@
         "framer-motion": "^12.34.0",
         "i18next": "^25.8.4",
         "i18next-browser-languagedetector": "^8.2.0",
-        "i18next-http-backend": "^3.0.2",
+        "i18next-http-backend": "^3.0.5",
         "isbot": "^5.1.33",
         "lucide-react": "^0.563.0",
         "monaco-editor": "^0.55.1",
@@ -8474,12 +8474,12 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "license": "MIT",
       "dependencies": {
-        "node-fetch": "^2.6.12"
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -10993,12 +10993,12 @@
       }
     },
     "node_modules/i18next-http-backend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-3.0.2.tgz",
-      "integrity": "sha512-PdlvPnvIp4E1sYi46Ik4tBYh/v/NbYfFFgTjkwFl0is8A18s7/bx9aXqsrOax9WUbeNS6mD2oix7Z0yGGf6m5g==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-3.0.6.tgz",
+      "integrity": "sha512-mBOqy8993jtqAoj6XaI1XeC/8/9v6EPS+681ziegrPvTB0DoaCY7PpTS0SpY56qLMoS4OI1TZEM2Zf59zNh05w==",
       "license": "MIT",
       "dependencies": {
-        "cross-fetch": "4.0.0"
+        "cross-fetch": "4.1.0"
       }
     },
     "node_modules/iconv-lite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "framer-motion": "^12.34.0",
     "i18next": "^25.8.4",
     "i18next-browser-languagedetector": "^8.2.0",
-    "i18next-http-backend": "^3.0.2",
+    "i18next-http-backend": "^3.0.5",
     "isbot": "^5.1.33",
     "lucide-react": "^0.563.0",
     "monaco-editor": "^0.55.1",


### PR DESCRIPTION
Human: Tested this locally
<img width="900" height="783" alt="Screenshot 2026-06-24 at 9 33 46 AM" src="https://github.com/user-attachments/assets/f7d999e1-df7f-48d6-be45-a1ada29e8ee1" />


## Security Fix: CVE-2026-41691

Updates `i18next-http-backend` from `3.0.2` to `^3.0.5` (resolved to `3.0.6`) to address CVE-2026-41691.

### Changes
- **`frontend/package.json`**: Updated `i18next-http-backend` version constraint from `^3.0.2` to `^3.0.5`
- **`frontend/package-lock.json`**: Regenerated lockfile (resolves to `3.0.6`)

### Details
- **CVE**: CVE-2026-41691
- **Package**: i18next-http-backend
- **Previous Version**: 3.0.2
- **Fixed Version**: ≥3.0.5
- **Dependency Type**: Direct dependency in `frontend/package.json`

---
_This PR was created by an AI agent (OpenHands) to remediate a security vulnerability._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-1c416ba   docker.openhands.dev/openhands/openhands:1c416ba
```