### PR TITLE
fix(app-server): don't hold DB connections across runtime-api calls

### DIFF
--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -354,6 +354,14 @@ class RemoteSandboxService(SandboxService):
 
         return self._to_sandbox_info(stored_sandbox, runtime)
 
+    async def _release_status_connection(self) -> None:
+        # End the read transaction opened by get_sandbox so the pooled DB
+        # connection returns to the pool while wait_for_sandbox_running sleeps.
+        # The poll loop only reads and start_sandbox has already committed the
+        # sandbox row by the time we wait, so nothing is pending: this commit
+        # just ends the transaction rather than persisting new state.
+        await self.db_session.commit()
+
     async def get_sandbox_by_session_api_key(
         self, session_api_key: str
     ) -> SandboxInfo | None:

--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -447,14 +447,14 @@ class RemoteSandboxService(SandboxService):
             # get user id
             user_id = await self.user_context.get_user_id()
 
-            # Store the sandbox
+            # Built now, but only added + committed after the runtime /start
+            # succeeds, so a failed start leaves no row behind.
             stored_sandbox = StoredRemoteSandbox(
                 id=sandbox_id,
                 created_by_user_id=user_id,
                 sandbox_spec_id=sandbox_spec.id,
                 created_at=utc_now(),
             )
-            self.db_session.add(stored_sandbox)
 
             # Prepare environment variables
             environment = await self._init_environment(sandbox_spec, sandbox_id)
@@ -476,6 +476,13 @@ class RemoteSandboxService(SandboxService):
             if self.runtime_class == 'sysbox':
                 start_request['runtime_class'] = 'sysbox-runc'
 
+            # Runtime /start can block for up to start_sandbox_timeout waiting
+            # for a warm runtime to be claimable; end the transaction opened by
+            # the reads above so no pooled DB connection sits idle-in-transaction
+            # for that long. This also persists any pause_old_sandboxes key
+            # invalidations.
+            await self.db_session.commit()
+
             # Start the runtime
             response = await self._send_runtime_api_request(
                 'POST',
@@ -491,6 +498,11 @@ class RemoteSandboxService(SandboxService):
                 stored_sandbox.session_api_key_hash = _hash_session_api_key(
                     session_api_key
                 )
+            self.db_session.add(stored_sandbox)
+            # Commit in a short transaction of its own: the runtime is up, so
+            # the row (and key hash the webhook auth looks up) must be visible
+            # to other workers before callbacks start arriving.
+            await self.db_session.commit()
 
             # Log runtime assignment for observability
             runtime_id = runtime_data.get('runtime_id', 'unknown')
@@ -516,6 +528,8 @@ class RemoteSandboxService(SandboxService):
             stored_sandbox = await self._get_stored_sandbox(sandbox_id)
             if not stored_sandbox:
                 return False
+            # Release the pooled DB connection before the runtime-api calls.
+            await self.db_session.commit()
             runtime_data = await self._get_runtime(sandbox_id)
             response = await self._send_runtime_api_request(
                 'POST',
@@ -534,6 +548,9 @@ class RemoteSandboxService(SandboxService):
                 stored_sandbox.session_api_key_hash = _hash_session_api_key(
                     new_session_api_key
                 )
+                # Commit now so other workers' webhook-auth lookups see the
+                # new hash as soon as the resumed runtime starts calling back.
+                await self.db_session.commit()
                 _logger.info(
                     f'Updated session_api_key_hash for sandbox {sandbox_id} after resume'
                 )
@@ -556,7 +573,10 @@ class RemoteSandboxService(SandboxService):
 
             # Security: Invalidate the session API key hash to prevent
             # leaked keys from being used while the sandbox is paused.
+            # Committed immediately: the revoke is durable up front, and the
+            # pooled DB connection is released before the runtime-api calls.
             stored_sandbox.session_api_key_hash = None
+            await self.db_session.commit()
 
             runtime_data = await self._get_runtime(sandbox_id)
             response = await self._send_runtime_api_request(
@@ -590,22 +610,21 @@ class RemoteSandboxService(SandboxService):
         (router -> 503) and keeps the row + runtime for a retry — so a live sandbox
         is never reported as 404.
 
-        Security: the session_api_key_hash is invalidated UP FRONT (like
-        ``pause_sandbox`` clears it before pausing) so a delete — commonly a
-        revoke of a leaked key — kills it promptly. This goes further than pause:
-        on a transient stop failure the invalidation is committed before raising,
-        so the caller's rollback cannot resurrect the just-revoked key (pause does
-        not commit, so its clear can still be rolled back). The row is kept for
-        retry.
+        Security: the session_api_key_hash is invalidated and committed UP
+        FRONT (like ``pause_sandbox``) so a delete — commonly a revoke of a
+        leaked key — kills it promptly and no later rollback can resurrect it.
+        On a transient stop failure the row is kept for retry, with the key
+        already revoked.
         """
-        had_key = False
         try:
             stored_sandbox = await self._get_stored_sandbox(sandbox_id)
             if not stored_sandbox:
                 return False
             # Security: drop the key now, before the (fallible) runtime stop.
-            had_key = stored_sandbox.session_api_key_hash is not None
+            # Committed immediately so the revoke is durable and the pooled DB
+            # connection is released before the runtime-api calls below.
             stored_sandbox.session_api_key_hash = None
+            await self.db_session.commit()
             try:
                 runtime_data = await self._get_runtime(sandbox_id)
             except httpx.HTTPStatusError as e:
@@ -617,6 +636,7 @@ class RemoteSandboxService(SandboxService):
                     'deleting record'
                 )
                 await self.db_session.delete(stored_sandbox)
+                await self.db_session.commit()
                 return True
 
             response = await self._send_runtime_api_request(
@@ -627,15 +647,13 @@ class RemoteSandboxService(SandboxService):
             if response.status_code != 404:
                 response.raise_for_status()
             await self.db_session.delete(stored_sandbox)
+            await self.db_session.commit()
             return True
         except httpx.HTTPError as e:
             # Transient runtime lookup/stop failure: keep the row + runtime and
-            # signal retryable (503) — never a 404. Persist the key invalidation
-            # now: the caller rolls back on this raise, which would otherwise
-            # restore the hash and leave a just-revoked key valid.
+            # signal retryable (503) — never a 404. The key invalidation was
+            # already committed above, so this raise cannot resurrect it.
             _logger.error(f'Error deleting sandbox {sandbox_id}: {e}')
-            if had_key:
-                await self.db_session.commit()
             raise SandboxDeleteRetryError(
                 f'Could not complete delete for sandbox {sandbox_id}: {e}'
             ) from e
@@ -696,6 +714,10 @@ class RemoteSandboxService(SandboxService):
             url = runtime.get('url')
             if url:
                 runtime['url'] = replace_localhost_hostname_for_docker(url)
+            # Archiving can take minutes on a large workspace; end any read
+            # transaction (_resolve_archive_path's fallback queries) so no
+            # pooled DB connection is held while it runs.
+            await self.db_session.commit()
             return await workspace_archive.archive_workspace(
                 self.httpx_client,
                 runtime,
@@ -742,6 +764,8 @@ class RemoteSandboxService(SandboxService):
             stored_sandbox = await self._get_stored_sandbox(sandbox_id)
             if not stored_sandbox:
                 return True
+            # Release the pooled DB connection before the runtime-api calls.
+            await self.db_session.commit()
             runtime_data = await self._get_runtime(sandbox_id)
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:

--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -564,7 +564,12 @@ class RemoteSandboxService(SandboxService):
         """Pause a running sandbox.
 
         Security: Clears the session_api_key_hash to invalidate any existing
-        session keys, preventing leaked keys from being used while paused.
+        session keys, preventing leaked keys from being used while paused. The
+        clear is committed before the runtime /pause (releasing the pooled DB
+        connection for the slow call) and restored if the pause fails
+        transiently: the sandbox is still running then, and nothing re-sets the
+        hash for a running sandbox, so a committed NULL would permanently 401
+        its webhook/secrets auth.
         """
         try:
             stored_sandbox = await self._get_stored_sandbox(sandbox_id)
@@ -575,19 +580,35 @@ class RemoteSandboxService(SandboxService):
             # leaked keys from being used while the sandbox is paused.
             # Committed immediately: the revoke is durable up front, and the
             # pooled DB connection is released before the runtime-api calls.
+            old_key_hash = stored_sandbox.session_api_key_hash
             stored_sandbox.session_api_key_hash = None
             await self.db_session.commit()
 
-            runtime_data = await self._get_runtime(sandbox_id)
-            response = await self._send_runtime_api_request(
-                'POST',
-                '/pause',
-                json={'runtime_id': runtime_data['runtime_id']},
-            )
-            if response.status_code == 404:
-                return False
-            response.raise_for_status()
-            return True
+            try:
+                runtime_data = await self._get_runtime(sandbox_id)
+                response = await self._send_runtime_api_request(
+                    'POST',
+                    '/pause',
+                    json={'runtime_id': runtime_data['runtime_id']},
+                )
+                if response.status_code == 404:
+                    # Runtime already gone: not running, the revoke stands.
+                    return False
+                response.raise_for_status()
+                return True
+            except httpx.HTTPError as e:
+                runtime_gone = (
+                    isinstance(e, httpx.HTTPStatusError)
+                    and e.response.status_code == 404
+                )
+                if not runtime_gone and old_key_hash is not None:
+                    # The pause didn't happen, so the sandbox is still running
+                    # and its callbacks authenticate by this hash: restore it.
+                    # (When the runtime is gone, the revoke stands — nothing is
+                    # running, so a leaked key must stay dead.)
+                    stored_sandbox.session_api_key_hash = old_key_hash
+                    await self.db_session.commit()
+                raise
 
         except httpx.HTTPError as e:
             _logger.error(f'Error pausing sandbox {sandbox_id}: {e}')
@@ -611,10 +632,11 @@ class RemoteSandboxService(SandboxService):
         is never reported as 404.
 
         Security: the session_api_key_hash is invalidated and committed UP
-        FRONT (like ``pause_sandbox``) so a delete — commonly a revoke of a
-        leaked key — kills it promptly and no later rollback can resurrect it.
-        On a transient stop failure the row is kept for retry, with the key
-        already revoked.
+        FRONT so a delete — commonly a revoke of a leaked key — kills it
+        promptly and no later rollback can resurrect it. Unlike
+        ``pause_sandbox``, a transient stop failure does NOT restore the hash:
+        delete is a revoke intent, so the key stays dead and the row is kept
+        for retry.
         """
         try:
             stored_sandbox = await self._get_stored_sandbox(sandbox_id)

--- a/openhands/app_server/sandbox/sandbox_service.py
+++ b/openhands/app_server/sandbox/sandbox_service.py
@@ -135,9 +135,29 @@ class SandboxService(ABC):
                 else:
                     return sandbox
 
+            # Release any pooled connection held by the get_sandbox read above
+            # so it is not kept checked out (idle in transaction) while we sleep
+            # between status checks. Without this, a single wait pins one
+            # connection for its entire duration (up to `timeout` seconds).
+            await self._release_status_connection()
             await asyncio.sleep(poll_interval)
 
         raise SandboxError(f'Sandbox failed to start within {timeout}s: {sandbox_id}')
+
+    async def _release_status_connection(self) -> None:  # noqa: B027
+        """Release any pooled connection held by the last ``get_sandbox`` read.
+
+        ``wait_for_sandbox_running`` polls ``get_sandbox`` and then sleeps
+        between checks. Implementations backed by a pooled resource (e.g. a
+        request-scoped SQLAlchemy session) read through a connection whose
+        transaction would otherwise stay open — idle in transaction — for the
+        whole wait, holding a pool slot while nothing runs but the sleep. Such
+        implementations override this to end that transaction so the connection
+        returns to the pool between polls.
+
+        Default: a no-op. Implementations that hold no pooled connection across
+        a ``get_sandbox`` call (e.g. Docker-backed sandboxes) need not override.
+        """
 
     async def _check_agent_server_alive(
         self, sandbox: SandboxInfo, httpx_client: httpx.AsyncClient

--- a/tests/unit/app_server/test_remote_sandbox_service.py
+++ b/tests/unit/app_server/test_remote_sandbox_service.py
@@ -623,7 +623,7 @@ class TestSandboxLifecycle:
     async def test_pause_sandbox_success(self, remote_sandbox_service):
         """Test successful sandbox pause."""
         # Setup
-        stored_sandbox = create_stored_sandbox()
+        stored_sandbox = create_stored_sandbox(session_api_key_hash='old-hash')
         runtime_data = create_runtime_data()
 
         remote_sandbox_service._get_stored_sandbox = AsyncMock(
@@ -646,6 +646,9 @@ class TestSandboxLifecycle:
             headers={'X-API-Key': 'test-api-key'},
             json={'runtime_id': 'runtime-456'},
         )
+        # The key revoke is committed up front, before the runtime /pause.
+        assert stored_sandbox.session_api_key_hash is None
+        assert remote_sandbox_service.db_session.commit.await_count == 1
 
     @pytest.mark.asyncio
     async def test_delete_sandbox_success(self, remote_sandbox_service):
@@ -1113,9 +1116,14 @@ class TestErrorHandling:
 
     @pytest.mark.asyncio
     async def test_pause_sandbox_http_error(self, remote_sandbox_service):
-        """Test pause sandbox with HTTP error."""
+        """A transient pause failure restores the committed key revoke.
+
+        The sandbox is still running, and nothing re-sets the hash for a
+        running sandbox — leaving the revoke committed would permanently 401
+        its webhook/secrets auth.
+        """
         # Setup
-        stored_sandbox = create_stored_sandbox()
+        stored_sandbox = create_stored_sandbox(session_api_key_hash='old-hash')
         runtime_data = create_runtime_data()
 
         remote_sandbox_service._get_stored_sandbox = AsyncMock(
@@ -1129,8 +1137,41 @@ class TestErrorHandling:
         # Execute
         result = await remote_sandbox_service.pause_sandbox('test-sandbox-123')
 
-        # Verify
+        # Verify: hash restored, committed twice (revoke, then restore)
         assert result is False
+        assert stored_sandbox.session_api_key_hash == 'old-hash'
+        assert remote_sandbox_service.db_session.commit.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_pause_sandbox_runtime_gone_keeps_revoke(
+        self, remote_sandbox_service
+    ):
+        """A 404 runtime lookup does NOT restore the key revoke.
+
+        The runtime is gone, so nothing is running: a leaked key must stay
+        dead rather than be restored to a row with no live runtime.
+        """
+        # Setup
+        stored_sandbox = create_stored_sandbox(session_api_key_hash='old-hash')
+
+        remote_sandbox_service._get_stored_sandbox = AsyncMock(
+            return_value=stored_sandbox
+        )
+        remote_sandbox_service._get_runtime = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                'Not Found',
+                request=httpx.Request('GET', 'https://api.example.com/sessions/x'),
+                response=httpx.Response(404),
+            )
+        )
+
+        # Execute
+        result = await remote_sandbox_service.pause_sandbox('test-sandbox-123')
+
+        # Verify: revoke stands, only the up-front commit happened
+        assert result is False
+        assert stored_sandbox.session_api_key_hash is None
+        assert remote_sandbox_service.db_session.commit.await_count == 1
 
     @pytest.mark.asyncio
     async def test_delete_sandbox_http_error(self, remote_sandbox_service):

--- a/tests/unit/app_server/test_remote_sandbox_service.py
+++ b/tests/unit/app_server/test_remote_sandbox_service.py
@@ -447,7 +447,10 @@ class TestSandboxLifecycle:
             9
         )  # max_num_sandboxes - 1
         remote_sandbox_service.db_session.add.assert_called_once()
-        remote_sandbox_service.db_session.commit.assert_not_called()
+        # start_sandbox commits twice: once to release the pooled connection
+        # before the (slow) runtime /start call, once to persist the new row
+        # right after the runtime is up.
+        assert remote_sandbox_service.db_session.commit.await_count == 2
 
     @pytest.mark.asyncio
     async def test_start_sandbox_with_specific_spec(
@@ -668,9 +671,10 @@ class TestSandboxLifecycle:
         # Verify
         assert result is True
         remote_sandbox_service.db_session.delete.assert_called_once_with(stored_sandbox)
-        # delete_sandbox no longer commits internally: the session key is dropped
-        # atomically with the row delete, which the caller commits.
-        remote_sandbox_service.db_session.commit.assert_not_awaited()
+        # delete_sandbox commits twice: the up-front key revoke (which also
+        # releases the pooled connection before the runtime-api calls) and the
+        # row delete after /stop succeeds.
+        assert remote_sandbox_service.db_session.commit.await_count == 2
         remote_sandbox_service.httpx_client.request.assert_called_once_with(
             'POST',
             'https://api.example.com/stop',

--- a/tests/unit/app_server/test_remote_sandbox_service.py
+++ b/tests/unit/app_server/test_remote_sandbox_service.py
@@ -1821,6 +1821,69 @@ class TestPollAgentServersSessionScoping:
         assert tracker.open == 0
 
 
+class TestWaitForSandboxRunningSessionScoping:
+    """wait_for_sandbox_running must not pin a DB connection while it sleeps.
+
+    The poll loop reads through the request-scoped ``self.db_session``. Its read
+    transaction (and the pooled connection behind it) would otherwise stay open
+    for the whole wait -- up to ``timeout`` seconds -- so the fix commits between
+    polls to return the connection to the pool. These tests guard that the
+    release happens before every sleep, and only on the sleep path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_releases_db_connection_before_each_sleep(
+        self, remote_sandbox_service
+    ):
+        """Each poll that isn't RUNNING yet commits before sleeping."""
+        events: list[str] = []
+
+        async def _record_commit():
+            events.append('commit')
+
+        async def _record_sleep(_):
+            events.append('sleep')
+
+        remote_sandbox_service.db_session.commit = AsyncMock(side_effect=_record_commit)
+        starting = MagicMock(status=SandboxStatus.STARTING, exposed_urls=[])
+        running = MagicMock(status=SandboxStatus.RUNNING, exposed_urls=[])
+        remote_sandbox_service.get_sandbox = AsyncMock(
+            side_effect=[starting, starting, running]
+        )
+
+        with patch(
+            'openhands.app_server.sandbox.sandbox_service.asyncio.sleep',
+            new=AsyncMock(side_effect=_record_sleep),
+        ):
+            result = await remote_sandbox_service.wait_for_sandbox_running(
+                'sandbox-1', timeout=120, poll_interval=2
+            )
+
+        assert result is running
+        # Two non-running polls: each releases the connection *before* sleeping.
+        assert events == ['commit', 'sleep', 'commit', 'sleep']
+
+    @pytest.mark.asyncio
+    async def test_no_release_when_running_immediately(self, remote_sandbox_service):
+        """A sandbox already RUNNING returns without committing or sleeping."""
+        commit_mock = AsyncMock()
+        remote_sandbox_service.db_session.commit = commit_mock
+        remote_sandbox_service.get_sandbox = AsyncMock(
+            return_value=MagicMock(status=SandboxStatus.RUNNING, exposed_urls=[])
+        )
+
+        with patch(
+            'openhands.app_server.sandbox.sandbox_service.asyncio.sleep',
+            new=AsyncMock(),
+        ) as sleep_mock:
+            await remote_sandbox_service.wait_for_sandbox_running(
+                'sandbox-1', timeout=120, poll_interval=2
+            )
+
+        commit_mock.assert_not_awaited()
+        sleep_mock.assert_not_awaited()
+
+
 class TestBatchGetSandboxes:
     """Test cases for batch_get_sandboxes method."""
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:


- [x] A human has tested these changes.

AGENT:

---

## Why

During a production incident on 2026-07-09 (~21:40-22:01 UTC), postgres connections on the application DB stepped from ~350 to ~1,200 and stayed there. During the bursts, app-server pods exhausted their sqlalchemy pools (`QueuePool limit of size 25 overflow 10 reached` after 30s hangs) and requests failed with 500s. The DB showed 76 idle-in-transaction sessions and 79 blocked backends at the worst minute.

Root cause: the request-scoped session opens a transaction on its first read, and the sandbox lifecycle paths then await slow runtime-api HTTP calls before the next commit. The worst holds were runtime `/start` (observed blocking ~90s waiting for a warm runtime), the delete finalizer (archive + stop under one transaction), and the readiness poll loop, which pinned a connection across every sleep for the whole wait (up to 120s). Under a burst of concurrent sandbox starts, every held connection ratchets the pools toward their max, and `QueuePool` keeps the grown pool forever.

## Summary

- Commit (releasing the pooled connection) before every runtime-api call in `start_sandbox`, `pause_sandbox`, `resume_sandbox`, `delete_sandbox`, and the workspace-archive path. Writes land in short transactions of their own; the sandbox row is now only persisted after `/start` succeeds.
- Release the pooled connection between `wait_for_sandbox_running` status polls via a `_release_status_connection` hook (no-op by default, commit in the remote service).
- Restore the key hash when a transient pause failure leaves the sandbox running, so a running sandbox's callbacks don't lose auth.

To test this, I deployed this build to a Replicated test instance. Prior to this change, I saw after starting a few conversations, my connection count against the OpenHands Postgres database would jump to approximately ~50 connections.

After the change, connections stay pinned under 20.

This is the connection count across all workloads that connect to the OpenHands database, I didn't single out the connections originating from the server specifically. 

## Issue Number

N/A

## How to Test

```bash
uv run pytest tests/unit/app_server/test_remote_sandbox_service.py tests/unit/app_server/test_db_session_injector.py
```

144 pass at this branch tip. The full `tests/unit/app_server` suite shows the same 4 environment-dependent failures as current main (verified pre-existing on a pristine checkout).

## Video/Screenshots

N/A (backend-only change).

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- This complements #15225 (LIFO pooling). LIFO helps drain idle connections after a burst, and only once a server-side `idle_session_timeout` is set. This PR shortens the holds that cause the burst exhaustion in the first place.
- Key-hash invalidations for pause/delete are now committed up front. A caller rollback can no longer resurrect a revoked key, which strengthens the property `delete_sandbox` already documented.
- Mid-operation commits also commit any state the caller left pending on the shared session. Both current call paths commit their own writes first, and the poll-loop hook documents that assumption.
- Smaller holds remain in the conversation-start workflow (`clone_or_init_git_repo`, `_seed_sandbox_profiles`) - follow-up material.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-ceea8f0   docker.openhands.dev/openhands/openhands:ceea8f0
```