### PR TITLE
Add support for Jules API keys and Jules models

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_router.py
+++ b/openhands/app_server/app_conversation/app_conversation_router.py
@@ -667,6 +667,7 @@ async def switch_conversation_profile(
         profile_llm,
         managed_proxy_url=LITE_LLM_API_URL,
         fallback_api_key=getattr(settings_llm, 'api_key', None),
+        jules_api_key=getattr(user_settings, 'jules_api_key', None),
     )
 
     # The agent-server's LLM registry is first-write-wins by ``usage_id``:

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1254,20 +1254,24 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             if not base_url:
                 updates['base_url'] = 'https://jules.googleapis.com/v1'
             jules_key = getattr(user, 'jules_api_key', None)
-            if jules_key:
+            if jules_key and isinstance(jules_key, SecretStr):
                 updates['api_key'] = jules_key
                 api_key_val = jules_key.get_secret_value()
+            elif jules_key:
+                updates['api_key'] = jules_key
+                api_key_val = str(jules_key)
             else:
-                api_key_val = (
-                    user.agent_settings.llm.api_key.get_secret_value()
-                    if hasattr(user.agent_settings.llm.api_key, 'get_secret_value')
-                    else str(user.agent_settings.llm.api_key)
-                    if user.agent_settings.llm.api_key
-                    else None
-                )
+                llm_key = user.agent_settings.llm.api_key
+                if isinstance(llm_key, SecretStr):
+                    api_key_val = llm_key.get_secret_value()
+                else:
+                    api_key_val = str(llm_key) if llm_key else None
             if api_key_val:
                 extra_headers = user.agent_settings.llm.extra_headers or {}
-                updates['extra_headers'] = {**extra_headers, 'x-goog-api-key': api_key_val}
+                updates['extra_headers'] = {
+                    **extra_headers,
+                    'x-goog-api-key': api_key_val,
+                }
 
         return user.agent_settings.llm.model_copy(update=updates)
 

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -997,6 +997,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                     profile_llm,
                     managed_proxy_url=LITE_LLM_API_URL,
                     fallback_api_key=fallback_api_key,
+                    jules_api_key=getattr(user, 'jules_api_key', None),
                 )
                 response = await self.httpx_client.post(
                     f'{base_url}/{name}',
@@ -1240,16 +1241,35 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             provider_base_url=self.openhands_provider_base_url,
         )
 
-        return user.agent_settings.llm.model_copy(
-            update={
-                'model': model,
-                'base_url': base_url,
-                'api_key': user.agent_settings.llm.api_key,
-                'usage_id': 'agent',
-                # Force streaming on (the SDK LLM defaults stream=False).
-                'stream': True,
-            }
-        )
+        updates: dict[str, Any] = {
+            'model': model,
+            'base_url': base_url,
+            'api_key': user.agent_settings.llm.api_key,
+            'usage_id': 'agent',
+            # Force streaming on (the SDK LLM defaults stream=False).
+            'stream': True,
+        }
+
+        if model.startswith('jules/'):
+            if not base_url:
+                updates['base_url'] = 'https://jules.googleapis.com/v1'
+            jules_key = getattr(user, 'jules_api_key', None)
+            if jules_key:
+                updates['api_key'] = jules_key
+                api_key_val = jules_key.get_secret_value()
+            else:
+                api_key_val = (
+                    user.agent_settings.llm.api_key.get_secret_value()
+                    if hasattr(user.agent_settings.llm.api_key, 'get_secret_value')
+                    else str(user.agent_settings.llm.api_key)
+                    if user.agent_settings.llm.api_key
+                    else None
+                )
+            if api_key_val:
+                extra_headers = user.agent_settings.llm.extra_headers or {}
+                updates['extra_headers'] = {**extra_headers, 'x-goog-api-key': api_key_val}
+
+        return user.agent_settings.llm.model_copy(update=updates)
 
     async def _add_system_mcp_servers(
         self, mcp_servers: dict[str, MCPServer], conversation_id: UUID

--- a/openhands/app_server/settings/llm_profiles.py
+++ b/openhands/app_server/settings/llm_profiles.py
@@ -61,16 +61,23 @@ def resolve_profile_llm(
         }
     )
     if resolved.model and resolved.model.startswith('jules/'):
-        actual_key = jules_api_key if has_real_api_key(jules_api_key) else resolved.api_key
+        actual_key = (
+            jules_api_key if has_real_api_key(jules_api_key) else resolved.api_key
+        )
         if not has_real_api_key(actual_key) and has_real_api_key(fallback_api_key):
             actual_key = fallback_api_key
         if has_real_api_key(actual_key):
             resolved = resolved.model_copy(update={'api_key': actual_key})
-            api_key_val = actual_key.get_secret_value() if hasattr(actual_key, 'get_secret_value') else str(actual_key)
+            if isinstance(actual_key, SecretStr):
+                api_key_val = actual_key.get_secret_value()
+            else:
+                api_key_val = str(actual_key) if actual_key is not None else ''
             extra_headers = resolved.extra_headers or {}
             resolved.extra_headers = {**extra_headers, 'x-goog-api-key': api_key_val}
     else:
-        if not has_real_api_key(resolved.api_key) and has_real_api_key(fallback_api_key):
+        if not has_real_api_key(resolved.api_key) and has_real_api_key(
+            fallback_api_key
+        ):
             resolved = resolved.model_copy(update={'api_key': fallback_api_key})
     return resolved
 

--- a/openhands/app_server/settings/llm_profiles.py
+++ b/openhands/app_server/settings/llm_profiles.py
@@ -39,6 +39,7 @@ def resolve_profile_llm(
     *,
     managed_proxy_url: str,
     fallback_api_key: Any = None,
+    jules_api_key: Any = None,
 ) -> LLM:
     """Resolve a saved profile's LLM for activation on the agent server.
 
@@ -59,8 +60,18 @@ def resolve_profile_llm(
             'stream': True,
         }
     )
-    if not has_real_api_key(resolved.api_key) and has_real_api_key(fallback_api_key):
-        resolved = resolved.model_copy(update={'api_key': fallback_api_key})
+    if resolved.model and resolved.model.startswith('jules/'):
+        actual_key = jules_api_key if has_real_api_key(jules_api_key) else resolved.api_key
+        if not has_real_api_key(actual_key) and has_real_api_key(fallback_api_key):
+            actual_key = fallback_api_key
+        if has_real_api_key(actual_key):
+            resolved = resolved.model_copy(update={'api_key': actual_key})
+            api_key_val = actual_key.get_secret_value() if hasattr(actual_key, 'get_secret_value') else str(actual_key)
+            extra_headers = resolved.extra_headers or {}
+            resolved.extra_headers = {**extra_headers, 'x-goog-api-key': api_key_val}
+    else:
+        if not has_real_api_key(resolved.api_key) and has_real_api_key(fallback_api_key):
+            resolved = resolved.model_copy(update={'api_key': fallback_api_key})
     return resolved
 
 

--- a/openhands/app_server/settings/settings_models.py
+++ b/openhands/app_server/settings/settings_models.py
@@ -365,6 +365,7 @@ class Settings(BaseModel):
     sandbox_runtime_container_image: str | None = None
     disabled_skills: list[str] | None = None
     search_api_key: SecretStr | None = None
+    jules_api_key: SecretStr | None = None
     sandbox_api_key: SecretStr | None = None
     max_budget_per_task: float | None = None
     email: str | None = None
@@ -591,6 +592,18 @@ class Settings(BaseModel):
             return secret_value
         return str(api_key)
 
+    @field_serializer('jules_api_key')
+    def jules_api_key_serializer(self, api_key: SecretStr | None, info: SerializationInfo):
+        if api_key is None:
+            return None
+        secret_value = api_key.get_secret_value()
+        if not secret_value or not secret_value.strip():
+            return None
+        context = info.context
+        if context and context.get('expose_secrets', False):
+            return secret_value
+        return str(api_key)
+
     @field_serializer('agent_settings')
     def agent_settings_serializer(
         self,
@@ -740,6 +753,7 @@ class GETSettingsModel(Settings):
     )
     llm_api_key_set: bool
     search_api_key_set: bool = False
+    jules_api_key_set: bool = False
 
     model_config = ConfigDict(use_enum_values=True)
 

--- a/openhands/app_server/settings/settings_models.py
+++ b/openhands/app_server/settings/settings_models.py
@@ -593,7 +593,9 @@ class Settings(BaseModel):
         return str(api_key)
 
     @field_serializer('jules_api_key')
-    def jules_api_key_serializer(self, api_key: SecretStr | None, info: SerializationInfo):
+    def jules_api_key_serializer(
+        self, api_key: SecretStr | None, info: SerializationInfo
+    ):
         if api_key is None:
             return None
         secret_value = api_key.get_secret_value()

--- a/openhands/app_server/settings/settings_router.py
+++ b/openhands/app_server/settings/settings_router.py
@@ -176,6 +176,8 @@ async def load_settings(
             llm_api_key_set=settings.llm_api_key_is_set,
             search_api_key_set=settings.search_api_key is not None
             and bool(settings.search_api_key),
+            jules_api_key_set=settings.jules_api_key is not None
+            and bool(settings.jules_api_key),
             provider_tokens_set=provider_tokens_set,
         )
 
@@ -194,6 +196,7 @@ async def load_settings(
         resp_llm.api_key = None
         settings_with_token_data.search_api_key = None
         settings_with_token_data.sandbox_api_key = None
+        settings_with_token_data.jules_api_key = None
 
         # Marketplace composition: Instance -> Org -> User (additive, name-keyed).
         # ``inherited`` (instance + org) is read-only; ``personal`` is the user's
@@ -293,6 +296,8 @@ async def store_settings(
         if existing_settings:
             if 'search_api_key' not in payload and settings.search_api_key is None:
                 settings.search_api_key = existing_settings.search_api_key
+            if 'jules_api_key' not in payload and settings.jules_api_key is None:
+                settings.jules_api_key = existing_settings.jules_api_key
             if settings.user_consents_to_analytics is None:
                 settings.user_consents_to_analytics = (
                     existing_settings.user_consents_to_analytics

--- a/openhands/app_server/utils/llm.py
+++ b/openhands/app_server/utils/llm.py
@@ -292,13 +292,17 @@ def get_supported_llm_models(
 
     # Assign canonical provider prefixes to bare LiteLLM names, then dedupe.
     all_models = (
-        openhands_models + CLARIFAI_MODELS + ['jules/gemini-3.5-flash'] + [_assign_provider(m) for m in model_list]
+        openhands_models
+        + CLARIFAI_MODELS
+        + ['jules/gemini-3.5-flash']
+        + [_assign_provider(m) for m in model_list]
     )
     unique_models = sorted(set(all_models))
 
     return ModelsResponse(
         models=unique_models,
-        verified_models=_derive_verified_models(openhands_models) + ['gemini-3.5-flash'],
+        verified_models=_derive_verified_models(openhands_models)
+        + ['gemini-3.5-flash'],
         verified_providers=VERIFIED_PROVIDERS,
         default_model=DEFAULT_OPENHANDS_MODEL,
     )

--- a/openhands/app_server/utils/llm.py
+++ b/openhands/app_server/utils/llm.py
@@ -59,7 +59,7 @@ CLARIFAI_MODELS = [
 # instead of ``openai/gpt-5.2``).  The backend uses these sets to assign
 # the canonical provider prefix *before* sending the list to the frontend.
 # ---------------------------------------------------------------------------
-VERIFIED_PROVIDERS: list[str] = list(_SDK_VERIFIED_MODELS.keys())
+VERIFIED_PROVIDERS: list[str] = list(_SDK_VERIFIED_MODELS.keys()) + ['jules']
 
 _BARE_OPENAI_MODELS: set[str] = set(_SDK_OPENAI)
 _BARE_ANTHROPIC_MODELS: set[str] = set(_SDK_ANTHROPIC)
@@ -173,6 +173,9 @@ def get_provider_api_base(model: str) -> str | None:
     Returns:
         The API base URL if found, None otherwise.
     """
+    if model.startswith('jules/'):
+        return 'https://jules.googleapis.com/v1'
+
     # First try get_api_base (handles OpenAI, Gemini with specific URL patterns)
     try:
         api_base = litellm.get_api_base(model, {})
@@ -289,13 +292,13 @@ def get_supported_llm_models(
 
     # Assign canonical provider prefixes to bare LiteLLM names, then dedupe.
     all_models = (
-        openhands_models + CLARIFAI_MODELS + [_assign_provider(m) for m in model_list]
+        openhands_models + CLARIFAI_MODELS + ['jules/gemini-3.5-flash'] + [_assign_provider(m) for m in model_list]
     )
     unique_models = sorted(set(all_models))
 
     return ModelsResponse(
         models=unique_models,
-        verified_models=_derive_verified_models(openhands_models),
+        verified_models=_derive_verified_models(openhands_models) + ['gemini-3.5-flash'],
         verified_providers=VERIFIED_PROVIDERS,
         default_model=DEFAULT_OPENHANDS_MODEL,
     )

--- a/tests/unit/app_server/test_settings_api.py
+++ b/tests/unit/app_server/test_settings_api.py
@@ -352,3 +352,34 @@ def test_store_settings_rejects_duplicate_personal_marketplace_names(test_client
     # Assert
     assert response.status_code == 400
     assert 'dup' in response.json()['error']
+
+
+def test_jules_api_key_settings(test_client):
+    """Test that jules_api_key can be saved, retrieved as a masked/set flag, and is preserved when omitted."""
+    # 1. Save settings with jules_api_key
+    response = test_client.post(
+        '/api/v1/settings',
+        json={'jules_api_key': 'my-super-secret-jules-key'},
+    )
+    assert response.status_code == 200
+
+    # 2. Retrieve settings and check that jules_api_key_set is True and jules_api_key is null/masked on GET
+    response = test_client.get('/api/v1/settings')
+    assert response.status_code == 200
+    data = response.json()
+    assert data['jules_api_key_set'] is True
+    assert data.get('jules_api_key') is None
+
+    # 3. Post a different field and verify that jules_api_key is preserved (not deleted)
+    response = test_client.post(
+        '/api/v1/settings',
+        json={'language': 'ja'},
+    )
+    assert response.status_code == 200
+
+    # 4. Verify it's still set
+    response = test_client.get('/api/v1/settings')
+    assert response.status_code == 200
+    data = response.json()
+    assert data['jules_api_key_set'] is True
+    assert data['language'] == 'ja'

--- a/tests/unit/utils/test_llm_utils.py
+++ b/tests/unit/utils/test_llm_utils.py
@@ -165,3 +165,37 @@ class TestGetProviderApiBase:
         # May return None or an API base depending on litellm behavior
         # The function should not raise an exception
         assert result is None or isinstance(result, str)
+
+
+class TestJulesLLM:
+    """Tests for Jules provider and model support."""
+
+    def test_jules_model_returns_jules_api_base(self):
+        """Test that Jules models return the correct Jules API base URL."""
+        assert get_provider_api_base('jules/gemini-3.5-flash') == 'https://jules.googleapis.com/v1'
+
+    def test_jules_supported_llm_models(self):
+        """Test that Jules provider and models are returned in supported models."""
+        response = llm_utils.get_supported_llm_models()
+        assert 'jules' in response.verified_providers
+        assert 'gemini-3.5-flash' in response.verified_models
+        assert 'jules/gemini-3.5-flash' in response.models
+
+    def test_resolve_profile_llm_with_jules_key(self):
+        """Test that resolve_profile_llm correctly sets keys and headers for jules/ models."""
+        from openhands.app_server.settings.llm_profiles import resolve_profile_llm
+        from openhands.sdk.llm import LLM
+        from pydantic import SecretStr
+
+        profile_llm = LLM(model='jules/gemini-3.5-flash')
+        jules_key = SecretStr('jules-secret-123')
+
+        resolved = resolve_profile_llm(
+            profile_llm,
+            managed_proxy_url='https://proxy',
+            jules_api_key=jules_key,
+        )
+
+        assert resolved.api_key == jules_key
+        assert resolved.extra_headers is not None
+        assert resolved.extra_headers.get('x-goog-api-key') == 'jules-secret-123'

--- a/tests/unit/utils/test_llm_utils.py
+++ b/tests/unit/utils/test_llm_utils.py
@@ -172,7 +172,10 @@ class TestJulesLLM:
 
     def test_jules_model_returns_jules_api_base(self):
         """Test that Jules models return the correct Jules API base URL."""
-        assert get_provider_api_base('jules/gemini-3.5-flash') == 'https://jules.googleapis.com/v1'
+        assert (
+            get_provider_api_base('jules/gemini-3.5-flash')
+            == 'https://jules.googleapis.com/v1'
+        )
 
     def test_jules_supported_llm_models(self):
         """Test that Jules provider and models are returned in supported models."""


### PR DESCRIPTION
HUMAN:- [ ] A human has tested these changes.

---

## Why

OpenHands currently does not provide built-in support for configuring or using Jules models. Users must manually configure endpoints and authentication, making Jules integration more difficult than other supported providers. This PR adds first-class support for Jules models and API keys.

## Summary

- Add support for configuring a dedicated `jules_api_key` in user settings.
- Add support for the `jules` provider and `jules/gemini-3.5-flash` model, including automatic API endpoint resolution and authentication headers.
- Add tests covering settings persistence, provider resolution, authentication, and model discovery.

## Issue Number

N/A

## How to Test

1. Configure a `jules_api_key` in the OpenHands settings.
2. Select `jules/gemini-3.5-flash` as the active model.
3. Verify requests are sent to `https://jules.googleapis.com/v1`.
4. Confirm the `x-goog-api-key` header is included in requests.
5. Update an unrelated setting and verify the Jules API key is preserved.
6. Run the test suite and confirm the new Jules-related tests pass.

## Video/Screenshots

N/A (backend-only change)

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This change is fully backward compatible. Existing providers and user settings continue to work as before. Jules support is opt-in and only applies when a `jules/` model is selected.