### PR TITLE
fix(enterprise): cascade-delete conversation_cost_events on conversation delete

### DIFF
--- a/enterprise/migrations/versions/136_update_conversation_cost_events_fk_to_cascade.py
+++ b/enterprise/migrations/versions/136_update_conversation_cost_events_fk_to_cascade.py
@@ -1,0 +1,58 @@
+"""Update conversation_cost_events foreign key to cascade deletes.
+
+Without ON DELETE CASCADE, deleting a row from conversation_metadata fails
+with a ForeignKeyViolationError when conversation_cost_events rows still
+reference it. The cost-delta stream is an audit trail whose running total
+is already maintained on conversation_metadata.accumulated_cost, so
+cascade-deleting the audit rows when the conversation is removed is safe.
+
+Revision ID: 136
+Revises: 135
+Create Date: 2026-07-09
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '136'
+down_revision = '135'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Drop the existing foreign key constraint
+    op.drop_constraint(
+        'conversation_cost_events_conversation_id_fkey',
+        'conversation_cost_events',
+        type_='foreignkey',
+    )
+
+    # Add the new foreign key constraint with cascade delete
+    op.create_foreign_key(
+        'conversation_cost_events_conversation_id_fkey',
+        'conversation_cost_events',
+        'conversation_metadata',
+        ['conversation_id'],
+        ['conversation_id'],
+        ondelete='CASCADE',
+    )
+
+
+def downgrade():
+    # Drop the cascade delete foreign key constraint
+    op.drop_constraint(
+        'conversation_cost_events_conversation_id_fkey',
+        'conversation_cost_events',
+        type_='foreignkey',
+    )
+
+    # Recreate the original foreign key constraint without cascade delete
+    op.create_foreign_key(
+        'conversation_cost_events_conversation_id_fkey',
+        'conversation_cost_events',
+        'conversation_metadata',
+        ['conversation_id'],
+        ['conversation_id'],
+    )

--- a/enterprise/tests/unit/storage/test_conversation_cost_events_cascade.py
+++ b/enterprise/tests/unit/storage/test_conversation_cost_events_cascade.py
@@ -1,0 +1,158 @@
+"""Tests for the conversation_cost_events foreign key cascade behavior.
+
+The ``conversation_cost_events`` table records per-event cost deltas whose
+running total is already mirrored on ``conversation_metadata.accumulated_cost``.
+Deleting a conversation must therefore also remove its cost-event rows so
+that ``delete_app_conversation_info`` does not fail with a
+``ForeignKeyViolationError``.
+
+These tests guard two invariants:
+
+1. The SQLAlchemy model declares the FK with ``ondelete='CASCADE'`` so
+   fresh-schema creation (tests, dev) matches the production migration.
+2. Deleting a conversation row actually removes its cost-event rows on a
+   backend that enforces foreign keys (SQLite with ``PRAGMA foreign_keys=ON``).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import AsyncGenerator
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import event, select
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from openhands.app_server.app_conversation.sql_app_conversation_info_service import (
+    SQLAppConversationInfoService,
+    StoredConversationCostEvent,
+    StoredConversationMetadata,
+)
+from openhands.app_server.user.specifiy_user_context import SpecifyUserContext
+
+
+@pytest.fixture
+async def engine() -> AsyncGenerator[AsyncEngine, None]:
+    """Async SQLite engine with FK enforcement enabled.
+
+    SQLite does not enforce foreign-key constraints unless each connection
+    runs ``PRAGMA foreign_keys=ON``; the engine ``connect`` event listener
+    applies it automatically.
+    """
+
+    engine = create_async_engine(
+        'sqlite+aiosqlite:///:memory:',
+        poolclass=StaticPool,
+        connect_args={'check_same_thread': False},
+    )
+
+    @event.listens_for(engine.sync_engine, 'connect')
+    def _enable_sqlite_fk(dbapi_connection, _connection_record):  # pragma: no cover
+        cursor = dbapi_connection.cursor()
+        cursor.execute('PRAGMA foreign_keys=ON')
+        cursor.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(StoredConversationMetadata.metadata.create_all)
+
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+async def session(engine: AsyncEngine) -> AsyncGenerator[AsyncSession, None]:
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_maker() as db_session:
+        yield db_session
+
+
+def test_cost_event_fk_declares_cascade():
+    """The model FK must declare ``ondelete='CASCADE'``.
+
+    Without this, any fresh database (tests, dev, on-prem deploys that
+    re-create the schema) ends up with the same broken constraint the
+    production migration is fixing.
+    """
+    conversation_id_column = StoredConversationCostEvent.__table__.c.conversation_id
+    foreign_keys = list(conversation_id_column.foreign_keys)
+    assert len(foreign_keys) == 1
+    fk = foreign_keys[0]
+    assert fk.column.table.name == 'conversation_metadata'
+    assert fk.ondelete == 'CASCADE'
+
+
+@pytest.mark.asyncio
+async def test_delete_conversation_cascades_cost_events(
+    engine: AsyncEngine, session: AsyncSession
+):
+    """Deleting a conversation must remove its cost-event rows.
+
+    Reproduces the production bug where deleting from
+    ``conversation_metadata`` fails with ``ForeignKeyViolationError`` because
+    ``conversation_cost_events`` still references the row.
+    """
+    conversation_id = str(uuid4())
+    other_conversation_id = str(uuid4())
+
+    session.add(
+        StoredConversationMetadata(
+            conversation_id=conversation_id,
+            created_at=datetime.now(timezone.utc),
+            last_updated_at=datetime.now(timezone.utc),
+        )
+    )
+    session.add(
+        StoredConversationMetadata(
+            conversation_id=other_conversation_id,
+            created_at=datetime.now(timezone.utc),
+            last_updated_at=datetime.now(timezone.utc),
+        )
+    )
+    await session.commit()
+
+    now = datetime.now(timezone.utc)
+    session.add_all(
+        [
+            StoredConversationCostEvent(
+                conversation_id=conversation_id, cost_delta=0.10, occurred_at=now
+            ),
+            StoredConversationCostEvent(
+                conversation_id=conversation_id, cost_delta=0.25, occurred_at=now
+            ),
+            StoredConversationCostEvent(
+                conversation_id=other_conversation_id,
+                cost_delta=0.99,
+                occurred_at=now,
+            ),
+        ]
+    )
+    await session.commit()
+
+    service = SQLAppConversationInfoService(
+        db_session=session, user_context=SpecifyUserContext(user_id=None)
+    )
+    deleted = await service.delete_app_conversation_info(UUID(conversation_id))
+    assert deleted is True
+
+    remaining_metadata = (
+        (await session.execute(select(StoredConversationMetadata.conversation_id)))
+        .scalars()
+        .all()
+    )
+    assert remaining_metadata == [other_conversation_id]
+
+    remaining_cost_events = (
+        (await session.execute(select(StoredConversationCostEvent.conversation_id)))
+        .scalars()
+        .all()
+    )
+    assert remaining_cost_events == [other_conversation_id]

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -154,7 +154,7 @@ class StoredConversationCostEvent(Base):
     id: Mapped[int] = mapped_column(Identity(), primary_key=True)
     conversation_id: Mapped[str] = mapped_column(
         String,
-        ForeignKey('conversation_metadata.conversation_id'),
+        ForeignKey('conversation_metadata.conversation_id', ondelete='CASCADE'),
         nullable=False,
         index=True,
     )


### PR DESCRIPTION
HUMAN:


- [x] A human has tested these changes.

AGENT:

---

## Why

Deleting a V1 conversation in prod fails with:

```
Error deleting V1 conversation 23742af5-6dfb-498c-8d96-787e407e7347:
(sqlalchemy.dialects.postgresql.asyncpg.IntegrityError)
<class 'asyncpg.exceptions.ForeignKeyViolationError'>: update or delete on
table "conversation_metadata" violates foreign key constraint
"conversation_cost_events_conversation_id_fkey" on table "conversation_cost_events"
```

Root cause: the `conversation_cost_events` table added in migration 135 (commit `acc8412ae`, "feat: track per-event cost deltas") declares its FK to `conversation_metadata.conversation_id` without `ON DELETE CASCADE`. Since cost-delta rows are inserted on every positive-cost agent-metrics update, essentially every active conversation has at least one row referencing it, so `SQLAppConversationInfoService.delete_app_conversation_info` blows up before it can delete the metadata row.

The cost-delta stream is an audit trail whose running total is already mirrored on `conversation_metadata.accumulated_cost`, so cascade-deleting the audit rows when the conversation is removed is safe — and matches the precedent set by migration 051, which did the same surgery on `conversation_callbacks` for the exact same reason.

## Summary

- New Alembic migration `136_update_conversation_cost_events_fk_to_cascade.py` drops `conversation_cost_events_conversation_id_fkey` and recreates it with `ondelete='CASCADE'`.
- `StoredConversationCostEvent.conversation_id` model declares `ondelete='CASCADE'` so fresh-schema creation (tests, dev, on-prem re-creates) matches prod.
- New regression tests in `enterprise/tests/unit/storage/test_conversation_cost_events_cascade.py`:
  - `test_cost_event_fk_declares_cascade` introspects the model FK and asserts `ondelete == 'CASCADE'`.
  - `test_delete_conversation_cascades_cost_events` runs an end-to-end delete against SQLite with `PRAGMA foreign_keys=ON` and verifies that deleting a conversation also removes its cost-event rows (and leaves unrelated conversations' events intact).

## Issue Number

None.

## How to Test

1. Pull the branch and run the new unit tests:
   ```
   cd enterprise
   PYTHONPATH=".:$PYTHONPATH" poetry run pytest \
     tests/unit/storage/test_conversation_cost_events_cascade.py -v
   ```
   Both tests should pass.
2. Run the broader enterprise storage suite to confirm no regressions:
   ```
   cd enterprise
   PYTHONPATH=".:$PYTHONPATH" poetry run pytest tests/unit/storage/ -q
   ```
   Expect 226 passed, 2 skipped (unchanged from `main`).
3. To exercise the migration against a real PostgreSQL DB, run `alembic upgrade head` and inspect the constraint:
   ```
   psql ... -c "\d conversation_cost_events"
   ```
   `conversation_id`'s FK should now show `ON DELETE CASCADE`.
4. End-to-end (requires staging): create a conversation, let it generate a couple of cost-event rows, then delete it via the V1 delete API — the delete should succeed instead of returning `ForeignKeyViolationError`.

## Video/Screenshots

Deletes now work as expected:
<img width="659" height="489" alt="image" src="https://github.com/user-attachments/assets/22c7b3df-cfe2-4d07-981b-fac765b43878" />
<img width="657" height="730" alt="image" src="https://github.com/user-attachments/assets/3652f46b-001b-4df7-851a-8baeedec66a8" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **No application-level pre-delete of cost events was added.** Migration 051 also relies purely on DB-level cascade for `conversation_callbacks`; doing the same here keeps `delete_app_conversation_info` a single statement.
- **Convention suggestion (follow-up):** this is the second time a child table was added to `conversation_metadata` without `ON DELETE CASCADE` and only caught in prod. Worth establishing a code-review checklist item: every new FK from a child table to `conversation_metadata.conversation_id` must include `ondelete='CASCADE'`.
- Migration revision chain: `134 → 135 → 136`. Safe to deploy on top of any env that already ran migration 135.

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-67ab546   docker.openhands.dev/openhands/openhands:67ab546
```