### PR TITLE
fix: Fix CVE-2026-48779: Update ws to 8.21.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8924,27 +8924,6 @@
         "xmlhttprequest-ssl": "~2.1.1"
       }
     },
-    "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -17481,9 +17460,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -131,6 +131,7 @@
   "overrides": {
     "dompurify": "3.4.11",
     "qs": "6.15.2",
-    "@opentelemetry/core": "2.8.0"
+    "@opentelemetry/core": "2.8.0",
+    "ws": ">=8.21.0"
   }
 }


### PR DESCRIPTION
Human: Tested this locally
<img width="904" height="791" alt="Screenshot 2026-06-26 at 12 18 19 PM" src="https://github.com/user-attachments/assets/4b548c26-b9d9-4303-8a41-4618a4ff6361" />


## Security Fix: CVE-2026-48779

**Package:** `ws`
**Current Version:** 8.18.3
**Fixed Version:** 8.21.0

### Changes

- Added npm `overrides` in `frontend/package.json` to enforce `ws >= 8.21.0`
- Regenerated `frontend/package-lock.json` to reflect the updated dependency

### Details

The `ws` package was a transitive dependency pulled in by `engine.io-client` (pinned to `~8.18.3`) and `jsdom` (via `^8.18.3`). Since `engine.io-client`'s tilde constraint prevented a simple `npm update` from resolving the vulnerability for its nested copy, an npm override was added to ensure all instances of `ws` in the dependency tree are at least version 8.21.0.

---
_This PR was created by an AI agent (OpenHands) to remediate CVE-2026-48779._

@mamoodi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2ae0b1e4-7aed-4a81-ba7d-266c750b35b1)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-63816d5   docker.openhands.dev/openhands/openhands:63816d5
```