### PR TITLE
docs(integrations): fix create_pr/create_mr docstring defaults

### DIFF
--- a/openhands/app_server/integrations/github/service/prs.py
+++ b/openhands/app_server/integrations/github/service/prs.py
@@ -24,9 +24,9 @@ class GitHubPRsMixin(GitHubMixinBase):
             repo_name: The full name of the repository (owner/repo)
             source_branch: The name of the branch where your changes are implemented
             target_branch: The name of the branch you want the changes pulled into
-            title: The title of the pull request (optional, defaults to a generic title)
+            title: The title of the pull request
             body: The body/description of the pull request (optional)
-            draft: Whether to create the PR as a draft (optional, defaults to False)
+            draft: Whether to create the PR as a draft (optional, defaults to True)
             labels: A list of labels to apply to the pull request (optional)
 
         Returns:

--- a/openhands/app_server/integrations/gitlab/service/prs.py
+++ b/openhands/app_server/integrations/gitlab/service/prs.py
@@ -23,7 +23,7 @@ class GitLabPRsMixin(GitLabMixinBase):
             id: The ID or URL-encoded path of the project
             source_branch: The name of the branch where your changes are implemented
             target_branch: The name of the branch you want the changes merged into
-            title: The title of the merge request (optional, defaults to a generic title)
+            title: The title of the merge request
             description: The description of the merge request (optional)
             labels: A list of labels to apply to the merge request (optional)
 

--- a/tests/unit/integrations/github/test_github_prs.py
+++ b/tests/unit/integrations/github/test_github_prs.py
@@ -1,0 +1,31 @@
+"""Tests for GitHubPRsMixin.create_pr documented defaults."""
+
+import inspect
+from unittest.mock import patch
+
+import pytest
+from pydantic import SecretStr
+
+from openhands.app_server.integrations.github.github_service import GitHubService
+
+
+def test_create_pr_draft_default_matches_docstring():
+    # The docstring states draft defaults to True; keep signature and prose aligned.
+    sig = inspect.signature(GitHubService.create_pr)
+    assert sig.parameters['draft'].default is True
+    # title is required (no default); the docstring must not call it optional.
+    assert sig.parameters['title'].default is inspect.Parameter.empty
+
+
+@pytest.mark.asyncio
+async def test_create_pr_defaults_to_draft_when_not_specified():
+    service = GitHubService(token=SecretStr('t'))
+    mock_response = {'number': 1, 'html_url': 'https://github.com/o/r/pull/1'}
+
+    with patch.object(
+        service, '_make_request', return_value=(mock_response, {})
+    ) as mock_req:
+        await service.create_pr('owner/repo', 'feature', 'main', 'My PR')
+
+    payload = mock_req.call_args.kwargs['params']
+    assert payload['draft'] is True


### PR DESCRIPTION

<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Anas: add a one-line human note here before shipping (the pr-readiness
workflow checks for non-empty text between HUMAN: and the checkbox on non-draft
PRs). Suggested: "Read both docstrings against their signatures and ran the new
test locally." Then tick the box once you have actually done so. -->

- [ ] A human has tested these changes.

AGENT:

---

## Why

The `create_pr` docstring in the GitHub integration mixin documented the wrong
default for `draft`. The signature is `draft: bool = True`, but the docstring
said `defaults to False`, so a caller trusting the docs would expect a normal PR
and silently get a draft one instead. GitHub is the only provider that defaults
`draft` to `True` (bitbucket, bitbucket_data_center and azure_devops all use
`draft: bool = False`), which confirms this was stale prose left behind when the
default was flipped, not the intended contract.

The same `create_pr` docstring, and the GitLab `create_mr` docstring, also
described the required `title` parameter as `optional, defaults to a generic
title`. `title` is a required positional argument and there is no generic-title
fallback anywhere in either method (only `body`/`description` gets a default).


- Fix the GitHub `create_pr` docstring so `draft` reads `defaults to True`,
  matching the `draft: bool = True` signature.
- Drop the false `optional, defaults to a generic title` clause from the `title`
  entry in both `create_pr` (GitHub) and `create_mr` (GitLab); `title` is
  required with no fallback.
- Add a regression test that pins the documented contract via
  `inspect.signature` (`draft` default is `True`, `title` has no default) plus a
  behavioral check that omitting `draft` sends `draft=True` in the request
  payload, so the docstring and signature stay aligned.

## Issue Number

N/A (self-identified documentation fix; no tracking issue).

## How to Test

Backend-only change. From the repo root:

```
poetry run pytest tests/unit/integrations/github/test_github_prs.py
```

Both tests pass. To confirm the test genuinely guards the contract, temporarily
change the signature back to `draft: bool = False` in
`openhands/app_server/integrations/github/service/prs.py`: both tests fail;
restoring `draft: bool = True` makes them pass again.

You can also just read the two docstrings against their signatures:
`openhands/app_server/integrations/github/service/prs.py` (`create_pr`) and
`openhands/app_server/integrations/gitlab/service/prs.py` (`create_mr`).

## Video/Screenshots

N/A (documentation and unit-test change, no UI).

## Type

- [x] Docs / chore

## Notes

No runtime behavior changes; the source stays byte-for-byte identical apart from
the three docstring lines. The new test lives at
`tests/unit/integrations/github/test_github_prs.py`, alongside the other
integration tests.
