### PR TITLE
fix: apply disabled_skills filter in conversation skills endpoint

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_router.py
+++ b/openhands/app_server/app_conversation/app_conversation_router.py
@@ -1312,6 +1312,7 @@ async def get_conversation_skills(
     ),
     sandbox_service: SandboxService = sandbox_service_dependency,
     sandbox_spec_service: SandboxSpecService = sandbox_spec_service_dependency,
+    user_context: UserContext = user_context_dependency,
 ) -> JSONResponse:
     """Get all skills associated with the conversation.
 
@@ -1360,6 +1361,12 @@ async def get_conversation_skills(
             f'Loaded {len(all_skills)} skills for conversation {conversation_id}: '
             f'{[s.name for s in all_skills]}'
         )
+
+        # Filter out disabled skills (mirroring _load_skills_and_update_agent)
+        user_info = await user_context.get_user_info()
+        if user_info and user_info.disabled_skills:
+            disabled_set = set(user_info.disabled_skills)
+            all_skills = [s for s in all_skills if s.name not in disabled_set]
 
         # Transform skills to response format
         skills_response = []

--- a/tests/unit/app_server/test_app_conversation_skills_endpoint.py
+++ b/tests/unit/app_server/test_app_conversation_skills_endpoint.py
@@ -30,6 +30,16 @@ from openhands.app_server.user.user_context import UserContext
 from openhands.sdk.skills import KeywordTrigger, Skill, TaskTrigger
 
 
+def _make_user_context_mock(
+    *,
+    get_user_info_return: object = None,
+):
+    """Create a mock UserContext with async get_user_info."""
+    mock_ctx = MagicMock(spec=UserContext)
+    mock_ctx.get_user_info = AsyncMock(return_value=get_user_info_return)
+    return mock_ctx
+
+
 def _make_service_mock(
     *,
     user_context: UserContext,
@@ -111,7 +121,7 @@ class TestGetConversationSkills:
         )
 
         # Mock services
-        mock_user_context = MagicMock(spec=UserContext)
+        mock_user_context = _make_user_context_mock()
         mock_app_conversation_service = _make_service_mock(
             user_context=mock_user_context,
             conversation_return=mock_conversation,
@@ -132,6 +142,7 @@ class TestGetConversationSkills:
             app_conversation_service=mock_app_conversation_service,
             sandbox_service=mock_sandbox_service,
             sandbox_spec_service=mock_sandbox_spec_service,
+            user_context=mock_user_context,
         )
 
         # Assert
@@ -171,7 +182,7 @@ class TestGetConversationSkills:
         # Arrange
         conversation_id = uuid4()
 
-        mock_user_context = MagicMock(spec=UserContext)
+        mock_user_context = _make_user_context_mock()
         mock_app_conversation_service = _make_service_mock(
             user_context=mock_user_context,
             conversation_return=None,
@@ -186,6 +197,7 @@ class TestGetConversationSkills:
             app_conversation_service=mock_app_conversation_service,
             sandbox_service=mock_sandbox_service,
             sandbox_spec_service=mock_sandbox_spec_service,
+            user_context=mock_user_context,
         )
 
         # Assert
@@ -215,7 +227,7 @@ class TestGetConversationSkills:
             sandbox_status=SandboxStatus.RUNNING,
         )
 
-        mock_user_context = MagicMock(spec=UserContext)
+        mock_user_context = _make_user_context_mock()
         mock_app_conversation_service = _make_service_mock(
             user_context=mock_user_context,
             conversation_return=mock_conversation,
@@ -232,6 +244,7 @@ class TestGetConversationSkills:
             app_conversation_service=mock_app_conversation_service,
             sandbox_service=mock_sandbox_service,
             sandbox_spec_service=mock_sandbox_spec_service,
+            user_context=mock_user_context,
         )
 
         # Assert
@@ -263,7 +276,7 @@ class TestGetConversationSkills:
             session_api_key='test-api-key',
         )
 
-        mock_user_context = MagicMock(spec=UserContext)
+        mock_user_context = _make_user_context_mock()
         mock_app_conversation_service = _make_service_mock(
             user_context=mock_user_context,
             conversation_return=mock_conversation,
@@ -280,6 +293,7 @@ class TestGetConversationSkills:
             app_conversation_service=mock_app_conversation_service,
             sandbox_service=mock_sandbox_service,
             sandbox_spec_service=mock_sandbox_spec_service,
+            user_context=mock_user_context,
         )
 
         # Assert
@@ -330,7 +344,7 @@ class TestGetConversationSkills:
             trigger=TaskTrigger(triggers=['task', 'execute']),
         )
 
-        mock_user_context = MagicMock(spec=UserContext)
+        mock_user_context = _make_user_context_mock()
         mock_app_conversation_service = _make_service_mock(
             user_context=mock_user_context,
             conversation_return=mock_conversation,
@@ -351,6 +365,7 @@ class TestGetConversationSkills:
             app_conversation_service=mock_app_conversation_service,
             sandbox_service=mock_sandbox_service,
             sandbox_spec_service=mock_sandbox_spec_service,
+            user_context=mock_user_context,
         )
 
         # Assert
@@ -397,7 +412,7 @@ class TestGetConversationSkills:
             id=str(uuid4()), command=None, working_dir='/workspace'
         )
 
-        mock_user_context = MagicMock(spec=UserContext)
+        mock_user_context = _make_user_context_mock()
         mock_app_conversation_service = _make_service_mock(
             user_context=mock_user_context,
             conversation_return=mock_conversation,
@@ -418,6 +433,7 @@ class TestGetConversationSkills:
             app_conversation_service=mock_app_conversation_service,
             sandbox_service=mock_sandbox_service,
             sandbox_spec_service=mock_sandbox_spec_service,
+            user_context=mock_user_context,
         )
 
         # Assert
@@ -462,7 +478,7 @@ class TestGetConversationSkills:
             id=str(uuid4()), command=None, working_dir='/workspace'
         )
 
-        mock_user_context = MagicMock(spec=UserContext)
+        mock_user_context = _make_user_context_mock()
         mock_app_conversation_service = _make_service_mock(
             user_context=mock_user_context,
             conversation_return=mock_conversation,
@@ -483,6 +499,7 @@ class TestGetConversationSkills:
             app_conversation_service=mock_app_conversation_service,
             sandbox_service=mock_sandbox_service,
             sandbox_spec_service=mock_sandbox_spec_service,
+            user_context=mock_user_context,
         )
 
         # Assert
@@ -528,7 +545,7 @@ class TestGetConversationSkills:
             id=str(uuid4()), command=None, working_dir='/workspace'
         )
 
-        mock_user_context = MagicMock(spec=UserContext)
+        mock_user_context = _make_user_context_mock()
         mock_app_conversation_service = _make_service_mock(
             user_context=mock_user_context,
             conversation_return=mock_conversation,
@@ -552,6 +569,7 @@ class TestGetConversationSkills:
             app_conversation_service=mock_app_conversation_service,
             sandbox_service=mock_sandbox_service,
             sandbox_spec_service=mock_sandbox_spec_service,
+            user_context=mock_user_context,
         )
 
         # Assert


### PR DESCRIPTION
The `GET /api/v1/app-conversations/{id}/skills` endpoint returns the full merged skill set without applying `disabled_skills`, while the agent-context path correctly filters them. This makes the "Available Skills" panel show skills the user has explicitly disabled, creating a confusing discrepancy.

This PR adds `user_context` injection and filters the returned skills by the user's `disabled_skills`, mirroring `_load_skills_and_update_agent` behaviour.

Fixes OpenHands/enterprise#74 (Bug 1)

HUMAN:
This PR fixes a UI discrepancy where the "Available Skills" panel in the conversation view showed skills the user had explicitly disabled. The root cause was that the conversation skills API endpoint returned all merged skills without checking the user's disabled_skills setting — even though the agent runtime correctly honored that setting when loading skills for execution. The fix injects the user context into the endpoint and filters out any skills listed in disabled_skills before returning the response, aligning the display with the actual agent behavior.
