### PR TITLE
fix(jira-dc): enable Connect button in email-match mode with managed service account (#15150)

### DIFF
--- a/frontend/src/api/option-service/option.types.ts
+++ b/frontend/src/api/option-service/option.types.ts
@@ -78,6 +78,7 @@ export interface WebClientConfig {
   provider_default_hosts?: Partial<Record<Provider, string>>;
   slack_enabled?: boolean;
   acp_providers?: ACPProviderConfig[];
+  jira_dc_host?: string | null;
   /** Jira DC host when DC OAuth is configured; used to pre-fill + lock the
    *  configure form's host field. Null/absent in email-match mode. */
   jira_dc_oauth_host?: string | null;

--- a/frontend/src/components/features/settings/project-management/jira-dc-integration-panel.test.tsx
+++ b/frontend/src/components/features/settings/project-management/jira-dc-integration-panel.test.tsx
@@ -1,0 +1,185 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { JiraDcIntegrationPanel } from "./jira-dc-integration-panel";
+
+// Mock the I18n hooks and translation keys
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+  initReactI18next: {
+    type: "3rdParty",
+    init: vi.fn(),
+  },
+}));
+
+// We can define variables that tests can override
+let mockConfig = {
+  jira_dc_oauth_host: null as string | null,
+  jira_dc_host: null as string | null,
+  jira_dc_service_account_managed: false,
+  jira_dc_service_account_email: "",
+};
+
+let mockIntegrationData = {
+  status: "inactive",
+  workspace: null as Record<string, unknown> | null,
+};
+
+let mockHasPermission = true;
+
+vi.mock("#/hooks/query/use-config", () => ({
+  useConfig: () => ({ data: mockConfig }),
+}));
+
+vi.mock("#/hooks/query/use-integration-status", () => ({
+  useIntegrationStatus: () => ({ data: mockIntegrationData }),
+}));
+
+vi.mock("#/hooks/mutation/use-configure-integration", () => ({
+  useConfigureIntegration: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("#/hooks/mutation/use-link-integration", () => ({
+  useLinkIntegration: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("#/hooks/mutation/use-unlink-integration", () => ({
+  useUnlinkIntegration: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("#/hooks/mutation/use-update-jira-dc-workspace-status", () => ({
+  useUpdateJiraDcWorkspaceStatus: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("#/hooks/mutation/use-validate-integration", () => ({
+  useValidateIntegration: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("#/hooks/query/use-me", () => ({
+  useMe: () => ({ data: { role: "admin" } }),
+}));
+
+vi.mock("#/hooks/organizations/use-permissions", () => ({
+  usePermission: () => ({
+    hasPermission: () => mockHasPermission,
+  }),
+}));
+
+vi.mock("#/hooks/query/use-jira-dc-instance-status", () => ({
+  useJiraDcInstanceStatus: () => ({
+    data: { configured: false, host: null },
+  }),
+}));
+
+const renderPanel = () =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <JiraDcIntegrationPanel />
+    </QueryClientProvider>,
+  );
+
+describe("JiraDcIntegrationPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfig = {
+      jira_dc_oauth_host: null,
+      jira_dc_host: null,
+      jira_dc_service_account_managed: false,
+      jira_dc_service_account_email: "",
+    };
+    mockIntegrationData = {
+      status: "inactive",
+      workspace: null,
+    };
+    mockHasPermission = true;
+  });
+
+  it("Managed + email-match: Connect becomes enabled", async () => {
+    // 1. Managed + email-match (jira_dc_oauth_host: null, jira_dc_service_account_managed: true)
+    mockConfig.jira_dc_oauth_host = null;
+    mockConfig.jira_dc_host = "jira.example.com";
+    mockConfig.jira_dc_service_account_managed = true;
+    mockConfig.jira_dc_service_account_email = "service@example.com";
+
+    renderPanel();
+
+    // Click Configure
+    const configureBtn = screen.getByTestId("jira-dc-configure-button");
+    fireEvent.click(configureBtn);
+
+    // Dialog opens. Admin PAT for auto-install (which is default)
+    // Find Connect button
+    const submitBtn = screen.getByTestId("jira-dc-submit-button");
+
+    // Initially disabled because auto-install requires admin PAT
+    expect(submitBtn).toBeDisabled();
+
+    // Fill in admin PAT
+    const patInput = screen.getByTestId("admin-api-key-input");
+    fireEvent.change(patInput, { target: { value: "my-admin-pat" } });
+
+    // Now it should be enabled!
+    expect(submitBtn).not.toBeDisabled();
+
+    // Switch to manual mode
+    const manualBtn = screen.getByTestId("webhook-mode-manual");
+    fireEvent.click(manualBtn);
+
+    // In manual mode, it should be enabled directly because it just generates details
+    expect(submitBtn).not.toBeDisabled();
+  });
+
+  it("Unmanaged + email-match: host input is rendered; Connect stays disabled until host filled", async () => {
+    // 2. Unmanaged + email-match
+    mockConfig.jira_dc_oauth_host = null;
+    mockConfig.jira_dc_host = null;
+    mockConfig.jira_dc_service_account_managed = false;
+
+    renderPanel();
+
+    const configureBtn = screen.getByTestId("jira-dc-configure-button");
+    fireEvent.click(configureBtn);
+
+    // Host input is rendered
+    const hostInput = screen.getByTestId("jira-dc-host-input");
+    expect(hostInput).toBeInTheDocument();
+
+    const submitBtn = screen.getByTestId("jira-dc-submit-button");
+    expect(submitBtn).toBeDisabled();
+
+    // Fill service account
+    const emailInput = screen.getByTestId("jira-dc-svc-email-input");
+    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+    const patInput = screen.getByTestId("jira-dc-svc-pat-input");
+    fireEvent.change(patInput, { target: { value: "svc-pat" } });
+
+    // Fill admin PAT
+    const adminPatInput = screen.getByTestId("admin-api-key-input");
+    fireEvent.change(adminPatInput, { target: { value: "admin-pat" } });
+
+    // Still disabled because host is empty
+    expect(submitBtn).toBeDisabled();
+
+    // Fill host
+    fireEvent.change(hostInput, { target: { value: "jira.example.com" } });
+
+    // Now it should be enabled
+    expect(submitBtn).not.toBeDisabled();
+  });
+
+  it("OAuth mode: existing behavior preserved", async () => {
+    // 3. OAuth mode
+    mockConfig.jira_dc_oauth_host = "oauth.example.com";
+    mockConfig.jira_dc_host = "oauth.example.com";
+    mockConfig.jira_dc_service_account_managed = false;
+
+    renderPanel();
+
+    // Entry action is Connect (direct OAuth link)
+    const connectBtn = screen.getByTestId("jira-dc-connect-button");
+    expect(connectBtn).toBeInTheDocument();
+    expect(connectBtn).not.toBeDisabled();
+  });
+});

--- a/frontend/src/components/features/settings/project-management/jira-dc-integration-panel.tsx
+++ b/frontend/src/components/features/settings/project-management/jira-dc-integration-panel.tsx
@@ -57,6 +57,7 @@ export function JiraDcIntegrationPanel() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const { data: config } = useConfig();
+  const jiraDcHost = config?.jira_dc_host ?? null;
   // OAuth installs already know the host; pre-fill + lock it.
   const jiraDcOAuthHost = config?.jira_dc_oauth_host ?? null;
   const serviceAccountManaged =
@@ -136,7 +137,7 @@ export function JiraDcIntegrationPanel() {
       setHasSavedApiKey(true);
       setIsActive(existingWorkspace.status === "active");
     } else {
-      setWorkspace(jiraDcOAuthHost ?? "");
+      setWorkspace(jiraDcOAuthHost ?? jiraDcHost ?? "");
       setServiceAccountEmail(
         serviceAccountManaged ? managedServiceAccountEmail : "",
       );
@@ -152,6 +153,7 @@ export function JiraDcIntegrationPanel() {
     setManualSetupSaved(false);
   }, [
     existingWorkspace,
+    jiraDcHost,
     jiraDcOAuthHost,
     managedServiceAccountEmail,
     serviceAccountManaged,
@@ -371,8 +373,9 @@ export function JiraDcIntegrationPanel() {
     manualInstructionKey =
       I18nKey.PROJECT_MANAGEMENT$JIRA_DC_MANUAL_INSTRUCTIONS;
   }
+  const requiresHostInput = !serviceAccountManaged;
   const isSubmitDisabled =
-    !workspace.trim() ||
+    (requiresHostInput && !workspace.trim()) ||
     !serviceAccountEmailSatisfied ||
     (apiKeyRequired && !serviceAccountApiKey.trim()) ||
     emailError !== null ||

--- a/openhands/app_server/web_client/default_web_client_config_injector.py
+++ b/openhands/app_server/web_client/default_web_client_config_injector.py
@@ -137,6 +137,19 @@ def _get_jira_dc_oauth_host() -> str | None:
     return urlparse(base_url).hostname or None
 
 
+def _get_jira_dc_host() -> str | None:
+    """Hostname of the Jira Data Center server.
+
+    Returns the host from JIRA_DC_BASE_URL regardless of whether OAuth is enabled.
+    Useful for pre-filling the host in email-match mode when the service account
+    is managed.
+    """
+    base_url = os.getenv('JIRA_DC_BASE_URL', '').strip()
+    if not base_url:
+        return None
+    return urlparse(base_url).hostname or None
+
+
 def _get_jira_dc_service_account_config_error() -> str | None:
     """Return a web-client-safe service-account config error, if any."""
     return get_jira_dc_service_account_env_config().error
@@ -218,6 +231,7 @@ class DefaultWebClientConfigInjector(WebClientConfigInjector):
         }
     )
     slack_enabled: bool = Field(default_factory=_get_slack_enabled)
+    jira_dc_host: str | None = Field(default_factory=_get_jira_dc_host)
     jira_dc_oauth_host: str | None = Field(default_factory=_get_jira_dc_oauth_host)
     jira_dc_service_account_managed: bool = Field(
         default_factory=_is_jira_dc_service_account_managed
@@ -265,6 +279,7 @@ class DefaultWebClientConfigInjector(WebClientConfigInjector):
             gitlab_enabled=self.gitlab_enabled,
             provider_default_hosts=self.provider_default_hosts,
             slack_enabled=self.slack_enabled,
+            jira_dc_host=self.jira_dc_host,
             jira_dc_oauth_host=self.jira_dc_oauth_host,
             jira_dc_service_account_managed=self.jira_dc_service_account_managed,
             jira_dc_service_account_email=self.jira_dc_service_account_email,

--- a/openhands/app_server/web_client/web_client_models.py
+++ b/openhands/app_server/web_client/web_client_models.py
@@ -77,6 +77,7 @@ class WebClientConfig(DiscriminatedUnionMixin):
     provider_default_hosts: dict[str, str] = Field(default_factory=dict)
     slack_enabled: bool = False
     acp_providers: list[ACPProviderConfig] = Field(default_factory=list)
+    jira_dc_host: str | None = None
     # Hostname of the Jira Data Center server when DC OAuth is configured, so the
     # configure form can pre-fill and lock the host field (the OAuth callback only
     # accepts this exact host). None in email-match mode / when DC isn't configured.


### PR DESCRIPTION
HUMAN:

This PR fixes the Jira Data Center Connect button being stuck greyed out in email-match mode with an admin-managed service account. The backend now passes the Jira host to the app in email-match mode (before it only did that for OAuth), and the settings form uses that host so Connect can turn on. I also added frontend tests for this case.

- [x] A human has tested these changes.

## Why

In the Jira Data Center settings, when the login mode is **email-match** and the service account is **managed by an admin**, the **Connect** button was always greyed out. There was no way to finish the webhook setup from the screen.

The reason: the Connect button needs a Jira host to turn on. But in email-match mode, the app never received the host, and the box to type it was hidden. So the host stayed empty and the button could never turn on.

## Summary

- **Backend:** now sends the Jira host to the app in email-match mode too (before, it only did this in OAuth mode).
- **Frontend:** reads that host and fills it into the form, so the Connect button can turn on.
- **Tests:** added tests to check Connect turns on in this mode, and that the other modes still work the same.

## Issue Number

Closes OpenHands/enterprise#55

## Testing

- Frontend tested on my machine: tests, lint, typecheck, and build all pass.
- Backend code reviewed but not run locally (no Python setup) — CI will test it.