### PR TITLE
fix(llm): normalize Workers AI model ids

### DIFF
--- a/enterprise/server/routes/org_models.py
+++ b/enterprise/server/routes/org_models.py
@@ -22,7 +22,11 @@ from openhands.app_server.settings.settings_models import (
     _load_persisted_conversation_settings,
     validate_and_convert_marketplaces,
 )
-from openhands.app_server.utils.llm import MASKED_API_KEY, resolve_llm_base_url
+from openhands.app_server.utils.llm import (
+    MASKED_API_KEY,
+    normalize_litellm_model,
+    resolve_llm_base_url,
+)
 from openhands.sdk.settings import (
     AgentSettingsConfig,
     ConversationSettings,
@@ -72,8 +76,7 @@ class OrgAuthorizationError(OrgDeletionError):
 
 
 class OrphanedUserError(OrgDeletionError):
-    """Raised when deleting an org would leave OTHER users (not the requester)
-    without any organization.
+    """Raised when deleting an org would leave other users organizationless.
 
     A user is "orphaned" when their only ``org_member`` row is for the org being
     deleted. The deletion path tolerates *the requester themselves* being orphaned
@@ -301,6 +304,8 @@ class OrgUpdate(BaseModel):
         if llm_diff is None:
             return
 
+        if model := llm_diff.get('model'):
+            llm_diff['model'] = normalize_litellm_model(model) or model
         self._lift_and_mask_llm_api_key(llm_diff)
         self._resolve_agent_llm_base_url(llm_diff)
 

--- a/enterprise/tests/unit/server/routes/test_org_models.py
+++ b/enterprise/tests/unit/server/routes/test_org_models.py
@@ -16,8 +16,23 @@ from unittest.mock import MagicMock, PropertyMock
 from uuid import uuid4
 
 from server.auth.authorization import RoleName
-from server.routes.org_models import MeResponse
+from server.routes.org_models import MeResponse, OrgUpdate
 from storage.org_member import OrgMember
+
+
+class TestOrgUpdate:
+    """Tests for org settings update normalization."""
+
+    def test_normalizes_bare_workers_ai_model_in_agent_settings_diff(self):
+        update = OrgUpdate(
+            agent_settings_diff={
+                'llm': {'model': '@cf/meta/llama-3.2-3b-instruct'},
+            }
+        )
+
+        assert update.agent_settings_diff == {
+            'llm': {'model': 'cloudflare/@cf/meta/llama-3.2-3b-instruct'}
+        }
 
 
 class TestMeResponseFromOrgMember:

--- a/openhands/app_server/settings/llm_profiles.py
+++ b/openhands/app_server/settings/llm_profiles.py
@@ -14,7 +14,7 @@ from pydantic import (
     model_validator,
 )
 
-from openhands.app_server.utils.llm import resolve_llm_base_url
+from openhands.app_server.utils.llm import normalize_litellm_model, resolve_llm_base_url
 from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.sdk.llm import LLM
 
@@ -48,10 +48,12 @@ def resolve_profile_llm(
     without the fallback the agent server would call the LiteLLM proxy with no
     credentials; BYOR profiles keep their own key (the fallback is skipped).
     """
+    model = normalize_litellm_model(profile_llm.model) or profile_llm.model
     resolved = profile_llm.model_copy(
         update={
+            'model': model,
             'base_url': resolve_llm_base_url(
-                model=profile_llm.model,
+                model=model,
                 base_url=profile_llm.base_url,
                 managed_proxy_url=managed_proxy_url,
             ),

--- a/openhands/app_server/settings/settings_router.py
+++ b/openhands/app_server/settings/settings_router.py
@@ -47,6 +47,7 @@ from openhands.app_server.utils.dependencies import get_dependencies
 from openhands.app_server.utils.llm import (
     get_provider_api_base,
     is_openhands_model,
+    normalize_litellm_model,
     resolve_llm_base_url,
 )
 from openhands.app_server.utils.logger import openhands_logger as logger
@@ -109,6 +110,9 @@ def _post_merge_llm_fixups(settings: Settings) -> None:
     if not isinstance(settings.agent_settings, OpenHandsAgentSettings):
         return
     llm = settings.agent_settings.llm
+    model = normalize_litellm_model(llm.model)
+    if model is not None:
+        llm.model = model
     llm.base_url = resolve_llm_base_url(
         model=llm.model,
         base_url=llm.base_url,

--- a/openhands/app_server/utils/llm.py
+++ b/openhands/app_server/utils/llm.py
@@ -114,6 +114,26 @@ def is_openhands_model(model: str | None) -> bool:
 # intentionally hidden."
 MASKED_API_KEY = '**********'
 
+_WORKERS_AI_SCOPED_MODEL_PREFIXES = ('@cf/', '@hf/')
+_CLOUDFLARE_PROVIDER_PREFIX = 'cloudflare/'
+
+
+def normalize_litellm_model(model: str | None) -> str | None:
+    """Normalize user-facing model ids into the LiteLLM routing shape.
+
+    Cloudflare Workers AI documents scoped model ids like
+    ``@hf/thebloke/codellama-7b-instruct-awq``. LiteLLM needs the provider
+    prefix (``cloudflare/@hf/...``); without it the id falls through to the
+    OpenAI route and Cloudflare keys are rejected as OpenAI keys.
+    """
+    if not model:
+        return model
+    if model.startswith(_CLOUDFLARE_PROVIDER_PREFIX):
+        return model
+    if model.startswith(_WORKERS_AI_SCOPED_MODEL_PREFIXES):
+        return f'{_CLOUDFLARE_PROVIDER_PREFIX}{model}'
+    return model
+
 
 def resolve_llm_base_url(
     model: str | None,
@@ -148,6 +168,7 @@ def resolve_llm_base_url(
         return None
     if base_url is not None:
         return base_url
+    model = normalize_litellm_model(model)
     if not model:
         return None
     if is_openhands_model(model):
@@ -225,11 +246,16 @@ def _assign_provider(model: str) -> str:
     """Prefix a bare model name with its canonical provider.
 
     Models that already contain a ``/`` provider separator are returned
-    unchanged. Bare names are first checked against the SDK's verified
-    sets (cheap, no network), then fall back to LiteLLM's own routing
+    unchanged unless they are Cloudflare Workers AI scoped ids (``@cf/...`` or
+    ``@hf/...``), which look provider-qualified but still need the LiteLLM
+    ``cloudflare/`` prefix. Bare names are first checked against the SDK's
+    verified sets (cheap, no network), then fall back to LiteLLM's own routing
     tables so that unverified names like ``claude-opus-4-7`` or
     ``gemini-2.0-flash`` still reach the provider-keyed dropdown.
     """
+    normalized = normalize_litellm_model(model)
+    if normalized is not None and normalized != model:
+        return normalized
     if '/' in model:
         return model
 

--- a/tests/unit/app_server/test_settings_api.py
+++ b/tests/unit/app_server/test_settings_api.py
@@ -260,6 +260,28 @@ async def test_saving_settings_with_frozen_secrets_store(test_client):
 
 
 @pytest.mark.asyncio
+async def test_store_settings_normalizes_bare_workers_ai_models(test_client):
+    response = test_client.post(
+        '/api/v1/settings',
+        json=_dump_update(
+            Settings(
+                agent_settings=OpenHandsAgentSettings(
+                    llm=LLM(model='@hf/thebloke/codellama-7b-instruct-awq')
+                ),
+            )
+        ),
+    )
+
+    assert response.status_code == 200
+    response = test_client.get('/api/v1/settings')
+    assert response.status_code == 200
+    assert (
+        response.json()['agent_settings']['llm']['model']
+        == 'cloudflare/@hf/thebloke/codellama-7b-instruct-awq'
+    )
+
+
+@pytest.mark.asyncio
 async def test_search_api_key_explicit_clear(test_client):
     """Explicit empty search_api_key payloads should clear the stored secret."""
     response = test_client.post(

--- a/tests/unit/storage/data_models/test_llm_profiles.py
+++ b/tests/unit/storage/data_models/test_llm_profiles.py
@@ -14,6 +14,7 @@ from openhands.app_server.settings.llm_profiles import (
     ProfileLimitExceededError,
     ProfileNotFoundError,
     StrictLLM,
+    resolve_profile_llm,
 )
 from openhands.sdk.llm import LLM
 
@@ -105,6 +106,15 @@ def test_summaries_resolves_base_url_with_managed_proxy_url():
 
     # Without the proxy url, base_url is returned raw (None for the managed one).
     assert {s['name']: s['base_url'] for s in profiles.summaries()}['managed'] is None
+
+
+def test_resolve_profile_llm_normalizes_bare_workers_ai_models():
+    resolved = resolve_profile_llm(
+        LLM(model='@cf/meta/llama-3.2-3b-instruct'),
+        managed_proxy_url='https://proxy.test',
+    )
+
+    assert resolved.model == 'cloudflare/@cf/meta/llama-3.2-3b-instruct'
 
 
 # ── Mutations ─────────────────────────────────────────────────────

--- a/tests/unit/utils/test_llm_utils.py
+++ b/tests/unit/utils/test_llm_utils.py
@@ -109,6 +109,37 @@ class TestAssignProvider:
         assert _assign_provider('whatever') == 'whatever'
 
 
+class TestNormalizeLitellmModel:
+    """Tests for model ids that need provider-prefix normalization."""
+
+    def test_bare_workers_ai_scoped_models_get_cloudflare_prefix(self):
+        """Workers AI @hf/@cf model ids need the LiteLLM cloudflare prefix."""
+        assert (
+            llm_utils.normalize_litellm_model('@hf/thebloke/codellama-7b-instruct-awq')
+            == 'cloudflare/@hf/thebloke/codellama-7b-instruct-awq'
+        )
+        assert (
+            llm_utils.normalize_litellm_model('@cf/meta/llama-3.2-3b-instruct')
+            == 'cloudflare/@cf/meta/llama-3.2-3b-instruct'
+        )
+
+    def test_prefixed_and_non_workers_models_are_left_unchanged(self):
+        assert (
+            llm_utils.normalize_litellm_model(
+                'cloudflare/@hf/thebloke/codellama-7b-instruct-awq'
+            )
+            == 'cloudflare/@hf/thebloke/codellama-7b-instruct-awq'
+        )
+        assert (
+            llm_utils.normalize_litellm_model(
+                'huggingface/meta-llama/Llama-3.1-8B-Instruct'
+            )
+            == 'huggingface/meta-llama/Llama-3.1-8B-Instruct'
+        )
+        assert llm_utils.normalize_litellm_model('openai/gpt-4o') == 'openai/gpt-4o'
+        assert llm_utils.normalize_litellm_model(None) is None
+
+
 class TestDeriveVerifiedModels:
     """Tests for the _derive_verified_models helper."""
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

Workers AI model ids such as `@hf/thebloke/codellama-7b-instruct-awq` include a slash but no LiteLLM provider prefix. OpenHands currently preserves that id unchanged, so LiteLLM routes it through the wrong provider and rejects Cloudflare credentials as OpenAI credentials. Fixes OpenHands/software-agent-sdk#4250.

## Summary

- Add a shared LLM model normalizer for Cloudflare Workers AI scoped ids (`@cf/...`, `@hf/...`) so they persist as `cloudflare/@cf/...` / `cloudflare/@hf/...`.
- Apply the normalizer before base URL resolution in personal settings, saved profile activation, model-list provider assignment, and enterprise org settings diffs.
- Add regression coverage for the utility, settings API round-trip, profile activation resolution, and org settings normalization.

## Issue Number

Fixes OpenHands/software-agent-sdk#4250

## How to Test

- `poetry run pytest tests/unit/utils/test_llm_utils.py tests/unit/app_server/test_settings_api.py tests/unit/storage/data_models/test_llm_profiles.py -q`
- `PYTHONPATH=".:$PYTHONPATH" poetry run --project=enterprise pytest enterprise/tests/unit/server/routes/test_org_models.py -q`
- `poetry run ruff check openhands/app_server/utils/llm.py openhands/app_server/settings/settings_router.py openhands/app_server/settings/llm_profiles.py tests/unit/utils/test_llm_utils.py tests/unit/app_server/test_settings_api.py tests/unit/storage/data_models/test_llm_profiles.py enterprise/server/routes/org_models.py enterprise/tests/unit/server/routes/test_org_models.py`
- `poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml`
- `PYTHONPATH=".:$PYTHONPATH" poetry run --project=enterprise pre-commit run --config enterprise/dev_config/python/.pre-commit-config.yaml --files enterprise/server/routes/org_models.py enterprise/tests/unit/server/routes/test_org_models.py --show-diff-on-failure`

Second-agent review: `claude -p` reviewed `/tmp/oss-pr-second-agent-review.diff` and returned `CLEAN — no blocking findings`.

API/user-visible evidence: the settings API regression posts `@hf/thebloke/codellama-7b-instruct-awq` to `/api/v1/settings`, reads it back, and asserts it is stored as `cloudflare/@hf/thebloke/codellama-7b-instruct-awq`. No browser screenshot is included because this is backend settings/model-routing behavior with no UI layout change.

## Video/Screenshots

N/A. Backend settings/model-routing fix; covered by API round-trip and unit tests above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This does not bypass the existing context-window minimum. It only fixes provider routing so Workers AI credentials are sent to Cloudflare instead of the OpenAI route; models with too-small context windows can still be rejected by the existing guard.
