### PR TITLE
perf(enterprise): index openhands_prs for the unprocessed-PR worker query (#14632)

### DIFF
--- a/enterprise/migrations/versions/128_add_openhands_prs_unprocessed_index.py
+++ b/enterprise/migrations/versions/128_add_openhands_prs_unprocessed_index.py
@@ -1,0 +1,44 @@
+"""Add composite index on openhands_prs for the unprocessed-PR worker query
+
+get_unprocessed_prs filters on (provider, processed) and orders by updated_at
+DESC, but only repo_id / pr_number / status were indexed. Every enrichment tick
+therefore full-scanned the table — openhands_prs was the 4th-heaviest
+sequential-scan table in prod (~72K seq scans / 13.9B rows read on ~648K live
+rows, INC-95). This composite index covers that query path.
+
+Plain CREATE INDEX (not CONCURRENTLY): the enterprise migration harness runs
+inside a transaction with a session advisory lock, where alembic's
+autocommit_block() (required for CREATE INDEX CONCURRENTLY) raises — see
+migration 117. The single-table build is brief and the short write lock is
+acceptable, consistent with migrations 117 and 118.
+
+Revision ID: 128
+Revises: 127
+Create Date: 2026-06-30
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = '128'
+down_revision: Union[str, None] = '127'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        'ix_openhands_prs_provider_processed_updated_at',
+        'openhands_prs',
+        ['provider', 'processed', 'updated_at'],
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        'ix_openhands_prs_provider_processed_updated_at',
+        table_name='openhands_prs',
+        if_exists=True,
+    )

--- a/enterprise/storage/openhands_pr.py
+++ b/enterprise/storage/openhands_pr.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from integrations.types import PRStatus
-from sqlalchemy import DateTime, Enum, Identity, String, text
+from sqlalchemy import DateTime, Enum, Identity, Index, String, text
 from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
 
@@ -12,6 +12,21 @@ class OpenhandsPR(Base):
     """
 
     __tablename__ = 'openhands_prs'
+
+    __table_args__ = (
+        # get_unprocessed_prs filters on (provider, processed) and orders by
+        # updated_at DESC, but only repo_id / pr_number / status were indexed, so
+        # the enrichment worker full-scanned all ~648K rows every tick (4th-heaviest
+        # sequential-scan table in prod: ~72K seq scans / 13.9B rows read, INC-95).
+        # This composite index covers that query path: provider/processed equality
+        # then updated_at for the ordered LIMIT.
+        Index(
+            'ix_openhands_prs_provider_processed_updated_at',
+            'provider',
+            'processed',
+            'updated_at',
+        ),
+    )
 
     id: Mapped[int] = mapped_column(Identity(), primary_key=True)
     repo_id: Mapped[str] = mapped_column(String, nullable=False, index=True)


### PR DESCRIPTION
HUMAN:

Resolves OpenHands/enterprise#27

- [ ] A human has tested these changes.

AGENT:

---

## Why

`openhands_prs` was the 4th-heaviest sequential-scan table in prod — ~72K seq scans reading **13.9B** tuples on a 648K-row table (INC-95). The culprit is the enrichment worker's `OpenhandsPRStore.get_unprocessed_prs`:

```python
select(OpenhandsPR)
.filter(and_(
    ~OpenhandsPR.processed,
    OpenhandsPR.process_attempts < max_retries,
    OpenhandsPR.provider == ProviderType.GITHUB.value,
))
.order_by(desc(OpenhandsPR.updated_at))
.limit(limit)
```

The table only had indexes on `repo_id` / `pr_number` / `status`, none of which match this `WHERE (provider, processed) ... ORDER BY updated_at DESC` path — so every tick full-scanned the table and sorted 648K rows.

## Summary

- Add a composite index `(provider, processed, updated_at)` that covers the query: `provider`/`processed` equality narrow the set, `updated_at` serves the `ORDER BY ... DESC LIMIT` (`process_attempts < max_retries` remains a cheap residual filter).
- Declared on `OpenhandsPR.__table_args__` and created via alembic migration `128`, mirroring the perf-index migrations `117` (event_callback) and `118` (conversation_metadata_saas) from the same INC-95 batch.
- Plain `CREATE INDEX` with `IF NOT EXISTS` (not `CONCURRENTLY`): the enterprise migration harness runs inside a transaction with a session advisory lock where alembic's `autocommit_block()` raises — see migration 117's note.

## Issue Number

Resolves OpenHands/enterprise#27

## How to Test

The index is exercised by `get_unprocessed_prs`. To confirm the planner uses it on a populated DB:

```sql
EXPLAIN (ANALYZE, BUFFERS)
SELECT * FROM openhands_prs
WHERE NOT processed AND process_attempts < 3 AND provider = 'github'
ORDER BY updated_at DESC LIMIT 50;
-- expect an Index Scan Backward using ix_openhands_prs_provider_processed_updated_at
-- instead of Seq Scan + Sort
```

Lint verified locally with the enterprise config (ruff 0.12.5, `enterprise/dev_config/python/ruff.toml`): `ruff format --check` → already formatted, `ruff check` → all checks passed. The alembic chain is linear (128 → 127, single head). I couldn't run the enterprise migration suite locally (separate env / no Postgres); the migration mirrors the already-merged 117/118.

## Video/Screenshots

N/A — DB index / migration.
