### PR TITLE
fix(app_server): create workspace dir from an existing cwd so nested/grouped clones work

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_service_base.py
+++ b/openhands/app_server/app_conversation/app_conversation_service_base.py
@@ -412,10 +412,15 @@ class AppConversationServiceBase(AppConversationService, ABC):
     ):
         request = task.request
 
-        # Create the projects directory if it does not exist yet
-        parent = Path(workspace.working_dir).parent
+        # Create the working directory if it does not exist yet. Run from '/'
+        # (always present): the target is absolute and `mkdir -p` creates every
+        # parent, so the cwd is irrelevant to the result. Using the target's own
+        # parent as the cwd fails when that parent does not exist yet — e.g. a
+        # grouped per-conversation workspace nested under a not-yet-created
+        # `/workspace/project` — because the shell cannot chdir into it, leaving
+        # the directory uncreated and the subsequent clone failing with ENOENT.
         result = await workspace.execute_command(
-            f'mkdir -p {workspace.working_dir}', parent
+            f'mkdir -p {workspace.working_dir}', '/'
         )
         if result.exit_code:
             _logger.warning(f'mkdir failed: {result.stderr}')

--- a/tests/unit/app_server/test_app_conversation_service_base.py
+++ b/tests/unit/app_server/test_app_conversation_service_base.py
@@ -1446,3 +1446,34 @@ class TestLoadSkillsAndUpdateAgent:
                 'registered_marketplaces'
             ]
             assert forwarded == marketplaces
+
+
+@pytest.mark.asyncio
+async def test_clone_or_init_git_repo_mkdir_runs_from_existing_cwd():
+    """The workspace ``mkdir`` must run from a directory that exists.
+
+    Regression: a nested working_dir (e.g. a grouped per-conversation workspace
+    ``/workspace/project/<conv>``) lives under a parent that has not been
+    created yet. Running ``mkdir -p`` from that missing parent as the cwd fails
+    to chdir, so the directory is never created and the subsequent clone fails
+    with ENOENT. The command must run from ``/`` (always present); ``mkdir -p``
+    with an absolute target creates every parent regardless of the cwd.
+    """
+    workspace = MagicMock()
+    workspace.working_dir = '/workspace/project/conv123'
+    workspace.execute_command = AsyncMock(return_value=MagicMock(exit_code=0))
+
+    # Minimal fake self exercising the no-repo path (mkdir + git init) only.
+    svc = MagicMock(spec=AppConversationServiceBase)
+    svc.init_git_in_empty_workspace = True
+    svc._configure_git_user_settings = AsyncMock()
+
+    task = MagicMock()
+    task.request.selected_repository = None
+
+    await AppConversationServiceBase.clone_or_init_git_repo(svc, task, workspace)
+
+    # First command is the mkdir; it must run from '/', not the missing parent.
+    first_cmd, first_cwd = workspace.execute_command.call_args_list[0].args[:2]
+    assert first_cmd == 'mkdir -p /workspace/project/conv123'
+    assert str(first_cwd) == '/'


### PR DESCRIPTION
HUMAN:

This fixes a bug where selecting a repository when starting a conversation left the workspace empty (only a bare `git init`, no `origin`). It happens when sandbox grouping is enabled: the per-conversation workspace is nested under `/workspace/project/<conv>`, and the `git clone` ran in that directory before it was created, so it failed and fell back to an empty init. I reproduced it and tested this fix on our self-hosted deployment with grouping turned on — the repository now clones correctly into the nested workspace.

- [x] A human has tested these changes.

AGENT:

---

## Why

Starting a conversation with a selected repository leaves the workspace empty
(only an empty `git init`, no `origin`) when the working directory is nested —
e.g. a grouped per-conversation workspace like `/workspace/project/<conv>`.

Root cause: `clone_or_init_git_repo` creates the working directory with

```python
parent = Path(workspace.working_dir).parent
await workspace.execute_command(f'mkdir -p {workspace.working_dir}', parent)
```

`execute_command` chdirs into the given cwd (`parent`) before running the
command. For a non-grouped workspace `parent` is `/workspace` (the mounted
volume, exists) so it works. But with sandbox grouping the working dir is
`/workspace/project/<conv>`, whose parent `/workspace/project` has not been
created yet — the chdir fails, the `mkdir` never runs, the directory is never
created, and the subsequent `git clone` fails with

```
git clone https://***@github.com/<owner>/<repo>.git <repo>:
[Errno 2] No such file or directory: '/workspace/project/<conv>'
```

falling back to the empty-workspace `git init`.

`mkdir -p` takes an absolute target and creates every parent, so the cwd is
irrelevant to the result — it only needs to be a directory that exists.

## Summary

- Run the workspace-creation `mkdir -p {working_dir}` from `/` (always present)
  instead of `working_dir`'s parent, which may not exist yet for a nested
  (grouped) workspace.
- Add a unit test asserting the mkdir runs from `/`, not the parent.

## Issue Number

<!-- fill in if an issue is opened -->

## How to Test

1. Enable sandbox grouping (`sandbox_grouping_strategy` != `NO_GROUPING`) so the
   per-conversation working dir nests under `/workspace/project/<conv>`.
2. Start a conversation with a selected repository.
3. Before this change: the workspace is empty (`git init` only, no `origin`).
   After this change: the repo is cloned into
   `/workspace/project/<conv>/<repo>` with `origin` set.

Unit test:

```
pytest tests/unit/app_server/test_app_conversation_service_base.py::test_clone_or_init_git_repo_mkdir_runs_from_existing_cwd
```
