### PR TITLE
fix(settings): prevent autocapitalize from mangling marketplace source

### DIFF
--- a/frontend/__tests__/components/features/settings/marketplace-modal.test.tsx
+++ b/frontend/__tests__/components/features/settings/marketplace-modal.test.tsx
@@ -40,6 +40,25 @@ describe("MarketplaceModal", () => {
     ).toBeInTheDocument();
   });
 
+  it("disables autocapitalize/autocorrect on case-sensitive source, ref and repo path inputs", () => {
+    render(<MarketplaceModal {...baseProps} />);
+
+    // A "github:owner/repo" source, a ref, and a repo subpath are all
+    // case-sensitive; mobile keyboard autocapitalization must not mangle them
+    // (e.g. turning "github:" into "Github:", which breaks parsing).
+    const caseSensitiveInputs = [
+      screen.getByPlaceholderText("github:owner/repo"),
+      screen.getByPlaceholderText("e.g., main, develop, v1.0.0"),
+      screen.getByPlaceholderText("e.g., marketplaces/internal"),
+    ];
+
+    caseSensitiveInputs.forEach((input) => {
+      expect(input).toHaveAttribute("autocapitalize", "none");
+      expect(input).toHaveAttribute("autocorrect", "off");
+      expect(input).toHaveAttribute("spellcheck", "false");
+    });
+  });
+
   it("shows name required error when name is empty", async () => {
     render(<MarketplaceModal {...baseProps} />);
     const user = userEvent.setup();

--- a/frontend/src/components/features/settings/marketplace-modal.tsx
+++ b/frontend/src/components/features/settings/marketplace-modal.tsx
@@ -182,6 +182,13 @@ export function MarketplaceModal({
           </label>
           <input
             type="text"
+            // A source like "github:owner/repo" is case-sensitive and must not be
+            // mangled by mobile keyboard autocapitalization/autocorrect (which
+            // turns "github:" into "Github:" and breaks source parsing).
+            autoCapitalize="none"
+            autoCorrect="off"
+            autoComplete="off"
+            spellCheck={false}
             value={source}
             onChange={(e) => {
               const nextSource = e.target.value;
@@ -271,6 +278,11 @@ export function MarketplaceModal({
           </label>
           <input
             type="text"
+            // Branch/tag/commit refs are case-sensitive; keep autocorrect off.
+            autoCapitalize="none"
+            autoCorrect="off"
+            autoComplete="off"
+            spellCheck={false}
             value={ref}
             onChange={(e) => setRef(e.target.value)}
             placeholder="e.g., main, develop, v1.0.0"
@@ -288,6 +300,11 @@ export function MarketplaceModal({
           </label>
           <input
             type="text"
+            // Repository subdirectory paths are case-sensitive; keep autocorrect off.
+            autoCapitalize="none"
+            autoCorrect="off"
+            autoComplete="off"
+            spellCheck={false}
             value={repoPath}
             onChange={(e) => {
               setRepoPath(e.target.value);


### PR DESCRIPTION
## Problem

In the skills settings marketplace modal (`marketplace-modal.tsx`), the **Repository (source)** field accepts case-sensitive values like `github:owner/repo`. The input is a bare `<input type="text">` with no autocapitalize/autocorrect controls, so on mobile the keyboard capitalizes the first letter and the user ends up submitting `Github:owner/repo`.

That capitalized source then fails to parse (the scheme match is case-sensitive) and surfaces a confusing error instead of installing the marketplace — the reported "UI breaks" symptom.

## Fix

Disable `autoCapitalize` / `autoCorrect` / `autoComplete` / `spellCheck` on the three case-sensitive inputs in the modal:
- **source** (`github:owner/repo`)
- **ref** (branch/tag/commit — e.g. `Release-2.0`)
- **repo path** (subdirectory — e.g. `MyDir/marketplace`)

The Name field is intentionally left alone (not case-sensitive in the same way).

Only the input behavior is changed; no value is force-lowercased, since refs and subpaths are legitimately case-sensitive.

## Tests

Added a regression test to `marketplace-modal.test.tsx` asserting the three inputs carry `autocapitalize="none"`, `autocorrect="off"`, and `spellcheck="false"`. Local run: **17 passed** (16 existing + 1 new); `prettier --check` clean on both files.

## Related

This is the frontend/trigger half of a two-part fix. The backend root cause — the `github:` scheme being matched case-sensitively in `parse_extension_source()` — is fixed in the SDK so that *any* entry path (paste, deep-links, marketplace catalog entries, API) is protected even without this input hardening:

**OpenHands/software-agent-sdk#4117**

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9d0d1069-8482-40c2-b74a-d681568eaab1)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-f4fb766   docker.openhands.dev/openhands/openhands:f4fb766
```