### PR TITLE
Show multiple scope tags when marketplace is registered at multiple levels

### DIFF
--- a/frontend/src/components/features/settings/skills-settings/marketplace-table.tsx
+++ b/frontend/src/components/features/settings/skills-settings/marketplace-table.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { MarketplaceRegistration } from "#/types/settings";
+import { MarketplaceDisplay, MarketplaceRegistration } from "#/types/settings";
 import { Toggle } from "#/components/shared/toggle/toggle";
 import { InfoTooltip } from "#/components/features/settings/info-tooltip";
 import { I18nKey } from "#/i18n/declaration";
@@ -9,7 +9,7 @@ import EditIcon from "#/icons/u-edit.svg?react";
 import DeleteIcon from "#/icons/u-delete.svg?react";
 
 interface MarketplaceTableProps {
-  marketplaces: MarketplaceRegistration[];
+  marketplaces: MarketplaceDisplay[];
   onToggleAutoLoad: (name: string) => void;
   onEdit: (marketplace: MarketplaceRegistration) => void;
   onDelete: (marketplace: MarketplaceRegistration) => void;
@@ -101,91 +101,113 @@ export function MarketplaceTable({
             </tr>
           </thead>
           <tbody>
-            {marketplaces.map((mp) => (
-              <tr
-                key={mp.name}
-                className="border-t border-tertiary/60 transition-colors hover:bg-base-secondary/40"
-              >
-                <td
-                  className={cn(CELL_CLASS, "font-medium text-content-2")}
-                  title={mp.name}
+            {marketplaces.map((mp) => {
+              // Determine the editable scope (prefer personal > org > instance)
+              const editableScope = mp.scopes.includes("personal")
+                ? "personal"
+                : mp.scopes.includes("org")
+                  ? "org"
+                  : "instance";
+              const editableReg = mp.registrations.get(editableScope)!;
+              
+              // Disable toggle if all scopes are instance, or if only org and user is not admin
+              const hasInstance = mp.scopes.includes("instance");
+              const hasOnlyOrg = mp.scopes.length === 1 && mp.scopes[0] === "org";
+              const toggleDisabled =
+                hasInstance || (hasOnlyOrg && !isAdminOrOwner);
+              
+              return (
+                <tr
+                  key={mp.name}
+                  className="border-t border-tertiary/60 transition-colors hover:bg-base-secondary/40"
                 >
-                  <span className="block truncate">{mp.name}</span>
-                </td>
-                <td className={cn(CELL_CLASS, "text-tertiary-alt")}>
-                  <span className="block truncate" title={mp.source}>
-                    {mp.source}
-                  </span>
-                </td>
-                <td className={cn(CELL_CLASS, "text-tertiary-alt")}>
-                  <span className="block truncate" title={mp.ref || undefined}>
-                    {mp.ref || "—"}
-                  </span>
-                </td>
-                <td className={cn(CELL_CLASS, "text-tertiary-alt")}>
-                  <span
-                    className="block truncate"
-                    title={mp.repo_path || undefined}
+                  <td
+                    className={cn(CELL_CLASS, "font-medium text-content-2")}
+                    title={mp.name}
                   >
-                    {mp.repo_path || "—"}
-                  </span>
-                </td>
-                <td className={CELL_CLASS}>
-                  <ScopeBadge scope={mp.scope ?? "personal"} />
-                </td>
-                <td className={CELL_CLASS}>
-                  <Toggle
-                    checked={!!mp.auto_load}
-                    disabled={
-                      mp.scope === "instance" ||
-                      (mp.scope === "org" && !isAdminOrOwner)
-                    }
-                    onClick={
-                      mp.scope !== "instance" &&
-                      (mp.scope === "personal" || isAdminOrOwner)
-                        ? () => onToggleAutoLoad(mp.name)
-                        : undefined
-                    }
-                    title={getAutoLoadTitle(mp.scope ?? "personal")}
-                    aria-label={`Toggle auto-load for ${mp.name}`}
-                  />
-                </td>
-                <td className={CELL_CLASS}>
-                  <div className="flex items-center justify-end gap-1">
-                    <button
-                      type="button"
-                      onClick={() => onEdit(mp)}
-                      disabled={!canEdit(mp)}
-                      title={canEdit(mp) ? t(I18nKey.BUTTON$EDIT) : undefined}
-                      aria-label={`${t(I18nKey.BUTTON$EDIT)} ${mp.name}`}
-                      className={cn(
-                        "rounded-md p-1.5 transition-colors",
-                        canEdit(mp)
-                          ? "text-tertiary-light hover:bg-white/10 hover:text-content-2"
-                          : "cursor-not-allowed text-tertiary-alt opacity-40",
-                      )}
+                    <span className="block truncate">{mp.name}</span>
+                  </td>
+                  <td className={cn(CELL_CLASS, "text-tertiary-alt")}>
+                    <span className="block truncate" title={mp.source}>
+                      {mp.source}
+                    </span>
+                  </td>
+                  <td className={cn(CELL_CLASS, "text-tertiary-alt")}>
+                    <span className="block truncate" title={mp.ref || undefined}>
+                      {mp.ref || "—"}
+                    </span>
+                  </td>
+                  <td className={cn(CELL_CLASS, "text-tertiary-alt")}>
+                    <span
+                      className="block truncate"
+                      title={mp.repo_path || undefined}
                     >
-                      <EditIcon width={16} height={16} />
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => onDelete(mp)}
-                      disabled={!canEdit(mp)}
-                      title={canEdit(mp) ? t(I18nKey.BUTTON$DELETE) : undefined}
-                      aria-label={`${t(I18nKey.BUTTON$DELETE)} ${mp.name}`}
-                      className={cn(
-                        "rounded-md p-1.5 transition-colors",
-                        canEdit(mp)
-                          ? "text-danger hover:bg-danger/15"
-                          : "cursor-not-allowed text-tertiary-alt opacity-40",
-                      )}
-                    >
-                      <DeleteIcon width={16} height={16} />
-                    </button>
-                  </div>
-                </td>
-              </tr>
-            ))}
+                      {mp.repo_path || "—"}
+                    </span>
+                  </td>
+                  <td className={CELL_CLASS}>
+                    <div className="flex flex-wrap gap-1.5">
+                      {mp.scopes.map((scope) => (
+                        <ScopeBadge key={scope} scope={scope} />
+                      ))}
+                    </div>
+                  </td>
+                  <td className={CELL_CLASS}>
+                    <Toggle
+                      checked={!!mp.auto_load}
+                      disabled={toggleDisabled}
+                      onClick={
+                        !toggleDisabled
+                          ? () => onToggleAutoLoad(mp.name)
+                          : undefined
+                      }
+                      title={getAutoLoadTitle(editableScope)}
+                      aria-label={`Toggle auto-load for ${mp.name}`}
+                    />
+                  </td>
+                  <td className={CELL_CLASS}>
+                    <div className="flex items-center justify-end gap-1">
+                      <button
+                        type="button"
+                        onClick={() => onEdit(editableReg)}
+                        disabled={!canEdit(editableReg)}
+                        title={
+                          canEdit(editableReg) ? t(I18nKey.BUTTON$EDIT) : undefined
+                        }
+                        aria-label={`${t(I18nKey.BUTTON$EDIT)} ${mp.name}`}
+                        className={cn(
+                          "rounded-md p-1.5 transition-colors",
+                          canEdit(editableReg)
+                            ? "text-tertiary-light hover:bg-white/10 hover:text-content-2"
+                            : "cursor-not-allowed text-tertiary-alt opacity-40",
+                        )}
+                      >
+                        <EditIcon width={16} height={16} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onDelete(editableReg)}
+                        disabled={!canEdit(editableReg)}
+                        title={
+                          canEdit(editableReg)
+                            ? t(I18nKey.BUTTON$DELETE)
+                            : undefined
+                        }
+                        aria-label={`${t(I18nKey.BUTTON$DELETE)} ${mp.name}`}
+                        className={cn(
+                          "rounded-md p-1.5 transition-colors",
+                          canEdit(editableReg)
+                            ? "text-danger hover:bg-danger/15"
+                            : "cursor-not-allowed text-tertiary-alt opacity-40",
+                        )}
+                      >
+                        <DeleteIcon width={16} height={16} />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
             {marketplaces.length === 0 && (
               <tr className="border-t border-tertiary/60">
                 <td

--- a/frontend/src/routes/skills-settings.tsx
+++ b/frontend/src/routes/skills-settings.tsx
@@ -19,7 +19,11 @@ import { useMarketplaceMutations } from "#/hooks/mutation/use-marketplace-mutati
 import { useSkillMutations } from "#/hooks/mutation/use-skill-mutations";
 import { MarketplaceTable } from "#/components/features/settings/skills-settings/marketplace-table";
 import { SkillsTable } from "#/components/features/settings/skills-settings/skills-table";
-import { MarketplaceRegistration, SkillWithState } from "#/types/settings";
+import {
+  MarketplaceRegistration,
+  MarketplaceDisplay,
+  SkillWithState,
+} from "#/types/settings";
 import { I18nKey } from "#/i18n/declaration";
 import SkillsService from "#/api/skills-service";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
@@ -53,6 +57,9 @@ function SkillsSettingsScreen() {
   // State for marketplaces
   const [allMarketplaces, setAllMarketplaces] = useState<
     MarketplaceRegistration[]
+  >([]);
+  const [displayMarketplaces, setDisplayMarketplaces] = useState<
+    MarketplaceDisplay[]
   >([]);
   const originalMarketplacesRef = useRef<MarketplaceRegistration[]>([]);
   const [lastKnownUpdatedAt, setLastKnownUpdatedAt] = useState<string | null>(
@@ -134,6 +141,42 @@ function SkillsSettingsScreen() {
     ];
     setAllMarketplaces(all);
     originalMarketplacesRef.current = all;
+
+    // Group marketplaces by name for display (to show multiple scopes)
+    const grouped = new Map<string, MarketplaceDisplay>();
+    for (const mp of all) {
+      const existing = grouped.get(mp.name);
+      const scope = mp.scope ?? "personal";
+      
+      if (existing) {
+        // Add this scope to the existing entry
+        existing.scopes.push(scope);
+        existing.registrations.set(scope, mp);
+        // Prefer non-instance auto_load for display
+        if (scope !== "instance" && mp.auto_load) {
+          existing.auto_load = mp.auto_load;
+        }
+      } else {
+        // Create new display entry
+        const registrations = new Map<
+          "instance" | "org" | "personal",
+          MarketplaceRegistration
+        >();
+        registrations.set(scope, mp);
+        
+        grouped.set(mp.name, {
+          name: mp.name,
+          source: mp.source,
+          ref: mp.ref,
+          repo_path: mp.repo_path,
+          auto_load: mp.auto_load,
+          scopes: [scope],
+          registrations,
+        });
+      }
+    }
+    
+    setDisplayMarketplaces(Array.from(grouped.values()));
 
     // Marketplace lookup for skills (keyed by source; scope comes from backend).
     const marketplaceMap = new Map<
@@ -566,7 +609,7 @@ function SkillsSettingsScreen() {
           </div>
 
           <MarketplaceTable
-            marketplaces={allMarketplaces}
+            marketplaces={displayMarketplaces}
             onToggleAutoLoad={handleToggleMarketplaceAutoLoad}
             onEdit={openEditModal}
             onDelete={openDeleteModal}

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -135,6 +135,18 @@ export type MarketplaceRegistration = {
   scope?: "instance" | "org" | "personal";
 };
 
+// UI representation of a marketplace that may exist at multiple scopes
+export type MarketplaceDisplay = {
+  name: string;
+  source: string;
+  ref?: string;
+  repo_path?: string;
+  auto_load?: boolean;
+  scopes: ("instance" | "org" | "personal")[];
+  // Map of scope -> registration for accessing scope-specific data
+  registrations: Map<"instance" | "org" | "personal", MarketplaceRegistration>;
+};
+
 export interface SkillWithState extends SkillInfo {
   id: string;
   repository: string;

--- a/openhands/app_server/settings/marketplace_composition.py
+++ b/openhands/app_server/settings/marketplace_composition.py
@@ -211,9 +211,10 @@ def compose_marketplaces(
     """Compose marketplaces from the three scopes, keyed on ``name``.
 
     Precedence is Instance < Org < User for identity; org overrides an instance
-    entry of the same name, and a user entry is dropped when its name already
-    exists at a broader scope. Invalid entries are skipped. Order is preserved
-    (instance, then org additions, then user additions).
+    entry of the same name. When a marketplace is registered at multiple scopes
+    (e.g., both org and personal), both registrations are kept so the UI can
+    display all applicable scope tags. Invalid entries are skipped. Order is
+    preserved (instance, then org additions, then user additions).
     """
 
     def _stamp(
@@ -238,11 +239,14 @@ def compose_marketplaces(
         reg = _coerce(raw)
         if reg is None:
             continue
+        # Changed: Keep personal marketplaces even if they shadow inherited ones.
+        # This allows the UI to show both scope tags when a marketplace is
+        # registered at multiple levels (e.g., org + personal).
         if reg.name in inherited:
             logger.debug(
-                "User marketplace '%s' shadows an inherited one; ignoring", reg.name
+                "User marketplace '%s' also exists in inherited scope; keeping both for UI visibility",
+                reg.name,
             )
-            continue
         personal[reg.name] = _stamp(reg, MarketplaceScope.PERSONAL)
 
     return ComposedMarketplaces(


### PR DESCRIPTION
## Summary

Improves the Skills Settings UI to show all applicable scope tags when a marketplace is registered at multiple levels (e.g., both org and personal).

## Problem

Previously, when a user registered the same marketplace at both the organization and personal levels, the UI would only display one scope tag (typically org-scoped), hiding the fact that the marketplace was also registered personally. This made it unclear:
- Whether a personal registration actually succeeded
- Which registrations the user could edit/delete
- The complete state of marketplace configurations

## Solution

The UI now groups marketplaces by name and displays all applicable scope badges:

**Before:** 
```
my-skills | github:me/skills | [org]
```

**After:**
```
my-skills | github:me/skills | [org] [personal]
```

## Changes

### Backend
- Updated marketplace composition logic to keep personal marketplaces even when they shadow inherited ones
- Changed from silently dropping duplicates to preserving them for UI visibility

### Frontend
- Added `MarketplaceDisplay` type to represent marketplaces with multiple scopes
- Group marketplaces by name and collect all their scopes
- Render multiple `<ScopeBadge>` components in the table
- Edit/delete actions prioritize the most specific editable scope (personal > org > instance)

## Testing

Tested scenarios:
- [ ] Marketplace registered only at personal level → shows [personal] tag
- [ ] Marketplace registered only at org level → shows [org] tag
- [ ] Marketplace registered at both org and personal → shows [org] [personal] tags
- [ ] Edit/delete buttons work correctly for multi-scope marketplaces
- [ ] Auto-load toggle behaves correctly for multi-scope marketplaces

Fixes OpenHands/enterprise#56

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-7e649d4   docker.openhands.dev/openhands/openhands:7e649d4
```