### PR TITLE
fix: pass column list to create_index in migration 013

### DIFF
--- a/openhands/app_server/app_lifespan/alembic/versions/013.py
+++ b/openhands/app_server/app_lifespan/alembic/versions/013.py
@@ -34,7 +34,7 @@ def upgrade() -> None:
         # Create index for efficient dashboard queries
         batch_op.create_index(
             'ix_conversation_metadata_execution_status',
-            'execution_status',
+            ['execution_status'],
             unique=False,
         )
 

--- a/tests/unit/test_migration_013_execution_status.py
+++ b/tests/unit/test_migration_013_execution_status.py
@@ -1,0 +1,77 @@
+"""Regression test for https://github.com/All-Hands-AI/OpenHands/issues/15173
+
+Migration 013 passed a bare string instead of a list of column names to
+``batch_op.create_index``. SQLAlchemy iterates the string character by
+character, so the batch copy-table reflection tried to add a column per
+character ('e', 'x', 'e', ...) and crashed with DuplicateColumnError on the
+second 'e', breaking ``alembic upgrade head`` on startup.
+"""
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / 'openhands'
+    / 'app_server'
+    / 'app_lifespan'
+    / 'alembic'
+    / 'versions'
+    / '013.py'
+)
+spec = spec_from_file_location('migration_013', MIGRATION_PATH)
+assert spec is not None and spec.loader is not None
+migration_013 = module_from_spec(spec)
+spec.loader.exec_module(migration_013)
+
+
+def _make_engine_with_pre_013_schema():
+    engine = sa.create_engine('sqlite://')
+    metadata = sa.MetaData()
+    sa.Table(
+        'conversation_metadata',
+        metadata,
+        sa.Column('id', sa.String(), primary_key=True),
+        sa.Column('title', sa.String(), nullable=True),
+    )
+    metadata.create_all(engine)
+    return engine
+
+
+def test_upgrade_creates_execution_status_column_and_index():
+    engine = _make_engine_with_pre_013_schema()
+    with engine.connect() as conn:
+        ctx = MigrationContext.configure(conn)
+        with Operations.context(ctx):
+            migration_013.upgrade()
+        conn.commit()
+
+    inspector = sa.inspect(engine)
+    columns = {c['name'] for c in inspector.get_columns('conversation_metadata')}
+    assert 'execution_status' in columns
+
+    indexes = {
+        idx['name']: idx['column_names']
+        for idx in inspector.get_indexes('conversation_metadata')
+    }
+    assert indexes.get('ix_conversation_metadata_execution_status') == [
+        'execution_status'
+    ]
+
+
+def test_downgrade_removes_execution_status_column_and_index():
+    engine = _make_engine_with_pre_013_schema()
+    with engine.connect() as conn:
+        ctx = MigrationContext.configure(conn)
+        with Operations.context(ctx):
+            migration_013.upgrade()
+            migration_013.downgrade()
+        conn.commit()
+
+    inspector = sa.inspect(engine)
+    columns = {c['name'] for c in inspector.get_columns('conversation_metadata')}
+    assert 'execution_status' not in columns


### PR DESCRIPTION
HUMAN:

This fixes a one-character-per-column crash in Alembic migration 013: it was passing the string `'execution_status'` to `create_index` instead of `['execution_status']`, so startup died with `DuplicateColumnError` on 'e'. The change makes it a list (matching every other migration in that folder) and adds a test that runs the migration up and down against SQLite.

- [ ] A human has tested these changes.

AGENT:

---

## Why

`alembic upgrade head` crashes on startup with `sqlalchemy.exc.DuplicateColumnError: A column with name 'e' is already present in table 'conversation_metadata'` (issue #15173). Migration 013 passes a bare string to `batch_op.create_index` where a list of column names is expected; SQLAlchemy iterates the string character by character during the batch copy-table reflection, so it tries to add a column per character and dies on the second `'e'` of `'execution_status'`. This prevents the server from starting.

## Summary

- Pass `['execution_status']` instead of `'execution_status'` to `batch_op.create_index` in `openhands/app_server/app_lifespan/alembic/versions/013.py` (matches the list form every other migration in the directory already uses)
- Add `tests/unit/test_migration_013_execution_status.py`: runs the migration's `upgrade()` and `downgrade()` against an in-memory SQLite database with the pre-013 schema; fails with the string-iteration error before the fix, passes after

## Issue Number

Fixes #15173

## How to Test

```
python -m pytest tests/unit/test_migration_013_execution_status.py -v
```

Both tests fail on the current main (column-per-character error from the batch reflection) and pass with this change. Verified with alembic 1.18.5 / SQLAlchemy 2.0.51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

