### PR TITLE
fix: Fix CVE-2026-49852: Update joserfc to >=1.6.8

### DIFF
--- a/enterprise/poetry.lock
+++ b/enterprise/poetry.lock
@@ -3974,14 +3974,14 @@ files = [
 
 [[package]]
 name = "joserfc"
-version = "1.6.5"
+version = "1.7.2"
 description = "The ultimate Python library for JOSE RFCs, including JWS, JWE, JWK, JWA, JWT"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "joserfc-1.6.5-py3-none-any.whl", hash = "sha256:e9878a0f8243fe7b95e11fdda81374ca9f7a689e302751579d3dfdeec559675e"},
-    {file = "joserfc-1.6.5.tar.gz", hash = "sha256:1482a7db78fb4602e44ed89e51b599d052e091288c7c532c5b694e20149dec48"},
+    {file = "joserfc-1.7.2-py3-none-any.whl", hash = "sha256:ddd818c0ca9b4f17bbc2d72cb3966e6ded7502be089316c62c3cc64ae86132b5"},
+    {file = "joserfc-1.7.2.tar.gz", hash = "sha256:537ffb8888b2df039cb5b6d017d7cff6f09d521ce65d89cc9b8ab752b1cff947"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -3739,14 +3739,14 @@ files = [
 
 [[package]]
 name = "joserfc"
-version = "1.6.5"
+version = "1.7.2"
 description = "The ultimate Python library for JOSE RFCs, including JWS, JWE, JWK, JWA, JWT"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "joserfc-1.6.5-py3-none-any.whl", hash = "sha256:e9878a0f8243fe7b95e11fdda81374ca9f7a689e302751579d3dfdeec559675e"},
-    {file = "joserfc-1.6.5.tar.gz", hash = "sha256:1482a7db78fb4602e44ed89e51b599d052e091288c7c532c5b694e20149dec48"},
+    {file = "joserfc-1.7.2-py3-none-any.whl", hash = "sha256:ddd818c0ca9b4f17bbc2d72cb3966e6ded7502be089316c62c3cc64ae86132b5"},
+    {file = "joserfc-1.7.2.tar.gz", hash = "sha256:537ffb8888b2df039cb5b6d017d7cff6f09d521ce65d89cc9b8ab752b1cff947"},
 ]
 
 [package.dependencies]
@@ -13763,4 +13763,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12,<3.14"
-content-hash = "cad64b376b764decdf4f400fb93bda8852c90f0b7d0c0fe5c807167ae0f8aeeb"
+content-hash = "adcdc545cc3e034a4ea135d5aa4efcbf538cb910e9e4312baf2a947d6aaf7259"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "ipywidgets==8.1.8",
   "jinja2==3.1.6",
   "joblib==1.5.3",
-  "joserfc>=1.0.0",
+  "joserfc>=1.6.8",
   "json-repair",
   "jupyter-kernel-gateway==3.0.1",
   "kubernetes>=33.1",
@@ -251,7 +251,7 @@ pybase62 = "1.0.0"
 openhands-sdk = "==1.31.2"
 openhands-agent-server = "==1.31.2"
 openhands-tools = "==1.31.2"
-joserfc = ">=1.0.0"
+joserfc = ">=1.6.8"
 sqlalchemy = { extras = [ "asyncio" ], version = "^2.0.40" }
 pg8000 = "1.31.5"
 asyncpg = ">=0.30,<0.32"

--- a/uv.lock
+++ b/uv.lock
@@ -2165,14 +2165,14 @@ wheels = [
 
 [[package]]
 name = "joserfc"
-version = "1.6.4"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/26/abe1ad855eb334b5ebc9c6495d4798e12bee70e5e8e815d54570710b8312/joserfc-1.7.2.tar.gz", hash = "sha256:537ffb8888b2df039cb5b6d017d7cff6f09d521ce65d89cc9b8ab752b1cff947", size = 233183, upload-time = "2026-06-29T09:03:10.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
+    { url = "https://files.pythonhosted.org/packages/13/80/d1b30336582cced4dce0dae776508a6011723e32f907bc7a702c0b25890a/joserfc-1.7.2-py3-none-any.whl", hash = "sha256:ddd818c0ca9b4f17bbc2d72cb3966e6ded7502be089316c62c3cc64ae86132b5", size = 70426, upload-time = "2026-06-29T09:03:09.393Z" },
 ]
 
 [[package]]
@@ -3336,7 +3336,7 @@ requires-dist = [
     { name = "ipywidgets", specifier = "==8.1.8" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "joblib", specifier = "==1.5.3" },
-    { name = "joserfc", specifier = ">=1.0.0" },
+    { name = "joserfc", specifier = ">=1.6.8" },
     { name = "json-repair" },
     { name = "jupyter-kernel-gateway", specifier = "==3.0.1" },
     { name = "kubernetes", specifier = ">=33.1" },


### PR DESCRIPTION
## Security Fix: CVE-2026-49852

Updates the `joserfc` dependency minimum version from `>=1.0.0` to `>=1.6.8` to address CVE-2026-49852.

### Changes
- **pyproject.toml**: Updated `joserfc` constraint from `>=1.0.0` to `>=1.6.8` (both in project dependencies and Poetry section)
- **uv.lock**: Regenerated — joserfc updated from 1.6.4 → 1.7.2
- **poetry.lock**: Regenerated — joserfc updated from 1.6.5 → 1.7.2
- **enterprise/poetry.lock**: Regenerated — joserfc updated from 1.6.5 → 1.7.2
- **enterprise/uv.lock**: Regenerated (joserfc is not a direct dependency in enterprise)

### Details
- **CVE**: CVE-2026-49852
- **Package**: joserfc
- **Previous version**: 1.6.5 (poetry.lock) / 1.6.4 (uv.lock)
- **Fixed version**: >=1.6.8 (resolved to 1.7.2)

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@mamoodi can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8166a850-4f91-42fe-a467-51f330d1793a)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-2d3aa85   docker.openhands.dev/openhands/openhands:2d3aa85
```