### PR TITLE
docs: fix dead link to self-hosting guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ or on a server in the cloud.
 
 The most powerful way to run OpenHands is on a server in the cloud. This allows your agents to continue running
 even when your laptop is shut, and makes it easier to trigger your agents through third-party services
-like Slack, GitHub, and Datadog. See [SELF_HOSTING.md](docs/SELF_HOSTING.md) for details, especially with respect to security hardening.
+like Slack, GitHub, and Datadog. See the [self-hosting guide](https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/vm) for details, especially with respect to security hardening.
 
 Notably, you can run the backend in _multiple different environments_, and switch between
 them from the same Agent Canvas frontend. E.g. you can share an Agent Server with your team for agents doing


### PR DESCRIPTION
HUMAN: The README linked to `docs/SELF_HOSTING.md`, but that file was removed (the whole `docs/` directory is gone) so the link 404s. I repointed it to the self-hosting guide on the docs site — the same URL the README already uses in its header/nav — so the security-hardening info is reachable again. One-line docs fix, verified the old path 404s and the new one resolves.

- [x] A human has tested these changes.

## Problem

The README links to `docs/SELF_HOSTING.md` for self-hosting / security-hardening details, but that file no longer exists — it returns a 404 (the `docs/` directory was removed from the repo).

```
raw .../docs/SELF_HOSTING.md  → 404
```

A reader who wants the self-hosting security guidance follows the link and hits a dead end.

## Fix

Point the link to the self-hosting guide on the docs site, which the README already references in its header/nav and which resolves correctly:

```diff
- See [SELF_HOSTING.md](docs/SELF_HOSTING.md) for details, especially with respect to security hardening.
+ See the [self-hosting guide](https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/vm) for details, especially with respect to security hardening.
```

Docs-only, one line.
