### PR TITLE
fix(enterprise): normalize log severity for expected integration webhook skips (#14891)

### DIFF
--- a/enterprise/server/routes/integration/jira.py
+++ b/enterprise/server/routes/integration/jira.py
@@ -150,10 +150,16 @@ async def verify_jira_signature(body: bytes, signature: str, payload: dict):
 
     workspace_name = jira_manager.get_workspace_name_from_payload(payload)
     if workspace_name is None:
+        # Unauthorized/malformed webhook that we reject with 403. Keep at WARNING
+        # but tag it as a client-input rejection (not an application failure) and
+        # avoid dumping the full, unredacted payload at warning severity.
         logger.warning(
             '[Jira] No workspace name found in webhook payload',
             extra={
-                'payload': payload,
+                'event_outcome': 'rejected',
+                'error_type': 'client_payload',
+                'provider': 'jira',
+                'http.status_code': 403,
             },
         )
         raise HTTPException(

--- a/enterprise/server/services/automation_event_service.py
+++ b/enterprise/server/services/automation_event_service.py
@@ -203,9 +203,17 @@ class AutomationEventService:
         git_org_name, owner_type, owner_id = self._extract_owner_info(provider, payload)
 
         if not git_org_name:
+            # Malformed payload we can't route: keep at WARNING but tag it as a
+            # client-input issue so app-failure monitors can exclude it by field
+            # instead of by string match.
             logger.warning(
                 f'[AutomationEventService] No repository owner in '
-                f'{provider.value} payload, skipping'
+                f'{provider.value} payload, skipping',
+                extra={
+                    'event_outcome': 'skipped',
+                    'error_type': 'client_payload',
+                    'provider': provider.value,
+                },
             )
             return None
 
@@ -228,9 +236,16 @@ class AutomationEventService:
             org_id = await self._resolve_default_org_fallback(provider, git_org_name)
 
         if not org_id:
-            logger.warning(
+            # Expected routing miss: the app is behaving as designed when a repo's
+            # org isn't claimed and there's no personal-org fallback. Log at INFO so
+            # it isn't surfaced as an application failure.
+            logger.info(
                 f'[AutomationEventService] {provider.value} org {git_org_name} '
-                f'not claimed and no personal org found, skipping'
+                f'not claimed and no personal org found, skipping',
+                extra={
+                    'event_outcome': 'skipped',
+                    'provider': provider.value,
+                },
             )
             return None
 

--- a/enterprise/tests/unit/server/routes/test_jira_integration_routes.py
+++ b/enterprise/tests/unit/server/routes/test_jira_integration_routes.py
@@ -524,9 +524,15 @@ class TestVerifyJiraSignature:
             'empty_payload',
         ],
     )
+    @patch('server.routes.integration.jira.logger')
     @patch('server.routes.integration.jira.jira_manager')
-    async def test_workspace_name_not_found(self, mock_manager, payload):
-        """Test that missing workspace name in payload raises HTTPException."""
+    async def test_workspace_name_not_found(self, mock_manager, mock_logger, payload):
+        """Test that missing workspace name in payload raises HTTPException.
+
+        The rejection is logged at WARNING with structured fields (so app-failure
+        monitors can exclude it as a client-input rejection) and must NOT dump the
+        full webhook payload.
+        """
         mock_manager.get_workspace_name_from_payload.return_value = None
         body = json.dumps(payload).encode()
 
@@ -535,6 +541,18 @@ class TestVerifyJiraSignature:
 
         assert exc_info.value.status_code == 403
         assert exc_info.value.detail == 'Workspace name not found in payload'
+
+        mock_logger.warning.assert_called_once()
+        assert 'No workspace name found' in str(mock_logger.warning.call_args)
+        extra = mock_logger.warning.call_args.kwargs['extra']
+        assert extra == {
+            'event_outcome': 'rejected',
+            'error_type': 'client_payload',
+            'provider': 'jira',
+            'http.status_code': 403,
+        }
+        # The full webhook payload must not be logged at warning severity.
+        assert 'payload' not in extra
 
     @pytest.mark.asyncio
     @patch('server.routes.integration.jira.jira_manager')

--- a/enterprise/tests/unit/server/services/test_automation_event_service.py
+++ b/enterprise/tests/unit/server/services/test_automation_event_service.py
@@ -494,6 +494,12 @@ class TestForwardEvent:
             mock_send.assert_not_called()
             mock_logger.warning.assert_called()
             assert 'No repository owner' in str(mock_logger.warning.call_args)
+            # Tagged as a client-input skip so monitors can exclude by field.
+            assert mock_logger.warning.call_args.kwargs['extra'] == {
+                'event_outcome': 'skipped',
+                'error_type': 'client_payload',
+                'provider': ProviderType.GITHUB.value,
+            }
 
     @pytest.mark.asyncio
     async def test_forward_event_org_not_claimed_and_not_personal(
@@ -502,7 +508,8 @@ class TestForwardEvent:
         """
         GIVEN: A GitHub event from an org that isn't claimed (and isn't personal)
         WHEN: forward_event is called
-        THEN: Event is skipped with warning log
+        THEN: Event is skipped and logged at INFO (expected routing miss, not a
+              failure)
         """
         from server.services.automation_event_service import AutomationEventService
 
@@ -532,8 +539,13 @@ class TestForwardEvent:
             )
 
             mock_send.assert_not_called()
-            mock_logger.warning.assert_called()
-            assert 'not claimed' in str(mock_logger.warning.call_args)
+            mock_logger.warning.assert_not_called()
+            mock_logger.info.assert_called()
+            assert 'not claimed' in str(mock_logger.info.call_args)
+            assert mock_logger.info.call_args.kwargs['extra'] == {
+                'event_outcome': 'skipped',
+                'provider': ProviderType.GITHUB.value,
+            }
 
     @pytest.mark.asyncio
     async def test_forward_bitbucket_dc_project_event_success(


### PR DESCRIPTION
HUMAN:

Resolves OpenHands/enterprise#35.

- [ ] A human has tested these changes.

AGENT:

---

## Why

The `OpenHands Integrations Application Failures` monitor currently needs broad
string exclusions for expected integration-webhook routing/validation messages,
because they are logged at `WARNING` with no structured fields to distinguish a
"behaving as designed" skip from a real application failure (#14891).

## Summary

- `automation_event_service`: downgrade the *"org not claimed and no personal org found"* skip to `INFO` — it's an expected routing miss, not a failure.
- `automation_event_service` + `jira` route: keep the malformed/unauthorized paths at `WARNING`, but tag them with structured fields (`event_outcome`, `error_type`, `provider`, `http.status_code`) so monitors can exclude them by field instead of by string match.
- `jira` route: stop logging the full, unredacted webhook payload at `WARNING`.
- Update the existing unit tests to assert the intended level + structured fields on each path.

No webhook-handling behavior changes — logging/severity only.

## Issue Number

OpenHands/enterprise#35

## How to Test

```bash
cd enterprise
poetry install   # (or: uv sync)
poetry run pytest \
  tests/unit/server/services/test_automation_event_service.py \
  -k "no_owner_in_payload or not_claimed_and_not_personal"
poetry run pytest \
  tests/unit/server/routes/test_jira_integration_routes.py \
  -k "workspace_name_not_found"
```

Note: I was unable to run the enterprise test suite in my local environment
(enterprise dependencies such as `keycloak` were not installed). I validated the
change with `py_compile` on all four files and with a standalone reproduction of
the structured JSON log output (confirming the `extra` fields — including the
dotted `http.status_code` Datadog key — serialize correctly and don't collide
with reserved `LogRecord` attributes). CI will exercise the updated tests.

## Video/Screenshots

N/A — logging severity / structured-field change.
