### PR TITLE
fix: Enable LIFO database connection pooling

### DIFF
--- a/enterprise/migrations/env.py
+++ b/enterprise/migrations/env.py
@@ -62,6 +62,7 @@ def get_engine(database_name=DB_NAME):
             pool_size=POOL_SIZE,
             max_overflow=MAX_OVERFLOW,
             pool_pre_ping=True,
+            pool_use_lifo=True,
         )
     else:
         scheme = f'postgresql+{DB_DRIVER}' if DB_DRIVER else 'postgresql'
@@ -73,6 +74,7 @@ def get_engine(database_name=DB_NAME):
             pool_size=POOL_SIZE,
             max_overflow=MAX_OVERFLOW,
             pool_pre_ping=True,
+            pool_use_lifo=True,
             connect_args=(
                 build_pg8000_connect_args(DB_SSL_MODE) if DB_DRIVER == 'pg8000' else {}
             ),

--- a/openhands/app_server/services/db_session_injector.py
+++ b/openhands/app_server/services/db_session_injector.py
@@ -37,6 +37,7 @@ class DbSessionInjector(BaseModel, Injector[AsyncSession]):
     pool_size: int = 25
     max_overflow: int = 10
     pool_recycle: int = 1800
+    pool_use_lifo: bool = True
     gcp_db_instance: str | None = None
     gcp_project: str | None = None
     gcp_region: str | None = None
@@ -125,6 +126,7 @@ class DbSessionInjector(BaseModel, Injector[AsyncSession]):
             pool_size=self.pool_size,
             max_overflow=self.max_overflow,
             pool_pre_ping=True,
+            pool_use_lifo=self.pool_use_lifo,
         )
         return engine
 
@@ -162,6 +164,7 @@ class DbSessionInjector(BaseModel, Injector[AsyncSession]):
             max_overflow=self.max_overflow,
             pool_pre_ping=True,
             pool_recycle=self.pool_recycle,
+            pool_use_lifo=self.pool_use_lifo,
         )
 
     async def get_async_db_engine(self) -> AsyncEngine:
@@ -199,6 +202,7 @@ class DbSessionInjector(BaseModel, Injector[AsyncSession]):
                     max_overflow=self.max_overflow,
                     pool_recycle=self.pool_recycle,
                     pool_pre_ping=True,
+                    pool_use_lifo=self.pool_use_lifo,
                 )
             else:
                 async_engine = create_async_engine(
@@ -243,6 +247,7 @@ class DbSessionInjector(BaseModel, Injector[AsyncSession]):
                 max_overflow=self.max_overflow,
                 pool_recycle=self.pool_recycle,
                 pool_pre_ping=True,
+                pool_use_lifo=self.pool_use_lifo,
             )
         assert engine is not None  # Always assigned in either branch above
         self._engine = engine

--- a/tests/unit/app_server/test_db_session_injector.py
+++ b/tests/unit/app_server/test_db_session_injector.py
@@ -105,6 +105,7 @@ class TestDbSessionInjectorConfiguration:
         assert service.echo is False
         assert service.pool_size == 25
         assert service.max_overflow == 10
+        assert service.pool_use_lifo is True
         assert service.gcp_db_instance is None
         assert service.gcp_project is None
         assert service.gcp_region is None
@@ -215,6 +216,7 @@ class TestDbSessionInjectorConnections:
             assert call_args[1]['pool_size'] == 25
             assert call_args[1]['max_overflow'] == 10
             assert call_args[1]['pool_pre_ping']
+            assert call_args[1]['pool_use_lifo'] is True
 
     @pytest.mark.asyncio
     async def test_postgres_async_connection_with_host(
@@ -248,6 +250,7 @@ class TestDbSessionInjectorConnections:
             assert call_args[1]['pool_size'] == 25
             assert call_args[1]['max_overflow'] == 10
             assert call_args[1]['pool_pre_ping']
+            assert call_args[1]['pool_use_lifo'] is True
 
     def test_postgres_connection_requires_ssl(self, temp_persistence_dir):
         service = DbSessionInjector(


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

Using Lifo to gradually recycle connections.

- [x] A human has tested these changes.

AGENT:

---

## Why

Database connection spikes can leave SQLAlchemy pools holding many idle PostgreSQL backends after burst traffic. LIFO pool reuse makes older idle connections stay untouched longer, allowing database-side idle session timeouts to reclaim them more effectively while `pool_pre_ping` handles reconnects on later checkout.

## Summary

- Enable `pool_use_lifo=True` for pooled sync and async database engines in `DbSessionInjector`.
- Enable LIFO for enterprise Alembic migration engine pools.
- Add unit assertions that database pools are configured with LIFO by default.

## Issue Number

N/A

## How to Test

```bash
poetry run pytest tests/unit/app_server/test_db_session_injector.py
poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml
```

Both commands passed locally.

## Video/Screenshots

<img width="1171" height="493" alt="image" src="https://github.com/user-attachments/assets/5c773a7b-8017-4214-afe3-410268cc8f8f" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR was created by an AI agent (OpenHands) on behalf of the user.

For best idle-connection reclamation, this should be paired with an appropriate PostgreSQL/Cloud SQL `idle_session_timeout`. `pool_pre_ping=True` is already enabled, so stale server-closed connections should be detected on checkout.

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a216f946-1c8a-4cbb-bcb3-5655fbc94edd)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-76d01b7   docker.openhands.dev/openhands/openhands:76d01b7
```