### PR TITLE
feat: surface email enabled for smtp/resend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,9 @@ The `enterprise/` directory contains additional functionality that extends the o
   the SMTP-driven UI email-enabled checks (SMTP_HOST).
 - Billing and subscription management (Stripe)
 - Telemetry and analytics (PostHog, custom metrics framework)
+- Email services: Resend remains in `enterprise/server/services/email_service.py`; SMTPEmailService lives in
+  `enterprise/server/services/smtp_email_service.py` and is used for org invitations/budget alerts plus
+  the SMTP-driven UI email-enabled checks (SMTP_HOST).
 
 ### Enterprise Development Setup
 

--- a/openhands/app_server/web_client/default_web_client_config_injector.py
+++ b/openhands/app_server/web_client/default_web_client_config_injector.py
@@ -125,8 +125,18 @@ def _get_email_enabled() -> bool:
     try:
         from server.services.smtp_email_service import SMTPEmailService
     except Exception:
-        return bool(os.getenv('SMTP_HOST', '').strip())
-    return SMTPEmailService.is_configured()
+        smtp_enabled = bool(os.getenv('SMTP_HOST', '').strip())
+    else:
+        smtp_enabled = SMTPEmailService.is_configured()
+
+    try:
+        from server.services.email_service import EmailService
+    except Exception:
+        resend_enabled = bool(os.getenv('RESEND_API_KEY', '').strip())
+    else:
+        resend_enabled = EmailService.is_configured()
+
+    return smtp_enabled or resend_enabled
 
 
 def _get_jira_dc_oauth_host() -> str | None:

--- a/openhands/app_server/web_client/web_client_models.py
+++ b/openhands/app_server/web_client/web_client_models.py
@@ -79,6 +79,7 @@ class WebClientConfig(DiscriminatedUnionMixin):
     gitlab_enabled: bool = False
     provider_default_hosts: dict[str, str] = Field(default_factory=dict)
     slack_enabled: bool = False
+    email_enabled: bool = False
     acp_providers: list[ACPProviderConfig] = Field(default_factory=list)
     # Hostname of the Jira Data Center server when DC OAuth is configured, so the
     # configure form can pre-fill and lock the host field (the OAuth callback only

--- a/tests/unit/app_server/test_default_web_client_config_injector.py
+++ b/tests/unit/app_server/test_default_web_client_config_injector.py
@@ -750,26 +750,56 @@ class TestGetSlackEnabled:
 class TestGetEmailEnabled:
     """Test cases for _get_email_enabled helper function."""
 
-    def test_returns_true_when_email_service_is_configured(self):
+    def test_returns_true_when_smtp_is_configured(self):
         """Email is enabled when the SMTP integration is configured."""
         from openhands.app_server.web_client.default_web_client_config_injector import (
             _get_email_enabled,
         )
 
-        with patch(
-            'server.services.smtp_email_service.SMTPEmailService.is_configured',
-            return_value=True,
+        with (
+            patch(
+                'server.services.smtp_email_service.SMTPEmailService.is_configured',
+                return_value=True,
+            ),
+            patch(
+                'server.services.email_service.EmailService.is_configured',
+                return_value=False,
+            ),
         ):
             assert _get_email_enabled() is True
 
-    def test_returns_false_when_email_service_is_not_configured(self):
-        """Email stays disabled when the SMTP integration is missing."""
+    def test_returns_true_when_resend_is_configured(self):
+        """Email is enabled when the Resend integration is configured."""
         from openhands.app_server.web_client.default_web_client_config_injector import (
             _get_email_enabled,
         )
 
-        with patch(
-            'server.services.smtp_email_service.SMTPEmailService.is_configured',
-            return_value=False,
+        with (
+            patch(
+                'server.services.smtp_email_service.SMTPEmailService.is_configured',
+                return_value=False,
+            ),
+            patch(
+                'server.services.email_service.EmailService.is_configured',
+                return_value=True,
+            ),
+        ):
+            assert _get_email_enabled() is True
+
+    def test_returns_false_when_email_services_not_configured(self):
+        """Email stays disabled when SMTP and Resend are missing."""
+        from openhands.app_server.web_client.default_web_client_config_injector import (
+            _get_email_enabled,
+        )
+
+        with (
+            patch(
+                'server.services.smtp_email_service.SMTPEmailService.is_configured',
+                return_value=False,
+            ),
+            patch(
+                'server.services.email_service.EmailService.is_configured',
+                return_value=False,
+            ),
         ):
             assert _get_email_enabled() is False


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN: Add a flag for enabling email that separates SMTP from Resend


- [X] A human has tested these changes.


---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-27ea232   docker.openhands.dev/openhands/openhands:27ea232
```