### PR TITLE
fix(app-server): cache remote runtime status lookups

### DIFF
--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -2,7 +2,8 @@ import asyncio
 import hashlib
 import logging
 import os
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, AsyncGenerator
 from urllib.parse import urlparse
@@ -66,6 +67,14 @@ AGENT_SERVER_PORT = 60000
 VSCODE_PORT = 60001
 WORKER_1_PORT = 12000
 WORKER_2_PORT = 12001
+RUNTIME_STATUS_CACHE_TTL_SECONDS = 2.0
+RUNTIME_STATUS_MISSING_BACKOFF_SECONDS = 2.0
+
+
+@dataclass
+class _RuntimeCacheEntry:
+    runtime: dict[str, Any]
+    expires_at: float
 
 
 def _hash_session_api_key(session_api_key: str) -> str:
@@ -117,6 +126,15 @@ class RemoteSandboxService(SandboxService):
     user_context: UserContext
     httpx_client: httpx.AsyncClient
     db_session: AsyncSession
+    _runtime_cache: dict[str, _RuntimeCacheEntry] = field(
+        default_factory=dict, init=False
+    )
+    _runtime_missing_backoff_until: dict[str, float] = field(
+        default_factory=dict, init=False
+    )
+    _runtime_inflight: dict[str, asyncio.Task[dict[str, Any]]] = field(
+        default_factory=dict, init=False
+    )
 
     async def _send_runtime_api_request(
         self, method: str, path: str, **kwargs: Any
@@ -222,13 +240,62 @@ class RemoteSandboxService(SandboxService):
         stored_sandbox = result.scalar_one_or_none()
         return stored_sandbox
 
-    async def _get_runtime(self, sandbox_id: str) -> dict[str, Any]:
+    def _get_cached_runtime(self, sandbox_id: str) -> dict[str, Any] | None:
+        entry = self._runtime_cache.get(sandbox_id)
+        if entry is None:
+            return None
+        if entry.expires_at <= time.monotonic():
+            self._runtime_cache.pop(sandbox_id, None)
+            return None
+        return entry.runtime
+
+    def _cache_runtime(self, sandbox_id: str, runtime: dict[str, Any]) -> None:
+        self._runtime_cache[sandbox_id] = _RuntimeCacheEntry(
+            runtime=runtime,
+            expires_at=time.monotonic() + RUNTIME_STATUS_CACHE_TTL_SECONDS,
+        )
+        self._runtime_missing_backoff_until.pop(sandbox_id, None)
+
+    def _mark_runtime_missing(self, sandbox_id: str) -> None:
+        self._runtime_missing_backoff_until[sandbox_id] = (
+            time.monotonic() + RUNTIME_STATUS_MISSING_BACKOFF_SECONDS
+        )
+
+    def _is_runtime_missing_backed_off(self, sandbox_id: str) -> bool:
+        backoff_until = self._runtime_missing_backoff_until.get(sandbox_id)
+        if backoff_until is None:
+            return False
+        if backoff_until <= time.monotonic():
+            self._runtime_missing_backoff_until.pop(sandbox_id, None)
+            return False
+        return True
+
+    async def _fetch_runtime(self, sandbox_id: str) -> dict[str, Any]:
         response = await self._send_runtime_api_request(
             'GET',
             f'/sessions/{sandbox_id}',
         )
         response.raise_for_status()
         runtime_data = response.json()
+        return runtime_data
+
+    async def _get_runtime(self, sandbox_id: str) -> dict[str, Any]:
+        cached_runtime = self._get_cached_runtime(sandbox_id)
+        if cached_runtime is not None:
+            return cached_runtime
+
+        task = self._runtime_inflight.get(sandbox_id)
+        if task is None:
+            task = asyncio.create_task(self._fetch_runtime(sandbox_id))
+            self._runtime_inflight[sandbox_id] = task
+
+        try:
+            runtime_data = await task
+        finally:
+            if self._runtime_inflight.get(sandbox_id) is task:
+                self._runtime_inflight.pop(sandbox_id, None)
+
+        self._cache_runtime(sandbox_id, runtime_data)
         return runtime_data
 
     async def _get_runtimes_batch(
@@ -245,8 +312,27 @@ class RemoteSandboxService(SandboxService):
         if not sandbox_ids:
             return {}
 
+        runtimes_by_id: dict[str, dict[str, Any]] = {}
+        uncached_ids = []
+        seen_ids = set()
+        for sandbox_id in sandbox_ids:
+            if sandbox_id in seen_ids:
+                continue
+            seen_ids.add(sandbox_id)
+
+            cached_runtime = self._get_cached_runtime(sandbox_id)
+            if cached_runtime is not None:
+                runtimes_by_id[sandbox_id] = cached_runtime
+                continue
+            if self._is_runtime_missing_backed_off(sandbox_id):
+                continue
+            uncached_ids.append(sandbox_id)
+
+        if not uncached_ids:
+            return runtimes_by_id
+
         # Build query parameters for the batch endpoint
-        params = [('ids', sandbox_id) for sandbox_id in sandbox_ids]
+        params = [('ids', sandbox_id) for sandbox_id in uncached_ids]
 
         response = await self._send_runtime_api_request(
             'GET',
@@ -258,10 +344,15 @@ class RemoteSandboxService(SandboxService):
 
         # The batch endpoint should return a list of runtimes
         # Convert to a dictionary keyed by session_id for easy lookup
-        runtimes_by_id = {}
         for runtime in batch_data:
             if runtime and 'session_id' in runtime:
-                runtimes_by_id[runtime['session_id']] = runtime
+                sandbox_id = runtime['session_id']
+                runtimes_by_id[sandbox_id] = runtime
+                self._cache_runtime(sandbox_id, runtime)
+
+        for sandbox_id in uncached_ids:
+            if sandbox_id not in runtimes_by_id:
+                self._mark_runtime_missing(sandbox_id)
 
         return runtimes_by_id
 

--- a/tests/unit/app_server/test_remote_sandbox_service.py
+++ b/tests/unit/app_server/test_remote_sandbox_service.py
@@ -23,6 +23,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from openhands.app_server.errors import SandboxError
+from openhands.app_server.sandbox import remote_sandbox_service as remote_sandbox_module
 from openhands.app_server.sandbox.remote_sandbox_service import (
     ALLOW_CORS_ORIGINS_VARIABLE,
     STATUS_MAPPING,
@@ -845,6 +846,119 @@ class TestSandboxSearch:
         assert 'sb1' in result
         assert 'sb2' not in result  # Missing from response
         assert 'sb3' in result
+
+    @pytest.mark.asyncio
+    async def test_get_runtime_uses_short_ttl_cache(self, remote_sandbox_service):
+        """Repeated runtime lookups inside the TTL reuse the cached runtime."""
+        sandbox_id = 'sb1'
+        runtime_data = create_runtime_data(sandbox_id)
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = runtime_data
+        remote_sandbox_service.httpx_client.request = AsyncMock(
+            return_value=mock_response
+        )
+
+        first = await remote_sandbox_service._get_runtime(sandbox_id)
+        second = await remote_sandbox_service._get_runtime(sandbox_id)
+
+        assert first == runtime_data
+        assert second == runtime_data
+        remote_sandbox_service.httpx_client.request.assert_called_once_with(
+            'GET',
+            'https://api.example.com/sessions/sb1',
+            headers={'X-API-Key': 'test-api-key'},
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_runtime_refreshes_after_cache_ttl(
+        self, remote_sandbox_service, monkeypatch
+    ):
+        """Runtime cache entries expire so status transitions can be observed."""
+        now = 100.0
+        monkeypatch.setattr(remote_sandbox_module.time, 'monotonic', lambda: now)
+        first_response = MagicMock()
+        first_response.raise_for_status.return_value = None
+        first_response.json.return_value = create_runtime_data('sb1', status='starting')
+        second_response = MagicMock()
+        second_response.raise_for_status.return_value = None
+        second_response.json.return_value = create_runtime_data('sb1', status='running')
+        remote_sandbox_service.httpx_client.request = AsyncMock(
+            side_effect=[first_response, second_response]
+        )
+
+        first = await remote_sandbox_service._get_runtime('sb1')
+        now += remote_sandbox_module.RUNTIME_STATUS_CACHE_TTL_SECONDS + 0.1
+        second = await remote_sandbox_service._get_runtime('sb1')
+
+        assert first['status'] == 'starting'
+        assert second['status'] == 'running'
+        assert remote_sandbox_service.httpx_client.request.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_get_runtime_coalesces_concurrent_duplicate_requests(
+        self, remote_sandbox_service
+    ):
+        """Concurrent lookups for the same sandbox share one runtime-api call."""
+        sandbox_id = 'sb1'
+        runtime_data = create_runtime_data(sandbox_id)
+        request_started = asyncio.Event()
+        release_response = asyncio.Event()
+
+        async def request_side_effect(*args, **kwargs):
+            request_started.set()
+            await release_response.wait()
+            mock_response = MagicMock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = runtime_data
+            return mock_response
+
+        remote_sandbox_service.httpx_client.request = AsyncMock(
+            side_effect=request_side_effect
+        )
+
+        first_task = asyncio.create_task(
+            remote_sandbox_service._get_runtime(sandbox_id)
+        )
+        await request_started.wait()
+        second_task = asyncio.create_task(
+            remote_sandbox_service._get_runtime(sandbox_id)
+        )
+        await asyncio.sleep(0)
+        release_response.set()
+
+        first, second = await asyncio.gather(first_task, second_task)
+
+        assert first == runtime_data
+        assert second == runtime_data
+        remote_sandbox_service.httpx_client.request.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_runtimes_batch_backs_off_missing_sandbox_ids(
+        self, remote_sandbox_service
+    ):
+        """Missing runtimes from a batch response are not immediately re-polled."""
+        first_response = MagicMock()
+        first_response.raise_for_status.return_value = None
+        first_response.json.return_value = [create_runtime_data('sb1')]
+        second_response = MagicMock()
+        second_response.raise_for_status.return_value = None
+        second_response.json.return_value = [create_runtime_data('sb2')]
+        remote_sandbox_service.httpx_client.request = AsyncMock(
+            side_effect=[first_response, second_response]
+        )
+
+        first = await remote_sandbox_service._get_runtimes_batch(['sb1', 'sb2'])
+        second = await remote_sandbox_service._get_runtimes_batch(['sb1', 'sb2'])
+
+        assert set(first) == {'sb1'}
+        assert set(second) == {'sb1'}
+        remote_sandbox_service.httpx_client.request.assert_called_once_with(
+            'GET',
+            'https://api.example.com/sessions/batch',
+            headers={'X-API-Key': 'test-api-key'},
+            params=[('ids', 'sb1'), ('ids', 'sb2')],
+        )
 
     @pytest.mark.asyncio
     async def test_get_sandbox_exists(self, remote_sandbox_service):


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

This PR reduces repeated remote runtime status polling by caching successful runtime lookups briefly, coalescing concurrent duplicate requests, and backing off briefly when batch status responses omit a sandbox ID.

- [ ] A human has tested these changes.

AGENT:

---

## Why

Remote sandbox status lookups can repeatedly hit runtime-api for the same sandbox while a runtime is starting, missing, unknown, or temporarily unavailable. That repeated polling can amplify load against runtime-api and its backing status store, especially when multiple app-server requests ask for the same sandbox state concurrently.

## Summary

- add a short per-service TTL cache for remote runtime status lookups
- coalesce concurrent single-sandbox runtime lookups so duplicate callers share one runtime-api request
- add short backoff for sandbox IDs missing from batch runtime responses while keeping cached successful statuses available
- add unit coverage for cache hits, TTL refresh, concurrent coalescing, and missing-runtime batch backoff

## Issue Number

Closes #14554

## How to Test

```bash
.venv/bin/pytest tests/unit/app_server/test_remote_sandbox_service.py
.venv/bin/pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files openhands/app_server/sandbox/remote_sandbox_service.py tests/unit/app_server/test_remote_sandbox_service.py
```

## Video/Screenshots

Not applicable. This PR changes backend runtime status lookup behavior and unit tests only.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The cache and missing-runtime backoff are intentionally short-lived, currently 2 seconds, so runtime status transitions such as starting to running can still be observed quickly.
- Validation was run locally using the repository `.venv` because this checkout did not have `poetry` on PATH for `make install-pre-commit-hooks`.
