### PR TITLE
fix: allow max_num_sandboxes=1 by accepting 0 in pause_old_sandboxes

### DIFF
--- a/openhands/app_server/sandbox/docker_sandbox_service.py
+++ b/openhands/app_server/sandbox/docker_sandbox_service.py
@@ -598,6 +598,7 @@ class DockerSandboxServiceInjector(SandboxServiceInjector):
     container_name_prefix: str = 'oh-agent-server-'
     max_num_sandboxes: int = Field(
         default=5,
+        ge=1,
         description='Maximum number of sandboxes allowed to run simultaneously',
     )
     mounts: list[VolumeMount] = Field(default_factory=list)

--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -601,8 +601,8 @@ class RemoteSandboxService(SandboxService):
         Uses _get_user_running_sandboxes (runtime /list + DB cross-reference) so
         only sandboxes that are actually running are considered.
         """
-        if max_num_sandboxes <= 0:
-            raise ValueError('max_num_sandboxes must be greater than 0')
+        if max_num_sandboxes < 0:
+            raise ValueError('max_num_sandboxes must be greater than or equal to 0')
 
         running = await self._get_user_running_sandboxes()
 
@@ -901,6 +901,7 @@ class RemoteSandboxServiceInjector(SandboxServiceInjector):
     )
     max_num_sandboxes: int = Field(
         default=10,
+        ge=1,
         description='Maximum number of sandboxes allowed to run simultaneously',
     )
 

--- a/openhands/app_server/sandbox/sandbox_service.py
+++ b/openhands/app_server/sandbox/sandbox_service.py
@@ -210,8 +210,8 @@ class SandboxService(ABC):
         Returns:
             List of sandbox IDs that were paused
         """
-        if max_num_sandboxes <= 0:
-            raise ValueError('max_num_sandboxes must be greater than 0')
+        if max_num_sandboxes < 0:
+            raise ValueError('max_num_sandboxes must be greater than or equal to 0')
 
         # Get all running sandboxes (iterate through all pages)
         running_sandboxes = []

--- a/tests/unit/app_server/test_sandbox_service.py
+++ b/tests/unit/app_server/test_sandbox_service.py
@@ -298,17 +298,41 @@ class TestCleanupOldSandboxes:
         assert mock_sandbox_service.pause_sandbox_mock.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_cleanup_invalid_max_num_sandboxes(self, mock_sandbox_service):
-        """Test cleanup raises ValueError for invalid max_num_sandboxes."""
-        # Test zero
-        with pytest.raises(
-            ValueError, match='max_num_sandboxes must be greater than 0'
-        ):
-            await mock_sandbox_service.pause_old_sandboxes(max_num_sandboxes=0)
+    async def test_cleanup_accepts_zero_max_num_sandboxes(self, mock_sandbox_service):
+        """Zero is valid: keep no other sandboxes, pause all running ones.
 
-        # Test negative
+        This is the value passed when ``max_num_sandboxes=1`` is configured
+        (callers invoke ``pause_old_sandboxes(max_num_sandboxes - 1)``), which is
+        the officially recommended setting for Docker host network mode. It must
+        not raise.
+        """
+        # Two running sandboxes; with a keep-count of 0 both should be paused.
+        now = datetime.now(timezone.utc)
+        sandboxes = [
+            create_sandbox_info(
+                'sandbox-1', SandboxStatus.RUNNING, now - timedelta(hours=2)
+            ),
+            create_sandbox_info(
+                'sandbox-2', SandboxStatus.RUNNING, now - timedelta(hours=1)
+            ),
+        ]
+        mock_sandbox_service.search_sandboxes_mock.return_value = SandboxPage(
+            items=sandboxes, next_page_id=None
+        )
+        mock_sandbox_service.pause_sandbox_mock.return_value = True
+
+        result = await mock_sandbox_service.pause_old_sandboxes(max_num_sandboxes=0)
+
+        assert set(result) == {'sandbox-1', 'sandbox-2'}
+        assert mock_sandbox_service.pause_sandbox_mock.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_cleanup_rejects_negative_max_num_sandboxes(
+        self, mock_sandbox_service
+    ):
+        """Negative values are invalid and must raise."""
         with pytest.raises(
-            ValueError, match='max_num_sandboxes must be greater than 0'
+            ValueError, match='max_num_sandboxes must be greater than or equal to 0'
         ):
             await mock_sandbox_service.pause_old_sandboxes(max_num_sandboxes=-1)
 


### PR DESCRIPTION
HUMAN: When `max_num_sandboxes` is set to 1, starting a conversation always crashes. I traced it: the sandbox start path calls `pause_old_sandboxes(max_num_sandboxes - 1)`, so a limit of 1 passes 0, and the guard `if max_num_sandboxes <= 0: raise` rejected 0 — even though 0 is a valid "keep no other sandboxes" request that the method body already handles correctly. This breaks the host-network setup the docs explicitly recommend (`max_num_sandboxes=1`). I fixed the guard, added a config lower-bound, and updated the tests. I verified by constructing a real DockerSandboxService with max_num_sandboxes=1 and confirming start_sandbox() no longer raises.

- [x] A human has tested these changes.

## Problem

Starting or resuming a sandbox **crashes whenever `max_num_sandboxes=1`**.

Callers reserve a slot for the new sandbox by invoking:

```python
await self.pause_old_sandboxes(self.max_num_sandboxes - 1)
```

So a limit of `1` passes `0`. But the guard rejected `0`:

```python
if max_num_sandboxes <= 0:
    raise ValueError('max_num_sandboxes must be greater than 0')
```

`0` is a **legitimate** value meaning "keep no other sandboxes" — the method body handles it correctly (`num_to_pause = len(running) - 0` pauses all). The guard kills it before that code runs, so **every** `start_sandbox` / `resume_sandbox` fails.

This matters in practice: the Docker service explicitly **recommends `max_num_sandboxes=1` for host network mode** (`docker_sandbox_service.py`). An operator following that advice breaks every conversation start.

Only `max_num_sandboxes=1` triggers it — other values pass `>= 1` to the guard. Verified by constructing a real `DockerSandboxService(max_num_sandboxes=1)` and calling `start_sandbox()`, which raised `ValueError: max_num_sandboxes must be greater than 0` before this fix.

## Fix

- Relax the guard in `SandboxService` and `RemoteSandboxService` from `<= 0` to `< 0`, and update the message to "greater than or equal to 0".
- Add a `ge=1` constraint to the `max_num_sandboxes` config `Field` in the Docker and remote services, so misconfigured `0`/negative limits are rejected at the source rather than crashing at runtime.
- Update `tests/unit/app_server/test_sandbox_service.py`: `0` must pause all running sandboxes; only negative values raise.

The `max_num_sandboxes - 1` reserve-a-slot logic is correct — the root cause is the over-strict guard plus the missing config lower-bound.

## Testing

```
poetry run pytest tests/unit/app_server/test_sandbox_service.py \
    tests/unit/app_server/test_docker_sandbox_service.py \
    tests/unit/app_server/test_remote_sandbox_service.py
```
All pass (132). `ruff check` clean on changed files.
