### PR TITLE
perf(app-server): page poll_agent_servers conversation read in batches (#14717)

### DIFF
--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -858,7 +858,9 @@ def _build_service_url(url: str, service_name: str, runtime_id: str) -> str:
         return f'{scheme}://{service_name}-{netloc}{path}'
 
 
-async def poll_agent_servers(api_url: str, api_key: str, sleep_interval: int):
+async def poll_agent_servers(
+    api_url: str, api_key: str, sleep_interval: int, batch_size: int = 100
+):
     """When the app server does not have a public facing url, we poll the agent
     servers for the most recent data.
 
@@ -868,6 +870,10 @@ async def poll_agent_servers(api_url: str, api_key: str, sleep_interval: int):
     network I/O. Services are imported locally inside the function bodies to
     ensure they are resolved in the correct context. We use a
     "fetch -> release -> network -> re-acquire -> write" pattern.
+
+    The conversation read is paged in fixed-size batches of ``batch_size`` so peak
+    memory stays flat (~one batch) regardless of the number of active
+    conversations, instead of buffering the entire list for the whole poll tick.
     """
     from openhands.app_server.config import (
         get_app_conversation_info_service,
@@ -898,42 +904,53 @@ async def poll_agent_servers(api_url: str, api_key: str, sleep_interval: int):
                         if runtime['status'] == 'running'
                     }
 
-                # Phase 1: Read - fetch all conversations into a list with a short DB session
-                # This releases the DB session before any network I/O
-                conversations_to_refresh: list[AppConversationInfo] = []
-                async with (
-                    get_app_conversation_info_service(
-                        state
-                    ) as app_conversation_info_service,
-                    get_db_session(state) as _db_session,
-                ):
-                    async for app_conversation_info in page_iterator(
-                        app_conversation_info_service.search_app_conversation_info
-                    ):
-                        conversations_to_refresh.append(app_conversation_info)
+                # Read conversations in fixed-size batches so peak memory stays
+                # flat (~one batch) regardless of the number of active
+                # conversations. Each batch keeps the
+                # "fetch -> release -> network -> re-acquire -> write" pattern:
+                # the read session is released before any agent-server network
+                # I/O, exactly as the single-shot read did (see PR #14637).
+                page_id: str | None = None
+                total_conversations = 0
+                matches = 0
+                async with get_httpx_client(state) as httpx_client:
+                    while True:
+                        # Phase 1: Read one batch with a short DB session, then
+                        # release it before any network I/O.
+                        async with (
+                            get_app_conversation_info_service(
+                                state
+                            ) as app_conversation_info_service,
+                            get_db_session(state) as _db_session,
+                        ):
+                            page = await app_conversation_info_service.search_app_conversation_info(
+                                page_id=page_id, limit=batch_size
+                            )
+
+                        # Phase 2: Network I/O for this batch WITHOUT any DB
+                        # session held.
+                        for app_conversation_info in page.items:
+                            total_conversations += 1
+                            runtime = runtimes_by_sandbox_id.get(
+                                app_conversation_info.sandbox_id
+                            )
+                            if runtime:
+                                matches += 1
+                                await refresh_conversation(
+                                    app_conversation_info=app_conversation_info,
+                                    runtime=runtime,
+                                    httpx_client=httpx_client,
+                                )
+
+                        page_id = page.next_page_id
+                        if not page_id:
+                            break
 
                 _logger.debug(
-                    f'Found {len(conversations_to_refresh)} conversations to check'
+                    f'Checked {total_conversations} conversations; matched '
+                    f'{len(runtimes_by_sandbox_id)} runtimes with {matches} '
+                    f'conversations.'
                 )
-
-                # Phase 2: Network I/O - fetch httpx client and do all network operations
-                # WITHOUT any DB session held
-                async with get_httpx_client(state) as httpx_client:
-                    matches = 0
-                    for app_conversation_info in conversations_to_refresh:
-                        runtime = runtimes_by_sandbox_id.get(
-                            app_conversation_info.sandbox_id
-                        )
-                        if runtime:
-                            matches += 1
-                            await refresh_conversation(
-                                app_conversation_info=app_conversation_info,
-                                runtime=runtime,
-                                httpx_client=httpx_client,
-                            )
-                    _logger.debug(
-                        f'Matched {len(runtimes_by_sandbox_id)} Runtimes with {matches} Conversations.'
-                    )
 
             except Exception as exc:
                 _logger.exception(
@@ -1063,6 +1080,15 @@ class RemoteSandboxServiceInjector(SandboxServiceInjector):
             'no public facing web_url'
         ),
     )
+    poll_batch_size: int = Field(
+        default=100,
+        gt=0,
+        description=(
+            'Number of conversations read per batch when polling agent servers. '
+            'Bounds peak memory to ~one batch regardless of the number of active '
+            'conversations.'
+        ),
+    )
     resource_factor: int = Field(
         default=1,
         description='Factor by which to scale resources in sandbox: 1, 2, 4, or 8',
@@ -1107,6 +1133,7 @@ class RemoteSandboxServiceInjector(SandboxServiceInjector):
                         api_url=self.api_url,
                         api_key=self.api_key,
                         sleep_interval=self.polling_interval,
+                        batch_size=self.poll_batch_size,
                     )
                 )
         async with (

--- a/tests/unit/app_server/test_remote_sandbox_service.py
+++ b/tests/unit/app_server/test_remote_sandbox_service.py
@@ -1629,6 +1629,116 @@ class TestPollAgentServersSessionScoping:
         conv_service.save_app_conversation_info.assert_awaited()
 
     @pytest.mark.asyncio
+    async def test_poll_agent_servers_reads_in_bounded_batches(self):
+        """poll_agent_servers must page the read and release the session per batch.
+
+        With ``batch_size`` set and the search returning multiple pages, the read
+        must be issued one page at a time, the DB session must be released between
+        batches (never more than one session open at any instant), and no session
+        may be held during network I/O.
+        """
+        from openhands.app_server.sandbox.remote_sandbox_service import (
+            poll_agent_servers,
+        )
+
+        tracker = _SessionTracker()
+        network_open_counts: list[int] = []
+
+        # Two conversations on two running sandboxes, returned across two pages.
+        conv1 = self._app_conv('sandbox-1')
+        conv2 = self._app_conv('sandbox-2')
+        list_payload = {
+            'runtimes': [
+                {
+                    'session_id': 'sandbox-1',
+                    'status': 'running',
+                    'url': 'https://sandbox1.example.com',
+                    'session_api_key': 'key1',
+                },
+                {
+                    'session_id': 'sandbox-2',
+                    'status': 'running',
+                    'url': 'https://sandbox2.example.com',
+                    'session_api_key': 'key2',
+                },
+            ]
+        }
+
+        async def probe_get(url, *args, **kwargs):
+            network_open_counts.append(tracker.open)
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = list_payload if url.endswith('/list') else {}
+            return resp
+
+        httpx_client = AsyncMock()
+        httpx_client.get.side_effect = probe_get
+
+        conv_service = AsyncMock()
+        # Page 1 -> conv1 (more to come), Page 2 -> conv2 (last page).
+        conv_service.search_app_conversation_info = AsyncMock(
+            side_effect=[
+                _make_page([conv1], 'page-2'),
+                _make_page([conv2], None),
+            ]
+        )
+        conv_service.save_app_conversation_info = AsyncMock()
+        event_service = AsyncMock()
+        event_service.get_event = AsyncMock(return_value=None)
+        callback_service = AsyncMock()
+
+        patches = self._patches(
+            tracker,
+            httpx_client,
+            conv_service,
+            event_service,
+            callback_service,
+            self._validated_conv(),
+            # One empty event page per refreshed conversation (two refreshes).
+            event_pages=[_make_page([], None), _make_page([], None)],
+        )
+        with ExitStack() as stack:
+            for patch_cm in patches:
+                stack.enter_context(patch_cm)
+            task = asyncio.create_task(
+                poll_agent_servers(
+                    api_url='https://api.example.com',
+                    api_key='test-key',
+                    sleep_interval=3600,  # long, so cancellation ends the loop
+                    batch_size=1,
+                )
+            )
+            await asyncio.sleep(0.1)
+            task.cancel()
+            await task
+
+        # The read was paged: one search call per page, advancing the cursor and
+        # honoring the configured batch_size as the page limit.
+        assert conv_service.search_app_conversation_info.await_count == 2
+        first_call, second_call = conv_service.search_app_conversation_info.await_args_list
+        assert first_call.kwargs == {'page_id': None, 'limit': 1}
+        assert second_call.kwargs == {'page_id': 'page-2', 'limit': 1}
+
+        # Both pages' conversations were matched and refreshed.
+        assert conv_service.save_app_conversation_info.await_count == 2
+
+        # No DB session may be open during any network call.
+        assert network_open_counts, 'expected agent-server network calls to fire'
+        assert all(count == 0 for count in network_open_counts), (
+            'DB session held during network I/O (idle-in-transaction risk); '
+            f'observed open-session counts at network calls: {network_open_counts}'
+        )
+        # The session is released between batches: at most one is ever open, so
+        # batches do not accumulate sessions (peak is bounded, not O(batches)).
+        assert tracker.max_open <= 1, (
+            'more than one DB session open at once; the per-batch read session '
+            'is not being released before the next batch'
+        )
+        # Non-vacuous: a read session per page (2) plus write sessions opened.
+        assert tracker.enter_count >= 3
+        assert tracker.open == 0, 'all DB sessions must be released after polling'
+
+    @pytest.mark.asyncio
     async def test_refresh_conversation_acquires_own_db_session(self):
         """refresh_conversation must open its own short-lived write sessions."""
         from openhands.app_server.sandbox.remote_sandbox_service import (

--- a/tests/unit/app_server/test_remote_sandbox_service.py
+++ b/tests/unit/app_server/test_remote_sandbox_service.py
@@ -1715,7 +1715,9 @@ class TestPollAgentServersSessionScoping:
         # The read was paged: one search call per page, advancing the cursor and
         # honoring the configured batch_size as the page limit.
         assert conv_service.search_app_conversation_info.await_count == 2
-        first_call, second_call = conv_service.search_app_conversation_info.await_args_list
+        first_call, second_call = (
+            conv_service.search_app_conversation_info.await_args_list
+        )
         assert first_call.kwargs == {'page_id': None, 'limit': 1}
         assert second_call.kwargs == {'page_id': 'page-2', 'limit': 1}
 


### PR DESCRIPTION
HUMAN: 

Resolves https://github.com/OpenHands/enterprise/issues/29

- [ ] A human has tested these changes.

AGENT:

---

## Why

`poll_agent_servers` (`openhands/app_server/sandbox/remote_sandbox_service.py`) currently buffers the **entire** list of conversations-to-refresh in memory for the whole poll tick — PR OpenHands/OpenHands#14637 deliberately read all conversations into a list under a short DB session, released the session, then did network I/O over the full list. That's correct, but peak memory grows with the number of active conversations (and on remote storage backends every tick is one big list call). This is the follow-up noted in the OpenHands/OpenHands#14637 review.

## Summary

- Page the Phase-1 read in fixed-size batches and interleave each batch's network I/O, so peak memory stays flat (~one batch) regardless of the number of active conversations.
- Each batch keeps the `fetch -> release -> network -> re-acquire -> write` pattern: the read DB session is released **before** any agent-server network call — now scoped per batch instead of per tick, so the OpenHands/OpenHands#14637 `idle in transaction` invariant is preserved.
- Add a configurable `poll_batch_size` (default `100`) on `RemoteSandboxServiceInjector`, threaded into `poll_agent_servers(..., batch_size=...)`.

## Issue Number

Resolves OpenHands/enterprise#29

## How to Test

```bash
uv run pytest tests/unit/app_server/test_remote_sandbox_service.py -k "poll_agent_servers"
```

New regression test `test_poll_agent_servers_reads_in_bounded_batches` (extends the existing `TestPollAgentServersSessionScoping` open-session-count harness) asserts:
- the read is paged — one `search_app_conversation_info` call per page, advancing the cursor and honoring `batch_size` as the page `limit`;
- the DB session is released **between** batches (never more than one open at any instant);
- no DB session is held during network I/O (the OpenHands/OpenHands#14637 guard).

Verified locally: the command above → **2 passed** (the new batch test plus the existing session-scoping test). `ruff 0.12.5 format`/`check` clean.

## Video/Screenshots

N/A — internal polling/perf change.
