### PR TITLE
fix: proxy workspace file previews with session key

### DIFF
--- a/openhands/app_server/app.py
+++ b/openhands/app_server/app.py
@@ -14,6 +14,9 @@ from fastapi import (
 from fastapi.responses import JSONResponse
 
 from openhands.app_server import v1_router
+from openhands.app_server.app_conversation.app_conversation_router import (
+    runtime_conversation_router,
+)
 from openhands.app_server.config import get_app_lifespan_service
 from openhands.app_server.integrations.service_types import AuthenticationError
 from openhands.app_server.mcp.mcp_router import init_tavily_proxy, mcp_server
@@ -69,6 +72,7 @@ async def authentication_error_handler(request: Request, exc: AuthenticationErro
 
 
 app.include_router(v1_router.router)
+app.include_router(runtime_conversation_router)
 app.include_router(health_router)
 
 # Middleware and static file setup (merged from listen.py)

--- a/openhands/app_server/app_conversation/app_conversation_router.py
+++ b/openhands/app_server/app_conversation/app_conversation_router.py
@@ -10,11 +10,12 @@ import tempfile
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Annotated, Any, AsyncGenerator, Literal
+from urllib.parse import quote
 from uuid import UUID
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from openhands.agent_server.models import Success
@@ -106,6 +107,11 @@ else:
 # is protected. The actual protection is provided by SetAuthCookieMiddleware
 router = APIRouter(
     prefix='/app-conversations', tags=['Conversations'], dependencies=get_dependencies()
+)
+runtime_conversation_router = APIRouter(
+    prefix='/api/conversations',
+    tags=['Runtime Conversations'],
+    dependencies=get_dependencies(),
 )
 logger = logging.getLogger(__name__)
 app_conversation_service_dependency = depends_app_conversation_service()
@@ -1208,6 +1214,68 @@ async def read_conversation_file(
                 pass
 
     return ''
+
+
+@runtime_conversation_router.get('/{conversation_id}/workspace/{file_path:path}')
+async def get_conversation_workspace_file(
+    conversation_id: UUID,
+    file_path: str,
+    app_conversation_service: AppConversationService = (
+        app_conversation_service_dependency
+    ),
+    sandbox_service: SandboxService = sandbox_service_dependency,
+    sandbox_spec_service: SandboxSpecService = sandbox_spec_service_dependency,
+    httpx_client: httpx.AsyncClient = httpx_client_dependency,
+) -> Response:
+    """Proxy legacy agent-canvas workspace file preview requests to the runtime.
+
+    The runtime protects workspace file reads with ``X-Session-API-Key``.
+    Browser requests to the app-server compatibility route do not have that
+    sandbox credential, so the app server resolves it and forwards the request
+    server-side.
+    """
+    ctx = await _get_agent_server_context(
+        conversation_id,
+        app_conversation_service,
+        sandbox_service,
+        sandbox_spec_service,
+    )
+    if isinstance(ctx, JSONResponse):
+        raise HTTPException(
+            status_code=ctx.status_code,
+            detail=f'Conversation {conversation_id} is not reachable',
+        )
+    if ctx is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail='Sandbox is paused; resume it before reading workspace files.',
+        )
+
+    headers = {'X-Session-API-Key': ctx.session_api_key} if ctx.session_api_key else {}
+    quoted_file_path = quote(file_path, safe='/')
+    runtime_url = (
+        f'{ctx.agent_server_url}/api/conversations/{conversation_id}'
+        f'/workspace/{quoted_file_path}'
+    )
+
+    try:
+        upstream = await httpx_client.get(
+            runtime_url,
+            headers=headers,
+            timeout=30.0,
+        )
+    except httpx.RequestError as e:
+        logger.error('Failed to reach agent server during workspace file read: %s', e)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Failed to reach agent server.',
+        )
+
+    return Response(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        headers={'content-type': upstream.headers.get('content-type', 'text/plain')},
+    )
 
 
 async def _proxy_git_runtime_call(

--- a/tests/unit/app_server/test_app_conversation_router.py
+++ b/tests/unit/app_server/test_app_conversation_router.py
@@ -26,6 +26,7 @@ from openhands.app_server.app_conversation.app_conversation_router import (
     count_app_conversations,
     get_conversation_git_changes,
     get_conversation_git_diff,
+    get_conversation_workspace_file,
     search_app_conversations,
     switch_conversation_profile,
 )
@@ -1084,6 +1085,47 @@ class TestGitProxyEndpoints:
 
         assert exc_info.value.status_code == status.HTTP_409_CONFLICT
         assert 'paused' in exc_info.value.detail.lower()
+
+
+@pytest.mark.asyncio
+class TestWorkspaceFileProxyEndpoint:
+    """Test suite for the agent-canvas workspace file preview compatibility route."""
+
+    async def test_forwards_workspace_file_request_with_session_key(self):
+        """Workspace file preview requests must be proxied with the sandbox
+        session key so the runtime does not reject them with 401 Unauthorized."""
+        # Arrange
+        conv_id = uuid4()
+        ctx = _make_agent_server_context(conv_id)
+        upstream_response = MagicMock()
+        upstream_response.status_code = status.HTTP_200_OK
+        upstream_response.content = b"export const token = 'abc';\n"
+        upstream_response.headers = {'content-type': 'text/plain; charset=utf-8'}
+        client = _make_get_httpx_client(get_return=upstream_response)
+
+        # Act
+        with patch(
+            'openhands.app_server.app_conversation.app_conversation_router.'
+            '_get_agent_server_context',
+            new=AsyncMock(return_value=ctx),
+        ):
+            response = await get_conversation_workspace_file(
+                conversation_id=conv_id,
+                file_path='frontend/src/stores/auth.ts',
+                app_conversation_service=MagicMock(),
+                sandbox_service=MagicMock(),
+                sandbox_spec_service=MagicMock(),
+                httpx_client=client,
+            )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        assert response.body == b"export const token = 'abc';\n"
+        client.get.assert_awaited_once_with(
+            f'http://agent.test/api/conversations/{conv_id}/workspace/frontend/src/stores/auth.ts',
+            headers={'X-Session-API-Key': 'sess-key'},
+            timeout=30.0,
+        )
 
 
 class TestFinalizeSandboxDelete:


### PR DESCRIPTION
HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

The agent canvas file preview can request workspace files through the app server without the sandbox session key, causing the agent-server workspace endpoint to return 401.

## Summary

- Add an app-server compatibility route for workspace file preview requests.
- Resolve the conversation sandbox context and forward requests with X-Session-API-Key.
- Add unit coverage for forwarding the workspace file request with the session key.

## Issue Number

Fixes #15278

## How to Test

- [x] uv run --frozen pytest tests/unit/app_server/test_app_conversation_router.py::TestWorkspaceFileProxyEndpoint::test_forwards_workspace_file_request_with_session_key -q
- [x] uv run --frozen ruff check openhands/app_server/app.py openhands/app_server/app_conversation/app_conversation_router.py tests/unit/app_server/test_app_conversation_router.py

## Video/Screenshots

N/A - backend route proxy fix covered by unit test.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

make install-pre-commit-hooks is blocked locally because the shell Python is 3.9.9 while the project requires Python >=3.12,<3.14. File-level pre-commit also cannot complete because the mypy hook installation fails while building litellm due to a missing Rust toolchain manifest.