### PR TITLE
docs: document TokenLab LLM setup

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -49,6 +49,11 @@ If you are running headless or CLI workflows, you can prepare local defaults wit
 make setup-config
 ```
 
+For OpenAI-compatible providers, enter the provider model name and base URL when
+prompted. For example, TokenLab can be configured with a model such as
+`openai/claude-sonnet-5`, your TokenLab API key, and
+`https://api.tokenlab.sh/v1` as the base URL.
+
 **Note on Alternative Models:**
 See [our documentation](https://docs.openhands.dev/openhands/usage/llms/llms) for recommended models.
 


### PR DESCRIPTION
HUMAN:
This docs-only PR adds TokenLab as an OpenAI-compatible LLM setup option for OpenHands users, using the TokenLab OpenAI-compatible base URL (`https://api.tokenlab.sh/v1`) without changing runtime behavior.

- [ ] A human has tested these changes.

## Summary
- Document TokenLab as an OpenAI-compatible LLM endpoint for OpenHands CLI/headless setup.
- Use the TokenLab OpenAI-compatible base URL: https://api.tokenlab.sh/v1
- No runtime behavior changes; documentation only.

## Verification
- git diff --check