### PR TITLE
fix(mcp): preserve MCP auth secrets stripped by settings GET round-trip

### DIFF
--- a/openhands/app_server/settings/settings_models.py
+++ b/openhands/app_server/settings/settings_models.py
@@ -369,7 +369,54 @@ def _restore_submitted_mcp_headers(
     return restored
 
 
+def _merge_redacted_mcp_auth(
+    value: Mapping[str, Any],
+    existing: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Merge a submitted ``auth`` credential onto the stored one.
+
+    The ``GET /settings`` round-trip strips secret sub-fields: the redaction
+    marker validates back to ``None`` (``validate_secret``) and is then dropped
+    from the response, so an unchanged credential reaches ``store`` as e.g.
+    ``{'strategy': 'bearer'}`` with no ``value`` at all — not as the
+    ``"**********"`` sentinel the plain restore logic looks for. Keep every
+    field the client actually sent (restoring any surviving redaction marker),
+    then carry over the stored sub-fields the client omitted. Only the secrets
+    are ever stripped, so an omitted key is always a stored secret to recover.
+
+    Recurses so nested secret carriers (``header`` strategy ``headers``,
+    ``oauth2`` ``authentication``/``state``) are restored the same way. Gated by
+    an equal ``strategy`` in the caller so a genuine credential-type switch is
+    honored as submitted rather than merged.
+    """
+    merged: dict[str, Any] = {}
+    for key, item in value.items():
+        existing_item = existing.get(key)
+        if isinstance(item, Mapping):
+            merged[key] = _merge_redacted_mcp_auth(
+                item, existing_item if isinstance(existing_item, Mapping) else {}
+            )
+            continue
+        restored = _restore_redacted_secret(item, existing_item)
+        if restored is not _MISSING_SECRET:
+            merged[key] = restored
+    for key, item in existing.items():
+        if key not in value:
+            merged[key] = deepcopy(item)
+    return merged
+
+
 def _restore_submitted_mcp_auth(value: object, existing: object) -> object:
+    # Same credential type: keep what the client sent, restore any surviving
+    # redaction marker, and recover stored secret sub-fields the GET round-trip
+    # stripped to absent (bearer ``value``, api_key ``value``, basic
+    # ``password``, header ``headers``, oauth2 ``state``/``client_secret``).
+    if (
+        isinstance(value, Mapping)
+        and isinstance(existing, Mapping)
+        and value.get('strategy') == existing.get('strategy')
+    ):
+        return _merge_redacted_mcp_auth(value, existing)
     if _has_redacted_mcp_secret(value) and existing is not None:
         if isinstance(value, Mapping) and isinstance(existing, Mapping):
             if value.get('strategy') != existing.get('strategy'):

--- a/tests/unit/storage/data_models/test_settings.py
+++ b/tests/unit/storage/data_models/test_settings.py
@@ -8,6 +8,7 @@ from pydantic import SecretStr, ValidationError
 import openhands.app_server.settings.settings_models as settings_module
 from openhands.app_server.settings.llm_profiles import ProfileNotFoundError
 from openhands.app_server.settings.settings_models import (
+    GETSettingsModel,
     MarketplaceRegistration,
     Settings,
 )
@@ -617,6 +618,169 @@ def test_settings_update_drops_redacted_mcp_env_when_args_change():
     )
 
     assert not settings.agent_settings.mcp_config['local'].env
+
+
+def _mcp_config_as_seen_by_frontend(settings: Settings) -> dict:
+    """The ``mcp_config`` the frontend receives from ``GET /settings``.
+
+    Mirrors ``settings_router.load_settings``: the response is built as
+    ``GETSettingsModel(**settings.model_dump(...))`` and then serialized. That
+    dump-then-revalidate strips every MCP secret to *absent* — redaction emits
+    ``"**********"``, ``validate_secret`` turns that marker back into ``None`` on
+    the way into ``GETSettingsModel``, and the ``None`` is dropped on the way
+    out. So an unchanged credential arrives at the client as e.g.
+    ``{'strategy': 'bearer'}`` with no ``value`` — not the ``"**********"``
+    sentinel — which is exactly what the client echoes back on the next save.
+    """
+    response = GETSettingsModel(
+        **settings.model_dump(exclude={'secrets_store'}),
+        llm_api_key_set=settings.llm_api_key_is_set,
+    )
+    return response.model_dump(mode='json')['agent_settings']['mcp_config']
+
+
+def test_get_settings_roundtrip_strips_mcp_auth_secret_to_absent():
+    """Document the root cause: the GET response omits the secret entirely."""
+    settings = Settings(
+        agent_settings=OpenHandsAgentSettings(
+            mcp_config={
+                'server': {
+                    'url': 'https://mcp.example.com',
+                    'transport': 'http',
+                    'auth': {'strategy': 'bearer', 'value': 'real-key'},
+                }
+            }
+        )
+    )
+
+    seen = _mcp_config_as_seen_by_frontend(settings)
+
+    # The secret is gone, not redacted to "**********".
+    assert seen['server']['auth'] == {'strategy': 'bearer'}
+
+
+def test_settings_update_preserves_mcp_auth_across_get_roundtrip_on_add():
+    """Adding a server must not wipe existing servers' keys (the reported bug).
+
+    Replays the real flow: read the values as the frontend receives them (secret
+    stripped), append a brand-new server with its own key, and save the whole
+    map back — exactly the payload the browser sends.
+    """
+    settings = Settings(
+        agent_settings=OpenHandsAgentSettings(
+            mcp_config={
+                'shttp': {
+                    'url': 'https://a.example.com',
+                    'transport': 'http',
+                    'auth': {'strategy': 'bearer', 'value': 'key-a'},
+                },
+                'shttp_1': {
+                    'url': 'https://b.example.com',
+                    'transport': 'http',
+                    'auth': {'strategy': 'bearer', 'value': 'key-b'},
+                },
+            }
+        )
+    )
+
+    submitted = _mcp_config_as_seen_by_frontend(settings)
+    submitted['shttp_2'] = {
+        'url': 'https://c.example.com',
+        'auth': {'strategy': 'bearer', 'value': 'key-c'},
+    }
+
+    settings.update({'agent_settings_diff': {'mcp_config': submitted}})
+
+    dumped = dump_mcp_config(
+        settings.agent_settings.mcp_config or {},
+        context={'expose_secrets': 'plaintext'},
+    )
+    assert dumped['shttp']['auth'] == {'strategy': 'bearer', 'value': 'key-a'}
+    assert dumped['shttp_1']['auth'] == {'strategy': 'bearer', 'value': 'key-b'}
+    assert dumped['shttp_2']['auth'] == {'strategy': 'bearer', 'value': 'key-c'}
+
+
+@pytest.mark.parametrize(
+    'auth,secret_path',
+    (
+        (
+            {'strategy': 'api_key', 'value': 'real-key', 'header_name': 'X-API-Key'},
+            ('value',),
+        ),
+        (
+            {'strategy': 'basic', 'username': 'user', 'password': 'real-key'},
+            ('password',),
+        ),
+        (
+            {'strategy': 'header', 'headers': {'X-API-Key': 'real-key'}},
+            ('headers', 'X-API-Key'),
+        ),
+        (
+            {'strategy': 'oauth2', 'state': {'tokens': {'access_token': 'real-key'}}},
+            ('state', 'tokens', 'access_token'),
+        ),
+    ),
+)
+def test_settings_update_preserves_typed_mcp_auth_across_get_roundtrip(
+    auth: dict, secret_path: tuple[str, ...]
+):
+    """Every typed strategy survives the stripped-secret round trip on an edit."""
+    settings = Settings(
+        agent_settings=OpenHandsAgentSettings(
+            mcp_config={
+                'server': {
+                    'url': 'https://mcp.example.com',
+                    'transport': 'http',
+                    'auth': auth,
+                }
+            }
+        )
+    )
+
+    submitted = _mcp_config_as_seen_by_frontend(settings)
+    # An unrelated edit (a new server) triggers a full-map save.
+    submitted['added'] = {
+        'url': 'https://added.example.com',
+        'auth': {'strategy': 'bearer', 'value': 'new-key'},
+    }
+
+    settings.update({'agent_settings_diff': {'mcp_config': submitted}})
+
+    dumped = dump_mcp_config(
+        settings.agent_settings.mcp_config or {},
+        context={'expose_secrets': 'plaintext'},
+    )
+    restored = dumped['server']['auth']
+    for key in secret_path:
+        restored = restored[key]
+    assert restored == 'real-key'
+
+
+def test_settings_update_preserves_stdio_env_across_get_roundtrip():
+    """A stdio server's env secrets survive when another server is added."""
+    settings = Settings(
+        agent_settings=OpenHandsAgentSettings(
+            mcp_config={
+                'local': {
+                    'command': 'mcp-server',
+                    'args': ['--stdio'],
+                    'env': {'API_KEY': 'real-key'},
+                }
+            }
+        )
+    )
+
+    submitted = _mcp_config_as_seen_by_frontend(settings)
+    submitted['added'] = {
+        'url': 'https://added.example.com',
+        'auth': {'strategy': 'bearer', 'value': 'new-key'},
+    }
+
+    settings.update({'agent_settings_diff': {'mcp_config': submitted}})
+
+    server = settings.agent_settings.mcp_config['local']
+    assert server.env is not None
+    assert server.env['API_KEY'].get_secret_value() == 'real-key'
 
 
 def test_settings_update_can_clear_mcp_config():


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:


- [x] A human has tested these changes.

AGENT:

---

## Why

Adding a new MCP server through the settings page wipes the stored API keys of every *other* remote server. Editing any server does the same. #15257 added encrypted MCP credential storage plus logic to preserve a redacted credential across a save, but that logic keys off the `"**********"` redaction marker - and the marker never actually reaches the backend.

The `GET /settings` response is built as `GETSettingsModel(**settings.model_dump(...))`. That dump-then-revalidate redacts each secret to `"**********"`, then `validate_secret` turns the marker back into `None` on the way in, and the `None` is dropped on the way out. So an unchanged credential reaches the browser as `{"strategy": "bearer"}` with no value at all. The frontend echoes that back on the next save, and the preservation logic - looking for a marker that isn't there - reads the absent secret as a deletion and drops the stored key.

So a save like this (existing servers have no `value`, only the just-added `mcp4` does) blanks the first three:

```json
{"agent_settings_diff":{"mcp_config":{
  "shttp":{"url":".../mcp","auth":{"strategy":"bearer"}},
  "shttp_1":{"url":".../mcp2","auth":{"strategy":"bearer"}},
  "shttp_2":{"url":".../mcp3","auth":{"strategy":"bearer"}},
  "shttp_3":{"url":".../mcp4","auth":{"strategy":"bearer","value":"my_test_key"}}}}}
```

## Summary

- `_restore_submitted_mcp_auth` now merges a submitted `auth` credential onto the stored one when the strategy is unchanged: it keeps what the client sent and carries over the secret sub-fields the round-trip stripped (bearer/api_key `value`, basic `password`, header `headers`, oauth2 `state`/`client_secret`).
- Added regression tests that drive the real GET->POST round trip. The existing tests fed the `"**********"` marker straight into `update()`, a shape the round trip never actually produces, which is why they stayed green while the real flow was broken.

## Issue Number

None.

## How to Test

Manual (SaaS settings > MCP):
1. Add a remote MCP server with an API key. Save.
2. Add a second server. Save.
3. Reload and confirm the first server's key is still set (previously it came back blank).

Automated:
```
pytest tests/unit/storage/data_models/test_settings.py -k "roundtrip or across_get"
```
The five `..._across_get_roundtrip...` cases fail on `main` and pass with this change.

## Video/Screenshots

N/A - backend fix, no UI change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The fix is on the backend, which is the security boundary, so it covers both add and edit regardless of client.

Only the `auth` path needed changing. The top-level `env`/`headers` secret maps go fully absent on the round trip and were already carried over by `_carry_omitted_mcp_secrets`; `auth` was the one field that arrived present-but-secretless.

Explicit credential clears still work - the frontend sends `auth: null` for those, which isn't a strategy-matched mapping, so the merge doesn't fire.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-d5e5e1f   docker.openhands.dev/openhands/openhands:d5e5e1f
```