### PR TITLE
fix(app-server): fix observability-metadata clobber; drop redundant repo probe

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1309,8 +1309,11 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
     ) -> tuple[dict[str, Any], list[str]]:
         """Build trace metadata and tag filters for a conversation.
 
-        Metadata uses explicit field names such as ``repo_name`` and
-        ``selected_branch``. Tags intentionally keep the concise
+        Metadata carries the conversation-identity fields (``app``,
+        ``conversation_id``, ``agent_kind``). Repo identity (repo/branch/commit)
+        is resolved live from the workspace by the agent-server and merged onto
+        the trace's root span there, so it covers repos cloned after start too
+        (not just repo-preselected conversations). Tags keep the concise
         ``repo:`` / ``branch:`` prefixes used by LiteLLM metadata filters.
         """
         metadata: dict[str, Any] = {
@@ -1321,15 +1324,11 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         tags = ['app:openhands', f'agent_kind:{agent_kind}']
 
         if selected_repository:
-            metadata['repo_name'] = selected_repository
             tags.append(f'repo:{selected_repository}')
         if selected_branch:
-            metadata['selected_branch'] = selected_branch
             tags.append(f'branch:{selected_branch}')
         if git_provider:
-            provider = git_provider.value
-            metadata['git_provider'] = provider
-            tags.append(f'git_provider:{provider}')
+            tags.append(f'git_provider:{git_provider.value}')
 
         return metadata, tags
 
@@ -1510,56 +1509,6 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             project_dir=project_dir,
             httpx_client=self.httpx_client,
         )
-
-    @staticmethod
-    async def _resolve_head_commit(
-        remote_workspace: AsyncRemoteWorkspace, project_dir: str
-    ) -> str:
-        """Best-effort post-clone HEAD sha for the Laminar trace; '' on failure.
-
-        ``--verify --quiet`` guarantees stdout is a validated object id (never
-        the literal ``HEAD`` an unborn repo would echo) and fails silently
-        rather than logging a ``fatal:`` line. The short timeout keeps this
-        trace-only lookup from delaying conversation startup if the workspace is
-        unresponsive — the metadata is simply dropped instead.
-        """
-        try:
-            result = await remote_workspace.execute_command(
-                'git rev-parse --verify --quiet HEAD', project_dir, timeout=10.0
-            )
-        except Exception as e:
-            _logger.debug('HEAD commit lookup for trace metadata failed: %s', e)
-            return ''
-        return result.stdout.strip() if not result.exit_code else ''
-
-    async def _build_observability_metadata(
-        self,
-        remote_workspace: AsyncRemoteWorkspace | None,
-        project_dir: str,
-        selected_repository: str | None,
-        selected_branch: str | None,
-        git_provider: ProviderType | None,
-    ) -> dict[str, str]:
-        """Repo identity for the Laminar trace so trajectories are searchable
-        by repo / branch / commit (the trace UI has no DB to join against).
-
-        Shared by the OpenHands and ACP request builders. The commit is the
-        post-clone HEAD, resolved best-effort from the (already-cloned)
-        workspace; omitted entirely for a repo-less conversation.
-        """
-        commit = ''
-        if selected_repository and remote_workspace is not None:
-            commit = await self._resolve_head_commit(remote_workspace, project_dir)
-        return {
-            key: value
-            for key, value in (
-                ('repo', selected_repository),
-                ('branch', selected_branch),
-                ('git_provider', git_provider.value if git_provider else None),
-                ('commit', commit),
-            )
-            if value
-        }
 
     async def _build_start_conversation_request_for_user(
         self,
@@ -1830,13 +1779,6 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         # injects it directly into the JSON body as a forward-compatible
         # fallback.
         laminar_user_id = await self.user_context.get_user_email() or user.id
-        observability_metadata = await self._build_observability_metadata(
-            remote_workspace,
-            project_dir,
-            selected_repository,
-            selected_branch,
-            git_provider,
-        )
         create_kwargs: dict[str, Any] = {'agent': agent, 'user_id': laminar_user_id}
         if observability_metadata:
             create_kwargs['observability_metadata'] = observability_metadata
@@ -2080,13 +2022,6 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         # prefer email over the internal id so Laminar traces are immediately
         # attributable, falling back to ``user.id`` when no email is available.
         laminar_user_id = await self.user_context.get_user_email() or user.id
-        observability_metadata = await self._build_observability_metadata(
-            remote_workspace,
-            project_dir,
-            selected_repository,
-            selected_branch,
-            git_provider,
-        )
         create_kwargs: dict[str, Any] = {
             'agent': acp_agent,
             'user_id': laminar_user_id,


### PR DESCRIPTION
HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

Two issues in the observability metadata on the conversation-request builders (`live_status_app_conversation_service.py`):

1. **Clobber (the bug):** both builders built `observability_metadata` from `_build_observability_context` (`app`/`conversation_id`/`agent_kind`) and then, two lines later, **reassigned** it from `_build_observability_metadata` (repo/branch/commit). The first dict was discarded — `app`/`conversation_id`/`agent_kind` never reached Laminar. Introduced by OpenHands/OpenHands#14431 landing on top of OpenHands/OpenHands#15059.

2. **Wrong layer:** `_build_observability_metadata` derived repo identity from the pre-selected `selected_repository`, which covers only ~23% of repo-bearing conversations (production trace analysis, OpenHands/enterprise#58). The dominant flow — a conversation that clones a repo *after* start — was never covered, and the `_resolve_head_commit` helper added a `git rev-parse` round-trip to the conversation startup path for the minority that were.

## Summary

- Delete `_build_observability_metadata` and `_resolve_head_commit`. Repo identity is now resolved **live from the workspace in the agent-server** (software-agent-sdk#4054) and merged onto the trace root span for **all** conversations, including clone-after-start — subsuming the request-time path and removing the startup round-trip.
- Both builders use `_build_observability_context` directly: `observability_metadata = {app, conversation_id, agent_kind}`, fixing the clobber.
- Tags are unchanged: `app:` / `agent_kind:` always, plus `repo:` / `branch:` / `git_provider:` for pre-selected conversations — so repo filtering keeps working (incl. during the window before the SDK bump ships).

## Issue Number

Part of OpenHands/enterprise#58 (the app-server half). Repo-identity backfill is software-agent-sdk#4054.

## How to Test

`_build_observability_context` is a pure static method:
```python
md, tags = svc._build_observability_context(cid, agent_kind='openhands',
                                            selected_repository='o/r',
                                            selected_branch='main', git_provider=github)
assert md == {'app':'openhands','conversation_id':str(cid),'agent_kind':'openhands'}
assert 'repo:o/r' in tags and 'branch:main' in tags and 'git_provider:github' in tags
```
Live: start any conversation and confirm the Laminar trace now carries `app`/`conversation_id`/`agent_kind` in metadata (previously dropped). Once the SDK bump (software-agent-sdk#4054) lands, `repo`/`branch`/`commit` appear for repos cloned after start too.

## Type

- [x] Bug fix

## Notes

- Coverage gap during the deploy window: between this merging and the SDK bump landing, the ~23% pre-selected conversations lose the `repo`/`branch`/`commit` **metadata fields** they had via `_build_observability_metadata`. They remain filterable by the `repo:`/`branch:` **tags** (unchanged), and regain full metadata (incl. clone-after-start) once the SDK bump ships. Sequence merge accordingly if the gap matters.
- Pure app-server change; no schema change. Trace metadata is write-only to Laminar, so the removed `repo_name`/`selected_branch` metadata keys have no downstream reader.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-0a81e4a   docker.openhands.dev/openhands/openhands:0a81e4a
```