### PR TITLE
docs: fix S3FileStore parameter name in file_store README

### DIFF
--- a/openhands/app_server/file_store/README.md
+++ b/openhands/app_server/file_store/README.md
@@ -43,12 +43,12 @@ In-memory storage keeps files in memory, useful for testing or temporary storage
 S3 storage uses Amazon S3 or compatible services for file storage.
 
 **Parameters:**
-- `bucket`: The S3 bucket name (falls back to `AWS_S3_BUCKET` environment variable if empty)
+- `bucket_name`: The S3 bucket name (falls back to `AWS_S3_BUCKET` environment variable if empty)
 
 **Environment Variables:**
 - `AWS_ACCESS_KEY_ID`: Your AWS access key
 - `AWS_SECRET_ACCESS_KEY`: Your AWS secret key
-- `AWS_S3_BUCKET`: Default bucket name (used if `bucket` parameter is empty)
+- `AWS_S3_BUCKET`: Default bucket name (used if `bucket_name` parameter is empty)
 - `AWS_S3_ENDPOINT`: Optional custom endpoint for S3-compatible services
 - `AWS_S3_SECURE`: Whether to use HTTPS (default: "true")
 


### PR DESCRIPTION

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

Reproduced the documented example against the current field definition and
confirmed the fix by reading the field, the factory, and the existing unit test.
See "How to Test" below.

- [ ] A human has tested these changes.

AGENT:

---

## Why

The Amazon S3 section of the file store README documents the constructor
parameter as `bucket`, but `S3FileStore` defines the field as `bucket_name`
(`openhands/app_server/file_store/s3.py`), and the base `FileStore` model sets
`model_config = ConfigDict(extra='forbid', ...)`
(`openhands/app_server/file_store/files.py`). Because extra fields are
forbidden, following the README and calling `S3FileStore(bucket="my-bucket")`
raises a Pydantic `ValidationError` instead of setting the bucket.

The adjacent `GoogleCloudFileStore` entry in the same README already documents
its field correctly as `bucket_name`, so only the S3 entry is out of sync with
the code.


- Document the S3 backend parameter as `bucket_name` (was `bucket`) to match the
  real `S3FileStore` field.
- Update the matching `AWS_S3_BUCKET` environment-variable note to reference
  `bucket_name`, mirroring the already-correct `GoogleCloudFileStore` entry.

## Issue Number

N/A

## How to Test

Docs-only change; no build step required. To confirm the underlying behavior the
docs now describe:

```python
from openhands.app_server.file_store.s3 import S3FileStore

# Field is bucket_name, and the base model forbids extra fields:
print(S3FileStore.model_fields.keys())        # dict_keys(['bucket_name'])

S3FileStore(bucket="my-bucket")               # raises pydantic.ValidationError (before this PR's documented form)
S3FileStore(bucket_name="my-bucket")          # works (matches the corrected docs)
```

The factory constructs it the same way
(`get_file_store` -> `S3FileStore(bucket_name=...)` in
`openhands/app_server/file_store/__init__.py`), and the existing unit test uses
`S3FileStore(bucket_name=...)`
(`tests/unit/app_server/file_store/test_file_store.py`).

## Video/Screenshots

N/A (documentation-only change).

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

None.
