### PR TITLE
fix(jira-dc): show host input in email + managed service account setup so Connect isn't a dead-end (#15150)

### DIFF
--- a/frontend/src/components/features/settings/project-management/jira-dc-integration-panel.tsx
+++ b/frontend/src/components/features/settings/project-management/jira-dc-integration-panel.tsx
@@ -410,7 +410,10 @@ export function JiraDcIntegrationPanel() {
 
   const colHead =
     "px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider";
-  const showServerAndServiceAccountSection = !serviceAccountManaged;
+  // Also show the section's host input when no host exists yet (email + managed
+  // SA + first-time); otherwise it's hidden and Connect stays disabled (#15150).
+  const showServerAndServiceAccountSection =
+    !serviceAccountManaged || !hostLocked;
 
   const serverAndServiceAccountSection = (
     <div className="flex flex-col gap-3">


### PR DESCRIPTION
HUMAN: Fixes OpenHands/enterprise#55 — in email-match mode with a KOTS-managed service account and no existing workspace, the Jira DC Configure dialog hid the only Jira host input, so `workspace` stayed empty and Connect was permanently disabled (a dead-end). Validated live on an OHE test install in that exact config: the admin Configure UI now renders the host input.

- [x] A human has tested these changes.

## Problem
In email-match mode + KOTS-managed service account + first-time workspace setup, `showServerAndServiceAccountSection = !serviceAccountManaged` hides the section containing the only Jira host input. Email mode never sets `jiraDcOAuthHost`, so `seedForm` leaves `workspace = ""`, and `isSubmitDisabled` (which requires a non-empty workspace) keeps Connect permanently disabled — the admin can't complete the webhook connection. Pre-existing from the single-stage Configure form redesign; this is the panel OpenHands/OpenHands#15040 reworked.

## Fix
Also render the section when the host isn't otherwise available (`!hostLocked`), so the admin can type the Jira host → `workspace` populates → Connect enables. The section already renders the managed service-account email read-only and omits the PAT, so nothing managed is exposed for editing. Unaffected for OAuth mode, non-managed SA, or existing workspaces.

## Testing
Validated live on an OHE test install in the exact bug config (email mode, KOTS-managed SA, fresh hookup, no existing workspace): before, the Configure dialog showed no host field and Connect was permanently greyed; after, the Jira host input renders and the admin can configure the integration.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-c7b3f17   docker.openhands.dev/openhands/openhands:c7b3f17
```