### PR TITLE
fix(logging): raise Alembic logger to WARNING so migration logs aren't ingested as errors (#14890)

### DIFF
--- a/enterprise/alembic.ini
+++ b/enterprise/alembic.ini
@@ -64,7 +64,10 @@ handlers =
 qualname = sqlalchemy.engine
 
 [logger_alembic]
-level = DEBUG
+# WARNING (not DEBUG): routine migration INFO/DEBUG records were written to
+# stderr and ingested as status:error by container log collectors (#14890).
+# Real problems still surface at WARNING/ERROR.
+level = WARNING
 handlers =
 qualname = alembic
 

--- a/openhands/app_server/app_lifespan/alembic.ini
+++ b/openhands/app_server/app_lifespan/alembic.ini
@@ -134,7 +134,10 @@ handlers =
 qualname = sqlalchemy.engine
 
 [logger_alembic]
-level = INFO
+# WARNING (not INFO): routine migration INFO records were written to stderr and
+# ingested as status:error by container log collectors (#14890). Real problems
+# still surface at WARNING/ERROR.
+level = WARNING
 handlers =
 qualname = alembic
 


### PR DESCRIPTION
HUMAN:

Addresses OpenHands/enterprise#34

- [ ] A human has tested these changes.

AGENT:

---

## Why

Both Alembic configs route the `alembic` logger through a `StreamHandler` on `sys.stderr`, at `DEBUG` (`enterprise/alembic.ini`) / `INFO` (`openhands/app_server/app_lifespan/alembic.ini`). Container log collectors map **stderr → `status:error`** regardless of the Python log level, so routine `Running upgrade … `-style migration output is ingested as application errors (#14890).

## Summary

- Raise the `alembic` logger to `WARNING` in both alembic configs. Routine migration `INFO`/`DEBUG` records no longer emit (the issue's "suppressed below monitor scope" acceptance criterion), while real `WARNING`/`ERROR` records still surface on stderr and are correctly flagged.
- Chose level-raising over re-routing the handler to stdout deliberately: sending the handler to stdout would also move genuine migration **errors** off stderr and risk *hiding* them. Raising the level keeps real errors error-tagged.

Scope: this is the **Alembic portion** of OpenHands/enterprise#34. The Uvicorn startup/shutdown stream routing (which needs container entrypoint / `--log-config` changes) is a separate, higher-risk follow-up not included here.

## Issue Number

Addresses OpenHands/enterprise#34 (Alembic portion)

## How to Test

`config`-only change. Verify the alembic logger level:

```bash
grep -A1 '\[logger_alembic\]' enterprise/alembic.ini openhands/app_server/app_lifespan/alembic.ini
# level = WARNING in both
```

After the change, running migrations emits no `INFO` "Running upgrade" lines on stderr; a failing migration still logs at `ERROR`.

## Video/Screenshots

N/A — logging configuration change.
