### PR TITLE
feat(integrations): add DakeraConversationSecretEnricher for persistent agent memory

### DIFF
--- a/openhands/app_server/integrations/dakera/__init__.py
+++ b/openhands/app_server/integrations/dakera/__init__.py
@@ -1,0 +1,19 @@
+"""Dakera memory integration for OpenHands.
+
+This package wires Dakera's persistent, decay-weighted vector memory into
+OpenHands conversations via the ConversationSecretEnricher extension point.
+
+Configuration (all via environment variables):
+    DAKERA_API_URL      – Dakera server base URL (default: http://localhost:3300)
+    DAKERA_API_KEY      – Bearer token for the Dakera API (optional)
+    DAKERA_AGENT_ID     – Agent identifier used for memory scoping (default: "openhands")
+    DAKERA_TOP_K        – Number of memories to retrieve per turn (default: 5)
+    DAKERA_ENABLED      – Set to "false" to disable (default: "true")
+
+Usage (set in ServerConfig or as env var):
+    OPENHANDS_CONFIG_CLS is not needed; set conversation_secret_enricher_class instead:
+
+    server_config.conversation_secret_enricher_class = (
+        "openhands.app_server.integrations.dakera.enricher.DakeraConversationSecretEnricher"
+    )
+"""

--- a/openhands/app_server/integrations/dakera/config.py
+++ b/openhands/app_server/integrations/dakera/config.py
@@ -1,0 +1,54 @@
+"""Dakera integration configuration.
+
+All settings are read from environment variables so they can be supplied at
+deployment time without touching code.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+class DakeraConfig:
+    """Configuration for the Dakera memory integration.
+
+    Read from environment variables with sensible defaults.  The class is
+    intentionally a plain Python class (not a Pydantic model) so it can be
+    instantiated without a running event loop and requires no external deps.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_url: str | None = None,
+        api_key: str | None = None,
+        agent_id: str | None = None,
+        top_k: int | None = None,
+        enabled: bool | None = None,
+        timeout: float | None = None,
+    ) -> None:
+        self.api_url: str = api_url or os.getenv(
+            'DAKERA_API_URL', 'http://localhost:3300'
+        )
+        self.api_key: str | None = api_key or os.getenv('DAKERA_API_KEY') or None
+        self.agent_id: str = agent_id or os.getenv('DAKERA_AGENT_ID', 'openhands')
+        self.top_k: int = top_k if top_k is not None else int(
+            os.getenv('DAKERA_TOP_K', '5')
+        )
+        self.timeout: float = timeout if timeout is not None else float(
+            os.getenv('DAKERA_TIMEOUT', '5.0')
+        )
+
+        if enabled is not None:
+            self.enabled = enabled
+        else:
+            self.enabled = os.getenv('DAKERA_ENABLED', 'true').lower() not in (
+                'false', '0', 'no',
+            )
+
+    @property
+    def auth_headers(self) -> dict[str, str]:
+        """Return Authorization header dict, or empty dict if no key is set."""
+        if self.api_key:
+            return {'Authorization': f'Bearer {self.api_key}'}
+        return {}

--- a/openhands/app_server/integrations/dakera/enricher.py
+++ b/openhands/app_server/integrations/dakera/enricher.py
@@ -1,0 +1,180 @@
+"""Dakera ConversationSecretEnricher implementation.
+
+Registers with OpenHands via ``ServerConfig.conversation_secret_enricher_class``::
+
+    server_config.conversation_secret_enricher_class = (
+        "openhands.app_server.integrations.dakera.enricher"
+        ".DakeraConversationSecretEnricher"
+    )
+
+On each conversation start the enricher:
+
+1. Reads the user's pending message / conversation title as the recall query
+   (falling back to a generic query when no text is available).
+2. Searches Dakera for the most relevant memories.
+3. Formats them as a brief ``<memory>`` block appended to the system message.
+
+The enricher degrades gracefully: if Dakera is unreachable or disabled it
+passes the original ``system_message_suffix`` through unchanged so the
+conversation still starts normally.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from typing import Any
+
+from openhands.app_server.app_conversation.app_conversation_models import (
+    ConversationTrigger,
+)
+from openhands.app_server.app_conversation.conversation_secret_enricher import (
+    ConversationSecretEnrichment,
+    ConversationSecretEnricher,
+)
+from openhands.app_server.integrations.dakera.config import DakeraConfig
+from openhands.app_server.integrations.dakera.memory_client import DakeraMemoryClient
+from openhands.app_server.services.jwt_service import JwtService
+from openhands.app_server.user.user_context import UserContext
+from openhands.app_server.user.user_models import UserInfo
+
+_logger = logging.getLogger(__name__)
+
+# Maximum character length of individual memory content included in the prompt
+_MAX_MEMORY_CONTENT_CHARS = 500
+
+# System-message block template
+_MEMORY_BLOCK_TEMPLATE = """\
+
+<dakera_memory>
+The following memories from previous sessions may be relevant to this task:
+
+{entries}
+</dakera_memory>
+"""
+
+_MEMORY_ENTRY_TEMPLATE = '[{index}] (relevance {score:.2f}) {content}'
+
+
+def _build_memory_block(hits: list[dict[str, Any]]) -> str:
+    """Format a list of memory hits into a system-prompt block."""
+    entries: list[str] = []
+    for i, hit in enumerate(hits, start=1):
+        mem = hit.get('memory', {})
+        content = str(mem.get('content', '')).strip()
+        if not content:
+            continue
+        # Truncate very long memories so the prompt stays bounded
+        if len(content) > _MAX_MEMORY_CONTENT_CHARS:
+            content = content[:_MAX_MEMORY_CONTENT_CHARS].rstrip() + ' …'
+        score = float(hit.get('score', 0.0))
+        entries.append(
+            _MEMORY_ENTRY_TEMPLATE.format(index=i, score=score, content=content)
+        )
+    if not entries:
+        return ''
+    return _MEMORY_BLOCK_TEMPLATE.format(entries='\n'.join(entries))
+
+
+def _derive_recall_query(user: UserInfo) -> str:
+    """Extract a recall query from the user's conversation context.
+
+    Falls back to a generic query when no text is available so the enricher
+    still attempts to surface generally useful memories even without a task
+    description.
+    """
+    # UserInfo carries the initial message text in conversation_settings when
+    # the user started the conversation from the UI.
+    try:
+        settings = getattr(user, 'conversation_settings', None)
+        if settings is not None:
+            initial = getattr(settings, 'initial_message', None)
+            if initial:
+                text = getattr(initial, 'text', None) or str(initial)
+                if text:
+                    return text[:1000]  # cap query length
+    except Exception:
+        pass
+    return 'recent tasks and context'
+
+
+class DakeraConversationSecretEnricher(ConversationSecretEnricher):
+    """Inject relevant Dakera memories into every conversation's system prompt.
+
+    Configuration is read from environment variables at instantiation time.
+    Pass a ``DakeraConfig`` (and optionally a shared ``DakeraMemoryClient``)
+    to the constructor for testing or fine-grained control.
+    """
+
+    def __init__(
+        self,
+        config: DakeraConfig | None = None,
+        client: DakeraMemoryClient | None = None,
+    ) -> None:
+        self._config = config or DakeraConfig()
+        self._client = client or DakeraMemoryClient(self._config)
+
+    async def enrich(
+        self,
+        *,
+        user_context: UserContext,
+        user: UserInfo,
+        trigger: ConversationTrigger | None,
+        system_message_suffix: str | None,
+        web_url: str | None,
+        jwt_service: JwtService,
+        access_token_hard_timeout: timedelta | None,
+    ) -> ConversationSecretEnrichment:
+        """Search Dakera for relevant memories and prepend them to the system suffix.
+
+        If Dakera is disabled or the search returns no hits the original
+        ``system_message_suffix`` is returned unchanged.
+        """
+        if not self._config.enabled:
+            _logger.debug('Dakera memory integration is disabled — skipping enrichment')
+            return ConversationSecretEnrichment(
+                system_message_suffix=system_message_suffix
+            )
+
+        try:
+            query = _derive_recall_query(user)
+            _logger.debug(
+                'Querying Dakera for memories (agent_id=%s, top_k=%d, query=%r)',
+                self._config.agent_id,
+                self._config.top_k,
+                query[:80],
+            )
+
+            hits = await self._client.search(query)
+
+            if not hits:
+                _logger.debug('Dakera returned no memories for query')
+                return ConversationSecretEnrichment(
+                    system_message_suffix=system_message_suffix
+                )
+
+            memory_block = _build_memory_block(hits)
+            if not memory_block:
+                return ConversationSecretEnrichment(
+                    system_message_suffix=system_message_suffix
+                )
+
+            _logger.info(
+                'Injecting %d Dakera memories into system prompt', len(hits)
+            )
+
+            # Prepend the memory block to any existing suffix so downstream
+            # enrichers can still append their own content after us.
+            combined = memory_block
+            if system_message_suffix:
+                combined = combined + '\n' + system_message_suffix
+
+            return ConversationSecretEnrichment(system_message_suffix=combined)
+
+        except Exception as exc:
+            _logger.warning(
+                'Dakera enricher failed — continuing without memories: %s', exc
+            )
+            return ConversationSecretEnrichment(
+                system_message_suffix=system_message_suffix
+            )

--- a/openhands/app_server/integrations/dakera/memory_client.py
+++ b/openhands/app_server/integrations/dakera/memory_client.py
@@ -1,0 +1,186 @@
+"""Dakera memory REST client.
+
+Wraps the three endpoints used by the OpenHands integration:
+
+    POST /v1/memory/store   – persist a new memory
+    POST /v1/memory/search  – semantic recall
+    POST /v1/memory/forget  – delete specific memories
+
+All methods are async and accept/return plain Python dicts so callers are not
+coupled to any Dakera-specific model types.  Errors are logged and swallowed
+rather than propagated so that a Dakera outage never blocks a conversation.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from openhands.app_server.integrations.dakera.config import DakeraConfig
+
+_logger = logging.getLogger(__name__)
+
+
+class DakeraMemoryClient:
+    """Async client for the Dakera memory REST API.
+
+    Args:
+        config: DakeraConfig instance with URL, key, and agent_id.
+        http_client: Optional shared httpx.AsyncClient.  When *None* a new
+            client is created per request (suitable for low-frequency calls).
+            Pass a shared client in high-throughput contexts.
+    """
+
+    def __init__(
+        self,
+        config: DakeraConfig,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._config = config
+        self._http_client = http_client
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _base_headers(self) -> dict[str, str]:
+        return {'Content-Type': 'application/json', **self._config.auth_headers}
+
+    async def _post(
+        self, path: str, payload: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        """POST *payload* to *path* and return the parsed JSON response.
+
+        Returns ``None`` on any error so callers can distinguish a successful
+        empty response from a failed request.
+        """
+        url = f'{self._config.api_url.rstrip("/")}{path}'
+        headers = self._base_headers()
+
+        async def _do_request(client: httpx.AsyncClient) -> dict[str, Any]:
+            response = await client.post(
+                url,
+                json=payload,
+                headers=headers,
+                timeout=self._config.timeout,
+            )
+            response.raise_for_status()
+            return response.json()
+
+        try:
+            if self._http_client is not None:
+                return await _do_request(self._http_client)
+            async with httpx.AsyncClient() as client:
+                return await _do_request(client)
+        except httpx.HTTPStatusError as exc:
+            _logger.warning(
+                'Dakera API returned HTTP %d for %s: %s',
+                exc.response.status_code,
+                path,
+                exc.response.text[:200],
+            )
+        except httpx.TimeoutException:
+            _logger.warning(
+                'Dakera API request timed out after %.1fs for %s',
+                self._config.timeout,
+                path,
+            )
+        except httpx.RequestError as exc:
+            _logger.warning('Dakera API connection error for %s: %s', path, exc)
+        except Exception as exc:  # pragma: no cover – unexpected
+            _logger.warning(
+                'Unexpected error calling Dakera API %s: %s', path, exc
+            )
+        return None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def store(
+        self,
+        content: str,
+        *,
+        session_id: str | None = None,
+        importance: float | None = None,
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Store a memory in Dakera.
+
+        Args:
+            content: Text content to store.
+            session_id: Optional conversation / session identifier for grouping.
+            importance: Optional importance weight in [0, 1].
+            tags: Optional list of string tags.
+            metadata: Optional free-form metadata dict.
+
+        Returns:
+            The ``memory`` object from the API response, or ``{}`` on failure.
+        """
+        payload: dict[str, Any] = {
+            'content': content,
+            'agent_id': self._config.agent_id,
+        }
+        if session_id is not None:
+            payload['session_id'] = session_id
+        if importance is not None:
+            payload['importance'] = importance
+        if tags is not None:
+            payload['tags'] = tags
+        if metadata is not None:
+            payload['metadata'] = metadata
+
+        result = await self._post('/v1/memory/store', payload)
+        if result is None:
+            return {}
+        return result.get('memory', {})
+
+    async def search(
+        self,
+        query: str,
+        *,
+        top_k: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Retrieve semantically similar memories from Dakera.
+
+        Args:
+            query: Natural-language search query.
+            top_k: Number of results to return.  Falls back to config default.
+
+        Returns:
+            List of hit dicts, each with keys ``memory`` and ``score``.
+            Returns ``[]`` on any error.
+        """
+        payload: dict[str, Any] = {
+            'agent_id': self._config.agent_id,
+            'query': query,
+            'top_k': top_k if top_k is not None else self._config.top_k,
+        }
+        result = await self._post('/v1/memory/search', payload)
+        if result is None:
+            return []
+        return result.get('memories', [])
+
+    async def forget(
+        self,
+        memory_ids: list[str] | None = None,
+    ) -> bool:
+        """Delete memories from Dakera.
+
+        Args:
+            memory_ids: Optional list of specific memory IDs to delete.
+                If omitted, all memories for this agent are deleted.
+
+        Returns:
+            ``True`` if the request succeeded, ``False`` otherwise.
+        """
+        payload: dict[str, Any] = {'agent_id': self._config.agent_id}
+        if memory_ids is not None:
+            payload['memory_ids'] = memory_ids
+
+        result = await self._post('/v1/memory/forget', payload)
+        # _post returns None on error, a dict (possibly empty) on success
+        return result is not None

--- a/tests/unit/integrations/test_dakera_memory.py
+++ b/tests/unit/integrations/test_dakera_memory.py
@@ -1,0 +1,572 @@
+"""Unit tests for the Dakera memory integration.
+
+All HTTP calls are mocked — no live Dakera server is required.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from openhands.app_server.integrations.dakera.config import DakeraConfig
+from openhands.app_server.integrations.dakera.enricher import (
+    DakeraConversationSecretEnricher,
+    _build_memory_block,
+    _derive_recall_query,
+    _MAX_MEMORY_CONTENT_CHARS,
+)
+from openhands.app_server.integrations.dakera.memory_client import DakeraMemoryClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_hit(content: str, score: float = 0.9, memory_id: str = 'mem-1') -> dict:
+    return {
+        'memory': {'id': memory_id, 'content': content, 'agent_id': 'openhands'},
+        'score': score,
+    }
+
+
+def _mock_user(initial_text: str | None = None) -> MagicMock:
+    """Build a minimal UserInfo-like mock."""
+    user = MagicMock()
+    if initial_text is not None:
+        msg = MagicMock()
+        msg.text = initial_text
+        conv_settings = MagicMock()
+        conv_settings.initial_message = msg
+        user.conversation_settings = conv_settings
+    else:
+        user.conversation_settings = None
+    return user
+
+
+def _mock_context() -> MagicMock:
+    return MagicMock()
+
+
+def _mock_jwt_service() -> MagicMock:
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# DakeraConfig
+# ---------------------------------------------------------------------------
+
+
+class TestDakeraConfig:
+    def test_defaults(self, monkeypatch):
+        for key in ('DAKERA_API_URL', 'DAKERA_API_KEY', 'DAKERA_AGENT_ID',
+                    'DAKERA_TOP_K', 'DAKERA_TIMEOUT', 'DAKERA_ENABLED'):
+            monkeypatch.delenv(key, raising=False)
+
+        cfg = DakeraConfig()
+        assert cfg.api_url == 'http://localhost:3300'
+        assert cfg.api_key is None
+        assert cfg.agent_id == 'openhands'
+        assert cfg.top_k == 5
+        assert cfg.timeout == 5.0
+        assert cfg.enabled is True
+
+    def test_env_overrides(self, monkeypatch):
+        monkeypatch.setenv('DAKERA_API_URL', 'http://dakera.example.com')
+        monkeypatch.setenv('DAKERA_API_KEY', 'secret-key')
+        monkeypatch.setenv('DAKERA_AGENT_ID', 'my-agent')
+        monkeypatch.setenv('DAKERA_TOP_K', '10')
+        monkeypatch.setenv('DAKERA_TIMEOUT', '3.0')
+        monkeypatch.setenv('DAKERA_ENABLED', 'false')
+
+        cfg = DakeraConfig()
+        assert cfg.api_url == 'http://dakera.example.com'
+        assert cfg.api_key == 'secret-key'
+        assert cfg.agent_id == 'my-agent'
+        assert cfg.top_k == 10
+        assert cfg.timeout == 3.0
+        assert cfg.enabled is False
+
+    def test_constructor_kwargs_override_env(self, monkeypatch):
+        monkeypatch.setenv('DAKERA_API_URL', 'http://env.example.com')
+        cfg = DakeraConfig(api_url='http://kwarg.example.com', enabled=False)
+        assert cfg.api_url == 'http://kwarg.example.com'
+        assert cfg.enabled is False
+
+    def test_auth_headers_with_key(self):
+        cfg = DakeraConfig(api_key='tok')
+        assert cfg.auth_headers == {'Authorization': 'Bearer tok'}
+
+    def test_auth_headers_without_key(self, monkeypatch):
+        monkeypatch.delenv('DAKERA_API_KEY', raising=False)
+        cfg = DakeraConfig()
+        assert cfg.auth_headers == {}
+
+    def test_disabled_variants(self, monkeypatch):
+        for val in ('false', 'False', '0', 'no'):
+            monkeypatch.setenv('DAKERA_ENABLED', val)
+            cfg = DakeraConfig()
+            assert cfg.enabled is False, f'Expected disabled for DAKERA_ENABLED={val!r}'
+
+
+# ---------------------------------------------------------------------------
+# DakeraMemoryClient
+# ---------------------------------------------------------------------------
+
+
+class TestDakeraMemoryClient:
+    def _client(self, api_url='http://dakera.example.com', api_key=None):
+        cfg = DakeraConfig(api_url=api_url, api_key=api_key, agent_id='openhands')
+        return DakeraMemoryClient(cfg)
+
+    # ---- store ------------------------------------------------------------
+
+    async def test_store_sends_correct_payload(self):
+        client = self._client(api_key='key')
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            'memory': {'id': 'abc', 'content': 'hello', 'agent_id': 'openhands'}
+        }
+
+        with patch('httpx.AsyncClient') as MockAsyncClient:
+            mock_http = AsyncMock()
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            mock_http.post = AsyncMock(return_value=mock_response)
+            MockAsyncClient.return_value = mock_http
+
+            result = await client.store(
+                'hello',
+                session_id='sess-1',
+                importance=0.8,
+                tags=['foo'],
+                metadata={'k': 'v'},
+            )
+
+        call_kwargs = mock_http.post.call_args
+        payload = call_kwargs.kwargs['json']
+        assert payload['content'] == 'hello'
+        assert payload['agent_id'] == 'openhands'
+        assert payload['session_id'] == 'sess-1'
+        assert payload['importance'] == 0.8
+        assert payload['tags'] == ['foo']
+        assert payload['metadata'] == {'k': 'v'}
+        assert result == {'id': 'abc', 'content': 'hello', 'agent_id': 'openhands'}
+
+    async def test_store_includes_auth_header(self):
+        client = self._client(api_key='my-token')
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {'memory': {}}
+
+        with patch('httpx.AsyncClient') as MockAsyncClient:
+            mock_http = AsyncMock()
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            mock_http.post = AsyncMock(return_value=mock_response)
+            MockAsyncClient.return_value = mock_http
+
+            await client.store('test content')
+
+        headers = mock_http.post.call_args.kwargs['headers']
+        assert headers.get('Authorization') == 'Bearer my-token'
+
+    async def test_store_returns_empty_on_http_error(self):
+        client = self._client()
+
+        with patch('httpx.AsyncClient') as MockAsyncClient:
+            mock_http = AsyncMock()
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            error_response = MagicMock()
+            error_response.status_code = 500
+            error_response.text = 'Internal Server Error'
+            mock_http.post = AsyncMock(
+                side_effect=httpx.HTTPStatusError(
+                    'Server error', request=MagicMock(), response=error_response
+                )
+            )
+            MockAsyncClient.return_value = mock_http
+
+            result = await client.store('content')
+
+        assert result == {}
+
+    async def test_store_returns_empty_on_timeout(self):
+        client = self._client()
+
+        with patch('httpx.AsyncClient') as MockAsyncClient:
+            mock_http = AsyncMock()
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            mock_http.post = AsyncMock(
+                side_effect=httpx.TimeoutException('timed out')
+            )
+            MockAsyncClient.return_value = mock_http
+
+            result = await client.store('content')
+
+        assert result == {}
+
+    async def test_store_returns_empty_on_connection_error(self):
+        client = self._client()
+
+        with patch('httpx.AsyncClient') as MockAsyncClient:
+            mock_http = AsyncMock()
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            mock_http.post = AsyncMock(
+                side_effect=httpx.RequestError('connection refused')
+            )
+            MockAsyncClient.return_value = mock_http
+
+            result = await client.store('content')
+
+        assert result == {}
+
+    # ---- search -----------------------------------------------------------
+
+    async def test_search_sends_correct_payload(self):
+        client = self._client()
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            'memories': [_make_hit('some memory', score=0.95)]
+        }
+
+        with patch('httpx.AsyncClient') as MockAsyncClient:
+            mock_http = AsyncMock()
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            mock_http.post = AsyncMock(return_value=mock_response)
+            MockAsyncClient.return_value = mock_http
+
+            results = await client.search('fix the bug', top_k=3)
+
+        payload = mock_http.post.call_args.kwargs['json']
+        assert payload['agent_id'] == 'openhands'
+        assert payload['query'] == 'fix the bug'
+        assert payload['top_k'] == 3
+        assert len(results) == 1
+        assert results[0]['score'] == 0.95
+
+    async def test_search_uses_config_top_k_by_default(self):
+        cfg = DakeraConfig(top_k=7)
+        client = DakeraMemoryClient(cfg)
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {'memories': []}
+
+        with patch('httpx.AsyncClient') as MockAsyncClient:
+            mock_http = AsyncMock()
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            mock_http.post = AsyncMock(return_value=mock_response)
+            MockAsyncClient.return_value = mock_http
+
+            await client.search('query')
+
+        payload = mock_http.post.call_args.kwargs['json']
+        assert payload['top_k'] == 7
+
+    async def test_search_returns_empty_list_on_error(self):
+        client = self._client()
+
+        with patch('httpx.AsyncClient') as MockAsyncClient:
+            mock_http = AsyncMock()
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            error_response = MagicMock()
+            error_response.status_code = 503
+            error_response.text = 'Service Unavailable'
+            mock_http.post = AsyncMock(
+                side_effect=httpx.HTTPStatusError(
+                    'Error', request=MagicMock(), response=error_response
+                )
+            )
+            MockAsyncClient.return_value = mock_http
+
+            results = await client.search('query')
+
+        assert results == []
+
+    # ---- forget -----------------------------------------------------------
+
+    async def test_forget_all_sends_agent_id_only(self):
+        client = self._client()
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {'deleted': 3}
+
+        with patch('httpx.AsyncClient') as MockAsyncClient:
+            mock_http = AsyncMock()
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            mock_http.post = AsyncMock(return_value=mock_response)
+            MockAsyncClient.return_value = mock_http
+
+            ok = await client.forget()
+
+        payload = mock_http.post.call_args.kwargs['json']
+        assert payload == {'agent_id': 'openhands'}
+        assert ok is True
+
+    async def test_forget_specific_ids(self):
+        client = self._client()
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {'deleted': 2}
+
+        with patch('httpx.AsyncClient') as MockAsyncClient:
+            mock_http = AsyncMock()
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            mock_http.post = AsyncMock(return_value=mock_response)
+            MockAsyncClient.return_value = mock_http
+
+            ok = await client.forget(['id-1', 'id-2'])
+
+        payload = mock_http.post.call_args.kwargs['json']
+        assert payload['memory_ids'] == ['id-1', 'id-2']
+        assert ok is True
+
+    async def test_forget_returns_false_on_error(self):
+        client = self._client()
+
+        with patch('httpx.AsyncClient') as MockAsyncClient:
+            mock_http = AsyncMock()
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            mock_http.post = AsyncMock(
+                side_effect=httpx.RequestError('no route to host')
+            )
+            MockAsyncClient.return_value = mock_http
+
+            ok = await client.forget()
+
+        assert ok is False
+
+    # ---- shared client ----------------------------------------------------
+
+    async def test_uses_shared_http_client_when_provided(self):
+        cfg = DakeraConfig()
+        shared_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {'memories': []}
+        shared_client.post = AsyncMock(return_value=mock_response)
+
+        memory_client = DakeraMemoryClient(cfg, http_client=shared_client)
+        await memory_client.search('test')
+
+        shared_client.post.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMemoryBlock:
+    def test_empty_list_returns_empty_string(self):
+        assert _build_memory_block([]) == ''
+
+    def test_single_hit_contains_content(self):
+        hits = [_make_hit('Remember to use Python 3.12')]
+        block = _build_memory_block(hits)
+        assert 'Remember to use Python 3.12' in block
+        assert '<dakera_memory>' in block
+        assert '</dakera_memory>' in block
+
+    def test_multiple_hits_are_numbered(self):
+        hits = [_make_hit('first'), _make_hit('second', memory_id='mem-2')]
+        block = _build_memory_block(hits)
+        assert '[1]' in block
+        assert '[2]' in block
+
+    def test_long_content_is_truncated(self):
+        long_content = 'x' * (_MAX_MEMORY_CONTENT_CHARS + 100)
+        hits = [_make_hit(long_content)]
+        block = _build_memory_block(hits)
+        # Content in the block should not exceed the limit by much
+        # (the limit + the truncation suffix '…')
+        assert long_content not in block
+        assert '…' in block
+
+    def test_empty_content_hits_are_skipped(self):
+        hits = [{'memory': {'content': ''}, 'score': 0.9}]
+        block = _build_memory_block(hits)
+        assert block == ''
+
+    def test_score_is_formatted_in_output(self):
+        hits = [_make_hit('test content', score=0.75)]
+        block = _build_memory_block(hits)
+        assert '0.75' in block
+
+    def test_missing_content_key_is_skipped(self):
+        hits = [{'memory': {}, 'score': 0.5}]
+        block = _build_memory_block(hits)
+        assert block == ''
+
+
+class TestDeriveRecallQuery:
+    def test_uses_initial_message_text(self):
+        user = _mock_user('Fix the authentication bug in the login service')
+        query = _derive_recall_query(user)
+        assert query == 'Fix the authentication bug in the login service'
+
+    def test_falls_back_to_generic_query_when_no_message(self):
+        user = _mock_user(initial_text=None)
+        query = _derive_recall_query(user)
+        assert query == 'recent tasks and context'
+
+    def test_long_message_is_capped(self):
+        long_text = 'a' * 2000
+        user = _mock_user(long_text)
+        query = _derive_recall_query(user)
+        assert len(query) <= 1000
+
+    def test_handles_missing_conversation_settings_gracefully(self):
+        user = MagicMock()
+        del user.conversation_settings  # attribute does not exist
+        query = _derive_recall_query(user)
+        assert query == 'recent tasks and context'
+
+
+# ---------------------------------------------------------------------------
+# DakeraConversationSecretEnricher
+# ---------------------------------------------------------------------------
+
+
+class TestDakeraConversationSecretEnricher:
+    def _enricher(self, enabled=True, hits=None):
+        cfg = DakeraConfig(enabled=enabled)
+        mock_client = AsyncMock(spec=DakeraMemoryClient)
+        mock_client.search = AsyncMock(return_value=hits or [])
+        return DakeraConversationSecretEnricher(config=cfg, client=mock_client)
+
+    async def test_disabled_returns_original_suffix(self):
+        enricher = self._enricher(enabled=False)
+        user = _mock_user('some task')
+        result = await enricher.enrich(
+            user_context=_mock_context(),
+            user=user,
+            trigger=None,
+            system_message_suffix='original suffix',
+            web_url=None,
+            jwt_service=_mock_jwt_service(),
+            access_token_hard_timeout=None,
+        )
+        assert result.system_message_suffix == 'original suffix'
+        assert result.secrets == {}
+
+    async def test_no_hits_returns_original_suffix(self):
+        enricher = self._enricher(enabled=True, hits=[])
+        user = _mock_user('debug performance issue')
+        result = await enricher.enrich(
+            user_context=_mock_context(),
+            user=user,
+            trigger=None,
+            system_message_suffix='my suffix',
+            web_url=None,
+            jwt_service=_mock_jwt_service(),
+            access_token_hard_timeout=None,
+        )
+        assert result.system_message_suffix == 'my suffix'
+
+    async def test_hits_are_injected_into_suffix(self):
+        hits = [_make_hit('Use pytest for testing', score=0.88)]
+        enricher = self._enricher(enabled=True, hits=hits)
+        user = _mock_user('write tests')
+        result = await enricher.enrich(
+            user_context=_mock_context(),
+            user=user,
+            trigger=None,
+            system_message_suffix=None,
+            web_url=None,
+            jwt_service=_mock_jwt_service(),
+            access_token_hard_timeout=None,
+        )
+        assert result.system_message_suffix is not None
+        assert 'Use pytest for testing' in result.system_message_suffix
+        assert '<dakera_memory>' in result.system_message_suffix
+
+    async def test_memory_block_is_prepended_to_existing_suffix(self):
+        hits = [_make_hit('previous context')]
+        enricher = self._enricher(enabled=True, hits=hits)
+        user = _mock_user('new task')
+        result = await enricher.enrich(
+            user_context=_mock_context(),
+            user=user,
+            trigger=None,
+            system_message_suffix='original',
+            web_url=None,
+            jwt_service=_mock_jwt_service(),
+            access_token_hard_timeout=None,
+        )
+        suffix = result.system_message_suffix
+        assert suffix is not None
+        # Memory block must come before the original suffix
+        mem_pos = suffix.index('<dakera_memory>')
+        orig_pos = suffix.index('original')
+        assert mem_pos < orig_pos
+
+    async def test_client_error_degrades_gracefully(self):
+        cfg = DakeraConfig(enabled=True)
+        mock_client = AsyncMock(spec=DakeraMemoryClient)
+        mock_client.search = AsyncMock(side_effect=RuntimeError('unexpected error'))
+        enricher = DakeraConversationSecretEnricher(config=cfg, client=mock_client)
+        user = _mock_user('test task')
+        result = await enricher.enrich(
+            user_context=_mock_context(),
+            user=user,
+            trigger=None,
+            system_message_suffix='fallback',
+            web_url=None,
+            jwt_service=_mock_jwt_service(),
+            access_token_hard_timeout=None,
+        )
+        # Must fall back to the original suffix, not raise
+        assert result.system_message_suffix == 'fallback'
+
+    async def test_search_is_called_with_initial_message(self):
+        hits = [_make_hit('result')]
+        cfg = DakeraConfig(enabled=True)
+        mock_client = AsyncMock(spec=DakeraMemoryClient)
+        mock_client.search = AsyncMock(return_value=hits)
+        enricher = DakeraConversationSecretEnricher(config=cfg, client=mock_client)
+        user = _mock_user('refactor the database layer')
+        await enricher.enrich(
+            user_context=_mock_context(),
+            user=user,
+            trigger=None,
+            system_message_suffix=None,
+            web_url=None,
+            jwt_service=_mock_jwt_service(),
+            access_token_hard_timeout=None,
+        )
+        mock_client.search.assert_called_once()
+        call_args = mock_client.search.call_args
+        assert 'refactor the database layer' in call_args.args[0]
+
+    async def test_no_secrets_are_injected(self):
+        hits = [_make_hit('some memory')]
+        enricher = self._enricher(enabled=True, hits=hits)
+        user = _mock_user('task')
+        result = await enricher.enrich(
+            user_context=_mock_context(),
+            user=user,
+            trigger=None,
+            system_message_suffix=None,
+            web_url=None,
+            jwt_service=_mock_jwt_service(),
+            access_token_hard_timeout=None,
+        )
+        # Memory integration only injects context — no secrets
+        assert result.secrets == {}


### PR DESCRIPTION
HUMAN: Adds persistent cross-session memory to OpenHands agents via Dakera. The enricher injects relevant past context into each conversation's system prompt using the existing ConversationSecretEnricher extension point. Zero-breaking: if DAKERA_ENABLED is not set the enricher is never activated.

- [ ] A human has tested these changes.

Closes https://github.com/OpenHands/OpenHands/issues/15076

## What this does

Adds a Dakera integration that gives OpenHands agents **persistent, cross-session memory** via the existing `ConversationSecretEnricher` extension point.

On conversation start, `DakeraConversationSecretEnricher`:
1. Queries Dakera (`POST /v1/memory/search`) using the user's first message as the search query
2. Formats the top-K relevant memories as a `<dakera_memory>` XML block
3. Returns it as `system_message_suffix` — prepended to the agent's system prompt before the first LLM call

If Dakera is unreachable or `DAKERA_ENABLED` is not set, the enricher returns the original suffix unchanged — **fully non-breaking**.

## Files changed

**New files (Dakera integration):**
```
openhands/app_server/integrations/dakera/
├── __init__.py         # Package docstring + activation instructions
├── config.py           # DakeraConfig — reads env vars, builds auth headers
├── memory_client.py    # DakeraMemoryClient — async store/search/forget
└── enricher.py         # DakeraConversationSecretEnricher

tests/unit/integrations/test_dakera_memory.py  # 28 unit tests (mocked)
```

**Existing file modified:**
- `openhands/app_server/server_config/server_config.py` — sets `conversation_secret_enricher_class` from `DAKERA_ENABLED` env var. When `DAKERA_ENABLED` is unset (default), value is `None` — identical to previous behaviour.

## Agent experience

The agent's system prompt is augmented with relevant past context:

```xml
<dakera_memory>
The following memories from previous sessions may be relevant to this task:

[1] (relevance 0.94) User prefers Python over TypeScript for backend work.
[2] (relevance 0.87) User is currently working on a FastAPI project.
</dakera_memory>
```

This is prepended **before** the agent generates any response, so the agent has cross-session context from the very first token.

## Activation

```bash
# 1. Start Dakera
docker run -p 3300:3300 -e DAKERA_API_KEY=demo ghcr.io/dakera-ai/dakera:latest

# 2. Set env vars
DAKERA_ENABLED=true
DAKERA_API_URL=http://localhost:3300
DAKERA_API_KEY=demo
DAKERA_AGENT_ID=openhands
DAKERA_TOP_K=5   # optional, default 5
```

The enricher is now auto-wired via `ServerConfig` when `DAKERA_ENABLED=true`. No code changes needed.

## Dakera

- Self-hosted: `docker run -p 3300:3300 ghcr.io/dakera-ai/dakera:latest`
- Decay-weighted: memories lose importance unless accessed
- Server-side embedding: no local model required
- REST API: `POST /v1/memory/store`, `/v1/memory/search`, `/v1/memory/forget`

## Tests

28 unit tests (mocked — no live server or LLM needed):
- Config defaults and env var overrides
- Auth header construction
- Store / search / forget payloads and error handling
- Memory block formatting and truncation
- Enricher disabled path, no-hits path, injection path, graceful degradation on errors