### PR TITLE
Self-heal stale managed LLM keys before conversation startup

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1240,6 +1240,70 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             }
         )
 
+
+    async def _maybe_refresh_managed_llm_key(
+        self, user: UserInfo, llm: LLM
+    ) -> LLM:
+        """Best-effort refresh for stale SaaS managed LiteLLM keys.
+
+        This intentionally only runs for SaaS managed LiteLLM keys that are the
+        current member's stored managed key. BYOK/custom keys and OSS/local
+        deployments are left untouched.
+        """
+        if self.app_mode != 'saas' or not user.id or not llm.api_key:
+            return llm
+
+        try:
+            from server.routes.api_keys import (  # type: ignore[import-not-found]
+                get_managed_llm_key_from_db,
+                refresh_managed_llm_api_key,
+            )
+            from storage.lite_llm_manager import (  # type: ignore[import-not-found]
+                LiteLlmManager,
+            )
+
+            from openhands.app_server.settings.settings_router import LITE_LLM_API_URL
+        except Exception:
+            return llm
+
+        if (llm.base_url or '').rstrip('/') != LITE_LLM_API_URL.rstrip('/'):
+            return llm
+
+        key = (
+            llm.api_key.get_secret_value()
+            if isinstance(llm.api_key, SecretStr)
+            else str(llm.api_key)
+        )
+        if not key or key == '**********':
+            return llm
+
+        get_effective_org_id = getattr(self.user_context, 'get_effective_org_id', None)
+        if get_effective_org_id is None:
+            return llm
+
+        try:
+            org_id = await get_effective_org_id()
+            if org_id is None:
+                return llm
+
+            managed_key = await get_managed_llm_key_from_db(user.id, org_id)
+            if managed_key != key:
+                return llm
+
+            if await LiteLlmManager.verify_key(key, user.id):
+                return llm
+
+            await refresh_managed_llm_api_key(user_id=user.id, effective_org_id=org_id)
+            refreshed_key = await get_managed_llm_key_from_db(user.id, org_id)
+            if refreshed_key:
+                return llm.model_copy(update={'api_key': SecretStr(refreshed_key)})
+        except Exception:
+            _logger.warning(
+                'Failed to refresh stale managed LLM key before conversation startup',
+                exc_info=True,
+            )
+        return llm
+
     async def _add_system_mcp_servers(
         self, mcp_servers: dict[str, Any], conversation_id: UUID
     ) -> None:
@@ -1322,6 +1386,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         """
         # Configure LLM
         llm = self._configure_llm(user, llm_model)
+        llm = await self._maybe_refresh_managed_llm_key(user, llm)
 
         # Configure MCP - SDK expects format: {'mcpServers': {'server_name': {...}}}
         mcp_servers: dict[str, Any] = {}

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -3,6 +3,8 @@
 import io
 import json
 import os
+import sys
+import types
 import zipfile
 from datetime import datetime
 from types import SimpleNamespace
@@ -621,6 +623,127 @@ class TestLiveStatusAppConversationService:
         assert 'MY_SECRET' in result
         assert isinstance(result['MY_SECRET'], StaticSecret)
         assert result['MY_SECRET'].description == ''
+
+
+    @staticmethod
+    def _install_managed_key_refresh_modules(
+        monkeypatch, *, get_key, refresh_key, verify_key
+    ):
+        server_mod = types.ModuleType('server')
+        routes_mod = types.ModuleType('server.routes')
+        api_keys_mod = types.ModuleType('server.routes.api_keys')
+        api_keys_mod.get_managed_llm_key_from_db = get_key
+        api_keys_mod.refresh_managed_llm_api_key = refresh_key
+
+        storage_mod = types.ModuleType('storage')
+        lite_llm_mod = types.ModuleType('storage.lite_llm_manager')
+        lite_llm_mod.LiteLlmManager = SimpleNamespace(verify_key=verify_key)
+
+        monkeypatch.setitem(sys.modules, 'server', server_mod)
+        monkeypatch.setitem(sys.modules, 'server.routes', routes_mod)
+        monkeypatch.setitem(sys.modules, 'server.routes.api_keys', api_keys_mod)
+        monkeypatch.setitem(sys.modules, 'storage', storage_mod)
+        monkeypatch.setitem(sys.modules, 'storage.lite_llm_manager', lite_llm_mod)
+
+    @pytest.mark.asyncio
+    async def test_maybe_refresh_managed_llm_key_refreshes_stale_key(self, monkeypatch):
+        org_id = uuid4()
+        self.service.app_mode = 'saas'
+        self.mock_user.id = 'user-123'
+        self.mock_user_context.get_effective_org_id = AsyncMock(return_value=org_id)
+
+        get_key = AsyncMock(side_effect=['sk-old-managed-key', 'sk-new-managed-key'])
+        refresh_key = AsyncMock()
+        verify_key = AsyncMock(return_value=False)
+        self._install_managed_key_refresh_modules(
+            monkeypatch, get_key=get_key, refresh_key=refresh_key, verify_key=verify_key
+        )
+
+        llm = LLM(
+            model='openhands/gpt-5.5',
+            base_url='https://llm-proxy.app.all-hands.dev',
+            api_key=SecretStr('sk-old-managed-key'),
+        )
+
+        refreshed = await self.service._maybe_refresh_managed_llm_key(
+            self.mock_user, llm
+        )
+
+        assert refreshed.api_key.get_secret_value() == 'sk-new-managed-key'
+        get_key.assert_any_await('user-123', org_id)
+        verify_key.assert_awaited_once_with('sk-old-managed-key', 'user-123')
+        refresh_key.assert_awaited_once_with(user_id='user-123', effective_org_id=org_id)
+
+    @pytest.mark.asyncio
+    async def test_maybe_refresh_managed_llm_key_skips_non_saas(self, monkeypatch):
+        self.service.app_mode = 'test'
+        get_key = AsyncMock()
+        refresh_key = AsyncMock()
+        verify_key = AsyncMock()
+        self._install_managed_key_refresh_modules(
+            monkeypatch, get_key=get_key, refresh_key=refresh_key, verify_key=verify_key
+        )
+        llm = LLM(
+            model='openhands/gpt-5.5',
+            base_url='https://llm-proxy.app.all-hands.dev',
+            api_key=SecretStr('sk-old-managed-key'),
+        )
+
+        result = await self.service._maybe_refresh_managed_llm_key(self.mock_user, llm)
+
+        assert result is llm
+        get_key.assert_not_called()
+        verify_key.assert_not_called()
+        refresh_key.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_maybe_refresh_managed_llm_key_skips_non_managed_base_url(
+        self, monkeypatch
+    ):
+        self.service.app_mode = 'saas'
+        self.mock_user.id = 'user-123'
+        get_key = AsyncMock()
+        refresh_key = AsyncMock()
+        verify_key = AsyncMock()
+        self._install_managed_key_refresh_modules(
+            monkeypatch, get_key=get_key, refresh_key=refresh_key, verify_key=verify_key
+        )
+        llm = LLM(
+            model='openai/gpt-4',
+            base_url='https://api.openai.com/v1',
+            api_key=SecretStr('sk-byok-key'),
+        )
+
+        result = await self.service._maybe_refresh_managed_llm_key(self.mock_user, llm)
+
+        assert result is llm
+        get_key.assert_not_called()
+        verify_key.assert_not_called()
+        refresh_key.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_maybe_refresh_managed_llm_key_skips_key_mismatch(self, monkeypatch):
+        org_id = uuid4()
+        self.service.app_mode = 'saas'
+        self.mock_user.id = 'user-123'
+        self.mock_user_context.get_effective_org_id = AsyncMock(return_value=org_id)
+        get_key = AsyncMock(return_value='sk-different-managed-key')
+        refresh_key = AsyncMock()
+        verify_key = AsyncMock()
+        self._install_managed_key_refresh_modules(
+            monkeypatch, get_key=get_key, refresh_key=refresh_key, verify_key=verify_key
+        )
+        llm = LLM(
+            model='openhands/gpt-5.5',
+            base_url='https://llm-proxy.app.all-hands.dev',
+            api_key=SecretStr('sk-profile-or-byok-key'),
+        )
+
+        result = await self.service._maybe_refresh_managed_llm_key(self.mock_user, llm)
+
+        assert result is llm
+        verify_key.assert_not_called()
+        refresh_key.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_with_custom_model(self):


### PR DESCRIPTION
## Summary

- Adds best-effort SaaS-only startup self-healing for stale managed LiteLLM keys.
- Only runs when the resolved LLM base URL is the managed LiteLLM proxy and the configured key matches the member's stored managed key.
- Skips OSS/local, BYOK/custom-provider base URLs, masked/missing keys, and profile/custom keys that do not match the member managed key.
- Reuses the managed refresh endpoint/helper introduced in #15023, then continues startup with the refreshed key.

Stacked on #15023. Closes #15022 when merged with #15023.

## Testing

- `PYTHONPATH=".:$PYTHONPATH" uv run pytest tests/unit/app_server/test_live_status_app_conversation_service.py -q` (128 passed)
- `PYTHONPATH=".:$PYTHONPATH" poetry run --project=enterprise pytest --forked -n auto -s -p no:ddtrace -p no:ddtrace.pytest_bdd -p no:ddtrace.pytest_benchmark ./enterprise/tests/unit/server/routes/test_api_keys.py -q` (28 passed)

_This PR was created by an AI agent (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-656eedd   docker.openhands.dev/openhands/openhands:656eedd
```