### PR TITLE
perf(enterprise): index gitlab_webhook and billing_sessions hot lookups (#14634)

### DIFF
--- a/enterprise/migrations/versions/128_add_gitlab_webhook_and_billing_session_indexes.py
+++ b/enterprise/migrations/versions/128_add_gitlab_webhook_and_billing_session_indexes.py
@@ -1,0 +1,74 @@
+"""Add indexes on gitlab_webhook and billing_sessions for hot lookup queries
+
+INC-95: two enterprise tables were sequentially scanned on hot paths because
+their lookup columns were unindexed.
+
+  - gitlab_webhook (no non-PK index): get / update / delete / reset-by-resource
+    filter on project_id or group_id (gitlab_webhook_store) — ~77K seq scans /
+    395M rows read. Add single-column indexes on project_id and group_id.
+  - billing_sessions: the completed-credit lookup filters on (user_id, status)
+    (user_store.py) — ~4.6K seq scans / 42M rows read. Add a composite
+    (user_id, status) index. The other lookup filters by id, served by the PK.
+
+resend_synced_users (also flagged in #14634) is intentionally left unchanged: it
+is already indexed on email / audience_id, and its remaining scans come from
+get_synced_emails_for_audience reading ~all rows of a single audience — a
+low-selectivity full read an index cannot improve (needs app-level caching).
+
+Plain CREATE INDEX (not CONCURRENTLY): the enterprise migration harness runs
+inside a transaction with a session advisory lock where alembic's
+autocommit_block() raises — see migration 117. The single-table builds are brief
+and the short write lock is acceptable, consistent with migrations 117 and 118.
+
+Revision ID: 128
+Revises: 127
+Create Date: 2026-06-30
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = '128'
+down_revision: Union[str, None] = '127'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        'ix_gitlab_webhook_project_id',
+        'gitlab_webhook',
+        ['project_id'],
+        if_not_exists=True,
+    )
+    op.create_index(
+        'ix_gitlab_webhook_group_id',
+        'gitlab_webhook',
+        ['group_id'],
+        if_not_exists=True,
+    )
+    op.create_index(
+        'ix_billing_sessions_user_id_status',
+        'billing_sessions',
+        ['user_id', 'status'],
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        'ix_billing_sessions_user_id_status',
+        table_name='billing_sessions',
+        if_exists=True,
+    )
+    op.drop_index(
+        'ix_gitlab_webhook_group_id',
+        table_name='gitlab_webhook',
+        if_exists=True,
+    )
+    op.drop_index(
+        'ix_gitlab_webhook_project_id',
+        table_name='gitlab_webhook',
+        if_exists=True,
+    )

--- a/enterprise/storage/billing_session.py
+++ b/enterprise/storage/billing_session.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import DECIMAL, DateTime, Enum, ForeignKey, String
+from sqlalchemy import DECIMAL, DateTime, Enum, ForeignKey, Index, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from storage.base import Base
 
@@ -18,6 +18,14 @@ class BillingSession(Base):
     """
 
     __tablename__ = 'billing_sessions'
+
+    __table_args__ = (
+        # The completed-credit lookup filters on (user_id, status) (user_store.py),
+        # but neither column was indexed, so it full-scanned billing_sessions
+        # (~4.6K seq scans / 42M rows read, INC-95). The other lookup filters by
+        # id and is served by the primary key.
+        Index('ix_billing_sessions_user_id_status', 'user_id', 'status'),
+    )
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
     user_id: Mapped[str] = mapped_column(String, nullable=False)

--- a/enterprise/storage/gitlab_webhook.py
+++ b/enterprise/storage/gitlab_webhook.py
@@ -6,6 +6,7 @@ from typing import Any
 from sqlalchemy import (
     ARRAY,
     DateTime,
+    Index,
     String,
     Text,
     text,
@@ -27,6 +28,14 @@ class GitlabWebhook(Base):
     """
 
     __tablename__ = 'gitlab_webhook'
+
+    __table_args__ = (
+        # Webhook lookups filter by project_id or group_id (gitlab_webhook_store
+        # get/update/delete/reset by resource), but the table had no non-PK index,
+        # so every lookup full-scanned it (~77K seq scans / 395M rows read, INC-95).
+        Index('ix_gitlab_webhook_project_id', 'project_id'),
+        Index('ix_gitlab_webhook_group_id', 'group_id'),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     group_id: Mapped[str | None] = mapped_column(String, nullable=True)


### PR DESCRIPTION
HUMAN:

Resolves #14634

- [ ] A human has tested these changes.

AGENT:

---

## Why

INC-95: two enterprise tables were sequentially scanned on hot paths because their lookup columns were unindexed (traced from the actual query sites):

- **`gitlab_webhook`** had **no non-PK index**, but `gitlab_webhook_store` get/update/delete/reset-by-resource all filter on `project_id` or `group_id` → ~77K seq scans / **395M** rows read.
- **`billing_sessions`**: the completed-credit lookup filters on `(user_id, status)` (`user_store.py:239`), neither column indexed → ~4.6K seq scans / **42M** rows read. (The other lookup filters by `id`, already served by the PK.)

## Summary

- `gitlab_webhook`: add single-column indexes on `project_id` and `group_id`.
- `billing_sessions`: add composite index `(user_id, status)`.
- Indexes declared on the models' `__table_args__` and created via alembic migration `128` (plain `CREATE INDEX IF NOT EXISTS`, mirroring the INC-95 migrations 117/118; the enterprise harness can't use `CONCURRENTLY` — see 117's note).
- **`resend_synced_users` (also listed in #14634) is intentionally left unchanged.** It's already indexed on `email`/`audience_id`; its remaining scans come from `get_synced_emails_for_audience` reading ~all rows of a single audience — a low-selectivity full read no index can improve. The real fix there is app-level caching, out of scope for an index migration.

## Issue Number

Resolves #14634

## How to Test

On a populated DB, confirm the planner switches from Seq Scan to Index Scan:

```sql
EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM gitlab_webhook WHERE project_id = '123';
EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM gitlab_webhook WHERE group_id = '123';
EXPLAIN (ANALYZE, BUFFERS)
  SELECT * FROM billing_sessions WHERE user_id = 'u' AND status = 'completed';
```

Lint verified locally with the enterprise config (ruff 0.12.5, `enterprise/dev_config/python/ruff.toml`): `format --check` → already formatted, `check` → all passed. Alembic chain is linear (128 → 127). I couldn't run the enterprise migration suite locally (separate env / no Postgres); the migration mirrors the already-merged 117/118.

Note: this adds migration `128`, the same next-revision as my open PR #15037 — whichever merges second will need a one-line renumber (the standard `check-sync` "synchronize before merging" case).

## Video/Screenshots

N/A — DB indexes / migration.
