### PR TITLE
feat(app-conversation): export evidence gate receipts

### DIFF
--- a/openhands/app_server/app_conversation/README.md
+++ b/openhands/app_server/app_conversation/README.md
@@ -18,3 +18,9 @@ This module provides services and models for managing conversations that run wit
 - Real-time conversation status updates
 - Pagination support for large conversation lists
 - Integration with sandbox environments
+- Trajectory exports include raw event JSON plus an
+  `evidence_gate_receipts.json` projection that links each action event to its
+  security risk, pre-tool hook decisions, observations, and post-tool hooks for
+  reviewer-facing audit evidence.
+  The receipt decision is a derived export projection from security risk and
+  hook block state, not a replacement for the runtime confirmation policy.

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -142,6 +142,117 @@ _conversation_info_type_adapter = TypeAdapter(list[ConversationInfo | None])
 _logger = logging.getLogger(__name__)
 
 _EXPORT_LOCK_KEY_PREFIX = 'app_conversation_export'
+_EVIDENCE_GATE_RECEIPTS_SCHEMA_VERSION = 'openhands.evidence_gate_receipts.v1'
+
+
+def _new_evidence_gate_context() -> dict[str, Any]:
+    return {
+        'pre_tool_hook_event_ids': [],
+        'blocked_by_hook_event_ids': [],
+        'blocked_reasons': [],
+        'observation_event_ids': [],
+        'post_tool_hook_event_ids': [],
+    }
+
+
+def _security_risk_value(value: Any) -> str:
+    if value is None:
+        return 'UNKNOWN'
+    return str(getattr(value, 'value', value))
+
+
+def _record_event_for_evidence_gate_receipts(
+    contexts: dict[str, dict[str, Any]], event_data: Mapping[str, Any]
+) -> None:
+    kind = event_data.get('kind')
+    if kind == 'ActionEvent':
+        action_id = str(event_data.get('id') or '')
+        if not action_id:
+            return
+        context = contexts.setdefault(action_id, _new_evidence_gate_context())
+        context['action_event_id'] = action_id
+        context['tool_name'] = event_data.get('tool_name')
+        context['tool_call_id'] = event_data.get('tool_call_id')
+        context['security_risk'] = _security_risk_value(event_data.get('security_risk'))
+        return
+
+    action_id_value = event_data.get('action_id')
+    if not action_id_value:
+        return
+
+    action_id = str(action_id_value)
+    context = contexts.setdefault(action_id, _new_evidence_gate_context())
+    event_id = str(event_data.get('id') or '')
+    if not event_id:
+        return
+
+    if kind == 'ObservationEvent':
+        context['observation_event_ids'].append(event_id)
+    elif kind == 'HookExecutionEvent':
+        hook_event_type = event_data.get('hook_event_type')
+        if hook_event_type == 'PreToolUse':
+            context['pre_tool_hook_event_ids'].append(event_id)
+            if event_data.get('blocked'):
+                context['blocked_by_hook_event_ids'].append(event_id)
+                if event_data.get('reason'):
+                    context['blocked_reasons'].append(str(event_data['reason']))
+        elif hook_event_type == 'PostToolUse':
+            context['post_tool_hook_event_ids'].append(event_id)
+
+
+def _evidence_gate_decision(context: Mapping[str, Any]) -> tuple[str, str]:
+    blocked_reasons = context.get('blocked_reasons') or []
+    if context.get('blocked_by_hook_event_ids'):
+        reason = blocked_reasons[0] if blocked_reasons else 'pre_tool_hook_blocked'
+        return 'BLOCK', reason
+
+    security_risk = _security_risk_value(context.get('security_risk'))
+    if security_risk == 'HIGH':
+        return 'ESCALATE', f'security_risk:{security_risk}'
+
+    return 'ALLOW', f'security_risk:{security_risk}'
+
+
+def _build_evidence_gate_receipts(
+    conversation_id: UUID, contexts: Mapping[str, Mapping[str, Any]]
+) -> dict[str, Any]:
+    receipts = []
+    for action_id, context in contexts.items():
+        if not context.get('action_event_id'):
+            continue
+        decision, reason = _evidence_gate_decision(context)
+        receipts.append(
+            {
+                'action_id': action_id,
+                'action_event_id': context['action_event_id'],
+                'tool_name': context.get('tool_name'),
+                'tool_call_id': context.get('tool_call_id'),
+                'decision': decision,
+                'decision_source': 'export_projection:security_risk_and_hooks',
+                'reason': reason,
+                'decision_evidence': {
+                    'security_risk': _security_risk_value(context.get('security_risk')),
+                    'pre_tool_hook_event_ids': context.get(
+                        'pre_tool_hook_event_ids', []
+                    ),
+                    'blocked_by_hook_event_ids': context.get(
+                        'blocked_by_hook_event_ids', []
+                    ),
+                },
+                'verification': {
+                    'observation_event_ids': context.get('observation_event_ids', []),
+                    'post_tool_hook_event_ids': context.get(
+                        'post_tool_hook_event_ids', []
+                    ),
+                },
+            }
+        )
+
+    return {
+        'schema_version': _EVIDENCE_GATE_RECEIPTS_SCHEMA_VERSION,
+        'conversation_id': str(conversation_id),
+        'receipts': receipts,
+    }
 
 
 class _StreamingZipBuffer(io.RawIOBase):
@@ -2361,6 +2472,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         self, conversation_id: UUID, conversation_info: AppConversationInfo
     ) -> AsyncGenerator[bytes, None]:
         zip_buffer = _StreamingZipBuffer()
+        evidence_gate_contexts: dict[str, dict[str, Any]] = {}
         with zipfile.ZipFile(
             cast(BinaryIO, zip_buffer), 'w', zipfile.ZIP_DEFLATED
         ) as zipf:
@@ -2374,11 +2486,24 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             ):
                 event_filename = f'event_{i:06d}_{event.id}.json'
                 event_data = event.model_dump(mode='json')
+                _record_event_for_evidence_gate_receipts(
+                    evidence_gate_contexts, event_data
+                )
                 event_json = json.dumps(event_data, indent=2)
                 zipf.writestr(event_filename, event_json)
                 for chunk in zip_buffer.drain():
                     yield chunk
                 i += 1
+
+            evidence_gate_receipts = _build_evidence_gate_receipts(
+                conversation_id, evidence_gate_contexts
+            )
+            zipf.writestr(
+                'evidence_gate_receipts.json',
+                json.dumps(evidence_gate_receipts, indent=2),
+            )
+            for chunk in zip_buffer.drain():
+                yield chunk
 
         for chunk in zip_buffer.drain():
             yield chunk

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -1531,6 +1531,202 @@ class TestLiveStatusAppConversationService:
         self.mock_event_service.search_events.assert_not_called()
         mock_conversation_info.model_dump_json.assert_called_once_with(indent=2)
 
+    async def test_export_conversation_includes_evidence_gate_receipts(self):
+        """Test trajectory export includes reviewer-facing action receipts."""
+        conversation_id = uuid4()
+        mock_conversation_info = Mock(spec=AppConversationInfo)
+        mock_conversation_info.id = conversation_id
+        mock_conversation_info.model_dump_json = Mock(
+            return_value='{"id": "test", "title": "Test Conversation"}'
+        )
+
+        self.mock_app_conversation_info_service.get_app_conversation_info = AsyncMock(
+            return_value=mock_conversation_info
+        )
+
+        action_event = Mock(spec=Event)
+        action_event.id = 'action-1'
+        action_event.timestamp = '2026-06-01T00:00:00'
+        action_event.kind = 'ActionEvent'
+        action_event.tool_name = 'execute_bash'
+        action_event.tool_call_id = 'tool-call-1'
+        action_event.security_risk = 'HIGH'
+        action_event.model_dump = Mock(
+            return_value={
+                'id': 'action-1',
+                'timestamp': action_event.timestamp,
+                'kind': 'ActionEvent',
+                'tool_name': action_event.tool_name,
+                'tool_call_id': action_event.tool_call_id,
+                'security_risk': action_event.security_risk,
+            }
+        )
+
+        observation_event = Mock(spec=Event)
+        observation_event.id = 'observation-1'
+        observation_event.kind = 'ObservationEvent'
+        observation_event.action_id = 'action-1'
+        observation_event.tool_call_id = 'tool-call-1'
+        observation_event.model_dump = Mock(
+            return_value={
+                'id': 'observation-1',
+                'kind': 'ObservationEvent',
+                'action_id': 'action-1',
+                'tool_call_id': 'tool-call-1',
+            }
+        )
+
+        self.mock_event_service.count_events = AsyncMock(return_value=2)
+        self.mock_event_service.iter_events_for_export = Mock(
+            return_value=_async_iter([action_event, observation_event])
+        )
+
+        result = await self.service.export_conversation(conversation_id)
+
+        with zipfile.ZipFile(io.BytesIO(result), 'r') as zipf:
+            assert 'evidence_gate_receipts.json' in zipf.namelist()
+            receipts = json.loads(
+                zipf.read('evidence_gate_receipts.json').decode('utf-8')
+            )
+
+        assert receipts['schema_version'] == 'openhands.evidence_gate_receipts.v1'
+        assert receipts['conversation_id'] == str(conversation_id)
+        assert receipts['receipts'] == [
+            {
+                'action_id': 'action-1',
+                'action_event_id': 'action-1',
+                'tool_name': 'execute_bash',
+                'tool_call_id': 'tool-call-1',
+                'decision': 'ESCALATE',
+                'decision_source': 'export_projection:security_risk_and_hooks',
+                'reason': 'security_risk:HIGH',
+                'decision_evidence': {
+                    'security_risk': 'HIGH',
+                    'pre_tool_hook_event_ids': [],
+                    'blocked_by_hook_event_ids': [],
+                },
+                'verification': {
+                    'observation_event_ids': ['observation-1'],
+                    'post_tool_hook_event_ids': [],
+                },
+            }
+        ]
+
+    async def test_export_conversation_receipts_include_hook_decisions(self):
+        """Test receipts preserve hook blocks and post-tool verification links."""
+        conversation_id = uuid4()
+        mock_conversation_info = Mock(spec=AppConversationInfo)
+        mock_conversation_info.id = conversation_id
+        mock_conversation_info.model_dump_json = Mock(return_value='{}')
+
+        self.mock_app_conversation_info_service.get_app_conversation_info = AsyncMock(
+            return_value=mock_conversation_info
+        )
+
+        blocked_pre_hook = Mock(spec=Event)
+        blocked_pre_hook.id = 'hook-block-1'
+        blocked_pre_hook.kind = 'HookExecutionEvent'
+        blocked_pre_hook.model_dump = Mock(
+            return_value={
+                'id': 'hook-block-1',
+                'kind': 'HookExecutionEvent',
+                'hook_event_type': 'PreToolUse',
+                'action_id': 'blocked-action',
+                'blocked': True,
+                'reason': 'outside declared scope',
+            }
+        )
+
+        blocked_action = Mock(spec=Event)
+        blocked_action.id = 'blocked-action'
+        blocked_action.kind = 'ActionEvent'
+        blocked_action.model_dump = Mock(
+            return_value={
+                'id': 'blocked-action',
+                'kind': 'ActionEvent',
+                'tool_name': 'str_replace_editor',
+                'tool_call_id': 'blocked-call',
+                'security_risk': 'LOW',
+            }
+        )
+
+        allowed_action = Mock(spec=Event)
+        allowed_action.id = 'allowed-action'
+        allowed_action.kind = 'ActionEvent'
+        allowed_action.model_dump = Mock(
+            return_value={
+                'id': 'allowed-action',
+                'kind': 'ActionEvent',
+                'tool_name': 'execute_bash',
+                'tool_call_id': 'allowed-call',
+                'security_risk': 'LOW',
+            }
+        )
+
+        allowed_observation = Mock(spec=Event)
+        allowed_observation.id = 'allowed-observation'
+        allowed_observation.kind = 'ObservationEvent'
+        allowed_observation.model_dump = Mock(
+            return_value={
+                'id': 'allowed-observation',
+                'kind': 'ObservationEvent',
+                'action_id': 'allowed-action',
+                'tool_call_id': 'allowed-call',
+            }
+        )
+
+        allowed_post_hook = Mock(spec=Event)
+        allowed_post_hook.id = 'allowed-post-hook'
+        allowed_post_hook.kind = 'HookExecutionEvent'
+        allowed_post_hook.model_dump = Mock(
+            return_value={
+                'id': 'allowed-post-hook',
+                'kind': 'HookExecutionEvent',
+                'hook_event_type': 'PostToolUse',
+                'action_id': 'allowed-action',
+                'blocked': False,
+            }
+        )
+
+        self.mock_event_service.count_events = AsyncMock(return_value=5)
+        self.mock_event_service.iter_events_for_export = Mock(
+            return_value=_async_iter(
+                [
+                    blocked_pre_hook,
+                    blocked_action,
+                    allowed_action,
+                    allowed_observation,
+                    allowed_post_hook,
+                ]
+            )
+        )
+
+        result = await self.service.export_conversation(conversation_id)
+
+        with zipfile.ZipFile(io.BytesIO(result), 'r') as zipf:
+            receipts = json.loads(
+                zipf.read('evidence_gate_receipts.json').decode('utf-8')
+            )['receipts']
+
+        receipts_by_action = {receipt['action_id']: receipt for receipt in receipts}
+        assert receipts_by_action['blocked-action']['decision'] == 'BLOCK'
+        assert (
+            receipts_by_action['blocked-action']['reason'] == 'outside declared scope'
+        )
+        assert receipts_by_action['blocked-action']['decision_evidence'][
+            'pre_tool_hook_event_ids'
+        ] == ['hook-block-1']
+        assert receipts_by_action['blocked-action']['decision_evidence'][
+            'blocked_by_hook_event_ids'
+        ] == ['hook-block-1']
+
+        assert receipts_by_action['allowed-action']['decision'] == 'ALLOW'
+        assert receipts_by_action['allowed-action']['reason'] == 'security_risk:LOW'
+        assert receipts_by_action['allowed-action']['verification'] == {
+            'observation_event_ids': ['allowed-observation'],
+            'post_tool_hook_event_ids': ['allowed-post-hook'],
+        }
+
     async def test_export_conversation_writes_utf8_when_platform_default_cannot_encode(
         self,
     ):


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

Reviewers can download a conversation trajectory today, but they have to stitch together raw action, hook, and observation events by hand to answer: what evidence existed around this agent action, and why was it allowed, blocked, or escalated?

This adds a small reviewer-facing projection to the existing trajectory export. It does not add a new enforcement engine or change runtime confirmation behavior.

Closes OpenHands/software-agent-sdk#4259

## Summary

- Adds `evidence_gate_receipts.json` to conversation trajectory ZIP exports.
- Links each `ActionEvent` to its security risk, pre-tool hook decisions, blocked hook IDs, observations, and post-tool hooks.
- Documents that receipt decisions are derived export projections, not a replacement for runtime confirmation policy.

## Issue Number

OpenHands/software-agent-sdk#4259

## How to Test

Focused regression and export evidence:

- RED first: `poetry run pytest tests/unit/app_server/test_live_status_app_conversation_service.py::TestLiveStatusAppConversationService::test_export_conversation_includes_evidence_gate_receipts -q` initially failed because `evidence_gate_receipts.json` was absent from the exported ZIP.
- GREEN/focused: `poetry run pytest tests/unit/app_server/test_live_status_app_conversation_service.py::TestLiveStatusAppConversationService::test_export_conversation_includes_evidence_gate_receipts tests/unit/app_server/test_live_status_app_conversation_service.py::TestLiveStatusAppConversationService::test_export_conversation_receipts_include_hook_decisions -q` → 2 passed.
- Export service/API-path coverage: `poetry run pytest tests/unit/app_server/test_live_status_app_conversation_service.py -q` → 126 passed.
- Backend checks: `poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files openhands/app_server/app_conversation/live_status_app_conversation_service.py tests/unit/app_server/test_live_status_app_conversation_service.py openhands/app_server/app_conversation/README.md` → passed.
- Whitespace: `git diff --check` → passed.

Second-agent review:

- Reviewer: `claude -p`
- Result: CLEAN, no blocking findings.
- Follow-up handled before this PR: added `decision_source`/README caveat and BLOCK/ALLOW/PostToolUse coverage after the first review's non-blocking notes.

API/ZIP evidence included in tests:

- High-risk action exports `decision: ESCALATE` and links its observation event.
- Pre-tool hook block exports `decision: BLOCK`, block reason, and blocked hook ID.
- Low-risk executed action exports `decision: ALLOW`, observation link, and post-tool hook link.

## Video/Screenshots

Not UI-visible. This changes the backend trajectory ZIP export artifact and is covered by ZIP-content tests above.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The receipt `decision` is intentionally labeled with `decision_source: export_projection:security_risk_and_hooks`. It is derived from exported security risk plus pre-tool hook block state, and should not be read as a substitute for runtime confirmation or future policy enforcement.
