### PR TITLE
chore: remove cloud-line release-please bootstrap last-release-sha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,11 @@ name: release
 
 # app (X.Y.Z, excludes enterprise/) and cloud (cloud-X.Y.Z) release lines.
 #
-# BOOTSTRAP: both configs set a top-level `last-release-sha` to bound the first
-# release's notes (the existing tags aren't reachable from main). Delete those
-# lines once each line's first release PR has merged — they cap every run, not
-# just the first.
+# BOOTSTRAP: a config sets a top-level `last-release-sha` to bound the first
+# release's notes (the existing tags aren't reachable from main). Delete that
+# line once the line's first release PR has merged — it caps every run, not
+# just the first. The cloud line is done; the app config still carries it until
+# its first release PR (#14747) merges.
 on:
   push:
     branches:

--- a/release-please-config.cloud.json
+++ b/release-please-config.cloud.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "last-release-sha": "2a3f06a75d4b166bef77a0240143efdcc092cfc2",
   "packages": {
     ".": {
       "release-type": "simple",


### PR DESCRIPTION
AGENT:

---

## Why

When release-please was first set up, both release lines (app and cloud) got a top-level `last-release-sha` in their config to bound the first release's notes, since the pre-existing tags aren't reachable from `main`. That SHA caps the commit scan on every run, not just the first, so it's meant to be removed once a line's first release PR merges.

The cloud line's first release PR (#14748, `cloud-1.39.0`) has now merged, so its bootstrap can come out. release-please will baseline off the `cloud-1.39.0` release going forward.

## Summary

- Removed `last-release-sha` from `release-please-config.cloud.json`.
- Updated the bootstrap comment in `release.yml` to reflect that only the app config still carries the line.

## Issue Number

## How to Test

No runtime behavior to exercise. `release-please-config.cloud.json` is still valid JSON (`python3 -c "import json; json.load(open('release-please-config.cloud.json'))"`). The real validation is the next cloud release PR generating correct notes off the `cloud-1.39.0` baseline.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

I deliberately left the app line's `last-release-sha` in `release-please-config.json` alone. Its first release PR (#14747, `release 1.9.0`) is still open, and removing the SHA now would shift the commit-scan boundary for that unmerged release. When #14747 merges, drop `last-release-sha` from `release-please-config.json` the same way and remove the trailing sentence from the `release.yml` comment.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-3c214cc   docker.openhands.dev/openhands/openhands:3c214cc
```