### PR TITLE
ci: PLTF-2960 open a chart image-tag bump PR on cloud release

### DIFF
--- a/.github/workflows/bump-chart.yml
+++ b/.github/workflows/bump-chart.yml
@@ -3,10 +3,6 @@
 # retags the sha-built image with the tag name (type=ref,event=tag)
 # concurrently, so the image tag matches the git tag verbatim — no prefix
 # stripping needed.
-#
-# Deliberately does NOT bump the coupled agent-server pins
-# (global.agentServerImage.tag / image-loader); those stay manual for now and
-# must move with the enterprise-server's pinned SDK version.
 name: Bump chart image tag
 
 on:

--- a/.github/workflows/bump-chart.yml
+++ b/.github/workflows/bump-chart.yml
@@ -1,0 +1,26 @@
+# Opens a PR in OpenHands/OpenHands-Cloud pointing the openhands chart's
+# image.tag at the enterprise-server image that was just tagged. tag-image.yml
+# retags the sha-built image with the tag name (type=ref,event=tag)
+# concurrently, so the image tag matches the git tag verbatim — no prefix
+# stripping needed.
+#
+# Deliberately does NOT bump the coupled agent-server pins
+# (global.agentServerImage.tag / image-loader); those stay manual for now and
+# must move with the enterprise-server's pinned SDK version.
+name: Bump chart image tag
+
+on:
+  push:
+    tags:
+      - 'cloud-[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  bump-chart:
+    # secrets: inherit forwards the org secrets RELEASE_APP_ID /
+    # RELEASE_APP_PRIVATE_KEY that the reusable workflow needs.
+    secrets: inherit
+    uses: OpenHands/OpenHands-Cloud/.github/workflows/bump-image-tag.yml@main
+    with:
+      component: openhands
+      chart_file: charts/openhands/values.yaml
+      tag: ${{ github.ref_name }}


### PR DESCRIPTION
HUMAN: CI workflow only change to create chart PR bumps after a release please release of cloud.


- [ ] A human has tested these changes.

AGENT:

---

## Why

Chart bumps after a cloud release are still manual (e.g. the `chore(charts): bump OpenHands image to cloud-1.41.0` commit in OpenHands-Cloud). The chart repo has a `bump-image-tag` reusable workflow that component repos (automation, runtime-api, integrations-hub, plugin-directory) already call to open the bump PR automatically; this wires this repo in for the enterprise-server image.

## Summary

- Add `.github/workflows/bump-chart.yml`: on a `cloud-X.Y.Z` tag push, call the chart repo's reusable workflow to open a `feat(openhands): bump image tag to cloud-X.Y.Z` PR against `charts/openhands/values.yaml` (`.image.tag`).
- The image tag matches the git tag verbatim (tag-image.yml retags via `type=ref,event=tag`), so the caller is a single job with no tag computation.

## Issue Number

PLTF-2960

## How to Test

Not testable before merge: the workflow triggers on tag pushes to this repo, and reusable-workflow callers only run from the default branch's tag ref. Pre-merge verification done instead: inputs checked against the reusable workflow's declared inputs; confirmed `tag-image.yml` publishes `ghcr.io/openhands/enterprise-server:<tag>` verbatim on tag push; confirmed the `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` org secrets are in scope for this repo; YAML parses. After merge: push the next `cloud-*` tag and confirm a bump PR appears in OpenHands-Cloud.

## Video/Screenshots

N/A — CI workflow only.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Deliberately does not bump the coupled agent-server pins (`global.agentServerImage.tag` / image-loader) — those must move with the enterprise-server's pinned SDK version and stay manual for now.

_This PR was drafted by an AI agent on behalf of the user._

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-f8c049f   docker.openhands.dev/openhands/openhands:f8c049f
```