### PR TITLE
fix: add retryable conversation list error state

### DIFF
--- a/frontend/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
+++ b/frontend/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
@@ -116,19 +116,34 @@ describe("ConversationPanel", () => {
     expect(emptyState).toBeInTheDocument();
   });
 
-  it("should handle an error when fetching conversations", async () => {
+  it("should show a retryable error state when fetching conversations fails", async () => {
+    const user = userEvent.setup();
     const searchConversationsSpy = vi.spyOn(
       V1ConversationService,
       "searchConversations",
     );
-    searchConversationsSpy.mockRejectedValue(
-      new Error("Failed to fetch conversations"),
-    );
+    searchConversationsSpy
+      .mockRejectedValueOnce(new Error("Request failed with status code 500"))
+      .mockResolvedValueOnce({
+        items: [...mockConversations],
+        next_page_id: null,
+      });
 
     renderConversationPanel();
 
-    const error = await screen.findByText("Failed to fetch conversations");
-    expect(error).toBeInTheDocument();
+    const error = await screen.findByTestId("conversation-list-error");
+    expect(error).toHaveTextContent("ERROR$GENERIC");
+    expect(
+      screen.queryByText("Request failed with status code 500"),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "BUTTON$REFRESH" }));
+
+    await waitFor(() => {
+      expect(searchConversationsSpy).toHaveBeenCalledTimes(2);
+    });
+    const cards = await screen.findAllByTestId("conversation-card");
+    expect(cards).toHaveLength(3);
   });
 
   it("should cancel deleting a conversation", async () => {

--- a/frontend/__tests__/components/features/home/recent-conversations.test.tsx
+++ b/frontend/__tests__/components/features/home/recent-conversations.test.tsx
@@ -36,17 +36,19 @@ describe("RecentConversations", () => {
 
   it("should not show empty state when there is an error", async () => {
     searchConversationsSpy.mockRejectedValue(
-      new Error("Failed to fetch conversations"),
+      new Error("Request failed with status code 500"),
     );
 
     renderRecentConversations();
 
-    // Wait for the error to be displayed
+    // Wait for the structured error state to be displayed.
     await waitFor(() => {
-      expect(
-        screen.getByText("Failed to fetch conversations"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("conversation-list-error")).toBeInTheDocument();
     });
+    expect(screen.getByText("ERROR$GENERIC")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Request failed with status code 500"),
+    ).not.toBeInTheDocument();
 
     // The empty state should NOT be displayed when there's an error
     expect(

--- a/frontend/src/components/features/conversation-panel/conversation-list-error-state.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-list-error-state.tsx
@@ -1,0 +1,45 @@
+import { RefreshCw } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { I18nKey } from "#/i18n/declaration";
+import { cn } from "#/utils/utils";
+
+interface ConversationListErrorStateProps {
+  className?: string;
+  isRetrying?: boolean;
+  onRetry: () => void;
+}
+
+export function ConversationListErrorState({
+  className,
+  isRetrying = false,
+  onRetry,
+}: ConversationListErrorStateProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      role="alert"
+      data-testid="conversation-list-error"
+      className={cn(
+        "flex h-full flex-col items-center justify-center gap-3 px-6 text-center",
+        className,
+      )}
+    >
+      <p className="text-sm font-medium text-neutral-200">
+        {t(I18nKey.ERROR$GENERIC)}
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        disabled={isRetrying}
+        aria-label={t(I18nKey.BUTTON$REFRESH)}
+        className="inline-flex items-center gap-2 rounded-md border border-neutral-600 px-3 py-2 text-xs font-medium text-neutral-100 transition-colors hover:bg-neutral-700 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        <RefreshCw size={14} className={isRetrying ? "animate-spin" : ""} />
+        <span>
+          {isRetrying ? t(I18nKey.HOME$LOADING) : t(I18nKey.BUTTON$REFRESH)}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/frontend/src/components/features/conversation-panel/conversation-panel.tsx
@@ -20,6 +20,7 @@ import { useConfig } from "#/hooks/query/use-config";
 import { ConversationCard } from "./conversation-card/conversation-card";
 import { StartTaskCard } from "./start-task-card/start-task-card";
 import { ConversationCardSkeleton } from "./conversation-card/conversation-card-skeleton";
+import { ConversationListErrorState } from "./conversation-list-error-state";
 
 interface ConversationPanelProps {
   onClose: () => void;
@@ -59,6 +60,7 @@ export function ConversationPanel({ onClose }: ConversationPanelProps) {
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
+    refetch,
   } = usePaginatedConversations();
 
   // Fetch in-progress start tasks
@@ -132,6 +134,10 @@ export function ConversationPanel({ onClose }: ConversationPanelProps) {
     }
   };
 
+  const handleRetry = () => {
+    refetch().catch(() => undefined);
+  };
+
   return (
     <div
       ref={(node) => {
@@ -152,17 +158,21 @@ export function ConversationPanel({ onClose }: ConversationPanelProps) {
       )}
 
       {error && (
-        <div className="flex flex-col items-center justify-center h-full">
-          <p className="text-danger">{error.message}</p>
-        </div>
+        <ConversationListErrorState
+          isRetrying={isFetching}
+          onRetry={handleRetry}
+        />
       )}
-      {!isFetching && conversations?.length === 0 && !startTasks?.length && (
-        <div className="flex flex-col items-center justify-center h-full">
-          <p className="text-neutral-400">
-            {t(I18nKey.CONVERSATION$NO_CONVERSATIONS)}
-          </p>
-        </div>
-      )}
+      {!error &&
+        !isFetching &&
+        conversations?.length === 0 &&
+        !startTasks?.length && (
+          <div className="flex flex-col items-center justify-center h-full">
+            <p className="text-neutral-400">
+              {t(I18nKey.CONVERSATION$NO_CONVERSATIONS)}
+            </p>
+          </div>
+        )}
       {/* Render in-progress start tasks first */}
       {startTasks?.map((task) => (
         <NavLink

--- a/frontend/src/components/features/home/recent-conversations/recent-conversations.tsx
+++ b/frontend/src/components/features/home/recent-conversations/recent-conversations.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
+import { ConversationListErrorState } from "#/components/features/conversation-panel/conversation-list-error-state";
 import { RecentConversationsSkeleton } from "./recent-conversations-skeleton";
 import { RecentConversation } from "./recent-conversation";
 import { usePaginatedConversations } from "#/hooks/query/use-paginated-conversations";
@@ -18,6 +19,7 @@ export function RecentConversations() {
     error,
     hasNextPage,
     fetchNextPage,
+    refetch,
   } = usePaginatedConversations(10);
 
   // Set up infinite scroll
@@ -48,6 +50,10 @@ export function RecentConversations() {
     setIsExpanded(!isExpanded);
   };
 
+  const handleRetry = () => {
+    refetch().catch(() => undefined);
+  };
+
   return (
     <section
       data-testid="recent-conversations"
@@ -65,9 +71,11 @@ export function RecentConversations() {
       </div>
 
       {error && (
-        <div className="flex flex-col items-center justify-center h-full pl-4">
-          <p className="text-danger">{error.message}</p>
-        </div>
+        <ConversationListErrorState
+          className="items-start px-4 text-left"
+          isRetrying={isFetching}
+          onRetry={handleRetry}
+        />
       )}
 
       <div className="flex flex-col">


### PR DESCRIPTION
## Summary
- replace the raw conversation-list error string with a structured error state
- add a refresh action for failed conversation list requests
- reuse the same fallback in the recent conversations section
- update component coverage for sanitized errors and retry behavior

Fixes #15071

## Tests
- `vitest run __tests__/components/features/conversation-panel/conversation-panel.test.tsx __tests__/components/features/home/recent-conversations.test.tsx`
- `eslint src/components/features/conversation-panel/conversation-list-error-state.tsx src/components/features/conversation-panel/conversation-panel.tsx src/components/features/home/recent-conversations/recent-conversations.tsx`
