### PR TITLE
test: add semicolon-separated multi-repo test cases

### DIFF
--- a/enterprise/tests/unit/test_utils.py
+++ b/enterprise/tests/unit/test_utils.py
@@ -194,6 +194,7 @@ def test_infer_repo_from_message():
         # FDE-86 (1finity): trailing punctuation must not drop a mention, and a
         # Jira/markdown link-wrapped clone URL must still resolve.
         ('Is this merged into PF/meta-fnos-pf?', ['PF/meta-fnos-pf']),
+        ('Please fix ACME-PROJECT/backend-api!', ['ACME-PROJECT/backend-api']),
         ('Please look at acme/widgets!', ['acme/widgets']),
         ('Check acme/widgets; thanks', ['acme/widgets']),
         ('The fix is in acme/widgets.', ['acme/widgets']),
@@ -205,6 +206,15 @@ def test_infer_repo_from_message():
             'see [https://bitbucket.fnc.fujitsu.com/scm/pf/meta-fnos-pf.git|'
             'https://bitbucket.fnc.fujitsu.com/scm/pf/meta-fnos-pf.git]',
             ['pf/meta-fnos-pf'],
+        ),
+        # Semicolon as delimiter between multiple repos (not just trailing punctuation)
+        (
+            'Check these repos: frontend/app; backend/api',
+            ['frontend/app', 'backend/api'],
+        ),
+        (
+            'Compare owner/repo1; owner/repo2; owner/repo3 for differences',
+            ['owner/repo1', 'owner/repo2', 'owner/repo3'],
         ),
         # Trailing dot must not leak a date as a repo.
         ('It is due on 1/2.', []),


### PR DESCRIPTION
## Summary

Extends test coverage for the trailing punctuation fix (PR OpenHands/OpenHands#15034, issue OpenHands/OpenHands#15052) to explicitly verify that semicolons work as delimiters between multiple repositories, not just as trailing punctuation.

## What & why

PR OpenHands/OpenHands#15034 added `;` to the regex right boundary to fix repo extraction when trailing punctuation follows a repo mention. While the fix handles semicolons correctly, the test suite only verified:
- Single repo followed by `;` then text (`'Check acme/widgets; thanks'`)

It did not explicitly test:
- **Multiple repos separated by semicolons** (the main multi-repo delimiter use case)

This PR adds those missing test cases to ensure complete coverage.

## Changes

Added three test cases to `enterprise/tests/unit/test_utils.py`:

1. **Exclamation mark with uppercase project format:**
   ```python
   ('Please fix ACME-PROJECT/backend-api!', ['ACME-PROJECT/backend-api'])
   ```
   Complements existing `acme/widgets!` test with uppercase/hyphen naming.

2. **Two repos separated by semicolons:**
   ```python
   ('Check these repos: frontend/app; backend/api', ['frontend/app', 'backend/api'])
   ```

3. **Three repos separated by semicolons:**
   ```python
   ('Compare owner/repo1; owner/repo2; owner/repo3 for differences', 
    ['owner/repo1', 'owner/repo2', 'owner/repo3'])
   ```

## Validation

The test cases follow the existing pattern and use the same assertion logic. CI will validate they pass against the merged regex fix from OpenHands/OpenHands#15034.

## Related Issues

- Fixes test coverage gap identified in OpenHands/OpenHands#15052 (now closed)
- Complements OpenHands/OpenHands#15034 (merged regex fix)
- Related to OpenHands/enterprise#44 (broader repo-optional enhancement)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-7d0bf59   docker.openhands.dev/openhands/openhands:7d0bf59
```