### PR TITLE
test: ops box write-path self-test (ignore, closing)

### DIFF
--- a/OPS_BOX_SELFTEST.md
+++ b/OPS_BOX_SELFTEST.md
@@ -1,0 +1,3 @@
+# Ops box self-test
+
+Automated write-path check from the OHE ops box. Draft + closed immediately.


### PR DESCRIPTION
Automated self-test of the OHE ops box write path. Closing immediately.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-933b473   docker.openhands.dev/openhands/openhands:933b473
```