### PR TITLE
fix: Fix CVE-2026-8723: Update qs to 6.15.2

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14501,9 +14501,10 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -129,6 +129,7 @@
     ]
   },
   "overrides": {
-    "dompurify": "3.4.11"
+    "dompurify": "3.4.11",
+    "qs": "6.15.2"
   }
 }


### PR DESCRIPTION
Human: Tested this locally
<img width="906" height="786" alt="Screenshot 2026-06-24 at 9 32 03 AM" src="https://github.com/user-attachments/assets/cd5d4ab8-1629-4654-911b-2bcb36d15b46" />

## Security Fix: CVE-2026-8723

### Summary
Updates the `qs` package from **6.14.2** to **6.15.2** to address **CVE-2026-8723**.

### Details
- **Package**: `qs`
- **Vulnerable Version**: 6.14.2
- **Fixed Version**: 6.15.2
- **Dependency Type**: Transitive (pulled in by `body-parser` and `express`)

### Changes
- Added `qs` to npm `overrides` in `frontend/package.json` to force the safe version (6.15.2)
- Regenerated `frontend/package-lock.json` to reflect the updated dependency

### Why overrides?
The `qs` package is not a direct dependency — it's pulled in transitively by `body-parser` and `express`. Using npm `overrides` is the standard approach to pin transitive dependencies to a specific version without modifying direct dependency declarations.

---
_This PR was created by an AI agent (OpenHands) to remediate a security vulnerability._

@mamoodi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9e557e7f-6dc3-45ba-ae81-1f6fd43fb119)

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-f3f0875   docker.openhands.dev/openhands/openhands:f3f0875
```