### PR TITLE
fix(file-store): respect path boundaries in memory store

### DIFF
--- a/openhands/app_server/file_store/memory.py
+++ b/openhands/app_server/file_store/memory.py
@@ -20,18 +20,19 @@ class InMemoryFileStore(FileStore):
         return self.files[path]
 
     def list(self, path: str) -> list[str]:
+        prefix = _directory_prefix(path)
         files = []
         for file in self.files:
-            if not file.startswith(path):
+            if prefix and not file.startswith(prefix):
                 continue
-            suffix = file.removeprefix(path)
+            suffix = file.removeprefix(prefix)
+            if not suffix:
+                continue
             parts = suffix.split('/')
-            if parts[0] == '':
-                parts.pop(0)
             if len(parts) == 1:
                 files.append(file)
             else:
-                dir_path = os.path.join(path, parts[0])
+                dir_path = os.path.join(prefix, parts[0])
                 if not dir_path.endswith('/'):
                     dir_path += '/'
                 if dir_path not in files:
@@ -40,9 +41,22 @@ class InMemoryFileStore(FileStore):
 
     def delete(self, path: str) -> None:
         try:
-            keys_to_delete = [key for key in self.files.keys() if key.startswith(path)]
+            path = path.rstrip('/')
+            prefix = _directory_prefix(path)
+            keys_to_delete = [
+                key
+                for key in self.files.keys()
+                if not path or key == path or key.startswith(prefix)
+            ]
             for key in keys_to_delete:
                 del self.files[key]
             logger.debug(f'Cleared in-memory file store: {path}')
         except Exception as e:
             logger.error(f'Error clearing in-memory file store: {str(e)}')
+
+
+def _directory_prefix(path: str) -> str:
+    path = path.rstrip('/')
+    if not path:
+        return ''
+    return f'{path}/'

--- a/tests/unit/app_server/file_store/test_file_store.py
+++ b/tests/unit/app_server/file_store/test_file_store.py
@@ -323,6 +323,22 @@ class TestInMemoryFileStore(TestCase, _StorageTest):
     def setUp(self):
         self.store = InMemoryFileStore()
 
+    def test_list_does_not_include_prefix_siblings(self):
+        self.store.write('foo/bar.txt', 'Hello, world!')
+        self.store.write('foobar.txt', 'Hello, world!')
+
+        self.assertEqual(self.store.list('foo'), ['foo/bar.txt'])
+
+    def test_delete_does_not_remove_prefix_siblings(self):
+        self.store.write('foo/bar.txt', 'Hello, world!')
+        self.store.write('foobar.txt', 'Hello, world!')
+
+        self.store.delete('foo')
+
+        self.assertEqual(self.store.read('foobar.txt'), 'Hello, world!')
+        with self.assertRaises(FileNotFoundError):
+            self.store.read('foo/bar.txt')
+
 
 @patch(
     'openhands.app_server.file_store.google_cloud.storage.Client',


### PR DESCRIPTION
HUMAN:

- [ ] A human has tested these changes.

AGENT:

---

## Why

`InMemoryFileStore` used raw prefix matching for `list()` and `delete()`. Listing or deleting `foo` could also match sibling keys such as `foobar.txt`.

## Summary

- Match directory paths with a `path/` boundary in the memory store.
- Preserve single-file deletion while preventing sibling-prefix deletion.
- Add regression tests for list and delete sibling-prefix cases.

## Issue Number

N/A

## How to Test

`uv run pytest tests/unit/app_server/file_store/test_file_store.py::TestInMemoryFileStore -q`

## Video/Screenshots

N/A

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No config or migration changes.