### PR TITLE
fix(app-server): pass index columns as a list in migration 013

### DIFF
--- a/openhands/app_server/app_lifespan/alembic/versions/013.py
+++ b/openhands/app_server/app_lifespan/alembic/versions/013.py
@@ -34,7 +34,7 @@ def upgrade() -> None:
         # Create index for efficient dashboard queries
         batch_op.create_index(
             'ix_conversation_metadata_execution_status',
-            'execution_status',
+            ['execution_status'],
             unique=False,
         )
 


### PR DESCRIPTION
HUMAN:

Fixing a bug in prod.

- [x] A human has tested these changes.

AGENT:

---

## Why

App startup crashes during the `012 -> 013` Alembic upgrade with:

```
sqlalchemy.exc.DuplicateColumnError: A column with name 'e' is already
present in table 'conversation_metadata'.
```

Migration `013` calls `batch_op.create_index()` with the columns argument
as the bare string `'execution_status'` instead of a list. Alembic expects
a list of column names and iterates the argument, so it walks the string
**character-by-character** (`'e'`, `'x'`, `'e'`, ...). The repeated `'e'`
collides and raises `DuplicateColumnError` — the phantom column `'e'` in
the error is just the first repeated character of `"execution_status"`.
The migration transaction rolls back, so the server never starts.

## Summary

- Wrap the index column name in a list: `'execution_status'` → `['execution_status']` in `013.py`.

## Issue Number

N/A

## How to Test

Point at a database still at revision `012` and start the app server (e.g.
`openhands serve`). Startup runs the `012 -> 013` migration to completion
and boots instead of crashing with `DuplicateColumnError`. The index
`ix_conversation_metadata_execution_status` is created over the
`execution_status` column as intended.

Because the failed upgrade ran in a transaction that rolled back, no manual
DB cleanup is required — databases are still at `012` and apply cleanly.

## Video/Screenshots

N/A — single-line migration fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Affects only migration `013`; no schema/behavior change beyond fixing the
index creation. The released `:latest` image still contains the buggy
version, so a new build is needed for `openhands serve --pull=always` users
to pick up the fix.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-d0cb396   docker.openhands.dev/openhands/openhands:d0cb396
```