### PR TITLE
fix: support branch search pagination

### DIFF
--- a/openhands/app_server/git/git_router.py
+++ b/openhands/app_server/git/git_router.py
@@ -243,22 +243,28 @@ async def search_branches(
     if decoded_page_id is not None:
         page = decoded_page_id
 
+    next_page_id = None
     if query:
-        if page != 1:
-            # TODO(#13883): Support pagination for branch search after refactoring.
-            # The search_branches method does not support paging in the same way as
-            # get_branches - those should be merged into a single paginated method
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail='Pagination not yet supported for branch search queries. Use empty query to list all branches with pagination.',
-            )
-        # Get search results - we'll handle pagination ourselves
         branches: list[Branch] = await client.search_branches(
             selected_provider=provider,
             repository=repository,
             query=query,
-            per_page=limit + 1,
+            per_page=limit,
+            page=page,
         )
+        if len(branches) > limit:
+            branches = branches[:limit]
+            next_page_id = encode_page_id(page + 1)
+        elif len(branches) == limit:
+            next_branches = await client.search_branches(
+                selected_provider=provider,
+                repository=repository,
+                query=query,
+                per_page=limit,
+                page=page + 1,
+            )
+            if next_branches:
+                next_page_id = encode_page_id(page + 1)
     else:
         current_page = await client.get_branches(
             repository=repository,
@@ -267,11 +273,9 @@ async def search_branches(
             per_page=limit + 1,
         )
         branches = current_page.branches
-
-    next_page_id = None
-    if len(branches) > limit:
-        branches = branches[:-1]
-        next_page_id = encode_page_id(page + 1)
+        if len(branches) > limit:
+            branches = branches[:-1]
+            next_page_id = encode_page_id(page + 1)
 
     return BranchPage(items=branches, next_page_id=next_page_id)
 

--- a/openhands/app_server/integrations/azure_devops/service/branches.py
+++ b/openhands/app_server/integrations/azure_devops/service/branches.py
@@ -140,7 +140,7 @@ class AzureDevOpsBranchesMixin(AzureDevOpsMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, per_page: int = 30, page: int = 1
     ) -> list[Branch]:
         """Search for branches within a repository."""
         # Parse repository string: organization/project/repo
@@ -167,12 +167,21 @@ class AzureDevOpsBranchesMixin(AzureDevOpsMixinBase):
 
             # Filter branches by query
             filtered_branches = []
+            start_idx = max((page - 1) * per_page, 0)
+            end_idx = start_idx + per_page
+            matched_count = 0
             for branch_data in branches_data:
                 # Extract branch name from the ref (e.g., "refs/heads/main" -> "main")
                 name = branch_data.get('name', '').replace('refs/heads/', '')
 
                 # Check if query matches branch name
                 if query.lower() in name.lower():
+                    matched_count += 1
+                    if matched_count <= start_idx:
+                        continue
+                    if matched_count > end_idx:
+                        break
+
                     object_id = branch_data.get('objectId', '')
 
                     # Get commit details for this branch
@@ -190,9 +199,6 @@ class AzureDevOpsBranchesMixin(AzureDevOpsMixinBase):
                         last_push_date=last_push_date,
                     )
                     filtered_branches.append(branch)
-
-                    if len(filtered_branches) >= per_page:
-                        break
 
             return filtered_branches
         except Exception:

--- a/openhands/app_server/integrations/bitbucket/service/branches.py
+++ b/openhands/app_server/integrations/bitbucket/service/branches.py
@@ -87,7 +87,7 @@ class BitBucketBranchesMixin(BitBucketMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, per_page: int = 30, page: int = 1
     ) -> list[Branch]:
         """Search branches by name using Bitbucket API with `q` param."""
         parts = repository.split('/')
@@ -101,6 +101,7 @@ class BitBucketBranchesMixin(BitBucketMixinBase):
         # Bitbucket filtering: name ~ "query"
         params = {
             'pagelen': per_page,
+            'page': page,
             'q': f'name~"{query}"',
             'sort': '-target.date',
         }

--- a/openhands/app_server/integrations/bitbucket_data_center/service/branches.py
+++ b/openhands/app_server/integrations/bitbucket_data_center/service/branches.py
@@ -72,14 +72,16 @@ class BitbucketDCBranchesMixin(BitbucketDCMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, per_page: int = 30, page: int = 1
     ) -> list[Branch]:
         """Search branches by name using Bitbucket data center API with `q` param."""
         owner, repo = self._extract_owner_and_repo(repository)
 
         url = f'{self._repo_api_base(owner, repo)}/branches'
+        start = max((page - 1) * per_page, 0)
         params = {
             'limit': per_page,
+            'start': start,
             'filterText': query,
             'orderBy': 'MODIFICATION',
         }

--- a/openhands/app_server/integrations/forgejo/service/branches.py
+++ b/openhands/app_server/integrations/forgejo/service/branches.py
@@ -68,10 +68,12 @@ class ForgejoBranchesMixin(ForgejoMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, per_page: int = 30, page: int = 1
     ) -> list[Branch]:  # type: ignore[override]
         all_branches = await self.get_branches(repository)
         lowered = query.lower()
+        start = max((page - 1) * per_page, 0)
+        end = start + per_page
         return [branch for branch in all_branches if lowered in branch.name.lower()][
-            :per_page
+            start:end
         ]

--- a/openhands/app_server/integrations/github/queries.py
+++ b/openhands/app_server/integrations/github/queries.py
@@ -129,12 +129,19 @@ query ($threadId: ID!, $page: Int = 50, $after: String) {
 # - query: partial branch name provided by the user
 # - first: pagination size (clamped by caller to GitHub limits)
 search_branches_graphql_query = """
-    query SearchBranches($owner: String!, $name: String!, $query: String!, $perPage: Int!) {
+    query SearchBranches(
+        $owner: String!,
+        $name: String!,
+        $query: String!,
+        $perPage: Int!,
+        $after: String
+    ) {
         repository(owner: $owner, name: $name) {
             refs(
                 refPrefix: "refs/heads/",
                 query: $query,
                 first: $perPage,
+                after: $after,
                 orderBy: { field: ALPHABETICAL, direction: ASC }
             ) {
                 nodes {
@@ -146,6 +153,10 @@ search_branches_graphql_query = """
                             committedDate
                         }
                     }
+                }
+                pageInfo {
+                    endCursor
+                    hasNextPage
                 }
             }
         }

--- a/openhands/app_server/integrations/github/service/branches_prs.py
+++ b/openhands/app_server/integrations/github/service/branches_prs.py
@@ -103,7 +103,7 @@ class GitHubBranchesMixin(GitHubMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, per_page: int = 30, page: int = 1
     ) -> list[Branch]:
         """Search branches by name using GitHub GraphQL with a partial query."""
         # Require a non-empty query
@@ -112,6 +112,7 @@ class GitHubBranchesMixin(GitHubMixinBase):
 
         # Clamp per_page to GitHub GraphQL limits
         per_page = min(max(per_page, 1), 100)
+        page = max(page, 1)
 
         # Extract owner and repo name from the repository string
         parts = repository.split('/')
@@ -119,28 +120,41 @@ class GitHubBranchesMixin(GitHubMixinBase):
             return []
         owner, name = parts[-2], parts[-1]
 
-        variables = {
-            'owner': owner,
-            'name': name,
-            'query': query or '',
-            'perPage': per_page,
-        }
+        cursor = None
+        refs = None
+        for _ in range(page):
+            variables = {
+                'owner': owner,
+                'name': name,
+                'query': query or '',
+                'perPage': per_page,
+                'after': cursor,
+            }
 
-        try:
-            result = await self.execute_graphql_query(
-                search_branches_graphql_query, variables
-            )
-        except Exception as e:
-            logger.warning(f'Failed to search for branches: {e}')
-            # Fallback to empty result on any GraphQL error
-            return []
+            try:
+                result = await self.execute_graphql_query(
+                    search_branches_graphql_query, variables
+                )
+            except Exception as e:
+                logger.warning(f'Failed to search for branches: {e}')
+                # Fallback to empty result on any GraphQL error
+                return []
 
-        repo = result.get('data', {}).get('repository')
-        if not repo or not repo.get('refs'):
+            repo = result.get('data', {}).get('repository')
+            if not repo or not repo.get('refs'):
+                return []
+
+            refs = repo['refs']
+            page_info = refs.get('pageInfo', {})
+            if not page_info.get('hasNextPage') and _ < page - 1:
+                return []
+            cursor = page_info.get('endCursor')
+
+        if refs is None:
             return []
 
         branches: list[Branch] = []
-        for node in repo['refs'].get('nodes', []):
+        for node in refs.get('nodes', []):
             bname = node.get('name') or ''
             target = node.get('target') or {}
             typename = target.get('__typename')

--- a/openhands/app_server/integrations/gitlab/service/branches.py
+++ b/openhands/app_server/integrations/gitlab/service/branches.py
@@ -88,13 +88,13 @@ class GitLabBranchesMixin(GitLabMixinBase):
         )
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, per_page: int = 30, page: int = 1
     ) -> list[Branch]:
         """Search branches using GitLab API which supports `search` param."""
         encoded_name = repository.replace('/', '%2F')
         url = f'{self.BASE_URL}/projects/{encoded_name}/repository/branches'
 
-        params = {'per_page': str(per_page), 'search': query}
+        params = {'per_page': str(per_page), 'page': str(page), 'search': query}
         response, _ = await self._make_request(url, params)
 
         branches: list[Branch] = []

--- a/openhands/app_server/integrations/provider.py
+++ b/openhands/app_server/integrations/provider.py
@@ -329,12 +329,13 @@ class ProviderHandler:
         repository: str,
         query: str,
         per_page: int = 30,
+        page: int = 1,
     ) -> list[Branch]:
         """Search for branches within a repository using the appropriate provider service."""
         if selected_provider:
             service = self.get_service(selected_provider)
             try:
-                return await service.search_branches(repository, query, per_page)
+                return await service.search_branches(repository, query, per_page, page)
             except Exception as e:
                 logger.warning(
                     f'Error searching branches from selected provider {selected_provider}: {e}'
@@ -345,7 +346,7 @@ class ProviderHandler:
         try:
             repo_details = await self.verify_repo_provider(repository)
             service = self.get_service(repo_details.git_provider)
-            return await service.search_branches(repository, query, per_page)
+            return await service.search_branches(repository, query, per_page, page)
         except Exception as e:
             logger.warning(f'Error searching branches for {repository}: {e}')
             return []

--- a/openhands/app_server/integrations/service_types.py
+++ b/openhands/app_server/integrations/service_types.py
@@ -304,7 +304,7 @@ class GitService(Protocol):
         """Get branches for a repository with pagination"""
 
     async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
+        self, repository: str, query: str, per_page: int = 30, page: int = 1
     ) -> list[Branch]:
         """Search for branches within a repository"""
 

--- a/tests/unit/app_server/test_git_router.py
+++ b/tests/unit/app_server/test_git_router.py
@@ -709,10 +709,14 @@ class TestSearchBranches:
         # Arrange
         mock_handler = MagicMock()
         mock_handler.search_branches = AsyncMock(
-            return_value=[
-                Branch(name='main', commit_sha='abc123', protected=False),
-                Branch(name='develop', commit_sha='def456', protected=False),
-                Branch(name='feature-branch', commit_sha='ghi789', protected=False),
+            side_effect=[
+                [
+                    Branch(name='main', commit_sha='abc123', protected=False),
+                    Branch(name='develop', commit_sha='def456', protected=False),
+                ],
+                [
+                    Branch(name='feature-branch', commit_sha='ghi789', protected=False),
+                ],
             ]
         )
         mock_handler_cls.return_value = mock_handler
@@ -739,6 +743,8 @@ class TestSearchBranches:
         assert result.items[0].name == 'main'
         assert result.items[1].name == 'develop'
         assert result.next_page_id == encode_page_id(2)
+        assert mock_handler.search_branches.call_args_list[0].kwargs.get('page') == 1
+        assert mock_handler.search_branches.call_args_list[1].kwargs.get('page') == 2
 
     @pytest.mark.asyncio
     @patch('openhands.app_server.git.git_router.ProviderHandler')
@@ -772,7 +778,54 @@ class TestSearchBranches:
         assert call_kwargs.get('selected_provider') == ProviderType.GITHUB
         assert call_kwargs.get('repository') == 'user/repo'
         assert call_kwargs.get('query') == 'feature'
-        assert call_kwargs.get('per_page') == 11  # limit + 1
+        assert call_kwargs.get('per_page') == 10
+        assert call_kwargs.get('page') == 1
+
+    @pytest.mark.asyncio
+    @patch('openhands.app_server.git.git_router.ProviderHandler')
+    async def test_passes_page_to_provider(self, mock_handler_cls):
+        """Test that branch search supports following pagination links."""
+        # Arrange
+        mock_handler = MagicMock()
+        mock_handler.search_branches = AsyncMock(
+            side_effect=[
+                [
+                    Branch(name='feature-3', commit_sha='ghi789', protected=False),
+                    Branch(name='feature-4', commit_sha='jkl012', protected=False),
+                ],
+                [
+                    Branch(name='feature-5', commit_sha='mno345', protected=False),
+                ],
+            ]
+        )
+        mock_handler_cls.return_value = mock_handler
+
+        mock_context = _make_mock_user_context(
+            provider_tokens={
+                ProviderType.GITHUB: ProviderToken(user_id='user-123', token='token')
+            },
+            user_id='user-123',
+        )
+
+        # Act
+        result = await search_branches(
+            provider=ProviderType.GITHUB,
+            repository='user/repo',
+            query='feature',
+            page_id=encode_page_id(2),
+            limit=2,
+            user_context=mock_context,
+        )
+
+        # Assert
+        assert [branch.name for branch in result.items] == ['feature-3', 'feature-4']
+        assert result.next_page_id == encode_page_id(3)
+        first_call = mock_handler.search_branches.call_args_list[0].kwargs
+        second_call = mock_handler.search_branches.call_args_list[1].kwargs
+        assert first_call.get('page') == 2
+        assert first_call.get('per_page') == 2
+        assert second_call.get('page') == 3
+        assert second_call.get('per_page') == 2
 
     def test_returns_403_when_no_provider_tokens(self, test_client):
         """Test that 403 is returned when no provider tokens."""

--- a/tests/unit/integrations/bitbucket/test_bitbucket_branches.py
+++ b/tests/unit/integrations/bitbucket/test_bitbucket_branches.py
@@ -76,6 +76,7 @@ async def test_search_branches_bitbucket_filters_by_name_contains():
         params = args[1]
         assert 'refs/branches' in url
         assert params['pagelen'] == 15
+        assert params['page'] == 1
         assert params['q'] == 'name~"bugfix"'
         assert params['sort'] == '-target.date'
 

--- a/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_branches.py
+++ b/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_branches.py
@@ -119,6 +119,7 @@ async def test_search_branches_uses_filter_text():
     call_url, call_params = mock_req.call_args[0]
     assert 'filterText' in call_params
     assert call_params['filterText'] == 'my-thing'
+    assert call_params['start'] == 0
     assert 'q' not in call_params
     assert len(branches) == 1
     assert branches[0].name == 'feature/my-thing'

--- a/tests/unit/integrations/github/test_github_branches.py
+++ b/tests/unit/integrations/github/test_github_branches.py
@@ -129,6 +129,7 @@ async def test_search_branches_github_success_and_variables():
         assert variables['owner'] == 'foo'
         assert variables['name'] == 'bar'
         assert variables['query'] == 'fe'
+        assert variables['after'] is None
         assert 1 <= variables['perPage'] <= 100
 
         assert len(branches) == 2
@@ -143,6 +144,55 @@ async def test_search_branches_github_success_and_variables():
         assert b1.commit_sha == ''
         assert b1.last_push_date is None
         assert b1.protected is False
+
+
+@pytest.mark.asyncio
+async def test_search_branches_github_uses_cursor_for_page():
+    service = GitHubService(token=SecretStr('t'))
+
+    first_page = {
+        'data': {
+            'repository': {
+                'refs': {
+                    'nodes': [{'name': 'feature/one', 'target': {'__typename': 'Tag'}}],
+                    'pageInfo': {'endCursor': 'cursor-1', 'hasNextPage': True},
+                }
+            }
+        }
+    }
+    second_page = {
+        'data': {
+            'repository': {
+                'refs': {
+                    'nodes': [
+                        {
+                            'name': 'feature/two',
+                            'target': {
+                                '__typename': 'Commit',
+                                'oid': 'bbb222',
+                                'committedDate': '2024-01-06T10:00:00Z',
+                            },
+                        }
+                    ],
+                    'pageInfo': {'endCursor': 'cursor-2', 'hasNextPage': False},
+                }
+            }
+        }
+    }
+
+    exec_mock = AsyncMock(side_effect=[first_page, second_page])
+    with patch.object(service, 'execute_graphql_query', exec_mock):
+        branches = await service.search_branches(
+            'foo/bar', query='feature', per_page=1, page=2
+        )
+
+    assert len(branches) == 1
+    assert branches[0].name == 'feature/two'
+    assert branches[0].commit_sha == 'bbb222'
+    first_call = exec_mock.call_args_list[0].args[1]
+    second_call = exec_mock.call_args_list[1].args[1]
+    assert first_call['after'] is None
+    assert second_call['after'] == 'cursor-1'
 
 
 @pytest.mark.asyncio

--- a/tests/unit/integrations/gitlab/test_gitlab_branches.py
+++ b/tests/unit/integrations/gitlab/test_gitlab_branches.py
@@ -105,6 +105,7 @@ async def test_search_branches_gitlab_uses_search_param():
         params = args[1]
         assert 'repository/branches' in url
         assert params['per_page'] == '50'
+        assert params['page'] == '1'
         assert params['search'] == 'feat'
 
         assert len(branches) == 2


### PR DESCRIPTION
HUMAN:
This PR fixes branch search pagination so users can follow `next_page_id` on non-empty branch queries instead of getting a 400 response. It threads page information through the provider layer and adds provider-specific pagination support, including cursor-based paging for GitHub branch search.

- [x] A human has tested these changes.
## Summary
- support pagination for branch search requests instead of returning 400 for non-first pages
- pass page information through ProviderHandler to provider-specific branch search implementations
- add cursor-based pagination for GitHub branch search
- add/adjust unit tests for paginated branch search behavior

## Tests
- `python -m compileall ...`
- target pytest could not be completed locally because Poetry/project dependencies are not installed in this environment (`fastapi`, `litellm` missing)