### PR TITLE
fix(oss-lifespan): fallback SQLite DB recreation on alembic open failure

### DIFF
--- a/openhands/app_server/app_lifespan/oss_app_lifespan_service.py
+++ b/openhands/app_server/app_lifespan/oss_app_lifespan_service.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
+from sqlalchemy.exc import OperationalError, SQLAlchemyError
 
 from openhands.app_server.app_lifespan.app_lifespan_service import AppLifespanService
+
+logger = logging.getLogger(__name__)
 
 
 class OssAppLifespanService(AppLifespanService):
@@ -20,7 +24,42 @@ class OssAppLifespanService(AppLifespanService):
     async def __aexit__(self, exc_type, exc_value, traceback):
         pass
 
-    def run_alembic(self):
+    def _get_sqlite_db_path(self) -> Path | None:
+        """Return the SQLite database file path if SQLite is in use."""
+        from openhands.app_server.config import get_global_config
+
+        db_session = get_global_config().db_session
+        if db_session.host:
+            return None
+        return db_session.persistence_dir / 'openhands.db'
+
+    def _ensure_db_parent_dir(self, db_path: Path) -> None:
+        """Ensure the parent directory exists and is readable/writable."""
+        parent_dir = db_path.parent
+        try:
+            parent_dir.mkdir(parents=True, exist_ok=True, mode=0o775)
+        except OSError as mkdir_err:
+            logger.warning(
+                'Could not create database parent directory %s: %s',
+                parent_dir,
+                mkdir_err,
+            )
+            return
+
+        try:
+            os.chmod(parent_dir, 0o775)
+        except OSError as chmod_err:
+            logger.warning(
+                'Could not update permissions for %s: %s',
+                parent_dir,
+                chmod_err,
+            )
+
+    def _run_alembic_upgrade(self, alembic_cfg: Config) -> None:
+        """Run the Alembic upgrade command."""
+        command.upgrade(alembic_cfg, 'head')
+
+    def run_alembic(self) -> None:
         # Run alembic upgrade head to ensure database is up to date
         alembic_dir = Path(__file__).parent / 'alembic'
         alembic_ini = alembic_dir / 'alembic.ini'
@@ -33,6 +72,40 @@ class OssAppLifespanService(AppLifespanService):
         original_cwd = os.getcwd()
         try:
             os.chdir(str(alembic_dir.parent))
-            command.upgrade(alembic_cfg, 'head')
+            try:
+                self._run_alembic_upgrade(alembic_cfg)
+            except Exception as e:
+                if not isinstance(e, (OperationalError, SQLAlchemyError)):
+                    raise
+
+                db_path = self._get_sqlite_db_path()
+                if db_path is None:
+                    raise
+
+                logger.warning(
+                    'Database migration failed for SQLite (%s: %s). '
+                    'Removing the database file and retrying.',
+                    type(e).__name__,
+                    e,
+                )
+
+                if db_path.exists():
+                    try:
+                        db_path.unlink()
+                    except OSError as unlink_err:
+                        logger.error(
+                            'Failed to remove SQLite database file %s: %s',
+                            db_path,
+                            unlink_err,
+                        )
+                        raise
+
+                self._ensure_db_parent_dir(db_path)
+
+                self._run_alembic_upgrade(alembic_cfg)
+                logger.warning(
+                    'SQLite database at %s was removed and migrations completed successfully.',
+                    db_path,
+                )
         finally:
             os.chdir(original_cwd)


### PR DESCRIPTION
HUMAN:

- [x] A human has tested these changes.

AGENT:

---

## Why

The OSS app server can fail during lifespan startup with `sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) unable to open database file` raised from `command.upgrade` in `oss_app_lifespan_service.py`. When the SQLite file is corrupted or the parent directory is unwritable, the container never passes the lifespan phase.

## Summary

- Wrapped `command.upgrade(alembic_cfg, 'head')` in `run_alembic` with a `try...except` that catches `sqlalchemy.exc.OperationalError` and generic `SQLAlchemyError`.
- For SQLite failures:
  - Determines the database path from `get_global_config().db_session`.
  - Removes the existing `openhands.db` file if present.
  - Creates the parent persistence directory with `0o775` permissions and `chmod`s it when possible.
  - Retries the Alembic migration so the database is recreated from scratch.
- Logs a warning before removing the file and a warning when the migration is retried successfully.

## Issue Number

## How to Test

Start the app with a missing or unwritable SQLite database path (e.g., `FILE_STORE_PATH=/.openhands` and the file removed or permission-denied). The lifespan should now recreate the database and continue startup.

## Video/Screenshots

## Type

- [x] Bug fix

## Notes

This fallback only applies to SQLite (`db_session.host` is not set). PostgreSQL and other database errors are re-raised.

Requested by: @afonsoft