### PR TITLE
feat(azure-devops): post resolver replies as a service-account bot (PAT, opt-in)

### DIFF
--- a/enterprise/integrations/azure_devops/azure_devops_bot_credential.py
+++ b/enterprise/integrations/azure_devops/azure_devops_bot_credential.py
@@ -1,0 +1,44 @@
+"""Bot posting-identity credentials for Azure DevOps integrations.
+
+When a bot credential is configured, the resolver posts its comments/reactions
+as the bot instead of the @-mentioning user; the agent job still runs with the
+mentioner's own token (unchanged authz). Phase 1 supports a PAT via HTTP Basic
+auth; the abstraction leaves room for service-principal / managed-identity
+credentials later. Opt-in: with no bot token we post as the mentioner.
+"""
+
+from abc import ABC, abstractmethod
+
+from integrations.azure_devops.azure_devops_service import SaaSAzureDevOpsService
+from pydantic import SecretStr
+from server.auth.constants import AZURE_DEVOPS_BOT_TOKEN
+
+
+class AdoBotCredential(ABC):
+    """A credential that authenticates the Azure DevOps bot posting identity."""
+
+    @abstractmethod
+    def build_service(self) -> SaaSAzureDevOpsService:
+        """Return a service authenticated as the bot (no per-user token)."""
+
+
+class AdoPatBotCredential(AdoBotCredential):
+    """Authenticate the bot via a PAT (HTTP Basic, ``:<pat>``)."""
+
+    def __init__(self, pat: str):
+        self._pat = pat
+
+    def build_service(self) -> SaaSAzureDevOpsService:
+        # The base service detects a non-JWT token and uses Basic auth; set the
+        # raw PAT directly and disable refresh (a static PAT never rotates here).
+        service = SaaSAzureDevOpsService()
+        service.token = SecretStr(self._pat)
+        service.refresh = False
+        return service
+
+
+def get_azure_devops_bot_credential() -> AdoBotCredential | None:
+    """Return the configured bot credential, or None to post as the mentioner."""
+    if AZURE_DEVOPS_BOT_TOKEN:
+        return AdoPatBotCredential(AZURE_DEVOPS_BOT_TOKEN)
+    return None

--- a/enterprise/integrations/azure_devops/azure_devops_manager.py
+++ b/enterprise/integrations/azure_devops/azure_devops_manager.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 from types import MappingProxyType
-from typing import cast
+from typing import Any, cast
 
+from integrations.azure_devops.azure_devops_bot_credential import (
+    get_azure_devops_bot_credential,
+)
 from integrations.azure_devops.azure_devops_service import SaaSAzureDevOpsService
 from integrations.azure_devops.azure_devops_view import (
     AzureDevOpsFactory,
@@ -23,9 +26,11 @@ from integrations.utils import (
 from integrations.v1_utils import get_saas_user_auth
 from jinja2 import Environment, FileSystemLoader
 from pydantic import SecretStr
+from server.auth.constants import AZURE_DEVOPS_BOT_USERNAME
 from server.auth.token_manager import TokenManager
 
 from openhands.app_server.integrations.azure_devops.azure_devops_service import (
+    AzureDevOpsService,
     AzureDevOpsServiceImpl,
 )
 from openhands.app_server.integrations.provider import ProviderToken, ProviderType
@@ -82,13 +87,33 @@ class AzureDevOpsManager(Manager[AzureDevOpsViewType]):
             message
         ) or AzureDevOpsFactory.is_work_item_comment(message)
 
+    @staticmethod
+    def _is_bot_actor(actor: dict[str, Any]) -> bool:
+        """Whether the event actor is the configured bot account."""
+        if not AZURE_DEVOPS_BOT_USERNAME:
+            return False
+        bot = AZURE_DEVOPS_BOT_USERNAME.lower()
+        return any(
+            str(actor.get(field) or '').lower() == bot
+            for field in ('uniqueName', 'displayName', 'id')
+        )
+
     async def receive_message(self, message: Message) -> None:
         self._confirm_incoming_source_type(message)
         if not self.is_job_requested(message):
             return
 
-        keycloak_user_id = await self._resolve_mentioner_keycloak_id(message)
         actor = AzureDevOpsFactory.extract_actor(message)
+        # Skip the bot's own comments so its reply (posted via the bot PAT) can't
+        # re-trigger a job, on top of the OpenHands content-marker guard.
+        if self._is_bot_actor(actor):
+            logger.info(
+                '[Azure DevOps] Ignoring event authored by the bot account '
+                f'{AZURE_DEVOPS_BOT_USERNAME!r}'
+            )
+            return
+
+        keycloak_user_id = await self._resolve_mentioner_keycloak_id(message)
         if not keycloak_user_id:
             logger.info(
                 f'[Azure DevOps] Mentioner {actor.get("displayName") or actor.get("uniqueName") or "unknown"} '
@@ -125,13 +150,26 @@ class AzureDevOpsManager(Manager[AzureDevOpsViewType]):
         )
         await self.start_job(azure_view)
 
+    def _posting_service(self, azure_view: ResolverViewInterface) -> AzureDevOpsService:
+        """Service used to POST comments/reactions.
+
+        Posts as the configured bot when AZURE_DEVOPS_BOT_TOKEN is set, else as
+        the @-mentioning user (backward compatible). Either way the resolver job
+        runs with the mentioner's own token (see start_job); the bot identity
+        only affects who posts.
+        """
+        bot_credential = get_azure_devops_bot_credential()
+        if bot_credential is not None:
+            return bot_credential.build_service()
+        return AzureDevOpsServiceImpl(
+            external_auth_id=azure_view.user_info.keycloak_user_id
+        )
+
     async def send_message(
         self, message: str, azure_view: ResolverViewInterface
     ) -> None:
         message = mark_openhands_comment(message)
-        azure_service = AzureDevOpsServiceImpl(
-            external_auth_id=azure_view.user_info.keycloak_user_id
-        )
+        azure_service = self._posting_service(azure_view)
 
         if isinstance(azure_view, AzureDevOpsPRComment):
             if azure_view.thread_id:

--- a/enterprise/server/auth/constants.py
+++ b/enterprise/server/auth/constants.py
@@ -24,6 +24,13 @@ AZURE_DEVOPS_CLIENT_SECRET = os.getenv('AZURE_DEVOPS_CLIENT_SECRET', '').strip()
 AZURE_DEVOPS_TENANT_ID = os.getenv('AZURE_DEVOPS_TENANT_ID', '').strip()
 AZURE_DEVOPS_ORGANIZATION = os.getenv('AZURE_DEVOPS_ORGANIZATION', '').strip()
 AZURE_DEVOPS_WEBHOOK_SECRET = os.getenv('AZURE_DEVOPS_WEBHOOK_SECRET', '').strip()
+# Optional bot service-account PAT. When set, the resolver posts its
+# comments/reactions as this bot (Basic auth) instead of the @-mentioning
+# user; the agent job still runs with the mentioner's own token. Opt-in.
+AZURE_DEVOPS_BOT_TOKEN = os.getenv('AZURE_DEVOPS_BOT_TOKEN', '').strip()
+# Username of the bot above (uniqueName/displayName/id). Lets us skip webhook
+# events the bot itself authored so its reply can't re-trigger a job.
+AZURE_DEVOPS_BOT_USERNAME = os.getenv('AZURE_DEVOPS_BOT_USERNAME', '').strip()
 AZURE_DEVOPS_SCOPE = os.getenv(
     'AZURE_DEVOPS_SCOPE', 'https://app.vssps.visualstudio.com/.default'
 ).strip()

--- a/enterprise/tests/unit/integrations/azure_devops/test_azure_devops_bot_credential.py
+++ b/enterprise/tests/unit/integrations/azure_devops/test_azure_devops_bot_credential.py
@@ -1,0 +1,41 @@
+"""Tests for the Azure DevOps bot posting-identity credential."""
+
+from unittest.mock import patch
+
+from integrations.azure_devops.azure_devops_bot_credential import (
+    AdoPatBotCredential,
+    get_azure_devops_bot_credential,
+)
+
+
+def test_get_credential_none_when_token_unset():
+    """No bot token configured -> post as the mentioner (returns None)."""
+    with patch(
+        'integrations.azure_devops.azure_devops_bot_credential.AZURE_DEVOPS_BOT_TOKEN',
+        '',
+    ):
+        assert get_azure_devops_bot_credential() is None
+
+
+def test_get_credential_returns_pat_credential_when_token_set():
+    """A bot token yields a PAT credential."""
+    with patch(
+        'integrations.azure_devops.azure_devops_bot_credential.AZURE_DEVOPS_BOT_TOKEN',
+        'bot-pat-123',
+    ):
+        credential = get_azure_devops_bot_credential()
+    assert isinstance(credential, AdoPatBotCredential)
+
+
+def test_pat_credential_builds_service_with_raw_token_and_no_refresh():
+    """build_service sets the raw PAT (Basic auth) and disables refresh."""
+    with patch(
+        'integrations.azure_devops.azure_devops_bot_credential.SaaSAzureDevOpsService'
+    ) as service_cls:
+        service = AdoPatBotCredential('bot-pat-123').build_service()
+
+    # No per-user auth; raw PAT set directly so _get_headers uses Basic ':<pat>'.
+    service_cls.assert_called_once_with()
+    assert 'external_auth_id' not in service_cls.call_args.kwargs
+    assert service.token.get_secret_value() == 'bot-pat-123'
+    assert service.refresh is False

--- a/enterprise/tests/unit/integrations/azure_devops/test_azure_devops_manager.py
+++ b/enterprise/tests/unit/integrations/azure_devops/test_azure_devops_manager.py
@@ -4,7 +4,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from integrations.azure_devops.azure_devops_manager import AzureDevOpsManager
+from integrations.azure_devops.azure_devops_view import AzureDevOpsPRComment
 from integrations.models import Message, SourceType
+from integrations.types import UserData
 
 
 def _pr_comment_message(body: str = '@openhands please fix this') -> Message:
@@ -78,3 +80,108 @@ async def test_receive_message_dispatches_when_commenter_has_write_access(monkey
 
     fake_service.has_contribute_access.assert_awaited_once_with('proj-1', 'repo-1')
     manager.start_job.assert_awaited_once()
+
+
+def _pr_comment_view(thread_id: int | None = 11) -> AzureDevOpsPRComment:
+    return AzureDevOpsPRComment(
+        installation_id='org/Project/Repo',
+        issue_number=7,
+        full_repo_name='org/Project/Repo',
+        is_public_repo=False,
+        user_info=UserData(
+            user_id='ado-user-id', username='alice', keycloak_user_id='kc-alice'
+        ),
+        raw_payload=_pr_comment_message(),
+        conversation_id='',
+        should_extract=True,
+        send_summary_instruction=True,
+        title='',
+        description='',
+        previous_comments=[],
+        project_name='Project',
+        project_id='proj-1',
+        repository_id='repo-1',
+        comment_id=2,
+        comment_body='@openhands please fix this',
+        thread_id=thread_id,
+        branch_name='feature/x',
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_message_posts_as_bot_when_token_set(monkeypatch):
+    """With a bot PAT set, replies post via the bot service, not the mentioner."""
+    manager = AzureDevOpsManager(AsyncMock())
+    bot_service = MagicMock()
+    bot_service.add_pr_comment_to_thread = AsyncMock()
+
+    monkeypatch.setattr(
+        'integrations.azure_devops.azure_devops_bot_credential.AZURE_DEVOPS_BOT_TOKEN',
+        'bot-pat-123',
+    )
+    monkeypatch.setattr(
+        'integrations.azure_devops.azure_devops_bot_credential.SaaSAzureDevOpsService',
+        lambda: bot_service,
+    )
+    mentioner_cls = MagicMock()
+    monkeypatch.setattr(
+        'integrations.azure_devops.azure_devops_manager.AzureDevOpsServiceImpl',
+        mentioner_cls,
+    )
+
+    await manager.send_message('Done', _pr_comment_view(thread_id=11))
+
+    bot_service.add_pr_comment_to_thread.assert_awaited_once()
+    assert bot_service.token.get_secret_value() == 'bot-pat-123'
+    mentioner_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_message_posts_as_mentioner_when_token_unset(monkeypatch):
+    """With no bot PAT, replies post as the mentioner (backward compatible)."""
+    manager = AzureDevOpsManager(AsyncMock())
+    mentioner_service = MagicMock()
+    mentioner_service.add_pr_comment_to_thread = AsyncMock()
+    mentioner_cls = MagicMock(return_value=mentioner_service)
+
+    monkeypatch.setattr(
+        'integrations.azure_devops.azure_devops_bot_credential.AZURE_DEVOPS_BOT_TOKEN',
+        '',
+    )
+    monkeypatch.setattr(
+        'integrations.azure_devops.azure_devops_manager.AzureDevOpsServiceImpl',
+        mentioner_cls,
+    )
+
+    await manager.send_message('Done', _pr_comment_view(thread_id=11))
+
+    mentioner_cls.assert_called_once_with(external_auth_id='kc-alice')
+    mentioner_service.add_pr_comment_to_thread.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'field,value',
+    [
+        ('uniqueName', 'openhands-bot'),
+        ('displayName', 'OpenHands-Bot'),  # case-insensitive match
+        ('id', 'openhands-bot'),
+    ],
+)
+async def test_receive_message_skips_event_authored_by_bot(monkeypatch, field, value):
+    """Events authored by the bot account never start a job."""
+    monkeypatch.setattr(
+        'integrations.azure_devops.azure_devops_manager.AZURE_DEVOPS_BOT_USERNAME',
+        'openhands-bot',
+    )
+    manager = AzureDevOpsManager(AsyncMock())
+    manager._resolve_mentioner_keycloak_id = AsyncMock(return_value='kc-alice')  # type: ignore[method-assign]
+    manager.start_job = AsyncMock()  # type: ignore[method-assign]
+
+    message = _pr_comment_message()
+    message.message['payload']['resource']['comment']['author'] = {field: value}
+
+    await manager.receive_message(message)
+
+    manager.start_job.assert_not_called()
+    manager._resolve_mentioner_keycloak_id.assert_not_awaited()


### PR DESCRIPTION
HUMAN: Phase-1 bot support for the Azure DevOps resolver. When a service-account PAT is configured, the resolver posts replies/reactions **as the bot** (not the mentioner) and skips the bot's own comments (loop guard). Fully **opt-in + backward compatible** — with no PAT it posts as the mentioner exactly as today. Needs the companion OpenHands-Cloud chart PR for the KOTS wiring before a real install can use it.

- [ ] A human has tested these changes.

## Why
Run-as-mentioner makes replies look like the human said them and risks the bot re-triggering on its own comments (seen on Bitbucket DC). A dedicated bot identity gives clear "OpenHands" attribution and breaks the loop — mirroring the Jira DC service-account model.

## What
- `AdoBotCredential` strategy abstraction (PAT now; service-principal / managed-identity slot in later) → builds a PAT-authenticated `SaaSAzureDevOpsService` (Basic auth, auto-detected by the base service's JWT-vs-PAT header logic).
- `send_message` posts via the bot service when `AZURE_DEVOPS_BOT_TOKEN` is set, else the mentioner's token (opt-in).
- Self-author guard: skip events whose actor matches `AZURE_DEVOPS_BOT_USERNAME` (on top of the existing content-marker guard).
- **The agent's repo access stays run-as-mentioner** — the hardened, mentioner-scoped write-gate is unchanged; the bot is only the voice.

## Env (provided by the companion chart PR)
`AZURE_DEVOPS_BOT_TOKEN`, `AZURE_DEVOPS_BOT_USERNAME`.

## Tests
8 new: post-as-bot when token set, mentioner fallback when unset, self-author guard (uniqueName/displayName/id, case-insensitive), and the PAT credential builder.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-ede9400   docker.openhands.dev/openhands/openhands:ede9400
```