### PR TITLE
test: guard app-server always requests public skills w/ auto-load

### DIFF
--- a/tests/unit/app_server/test_app_conversation_service_base.py
+++ b/tests/unit/app_server/test_app_conversation_service_base.py
@@ -1463,6 +1463,70 @@ class TestLoadAndMergeAllSkills:
             sent = mock_load_skills.call_args.kwargs['registered_marketplaces']
             assert [reg.source for reg in sent] == [authenticated_url]
 
+    @pytest.mark.asyncio
+    @patch(
+        'openhands.app_server.app_conversation.app_conversation_service_base.load_skills_from_agent_server'
+    )
+    @patch(
+        'openhands.app_server.app_conversation.app_conversation_service_base.build_org_configs'
+    )
+    @patch(
+        'openhands.app_server.app_conversation.app_conversation_service_base.build_sandbox_config'
+    )
+    async def test_keeps_loading_public_skills_when_auto_load_marketplace_present(
+        self,
+        mock_build_sandbox_config,
+        mock_build_org_configs,
+        mock_load_skills,
+    ):
+        """Default public/user/org/project skill loading must stay enabled even
+        when an auto-load repository marketplace is registered (regression
+        guard for #15237: registering a repo for auto-load must not suppress
+        the default public skills, e.g. ``openhands-automation``)."""
+        # Arrange
+        from openhands.app_server.settings.settings_models import (
+            MarketplaceRegistration,
+        )
+
+        mock_user_context = Mock(spec=UserContext)
+        mock_user_context.get_authenticated_git_url = AsyncMock(
+            return_value='https://x-access-token:tok@github.com/o/repo.git'
+        )
+        with patch.object(AppConversationServiceBase, '__abstractmethods__', set()):
+            service = AppConversationServiceBase(
+                init_git_in_empty_workspace=True, user_context=mock_user_context
+            )
+
+            sandbox = Mock(spec=SandboxInfo)
+            sandbox.exposed_urls = []
+            sandbox.session_api_key = 'test-key'
+
+            mock_load_skills.return_value = []
+            mock_build_org_configs.return_value = []
+            mock_build_sandbox_config.return_value = None
+
+            marketplaces = [
+                MarketplaceRegistration(
+                    name='team', source='github:o/repo', auto_load=True
+                )
+            ]
+
+            # Act
+            await service.load_and_merge_all_skills(
+                sandbox,
+                'owner/repo',
+                '/workspace/repo',
+                'http://localhost:8000',
+                registered_marketplaces=marketplaces,
+            )
+
+            # Assert
+            call_kwargs = mock_load_skills.call_args.kwargs
+            assert call_kwargs['load_public'] is True
+            assert call_kwargs['load_user'] is True
+            assert call_kwargs['load_org'] is True
+            assert call_kwargs['load_project'] is True
+
 
 class TestLoadSkillsAndUpdateAgent:
     """_load_skills_and_update_agent threads marketplaces into skill loading."""


### PR DESCRIPTION
## What

Adds a regression test for #15237 ("Default public skills not loading when repository auto-load is enabled") covering this repository's half of the skill-loading contract.

## Why

Investigating this bug report showed that `AppConversationServiceBase.load_and_merge_all_skills` (`openhands/app_server/app_conversation/app_conversation_service_base.py:154-165`) already unconditionally passes `load_public=True` (along with `load_user=True`, `load_org=True`, `load_project=True`) to `load_skills_from_agent_server`, regardless of whether an auto-load repository/marketplace is registered. There is no branch in this app-server code that suppresses public skills when a repo is auto-loaded — the app-server's request to the agent-server always asks for everything.

The actual skill-merging logic (deciding how `load_public` and `registered_marketplaces` combine into the final skill set) runs in the external agent-server's `/api/skills` endpoint — a separately versioned, pinned SDK/service that is **not part of this repository** (per the module docstring in `openhands/app_server/app_conversation/skill_loader.py:1-11`: "the agent-server ... centralizes all skill loading logic"). The reported symptom (default public skills like `openhands-automation` disappearing when a repo auto-load is enabled) most likely stems from that external merge logic dropping the public-skills batch when `registered_marketplaces` is non-empty — code this repository cannot fix.

## How

Added `test_keeps_loading_public_skills_when_auto_load_marketplace_present` to `TestLoadAndMergeAllSkills` in `tests/unit/app_server/test_app_conversation_service_base.py`. It registers an `auto_load=True` marketplace and asserts `load_skills_from_agent_server` is still called with `load_public`, `load_user`, `load_org`, and `load_project` all `True`. This locks in the correct, already-present invariant so a future refactor can never regress this repo's side of the contract by making `load_public` conditional on `registered_marketplaces`.

**No production code changes are included** — this repo's code was already correct for this invariant. The actual fix for the reported bug needs to happen in the agent-server/SDK repository's `/api/skills` merge logic.

## Testing
Ran the new test locally as part of `tests/unit/app_server/test_app_conversation_service_base.py::TestLoadAndMergeAllSkills`; it follows the same mocking pattern as the adjacent `test_sends_authenticated_marketplace_sources_to_agent_server` test (patching `load_skills_from_agent_server`, `build_org_configs`, `build_sandbox_config`, and mocking `get_authenticated_git_url` for the auto_load marketplace resolution path). All existing tests in the file are unchanged and continue to pass — this is additive, test-only coverage. Full end-to-end verification of the reported bug (adding an auto-load repo in the Skills view, starting a conversation, confirming `openhands-automation` and repo skills both appear) requires a live agent-server and cannot be exercised from this repo alone.

## Rollout
Test-only change with zero production code impact — safe to merge and deploy with no special sequencing. This does not resolve the underlying user-facing bug; that fix must land in the agent-server/SDK repository's `/api/skills` merge logic. Recommend filing/cross-linking a companion issue in that repo referencing #15237 so the actual fix is tracked, and keeping this issue open until that lands and is verified end-to-end against a real agent-server.

## Rollback
Revert the single commit touching `tests/unit/app_server/test_app_conversation_service_base.py`. No runtime behavior, schema, or config changes are involved, so a straight revert is fully safe.

## Release notes
No user-facing change in this repo; added test coverage confirming the app-server always requests default public skills alongside auto-loaded repository skills (the underlying delivery bug is being tracked separately in the agent-server component).

---
*Opened by CodeForge after human approval of plan and diff.*