### PR TITLE
docs: remove stale sdk_settings_compat entry from app_server utils README

### DIFF
--- a/openhands/app_server/utils/README.md
+++ b/openhands/app_server/utils/README.md
@@ -16,7 +16,6 @@ This module provides utility functions that are used across OpenHands for common
 - **import_utils**: Dynamic module import utilities
 - **jsonpatch_compat**: JSON patch compatibility utilities
 - **llm**: LLM model management and configuration
-- **sdk_settings_compat**: SDK settings compatibility layer
 - **search_utils**: Pagination and search utilities
 - **shutdown_listener**: Graceful shutdown signal handling
 - **sql_utils**: SQL database operation helpers


### PR DESCRIPTION

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

Verified by reading the file and git history: `openhands/app_server/utils/README.md`
listed a `sdk_settings_compat` module in "Key Components" that no longer exists in
the directory. Confirmed with `rg sdk_settings_compat openhands/` (no matches after
this change) and by finding the module's removal in the git log (#14217). Every
other bullet in the list still maps 1:1 to a real file in that directory.

- [ ] A human has tested these changes.

AGENT:

## Why

The "Key Components" list in `openhands/app_server/utils/README.md` documents the
utility modules in that directory. Every bullet maps to a real file except
`- **sdk_settings_compat**: SDK settings compatibility layer`. That module was
removed in #14217 (the compat shim was dropped), but its README bullet was left
behind, so a reader scanning the list is pointed at code that no longer exists.


- Remove the stale `sdk_settings_compat` bullet from the "Key Components" list in
  `openhands/app_server/utils/README.md`.

## Issue Number

N/A (self-identified stale-doc fix; no tracking issue).

## How to Test

Docs-only change; no runtime behavior is affected. To confirm the reference is
gone repo-wide:

```bash
rg sdk_settings_compat openhands/
```

Before this change it matched only the README line; after it returns nothing
(exit code 1). You can also confirm the module was intentionally removed:

```bash
git log --all --diff-filter=D -- '**/sdk_settings_compat.py'
```

which shows a single deletion in #14217.

## Video/Screenshots

N/A (documentation-only change, no UI).

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

The same list currently omits several real modules in the directory (for example
`auth`, `dependencies`, `env_var_validation`, `llm_metadata`, `logger`, `models`,
`paging_utils`, `redis`, `redis_lock`). This PR deliberately keeps the diff to
removing the one stale reference rather than expanding the list, since making the
list exhaustive is a separate editorial decision. Happy to follow up if
maintainers want the list kept complete.
