### PR TITLE
fix: Fix CVE-2026-54285: Update @opentelemetry/core to 2.8.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3363,9 +3363,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
-      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -3463,21 +3463,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
-      "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -130,6 +130,7 @@
   },
   "overrides": {
     "dompurify": "3.4.11",
-    "qs": "6.15.2"
+    "qs": "6.15.2",
+    "@opentelemetry/core": "2.8.0"
   }
 }


### PR DESCRIPTION
Human: Tested locally
<img width="908" height="777" alt="Screenshot 2026-06-25 at 9 31 44 AM" src="https://github.com/user-attachments/assets/c4542f3b-3c56-4cdd-8508-ca3374b8dc17" />


## Security Fix: CVE-2026-54285

### Summary
Updates `@opentelemetry/core` from version 2.2.0 to 2.8.0 to address the security vulnerability CVE-2026-54285.

### Changes
- Added an npm `overrides` entry in `frontend/package.json` to force `@opentelemetry/core` to version 2.8.0
- Regenerated `frontend/package-lock.json` to reflect the updated version

### Details
`@opentelemetry/core` is a **transitive dependency** in the frontend, pulled in by `posthog-js` through various `@opentelemetry/*` packages. Since it's not a direct dependency, an npm override was used to enforce the secure version across the entire dependency tree.

### Verification
After the update, the lockfile confirms all instances of `@opentelemetry/core` are resolved to version 2.8.0.

---
_This PR was created by an AI agent (OpenHands) to remediate a security vulnerability._

@mamoodi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/dd051c43-e819-465f-b39c-118c2c91fc5f)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-2c9d1ff   docker.openhands.dev/openhands/openhands:2c9d1ff
```