### PR TITLE
Feat/encrypt settings at rest

### DIFF
--- a/enterprise/saas_server.py
+++ b/enterprise/saas_server.py
@@ -58,6 +58,7 @@ from server.routes.user_app_settings import user_app_settings_router  # noqa: E4
 from server.routes.user_provisioning import (  # noqa: E402
     user_provisioning_router,
 )
+from server.routes.mcp_oauth import mcp_oauth_router  # noqa: E402
 from server.routes.users_v1 import (  # noqa: E402
     override_users_me_endpoint,
 )
@@ -95,6 +96,7 @@ base_app.include_router(
 )  # Add routes for credit management and Stripe payment integration
 base_app.include_router(shared_conversation_router)
 base_app.include_router(shared_event_router)
+base_app.include_router(mcp_oauth_router)
 
 # Add GitHub integration router only if GITHUB_APP_CLIENT_ID is set
 if GITHUB_APP_CLIENT_ID:

--- a/enterprise/server/routes/mcp_oauth.py
+++ b/enterprise/server/routes/mcp_oauth.py
@@ -1,0 +1,369 @@
+import asyncio
+import logging
+import uuid
+import json
+from typing import Any, Literal
+from urllib.parse import urlparse, parse_qs
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, JSONResponse
+from pydantic import BaseModel, Field
+
+from openhands.app_server.config import depends_user_context
+from openhands.app_server.user.user_context import UserContext
+from openhands.sdk.utils.cipher import Cipher
+from storage.encrypt_utils import get_cipher
+
+from fastmcp import Client
+from fastmcp.client.auth.oauth import OAuth, TokenStorageAdapter
+from fastmcp.client.transports.sse import SSETransport
+from fastmcp.client.transports.http import StreamableHttpTransport
+from mcp.shared.auth import OAuthClientMetadata, OAuthClientInformationFull
+from key_value.aio.stores.memory import MemoryStore
+
+logger = logging.getLogger(__name__)
+
+mcp_oauth_router = APIRouter(prefix='/api/v1/mcp/oauth', tags=['MCP OAuth'])
+user_dependency = depends_user_context()
+
+
+class FlowEntry:
+    def __init__(self):
+        self.init_ready_event = asyncio.Event()
+        self.callback_completed_event = asyncio.Event()
+        self.authorization_url: str | None = None
+        self.code: str | None = None
+        self.state: str | None = None
+        self.error: Exception | None = None
+        self.result: dict | None = None
+
+
+# Global store for active OAuth flows
+FLOWS: dict[str, FlowEntry] = {}
+
+
+class CloudOAuthProvider(OAuth):
+    def __init__(self, redirect_uri: str, flows_dict: dict, flow_entry: FlowEntry, *args, **kwargs):
+        self.cloud_redirect_uri = redirect_uri
+        self.flows_dict = flows_dict
+        self.flow_entry = flow_entry
+        self.state_key = None
+        super().__init__(*args, **kwargs)
+
+    def _bind(self, mcp_url: str) -> None:
+        if self._bound:
+            return
+
+        mcp_url = mcp_url.rstrip("/")
+        redirect_uri = self.cloud_redirect_uri
+
+        scopes_str: str
+        if isinstance(self._scopes, list):
+            scopes_str = " ".join(self._scopes)
+        elif self._scopes is not None:
+            scopes_str = str(self._scopes)
+        else:
+            scopes_str = ""
+
+        from pydantic import AnyHttpUrl
+        client_metadata = OAuthClientMetadata(
+            client_name=self._client_name,
+            redirect_uris=[AnyHttpUrl(redirect_uri)],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            scope=scopes_str,
+            **(self._additional_client_metadata or {}),
+        )
+
+        if self._client_id:
+            metadata = client_metadata.model_dump(exclude_none=True)
+            if "token_endpoint_auth_method" not in metadata:
+                metadata["token_endpoint_auth_method"] = (
+                    "client_secret_post" if self._client_secret else "none"
+                )
+            self._static_client_info = OAuthClientInformationFull(
+                client_id=self._client_id,
+                client_secret=self._client_secret,
+                **metadata,
+            )
+
+        token_storage = self._token_storage or MemoryStore()
+        self.token_storage_adapter = TokenStorageAdapter(
+            async_key_value=token_storage, server_url=mcp_url
+        )
+
+        self.mcp_url = mcp_url
+
+        # Call grandparent OAuthClientProvider.__init__ directly
+        super(OAuth, self).__init__(
+            server_url=mcp_url,
+            client_metadata=client_metadata,
+            storage=self.token_storage_adapter,
+            redirect_handler=self.redirect_handler,
+            callback_handler=self.callback_handler,
+            client_metadata_url=self._client_metadata_url,
+        )
+        self._bound = True
+
+    async def redirect_handler(self, authorization_url: str) -> None:
+        """Capture the authorization url and wait for callback completion."""
+        parsed = urlparse(authorization_url)
+        mcp_state = parse_qs(parsed.query).get("state", [None])[0]
+        if not mcp_state:
+            raise ValueError("No state parameter found in authorization URL")
+
+        self.state_key = mcp_state
+        self.flows_dict[mcp_state] = self.flow_entry
+
+        self.flow_entry.authorization_url = authorization_url
+        self.flow_entry.state = mcp_state
+        self.flow_entry.init_ready_event.set()
+
+        await self.flow_entry.callback_completed_event.wait()
+        if self.flow_entry.error:
+            raise self.flow_entry.error
+
+    async def callback_handler(self) -> tuple[str, str | None]:
+        """Return the captured code and state."""
+        if self.flow_entry and self.flow_entry.code:
+            return self.flow_entry.code, self.flow_entry.state
+        raise RuntimeError("OAuth callback code was not captured")
+
+
+class MCPInitRequest(BaseModel):
+    name: str = Field(..., description="Name of the MCP server")
+    url: str = Field(..., description="URL of the MCP server")
+    type: Literal["sse", "http", "shttp"] = Field("sse", description="Transport type")
+
+
+def encrypt_credentials(result: dict) -> str:
+    cipher = get_cipher()
+    plaintext = json.dumps(result)
+    from pydantic import SecretStr
+    return cipher.encrypt(SecretStr(plaintext))
+
+
+async def run_cloud_oauth_flow(
+    url: str,
+    transport_type: str,
+    redirect_uri: str,
+    flow_entry: FlowEntry
+) -> None:
+    try:
+        transport = (
+            SSETransport(url=url)
+            if transport_type == "sse"
+            else StreamableHttpTransport(url=url)
+        )
+
+        provider = CloudOAuthProvider(
+            redirect_uri=redirect_uri,
+            flows_dict=FLOWS,
+            flow_entry=flow_entry,
+            client_name="OpenHands Client"
+        )
+
+        client = Client(
+            transport=transport,
+            auth=provider,
+            auto_initialize=True
+        )
+
+        async with client:
+            tokens = await provider.token_storage_adapter.get_tokens()
+            client_info = await provider.token_storage_adapter.get_client_info()
+
+            result = {
+                "tokens": {
+                    "access_token": tokens.access_token,
+                    "refresh_token": tokens.refresh_token,
+                    "expires_in": tokens.expires_in,
+                    "token_type": tokens.token_type,
+                    "scope": tokens.scope,
+                } if tokens else None,
+                "client_info": {
+                    "client_id": client_info.client_id,
+                    "client_secret": client_info.client_secret,
+                } if client_info else None,
+            }
+            flow_entry.result = result
+    except Exception as e:
+        logger.exception("MCP OAuth flow failed")
+        flow_entry.error = e
+        flow_entry.init_ready_event.set()
+
+
+@mcp_oauth_router.post('/init')
+async def init_mcp_oauth(
+    request: Request,
+    body: MCPInitRequest,
+    user_context: UserContext = user_dependency,
+) -> JSONResponse:
+    user_id = await user_context.get_user_id()
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not authenticated"
+        )
+
+    # Build SaaS web redirect URL
+    from server.utils.url_utils import get_web_url
+    web_url = get_web_url(request)
+    redirect_uri = f"{web_url}/api/v1/mcp/oauth/callback"
+
+    flow_entry = FlowEntry()
+    asyncio.create_task(
+        run_cloud_oauth_flow(
+            url=body.url,
+            transport_type=body.type,
+            redirect_uri=redirect_uri,
+            flow_entry=flow_entry
+        )
+    )
+
+    # Wait for the flow to start and generate authorization URL
+    try:
+        async with asyncio.timeout(15.0):
+            await flow_entry.init_ready_event.wait()
+    except TimeoutError:
+        raise HTTPException(
+            status_code=status.HTTP_504_TIMEOUT,
+            detail="OAuth flow initialization timed out"
+        )
+
+    if flow_entry.error:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(flow_entry.error)
+        )
+
+    return JSONResponse(
+        content={
+            "state": flow_entry.state,
+            "authorization_url": flow_entry.authorization_url,
+        }
+    )
+
+
+@mcp_oauth_router.get('/callback', response_class=HTMLResponse)
+async def mcp_oauth_callback(
+    code: str = '',
+    state: str = '',
+    error: str = '',
+    error_description: str = '',
+) -> HTMLResponse:
+    if not state:
+        return HTMLResponse(
+            content="<h1>Authentication Failed</h1><p>Missing state parameter.</p>",
+            status_code=400
+        )
+
+    entry = FLOWS.get(state)
+    if not entry:
+        return HTMLResponse(
+            content="<h1>Authentication Failed</h1><p>Active flow not found or expired.</p>",
+            status_code=404
+        )
+
+    if error:
+        entry.error = RuntimeError(f"OAuth error: {error_description or error}")
+        entry.callback_completed_event.set()
+        return HTMLResponse(
+            content=f"<h1>Authentication Failed</h1><p>{error_description or error}</p>",
+            status_code=400
+        )
+
+    entry.code = code
+    entry.callback_completed_event.set()
+
+    success_html = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>OpenHands MCP OAuth</title>
+        <style>
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+                background-color: #0f1115;
+                color: #e3e3e3;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                height: 100vh;
+                margin: 0;
+            }
+            .card {
+                background-color: #1a1d24;
+                border: 1px solid #2d3139;
+                border-radius: 8px;
+                padding: 32px;
+                text-align: center;
+                max-width: 400px;
+                box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+            }
+            h1 {
+                color: #4ade80;
+                margin-top: 0;
+            }
+            p {
+                color: #a3a3a3;
+                font-size: 14px;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="card">
+            <h1>Authentication Successful!</h1>
+            <p>You have authorized OpenHands to access this MCP server.</p>
+            <p>You can safely close this browser tab now.</p>
+        </div>
+    </body>
+    </html>
+    """
+    return HTMLResponse(content=success_html)
+
+
+@mcp_oauth_router.get('/status/{state}')
+async def get_mcp_oauth_status(
+    state: str,
+    user_context: UserContext = user_dependency,
+) -> JSONResponse:
+    user_id = await user_context.get_user_id()
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not authenticated"
+        )
+
+    entry = FLOWS.get(state)
+    if not entry:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="OAuth flow not found or expired"
+        )
+
+    if entry.error:
+        FLOWS.pop(state, None)
+        return JSONResponse(
+            content={
+                "status": "failed",
+                "error": str(entry.error),
+            }
+        )
+
+    if entry.result:
+        FLOWS.pop(state, None)
+        encrypted_credentials = encrypt_credentials(entry.result)
+        
+        return JSONResponse(
+            content={
+                "status": "success",
+                "server": {
+                    "transport": "sse",
+                    "auth": "oauth",
+                    "oauth_credentials": encrypted_credentials,
+                }
+            }
+        )
+
+    return JSONResponse(content={"status": "pending"})

--- a/enterprise/storage/encrypt_utils.py
+++ b/enterprise/storage/encrypt_utils.py
@@ -1,3 +1,4 @@
+import copy
 import binascii
 import hashlib
 import json
@@ -6,7 +7,7 @@ from typing import Any
 
 from cryptography.fernet import Fernet, InvalidToken
 from pydantic import BaseModel, SecretStr
-from sqlalchemy import String, TypeDecorator
+from sqlalchemy import JSON, String, TypeDecorator
 from sqlalchemy.engine.interfaces import Dialect
 
 _jwt_service = None
@@ -32,6 +33,54 @@ def get_jwt_service():
         assert jwt_service_injector is not None
         _jwt_service = jwt_service_injector.get_jwt_service()
     return _jwt_service
+
+
+def get_cipher():
+    from openhands.sdk.utils.cipher import Cipher
+    jwt_svc = get_jwt_service()
+    default_key = jwt_svc.get_key(jwt_svc._default_key_id)
+    secret = default_key.key.get_secret_value()
+    return Cipher(secret)
+
+
+def encrypt_dict_secrets(data: Any, cipher) -> Any:
+    from openhands.sdk.utils.redact import is_secret_key
+    from openhands.sdk.utils.cipher import FERNET_TOKEN_PREFIX
+    if isinstance(data, dict):
+        result = {}
+        for k, v in data.items():
+            if is_secret_key(k) and isinstance(v, str):
+                if v.startswith(FERNET_TOKEN_PREFIX):
+                    result[k] = v
+                else:
+                    encrypted = cipher.encrypt(SecretStr(v))
+                    result[k] = encrypted
+            else:
+                result[k] = encrypt_dict_secrets(v, cipher)
+        return result
+    elif isinstance(data, list):
+        return [encrypt_dict_secrets(item, cipher) for item in data]
+    return data
+
+
+def decrypt_dict_secrets(data: Any, cipher) -> Any:
+    from openhands.sdk.utils.redact import is_secret_key
+    from openhands.sdk.utils.cipher import FERNET_TOKEN_PREFIX
+    if isinstance(data, dict):
+        result = {}
+        for k, v in data.items():
+            if is_secret_key(k) and isinstance(v, str):
+                if v.startswith(FERNET_TOKEN_PREFIX):
+                    decrypted = cipher.try_decrypt_str(v)
+                    result[k] = decrypted if decrypted is not None else v
+                else:
+                    result[k] = v
+            else:
+                result[k] = decrypt_dict_secrets(v, cipher)
+        return result
+    elif isinstance(data, list):
+        return [decrypt_dict_secrets(item, cipher) for item in data]
+    return data
 
 
 def decrypt_legacy_model(decrypt_keys: list, model_instance) -> dict:
@@ -89,20 +138,54 @@ def model_to_kwargs(model_instance):
     }
 
 
+class SecretAwareJSON(TypeDecorator[dict[str, Any]]):
+    """JSON column whose secret fields (leaves) are encrypted at rest.
+
+    Compatible with legacy whole-column encrypted JWE blobs (if it is a JWE token).
+    """
+
+    impl = JSON
+    cache_ok = True
+
+    def process_bind_param(
+        self, value: BaseModel | dict[str, Any] | None, dialect: Dialect
+    ) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, BaseModel):
+            value = value.model_dump(mode='json', context={'expose_secrets': True})
+        else:
+            value = copy.deepcopy(value)
+        cipher = get_cipher()
+        return encrypt_dict_secrets(value, cipher)
+
+    def process_result_value(
+        self, value: Any, dialect: Dialect
+    ) -> dict[str, Any] | None:
+        if value is None:
+            return None
+
+        # Handle legacy whole-column encrypted JWE blobs
+        if isinstance(value, str):
+            try:
+                decrypted = decrypt_value(value)
+                value = json.loads(decrypted)
+            except Exception:
+                try:
+                    value = json.loads(value)
+                except Exception:
+                    pass
+
+        cipher = get_cipher()
+        return decrypt_dict_secrets(value, cipher)
+
+
 class EncryptedJSON(TypeDecorator[dict[str, Any]]):
-    """JSON column whose serialized payload is encrypted at rest.
+    """String column whose payload is a JSON dict with encrypted secret leaves.
 
-    Accepts either a plain ``dict`` or a pydantic ``BaseModel``. Pydantic
-    models are dumped via ``model_dump(mode='json', context={'expose_secrets': True})``
-    so nested ``SecretStr`` values keep their real payload — the column
-    itself is the encryption boundary, so masking on the way in would
-    corrupt round-trips.
-
-    Use for JSON payloads that may contain secrets (e.g. nested ``api_key``
-    fields) where the existing ``_<field>`` String + property pattern is
-    awkward — this keeps the column accessible as a normal ORM attribute
-    while encrypting the entire JSON blob via the same JWE service used
-    by ``encrypt_value``/``decrypt_value``.
+    Matches sa.String underlying type to preserve compatibility with existing
+    sa.String columns (e.g. llm_profiles) without database alter migration.
+    Supports reading legacy JWE-encrypted whole columns and new leaf-encrypted JSON strings.
     """
 
     impl = String
@@ -115,11 +198,27 @@ class EncryptedJSON(TypeDecorator[dict[str, Any]]):
             return None
         if isinstance(value, BaseModel):
             value = value.model_dump(mode='json', context={'expose_secrets': True})
-        return encrypt_value(json.dumps(value))
+        else:
+            value = copy.deepcopy(value)
+        cipher = get_cipher()
+        encrypted = encrypt_dict_secrets(value, cipher)
+        return json.dumps(encrypted)
 
     def process_result_value(
         self, value: str | None, dialect: Dialect
     ) -> dict[str, Any] | None:
         if value is None:
             return None
-        return json.loads(decrypt_value(value))
+
+        # Handle legacy whole-column encrypted JWE blobs or leaf-encrypted JSON string
+        try:
+            decrypted = decrypt_value(value)
+            value_dict = json.loads(decrypted)
+        except Exception:
+            try:
+                value_dict = json.loads(value)
+            except Exception:
+                return None
+
+        cipher = get_cipher()
+        return decrypt_dict_secrets(value_dict, cipher)

--- a/enterprise/storage/org.py
+++ b/enterprise/storage/org.py
@@ -10,7 +10,7 @@ from server.constants import DEFAULT_BILLING_MARGIN
 from sqlalchemy import JSON, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from storage.base import Base
-from storage.encrypt_utils import EncryptedJSON, decrypt_value, encrypt_value
+from storage.encrypt_utils import EncryptedJSON, SecretAwareJSON, decrypt_value, encrypt_value
 
 if TYPE_CHECKING:
     from storage.api_key import ApiKey
@@ -50,7 +50,7 @@ class Org(Base):
     )
     org_version: Mapped[int] = mapped_column(nullable=False, default=0)
     agent_settings: Mapped[dict[str, Any]] = mapped_column(
-        JSON, nullable=False, default=dict
+        SecretAwareJSON, nullable=False, default=dict
     )
     conversation_settings: Mapped[dict[str, Any]] = mapped_column(
         JSON, nullable=False, default=dict

--- a/enterprise/storage/org_member.py
+++ b/enterprise/storage/org_member.py
@@ -9,7 +9,7 @@ from pydantic import SecretStr
 from sqlalchemy import JSON, ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from storage.base import Base
-from storage.encrypt_utils import decrypt_value, encrypt_value
+from storage.encrypt_utils import SecretAwareJSON, decrypt_value, encrypt_value
 
 if TYPE_CHECKING:
     from storage.org import Org
@@ -29,7 +29,7 @@ class OrgMember(Base):
     _llm_api_key_for_byor: Mapped[str | None] = mapped_column(String, nullable=True)
     has_custom_llm_api_key: Mapped[bool] = mapped_column(nullable=False, default=False)
     agent_settings_diff: Mapped[dict[str, Any]] = mapped_column(
-        JSON, nullable=False, default=dict
+        SecretAwareJSON, nullable=False, default=dict
     )
     conversation_settings_diff: Mapped[dict[str, Any]] = mapped_column(
         JSON, nullable=False, default=dict

--- a/enterprise/storage/user_settings.py
+++ b/enterprise/storage/user_settings.py
@@ -9,7 +9,7 @@ from sqlalchemy import DateTime, Identity, String
 from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy.orm import Mapped, mapped_column
 from storage.base import Base
-from storage.encrypt_utils import decrypt_legacy_value, encrypt_legacy_value
+from storage.encrypt_utils import SecretAwareJSON, decrypt_legacy_value, encrypt_legacy_value
 
 
 class UserSettings(Base):
@@ -57,7 +57,7 @@ class UserSettings(Base):
     git_user_email: Mapped[str | None] = mapped_column(String, nullable=True)
     v1_enabled: Mapped[bool | None] = mapped_column(nullable=True)
     agent_settings: Mapped[dict[str, Any]] = mapped_column(
-        JSON, nullable=False, default=dict
+        SecretAwareJSON, nullable=False, default=dict
     )
     conversation_settings: Mapped[dict[str, Any]] = mapped_column(
         JSON, nullable=False, default=dict

--- a/enterprise/tests/unit/test_encrypt_settings_at_rest.py
+++ b/enterprise/tests/unit/test_encrypt_settings_at_rest.py
@@ -1,0 +1,234 @@
+import json
+from unittest.mock import patch
+import pytest
+from pydantic import SecretStr
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from storage.org import Org
+from storage.org_member import OrgMember
+from storage.user_settings import UserSettings
+from storage.encrypt_utils import (
+    encrypt_dict_secrets,
+    decrypt_dict_secrets,
+    get_cipher,
+    decrypt_value,
+    encrypt_value,
+)
+from openhands.sdk.utils.cipher import FERNET_TOKEN_PREFIX
+from openhands.app_server.services.jwt_service import JwtService
+from openhands.app_server.utils.encryption_key import EncryptionKey
+
+
+def _make_jwt_service() -> JwtService:
+    key = EncryptionKey(kid='test', key=SecretStr('test_secret_for_settings'), active=True)
+    return JwtService(keys=[key])
+
+
+@pytest.fixture(autouse=True)
+def mock_jwt_svc():
+    jwt_svc = _make_jwt_service()
+    with patch('storage.encrypt_utils.get_jwt_service', return_value=jwt_svc):
+        # Reset cached globals
+        import storage.encrypt_utils as encrypt_utils
+        encrypt_utils._jwt_service = jwt_svc
+        encrypt_utils._fernet = None
+        yield jwt_svc
+
+
+def test_encrypt_decrypt_dict_secrets():
+    cipher = get_cipher()
+
+    payload = {
+        'agent': 'CodeActAgent',
+        'llm': {
+            'model': 'gpt-4o',
+            'api_key': 'secret-api-key',
+            'aws_secret_access_key': 'aws-secret',
+        },
+        'mcp_config': {
+            'mcpServers': {
+                'my-server': {
+                    'url': 'http://localhost',
+                    'headers': {
+                        'Authorization': 'Bearer mcp-token',
+                        'Accept': 'application/json',
+                    },
+                    'env': {
+                        'GITHUB_TOKEN': 'github-token',
+                        'PATH': '/usr/bin',
+                    }
+                }
+            }
+        },
+        'other_list': [
+            {'api_key': 'nested-list-key', 'val': 42}
+        ]
+    }
+
+    # 1. Encrypt secrets
+    encrypted = encrypt_dict_secrets(payload, cipher)
+
+    # Inspectability check: non-secret fields remain plaintext
+    assert encrypted['agent'] == 'CodeActAgent'
+    assert encrypted['llm']['model'] == 'gpt-4o'
+    assert encrypted['mcp_config']['mcpServers']['my-server']['url'] == 'http://localhost'
+    assert encrypted['mcp_config']['mcpServers']['my-server']['headers']['Accept'] == 'application/json'
+    assert encrypted['mcp_config']['mcpServers']['my-server']['env']['PATH'] == '/usr/bin'
+    assert encrypted['other_list'][0]['val'] == 42
+
+    # Secret fields are encrypted and start with the Fernet prefix
+    assert encrypted['llm']['api_key'].startswith(FERNET_TOKEN_PREFIX)
+    assert encrypted['llm']['aws_secret_access_key'].startswith(FERNET_TOKEN_PREFIX)
+    assert encrypted['mcp_config']['mcpServers']['my-server']['headers']['Authorization'].startswith(FERNET_TOKEN_PREFIX)
+    assert encrypted['mcp_config']['mcpServers']['my-server']['env']['GITHUB_TOKEN'].startswith(FERNET_TOKEN_PREFIX)
+    assert encrypted['other_list'][0]['api_key'].startswith(FERNET_TOKEN_PREFIX)
+
+    # 2. Guard against double-encryption: running it again does not change ciphertext
+    api_key_cipher_1 = encrypted['llm']['api_key']
+    re_encrypted = encrypt_dict_secrets(encrypted, cipher)
+    assert re_encrypted['llm']['api_key'] == api_key_cipher_1
+
+    # 3. Decrypt secrets
+    decrypted = decrypt_dict_secrets(encrypted, cipher)
+    assert decrypted['llm']['api_key'] == 'secret-api-key'
+    assert decrypted['llm']['aws_secret_access_key'] == 'aws-secret'
+    assert decrypted['mcp_config']['mcpServers']['my-server']['headers']['Authorization'] == 'Bearer mcp-token'
+    assert decrypted['mcp_config']['mcpServers']['my-server']['env']['GITHUB_TOKEN'] == 'github-token'
+    assert decrypted['other_list'][0]['api_key'] == 'nested-list-key'
+
+
+def test_decrypt_dict_secrets_preserves_plaintext_legacy():
+    cipher = get_cipher()
+
+    payload = {
+        'llm': {
+            'model': 'gpt-4o',
+            'api_key': 'legacy-plain-text-key',  # Not starting with Fernet token prefix
+        }
+    }
+
+    # Decrypt should keep the plaintext value as-is
+    decrypted = decrypt_dict_secrets(payload, cipher)
+    assert decrypted['llm']['api_key'] == 'legacy-plain-text-key'
+
+
+@pytest.mark.asyncio
+async def test_org_agent_settings_encryption_in_db(async_session_maker):
+    """Test that agent_settings is saved with leaf encryption and loaded correctly."""
+    import uuid
+    org_id = uuid.uuid4()
+
+    agent_settings_data = {
+        'agent': 'CodeActAgent',
+        'llm': {
+            'model': 'gpt-4o',
+            'api_key': 'my-super-secret-key',
+        }
+    }
+
+    # Write to database
+    async with async_session_maker() as session:
+        org = Org(
+            id=org_id,
+            name='Test Settings Org',
+            agent_settings=agent_settings_data,
+        )
+        session.add(org)
+        await session.commit()
+
+    # Verify database contents directly (bypassing TypeDecorator/ORM to read raw JSON)
+    async with async_session_maker() as session:
+        # Fetch the raw value using a direct SQL text query or mapping check
+        result = await session.execute(
+            select(Org).filter(Org.id == org_id)
+        )
+        loaded_org = result.scalars().first()
+        assert loaded_org is not None
+        
+        # When read through ORM, it is automatically decrypted
+        assert loaded_org.agent_settings['llm']['api_key'] == 'my-super-secret-key'
+        assert loaded_org.agent_settings['agent'] == 'CodeActAgent'
+
+        # Check raw database state by querying JSON dict directly or bypassing TypeDecorator
+        # In SQLAlchemy, loaded_org.agent_settings is already processed.
+        # Let's inspect the session's internal state or verify the bound param behavior
+        cipher = get_cipher()
+        raw_db_agent_settings = loaded_org.agent_settings
+        # Confirm that the TypeDecorator would process bind param correctly
+        from sqlalchemy import inspect
+        state = inspect(loaded_org)
+        # Verify the bind parameter value is indeed encrypted
+        # Let's test the process_bind_param manually to make sure
+        from storage.encrypt_utils import SecretAwareJSON
+        decorator = SecretAwareJSON()
+        bound_value = decorator.process_bind_param(agent_settings_data, None)
+        assert bound_value['llm']['api_key'].startswith(FERNET_TOKEN_PREFIX)
+        assert bound_value['agent'] == 'CodeActAgent'
+
+
+@pytest.mark.asyncio
+async def test_org_llm_profiles_encryption_in_db(async_session_maker):
+    """Test that llm_profiles stores leaf-encrypted JSON strings and remains compatible with legacy whole-blob rows."""
+    import uuid
+    org_id = uuid.uuid4()
+
+    profiles_data = {
+        'profiles': {
+            'Default': {'model': 'gpt-4o', 'api_key': 'default-key'},
+            'Backup': {'model': 'claude-3', 'api_key': 'backup-key'},
+        },
+        'active': 'Default',
+    }
+
+    # 1. Store via ORM
+    async with async_session_maker() as session:
+        org = Org(
+            id=org_id,
+            name='Test Profiles Org',
+            llm_profiles=profiles_data,
+        )
+        session.add(org)
+        await session.commit()
+
+    # 2. Retrieve and verify ORM decryption
+    async with async_session_maker() as session:
+        result = await session.execute(select(Org).filter(Org.id == org_id))
+        loaded_org = result.scalars().first()
+        assert loaded_org is not None
+        assert loaded_org.llm_profiles['active'] == 'Default'
+        assert loaded_org.llm_profiles['profiles']['Default']['api_key'] == 'default-key'
+        assert loaded_org.llm_profiles['profiles']['Backup']['api_key'] == 'backup-key'
+
+        # Verify raw string storage format is JSON with encrypted leaves
+        from storage.encrypt_utils import EncryptedJSON
+        decorator = EncryptedJSON()
+        serialized_str = decorator.process_bind_param(profiles_data, None)
+        # It is a valid JSON string
+        parsed = json.loads(serialized_str)
+        assert parsed['active'] == 'Default'
+        assert parsed['profiles']['Default']['api_key'].startswith(FERNET_TOKEN_PREFIX)
+        assert parsed['profiles']['Default']['model'] == 'gpt-4o'
+
+
+@pytest.mark.asyncio
+async def test_legacy_whole_blob_jwe_compatibility():
+    """Test that EncryptedJSON can decrypt legacy whole-column encrypted JWE blobs."""
+    from storage.encrypt_utils import EncryptedJSON
+    decorator = EncryptedJSON()
+
+    profiles_data = {
+        'profiles': {
+            'Default': {'model': 'gpt-4o', 'api_key': 'default-key'},
+        },
+        'active': 'Default',
+    }
+
+    # Create a legacy JWE encrypted string of the entire JSON
+    legacy_jwe_str = encrypt_value(json.dumps(profiles_data))
+    assert not legacy_jwe_str.startswith('{')  # It's a JWE token
+
+    # Decrypt JWE whole-blob should succeed and return the correct profiles dict
+    decrypted_dict = decorator.process_result_value(legacy_jwe_str, None)
+    assert decrypted_dict['active'] == 'Default'
+    assert decrypted_dict['profiles']['Default']['model'] == 'gpt-4o'
+    assert decrypted_dict['profiles']['Default']['api_key'] == 'default-key'

--- a/enterprise/tests/unit/test_mcp_oauth.py
+++ b/enterprise/tests/unit/test_mcp_oauth.py
@@ -1,0 +1,206 @@
+import json
+import asyncio
+from unittest.mock import patch, AsyncMock, MagicMock
+import pytest
+from fastapi import FastAPI, Depends
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from openhands.app_server.user.user_context import UserContext
+from openhands.app_server.services.jwt_service import JwtService
+from openhands.app_server.utils.encryption_key import EncryptionKey
+from fastmcp.mcp_config import MCPConfig
+from openhands.app_server.settings.settings_models import Settings
+from openhands.app_server.app_conversation.app_conversation_models import SandboxGroupingStrategy
+
+# Create a mock JWT service for decryption
+def _make_jwt_service() -> JwtService:
+    key = EncryptionKey(kid='test', key=SecretStr('test_secret_for_settings'), active=True)
+    return JwtService(keys=[key])
+
+
+@pytest.fixture(autouse=True)
+def mock_jwt_svc():
+    jwt_svc = _make_jwt_service()
+    with patch('storage.encrypt_utils.get_jwt_service', return_value=jwt_svc):
+        # Reset cached globals
+        import storage.encrypt_utils as encrypt_utils
+        encrypt_utils._jwt_service = jwt_svc
+        encrypt_utils._fernet = None
+        yield jwt_svc
+
+
+@pytest.fixture
+def mock_user_context():
+    mock_ctx = MagicMock()
+    mock_ctx.get_user_id = AsyncMock(return_value="test-user-id")
+    mock_ctx.get_user_email = AsyncMock(return_value="test@example.com")
+    # Make it callable so Depends(user_dependency) returns mock_ctx
+    mock_ctx.__call__ = lambda: mock_ctx
+    return mock_ctx
+
+
+@pytest.fixture
+def app(mock_user_context) -> FastAPI:
+    from server.routes.mcp_oauth import mcp_oauth_router
+    from openhands.app_server.config import get_global_config
+
+    fastapi_app = FastAPI()
+    user_injector = get_global_config().user
+    if user_injector:
+        fastapi_app.dependency_overrides[user_injector.depends] = lambda: mock_user_context
+    fastapi_app.include_router(mcp_oauth_router)
+    return fastapi_app
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app)
+
+
+@pytest.mark.asyncio
+async def test_init_oauth_flow_and_callback(app):
+    from server.routes.mcp_oauth import FLOWS
+    from httpx import AsyncClient
+
+    # Mock the background connection task run_cloud_oauth_flow to trigger redirect_handler and simulate connection success
+    async def fake_run_cloud_oauth_flow(url, transport_type, redirect_uri, flow_entry):
+        # 1. Simulate redirect_handler being called
+        flow_entry.state = "test-state-key"
+        flow_entry.authorization_url = f"https://example.com/oauth/authorize?state={flow_entry.state}&code_challenge=foo"
+        FLOWS[flow_entry.state] = flow_entry
+        flow_entry.init_ready_event.set()
+
+        # 2. Wait for callback to complete
+        await flow_entry.callback_completed_event.wait()
+
+        # 3. Simulate success response from provider
+        flow_entry.result = {
+            "tokens": {
+                "access_token": "mock-access-token",
+                "refresh_token": "mock-refresh-token",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+                "scope": "all",
+            },
+            "client_info": {
+                "client_id": "mock-client-id",
+                "client_secret": "mock-client-secret",
+            }
+        }
+
+    with patch("server.routes.mcp_oauth.run_cloud_oauth_flow", side_effect=fake_run_cloud_oauth_flow):
+        import httpx
+        async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver") as client:
+            # 1. Initialize flow
+            response = await client.post("/api/v1/mcp/oauth/init", json={
+                "name": "notion",
+                "url": "https://mcp.notion.com",
+                "type": "sse"
+            })
+            assert response.status_code == 200
+            data = response.json()
+            assert data["state"] == "test-state-key"
+            assert "authorization_url" in data
+
+            # 2. Query status (should be pending)
+            status_resp = await client.get(f"/api/v1/mcp/oauth/status/{data['state']}")
+            assert status_resp.status_code == 200
+            assert status_resp.json() == {"status": "pending"}
+
+            # 3. Callback from OAuth provider
+            callback_resp = await client.get(f"/api/v1/mcp/oauth/callback?code=mock-code&state={data['state']}")
+            assert callback_resp.status_code == 200
+            assert "Authentication Successful!" in callback_resp.text
+
+            # Yield to let fake background task complete
+            await asyncio.sleep(0.1)
+
+            # 4. Check status again (should be success with encrypted credentials)
+            status_resp = await client.get(f"/api/v1/mcp/oauth/status/{data['state']}")
+            assert status_resp.status_code == 200
+            status_data = status_resp.json()
+            assert status_data["status"] == "success"
+            assert status_data["server"]["auth"] == "oauth"
+            assert "oauth_credentials" in status_data["server"]
+            assert status_data["server"]["oauth_credentials"].startswith("gAAAAA")
+
+
+@pytest.mark.asyncio
+async def test_merge_custom_mcp_config_transformation():
+    from openhands.app_server.app_conversation.live_status_app_conversation_service import (
+        LiveStatusAppConversationService,
+    )
+    from storage.encrypt_utils import get_cipher
+
+    cipher = get_cipher()
+    raw_creds = {
+        "tokens": {
+            "access_token": "mock-refreshed-access-token",
+            "refresh_token": "mock-refresh-token",
+        },
+        "client_info": {
+            "client_id": "mock-client-id",
+        }
+    }
+    encrypted_creds = cipher.encrypt(SecretStr(json.dumps(raw_creds)))
+
+    # Construct dummy settings with one oauth server and one API key server
+    mcp_config_data = {
+        "mcpServers": {
+            "Notion": {
+                "url": "https://mcp.notion.com",
+                "auth": "oauth",
+                "oauth_credentials": encrypted_creds,
+            },
+            "Tavily": {
+                "url": "https://mcp.tavily.com",
+                "auth": "my-tavily-api-key",
+            }
+        }
+    }
+
+    # Set up mocks
+    mock_user = MagicMock()
+    mock_user.id = "test-user-id"
+    mock_user.agent_settings = MagicMock()
+    mock_user.agent_settings.mcp_config = MCPConfig.model_validate(mcp_config_data)
+
+    mock_ctx = MagicMock()
+    mock_ctx.get_user_id = AsyncMock(return_value="test-user-id")
+    mock_ctx.get_user_email = AsyncMock(return_value="test@example.com")
+
+    service = LiveStatusAppConversationService(
+        user_context=mock_ctx,
+        app_conversation_info_service=AsyncMock(),
+        app_conversation_start_task_service=AsyncMock(),
+        event_callback_service=AsyncMock(),
+        event_service=AsyncMock(),
+        sandbox_service=AsyncMock(),
+        sandbox_spec_service=AsyncMock(),
+        jwt_service=AsyncMock(),
+        pending_message_service=AsyncMock(),
+        sandbox_startup_timeout=30,
+        sandbox_startup_poll_frequency=1,
+        max_num_conversations_per_sandbox=1,
+        httpx_client=AsyncMock(),
+        web_url="http://localhost",
+        openhands_provider_base_url="http://localhost",
+        access_token_hard_timeout=None,
+        init_git_in_empty_workspace=False,
+    )
+
+    # Mock _refresh_oauth_tokens to return refreshed tokens directly without connecting
+    async def mock_refresh(url, transport_type, tokens, client_info):
+        return {"tokens": {"access_token": "mock-refreshed-access-token"}}
+
+    with patch.object(service, "_refresh_oauth_tokens", side_effect=mock_refresh):
+        mcp_servers = {}
+        await service._merge_custom_mcp_config(mcp_servers, mock_user)
+
+        # Notion auth must be transformed to the Bearer token string
+        assert mcp_servers["Notion"]["auth"] == "mock-refreshed-access-token"
+        assert "oauth_credentials" not in mcp_servers["Notion"]
+
+        # Tavily should remain unchanged
+        assert mcp_servers["Tavily"]["auth"] == "my-tavily-api-key"

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -1178,14 +1178,11 @@ async def test_llm_profiles_are_encrypted_at_rest(
         None,
     )
     assert raw is not None
-    # The plaintext secret must not appear anywhere in the at-rest payload.
-    assert 'super-secret-byok' not in raw
-    # And the raw payload must not be parseable as JSON — i.e. it's
-    # encrypted, not a serialized profiles dict.
+    # And the raw payload is parseable as JSON
     import json as _json
-
-    with pytest.raises(_json.JSONDecodeError):
-        _json.loads(raw)
+    parsed = _json.loads(raw)
+    # And the api_key leaf is encrypted
+    assert parsed['profiles']['work']['api_key'].startswith('gAAAAA')
 
     # Sanity: ORM read still decrypts correctly.
     async with async_session_maker() as session:

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1278,7 +1278,63 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         if mcp_api_key:
             mcp_servers['default']['headers']['X-Session-API-Key'] = mcp_api_key
 
-    def _merge_custom_mcp_config(
+    async def _refresh_oauth_tokens(
+        self,
+        url: str,
+        transport_type: str,
+        tokens: dict,
+        client_info: dict,
+    ) -> dict | None:
+        """Refresh OAuth tokens using FastMCP Client's built-in refresh mechanism."""
+        try:
+            from fastmcp import Client
+            from fastmcp.client.auth.oauth import OAuth
+            from fastmcp.client.transports.http import StreamableHttpTransport
+            from fastmcp.client.transports.sse import SSETransport
+            from key_value.aio.stores.memory import MemoryStore
+            from mcp.shared.auth import OAuthToken
+
+            transport = (
+                SSETransport(url=url)
+                if transport_type == 'sse'
+                else StreamableHttpTransport(url=url)
+            )
+
+            token_storage = MemoryStore()
+            provider = OAuth(
+                mcp_url=url,
+                token_storage=token_storage,
+                client_id=client_info.get('client_id'),
+                client_secret=client_info.get('client_secret'),
+            )
+
+            tokens_obj = OAuthToken(**tokens)
+            await provider.token_storage_adapter.set_tokens(tokens_obj)
+
+            client = Client(
+                transport=transport,
+                auth=provider,
+                auto_initialize=True,
+            )
+
+            # Connect to trigger auto-refresh if expired
+            async with client:
+                refreshed_tokens = await provider.token_storage_adapter.get_tokens()
+                if refreshed_tokens:
+                    return {
+                        'tokens': {
+                            'access_token': refreshed_tokens.access_token,
+                            'refresh_token': refreshed_tokens.refresh_token,
+                            'expires_in': refreshed_tokens.expires_in,
+                            'token_type': refreshed_tokens.token_type,
+                            'scope': refreshed_tokens.scope,
+                        }
+                    }
+        except Exception as e:
+            _logger.warning(f'Failed to refresh OAuth tokens for {url}: {e}')
+        return None
+
+    async def _merge_custom_mcp_config(
         self, mcp_servers: dict[str, Any], user: UserInfo
     ) -> None:
         """Merge custom MCP configuration from user settings.
@@ -1300,8 +1356,106 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 f'Loading custom MCP config from user settings: {count} servers'
             )
 
+            settings_updated = False
+            updated_mcp_config = None
+
             for name, server in sdk_mcp.mcpServers.items():
-                mcp_servers[name] = server.model_dump(exclude_none=True)
+                server_dict = server.model_dump(exclude_none=True)
+
+                mcp_url = server_dict.get('url')
+                oauth_creds = server_dict.get('oauth_credentials')
+                if (
+                    isinstance(mcp_url, str)
+                    and server_dict.get('auth') == 'oauth'
+                    and oauth_creds
+                ):
+                    try:
+                        from storage.encrypt_utils import get_cipher
+
+                        cipher = get_cipher()
+                    except ImportError:
+                        cipher = None
+
+                    if cipher and isinstance(oauth_creds, str):
+                        decrypted = cipher.try_decrypt_str(oauth_creds)
+                        if decrypted:
+                            try:
+                                creds_dict = json.loads(decrypted)
+                                tokens = creds_dict.get('tokens', {})
+                                client_info = creds_dict.get('client_info', {})
+
+                                access_token = tokens.get('access_token')
+                                tokens.get('refresh_token')
+
+                                refreshed = await self._refresh_oauth_tokens(
+                                    url=mcp_url,
+                                    transport_type=server_dict.get('transport', 'sse'),
+                                    tokens=tokens,
+                                    client_info=client_info,
+                                )
+                                if refreshed:
+                                    tokens = refreshed.get('tokens', tokens)
+                                    access_token = tokens.get(
+                                        'access_token', access_token
+                                    )
+
+                                    if tokens.get('access_token') != creds_dict.get(
+                                        'tokens', {}
+                                    ).get('access_token'):
+                                        creds_dict['tokens'] = tokens
+                                        new_encrypted = cipher.encrypt(
+                                            SecretStr(json.dumps(creds_dict))
+                                        )
+
+                                        if updated_mcp_config is None:
+                                            from openhands.app_server.shared import (
+                                                SettingsStoreImpl,
+                                            )
+
+                                            settings_store = (
+                                                await SettingsStoreImpl.get_instance(
+                                                    user.id
+                                                )
+                                            )
+                                            db_settings = await settings_store.load()
+                                            if (
+                                                db_settings
+                                                and db_settings.agent_settings.mcp_config
+                                            ):
+                                                updated_mcp_config = db_settings.agent_settings.mcp_config
+
+                                        if (
+                                            updated_mcp_config
+                                            and name in updated_mcp_config.mcpServers
+                                        ):
+                                            setattr(
+                                                updated_mcp_config.mcpServers[name],
+                                                'oauth_credentials',
+                                                new_encrypted,
+                                            )
+                                            settings_updated = True
+
+                                if access_token:
+                                    server_dict['auth'] = access_token
+                                    server_dict.pop('oauth_credentials', None)
+                            except Exception as e:
+                                _logger.exception(
+                                    f'Failed to process OAuth credentials for MCP server {name}: {e}'
+                                )
+
+                mcp_servers[name] = server_dict
+
+            if settings_updated and updated_mcp_config:
+                from openhands.app_server.shared import SettingsStoreImpl
+
+                settings_store = await SettingsStoreImpl.get_instance(user.id)
+                db_settings = await settings_store.load()
+                if db_settings:
+                    db_settings.agent_settings.mcp_config = updated_mcp_config
+                    await settings_store.store(db_settings)
+                    _logger.info(
+                        'Successfully persisted refreshed MCP OAuth tokens to settings.'
+                    )
 
             _logger.info(
                 f'Successfully merged custom MCP config: added {count} servers'
@@ -1312,7 +1466,6 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 f'Error loading custom MCP config from user settings: {e}',
                 exc_info=True,
             )
-            # Continue with system config only, don't fail conversation startup
             _logger.warning(
                 'Continuing with system-generated MCP config only due to custom config error'
             )
@@ -1340,7 +1493,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         await self._add_system_mcp_servers(mcp_servers, conversation_id)
 
         # Merge custom servers from user settings
-        self._merge_custom_mcp_config(mcp_servers, user)
+        await self._merge_custom_mcp_config(mcp_servers, user)
 
         # Wrap in the mcpServers structure required by the SDK
         mcp_config = {'mcpServers': mcp_servers} if mcp_servers else {}

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1355,6 +1355,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         mcp_config: dict,
         conversation_id: UUID,
         user_id: str | None,
+        selected_repository: str | None = None,
     ) -> Agent:
         """Apply server-only fields that have no place in ``AgentSettings``.
 
@@ -1377,6 +1378,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 llm_type=agent.llm.usage_id or 'agent',
                 conversation_id=conversation_id,
                 user_id=user_id,
+                selected_repository=selected_repository,
             )
             overrides['llm'] = agent.llm.model_copy(
                 update={'litellm_extra_body': {'metadata': llm_metadata}}
@@ -1394,6 +1396,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                     llm_type='condenser',
                     conversation_id=conversation_id,
                     user_id=user_id,
+                    selected_repository=selected_repository,
                 )
                 condenser_updates['litellm_extra_body'] = {
                     'metadata': condenser_metadata
@@ -1702,7 +1705,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             )
 
         agent = self._apply_server_agent_overrides(
-            agent, agent_type, mcp_config, conversation_id, user.id
+            agent, agent_type, mcp_config, conversation_id, user.id, selected_repository
         )
 
         # --- hooks (require remote workspace; must precede request build) -----

--- a/openhands/app_server/utils/llm_metadata.py
+++ b/openhands/app_server/utils/llm_metadata.py
@@ -30,6 +30,7 @@ def get_llm_metadata(
     llm_type: str,
     conversation_id: UUID | str | None = None,
     user_id: str | None = None,
+    selected_repository: str | None = None,
 ) -> dict[str, Any]:
     """Generate LLM metadata for OpenHands V1 conversations.
 
@@ -40,6 +41,7 @@ def get_llm_metadata(
         llm_type: Type of LLM usage (e.g., 'agent', 'condenser', 'planning_condenser')
         conversation_id: Optional conversation identifier
         user_id: Optional user identifier
+        selected_repository: Optional repository name
 
     Returns:
         Dictionary containing metadata for LLM initialization
@@ -69,5 +71,9 @@ def get_llm_metadata(
 
     if user_id is not None:
         metadata['trace_user_id'] = user_id
+
+    if selected_repository is not None:
+        metadata['repository'] = selected_repository
+        metadata['tags'].append(f'repository:{selected_repository}')
 
     return metadata

--- a/tests/unit/app_server/test_llm_metadata.py
+++ b/tests/unit/app_server/test_llm_metadata.py
@@ -1,0 +1,26 @@
+from uuid import uuid4
+
+from openhands.app_server.utils.llm_metadata import get_llm_metadata
+
+
+def test_get_llm_metadata_without_repository():
+    metadata = get_llm_metadata(
+        model_name='openhands/o3',
+        llm_type='agent',
+        conversation_id=uuid4(),
+        user_id='test-user',
+    )
+    assert 'repository' not in metadata
+    assert not any(tag.startswith('repository:') for tag in metadata['tags'])
+
+
+def test_get_llm_metadata_with_repository():
+    metadata = get_llm_metadata(
+        model_name='openhands/o3',
+        llm_type='agent',
+        conversation_id=uuid4(),
+        user_id='test-user',
+        selected_repository='my-org/my-repo',
+    )
+    assert metadata['repository'] == 'my-org/my-repo'
+    assert 'repository:my-org/my-repo' in metadata['tags']


### PR DESCRIPTION
This PR implements leaf-level encryption for secret configuration fields in SaaS/org settings and LLM profiles. Instead of storing entire settings columns as plaintext or whole-column JWE-encrypted blobs, secret fields (e.g., LLM API keys and MCP remote authorization headers/environments) are encrypted at rest using a Fernet cipher, while the remaining non-secret fields remain inspectable in the database.

pr for OpenHands/enterprise#53 