### PR TITLE
fix: default ENABLE_ACP on so ACP agent settings show in OH Cloud

### DIFF
--- a/openhands/app_server/web_client/default_web_client_config_injector.py
+++ b/openhands/app_server/web_client/default_web_client_config_injector.py
@@ -160,12 +160,15 @@ def _get_feature_flags() -> WebClientFeatureFlags:
 
     Reads ENABLE_BILLING, HIDE_LLM_SETTINGS, ENABLE_JIRA, ENABLE_JIRA_DC,
     ENABLE_LINEAR, HIDE_USERS_PAGE, HIDE_BILLING_PAGE, HIDE_INTEGRATIONS_PAGE,
-    HIDE_PERSONAL_WORKSPACES, ENABLE_ACP, and OH_ENABLE_ONBOARDING from
-    environment. Each flag is True only if the corresponding env var is
-    exactly 'true', otherwise False.
+    HIDE_PERSONAL_WORKSPACES, and OH_ENABLE_ONBOARDING from environment. Each
+    flag is True only if the corresponding env var is exactly 'true', otherwise
+    False.
 
-    OH_ALLOW_USER_LLM_CONFIGURATION is the exception: it defaults to 'true'
-    when unset so SaaS and existing installs keep the BYOK editing UI.
+    OH_ALLOW_USER_LLM_CONFIGURATION and ENABLE_ACP are the exceptions: they
+    default to 'true' when unset. OH_ALLOW_USER_LLM_CONFIGURATION keeps the
+    BYOK editing UI visible; ENABLE_ACP keeps the ACP agent configuration UI
+    (Settings > Agent) visible on SaaS and existing installs, matching Agent
+    Canvas. Set ENABLE_ACP=false to hide it.
     """
     return WebClientFeatureFlags(
         enable_billing=os.getenv('ENABLE_BILLING', 'false') == 'true',
@@ -182,7 +185,7 @@ def _get_feature_flags() -> WebClientFeatureFlags:
             'OH_ALLOW_USER_LLM_CONFIGURATION', 'true'
         )
         == 'true',
-        enable_acp=os.getenv('ENABLE_ACP', 'false') == 'true',
+        enable_acp=os.getenv('ENABLE_ACP', 'true') == 'true',
         enable_onboarding=os.getenv('OH_ENABLE_ONBOARDING', 'false') == 'true',
         enable_automations=os.getenv('ENABLE_AUTOMATIONS', 'true') == 'true',
     )

--- a/openhands/app_server/web_client/web_client_models.py
+++ b/openhands/app_server/web_client/web_client_models.py
@@ -33,7 +33,10 @@ class WebClientFeatureFlags(BaseModel):
     # existing installs are unaffected. UI-level only — previously saved BYOK
     # settings keep working at runtime.
     allow_user_llm_configuration: bool = True
-    enable_acp: bool = False
+    # Defaults to True so the ACP agent configuration UI (Settings > Agent) is
+    # visible on SaaS and existing installs, matching Agent Canvas. Set
+    # ENABLE_ACP=false to hide it. UI-level only.
+    enable_acp: bool = True
     deployment_mode: DeploymentMode | None = None
     enable_onboarding: bool = False
     enable_automations: bool = True

--- a/tests/unit/app_server/test_default_web_client_config_injector.py
+++ b/tests/unit/app_server/test_default_web_client_config_injector.py
@@ -303,6 +303,41 @@ class TestGetFeatureFlags:
             result = _get_feature_flags()
             assert result.enable_automations is True
 
+    def test_enable_acp_true_by_default(self):
+        """When ENABLE_ACP is unset, enable_acp defaults to True.
+
+        Keeps the ACP agent configuration UI (Settings > Agent) visible on
+        SaaS and existing installs, matching Agent Canvas.
+        """
+        from openhands.app_server.web_client.default_web_client_config_injector import (
+            _get_feature_flags,
+        )
+
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop('ENABLE_ACP', None)
+            result = _get_feature_flags()
+            assert result.enable_acp is True
+
+    def test_enable_acp_false_when_env_var_false(self):
+        """When ENABLE_ACP is 'false', enable_acp flag is False."""
+        from openhands.app_server.web_client.default_web_client_config_injector import (
+            _get_feature_flags,
+        )
+
+        with patch.dict(os.environ, {'ENABLE_ACP': 'false'}):
+            result = _get_feature_flags()
+            assert result.enable_acp is False
+
+    def test_enable_acp_true_when_env_var_true(self):
+        """When ENABLE_ACP is 'true', enable_acp flag is True."""
+        from openhands.app_server.web_client.default_web_client_config_injector import (
+            _get_feature_flags,
+        )
+
+        with patch.dict(os.environ, {'ENABLE_ACP': 'true'}):
+            result = _get_feature_flags()
+            assert result.enable_acp is True
+
 
 class TestGetJiraDcServiceAccountConfig:
     """Test cases for Jira DC service-account web-client config helpers."""


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

The ACP agent configuration UI (Settings > Agent: agent-type selector, preset, command, model, credentials) is fully implemented in both the frontend and backend, but the whole surface is gated on the `enable_acp` web-client feature flag. That flag was sourced from ENABLE_ACP defaulting to 'false', so OpenHands Cloud (app.all-hands.dev) — which never sets the variable — hid the UI and showed only the sub-agents toggle. Agent Canvas renders the same UI ungated, so the two UIs diverged.

Default enable_acp to true (both the WebClientFeatureFlags model default and the env lookup), mirroring the sibling enable_automations / allow_user_llm_configuration flags. Deployments can still hide it with ENABLE_ACP=false. No frontend changes are needed — the UI already exists and renders once the flag is on.

- [x] A human has tested these changes.

AGENT:

---

## Why

<!-- Describe problem, motivation, etc.-->

OpenHands Cloud (app.all-hands.dev → Settings › Agent) shows only the "Enable sub-agents" toggle, while Agent Canvas — connected to the same OpenHands Cloud backend — shows the full ACP configuration UI. Customers want to run third-party ACP agents (Codex, Claude Code, Gemini CLI) in OHE sandboxes, so both UIs must offer ACP support in OH Cloud.

The ACP UI is already fully built in the frontend and backend; the entire surface is gated on the `enable_acp` web-client feature flag, sourced from `ENABLE_ACP` defaulting to `false`. Cloud never sets that variable, so the UI stayed hidden. Agent Canvas renders the same UI ungated — hence the mismatch.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Default `enable_acp` to `true` in `_get_feature_flags` (`ENABLE_ACP` env lookup) and in the `WebClientFeatureFlags` model default, mirroring the sibling `enable_automations` / `allow_user_llm_configuration` flags; `ENABLE_ACP=false` still hides the UI.
- Update the `_get_feature_flags` docstring so `ENABLE_ACP` is documented as a defaults-on flag.
- Add unit tests covering the `enable_acp` default (unset → True, `false` → False, `true` → True).

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

N/A.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Unit tests: `pytest tests/unit/app_server/test_default_web_client_config_injector.py::TestGetFeatureFlags` (18 passed).
2. Start the app server with `ENABLE_ACP` unset and open Settings › Agent: the **Agent** dropdown (OpenHands vs "ACP (external subprocess)") now appears; selecting ACP reveals Preset (Codex / Claude Code / Gemini CLI / Custom), Command, Model, and Credentials — matching Agent Canvas.
3. Confirm `GET /api/options/config` returns `feature_flags.enable_acp: true` and a populated `acp_providers`.
4. Regression: set `ENABLE_ACP=false`, reload Settings › Agent, confirm only the "Enable sub-agents" toggle shows.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/6e989e71-9c7a-4af4-ad5f-b33b3d9bb536

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-e063eeb   docker.openhands.dev/openhands/openhands:e063eeb
```