### PR TITLE
fix(onboarding): remove redundant tabIndex on native button

### DIFF
--- a/frontend/src/components/features/onboarding/step-option.tsx
+++ b/frontend/src/components/features/onboarding/step-option.tsx
@@ -13,7 +13,6 @@ export function StepOption({ id, label, selected, onClick }: StepOptionProps) {
     <button
       data-testid={`step-option-${id}`}
       type="button"
-      tabIndex={0}
       onClick={onClick}
       className={cn(
         "min-h-10 w-full rounded-md border text-left px-4 py-2.5 transition-colors text-white cursor-pointer",


### PR DESCRIPTION
Removed a redundant accessibility attribute in onboarding by deleting tabIndex={0} from the native StepOption button. Native <button> elements are already keyboard-focusable by default, so this change does not alter behavior or UI; it only improves code clarity and follows semantic/accessibility best practices.

Tested by verifying onboarding step options remain focusable with keyboard navigation (Tab/Shift+Tab) and still selectable with Enter/Space.