### PR TITLE
fix(app-server): lower DB pool defaults and make them env-tunable

### DIFF
--- a/openhands/app_server/services/db_session_injector.py
+++ b/openhands/app_server/services/db_session_injector.py
@@ -34,7 +34,8 @@ class DbSessionInjector(BaseModel, Injector[AsyncSession]):
     user: str | None = None
     password: SecretStr | None = None
     echo: bool = False
-    pool_size: int = 25
+    # Defaults follow SQLAlchemy's own pool_size=5, max_overflow=10)
+    pool_size: int = 5
     max_overflow: int = 10
     pool_recycle: int = 1800
     pool_use_lifo: bool = True
@@ -71,6 +72,12 @@ class DbSessionInjector(BaseModel, Injector[AsyncSession]):
             self.gcp_region = os.getenv('GCP_REGION')
         if self.ssl_mode is None:
             self.ssl_mode = os.getenv('DB_SSL_MODE') or os.getenv('PGSSLMODE')
+        pool_size = os.getenv('DB_POOL_SIZE')
+        if pool_size:
+            self.pool_size = int(pool_size)
+        max_overflow = os.getenv('DB_MAX_OVERFLOW')
+        if max_overflow:
+            self.max_overflow = int(max_overflow)
         return self
 
     def _create_gcp_db_connection(self):

--- a/tests/unit/app_server/test_db_session_injector.py
+++ b/tests/unit/app_server/test_db_session_injector.py
@@ -103,7 +103,7 @@ class TestDbSessionInjectorConfiguration:
             service.password.get_secret_value() == 'postgres'
         )  # Default from env var processing
         assert service.echo is False
-        assert service.pool_size == 25
+        assert service.pool_size == 5
         assert service.max_overflow == 10
         assert service.pool_use_lifo is True
         assert service.gcp_db_instance is None
@@ -137,6 +137,14 @@ class TestDbSessionInjectorConfiguration:
             assert service.gcp_project == 'env_project'
             assert service.gcp_region == 'env_region'
             assert service.ssl_mode == 'require'
+
+    def test_pool_size_env_vars_override_defaults(self, temp_persistence_dir):
+        """DB_POOL_SIZE / DB_MAX_OVERFLOW override the model defaults."""
+        with patch.dict(os.environ, {'DB_POOL_SIZE': '30', 'DB_MAX_OVERFLOW': '7'}):
+            service = DbSessionInjector(persistence_dir=temp_persistence_dir)
+
+            assert service.pool_size == 30
+            assert service.max_overflow == 7
 
     def test_explicit_values_override_env_vars(self, temp_persistence_dir):
         """Test that explicitly provided values override environment variables."""
@@ -213,7 +221,7 @@ class TestDbSessionInjectorConnections:
 
             # Verify other parameters
             assert call_args[1]['connect_args'] == {}
-            assert call_args[1]['pool_size'] == 25
+            assert call_args[1]['pool_size'] == 5
             assert call_args[1]['max_overflow'] == 10
             assert call_args[1]['pool_pre_ping']
             assert call_args[1]['pool_use_lifo'] is True
@@ -247,7 +255,7 @@ class TestDbSessionInjectorConnections:
 
             # Verify other parameters
             assert call_args[1]['connect_args'] == {}
-            assert call_args[1]['pool_size'] == 25
+            assert call_args[1]['pool_size'] == 5
             assert call_args[1]['max_overflow'] == 10
             assert call_args[1]['pool_pre_ping']
             assert call_args[1]['pool_use_lifo'] is True


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Human-written purpose: in a distributed deployment the current pool configuration can quickly exhaust common pool size limitations. This PR seeks to bring the defaults inline with the [SQLAlchemy defaults](https://docs.sqlalchemy.org/en/20/core/pooling.html#sqlalchemy.pool.QueuePool) (pictured below). For non-default configurations, two ENV's are exposed that can override
<img width="828" height="249" alt="image" src="https://github.com/user-attachments/assets/dd036f21-9b05-4c76-a413-06a3a0d2c24b" />

- [x] A human has tested these changes. I tested these by running the uv/python commands below to observe the set values of these attributes

AGENT:

---

## Why

`DbSessionInjector` shipped with `pool_size=25` — 5× SQLAlchemy's own default of 5 — inherited from the old SaaS pool config back in the V1 integration. Every process holds its own pool, so in a distributed deployment total connections are `pool_size × workers × replicas`, and 25 multiplies badly.

**The arithmetic.** SQLAlchemy retains up to `pool_size` connections per process (the idle floor, kept open once reached), and can burst to `pool_size + max_overflow` (overflow connections are opened on demand and closed on return). Production runs 15 replicas × 3 uvicorn workers = **45 processes**:

| | pool_size | idle floor (`pool_size × 45`) | burst ceiling (`(pool_size+overflow) × 45`) |
|---|---|---|---|
| before | 25 | 25 × 45 = **1,125** | 35 × 45 = **1,575** |
| after | 5 | 5 × 45 = **225** | 15 × 45 = **675** |

**Observed vs. provisioned.** In a production cluster, an observed 30-day p95 showed the following: active ≈ 1.5, idle-in-transaction ≈ 5, idle ≈ 752. Real concurrent work across the *entire fleet* is ~6–7 connections; the ~752 idle is an excessively, purely retained pool floor

**At what scale does a big `pool_size` bite?** It's purely multiplicative — `pool_size × processes` must stay under `max_connections` minus headroom. With `pool_size=25` you can only run `floor(max_connections / 25)` processes before the idle floor alone saturates the DB:

- `max_connections=100` (Postgres default) → **4 processes**
- `max_connections=500` → **20 processes**
- `max_connections=1500` → **60 processes**

Any horizontally-scaled deployment passes that quickly. At `pool_size=5` the headroom is 5× larger, and a `5 + 10 = 15` per-process ceiling is still ~10× this workload's whole-fleet p95 demand — so exhaustion is effectively impossible here while the idle floor drops ~5×.

## Summary

- `pool_size` default `25 → 5`, matching SQLAlchemy's own defaults (`max_overflow` already `10`). Behavior only changes for operators relying on the inflated default.
- `pool_size` / `max_overflow` now read from `DB_POOL_SIZE` / `DB_MAX_OVERFLOW` env vars (the same names the Alembic migration runner already uses), so deployments can tune pooling without code changes. Unset = defaults, so no behavior change unless opted in.

## Issue Number
OpenHands/enterprise#60 

## How to Test

```bash
# Override via env
DB_POOL_SIZE=7 DB_MAX_OVERFLOW=3 uv run python -c "
from openhands.app_server.services.db_session_injector import DbSessionInjector
from pathlib import Path
i = DbSessionInjector(persistence_dir=Path('/tmp'))
print(i.pool_size, i.max_overflow)  # -> 7 3
"

# Default (no env)
uv run python -c "
from openhands.app_server.services.db_session_injector import DbSessionInjector
from pathlib import Path
i = DbSessionInjector(persistence_dir=Path('/tmp'))
print(i.pool_size, i.max_overflow)  # -> 5 10  (was 25 10)
"
```

## Video/Screenshots

N/A — no UI changes.

## Type

- [x] Bug fix

## Notes

- **Rollout:** `DB_POOL_SIZE` / `DB_MAX_OVERFLOW` are already present in prod pod env but were previously ignored by this engine, so deploying this makes them take effect immediately. Any chart-side `DB_MAX_OVERFLOW` change should land in the same rollout to avoid transiently widening the per-process ceiling.
- **Changelog:** Lowered the DB connection pool defaults (`pool_size` 25→5) and made pooling configurable via `DB_POOL_SIZE` / `DB_MAX_OVERFLOW`.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-4b88b07   docker.openhands.dev/openhands/openhands:4b88b07
```