### PR TITLE
fix: Avoid logout on transient provider get_user errors

### DIFF
--- a/openhands/app_server/integrations/provider.py
+++ b/openhands/app_server/integrations/provider.py
@@ -166,7 +166,7 @@ class ProviderHandler:
         )
 
     async def get_user(self) -> User:
-        """Get user information from the first available provider"""
+        """Get user information from the first available provider."""
         exceptions: list[tuple[ProviderType, Exception]] = []
         for provider in self.provider_tokens:
             try:
@@ -175,11 +175,21 @@ class ProviderHandler:
             except Exception as e:
                 exceptions.append((provider, e))
                 continue
+
         for provider, exc in exceptions:
             logger.warning(
                 f'Failed to get user from provider {provider}: {exc}',
                 exc_info=(type(exc), exc, exc.__traceback__),
             )
+
+        # Only invalid provider credentials should surface as an authentication
+        # failure. Transient upstream/provider errors (for example GitHub 5xx or
+        # timeouts) must not become 401s, because the web client treats a 401
+        # from /users/git-info as a signal to log out the browser session.
+        for _, exc in exceptions:
+            if not isinstance(exc, AuthenticationError):
+                raise exc
+
         raise AuthenticationError('Need valid provider token')
 
     async def _get_latest_provider_token(

--- a/tests/unit/integrations/test_provider_get_user.py
+++ b/tests/unit/integrations/test_provider_get_user.py
@@ -1,0 +1,71 @@
+from types import MappingProxyType
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import SecretStr
+
+from openhands.app_server.integrations.provider import ProviderHandler, ProviderToken
+from openhands.app_server.integrations.service_types import (
+    AuthenticationError,
+    ProviderType,
+    UnknownException,
+    User,
+)
+
+
+def _handler_with_tokens(*providers: ProviderType) -> ProviderHandler:
+    return ProviderHandler(
+        MappingProxyType(
+            {
+                provider: ProviderToken(token=SecretStr(f'{provider.value}-token'))
+                for provider in providers
+            }
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_user_reraises_transient_provider_errors(monkeypatch):
+    handler = _handler_with_tokens(ProviderType.GITHUB)
+    service = AsyncMock()
+    service.get_user.side_effect = UnknownException(
+        'Unknown error: GitHub API returned 503'
+    )
+    monkeypatch.setattr(handler, 'get_service', lambda provider: service)
+
+    with pytest.raises(UnknownException, match='GitHub API returned 503'):
+        await handler.get_user()
+
+
+@pytest.mark.asyncio
+async def test_get_user_keeps_authentication_error_for_invalid_tokens(monkeypatch):
+    handler = _handler_with_tokens(ProviderType.GITHUB)
+    service = AsyncMock()
+    service.get_user.side_effect = AuthenticationError('Invalid github token')
+    monkeypatch.setattr(handler, 'get_service', lambda provider: service)
+
+    with pytest.raises(AuthenticationError, match='Need valid provider token'):
+        await handler.get_user()
+
+
+@pytest.mark.asyncio
+async def test_get_user_still_tries_next_provider_after_failure(monkeypatch):
+    handler = _handler_with_tokens(ProviderType.GITHUB, ProviderType.GITLAB)
+    gitlab_user = User(
+        id='gitlab-user-id',
+        login='gitlab-user',
+        avatar_url='https://example.com/avatar.png',
+    )
+    services = {
+        ProviderType.GITHUB: AsyncMock(),
+        ProviderType.GITLAB: AsyncMock(),
+    }
+    services[ProviderType.GITHUB].get_user.side_effect = UnknownException(
+        'GitHub unavailable'
+    )
+    services[ProviderType.GITLAB].get_user.return_value = gitlab_user
+    monkeypatch.setattr(handler, 'get_service', lambda provider: services[provider])
+
+    assert await handler.get_user() == gitlab_user
+    services[ProviderType.GITHUB].get_user.assert_awaited_once()
+    services[ProviderType.GITLAB].get_user.assert_awaited_once()


### PR DESCRIPTION
This PR was created by an AI agent (OpenHands) on behalf of the user.

## Summary
- preserve transient provider errors from `ProviderHandler.get_user()` instead of collapsing every provider failure into `AuthenticationError`
- keep invalid provider credentials mapped to `AuthenticationError` so real token failures still return auth failures
- add unit tests covering transient GitHub-style failures, invalid-token failures, and fallback to the next provider

## Why
Feature deployments were logging users out when GitHub returned a transient 503 from `GET https://api.github.com/user`. The provider layer converted that upstream 503 into `AuthenticationError('Need valid provider token')`, which becomes a 401 from `/api/v1/users/git-info`. The web client treats a 401 from that endpoint as a signal to logout in SaaS mode.

With this change, upstream provider outages remain non-auth errors, so they should surface as a transient request failure instead of logging out the browser session.

## Validation
- `uv run python -m pytest tests/unit/integrations/test_provider_get_user.py tests/unit/integrations/test_provider_immutability.py -q`

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/43b06efe-19ee-404e-b5fa-5d03258252ff)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-20289d1   docker.openhands.dev/openhands/openhands:20289d1
```