### PR TITLE
fix(llm): restore managed member-key fallback in effective LLM key resolution

### DIFF
--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -127,10 +127,13 @@ class SaasSettingsStore(SettingsStore):
     ) -> SecretStr | None:
         if org_member.has_custom_llm_api_key:
             return org_member.llm_api_key
-        # When has_custom_llm_api_key is False, only return org-level key
-        # Don't fall back to org_member.llm_api_key as it may not be set
-        # and accessing it would trigger decryption of an empty/null value
-        return org.llm_api_key
+        if org.llm_api_key:
+            return org.llm_api_key
+        # Managed keys are stored on the member row (has_custom=False); fall back to
+        # it, but only decrypt when actually set to avoid the empty-value error (#14898).
+        if org_member._llm_api_key:
+            return org_member.llm_api_key
+        return None
 
     @staticmethod
     def _get_persisted_agent_settings(item: Settings) -> dict[str, Any]:

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -1333,8 +1333,14 @@ class TestGetEffectiveLlmApiKey:
         # Must return org key when has_custom_llm_api_key is False
         assert result == SecretStr('org-api-key')
 
-    def test_returns_org_key_when_member_has_custom_false_and_org_has_no_key(self):
-        """When has_custom_llm_api_key is False but org has no key, returns None."""
+    def test_falls_back_to_managed_member_key_when_org_key_unset(self):
+        """has_custom False + no org key: fall back to the managed key on the member row.
+
+        Managed/proxy keys are persisted on org_member.llm_api_key with
+        has_custom_llm_api_key=False. #14898 dropped this fallback entirely, which
+        left managed-key users with no key (and wiped it on settings save).
+        """
+        from pydantic import SecretStr
         from storage.saas_settings_store import SaasSettingsStore
 
         org = MagicMock()
@@ -1342,8 +1348,25 @@ class TestGetEffectiveLlmApiKey:
 
         member = MagicMock()
         member.has_custom_llm_api_key = False
+        member._llm_api_key = 'encrypted-managed-key'  # truthy => set
+        type(member).llm_api_key = PropertyMock(return_value=SecretStr('managed-key'))
+
+        result = SaasSettingsStore._get_effective_llm_api_key(org, member)
+
+        assert result == SecretStr('managed-key')
+
+    def test_returns_none_without_decrypting_when_member_key_unset(self):
+        """has_custom False, no org key, empty member key: None, never decrypt (#14898)."""
+        from storage.saas_settings_store import SaasSettingsStore
+
+        org = MagicMock()
+        org.llm_api_key = None
+
+        member = MagicMock()
+        member.has_custom_llm_api_key = False
+        member._llm_api_key = ''  # falsy => not set; must NOT decrypt
         type(member).llm_api_key = PropertyMock(
-            side_effect=AssertionError('should not be accessed')
+            side_effect=AssertionError('should not decrypt an unset member key')
         )
 
         result = SaasSettingsStore._get_effective_llm_api_key(org, member)


### PR DESCRIPTION
HUMAN: Fixes a regression where managed-key (BYOK-disabled) users get no LLM key — the agent fails with `LLMAuthenticationError`, and saving any user setting wipes the stored key. Root-caused from a live install; verifying via CI + a Replicated test install before marking ready.

- [x] A human has tested these changes.

## The bug (regression from #14898)
#14898 changed `_get_effective_llm_api_key` to return **only** `org.llm_api_key` when `has_custom_llm_api_key` is `False`, dropping the member-key fallback:
```diff
- return org.llm_api_key or org_member.llm_api_key
+ return org.llm_api_key
```
But **managed/proxy keys are persisted on `org_member.llm_api_key` with `has_custom_llm_api_key=False`** (`saas_settings_store.py` write path), and **`org.llm_api_key` is never seeded** (no assignment path anywhere). So for managed-key users the effective key resolves to `None`, with two symptoms:
1. **Runtime:** the agent calls the LiteLLM proxy with no key → `401 No api key passed in` → `LLMAuthenticationError`.
2. **Settings save wipes the key:** the save path loads the effective key (now `None`), then the `if uses_managed_llm_key and current_member_llm_api_key is not None:` branch is skipped, so the stored key isn't re-written — matching the reported "updating any user setting removes your LLM api key."

#14898's goal was to avoid decrypting an unset member key — that's preserved.

## Scope
Any BYOK-disabled / managed-key install (everyone has `has_custom=False`). Not in `cloud-1.39.0` (current released); it's in `main` and would ship with `cloud-1.40.0`, so this is catch-before-release.

## The fix
Restore the fallback **null-safely**: `has_custom` → member key; else `org.llm_api_key` if set; else the member key **only when the raw column is set** (so an unset key is never decrypted).

## Tests
Updated `TestGetEffectiveLlmApiKey`: the prior test encoded the buggy "never touch the member key" behavior; replaced with the managed-key fallback case (org key unset + member key set → returns member key) and the null-safe case (both unset → `None`, no decrypt).

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-69392cb   docker.openhands.dev/openhands/openhands:69392cb
```