### PR TITLE
perf: cache user_authorizations rule set instead of querying on every auth check

### DIFF
--- a/enterprise/storage/user_authorization_store.py
+++ b/enterprise/storage/user_authorization_store.py
@@ -1,5 +1,9 @@
 """Store class for managing user authorizations."""
 
+import os
+import re
+import time
+from functools import lru_cache
 from typing import Optional
 
 from sqlalchemy import func, or_, select
@@ -7,9 +11,91 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from storage.database import a_session_maker
 from storage.user_authorization import UserAuthorization, UserAuthorizationType
 
+# The user_authorizations table is tiny (a few dozen rows) but is read on every
+# authentication/authorization request. Querying it per request dominates the
+# load on the table even though each scan is cheap. Instead, cache the full rule
+# set in process memory behind a short TTL and evaluate the email/provider match
+# in Python. The cache is invalidated on writes so changes take effect promptly.
+_CACHE_TTL_SECONDS = float(os.getenv('USER_AUTHORIZATION_CACHE_TTL_SECONDS', '30'))
+
+_cached_authorizations: list[UserAuthorization] | None = None
+_cache_expires_at: float = 0.0
+
+
+@lru_cache(maxsize=1024)
+def _compile_like_pattern(pattern: str) -> re.Pattern[str]:
+    """Translate a SQL LIKE pattern into a compiled, case-insensitive regex.
+
+    Mirrors the semantics of ``LOWER(email) LIKE LOWER(email_pattern)`` used by
+    the SQL query: ``%`` matches any sequence of characters, ``_`` matches a
+    single character, and every other character is matched literally.
+    """
+    regex_parts = ['^']
+    for char in pattern:
+        if char == '%':
+            regex_parts.append('.*')
+        elif char == '_':
+            regex_parts.append('.')
+        else:
+            regex_parts.append(re.escape(char))
+    regex_parts.append('$')
+    return re.compile(''.join(regex_parts), re.IGNORECASE | re.DOTALL)
+
 
 class UserAuthorizationStore:
     """Store for managing user authorization rules."""
+
+    @staticmethod
+    def invalidate_cache() -> None:
+        """Clear the in-memory authorization cache.
+
+        Called after any write so subsequent reads reflect the new rule set.
+        """
+        global _cached_authorizations, _cache_expires_at
+        _cached_authorizations = None
+        _cache_expires_at = 0.0
+
+    @staticmethod
+    async def _get_cached_authorizations() -> list[UserAuthorization]:
+        """Return all authorization rules, loading them from the DB on cache miss.
+
+        The returned list is shared and must not be mutated by callers.
+        """
+        global _cached_authorizations, _cache_expires_at
+        now = time.monotonic()
+        if _cached_authorizations is not None and now < _cache_expires_at:
+            return _cached_authorizations
+
+        async with a_session_maker() as session:
+            result = await session.execute(select(UserAuthorization))
+            authorizations = list(result.scalars().all())
+            # Detach so the rows remain usable after the session closes.
+            session.expunge_all()
+
+        _cached_authorizations = authorizations
+        _cache_expires_at = time.monotonic() + _CACHE_TTL_SECONDS
+        return authorizations
+
+    @staticmethod
+    def _matches_rule(
+        authorization: UserAuthorization,
+        email: str,
+        provider_type: str | None,
+    ) -> bool:
+        """Replicate the SQL matching logic for a single rule in Python.
+
+        - provider_type IS NULL matches any provider, otherwise it must be equal
+        - email_pattern IS NULL matches any email, otherwise SQL LIKE applies
+        """
+        if (
+            authorization.provider_type is not None
+            and authorization.provider_type != provider_type
+        ):
+            return False
+        if authorization.email_pattern is None:
+            return True
+        pattern = _compile_like_pattern(authorization.email_pattern)
+        return pattern.match(email) is not None
 
     @staticmethod
     async def _get_matching_authorizations(
@@ -65,13 +151,17 @@ class UserAuthorizationStore:
             List of matching UserAuthorization objects
         """
         if session is not None:
+            # A caller-supplied session may include uncommitted writes, so query
+            # the database directly to honour the transaction's view of the data.
             return await UserAuthorizationStore._get_matching_authorizations(
                 email, provider_type, session
             )
-        async with a_session_maker() as new_session:
-            return await UserAuthorizationStore._get_matching_authorizations(
-                email, provider_type, new_session
-            )
+        authorizations = await UserAuthorizationStore._get_cached_authorizations()
+        return [
+            authorization
+            for authorization in authorizations
+            if UserAuthorizationStore._matches_rule(authorization, email, provider_type)
+        ]
 
     @staticmethod
     async def get_authorization_type(
@@ -151,15 +241,17 @@ class UserAuthorizationStore:
             The created UserAuthorization object
         """
         if session is not None:
-            return await UserAuthorizationStore._create_authorization(
+            auth = await UserAuthorizationStore._create_authorization(
                 email_pattern, provider_type, auth_type, session
             )
-        async with a_session_maker() as new_session:
-            auth = await UserAuthorizationStore._create_authorization(
-                email_pattern, provider_type, auth_type, new_session
-            )
-            await new_session.commit()
-            return auth
+        else:
+            async with a_session_maker() as new_session:
+                auth = await UserAuthorizationStore._create_authorization(
+                    email_pattern, provider_type, auth_type, new_session
+                )
+                await new_session.commit()
+        UserAuthorizationStore.invalidate_cache()
+        return auth
 
     @staticmethod
     async def _delete_authorization(
@@ -191,13 +283,16 @@ class UserAuthorizationStore:
             True if deleted, False if not found
         """
         if session is not None:
-            return await UserAuthorizationStore._delete_authorization(
+            deleted = await UserAuthorizationStore._delete_authorization(
                 authorization_id, session
             )
-        async with a_session_maker() as new_session:
-            deleted = await UserAuthorizationStore._delete_authorization(
-                authorization_id, new_session
-            )
-            if deleted:
-                await new_session.commit()
-            return deleted
+        else:
+            async with a_session_maker() as new_session:
+                deleted = await UserAuthorizationStore._delete_authorization(
+                    authorization_id, new_session
+                )
+                if deleted:
+                    await new_session.commit()
+        if deleted:
+            UserAuthorizationStore.invalidate_cache()
+        return deleted

--- a/enterprise/tests/unit/storage/test_user_authorization_store.py
+++ b/enterprise/tests/unit/storage/test_user_authorization_store.py
@@ -34,6 +34,30 @@ async def async_session_maker(async_engine):
     return session_maker
 
 
+@pytest.fixture(autouse=True)
+def reset_authorization_cache():
+    """Reset the module-level authorization cache around each test.
+
+    The cache is process-global, so it must be cleared between tests to avoid
+    one test's rules leaking into another.
+    """
+    UserAuthorizationStore.invalidate_cache()
+    yield
+    UserAuthorizationStore.invalidate_cache()
+
+
+class CountingSessionMaker:
+    """Wraps a session maker and counts how many sessions it opens."""
+
+    def __init__(self, session_maker):
+        self._session_maker = session_maker
+        self.call_count = 0
+
+    def __call__(self, *args, **kwargs):
+        self.call_count += 1
+        return self._session_maker(*args, **kwargs)
+
+
 class TestGetMatchingAuthorizations:
     """Tests for get_matching_authorizations method."""
 
@@ -633,3 +657,116 @@ class TestPatternMatchingEdgeCases:
                 provider_type='github',
             )
             assert len(result) == 0
+
+
+class TestAuthorizationCaching:
+    """Tests for the in-memory TTL cache on the read (no-session) path."""
+
+    @pytest.mark.asyncio
+    async def test_repeated_lookup_within_ttl_issues_no_query(
+        self, async_session_maker
+    ):
+        """A second lookup within the TTL window must not touch the database."""
+        counter = CountingSessionMaker(async_session_maker)
+        with patch('storage.user_authorization_store.a_session_maker', counter):
+            await UserAuthorizationStore.create_authorization(
+                email_pattern='%@example.com',
+                provider_type=None,
+                auth_type=UserAuthorizationType.WHITELIST,
+            )
+
+            # First read loads the rule set from the database.
+            result = await UserAuthorizationStore.get_authorization_type(
+                email='user@example.com',
+                provider_type='github',
+            )
+            assert result == UserAuthorizationType.WHITELIST
+            calls_after_first = counter.call_count
+
+            # Subsequent reads within the TTL are served from the cache.
+            for _ in range(5):
+                result = await UserAuthorizationStore.get_authorization_type(
+                    email='user@example.com',
+                    provider_type='github',
+                )
+                assert result == UserAuthorizationType.WHITELIST
+
+            assert counter.call_count == calls_after_first
+
+    @pytest.mark.asyncio
+    async def test_create_invalidates_cache(self, async_session_maker):
+        """Creating a rule must invalidate the cache so the next read sees it."""
+        with patch(
+            'storage.user_authorization_store.a_session_maker', async_session_maker
+        ):
+            # Prime the cache with the empty rule set.
+            result = await UserAuthorizationStore.get_authorization_type(
+                email='user@example.com',
+                provider_type='github',
+            )
+            assert result is None
+
+            await UserAuthorizationStore.create_authorization(
+                email_pattern='%@example.com',
+                provider_type=None,
+                auth_type=UserAuthorizationType.BLACKLIST,
+            )
+
+            result = await UserAuthorizationStore.get_authorization_type(
+                email='user@example.com',
+                provider_type='github',
+            )
+            assert result == UserAuthorizationType.BLACKLIST
+
+    @pytest.mark.asyncio
+    async def test_delete_invalidates_cache(self, async_session_maker):
+        """Deleting a rule must invalidate the cache so the next read drops it."""
+        with patch(
+            'storage.user_authorization_store.a_session_maker', async_session_maker
+        ):
+            auth = await UserAuthorizationStore.create_authorization(
+                email_pattern='%@example.com',
+                provider_type=None,
+                auth_type=UserAuthorizationType.BLACKLIST,
+            )
+
+            # Prime the cache with the rule present.
+            result = await UserAuthorizationStore.get_authorization_type(
+                email='user@example.com',
+                provider_type='github',
+            )
+            assert result == UserAuthorizationType.BLACKLIST
+
+            await UserAuthorizationStore.delete_authorization(auth.id)
+
+            result = await UserAuthorizationStore.get_authorization_type(
+                email='user@example.com',
+                provider_type='github',
+            )
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_expired_cache_reloads_from_database(self, async_session_maker):
+        """Once the TTL elapses, the next read reloads from the database."""
+        counter = CountingSessionMaker(async_session_maker)
+        with patch('storage.user_authorization_store.a_session_maker', counter):
+            await UserAuthorizationStore.create_authorization(
+                email_pattern='%@example.com',
+                provider_type=None,
+                auth_type=UserAuthorizationType.WHITELIST,
+            )
+
+            await UserAuthorizationStore.get_authorization_type(
+                email='user@example.com',
+                provider_type='github',
+            )
+            calls_after_first = counter.call_count
+
+            # Force the cached entry to look expired.
+            with patch('storage.user_authorization_store._cache_expires_at', 0.0):
+                await UserAuthorizationStore.get_authorization_type(
+                    email='user@example.com',
+                    provider_type='github',
+                )
+
+            assert counter.call_count == calls_after_first + 1


### PR DESCRIPTION
## Why

Closes OpenHands/enterprise#45 (follow-up to OpenHands/OpenHands#14633).

The `user_authorizations` table is tiny (~31 rows / a single ~8 KB page), so the Postgres planner will always choose a sequential scan over any index — adding indexes does **not** reduce load. The actual cost driver is **query volume**: the table is read on every authentication/authorization request through `UserAuthorizationStore.get_authorization_type`, which issues a query per request (millions of calls).

The effective fix is to stop hitting the DB on the hot path: cache the small, rarely-changing rule set in process memory behind a short TTL and evaluate the email/provider match in Python.

## What changed

`enterprise/storage/user_authorization_store.py`:
- Load the **full** `user_authorizations` rule set into a process-local cache with a short TTL (`USER_AUTHORIZATION_CACHE_TTL_SECONDS`, default `30s`).
- Evaluate the email/provider match in Python via `_matches_rule` + `_compile_like_pattern`, which faithfully replicates the SQL semantics:
  - `provider_type IS NULL` matches any provider, otherwise it must be equal.
  - `email_pattern IS NULL` matches any email, otherwise SQL `LIKE` applies (`%` → any sequence, `_` → single char, case-insensitive — mirroring `LOWER(email) LIKE LOWER(email_pattern)`).
- Invalidate the cache on `create_authorization` / `delete_authorization`.
- Reads that pass an explicit `session` still query the DB directly, so a caller's in-transaction (uncommitted) view is preserved. Only the hot path (no session) uses the cache.

No change to the public API or matching behavior.

## Effect

`seq_scan` / `calls` for `user_authorizations` in `pg_stat_user_tables` drop to roughly `(replicas × table_count) / TTL` instead of tracking auth request volume. Because writes are rare and the cache is invalidated on write, the staleness window is at most one short TTL on replicas that did not perform the write.

> Note: `blocked_email_domains` was already migrated into `user_authorizations` in migration `099`, so caching this single table covers both tables referenced in the issue.

## Tests

Added `TestAuthorizationCaching` in `enterprise/tests/unit/storage/test_user_authorization_store.py`:
- A repeated lookup within the TTL issues no new DB query (verified with a session-maker call counter).
- `create_authorization` and `delete_authorization` each invalidate the cache.
- An expired cache reloads from the DB.
- Added an autouse fixture to reset the process-global cache between tests.

Existing pattern-matching tests continue to exercise the same scenarios through the cached path.

### Validation note

The full enterprise pytest suite requires the heavy `openhands` SDK / cloud dependency chain, which is not installed in this environment. I validated the **actual** store code paths (LIKE matching incl. `_`/`%`/case-insensitivity/subdomain rejection, whitelist precedence, cache hits issuing no queries, create/delete invalidation, and TTL expiry reload) against an in-memory SQLite database using a standalone harness — all checks passed. `ruff check` passes on the changed files.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@aivong-openhands can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f4472701-9dc0-4d70-ae0d-fa3352d6629e)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-4dd8772   docker.openhands.dev/openhands/openhands:4dd8772
```