### PR TITLE
fix: remove duplicate Close button on the org invite links modal

### DIFF
--- a/frontend/src/components/features/org/invite-organization-member-modal.tsx
+++ b/frontend/src/components/features/org/invite-organization-member-modal.tsx
@@ -86,6 +86,7 @@ export function InviteOrganizationMemberModal({
         primaryButtonText={t(I18nKey.BUTTON$CLOSE)}
         onPrimaryClick={() => onClose()}
         onClose={onClose}
+        hideSecondaryButton
       >
         <div className="flex flex-col gap-2" data-testid="invite-links-list">
           {/* With email configured the modal only stays open to show failures;

--- a/frontend/src/components/shared/modals/modal-button-group.tsx
+++ b/frontend/src/components/shared/modals/modal-button-group.tsx
@@ -15,6 +15,9 @@ interface ModalButtonGroupProps {
   primaryTestId?: string;
   secondaryTestId?: string;
   fullWidth?: boolean;
+  // For single-action modals where the primary button already closes; avoids a
+  // redundant second "Close" button next to it.
+  hideSecondaryButton?: boolean;
 }
 
 export function ModalButtonGroup({
@@ -27,6 +30,7 @@ export function ModalButtonGroup({
   primaryTestId,
   secondaryTestId,
   fullWidth = false,
+  hideSecondaryButton = false,
 }: ModalButtonGroupProps) {
   const { t } = useTranslation();
   const closeText = secondaryText ?? t(I18nKey.BUTTON$CLOSE);
@@ -55,16 +59,18 @@ export function ModalButtonGroup({
           primaryText
         )}
       </BrandButton>
-      <BrandButton
-        type="button"
-        variant="secondary"
-        onClick={onSecondaryClick}
-        className={cn(fullWidth ? "w-full" : "grow")}
-        testId={secondaryTestId}
-        isDisabled={isLoading}
-      >
-        {closeText}
-      </BrandButton>
+      {!hideSecondaryButton && (
+        <BrandButton
+          type="button"
+          variant="secondary"
+          onClick={onSecondaryClick}
+          className={cn(fullWidth ? "w-full" : "grow")}
+          testId={secondaryTestId}
+          isDisabled={isLoading}
+        >
+          {closeText}
+        </BrandButton>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/shared/modals/org-modal.tsx
+++ b/frontend/src/components/shared/modals/org-modal.tsx
@@ -20,6 +20,7 @@ interface OrgModalProps {
   asForm?: boolean;
   formAction?: (formData: FormData) => void;
   fullWidthButtons?: boolean;
+  hideSecondaryButton?: boolean;
 }
 
 export function OrgModal({
@@ -39,6 +40,7 @@ export function OrgModal({
   asForm = false,
   formAction,
   fullWidthButtons = false,
+  hideSecondaryButton = false,
 }: OrgModalProps) {
   const content = (
     <>
@@ -59,6 +61,7 @@ export function OrgModal({
         primaryTestId={primaryButtonTestId}
         secondaryTestId={secondaryButtonTestId}
         fullWidth={fullWidthButtons}
+        hideSecondaryButton={hideSecondaryButton}
       />
     </>
   );


### PR DESCRIPTION
HUMAN: Verified via the local ui-verify Playwright harness (mock SaaS frontend) — the invite-links result view goes from 2 Close buttons to 1. Not yet run on a live instance.

- [x] A human has tested these changes.

## What
The org invite **links** result view (shown after sending invites when email delivery isn't configured) rendered **two "Close" buttons**: the primary action passed `BUTTON$CLOSE`, while `ModalButtonGroup` also rendered its default "Close" secondary. This adds an opt-in `hideSecondaryButton` to `ModalButtonGroup` (threaded through `OrgModal`) and sets it on the invite-links view, leaving a single Close button. The normal invite view ("Add" + "Close") is unchanged.

## Verification — ui-verify (Playwright, mock SaaS)
A Playwright walkthrough drives `/settings/org-members` -> Invite -> enter emails -> submit -> the invite-links result view, asserting the **Close-button count goes 2 -> 1**.

<!-- ui-verify:start -->
- [Click-through walkthrough (GIF)](https://github.com/OpenHands/OpenHands/blob/ui-verify-artifacts/pr-14974/walkthrough.gif)
- [Before - 2 Close buttons](https://github.com/OpenHands/OpenHands/blob/ui-verify-artifacts/pr-14974/before-2-close-buttons.png)
- [After - 1 Close button](https://github.com/OpenHands/OpenHands/blob/ui-verify-artifacts/pr-14974/after-1-close-button.png)
- [summary.json](https://github.com/OpenHands/OpenHands/blob/ui-verify-artifacts/pr-14974/summary.json)
<!-- ui-verify:end -->

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-ca4b210   docker.openhands.dev/openhands/openhands:ca4b210
```