### PR TITLE
fix(frontend): scope plan build shortcut

### DIFF
--- a/frontend/__tests__/components/chat/chat-interface.test.tsx
+++ b/frontend/__tests__/components/chat/chat-interface.test.tsx
@@ -8,7 +8,7 @@ import {
   test,
   vi,
 } from "vitest";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -26,12 +26,22 @@ import { OpenHandsAction } from "#/types/core/actions";
 import { useEventStore } from "#/stores/use-event-store";
 import { useAgentState } from "#/hooks/use-agent-state";
 import { AgentState } from "#/types/agent-state";
+import { useConversationStore } from "#/stores/conversation-store";
+
+const { handleBuildPlanClickMock } = vi.hoisted(() => ({
+  handleBuildPlanClickMock: vi.fn(),
+}));
 
 vi.mock("#/context/ws-client-provider");
 vi.mock("#/hooks/query/use-config");
 vi.mock("#/hooks/mutation/use-get-trajectory");
 vi.mock("#/hooks/mutation/use-unified-upload-files");
 vi.mock("#/hooks/use-conversation-id");
+vi.mock("#/hooks/use-handle-build-plan-click", () => ({
+  useHandleBuildPlanClick: () => ({
+    handleBuildPlanClick: handleBuildPlanClickMock,
+  }),
+}));
 
 vi.mock("#/hooks/use-user-providers", () => ({
   useUserProviders: () => ({
@@ -93,6 +103,66 @@ beforeEach(() => {
   useParamsMock.mockReturnValue({ conversationId: "test-conversation-id" });
   vi.mocked(useConversationId).mockReturnValue({
     conversationId: "test-conversation-id",
+  });
+});
+
+describe("ChatInterface - Build shortcut", () => {
+  beforeEach(() => {
+    handleBuildPlanClickMock.mockReset();
+    (useConfig as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { app_mode: "local" },
+    });
+    (useGetTrajectory as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn(),
+      isLoading: false,
+    });
+    (
+      useUnifiedUploadFiles as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue({
+      mutateAsync: vi
+        .fn()
+        .mockResolvedValue({ skipped_files: [], uploaded_files: [] }),
+      isLoading: false,
+    });
+    vi.mocked(useAgentState).mockReturnValue({
+      curAgentState: AgentState.AWAITING_USER_INPUT,
+      isArchived: false,
+    });
+    useConversationStore.setState({
+      conversationMode: "code",
+      planContent: null,
+    });
+  });
+
+  it("does not build outside plan mode", () => {
+    useConversationStore.setState({ planContent: "# Plan" });
+    renderChatInterfaceWithRouter();
+
+    fireEvent.keyDown(document, { key: "Enter", ctrlKey: true });
+
+    expect(handleBuildPlanClickMock).not.toHaveBeenCalled();
+  });
+
+  it("does not build when no plan exists", () => {
+    useConversationStore.setState({ conversationMode: "plan" });
+    renderChatInterfaceWithRouter();
+
+    fireEvent.keyDown(document, { key: "Enter", ctrlKey: true });
+
+    expect(handleBuildPlanClickMock).not.toHaveBeenCalled();
+  });
+
+  it("builds in plan mode when a plan exists", () => {
+    useConversationStore.setState({
+      conversationMode: "plan",
+      planContent: "# Plan",
+    });
+    renderChatInterfaceWithRouter();
+
+    fireEvent.keyDown(document, { key: "Enter", ctrlKey: true });
+
+    expect(handleBuildPlanClickMock).toHaveBeenCalledOnce();
   });
 });
 

--- a/frontend/src/components/features/chat/chat-interface.tsx
+++ b/frontend/src/components/features/chat/chat-interface.tsx
@@ -38,7 +38,8 @@ import { ArchivedBanner } from "./archived-banner";
 import { useModelStore } from "#/stores/model-store";
 
 export function ChatInterface() {
-  const { setMessageToSend } = useConversationStore();
+  const { setMessageToSend, conversationMode, planContent } =
+    useConversationStore();
   const { errorMessage, removeErrorMessage } = useErrorMessageStore();
   const { isTask, taskStatus, taskDetail } = useTaskPolling();
   const conversationWebSocket = useConversationWebSocket();
@@ -76,12 +77,14 @@ export function ChatInterface() {
   const isAgentRunning =
     curAgentState === AgentState.RUNNING ||
     curAgentState === AgentState.LOADING;
+  const canBuildPlan =
+    !isAgentRunning && conversationMode === "plan" && Boolean(planContent);
 
   // Global keyboard shortcut for Build button (Cmd+Enter / Ctrl+Enter)
   // This is placed here instead of PlanPreview to avoid duplicate listeners
   // when multiple PlanPreview components exist in the chat
   React.useEffect(() => {
-    if (isAgentRunning) {
+    if (!canBuildPlan) {
       return undefined;
     }
 
@@ -100,7 +103,7 @@ export function ChatInterface() {
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [isAgentRunning, handleBuildPlanClick, scrollDomToBottom]);
+  }, [canBuildPlan, handleBuildPlanClick, scrollDomToBottom]);
 
   const params = useParams();
   const { mutateAsync: uploadFiles } = useUnifiedUploadFiles();


### PR DESCRIPTION
HUMAN:

I changed the global Build shortcut so it only runs when the conversation is in Plan mode, a plan exists, and the agent is idle. I also added focused component tests for the valid and excluded shortcut states.

- [x] A human has tested these changes.

## Why

`ChatInterface` registered the global `Cmd/Ctrl+Enter` shortcut whenever the agent was idle. In code mode or before a plan existed, the shortcut therefore sent the hard-coded plan execution prompt as a user message.

## Summary

- Register the global Build shortcut only when the agent is idle, the conversation is in plan mode, and plan content exists.
- Add component coverage for code mode, missing-plan, and valid plan-mode behavior.

## Issue Number

Fixes #15293

## How to Test

```text
npm test -- __tests__/components/chat/chat-interface.test.tsx -t "ChatInterface - Build shortcut"
```

The three focused shortcut tests pass.

## Video/Screenshots

Not applicable

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Explicit Build buttons and the plan execution message flow are unchanged.
