### PR TITLE
feat(app): add MCP server validation endpoint

### DIFF
--- a/openhands/app_server/mcp/mcp_validation.py
+++ b/openhands/app_server/mcp/mcp_validation.py
@@ -1,0 +1,76 @@
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+from fastmcp import Client
+from fastmcp.mcp_config import MCPConfig
+from pydantic import BaseModel, Field, ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+class MCPServerValidationResult(BaseModel):
+    ok: bool
+    error_kind: str | None = None
+    message: str
+    tools: list[str] = Field(default_factory=list)
+
+
+def _safe_error_response(exc: Exception) -> tuple[str, str]:
+    if isinstance(exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
+        return 'timeout', 'Timed out while connecting to the MCP server.'
+
+    if isinstance(exc, httpx.HTTPStatusError):
+        status_code = exc.response.status_code
+        if status_code in (401, 403):
+            return 'auth', 'MCP server authentication failed.'
+        return 'http_status', 'MCP server returned an error response.'
+
+    if isinstance(exc, (httpx.ConnectError, httpx.NetworkError, httpx.RequestError)):
+        return 'connection', 'Could not connect to the MCP server.'
+
+    if isinstance(exc, OSError):
+        return 'connection', 'Could not connect to the MCP server.'
+
+    return 'unknown', 'Could not validate the MCP server.'
+
+
+async def validate_mcp_server_config(
+    server_name: str,
+    server_config: dict[str, Any],
+    timeout: float = 5,
+) -> MCPServerValidationResult:
+    try:
+        mcp_config = MCPConfig.model_validate(
+            {'mcpServers': {server_name: server_config}}
+        )
+    except ValidationError:
+        logger.info('Invalid MCP server config for %s', server_name)
+        return MCPServerValidationResult(
+            ok=False,
+            error_kind='invalid_config',
+            message='MCP server config is invalid.',
+        )
+
+    try:
+        async with Client(
+            mcp_config,
+            timeout=timeout,
+            init_timeout=timeout,
+        ) as client:
+            tools = await client.list_tools()
+    except Exception as exc:
+        error_kind, message = _safe_error_response(exc)
+        logger.info('MCP validation failed for %s: %s', server_name, error_kind)
+        return MCPServerValidationResult(
+            ok=False,
+            error_kind=error_kind,
+            message=message,
+        )
+
+    return MCPServerValidationResult(
+        ok=True,
+        message='MCP server is reachable.',
+        tools=[tool.name for tool in tools],
+    )

--- a/openhands/app_server/mcp/mcp_validation_router.py
+++ b/openhands/app_server/mcp/mcp_validation_router.py
@@ -1,0 +1,36 @@
+from typing import Any
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from openhands.app_server.mcp.mcp_validation import (
+    MCPServerValidationResult,
+    validate_mcp_server_config,
+)
+from openhands.app_server.utils.dependencies import get_dependencies
+
+router = APIRouter(
+    prefix='/mcp',
+    tags=['MCP'],
+    dependencies=get_dependencies(),
+)
+
+
+class MCPServerValidationRequest(BaseModel):
+    server_name: str = Field(
+        ...,
+        min_length=1,
+        max_length=128,
+        pattern=r'^[A-Za-z0-9_.-]+$',
+    )
+    server_config: dict[str, Any]
+
+
+@router.post('/test', response_model=MCPServerValidationResult)
+async def test_mcp_server(
+    request: MCPServerValidationRequest,
+) -> MCPServerValidationResult:
+    return await validate_mcp_server_config(
+        request.server_name,
+        request.server_config,
+    )

--- a/openhands/app_server/v1_router.py
+++ b/openhands/app_server/v1_router.py
@@ -7,6 +7,7 @@ from openhands.app_server.event_callback import (
     webhook_router,
 )
 from openhands.app_server.git.git_router import router as git_router
+from openhands.app_server.mcp.mcp_validation_router import router as mcp_router
 from openhands.app_server.pending_messages.pending_message_router import (
     router as pending_message_router,
 )
@@ -35,3 +36,4 @@ router.include_router(webhook_router.router)
 router.include_router(web_client_router.router)
 router.include_router(git_router)
 router.include_router(config_router)
+router.include_router(mcp_router)

--- a/tests/unit/app_server/test_mcp_validation_router.py
+++ b/tests/unit/app_server/test_mcp_validation_router.py
@@ -1,0 +1,129 @@
+from types import SimpleNamespace
+
+import httpx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from openhands.app_server.mcp.mcp_validation_router import router
+
+
+class _FakeMCPClient:
+    captured_config = None
+
+    def __init__(self, config, **kwargs):
+        self.__class__.captured_config = config
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return None
+
+    async def list_tools(self):
+        return [
+            SimpleNamespace(name='search_docs'),
+            SimpleNamespace(name='open_file'),
+        ]
+
+
+class _FailingMCPClient(_FakeMCPClient):
+    async def list_tools(self):
+        raise httpx.ConnectError('connection refused with token SECRET_TOKEN')
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router, prefix='/api/v1')
+    return TestClient(app)
+
+
+def test_mcp_validation_endpoint_returns_available_tool_names(monkeypatch):
+    monkeypatch.setattr(
+        'openhands.app_server.mcp.mcp_validation.Client',
+        _FakeMCPClient,
+    )
+
+    response = _client().post(
+        '/api/v1/mcp/test',
+        json={
+            'server_name': 'docs',
+            'server_config': {'url': 'http://mcp.example.com/mcp'},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        'ok': True,
+        'error_kind': None,
+        'message': 'MCP server is reachable.',
+        'tools': ['search_docs', 'open_file'],
+    }
+    assert 'docs' in _FakeMCPClient.captured_config.mcpServers
+
+
+def test_mcp_validation_endpoint_rejects_invalid_config_without_echoing_secrets():
+    response = _client().post(
+        '/api/v1/mcp/test',
+        json={
+            'server_name': 'broken',
+            'server_config': {
+                'headers': {'Authorization': 'Bearer SECRET_TOKEN'},
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {
+        'ok': False,
+        'error_kind': 'invalid_config',
+        'message': 'MCP server config is invalid.',
+        'tools': [],
+    }
+    assert 'SECRET_TOKEN' not in response.text
+
+
+def test_mcp_validation_endpoint_returns_safe_connection_error(monkeypatch):
+    monkeypatch.setattr(
+        'openhands.app_server.mcp.mcp_validation.Client',
+        _FailingMCPClient,
+    )
+
+    response = _client().post(
+        '/api/v1/mcp/test',
+        json={
+            'server_name': 'offline',
+            'server_config': {'url': 'http://localhost:9/mcp'},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        'ok': False,
+        'error_kind': 'connection',
+        'message': 'Could not connect to the MCP server.',
+        'tools': [],
+    }
+    assert 'SECRET_TOKEN' not in response.text
+
+
+def test_v1_router_exposes_mcp_validation_endpoint(monkeypatch):
+    from openhands.app_server import v1_router
+
+    monkeypatch.setattr(
+        'openhands.app_server.mcp.mcp_validation.Client',
+        _FakeMCPClient,
+    )
+    app = FastAPI()
+    app.include_router(v1_router.router)
+
+    response = TestClient(app).post(
+        '/api/v1/mcp/test',
+        json={
+            'server_name': 'docs',
+            'server_config': {'url': 'http://mcp.example.com/mcp'},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()['ok'] is True


### PR DESCRIPTION
HUMAN:
This adds a backend MCP server validation endpoint so users can test a configured MCP server before relying on it in the app. I reviewed the implementation scope and local test evidence; it returns safe success/error details without exposing secrets or raw tracebacks.

---
## Summary
- add a V1 `POST /api/v1/mcp/test` endpoint for validating one MCP server config
- validate raw server config through `fastmcp.MCPConfig` and `Client.list_tools()`
- return a safe response contract with `ok`, `error_kind`, `message`, and discovered `tools` without echoing secrets or exception details

## Context
This is a narrow backend-first slice for OpenHands/enterprise#40. It standardizes the app-server validation contract before any settings UI decision about an explicit test button or automatic validation on save/update.

## Tests
- `PYTHONPATH=$PWD OPENHANDS_SUPPRESS_BANNER=1 pytest tests/unit/app_server/test_mcp_validation_router.py tests/unit/app_server/test_settings_api.py -q`
- `pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files openhands/app_server/mcp/mcp_validation.py openhands/app_server/mcp/mcp_validation_router.py openhands/app_server/v1_router.py tests/unit/app_server/test_mcp_validation_router.py`