### PR TITLE
PLTF-2992: show TESTING text on login page for preview-env validation, do not merge

### DIFF
--- a/frontend/src/components/features/auth/login-content.tsx
+++ b/frontend/src/components/features/auth/login-content.tsx
@@ -204,7 +204,7 @@ export function LoginContent({
         </div>
 
         <h1 className="text-[39px] leading-5 font-medium text-white text-center">
-          {t(I18nKey.AUTH$LETS_GET_STARTED)}
+          TESTING
         </h1>
 
         {shouldShownHelperText && (


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

Follow-up to #15090: the yellow app background was hard to notice once the app loaded, so this validates the preview environment with a more obvious signal instead. The login page heading is replaced with the literal text "TESTING". Not intended to merge — will be closed after validation.

## Summary

- Replace the login page heading ("Let's get started") with hardcoded "TESTING" text in `login-content.tsx`.

## Issue Number

PLTF-2992

## How to Test

Open the preview environment for this PR and load the login page; the heading should read "TESTING".

## Video/Screenshots

N/A — validated by viewing the preview environment login page.

## Type

- [x] Docs / chore

## Notes

Do not merge. This PR exists only to validate the preview environment and will be closed afterwards.

_This was created by an AI assistant._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-de29c7e   docker.openhands.dev/openhands/openhands:de29c7e
```