### PR TITLE
fix: do not fail login when IdP broker token fetch fails

### DIFF
--- a/enterprise/server/routes/auth.py
+++ b/enterprise/server/routes/auth.py
@@ -455,9 +455,18 @@ async def keycloak_callback(
     # Only fetch/store IdP tokens for OAuth-based IdPs (not SAML)
     # SAML IdPs don't have OAuth tokens to retrieve from Keycloak's broker endpoint
     if idp_type != 'saml':
-        await token_manager.store_idp_tokens(
-            ProviderType(idp), user_id, keycloak_access_token
-        )
+        try:
+            await token_manager.store_idp_tokens(
+                ProviderType(idp), user_id, keycloak_access_token
+            )
+        except Exception:
+            # Realm-local users have no brokered IdP link, so the broker-token
+            # fetch 400s; that must not 500 login — they simply have no IdP tokens.
+            logger.warning(
+                'Failed to store IdP tokens; continuing login without them',
+                extra={'user_id': user_id, 'idp': idp},
+                exc_info=True,
+            )
 
     valid_offline_token = (
         await token_manager.validate_offline_token(user_id=user_info.sub)

--- a/enterprise/tests/unit/test_auth_routes.py
+++ b/enterprise/tests/unit/test_auth_routes.py
@@ -305,6 +305,87 @@ async def test_keycloak_callback_success_with_valid_offline_token(
 
 
 @pytest.mark.asyncio
+async def test_keycloak_callback_idp_token_failure_non_fatal(
+    mock_request, mock_background_tasks, create_keycloak_user_info
+):
+    """A store_idp_tokens failure (realm-local user with no broker link) must not
+    500 the callback — login should still complete."""
+    mock_org = MagicMock()
+    mock_org.id = 'test_org_id'
+    mock_org.name = 'Test Org'
+
+    with (
+        patch('server.routes.auth.token_manager') as mock_token_manager,
+        patch('server.routes.auth.set_response_cookie'),
+        patch('server.routes.auth.UserStore') as mock_user_store,
+        patch('server.routes.auth.get_analytics_service', return_value=MagicMock()),
+        patch(
+            'storage.org_store.OrgStore.get_org_by_id',
+            new_callable=AsyncMock,
+            return_value=mock_org,
+        ),
+        patch(
+            'storage.org_store.OrgStore.get_orgs_by_ids',
+            new_callable=AsyncMock,
+            return_value=[mock_org],
+        ),
+        patch(
+            'storage.org_member_store.OrgMemberStore.get_org_members_count',
+            new_callable=AsyncMock,
+            return_value=1,
+        ),
+        patch(
+            'server.routes.auth._should_redirect_to_onboarding',
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+    ):
+        mock_user = MagicMock()
+        mock_user.id = 'test_user_id'
+        mock_user.current_org_id = 'test_org_id'
+        mock_user.accepted_tos = '2025-01-01'
+        mock_user.user_consents_to_analytics = True
+        mock_user.org_members = []
+
+        mock_user_store.get_user_by_id = AsyncMock(return_value=mock_user)
+        mock_user_store.create_user = AsyncMock(return_value=mock_user)
+        mock_user_store.migrate_user = AsyncMock(return_value=mock_user)
+        mock_user_store.backfill_contact_name = AsyncMock()
+        mock_user_store.backfill_user_email = AsyncMock()
+
+        mock_token_manager.get_keycloak_tokens = AsyncMock(
+            return_value=('test_access_token', 'test_refresh_token')
+        )
+        mock_token_manager.get_user_info = AsyncMock(
+            return_value=create_keycloak_user_info(
+                sub='test_user_id',
+                preferred_username='test_user',
+                identity_provider='github',
+                email_verified=True,
+            )
+        )
+        # Realm-local user: no brokered IdP link, so the broker fetch 400s.
+        mock_token_manager.store_idp_tokens = AsyncMock(
+            side_effect=Exception('400 from broker endpoint')
+        )
+        mock_token_manager.validate_offline_token = AsyncMock(return_value=True)
+
+        result = await keycloak_callback(
+            code='test_code',
+            state='test_state',
+            request=mock_request,
+            background_tasks=mock_background_tasks,
+            user_authorizer=create_mock_user_authorizer(),
+        )
+
+        # Login still completes despite the broker-token failure.
+        assert isinstance(result, RedirectResponse)
+        assert result.status_code == 302
+        assert result.headers['location'] == 'test_state'
+        mock_token_manager.store_idp_tokens.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_keycloak_callback_email_not_verified(
     mock_request, mock_background_tasks, create_keycloak_user_info
 ):


### PR DESCRIPTION
## Problem

On OHE (self-hosted) installs, a **realm-local Keycloak user** (created directly in the realm, with no brokered IdP link) cannot log in: `keycloak_callback` defaults a missing `identity_provider` claim to GitHub and then calls `store_idp_tokens`, which fetches the brokered token from Keycloak's broker endpoint. For a realm-local user there is no broker link, so that fetch returns 400 and the whole `/oauth/keycloak/callback` returns an unhandled **500** — login is impossible. (Reproduced live on a real instance; the manual workaround was setting an `identity_provider=<provider>:saml` user attribute.)

## Fix

Make the broker-token fetch **non-fatal**: if `store_idp_tokens` raises, log a warning and continue the login. A realm-local user simply has no brokered provider tokens to store (which they never had). The SAML skip and the default-to-github behavior (and its existing TODO) are untouched — only the failure is prevented from 500ing.

Happy to narrow the exception handling (e.g. catch only the specific broker 400, or gate on the user being realm-local) if reviewers prefer.

## Test

`test_keycloak_callback_idp_token_failure_non_fatal` mocks `store_idp_tokens` to raise and asserts the callback still returns a 302 redirect (fails on current code with the unhandled exception, passes with the fix). Full `test_auth_routes.py` suite passes.

HUMAN: Reproduced the 500 live on a real OHE instance; fix verified by a red→green unit test. Not yet manually re-tested on an instance after the fix.

- [ ] A human has tested these changes.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-99dabc8   docker.openhands.dev/openhands/openhands:99dabc8
```