### PR TITLE
fix: Alembic index creation for execution_status migration

### DIFF
--- a/openhands/app_server/app_lifespan/alembic/versions/013.py
+++ b/openhands/app_server/app_lifespan/alembic/versions/013.py
@@ -34,7 +34,7 @@ def upgrade() -> None:
         # Create index for efficient dashboard queries
         batch_op.create_index(
             'ix_conversation_metadata_execution_status',
-            'execution_status',
+            ['execution_status'],
             unique=False,
         )
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

- [x] A human has tested these changes.

AGENT:

---

## Why

<!-- Describe problem, motivation, etc.-->

Migration `013.py` creates an index by passing `execution_status` as a string to `batch_op.create_index`.

Alembic expects the index columns argument to be a sequence/list of column names. Passing a string can cause it to be interpreted as an iterable of characters instead of a single column name, which can make the migration fail when creating the index.

Docs: https://alembic.sqlalchemy.org/en/latest/api/operations.html

## Summary

<!-- 1-3 bullets describing what changed. -->
- Wrapped `execution_status` in a list when creating the index.
- Kept the existing index name and `unique=False` behavior unchanged.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

N/A

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

Run `make run` with a local database that apply migration `013.py`.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

N/A

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->