### PR TITLE
fix(frontend): stop polling app-conversations with task IDs on new conversation

### DIFF
--- a/frontend/__tests__/hooks/query/use-batch-app-conversations.test.tsx
+++ b/frontend/__tests__/hooks/query/use-batch-app-conversations.test.tsx
@@ -1,0 +1,58 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import V1ConversationService from "#/api/conversation-service/v1-conversation-service.api";
+import { useBatchAppConversations } from "#/hooks/query/use-batch-app-conversations";
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useBatchAppConversations", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not call the app-conversations endpoint for task IDs", () => {
+    // Arrange: a task ID (format "task-{uuid}") is not a valid conversation UUID
+    const batchGetAppConversations = vi
+      .spyOn(V1ConversationService, "batchGetAppConversations")
+      .mockResolvedValue([]);
+
+    // Act
+    renderHook(
+      () => useBatchAppConversations(["task-949349dbeae346e895e25679b16f8193"]),
+      { wrapper: createWrapper() },
+    );
+
+    // Assert: the endpoint is never hit, so the backend never returns a 400
+    expect(batchGetAppConversations).not.toHaveBeenCalled();
+  });
+
+  it("calls the app-conversations endpoint for valid conversation IDs", async () => {
+    // Arrange
+    const conversationId = "5c99c669-1151-4413-a75d-1fa4f2cc5355";
+    const batchGetAppConversations = vi
+      .spyOn(V1ConversationService, "batchGetAppConversations")
+      .mockResolvedValue([]);
+
+    // Act
+    renderHook(() => useBatchAppConversations([conversationId]), {
+      wrapper: createWrapper(),
+    });
+
+    // Assert
+    await waitFor(() =>
+      expect(batchGetAppConversations).toHaveBeenCalledWith([conversationId]),
+    );
+  });
+});

--- a/frontend/src/hooks/query/use-batch-app-conversations.ts
+++ b/frontend/src/hooks/query/use-batch-app-conversations.ts
@@ -5,7 +5,8 @@ export const useBatchAppConversations = (ids: string[]) =>
   useQuery({
     queryKey: ["v1-batch-get-app-conversations", ids],
     queryFn: () => V1ConversationService.batchGetAppConversations(ids),
-    enabled: ids.length > 0,
+    // task-{uuid} IDs are not valid conversation UUIDs; skip to avoid a 400.
+    enabled: ids.length > 0 && !ids.some((id) => id.startsWith("task-")),
     staleTime: 1000 * 60 * 5, // 5 minutes
     gcTime: 1000 * 60 * 15, // 15 minutes
   });

--- a/frontend/src/hooks/query/use-unified-vscode-url.ts
+++ b/frontend/src/hooks/query/use-unified-vscode-url.ts
@@ -20,9 +20,13 @@ export const useUnifiedVSCodeUrl = () => {
   const { conversationId } = useConversationId();
   const runtimeIsReady = useRuntimeIsReady({ allowAgentError: true });
 
+  // Don't fetch for task IDs (format: "task-{uuid}"); the real conversation ID is
+  // resolved by useTaskPolling. Mirrors useActiveConversation.
+  const isTaskId = conversationId.startsWith("task-");
+
   // Fetch V1 app conversation to get sandbox_id
   const appConversationsQuery = useBatchAppConversations(
-    conversationId ? [conversationId] : [],
+    isTaskId ? [] : [conversationId],
   );
   const appConversation = appConversationsQuery.data?.[0];
   const sandboxId = appConversation?.sandbox_id;


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

- [x] A human has tested these changes.

AGENT:

---

## Why

<!-- Describe problem, motivation, etc.-->

<img width="1395" height="1527" alt="issue" src="https://github.com/user-attachments/assets/7f6eac0c-b67d-47b0-aeb0-ff8b24641519" />

Creating a new conversation shows a red `Invalid UUID format for ids: ['task-…']` toast. While the conversation page polls the start-task, `useUnifiedVSCodeUrl` calls `GET /api/v1/app-conversations?ids=task-{uuid}` with a **task ID** — the URL param is `task-{uuid}` until `useTaskPolling` swaps in the real conversation UUID. The backend correctly rejects non-UUID ids with HTTP 400.

`useUnifiedVSCodeUrl` (rendered unconditionally via `conversation-tabs` → `vscode-tooltip-content`) was the only conversation-data hook missing the `task-` guard that `useActiveConversation`, `useUserConversation`, and `useTaskPolling` already have.

## Summary

<!-- 1-3 bullets describing what changed. -->
- `useUnifiedVSCodeUrl`: skip the app-conversations fetch for task IDs (mirrors `useActiveConversation`).
- `useBatchAppConversations`: disable the query when any id is a task id — a central guard for every caller of the endpoint.
- Add unit tests asserting the endpoint is **not** called for `task-{uuid}` ids and **is** called for valid ids.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

**Automated**

- `cd frontend && npm run test` (or `npx vitest run __tests__/hooks/query/use-batch-app-conversations.test.tsx`) — passes.
- `cd frontend && npm run lint` — typecheck + prettier clean.

**Manual**

1. Create a new conversation → you land on `/conversations/task-{uuid}`.
2. With DevTools → Network open, confirm there is **no** `GET /api/v1/app-conversations?ids=task-…` request and **no** "Invalid UUID format" toast.
3. After `useTaskPolling` redirects to `/conversations/{uuid}`, confirm `app-conversations` is now called with the real UUID and the VS Code tab/tooltip URL still resolves.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No backend change — the 400 is correct behavior for a non-UUID id. The two guards are defense-in-depth: behaviorally identical today (a single caller), but the central guard prevents any future caller from hitting the endpoint with a task id. Disabled TanStack queries report `isLoading: false`, so the loading state and VS Code URL resolution on the happy path are unchanged.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-b6f7226   docker.openhands.dev/openhands/openhands:b6f7226
```