### PR TITLE
feat(jira-dc): email-mode auto-link, targeted repo lookup, and picker mentions

### DIFF
--- a/enterprise/integrations/jira_dc/jira_dc_manager.py
+++ b/enterprise/integrations/jira_dc/jira_dc_manager.py
@@ -21,7 +21,6 @@ from integrations.models import JobContext, Message
 from integrations.utils import (
     HOST_URL,
     OPENHANDS_RESOLVER_TEMPLATES_DIR,
-    filter_potential_repos_by_user_msg,
     get_account_not_linked_message,
     get_jira_dc_relink_message,
     get_session_expired_message,
@@ -39,7 +38,6 @@ from storage.jira_dc_workspace import JiraDcWorkspace
 
 from openhands.app_server.integrations.provider import ProviderHandler
 from openhands.app_server.integrations.service_types import Comment, Repository
-from openhands.app_server.shared import server_config
 from openhands.app_server.types import (
     LLMAuthenticationError,
     MissingSettingsError,
@@ -140,6 +138,15 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
             jira_dc_user = await self.integration_store.get_active_user_by_keycloak_id_and_workspace(
                 keycloak_user_id, workspace_id
             )
+            # Email mode is itself the admin's opt-in: a user whose Jira email
+            # matches an OpenHands account is auto-enrolled, no manual link step.
+            # Never in OAuth mode, which requires a verified per-user token.
+            if not jira_dc_user and not JIRA_DC_ENABLE_OAUTH:
+                jira_dc_user = (
+                    await self.integration_store.get_or_create_active_email_link(
+                        keycloak_user_id, workspace_id
+                    )
+                )
         else:
             jira_dc_user = await self.integration_store.get_active_user(
                 jira_dc_user_id, workspace_id
@@ -156,22 +163,36 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
         )
         return jira_dc_user, saas_user_auth
 
-    async def _get_repositories(self, user_auth: UserAuth) -> list[Repository]:
-        """Get repositories that the user has access to."""
+    async def _create_provider_handler(
+        self, user_auth: UserAuth
+    ) -> ProviderHandler | None:
+        """Build a ProviderHandler for the user, or None if no provider is linked."""
         provider_tokens = await user_auth.get_provider_tokens()
         if provider_tokens is None:
-            return []
+            return None
         access_token = await user_auth.get_access_token()
         user_id = await user_auth.get_user_id()
-        client = ProviderHandler(
+        return ProviderHandler(
             provider_tokens=provider_tokens,
             external_auth_token=access_token,
             external_auth_id=user_id,
         )
-        repos: list[Repository] = await client.get_repositories(
-            'pushed', server_config.app_mode, None, None, None, None
-        )
-        return repos
+
+    async def _verify_mentioned_repos(
+        self, provider_handler: ProviderHandler, mentioned_repos: list[str]
+    ) -> list[Repository]:
+        """Resolve each mentioned repo with a targeted lookup.
+
+        Avoids enumerating the user's full repo list, which is capped and misses
+        repos on large Bitbucket DC instances (40k+ repos).
+        """
+        verified: list[Repository] = []
+        for repo_name in mentioned_repos:
+            try:
+                verified.append(await provider_handler.verify_repo_provider(repo_name))
+            except Exception as e:
+                logger.debug(f'[Jira DC] Repo verification failed for {repo_name}: {e}')
+        return verified
 
     async def validate_request(
         self, request: Request
@@ -441,36 +462,33 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
             return True
 
         try:
-            # Get user repositories
-            user_repos: list[Repository] = await self._get_repositories(
-                jira_dc_view.saas_user_auth
-            )
-
             target_str = f'{jira_dc_view.job_context.issue_description}\n{jira_dc_view.job_context.user_msg}'
             mentioned_repos = infer_repo_from_message(target_str)
 
-            # Try to infer repository from issue description
-            match, repos = filter_potential_repos_by_user_msg(target_str, user_repos)
+            # Verify each mentioned repo directly rather than enumerating the
+            # user's full repo list (which is capped and misses repos on large
+            # Bitbucket DC instances).
+            provider_handler = await self._create_provider_handler(
+                jira_dc_view.saas_user_auth
+            )
+            verified_repos = (
+                await self._verify_mentioned_repos(provider_handler, mentioned_repos)
+                if provider_handler
+                else []
+            )
 
-            if match:
-                # Found exact repository match
-                jira_dc_view.selected_repo = repos[0].full_name
-                logger.info(f'[Jira DC] Inferred repository: {repos[0].full_name}')
-                return True
-            else:
-                # No clear match - send repository selection comment
-                matched_repos = [
-                    repo
-                    for repo in user_repos
-                    if any(
-                        mentioned_repo.lower() in repo.full_name.lower()
-                        for mentioned_repo in mentioned_repos
-                    )
-                ]
-                await self._send_repo_selection_comment(
-                    jira_dc_view, mentioned_repos, matched_repos
+            if len(verified_repos) == 1:
+                jira_dc_view.selected_repo = verified_repos[0].full_name
+                logger.info(
+                    f'[Jira DC] Inferred repository: {verified_repos[0].full_name}'
                 )
-                return False
+                return True
+
+            # Zero or multiple matches -- ask the user to disambiguate.
+            await self._send_repo_selection_comment(
+                jira_dc_view, mentioned_repos, verified_repos
+            )
+            return False
 
         except Exception as e:
             logger.error(f'[Jira DC] Error in is_job_requested: {str(e)}')

--- a/enterprise/integrations/jira_dc/jira_dc_manager.py
+++ b/enterprise/integrations/jira_dc/jira_dc_manager.py
@@ -105,6 +105,20 @@ def _extract_workspace_hosts(payload: Dict) -> set[str]:
     }
 
 
+def _comment_addresses_openhands(comment: str, bot_mentions: set[str] | None) -> bool:
+    # Literal @openhands always triggers (works even when the bot username can't
+    # be resolved). Jira's mention picker serializes a real mention as wiki
+    # markup [~name]/[~key], so match those too once resolved.
+    if not comment:
+        return False
+    if '@openhands' in comment:
+        return True
+    if bot_mentions:
+        lowered = comment.lower()
+        return any(token in lowered for token in bot_mentions)
+    return False
+
+
 class JiraDcManager(Manager[JiraDcViewInterface]):
     def __init__(self, token_manager: TokenManager):
         self.token_manager = token_manager
@@ -112,6 +126,9 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
         self.jinja_env = Environment(
             loader=FileSystemLoader(OPENHANDS_RESOLVER_TEMPLATES_DIR + 'jira_dc')
         )
+        # Bot mention tokens ([~name]/[~key]/...) per workspace.id, resolved
+        # lazily from /myself for matching picker mentions.
+        self._svc_mentions_cache: dict[int, set[str]] = {}
 
     async def authenticate_user(
         self, user_email: str, jira_dc_user_id: str, workspace_id: int
@@ -265,7 +282,9 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
 
         return False, None, None, None
 
-    def parse_webhook(self, payload: Dict) -> JobContext | None:
+    def parse_webhook(
+        self, payload: Dict, bot_mentions: set[str] | None = None
+    ) -> JobContext | None:
         event_type = payload.get('webhookEvent')
 
         if event_type == 'comment_created':
@@ -273,7 +292,7 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
             comment = comment_data.get('body', '')
             comment_id = comment_data.get('id')
 
-            if '@openhands' not in comment:
+            if not _comment_addresses_openhands(comment, bot_mentions):
                 return None
 
             issue_data = payload.get('issue', {})
@@ -345,7 +364,8 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
     async def receive_message(self, message: Message):
         """Process incoming Jira DC webhook message."""
         payload = message.message.get('payload', {})
-        job_context = self.parse_webhook(payload)
+        bot_mentions = await self._resolve_service_account_mentions(payload)
+        job_context = self.parse_webhook(payload, bot_mentions)
 
         if not job_context:
             logger.info('[Jira DC] Webhook does not match trigger conditions')
@@ -551,6 +571,64 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
             )
         except Exception as e:
             logger.error(f'[Jira] Failed to send response message: {str(e)}')
+
+    async def _resolve_service_account_mentions(self, payload: Dict) -> set[str] | None:
+        """Best-effort bot mention tokens ([~name]/[~key]) for a picker mention.
+
+        Gated so only wiki-markup mentions pay a lookup; literal @openhands and
+        non-comment payloads short-circuit. Cached per workspace; failures are not
+        cached, so a transient /myself error self-heals on the next webhook.
+        """
+        comment = (payload.get('comment') or {}).get('body', '') or ''
+        if '@openhands' in comment or '[~' not in comment:
+            return None
+        try:
+            base_api_url = (
+                (payload.get('issue') or {}).get('self', '').split('/rest/')[0]
+            )
+            workspace_name = urlparse(base_api_url).hostname
+            if not workspace_name:
+                return None
+            workspace = await self.integration_store.get_workspace_by_name(
+                workspace_name
+            )
+            if not workspace:
+                return None
+            if workspace.id in self._svc_mentions_cache:
+                return self._svc_mentions_cache[workspace.id]
+            service_account = resolve_jira_dc_service_account(
+                workspace, self.token_manager
+            )
+            name, key = await self._fetch_service_account_identity(
+                base_api_url, service_account.api_key
+            )
+            mentions = {
+                token.lower()
+                for token in (
+                    f'[~{name}]' if name else None,
+                    f'[~{key}]' if key else None,
+                    f'[~accountid:{key}]' if key else None,
+                )
+                if token
+            }
+            if mentions:
+                self._svc_mentions_cache[workspace.id] = mentions
+            return mentions or None
+        except Exception as e:
+            logger.warning(f'[Jira DC] Could not resolve bot mentions: {str(e)}')
+            return None
+
+    async def _fetch_service_account_identity(
+        self, base_api_url: str, svc_acc_api_key: str
+    ) -> tuple[str | None, str | None]:
+        """Return the service account's Jira (name, key) from /myself."""
+        url = f'{base_api_url}/rest/api/2/myself'
+        headers = {'Authorization': f'Bearer {svc_acc_api_key}'}
+        async with httpx.AsyncClient(verify=httpx_verify_option()) as client:
+            response = await client.get(url, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+            return data.get('name'), data.get('key')
 
     async def get_issue_details(
         self, job_context: JobContext, svc_acc_api_key: str

--- a/enterprise/integrations/jira_dc/jira_dc_manager.py
+++ b/enterprise/integrations/jira_dc/jira_dc_manager.py
@@ -25,6 +25,7 @@ from integrations.utils import (
     get_jira_dc_relink_message,
     get_session_expired_message,
     get_user_not_found_message,
+    has_exact_mention,
     infer_repo_from_message,
     markdown_to_jira_markup,
 )
@@ -111,7 +112,9 @@ def _comment_addresses_openhands(comment: str, bot_mentions: set[str] | None) ->
     # markup [~name]/[~key], so match those too once resolved.
     if not comment:
         return False
-    if '@openhands' in comment:
+    # Boundary-aware + case-insensitive: matches @OpenHands but not an email like
+    # someone@openhands.dev (incl. the service account's own address).
+    if has_exact_mention(comment, '@openhands'):
         return True
     if bot_mentions:
         lowered = comment.lower()
@@ -203,13 +206,20 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
         Avoids enumerating the user's full repo list, which is capped and misses
         repos on large Bitbucket DC instances (40k+ repos).
         """
-        verified: list[Repository] = []
+        # Dedupe by canonical full_name: two forms of one repo (case/URL variants,
+        # a rename) resolve to the same repo and must count once -- otherwise
+        # is_job_requested sees >1 and asks the user to disambiguate a single repo.
+        verified: dict[str, Repository] = {}
         for repo_name in mentioned_repos:
             try:
-                verified.append(await provider_handler.verify_repo_provider(repo_name))
+                repo = await provider_handler.verify_repo_provider(
+                    repo_name, is_optional=True
+                )
             except Exception as e:
                 logger.debug(f'[Jira DC] Repo verification failed for {repo_name}: {e}')
-        return verified
+                continue
+            verified.setdefault(repo.full_name.lower(), repo)
+        return list(verified.values())
 
     async def validate_request(
         self, request: Request
@@ -577,10 +587,11 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
 
         Gated so only wiki-markup mentions pay a lookup; literal @openhands and
         non-comment payloads short-circuit. Cached per workspace; failures are not
-        cached, so a transient /myself error self-heals on the next webhook.
+        cached, so a later comment re-attempts resolution (this event is dropped,
+        not retried).
         """
         comment = (payload.get('comment') or {}).get('body', '') or ''
-        if '@openhands' in comment or '[~' not in comment:
+        if has_exact_mention(comment, '@openhands') or '[~' not in comment:
             return None
         try:
             base_api_url = (

--- a/enterprise/server/auth/token_manager.py
+++ b/enterprise/server/auth/token_manager.py
@@ -624,10 +624,19 @@ class TokenManager:
     async def get_user_id_from_user_email(self, email: str) -> str | None:
         keycloak_admin = get_keycloak_admin(self.external)
         users = await keycloak_admin.a_get_users({'q': f'email:{email}'})
-        if not users:
+        # Keycloak's email query is a substring match, so narrow to an exact,
+        # unique match -- otherwise users[0] could be a different user whose email
+        # merely contains this one (e.g. bob@acme.com vs bob@acme.com.au).
+        exact = [u for u in users if (u.get('email') or '').lower() == email.lower()]
+        if not exact:
             logger.error(f'User with email {email} not found.')
             return None
-        keycloak_user_id = users[0]['id']
+        if len(exact) > 1:
+            logger.error(
+                f'Multiple users with email {email}; refusing ambiguous match.'
+            )
+            return None
+        keycloak_user_id = exact[0]['id']
         logger.info(f'Got user ID {keycloak_user_id} from email: {email}')
         return keycloak_user_id
 

--- a/enterprise/storage/jira_dc_integration_store.py
+++ b/enterprise/storage/jira_dc_integration_store.py
@@ -5,6 +5,7 @@ from typing import Optional
 from uuid import UUID
 
 from sqlalchemy import select, update
+from sqlalchemy.exc import IntegrityError
 from storage.database import a_session_maker
 from storage.jira_dc_conversation import JiraDcConversation
 from storage.jira_dc_user import JiraDcUser
@@ -181,6 +182,47 @@ class JiraDcIntegrationStore:
                 )
             )
             return result.scalar_one_or_none()
+
+    async def get_or_create_active_email_link(
+        self, keycloak_user_id: str, jira_dc_workspace_id: int
+    ) -> Optional[JiraDcUser]:
+        """Return the user's active link for this workspace, creating one if absent.
+
+        Used by email-match mode to auto-enroll a matched user; the row mirrors a
+        manually-linked email row ('unavailable' Jira id, no OAuth tokens). Safe
+        under concurrent first webhooks: a losing insert trips the partial unique
+        index, and we re-read the winner.
+        """
+        existing = await self.get_active_user_by_keycloak_id_and_workspace(
+            keycloak_user_id, jira_dc_workspace_id
+        )
+        if existing:
+            return existing
+
+        user = JiraDcUser(
+            keycloak_user_id=keycloak_user_id,
+            jira_dc_user_id='unavailable',
+            jira_dc_workspace_id=jira_dc_workspace_id,
+            status='active',
+        )
+        async with a_session_maker() as session:
+            session.add(user)
+            try:
+                await session.commit()
+                await session.refresh(user)
+                logger.info(
+                    f'[Jira DC] Auto-enrolled email-match user for workspace '
+                    f'{jira_dc_workspace_id}'
+                )
+                return user
+            except IntegrityError:
+                await session.rollback()
+
+        # A concurrent insert (or a stale active link elsewhere) won the unique
+        # index; return whatever active row now exists for this workspace.
+        return await self.get_active_user_by_keycloak_id_and_workspace(
+            keycloak_user_id, jira_dc_workspace_id
+        )
 
     async def update_user_integration_status(
         self, keycloak_user_id: str, jira_dc_workspace_id: int, status: str

--- a/enterprise/storage/jira_dc_integration_store.py
+++ b/enterprise/storage/jira_dc_integration_store.py
@@ -186,27 +186,40 @@ class JiraDcIntegrationStore:
     async def get_or_create_active_email_link(
         self, keycloak_user_id: str, jira_dc_workspace_id: int
     ) -> Optional[JiraDcUser]:
-        """Return the user's active link for this workspace, creating one if absent.
+        """Return the user's active link for this workspace, reactivating a prior
+        inactive link or creating one if none exists.
 
-        Used by email-match mode to auto-enroll a matched user; the row mirrors a
-        manually-linked email row ('unavailable' Jira id, no OAuth tokens). Safe
-        under concurrent first webhooks: a losing insert trips the partial unique
-        index, and we re-read the winner.
+        Used by email-match mode to auto-enroll a matched user; a new row mirrors a
+        manually-linked email row ('unavailable' Jira id, no OAuth tokens). Reuses
+        the existing (user, workspace) row so callers that treat the pair as unique
+        (status-agnostic scalar_one_or_none) stay valid. Safe under concurrent first
+        webhooks: a losing write trips the partial unique index and we re-read the
+        winner.
         """
-        existing = await self.get_active_user_by_keycloak_id_and_workspace(
-            keycloak_user_id, jira_dc_workspace_id
-        )
-        if existing:
-            return existing
-
-        user = JiraDcUser(
-            keycloak_user_id=keycloak_user_id,
-            jira_dc_user_id='unavailable',
-            jira_dc_workspace_id=jira_dc_workspace_id,
-            status='active',
-        )
         async with a_session_maker() as session:
-            session.add(user)
+            # Match ANY status so a prior inactive link is reactivated in place,
+            # not duplicated.
+            result = await session.execute(
+                select(JiraDcUser).where(
+                    JiraDcUser.keycloak_user_id == keycloak_user_id,
+                    JiraDcUser.jira_dc_workspace_id == jira_dc_workspace_id,
+                )
+            )
+            user = result.scalar_one_or_none()
+            if user is not None and user.status == 'active':
+                return user
+
+            if user is None:
+                user = JiraDcUser(
+                    keycloak_user_id=keycloak_user_id,
+                    jira_dc_user_id='unavailable',
+                    jira_dc_workspace_id=jira_dc_workspace_id,
+                    status='active',
+                )
+                session.add(user)
+            else:
+                user.status = 'active'
+
             try:
                 await session.commit()
                 await session.refresh(user)
@@ -218,8 +231,8 @@ class JiraDcIntegrationStore:
             except IntegrityError:
                 await session.rollback()
 
-        # A concurrent insert (or a stale active link elsewhere) won the unique
-        # index; return whatever active row now exists for this workspace.
+        # A concurrent insert, or an active link in another workspace (the
+        # one-active-link index), won; return whatever active row now exists.
         return await self.get_active_user_by_keycloak_id_and_workspace(
             keycloak_user_id, jira_dc_workspace_id
         )

--- a/enterprise/storage/jira_dc_integration_store.py
+++ b/enterprise/storage/jira_dc_integration_store.py
@@ -233,9 +233,19 @@ class JiraDcIntegrationStore:
 
         # A concurrent insert, or an active link in another workspace (the
         # one-active-link index), won; return whatever active row now exists.
-        return await self.get_active_user_by_keycloak_id_and_workspace(
+        active = await self.get_active_user_by_keycloak_id_and_workspace(
             keycloak_user_id, jira_dc_workspace_id
         )
+        if active is None:
+            # Most likely cause for an empty re-read: the user already holds an
+            # active link in a different workspace (one-active-link constraint), so
+            # auto-enroll here is rejected and they'll see "account not linked".
+            logger.warning(
+                f'[Jira DC] Could not auto-enroll {keycloak_user_id} in workspace '
+                f'{jira_dc_workspace_id}; they likely have an active link in another '
+                f'workspace (one-active-link constraint)'
+            )
+        return active
 
     async def update_user_integration_status(
         self, keycloak_user_id: str, jira_dc_workspace_id: int, status: str

--- a/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_manager.py
+++ b/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_manager.py
@@ -214,7 +214,9 @@ class TestGetRepositories:
         )
 
         assert verified == [repo]
-        handler.verify_repo_provider.assert_awaited_once_with('company/repo')
+        handler.verify_repo_provider.assert_awaited_once_with(
+            'company/repo', is_optional=True
+        )
 
     @pytest.mark.asyncio
     async def test_verify_mentioned_repos_skips_inaccessible(self, jira_dc_manager):
@@ -225,6 +227,28 @@ class TestGetRepositories:
         verified = await jira_dc_manager._verify_mentioned_repos(handler, ['x/y'])
 
         assert verified == []
+
+    @pytest.mark.asyncio
+    async def test_verify_mentioned_repos_dedupes_same_repo(self, jira_dc_manager):
+        """Two forms of one repo (case/URL variants, a rename) resolve to the same
+        canonical full_name and must collapse to a single entry -- otherwise the
+        len()==1 auto-select in is_job_requested fails and asks the user to pick
+        between a repo and itself."""
+        canonical = Repository(
+            id='1',
+            full_name='PF/WebApp',
+            stargazers_count=0,
+            git_provider=ProviderType.GITHUB,
+            is_public=True,
+        )
+        handler = MagicMock()
+        handler.verify_repo_provider = AsyncMock(return_value=canonical)
+
+        verified = await jira_dc_manager._verify_mentioned_repos(
+            handler, ['PF/WebApp', 'pf/webapp']
+        )
+
+        assert verified == [canonical]  # one unique repo, not two
 
 
 class TestValidateRequest:
@@ -678,6 +702,19 @@ class TestParseWebhook:
         payload = _jdc_comment_payload('cc [~openhands] please')
         assert jira_dc_manager.parse_webhook(payload, bot_mentions=None) is None
 
+    def test_parse_webhook_literal_mention_case_insensitive(self, jira_dc_manager):
+        """@OpenHands (any case) triggers like @openhands."""
+        payload = _jdc_comment_payload('Hey @OpenHands take a look')
+        assert jira_dc_manager.parse_webhook(payload, bot_mentions=None) is not None
+
+    def test_parse_webhook_email_substring_does_not_trigger(self, jira_dc_manager):
+        """An email merely containing '@openhands' (e.g. the service account's own
+        address) must NOT be treated as a mention."""
+        payload = _jdc_comment_payload(
+            'Reassigned from alona+jdcbot@openhands.dev for review'
+        )
+        assert jira_dc_manager.parse_webhook(payload, bot_mentions=None) is None
+
     def test_parse_webhook_issue_update_with_openhands_label(
         self, jira_dc_manager, sample_issue_update_webhook_payload
     ):
@@ -1118,7 +1155,9 @@ class TestIsJobRequested:
 
         assert result is True
         assert mock_view.selected_repo == 'pf/deep-repo'
-        handler.verify_repo_provider.assert_awaited_once_with('pf/deep-repo')
+        handler.verify_repo_provider.assert_awaited_once_with(
+            'pf/deep-repo', is_optional=True
+        )
 
     @pytest.mark.asyncio
     async def test_is_job_requested_exception(self, jira_dc_manager, sample_user_auth):

--- a/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_manager.py
+++ b/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_manager.py
@@ -496,6 +496,114 @@ class TestValidateRequest:
         assert payload is None
 
 
+def _jdc_comment_payload(body: str) -> dict:
+    return {
+        'webhookEvent': 'comment_created',
+        'comment': {
+            'id': '999',
+            'body': body,
+            'author': {
+                'emailAddress': 'user@company.com',
+                'displayName': 'Test User',
+                'key': 'JIRAUSER10000',
+            },
+        },
+        'issue': {
+            'id': '12345',
+            'key': 'PROJ-123',
+            'self': 'https://jira.company.com/rest/api/2/issue/12345',
+        },
+    }
+
+
+class TestResolveServiceAccountMentions:
+    """Lazy, cached bot-username resolution for picker mentions (FDE-84)."""
+
+    @pytest.mark.asyncio
+    async def test_skips_ordinary_comment(self, jira_dc_manager):
+        jira_dc_manager.integration_store.get_workspace_by_name = AsyncMock()
+        result = await jira_dc_manager._resolve_service_account_mentions(
+            _jdc_comment_payload('just a regular comment')
+        )
+        assert result is None
+        jira_dc_manager.integration_store.get_workspace_by_name.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skips_literal_mention(self, jira_dc_manager):
+        """Literal @openhands never pays a /myself lookup."""
+        jira_dc_manager.integration_store.get_workspace_by_name = AsyncMock()
+        result = await jira_dc_manager._resolve_service_account_mentions(
+            _jdc_comment_payload('hey @openhands and [~openhands]')
+        )
+        assert result is None
+        jira_dc_manager.integration_store.get_workspace_by_name.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_resolves_name_and_key_then_caches(self, jira_dc_manager):
+        workspace = MagicMock()
+        workspace.id = 1
+        jira_dc_manager.integration_store.get_workspace_by_name = AsyncMock(
+            return_value=workspace
+        )
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {'name': 'openhands', 'key': 'JIRAUSER1'}
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        payload = _jdc_comment_payload('cc [~openhands]')
+        with (
+            patch(
+                'integrations.jira_dc.jira_dc_manager.resolve_jira_dc_service_account',
+                return_value=MagicMock(api_key='pat'),
+            ),
+            patch('httpx.AsyncClient', return_value=mock_client),
+        ):
+            first = await jira_dc_manager._resolve_service_account_mentions(payload)
+            second = await jira_dc_manager._resolve_service_account_mentions(payload)
+
+        assert '[~openhands]' in first
+        assert '[~jirauser1]' in first
+        assert '[~accountid:jirauser1]' in first
+        assert jira_dc_manager._svc_mentions_cache[1] == first
+        # Second call served from cache -> only one /myself fetch.
+        mock_client.get.assert_awaited_once()
+        assert second == first
+
+    @pytest.mark.asyncio
+    async def test_myself_failure_not_cached(self, jira_dc_manager):
+        workspace = MagicMock()
+        workspace.id = 1
+        jira_dc_manager.integration_store.get_workspace_by_name = AsyncMock(
+            return_value=workspace
+        )
+        with (
+            patch(
+                'integrations.jira_dc.jira_dc_manager.resolve_jira_dc_service_account',
+                return_value=MagicMock(api_key='pat'),
+            ),
+            patch('httpx.AsyncClient', side_effect=Exception('myself down')),
+        ):
+            result = await jira_dc_manager._resolve_service_account_mentions(
+                _jdc_comment_payload('cc [~openhands]')
+            )
+        assert result is None
+        assert 1 not in jira_dc_manager._svc_mentions_cache
+
+    @pytest.mark.asyncio
+    async def test_missing_workspace(self, jira_dc_manager):
+        jira_dc_manager.integration_store.get_workspace_by_name = AsyncMock(
+            return_value=None
+        )
+        result = await jira_dc_manager._resolve_service_account_mentions(
+            _jdc_comment_payload('cc [~openhands]')
+        )
+        assert result is None
+
+
 class TestParseWebhook:
     """Test webhook parsing functionality."""
 
@@ -535,6 +643,40 @@ class TestParseWebhook:
 
         job_context = jira_dc_manager.parse_webhook(payload)
         assert job_context is None
+
+    def test_parse_webhook_literal_mention_without_username(self, jira_dc_manager):
+        """Literal @openhands triggers even when the bot username is unresolved."""
+        payload = _jdc_comment_payload('Please fix this @openhands')
+        assert jira_dc_manager.parse_webhook(payload, bot_mentions=None) is not None
+
+    def test_parse_webhook_wiki_mention_triggers(self, jira_dc_manager):
+        """A picker mention [~name] triggers once the bot mentions are known."""
+        payload = _jdc_comment_payload('cc [~openhands] please review')
+        result = jira_dc_manager.parse_webhook(payload, bot_mentions={'[~openhands]'})
+        assert result is not None
+
+    def test_parse_webhook_wiki_mention_case_insensitive(self, jira_dc_manager):
+        payload = _jdc_comment_payload('cc [~OpenHands]')
+        result = jira_dc_manager.parse_webhook(payload, bot_mentions={'[~openhands]'})
+        assert result is not None
+
+    def test_parse_webhook_wiki_mention_by_key(self, jira_dc_manager):
+        """The bot's Jira key form ([~JIRAUSER...]) also triggers."""
+        payload = _jdc_comment_payload('cc [~jirauser173929] please')
+        result = jira_dc_manager.parse_webhook(
+            payload, bot_mentions={'[~jirauser173929]'}
+        )
+        assert result is not None
+
+    def test_parse_webhook_wiki_mention_other_user_no_trigger(self, jira_dc_manager):
+        payload = _jdc_comment_payload('cc [~someoneelse] review')
+        result = jira_dc_manager.parse_webhook(payload, bot_mentions={'[~openhands]'})
+        assert result is None
+
+    def test_parse_webhook_wiki_mention_dropped_when_unresolved(self, jira_dc_manager):
+        """Picker mention with no resolved username falls back to literal-only."""
+        payload = _jdc_comment_payload('cc [~openhands] please')
+        assert jira_dc_manager.parse_webhook(payload, bot_mentions=None) is None
 
     def test_parse_webhook_issue_update_with_openhands_label(
         self, jira_dc_manager, sample_issue_update_webhook_payload

--- a/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_manager.py
+++ b/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_manager.py
@@ -136,41 +136,95 @@ class TestAuthenticateUser:
         )
         jira_dc_manager.integration_store.get_active_user.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_authenticate_user_email_mode_auto_enrolls(
+        self,
+        jira_dc_manager,
+        mock_token_manager,
+        sample_jira_dc_user,
+        sample_user_auth,
+    ):
+        """Email mode auto-enrolls a matched user who has no link row yet."""
+        mock_token_manager.get_user_id_from_user_email.return_value = 'kc-id'
+        jira_dc_manager.integration_store.get_active_user_by_keycloak_id_and_workspace = AsyncMock(
+            return_value=None
+        )
+        jira_dc_manager.integration_store.get_or_create_active_email_link = AsyncMock(
+            return_value=sample_jira_dc_user
+        )
+
+        with (
+            patch('integrations.jira_dc.jira_dc_manager.JIRA_DC_ENABLE_OAUTH', False),
+            patch(
+                'integrations.jira_dc.jira_dc_manager.get_user_auth_from_keycloak_id',
+                return_value=sample_user_auth,
+            ),
+        ):
+            jira_dc_user, user_auth = await jira_dc_manager.authenticate_user(
+                'user@company.com', 'none', 1
+            )
+
+        assert jira_dc_user == sample_jira_dc_user
+        assert user_auth == sample_user_auth
+        jira_dc_manager.integration_store.get_or_create_active_email_link.assert_called_once_with(
+            'kc-id', 1
+        )
+
+    @pytest.mark.asyncio
+    async def test_authenticate_user_oauth_mode_does_not_auto_enroll(
+        self, jira_dc_manager, mock_token_manager
+    ):
+        """OAuth mode never auto-enrolls, even when the email branch is reached via
+        a missing/sentinel Jira id."""
+        mock_token_manager.get_user_id_from_user_email.return_value = 'kc-id'
+        jira_dc_manager.integration_store.get_active_user_by_keycloak_id_and_workspace = AsyncMock(
+            return_value=None
+        )
+        jira_dc_manager.integration_store.get_or_create_active_email_link = AsyncMock()
+
+        with patch('integrations.jira_dc.jira_dc_manager.JIRA_DC_ENABLE_OAUTH', True):
+            jira_dc_user, user_auth = await jira_dc_manager.authenticate_user(
+                'user@company.com', 'none', 1
+            )
+
+        assert jira_dc_user is None
+        assert user_auth is None
+        jira_dc_manager.integration_store.get_or_create_active_email_link.assert_not_called()
+
 
 class TestGetRepositories:
     """Test repository retrieval functionality."""
 
     @pytest.mark.asyncio
-    async def test_get_repositories_success(self, jira_dc_manager, sample_user_auth):
-        """Test successful repository retrieval."""
-        mock_repos = [
-            Repository(
-                id='1',
-                full_name='company/repo1',
-                stargazers_count=10,
-                git_provider=ProviderType.GITHUB,
-                is_public=True,
-            ),
-            Repository(
-                id='2',
-                full_name='company/repo2',
-                stargazers_count=5,
-                git_provider=ProviderType.GITHUB,
-                is_public=False,
-            ),
-        ]
+    async def test_verify_mentioned_repos_targeted_lookup(self, jira_dc_manager):
+        """Each mentioned repo is resolved via a targeted verify_repo_provider
+        call -- not by enumerating the user's full (capped) repo list."""
+        repo = Repository(
+            id='1',
+            full_name='company/repo',
+            stargazers_count=0,
+            git_provider=ProviderType.GITHUB,
+            is_public=True,
+        )
+        handler = MagicMock()
+        handler.verify_repo_provider = AsyncMock(return_value=repo)
 
-        with patch(
-            'integrations.jira_dc.jira_dc_manager.ProviderHandler'
-        ) as mock_provider:
-            mock_client = MagicMock()
-            mock_client.get_repositories = AsyncMock(return_value=mock_repos)
-            mock_provider.return_value = mock_client
+        verified = await jira_dc_manager._verify_mentioned_repos(
+            handler, ['company/repo']
+        )
 
-            repos = await jira_dc_manager._get_repositories(sample_user_auth)
+        assert verified == [repo]
+        handler.verify_repo_provider.assert_awaited_once_with('company/repo')
 
-            assert repos == mock_repos
-            mock_client.get_repositories.assert_called_once()
+    @pytest.mark.asyncio
+    async def test_verify_mentioned_repos_skips_inaccessible(self, jira_dc_manager):
+        """A repo that fails verification is dropped, not raised."""
+        handler = MagicMock()
+        handler.verify_repo_provider = AsyncMock(side_effect=Exception('no access'))
+
+        verified = await jira_dc_manager._verify_mentioned_repos(handler, ['x/y'])
+
+        assert verified == []
 
 
 class TestValidateRequest:
@@ -851,69 +905,89 @@ class TestIsJobRequested:
         mock_view.saas_user_auth = sample_user_auth
         mock_view.job_context = sample_job_context
 
-        mock_repos = [
-            Repository(
-                id='1',
-                full_name='company/repo',
-                stargazers_count=10,
-                git_provider=ProviderType.GITHUB,
-                is_public=True,
-            )
-        ]
-        jira_dc_manager._get_repositories = AsyncMock(return_value=mock_repos)
+        repo = Repository(
+            id='1',
+            full_name='company/repo',
+            stargazers_count=10,
+            git_provider=ProviderType.GITHUB,
+            is_public=True,
+        )
+        jira_dc_manager._create_provider_handler = AsyncMock(return_value=MagicMock())
+        jira_dc_manager._verify_mentioned_repos = AsyncMock(return_value=[repo])
 
-        with patch(
-            'integrations.jira_dc.jira_dc_manager.filter_potential_repos_by_user_msg'
-        ) as mock_filter:
-            mock_filter.return_value = (True, mock_repos)
+        message = Message(source=SourceType.JIRA_DC, message={})
+        result = await jira_dc_manager.is_job_requested(message, mock_view)
 
-            message = Message(source=SourceType.JIRA_DC, message={})
-            result = await jira_dc_manager.is_job_requested(message, mock_view)
-
-            assert result is True
-            assert mock_view.selected_repo == 'company/repo'
+        assert result is True
+        assert mock_view.selected_repo == 'company/repo'
 
     @pytest.mark.asyncio
     async def test_is_job_requested_new_conversation_no_repo_match(
         self, jira_dc_manager, sample_job_context, sample_user_auth
     ):
-        """Test job request validation for new conversation without repository match."""
+        """Zero verified repos -> repository-selection comment, job blocked."""
         mock_view = MagicMock(spec=JiraDcNewConversationView)
         mock_view.saas_user_auth = sample_user_auth
         mock_view.job_context = sample_job_context
 
-        mock_repos = [
-            Repository(
-                id='1',
-                full_name='company/repo',
-                stargazers_count=10,
-                git_provider=ProviderType.GITHUB,
-                is_public=True,
-            )
-        ]
-        jira_dc_manager._get_repositories = AsyncMock(return_value=mock_repos)
+        jira_dc_manager._create_provider_handler = AsyncMock(return_value=MagicMock())
+        jira_dc_manager._verify_mentioned_repos = AsyncMock(return_value=[])
         jira_dc_manager._send_repo_selection_comment = AsyncMock()
 
         with patch(
-            'integrations.jira_dc.jira_dc_manager.filter_potential_repos_by_user_msg'
-        ) as mock_filter:
-            mock_filter.return_value = (False, [])
-
+            'integrations.jira_dc.jira_dc_manager.infer_repo_from_message',
+            return_value=[],
+        ):
             message = Message(source=SourceType.JIRA_DC, message={})
             result = await jira_dc_manager.is_job_requested(message, mock_view)
 
-            assert result is False
-            jira_dc_manager._send_repo_selection_comment.assert_called_once_with(
-                mock_view, [], []
-            )
+        assert result is False
+        jira_dc_manager._send_repo_selection_comment.assert_called_once_with(
+            mock_view, [], []
+        )
+
+    @pytest.mark.asyncio
+    async def test_is_job_requested_resolves_repo_beyond_enumeration_cap(
+        self, jira_dc_manager, sample_job_context, sample_user_auth
+    ):
+        """FDE-86: a repo a capped full-list enumeration would miss still resolves,
+        because verification is a targeted per-repo lookup."""
+        mock_view = MagicMock(spec=JiraDcNewConversationView)
+        mock_view.saas_user_auth = sample_user_auth
+        mock_view.job_context = sample_job_context
+
+        deep = Repository(
+            id='99',
+            full_name='pf/deep-repo',
+            stargazers_count=0,
+            git_provider=ProviderType.GITHUB,
+            is_public=False,
+        )
+        handler = MagicMock()
+        handler.verify_repo_provider = AsyncMock(return_value=deep)
+        jira_dc_manager._create_provider_handler = AsyncMock(return_value=handler)
+
+        with patch(
+            'integrations.jira_dc.jira_dc_manager.infer_repo_from_message',
+            return_value=['pf/deep-repo'],
+        ):
+            message = Message(source=SourceType.JIRA_DC, message={})
+            result = await jira_dc_manager.is_job_requested(message, mock_view)
+
+        assert result is True
+        assert mock_view.selected_repo == 'pf/deep-repo'
+        handler.verify_repo_provider.assert_awaited_once_with('pf/deep-repo')
 
     @pytest.mark.asyncio
     async def test_is_job_requested_exception(self, jira_dc_manager, sample_user_auth):
-        """Test job request validation when an exception occurs."""
+        """An unexpected error blocks the job (returns False)."""
         mock_view = MagicMock(spec=JiraDcNewConversationView)
         mock_view.saas_user_auth = sample_user_auth
-        jira_dc_manager._get_repositories = AsyncMock(
-            side_effect=Exception('Repository error')
+        mock_view.job_context = MagicMock()
+        mock_view.job_context.issue_description = ''
+        mock_view.job_context.user_msg = ''
+        jira_dc_manager._create_provider_handler = AsyncMock(
+            side_effect=Exception('boom')
         )
 
         message = Message(source=SourceType.JIRA_DC, message={})

--- a/enterprise/tests/unit/storage/test_jira_dc_active_link_constraint.py
+++ b/enterprise/tests/unit/storage/test_jira_dc_active_link_constraint.py
@@ -178,16 +178,25 @@ async def test_deactivate_user_links_except_workspace_targets_stale_active_links
     session.commit.assert_awaited_once()
 
 
-@pytest.mark.asyncio
-async def test_get_or_create_active_email_link_returns_existing_without_insert():
-    store = JiraDcIntegrationStore()
-    existing = Mock(spec=JiraDcUser)
-    store.get_active_user_by_keycloak_id_and_workspace = AsyncMock(
-        return_value=existing
-    )
-
+def _session_with_existing(existing):
+    """Mock session whose initial (user, workspace) SELECT yields `existing`."""
+    result = Mock()
+    result.scalar_one_or_none.return_value = existing
     session = Mock()
+    session.execute = AsyncMock(return_value=result)
     session.add = Mock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    session.rollback = AsyncMock()
+    return session
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_active_email_link_returns_existing_active():
+    store = JiraDcIntegrationStore()
+    active = Mock(spec=JiraDcUser)
+    active.status = 'active'
+    session = _session_with_existing(active)
 
     @asynccontextmanager
     async def mock_session_maker():
@@ -196,19 +205,15 @@ async def test_get_or_create_active_email_link_returns_existing_without_insert()
     with patch('storage.jira_dc_integration_store.a_session_maker', mock_session_maker):
         result = await store.get_or_create_active_email_link('kc-1', 1)
 
-    assert result is existing
-    session.add.assert_not_called()  # no insert when a link already exists
+    assert result is active
+    session.add.assert_not_called()
+    session.commit.assert_not_awaited()  # already active, nothing written
 
 
 @pytest.mark.asyncio
-async def test_get_or_create_active_email_link_inserts_email_mode_row():
+async def test_get_or_create_active_email_link_inserts_when_absent():
     store = JiraDcIntegrationStore()
-    store.get_active_user_by_keycloak_id_and_workspace = AsyncMock(return_value=None)
-
-    session = Mock()
-    session.add = Mock()
-    session.commit = AsyncMock()
-    session.refresh = AsyncMock()
+    session = _session_with_existing(None)
 
     @asynccontextmanager
     async def mock_session_maker():
@@ -230,22 +235,41 @@ async def test_get_or_create_active_email_link_inserts_email_mode_row():
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_active_email_link_reactivates_inactive_link():
+    """A prior inactive link for the same workspace is reactivated in place, not
+    duplicated -- otherwise status-agnostic scalar_one_or_none callers (unlink,
+    relink) hit MultipleResultsFound."""
+    store = JiraDcIntegrationStore()
+    inactive = Mock(spec=JiraDcUser)
+    inactive.status = 'inactive'
+    session = _session_with_existing(inactive)
+
+    @asynccontextmanager
+    async def mock_session_maker():
+        yield session
+
+    with patch('storage.jira_dc_integration_store.a_session_maker', mock_session_maker):
+        result = await store.get_or_create_active_email_link('kc-1', 1)
+
+    assert inactive.status == 'active'  # reactivated in place
+    session.add.assert_not_called()  # no duplicate row
+    session.commit.assert_awaited_once()
+    session.refresh.assert_awaited_once_with(inactive)
+    assert result is inactive
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_active_email_link_handles_concurrent_insert_race():
     """A concurrent first webhook wins the insert; ours trips the unique index ->
     IntegrityError -> rollback -> re-read returns the winning row."""
     store = JiraDcIntegrationStore()
     winner = Mock(spec=JiraDcUser)
-    # initial check -> None; re-read after IntegrityError -> the row the racer inserted
-    store.get_active_user_by_keycloak_id_and_workspace = AsyncMock(
-        side_effect=[None, winner]
-    )
+    store.get_active_user_by_keycloak_id_and_workspace = AsyncMock(return_value=winner)
 
-    session = Mock()
-    session.add = Mock()
+    session = _session_with_existing(None)
     session.commit = AsyncMock(
         side_effect=IntegrityError('insert', {}, Exception('unique violation'))
     )
-    session.rollback = AsyncMock()
 
     @asynccontextmanager
     async def mock_session_maker():
@@ -255,6 +279,6 @@ async def test_get_or_create_active_email_link_handles_concurrent_insert_race():
         result = await store.get_or_create_active_email_link('kc-1', 1)
 
     session.commit.assert_awaited_once()
-    session.rollback.assert_awaited_once()  # failed insert rolled back, not cached
+    session.rollback.assert_awaited_once()  # failed write rolled back, not cached
     assert result is winner
-    assert store.get_active_user_by_keycloak_id_and_workspace.await_count == 2
+    store.get_active_user_by_keycloak_id_and_workspace.assert_awaited_once()

--- a/enterprise/tests/unit/storage/test_jira_dc_active_link_constraint.py
+++ b/enterprise/tests/unit/storage/test_jira_dc_active_link_constraint.py
@@ -176,3 +176,85 @@ async def test_deactivate_user_links_except_workspace_targets_stale_active_links
     assert 'jira_dc_users.jira_dc_workspace_id !=' in statement_text
     assert 'jira_dc_users.status' in statement_text
     session.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_active_email_link_returns_existing_without_insert():
+    store = JiraDcIntegrationStore()
+    existing = Mock(spec=JiraDcUser)
+    store.get_active_user_by_keycloak_id_and_workspace = AsyncMock(
+        return_value=existing
+    )
+
+    session = Mock()
+    session.add = Mock()
+
+    @asynccontextmanager
+    async def mock_session_maker():
+        yield session
+
+    with patch('storage.jira_dc_integration_store.a_session_maker', mock_session_maker):
+        result = await store.get_or_create_active_email_link('kc-1', 1)
+
+    assert result is existing
+    session.add.assert_not_called()  # no insert when a link already exists
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_active_email_link_inserts_email_mode_row():
+    store = JiraDcIntegrationStore()
+    store.get_active_user_by_keycloak_id_and_workspace = AsyncMock(return_value=None)
+
+    session = Mock()
+    session.add = Mock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+
+    @asynccontextmanager
+    async def mock_session_maker():
+        yield session
+
+    with patch('storage.jira_dc_integration_store.a_session_maker', mock_session_maker):
+        result = await store.get_or_create_active_email_link('kc-1', 7)
+
+    session.add.assert_called_once()
+    added = session.add.call_args.args[0]
+    assert isinstance(added, JiraDcUser)
+    assert added.keycloak_user_id == 'kc-1'
+    assert added.jira_dc_workspace_id == 7
+    assert added.jira_dc_user_id == 'unavailable'  # email-mode sentinel
+    assert added.status == 'active'
+    session.commit.assert_awaited_once()
+    session.refresh.assert_awaited_once_with(added)
+    assert result is added
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_active_email_link_handles_concurrent_insert_race():
+    """A concurrent first webhook wins the insert; ours trips the unique index ->
+    IntegrityError -> rollback -> re-read returns the winning row."""
+    store = JiraDcIntegrationStore()
+    winner = Mock(spec=JiraDcUser)
+    # initial check -> None; re-read after IntegrityError -> the row the racer inserted
+    store.get_active_user_by_keycloak_id_and_workspace = AsyncMock(
+        side_effect=[None, winner]
+    )
+
+    session = Mock()
+    session.add = Mock()
+    session.commit = AsyncMock(
+        side_effect=IntegrityError('insert', {}, Exception('unique violation'))
+    )
+    session.rollback = AsyncMock()
+
+    @asynccontextmanager
+    async def mock_session_maker():
+        yield session
+
+    with patch('storage.jira_dc_integration_store.a_session_maker', mock_session_maker):
+        result = await store.get_or_create_active_email_link('kc-1', 1)
+
+    session.commit.assert_awaited_once()
+    session.rollback.assert_awaited_once()  # failed insert rolled back, not cached
+    assert result is winner
+    assert store.get_active_user_by_keycloak_id_and_workspace.await_count == 2

--- a/enterprise/tests/unit/test_token_manager.py
+++ b/enterprise/tests/unit/test_token_manager.py
@@ -518,3 +518,57 @@ class TestCreateKeycloakUser:
             # the atomic create failed, so nothing was persisted.
             mock_admin.a_set_user_password.assert_not_called()
             mock_admin.delete_user.assert_not_called()
+
+
+class TestGetUserIdFromUserEmail:
+    """Keycloak's email query is a substring match, so the result must be
+    narrowed to an exact, unique email match."""
+
+    @pytest.mark.asyncio
+    async def test_picks_exact_match_not_substring_collision(self, token_manager):
+        """A substring-colliding email (bob@acme.com vs bob@acme.com.au) must not
+        be returned in place of the exact user, regardless of result order."""
+        with patch('server.auth.token_manager.get_keycloak_admin') as mock_get_admin:
+            mock_admin = MagicMock()
+            mock_admin.a_get_users = AsyncMock(
+                return_value=[
+                    {'id': 'wrong', 'email': 'bob@acme.com.au'},
+                    {'id': 'right', 'email': 'bob@acme.com'},
+                ]
+            )
+            mock_get_admin.return_value = mock_admin
+
+            result = await token_manager.get_user_id_from_user_email('bob@acme.com')
+
+        assert result == 'right'
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_only_substring_matches(self, token_manager):
+        """If the query returns only non-exact matches, refuse (no wrong user)."""
+        with patch('server.auth.token_manager.get_keycloak_admin') as mock_get_admin:
+            mock_admin = MagicMock()
+            mock_admin.a_get_users = AsyncMock(
+                return_value=[{'id': 'wrong', 'email': 'bob@acme.com.au'}]
+            )
+            mock_get_admin.return_value = mock_admin
+
+            result = await token_manager.get_user_id_from_user_email('bob@acme.com')
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_ambiguous_duplicate_email(self, token_manager):
+        """Two users with the same exact email is ambiguous -> refuse."""
+        with patch('server.auth.token_manager.get_keycloak_admin') as mock_get_admin:
+            mock_admin = MagicMock()
+            mock_admin.a_get_users = AsyncMock(
+                return_value=[
+                    {'id': 'a', 'email': 'bob@acme.com'},
+                    {'id': 'b', 'email': 'BOB@acme.com'},
+                ]
+            )
+            mock_get_admin.return_value = mock_admin
+
+            result = await token_manager.get_user_id_from_user_email('bob@acme.com')
+
+        assert result is None


### PR DESCRIPTION
## Summary

Three fixes that make the Jira Data Center integration usable on large, self-hosted installs (driven by 1Finity/Fujitsu):

**FDE-86 — targeted repo lookup (fix).** `@openhands` mentions resolved the referenced repo by enumerating the user's full repo list (capped at `MAX_REPOS = 1000`) and matching locally, so a repo past the cap on a large Bitbucket DC instance (40k+ repos) failed with "Could not access any of the mentioned repositories." Now each mentioned repo is verified with a targeted `verify_repo_provider` lookup — mirroring the existing Jira Cloud path — so repo volume no longer matters.

**Email-mode auto-link (feat).** In email-match mode, a user whose Jira email matches an OpenHands account is auto-enrolled on first `@openhands`, instead of requiring a manual link step. Email mode is itself the admin's opt-in, so there is no new flag; strictly OAuth-isolated (OAuth still requires a verified per-user token); concurrency-safe against the one-active-link partial unique index.

**FDE-84 — real picker mentions (feat).** Jira's mention picker serializes a real @-mention as wiki markup `[~name]`, which the literal `'@openhands'` substring check silently dropped. The service account's Jira `name`/`key` are now resolved lazily from `/rest/api/2/myself` (using the PAT we already have), cached per workspace, and `[~name]`/`[~key]`/`[~accountid:key]` are matched in addition to literal `@openhands`. The literal path always works and never depends on resolution; a `/myself` failure self-heals. No new KOTS field.

No DB migration (reuses existing columns + the partial unique index).

## Testing

- `enterprise/tests/unit/integrations/jira_dc/` — 107 tests pass (added coverage for the >1000-repo targeted lookup, email auto-enroll + OAuth-isolation, concurrency, and the picker-mention predicate/resolution).
- ruff check + format clean (enterprise config).
## Evidence — live end-to-end on a Replicated OHE install (email mode, PR-1 image `sha-350fb27`)

A real Jira DC comment was posted via the REST API on a live install; the app-pod logs + DB show the full flow (sanitized):

Real webhook delivered → user auto-enrolled → repo resolved via targeted lookup:
```
[Jira DC] Webhook signature verified successfully
"POST /integration/jira-dc/connections/1/events HTTP/1.1" 200
[Jira DC] Auto-enrolled email-match user for workspace 1     # email-mode auto-link
[Jira DC] Inferred repository: <group>/<project>            # targeted verify_repo_provider (no 1000-cap enumeration)
```
Resulting `jira_dc_users` row auto-created (email-mode shape — `unavailable` Jira id is intentional):
```
(<id>, '<keycloak_user_id>', 'unavailable', 'active')
```
Job started + bot replied on the issue:
```
Callback Invoked for event MessageEvent (user) ... execution_status = running
Bot comment: "I'm on it! <user> can track my progress here|https://.../conversation/<id>"
```
Picker-mention (FDE-84) — a comment containing only `[~OpenHands]` (NO literal `@openhands`) triggered a job, after resolving the bot's Jira name from `/myself`:
```
"POST /integration/jira-dc/connections/1/events HTTP/1.1" 200
[Jira DC] Inferred repository: <group>/<project>
```

HUMAN: makes email-mode JDC work without the per-user curl workaround and resolves repos on large Bitbucket DC instances; OAuth-mode behavior unchanged. Validated live end-to-end (Evidence above) on a Replicated OHE install with the PR-1 image, directed/observed by the PR author.

- [x] A human has tested these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-5a075f8   docker.openhands.dev/openhands/openhands:5a075f8
```