### PR TITLE
fix: Fix GHSA-cmwh-pvxp-8882: Update dompurify to 3.4.11

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8854,9 +8854,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.6.tgz",
-      "integrity": "sha512-+7gzEI8trIIQkVCvQ3ucGtNfH3nOmDgVTzc62rAAOlMxLth78pwpPoZCPc7CyRzAQF89MqcfPdEWkDwnjgqktg==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -129,6 +129,6 @@
     ]
   },
   "overrides": {
-    "dompurify": "3.4.6"
+    "dompurify": "3.4.11"
   }
 }


### PR DESCRIPTION
Human: Tested this locally
<img width="899" height="782" alt="Screenshot 2026-06-24 at 9 35 25 AM" src="https://github.com/user-attachments/assets/9dcb170e-8a8e-4424-b7fe-40e7a56cabc6" />


## Security Fix: GHSA-cmwh-pvxp-8882

This PR updates `dompurify` from version 3.4.6 to 3.4.11 to address the security vulnerability [GHSA-cmwh-pvxp-8882](https://github.com/advisories/GHSA-cmwh-pvxp-8882).

### Changes
- Updated `dompurify` direct dependency in `frontend/package.json` from `3.4.6` to `3.4.11`
- Regenerated `frontend/package-lock.json` to reflect the updated dependency

### Vulnerability Details
- **Advisory**: GHSA-cmwh-pvxp-8882
- **Package**: dompurify
- **Previous Version**: 3.4.6
- **Fixed Version**: 3.4.11

---
*This PR was created by an AI agent (OpenHands) on behalf of the user to remediate a security vulnerability.*

@mamoodi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b0788610-5835-491e-a5ed-67b21b7c77f2)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-fc3889a   docker.openhands.dev/openhands/openhands:fc3889a
```