### PR TITLE
perf(event-service): avoid full-history page validation

### DIFF
--- a/openhands/app_server/event/event_service_base.py
+++ b/openhands/app_server/event/event_service_base.py
@@ -63,6 +63,22 @@ class EventServiceBase(EventService, ABC):
 
         return await asyncio.gather(*(load_event(path) for path in paths))
 
+    async def _scan_event_timestamps(
+        self, paths: list[Path]
+    ) -> list[tuple[Path, str]] | None:
+        """Return a (path, timestamp) pair per readable event, or None.
+
+        Backends where reading the raw stored payload is much cheaper than a
+        full ``Event`` validation (e.g. the local filesystem) can override
+        this so that unfiltered ``search_events`` pages only fully load the
+        ordered prefix needed to reach the requested page and its lookahead,
+        instead of the entire conversation history.
+        Unreadable events must be omitted, matching ``_load_event`` failure
+        semantics. Returning None (the default) means no cheap scan is
+        available and ``search_events`` falls back to loading every event.
+        """
+        return None
+
     async def get_conversation_path(self, conversation_id: UUID) -> Path:
         """Get a path for a conversation. Ensure user_id is included if possible."""
         path = self.prefix
@@ -105,6 +121,45 @@ class EventServiceBase(EventService, ABC):
         loop = asyncio.get_running_loop()
         prefix = await self.get_conversation_path(conversation_id)
         paths = await loop.run_in_executor(None, self._search_paths, prefix)
+
+        # Fast path for unfiltered queries (the common "open a conversation"
+        # page pattern): sort and paginate on cheaply-scanned timestamps and
+        # fully load only the ordered prefix needed for the requested page,
+        # instead of loading and validating every event in the conversation.
+        if kind__eq is None and timestamp__gte is None and timestamp__lt is None:
+            scanned = await self._scan_event_timestamps(paths)
+            if scanned is not None:
+                scanned.sort(
+                    key=lambda path_and_timestamp: path_and_timestamp[1],
+                    reverse=(sort_order == EventSortOrder.TIMESTAMP_DESC),
+                )
+                start_offset = int(page_id) if page_id else 0
+                valid_events_seen = 0
+                items: list[Event] = []
+                has_next_page = False
+                batch_size = max(1, min(_event_load_concurrency(), limit + 1))
+                for index in range(0, len(scanned), batch_size):
+                    paths_to_load = [
+                        path for path, _ in scanned[index : index + batch_size]
+                    ]
+                    for event in await self._load_events_from_paths(paths_to_load):
+                        if not event:
+                            continue
+                        if valid_events_seen < start_offset:
+                            valid_events_seen += 1
+                            continue
+                        if len(items) < limit:
+                            items.append(event)
+                            valid_events_seen += 1
+                            continue
+                        has_next_page = True
+                        break
+                    if has_next_page:
+                        break
+                return EventPage(
+                    items=items,
+                    next_page_id=str(start_offset + limit) if has_next_page else None,
+                )
 
         events = await self._load_events_from_paths(paths)
         # Convert datetime filters to ISO strings so they can be compared

--- a/openhands/app_server/event/filesystem_event_service.py
+++ b/openhands/app_server/event/filesystem_event_service.py
@@ -1,4 +1,6 @@
+import asyncio
 import glob
+import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -40,6 +42,34 @@ class FilesystemEventService(EventServiceBase):
         files = glob.glob(str(search_path))
         paths = [Path(file) for file in files]
         return paths
+
+    async def _scan_event_timestamps(
+        self, paths: list[Path]
+    ) -> list[tuple[Path, str]] | None:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._read_event_timestamps, paths)
+
+    def _read_event_timestamps(self, paths: list[Path]) -> list[tuple[Path, str]]:
+        """Read only the timestamp of each stored event.
+
+        A plain ``json.loads`` of the stored payload is an order of magnitude
+        cheaper than validating the full ``Event`` discriminated union, which
+        bounds unfiltered ``search_events`` validation to the requested page's
+        ordered prefix instead of every stored event. Reads happen in a single
+        executor call because the per-file work is too small to amortize one
+        task per file.
+        """
+        scanned = []
+        for path in paths:
+            try:
+                timestamp = json.loads(path.read_text())['timestamp']
+            except Exception:
+                if path.exists():
+                    _logger.exception('Error reading event', stack_info=True)
+                continue
+            if isinstance(timestamp, str):
+                scanned.append((path, timestamp))
+        return scanned
 
 
 class FilesystemEventServiceInjector(EventServiceInjector):

--- a/tests/unit/app_server/test_filesystem_event_service.py
+++ b/tests/unit/app_server/test_filesystem_event_service.py
@@ -467,3 +467,204 @@ class TestFilesystemEventServiceIntegration:
 
         result = await service.search_events(conversation_id)
         assert len(result.items) == 3
+
+
+class TestFilesystemEventServiceTimestampScan:
+    """Regression tests for the unfiltered search_events timestamp-scan fast path.
+
+    Unfiltered searches sort and paginate on cheaply-scanned timestamps and must
+    fully load (validate) only the ordered prefix needed for the requested page,
+    while returning exactly what a full-load search would return.
+    """
+
+    def _create_token_event_at(self, timestamp: str) -> TokenEvent:
+        return TokenEvent(
+            source='agent',
+            prompt_token_ids=[1, 2],
+            response_token_ids=[3, 4],
+            timestamp=timestamp,
+        )
+
+    def _count_full_loads(self, service: FilesystemEventService) -> list[int]:
+        """Wrap service._load_event with a counter; returns the counter holder."""
+        calls = [0]
+        original_load = service._load_event
+
+        def counting_load(path: Path):
+            calls[0] += 1
+            return original_load(path)
+
+        service._load_event = counting_load  # type: ignore[method-assign]
+        return calls
+
+    @pytest.mark.asyncio
+    async def test_unfiltered_page_uses_bounded_lookahead(
+        self, service: FilesystemEventService
+    ):
+        """A page of an unfiltered search must not load the whole conversation."""
+        conversation_id = uuid4()
+        total_events = 10
+        page_limit = 3
+
+        for i in range(total_events):
+            await service.save_event(
+                conversation_id,
+                self._create_token_event_at(f'2026-01-01T00:00:{i:02d}'),
+            )
+
+        calls = self._count_full_loads(service)
+        result = await service.search_events(conversation_id, limit=page_limit)
+
+        assert len(result.items) == page_limit
+        assert calls[0] == page_limit + 1
+
+    @pytest.mark.asyncio
+    async def test_unfiltered_pages_use_bounded_ordered_hydration(
+        self, service: FilesystemEventService
+    ):
+        """Each page validates only its offset, items, and one-item lookahead."""
+        conversation_id = uuid4()
+        total_events = 10
+        page_limit = 3
+
+        for i in range(total_events):
+            await service.save_event(
+                conversation_id,
+                self._create_token_event_at(f'2026-01-01T00:00:{i:02d}'),
+            )
+
+        page_id = None
+        collected_ids = []
+        page_calls = []
+        calls = self._count_full_loads(service)
+        previous_calls = 0
+        while True:
+            result = await service.search_events(
+                conversation_id, page_id=page_id, limit=page_limit
+            )
+            page_calls.append(calls[0] - previous_calls)
+            previous_calls = calls[0]
+            collected_ids.extend(item.id for item in result.items)
+            if result.next_page_id is None:
+                break
+            page_id = result.next_page_id
+
+        assert len(collected_ids) == total_events
+        assert page_calls == [4, 8, 10, 10]
+
+    @pytest.mark.asyncio
+    async def test_unfiltered_search_matches_filtered_slow_path(
+        self, service: FilesystemEventService
+    ):
+        """Fast path must return the same events, order and paging as full load."""
+        conversation_id = uuid4()
+        for i in range(7):
+            await service.save_event(
+                conversation_id,
+                self._create_token_event_at(f'2026-01-01T00:00:{i:02d}'),
+            )
+        for _ in range(2):
+            await service.save_event(
+                conversation_id,
+                self._create_token_event_at('2026-01-01T00:00:03'),
+            )
+
+        for sort_order in (EventSortOrder.TIMESTAMP, EventSortOrder.TIMESTAMP_DESC):
+            for page_id in (None, '3'):
+                fast = await service.search_events(
+                    conversation_id, sort_order=sort_order, page_id=page_id, limit=3
+                )
+                # kind__eq matches every stored event but disables the fast path
+                slow = await service.search_events(
+                    conversation_id,
+                    kind__eq='TokenEvent',
+                    sort_order=sort_order,
+                    page_id=page_id,
+                    limit=3,
+                )
+                assert [e.id for e in fast.items] == [e.id for e in slow.items]
+                assert [e.timestamp for e in fast.items] == [
+                    e.timestamp for e in slow.items
+                ]
+                assert fast.next_page_id == slow.next_page_id
+
+    @pytest.mark.asyncio
+    async def test_unfiltered_search_skips_unreadable_files(
+        self, service: FilesystemEventService
+    ):
+        """Corrupt event files are skipped, as in the full-load path."""
+        conversation_id = uuid4()
+        events = [
+            self._create_token_event_at(f'2026-01-01T00:00:{i:02d}') for i in range(3)
+        ]
+        for event in events:
+            await service.save_event(conversation_id, event)
+
+        conversation_path = await service.get_conversation_path(conversation_id)
+        (conversation_path / 'corrupt.json').write_text('not valid json{')
+
+        result = await service.search_events(conversation_id)
+
+        assert len(result.items) == 3
+        assert {item.id for item in result.items} == {event.id for event in events}
+
+    @pytest.mark.asyncio
+    async def test_timestamp_scan_skips_invalid_timestamped_event_payload(
+        self, service: FilesystemEventService
+    ):
+        """Timestamp scans must not let invalid Event JSON consume page offsets."""
+        conversation_id = uuid4()
+        for i in range(5):
+            await service.save_event(
+                conversation_id,
+                self._create_token_event_at(f'2026-01-01T00:00:{i:02d}'),
+            )
+
+        conversation_path = await service.get_conversation_path(conversation_id)
+        (conversation_path / 'invalid-timestamp.json').write_text(
+            '{"timestamp": "2026-01-01T00:00:01.500000", "kind": "InvalidEvent"}'
+        )
+
+        for sort_order in (EventSortOrder.TIMESTAMP, EventSortOrder.TIMESTAMP_DESC):
+            for page_id in (None, '2'):
+                fast = await service.search_events(
+                    conversation_id, sort_order=sort_order, page_id=page_id, limit=2
+                )
+                slow = await service.search_events(
+                    conversation_id,
+                    kind__eq='TokenEvent',
+                    sort_order=sort_order,
+                    page_id=page_id,
+                    limit=2,
+                )
+                assert [event.id for event in fast.items] == [
+                    event.id for event in slow.items
+                ]
+                assert [event.timestamp for event in fast.items] == [
+                    event.timestamp for event in slow.items
+                ]
+                assert fast.next_page_id == slow.next_page_id
+
+        fast_zero = await service.search_events(conversation_id, limit=0)
+        slow_zero = await service.search_events(
+            conversation_id, kind__eq='TokenEvent', limit=0
+        )
+        assert fast_zero.items == slow_zero.items == []
+        assert fast_zero.next_page_id == slow_zero.next_page_id
+
+        invalid_only_conversation_id = uuid4()
+        invalid_only_path = await service.get_conversation_path(
+            invalid_only_conversation_id
+        )
+        invalid_only_path.mkdir(parents=True)
+        (invalid_only_path / 'invalid-timestamp.json').write_text(
+            '{"timestamp": "2026-01-01T00:00:00", "kind": "InvalidEvent"}'
+        )
+        fast_invalid_only = await service.search_events(
+            invalid_only_conversation_id, limit=0
+        )
+        slow_invalid_only = await service.search_events(
+            invalid_only_conversation_id, kind__eq='TokenEvent', limit=0
+        )
+        assert fast_invalid_only.items == slow_invalid_only.items == []
+        assert fast_invalid_only.next_page_id == slow_invalid_only.next_page_id


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

This PR reduces the cost of loading paginated local conversation histories. It keeps the existing event order and pagination contract, including when stored JSON has a timestamp but is not a valid Event.

- [ ] A human has tested these changes.

AGENT:

---

## Why

`EventServiceBase.search_events()` currently reads and Pydantic-validates every stored event before applying an unfiltered page limit. Fetching the first pages of a large local conversation therefore repeats full discriminated-union validation across the entire history.

This addresses #13335, which reports that `search_events()` loads all events before applying `limit` and `page_id`. It is also related to #12705 and the earlier attempt in #14447.

## What changed

- Added an optional `_scan_event_timestamps()` hook to `EventServiceBase`.
- Implemented the hook for `FilesystemEventService` with a plain JSON decode that extracts each stored timestamp without constructing an `Event` model.
- For unfiltered filesystem searches, sort the scanned candidates and fully validate only the ordered prefix needed to skip valid events before the offset, fill the requested page, and find one valid lookahead event.
- Keep invalid timestamp-bearing JSON from consuming an offset or shortening a page.
- Keep filtered searches and remote backends on the existing full-load path.

The fast path still reads and JSON-decodes all candidate files to obtain timestamps. The improvement is specifically fewer full Pydantic `Event` validations: from `O(N)` per page to a bounded ordered prefix of approximately `O(offset + limit)`, plus invalid records and batch lookahead.

## Measured impact

Strict fixture: 3,003 valid `TokenEvent` files, three timestamp-bearing invalid Event payloads placed before/inside/after page boundaries, and two consecutive 100-event page requests.

| Metric | Before | After | Change |
|---|---:|---:|---:|
| `event_page_full_validations` | 6,012 | 320 | **94.7% fewer (18.8x)** |
| Two-page wall time, run 1 | 1.830 s | 0.442 s | **4.14x faster** |
| Two-page wall time, run 2 | 1.624 s | 0.398 s | **4.08x faster** |

Both strict runs produced the same structural metric. Wall time is secondary and was measured on the same machine; the validation count is deterministic and hardware-independent.

Correctness gates compare the fast path with the existing full-load path for:

- ascending and descending order;
- first and non-zero-offset pages;
- timestamp-bearing invalid Event payloads;
- equal timestamps and stable ordering;
- `limit=0` and invalid-only storage;
- matching items and `next_page_id` values.

## Autoresearch

[Public autoresearch trajectory](https://dashboard.weco.ai/share/kv08hJASdX308QaGaSjqx-njM5KSMwEc)

## Issue Number

Fixes #13335

Related: #12705, #14447

## How to Test

```bash
pytest tests/unit/app_server/test_filesystem_event_service.py \
  tests/unit/app_server/test_aws_event_service.py \
  tests/unit/app_server/test_event_router.py -q
```

Result: `53 passed`.

Also passed:

```bash
uvx --from ruff==0.12.5 ruff check --fix .
uvx --from ruff==0.12.5 ruff format --check \
  openhands/app_server/event/event_service_base.py \
  openhands/app_server/event/filesystem_event_service.py \
  tests/unit/app_server/test_filesystem_event_service.py
mypy --config-file dev_config/python/mypy.ini \
  openhands/app_server/event/event_service_base.py \
  openhands/app_server/event/filesystem_event_service.py
pre-commit run -c dev_config/python/.pre-commit-config.yaml --files \
  openhands/app_server/event/event_service_base.py \
  openhands/app_server/event/filesystem_event_service.py \
  tests/unit/app_server/test_filesystem_event_service.py
```

## Video/Screenshots

N/A (backend performance change).

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The hook defaults to `None`, so AWS and Google Cloud event services retain the previous behavior.
- The implementation preserves Python's stable timestamp ordering by scanning and sorting the same `_search_paths()` sequence used by the full-load path.
- This overlaps #14447. I have asked maintainers which implementation they prefer and will follow their direction.
