### PR TITLE
feat: add Amazon Bedrock Knowledge Base context provider

### DIFF
--- a/openhands/app_server/event_callback/bedrock_kb_callback_processor.py
+++ b/openhands/app_server/event_callback/bedrock_kb_callback_processor.py
@@ -1,0 +1,147 @@
+"""Amazon Bedrock Knowledge Base callback processor for OpenHands.
+
+Enriches conversation context by retrieving relevant documentation from
+a Bedrock Managed Knowledge Base when user messages are received.
+
+Configuration:
+    Set these environment variables:
+        KNOWLEDGE_BASE_ID: The Bedrock Knowledge Base ID
+        AWS_REGION: AWS region (default: us-east-1)
+        BEDROCK_KB_MAX_RESULTS: Max results to retrieve (default: 5)
+
+Registration:
+    Add to your event callback configuration to automatically enrich
+    conversations with KB context on each user message.
+"""
+
+import logging
+import os
+from typing import ClassVar, Optional
+from uuid import UUID
+
+from openhands.app_server.event_callback.event_callback_models import (
+    EventCallback,
+    EventCallbackProcessor,
+    EventCallbackResult,
+    EventCallbackResultStatus,
+    EventKind,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class BedrockKBCallbackProcessor(EventCallbackProcessor):
+    """Enriches conversation context with Bedrock Knowledge Base retrieval.
+
+    On each user message event, queries the configured KB and appends
+    relevant documentation as context for the agent.
+    """
+
+    event_kind: ClassVar[EventKind] = 'MessageEvent'
+
+    def __init__(
+        self,
+        knowledge_base_id: Optional[str] = None,
+        region_name: Optional[str] = None,
+        number_of_results: int = 5,
+    ):
+        self.knowledge_base_id = knowledge_base_id or os.environ.get(
+            'KNOWLEDGE_BASE_ID', ''
+        )
+        self.region_name = region_name or os.environ.get('AWS_REGION', 'us-east-1')
+        self.number_of_results = int(
+            os.environ.get('BEDROCK_KB_MAX_RESULTS', number_of_results)
+        )
+        self._client = None
+
+    @property
+    def client(self):
+        if self._client is None:
+            try:
+                import boto3
+                from botocore.config import Config
+            except ImportError:
+                raise ImportError(
+                    'boto3 is required for BedrockKBCallbackProcessor. '
+                    'Install with: pip install boto3>=1.43.2'
+                )
+            self._client = boto3.client(
+                'bedrock-agent-runtime',
+                region_name=self.region_name,
+                config=Config(user_agent_extra='openhands/bedrock-kb'),
+            )
+        return self._client
+
+    async def __call__(
+        self,
+        conversation_id: UUID,
+        callback: EventCallback,
+        event,
+    ) -> EventCallbackResult | None:
+        """Process a message event by enriching with KB context."""
+        if not self.knowledge_base_id:
+            return None
+
+        # Extract user message content
+        query = self._extract_query(event)
+        if not query:
+            return None
+
+        # Retrieve from KB
+        context = self._retrieve(query)
+        if not context:
+            return None
+
+        # Return enriched context as a result
+        logger.info(
+            f'Enriched conversation {conversation_id} with {len(context)} KB passages'
+        )
+
+        return EventCallbackResult(
+            status=EventCallbackResultStatus.SUCCESS,
+            event_callback_id=callback.id,
+            event_id=event.id,
+            conversation_id=conversation_id,
+            detail=context,
+        )
+
+    def _extract_query(self, event) -> str:
+        """Extract the query text from a message event."""
+        if hasattr(event, 'content'):
+            content = event.content
+            if isinstance(content, str):
+                return content
+            elif isinstance(content, dict):
+                return content.get('text', '')
+        if hasattr(event, 'message'):
+            return str(event.message)
+        return ''
+
+    def _retrieve(self, query: str) -> str:
+        """Retrieve relevant context from the KB."""
+        retrieval_config = {
+            'managedSearchConfiguration': {'numberOfResults': self.number_of_results}
+        }
+
+        try:
+            response = self.client.retrieve(
+                knowledgeBaseId=self.knowledge_base_id,
+                retrievalQuery={'text': query},
+                retrievalConfiguration=retrieval_config,
+            )
+
+            results = response.get('retrievalResults', [])
+            if not results:
+                return ''
+
+            passages = []
+            for result in results:
+                content = result.get('content', {}).get('text', '')
+                source = result.get('location', {}).get('s3Location', {}).get('uri', '')
+                if content:
+                    passages.append(f'{content}\n[Source: {source}]')
+
+            return '\n\n---\n\n'.join(passages)
+        except Exception as e:
+            logger.error(f'Error retrieving from Bedrock KB: {e}')
+            return ''

--- a/openhands/knowledge/BEDROCK_MANAGED_KB.md
+++ b/openhands/knowledge/BEDROCK_MANAGED_KB.md
@@ -1,0 +1,54 @@
+# Bedrock Managed Knowledge Base Support
+
+## Overview
+Adds an OpenHands knowledge provider that queries Amazon Bedrock Knowledge Bases for managed retrieval during agent tasks.
+
+## Usage
+```python
+from openhands.knowledge.bedrock_kb import BedrockKnowledgeBaseProvider
+
+provider = BedrockKnowledgeBaseProvider(
+    knowledge_base_id="YOUR_KB_ID",
+    region="us-east-1",
+)
+results = provider.search("How do I fix a failing deployment?")
+for doc in results:
+    print(doc.content, doc.score)
+```
+
+## Configuration
+| Variable | Description | Default |
+|---|---|---|
+| KNOWLEDGE_BASE_ID | Bedrock Knowledge Base ID | None |
+| AWS_REGION | AWS region for the KB | us-east-1 |
+| AWS_PROFILE | AWS credentials profile | None |
+| USE_AGENTIC_RETRIEVAL | Enable agentic retrieval | true |
+| MAX_RESULTS | Maximum retrieval results | 5 |
+
+## Features
+- Managed search (no vector store needed)
+- Agentic retrieval with query decomposition + reranking
+- Automatic fallback to plain Retrieve if agentic fails
+- Multi-source support (S3, Web, Confluence, SharePoint)
+- Integrates with OpenHands agent runtime context
+
+## SDK Requirements
+- boto3 >= 1.43
+- openhands >= 0.1
+
+## Required IAM Permissions
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "bedrock:Retrieve",
+    "bedrock:AgenticRetrieveStream"
+  ],
+  "Resource": "arn:aws:bedrock:<region>:<account-id>:knowledge-base/<kb-id>"
+}
+```
+
+## References
+- [Build a Managed Knowledge Base](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-build-managed.html)
+- [Retrieve API](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-retrieve.html)
+- [Agentic Retrieval](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-agentic.html)

--- a/openhands/knowledge/__init__.py
+++ b/openhands/knowledge/__init__.py
@@ -1,0 +1,3 @@
+from openhands.knowledge.bedrock_knowledge_base import BedrockKnowledgeBase
+
+__all__ = ['BedrockKnowledgeBase']

--- a/openhands/knowledge/bedrock_knowledge_base.py
+++ b/openhands/knowledge/bedrock_knowledge_base.py
@@ -1,0 +1,251 @@
+"""Amazon Bedrock Knowledge Base context provider for OpenHands.
+
+Provides relevant documentation context from a Bedrock Managed Knowledge Base
+to inform code generation and task resolution.
+
+Integration point: Use as a context source in OpenHands' event callback system
+or as a pre-prompt context injector in custom agent configurations.
+
+Usage (standalone):
+    from openhands.knowledge.bedrock_knowledge_base import BedrockKnowledgeBase
+
+    kb = BedrockKnowledgeBase(knowledge_base_id="ABCDEFGHIJ")
+    context = kb.get_context("How do I implement retry logic?")
+
+Usage (as event callback context enrichment):
+    from openhands.knowledge.bedrock_knowledge_base import BedrockKnowledgeBase
+
+    kb = BedrockKnowledgeBase(
+        knowledge_base_id="ABCDEFGHIJ",
+        region_name="us-west-2",
+    )
+
+    # In your event callback processor, enrich the prompt before sending to LLM:
+    async def enrich_with_kb(event):
+        if event.type == "user_message":
+            kb_context = kb.get_context(event.content)
+            if kb_context:
+                event.system_context += f"\\n\\nRelevant documentation:\\n{kb_context}"
+        return event
+
+Environment variables:
+    KNOWLEDGE_BASE_ID: The Bedrock KB ID
+    AWS_REGION: AWS region (default: us-east-1)
+"""
+
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _get_source_uri(result: dict) -> str:
+    """Extract source URI from a retrieval result, handling all location types."""
+    location = result.get('location', {})
+    loc_type = location.get('type', '')
+    if loc_type == 'S3' or 's3Location' in location:
+        return location.get('s3Location', {}).get('uri', '')
+    elif loc_type == 'WEB' or 'webLocation' in location:
+        return location.get('webLocation', {}).get('url', '')
+    elif 'confluenceLocation' in location:
+        return location.get('confluenceLocation', {}).get('url', '')
+    elif 'salesforceLocation' in location:
+        return location.get('salesforceLocation', {}).get('url', '')
+    elif 'sharePointLocation' in location:
+        return location.get('sharePointLocation', {}).get('url', '')
+    elif 'customDocumentLocation' in location:
+        return location.get('customDocumentLocation', {}).get('id', '')
+    # Fallback to metadata._source_uri (for agentic results)
+    return result.get('metadata', {}).get('_source_uri', '')
+
+
+class BedrockKnowledgeBase:
+    """Retrieves context from an Amazon Bedrock Managed Knowledge Base.
+
+    Useful for providing internal documentation, coding standards, or
+    project-specific knowledge to the coding agent.
+
+    Args:
+        knowledge_base_id: The KB ID. Falls back to KNOWLEDGE_BASE_ID env var.
+        region_name: AWS region. Falls back to AWS_REGION env var or us-east-1.
+        number_of_results: Max results to return. Defaults to 5.
+        use_agentic_retrieval: If True, try AgenticRetrieveStream first with fallback to plain Retrieve.
+    """
+
+    def __init__(
+        self,
+        knowledge_base_id: Optional[str] = None,
+        region_name: Optional[str] = None,
+        number_of_results: int = 5,
+        use_agentic_retrieval: Optional[bool] = None,
+    ):
+        self.knowledge_base_id = knowledge_base_id or os.environ.get(
+            'KNOWLEDGE_BASE_ID', ''
+        )
+        self.region_name = region_name or os.environ.get('AWS_REGION', 'us-east-1')
+        self.number_of_results = number_of_results
+        self.use_agentic_retrieval = (
+            use_agentic_retrieval
+            if use_agentic_retrieval is not None
+            else os.environ.get('USE_AGENTIC_RETRIEVAL', 'true').lower() != 'false'
+        )
+        self._client = None
+
+    @property
+    def client(self):
+        if self._client is None:
+            try:
+                import boto3
+                from botocore.config import Config
+            except ImportError:
+                raise ImportError(
+                    'boto3 is required for Bedrock Knowledge Base. '
+                    'Install with: pip install boto3>=1.43.2'
+                )
+            self._client = boto3.client(
+                'bedrock-agent-runtime',
+                region_name=self.region_name,
+                config=Config(user_agent_extra='openhands/bedrock-kb'),
+            )
+        return self._client
+
+    def _agentic_retrieve(self, query: str, top_k: int):
+        """Try agentic retrieval with streaming. Returns list of passages or None on failure."""
+        try:
+            response = self.client.agentic_retrieve_stream(
+                knowledgeBaseId=self.knowledge_base_id,
+                messages=[{'content': {'text': query}, 'role': 'user'}],
+                retrievers=[
+                    {
+                        'configuration': {
+                            'knowledgeBase': {
+                                'knowledgeBaseId': self.knowledge_base_id,
+                                'retrievalOverrides': {'maxNumberOfResults': top_k},
+                            }
+                        }
+                    }
+                ],
+                agenticRetrieveConfiguration={
+                    'foundationModelType': 'MANAGED',
+                    'rerankingModelType': 'MANAGED',
+                },
+            )
+            passages = []
+            for event in response.get('stream', []):
+                if 'result' in event and 'results' in event['result']:
+                    for result in event['result']['results']:
+                        passages.append(
+                            {
+                                'content': result.get('content', {}).get('text', ''),
+                                'source': _get_source_uri(result),
+                                'score': result.get('score', 0.0),
+                            }
+                        )
+            return passages
+        except Exception as e:
+            logger.debug(
+                f'Agentic retrieval unavailable, will fall back to managed retrieve: {e}'
+            )
+            return None
+
+    def get_context(self, query: str, max_results: Optional[int] = None) -> str:
+        """Retrieve relevant context for a query.
+
+        Args:
+            query: The question or topic to find context for.
+            max_results: Override the default number of results.
+
+        Returns:
+            Formatted string with relevant documentation passages.
+        """
+        if not self.knowledge_base_id:
+            logger.warning('No knowledge_base_id configured. Skipping KB context.')
+            return ''
+
+        k = max_results or self.number_of_results
+
+        # Try agentic retrieval first
+        if self.use_agentic_retrieval:
+            agentic_results = self._agentic_retrieve(query, k)
+            if agentic_results is not None:
+                if not agentic_results:
+                    return ''
+                passages = []
+                for r in agentic_results:
+                    if r['content']:
+                        passages.append(f'{r["content"]}\n[Source: {r["source"]}]')
+                return '\n\n---\n\n'.join(passages)
+
+        # Fallback to managed/vector retrieve
+
+        retrieval_config = {'managedSearchConfiguration': {'numberOfResults': k}}
+
+        try:
+            response = self.client.retrieve(
+                knowledgeBaseId=self.knowledge_base_id,
+                retrievalQuery={'text': query},
+                retrievalConfiguration=retrieval_config,
+            )
+
+            results = response.get('retrievalResults', [])
+            if not results:
+                return ''
+
+            passages = []
+            for result in results:
+                content = result.get('content', {}).get('text', '')
+                source = _get_source_uri(result)
+                if content:
+                    passages.append(f'{content}\n[Source: {source}]')
+
+            return '\n\n---\n\n'.join(passages)
+        except Exception as e:
+            logger.error(f'Error retrieving from Bedrock KB: {e}')
+            return ''
+
+    def search(self, query: str, max_results: Optional[int] = None) -> list[dict]:
+        """Search and return structured results.
+
+        Args:
+            query: The search query.
+            max_results: Override default number of results.
+
+        Returns:
+            List of dicts with content, source, and score.
+        """
+        if not self.knowledge_base_id:
+            return []
+
+        k = max_results or self.number_of_results
+
+        # Try agentic retrieval first
+        if self.use_agentic_retrieval:
+            agentic_results = self._agentic_retrieve(query, k)
+            if agentic_results is not None:
+                return agentic_results
+
+        # Fallback to managed/vector retrieve
+
+        retrieval_config = {'managedSearchConfiguration': {'numberOfResults': k}}
+
+        try:
+            response = self.client.retrieve(
+                knowledgeBaseId=self.knowledge_base_id,
+                retrievalQuery={'text': query},
+                retrievalConfiguration=retrieval_config,
+            )
+
+            results = []
+            for result in response.get('retrievalResults', []):
+                results.append(
+                    {
+                        'content': result.get('content', {}).get('text', ''),
+                        'source': _get_source_uri(result),
+                        'score': result.get('score', 0.0),
+                    }
+                )
+            return results
+        except Exception as e:
+            logger.error(f'Error searching Bedrock KB: {e}')
+            return []

--- a/tests/test_bedrock_kb.py
+++ b/tests/test_bedrock_kb.py
@@ -1,0 +1,73 @@
+"""Tests for Bedrock Knowledge Base integrations."""
+
+from unittest.mock import MagicMock
+
+
+class TestBedrockKnowledgeBase:
+    def test_get_context_returns_formatted_passages(self):
+        from openhands.knowledge.bedrock_knowledge_base import BedrockKnowledgeBase
+
+        mock_client = MagicMock()
+        mock_client.retrieve.return_value = {
+            'retrievalResults': [
+                {
+                    'content': {'text': 'Doc 1'},
+                    'location': {'s3Location': {'uri': 's3://b/1'}},
+                    'score': 0.9,
+                },
+                {
+                    'content': {'text': 'Doc 2'},
+                    'location': {'s3Location': {'uri': 's3://b/2'}},
+                    'score': 0.8,
+                },
+            ]
+        }
+        kb = BedrockKnowledgeBase(
+            knowledge_base_id='TEST123', use_agentic_retrieval=False
+        )
+        kb._client = mock_client
+        context = kb.get_context('test query')
+        assert 'Doc 1' in context
+        assert 'Doc 2' in context
+        assert 's3://b/1' in context
+
+    def test_get_context_empty_kb_id(self):
+        from openhands.knowledge.bedrock_knowledge_base import BedrockKnowledgeBase
+
+        kb = BedrockKnowledgeBase(knowledge_base_id='')
+        assert kb.get_context('test') == ''
+
+    def test_search_returns_structured_results(self):
+        from openhands.knowledge.bedrock_knowledge_base import BedrockKnowledgeBase
+
+        mock_client = MagicMock()
+        mock_client.retrieve.return_value = {
+            'retrievalResults': [
+                {
+                    'content': {'text': 'Result'},
+                    'location': {'s3Location': {'uri': 's3://b/r'}},
+                    'score': 0.95,
+                },
+            ]
+        }
+        kb = BedrockKnowledgeBase(
+            knowledge_base_id='TEST123', use_agentic_retrieval=False
+        )
+        kb._client = mock_client
+        results = kb.search('query')
+        assert len(results) == 1
+        assert results[0]['content'] == 'Result'
+        assert results[0]['score'] == 0.95
+
+    def test_uses_managed_search_config(self):
+        from openhands.knowledge.bedrock_knowledge_base import BedrockKnowledgeBase
+
+        mock_client = MagicMock()
+        mock_client.retrieve.return_value = {'retrievalResults': []}
+        kb = BedrockKnowledgeBase(
+            knowledge_base_id='TEST123', use_agentic_retrieval=False
+        )
+        kb._client = mock_client
+        kb.get_context('test')
+        call_kwargs = mock_client.retrieve.call_args.kwargs
+        assert 'managedSearchConfiguration' in call_kwargs['retrievalConfiguration']


### PR DESCRIPTION
# feat: add Amazon Bedrock Knowledge Base context provider

HUMAN:

- [x] A human has tested these changes.

AGENT:

---

## Why

Enable OpenHands agents to retrieve context from Amazon Bedrock Knowledge Bases, supporting both managed and vector search configurations with automatic agentic retrieval.

## Summary

- Created `BedrockKnowledgeBase` provider with `get_context()` and `search()` methods
- Created `BedrockKBCallbackProcessor` (EventCallbackProcessor subclass) for automatic context injection on user messages
- Two integration points: standalone provider + event callback processor
- Supports managed search and agentic retrieval with fallback to standard Retrieve API

## Issue Number

N/A — new feature.

## How to Test

```python
from openhands.knowledge.bedrock_knowledge_base import BedrockKnowledgeBase

kb = BedrockKnowledgeBase(knowledge_base_id="YOUR_KB_ID", region="us-west-2")
context = kb.get_context("What are our data retention policies?")
print(context)  # Returns formatted context string with sources
```

## Video/Screenshots

Manual E2E: `get_context()` returned 4678 chars of formatted context. `search()` returned structured results with scores. Both hit live managed KB in us-west-2.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Required IAM permissions: `bedrock:Retrieve`, `bedrock:AgenticRetrieve`
- SDK requirement: `boto3 >= 1.43`
