### PR TITLE
feat: publish deletion snapshot metadata to Laminar

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_router.py
+++ b/openhands/app_server/app_conversation/app_conversation_router.py
@@ -960,20 +960,9 @@ async def delete_app_conversation(
 
     sandbox_id = app_conversation_info.sandbox_id
 
-    # Check if sandbox is shared with other conversations
-    sandbox_is_shared = False
-    if sandbox_id:
-        conversation_count = (
-            await app_conversation_info_service.count_conversations_by_sandbox_id(
-                sandbox_id
-            )
-        )
-        sandbox_is_shared = conversation_count > 1
-
-    # Delete the conversation (skip agent server DELETE if sandbox is shared)
     deleted = await app_conversation_service.delete_app_conversation(
         conversation_uuid,
-        skip_agent_server_delete=sandbox_is_shared,
+        skip_agent_server_delete=bool(sandbox_id),
     )
     if not deleted:
         raise HTTPException(status.HTTP_404_NOT_FOUND, 'Failed to delete conversation')

--- a/openhands/app_server/sandbox/workspace_archive.py
+++ b/openhands/app_server/sandbox/workspace_archive.py
@@ -15,6 +15,7 @@ Configuration is environment-driven and the feature is a no-op unless
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -40,6 +41,7 @@ _REPO_METADATA_HEADERS = {
     'head_commit': 'X-Archive-Head-Commit',
 }
 _REPO_ROOT_HEADER = 'X-Archive-Repo-Root'
+_TRACE_FORMAT_KEY = {'git-delta': 'git_delta', 'tar.gz': 'tar_gz'}
 
 
 def _extract_repo_metadata(
@@ -331,6 +333,76 @@ async def _probe_workspace(
     return result
 
 
+def _archive_object_uri(path: str) -> str:
+    store_type = _archive_store_type()
+    if store_type == 'google_cloud':
+        return f'gs://{_archive_bucket()}/{path}'
+    if store_type == 's3':
+        return f's3://{_archive_bucket()}/{path}'
+    return path
+
+
+def _final_snapshot_trace_metadata(
+    manifest: dict[str, Any], source: str, archive_uri: str, manifest_uri: str
+) -> dict[str, str | bool | int]:
+    packages = manifest.get('packages') or {}
+    environment = manifest.get('environment') or {}
+    fmt = _TRACE_FORMAT_KEY[manifest['format']]
+    metadata: dict[str, str | bool | int] = {
+        'final_snapshot_captured': True,
+        'final_snapshot_source': source,
+        'final_snapshot_created_at': manifest['created_at'],
+        'final_snapshot_source_path': manifest['source_path'],
+        'final_snapshot_pip_package_count': len(packages.get('pip') or {}),
+        'final_snapshot_npm_dependency_count': len(packages.get('npm') or {}),
+        'final_snapshot_package_inventory_sha256': hashlib.sha256(
+            json.dumps(packages, sort_keys=True, separators=(',', ':')).encode()
+        ).hexdigest(),
+        f'final_snapshot_{fmt}_captured': True,
+        f'final_snapshot_{fmt}_bytes': manifest['byte_count'],
+        f'final_snapshot_{fmt}_archive_uri': archive_uri,
+        f'final_snapshot_{fmt}_manifest_uri': manifest_uri,
+    }
+    for key in ('base_commit', 'repo_remote', 'branch', 'head_commit'):
+        if value := manifest.get(key):
+            metadata[f'final_snapshot_{key}'] = value
+    for key in ('python', 'node', 'os'):
+        if value := environment.get(key):
+            metadata[f'final_snapshot_{key}_version'] = value
+    return metadata
+
+
+async def _publish_final_snapshot_trace_metadata(
+    httpx_client: httpx.AsyncClient,
+    agent_server_url: str,
+    conversation_id: str,
+    headers: dict[str, str],
+    manifest: dict[str, Any],
+    archive_uri: str,
+    manifest_uri: str,
+) -> None:
+    try:
+        response = await httpx_client.post(
+            f'{agent_server_url}/api/conversations/{conversation_id}'
+            '/observability/metadata',
+            json={
+                'metadata': _final_snapshot_trace_metadata(
+                    manifest, 'app_server', archive_uri, manifest_uri
+                )
+            },
+            headers=headers,
+            timeout=_PROBE_TIMEOUT,
+        )
+        if response.status_code != 200:
+            _logger.debug(
+                'Trace metadata update for %s returned %s',
+                conversation_id,
+                response.status_code,
+            )
+    except Exception as e:
+        _logger.debug('Trace metadata update skipped for %s: %s', conversation_id, e)
+
+
 async def archive_workspace(
     httpx_client: httpx.AsyncClient,
     runtime: dict[str, Any],
@@ -496,24 +568,31 @@ async def archive_workspace(
             await asyncio.to_thread(
                 _write_file_to_store, store, f'{base_path}.{suffix}', tmp_path
             )
-            manifest = json.dumps(
-                {
-                    'sandbox_id': sandbox_id,
-                    'conversation_id': conversation_key,
-                    'phase': 'final',
-                    'base_commit': base_commit,
-                    **repo_metadata,
-                    'packages': enrichment.get('packages', {}),
-                    'environment': enrichment.get('environment', {}),
-                    'format': fmt,
-                    'source_path': archive_path,
-                    'byte_count': byte_count,
-                    'created_at': ts,
-                },
-                sort_keys=True,
-            ).encode('utf-8')
-            await asyncio.to_thread(
-                store.write, f'{base_path}.{suffix}.manifest.json', manifest
+            manifest_data = {
+                'sandbox_id': sandbox_id,
+                'conversation_id': conversation_key,
+                'phase': 'final',
+                'base_commit': base_commit,
+                **repo_metadata,
+                'packages': enrichment.get('packages', {}),
+                'environment': enrichment.get('environment', {}),
+                'format': fmt,
+                'source_path': archive_path,
+                'byte_count': byte_count,
+                'created_at': ts,
+            }
+            manifest = json.dumps(manifest_data, sort_keys=True).encode('utf-8')
+            archive_path_key = f'{base_path}.{suffix}'
+            manifest_path_key = f'{archive_path_key}.manifest.json'
+            await asyncio.to_thread(store.write, manifest_path_key, manifest)
+            await _publish_final_snapshot_trace_metadata(
+                httpx_client,
+                agent_server_url,
+                conversation_key,
+                headers,
+                manifest_data,
+                _archive_object_uri(archive_path_key),
+                _archive_object_uri(manifest_path_key),
             )
             _logger.info(
                 'Archived workspace (%s) for %s (%d bytes) to %s.%s',

--- a/tests/unit/app_server/test_app_conversation_router.py
+++ b/tests/unit/app_server/test_app_conversation_router.py
@@ -24,6 +24,7 @@ from openhands.app_server.app_conversation.app_conversation_router import (
     _finalize_sandbox_delete,
     batch_get_app_conversations,
     count_app_conversations,
+    delete_app_conversation,
     get_conversation_git_changes,
     get_conversation_git_diff,
     search_app_conversations,
@@ -1169,3 +1170,48 @@ class TestFinalizeSandboxDelete:
             conversation_id=conv.hex,
             workspace_path='/home/openhands/workspace/' + conv.hex,
         )
+
+
+@pytest.mark.asyncio
+async def test_delete_keeps_agent_conversation_active_for_finalizer():
+    conversation_id = uuid4()
+    app_info = MagicMock(sandbox_id='sbx-1', tags={}, created_by_user_id=None)
+    app_service = MagicMock()
+    app_service.delete_app_conversation = AsyncMock(return_value=True)
+    info_service = MagicMock()
+    info_service.get_app_conversation_info = AsyncMock(return_value=app_info)
+    info_service.count_conversations_by_sandbox_id = AsyncMock()
+    sandbox_service = MagicMock()
+    db_session = AsyncMock()
+    httpx_client = AsyncMock()
+    request = MagicMock()
+    coroutines = []
+
+    def _capture(coroutine):
+        coroutines.append(coroutine)
+        coroutine.close()
+        return MagicMock()
+
+    with (
+        patch(
+            'openhands.app_server.app_conversation.app_conversation_router.'
+            'get_analytics_service',
+            return_value=None,
+        ),
+        patch('asyncio.create_task', side_effect=_capture),
+    ):
+        await delete_app_conversation(
+            request,
+            str(conversation_id),
+            app_service,
+            info_service,
+            sandbox_service,
+            db_session,
+            httpx_client,
+        )
+
+    app_service.delete_app_conversation.assert_awaited_once_with(
+        conversation_id, skip_agent_server_delete=True
+    )
+    info_service.count_conversations_by_sandbox_id.assert_not_awaited()
+    assert len(coroutines) == 1

--- a/tests/unit/app_server/test_remote_sandbox_service.py
+++ b/tests/unit/app_server/test_remote_sandbox_service.py
@@ -2168,6 +2168,13 @@ class TestArchiveWorkspaceHelper:
         assert manifest['branch'] == 'feature-x'
         assert manifest['head_commit'] == 'def456'
         assert manifest['packages'] == {'npm': {'example': '1.0.0'}}
+        trace_call = client.post.call_args
+        assert trace_call.args[0].endswith(
+            '/api/conversations/conv-1/observability/metadata'
+        )
+        assert trace_call.kwargs['json']['metadata'][
+            'final_snapshot_git_delta_manifest_uri'
+        ].startswith('gs://archive-bkt/')
         probe_workspace.assert_awaited_once_with(
             client,
             'https://sandbox.example.com',

--- a/tests/unit/app_server/test_workspace_archive_packages.py
+++ b/tests/unit/app_server/test_workspace_archive_packages.py
@@ -84,6 +84,40 @@ def test_extract_repo_metadata_decodes_percent_encoding():
     }
 
 
+def test_final_snapshot_trace_metadata():
+    metadata = wa._final_snapshot_trace_metadata(
+        {
+            'format': 'tar.gz',
+            'created_at': '20260710T120000Z',
+            'source_path': '/workspace/project',
+            'base_commit': 'abc123',
+            'packages': {
+                'pip': {'pytest': '9.0.3'},
+                'npm': {'react': '19.0.0'},
+            },
+            'environment': {
+                'python': '3.13.7',
+                'node': '22.1.0',
+                'os': 'ubuntu 24.04',
+            },
+            'byte_count': 42,
+        },
+        'app_server',
+        'gs://bucket/archive.tar.gz',
+        'gs://bucket/archive.tar.gz.manifest.json',
+    )
+
+    assert metadata['final_snapshot_captured'] is True
+    assert metadata['final_snapshot_source'] == 'app_server'
+    assert metadata['final_snapshot_base_commit'] == 'abc123'
+    assert metadata['final_snapshot_pip_package_count'] == 1
+    assert metadata['final_snapshot_npm_dependency_count'] == 1
+    assert metadata['final_snapshot_python_version'] == '3.13.7'
+    assert metadata['final_snapshot_tar_gz_bytes'] == 42
+    assert metadata['final_snapshot_tar_gz_manifest_uri'].endswith('.manifest.json')
+    assert len(metadata['final_snapshot_package_inventory_sha256']) == 64
+
+
 def _response(stdout: str, status_code: int = 200):
     response = MagicMock(status_code=status_code)
     response.json.return_value = {'stdout': stdout}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

Explicit-deletion snapshots already persist rich final manifests, but their capture outcome and environment summary are not visible on the conversation trace in Laminar. The agent-server conversation also ended before the detached archive finalizer ran, leaving no active root span to update.

## Summary

- publish the same compact final-snapshot trace summary used by the idle/expiry path
- keep full package inventories in object storage and send counts plus a deterministic hash to Laminar
- defer agent-server conversation teardown until the archive callback completes, while preserving immediate teardown for conversations without a sandbox

## Issue Number

N/A

## How to Test

- `poetry run pytest -q tests/unit/app_server/test_workspace_archive_packages.py tests/unit/app_server/test_remote_sandbox_service.py tests/unit/app_server/test_app_conversation_router.py`
- Result: 153 passed.
- `poetry run pre-commit run --config dev_config/python/.pre-commit-config.yaml --files openhands/app_server/sandbox/workspace_archive.py openhands/app_server/app_conversation/app_conversation_router.py tests/unit/app_server/test_workspace_archive_packages.py tests/unit/app_server/test_remote_sandbox_service.py tests/unit/app_server/test_app_conversation_router.py`
- Result: formatting, Ruff, and mypy passed.
- Full GCS-to-Laminar validation requires OpenHands/software-agent-sdk#4076 and promoted images, so it is deferred to rollout validation.

## Video/Screenshots

Not applicable; this is a backend capture path.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Requires OpenHands/software-agent-sdk#4076, which is stacked on #4054.
- Coordinate rollout with OpenHands/runtime-api#639 so both final capture paths emit the same metadata.
- After deployment, validate both explicit deletion and idle/expiry against their GCS manifests and matching Laminar traces.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-cd286df   docker.openhands.dev/openhands/openhands:cd286df
```