### PR TITLE
fix: redact Tavily MCP API key in init errors

### DIFF
--- a/openhands/app_server/mcp/mcp_router.py
+++ b/openhands/app_server/mcp/mcp_router.py
@@ -46,6 +46,11 @@ HOST = f'https://{os.getenv("WEB_HOST", "app.all-hands.dev").strip()}'
 CONVERSATION_URL = HOST + '/conversations/{}'
 
 
+def _redact_tavily_api_key(value: str) -> str:
+    """Redact the Tavily MCP API key from loggable strings."""
+    return re.sub(r'(tavilyApiKey=)[^&\s]+', r'\1<redacted>', value)
+
+
 def init_tavily_proxy() -> None:
     """Initialize the Tavily MCP proxy if API key is configured.
 
@@ -72,7 +77,9 @@ def init_tavily_proxy() -> None:
         mcp_server.mount(namespace='tavily', server=proxy_server)
         logger.info('Tavily MCP proxy initialized successfully')
     except Exception as e:
-        logger.error(f'Failed to initialize Tavily MCP proxy: {e}')
+        logger.error(
+            f'Failed to initialize Tavily MCP proxy: {_redact_tavily_api_key(str(e))}'
+        )
 
 
 async def get_conversation_link(

--- a/tests/unit/server/routes/test_mcp_routes.py
+++ b/tests/unit/server/routes/test_mcp_routes.py
@@ -259,6 +259,39 @@ class TestInitTavilyProxy:
                 'Tavily MCP proxy initialized successfully'
             )
 
+    def test_init_tavily_proxy_redacts_api_key_from_errors(self):
+        """Test init_tavily_proxy does not log the Tavily API key on failure."""
+        with (
+            patch(
+                'openhands.app_server.mcp.mcp_router.get_global_config'
+            ) as mock_config,
+            patch('openhands.app_server.mcp.mcp_router.logger') as mock_logger,
+            patch('openhands.app_server.mcp.mcp_router.Client') as mock_client,
+            patch(
+                'openhands.app_server.mcp.mcp_router.StreamableHttpTransport'
+            ) as mock_transport,
+            patch(
+                'openhands.app_server.mcp.mcp_router.create_proxy'
+            ) as mock_create_proxy,
+            patch('openhands.app_server.mcp.mcp_router.mcp_server') as mock_mcp_server,
+        ):
+            mock_config.return_value.tavily_api_key = 'test-tavily-key'
+            mock_transport_instance = MagicMock()
+            mock_transport.return_value = mock_transport_instance
+            mock_client_instance = MagicMock()
+            mock_client.return_value = mock_client_instance
+            mock_create_proxy.side_effect = RuntimeError(
+                'connect failed: https://mcp.tavily.com/mcp/?tavilyApiKey=test-tavily-key&x=1'
+            )
+
+            init_tavily_proxy()
+
+            mock_mcp_server.mount.assert_not_called()
+            mock_logger.error.assert_called_once()
+            logged_message = mock_logger.error.call_args.args[0]
+            assert 'test-tavily-key' not in logged_message
+            assert 'tavilyApiKey=<redacted>' in logged_message
+
     def test_init_tavily_proxy_handles_exception(self):
         """Test init_tavily_proxy handles exceptions gracefully."""
         with (


### PR DESCRIPTION
HUMAN:
This PR prevents Tavily MCP proxy initialization failures from writing the raw `tavilyApiKey` query parameter into logs. The error is still logged for debugging, but the secret value is redacted first.

- [x] A human has tested these changes.

AGENT:

## Why
The Tavily MCP proxy builds its upstream URL with `tavilyApiKey` as a query parameter. If initialization fails and the raised exception includes that URL, the current error log can persist the API key.

## Summary
- Add a small Tavily MCP URL redactor for loggable error strings.
- Use it when logging Tavily MCP proxy initialization failures.
- Add a regression test that confirms the raw API key is not logged while the failure remains visible.

## Issue Number
N/A

## How to Test
- `git diff --check`
- `.venv/bin/python -m py_compile openhands/app_server/mcp/mcp_router.py tests/unit/server/routes/test_mcp_routes.py`

I also attempted to run `pytest tests/unit/server/routes/test_mcp_routes.py -q` locally, but the sparse local environment did not have the full OpenHands dependency set available; installing the split `openhands-*` packages hit a pip dependency-resolution conflict. The changed files compile successfully, and the added test follows the existing mocked Tavily proxy test style.