### PR TITLE
fix: retry idempotent runtime-api reads once on timeout

### DIFF
--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -127,17 +127,28 @@ class RemoteSandboxService(SandboxService):
         self, method: str, path: str, **kwargs: Any
     ) -> httpx.Response:
         """Send a request to the remote runtime API."""
-        try:
-            url = self.api_url + path
-            return await self.httpx_client.request(
-                method, url, headers={'X-API-Key': self.api_key}, **kwargs
-            )
-        except httpx.TimeoutException:
-            _logger.error(f'No response received within timeout for URL: {url}')
-            raise
-        except httpx.HTTPError as e:
-            _logger.error(f'HTTP error for URL {url}: {e}')
-            raise
+        url = self.api_url + path
+        # A stalled runtime-api request (e.g. dead pooled DB connection on its
+        # side) times out once, while a retry on a fresh connection succeeds —
+        # so retry idempotent reads once instead of failing conversation start.
+        attempts = 2 if method in ('GET', 'HEAD') else 1
+        last_exc: httpx.TimeoutException | None = None
+        for attempt in range(attempts):
+            try:
+                return await self.httpx_client.request(
+                    method, url, headers={'X-API-Key': self.api_key}, **kwargs
+                )
+            except httpx.TimeoutException as e:
+                last_exc = e
+                if attempt + 1 < attempts:
+                    _logger.warning(f'Timeout for URL {url}; retrying')
+                    continue
+                _logger.error(f'No response received within timeout for URL: {url}')
+                raise
+            except httpx.HTTPError as e:
+                _logger.error(f'HTTP error for URL {url}: {e}')
+                raise
+        raise last_exc  # type: ignore[misc]  # unreachable; keeps mypy happy
 
     def _to_sandbox_info(
         self, stored: StoredRemoteSandbox, runtime: dict[str, Any] | None = None

--- a/tests/unit/app_server/test_remote_sandbox_service.py
+++ b/tests/unit/app_server/test_remote_sandbox_service.py
@@ -212,6 +212,42 @@ class TestRemoteSandboxService:
             await remote_sandbox_service._send_runtime_api_request('GET', '/test')
 
     @pytest.mark.asyncio
+    async def test_send_runtime_api_request_get_retries_once_on_timeout(
+        self, remote_sandbox_service
+    ):
+        """A timed-out idempotent read is retried once and can succeed."""
+        # Setup
+        mock_response = MagicMock()
+        remote_sandbox_service.httpx_client.request.side_effect = [
+            httpx.TimeoutException('Request timeout'),
+            mock_response,
+        ]
+
+        # Execute
+        response = await remote_sandbox_service._send_runtime_api_request(
+            'GET', '/test'
+        )
+
+        # Verify
+        assert response == mock_response
+        assert remote_sandbox_service.httpx_client.request.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_send_runtime_api_request_post_does_not_retry(
+        self, remote_sandbox_service
+    ):
+        """Non-idempotent requests are not retried on timeout."""
+        # Setup
+        remote_sandbox_service.httpx_client.request.side_effect = (
+            httpx.TimeoutException('Request timeout')
+        )
+
+        # Execute & Verify
+        with pytest.raises(httpx.TimeoutException):
+            await remote_sandbox_service._send_runtime_api_request('POST', '/start')
+        assert remote_sandbox_service.httpx_client.request.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_send_runtime_api_request_http_error(self, remote_sandbox_service):
         """Test API request HTTP error handling."""
         # Setup


### PR DESCRIPTION
HUMAN: Companion to OpenHands/runtime-api#640. A customer's conversation starts returned 500s when a runtime-api control-plane read (`GET /list` in `pause_old_sandboxes`) timed out on a stalled request — while an immediate manual retry succeeded in ~0.1-1s (verified in their support bundle and reproduced live). This makes that retry automatic.

- [x] A human has tested these changes.

## Change

`_send_runtime_api_request` retries **idempotent reads (GET/HEAD) once** after an `httpx.TimeoutException`. Writes (`POST /start` etc.) are not retried — they create state and runtime-api's dedupe semantics aren't guaranteed.

Why one retry is enough here: the stall comes from a dead pooled DB connection on the runtime-api side (silently dropped by a firewall); a retried read is a new request that almost always checks out a fresh connection. Reproduced both halves on a live install: frozen connection → first `/list` times out, immediate second `/list` returns 200 in 0.1s. Paired with runtime-api#640 (which bounds and self-heals the stall server-side), the user-visible 500 disappears entirely.

## Testing

- 2 new unit tests: GET timeout→retry→success (2 calls), POST timeout→no retry (1 call); existing timeout/error tests unchanged and passing (105 total in the file).
- ruff + format clean; mypy shows only the pre-existing `base62` stubs warning.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-3b06759   docker.openhands.dev/openhands/openhands:3b06759
```