### PR TITLE
fix: Fix GHSA-jm82-fx9c-mx94: Update pypdf to >=6.13.3

### DIFF
--- a/enterprise/poetry.lock
+++ b/enterprise/poetry.lock
@@ -11112,22 +11112,23 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pypdf"
-version = "6.10.2"
+version = "6.14.2"
 description = "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pypdf-6.10.2-py3-none-any.whl", hash = "sha256:aa53be9826655b51c96741e5d7983ca224d898ac0a77896e64636810517624aa"},
-    {file = "pypdf-6.10.2.tar.gz", hash = "sha256:7d09ce108eff6bf67465d461b6ef352dcb8d84f7a91befc02f904455c6eea11d"},
+    {file = "pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946"},
+    {file = "pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25"},
 ]
 
 [package.extras]
-crypto = ["cryptography"]
+crypto = ["cryptography (>3.0)"]
 cryptodome = ["PyCryptodome"]
 dev = ["flit", "pip-tools", "pre-commit", "pytest-cov", "pytest-socket", "pytest-timeout", "pytest-xdist", "wheel"]
 docs = ["myst_parser", "sphinx", "sphinx_rtd_theme"]
-full = ["Pillow (>=8.0.0)", "cryptography"]
+fonts = ["fonttools"]
+full = ["Pillow (>=8.0.0)", "cryptography (>3.0)", "fonttools"]
 image = ["Pillow (>=8.0.0)"]
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -10652,22 +10652,23 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pypdf"
-version = "6.10.2"
+version = "6.14.2"
 description = "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pypdf-6.10.2-py3-none-any.whl", hash = "sha256:aa53be9826655b51c96741e5d7983ca224d898ac0a77896e64636810517624aa"},
-    {file = "pypdf-6.10.2.tar.gz", hash = "sha256:7d09ce108eff6bf67465d461b6ef352dcb8d84f7a91befc02f904455c6eea11d"},
+    {file = "pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946"},
+    {file = "pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25"},
 ]
 
 [package.extras]
-crypto = ["cryptography"]
+crypto = ["cryptography (>3.0)"]
 cryptodome = ["PyCryptodome"]
 dev = ["flit", "pip-tools", "pre-commit", "pytest-cov", "pytest-socket", "pytest-timeout", "pytest-xdist", "wheel"]
 docs = ["myst_parser", "sphinx", "sphinx_rtd_theme"]
-full = ["Pillow (>=8.0.0)", "cryptography"]
+fonts = ["fonttools"]
+full = ["Pillow (>=8.0.0)", "cryptography (>3.0)", "fonttools"]
 image = ["Pillow (>=8.0.0)"]
 
 [[package]]
@@ -13761,4 +13762,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12,<3.14"
-content-hash = "be368252155fc1e64794bea5352cf6b3be28e5b30fdc274abb4ea927c777ee78"
+content-hash = "4a9c8b315062b1c6315bf6f78b108d2493c232c32e5473864f35871c016b9a0a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
   "pygithub>=2.5",
   "pyjwt>=2.13.0",
   "pylatexenc",
-  "pypdf>=6.10.2",
+  "pypdf>=6.13.3",
   "python-docx",
   "python-dotenv",
   "python-frontmatter>=1.1",
@@ -221,7 +221,7 @@ bashlex = "^0.18"
 binaryornot = ">=0.5.0,<1"
 
 # Explicitly pinned packages for latest versions
-pypdf = "^6.10.2"
+pypdf = "^6.13.3"
 pillow = "^12.1.1"
 starlette = ">=0.49.1,<1.1.0"
 urllib3 = "^2.7.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3366,7 +3366,7 @@ requires-dist = [
     { name = "pygithub", specifier = ">=2.5" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "pylatexenc" },
-    { name = "pypdf", specifier = ">=6.10.2" },
+    { name = "pypdf", specifier = ">=6.13.3" },
     { name = "python-docx" },
     { name = "python-dotenv" },
     { name = "python-frontmatter", specifier = ">=1.1" },
@@ -6867,11 +6867,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.10.2"
+version = "6.14.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/3f/9f2167401c2e94833ca3b69535bad89e533b5de75fefe4197a2c224baec2/pypdf-6.10.2.tar.gz", hash = "sha256:7d09ce108eff6bf67465d461b6ef352dcb8d84f7a91befc02f904455c6eea11d", size = 5315679, upload-time = "2026-04-15T16:37:36.978Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/d6/1d5c60cc17bbdf37c1552d9c03862fc6d32c5836732a0415b2d637edc2d0/pypdf-6.10.2-py3-none-any.whl", hash = "sha256:aa53be9826655b51c96741e5d7983ca224d898ac0a77896e64636810517624aa", size = 336308, upload-time = "2026-04-15T16:37:34.851Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Human: Tested this locally
<img width="893" height="788" alt="Screenshot 2026-06-24 at 9 54 40 AM" src="https://github.com/user-attachments/assets/417c56e5-c3f8-4061-99bd-ad0c396a0158" />


## Security Fix

This PR addresses **GHSA-jm82-fx9c-mx94** by updating the `pypdf` dependency from `>=6.10.2` / `^6.10.2` to `>=6.13.3` / `^6.13.3`.

### Changes
- Updated `pypdf` version constraint in `pyproject.toml` (both in `dependencies` and `[tool.poetry.dependencies]` sections)
- Regenerated `poetry.lock`, `enterprise/poetry.lock`, and `uv.lock` — only pypdf was updated; no other packages were changed
- pypdf resolved to version **6.14.2** in all lockfiles (satisfies the >=6.13.3 fix requirement)

### CVE Details
- **Advisory**: https://github.com/advisories/GHSA-jm82-fx9c-mx94
- **Package**: pypdf
- **Previous version**: 6.10.2
- **Fixed version**: >=6.13.3

---
_This PR was created by an AI agent (OpenHands) to remediate a security vulnerability._

@mamoodi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9cd48248-0dc6-4af5-bcc8-0002a00d6dd9)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-acb7d25   docker.openhands.dev/openhands/openhands:acb7d25
```