### PR TITLE
fix: crash when request.client is None in InMemoryRateLimiter

### DIFF
--- a/openhands/app_server/middleware.py
+++ b/openhands/app_server/middleware.py
@@ -93,7 +93,7 @@ class InMemoryRateLimiter:
         self.history[key] = [ts for ts in self.history[key] if ts > cutoff]
 
     async def __call__(self, request: Request) -> bool:
-        key = request.client.host
+        key = request.client.host if request.client else 'unknown'
         now = datetime.now()
 
         self._clean_old_requests(key)

--- a/tests/unit/server/test_middleware.py
+++ b/tests/unit/server/test_middleware.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.middleware.cors import CORSMiddleware
+from starlette.requests import Request
 
 from openhands.app_server.middleware import (
     InMemoryRateLimiter,
@@ -190,3 +191,11 @@ def test_rate_limit_middleware_exempts_sandbox_resume():
     assert rate_limited_response.status_code == 429
     assert resume_response.status_code == 200
     assert resume_response.json() == {'sandbox_id': 'sandbox-123'}
+
+
+async def test_in_memory_rate_limiter_client_none():
+    """Test that InMemoryRateLimiter handles a request with client=None."""
+    request = Request({'type': 'http', 'client': None})
+    rate_limiter = InMemoryRateLimiter()
+    result = await rate_limiter(request)
+    assert result is True


### PR DESCRIPTION

HUMAN:

This PR fixes #15118 , a crash in `InMemoryRateLimiter` when `request.client` is `None`. Instead of raising an `AttributeError` and returning a 500 response, it falls back to an `"unknown"` rate-limit key so requests are handled gracefully.

- [x] A human has tested these changes.

AGENT:

---

## Why

`InMemoryRateLimiter` accessed `request.client.host` unconditionally, but `request.client` is optional in Starlette and may be `None` in environments such as ASGI transports, Unix sockets, some proxy setups, or tests. This caused an `AttributeError` and returned a 500 response instead of applying rate limiting.

## Summary

- Handle missing `request.client` in `InMemoryRateLimiter`.
- Use a fallback rate-limit key (`"unknown"`) when client information is unavailable.
- Prevent `AttributeError` and avoid 500 responses for affected requests.


## Issue Number

#15118 

## How to Test

1. Start the application.
2. Send a request where `request.client` is `None` (e.g. using an ASGI transport or a test request without client information).
3. Verify the request no longer fails with `AttributeError`.
4. Verify normal requests continue to be rate limited using the client IP.

I could not fully test the `request.client is None` scenario locally because it requires a request environment where the ASGI scope omits client information. However tests added passed.


## Video/Screenshots

n/a

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Requests without client information will share the `"unknown"` rate-limit bucket instead of causing a 500 error.