### PR TITLE
fix(app-server): preserve selected repository across webhook metadata races

### DIFF
--- a/enterprise/server/utils/saas_app_conversation_info_injector.py
+++ b/enterprise/server/utils/saas_app_conversation_info_injector.py
@@ -351,11 +351,16 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         return results
 
     async def save_app_conversation_info(
-        self, info: AppConversationInfo
+        self,
+        info: AppConversationInfo,
+        *,
+        preserve_git_fields_on_null: bool = False,
     ) -> AppConversationInfo:
         """Save conversation info and create/update SAAS metadata with user_id and org_id."""
         # Save the base conversation metadata
-        await super().save_app_conversation_info(info)
+        await super().save_app_conversation_info(
+            info, preserve_git_fields_on_null=preserve_git_fields_on_null
+        )
 
         # Get current user_id for SAAS metadata
         # Fall back to info.created_by_user_id for webhook callbacks (which use ADMIN context)

--- a/openhands/app_server/app_conversation/app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/app_conversation_info_service.py
@@ -96,7 +96,10 @@ class AppConversationInfoService(ABC):
 
     @abstractmethod
     async def save_app_conversation_info(
-        self, info: AppConversationInfo
+        self,
+        info: AppConversationInfo,
+        *,
+        preserve_git_fields_on_null: bool = False,
     ) -> AppConversationInfo:
         """Store the sandboxed conversation info object given.
 

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -32,8 +32,10 @@ from sqlalchemy import (
     String,
     func,
     select,
+    update,
 )
 from sqlalchemy.engine import CursorResult
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -383,8 +385,43 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             tags=info.tags if info.tags else None,
         )
 
-        await self.db_session.merge(stored)
-        await self.db_session.commit()
+        # selected_repository / selected_branch / git_provider are set once when
+        # the conversation is created. A startup webhook racing the create only
+        # sees a not-yet-persisted stub (git fields None); it must not overwrite
+        # the stored repository with None, or it silently disappears from a
+        # running conversation. COALESCE keeps the stored value whenever the
+        # incoming write is None, independent of which writer commits last.
+        update_values: dict = {
+            column.name: getattr(stored, column.name)
+            for column in StoredConversationMetadata.__table__.columns
+            if column.name != 'conversation_id'
+        }
+        for field in ('selected_repository', 'selected_branch', 'git_provider'):
+            update_values[field] = func.coalesce(
+                getattr(stored, field),
+                getattr(StoredConversationMetadata, field),
+            )
+        update_stmt = (
+            update(StoredConversationMetadata)
+            .where(StoredConversationMetadata.conversation_id == stored.conversation_id)
+            .values(update_values)
+        )
+
+        result = await self.db_session.execute(update_stmt)
+        if result.rowcount == 0:
+            # No row yet: insert it. A concurrent writer may win the insert
+            # race (duplicate primary key); fall back to the git-preserving
+            # update instead of surfacing the IntegrityError, which would
+            # otherwise leave a started conversation without metadata.
+            try:
+                self.db_session.add(stored)
+                await self.db_session.commit()
+            except IntegrityError:
+                await self.db_session.rollback()
+                await self.db_session.execute(update_stmt)
+                await self.db_session.commit()
+        else:
+            await self.db_session.commit()
         return info
 
     async def update_conversation_statistics(

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -347,7 +347,10 @@ class SQLAppConversationInfoService(AppConversationInfoService):
         return results
 
     async def save_app_conversation_info(
-        self, info: AppConversationInfo
+        self,
+        info: AppConversationInfo,
+        *,
+        preserve_git_fields_on_null: bool = False,
     ) -> AppConversationInfo:
         metrics = info.metrics or MetricsSnapshot()
         usage = metrics.accumulated_token_usage or TokenUsage()
@@ -385,22 +388,20 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             tags=info.tags if info.tags else None,
         )
 
-        # selected_repository / selected_branch / git_provider are set once when
-        # the conversation is created. A startup webhook racing the create only
-        # sees a not-yet-persisted stub (git fields None); it must not overwrite
-        # the stored repository with None, or it silently disappears from a
-        # running conversation. COALESCE keeps the stored value whenever the
-        # incoming write is None, independent of which writer commits last.
+        # Git fields are write-once for the webhook/startup path: a stub racing the
+        # create carries None and must not wipe a stored repo (see #14476). Explicit
+        # update callers leave the flag off so a None still clears them.
         update_values: dict = {
             column.name: getattr(stored, column.name)
             for column in StoredConversationMetadata.__table__.columns
             if column.name != 'conversation_id'
         }
-        for field in ('selected_repository', 'selected_branch', 'git_provider'):
-            update_values[field] = func.coalesce(
-                getattr(stored, field),
-                getattr(StoredConversationMetadata, field),
-            )
+        if preserve_git_fields_on_null:
+            for field in ('selected_repository', 'selected_branch', 'git_provider'):
+                update_values[field] = func.coalesce(
+                    getattr(stored, field),
+                    getattr(StoredConversationMetadata, field),
+                )
         update_stmt = (
             update(StoredConversationMetadata)
             .where(StoredConversationMetadata.conversation_id == stored.conversation_id)
@@ -409,10 +410,9 @@ class SQLAppConversationInfoService(AppConversationInfoService):
 
         result = cast(CursorResult, await self.db_session.execute(update_stmt))
         if result.rowcount == 0:
-            # No row yet: insert it. A concurrent writer may win the insert
-            # race (duplicate primary key); fall back to the git-preserving
-            # update instead of surfacing the IntegrityError, which would
-            # otherwise leave a started conversation without metadata.
+            # No row yet: insert it. A concurrent writer may win the insert race
+            # (duplicate PK); recover by re-running the update instead of raising,
+            # which would otherwise leave a started conversation without metadata.
             try:
                 self.db_session.add(stored)
                 await self.db_session.commit()

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -407,7 +407,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             .values(update_values)
         )
 
-        result = await self.db_session.execute(update_stmt)
+        result = cast(CursorResult, await self.db_session.execute(update_stmt))
         if result.rowcount == 0:
             # No row yet: insert it. A concurrent writer may win the insert
             # race (duplicate primary key); fall back to the git-preserving

--- a/openhands/app_server/event_callback/webhook_router.py
+++ b/openhands/app_server/event_callback/webhook_router.py
@@ -411,8 +411,12 @@ async def on_conversation_update(
         # Store merged tags (includes automation context, skills, etc.)
         tags=merged_tags,
     )
+    # Git fields here are sourced from ``existing``, which is a None-filled stub when
+    # the create has not yet been persisted (the startup race). Preserve any stored
+    # repo rather than letting that stub null it; see #14476.
     await app_conversation_info_service.save_app_conversation_info(
-        app_conversation_info
+        app_conversation_info,
+        preserve_git_fields_on_null=True,
     )
 
     # Register SetTitleCallbackProcessor for new conversations created via webhook.

--- a/tests/unit/app_server/test_sql_app_conversation_info_service.py
+++ b/tests/unit/app_server/test_sql_app_conversation_info_service.py
@@ -10,6 +10,7 @@ from typing import AsyncGenerator
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
@@ -1273,24 +1274,29 @@ class TestFixTimezone:
 
 
 class TestSaveGitWriteOnce:
-    """selected_repository / selected_branch / git_provider are write-once.
+    """``preserve_git_fields_on_null`` makes the git fields write-once for the
+    webhook/startup path only.
 
-    Conversation startup persists the repository, then a webhook update can
-    arrive carrying a not-yet-populated stub (git fields None). That update must
-    not wipe the repository from a running conversation. Regression cover for
-    the conversation metadata save race (#14476).
+    The conversation-start webhook sees a None-filled stub when the create has not
+    yet been persisted (the race), so it saves with ``preserve_git_fields_on_null=
+    True`` and a None must not wipe a stored repo. The default (flag off, used by
+    explicit update/PATCH callers) still lets a None clear the fields, preserving
+    the documented "set repository to null to remove it" contract. Regression cover
+    for the conversation metadata save race (#14476).
     """
 
     @pytest.mark.asyncio
-    async def test_stub_update_does_not_null_repository(
+    async def test_webhook_stub_does_not_null_repository(
         self,
         service: SQLAppConversationInfoService,
         sample_conversation_info: AppConversationInfo,
     ):
-        """A later None-valued git update must not overwrite a stored repo."""
+        """The exact race: create commits the repo, then the webhook saves a None
+        stub with the preserve flag. Pre-fix ``merge()`` nulled it; COALESCE keeps
+        it."""
         await service.save_app_conversation_info(sample_conversation_info)
 
-        stub_update = sample_conversation_info.model_copy(
+        stub = sample_conversation_info.model_copy(
             update={
                 'selected_repository': None,
                 'selected_branch': None,
@@ -1298,7 +1304,7 @@ class TestSaveGitWriteOnce:
                 'title': f'Conversation {sample_conversation_info.id.hex}',
             }
         )
-        await service.save_app_conversation_info(stub_update)
+        await service.save_app_conversation_info(stub, preserve_git_fields_on_null=True)
 
         retrieved = await service.get_app_conversation_info(sample_conversation_info.id)
         assert retrieved is not None
@@ -1310,20 +1316,21 @@ class TestSaveGitWriteOnce:
         assert retrieved.git_provider == sample_conversation_info.git_provider
 
     @pytest.mark.asyncio
-    async def test_repository_survives_when_stub_persisted_first(
+    async def test_webhook_stub_wins_when_persisted_first(
         self,
         service: SQLAppConversationInfoService,
         sample_conversation_info: AppConversationInfo,
     ):
-        """COALESCE is order-independent: the non-null repository still wins."""
-        stub_first = sample_conversation_info.model_copy(
+        """Order-independent: a webhook stub landing before the create still ends
+        up with the repo once the create (default flag) writes it."""
+        stub = sample_conversation_info.model_copy(
             update={
                 'selected_repository': None,
                 'selected_branch': None,
                 'git_provider': None,
             }
         )
-        await service.save_app_conversation_info(stub_first)
+        await service.save_app_conversation_info(stub, preserve_git_fields_on_null=True)
         await service.save_app_conversation_info(sample_conversation_info)
 
         retrieved = await service.get_app_conversation_info(sample_conversation_info.id)
@@ -1334,12 +1341,77 @@ class TestSaveGitWriteOnce:
         )
 
     @pytest.mark.asyncio
-    async def test_repository_stays_none_without_repo(
+    async def test_explicit_update_can_clear_repository(
         self,
         service: SQLAppConversationInfoService,
         sample_conversation_info: AppConversationInfo,
     ):
-        """A conversation created without a repo keeps a null repository."""
+        """Default flag off: an explicit None update still clears the repo, so the
+        documented PATCH "remove repository" contract keeps working."""
+        await service.save_app_conversation_info(sample_conversation_info)
+
+        cleared = sample_conversation_info.model_copy(
+            update={
+                'selected_repository': None,
+                'selected_branch': None,
+                'git_provider': None,
+            }
+        )
+        await service.save_app_conversation_info(cleared)
+
+        retrieved = await service.get_app_conversation_info(sample_conversation_info.id)
+        assert retrieved is not None
+        assert retrieved.selected_repository is None
+        assert retrieved.selected_branch is None
+        assert retrieved.git_provider is None
+
+    @pytest.mark.asyncio
+    async def test_save_recovers_from_insert_integrity_race(
+        self,
+        service: SQLAppConversationInfoService,
+        sample_conversation_info: AppConversationInfo,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A concurrent writer can win the insert race (duplicate PK). The loser
+        rolls back and re-runs the update instead of surfacing the IntegrityError,
+        which would otherwise leave a started conversation unsaved."""
+        real_commit = service.db_session.commit
+        real_rollback = service.db_session.rollback
+        calls = {'commit': 0, 'rollback': 0}
+
+        async def flaky_commit():
+            calls['commit'] += 1
+            if calls['commit'] == 1:
+                raise IntegrityError(
+                    'INSERT INTO conversation_metadata ...',
+                    {},
+                    Exception(
+                        'UNIQUE constraint failed: conversation_metadata.conversation_id'
+                    ),
+                )
+            await real_commit()
+
+        async def counting_rollback():
+            calls['rollback'] += 1
+            await real_rollback()
+
+        monkeypatch.setattr(service.db_session, 'commit', flaky_commit)
+        monkeypatch.setattr(service.db_session, 'rollback', counting_rollback)
+
+        # Must not raise; the first (insert) commit fails, then rollback + retry.
+        await service.save_app_conversation_info(
+            sample_conversation_info, preserve_git_fields_on_null=True
+        )
+        assert calls == {'commit': 2, 'rollback': 1}
+
+    @pytest.mark.asyncio
+    async def test_no_repo_conversation_stays_none(
+        self,
+        service: SQLAppConversationInfoService,
+        sample_conversation_info: AppConversationInfo,
+    ):
+        """A repo-less conversation saved twice via the webhook path stays None
+        (COALESCE(None, None) is None)."""
         no_repo = sample_conversation_info.model_copy(
             update={
                 'selected_repository': None,
@@ -1347,8 +1419,12 @@ class TestSaveGitWriteOnce:
                 'git_provider': None,
             }
         )
-        await service.save_app_conversation_info(no_repo)
-        await service.save_app_conversation_info(no_repo)
+        await service.save_app_conversation_info(
+            no_repo, preserve_git_fields_on_null=True
+        )
+        await service.save_app_conversation_info(
+            no_repo, preserve_git_fields_on_null=True
+        )
 
         retrieved = await service.get_app_conversation_info(no_repo.id)
         assert retrieved is not None

--- a/tests/unit/app_server/test_sql_app_conversation_info_service.py
+++ b/tests/unit/app_server/test_sql_app_conversation_info_service.py
@@ -1270,3 +1270,87 @@ class TestFixTimezone:
         aware_dt = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
         result = service._fix_timezone(aware_dt)
         assert result == aware_dt
+
+
+class TestSaveGitWriteOnce:
+    """selected_repository / selected_branch / git_provider are write-once.
+
+    Conversation startup persists the repository, then a webhook update can
+    arrive carrying a not-yet-populated stub (git fields None). That update must
+    not wipe the repository from a running conversation. Regression cover for
+    the conversation metadata save race (#14476).
+    """
+
+    @pytest.mark.asyncio
+    async def test_stub_update_does_not_null_repository(
+        self,
+        service: SQLAppConversationInfoService,
+        sample_conversation_info: AppConversationInfo,
+    ):
+        """A later None-valued git update must not overwrite a stored repo."""
+        await service.save_app_conversation_info(sample_conversation_info)
+
+        stub_update = sample_conversation_info.model_copy(
+            update={
+                'selected_repository': None,
+                'selected_branch': None,
+                'git_provider': None,
+                'title': f'Conversation {sample_conversation_info.id.hex}',
+            }
+        )
+        await service.save_app_conversation_info(stub_update)
+
+        retrieved = await service.get_app_conversation_info(sample_conversation_info.id)
+        assert retrieved is not None
+        assert (
+            retrieved.selected_repository
+            == sample_conversation_info.selected_repository
+        )
+        assert retrieved.selected_branch == sample_conversation_info.selected_branch
+        assert retrieved.git_provider == sample_conversation_info.git_provider
+
+    @pytest.mark.asyncio
+    async def test_repository_survives_when_stub_persisted_first(
+        self,
+        service: SQLAppConversationInfoService,
+        sample_conversation_info: AppConversationInfo,
+    ):
+        """COALESCE is order-independent: the non-null repository still wins."""
+        stub_first = sample_conversation_info.model_copy(
+            update={
+                'selected_repository': None,
+                'selected_branch': None,
+                'git_provider': None,
+            }
+        )
+        await service.save_app_conversation_info(stub_first)
+        await service.save_app_conversation_info(sample_conversation_info)
+
+        retrieved = await service.get_app_conversation_info(sample_conversation_info.id)
+        assert retrieved is not None
+        assert (
+            retrieved.selected_repository
+            == sample_conversation_info.selected_repository
+        )
+
+    @pytest.mark.asyncio
+    async def test_repository_stays_none_without_repo(
+        self,
+        service: SQLAppConversationInfoService,
+        sample_conversation_info: AppConversationInfo,
+    ):
+        """A conversation created without a repo keeps a null repository."""
+        no_repo = sample_conversation_info.model_copy(
+            update={
+                'selected_repository': None,
+                'selected_branch': None,
+                'git_provider': None,
+            }
+        )
+        await service.save_app_conversation_info(no_repo)
+        await service.save_app_conversation_info(no_repo)
+
+        retrieved = await service.get_app_conversation_info(no_repo.id)
+        assert retrieved is not None
+        assert retrieved.selected_repository is None
+        assert retrieved.git_provider is None

--- a/tests/unit/app_server/test_webhook_router_auto_title.py
+++ b/tests/unit/app_server/test_webhook_router_auto_title.py
@@ -412,9 +412,9 @@ class TestOnConversationUpdateAutoTitle:
 
         original_save = app_conversation_info_service.save_app_conversation_info
 
-        async def tracking_save(info):
+        async def tracking_save(info, **kwargs):
             operation_order.append('save_conversation')
-            return await original_save(info)
+            return await original_save(info, **kwargs)
 
         async def mock_save_event_callback(callback):
             operation_order.append('save_callback')


### PR DESCRIPTION
HUMAN:

On a self-hosted box the selected repo kept vanishing from running conversations (the UI flips to "no repo connected"). I traced it to the conversation-start webhook racing the create: it reads the metadata before the create is visible, gets a blank stub, and writes the row back with the git fields nulled, wiping the repo that was just saved. This change makes selected_repository / selected_branch / git_provider write-once so a late stub write can't null them, and keeps the duplicate-key insert-race recovery from OpenHands/enterprise#26.

- [x] A human has tested these changes.

AGENT:

---

## Why

`selected_repository`, `selected_branch` and `git_provider` are set once, when a conversation is created. The conversation-start webhook (`on_conversation_update`) also reads the conversation metadata and writes it back. When the webhook's read lands before the create transaction is visible, `valid_conversation` returns a stub with the git fields set to `None`, and the blind `merge()` in `save_app_conversation_info` then overwrites the stored repository with `None`. The repository silently disappears from a running conversation (the UI shows "no repo connected").

This is the same race as OpenHands/enterprise#26, but a different symptom. The open retry PRs (#14579, OpenHands/OpenHands#14940) recover the duplicate-key insert crash, but re-merging the stub still writes `None` over the repository, so the data loss remains.

## Summary

- Make the three git fields write-once in `save_app_conversation_info`: existing rows are updated with `COALESCE(incoming, stored)`, so an incoming `None` never overwrites a populated value.
- When the row does not exist yet it is inserted, and a concurrent insert (duplicate primary key) is recovered by re-applying the git-preserving update.
- Order-independent: whichever writer supplies a non-null repository wins regardless of commit order, and the OpenHands/enterprise#26 insert race is recovered as well.

## Issue Number

Fixes OpenHands/enterprise#26

## How to Test

- Unit tests (`tests/unit/app_server/test_sql_app_conversation_info_service.py::TestSaveGitWriteOnce`): a stub update does not null a stored repository, the repository survives when the stub commits first, and a repo-less conversation stays `None`. Run `uv run --python 3.12 pytest tests/unit/app_server/test_sql_app_conversation_info_service.py -q`.
- `ruff check` and `ruff format --check` clean on both changed files (config auto-discovered from `pyproject.toml`, ruff 0.12.5).
- Reproduced end to end on a self-hosted instance (`ghcr.io/openhands/openhands:main`, SQLite): firing concurrent repository-backed conversation starts nulled roughly 40% of repositories before the change and 0 after, including starts where the webhook stub demonstrably fired.

## Video/Screenshots

N/A. Backend metadata-persistence change, covered by the unit tests and the before/after reproduction above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The retry-only PRs for OpenHands/enterprise#26 (#14579, OpenHands/OpenHands#14940) recover the duplicate-key crash but not this data-loss symptom. This change keeps the same insert-race recovery while also preventing the repository from being nulled, so it could supersede them.
