### PR TITLE
fix: tolerate malformed pagination cursors in page_id_to_offset

### DIFF
--- a/openhands/app_server/utils/search_utils.py
+++ b/openhands/app_server/utils/search_utils.py
@@ -1,4 +1,5 @@
 import base64
+import binascii
 from typing import AsyncIterator, Callable
 
 
@@ -12,8 +13,12 @@ def offset_to_page_id(offset: int, has_next: bool) -> str | None:
 def page_id_to_offset(page_id: str | None) -> int:
     if not page_id:
         return 0
-    offset = int(base64.b64decode(page_id).decode())
-    return offset
+    try:
+        return int(base64.b64decode(page_id).decode())
+    except (ValueError, UnicodeDecodeError, binascii.Error):
+        # Malformed/opaque page_id -> start from the beginning, mirroring
+        # paging_utils.decode_page_id which also tolerates bad cursors.
+        return 0
 
 
 async def iterate(fn: Callable, **kwargs) -> AsyncIterator:

--- a/tests/unit/utils/test_search_utils.py
+++ b/tests/unit/utils/test_search_utils.py
@@ -1,3 +1,4 @@
+import base64
 from dataclasses import dataclass
 
 import pytest
@@ -33,6 +34,22 @@ def test_offset_to_page_id():
 def test_page_id_to_offset():
     # Test with None should return 0
     assert page_id_to_offset(None) == 0
+
+
+@pytest.mark.parametrize(
+    'bad_page_id',
+    [
+        '!!!not-base64!!!',  # invalid base64 -> binascii.Error
+        'ab',  # incorrect base64 padding -> binascii.Error
+        '####',  # decodes to empty string -> ValueError from int('')
+        base64.b64encode(b'not-an-int').decode(),  # valid base64, non-int -> ValueError
+        base64.b64encode(b'\xff\xfe').decode(),  # non-utf-8 bytes -> UnicodeDecodeError
+    ],
+)
+def test_page_id_to_offset_malformed_returns_zero(bad_page_id):
+    # A malformed/opaque cursor must not raise; it falls back to offset 0,
+    # mirroring paging_utils.decode_page_id's tolerance of bad cursors.
+    assert page_id_to_offset(bad_page_id) == 0
 
 
 def test_bidirectional_conversion():


### PR DESCRIPTION
HUMAN:

This fixes a crash in the app server's pagination. If a client sends a bad or stale `page_id` cursor, the search helper tried to base64-decode it and `int()` the result with no guard, so the whole request failed with a 500 instead of simply starting from the first page. I changed it to fall back to offset 0 on a malformed cursor — the same way the other pagination helper (`paging_utils.decode_page_id`) already tolerates bad input — and added tests covering the malformed-input cases.

- [x] A human has tested these changes.

---

## Why

`page_id_to_offset` in `openhands/app_server/utils/search_utils.py` decoded a client-supplied
pagination cursor with `int(base64.b64decode(page_id).decode())` and **no error handling**. Any
malformed `page_id` therefore raised an exception that propagates as an unhandled **HTTP 500**:

- invalid base64 / bad padding → `binascii.Error`
- valid base64 whose payload isn't an integer → `ValueError`
- valid base64 that isn't UTF-8 → `UnicodeDecodeError`

The cursor is meant to be an opaque token, so a stale or garbled value from a client should degrade
gracefully rather than error. The sibling helper `paging_utils.decode_page_id` already wraps the
identical base64-decode + `int()` in a `try/except` and returns a safe sentinel on bad input — this
change makes `page_id_to_offset` consistent with that convention.

## Summary

- Wrap the decode in `page_id_to_offset` and fall back to offset `0` (the same "start from the
  beginning" behavior already used for a `None` cursor) on `ValueError` / `UnicodeDecodeError` /
  `binascii.Error`.
- Add parametrized regression tests covering each malformed-input path.

## Issue Number

N/A

## How to Test

```bash
pip install pytest pytest-asyncio
python -m pytest tests/unit/utils/test_search_utils.py -q
```

All existing tests plus the new `test_page_id_to_offset_malformed_returns_zero` cases pass. Valid
cursors are unaffected (`offset_to_page_id`/`page_id_to_offset` round-trip is unchanged).

## Type

- [x] Bug fix

## Notes

Scoped to the one function. The two base64 pagination schemes in the repo (`search_utils` standard
b64 vs `paging_utils` url-safe b64) are left as-is to keep the change minimal.
