### PR TITLE
feat(app-server): store and serve forwarded sub-agent events on a separate sub-stream

### DIFF
--- a/openhands/app_server/event/event_service.py
+++ b/openhands/app_server/event/event_service.py
@@ -61,6 +61,18 @@ class EventService(ABC):
     async def save_event(self, conversation_id: UUID, event: Event):
         """Save an event. Internal method intended not be part of the REST api."""
 
+    async def save_subagent_event(
+        self, conversation_id: UUID, tool_call_id: str, event: Event
+    ) -> None:
+        """Persist a sub-agent event under a separate store keyed by tool_call_id.
+
+        Default implementation delegates to save_event so that EventService
+        implementations that don't override this still work correctly.
+        Concrete implementations (e.g. FilesystemEventService / AWS) override
+        this to write to an isolated sub-agent directory.
+        """
+        await self.save_event(conversation_id, event)
+
     async def batch_get_events(
         self, conversation_id: UUID, event_ids: list[UUID]
     ) -> list[Event | None]:

--- a/openhands/app_server/event/event_service.py
+++ b/openhands/app_server/event/event_service.py
@@ -73,6 +73,17 @@ class EventService(ABC):
         """
         await self.save_event(conversation_id, event)
 
+    async def search_subagent_events(
+        self, conversation_id: UUID, tool_call_id: str
+    ) -> list[Event]:
+        """Return all events stored for the given sub-agent (tool_call_id).
+
+        Default implementation returns an empty list. Concrete implementations
+        (e.g. FilesystemEventService / AWS) override this to read from the
+        isolated sub-agent directory.
+        """
+        return []
+
     async def batch_get_events(
         self, conversation_id: UUID, event_ids: list[UUID]
     ) -> list[Event | None]:

--- a/openhands/app_server/event/event_service_base.py
+++ b/openhands/app_server/event/event_service_base.py
@@ -203,3 +203,36 @@ class EventServiceBase(EventService, ABC):
         return await asyncio.gather(
             *[self.get_event(conversation_id, event_id) for event_id in event_ids]
         )
+
+    async def get_subagent_conversation_path(
+        self, conversation_id: UUID, tool_call_id: str
+    ) -> Path:
+        """Return the directory where sub-agent events for a given tool_call_id are stored.
+
+        Path layout: <conversation path>/subagents/<tool_call_id>/events
+        """
+        base = await self.get_conversation_path(conversation_id)
+        return base / 'subagents' / tool_call_id / 'events'
+
+    async def save_subagent_event(
+        self, conversation_id: UUID, tool_call_id: str, event: Event
+    ):
+        """Persist a sub-agent event under a separate directory keyed by tool_call_id."""
+        id_hex = (
+            event.id.replace('-', '') if isinstance(event.id, str) else event.id.hex
+        )  # type: ignore[union-attr]
+        path = (
+            await self.get_subagent_conversation_path(conversation_id, tool_call_id)
+        ) / f'{id_hex}.json'
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._store_event, path, event)
+
+    async def search_subagent_events(
+        self, conversation_id: UUID, tool_call_id: str
+    ) -> list[Event]:
+        """Return all events stored for the given sub-agent (tool_call_id)."""
+        base = await self.get_subagent_conversation_path(conversation_id, tool_call_id)
+        loop = asyncio.get_running_loop()
+        paths = await loop.run_in_executor(None, self._search_paths, base)
+        events = await self._load_events_from_paths(sorted(paths))
+        return [e for e in events if e is not None]

--- a/openhands/app_server/event/subagent_event_router.py
+++ b/openhands/app_server/event/subagent_event_router.py
@@ -1,0 +1,32 @@
+"""Sub-agent event router for OpenHands App Server.
+
+Provides: GET /conversation/{conversation_id}/subagents/{tool_call_id}/events
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter
+
+from openhands.app_server.config import depends_event_service
+from openhands.app_server.event.event_service import EventService
+from openhands.app_server.utils.dependencies import get_dependencies
+from openhands.sdk import Event
+
+subagent_router = APIRouter(
+    prefix='/conversation/{conversation_id}',
+    tags=['Events'],
+    dependencies=get_dependencies(),
+)
+event_service_dependency = depends_event_service()
+
+
+@subagent_router.get('/subagents/{tool_call_id}/events')
+async def search_subagent_events(
+    conversation_id: str,
+    tool_call_id: str,
+    event_service: EventService = event_service_dependency,
+) -> list[Event]:
+    """Return all events for a sub-agent task identified by tool_call_id."""
+    return await event_service.search_subagent_events(
+        UUID(conversation_id), tool_call_id
+    )

--- a/openhands/app_server/event_callback/webhook_router.py
+++ b/openhands/app_server/event_callback/webhook_router.py
@@ -460,13 +460,26 @@ async def on_event(
 ) -> Success:
     """Webhook callback for when event stream events occur."""
     try:
-        # Save events...
+        # Save events — sub-agent events go to their own store keyed by tool_use_id.
         await asyncio.gather(
-            *[event_service.save_event(conversation_id, event) for event in events]
+            *[
+                (
+                    event_service.save_subagent_event(
+                        conversation_id,
+                        getattr(event, 'parent_tool_use_id'),
+                        event,
+                    )
+                    if getattr(event, 'parent_tool_use_id', None)
+                    else event_service.save_event(conversation_id, event)
+                )
+                for event in events
+            ]
         )
 
-        # Process stats events for V1 conversations
+        # Process stats events for V1 conversations (main-agent events only)
         for event in events:
+            if getattr(event, 'parent_tool_use_id', None):
+                continue
             if isinstance(event, ConversationStateUpdateEvent) and event.key == 'stats':
                 await app_conversation_info_service.process_stats_event(
                     event, conversation_id
@@ -479,8 +492,11 @@ async def on_event(
         # switch-profile button would otherwise stay stale until the next full
         # conversation-info webhook (which only fires on start/pause/interrupt/
         # delete, never mid-run). ``active_model`` is only set on success.
+        # Sub-agent events are skipped — only the main agent governs the LLM model.
         switched_model: str | None = None
         for event in events:
+            if getattr(event, 'parent_tool_use_id', None):
+                continue
             if (
                 isinstance(event, ObservationEvent)
                 and isinstance(event.observation, SwitchLLMObservation)
@@ -495,8 +511,10 @@ async def on_event(
                 info.llm_model = switched_model
                 await app_conversation_info_service.save_app_conversation_info(info)
 
-        # Analytics: conversation terminal state detection
+        # Analytics: conversation terminal state detection (main-agent events only)
         for event in events:
+            if getattr(event, 'parent_tool_use_id', None):
+                continue
             if not isinstance(event, ConversationStateUpdateEvent):
                 continue
             if event.key != 'execution_status':

--- a/openhands/app_server/v1_router.py
+++ b/openhands/app_server/v1_router.py
@@ -3,6 +3,9 @@ from fastapi import APIRouter
 from openhands.app_server.app_conversation import app_conversation_router
 from openhands.app_server.config_api.config_router import router as config_router
 from openhands.app_server.event import event_router
+from openhands.app_server.event.subagent_event_router import (
+    subagent_router as subagent_event_router,
+)
 from openhands.app_server.event_callback import (
     webhook_router,
 )
@@ -23,6 +26,7 @@ from openhands.app_server.web_client import web_client_router
 # Include routers
 router = APIRouter(prefix='/api/v1')
 router.include_router(event_router.router)
+router.include_router(subagent_event_router)
 router.include_router(app_conversation_router.router)
 router.include_router(pending_message_router)
 router.include_router(sandbox_router.router)

--- a/tests/unit/app_server/test_on_event_subagent_routing.py
+++ b/tests/unit/app_server/test_on_event_subagent_routing.py
@@ -1,0 +1,123 @@
+"""Tests for sub-agent event routing in on_event webhook handler.
+
+Verifies that events with a non-null parent_tool_use_id are routed to
+save_subagent_event(), while events without it use the regular save_event()
+path.  Also verifies that analytics loops (stats, SwitchLLM, terminal-state)
+skip sub-agent events.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from openhands.app_server.app_conversation.app_conversation_models import (
+    AppConversationInfo,
+)
+from openhands.app_server.event_callback.webhook_router import on_event
+from openhands.sdk.event import TokenEvent
+
+
+@pytest.fixture
+def make_event():
+    """Create a TokenEvent with optional id and parent_tool_use_id overrides."""
+
+    def _make(id: uuid.UUID | None = None, parent_tool_use_id: str | None = None):
+        ev = TokenEvent(
+            source='agent',
+            prompt_token_ids=[1, 2],
+            response_token_ids=[3, 4],
+            parent_tool_use_id=parent_tool_use_id,
+        )
+        if id is not None:
+            ev = ev.model_copy(update={'id': str(id)})
+        return ev
+
+    return _make
+
+
+@pytest.mark.asyncio
+async def test_subagent_event_routed_to_subagent_store(make_event):
+    """Main events use save_event; sub-agent events use save_subagent_event."""
+    svc = AsyncMock()
+    cid = uuid.uuid4()
+    main = make_event(id=uuid.uuid4(), parent_tool_use_id=None)
+    sub = make_event(id=uuid.uuid4(), parent_tool_use_id='toolu_1')
+
+    mock_app_conversation_info = AppConversationInfo(
+        id=cid,
+        sandbox_id='sandbox_test',
+        created_by_user_id='user_1',
+    )
+
+    with patch(
+        'openhands.app_server.event_callback.webhook_router._run_callbacks_in_bg_and_close'
+    ):
+        await on_event(
+            events=[main, sub],
+            conversation_id=cid,
+            app_conversation_info=mock_app_conversation_info,
+            app_conversation_info_service=AsyncMock(),
+            event_service=svc,
+        )
+
+    svc.save_event.assert_awaited_once_with(cid, main)
+    svc.save_subagent_event.assert_awaited_once_with(cid, 'toolu_1', sub)
+
+
+@pytest.mark.asyncio
+async def test_all_main_events_use_save_event(make_event):
+    """When all events have parent_tool_use_id=None, only save_event is used."""
+    svc = AsyncMock()
+    cid = uuid.uuid4()
+    e1 = make_event(id=uuid.uuid4(), parent_tool_use_id=None)
+    e2 = make_event(id=uuid.uuid4(), parent_tool_use_id=None)
+
+    mock_app_conversation_info = AppConversationInfo(
+        id=cid,
+        sandbox_id='sandbox_test',
+        created_by_user_id='user_1',
+    )
+
+    with patch(
+        'openhands.app_server.event_callback.webhook_router._run_callbacks_in_bg_and_close'
+    ):
+        await on_event(
+            events=[e1, e2],
+            conversation_id=cid,
+            app_conversation_info=mock_app_conversation_info,
+            app_conversation_info_service=AsyncMock(),
+            event_service=svc,
+        )
+
+    assert svc.save_event.await_count == 2
+    svc.save_subagent_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_all_subagent_events_use_save_subagent_event(make_event):
+    """When all events have a parent_tool_use_id, only save_subagent_event is used."""
+    svc = AsyncMock()
+    cid = uuid.uuid4()
+    sub1 = make_event(id=uuid.uuid4(), parent_tool_use_id='toolu_1')
+    sub2 = make_event(id=uuid.uuid4(), parent_tool_use_id='toolu_2')
+
+    mock_app_conversation_info = AppConversationInfo(
+        id=cid,
+        sandbox_id='sandbox_test',
+        created_by_user_id='user_1',
+    )
+
+    with patch(
+        'openhands.app_server.event_callback.webhook_router._run_callbacks_in_bg_and_close'
+    ):
+        await on_event(
+            events=[sub1, sub2],
+            conversation_id=cid,
+            app_conversation_info=mock_app_conversation_info,
+            app_conversation_info_service=AsyncMock(),
+            event_service=svc,
+        )
+
+    svc.save_event.assert_not_awaited()
+    assert svc.save_subagent_event.await_count == 2

--- a/tests/unit/app_server/test_subagent_event_store.py
+++ b/tests/unit/app_server/test_subagent_event_store.py
@@ -1,0 +1,51 @@
+"""Tests for sub-agent event store paths in FilesystemEventService."""
+
+import uuid
+
+import pytest
+
+from openhands.app_server.event.filesystem_event_service import FilesystemEventService
+from openhands.sdk.event import TokenEvent
+
+
+@pytest.fixture
+def make_event():
+    """Create a TokenEvent with optional overrides."""
+
+    def _make(id: uuid.UUID | None = None, parent_tool_use_id: str | None = None):
+        ev = TokenEvent(
+            source='agent',
+            prompt_token_ids=[1, 2],
+            response_token_ids=[3, 4],
+            parent_tool_use_id=parent_tool_use_id,
+        )
+        if id is not None:
+            # Override the auto-generated id using model_copy
+            ev = ev.model_copy(update={'id': str(id)})
+        return ev
+
+    return _make
+
+
+@pytest.mark.asyncio
+async def test_subagent_events_go_to_separate_dir(tmp_path, make_event):
+    svc = FilesystemEventService(
+        prefix=tmp_path,
+        user_id='u1',
+        app_conversation_info_service=None,
+        app_conversation_info_load_tasks={},
+    )
+    parent = uuid.uuid4()
+    ev = make_event(id=uuid.uuid4(), parent_tool_use_id='toolu_1')
+    await svc.save_subagent_event(parent, 'toolu_1', ev)
+
+    sub_dir = await svc.get_subagent_conversation_path(parent, 'toolu_1')
+    parent_dir = await svc.get_conversation_path(parent)
+    assert sub_dir.exists() and list(sub_dir.glob('*.json'))
+    assert 'subagents' in str(sub_dir) and 'toolu_1' in str(sub_dir)
+    # parent flat events dir must NOT contain the sub-agent event
+    id_hex = ev.id.replace('-', '') if isinstance(ev.id, str) else ev.id.hex
+    assert not (parent_dir / f'{id_hex}.json').exists()
+
+    found = await svc.search_subagent_events(parent, 'toolu_1')
+    assert [e.parent_tool_use_id for e in found] == ['toolu_1']

--- a/tests/unit/app_server/test_subagent_events_endpoint.py
+++ b/tests/unit/app_server/test_subagent_events_endpoint.py
@@ -1,0 +1,104 @@
+"""Unit tests for the sub-agent events endpoint.
+
+GET /api/v1/conversation/{conversation_id}/subagents/{tool_call_id}/events
+"""
+
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from openhands.app_server.event.filesystem_event_service import FilesystemEventService
+from openhands.app_server.event.subagent_event_router import subagent_router
+from openhands.app_server.utils.dependencies import check_session_api_key
+from openhands.sdk.event import TokenEvent
+
+
+def _make_token_event(parent_tool_use_id: str) -> TokenEvent:
+    return TokenEvent(
+        source='agent',
+        prompt_token_ids=[1, 2],
+        response_token_ids=[3, 4],
+        parent_tool_use_id=parent_tool_use_id,
+    )
+
+
+@pytest.fixture
+def tmp_dir(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+@pytest.fixture
+def event_service(tmp_dir: Path) -> FilesystemEventService:
+    return FilesystemEventService(
+        prefix=tmp_dir,
+        user_id='test_user',
+        app_conversation_info_service=None,
+        app_conversation_info_load_tasks={},
+    )
+
+
+@pytest.fixture
+def app(event_service: FilesystemEventService) -> FastAPI:
+    """Build a minimal FastAPI app with the subagent_router included, mocking auth."""
+    _app = FastAPI()
+    _app.include_router(subagent_router)
+
+    # Override auth to bypass session key check
+    _app.dependency_overrides[check_session_api_key] = lambda: None
+
+    # Override the event service dependency with our in-memory filesystem service
+
+    # We need to override the injector's depends callable.
+    # Get the injector from a default config, then override its depends.
+    # Simpler: create a trivial dependency override for the event_service parameter.
+    # The subagent_router uses event_service_dependency from event_router module.
+    from openhands.app_server.event.subagent_event_router import (
+        event_service_dependency,
+    )
+
+    async def override_event_service():
+        yield event_service
+
+    _app.dependency_overrides[event_service_dependency.dependency] = (
+        override_event_service
+    )
+
+    return _app
+
+
+@pytest.fixture
+async def app_client(app: FastAPI):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url='http://test'
+    ) as client:
+        yield client
+
+
+@pytest.fixture
+async def seed_subagent_events(
+    event_service: FilesystemEventService,
+) -> tuple[str, str]:
+    """Write 2 sub-agent events and return (conversation_id, tool_call_id)."""
+    conversation_id = uuid4()
+    tool_call_id = 'toolu_abc123'
+
+    ev1 = _make_token_event(parent_tool_use_id=tool_call_id)
+    ev2 = _make_token_event(parent_tool_use_id=tool_call_id)
+
+    await event_service.save_subagent_event(conversation_id, tool_call_id, ev1)
+    await event_service.save_subagent_event(conversation_id, tool_call_id, ev2)
+
+    return str(conversation_id), tool_call_id
+
+
+@pytest.mark.asyncio
+async def test_subagent_events_endpoint(app_client, seed_subagent_events):
+    cid, tool_call_id = seed_subagent_events
+    r = await app_client.get(f'/conversation/{cid}/subagents/{tool_call_id}/events')
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body) == 2
+    assert all(e['parent_tool_use_id'] == tool_call_id for e in body)


### PR DESCRIPTION
Refs OpenHands/software-agent-sdk#3907
Companion SDK PR: OpenHands/software-agent-sdk#3908

## Why
App-server side of live sub-agent event forwarding. When the agent-server forwards
sub-agent (`TaskToolSet`) inner events on the parent conversation stream (tagged
with `parent_tool_use_id`), the app-server should persist/serve them **separately**
so the parent conversation stream stays clean (only `TaskAction` +
`TaskObservation`) and the main agent's context is unaffected.

## Summary
- **Separate on-disk store** for sub-agent events: `EventServiceBase` gains
  `get_subagent_conversation_path` / `save_subagent_event` / `search_subagent_events`
  → `…/<conversation_id>/subagents/<tool_call_id>/events/` (not the parent's flat dir).
- **Webhook routing + analytics guard** (`event_callback/webhook_router.py`):
  events with a non-null `parent_tool_use_id` are routed to `save_subagent_event`;
  all analytics scans (stats, terminal-state, switch-LLM) skip them so sub-agent
  activity never skews conversation metrics.
- **Sub-stream read endpoint**: `GET /api/v1/conversation/{id}/subagents/{tool_call_id}/events`.

## How to Test
- `poetry run pytest tests/unit/app_server/test_subagent_event_store.py tests/unit/app_server/test_on_event_subagent_routing.py tests/unit/app_server/test_subagent_events_endpoint.py -v`
- End-to-end (with the companion SDK change + `OH_FORWARD_SUBAGENT_EVENTS=true`):
  delegate to a sub-agent, then `GET …/subagents/<tool_call_id>/events` returns the
  inner events (tagged), while `…/events/search` shows only `TaskAction` +
  `TaskObservation`.

## Type
- [x] Feature

## Notes
- **Depends on the companion SDK PR (#3908)** which adds `Event.parent_tool_use_id`
  and the forwarding. Until that lands and is released, this PR's tests (which build
  events carrying `parent_tool_use_id`) will not pass in CI — opening as **draft**
  pending the SDK approach agreed in #3907.
- Keyed by `tool_call_id` (the on-the-wire correlation id) to keep one directory per
  sub-agent task without adding a second event field.
