### PR TITLE
fix(app-server): support pagination for branch search

### DIFF
--- a/openhands/app_server/git/git_router.py
+++ b/openhands/app_server/git/git_router.py
@@ -20,7 +20,6 @@ from openhands.app_server.git.git_models import (
 )
 from openhands.app_server.integrations.provider import ProviderHandler
 from openhands.app_server.integrations.service_types import (
-    Branch,
     ProviderType,
     Repository,
     SuggestedTask,
@@ -243,30 +242,14 @@ async def search_branches(
     if decoded_page_id is not None:
         page = decoded_page_id
 
-    if query:
-        if page != 1:
-            # TODO(#13883): Support pagination for branch search after refactoring.
-            # The search_branches method does not support paging in the same way as
-            # get_branches - those should be merged into a single paginated method
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail='Pagination not yet supported for branch search queries. Use empty query to list all branches with pagination.',
-            )
-        # Get search results - we'll handle pagination ourselves
-        branches: list[Branch] = await client.search_branches(
-            selected_provider=provider,
-            repository=repository,
-            query=query,
-            per_page=limit + 1,
-        )
-    else:
-        current_page = await client.get_branches(
-            repository=repository,
-            specified_provider=provider,
-            page=page,
-            per_page=limit + 1,
-        )
-        branches = current_page.branches
+    current_page = await client.get_branches(
+        repository=repository,
+        specified_provider=provider,
+        page=page,
+        per_page=limit + 1,
+        query=query or None,
+    )
+    branches = current_page.branches
 
     next_page_id = None
     if len(branches) > limit:

--- a/openhands/app_server/git/git_router.py
+++ b/openhands/app_server/git/git_router.py
@@ -246,15 +246,16 @@ async def search_branches(
         repository=repository,
         specified_provider=provider,
         page=page,
-        per_page=limit + 1,
+        per_page=limit,
         query=query or None,
     )
     branches = current_page.branches
 
-    next_page_id = None
-    if len(branches) > limit:
-        branches = branches[:-1]
-        next_page_id = encode_page_id(page + 1)
+    # Rely on the provider's has_next_page rather than an over-fetch sentinel.
+    # The sentinel approach (fetch limit + 1) is incompatible with offset-based
+    # pagination: the next page would start one item past the sentinel, silently
+    # dropping a branch at every page boundary (see issue #13883).
+    next_page_id = encode_page_id(page + 1) if current_page.has_next_page else None
 
     return BranchPage(items=branches, next_page_id=next_page_id)
 

--- a/openhands/app_server/integrations/azure_devops/service/branches.py
+++ b/openhands/app_server/integrations/azure_devops/service/branches.py
@@ -69,9 +69,17 @@ class AzureDevOpsBranchesMixin(AzureDevOpsMixinBase):
         return all_branches
 
     async def get_paginated_branches(
-        self, repository: str, page: int = 1, per_page: int = 30
+        self,
+        repository: str,
+        page: int = 1,
+        per_page: int = 30,
+        query: str | None = None,
     ) -> PaginatedBranchesResponse:
-        """Get branches for a repository with pagination."""
+        """Get branches for a repository with pagination.
+
+        Azure DevOps returns all refs in a single call, so filtering by
+        ``query`` and pagination are both applied client-side.
+        """
         # Parse repository string: organization/project/repo
         parts = repository.split('/')
         if len(parts) < 3:
@@ -99,6 +107,16 @@ class AzureDevOpsBranchesMixin(AzureDevOpsMixinBase):
 
         response, _ = await self._make_request(url)
         branches_data = response.get('value', [])
+
+        # Filter by query (case-insensitive name match) before paginating
+        if query:
+            lowered = query.lower()
+            branches_data = [
+                branch_data
+                for branch_data in branches_data
+                if lowered
+                in branch_data.get('name', '').replace('refs/heads/', '').lower()
+            ]
 
         # Calculate pagination
         start_idx = (page - 1) * per_page
@@ -137,64 +155,5 @@ class AzureDevOpsBranchesMixin(AzureDevOpsMixinBase):
             has_next_page=has_next_page,
             current_page=page,
             per_page=per_page,
+            total_count=len(branches_data),
         )
-
-    async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
-    ) -> list[Branch]:
-        """Search for branches within a repository."""
-        # Parse repository string: organization/project/repo
-        parts = repository.split('/')
-        if len(parts) < 3:
-            raise ValueError(
-                f'Invalid repository format: {repository}. Expected format: organization/project/repo'
-            )
-
-        org = parts[0]
-        project = parts[1]
-        repo_name = parts[2]
-
-        # URL-encode components to handle spaces and special characters
-        org_enc = self._encode_url_component(org)
-        project_enc = self._encode_url_component(project)
-        repo_enc = self._encode_url_component(repo_name)
-
-        url = f'https://dev.azure.com/{org_enc}/{project_enc}/_apis/git/repositories/{repo_enc}/refs?api-version=7.1&filter=heads/'
-
-        try:
-            response, _ = await self._make_request(url)
-            branches_data = response.get('value', [])
-
-            # Filter branches by query
-            filtered_branches = []
-            for branch_data in branches_data:
-                # Extract branch name from the ref (e.g., "refs/heads/main" -> "main")
-                name = branch_data.get('name', '').replace('refs/heads/', '')
-
-                # Check if query matches branch name
-                if query.lower() in name.lower():
-                    object_id = branch_data.get('objectId', '')
-
-                    # Get commit details for this branch
-                    commit_url = f'https://dev.azure.com/{org_enc}/{project_enc}/_apis/git/repositories/{repo_enc}/commits/{object_id}?api-version=7.1'
-                    try:
-                        commit_data, _ = await self._make_request(commit_url)
-                        last_push_date = commit_data.get('committer', {}).get('date')
-                    except Exception:
-                        last_push_date = None
-
-                    branch = Branch(
-                        name=name,
-                        commit_sha=object_id,
-                        protected=False,  # Skip protected check for search to improve performance
-                        last_push_date=last_push_date,
-                    )
-                    filtered_branches.append(branch)
-
-                    if len(filtered_branches) >= per_page:
-                        break
-
-            return filtered_branches
-        except Exception:
-            # Return empty list on error instead of None
-            return []

--- a/openhands/app_server/integrations/bitbucket/service/branches.py
+++ b/openhands/app_server/integrations/bitbucket/service/branches.py
@@ -42,9 +42,17 @@ class BitBucketBranchesMixin(BitBucketMixinBase):
         return branches
 
     async def get_paginated_branches(
-        self, repository: str, page: int = 1, per_page: int = 30
+        self,
+        repository: str,
+        page: int = 1,
+        per_page: int = 30,
+        query: str | None = None,
     ) -> PaginatedBranchesResponse:
-        """Get branches for a repository with pagination."""
+        """Get branches for a repository with pagination.
+
+        When ``query`` is provided, Bitbucket's ``q`` filter narrows results to
+        branches whose name contains the query while preserving pagination.
+        """
         # Extract owner and repo from the repository string (e.g., "owner/repo")
         parts = repository.split('/')
         if len(parts) < 2:
@@ -60,6 +68,8 @@ class BitBucketBranchesMixin(BitBucketMixinBase):
             'page': page,
             'sort': '-target.date',  # Sort by most recent commit date, descending
         }
+        if query:
+            params['q'] = f'name~"{query}"'
 
         response, _ = await self._make_request(url, params)
 
@@ -85,35 +95,3 @@ class BitBucketBranchesMixin(BitBucketMixinBase):
             per_page=per_page,
             total_count=total_count,
         )
-
-    async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
-    ) -> list[Branch]:
-        """Search branches by name using Bitbucket API with `q` param."""
-        parts = repository.split('/')
-        if len(parts) < 2:
-            raise ValueError(f'Invalid repository name: {repository}')
-
-        owner = parts[-2]
-        repo = parts[-1]
-
-        url = f'{self.BASE_URL}/repositories/{owner}/{repo}/refs/branches'
-        # Bitbucket filtering: name ~ "query"
-        params = {
-            'pagelen': per_page,
-            'q': f'name~"{query}"',
-            'sort': '-target.date',
-        }
-        response, _ = await self._make_request(url, params)
-
-        branches: list[Branch] = []
-        for branch in response.get('values', []):
-            branches.append(
-                Branch(
-                    name=branch.get('name', ''),
-                    commit_sha=branch.get('target', {}).get('hash', ''),
-                    protected=False,
-                    last_push_date=branch.get('target', {}).get('date', None),
-                )
-            )
-        return branches

--- a/openhands/app_server/integrations/bitbucket_data_center/service/branches.py
+++ b/openhands/app_server/integrations/bitbucket_data_center/service/branches.py
@@ -35,9 +35,18 @@ class BitbucketDCBranchesMixin(BitbucketDCMixinBase):
         return [self._parse_branch(branch) for branch in branch_data]
 
     async def get_paginated_branches(
-        self, repository: str, page: int = 1, per_page: int = 30
+        self,
+        repository: str,
+        page: int = 1,
+        per_page: int = 30,
+        query: str | None = None,
     ) -> PaginatedBranchesResponse:
-        """Get branches for a repository with pagination."""
+        """Get branches for a repository with pagination.
+
+        When ``query`` is provided, Bitbucket Data Center's ``filterText``
+        parameter narrows results to matching branch names while preserving
+        pagination.
+        """
         # Extract owner and repo from the repository string (e.g., "owner/repo")
         owner, repo = self._extract_owner_and_repo(repository)
         parts = repository.split('/')
@@ -55,6 +64,8 @@ class BitbucketDCBranchesMixin(BitbucketDCMixinBase):
             'start': start,
             'orderBy': 'MODIFICATION',
         }
+        if query:
+            params['filterText'] = query
 
         response, _ = await self._make_request(url, params)
 
@@ -70,23 +81,6 @@ class BitbucketDCBranchesMixin(BitbucketDCMixinBase):
             per_page=per_page,
             total_count=total_count,
         )
-
-    async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
-    ) -> list[Branch]:
-        """Search branches by name using Bitbucket data center API with `q` param."""
-        owner, repo = self._extract_owner_and_repo(repository)
-
-        url = f'{self._repo_api_base(owner, repo)}/branches'
-        params = {
-            'limit': per_page,
-            'filterText': query,
-            'orderBy': 'MODIFICATION',
-        }
-
-        response, _ = await self._make_request(url, params)
-
-        return [self._parse_branch(branch) for branch in response.get('values', [])]
 
     def _parse_branch(self, branch: dict) -> Branch:
         """Normalize Bitbucket branch representations across Cloud and Server."""

--- a/openhands/app_server/integrations/forgejo/service/branches.py
+++ b/openhands/app_server/integrations/forgejo/service/branches.py
@@ -25,8 +25,17 @@ class ForgejoBranchesMixin(ForgejoMixinBase):
         return branches
 
     async def get_paginated_branches(
-        self, repository: str, page: int = 1, per_page: int = 30
+        self,
+        repository: str,
+        page: int = 1,
+        per_page: int = 30,
+        query: str | None = None,
     ) -> PaginatedBranchesResponse:  # type: ignore[override]
+        if query:
+            return await self._search_paginated_branches(
+                repository, page, per_page, query
+            )
+
         owner, repo = self._split_repo(repository)
         url = self._build_repo_api_url(owner, repo, 'branches')
         params = {
@@ -67,11 +76,26 @@ class ForgejoBranchesMixin(ForgejoMixinBase):
             total_count=total_count,
         )
 
-    async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
-    ) -> list[Branch]:  # type: ignore[override]
+    async def _search_paginated_branches(
+        self, repository: str, page: int, per_page: int, query: str
+    ) -> PaginatedBranchesResponse:
+        """Filter branches by name client-side, then paginate.
+
+        Forgejo's branches API has no server-side search parameter, so all
+        branches are fetched, filtered, and paginated in-process.
+        """
         all_branches = await self.get_branches(repository)
         lowered = query.lower()
-        return [branch for branch in all_branches if lowered in branch.name.lower()][
-            :per_page
-        ]
+        matches = [branch for branch in all_branches if lowered in branch.name.lower()]
+
+        start = (page - 1) * per_page
+        page_branches = matches[start : start + per_page]
+        has_next_page = len(matches) > start + per_page
+
+        return PaginatedBranchesResponse(
+            branches=page_branches,
+            has_next_page=has_next_page,
+            current_page=page,
+            per_page=per_page,
+            total_count=len(matches),
+        )

--- a/openhands/app_server/integrations/github/queries.py
+++ b/openhands/app_server/integrations/github/queries.py
@@ -137,6 +137,10 @@ search_branches_graphql_query = """
                 first: $perPage,
                 orderBy: { field: ALPHABETICAL, direction: ASC }
             ) {
+                totalCount
+                pageInfo {
+                    hasNextPage
+                }
                 nodes {
                     name
                     target {

--- a/openhands/app_server/integrations/github/service/branches_prs.py
+++ b/openhands/app_server/integrations/github/service/branches_prs.py
@@ -61,9 +61,23 @@ class GitHubBranchesMixin(GitHubMixinBase):
         return all_branches
 
     async def get_paginated_branches(
-        self, repository: str, page: int = 1, per_page: int = 30
+        self,
+        repository: str,
+        page: int = 1,
+        per_page: int = 30,
+        query: str | None = None,
     ) -> PaginatedBranchesResponse:
-        """Get branches for a repository with pagination"""
+        """Get branches for a repository with pagination.
+
+        When ``query`` is provided, branches are filtered by name using the
+        GitHub GraphQL ``refs`` search and paginated with the same page/per_page
+        contract used for plain listing.
+        """
+        if query:
+            return await self._search_paginated_branches(
+                repository, page, per_page, query
+            )
+
         url = f'{self.BASE_URL}/repos/{repository}/branches'
 
         params = {'per_page': str(per_page), 'page': str(page)}
@@ -102,28 +116,36 @@ class GitHubBranchesMixin(GitHubMixinBase):
             total_count=None,  # GitHub doesn't provide total count in branch API
         )
 
-    async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
-    ) -> list[Branch]:
-        """Search branches by name using GitHub GraphQL with a partial query."""
-        # Require a non-empty query
-        if not query:
-            return []
+    async def _search_paginated_branches(
+        self, repository: str, page: int, per_page: int, query: str
+    ) -> PaginatedBranchesResponse:
+        """Search branches by name via GitHub GraphQL with page-based pagination.
 
-        # Clamp per_page to GitHub GraphQL limits
+        GitHub's GraphQL ``refs`` connection is cursor-based; we emulate
+        page-based pagination by fetching up to ``page * per_page`` matches
+        (clamped to GitHub's 100-item limit) and slicing the requested page.
+        """
+        # GitHub GraphQL caps the connection page size at 100.
         per_page = min(max(per_page, 1), 100)
+        fetch_count = min(max(page, 1) * per_page, 100)
 
         # Extract owner and repo name from the repository string
         parts = repository.split('/')
         if len(parts) < 2:
-            return []
+            return PaginatedBranchesResponse(
+                branches=[],
+                has_next_page=False,
+                current_page=page,
+                per_page=per_page,
+                total_count=0,
+            )
         owner, name = parts[-2], parts[-1]
 
         variables = {
             'owner': owner,
             'name': name,
-            'query': query or '',
-            'perPage': per_page,
+            'query': query,
+            'perPage': fetch_count,
         }
 
         try:
@@ -133,14 +155,27 @@ class GitHubBranchesMixin(GitHubMixinBase):
         except Exception as e:
             logger.warning(f'Failed to search for branches: {e}')
             # Fallback to empty result on any GraphQL error
-            return []
+            return PaginatedBranchesResponse(
+                branches=[],
+                has_next_page=False,
+                current_page=page,
+                per_page=per_page,
+                total_count=None,
+            )
 
         repo = result.get('data', {}).get('repository')
-        if not repo or not repo.get('refs'):
-            return []
+        refs = repo.get('refs') if repo else None
+        if not refs:
+            return PaginatedBranchesResponse(
+                branches=[],
+                has_next_page=False,
+                current_page=page,
+                per_page=per_page,
+                total_count=0,
+            )
 
-        branches: list[Branch] = []
-        for node in repo['refs'].get('nodes', []):
+        all_branches: list[Branch] = []
+        for node in refs.get('nodes', []):
             bname = node.get('name') or ''
             target = node.get('target') or {}
             typename = target.get('__typename')
@@ -152,7 +187,7 @@ class GitHubBranchesMixin(GitHubMixinBase):
 
             protected = node.get('branchProtectionRule') is not None
 
-            branches.append(
+            all_branches.append(
                 Branch(
                     name=bname,
                     commit_sha=commit_sha,
@@ -161,4 +196,19 @@ class GitHubBranchesMixin(GitHubMixinBase):
                 )
             )
 
-        return branches
+        start = (page - 1) * per_page
+        page_branches = all_branches[start : start + per_page]
+
+        # There is a next page if either the current fetch already holds more
+        # matches beyond this page, or GraphQL reports additional matches that
+        # were truncated by the 100-item fetch limit.
+        graphql_has_next = bool(refs.get('pageInfo', {}).get('hasNextPage'))
+        has_next_page = len(all_branches) > start + per_page or graphql_has_next
+
+        return PaginatedBranchesResponse(
+            branches=page_branches,
+            has_next_page=has_next_page,
+            current_page=page,
+            per_page=per_page,
+            total_count=refs.get('totalCount'),
+        )

--- a/openhands/app_server/integrations/gitlab/service/branches.py
+++ b/openhands/app_server/integrations/gitlab/service/branches.py
@@ -80,7 +80,7 @@ class GitLabBranchesMixin(GitLabMixinBase):
 
         has_next_page = False
         total_count = None
-        if headers.get('Link', ''):
+        if 'rel="next"' in headers.get('Link', ''):
             has_next_page = True
 
         if 'X-Total' in headers:

--- a/openhands/app_server/integrations/gitlab/service/branches.py
+++ b/openhands/app_server/integrations/gitlab/service/branches.py
@@ -49,13 +49,23 @@ class GitLabBranchesMixin(GitLabMixinBase):
         return all_branches
 
     async def get_paginated_branches(
-        self, repository: str, page: int = 1, per_page: int = 30
+        self,
+        repository: str,
+        page: int = 1,
+        per_page: int = 30,
+        query: str | None = None,
     ) -> PaginatedBranchesResponse:
-        """Get branches for a repository with pagination"""
+        """Get branches for a repository with pagination.
+
+        When ``query`` is provided, GitLab's ``search`` parameter filters
+        branches by name while preserving pagination.
+        """
         encoded_name = repository.replace('/', '%2F')
         url = f'{self.BASE_URL}/projects/{encoded_name}/repository/branches'
 
         params = {'per_page': str(per_page), 'page': str(page)}
+        if query:
+            params['search'] = query
         response, headers = await self._make_request(url, params)
 
         branches: list[Branch] = []
@@ -86,25 +96,3 @@ class GitLabBranchesMixin(GitLabMixinBase):
             per_page=per_page,
             total_count=total_count,
         )
-
-    async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
-    ) -> list[Branch]:
-        """Search branches using GitLab API which supports `search` param."""
-        encoded_name = repository.replace('/', '%2F')
-        url = f'{self.BASE_URL}/projects/{encoded_name}/repository/branches'
-
-        params = {'per_page': str(per_page), 'search': query}
-        response, _ = await self._make_request(url, params)
-
-        branches: list[Branch] = []
-        for branch_data in response:
-            branches.append(
-                Branch(
-                    name=branch_data.get('name'),
-                    commit_sha=branch_data.get('commit', {}).get('id', ''),
-                    protected=branch_data.get('protected', False),
-                    last_push_date=branch_data.get('commit', {}).get('committed_date'),
-                )
-            )
-        return branches

--- a/openhands/app_server/integrations/provider.py
+++ b/openhands/app_server/integrations/provider.py
@@ -31,7 +31,6 @@ from openhands.app_server.integrations.gitlab.constants import GITLAB_HOST
 from openhands.app_server.integrations.gitlab.gitlab_service import GitLabServiceImpl
 from openhands.app_server.integrations.service_types import (
     AuthenticationError,
-    Branch,
     GitService,
     InstallationsService,
     PaginatedBranchesResponse,
@@ -323,33 +322,6 @@ class ProviderHandler:
 
         return tasks
 
-    async def search_branches(
-        self,
-        selected_provider: ProviderType | None,
-        repository: str,
-        query: str,
-        per_page: int = 30,
-    ) -> list[Branch]:
-        """Search for branches within a repository using the appropriate provider service."""
-        if selected_provider:
-            service = self.get_service(selected_provider)
-            try:
-                return await service.search_branches(repository, query, per_page)
-            except Exception as e:
-                logger.warning(
-                    f'Error searching branches from selected provider {selected_provider}: {e}'
-                )
-                return []
-
-        # If provider not specified, determine provider by verifying repository access
-        try:
-            repo_details = await self.verify_repo_provider(repository)
-            service = self.get_service(repo_details.git_provider)
-            return await service.search_branches(repository, query, per_page)
-        except Exception as e:
-            logger.warning(f'Error searching branches for {repository}: {e}')
-            return []
-
     async def search_repositories(
         self,
         selected_provider: ProviderType | None,
@@ -460,6 +432,7 @@ class ProviderHandler:
         specified_provider: ProviderType | None = None,
         page: int = 1,
         per_page: int = 30,
+        query: str | None = None,
     ) -> PaginatedBranchesResponse:
         """Get branches for a repository
 
@@ -468,6 +441,9 @@ class ProviderHandler:
             specified_provider: Optional provider type to use
             page: Page number for pagination (default: 1)
             per_page: Number of branches per page (default: 30)
+            query: Optional branch name filter. When provided, only branches
+                matching the query are returned, paginated the same way as a
+                plain listing.
 
         Returns:
             A paginated response with branches for the repository
@@ -475,7 +451,9 @@ class ProviderHandler:
         if specified_provider:
             try:
                 service = self.get_service(specified_provider)
-                return await service.get_paginated_branches(repository, page, per_page)
+                return await service.get_paginated_branches(
+                    repository, page, per_page, query
+                )
             except Exception as e:
                 logger.warning(
                     f'Error fetching branches from {specified_provider}: {e}'
@@ -484,7 +462,9 @@ class ProviderHandler:
         for provider in self.provider_tokens:
             try:
                 service = self.get_service(provider)
-                return await service.get_paginated_branches(repository, page, per_page)
+                return await service.get_paginated_branches(
+                    repository, page, per_page, query
+                )
             except Exception as e:
                 logger.warning(f'Error fetching branches from {provider}: {e}')
 

--- a/openhands/app_server/integrations/service_types.py
+++ b/openhands/app_server/integrations/service_types.py
@@ -299,14 +299,18 @@ class GitService(Protocol):
         """Get branches for a repository"""
 
     async def get_paginated_branches(
-        self, repository: str, page: int = 1, per_page: int = 30
+        self,
+        repository: str,
+        page: int = 1,
+        per_page: int = 30,
+        query: str | None = None,
     ) -> PaginatedBranchesResponse:
-        """Get branches for a repository with pagination"""
+        """Get branches for a repository with pagination.
 
-    async def search_branches(
-        self, repository: str, query: str, per_page: int = 30
-    ) -> list[Branch]:
-        """Search for branches within a repository"""
+        When ``query`` is provided, results are filtered to branches whose name
+        matches the query, while preserving the same pagination contract used
+        for plain branch listing.
+        """
 
     async def get_pr_details(self, repository: str, pr_number: int) -> dict:
         """Get detailed information about a specific pull request/merge request

--- a/tests/unit/app_server/test_git_router.py
+++ b/tests/unit/app_server/test_git_router.py
@@ -714,11 +714,10 @@ class TestSearchBranches:
                 branches=[
                     Branch(name='main', commit_sha='abc123', protected=False),
                     Branch(name='develop', commit_sha='def456', protected=False),
-                    Branch(name='feature-branch', commit_sha='ghi789', protected=False),
                 ],
                 has_next_page=True,
                 current_page=1,
-                per_page=3,
+                per_page=2,
             )
         )
         mock_handler_cls.return_value = mock_handler
@@ -740,7 +739,8 @@ class TestSearchBranches:
             user_context=mock_context,
         )
 
-        # Assert
+        # Assert: branches are returned verbatim (no over-fetch sentinel), and
+        # next_page_id is driven by the provider's has_next_page flag.
         assert len(result.items) == 2
         assert result.items[0].name == 'main'
         assert result.items[1].name == 'develop'
@@ -757,7 +757,7 @@ class TestSearchBranches:
                 branches=[],
                 has_next_page=False,
                 current_page=1,
-                per_page=11,
+                per_page=10,
             )
         )
         mock_handler_cls.return_value = mock_handler
@@ -770,7 +770,7 @@ class TestSearchBranches:
         )
 
         # Act
-        await search_branches(
+        result = await search_branches(
             provider=ProviderType.GITHUB,
             repository='user/repo',
             query='feature',
@@ -786,7 +786,11 @@ class TestSearchBranches:
         assert call_kwargs.get('repository') == 'user/repo'
         assert call_kwargs.get('query') == 'feature'
         assert call_kwargs.get('page') == 1
-        assert call_kwargs.get('per_page') == 11  # limit + 1
+        # per_page equals the requested limit: pagination is driven by the
+        # provider's has_next_page flag, not an over-fetch sentinel.
+        assert call_kwargs.get('per_page') == 10
+        # Last page (has_next_page=False) yields no next_page_id.
+        assert result.next_page_id is None
 
     @pytest.mark.asyncio
     @patch('openhands.app_server.git.git_router.ProviderHandler')
@@ -799,11 +803,10 @@ class TestSearchBranches:
                 branches=[
                     Branch(name='feature-3', commit_sha='c3', protected=False),
                     Branch(name='feature-4', commit_sha='c4', protected=False),
-                    Branch(name='feature-5', commit_sha='c5', protected=False),
                 ],
                 has_next_page=True,
                 current_page=2,
-                per_page=3,
+                per_page=2,
             )
         )
         mock_handler_cls.return_value = mock_handler

--- a/tests/unit/app_server/test_git_router.py
+++ b/tests/unit/app_server/test_git_router.py
@@ -21,6 +21,7 @@ from openhands.app_server.git.git_router import (
 from openhands.app_server.integrations.provider import ProviderToken
 from openhands.app_server.integrations.service_types import (
     Branch,
+    PaginatedBranchesResponse,
     ProviderType,
     Repository,
     SuggestedTask,
@@ -708,12 +709,17 @@ class TestSearchBranches:
         """Test that search branches are returned with pagination."""
         # Arrange
         mock_handler = MagicMock()
-        mock_handler.search_branches = AsyncMock(
-            return_value=[
-                Branch(name='main', commit_sha='abc123', protected=False),
-                Branch(name='develop', commit_sha='def456', protected=False),
-                Branch(name='feature-branch', commit_sha='ghi789', protected=False),
-            ]
+        mock_handler.get_branches = AsyncMock(
+            return_value=PaginatedBranchesResponse(
+                branches=[
+                    Branch(name='main', commit_sha='abc123', protected=False),
+                    Branch(name='develop', commit_sha='def456', protected=False),
+                    Branch(name='feature-branch', commit_sha='ghi789', protected=False),
+                ],
+                has_next_page=True,
+                current_page=1,
+                per_page=3,
+            )
         )
         mock_handler_cls.return_value = mock_handler
 
@@ -746,7 +752,14 @@ class TestSearchBranches:
         """Test that all parameters are passed through to the provider."""
         # Arrange
         mock_handler = MagicMock()
-        mock_handler.search_branches = AsyncMock(return_value=[])
+        mock_handler.get_branches = AsyncMock(
+            return_value=PaginatedBranchesResponse(
+                branches=[],
+                has_next_page=False,
+                current_page=1,
+                per_page=11,
+            )
+        )
         mock_handler_cls.return_value = mock_handler
 
         mock_context = _make_mock_user_context(
@@ -767,12 +780,58 @@ class TestSearchBranches:
         )
 
         # Assert
-        mock_handler.search_branches.assert_called_once()
-        call_kwargs = mock_handler.search_branches.call_args.kwargs
-        assert call_kwargs.get('selected_provider') == ProviderType.GITHUB
+        mock_handler.get_branches.assert_called_once()
+        call_kwargs = mock_handler.get_branches.call_args.kwargs
+        assert call_kwargs.get('specified_provider') == ProviderType.GITHUB
         assert call_kwargs.get('repository') == 'user/repo'
         assert call_kwargs.get('query') == 'feature'
+        assert call_kwargs.get('page') == 1
         assert call_kwargs.get('per_page') == 11  # limit + 1
+
+    @pytest.mark.asyncio
+    @patch('openhands.app_server.git.git_router.ProviderHandler')
+    async def test_paginates_search_with_page_id(self, mock_handler_cls):
+        """Passing a page_id with a query returns that page (no longer a 400)."""
+        # Arrange
+        mock_handler = MagicMock()
+        mock_handler.get_branches = AsyncMock(
+            return_value=PaginatedBranchesResponse(
+                branches=[
+                    Branch(name='feature-3', commit_sha='c3', protected=False),
+                    Branch(name='feature-4', commit_sha='c4', protected=False),
+                    Branch(name='feature-5', commit_sha='c5', protected=False),
+                ],
+                has_next_page=True,
+                current_page=2,
+                per_page=3,
+            )
+        )
+        mock_handler_cls.return_value = mock_handler
+
+        mock_context = _make_mock_user_context(
+            provider_tokens={
+                ProviderType.GITHUB: ProviderToken(user_id='user-123', token='token')
+            },
+            user_id='user-123',
+        )
+
+        # Act: request page 2 of a search
+        result = await search_branches(
+            provider=ProviderType.GITHUB,
+            repository='user/repo',
+            query='feature',
+            page_id=encode_page_id(2),
+            limit=2,
+            user_context=mock_context,
+        )
+
+        # Assert: second page returned, query + page forwarded to provider
+        assert len(result.items) == 2
+        assert result.items[0].name == 'feature-3'
+        assert result.next_page_id == encode_page_id(3)
+        call_kwargs = mock_handler.get_branches.call_args.kwargs
+        assert call_kwargs.get('query') == 'feature'
+        assert call_kwargs.get('page') == 2
 
     def test_returns_403_when_no_provider_tokens(self, test_client):
         """Test that 403 is returned when no provider tokens."""

--- a/tests/unit/integrations/bitbucket/test_bitbucket_branches.py
+++ b/tests/unit/integrations/bitbucket/test_bitbucket_branches.py
@@ -65,21 +65,29 @@ async def test_search_branches_bitbucket_filters_by_name_contains():
                 'name': 'bugfix/issue-1',
                 'target': {'hash': 'hhh', 'date': '2024-01-10T10:00:00Z'},
             }
-        ]
+        ],
+        'next': 'https://api.bitbucket.org/2.0/repositories/w/r/refs/branches?page=2',
+        'size': 4,
     }
 
     with patch.object(service, '_make_request', return_value=(mock_response, {})) as m:
-        branches = await service.search_branches('w/r', query='bugfix', per_page=15)
+        res = await service.get_paginated_branches(
+            'w/r', page=1, per_page=15, query='bugfix'
+        )
 
-        args, kwargs = m.call_args
+        args, _kwargs = m.call_args
         url = args[0]
         params = args[1]
         assert 'refs/branches' in url
         assert params['pagelen'] == 15
+        assert params['page'] == 1
         assert params['q'] == 'name~"bugfix"'
         assert params['sort'] == '-target.date'
 
-        assert branches == [
+        assert isinstance(res, PaginatedBranchesResponse)
+        assert res.has_next_page is True
+        assert res.total_count == 4
+        assert res.branches == [
             Branch(
                 name='bugfix/issue-1',
                 commit_sha='hhh',

--- a/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_branches.py
+++ b/tests/unit/integrations/bitbucket_data_center/test_bitbucket_dc_branches.py
@@ -1,4 +1,4 @@
-"""Tests for BitbucketDCBranchesMixin: get_paginated_branches, search_branches, get_branches."""
+"""Tests for BitbucketDCBranchesMixin: get_paginated_branches (list + search), get_branches."""
 
 from unittest.mock import patch
 
@@ -107,21 +107,29 @@ async def test_get_paginated_branches_total_count():
 @pytest.mark.asyncio
 async def test_search_branches_uses_filter_text():
     svc = make_service()
-    mock_response = {'values': [_dc_branch('feature/my-thing', 'sha1')]}
+    mock_response = {
+        'values': [_dc_branch('feature/my-thing', 'sha1')],
+        'isLastPage': False,
+        'size': 3,
+    }
 
     with patch.object(
         svc, '_make_request', return_value=(mock_response, {})
     ) as mock_req:
-        branches = await svc.search_branches(
-            'PROJ/myrepo', query='my-thing', per_page=15
+        res = await svc.get_paginated_branches(
+            'PROJ/myrepo', page=1, per_page=15, query='my-thing'
         )
 
     call_url, call_params = mock_req.call_args[0]
     assert 'filterText' in call_params
     assert call_params['filterText'] == 'my-thing'
+    assert call_params['limit'] == 15
+    assert call_params['start'] == 0
     assert 'q' not in call_params
-    assert len(branches) == 1
-    assert branches[0].name == 'feature/my-thing'
+    assert res.has_next_page is True
+    assert res.total_count == 3
+    assert len(res.branches) == 1
+    assert res.branches[0].name == 'feature/my-thing'
 
 
 # ── get_branches (all pages via _fetch_paginated_data) ───────────────────────

--- a/tests/unit/integrations/github/test_github_branches.py
+++ b/tests/unit/integrations/github/test_github_branches.py
@@ -94,6 +94,8 @@ async def test_search_branches_github_success_and_variables():
         'data': {
             'repository': {
                 'refs': {
+                    'totalCount': 2,
+                    'pageInfo': {'hasNextPage': False},
                     'nodes': [
                         {
                             'name': 'feature/bar',
@@ -112,7 +114,7 @@ async def test_search_branches_github_success_and_variables():
                             },
                             'branchProtectionRule': None,
                         },
-                    ]
+                    ],
                 }
             }
         }
@@ -120,19 +122,24 @@ async def test_search_branches_github_success_and_variables():
 
     exec_mock = AsyncMock(return_value=graphql_result)
     with patch.object(service, 'execute_graphql_query', exec_mock) as mock_exec:
-        branches = await service.search_branches('foo/bar', query='fe', per_page=999)
+        result = await service.get_paginated_branches(
+            'foo/bar', page=1, per_page=999, query='fe'
+        )
 
         # per_page should be clamped to <= 100 when passed to GraphQL variables
-        args, kwargs = mock_exec.call_args
-        _query = args[0]
+        args, _kwargs = mock_exec.call_args
         variables = args[1]
         assert variables['owner'] == 'foo'
         assert variables['name'] == 'bar'
         assert variables['query'] == 'fe'
         assert 1 <= variables['perPage'] <= 100
 
-        assert len(branches) == 2
-        b0, b1 = branches
+        assert isinstance(result, PaginatedBranchesResponse)
+        assert result.current_page == 1
+        assert result.total_count == 2
+        assert result.has_next_page is False
+        assert len(result.branches) == 2
+        b0, b1 = result.branches
         assert b0.name == 'feature/bar'
         assert b0.commit_sha == 'aaa111'
         assert b0.protected is True
@@ -146,18 +153,59 @@ async def test_search_branches_github_success_and_variables():
 
 
 @pytest.mark.asyncio
+async def test_search_branches_github_paginates_results():
+    """Search results are paginated by page/per_page using GraphQL slicing."""
+    service = GitHubService(token=SecretStr('t'))
+
+    nodes = [
+        {
+            'name': f'feature/{i}',
+            'target': {
+                '__typename': 'Commit',
+                'oid': f'sha{i}',
+                'committedDate': '2024-01-05T10:00:00Z',
+            },
+            'branchProtectionRule': None,
+        }
+        for i in range(3)
+    ]
+    graphql_result = {
+        'data': {
+            'repository': {
+                'refs': {
+                    'totalCount': 3,
+                    'pageInfo': {'hasNextPage': False},
+                    'nodes': nodes,
+                }
+            }
+        }
+    }
+
+    exec_mock = AsyncMock(return_value=graphql_result)
+    with patch.object(service, 'execute_graphql_query', exec_mock):
+        page1 = await service.get_paginated_branches(
+            'foo/bar', page=1, per_page=2, query='feature'
+        )
+        assert [b.name for b in page1.branches] == ['feature/0', 'feature/1']
+        assert page1.has_next_page is True
+
+        page2 = await service.get_paginated_branches(
+            'foo/bar', page=2, per_page=2, query='feature'
+        )
+        assert [b.name for b in page2.branches] == ['feature/2']
+        assert page2.has_next_page is False
+
+
+@pytest.mark.asyncio
 async def test_search_branches_github_edge_cases():
     service = GitHubService(token=SecretStr('t'))
 
-    # Empty query should return [] without issuing a GraphQL call
-    branches = await service.search_branches('foo/bar', query='')
-    assert branches == []
-
-    # Invalid repository string should return [] without calling GraphQL
+    # Invalid repository string should return an empty page without calling GraphQL
     exec_mock = AsyncMock()
     with patch.object(service, 'execute_graphql_query', exec_mock):
-        branches = await service.search_branches('invalidrepo', query='q')
-        assert branches == []
+        result = await service.get_paginated_branches('invalidrepo', query='q')
+        assert isinstance(result, PaginatedBranchesResponse)
+        assert result.branches == []
         exec_mock.assert_not_called()
 
 
@@ -167,5 +215,7 @@ async def test_search_branches_github_graphql_error_returns_empty():
 
     exec_mock = AsyncMock(side_effect=Exception('Boom'))
     with patch.object(service, 'execute_graphql_query', exec_mock):
-        branches = await service.search_branches('foo/bar', query='q')
-        assert branches == []
+        result = await service.get_paginated_branches('foo/bar', query='q')
+        assert isinstance(result, PaginatedBranchesResponse)
+        assert result.branches == []
+        assert result.has_next_page is False

--- a/tests/unit/integrations/gitlab/test_gitlab_branches.py
+++ b/tests/unit/integrations/gitlab/test_gitlab_branches.py
@@ -93,28 +93,39 @@ async def test_search_branches_gitlab_uses_search_param():
             'protected': True,
         },
     ]
+    headers = {
+        'Link': '<https://gitlab.com/api/v4/projects/1/repository/branches?page=3>; rel="next"',
+        'X-Total': '5',
+    }
 
-    with patch.object(service, '_make_request', return_value=(mock_response, {})) as m:
-        branches = await service.search_branches(
-            'group/repo', query='feat', per_page=50
+    with patch.object(
+        service, '_make_request', return_value=(mock_response, headers)
+    ) as m:
+        result = await service.get_paginated_branches(
+            'group/repo', page=2, per_page=50, query='feat'
         )
 
-        # Verify parameters
-        args, kwargs = m.call_args
+        # Verify parameters: search filter + pagination are both sent
+        args, _kwargs = m.call_args
         url = args[0]
         params = args[1]
         assert 'repository/branches' in url
         assert params['per_page'] == '50'
+        assert params['page'] == '2'
         assert params['search'] == 'feat'
 
-        assert len(branches) == 2
-        assert branches[0] == Branch(
+        assert isinstance(result, PaginatedBranchesResponse)
+        assert result.current_page == 2
+        assert result.has_next_page is True
+        assert result.total_count == 5
+        assert len(result.branches) == 2
+        assert result.branches[0] == Branch(
             name='feat/new',
             commit_sha='111',
             protected=False,
             last_push_date='2024-01-04T00:00:00Z',
         )
-        assert branches[1] == Branch(
+        assert result.branches[1] == Branch(
             name='feature/xyz',
             commit_sha='222',
             protected=True,


### PR DESCRIPTION
Merge branch search into the paginated get_paginated_branches contract so that passing a page_id together with a query returns the requested search page instead of a 400.

- add optional query param to get_paginated_branches across GitHub, GitLab, Bitbucket Cloud, Bitbucket Data Center, Azure DevOps and Forgejo
- route both listing and search through ProviderHandler.get_branches
- remove the now-redundant search_branches methods and the 400 guard
- GitHub paginates GraphQL refs by page/per_page; Azure DevOps and Forgejo filter+paginate client-side; other providers use native filters
- update unit tests and add paginated-search coverage

Fixes OpenHands/enterprise#22

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:


- [x] A human has tested these changes.

AGENT:

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->
