### PR TITLE
fix(config): ignore malformed Ollama tags responses

### DIFF
--- a/openhands/app_server/config_api/default_llm_model_service.py
+++ b/openhands/app_server/config_api/default_llm_model_service.py
@@ -169,9 +169,21 @@ class DefaultLLMModelService(LLMModelService):
             try:
                 async with httpx.AsyncClient() as client:
                     resp = await client.get(ollama_url, timeout=3)
-                    ollama_models_list = resp.json()['models']
-                extra_models.extend('ollama/' + m['name'] for m in ollama_models_list)
-            except httpx.HTTPError as e:
+                    resp.raise_for_status()
+                    payload = resp.json()
+                    if not isinstance(payload, dict):
+                        raise ValueError('Ollama tags response must be a JSON object')
+                    ollama_models_list = payload.get('models', [])
+                    if not isinstance(ollama_models_list, list):
+                        raise ValueError('Ollama tags response models must be a list')
+                extra_models.extend(
+                    'ollama/' + model['name']
+                    for model in ollama_models_list
+                    if isinstance(model, dict)
+                    and isinstance(model.get('name'), str)
+                    and model['name']
+                )
+            except (httpx.HTTPError, KeyError, TypeError, ValueError) as e:
                 _logger.error(f'Error getting OLLAMA models: {e}')
 
         self._cached_response = get_supported_llm_models(

--- a/tests/unit/app_server/test_llm_model_service.py
+++ b/tests/unit/app_server/test_llm_model_service.py
@@ -162,6 +162,26 @@ class TestDefaultLLMModelServiceSearchModels:
         assert len(result.items) > 0
 
     @pytest.mark.asyncio
+    async def test_ollama_malformed_response_handled_gracefully(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'models': {'llama3': {}}}
+
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch('httpx.AsyncClient', return_value=mock_client):
+            service = DefaultLLMModelService(
+                ollama_base_url='http://localhost:11434',
+            )
+            result = await service.search_llm_models()
+
+        mock_response.raise_for_status.assert_called_once()
+        assert isinstance(result, LLMModelPage)
+        assert len(result.items) > 0
+
+    @pytest.mark.asyncio
     async def test_response_is_cached(self):
         service = DefaultLLMModelService()
 


### PR DESCRIPTION
HUMAN:

- [ ] A human has tested these changes.

AGENT:

---

## Why

When an Ollama `/api/tags` endpoint is reachable but returns a malformed payload, model discovery can raise while indexing `response.json()["models"]`. This should degrade the same way as an Ollama connection error: keep returning the built-in model list.

## Summary

- Validate the Ollama tags payload before reading model names.
- Call `raise_for_status()` so non-2xx Ollama responses are handled in the existing error path.
- Add coverage for malformed Ollama tags responses.

## Issue Number

N/A

## How to Test

`uv run pytest tests/unit/app_server/test_llm_model_service.py::TestDefaultLLMModelServiceSearchModels -q`

## Video/Screenshots

N/A

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No config or migration changes.