### PR TITLE
fix: accept numeric environment toggle values

### DIFF
--- a/openhands/app_server/app.py
+++ b/openhands/app_server/app.py
@@ -71,8 +71,13 @@ async def authentication_error_handler(request: Request, exc: AuthenticationErro
 app.include_router(v1_router.router)
 app.include_router(health_router)
 
+
+def _should_serve_frontend() -> bool:
+    return os.getenv('SERVE_FRONTEND', 'true').lower() in ('true', '1')
+
+
 # Middleware and static file setup (merged from listen.py)
-if os.getenv('SERVE_FRONTEND', 'true').lower() == 'true':
+if _should_serve_frontend():
     if os.path.isdir('./frontend/build'):
         app.mount(
             '/', SPAStaticFiles(directory='./frontend/build', html=True), name='dist'

--- a/openhands/app_server/event/aws_event_service.py
+++ b/openhands/app_server/event/aws_event_service.py
@@ -81,7 +81,7 @@ def _get_default_aws_endpoint_url() -> str | None:
     endpoint_url = os.getenv('AWS_S3_ENDPOINT')
     if not endpoint_url:
         return None
-    secure = os.getenv('AWS_S3_SECURE', 'true').lower() == 'true'
+    secure = os.getenv('AWS_S3_SECURE', 'true').lower() in ('true', '1')
     if secure:
         if not endpoint_url.startswith('https://'):
             endpoint_url = 'https://' + endpoint_url.removeprefix('http://')

--- a/openhands/app_server/file_store/s3.py
+++ b/openhands/app_server/file_store/s3.py
@@ -43,7 +43,7 @@ class S3FileStore(FileStore):
         if self._client is None:
             access_key = os.getenv('AWS_ACCESS_KEY_ID')
             secret_key = os.getenv('AWS_SECRET_ACCESS_KEY')
-            secure = os.getenv('AWS_S3_SECURE', 'true').lower() == 'true'
+            secure = os.getenv('AWS_S3_SECURE', 'true').lower() in ('true', '1')
             endpoint = self._ensure_url_scheme(secure, os.getenv('AWS_S3_ENDPOINT'))
             self._client = boto3.client(
                 's3',

--- a/tests/unit/app_server/file_store/test_file_store.py
+++ b/tests/unit/app_server/file_store/test_file_store.py
@@ -11,6 +11,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import botocore.exceptions
+import pytest
 from google.api_core.exceptions import NotFound
 
 from openhands.app_server.file_store.files import FileStore
@@ -337,3 +338,27 @@ class TestGoogleCloudFileStore(TestCase, _StorageTest):
 class TestS3FileStore(TestCase, _StorageTest):
     def setUp(self):
         self.store = S3FileStore(bucket_name='dear-liza')
+
+
+@pytest.mark.parametrize(
+    ('secure_env', 'expected'),
+    [(None, True), ('true', True), ('1', True), ('false', False), ('0', False)],
+)
+def test_s3_file_store_secure_env(secure_env, expected, monkeypatch):
+    if secure_env is None:
+        monkeypatch.delenv('AWS_S3_SECURE', raising=False)
+    else:
+        monkeypatch.setenv('AWS_S3_SECURE', secure_env)
+
+    client_kwargs = {}
+
+    def create_client(service, **kwargs):
+        assert service == 's3'
+        client_kwargs.update(kwargs)
+        return _MockS3Client()
+
+    monkeypatch.setattr('boto3.client', create_client)
+
+    S3FileStore(bucket_name='dear-liza').client
+
+    assert client_kwargs['use_ssl'] is expected

--- a/tests/unit/app_server/test_app_frontend.py
+++ b/tests/unit/app_server/test_app_frontend.py
@@ -1,0 +1,16 @@
+import pytest
+
+from openhands.app_server.app import _should_serve_frontend
+
+
+@pytest.mark.parametrize(
+    ('serve_frontend', 'expected'),
+    [(None, True), ('true', True), ('1', True), ('false', False), ('0', False)],
+)
+def test_serve_frontend_env(serve_frontend, expected, monkeypatch):
+    if serve_frontend is None:
+        monkeypatch.delenv('SERVE_FRONTEND', raising=False)
+    else:
+        monkeypatch.setenv('SERVE_FRONTEND', serve_frontend)
+
+    assert _should_serve_frontend() is expected

--- a/tests/unit/app_server/test_aws_event_service.py
+++ b/tests/unit/app_server/test_aws_event_service.py
@@ -299,6 +299,27 @@ class TestGetDefaultAwsEndpointUrl:
         result = aws_event_service._get_default_aws_endpoint_url()
         assert result == 'https://minio.example.com:9000'
 
+    @pytest.mark.parametrize(
+        ('secure_env', 'expected_scheme'),
+        [
+            (None, 'https://'),
+            ('true', 'https://'),
+            ('1', 'https://'),
+            ('false', 'http://'),
+            ('0', 'http://'),
+        ],
+    )
+    def test_secure_env_values(self, monkeypatch, secure_env, expected_scheme):
+        monkeypatch.setenv('AWS_S3_ENDPOINT', 'minio.example.com:9000')
+        if secure_env is None:
+            monkeypatch.delenv('AWS_S3_SECURE', raising=False)
+        else:
+            monkeypatch.setenv('AWS_S3_SECURE', secure_env)
+
+        result = aws_event_service._get_default_aws_endpoint_url()
+
+        assert result == f'{expected_scheme}minio.example.com:9000'
+
 
 class TestAwsEventServiceInjectorEndpointUrl:
     """Test cases for AwsEventServiceInjector endpoint_url field."""


### PR DESCRIPTION
HUMAN:

This PR fixes boolean environment variable handling so that both `true` and `1` correctly enable frontend serving and secure S3 connections. It keeps the change focused on the three reported call sites and adds regression tests for the supported true and false values.

- [ ] A human has tested these changes.

## Summary

- accept the documented numeric `1` value for `SERVE_FRONTEND`
- preserve HTTPS when `AWS_S3_SECURE=1` in both file-store and event-service paths
- add focused regression coverage for defaults, `true`/`1`, and `false`/`0`

## Verification

- `58 passed` across the three affected test modules
- staged-file pre-commit checks passed (whitespace, EOF, debug statements, AppMode check, Ruff lint and format)
- independent review completed

Fixes OpenHands/enterprise#57
