### PR TITLE
fix: persist conversation events as UTF-8 in FilesystemEventService

### DIFF
--- a/openhands/app_server/event/filesystem_event_service.py
+++ b/openhands/app_server/event/filesystem_event_service.py
@@ -22,7 +22,7 @@ class FilesystemEventService(EventServiceBase):
 
     def _load_event(self, path: Path) -> Event | None:
         try:
-            content = path.read_text()
+            content = path.read_text(encoding='utf-8')
             content = Event.model_validate_json(content)  # type: ignore[assignment]
             return content  # type: ignore[return-value]
         except Exception:
@@ -33,7 +33,7 @@ class FilesystemEventService(EventServiceBase):
     def _store_event(self, path: Path, event: Event):
         path.parent.mkdir(parents=True, exist_ok=True)
         content = event.model_dump_json(indent=2)
-        path.write_text(content)
+        path.write_text(content, encoding='utf-8')
 
     def _search_paths(self, prefix: Path, page_id: str | None = None) -> list[Path]:
         search_path = f'{prefix}/*'

--- a/tests/unit/app_server/test_filesystem_event_service.py
+++ b/tests/unit/app_server/test_filesystem_event_service.py
@@ -8,6 +8,7 @@ import tempfile
 import time
 from datetime import datetime
 from pathlib import Path
+from unittest import mock
 from uuid import uuid4
 
 import pytest
@@ -467,3 +468,54 @@ class TestFilesystemEventServiceIntegration:
 
         result = await service.search_events(conversation_id)
         assert len(result.items) == 3
+
+
+class TestFilesystemEventServiceEncoding:
+    """Regression tests for UTF-8 persistence on non-UTF-8 default-encoding hosts."""
+
+    @pytest.mark.asyncio
+    async def test_non_ascii_event_round_trips_on_non_utf8_host(
+        self, service: FilesystemEventService
+    ):
+        """Events with non-ASCII text must round-trip even when the host's default
+        text encoding is not UTF-8 (Windows cp1252/cp936, POSIX 'ascii' locale).
+
+        Regression: _store_event / _load_event omitted encoding='utf-8', so
+        non-ASCII payloads raised UnicodeEncodeError on write and were silently
+        dropped on read. The default encoding is simulated deterministically so
+        the test also fails on a UTF-8 CI host without the fix.
+        """
+        from openhands.sdk import Message, MessageEvent, TextContent
+
+        real_write, real_read = Path.write_text, Path.read_text
+
+        def fake_write(self, data, encoding=None, errors=None, newline=None):
+            return real_write(
+                self,
+                data,
+                encoding=encoding or 'cp1252',
+                errors=errors,
+                newline=newline,
+            )
+
+        def fake_read(self, encoding=None, errors=None):
+            return real_read(self, encoding=encoding or 'cp1252', errors=errors)
+
+        conversation_id = uuid4()
+        event = MessageEvent(
+            source='user',
+            llm_message=Message(
+                role='user', content=[TextContent(text='café 日本語 😀')]
+            ),
+        )
+
+        with (
+            mock.patch.object(Path, 'write_text', fake_write),
+            mock.patch.object(Path, 'read_text', fake_read),
+        ):
+            # Without the fix this raises UnicodeEncodeError on the emoji.
+            await service.save_event(conversation_id, event)
+            result = await service.search_events(conversation_id)
+
+        assert len(result.items) == 1
+        assert result.items[0].id == event.id


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:
I'm a Windows (cp936) user who hit this. Verified at two levels — unit tests and an end-to-end run of the real FilesystemEventService on a cp936 host (both fail before the fix, pass after).

- [x] A human has tested these changes.

AGENT:

## Why

`FilesystemEventService` (the default event store for OSS / self-hosted deployments) reads and writes event JSON without specifying an encoding:

- `_load_event`: `path.read_text()`
- `_store_event`: `path.write_text(content)`

Without `encoding=`, these use the host's locale default (Windows `cp1252`/`cp936`, POSIX `ascii` locale). Event content from `model_dump_json()` routinely contains non-ASCII characters (emoji, CJK, accents) from user/agent messages, so on a non-UTF-8 host:

- **Write crash / lost event**: an event containing e.g. an emoji makes `_store_event` raise `UnicodeEncodeError`, so it never persists.
- **Silent read data loss**: `_load_event` wraps everything in `except Exception: ... return None`, so a UTF-8 event file read on a non-UTF-8 host raises `UnicodeDecodeError` that is swallowed ??the event silently disappears from `search_events` / `count_events` / export.

Reproduced on Windows (`locale.getpreferredencoding()` = `cp936`): writing an event containing `??` raises `UnicodeEncodeError: 'gbk' codec can't encode character '\U0001f600'`.

## Summary

- Pin `_load_event` / `_store_event` to `encoding='utf-8'` (2 lines).
- Matches the repo convention (e.g. `skills_router.py` already uses `read_text(encoding='utf-8')`) and the same fix accepted for sibling components: #14810 *write trajectory exports as utf-8* (merged) and #14924 *pin FileStore text I/O to UTF-8* (in review) ??the latter covers the FileStore backends + GCS event service but **not** `FilesystemEventService`; this PR fills that gap.
- Adds a regression test.

## Issue Number

None ??found via a code audit of file I/O encoding.

## How to Test

```
pytest tests/unit/app_server/test_filesystem_event_service.py
```

The new `TestFilesystemEventServiceEncoding::test_non_ascii_event_round_trips_on_non_utf8_host` deterministically simulates a non-UTF-8 default encoding (defaults `Path.read_text/write_text` to `cp1252` when no encoding is passed), so it **fails before the change** (`UnicodeEncodeError`) and **passes after**. Full file: 19 passed. `ruff check` and `ruff format --check` are clean.
