### PR TITLE
fix(enterprise): add alembic migration for execution_status column

### DIFF
--- a/enterprise/migrations/versions/127_add_execution_status_to_conversation_metadata.py
+++ b/enterprise/migrations/versions/127_add_execution_status_to_conversation_metadata.py
@@ -1,0 +1,45 @@
+"""Add execution_status column to conversation_metadata table.
+
+Stores the current execution status of conversations
+(idle, running, paused, finished, error, stuck, deleting) for org-wide
+dashboard queries without requiring agent server calls. This mirrors the
+OSS app-lifespan migration 013 (introduced in PR #14846); the enterprise
+deployment maintains its own migration chain and therefore needs this
+parallel migration.
+
+Revision ID: 127
+Revises: 126
+Create Date: 2026-06-29 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '127'
+down_revision: Union[str, None] = '126'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('conversation_metadata') as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                'execution_status',
+                sa.String(),
+                nullable=True,
+            )
+        )
+        batch_op.create_index(
+            'ix_conversation_metadata_execution_status',
+            'execution_status',
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('conversation_metadata') as batch_op:
+        batch_op.drop_index('ix_conversation_metadata_execution_status')
+        batch_op.drop_column('execution_status')


### PR DESCRIPTION
## Why

PR #14846 added the `execution_status` column to the V1 `conversation_metadata` table (alembic migration `013`) and to the `StoredConversationMetadata` SQLAlchemy model, but it did not add the parallel migration to the **enterprise** alembic chain. Without it, enterprise deployments are missing the column that the org-wide admin dashboard uses for status filtering, and inserts via `enterprise/scripts/seed_conversation_data.py` (which writes `execution_status` and `sandbox_status`) would fail.

This PR adds the missing migration to keep the enterprise schema in sync with the V1 model.

## Summary

- Adds `enterprise/migrations/versions/127_add_execution_status_to_conversation_metadata.py` which:
  - Adds a nullable `execution_status VARCHAR` column to `conversation_metadata`.
  - Creates `ix_conversation_metadata_execution_status` for efficient dashboard queries.
  - Chains off the current head (`126`).
  - Provides a working `downgrade()` that drops the index then the column.

## Issue Number

<!-- none -->

## How to Test

1. Run the migration integrity check:
   ```bash
   python3 scripts/check_enterprise_migration_integrity.py
   ```
2. Run the migration integrity test suite:
   ```bash
   poetry run pytest tests/unit/test_enterprise_migration_integrity.py -v
   ```
3. Apply the migration chain against a local Postgres (DB_HOST=localhost, DB_USER=openhands, DB_PASS=openhands, DB_NAME=openhands):
   ```bash
   cd enterprise
   poetry run alembic upgrade head
   poetry run alembic downgrade -1   # then re-upgrade to round-trip
   ```
4. Verify the column and index exist:
   ```sql
   \d conversation_metadata
   SELECT indexname FROM pg_indexes WHERE tablename = 'conversation_metadata';
   ```

## Video/Screenshots

N/A — schema-only change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Mirrors V1 migration `openhands/app_server/app_lifespan/alembic/versions/013.py` (column type, nullable, index name pattern).
- The other 014 migration from PR #14846 (`recaptcha_logs`) is intentionally **not** mirrored because enterprise uses a different GCP Enterprise recaptcha service (`server.auth.recaptcha_service`) rather than the V1 SQL-based `recaptcha_logs` table.
- The `seed_conversation_data.py` script already references `execution_status` and would have failed on existing enterprise databases without this migration.
- Pre-commit (ruff, ruff-format, mypy) all pass on the new file.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-83ca9f8   docker.openhands.dev/openhands/openhands:83ca9f8
```