### PR TITLE
fix(app-server): paginate AWS event listings

### DIFF
--- a/openhands/app_server/event/aws_event_service.py
+++ b/openhands/app_server/event/aws_event_service.py
@@ -61,19 +61,22 @@ class AwsEventService(EventServiceBase):
             Body=json_str.encode('utf-8'),
         )
 
-    def _search_paths(self, prefix: Path, page_id: str | None = None) -> list[Path]:
-        """Search paths."""
+    def _search_paths(self, prefix: Path) -> list[Path]:
+        """Search all paths, following S3 continuation tokens."""
         kwargs: dict[str, Any] = {
             'Bucket': self.bucket_name,
             'Prefix': str(prefix),
         }
-        if page_id:
-            kwargs['ContinuationToken'] = page_id
+        paths: list[Path] = []
+        while True:
+            response = self.s3_client.list_objects_v2(**kwargs)
+            contents = response.get('Contents', [])
+            paths.extend(Path(obj['Key']) for obj in contents)
 
-        response = self.s3_client.list_objects_v2(**kwargs)
-        contents = response.get('Contents', [])
-        paths = [Path(obj['Key']) for obj in contents]
-        return paths
+            continuation_token = response.get('NextContinuationToken')
+            if not continuation_token:
+                return paths
+            kwargs['ContinuationToken'] = continuation_token
 
 
 def _get_default_aws_endpoint_url() -> str | None:

--- a/tests/unit/app_server/test_aws_event_service.py
+++ b/tests/unit/app_server/test_aws_event_service.py
@@ -7,7 +7,7 @@ focusing on search functionality and S3 operations.
 import importlib
 import json
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 from uuid import uuid4
 
 import botocore.exceptions
@@ -156,19 +156,29 @@ class TestAwsEventServiceSearchPaths:
 
         assert len(result) == 0
 
-    def test_search_paths_with_page_id(self, service: AwsEventService, mock_s3_client):
-        """Test that _search_paths uses continuation token."""
-        mock_s3_client.list_objects_v2.return_value = {
-            'Contents': [{'Key': 'event.json'}]
-        }
+    def test_search_paths_follows_continuation_tokens(
+        self, service: AwsEventService, mock_s3_client
+    ):
+        """Test that _search_paths returns objects from every S3 page."""
+        mock_s3_client.list_objects_v2.side_effect = [
+            {
+                'Contents': [{'Key': 'event1.json'}],
+                'NextContinuationToken': 'continuation_token',
+            },
+            {'Contents': [{'Key': 'event2.json'}]},
+        ]
 
-        service._search_paths(Path('prefix'), page_id='continuation_token')
+        result = service._search_paths(Path('prefix'))
 
-        mock_s3_client.list_objects_v2.assert_called_once_with(
-            Bucket='test-bucket',
-            Prefix='prefix',
-            ContinuationToken='continuation_token',
-        )
+        assert result == [Path('event1.json'), Path('event2.json')]
+        assert mock_s3_client.list_objects_v2.call_args_list == [
+            call(Bucket='test-bucket', Prefix='prefix'),
+            call(
+                Bucket='test-bucket',
+                Prefix='prefix',
+                ContinuationToken='continuation_token',
+            ),
+        ]
 
 
 class TestAwsEventServiceIntegration:


### PR DESCRIPTION
HUMAN:

  Manual testing has not yet been completed. The change has been validated through the focused AWS tests, full backend unit suite, and
  pre-commit checks.

  - [ ] A human has tested these changes.

  AGENT:

  Implemented and validated by an AI coding agent. The final diff was reviewed for scope, formatting, debug code, and unrelated
  changes.

  ---

  ## Why

  The AWS-backed event service previously made only one `list_objects_v2` request when listing events stored in S3.

  S3 returns at most 1,000 objects per `list_objects_v2` response. When a conversation contained more than 1,000 stored event objects,
  the response included a `NextContinuationToken`, but the service did not follow it.

  As a result, long AWS-backed conversations could be silently truncated in several operations:

  - Event searches
  - Filtered event counts
  - Unfiltered event counts
  - Conversation trajectory exports

  The existing `_search_paths()` method accepted an optional continuation token, but production callers invoked it only once and never
  supplied subsequent tokens.

  ## Summary

  - Follow S3 continuation tokens until every page has been retrieved.
  - Return the complete collection of event paths to all existing callers.
  - Align the AWS `_search_paths()` signature with the base `EventServiceBase` interface.
  - Replace the previous manual-token test with a multi-page regression test.

  ## Behavior Before

  `AwsEventService._search_paths()` performed one request:

  ```python
  response = self.s3_client.list_objects_v2(
      Bucket=self.bucket_name,
      Prefix=str(prefix),
  )

  Only the first response’s Contents were returned. If S3 indicated that additional pages existed, those pages were ignored.

  For a conversation with more than 1,000 event objects, callers received only the first 1,000 paths.

  ## Behavior After

  _search_paths() now repeatedly calls list_objects_v2().

  After each response:

  1. Its object keys are added to the result.
  2. NextContinuationToken is inspected.
  3. If a token is present, it is passed as ContinuationToken in the next request.
  4. Listing stops when no continuation token remains.

  All callers continue using the same _search_paths(prefix) interface and now receive the complete event set.

  ## Affected Operations

  The fix applies automatically to the following EventServiceBase paths:

  ### Event search

  search_events() receives all stored paths before loading, filtering, sorting, and applying API pagination.

  ### Event count

  _count_events_no_filter() now counts paths across all S3 pages.

  Filtered counts use search_events(), so they also operate on the complete event set.

  ### Conversation export

  iter_events_for_export() now loads and exports events from every S3 page rather than only the first page.

  ## Issue Number

  No linked issue. This problem was identified through a static audit of the AWS event-storage implementation.

  ## How to Test

  Run the focused AWS event-service tests:

  poetry run pytest tests/unit/app_server/test_aws_event_service.py

  Expected result:

  22 passed

  Run the full backend unit suite:

  TMPDIR=/tmp poetry run pytest tests/unit

  Expected result:

  2166 passed

  Run the backend pre-commit suite:

  poetry run pre-commit run --all-files --show-diff-on-failure \
    --config ./dev_config/python/.pre-commit-config.yaml

  Expected result: all hooks pass, including Ruff, Ruff format, mypy, configuration validation, and repository policy checks.

  ## Automated Test Coverage

  The updated regression test simulates two S3 responses:

  - The first page contains an event and a NextContinuationToken.
  - The second page contains another event and no continuation token.

  It verifies that:

  - Events from both pages are returned.
  - The initial request contains the expected bucket and prefix.
  - The second request includes the continuation token returned by the first page.
  - Listing stops after the final page.

  Existing tests continue covering empty listings, single-page listings, event loading, event storage, and AWS service configuration.

  ## Video/Screenshots

  Not applicable. This is a backend storage correctness fix with no UI changes.

  ## Type

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Docs / chore

  ## Changelog

  Fixed AWS-backed event storage so conversations containing more than 1,000 events are fully included in searches, counts, and
  trajectory exports.

  ## Notes

  - No database or storage migration is required.
  - No API schema changes are introduced.
  - No frontend changes are required.
  - Filesystem and Google Cloud event-storage implementations are unchanged.
  - This preserves the existing in-memory sorting and API pagination behavior; it only ensures that the input contains every S3
    object.