### PR TITLE
fix: handle None git_full_clone from DB in SaasSettingsStore

### DIFF
--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -218,6 +218,9 @@ class SaasSettingsStore(SettingsStore):
         # Apply default if sandbox_grouping_strategy is None in the database
         if kwargs.get('sandbox_grouping_strategy') is None:
             kwargs.pop('sandbox_grouping_strategy', None)
+        # Apply default if git_full_clone is None in the database (pre-existing rows)
+        if kwargs.get('git_full_clone') is None:
+            kwargs.pop('git_full_clone', None)
         # Profiles in SaaS live on the org (managed via
         # /api/organizations/{org_id}/profiles). Surface them through
         # Settings.llm_profiles so the chat-layer endpoints


### PR DESCRIPTION
H:

- [x] A human has tested these changes.

AGENT:

---

## Why

Adding a new non-optional boolean field to `Settings` (`git_full_clone: bool = False`) causes a `ValidationError` for any existing user whose DB row pre-dates the column. The `SaasSettingsStore.load()` method builds its `kwargs` dict by iterating over all DB columns that match `Settings.model_fields`; for those older rows the column value is `None`. Pydantic v2 does **not** fall back to a field default when the value is explicitly supplied as `None` — it attempts to coerce `None` to `bool` and raises:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
git_full_clone
  Input should be a valid boolean [type=bool_type, input_value=None, input_type=NoneType]
```

This broke settings loading (and therefore every page load) in enterprise for all users whose accounts existed before `git_full_clone` was introduced.

## Summary

- Pop `git_full_clone` from `kwargs` when its DB value is `None`, so Pydantic uses the declared field default (`False`).
- Mirrors the identical pattern already used for `sandbox_grouping_strategy` two lines above.

## Screenshots

<img width="1377" height="754" alt="image" src="https://github.com/user-attachments/assets/790479c6-0f2d-4521-bf83-b7613c3d8166" />

## Issue Number

N/A (production regression from recently merged `git_full_clone` field addition)

## How to Test

1. Simulate a pre-existing user (DB row has `git_full_clone = NULL`).
2. Call `GET /api/v1/settings` — previously returned 500, now returns 200 with `git_full_clone: false`.

Alternatively: the existing `test_saas_settings_store.py` integration tests still pass (settings load succeeds).

## Type

- [x] Bug fix

## Notes

The same migration guard is already present for `sandbox_grouping_strategy` (line 219) and `v1_enabled` (line 216–217) in the same file. This fix follows the established pattern.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-3ebe3ea   docker.openhands.dev/openhands/openhands:3ebe3ea
```