### PR TITLE
feat: add OmniRoute LLM provider support

### DIFF
--- a/frontend/src/routes/llm-settings.tsx
+++ b/frontend/src/routes/llm-settings.tsx
@@ -76,6 +76,7 @@ const getSchemaFieldDefaultValue = (
 
 const KNOWN_PROVIDER_DEFAULT_BASE_URLS: Partial<Record<string, Set<string>>> = {
   openai: new Set(["https://api.openai.com", "https://api.openai.com/v1"]),
+  omniroute: new Set(["http://localhost:20128/v1"]),
 };
 
 const normalizeBaseUrl = (baseUrl: string) => {

--- a/frontend/src/utils/map-provider.ts
+++ b/frontend/src/utils/map-provider.ts
@@ -23,6 +23,7 @@ export const MAP_PROVIDER = {
   replicate: "Replicate",
   voyage: "Voyage AI",
   openrouter: "OpenRouter",
+  omniroute: "OmniRoute",
   openhands: "OpenHands",
   lemonade: "Lemonade",
   clarifai: "Clarifai",

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -110,6 +110,11 @@ from openhands.app_server.utils.docker_utils import (
 )
 from openhands.app_server.utils.git import ensure_valid_git_branch_name
 from openhands.app_server.utils.import_utils import get_impl
+from openhands.app_server.utils.llm import (
+    OMNIROUTE_DEFAULT_BASE_URL,
+    is_omniroute_model,
+    resolve_omniroute_model,
+)
 from openhands.app_server.utils.llm_metadata import (
     get_llm_metadata,
     should_set_litellm_extra_body,
@@ -505,7 +510,16 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 if isinstance(acp_user.agent_settings, ACPAgentSettings):
                     tags[ACP_SERVER_TAG_KEY] = acp_user.agent_settings.acp_server
             else:
-                llm_model = request_agent.llm.model
+                # Use the canonical name when it is a real string (e.g. OmniRoute
+                # keeps its original provider name for display while the runtime
+                # model is OpenAI-facing).
+                canonical_name = getattr(
+                    request_agent.llm, 'model_canonical_name', None
+                )
+                if isinstance(canonical_name, str):
+                    llm_model = canonical_name
+                else:
+                    llm_model = request_agent.llm.model
                 agent_kind = 'openhands'
 
             app_conversation_info = AppConversationInfo(
@@ -1176,28 +1190,33 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         Returns:
             Configured LLM instance
         """
-        model: str = (
+        original_model: str = (
             llm_model
             or user.agent_settings.llm.model
             or LLM.model_fields['model'].default
         )
 
         base_url = resolve_provider_llm_base_url(
-            model,
+            original_model,
             user.agent_settings.llm.base_url,
             provider_base_url=self.openhands_provider_base_url,
         )
+        if is_omniroute_model(original_model) and not base_url:
+            base_url = OMNIROUTE_DEFAULT_BASE_URL
 
-        return user.agent_settings.llm.model_copy(
-            update={
-                'model': model,
-                'base_url': base_url,
-                'api_key': user.agent_settings.llm.api_key,
-                'usage_id': 'agent',
-                # Force streaming on (the SDK LLM defaults stream=False).
-                'stream': True,
-            }
-        )
+        runtime_model, canonical_name = resolve_omniroute_model(original_model)
+        update: dict[str, Any] = {
+            'model': runtime_model,
+            'base_url': base_url,
+            'api_key': user.agent_settings.llm.api_key,
+            'usage_id': 'agent',
+            # Force streaming on (the SDK LLM defaults stream=False).
+            'stream': True,
+        }
+        if canonical_name is not None:
+            update['model_canonical_name'] = canonical_name
+
+        return user.agent_settings.llm.model_copy(update=update)
 
     async def _add_system_mcp_servers(
         self, mcp_servers: dict[str, MCPServer], conversation_id: UUID

--- a/openhands/app_server/config_api/default_llm_model_service.py
+++ b/openhands/app_server/config_api/default_llm_model_service.py
@@ -25,6 +25,7 @@ from openhands.app_server.config_api.llm_model_service import (
 from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.utils.async_utils import call_sync_from_async
 from openhands.app_server.utils.llm import (
+    OMNIROUTE_DEFAULT_BASE_URL,
     ModelsResponse,
     get_supported_llm_models,
 )
@@ -110,16 +111,18 @@ def _to_providers(models_response: ModelsResponse) -> list[Provider]:
 
 
 class DefaultLLMModelService(LLMModelService):
-    """Model discovery via litellm catalogue, optional Bedrock, and optional Ollama."""
+    """Model discovery via litellm catalogue, optional Bedrock, optional Ollama, and optional OmniRoute."""
 
     def __init__(
         self,
         *,
         bedrock_client: Any | None = None,
         ollama_base_url: str | None = None,
+        omniroute_base_url: str | None = None,
     ) -> None:
         self._bedrock_client = bedrock_client
         self._ollama_base_url = ollama_base_url
+        self._omniroute_base_url = omniroute_base_url
         self._cached_response: ModelsResponse | None = None
 
     def _list_foundation_models(self) -> list[str]:
@@ -173,6 +176,24 @@ class DefaultLLMModelService(LLMModelService):
                 extra_models.extend('ollama/' + m['name'] for m in ollama_models_list)
             except httpx.HTTPError as e:
                 _logger.error(f'Error getting OLLAMA models: {e}')
+
+        if self._omniroute_base_url:
+            omniroute_url = self._omniroute_base_url.strip('/') + '/v1/models'
+            try:
+                async with httpx.AsyncClient() as client:
+                    resp = await client.get(omniroute_url, timeout=3)
+                    data = resp.json()
+                    models = data.get('data', [])
+                extra_models.extend(
+                    'omniroute/' + m['id'] for m in models if m.get('id')
+                )
+            except httpx.HTTPError as e:
+                _logger.warning(f'Error getting OmniRoute models: {e}')
+
+        # Always include the OmniRoute smart-routing fallback so the provider
+        # is selectable even when the local server is not running. ``get_supported_llm_models``
+        # deduplicates, so this is safe even when discovery returns the same id.
+        extra_models.append('omniroute/auto')
 
         self._cached_response = get_supported_llm_models(
             verified_models=verified_models,
@@ -236,7 +257,7 @@ class DefaultLLMModelService(LLMModelService):
 
 
 class DefaultLLMModelServiceInjector(LLMModelServiceInjector):
-    """Injector that reads AWS / Ollama credentials from its own fields.
+    """Injector that reads AWS / Ollama / OmniRoute credentials from its own fields.
 
     When AWS credentials are provided, a ``boto3`` Bedrock client is created
     once and passed to every service instance, avoiding repeated credential
@@ -249,6 +270,10 @@ class DefaultLLMModelServiceInjector(LLMModelServiceInjector):
     ollama_base_url: str | None = Field(
         default=None,
         description='Base URL for a local Ollama instance (e.g. http://localhost:11434)',
+    )
+    omniroute_base_url: str | None = Field(
+        default=OMNIROUTE_DEFAULT_BASE_URL,
+        description='Base URL for an OmniRoute instance (e.g. http://localhost:20128/v1)',
     )
 
     _bedrock_client: Any | None = None
@@ -277,4 +302,5 @@ class DefaultLLMModelServiceInjector(LLMModelServiceInjector):
         yield DefaultLLMModelService(
             bedrock_client=self._get_bedrock_client(),
             ollama_base_url=self.ollama_base_url,
+            omniroute_base_url=self.omniroute_base_url,
         )

--- a/openhands/app_server/settings/llm_profiles.py
+++ b/openhands/app_server/settings/llm_profiles.py
@@ -14,7 +14,11 @@ from pydantic import (
     model_validator,
 )
 
-from openhands.app_server.utils.llm import resolve_llm_base_url
+from openhands.app_server.utils.llm import (
+    is_omniroute_model,
+    resolve_llm_base_url,
+    resolve_omniroute_model,
+)
 from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.sdk.llm import LLM
 
@@ -48,17 +52,21 @@ def resolve_profile_llm(
     without the fallback the agent server would call the LiteLLM proxy with no
     credentials; BYOR profiles keep their own key (the fallback is skipped).
     """
-    resolved = profile_llm.model_copy(
-        update={
-            'base_url': resolve_llm_base_url(
-                model=profile_llm.model,
-                base_url=profile_llm.base_url,
-                managed_proxy_url=managed_proxy_url,
-            ),
-            # Force streaming on (profiles default to the SDK's stream=False).
-            'stream': True,
-        }
+    resolved_base_url = resolve_llm_base_url(
+        model=profile_llm.model,
+        base_url=profile_llm.base_url,
+        managed_proxy_url=managed_proxy_url,
     )
+    update: dict[str, Any] = {
+        'base_url': resolved_base_url,
+        # Force streaming on (profiles default to the SDK's stream=False).
+        'stream': True,
+    }
+    if is_omniroute_model(profile_llm.model):
+        runtime_model, canonical_name = resolve_omniroute_model(profile_llm.model)
+        update['model'] = runtime_model
+        update['model_canonical_name'] = canonical_name
+    resolved = profile_llm.model_copy(update=update)
     if not has_real_api_key(resolved.api_key) and has_real_api_key(fallback_api_key):
         resolved = resolved.model_copy(update={'api_key': fallback_api_key})
     return resolved

--- a/openhands/app_server/utils/llm.py
+++ b/openhands/app_server/utils/llm.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Final
 
 from pydantic import BaseModel
 
@@ -106,6 +107,31 @@ def is_openhands_model(model: str | None) -> bool:
     return bool(model and model.startswith('openhands/'))
 
 
+OMNIROUTE_PROVIDER_PREFIX: Final[str] = 'omniroute/'
+OMNIROUTE_DEFAULT_BASE_URL: Final[str] = 'http://localhost:20128/v1'
+
+
+def is_omniroute_model(model: str | None) -> bool:
+    """Return True when the model uses the OmniRoute provider prefix."""
+    return bool(model and model.startswith(OMNIROUTE_PROVIDER_PREFIX))
+
+
+def resolve_omniroute_model(model: str) -> tuple[str, str | None]:
+    """Return the OpenAI-facing model name and original OmniRoute name.
+
+    litellm does not know the ``omniroute`` provider, so we rewrite the
+    request to ``openai/<model>`` and route it through the OmniRoute base URL.
+    The original name is returned as ``model_canonical_name`` so the UI and
+    conversation metadata stay consistent.
+    """
+    if is_omniroute_model(model):
+        return (
+            f'openai/{model.removeprefix(OMNIROUTE_PROVIDER_PREFIX)}',
+            model,
+        )
+    return model, None
+
+
 # Canonical masked placeholder for LLM API keys. Matches pydantic's
 # ``SecretStr`` default representation so request/response payloads that pass
 # through ``model_dump(mode='json')`` stay consistent with payloads that the
@@ -162,6 +188,9 @@ def resolve_llm_base_url(
 def get_provider_api_base(model: str) -> str | None:
     """Get the API base URL for a model using litellm.
 
+    OmniRoute is OpenAI-compatible but not a litellm-native provider, so its
+    default base URL is resolved locally before falling back to litellm.
+
     This function tries multiple approaches to determine the API base URL:
     1. First tries litellm.get_api_base() which handles OpenAI, Gemini, Mistral
     2. Falls back to ProviderConfigManager.get_provider_model_info() for providers
@@ -173,6 +202,8 @@ def get_provider_api_base(model: str) -> str | None:
     Returns:
         The API base URL if found, None otherwise.
     """
+    if is_omniroute_model(model):
+        return OMNIROUTE_DEFAULT_BASE_URL
     # First try get_api_base (handles OpenAI, Gemini with specific URL patterns)
     try:
         api_base = litellm.get_api_base(model, {})


### PR DESCRIPTION
HUMAN: 

- [x] A human has tested these changes.

## Why

litellm has no native `omniroute` provider, but OmniRoute exposes an OpenAI-compatible API. Users need to select it from the model dropdown and have the agent runtime route calls correctly without manual provider mapping.

## Summary

- Adds OmniRoute constants and helpers in `openhands/app_server/utils/llm.py`: `is_omniroute_model`, `resolve_omniroute_model`, and `OMNIROUTE_DEFAULT_BASE_URL` (`http://localhost:20128/v1`).
- Transforms `omniroute/<model>` payloads to `openai/<model>` with the OmniRoute base URL in `_configure_llm` and `resolve_profile_llm`, preserving the original name in `model_canonical_name` for UI/conversation metadata.
- Extends `DefaultLLMModelService` to discover `/v1/models` from the OmniRoute instance and falls back to `omniroute/auto` so the provider appears in the dropdown.
- Adds `omniroute` to `MAP_PROVIDER` and `KNOWN_PROVIDER_DEFAULT_BASE_URLS` in the frontend.

## How to Test

1. Run `pre-commit run --config ./dev_config/python/.pre-commit-config.yaml` on changed backend files — all hooks pass.
2. Run `cd frontend && npm run lint:fix && npm run build` — builds successfully.
3. Run `pytest tests/unit/utils/test_llm_utils.py tests/unit/app_server/test_llm_model_service.py tests/unit/app_server/test_live_status_app_conversation_service.py` — 171 tests pass.
4. Verify routing with the provided smoke test: selecting `omniroute/gpt-4o-preview` results in `LLM._litellm_call_kwargs()` returning `model='openai/gpt-4o-preview'` and `api_base='http://localhost:20128/v1'`.

## Type

- [x] Feature

## Notes

No new environment variables are introduced. The default OmniRoute base URL is hardcoded to match the local-first OmniRoute default; users can override it via the advanced base URL field. Model-name suffixes such as `-preview` are preserved end-to-end.

Requested by: @afonsoft