### PR TITLE
fix(frontend): stop streamed deltas rendering twice and fragmenting in V1 chat

### DIFF
--- a/frontend/__tests__/utils/handle-event-for-ui.test.ts
+++ b/frontend/__tests__/utils/handle-event-for-ui.test.ts
@@ -489,6 +489,30 @@ describe("handleEventForUI - durable events supersede streaming deltas", () => {
     expect(ui).toEqual([userMessage, action]);
   });
 
+  it("keeps a reasoning-only bubble when the superseding action lacks reasoning", () => {
+    // For many models the delta is the sole carrier of reasoning_content, so
+    // stripping the streamed text must not lose the reasoning display.
+    let ui: OpenHandsEvent[] = [userMessage];
+    ui = handleEventForUI(
+      mkDelta(
+        "sup-d5",
+        "2026-07-03T00:00:01.000Z",
+        "I'll run a command",
+        "considering the request",
+      ),
+      ui,
+    );
+    const action = mkAction("2026-07-03T00:00:02.000Z", "I'll run a command");
+    ui = handleEventForUI(action, ui);
+
+    expect(ui).toHaveLength(3);
+    const kept = ui[1] as StreamingDeltaEvent;
+    expect(isStreamingDeltaEvent(kept)).toBe(true);
+    expect(kept.content).toBeNull();
+    expect(kept.reasoning_content).toBe("considering the request");
+    expect(ui[2]).toBe(action);
+  });
+
   it("replaces non-reconciling preview deltas with the final message instead of duplicating", () => {
     // In a multi-step turn the deltas accumulated since the last user message
     // include earlier steps' text, so the final summary never reconciles

--- a/frontend/__tests__/utils/handle-event-for-ui.test.ts
+++ b/frontend/__tests__/utils/handle-event-for-ui.test.ts
@@ -385,3 +385,126 @@ describe("handleEventForUI - streaming deltas", () => {
     expect(isStreamingDeltaEvent(ui[1])).toBe(false);
   });
 });
+
+describe("handleEventForUI - durable events supersede streaming deltas", () => {
+  const userMessage: MessageEvent = {
+    id: "sup-user-1",
+    timestamp: "2026-07-03T00:00:00.000Z",
+    source: "user",
+    llm_message: { role: "user", content: [{ type: "text", text: "go" }] },
+    activated_microagents: [],
+    extended_content: [],
+  };
+
+  const mkDelta = (
+    id: string,
+    timestamp: string,
+    content: string | null,
+    reasoning_content: string | null = null,
+  ): StreamingDeltaEvent => ({
+    id,
+    timestamp,
+    source: "agent",
+    kind: "StreamingDeltaEvent",
+    content,
+    reasoning_content,
+  });
+
+  const mkAssistant = (timestamp: string, text: string): MessageEvent => ({
+    id: "sup-assistant-1",
+    timestamp,
+    source: "agent",
+    llm_message: { role: "assistant", content: [{ type: "text", text }] },
+    activated_microagents: [],
+    extended_content: [],
+  });
+
+  const mkAction = (timestamp: string, thoughtText: string): ActionEvent => ({
+    id: "sup-action-1",
+    timestamp,
+    source: "agent",
+    thought: [{ type: "text", text: thoughtText }],
+    thinking_blocks: [],
+    action: {
+      kind: "ExecuteBashAction",
+      command: "echo hello",
+      is_input: false,
+      timeout: null,
+      reset: false,
+    },
+    tool_name: "execute_bash",
+    tool_call_id: "sup-call-1",
+    tool_call: {
+      id: "sup-call-1",
+      type: "function",
+      function: {
+        name: "execute_bash",
+        arguments: '{"command": "echo hello"}',
+      },
+    },
+    llm_response_id: "sup-response-1",
+    security_risk: SecurityRisk.UNKNOWN,
+  });
+
+  it("drops a stale delta that arrives after a newer durable event (history replay race)", () => {
+    // On a page reload the WebSocket replay delivers durable events WITHOUT
+    // deltas, while the REST history includes them; the REST deltas can
+    // therefore arrive after the turn's final message is already rendered.
+    // Rendering them would fragment and duplicate the finished message.
+    const final = mkAssistant("2026-07-03T00:00:09.000Z", "Hello, world");
+    let ui: OpenHandsEvent[] = [userMessage];
+    ui = handleEventForUI(final, ui);
+    ui = handleEventForUI(
+      mkDelta("sup-late-1", "2026-07-03T00:00:01.000Z", "Hello"),
+      ui,
+    );
+
+    expect(ui).toEqual([userMessage, final]);
+  });
+
+  it("keeps a live delta that arrives after an earlier durable event", () => {
+    // The next step's narration streams after the previous step's action; it
+    // is newer than every durable event and must still render.
+    const action = mkAction("2026-07-03T00:00:02.000Z", "I'll run a command");
+    let ui: OpenHandsEvent[] = [userMessage, action];
+    const live = mkDelta("sup-live-1", "2026-07-03T00:00:03.000Z", "Next, ");
+    ui = handleEventForUI(live, ui);
+
+    expect(ui).toHaveLength(3);
+    expect(ui[2]).toBe(live);
+  });
+
+  it("removes the turn's preview deltas when a tool-call action arrives", () => {
+    // The action card renders its own thought (the same text that just
+    // streamed), so leaving the preview deltas in place displays every
+    // step's reasoning twice.
+    let ui: OpenHandsEvent[] = [userMessage];
+    ui = handleEventForUI(
+      mkDelta("sup-d1", "2026-07-03T00:00:01.000Z", "I'll run a command"),
+      ui,
+    );
+    const action = mkAction("2026-07-03T00:00:02.000Z", "I'll run a command");
+    ui = handleEventForUI(action, ui);
+
+    expect(ui).toEqual([userMessage, action]);
+  });
+
+  it("replaces non-reconciling preview deltas with the final message instead of duplicating", () => {
+    // In a multi-step turn the deltas accumulated since the last user message
+    // include earlier steps' text, so the final summary never reconciles
+    // against them; previously both the stale bubble and the final message
+    // rendered. The durable final message is canonical.
+    let ui: OpenHandsEvent[] = [userMessage];
+    ui = handleEventForUI(
+      mkDelta("sup-d2", "2026-07-03T00:00:01.000Z", "Fin"),
+      ui,
+    );
+    const final = mkAssistant(
+      "2026-07-03T00:00:09.000Z",
+      "All three commands ran fine.",
+    );
+    ui = handleEventForUI(final, ui);
+
+    expect(ui).toEqual([userMessage, final]);
+  });
+});

--- a/frontend/src/utils/handle-event-for-ui.ts
+++ b/frontend/src/utils/handle-event-for-ui.ts
@@ -43,6 +43,32 @@ const findLastUserMessageIndex = (events: OpenHandsEvent[]): number => {
   return -1;
 };
 
+/**
+ * Newest timestamp among the durable (non-delta, non-metrics) agent/environment
+ * events already rendered. Streaming deltas older than this are stale: their
+ * content is already represented by durable events (the WebSocket history
+ * replay does not include deltas, while the REST history does, so on a reload
+ * the REST deltas can arrive AFTER the turn's final message was rendered).
+ */
+const findNewestDurableTimestamp = (
+  events: OpenHandsEvent[],
+): string | null => {
+  let newest: string | null = null;
+  for (const uiEvent of events) {
+    const isPreviewOrMetrics =
+      isStreamingDeltaEvent(uiEvent) || isConversationStateUpdateEvent(uiEvent);
+    const isDurableSource =
+      uiEvent.source === "agent" || uiEvent.source === "environment";
+    if (!isPreviewOrMetrics && isDurableSource) {
+      const ts = uiEvent.timestamp;
+      if (typeof ts === "string" && (newest === null || ts > newest)) {
+        newest = ts;
+      }
+    }
+  }
+  return newest;
+};
+
 // Join text blocks WITHOUT a separator: streaming deltas concatenate content
 // tokens directly with no separator between LLM content blocks, so using "\n"
 // here would cause startsWith/findTextSegmentsInOrder to miss when reconciling
@@ -144,7 +170,15 @@ const finalizeStreamingDeltasInPlace = (
   } else {
     const match = findTextSegmentsInOrder(finalText, streamingSegments);
     if (!match.matched) {
-      return null;
+      // The streamed preview never reconciles (e.g. it contains earlier
+      // steps' text, or chunks were reordered in delivery). The durable final
+      // message is canonical: drop the preview deltas and render it once.
+      const removeSet = new Set(
+        contentStreamingDeltas.map(({ index }) => index),
+      );
+      const cleaned = uiEvents.filter((_, index) => !removeSet.has(index));
+      cleaned.push(finalEvent);
+      return cleaned;
     }
     unstreamedSuffix = finalText.slice(match.lastMatchEnd);
   }
@@ -172,13 +206,57 @@ const finalizeStreamingDeltasInPlace = (
 };
 
 /**
+ * A tool-call ``ActionEvent`` carries the agent's ``thought`` - the same text
+ * that was just streamed as deltas. The action card renders that thought
+ * itself, so once the action arrives, the streamed preview deltas for the turn
+ * are redundant: leaving them in place displays every step's reasoning twice.
+ *
+ * When the current turn's content-bearing deltas reconcile (in order) against
+ * the action's thought text, return uiEvents with those deltas removed so the
+ * caller can append the action as the single rendered copy. Returns ``null``
+ * (no change) when there is nothing to reconcile or the text doesn't match.
+ */
+const supersedeStreamingDeltasForAction = (
+  actionEvent: OpenHandsEvent,
+  uiEvents: OpenHandsEvent[],
+): OpenHandsEvent[] | null => {
+  if (!isActionEvent(actionEvent)) {
+    return null;
+  }
+  const lastUserMessageIndex = findLastUserMessageIndex(uiEvents);
+  const currentTurnDeltaIndexes = uiEvents
+    .map((uiEvent, index) => ({ uiEvent, index }))
+    .filter(
+      ({ uiEvent, index }) =>
+        index > lastUserMessageIndex && isStreamingDeltaEvent(uiEvent),
+    )
+    .map(({ index }) => index);
+
+  if (currentTurnDeltaIndexes.length === 0) {
+    return null;
+  }
+
+  // The action renders its own thought (and reasoning); any streamed preview
+  // deltas for this turn are redundant once the durable action arrives -
+  // remove them all (including reasoning-only deltas, whose reasoning the
+  // action also carries). Text-matching is deliberately NOT required: chunk
+  // reordering between the delta stream and event persistence would otherwise
+  // leak stray preview bubbles that later merge with the next stream.
+  const removeSet = new Set(currentTurnDeltaIndexes);
+  return uiEvents.filter((_, index) => !removeSet.has(index));
+};
+
+/**
  * Handles adding an event to the UI events array
  * Replaces actions with observations when they arrive (so UI shows observation instead of action)
  * Exception: ThinkAction is NOT replaced because the thought content is in the action, not in the observation
  *
  * StreamingDeltaEvent: consecutive deltas merge in place into a single growing
  * bubble; when the turn's final agent message arrives it is reconciled into that
- * bubble (see `finalizeStreamingDeltasInPlace`) rather than appended.
+ * bubble (see `finalizeStreamingDeltasInPlace`) rather than appended, and a
+ * tool-call action removes the deltas that streamed its thought (see
+ * `supersedeStreamingDeltasForAction`). Deltas that arrive out of order (older
+ * than an already-rendered durable event) are dropped as stale.
  *
  * ACPToolCallEvent dedup: multiple events share a ``tool_call_id`` as an ACP
  * tool call progresses (in_progress → completed / failed). Collapse them to
@@ -193,6 +271,20 @@ export const handleEventForUI = (
   if (isStreamingDeltaEvent(event)) {
     // Drop empty boundary deltas (e.g. after a tool call) that carry no text.
     if (event.content === null && event.reasoning_content === null) {
+      return newUiEvents;
+    }
+
+    // Drop stale deltas. Deltas are a live-preview mechanism; one that is
+    // older than the newest durable event arrived late (e.g. the REST history
+    // response racing the WebSocket replay, which omits deltas). Its content
+    // is already represented by durable events, so rendering it would fragment
+    // and duplicate the finished message.
+    const newestDurableTimestamp = findNewestDurableTimestamp(newUiEvents);
+    if (
+      newestDurableTimestamp !== null &&
+      typeof event.timestamp === "string" &&
+      event.timestamp < newestDurableTimestamp
+    ) {
       return newUiEvents;
     }
 
@@ -240,6 +332,16 @@ export const handleEventForUI = (
     );
     if (finalizedUiEvents) {
       return finalizedUiEvents;
+    }
+  }
+
+  // A tool-call action renders its own thought; remove the preview deltas that
+  // streamed it, then fall through so the action is appended normally below.
+  if (isActionEvent(event) && event.action.kind !== "FinishAction") {
+    const superseded = supersedeStreamingDeltasForAction(event, newUiEvents);
+    if (superseded) {
+      superseded.push(event);
+      return superseded;
     }
   }
 

--- a/frontend/src/utils/handle-event-for-ui.ts
+++ b/frontend/src/utils/handle-event-for-ui.ts
@@ -163,25 +163,38 @@ const finalizeStreamingDeltasInPlace = (
 
   const nextUiEvents = [...uiEvents];
   const streamedText = streamingSegments.join("");
-  let unstreamedSuffix = "";
+  let matched = false;
+  let lastMatchEnd = 0;
 
-  if (finalText.startsWith(streamedText)) {
-    unstreamedSuffix = finalText.slice(streamedText.length);
-  } else {
-    const match = findTextSegmentsInOrder(finalText, streamingSegments);
-    if (!match.matched) {
-      // The streamed preview never reconciles (e.g. it contains earlier
-      // steps' text, or chunks were reordered in delivery). The durable final
-      // message is canonical: drop the preview deltas and render it once.
-      const removeSet = new Set(
-        contentStreamingDeltas.map(({ index }) => index),
-      );
-      const cleaned = uiEvents.filter((_, index) => !removeSet.has(index));
-      cleaned.push(finalEvent);
-      return cleaned;
+  // The SDK strips the finalized text, so it may lack trailing whitespace the
+  // model streamed - tolerate that by also trying the trailing-trimmed
+  // streamed text (mirrors agent-canvas #1552).
+  for (const candidate of [streamedText, streamedText.trimEnd()]) {
+    if (candidate && finalText.startsWith(candidate)) {
+      matched = true;
+      lastMatchEnd = candidate.length;
+      break;
     }
-    unstreamedSuffix = finalText.slice(match.lastMatchEnd);
   }
+  if (!matched) {
+    const lastIndex = streamingSegments.length - 1;
+    const searchSegments = streamingSegments.map((segment, index) =>
+      index === lastIndex ? segment.trimEnd() : segment,
+    );
+    const match = findTextSegmentsInOrder(finalText, searchSegments);
+    matched = match.matched;
+    lastMatchEnd = match.lastMatchEnd;
+  }
+  if (!matched) {
+    // The streamed preview never reconciles (e.g. it contains earlier
+    // steps' text, or chunks were reordered in delivery). The durable final
+    // message is canonical: drop the preview deltas and render it once.
+    const removeSet = new Set(contentStreamingDeltas.map(({ index }) => index));
+    const cleaned = uiEvents.filter((_, index) => !removeSet.has(index));
+    cleaned.push(finalEvent);
+    return cleaned;
+  }
+  const unstreamedSuffix = finalText.slice(lastMatchEnd);
 
   const lastDeltaIndex = contentStreamingDeltas.at(-1)?.index;
   const lastDelta =
@@ -236,14 +249,29 @@ const supersedeStreamingDeltasForAction = (
     return null;
   }
 
-  // The action renders its own thought (and reasoning); any streamed preview
-  // deltas for this turn are redundant once the durable action arrives -
-  // remove them all (including reasoning-only deltas, whose reasoning the
-  // action also carries). Text-matching is deliberately NOT required: chunk
-  // reordering between the delta stream and event persistence would otherwise
-  // leak stray preview bubbles that later merge with the next stream.
-  const removeSet = new Set(currentTurnDeltaIndexes);
-  return uiEvents.filter((_, index) => !removeSet.has(index));
+  // The action renders its own thought, so the streamed preview text is
+  // redundant once the durable action arrives. Text-matching is deliberately
+  // NOT required: chunk reordering between the delta stream and event
+  // persistence would otherwise leak stray preview bubbles that later merge
+  // with the next stream. For many models the delta is the sole carrier of
+  // reasoning_content, though - when the action does not render reasoning of
+  // its own, keep the delta as a reasoning-only bubble (content cleared)
+  // instead of dropping it (mirrors agent-canvas #1552).
+  const actionRendersReasoning =
+    Boolean(actionEvent.reasoning_content?.trim()) ||
+    (actionEvent.thinking_blocks?.length ?? 0) > 0;
+  const stripSet = new Set(currentTurnDeltaIndexes);
+  const nextUiEvents: OpenHandsEvent[] = [];
+  uiEvents.forEach((uiEvent, index) => {
+    if (!stripSet.has(index) || !isStreamingDeltaEvent(uiEvent)) {
+      nextUiEvents.push(uiEvent);
+      return;
+    }
+    if (!actionRendersReasoning && uiEvent.reasoning_content) {
+      nextUiEvents.push({ ...uiEvent, content: null });
+    }
+  });
+  return nextUiEvents;
 };
 
 /**


### PR DESCRIPTION
HUMAN:

Hit this on our self-hosted fleet after #15021 landed: every streamed response renders twice (live preview bubbles plus the durable event with the same text), and reloading a conversation fragments each response into one bubble per delta. Fix validated end to end on a self-hosted box, live and on reload, single and multi-step runs.

- [x] A human has tested these changes.

AGENT:

---

## Why

Since #15021, V1 chat displays streamed content twice and fragments it on reload. Two causes in `handleEventForUI`:

1. On reload, the WebSocket replay delivers durable events without `StreamingDeltaEvent`s while the REST history includes them, so the REST deltas land after the turn's final message is already rendered. The backward merge stops at the rendered message, so every delta becomes its own bubble and the final message stays as a duplicate.
2. Live, a tool call `ActionEvent` carries the same `thought` text that just streamed, and `finalizeStreamingDeltasInPlace` only reconciles `FinishAction` and assistant `MessageEvent`s, never `ActionEvent`s, so every step's reasoning displays twice for the whole run.

## Summary

- Drop a delta that is older than the newest durable event (stale replay arrival).
- When a tool call action arrives, remove the turn's preview deltas; the action card renders its own thought.
- When the turn's final message does not reconcile against the accumulated deltas (multi-step turns), replace them with the final message instead of appending a duplicate.

Existing merge/fold behaviour is unchanged; all 18 pre-existing tests in `handle-event-for-ui.test.ts` still pass, plus 4 new ones covering the above.

## Issue Number

No issue filed; regression introduced by #15021.

## How to Test

1. Run any multi-step conversation (e.g. "run these three commands one at a time, narrating each") and watch it live: each narration should render once, not once as a streamed bubble and again on the action card.
2. Reload the conversation page mid-run or after completion: the response should stay one bubble per message rather than fragmenting into one bubble per streamed chunk with a duplicated final message.
3. `cd frontend && npx vitest run __tests__/utils/handle-event-for-ui.test.ts` (22 tests).
