### PR TITLE
fix: settings page scroll layout

### DIFF
--- a/frontend/src/components/features/settings/settings-layout.tsx
+++ b/frontend/src/components/features/settings/settings-layout.tsx
@@ -18,14 +18,14 @@ export function SettingsLayout({
   const closeMobileMenu = () => setIsMobileMenuOpen(false);
 
   return (
-    <div className="flex flex-col h-full px-[14px] pt-8">
+    <div className="flex flex-col h-full min-h-0 px-[14px] pt-8">
       {/* Mobile header */}
       <MobileHeader
         isMobileMenuOpen={isMobileMenuOpen}
         onToggleMenu={toggleMobileMenu}
       />
       {/* Desktop layout with navigation and main content */}
-      <div className="flex flex-1 overflow-hidden gap-10">
+      <div className="flex flex-1 min-h-0 overflow-hidden gap-10">
         {/* Navigation */}
         <SettingsNavigation
           isMobileMenuOpen={isMobileMenuOpen}
@@ -33,7 +33,7 @@ export function SettingsLayout({
           navigationItems={navigationItems}
         />
         {/* Main content */}
-        <main className="flex-1 min-w-0 overflow-auto custom-scrollbar-always">
+        <main className="flex-1 min-w-0 min-h-0 overflow-auto custom-scrollbar-always">
           {children}
         </main>
       </div>

--- a/frontend/src/components/features/settings/settings-navigation.tsx
+++ b/frontend/src/components/features/settings/settings-navigation.tsx
@@ -38,7 +38,7 @@ export function SettingsNavigation({
       <nav
         data-testid="settings-navbar"
         className={cn(
-          "flex flex-col gap-6 transition-transform duration-300 ease-in-out",
+          "flex flex-col gap-6 transition-transform duration-300 ease-in-out min-h-0 overflow-y-auto",
           // Mobile: full screen overlay with dark background matching desktop
           "fixed inset-0 z-50 w-full bg-[#050505] p-4 transform md:transform-none",
           isMobileMenuOpen ? "translate-x-0" : "-translate-x-full",


### PR DESCRIPTION
HUMAN: Fixes a scrolling issue on admin settings where you can't move the left pane :(

- [X] A human has tested these changes.

## Summary
- add min-h-0 to settings layout containers to fix scrolling behavior
- allow the settings navigation list to scroll within the layout

## Testing
- not run (not requested)

_This PR description was updated by an AI agent (OpenHands) on behalf of the user._

---

Demo is up here:
https://admin-dashboard.ohe-staging.platform-team.all-hands.dev/settings/budgets

(scroll the left hand side, it should flow now)