### PR TITLE
fix(app-server): deduplicate repositories by full_name in ProviderHandler

### DIFF
--- a/openhands/app_server/integrations/provider.py
+++ b/openhands/app_server/integrations/provider.py
@@ -399,7 +399,7 @@ class ProviderHandler:
         unique_repos = []
         for repo in repos:
             if repo.full_name not in seen:
-                seen.add(repo.id)
+                seen.add(repo.full_name)
                 unique_repos.append(repo)
         return unique_repos
 

--- a/tests/unit/integrations/test_provider_dedup.py
+++ b/tests/unit/integrations/test_provider_dedup.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from types import MappingProxyType
+
+from pydantic import SecretStr
+
+from openhands.app_server.integrations.provider import (
+    ProviderHandler,
+    ProviderToken,
+    ProviderType,
+    Repository,
+)
+
+
+def _repo(repo_id: str, full_name: str) -> Repository:
+    return Repository(
+        id=repo_id,
+        full_name=full_name,
+        git_provider=ProviderType.GITHUB,
+        is_public=True,
+    )
+
+
+def _handler() -> ProviderHandler:
+    tokens = MappingProxyType(
+        {ProviderType.GITHUB: ProviderToken(token=SecretStr('test'))}
+    )
+    return ProviderHandler(provider_tokens=tokens)
+
+
+def test_deduplicate_repositories_removes_duplicate_full_names():
+    """Repos sharing a full_name collapse to the first occurrence."""
+    handler = _handler()
+    repos = [
+        _repo('1', 'owner/repo'),
+        _repo('2', 'owner/repo'),  # duplicate full_name, distinct id
+        _repo('3', 'owner/other'),
+    ]
+
+    result = handler._deduplicate_repositories(repos)
+
+    assert [r.full_name for r in result] == ['owner/repo', 'owner/other']
+    assert [r.id for r in result] == ['1', '3']  # first occurrence wins
+
+
+def test_deduplicate_repositories_keeps_distinct_full_names():
+    """Distinct full_names are all preserved, order intact."""
+    handler = _handler()
+    repos = [_repo('1', 'a/one'), _repo('2', 'b/two'), _repo('3', 'c/three')]
+
+    result = handler._deduplicate_repositories(repos)
+
+    assert [r.full_name for r in result] == ['a/one', 'b/two', 'c/three']


### PR DESCRIPTION
HUMAN:
While I look through the git provider integration code I noticed the repository dedup helper wasn't actually removing duplicates. it checks `full_name` but adds `id` to the seen set, so it never matches. I fix the one line and added a unit test that fails on the old code and passes on the fix. I also ran the integration tests locally, all green.
- [x] A human has tested these changes.

## What & why

`ProviderHandler._deduplicate_repositories` is documented as *"Remove duplicate repositories based on `full_name`"*, but it never removed anything. The loop tested membership with `repo.full_name not in seen` while populating the `seen` set with `repo.id`:

```python
if repo.full_name not in seen:
    seen.add(repo.id)          # bug: adds id, but membership is tested by full_name
    unique_repos.append(repo)
```

Since `Repository.id` and `Repository.full_name` are distinct string fields, a `full_name` never matches an `id` in the set, so the guard could never fire and duplicate repositories were returned unchanged. This is reachable from `search_repositories` when a provider is selected, so duplicate repos could surface in repository search results.

## Fix

One line populate `seen` with `full_name` so it matches the membership test:

```python
seen.add(repo.full_name)
```

## Tests

Adds `tests/unit/integrations/test_provider_dedup.py`:

- `test_deduplicate_repositories_removes_duplicate_full_names` — fails before this fix, passes after.
- `test_deduplicate_repositories_keeps_distinct_full_names` — guards against over-deduping / reordering.

Verified locally: both new tests pass, all existing `test_provider_immutability.py` tests still pass, `ruff check` / `ruff format --check` clean.

## Scope note

The multi-provider search branch intentionally does not dedup (the same `full_name` from different providers are genuinely distinct repos), so it is left unchanged.

## Changelog

> Fixed repository search returning duplicate repositories (`ProviderHandler` deduplication was a no-op).