### PR TITLE
fix: clamp negative elapsed time formatting

### DIFF
--- a/frontend/__tests__/utils/format-time-delta.test.ts
+++ b/frontend/__tests__/utils/format-time-delta.test.ts
@@ -72,4 +72,9 @@ describe("formatTimeDelta", () => {
     const threeSecondsAgo = new Date("2023-12-31T23:59:57Z");
     expect(formatTimeDelta(threeSecondsAgo)).toBe("3s");
   });
+
+  it("does not render negative values for timestamps slightly in the future", () => {
+    const futureTimestamp = new Date("2024-01-01T00:02:00Z");
+    expect(formatTimeDelta(futureTimestamp)).toBe("0s");
+  });
 });

--- a/frontend/src/utils/format-time-delta.ts
+++ b/frontend/src/utils/format-time-delta.ts
@@ -39,7 +39,7 @@ export const formatTimeDelta = (date: Date | string) => {
   // Parse string dates as UTC if needed, or use Date object directly
   const dateObj = typeof date === "string" ? parseDateAsUTC(date) : date;
   const now = new Date();
-  const delta = now.getTime() - dateObj.getTime();
+  const delta = Math.max(0, now.getTime() - dateObj.getTime());
 
   const seconds = Math.floor(delta / 1000);
   const minutes = Math.floor(seconds / 60);


### PR DESCRIPTION
HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

Future timestamps can render negative elapsed-time values in the UI.

## Summary

- Clamp elapsed time deltas at zero before formatting.
- Add regression coverage for future timestamps rendering as 0s.

## Issue Number

Fixes OpenHands/enterprise#23

## How to Test

- [x] npm run test -- format-time-delta

## Video/Screenshots

N/A - unit-level formatting fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Commit hook execution was blocked locally because the backend pre-commit step calls poetry, which is not installed in this environment. The targeted frontend test passed.