### PR TITLE
feat(app_server): inject self-hosted provider host (BITBUCKET_DATA_CENTER_HOST) into agent runtime

### DIFF
--- a/openhands/app_server/integrations/provider.py
+++ b/openhands/app_server/integrations/provider.py
@@ -408,6 +408,17 @@ class ProviderHandler:
         """Map ProviderType value to the environment variable name in the runtime"""
         return f'{provider.value}_token'.lower()
 
+    @classmethod
+    def get_provider_host_env_key(cls, provider: ProviderType) -> str:
+        """Map ProviderType value to the host environment variable name in the runtime.
+
+        Self-hosted providers (e.g. Bitbucket Data Center, self-managed GitLab)
+        have no fixed public domain, so the agent needs the configured host to
+        build REST API and git remote URLs — including before any repository is
+        cloned. This mirrors ``get_provider_env_key`` for the host value.
+        """
+        return f'{provider.value}_host'.lower()
+
     async def verify_repo_provider(
         self,
         repository: str,

--- a/openhands/app_server/user/auth_user_context.py
+++ b/openhands/app_server/user/auth_user_context.py
@@ -89,6 +89,15 @@ class AuthUserContext(UserContext):
                     token_value = provider_token.token.get_secret_value()
                     if token_value:
                         results[env_key] = token_value
+                # Expose the configured host (e.g. bitbucket_data_center_host) so
+                # the agent can build REST API and git remote URLs for self-hosted
+                # providers even before — or without — cloning a repository. Azure
+                # DevOps is excluded because its host field may hold an
+                # org/project path rather than a bare host (see
+                # ProviderHandler.get_authenticated_git_url).
+                if provider_token.host and provider_type != ProviderType.AZURE_DEVOPS:
+                    host_key = ProviderHandler.get_provider_host_env_key(provider_type)
+                    results[host_key] = provider_token.host
         return results
 
     async def get_provider_handler(self):

--- a/skills/bitbucket_data_center.md
+++ b/skills/bitbucket_data_center.md
@@ -12,10 +12,10 @@ You have access to an environment variable, `BITBUCKET_DATA_CENTER_TOKEN`, which
 a basic auth token in the format `username:your-token` that allows you to interact with the git repository.
 
 Because Bitbucket Data Center is self-hosted, there is no fixed domain like `bitbucket.org`.
-The host/domain comes from the `BITBUCKET_DATA_CENTER_HOST` environment variable, which is
-the same variable the OpenHands Bitbucket Data Center integration uses to build its base URL
-(`https://{host}/rest/api/1.0`). Substitute `${BITBUCKET_DATA_CENTER_HOST}` wherever you see
-`{domain}` below. If `BITBUCKET_DATA_CENTER_HOST` is not set, ask the user for the host
+The host/domain is provided to you as the `BITBUCKET_DATA_CENTER_HOST` environment variable,
+which OpenHands injects into your environment alongside `BITBUCKET_DATA_CENTER_TOKEN` (it is
+available even before any repository is cloned). Substitute `${BITBUCKET_DATA_CENTER_HOST}`
+wherever you see `{domain}` below. In the rare case it is not set, ask the user for the host
 instead of guessing.
 
 You can also use this token to interact with Bitbucket Data Center's REST API:

--- a/skills/bitbucket_data_center.md
+++ b/skills/bitbucket_data_center.md
@@ -11,9 +11,16 @@ triggers:
 You have access to an environment variable, `BITBUCKET_DATA_CENTER_TOKEN`, which contains
 a basic auth token in the format `username:your-token` that allows you to interact with the git repository.
 
+Because Bitbucket Data Center is self-hosted, there is no fixed domain like `bitbucket.org`.
+The host/domain comes from the `BITBUCKET_DATA_CENTER_HOST` environment variable, which is
+the same variable the OpenHands Bitbucket Data Center integration uses to build its base URL
+(`https://{host}/rest/api/1.0`). Substitute `${BITBUCKET_DATA_CENTER_HOST}` wherever you see
+`{domain}` below. If `BITBUCKET_DATA_CENTER_HOST` is not set, ask the user for the host
+instead of guessing.
+
 You can also use this token to interact with Bitbucket Data Center's REST API:
 ```bash
-curl -u "${BITBUCKET_DATA_CENTER_TOKEN}" https://{domain}/rest/api/1.0/...
+curl -u "${BITBUCKET_DATA_CENTER_TOKEN}" "https://${BITBUCKET_DATA_CENTER_HOST}/rest/api/1.0/..."
 ```
 
 <IMPORTANT>
@@ -21,7 +28,7 @@ ALWAYS use the Bitbucket Data Center API for operations instead of a web browser
 ALWAYS use the `create_bitbucket_data_center_pr` tool to open a pull request
 </IMPORTANT>
 
-If you encounter authentication issues when pushing to Bitbucket Data Center (such as password prompts or permission errors), the old token may have expired. In such case, update the remote URL to include the current token: `git remote set-url origin https://${BITBUCKET_DATA_CENTER_TOKEN}@{domain}/scm/{project_lower}/{repo}.git`
+If you encounter authentication issues when pushing to Bitbucket Data Center (such as password prompts or permission errors), the old token may have expired. In such case, update the remote URL to include the current token: `git remote set-url origin https://${BITBUCKET_DATA_CENTER_TOKEN}@${BITBUCKET_DATA_CENTER_HOST}/scm/{project_lower}/{repo}.git`
 
 The repository format for Bitbucket Data Center is `PROJECT/repo_slug` (project key, slash, repo slug).
 

--- a/tests/unit/app_server/test_sandbox_secrets_router.py
+++ b/tests/unit/app_server/test_sandbox_secrets_router.py
@@ -820,6 +820,60 @@ class TestProviderTokensInEndpoints:
         assert result[gl_key] == 'glpat-test456'
         ctx.get_latest_token.assert_not_called()  # type: ignore[attr-defined]
 
+    async def test_get_provider_tokens_as_env_vars_includes_host(self):
+        """A self-hosted provider host is exposed alongside its token.
+
+        This must work independently of any repository so the agent can build
+        REST API / git remote URLs before — or without — cloning a repo.
+        """
+        mock_user_auth = AsyncMock()
+        mock_user_auth.get_provider_tokens = AsyncMock(
+            return_value={
+                ProviderType.BITBUCKET_DATA_CENTER: ProviderToken(
+                    token=SecretStr('user:dc_token'),
+                    host='bitbucket.internal.example.com',
+                ),
+                # Cloud provider with no host must NOT add a host key.
+                ProviderType.GITHUB: ProviderToken(token=SecretStr('ghp_test123')),
+            }
+        )
+
+        ctx = AuthUserContext(user_auth=mock_user_auth)
+        result = await ctx.get_provider_tokens(as_env_vars=True)
+
+        token_key = ProviderHandler.get_provider_env_key(
+            ProviderType.BITBUCKET_DATA_CENTER
+        )
+        host_key = ProviderHandler.get_provider_host_env_key(
+            ProviderType.BITBUCKET_DATA_CENTER
+        )
+        gh_host_key = ProviderHandler.get_provider_host_env_key(ProviderType.GITHUB)
+        assert host_key == 'bitbucket_data_center_host'
+        assert result[token_key] == 'user:dc_token'
+        assert result[host_key] == 'bitbucket.internal.example.com'
+        assert gh_host_key not in result
+
+    async def test_get_provider_tokens_as_env_vars_excludes_azure_host(self):
+        """Azure DevOps host is not exposed (its host field may hold a path)."""
+        mock_user_auth = AsyncMock()
+        mock_user_auth.get_provider_tokens = AsyncMock(
+            return_value={
+                ProviderType.AZURE_DEVOPS: ProviderToken(
+                    token=SecretStr('azure_token'),
+                    host='dev.azure.com/myorg/myproject',
+                ),
+            }
+        )
+
+        ctx = AuthUserContext(user_auth=mock_user_auth)
+        ctx.get_latest_token = AsyncMock(return_value=None)  # type: ignore[method-assign]
+        result = await ctx.get_provider_tokens(as_env_vars=True)
+
+        azure_host_key = ProviderHandler.get_provider_host_env_key(
+            ProviderType.AZURE_DEVOPS
+        )
+        assert azure_host_key not in result
+
     async def test_get_provider_tokens_as_env_vars_prefers_latest_token(self):
         """Provider env vars resolve through the provider service at call time."""
         mock_user_auth = AsyncMock()


### PR DESCRIPTION
## Problem

For **Bitbucket Data Center** (and other self-hosted providers) there is no fixed public domain like `bitbucket.org`. An agent needs the configured host to call the REST API or build a git remote URL. Today the host (`BITBUCKET_DATA_CENTER_HOST`) is a **server-side** variable only — it is read in `enterprise/server/auth/constants.py`, used to populate `ProviderToken.host`, and consumed server-side (authenticated git URL, `create_bitbucket_data_center_pr` MCP tool). It is **never injected into the agent sandbox**.

Provider credentials reach the sandbox solely through `AuthUserContext.get_provider_tokens(as_env_vars=True)`, surfaced via the `sandbox_router` secret-lookup endpoints. That method exported only the **token** (`bitbucket_data_center_token`), so the agent could authenticate but had no way to learn the host — **especially before a repository is cloned, or in conversations with no repository at all** (where deriving the host from the cloned repo's git remote isn't an option).

## Change

- **`app_server/integrations/provider.py`** — add `ProviderHandler.get_provider_host_env_key(provider)` (`{provider}_host`), mirroring `get_provider_env_key`.
- **`app_server/user/auth_user_context.py`** — in `get_provider_tokens(as_env_vars=True)`, also export the provider host as `{provider}_host` (e.g. `bitbucket_data_center_host`) whenever `ProviderToken.host` is set. Same repo-independent secret-lookup path, so it is available **before or without** cloning a repo. **Azure DevOps is excluded** because its `host` field may contain an org/project path rather than a bare host (consistent with `get_authenticated_git_url`). Also future-proofs self-managed GitLab.
- **`skills/bitbucket_data_center.md`** — document that `BITBUCKET_DATA_CENTER_HOST` is injected by OpenHands and resolve the bare `{domain}` placeholder to `${BITBUCKET_DATA_CENTER_HOST}`.
- **Tests** — extend `tests/unit/app_server/test_sandbox_secrets_router.py` (DC host exported; cloud token adds no host key; Azure host excluded).

## Why this mechanism

The `as_env_vars=True` dict is the **only** path by which git creds reach the sandbox (`sandbox_router.list_secret_names` / `get_secret_value`), and it does not depend on `selected_repository`. Adding the host there makes `${BITBUCKET_DATA_CENTER_HOST}` resolvable by the runtime's secret auto-injection (case-insensitive match to `bitbucket_data_center_host`) in every conversation, pre-clone included.

## Validation

Targeted logic verified in isolation (enum values, `get_provider_host_env_key` formula, export/exclusion branch). Full `pytest` needs the project's managed env (`uv sync`), not provisioned here; the new unit tests mirror the existing `as_env_vars` tests and should run in CI.

## Related

Companion: **OpenHands/extensions#361** (same guidance for the registry `bitbucket-data-center` skill).

Kept as a **draft** pending review of the secret-handling change.

---
_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-7f82126   docker.openhands.dev/openhands/openhands:7f82126
```