### PR TITLE
fix(app-server): retain failed pending messages

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -2205,8 +2205,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
     ) -> None:
         """Process pending messages queued before conversation was ready.
 
-        Messages are delivered concurrently to the agent server. After processing,
-        all messages are deleted from the database regardless of success or failure.
+        Messages are delivered sequentially to the agent server. Successfully
+        delivered messages are deleted from the database. If delivery fails, that
+        message and all later messages remain queued to preserve their order.
 
         Args:
             task_id: The start task ID (may have been used as conversation_id initially)
@@ -2247,6 +2248,8 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             f'conversation {conversation_id_str}'
         )
 
+        delivered_count = 0
+
         # Process messages sequentially to preserve order
         for msg in pending_messages:
             try:
@@ -2264,19 +2267,18 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                     timeout=30.0,
                 )
                 response.raise_for_status()
-                _logger.debug(f'Delivered pending message {msg.id}')
             except Exception as e:
                 _logger.warning(f'Failed to deliver pending message {msg.id}: {e}')
+                break
 
-        # Delete all pending messages after processing (regardless of success/failure)
-        deleted_count = (
-            await self.pending_message_service.delete_messages_for_conversation(
-                conversation_id_str
-            )
-        )
+            await self.pending_message_service.delete_message(msg.id)
+            delivered_count += 1
+            _logger.debug(f'Delivered pending message {msg.id}')
+
+        retained_count = len(pending_messages) - delivered_count
         _logger.info(
             f'Finished processing pending messages for conversation {conversation_id_str}. '
-            f'Deleted {deleted_count} messages.'
+            f'Delivered {delivered_count} messages; retained {retained_count} messages.'
         )
 
     async def update_agent_server_conversation_title(

--- a/openhands/app_server/pending_messages/pending_message_models.py
+++ b/openhands/app_server/pending_messages/pending_message_models.py
@@ -13,8 +13,8 @@ class PendingMessage(BaseModel):
     """A message queued for delivery when conversation becomes ready.
 
     Pending messages are stored in the database and delivered to the agent_server
-    when the conversation transitions to READY status. Messages are deleted after
-    processing, regardless of success or failure.
+    when the conversation transitions to READY status. Successfully delivered
+    messages are deleted after processing; failed messages remain queued.
     """
 
     id: str = Field(default_factory=lambda: str(uuid4()))

--- a/openhands/app_server/pending_messages/pending_message_service.py
+++ b/openhands/app_server/pending_messages/pending_message_service.py
@@ -59,6 +59,10 @@ class PendingMessageService(ABC):
         """Count pending messages for a conversation."""
 
     @abstractmethod
+    async def delete_message(self, message_id: str) -> bool:
+        """Delete a pending message, returning True if deleted."""
+
+    @abstractmethod
     async def delete_messages_for_conversation(self, conversation_id: str) -> int:
         """Delete all pending messages for a conversation, returning count deleted."""
 
@@ -147,6 +151,18 @@ class SQLPendingMessageService(PendingMessageService):
         )
         result = await self.db_session.execute(count_stmt)
         return result.scalar() or 0
+
+    async def delete_message(self, message_id: str) -> bool:
+        """Delete a pending message, returning True if deleted."""
+        stmt = select(StoredPendingMessage).where(StoredPendingMessage.id == message_id)
+        result = await self.db_session.execute(stmt)
+        stored_message = result.scalar_one_or_none()
+        if stored_message is None:
+            return False
+
+        await self.db_session.delete(stored_message)
+        await self.db_session.commit()
+        return True
 
     async def delete_messages_for_conversation(self, conversation_id: str) -> int:
         """Delete all pending messages for a conversation, returning count deleted."""

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -6,7 +6,7 @@ import os
 import zipfile
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 from uuid import uuid4
 
 import pytest
@@ -34,6 +34,7 @@ from openhands.app_server.app_conversation.live_status_app_conversation_service 
 )
 from openhands.app_server.integrations.provider import ProviderToken, ProviderType
 from openhands.app_server.integrations.service_types import SuggestedTask, TaskType
+from openhands.app_server.pending_messages.pending_message_models import PendingMessage
 from openhands.app_server.sandbox.sandbox_models import (
     AGENT_SERVER,
     ExposedUrl,
@@ -279,6 +280,91 @@ class TestLiveStatusAppConversationService:
         # Default mock for hooks loading - returns None (no hooks found)
         # Tests that specifically test hooks loading can override this mock
         self.service._load_hooks_from_workspace = AsyncMock(return_value=None)
+
+    @pytest.mark.asyncio
+    async def test_process_pending_messages_deletes_delivered_messages(self):
+        """Successfully delivered pending messages are removed from the queue."""
+        task_id = uuid4()
+        conversation_id = uuid4()
+        messages = [
+            PendingMessage(
+                conversation_id=str(conversation_id),
+                content=[TextContent(text='first')],
+            ),
+            PendingMessage(
+                conversation_id=str(conversation_id),
+                content=[TextContent(text='second')],
+            ),
+        ]
+        self.mock_pending_message_service.update_conversation_id = AsyncMock(
+            return_value=2
+        )
+        self.mock_pending_message_service.get_pending_messages = AsyncMock(
+            return_value=messages
+        )
+        self.mock_pending_message_service.delete_message = AsyncMock(return_value=True)
+        response = Mock()
+        response.raise_for_status = Mock()
+        self.mock_httpx_client.post = AsyncMock(return_value=response)
+
+        await self.service._process_pending_messages(
+            task_id=task_id,
+            conversation_id=conversation_id,
+            agent_server_url='http://agent-server:8000',
+            session_api_key='test-key',
+        )
+
+        assert self.mock_httpx_client.post.await_count == 2
+        assert self.mock_pending_message_service.delete_message.await_args_list == [
+            call(messages[0].id),
+            call(messages[1].id),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_process_pending_messages_retains_failed_and_later_messages(self):
+        """A failed message and later messages remain queued in FIFO order."""
+        task_id = uuid4()
+        conversation_id = uuid4()
+        messages = [
+            PendingMessage(
+                conversation_id=str(conversation_id),
+                content=[TextContent(text='first')],
+            ),
+            PendingMessage(
+                conversation_id=str(conversation_id),
+                content=[TextContent(text='second')],
+            ),
+            PendingMessage(
+                conversation_id=str(conversation_id),
+                content=[TextContent(text='third')],
+            ),
+        ]
+        self.mock_pending_message_service.update_conversation_id = AsyncMock(
+            return_value=3
+        )
+        self.mock_pending_message_service.get_pending_messages = AsyncMock(
+            return_value=messages
+        )
+        self.mock_pending_message_service.delete_message = AsyncMock(return_value=True)
+        success_response = Mock()
+        success_response.raise_for_status = Mock()
+        failed_response = Mock()
+        failed_response.raise_for_status = Mock(side_effect=RuntimeError('unavailable'))
+        self.mock_httpx_client.post = AsyncMock(
+            side_effect=[success_response, failed_response]
+        )
+
+        await self.service._process_pending_messages(
+            task_id=task_id,
+            conversation_id=conversation_id,
+            agent_server_url='http://agent-server:8000',
+            session_api_key='test-key',
+        )
+
+        assert self.mock_httpx_client.post.await_count == 2
+        self.mock_pending_message_service.delete_message.assert_awaited_once_with(
+            messages[0].id
+        )
 
     @pytest.mark.asyncio
     async def test_seed_sandbox_profiles_upserts_resolved_keys_and_prunes(self):

--- a/tests/unit/app_server/test_pending_message_service.py
+++ b/tests/unit/app_server/test_pending_message_service.py
@@ -214,6 +214,34 @@ class TestSQLPendingMessageService:
         assert await service.count_pending_messages(other_conversation_id) == 1
 
     @pytest.mark.asyncio
+    async def test_delete_message_removes_only_matching_message(
+        self,
+        service: SQLPendingMessageService,
+        sample_content: list[TextContent],
+    ):
+        """Test that delete_message removes only the requested message."""
+        # Arrange
+        conversation_id = f'task-{uuid4().hex}'
+        first = await service.add_message(conversation_id, sample_content)
+        second = await service.add_message(conversation_id, sample_content)
+
+        # Act
+        deleted = await service.delete_message(first.id)
+
+        # Assert
+        assert deleted is True
+        messages = await service.get_pending_messages(conversation_id)
+        assert [message.id for message in messages] == [second.id]
+
+    @pytest.mark.asyncio
+    async def test_delete_message_returns_false_when_not_found(
+        self,
+        service: SQLPendingMessageService,
+    ):
+        """Test that delete_message returns False for an unknown message."""
+        assert await service.delete_message(str(uuid4())) is False
+
+    @pytest.mark.asyncio
     async def test_delete_messages_for_conversation_returns_zero_when_none_exist(
         self,
         service: SQLPendingMessageService,


### PR DESCRIPTION
PR description:

  HUMAN:

  Manual testing has not yet been completed. This PR has been validated through the automated backend unit and pre-commit suites.

  - [ ] A human has tested these changes.

  AGENT:

  Implemented and validated by an AI coding agent. The final diff was reviewed for scope, formatting, debug code, and unrelated
  changes.

  ---

  ## Why

  Pending messages are stored while a conversation is starting and delivered once the conversation reaches the `READY` state.

  Previously, `_process_pending_messages()` attempted to deliver every queued message and then deleted all pending messages for the
  conversation, regardless of whether individual deliveries succeeded. If the agent server returned an error or could not be reached,
  the failure was logged but the undelivered message was still removed from the database.

  This caused permanent message loss during transient failures such as:

  - Agent-server connection errors
  - Request timeouts
  - Agent-server restarts
  - Non-success HTTP responses

  It could also violate message ordering: if an earlier message failed while a later message succeeded, the queue would no longer
  preserve its original FIFO semantics.

  ## Summary

  - Delete each pending message only after the agent server confirms successful delivery.
  - Stop processing after the first failed message so that it and all later messages remain queued in FIFO order.
  - Add a single-message deletion operation to `PendingMessageService`.
  - Update pending-message documentation to reflect the new behavior.
  - Add regression tests covering successful delivery, failed delivery, FIFO preservation, and individual message deletion.

  ## Behavior Before

  Given three queued messages:

  1. Message A succeeds.
  2. Message B fails.
  3. Message C succeeds or is attempted afterward.

  The service deleted A, B, and C from the database after processing. Message B was permanently lost even though the agent server
  never accepted it.

  ## Behavior After

  Given the same queue:

  1. Message A succeeds and is deleted.
  2. Message B fails and remains queued.
  3. Processing stops, so Message C also remains queued behind B.

  This preserves the successfully delivered prefix while retaining the failed message and subsequent messages in their original order.

  ## Implementation Details

  `PendingMessageService` now exposes:

  ```python
  async def delete_message(self, message_id: str) -> bool

  The SQL implementation deletes and commits only the matching pending-message row.

  _process_pending_messages() continues to send messages sequentially. After each successful response, it deletes that message. If
  delivery raises an exception, processing stops without deleting the failed row or any later rows.

  The existing conversation-wide bulk deletion method remains unchanged for its other cleanup use cases.

  ## Scope and Limitations

  This PR prevents failed pending messages from being discarded. It does not introduce a new retry scheduler.

  _process_pending_messages() currently runs once when conversation startup reaches READY. Failed rows therefore remain available for
  a future retry mechanism instead of being lost, but this PR does not add the mechanism that triggers that later retry.

  Adding durable retry scheduling, attempt counters, or retry backoff would require a broader lifecycle and persistence design and is
  intentionally outside this fix.

  ## Issue Number

  No linked issue. This problem was identified through a static audit of the pending-message delivery path.

  ## How to Test

  Run the focused regression tests:

  poetry run pytest \
    tests/unit/app_server/test_pending_message_service.py \
    tests/unit/app_server/test_live_status_app_conversation_service.py

  Expected result:

  155 passed

  Run the complete backend unit suite:

  TMPDIR=/tmp poetry run pytest tests/unit

  Expected result:

  2170 passed

  Run the backend pre-commit suite:

  poetry run pre-commit run --all-files --show-diff-on-failure \
    --config ./dev_config/python/.pre-commit-config.yaml

  Expected result: all hooks pass, including Ruff formatting, Ruff linting, mypy, repository policy checks, and project configuration
  validation.

  ## Automated Test Coverage

  The new tests verify that:

  - All successfully delivered messages are individually deleted.
  - Delivery stops at the first failed message.
  - A failed message is not deleted.
  - Messages following a failed message are not attempted or deleted.
  - Deleting one pending message does not affect other messages.
  - Deleting an unknown message returns False.

  ## Video/Screenshots

  Not applicable. This is a backend reliability fix with no visual UI changes.

  ## Type

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Docs / chore

  ## Changelog

  Fixed an issue where messages queued during conversation startup could be permanently lost if delivery to the agent server failed.

  ## Notes

  - No database migration is required.
  - No API request or response schema changes are introduced.
  - No frontend changes are required.
  - Existing successfully delivered messages continue to be removed normally.
  - Failed and later messages now remain in the pending-message table instead of being discarded.