### PR TITLE
feat(enterprise): make BYOR key alias pattern configurable

### DIFF
--- a/enterprise/server/constants.py
+++ b/enterprise/server/constants.py
@@ -18,6 +18,12 @@ IS_FEATURE_ENV = (
 )  # Does not include the staging deployment
 IS_LOCAL_ENV = bool(HOST == 'localhost')
 
+# Pattern for byor keys. Making this an environment variable allows different patterns so multiple environments can use
+# the same litellm instance in development
+BYOR_KEY_ALIAS_PATTERN = os.getenv(
+    'BYOR_KEY_ALIAS_PATTERN', 'BYOR Key - user {user_id}, org {org_id}'
+)
+
 
 # Explicit OH_DEPLOYMENT_MODE wins; _is_all_hands_managed_domain() is the host fallback.
 def _is_all_hands_managed_domain(host: str) -> bool:

--- a/enterprise/server/routes/api_keys.py
+++ b/enterprise/server/routes/api_keys.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, SecretStr, field_validator, model_validator
 from server.auth.authorization import get_user_super_role
 from server.auth.org_context import EFFECTIVE_ORG_ID
 from server.auth.saas_user_auth import SaasUserAuth
+from server.constants import BYOR_KEY_ALIAS_PATTERN
 from storage.api_key import ApiKey
 from storage.api_key_store import ApiKeyStore
 from storage.lite_llm_manager import LiteLlmManager
@@ -56,6 +57,11 @@ async def store_byor_key_in_db(user_id: str, org_id: UUID, key: str) -> None:
     await OrgMemberStore.update_org_member(org_member)
 
 
+def _create_byor_key_alias(user_id: str, org_id: str) -> str:
+    alias = BYOR_KEY_ALIAS_PATTERN.format(user_id=user_id, org_id=org_id)
+    return alias
+
+
 async def generate_byor_key(user_id: str, org_id: UUID) -> str | None:
     """Generate a new BYOR key for a user in a specific org."""
     try:
@@ -63,7 +69,7 @@ async def generate_byor_key(user_id: str, org_id: UUID) -> str | None:
         key = await LiteLlmManager.generate_key(
             user_id,
             org_id_str,
-            f'BYOR Key - user {user_id}, org {org_id_str}',
+            _create_byor_key_alias(user_id, org_id_str),
             {'type': 'byor'},
         )
 
@@ -93,7 +99,7 @@ async def delete_byor_key_from_litellm(
     to clean up orphaned aliases that could block key regeneration.
     """
     try:
-        key_alias = f'BYOR Key - user {user_id}, org {org_id}'
+        key_alias = _create_byor_key_alias(user_id, str(org_id))
         await LiteLlmManager.delete_key(byor_key, key_alias=key_alias)
         logger.info(
             'Successfully deleted BYOR key from LiteLLM',

--- a/enterprise/tests/unit/server/routes/test_api_keys.py
+++ b/enterprise/tests/unit/server/routes/test_api_keys.py
@@ -9,12 +9,15 @@ import pytest
 from fastapi import HTTPException
 from pydantic import SecretStr
 from server.auth.saas_user_auth import SaasUserAuth
+from server.constants import BYOR_KEY_ALIAS_PATTERN
 from server.routes.api_keys import (
     ByorPermittedResponse,
     CurrentApiKeyResponse,
     LlmApiKeyResponse,
+    _create_byor_key_alias,
     check_byor_permitted,
     delete_byor_key_from_litellm,
+    generate_byor_key,
     get_current_api_key,
     get_llm_api_key_for_byor,
 )
@@ -400,8 +403,33 @@ class TestDeleteByorKeyFromLitellm:
         user_id = 'user-123'
         org_id = uuid.uuid4()
         byor_key = 'sk-byor-key-to-delete'
-        expected_alias = f'BYOR Key - user {user_id}, org {org_id}'
+        expected_alias = BYOR_KEY_ALIAS_PATTERN.format(
+            user_id=user_id, org_id=str(org_id)
+        )
         mock_delete_key.return_value = None
+
+        # Act
+        result = await delete_byor_key_from_litellm(user_id, org_id, byor_key)
+
+        # Assert
+        assert result is True
+        mock_delete_key.assert_called_once_with(byor_key, key_alias=expected_alias)
+
+    @pytest.mark.asyncio
+    @patch('server.routes.api_keys.BYOR_KEY_ALIAS_PATTERN', 'env/{org_id}/u={user_id}')
+    @patch('storage.lite_llm_manager.LiteLlmManager.delete_key')
+    async def test_delete_uses_env_override_alias(self, mock_delete_key):
+        """An overridden BYOR_KEY_ALIAS_PATTERN flows through to delete_key.
+
+        Patches the imported constant in the api_keys module since the env
+        var is read once at import time (see constants.py).
+        """
+        # Arrange
+        user_id = 'user-123'
+        org_id = uuid.uuid4()
+        byor_key = 'sk-byor-key-to-delete'
+        mock_delete_key.return_value = None
+        expected_alias = f'env/{org_id}/u={user_id}'
 
         # Act
         result = await delete_byor_key_from_litellm(user_id, org_id, byor_key)
@@ -425,6 +453,111 @@ class TestDeleteByorKeyFromLitellm:
 
         # Assert
         assert result is False
+
+
+class TestCreateByorKeyAlias:
+    """Test the _create_byor_key_alias helper."""
+
+    def test_uses_default_pattern(self):
+        """Default pattern formats user_id and org_id with the literal defaults."""
+        # Arrange
+        user_id = 'user-123'
+        org_id_str = str(uuid.uuid4())
+        expected = BYOR_KEY_ALIAS_PATTERN.format(user_id=user_id, org_id=org_id_str)
+
+        # Act
+        result = _create_byor_key_alias(user_id, org_id_str)
+
+        # Assert
+        assert result == expected
+        # The default should keep the production literal that LiteLLM
+        # currently has provisioned keys tagged with.
+        assert 'BYOR Key' in result
+        assert user_id in result
+        assert org_id_str in result
+
+    def test_respects_env_override_pattern(self):
+        """An overridden BYOR_KEY_ALIAS_PATTERN flows through the helper.
+
+        Patches the imported constant in the api_keys module since it's
+        read once at import time (mirrors the env-var read in constants.py).
+        """
+        custom_pattern = 'env/{org_id}/u={user_id}'
+        with patch('server.routes.api_keys.BYOR_KEY_ALIAS_PATTERN', custom_pattern):
+            result = _create_byor_key_alias('user-9', 'org-7')
+
+        assert result == 'env/org-7/u=user-9'
+
+    def test_missing_placeholder_raises_keyerror(self):
+        """A pattern with an unexpected placeholder fails loudly (str.format KeyError)."""
+        bad_pattern = '{environment}/{something_else}'
+        with patch('server.routes.api_keys.BYOR_KEY_ALIAS_PATTERN', bad_pattern):
+            with pytest.raises(KeyError):
+                _create_byor_key_alias('user-9', 'org-7')
+
+
+class TestGenerateByorKey:
+    """Test the generate_byor_key function."""
+
+    @pytest.mark.asyncio
+    @patch('storage.lite_llm_manager.LiteLlmManager.generate_key')
+    async def test_passes_default_alias_and_team_id_to_litellm(self, mock_generate_key):
+        """generate_byor_key builds the alias from the helper and passes org_id as str."""
+        # Arrange
+        user_id = 'user-123'
+        org_id = uuid.uuid4()
+        org_id_str = str(org_id)
+        new_key = 'sk-new-generated-key'
+        mock_generate_key.return_value = new_key
+        expected_alias = BYOR_KEY_ALIAS_PATTERN.format(
+            user_id=user_id, org_id=org_id_str
+        )
+
+        # Act
+        result = await generate_byor_key(user_id, org_id)
+
+        # Assert
+        assert result == new_key
+        mock_generate_key.assert_called_once_with(
+            user_id,
+            org_id_str,
+            expected_alias,
+            {'type': 'byor'},
+        )
+
+    @pytest.mark.asyncio
+    @patch('storage.lite_llm_manager.LiteLlmManager.generate_key')
+    async def test_uses_env_override_alias(self, mock_generate_key):
+        """An overridden pattern flows through to LiteLLM.generate_key."""
+        # Arrange
+        user_id = 'user-123'
+        org_id = uuid.uuid4()
+        mock_generate_key.return_value = 'sk-key'
+        custom_pattern = 'custom/{org_id}/{user_id}'
+
+        with patch('server.routes.api_keys.BYOR_KEY_ALIAS_PATTERN', custom_pattern):
+            await generate_byor_key(user_id, org_id)
+
+        # Assert
+        mock_generate_key.assert_called_once_with(
+            user_id,
+            str(org_id),
+            custom_pattern.format(user_id=user_id, org_id=str(org_id)),
+            {'type': 'byor'},
+        )
+
+    @pytest.mark.asyncio
+    @patch('storage.lite_llm_manager.LiteLlmManager.generate_key')
+    async def test_returns_none_on_exception(self, mock_generate_key):
+        """Exceptions during generation surface as None (caller handles 500)."""
+        # Arrange
+        mock_generate_key.side_effect = Exception('LiteLLM API error')
+
+        # Act
+        result = await generate_byor_key('user-123', uuid.uuid4())
+
+        # Assert
+        assert result is None
 
 
 class TestCheckByorPermitted:


### PR DESCRIPTION
HUMAN:

Allows local testing / feature branch testing of LLM keys (with an appropriate environment variable) when the instance of litellm is shared between deployments.

- [x] A human has tested these changes.

AGENT:

---

## Why

The BYOR key alias sent to LiteLLM was hardcoded as
`BYOR Key - user {user_id}, org {org_id}`. When several OpenHands
deployments share a single LiteLLM instance (typical in local dev,
where a developer might point a feature-env backend at a shared
litellm proxy), their per-user keys collide on the alias.

## Summary

- Extracts the alias pattern into a new env-overridable constant
  `BYOR_KEY_ALIAS_PATTERN` in `enterprise/server/constants.py` and a
  private helper `_create_byor_key_alias()` in
  `enterprise/server/routes/api_keys.py`. The default value matches
  the previous literal, so production is unaffected unless
  `BYOR_KEY_ALIAS_PATTERN` is set.
- Both call sites (`generate_byor_key`, `delete_byor_key_from_litellm`)
  now route through the helper.
- Adds direct unit coverage for the previously untested
  `generate_byor_key` and the new helper, plus an env-override case for
  both generate and delete. The existing
  `test_delete_constructs_alias_from_org` assertion is re-anchored to
  the constant so it stays in sync if the default ever changes.

## Issue Number

None.

## How to Test

1. `cd enterprise && poetry install --with dev,test`
   (or skip if the env is already set up).
2. `cd enterprise && PYTHONPATH=.:$PYTHONPATH python -m pytest tests/unit/server/routes/test_api_keys.py`
   — should show `41 passed`.
3. `cd /projects/OpenHands && pre-commit run --config enterprise/dev_config/python/.pre-commit-config.yaml --files enterprise/server/constants.py enterprise/server/routes/api_keys.py enterprise/tests/unit/server/routes/test_api_keys.py`
   — should pass ruff + mypy.
4. Optional manual check: set
   `BYOR_KEY_ALIAS_PATTERN='dev/{org_id}/{user_id}'` in the env, hit
   `POST /api/keys/llm/byor`, and confirm the new alias appears in
   LiteLLM's key list.

## Video/Screenshots

N/A — backend-only refactor with no UI changes.

## Type

- [x] Refactor
- [x] Feature (configurable pattern is opt-in)

## Notes

- Default value preserves existing behavior; no migrations or data
  backfills needed.
- Follow-up (out of scope): if multiple environments legitimately need
  to share a LiteLLM instance long-term, we may want to also prefix
  the alias with the deployment name (e.g. derived from
  `WEB_HOST`) instead of relying on operators to set the env var.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-4067b7f   docker.openhands.dev/openhands/openhands:4067b7f
```