### PR TITLE
fix(enterprise): PLTF-3259 recognize openhands.dev in staging/feature + managed-domain detection

### DIFF
--- a/enterprise/server/constants.py
+++ b/enterprise/server/constants.py
@@ -6,15 +6,18 @@ HOST = os.getenv('WEB_HOST', 'app.all-hands.dev').strip()
 
 # Check if this is a feature environment
 # Feature environments have a host format like {some-text}.staging.all-hands.dev
-# or {some-text}.ohe-staging.platform-team.all-hands.dev (for platform-team sandbox)
-# Just staging.all-hands.dev doesn't count as a feature environment
+# or {some-text}.staging.openhands.dev (the domain the staging/feature stack is
+# migrating to), or {some-text}.ohe-staging.platform-team.all-hands.dev (for the
+# platform-team sandbox). The bare staging host (staging.all-hands.dev /
+# staging.openhands.dev) does not count as a feature environment.
+STAGING_BASE_HOSTS = ('staging.all-hands.dev', 'staging.openhands.dev')
 IS_STAGING_ENV = bool(
-    re.match(r'^.+\.staging\.all-hands\.dev$', HOST)
+    re.match(r'^.+\.staging\.(?:all-hands|openhands)\.dev$', HOST)
     or re.match(r'^.+\.ohe-staging\.platform-team\.all-hands\.dev$', HOST)
-    or HOST == 'staging.all-hands.dev'
+    or HOST in STAGING_BASE_HOSTS
 )  # Includes the staging deployment + feature deployments
 IS_FEATURE_ENV = (
-    IS_STAGING_ENV and HOST != 'staging.all-hands.dev'
+    IS_STAGING_ENV and HOST not in STAGING_BASE_HOSTS
 )  # Does not include the staging deployment
 IS_LOCAL_ENV = bool(HOST == 'localhost')
 
@@ -33,6 +36,7 @@ def _is_all_hands_managed_domain(host: str) -> bool:
         or host == 'app.openhands.ai'
         or host.endswith('.all-hands.dev')
         or host.endswith('.openhands.ai')
+        or host.endswith('.openhands.dev')
     )
 
 

--- a/enterprise/tests/unit/server/test_constants.py
+++ b/enterprise/tests/unit/server/test_constants.py
@@ -22,6 +22,10 @@ class TestDeploymentMode:
             ('feature-123.staging.all-hands.dev', 'cloud'),
             ('pr-456.staging.all-hands.dev', 'cloud'),
             ('app.openhands.ai', 'cloud'),
+            # openhands.dev is also an All-Hands managed domain
+            ('app.openhands.dev', 'cloud'),
+            ('staging.openhands.dev', 'cloud'),
+            ('pr-456.staging.openhands.dev', 'cloud'),
             # Customer domains should return 'self_hosted'
             ('openhands.acme.com', 'self_hosted'),
             ('internal.company.io', 'self_hosted'),
@@ -81,9 +85,13 @@ class TestDeploymentMode:
             ('staging.all-hands.dev', True),
             ('feature.staging.all-hands.dev', True),
             ('app.openhands.ai', True),
+            ('app.openhands.dev', True),
+            ('staging.openhands.dev', True),
+            ('pr-1.staging.openhands.dev', True),
             ('localhost', False),  # localhost is not a managed domain
             ('customer.example.com', False),
             ('all-hands.dev', False),
+            ('openhands.dev', False),  # apex is not a subdomain, so not managed
         ],
     )
     def test_is_all_hands_managed_domain(self, host: str, expected: bool):
@@ -108,6 +116,45 @@ class TestDeploymentMode:
 
             # Default WEB_HOST is 'app.all-hands.dev' which should be 'cloud'
             assert constants_module.DEPLOYMENT_MODE == 'cloud'
+
+
+class TestStagingAndFeatureEnvDetection:
+    """IS_STAGING_ENV / IS_FEATURE_ENV must recognize both the legacy
+    all-hands.dev and the new openhands.dev staging/feature hosts."""
+
+    @pytest.mark.parametrize(
+        'web_host,is_staging,is_feature',
+        [
+            # Bare staging hosts: a staging env, but NOT a feature env
+            ('staging.all-hands.dev', True, False),
+            ('staging.openhands.dev', True, False),
+            # Feature / preview hosts on both domains
+            ('feature-123.staging.all-hands.dev', True, True),
+            ('pr-279.staging.all-hands.dev', True, True),
+            ('pr-279.staging.openhands.dev', True, True),
+            ('feature-123.staging.openhands.dev', True, True),
+            # Platform-team sandbox
+            ('pr-279.ohe-staging.platform-team.all-hands.dev', True, True),
+            # Production / customer / local hosts are neither
+            ('app.all-hands.dev', False, False),
+            ('app.openhands.dev', False, False),
+            ('openhands.acme.com', False, False),
+            ('localhost', False, False),
+        ],
+    )
+    def test_staging_and_feature_env_detection(
+        self, web_host: str, is_staging: bool, is_feature: bool
+    ):
+        """WEB_HOST drives IS_STAGING_ENV / IS_FEATURE_ENV for both domains."""
+        with patch.dict('os.environ', {'WEB_HOST': web_host}):
+            import importlib
+
+            import server.constants as constants_module
+
+            importlib.reload(constants_module)
+
+            assert constants_module.IS_STAGING_ENV is is_staging
+            assert constants_module.IS_FEATURE_ENV is is_feature
 
 
 class TestDeploymentModeInConfig:


### PR DESCRIPTION
## Problem

The staging/feature stack is migrating from `*.staging.all-hands.dev` to `*.staging.openhands.dev`, but `enterprise/server/constants.py` hardcodes `all-hands.dev` (and `openhands.ai`) when deciding what kind of environment it is running in. On the new domain the server misclassifies itself:

- `IS_STAGING_ENV` / `IS_FEATURE_ENV` — the regex only matches `*.staging.all-hands.dev`, so a feature preview on `pr-279.staging.openhands.dev` gets `IS_STAGING_ENV=False` / `IS_FEATURE_ENV=False`.
- `_is_all_hands_managed_domain()` — omits `openhands.dev`, so `DEPLOYMENT_MODE` resolves to `self_hosted` instead of `cloud` for `*.openhands.dev` hosts.

Both were observed on a live feature preview: the login event logged `is_feature_env: false` and `deployment_mode: self_hosted` for `WEB_HOST=pr-280.staging.openhands.dev`.

### Impact

`IS_FEATURE_ENV` / `IS_STAGING_ENV` drive `get_cookie_domain()` and `get_cookie_samesite()` in `server/utils/url_utils.py`. Misdetection pushes feature/staging previews onto the production cookie path (full-host cookie domain + `SameSite=strict`) instead of the intended feature/staging behavior (`domain=None`, `SameSite=lax`), which contributed to sessions dropping right after login on `openhands.dev` previews. `DEPLOYMENT_MODE` misdetection similarly flips cloud previews to `self_hosted` behavior.

## Fix

Teach the environment detection about `openhands.dev` as a first-party All-Hands domain:

- `IS_STAGING_ENV` regex now matches `*.staging.(all-hands|openhands).dev`, and the bare-staging check covers both `staging.all-hands.dev` and `staging.openhands.dev` (extracted to `STAGING_BASE_HOSTS`).
- `_is_all_hands_managed_domain()` also treats `*.openhands.dev` as managed.

The legacy `all-hands.dev` behavior is unchanged; this is purely additive. The apex `openhands.dev` is intentionally still not "managed" (matching the existing `all-hands.dev` apex behavior).

## Tests

`enterprise/tests/unit/server/test_constants.py`:
- New `TestStagingAndFeatureEnvDetection` parametrized over both domains (bare staging, feature/preview, platform-team sandbox, production/customer/local).
- Extended `test_deployment_mode_detection` and `test_is_all_hands_managed_domain` with `openhands.dev` cases (including the apex-not-managed edge case).

Detection logic validated standalone across all the above hosts.

---
This PR was created by an AI agent (OpenHands) on behalf of @aivong-openhands.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-9885085   docker.openhands.dev/openhands/openhands:9885085
```


---

## Edit: reframing after further investigation

**This is a correctness fix, not a login fix.** The feature/staging "logged out on conversation start" symptom that originally motivated this PR turned out to be a **GitHub REST API incident** (503s on `api.github.com/user` → the `authenticate` handler cleared the cookie → 401 → logout), not the environment misdetection. Once GitHub recovered, feature/staging login + conversations work on the **unchanged pre-#15304 image** (`cloud-1.46.1`). So nothing here is required to keep login working.

Why misdetection didn't break login: on `openhands.dev` the "production" cookie path the misdetection selects (`SameSite=strict`, full-host domain) is coincidentally fine, because the app and Keycloak share the same registrable domain (`openhands.dev`) — so `SameSite=strict` doesn't block the OAuth redirect, and a full-host cookie still covers the single host.

**`DEPLOYMENT_MODE` is a behavior switch, not a hosting fact.** "cloud" vs "self_hosted" only gates onboarding (`cloud` → all users onboard; `self_hosted` → only the org super-admin) and the frontend `FEATURE_FLAGS.DEPLOYMENT_MODE`. Our SaaS is self-hosted infrastructure too, so inferring this flag from the hostname is fragile — a domain migration silently flips a behavior flag. The mode should be set **deliberately per environment** via `OH_DEPLOYMENT_MODE` (which already takes precedence over the host heuristic), not derived from the domain.

**Two independent halves of this PR:**
1. `IS_STAGING_ENV` / `IS_FEATURE_ENV` recognizing `openhands.dev` — a genuine correctness fix (a preview is a preview) for cookie settings and analytics tagging; independent of the cloud/self_hosted question. **Keep.**
2. `_is_all_hands_managed_domain` → `DEPLOYMENT_MODE=cloud` for `*.openhands.dev` — only sets the *default* mode when `OH_DEPLOYMENT_MODE` is unset. Preferred direction is to set `OH_DEPLOYMENT_MODE` explicitly per environment (cloud/staging/dev/feature) so the mode is intentional and migration-proof; with that in place this half is just a safety default that explicit config overrides.

**Impact on self-hosted / customer installs: none.** Additive only — customer hosts match none of the added patterns, and any host we newly recognize is an All-Hands-owned domain a customer can't use. See the full impact matrix in the PR comment.

_This edit was added by an AI agent (OpenHands) on behalf of @aivong-openhands._
