### PR TITLE
feat: Use interrupt endpoint for agent pause UI

### DIFF
--- a/frontend/__tests__/api/v1-conversation-service.test.ts
+++ b/frontend/__tests__/api/v1-conversation-service.test.ts
@@ -114,4 +114,35 @@ describe("V1ConversationService", () => {
       expect(headers).toHaveProperty("Content-Type", "multipart/form-data");
     });
   });
+
+  describe("interruptConversation", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      (axios.post as Mock).mockResolvedValue({ data: { success: true } });
+    });
+
+    afterEach(() => {
+      vi.resetAllMocks();
+    });
+
+    it("calls the runtime interrupt endpoint with session headers", async () => {
+      const conversationId = "conv-123";
+      const conversationUrl =
+        "http://localhost:54928/api/conversations/conv-123";
+      const sessionApiKey = "test-api-key";
+
+      const result = await V1ConversationService.interruptConversation(
+        conversationId,
+        conversationUrl,
+        sessionApiKey,
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(axios.post).toHaveBeenCalledWith(
+        "http://localhost:54928/api/conversations/conv-123/interrupt",
+        {},
+        { headers: { "X-Session-API-Key": sessionApiKey } },
+      );
+    });
+  });
 });

--- a/frontend/src/api/conversation-service/v1-conversation-service.api.ts
+++ b/frontend/src/api/conversation-service/v1-conversation-service.api.ts
@@ -179,7 +179,7 @@ class V1ConversationService {
   }
 
   /**
-   * Pause a V1 conversation
+   * Interrupt a V1 conversation
    * Uses the custom runtime URL from the conversation
    *
    * @param conversationId The conversation ID
@@ -187,14 +187,14 @@ class V1ConversationService {
    * @param sessionApiKey Session API key for authentication (required for V1)
    * @returns Success response
    */
-  static async pauseConversation(
+  static async interruptConversation(
     conversationId: string,
     conversationUrl: string | null | undefined,
     sessionApiKey?: string | null,
   ): Promise<{ success: boolean }> {
     const url = this.buildRuntimeUrl(
       conversationUrl,
-      `/api/conversations/${conversationId}/pause`,
+      `/api/conversations/${conversationId}/interrupt`,
     );
     const headers = buildSessionHeaders(sessionApiKey);
 

--- a/frontend/src/hooks/mutation/conversation-mutation-utils.ts
+++ b/frontend/src/hooks/mutation/conversation-mutation-utils.ts
@@ -39,12 +39,12 @@ export const pauseV1ConversationSandbox = async (conversationId: string) => {
 };
 
 /**
- * Pause a V1 conversation by fetching the conversation data and pausing it
+ * Interrupt a V1 conversation by fetching the conversation data and interrupting it
  */
-export const pauseV1Conversation = async (conversationId: string) => {
+export const interruptV1Conversation = async (conversationId: string) => {
   const { conversationUrl, sessionApiKey } =
     await fetchV1ConversationData(conversationId);
-  return V1ConversationService.pauseConversation(
+  return V1ConversationService.interruptConversation(
     conversationId,
     conversationUrl,
     sessionApiKey,

--- a/frontend/src/hooks/mutation/use-v1-pause-conversation.ts
+++ b/frontend/src/hooks/mutation/use-v1-pause-conversation.ts
@@ -1,12 +1,12 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { pauseV1Conversation } from "./conversation-mutation-utils";
+import { interruptV1Conversation } from "./conversation-mutation-utils";
 
 export const useV1PauseConversation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (variables: { conversationId: string }) =>
-      pauseV1Conversation(variables.conversationId),
+      interruptV1Conversation(variables.conversationId),
     onMutate: async () => {
       await queryClient.cancelQueries({ queryKey: ["user", "conversations"] });
       const previousConversations = queryClient.getQueryData([


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

Demonstrating instant interrupts (one was prompt after each prompt)

<img width="1444" height="1590" alt="image" src="https://github.com/user-attachments/assets/888d2f6e-d82e-45ca-a9fa-8815581d58c0" />


- [x] A human has tested these changes.

AGENT:

---

## Why

The frontend pause control for V1 conversations was still calling the agent server's `/pause` endpoint. The agent server provides `/interrupt`, which cancels in-flight work immediately while transitioning the conversation to a paused/resumable state.

## Summary

- Switch the V1 conversation pause UI flow to call `POST /api/conversations/{conversationId}/interrupt`.
- Rename the frontend API/mutation utility to reflect interrupt semantics while preserving the existing pause UI hook.
- Add API test coverage for the interrupt endpoint and session API key header.

## Issue Number

N/A

## How to Test

- `cd frontend && npm test -- --run __tests__/api/v1-conversation-service.test.ts`
- `cd frontend && npm run lint:fix && npm run build`

## Video/Screenshots

N/A — API endpoint migration with unit coverage and build validation.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The sandbox lifecycle stop flow still uses `/api/v1/sandboxes/{id}/pause`; this PR only changes the agent execution pause control to use the agent-server interrupt endpoint.

This PR was created by an AI agent (OpenHands) on behalf of the user.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e8f7d228-fe28-492c-86f5-272842d24ab1)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-4e28147   docker.openhands.dev/openhands/openhands:4e28147
```