### PR TITLE
fix(app-server): preserve conversation created_at across lifecycle webhooks

### DIFF
--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -397,6 +397,28 @@ class SQLAppConversationInfoService(AppConversationInfoService):
         metrics = info.metrics or MetricsSnapshot()
         usage = metrics.accumulated_token_usage or TokenUsage()
 
+        # Preserve the original creation time on update.
+        #
+        # ``save`` is an upsert (``merge`` on the primary key), and several
+        # callers rebuild an ``AppConversationInfo`` from scratch rather than
+        # mutating the loaded row (e.g. the ``on_conversation_update`` webhook,
+        # which fires on every start/pause/resume/interrupt). Those callers do
+        # not carry ``created_at`` forward, so ``AppConversationInfo`` fills it
+        # from ``default_factory=utc_now``. Without this guard the merge would
+        # overwrite the persisted ``created_at`` with "now" on every lifecycle
+        # webhook, corrupting created-at ordering and the usage/billing
+        # dashboards that bucket conversations by creation time. Look up the
+        # stored value directly by primary key (not via ``_secure_select``) so
+        # this works under the ADMIN webhook context as well.
+        created_at = info.created_at
+        existing_created_at = await self.db_session.scalar(
+            select(StoredConversationMetadata.created_at).where(
+                StoredConversationMetadata.conversation_id == str(info.id)
+            )
+        )
+        if existing_created_at is not None:
+            created_at = existing_created_at
+
         stored = StoredConversationMetadata(
             conversation_id=str(info.id),
             selected_repository=info.selected_repository,
@@ -404,7 +426,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             git_provider=info.git_provider.value if info.git_provider else None,
             title=info.title,
             last_updated_at=info.updated_at,
-            created_at=info.created_at,
+            created_at=created_at,
             trigger=info.trigger.value if info.trigger else None,
             pr_number=info.pr_number or [],
             # Cost and token metrics

--- a/tests/unit/app_server/test_sql_app_conversation_info_service.py
+++ b/tests/unit/app_server/test_sql_app_conversation_info_service.py
@@ -1270,3 +1270,110 @@ class TestFixTimezone:
         aware_dt = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
         result = service._fix_timezone(aware_dt)
         assert result == aware_dt
+
+
+class TestCreatedAtPreservation:
+    """Regression tests: created_at must be immutable across re-saves.
+
+    The ``on_conversation_update`` webhook rebuilds an ``AppConversationInfo``
+    from scratch on every lifecycle transition and does not carry ``created_at``
+    forward, so the model defaults it to ``utc_now()``. ``save_app_conversation_info``
+    is an upsert, so without a guard the merge would clobber the persisted
+    ``created_at`` with "now" on every webhook.
+    """
+
+    @pytest.mark.asyncio
+    async def test_created_at_preserved_when_omitted_on_resave(
+        self,
+        service: SQLAppConversationInfoService,
+    ):
+        """A re-save that defaults created_at must not overwrite the stored value."""
+        conversation_id = uuid4()
+        original_created_at = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+        await service.save_app_conversation_info(
+            AppConversationInfo(
+                id=conversation_id,
+                created_by_user_id=None,
+                sandbox_id='sandbox_123',
+                title='Original',
+                created_at=original_created_at,
+                updated_at=original_created_at,
+            )
+        )
+
+        # Simulate the webhook rebuild: a fresh model whose created_at/updated_at
+        # come from the default_factory (i.e. "now"), not the stored value.
+        rebuilt = AppConversationInfo(
+            id=conversation_id,
+            created_by_user_id=None,
+            sandbox_id='sandbox_123',
+            title='Updated via webhook',
+        )
+        assert rebuilt.created_at > original_created_at  # default_factory ran
+
+        await service.save_app_conversation_info(rebuilt)
+
+        stored = await service.get_app_conversation_info(conversation_id)
+        assert stored is not None
+        # created_at is preserved from the original insert...
+        assert stored.created_at == original_created_at
+        # ...while other fields (title) still update.
+        assert stored.title == 'Updated via webhook'
+
+    @pytest.mark.asyncio
+    async def test_created_at_stable_across_repeated_webhooks(
+        self,
+        service: SQLAppConversationInfoService,
+    ):
+        """Repeated lifecycle webhooks must not drift created_at forward."""
+        conversation_id = uuid4()
+        original_created_at = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+        await service.save_app_conversation_info(
+            AppConversationInfo(
+                id=conversation_id,
+                created_by_user_id=None,
+                sandbox_id='sandbox_123',
+                title='Original',
+                created_at=original_created_at,
+                updated_at=original_created_at,
+            )
+        )
+
+        for i in range(3):
+            await service.save_app_conversation_info(
+                AppConversationInfo(
+                    id=conversation_id,
+                    created_by_user_id=None,
+                    sandbox_id='sandbox_123',
+                    title=f'Webhook update {i}',
+                )
+            )
+            stored = await service.get_app_conversation_info(conversation_id)
+            assert stored is not None
+            assert stored.created_at == original_created_at
+
+    @pytest.mark.asyncio
+    async def test_created_at_used_on_first_insert(
+        self,
+        service: SQLAppConversationInfoService,
+    ):
+        """On the initial insert, the provided created_at is honored."""
+        conversation_id = uuid4()
+        created_at = datetime(2023, 6, 15, 8, 30, 0, tzinfo=timezone.utc)
+
+        await service.save_app_conversation_info(
+            AppConversationInfo(
+                id=conversation_id,
+                created_by_user_id=None,
+                sandbox_id='sandbox_123',
+                title='Fresh',
+                created_at=created_at,
+                updated_at=created_at,
+            )
+        )
+
+        stored = await service.get_app_conversation_info(conversation_id)
+        assert stored is not None
+        assert stored.created_at == created_at


### PR DESCRIPTION
HUMAN:

This fixes a data-integrity bug where a conversation's `created_at` gets overwritten with the current time every time a lifecycle webhook fires (start/pause/resume/interrupt). The webhook handler rebuilds the conversation metadata object without carrying `created_at` forward, and since the save is an upsert, the real creation time gets clobbered. That breaks "sort by created_at" in the conversation list and skews the usage/budgets dashboards that group conversations by day. The fix makes the save preserve the existing `created_at` for rows that already exist. Added unit tests that reproduce the clobber and confirm it's fixed. I have not manually tested this in a running deployment yet, so a maintainer should sanity-check before merge.

- [x] A human has tested these changes.

AGENT:

Prepared via an automated engineering audit of `main`.

---

## Why

`SQLAppConversationInfoService.save_app_conversation_info` is an upsert (`merge` on the primary key). Several callers rebuild an `AppConversationInfo` from scratch instead of mutating the row loaded from the DB. The clearest case is the `on_conversation_update` webhook (`event_callback/webhook_router.py`), which fires on **every** conversation lifecycle transition (start / pause / resume / interrupt) and constructs a fresh `AppConversationInfo` from `existing` **without** carrying `created_at` forward.

Because `AppConversationInfo.created_at` is declared with `default_factory=utc_now`, the omitted field is silently filled with "now", and the subsequent `merge` overwrites the persisted `created_at` column. Net effect: a conversation's `created_at` drifts to its most recent lifecycle event instead of its true creation time.

Impact:
- `CREATED_AT` / `CREATED_AT_DESC` conversation list ordering becomes wrong (conversations jump around on pause/resume).
- `created_at__gte` / `created_at__lt` filters return incorrect results.
- The usage & monitoring / budgets dashboards, which bucket conversations by creation time, mis-attribute conversations to the wrong day.
- The SaaS store (`SaasSQLAppConversationInfoService`) calls `super().save_app_conversation_info(...)`, so **OpenHands Cloud is affected too**.

### Execution trace
1. Conversation starts → metadata saved with real `created_at = T0`.
2. Agent-server posts `POST /api/v1/webhooks/conversations` on a lifecycle transition.
3. `on_conversation_update` builds a new `AppConversationInfo` (no `created_at`) → defaults to `T1 = now()`.
4. `save_app_conversation_info` → `merge` → `UPDATE conversation_metadata SET created_at = T1 ...`.
5. Repeats on every subsequent lifecycle webhook.

## Summary
- Preserve the persisted `created_at` at the service level: on save, look up the stored value by primary key and keep it when the row already exists. All callers (webhook, MCP, remote refresh, update) are protected, not just the one that surfaced the bug.
- The lookup is a direct primary-key read (not `_secure_select`) so it also works under the ADMIN webhook context. First inserts still honor the provided `created_at`.
- Add regression tests: webhook-rebuild scenario, repeated lifecycle webhooks, and the first-insert path.

## Issue Number
N/A (found via audit)

## How to Test

```bash
# OSS unit tests for the changed service (SQLite in-memory)
poetry run pytest tests/unit/app_server/test_sql_app_conversation_info_service.py -q
# Webhook router tests exercising the save path
poetry run pytest tests/unit/app_server/test_webhook_router_stats.py \
  tests/unit/app_server/test_webhook_router_auto_title.py -q
```

The new `TestCreatedAtPreservation` cases fail without the guard (they reproduce the clobber) and pass with it. Verified locally: the full `test_sql_app_conversation_info_service.py` (34 tests) and the webhook router tests pass; the two new reproduction tests fail when the guard is neutralized.

Manual check: start a V1 conversation, note `conversation_metadata.created_at`, then pause/resume it and re-query — `created_at` should be unchanged while `last_updated_at` advances.

## Video/Screenshots
N/A (backend data-integrity fix, no UI surface of its own).

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes
- No migration required.
- Adjacent to open PR #14579 ("retry conversation metadata save races"), which touches the same function for a *different* problem (insert-race `IntegrityError` retry). The two are complementary; whichever lands second should expect a small conflict in `save_app_conversation_info`.


