### PR TITLE
fix(events): ignore invalid page ids

### DIFF
--- a/openhands/app_server/event/event_service_base.py
+++ b/openhands/app_server/event/event_service_base.py
@@ -28,6 +28,15 @@ def _event_load_concurrency() -> int:
         return 10
 
 
+def _event_page_offset(page_id: str | None) -> int:
+    if not page_id:
+        return 0
+    try:
+        return max(0, int(page_id))
+    except ValueError:
+        return 0
+
+
 @dataclass
 class EventServiceBase(EventService, ABC):
     """Event Service for getting events - the only check on permissions for events is
@@ -131,10 +140,9 @@ class EventServiceBase(EventService, ABC):
             )
 
         # Apply pagination to items (not paths)
-        start_offset = 0
+        start_offset = _event_page_offset(page_id)
         next_page_id = None
-        if page_id:
-            start_offset = int(page_id)
+        if start_offset:
             items = items[start_offset:]
         if len(items) > limit:
             next_page_id = str(start_offset + limit)

--- a/tests/unit/app_server/test_filesystem_event_service.py
+++ b/tests/unit/app_server/test_filesystem_event_service.py
@@ -294,6 +294,25 @@ class TestFilesystemEventServiceSearchEvents:
         assert len(collected_ids) == 5
 
     @pytest.mark.asyncio
+    async def test_search_events_invalid_page_id_starts_at_first_page(
+        self, service: FilesystemEventService
+    ):
+        """Test that invalid page tokens do not crash event search."""
+        conversation_id = uuid4()
+
+        for _ in range(3):
+            await service.save_event(conversation_id, create_token_event())
+
+        result = await service.search_events(
+            conversation_id,
+            page_id='not-an-offset',
+            limit=2,
+        )
+
+        assert len(result.items) == 2
+        assert result.next_page_id == '2'
+
+    @pytest.mark.asyncio
     async def test_search_events_filter_by_timestamp_gte(
         self, service: FilesystemEventService
     ):


### PR DESCRIPTION
HUMAN:

- [ ] A human has tested these changes.

AGENT:

---

## Why

`EventServiceBase.search_events()` converts `page_id` directly with `int(page_id)`. A malformed page token can raise `ValueError` and fail the event list request.

## Summary

- Parse event page offsets through a small helper.
- Treat invalid, empty, and negative page IDs as the first page.
- Add filesystem event-service coverage for an invalid page token.

## Issue Number

N/A

## How to Test

`uv run pytest tests/unit/app_server/test_filesystem_event_service.py::TestFilesystemEventServiceSearchEvents -q`

## Video/Screenshots

N/A

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No config or migration changes.