### PR TITLE
Fix conversation metadata save race

### DIFF
--- a/enterprise/server/utils/saas_app_conversation_info_injector.py
+++ b/enterprise/server/utils/saas_app_conversation_info_injector.py
@@ -1,11 +1,14 @@
 """Enterprise injector for SQLAppConversationInfoService with SAAS filtering."""
 
+import logging
 from datetime import datetime
-from typing import AsyncGenerator
+from typing import Any, AsyncGenerator
 from uuid import UUID
 
 from fastapi import Request
 from sqlalchemy import ColumnElement, func, select
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from storage.stored_conversation_metadata import StoredConversationMetadata
 from storage.stored_conversation_metadata_saas import StoredConversationMetadataSaas
 from storage.user import User
@@ -25,6 +28,8 @@ from openhands.app_server.app_conversation.sql_app_conversation_info_service imp
 from openhands.app_server.errors import AuthError
 from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.user.specifiy_user_context import ADMIN
+
+logger = logging.getLogger(__name__)
 
 
 class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
@@ -75,7 +80,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         user_id_str = await self.user_context.get_user_id()
         if not user_id_str:
             # Secure default: no user means no access, not "show everything"
-            raise AuthError('User authentication required')
+            raise AuthError("User authentication required")
 
         user_id_uuid = UUID(user_id_str)
         query = query.where(StoredConversationMetadataSaas.user_id == user_id_uuid)
@@ -97,8 +102,8 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         user.current_org_id) when the user is authenticated via SAAS auth,
         otherwise falls back to the user's persisted current_org_id.
         """
-        user_auth = getattr(self.user_context, 'user_auth', None)
-        if user_auth is not None and hasattr(user_auth, 'get_effective_org_id'):
+        user_auth = getattr(self.user_context, "user_auth", None)
+        if user_auth is not None and hasattr(user_auth, "get_effective_org_id"):
             return await user_auth.get_effective_org_id()
         user = await self._get_current_user()
         return user.current_org_id if user else None
@@ -111,7 +116,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
                 StoredConversationMetadata.conversation_id
                 == StoredConversationMetadataSaas.conversation_id,
             )
-            .where(StoredConversationMetadata.conversation_version == 'V1')
+            .where(StoredConversationMetadata.conversation_version == "V1")
         )
         return await self._apply_user_and_org_filter(query)
 
@@ -124,7 +129,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
                 StoredConversationMetadata.conversation_id
                 == StoredConversationMetadataSaas.conversation_id,
             )
-            .where(StoredConversationMetadata.conversation_version == 'V1')
+            .where(StoredConversationMetadata.conversation_version == "V1")
         )
         return await self._apply_user_and_org_filter(query)
 
@@ -226,7 +231,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
                 StoredConversationMetadata.conversation_id
                 == StoredConversationMetadataSaas.conversation_id,
             )
-            .where(StoredConversationMetadata.conversation_version == 'V1')
+            .where(StoredConversationMetadata.conversation_version == "V1")
         )
 
         # Apply user and organization filtering
@@ -261,7 +266,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         conditions: list[ColumnElement[bool]] = []
         if title__contains is not None:
             conditions.append(
-                StoredConversationMetadata.title.like(f'%{title__contains}%')
+                StoredConversationMetadata.title.like(f"%{title__contains}%")
             )
 
         if created_at__gte is not None:
@@ -382,35 +387,85 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
             # This intentionally trumps the effective org because resolver
             # conversations are authored against a webhook-resolved org,
             # not the caller's session org.
-            resolver_org_id = getattr(self.user_context, 'resolver_org_id', None)
+            resolver_org_id = getattr(self.user_context, "resolver_org_id", None)
             if resolver_org_id is not None:
                 org_id = resolver_org_id
 
-            # Check if SAAS metadata already exists
-            saas_query = select(StoredConversationMetadataSaas).where(
-                StoredConversationMetadataSaas.conversation_id == str(info.id)
+            await self._upsert_saas_conversation_metadata(
+                conversation_id=str(info.id), user_id=user_id_uuid, org_id=org_id
             )
-            saas_result = await self.db_session.execute(saas_query)
-            existing_saas_metadata = saas_result.scalar_one_or_none()
-
-            # org_id is not asserted: it falls back to user.current_org_id, which changes when the user switches orgs.
-            assert (
-                existing_saas_metadata is None
-                or existing_saas_metadata.user_id == user_id_uuid
-            )
-
-            if not existing_saas_metadata:
-                # Create new SAAS metadata with the determined org_id
-                saas_metadata = StoredConversationMetadataSaas(
-                    conversation_id=str(info.id),
-                    user_id=user_id_uuid,
-                    org_id=org_id,
-                )
-                self.db_session.add(saas_metadata)
-
             await self.db_session.commit()
 
         return info
+
+    async def _upsert_saas_conversation_metadata(
+        self, conversation_id: str, user_id: UUID, org_id: UUID
+    ) -> None:
+        existing_saas_metadata = await self._get_saas_conversation_metadata(
+            conversation_id
+        )
+        if existing_saas_metadata is not None:
+            self._log_saas_metadata_user_mismatch(
+                conversation_id=conversation_id,
+                existing_user_id=existing_saas_metadata.user_id,
+                incoming_user_id=user_id,
+            )
+            return
+
+        values = {
+            "conversation_id": conversation_id,
+            "user_id": user_id,
+            "org_id": org_id,
+        }
+        dialect_name = self.db_session.get_bind().dialect.name
+        insert_stmt: Any
+        if dialect_name == "postgresql":
+            insert_stmt = postgresql_insert(StoredConversationMetadataSaas).values(
+                **values
+            )
+        elif dialect_name == "sqlite":
+            insert_stmt = sqlite_insert(StoredConversationMetadataSaas).values(**values)
+        else:
+            self.db_session.add(StoredConversationMetadataSaas(**values))
+            return
+
+        await self.db_session.execute(
+            insert_stmt.on_conflict_do_nothing(
+                index_elements=[StoredConversationMetadataSaas.conversation_id]
+            )
+        )
+
+        saved_saas_metadata = await self._get_saas_conversation_metadata(
+            conversation_id
+        )
+        if saved_saas_metadata is not None:
+            self._log_saas_metadata_user_mismatch(
+                conversation_id=conversation_id,
+                existing_user_id=saved_saas_metadata.user_id,
+                incoming_user_id=user_id,
+            )
+
+    async def _get_saas_conversation_metadata(
+        self, conversation_id: str
+    ) -> StoredConversationMetadataSaas | None:
+        saas_query = select(StoredConversationMetadataSaas).where(
+            StoredConversationMetadataSaas.conversation_id == conversation_id
+        )
+        saas_result = await self.db_session.execute(saas_query)
+        return saas_result.scalar_one_or_none()
+
+    def _log_saas_metadata_user_mismatch(
+        self, conversation_id: str, existing_user_id: UUID, incoming_user_id: UUID
+    ) -> None:
+        if existing_user_id == incoming_user_id:
+            return
+        logger.warning(
+            "Ignoring conflicting SaaS conversation metadata owner for "
+            "conversation %s: existing user %s, incoming user %s",
+            conversation_id,
+            existing_user_id,
+            incoming_user_id,
+        )
 
     def _to_info_with_user_id(
         self,

--- a/enterprise/tests/unit/storage/test_saas_conversation_metadata_race.py
+++ b/enterprise/tests/unit/storage/test_saas_conversation_metadata_race.py
@@ -1,0 +1,118 @@
+"""Race-safety tests for SaaS conversation metadata saves."""
+
+import logging
+from typing import AsyncGenerator
+from uuid import UUID, uuid4
+
+import pytest
+from server.utils.saas_app_conversation_info_injector import (
+    SaasSQLAppConversationInfoService,
+)
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+from storage.base import Base
+from storage.org import Org
+from storage.stored_conversation_metadata_saas import StoredConversationMetadataSaas
+from storage.user import User
+
+from openhands.app_server.app_conversation.app_conversation_models import (
+    AppConversationInfo,
+)
+from openhands.app_server.user.specifiy_user_context import SpecifyUserContext
+
+USER1_ID = UUID("a1111111-1111-1111-1111-111111111111")
+USER2_ID = UUID("b2222222-2222-2222-2222-222222222222")
+ORG1_ID = UUID("c1111111-1111-1111-1111-111111111111")
+ORG2_ID = UUID("d2222222-2222-2222-2222-222222222222")
+
+
+@pytest.fixture
+async def async_engine():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+        echo=False,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+async def async_session_with_users(async_engine) -> AsyncGenerator[AsyncSession, None]:
+    async_session_maker = async_sessionmaker(
+        async_engine, class_=AsyncSession, expire_on_commit=False
+    )
+    async with async_session_maker() as db_session:
+        db_session.add_all(
+            [
+                Org(
+                    id=ORG1_ID,
+                    name="test-org-1",
+                    enable_proactive_conversation_starters=True,
+                ),
+                Org(
+                    id=ORG2_ID,
+                    name="test-org-2",
+                    enable_proactive_conversation_starters=True,
+                ),
+            ]
+        )
+        await db_session.flush()
+        db_session.add_all(
+            [
+                User(id=USER1_ID, current_org_id=ORG1_ID),
+                User(id=USER2_ID, current_org_id=ORG2_ID),
+            ]
+        )
+        await db_session.commit()
+        yield db_session
+
+
+@pytest.mark.asyncio
+async def test_existing_saas_metadata_with_different_user_is_preserved(
+    async_session_with_users: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+):
+    user1_service = SaasSQLAppConversationInfoService(
+        db_session=async_session_with_users,
+        user_context=SpecifyUserContext(user_id=str(USER1_ID)),
+    )
+
+    conv_id = uuid4()
+    await user1_service.save_app_conversation_info(
+        AppConversationInfo(
+            id=conv_id,
+            created_by_user_id=str(USER1_ID),
+            sandbox_id="sandbox_owner_race",
+            title="Original owner conversation",
+        )
+    )
+
+    user2_service = SaasSQLAppConversationInfoService(
+        db_session=async_session_with_users,
+        user_context=SpecifyUserContext(user_id=str(USER2_ID)),
+    )
+    with caplog.at_level(logging.WARNING):
+        await user2_service.save_app_conversation_info(
+            AppConversationInfo(
+                id=conv_id,
+                created_by_user_id=str(USER2_ID),
+                sandbox_id="sandbox_owner_race",
+                title="Conflicting owner conversation",
+            )
+        )
+
+    saas_query = select(StoredConversationMetadataSaas).where(
+        StoredConversationMetadataSaas.conversation_id == str(conv_id)
+    )
+    result = await async_session_with_users.execute(saas_query)
+    saas_metadata = result.scalar_one_or_none()
+
+    assert saas_metadata is not None
+    assert saas_metadata.user_id == USER1_ID
+    assert saas_metadata.org_id == ORG1_ID
+    assert "Ignoring conflicting SaaS conversation metadata owner" in caplog.text

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -21,7 +21,7 @@ import logging
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import AsyncGenerator, cast
+from typing import Any, AsyncGenerator, cast
 from uuid import UUID
 
 from fastapi import Request
@@ -33,6 +33,8 @@ from sqlalchemy import (
     func,
     select,
 )
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
@@ -352,45 +354,72 @@ class SQLAppConversationInfoService(AppConversationInfoService):
     async def save_app_conversation_info(
         self, info: AppConversationInfo
     ) -> AppConversationInfo:
+        values = self._stored_conversation_metadata_values(info)
+        await self._upsert_stored_conversation_metadata(values)
+        await self.db_session.commit()
+        return info
+
+    def _stored_conversation_metadata_values(
+        self, info: AppConversationInfo
+    ) -> dict[str, object]:
         metrics = info.metrics or MetricsSnapshot()
         usage = metrics.accumulated_token_usage or TokenUsage()
 
-        stored = StoredConversationMetadata(
-            conversation_id=str(info.id),
-            selected_repository=info.selected_repository,
-            selected_branch=info.selected_branch,
-            git_provider=info.git_provider.value if info.git_provider else None,
-            title=info.title,
-            last_updated_at=info.updated_at,
-            created_at=info.created_at,
-            trigger=info.trigger.value if info.trigger else None,
-            pr_number=info.pr_number or [],
-            # Cost and token metrics
-            accumulated_cost=metrics.accumulated_cost,
-            prompt_tokens=usage.prompt_tokens,
-            completion_tokens=usage.completion_tokens,
-            total_tokens=0,
-            max_budget_per_task=metrics.max_budget_per_task,
-            cache_read_tokens=usage.cache_read_tokens,
-            cache_write_tokens=usage.cache_write_tokens,
-            context_window=usage.context_window,
-            per_turn_token=usage.per_turn_token,
-            llm_model=info.llm_model,
-            agent_kind=info.agent_kind,
-            conversation_version='V1',
-            sandbox_id=info.sandbox_id,
-            parent_conversation_id=(
+        return {
+            'conversation_id': str(info.id),
+            'selected_repository': info.selected_repository,
+            'selected_branch': info.selected_branch,
+            'git_provider': info.git_provider.value if info.git_provider else None,
+            'title': info.title,
+            'last_updated_at': info.updated_at,
+            'created_at': info.created_at,
+            'trigger': info.trigger.value if info.trigger else None,
+            'pr_number': info.pr_number or [],
+            'accumulated_cost': metrics.accumulated_cost,
+            'prompt_tokens': usage.prompt_tokens,
+            'completion_tokens': usage.completion_tokens,
+            'total_tokens': 0,
+            'max_budget_per_task': metrics.max_budget_per_task,
+            'cache_read_tokens': usage.cache_read_tokens,
+            'cache_write_tokens': usage.cache_write_tokens,
+            'reasoning_tokens': usage.reasoning_tokens,
+            'context_window': usage.context_window,
+            'per_turn_token': usage.per_turn_token,
+            'llm_model': info.llm_model,
+            'agent_kind': info.agent_kind,
+            'conversation_version': 'V1',
+            'sandbox_id': info.sandbox_id,
+            'parent_conversation_id': (
                 str(info.parent_conversation_id)
                 if info.parent_conversation_id
                 else None
             ),
-            public=info.public,
-            tags=info.tags if info.tags else None,
-        )
+            'public': info.public,
+            'tags': info.tags if info.tags else None,
+        }
 
-        await self.db_session.merge(stored)
-        await self.db_session.commit()
-        return info
+    async def _upsert_stored_conversation_metadata(
+        self, values: dict[str, object]
+    ) -> None:
+        dialect_name = self.db_session.get_bind().dialect.name
+        insert_stmt: Any
+        if dialect_name == 'postgresql':
+            insert_stmt = postgresql_insert(StoredConversationMetadata).values(**values)
+        elif dialect_name == 'sqlite':
+            insert_stmt = sqlite_insert(StoredConversationMetadata).values(**values)
+        else:
+            await self.db_session.merge(StoredConversationMetadata(**values))
+            return
+
+        update_values = {
+            key: insert_stmt.excluded[key] for key in values if key != 'conversation_id'
+        }
+        await self.db_session.execute(
+            insert_stmt.on_conflict_do_update(
+                index_elements=[StoredConversationMetadata.conversation_id],
+                set_=update_values,
+            )
+        )
 
     async def update_conversation_statistics(
         self, conversation_id: UUID, stats: ConversationStats

--- a/tests/unit/app_server/test_sql_app_conversation_info_service.py
+++ b/tests/unit/app_server/test_sql_app_conversation_info_service.py
@@ -5,6 +5,7 @@ focusing on basic CRUD operations, search functionality, filtering, pagination,
 and batch operations using SQLite as a mock database.
 """
 
+import asyncio
 from datetime import datetime, timezone
 from typing import AsyncGenerator
 from uuid import uuid4
@@ -610,6 +611,71 @@ class TestSQLAppConversationInfoService:
             created_at__gte=start_time, created_at__lt=end_time
         )
         assert count == 2
+
+    @pytest.mark.asyncio
+    async def test_concurrent_saves_for_same_conversation_id_do_not_duplicate_key(
+        self, tmp_path
+    ):
+        """Concurrent startup/webhook saves for one conversation should be safe."""
+        engine = create_async_engine(
+            f'sqlite+aiosqlite:///{tmp_path / "conversation-race.db"}',
+            echo=False,
+        )
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        async_session_maker = async_sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+        conversation_id = uuid4()
+        now = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+        async with (
+            async_session_maker() as session_one,
+            async_session_maker() as session_two,
+        ):
+            service_one = SQLAppConversationInfoService(
+                db_session=session_one,
+                user_context=SpecifyUserContext(user_id=None),
+            )
+            service_two = SQLAppConversationInfoService(
+                db_session=session_two,
+                user_context=SpecifyUserContext(user_id=None),
+            )
+            first_info = AppConversationInfo(
+                id=conversation_id,
+                created_by_user_id=None,
+                sandbox_id='sandbox-start-path',
+                title='Started from live status path',
+                created_at=now,
+                updated_at=now,
+            )
+            second_info = AppConversationInfo(
+                id=conversation_id,
+                created_by_user_id=None,
+                sandbox_id='sandbox-webhook-path',
+                title='Started from webhook path',
+                created_at=now,
+                updated_at=now,
+            )
+
+            await asyncio.gather(
+                service_one.save_app_conversation_info(first_info),
+                service_two.save_app_conversation_info(second_info),
+            )
+
+        async with async_session_maker() as verify_session:
+            verify_service = SQLAppConversationInfoService(
+                db_session=verify_session,
+                user_context=SpecifyUserContext(user_id=None),
+            )
+            saved_info = await verify_service.get_app_conversation_info(conversation_id)
+
+        await engine.dispose()
+
+        assert saved_info is not None
+        assert saved_info.title in {first_info.title, second_info.title}
+        assert saved_info.sandbox_id in {first_info.sandbox_id, second_info.sandbox_id}
 
     @pytest.mark.asyncio
     async def test_search_excludes_sub_conversations_by_default(


### PR DESCRIPTION
## Summary

Fixes a race in conversation metadata persistence where concurrent startup and webhook writers could cause duplicate-key failures and hide started resolver conversations.

Linear: https://linear.app/all-hands-ai/issue/APP-1872/race-in-conversation-metadata-save-can-hide-started-resolver

## Changes

- Use database-level upserts for base conversation metadata saves.
- Make SaaS metadata creation idempotent with conflict-safe insertion.
- Preserve existing SaaS metadata ownership on conflicting later writes and log mismatches.
- Add regression tests for concurrent same-conversation saves and SaaS owner-conflict handling.

## Tests

- `poetry run pytest tests/unit/app_server/test_sql_app_conversation_info_service.py -q`
- `cd enterprise && PYTHONPATH=. poetry run pytest tests/unit/storage/test_saas_sql_app_conversation_info_service.py tests/unit/storage/test_saas_conversation_metadata_race.py -q`
- `poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files openhands/app_server/app_conversation/sql_app_conversation_info_service.py enterprise/server/utils/saas_app_conversation_info_injector.py tests/unit/app_server/test_sql_app_conversation_info_service.py enterprise/tests/unit/storage/test_saas_conversation_metadata_race.py`

This PR was created by an AI agent (OpenHands) on behalf of the user.

@erisfully can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8a77ed34-7101-4b39-a01d-aac6341dd68c)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-6721408   docker.openhands.dev/openhands/openhands:6721408
```