### PR TITLE
fix: accept 1 for env enable toggles

### DIFF
--- a/openhands/app_server/app.py
+++ b/openhands/app_server/app.py
@@ -72,7 +72,7 @@ app.include_router(v1_router.router)
 app.include_router(health_router)
 
 # Middleware and static file setup (merged from listen.py)
-if os.getenv('SERVE_FRONTEND', 'true').lower() == 'true':
+if os.getenv('SERVE_FRONTEND', 'true').lower() in ('true', '1'):
     if os.path.isdir('./frontend/build'):
         app.mount(
             '/', SPAStaticFiles(directory='./frontend/build', html=True), name='dist'

--- a/openhands/app_server/event/aws_event_service.py
+++ b/openhands/app_server/event/aws_event_service.py
@@ -81,7 +81,7 @@ def _get_default_aws_endpoint_url() -> str | None:
     endpoint_url = os.getenv('AWS_S3_ENDPOINT')
     if not endpoint_url:
         return None
-    secure = os.getenv('AWS_S3_SECURE', 'true').lower() == 'true'
+    secure = os.getenv('AWS_S3_SECURE', 'true').lower() in ('true', '1')
     if secure:
         if not endpoint_url.startswith('https://'):
             endpoint_url = 'https://' + endpoint_url.removeprefix('http://')

--- a/openhands/app_server/file_store/s3.py
+++ b/openhands/app_server/file_store/s3.py
@@ -43,7 +43,7 @@ class S3FileStore(FileStore):
         if self._client is None:
             access_key = os.getenv('AWS_ACCESS_KEY_ID')
             secret_key = os.getenv('AWS_SECRET_ACCESS_KEY')
-            secure = os.getenv('AWS_S3_SECURE', 'true').lower() == 'true'
+            secure = os.getenv('AWS_S3_SECURE', 'true').lower() in ('true', '1')
             endpoint = self._ensure_url_scheme(secure, os.getenv('AWS_S3_ENDPOINT'))
             self._client = boto3.client(
                 's3',

--- a/tests/unit/app_server/file_store/test_file_store.py
+++ b/tests/unit/app_server/file_store/test_file_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 import tempfile
 import threading
@@ -331,6 +332,24 @@ class TestInMemoryFileStore(TestCase, _StorageTest):
 class TestGoogleCloudFileStore(TestCase, _StorageTest):
     def setUp(self):
         self.store = GoogleCloudFileStore(bucket_name='dear-liza')
+
+
+@patch('boto3.client')
+class TestS3FileStoreEnv(TestCase):
+    def test_s3_secure_accepts_one(self, mock_boto_client):
+        os.environ['AWS_S3_ENDPOINT'] = 'minio.example.com:9000'
+        os.environ['AWS_S3_SECURE'] = '1'
+        try:
+            store = S3FileStore(bucket_name='dear-liza')
+            store.client
+        finally:
+            os.environ.pop('AWS_S3_ENDPOINT', None)
+            os.environ.pop('AWS_S3_SECURE', None)
+
+        mock_boto_client.assert_called_once()
+        _, kwargs = mock_boto_client.call_args
+        self.assertEqual(kwargs['endpoint_url'], 'https://minio.example.com:9000')
+        self.assertTrue(kwargs['use_ssl'])
 
 
 @patch('boto3.client', lambda service, **kwargs: _MockS3Client())

--- a/tests/unit/app_server/test_aws_event_service.py
+++ b/tests/unit/app_server/test_aws_event_service.py
@@ -249,6 +249,16 @@ class TestGetDefaultAwsEndpointUrl:
         result = aws_event_service._get_default_aws_endpoint_url()
         assert result == 'https://minio.example.com:9000'
 
+    def test_endpoint_without_https_prefix_secure_one(self, monkeypatch):
+        """Test endpoint without https:// prefix when secure=1 adds it."""
+        monkeypatch.setenv('AWS_S3_ENDPOINT', 'minio.example.com:9000')
+        monkeypatch.setenv('AWS_S3_SECURE', '1')
+
+        importlib.reload(aws_event_service)
+
+        result = aws_event_service._get_default_aws_endpoint_url()
+        assert result == 'https://minio.example.com:9000'
+
     def test_endpoint_with_http_prefix_insecure(self, monkeypatch):
         """Test endpoint with http:// prefix when secure=false."""
         monkeypatch.setenv('AWS_S3_ENDPOINT', 'http://minio.example.com:9000')


### PR DESCRIPTION
HUMAN:
This PR fixes three boolean environment checks that still treated only the literal string `true` as enabled. With this change, `SERVE_FRONTEND=1` and `AWS_S3_SECURE=1` behave as enabled too, matching the project guidance for Helm-style env values.

- [x] A human has tested these changes.

## What
- Treat `SERVE_FRONTEND=1` the same as `true` when deciding whether to mount the frontend.
- Treat `AWS_S3_SECURE=1` the same as `true` in both S3 event storage and S3 file-store setup.
- Add regression coverage for the `AWS_S3_SECURE=1` path.

## Why
The project guidance says boolean env toggles should accept both `true` and `1`, but these paths only accepted `true`. That can silently disable the frontend mount or make S3 endpoints use `http://` in deployments that set Helm-style `1` values.

## Test
- `git diff --check`
- `uv run pytest tests/unit/app_server/test_aws_event_service.py tests/unit/app_server/file_store/test_file_store.py -q` (45 passed)
- `uv run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files openhands/app_server/app.py openhands/app_server/event/aws_event_service.py openhands/app_server/file_store/s3.py tests/unit/app_server/test_aws_event_service.py tests/unit/app_server/file_store/test_file_store.py`

Note: `make install-pre-commit-hooks` currently stops at dependency install with `pyproject.toml changed significantly since poetry.lock was last generated`; I ran the targeted checks above through `uv run` instead.
