### PR TITLE
fix: pass column list in execution status migration

### DIFF
--- a/openhands/app_server/app_lifespan/alembic/versions/013.py
+++ b/openhands/app_server/app_lifespan/alembic/versions/013.py
@@ -34,7 +34,7 @@ def upgrade() -> None:
         # Create index for efficient dashboard queries
         batch_op.create_index(
             'ix_conversation_metadata_execution_status',
-            'execution_status',
+            ['execution_status'],
             unique=False,
         )
 


### PR DESCRIPTION
HUMAN:
This fixes the Alembic 013 migration by passing the `execution_status` index column as a list instead of a scalar string, so Alembic no longer treats the column name as individual characters during SQLite batch index creation. I verified the migration upgrade/downgrade path with a SQLite `conversation_metadata` table: the old version reproduces `DuplicateColumnError`, and the patched version creates and drops the index cleanly.

- [ ] A human has tested these changes.

AGENT:

---

## Why

Migration 013 currently passes `"execution_status"` directly to `batch_create_index`. Alembic expects an iterable of column names there, so the string is interpreted as individual column names and the migration can fail while creating the batch index.

## Summary

- Pass the `execution_status` index column as a list in migration 013.
- Keep Alembic from treating the scalar string as individual column names during batch index creation.
- Verify upgrade and downgrade against a SQLite `conversation_metadata` table.

## Issue Number

Fixes #15173.

## How to Test

- `make install-pre-commit-hooks`
- Python migration harness for 013 upgrade/downgrade, reproducing the pre-fix `DuplicateColumnError` and passing after this change
- `pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files openhands/app_server/app_lifespan/alembic/versions/013.py`
- `git diff --check`

## Video/Screenshots

Not applicable; this is a backend migration fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No schema shape change beyond fixing the existing migration's index column argument.