### PR TITLE
fix: add client-side posthog.capture for PR button survey targeting

### DIFF
--- a/frontend/__tests__/hooks/mutation/use-track-create-pr-button-clicked.test.tsx
+++ b/frontend/__tests__/hooks/mutation/use-track-create-pr-button-clicked.test.tsx
@@ -5,6 +5,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { analyticsEventsService } from "#/api/analytics-service/analytics-events.api";
 import { useTrackCreatePrButtonClicked } from "#/hooks/mutation/use-track-create-pr-button-clicked";
 
+const mockCapture = vi.fn();
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: mockCapture }),
+}));
+
 describe("useTrackCreatePrButtonClicked", () => {
   let queryClient: QueryClient;
 
@@ -36,6 +41,24 @@ describe("useTrackCreatePrButtonClicked", () => {
     await waitFor(() => {
       expect(spy).toHaveBeenCalledWith({
         event_type: "create pr button clicked",
+        git_provider: "github",
+      });
+    });
+  });
+
+  it("fires a client-side posthog.capture for survey targeting", async () => {
+    vi.spyOn(analyticsEventsService, "trackEvent").mockResolvedValue({
+      status: "ok",
+    });
+
+    const { result } = renderHook(() => useTrackCreatePrButtonClicked(), {
+      wrapper,
+    });
+
+    result.current.mutate("github");
+
+    await waitFor(() => {
+      expect(mockCapture).toHaveBeenCalledWith("create pr button clicked", {
         git_provider: "github",
       });
     });

--- a/frontend/src/hooks/mutation/use-track-create-pr-button-clicked.ts
+++ b/frontend/src/hooks/mutation/use-track-create-pr-button-clicked.ts
@@ -1,6 +1,9 @@
 import { useMutation } from "@tanstack/react-query";
+import { usePostHog } from "posthog-js/react";
 import { analyticsEventsService } from "#/api/analytics-service/analytics-events.api";
 import { Provider } from "#/types/settings";
+
+const EVENT_NAME = "create pr button clicked";
 
 /**
  * Mutation hook that notifies the server when the user clicks the
@@ -8,16 +11,25 @@ import { Provider } from "#/types/settings";
  * `POST /api/analytics/events` endpoint with `event_type =
  * "create pr button clicked"`; the server fires the matching PostHog event.
  *
+ * A client-side `posthog.capture()` is also fired so that PostHog
+ * surveys targeting this event can be triggered by the JS SDK.
+ *
  * Tracking is fire-and-forget: errors are swallowed so a telemetry outage
  * never blocks the user's primary action of submitting the prompt.
  */
-export const useTrackCreatePrButtonClicked = () =>
-  useMutation({
-    mutationFn: (gitProvider: Provider | null) =>
-      analyticsEventsService.trackEvent({
-        event_type: "create pr button clicked",
+export const useTrackCreatePrButtonClicked = () => {
+  const posthog = usePostHog();
+
+  return useMutation({
+    mutationFn: (gitProvider: Provider | null) => {
+      posthog?.capture(EVENT_NAME, { git_provider: gitProvider });
+
+      return analyticsEventsService.trackEvent({
+        event_type: EVENT_NAME,
         git_provider: gitProvider,
-      }),
+      });
+    },
     // Intentionally swallow errors - analytics must not block the UX.
     onError: () => {},
   });
+};


### PR DESCRIPTION
## Problem

PostHog surveys configured to trigger on the `"create pr button clicked"` event stopped receiving responses around June 2 (after `cloud-1.37.0` deployed).

**Root cause:** When analytics moved server-side in #14006 (May 4), the client-side `posthog.capture()` call was removed. #14519 (May 27) restored the event but only as a server-side capture via `POST /api/analytics/events`. PostHog surveys require the JS SDK to observe client-side `capture()` calls to trigger survey popups — server-side events are invisible to the JS SDK.

## Fix

Adds a client-side `posthog.capture("create pr button clicked", ...)` call in `useTrackCreatePrButtonClicked` alongside the existing server-side event. The server-side capture is preserved for backend analytics; the client-side capture enables PostHog survey targeting.

## Changes

- **`frontend/src/hooks/mutation/use-track-create-pr-button-clicked.ts`** — Import `usePostHog` and fire `posthog.capture()` before the server-side POST.
- **`frontend/__tests__/hooks/mutation/use-track-create-pr-button-clicked.test.tsx`** — Mock `posthog-js/react` and add a test verifying the client-side capture fires with the correct event name and properties.

## Note

The PostHog survey in the dashboard may also need its event name updated — the old client-side event was `"create_pr_button_clicked"` (underscores) while the current event name is `"create pr button clicked"` (spaces).

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-16c8ac4   docker.openhands.dev/openhands/openhands:16c8ac4
```