### PR TITLE
fix: run .openhands setup.sh with POSIX source

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -614,7 +614,7 @@ printf 'password=%s\\n' "$token"
         setup_script = project_dir + '/.openhands/setup.sh'
 
         await workspace.execute_command(
-            f'chmod +x {setup_script} && source {setup_script}',
+            f'chmod +x {setup_script} && . {setup_script}',
             cwd=project_dir,
             timeout=600,
         )

--- a/tests/unit/app_server/test_app_conversation_service_base.py
+++ b/tests/unit/app_server/test_app_conversation_service_base.py
@@ -1446,3 +1446,24 @@ class TestLoadSkillsAndUpdateAgent:
                 'registered_marketplaces'
             ]
             assert forwarded == marketplaces
+
+
+@pytest.mark.asyncio
+async def test_maybe_run_setup_script_uses_posix_source_command():
+    """Test setup.sh is executed with POSIX-compatible shell syntax."""
+    workspace = AsyncMock()
+    mock_user_context = Mock(spec=UserContext)
+
+    with patch.object(AppConversationServiceBase, '__abstractmethods__', set()):
+        service = AppConversationServiceBase(
+            init_git_in_empty_workspace=True,
+            user_context=mock_user_context,
+        )
+
+        await service.maybe_run_setup_script(workspace, '/workspace/repo')
+
+    workspace.execute_command.assert_awaited_once_with(
+        'chmod +x /workspace/repo/.openhands/setup.sh && . /workspace/repo/.openhands/setup.sh',
+        cwd='/workspace/repo',
+        timeout=600,
+    )


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

Fixes setup hooks that failed under `sh` by replacing Bash-only `source` with POSIX `.` when OpenHands runs `.openhands/setup.sh`.

- [x] A human has tested these changes.

AGENT:

I tested the focused backend unit test locally with:

```bash
.venv/bin/python -m pytest -q tests/unit/app_server/test_app_conversation_service_base.py
```

Result: `48 passed in 2.96s`.

---

## Why

`maybe_run_setup_script()` shells out under `sh`, where `source` is not portable. That made repository-provided `.openhands/setup.sh` hooks fail before the setup script could run.

## Summary

- Use POSIX `.` instead of Bash-only `source` for the setup hook command.
- Add a regression test for the exact command OpenHands sends to the workspace.
- Keep the change scoped to setup-script invocation only.

## Issue Number

Fixes OpenHands/enterprise#41.

## How to Test

Run the focused backend test:

```bash
.venv/bin/python -m pytest -q tests/unit/app_server/test_app_conversation_service_base.py
```

## Video/Screenshots

N/A; this is backend command construction only.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

User-facing changelog note:

- Repository `.openhands/setup.sh` hooks now run with POSIX-compatible sourcing, so setup scripts work under `sh` instead of depending on Bash-only `source`.
