### PR TITLE
fix: align DELETE sandbox path param with handler arg name

### DIFF
--- a/openhands/app_server/sandbox/sandbox_router.py
+++ b/openhands/app_server/sandbox/sandbox_router.py
@@ -105,7 +105,7 @@ async def resume_sandbox(
     return Success()
 
 
-@router.delete('/{id}', responses={404: {'description': 'Item not found'}})
+@router.delete('/{sandbox_id}', responses={404: {'description': 'Item not found'}})
 async def delete_sandbox(
     sandbox_id: str,
     sandbox_service: SandboxService = sandbox_service_dependency,


### PR DESCRIPTION
The `DELETE /api/v1/sandboxes/{id}` route's path placeholder `{id}` does not match the handler argument `sandbox_id`, causing FastAPI to treat `sandbox_id` as a required query parameter instead of binding it from the path.

This renames `{id}` to `{sandbox_id}` to match the sibling pause/resume routes and restore correct RESTful behaviour.

Fixes OpenHands/enterprise#39

HUMAN:
This PR fixes a path parameter mismatch in the DELETE sandbox endpoint. The route defined `{id}` but the handler function expected `sandbox_id`, which caused FastAPI to not bind the URL path value to the function argument — essentially breaking the sandbox deletion API. The fix renames the path placeholder from `{id}` to `{sandbox_id}`, matching the existing pause and resume routes and restoring the endpoint's correct RESTful behavior.
