### PR TITLE
fix(config): trim storage provider env values

### DIFF
--- a/openhands/app_server/utils/environment.py
+++ b/openhands/app_server/utils/environment.py
@@ -28,11 +28,11 @@ def get_storage_provider() -> StorageProvider:
     Returns:
         StorageProvider: The configured storage provider (AWS, GCP, or FILESYSTEM)
     """
-    provider = os.environ.get('SHARED_EVENT_STORAGE_PROVIDER', '').lower()
+    provider = os.environ.get('SHARED_EVENT_STORAGE_PROVIDER', '').strip().lower()
 
     # If not explicitly set, fall back to FILE_STORE
     if not provider:
-        provider = os.environ.get('FILE_STORE', '').lower()
+        provider = os.environ.get('FILE_STORE', '').strip().lower()
 
     if provider in ('aws', 's3'):
         return StorageProvider.AWS

--- a/tests/unit/utils/test_environment.py
+++ b/tests/unit/utils/test_environment.py
@@ -76,3 +76,13 @@ class TestGetStorageProvider:
 
         monkeypatch.setenv('SHARED_EVENT_STORAGE_PROVIDER', 'GCP')
         assert get_storage_provider() == StorageProvider.GCP
+
+    def test_strips_shared_event_storage_provider(self, monkeypatch):
+        monkeypatch.setenv('SHARED_EVENT_STORAGE_PROVIDER', ' aws ')
+        monkeypatch.delenv('FILE_STORE', raising=False)
+        assert get_storage_provider() == StorageProvider.AWS
+
+    def test_strips_file_store_fallback(self, monkeypatch):
+        monkeypatch.delenv('SHARED_EVENT_STORAGE_PROVIDER', raising=False)
+        monkeypatch.setenv('FILE_STORE', ' google_cloud ')
+        assert get_storage_provider() == StorageProvider.GCP


### PR DESCRIPTION
HUMAN:

- [ ] A human has tested these changes.

AGENT:

---

## Why

`get_storage_provider()` already treats provider names case-insensitively, but values copied from env files with surrounding whitespace fall through to filesystem storage.

## Summary

- Strip `SHARED_EVENT_STORAGE_PROVIDER` before matching provider aliases.
- Strip the legacy `FILE_STORE` fallback the same way.
- Add coverage for whitespace-padded env values.

## Issue Number

N/A

## How to Test

`uv run pytest tests/unit/utils/test_environment.py -q`

## Video/Screenshots

N/A

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No config or migration changes.