### PR TITLE
fix(frontend): mention SMTP env vars for budget alerts

### DIFF
--- a/frontend/src/components/features/budgets/budgets-tabs.tsx
+++ b/frontend/src/components/features/budgets/budgets-tabs.tsx
@@ -188,8 +188,8 @@ export function OrganizationBudgetTab({
               <div className="mt-2 space-y-1 text-xs text-amber-400">
                 {!emailIntegrationEnabled && (
                   <p>
-                    Email alerts require RESEND_API_KEY set in the deployment
-                    environment and a restart.
+                    Email alerts require RESEND_API_KEY or SMTP_* env vars set
+                    in the deployment environment and a restart.
                   </p>
                 )}
                 {!slackIntegrationEnabled && (
@@ -249,7 +249,7 @@ export function OrganizationBudgetTab({
                     title={
                       emailIntegrationEnabled
                         ? "Email org admins"
-                        : "Email alerts require RESEND_API_KEY in deployment (restart required)"
+                        : "Email alerts require RESEND_API_KEY or SMTP_* env vars in deployment (restart required)"
                     }
                   >
                     <PillBadge


### PR DESCRIPTION
## Summary
- mention SMTP_* env vars alongside RESEND_API_KEY in budget email alert copy
- update the email alert tooltip copy accordingly

## Testing
- not run (copy-only change)

_This PR description was created by an AI agent (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-9c0452f   docker.openhands.dev/openhands/openhands:9c0452f
```