### PR TITLE
fix(alembic): pass execution_status as a list to create_index in migration 013

### DIFF
--- a/openhands/app_server/app_lifespan/alembic/versions/013.py
+++ b/openhands/app_server/app_lifespan/alembic/versions/013.py
@@ -34,7 +34,7 @@ def upgrade() -> None:
         # Create index for efficient dashboard queries
         batch_op.create_index(
             'ix_conversation_metadata_execution_status',
-            'execution_status',
+            ['execution_status'],
             unique=False,
         )
 


### PR DESCRIPTION
HUMAN:

Hit this upgrading a self-hosted (SQLite, Docker) box to latest `main`: the app won't start, alembic dies with `DuplicateColumnError: A column with name 'e' is already present in table 'conversation_metadata'` running migration `013`. Turned out `013`'s `create_index` gets the column as a bare string, so SQLite batch mode iterates it character by character and the repeated `e` in "ex**e**cution_status" collides. One-line fix: pass it as a list.

- [ ] A human has tested these changes.

AGENT:

---

## Why

On a fresh SQLite database, startup runs the migrations and fails at `013`:

```
sqlalchemy.exc.DuplicateColumnError: A column with name 'e' is already present
in table 'conversation_metadata'.
  File ".../app_lifespan/alembic/versions/013.py", line 35, in upgrade   # batch_op.create_index(...)
```

`batch_op.create_index(name, columns, ...)` expects `columns` to be a list. Migration `013` passes the bare string `'execution_status'`. Under SQLite's batch (copy-and-move) mode, alembic's `_textual_index_column` iterates the value, so the string is treated as the character sequence `e, x, e, c, ...` and the second `e` raises `DuplicateColumnError`. Postgres' non-batch path tolerates a string, which is why this only bites SQLite / self-hosted fresh installs.

## Summary

- `openhands/app_server/app_lifespan/alembic/versions/013.py`: pass `['execution_status']` (a list) to `batch_op.create_index` instead of the bare string.

## Issue Number

None filed; happy to open one if preferred.

## How to Test

Fresh SQLite DB, run migrations to head (e.g. start the latest `:main` image with an empty config dir):

- Before: `Running upgrade 012 -> 013` raises `DuplicateColumnError: column 'e' ...` and `Application startup failed. Exiting.`
- After: `012 -> 013 -> 014` complete, `Application startup complete`, and `conversation_metadata` has the `execution_status` column plus the `ix_conversation_metadata_execution_status` index.

Reproduced and verified against the current `:main` image on a self-hosted Docker/SQLite host.

## Video/Screenshots

N/A (migration fix; covered by the repro above).

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

SQLite-only (batch mode); Postgres is unaffected. The `downgrade` path already uses the index name and is unaffected. No change to the intended schema; this just lets the index actually build.
