### PR TITLE
fix(app-server): list ~/.openhands/skills (V1) user skills in /skills/search

### DIFF
--- a/openhands/app_server/user/skills_router.py
+++ b/openhands/app_server/user/skills_router.py
@@ -28,7 +28,10 @@ user_context_dependency = depends_user_context()
 
 # skills/ is at the repo root, two levels above the openhands package __file__
 GLOBAL_SKILLS_DIR = Path(openhands.__file__).parent.parent / 'skills'
-USER_SKILLS_DIR = Path.home() / '.openhands' / 'microagents'
+# User skills live under ~/.openhands. V1 prefers skills/; microagents/ is the
+# V0 legacy path kept for backward compatibility. V1 wins on name collisions.
+USER_SKILLS_DIR = Path.home() / '.openhands' / 'skills'
+USER_SKILLS_DIR_LEGACY = Path.home() / '.openhands' / 'microagents'
 
 
 class SkillInfo(BaseModel):
@@ -167,9 +170,16 @@ async def search_skills(
     except Exception as e:
         logger.warning(f'Failed to load global skills: {e}')
 
-    # Load user-level skills
+    # Load user-level skills from both the V1 (preferred) and V0 (legacy)
+    # locations, deduplicated by name with the V1 path winning collisions.
     try:
-        skills.extend(_load_skills_from_dir(USER_SKILLS_DIR, 'user'))
+        seen_user_names: set[str] = set()
+        for user_dir in (USER_SKILLS_DIR, USER_SKILLS_DIR_LEGACY):
+            for skill in _load_skills_from_dir(user_dir, 'user'):
+                if skill.name in seen_user_names:
+                    continue
+                seen_user_names.add(skill.name)
+                skills.append(skill)
     except Exception as e:
         logger.warning(f'Failed to load user skills: {e}')
 

--- a/tests/unit/server/routes/test_skills_api.py
+++ b/tests/unit/server/routes/test_skills_api.py
@@ -155,6 +155,77 @@ async def test_skills_search_returns_skills(test_client, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_skills_search_includes_v1_user_skills(test_client, tmp_path):
+    """User skills placed in the V1 ~/.openhands/skills/ path are listed.
+
+    Regression test for the WebUI skills list only scanning the V0
+    ~/.openhands/microagents/ path while the docs and the conversation-skills
+    endpoint treat ~/.openhands/skills/ as the preferred V1 location.
+    """
+    v1_dir = tmp_path / 'skills'
+    _write_skill_file(v1_dir, 'my_v1_skill', skill_type='knowledge')
+
+    with (
+        patch(
+            'openhands.app_server.user.skills_router.GLOBAL_SKILLS_DIR',
+            tmp_path / 'no_global',
+        ),
+        patch('openhands.app_server.user.skills_router.USER_SKILLS_DIR', v1_dir),
+        patch(
+            'openhands.app_server.user.skills_router.USER_SKILLS_DIR_LEGACY',
+            tmp_path / 'no_legacy',
+        ),
+    ):
+        response = test_client.get('/api/v1/skills/search')
+
+    assert response.status_code == 200
+    data = response.json()
+    names = [s['name'] for s in data['items']]
+    assert 'my_v1_skill' in names
+    v1_skill = next(s for s in data['items'] if s['name'] == 'my_v1_skill')
+    assert v1_skill['source'] == 'user'
+
+
+@pytest.mark.asyncio
+async def test_skills_search_merges_user_paths_v1_wins(test_client, tmp_path):
+    """Both user paths are scanned; on a name collision the V1 copy wins."""
+    v1_dir = tmp_path / 'skills'
+    v0_dir = tmp_path / 'microagents'
+
+    _write_skill_file(v1_dir, 'only_v1', skill_type='knowledge')
+    _write_skill_file(v0_dir, 'only_v0', skill_type='knowledge')
+    # Same name in both locations, different metadata, so we can tell them apart.
+    _write_skill_file(v1_dir, 'shared', skill_type='repo')
+    _write_skill_file(v0_dir, 'shared', skill_type='knowledge', triggers=['legacyword'])
+
+    with (
+        patch(
+            'openhands.app_server.user.skills_router.GLOBAL_SKILLS_DIR',
+            tmp_path / 'no_global',
+        ),
+        patch('openhands.app_server.user.skills_router.USER_SKILLS_DIR', v1_dir),
+        patch(
+            'openhands.app_server.user.skills_router.USER_SKILLS_DIR_LEGACY',
+            v0_dir,
+        ),
+    ):
+        response = test_client.get('/api/v1/skills/search')
+
+    assert response.status_code == 200
+    data = response.json()
+    names = [s['name'] for s in data['items']]
+
+    assert 'only_v1' in names
+    assert 'only_v0' in names
+    # Collision is deduplicated to a single entry...
+    assert names.count('shared') == 1
+    # ...and the surviving copy is the V1 one.
+    shared = next(s for s in data['items'] if s['name'] == 'shared')
+    assert shared['type'] == 'repo'
+    assert shared['triggers'] is None
+
+
+@pytest.mark.asyncio
 async def test_skills_search_handles_missing_dirs(test_client, tmp_path):
     """Test that the endpoint handles missing directories gracefully."""
     with (
@@ -165,6 +236,10 @@ async def test_skills_search_handles_missing_dirs(test_client, tmp_path):
         patch(
             'openhands.app_server.user.skills_router.USER_SKILLS_DIR',
             tmp_path / 'also_missing',
+        ),
+        patch(
+            'openhands.app_server.user.skills_router.USER_SKILLS_DIR_LEGACY',
+            tmp_path / 'also_missing_legacy',
         ),
     ):
         response = test_client.get('/api/v1/skills/search')


### PR DESCRIPTION
## What
Make the WebUI skills list (`GET /api/v1/skills/search`) scan user skills from both `~/.openhands/skills/` (V1, preferred) and `~/.openhands/microagents/` (V0, legacy), deduplicating by name with the V1 copy winning on collisions.

## Why
The endpoint scanned only `~/.openhands/microagents/` (V0). But `skills/README.md` documents V1 as supporting **both** `~/.openhands/skills/` (preferred) and `~/.openhands/microagents/` (backward compat), and the sibling conversation-skills endpoint already treats `~/.openhands/skills/` as the user path (`app_conversation_router.py`, "User skills (~/.openhands/skills/)"). So a user who follows the preferred V1 convention gets their skills loaded into conversations but never listed in the WebUI, the two endpoints disagreed on where user skills live.

This addresses the **WebUI-visibility** half of OpenHands/software-agent-sdk#4252. The runtime "host-home-vs-container" visibility half discussed in that thread is separate (and out of scope here), so this is linked as `Refs`, not `Closes`.

## How
- `skills_router.py`: `USER_SKILLS_DIR` now points at the V1 `~/.openhands/skills/`; added `USER_SKILLS_DIR_LEGACY` for the V0 path. `search_skills` loops both (V1 first) and dedups by name, mirroring the existing `_merge_skills` idiom (later/legacy loses on collision). Dedup also protects the name-keyed pagination cursor from duplicate entries.

## Testing
- `test_skills_search_includes_v1_user_skills`: proves V1-path skills now appear (fails on `main`, passes here).
- `test_skills_search_merges_user_paths_v1_wins`: proves both paths scanned, name collision deduped to one entry, V1 copy wins.
- Existing search tests gained a `USER_SKILLS_DIR_LEGACY` patch so they stay deterministic across machines.
- `pytest tests/unit/server/routes/test_skills_api.py` → 12 passed. ruff check + format clean; mypy no new errors.

## HUMAN:
I hit this myself: put a skill in `~/.openhands/skills/` per the README's "preferred" note and it never showed up in the WebUI skills list. Traced it to the endpoint only scanning the old `microagents/` path. Verified locally: the new test fails before the change and passes after, and the full `test_skills_api.py` file is green.

- [x] A human has tested these changes.