### PR TITLE
fix(frontend): correct Perplexity provider key typo (perlexity -> perplexity)

### DIFF
--- a/frontend/__tests__/utils/map-provider.test.ts
+++ b/frontend/__tests__/utils/map-provider.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "vitest";
-import { mapProvider } from "../../src/utils/map-provider";
+import { mapProvider, getProviderId } from "../../src/utils/map-provider";
 
 test("mapProvider", () => {
   expect(mapProvider("azure")).toBe("Azure");
@@ -14,7 +14,7 @@ test("mapProvider", () => {
   expect(mapProvider("anyscale")).toBe("Anyscale");
   expect(mapProvider("databricks")).toBe("Databricks");
   expect(mapProvider("ollama")).toBe("Ollama");
-  expect(mapProvider("perlexity")).toBe("Perplexity AI");
+  expect(mapProvider("perplexity")).toBe("Perplexity AI");
   expect(mapProvider("friendliai")).toBe("FriendliAI");
   expect(mapProvider("groq")).toBe("Groq");
   expect(mapProvider("fireworks_ai")).toBe("Fireworks AI");
@@ -25,4 +25,10 @@ test("mapProvider", () => {
   expect(mapProvider("voyage")).toBe("Voyage AI");
   expect(mapProvider("openrouter")).toBe("OpenRouter");
   expect(mapProvider("clarifai")).toBe("Clarifai");
+});
+
+test("getProviderId maps display names back to LiteLLM provider ids", () => {
+  expect(getProviderId("Perplexity AI")).toBe("perplexity");
+  expect(getProviderId("OpenAI")).toBe("openai");
+  expect(getProviderId("Anthropic")).toBe("anthropic");
 });

--- a/frontend/src/utils/map-provider.ts
+++ b/frontend/src/utils/map-provider.ts
@@ -13,7 +13,7 @@ export const MAP_PROVIDER = {
   anyscale: "Anyscale",
   databricks: "Databricks",
   ollama: "Ollama",
-  perlexity: "Perplexity AI",
+  perplexity: "Perplexity AI",
   friendliai: "FriendliAI",
   groq: "Groq",
   fireworks_ai: "Fireworks AI",


### PR DESCRIPTION

<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

- [ ] A human has tested these changes.

AGENT:

Ran the frontend gate locally: `npm run test -- --run map-provider` (2/2 pass), the full
vitest suite (2437 pass, 0 unexpected failures), `npm run lint` (0 errors), and
`npm run build` (green). Confirmed the regression by temporarily reverting only the source
key back to `perlexity`, which made both new assertions fail, then restored the fix.

---

## Why

`MAP_PROVIDER` in `frontend/src/utils/map-provider.ts` maps LiteLLM provider ids to branded
display names, and the file comment states these keys "are provider names, not user-facing
text" (i.e. each key must equal LiteLLM's real provider id). The Perplexity entry was keyed
on a misspelled id, `perlexity`, but LiteLLM's actual provider id is `perplexity` (its models
are `perplexity/sonar-*`). The lookup therefore missed on both sides:

- `mapProvider("perplexity")` (called in `model-selector.tsx` on the backend-sourced provider
  list) fell through to the raw lowercase `perplexity` instead of returning `"Perplexity AI"`,
  so the model/provider selector showed the un-branded name.
- `getProviderId("Perplexity AI")` (called in `settings-utils.ts`) returned the misspelled
  `perlexity`, which is then used to build the model identifier `${provider}/${model}`,
  yielding an invalid `perlexity/<model>` string.

`perlexity` was never spelled that way anywhere else in the codebase, so this is a
one-sided typo in a lookup key, not a consistent internal identifier.


- Fix the `MAP_PROVIDER` key `perlexity` -> `perplexity` in `frontend/src/utils/map-provider.ts`
  (display value `"Perplexity AI"` unchanged).
- Update the colocated unit test in `frontend/__tests__/utils/map-provider.test.ts` (it had
  asserted the misspelled key, which locked in the bug) and add a `getProviderId` round-trip
  test covering the reverse lookup.

## Issue Number

N/A (no existing issue).

## How to Test

```bash
cd frontend
npm ci
npm run test -- --run map-provider   # map-provider unit tests pass (2/2)
npm run lint                          # tsc + eslint + prettier, 0 errors
npm run build                         # production build succeeds
```

To see the regression the test guards against: revert just the source line back to
`perlexity: "Perplexity AI"` and re-run `npm run test -- --run map-provider`; both new
assertions fail. Restore the fix and they pass.

## Video/Screenshots

Not applicable: this is a one-key data fix in a provider-id lookup table with no standalone
UI of its own; behavior is covered by the unit tests above. The user-visible effect is that
the model/provider selector now shows "Perplexity AI" instead of the raw "perplexity".

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Surgical: 2 files, +9/-3, no other code paths touched. The commit will be rebased onto the
latest `main` and re-signed (`-S -s`) at ship time.
