### PR TITLE
feat: add multi-repo dependency support (closes #11938)

### DIFF
--- a/frontend/src/types/git.d.ts
+++ b/frontend/src/types/git.d.ts
@@ -66,6 +66,15 @@ interface GitRepository {
   main_branch?: string;
 }
 
+/**
+ * Specification for a dependency repository to clone alongside the main repo.
+ */
+interface DependencyRepo {
+  name: string;
+  repo: string;
+  ref?: string | null;
+}
+
 interface GitHubCommit {
   html_url: string;
   sha: string;

--- a/openhands/app_server/app_conversation/app_conversation_models.py
+++ b/openhands/app_server/app_conversation/app_conversation_models.py
@@ -120,6 +120,7 @@ class AppConversationInfo(BaseModel):
     selected_repository: str | None = None
     selected_branch: str | None = None
     git_provider: ProviderType | None = None
+    dependency_repos: list[DependencyRepo] | None = None
     title: str | None = None
     trigger: ConversationTrigger | None = None
     pr_number: list[int] = Field(default_factory=list)
@@ -215,6 +216,7 @@ class AppConversationStartRequest(OpenHandsModel):
     selected_repository: str | None = None
     selected_branch: str | None = None
     git_provider: ProviderType | None = None
+    dependency_repos: list[DependencyRepo] | None = None
     suggested_task: SuggestedTask | None = None
     title: str | None = None
     trigger: ConversationTrigger | None = None
@@ -257,6 +259,36 @@ class AppConversationUpdateRequest(BaseModel):
     selected_repository: str | None = None
     selected_branch: str | None = None
     git_provider: ProviderType | None = None
+    dependency_repos: list[DependencyRepo] | None = None
+
+
+class DependencyRepo(OpenHandsModel):
+    """Specification for a dependency repository to clone alongside the main repo.
+
+    Each entry describes an additional repository the agent should
+    have access to. The repos are cloned into the workspace alongside
+    the primary repository.
+    """
+
+    name: str = Field(
+        ...,
+        description='Short alias for this dependency (e.g. "frontend", "backend")',
+        min_length=1,
+        max_length=64,
+    )
+    repo: str = Field(
+        ...,
+        description='Repository path in owner/repo format (e.g. "OpenHands/software-agent-sdk")',
+        min_length=1,
+    )
+    ref: str | None = Field(
+        default=None,
+        description='Optional branch, tag, or SHA to checkout',
+    )
+
+    def clone_dir_name(self) -> str:
+        """Directory name used when cloning into the workspace."""
+        return self.name
 
 
 class AppConversationStartTaskStatus(Enum):

--- a/openhands/app_server/app_conversation/app_conversation_models.py
+++ b/openhands/app_server/app_conversation/app_conversation_models.py
@@ -109,6 +109,35 @@ class PluginSpec(PluginSource):
         )
 
 
+class DependencyRepo(OpenHandsModel):
+    """Specification for a dependency repository to clone alongside the main repo.
+
+    Each entry describes an additional repository the agent should
+    have access to. The repos are cloned into the workspace alongside
+    the primary repository.
+    """
+
+    name: str = Field(
+        ...,
+        description='Short alias for this dependency (e.g. "frontend", "backend")',
+        min_length=1,
+        max_length=64,
+    )
+    repo: str = Field(
+        ...,
+        description='Repository path in owner/repo format (e.g. "OpenHands/software-agent-sdk")',
+        min_length=1,
+    )
+    ref: str | None = Field(
+        default=None,
+        description='Optional branch, tag, or SHA to checkout',
+    )
+
+    def clone_dir_name(self) -> str:
+        """Directory name used when cloning into the workspace."""
+        return self.name
+
+
 class AppConversationInfo(BaseModel):
     """Conversation info which does not contain status."""
 
@@ -260,35 +289,6 @@ class AppConversationUpdateRequest(BaseModel):
     selected_branch: str | None = None
     git_provider: ProviderType | None = None
     dependency_repos: list[DependencyRepo] | None = None
-
-
-class DependencyRepo(OpenHandsModel):
-    """Specification for a dependency repository to clone alongside the main repo.
-
-    Each entry describes an additional repository the agent should
-    have access to. The repos are cloned into the workspace alongside
-    the primary repository.
-    """
-
-    name: str = Field(
-        ...,
-        description='Short alias for this dependency (e.g. "frontend", "backend")',
-        min_length=1,
-        max_length=64,
-    )
-    repo: str = Field(
-        ...,
-        description='Repository path in owner/repo format (e.g. "OpenHands/software-agent-sdk")',
-        min_length=1,
-    )
-    ref: str | None = Field(
-        default=None,
-        description='Optional branch, tag, or SHA to checkout',
-    )
-
-    def clone_dir_name(self) -> str:
-        """Directory name used when cloning into the workspace."""
-        return self.name
 
 
 class AppConversationStartTaskStatus(Enum):

--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -531,19 +531,18 @@ printf 'password=%s\\n' "$token"
         Failures for individual dependency repos are logged but do not
         prevent the conversation from starting.
         """
-        if not request.dependency_repos:
+        dep_repos = request.dependency_repos
+        if not dep_repos or not isinstance(dep_repos, list):
             return
 
         _logger.info(
-            f'Cloning {len(request.dependency_repos)} dependency repo(s): '
-            f'{[d.repo for d in request.dependency_repos]}'
+            f'Cloning {len(dep_repos)} dependency repo(s): '
+            f'{[d.repo for d in dep_repos]}'
         )
 
-        for dep in request.dependency_repos:
+        for dep in dep_repos:
             try:
-                remote_url = await self.user_context.get_authenticated_git_url(
-                    dep.repo
-                )
+                remote_url = await self.user_context.get_authenticated_git_url(dep.repo)
                 if not remote_url:
                     _logger.warning(
                         f'Could not get authenticated URL for dependency '

--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -349,6 +349,8 @@ class AppConversationServiceBase(AppConversationService, ABC):
                     _logger.warning(f'Git init failed: {result.stderr}')
             else:
                 _logger.info('Not initializing a new git repository.')
+            # Still clone dependency repos even without a main repo
+            await self._clone_dependency_repos(request, workspace, sandbox)
             return
 
         user_info = await self.user_context.get_user_info()
@@ -417,6 +419,9 @@ class AppConversationServiceBase(AppConversationService, ABC):
         result = await workspace.execute_command(checkout_command, git_dir)
         if result.exit_code:
             _logger.warning(f'Git checkout failed: {result.stderr}')
+
+        # Clone dependency repos alongside the main repo
+        await self._clone_dependency_repos(request, workspace, sandbox)
 
     async def _get_azure_devops_bearer_token_for_git(
         self,
@@ -513,6 +518,75 @@ printf 'password=%s\\n' "$token"
             _logger.warning(
                 f'Azure DevOps git credential helper setup failed: {result.stderr}'
             )
+
+    async def _clone_dependency_repos(
+        self,
+        request,
+        workspace: AsyncRemoteWorkspace,
+        sandbox: SandboxInfo | None = None,
+    ) -> None:
+        """Clone dependency repositories into the workspace alongside the main repo.
+
+        Each dependency repo is cloned into ``{working_dir}/{dep.name}``.
+        Failures for individual dependency repos are logged but do not
+        prevent the conversation from starting.
+        """
+        if not request.dependency_repos:
+            return
+
+        _logger.info(
+            f'Cloning {len(request.dependency_repos)} dependency repo(s): '
+            f'{[d.repo for d in request.dependency_repos]}'
+        )
+
+        for dep in request.dependency_repos:
+            try:
+                remote_url = await self.user_context.get_authenticated_git_url(
+                    dep.repo
+                )
+                if not remote_url:
+                    _logger.warning(
+                        f'Could not get authenticated URL for dependency '
+                        f'repo "{dep.repo}" — skipping'
+                    )
+                    continue
+
+                dir_name = dep.clone_dir_name()
+                quoted_url = shlex.quote(remote_url)
+                quoted_dir = shlex.quote(dir_name)
+                git_dir = Path(workspace.working_dir) / dir_name
+
+                _logger.debug(f'Cloning dependency repo {dep.repo} → {git_dir}')
+                result = await workspace.execute_command(
+                    f'git clone {quoted_url} {quoted_dir}',
+                    workspace.working_dir,
+                    120,
+                )
+                if result.exit_code:
+                    _logger.warning(
+                        f'Failed to clone dependency repo "{dep.repo}": '
+                        f'{result.stderr}'
+                    )
+                    continue
+
+                if dep.ref:
+                    ensure_valid_git_branch_name(dep.ref)
+                    checkout_result = await workspace.execute_command(
+                        f'git checkout {shlex.quote(dep.ref)}', git_dir
+                    )
+                    if checkout_result.exit_code:
+                        _logger.warning(
+                            f'Failed to checkout ref "{dep.ref}" for '
+                            f'dependency repo "{dep.repo}": '
+                            f'{checkout_result.stderr}'
+                        )
+
+                _logger.info(f'Cloned dependency repo "{dep.repo}" → {git_dir}')
+            except Exception as e:
+                _logger.warning(
+                    f'Error cloning dependency repo "{dep.repo}": {e}',
+                    exc_info=True,
+                )
 
     async def maybe_run_setup_script(
         self,

--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -257,6 +257,9 @@ class AppConversationServiceBase(AppConversationService, ABC):
         yield task
         await self.clone_or_init_git_repo(task, workspace, sandbox)
 
+        # Clone dependency repos alongside the main repo
+        await self._clone_dependency_repos(task.request, workspace, sandbox)
+
         # Compute the project root — the cloned repo directory when a repo is
         # selected, or the sandbox working_dir otherwise.  This must be used
         # for all .openhands/ features (setup.sh, pre-commit.sh, skills).
@@ -349,8 +352,6 @@ class AppConversationServiceBase(AppConversationService, ABC):
                     _logger.warning(f'Git init failed: {result.stderr}')
             else:
                 _logger.info('Not initializing a new git repository.')
-            # Still clone dependency repos even without a main repo
-            await self._clone_dependency_repos(request, workspace, sandbox)
             return
 
         user_info = await self.user_context.get_user_info()
@@ -419,9 +420,6 @@ class AppConversationServiceBase(AppConversationService, ABC):
         result = await workspace.execute_command(checkout_command, git_dir)
         if result.exit_code:
             _logger.warning(f'Git checkout failed: {result.stderr}')
-
-        # Clone dependency repos alongside the main repo
-        await self._clone_dependency_repos(request, workspace, sandbox)
 
     async def _get_azure_devops_bearer_token_for_git(
         self,

--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -564,8 +564,7 @@ printf 'password=%s\\n' "$token"
                 )
                 if result.exit_code:
                     _logger.warning(
-                        f'Failed to clone dependency repo "{dep.repo}": '
-                        f'{result.stderr}'
+                        f'Failed to clone dependency repo "{dep.repo}": {result.stderr}'
                     )
                     continue
 

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -512,6 +512,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 selected_repository=request.selected_repository,
                 selected_branch=request.selected_branch,
                 git_provider=request.git_provider,
+                dependency_repos=request.dependency_repos,
                 trigger=request.trigger,
                 pr_number=request.pr_number,
                 parent_conversation_id=request.parent_conversation_id,
@@ -1060,6 +1061,8 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             request.selected_branch = parent_info.selected_branch
         if not request.git_provider:
             request.git_provider = parent_info.git_provider
+        if not request.dependency_repos:
+            request.dependency_repos = parent_info.dependency_repos
 
         # Inherit LLM model from parent if not provided
         if not request.llm_model and parent_info.llm_model:

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -561,9 +561,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
         # Reconstruct dependency repos from stored JSON dicts
         dependency_repos = None
         if stored.dependency_repos:
-            dependency_repos = [
-                DependencyRepo(**d) for d in stored.dependency_repos
-            ]
+            dependency_repos = [DependencyRepo(**d) for d in stored.dependency_repos]
 
         return AppConversationInfo(
             id=UUID(stored.conversation_id),

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -47,6 +47,7 @@ from openhands.app_server.app_conversation.app_conversation_models import (
     AppConversationInfoPage,
     AppConversationSortOrder,
     ConversationTrigger,
+    DependencyRepo,
 )
 from openhands.app_server.integrations.provider import ProviderType
 from openhands.app_server.services.injector import InjectorState
@@ -114,6 +115,11 @@ class StoredConversationMetadata(Base):
     # Tags for conversation metadata (e.g., automation context, skills used)
     tags: Mapped[dict[str, str] | None] = mapped_column(
         create_json_type_decorator(dict[str, str]), nullable=True
+    )
+
+    # JSON list of dependency repo specs (stored as raw dicts)
+    dependency_repos: Mapped[list[dict] | None] = mapped_column(
+        create_json_type_decorator(list[dict]), nullable=True
     )
 
 
@@ -355,6 +361,11 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             selected_repository=info.selected_repository,
             selected_branch=info.selected_branch,
             git_provider=info.git_provider.value if info.git_provider else None,
+            dependency_repos=(
+                [d.model_dump() for d in info.dependency_repos]
+                if info.dependency_repos
+                else None
+            ),
             title=info.title,
             last_updated_at=info.updated_at,
             created_at=info.created_at,
@@ -547,6 +558,13 @@ class SQLAppConversationInfoService(AppConversationInfoService):
         created_at = self._fix_timezone(stored.created_at)
         updated_at = self._fix_timezone(stored.last_updated_at)
 
+        # Reconstruct dependency repos from stored JSON dicts
+        dependency_repos = None
+        if stored.dependency_repos:
+            dependency_repos = [
+                DependencyRepo(**d) for d in stored.dependency_repos
+            ]
+
         return AppConversationInfo(
             id=UUID(stored.conversation_id),
             created_by_user_id=None,  # User ID is now stored in ConversationMetadataSaas
@@ -556,6 +574,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             git_provider=(
                 ProviderType(stored.git_provider) if stored.git_provider else None
             ),
+            dependency_repos=dependency_repos,
             title=stored.title,
             trigger=ConversationTrigger(stored.trigger) if stored.trigger else None,
             pr_number=stored.pr_number or [],

--- a/openhands/app_server/app_lifespan/alembic/versions/013.py
+++ b/openhands/app_server/app_lifespan/alembic/versions/013.py
@@ -1,0 +1,37 @@
+"""Add dependency_repos column to conversation_metadata
+
+Revision ID: 013
+Revises: 012
+Create Date: 2026-06-24 00:00:00.000000
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '013'
+down_revision: str | None = '012'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add dependency_repos JSON column to conversation_metadata.
+
+    Stores a list of dependency repository specs (name, repo, ref)
+    that the agent can work with alongside the primary repository.
+    """
+    with op.batch_alter_table('conversation_metadata') as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                'dependency_repos',
+                sa.JSON(),
+                nullable=True,
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('conversation_metadata') as batch_op:
+        batch_op.drop_column('dependency_repos')


### PR DESCRIPTION
HUMAN: This PR adds support for specifying additional "dependency repositories" that get cloned alongside the primary repository when starting an OpenHands conversation. For example, if your project spans a frontend repo and a backend repo, you can now have both cloned into the workspace automatically. Each dependency repo is cloned into its own subdirectory, and individual clone failures do not block the conversation from starting. The feature also supports inheriting dependency repos from parent conversations, so forked or continued conversations preserve the same multi-repo workspace setup.

- [ ] A human has tested these changes.

## Summary

Adds support for specifying dependency repositories that are cloned alongside the primary repository when starting an OpenHands conversation.

Closes OpenHands/software-agent-sdk#4242.

## Changes

### Backend
- **`DependencyRepo` model** — new Pydantic model with `name`, `repo`, and optional `ref` fields
- **`AppConversationStartRequest` / `AppConversationInfo` / `AppConversationUpdateRequest`** — added `dependency_repos: list[DependencyRepo] | None` field
- **`clone_or_init_git_repo()`** — extended to clone dependency repos alongside the main repo via new `_clone_dependency_repos()` method
- **SQL persistence** — `dependency_repos` stored as JSON column in `conversation_metadata` table
- **Alembic migration 013** — adds the `dependency_repos` column

### Frontend
- **`DependencyRepo` TypeScript interface** — added to `git.d.ts`