### PR TITLE
fix: normalize local LLM models for OpenAI-compatible endpoints

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -112,6 +112,7 @@ from openhands.app_server.utils.docker_utils import (
 )
 from openhands.app_server.utils.git import ensure_valid_git_branch_name
 from openhands.app_server.utils.import_utils import get_impl
+from openhands.app_server.utils.llm import resolve_llm_model
 from openhands.app_server.utils.llm_metadata import (
     get_llm_metadata,
     should_set_litellm_extra_body,
@@ -1233,6 +1234,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             or user.agent_settings.llm.model
             or LLM.model_fields['model'].default
         )
+        model = resolve_llm_model(model, user.agent_settings.llm.base_url)
 
         base_url = resolve_provider_llm_base_url(
             model,

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -1234,7 +1234,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             or user.agent_settings.llm.model
             or LLM.model_fields['model'].default
         )
-        model = resolve_llm_model(model, user.agent_settings.llm.base_url)
+        resolved_model = resolve_llm_model(model, user.agent_settings.llm.base_url)
+        if resolved_model is not None:
+            model = resolved_model
 
         base_url = resolve_provider_llm_base_url(
             model,

--- a/openhands/app_server/settings/llm_profiles.py
+++ b/openhands/app_server/settings/llm_profiles.py
@@ -14,7 +14,7 @@ from pydantic import (
     model_validator,
 )
 
-from openhands.app_server.utils.llm import resolve_llm_base_url
+from openhands.app_server.utils.llm import resolve_llm_base_url, resolve_llm_model
 from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.sdk.llm import LLM
 
@@ -48,10 +48,12 @@ def resolve_profile_llm(
     without the fallback the agent server would call the LiteLLM proxy with no
     credentials; BYOR profiles keep their own key (the fallback is skipped).
     """
+    model = resolve_llm_model(profile_llm.model, profile_llm.base_url)
     resolved = profile_llm.model_copy(
         update={
+            'model': model,
             'base_url': resolve_llm_base_url(
-                model=profile_llm.model,
+                model=model,
                 base_url=profile_llm.base_url,
                 managed_proxy_url=managed_proxy_url,
             ),

--- a/openhands/app_server/settings/settings_router.py
+++ b/openhands/app_server/settings/settings_router.py
@@ -48,6 +48,7 @@ from openhands.app_server.utils.llm import (
     get_provider_api_base,
     is_openhands_model,
     resolve_llm_base_url,
+    resolve_llm_model,
 )
 from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.sdk.llm import LLM
@@ -109,6 +110,7 @@ def _post_merge_llm_fixups(settings: Settings) -> None:
     if not isinstance(settings.agent_settings, OpenHandsAgentSettings):
         return
     llm = settings.agent_settings.llm
+    llm.model = resolve_llm_model(llm.model, llm.base_url)
     llm.base_url = resolve_llm_base_url(
         model=llm.model,
         base_url=llm.base_url,
@@ -583,6 +585,10 @@ async def save_profile(
             # Caller has no new key: keep the profile's stored key (even "no
             # key") instead of the snapshotted active-settings key.
             llm = llm.model_copy(update={'api_key': existing.api_key})
+
+        llm = llm.model_copy(
+            update={'model': resolve_llm_model(llm.model, llm.base_url)}
+        )
 
         try:
             settings.llm_profiles.save(

--- a/openhands/app_server/settings/settings_router.py
+++ b/openhands/app_server/settings/settings_router.py
@@ -110,7 +110,9 @@ def _post_merge_llm_fixups(settings: Settings) -> None:
     if not isinstance(settings.agent_settings, OpenHandsAgentSettings):
         return
     llm = settings.agent_settings.llm
-    llm.model = resolve_llm_model(llm.model, llm.base_url)
+    resolved_model = resolve_llm_model(llm.model, llm.base_url)
+    if resolved_model is not None:
+        llm.model = resolved_model
     llm.base_url = resolve_llm_base_url(
         model=llm.model,
         base_url=llm.base_url,

--- a/openhands/app_server/utils/llm.py
+++ b/openhands/app_server/utils/llm.py
@@ -1,4 +1,6 @@
+import ipaddress
 import warnings
+from urllib.parse import urlparse
 
 from pydantic import BaseModel
 
@@ -104,6 +106,77 @@ class ModelsResponse(BaseModel):
 def is_openhands_model(model: str | None) -> bool:
     """Return True when the model uses the public OpenHands provider prefix."""
     return bool(model and model.startswith('openhands/'))
+
+
+def _has_known_litellm_provider_prefix(model: str) -> bool:
+    provider, separator, _ = model.partition('/')
+    if not separator:
+        return False
+    try:
+        LlmProviders(provider)
+    except ValueError:
+        return False
+    return True
+
+
+def _can_litellm_resolve_model(model: str) -> bool:
+    try:
+        get_llm_provider(model)
+    except Exception:
+        return False
+    return True
+
+
+def _is_local_llm_base_url(base_url: str) -> bool:
+    hostname = urlparse(base_url).hostname
+    if not hostname:
+        return False
+
+    hostname = hostname.lower()
+    if hostname == 'localhost' or hostname.endswith(('.localhost', '.local')):
+        return True
+    if hostname == 'host.docker.internal':
+        return True
+
+    try:
+        ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        return False
+    return ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_unspecified
+
+
+def resolve_llm_model(model: str | None, base_url: str | None) -> str | None:
+    """Resolve model routing for OpenAI-compatible custom endpoints.
+
+    LiteLLM needs a provider prefix to route requests. OpenAI-compatible local
+    servers such as LM Studio often expose model ids like
+    ``lmstudio-community/gemma-...`` where the left side is a model namespace,
+    not a LiteLLM provider. When a custom local ``base_url`` is set and the
+    model cannot otherwise be resolved, route through the OpenAI-compatible
+    provider and keep the actual model id on the right.
+    """
+    if not model:
+        return model
+
+    model = model.strip()
+    if not model:
+        return model
+
+    base_url = base_url.strip() if base_url else ''
+    if not base_url:
+        return model
+
+    if _has_known_litellm_provider_prefix(model):
+        return model
+
+    if not _is_local_llm_base_url(base_url):
+        return model
+
+    _, separator, model_name = model.partition('/')
+    if separator:
+        return f'openai/{model_name}'
+
+    return model if _can_litellm_resolve_model(model) else f'openai/{model}'
 
 
 # Canonical masked placeholder for LLM API keys. Matches pydantic's

--- a/tests/unit/app_server/test_app_conversation_router.py
+++ b/tests/unit/app_server/test_app_conversation_router.py
@@ -661,6 +661,56 @@ class TestSwitchConversationProfile:
         assert post_kwargs['json']['llm']['usage_id'].startswith('profile:gpt-5:')
         assert post_kwargs['json']['llm']['stream'] is True
 
+    async def test_switch_profile_normalizes_openai_compatible_custom_model(self):
+        """LM Studio model namespaces are normalized before hitting LiteLLM."""
+        conv_id = uuid4()
+        settings = Settings(
+            agent_settings=OpenHandsAgentSettings(
+                llm=LLM(model='openai/gpt-4o', api_key='managed-proxy-key')
+            ),
+            llm_profiles=LLMProfiles(
+                profiles={
+                    'lmstudio': LLM(
+                        model='lmstudio-community/gemma-4-e4b-it-mlx',
+                        base_url='http://localhost:1234/v1',
+                    )
+                }
+            ),
+        )
+        ctx = _make_agent_server_context(conv_id, llm_model='openai/old-model')
+        ok_response = MagicMock()
+        ok_response.status_code = 200
+        ok_response.raise_for_status = MagicMock()
+        client = _make_httpx_client(post_return=ok_response)
+        info_service = MagicMock()
+        info_service.get_app_conversation_info = AsyncMock(
+            return_value=ctx.conversation,
+        )
+        info_service.save_app_conversation_info = AsyncMock()
+
+        with patch(
+            'openhands.app_server.app_conversation.app_conversation_router.'
+            '_get_agent_server_context',
+            new=AsyncMock(return_value=ctx),
+        ):
+            await switch_conversation_profile(
+                conversation_id=conv_id,
+                request=SwitchProfileRequest(profile_name='lmstudio'),
+                user_settings=settings,
+                app_conversation_service=MagicMock(),
+                app_conversation_info_service=info_service,
+                sandbox_service=MagicMock(),
+                sandbox_spec_service=MagicMock(),
+                httpx_client=client,
+            )
+
+        post_kwargs = client.post.await_args.kwargs
+        llm_payload = post_kwargs['json']['llm']
+        assert llm_payload['model'] == 'openai/gemma-4-e4b-it-mlx'
+        assert llm_payload['base_url'] == 'http://localhost:1234/v1'
+        saved_info = info_service.save_app_conversation_info.await_args[0][0]
+        assert saved_info.llm_model == 'openai/gemma-4-e4b-it-mlx'
+
     async def test_falls_back_to_settings_api_key_when_profile_has_none(self):
         """SaaS: managed profiles persist no key, so the switch must source the
         effective ``agent_settings.llm.api_key`` — otherwise the agent server

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -861,6 +861,25 @@ class TestLiveStatusAppConversationService:
         assert llm.base_url == 'https://user-llm.example.com'
 
     @pytest.mark.asyncio
+    async def test_configure_llm_and_mcp_normalizes_openai_compatible_custom_model(
+        self,
+    ):
+        """LM Studio model namespaces are normalized before runtime startup."""
+        # Arrange
+        self.mock_user.llm_model = 'lmstudio-community/gemma-4-e4b-it-mlx'
+        self.mock_user.llm_base_url = 'http://localhost:1234/v1'
+        self.mock_user_context.get_mcp_api_key.return_value = None
+
+        # Act
+        llm, _ = await self.service._configure_llm_and_mcp(
+            self.mock_user, None, self.conversation_id
+        )
+
+        # Assert
+        assert llm.model == 'openai/gemma-4-e4b-it-mlx'
+        assert llm.base_url == 'http://localhost:1234/v1'
+
+    @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_with_user_default_model(self):
         """Test _configure_llm_and_mcp using user's default model."""
         # Arrange

--- a/tests/unit/app_server/test_profiles_api.py
+++ b/tests/unit/app_server/test_profiles_api.py
@@ -251,6 +251,29 @@ async def test_save_profile_with_explicit_llm_persists(test_client, settings_sto
 
 
 @pytest.mark.asyncio
+async def test_save_profile_normalizes_openai_compatible_custom_model(
+    test_client, settings_store
+):
+    await _seed(settings_store, _base_settings())
+
+    response = test_client.post(
+        '/api/v1/settings/profiles/lmstudio',
+        json={
+            'llm': {
+                'model': 'lmstudio-community/gemma-4-e4b-it-mlx',
+                'base_url': 'http://localhost:1234/v1',
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    stored = await settings_store.load()
+    saved_llm = stored.llm_profiles.get('lmstudio')
+    assert saved_llm.model == 'openai/gemma-4-e4b-it-mlx'
+    assert saved_llm.base_url == 'http://localhost:1234/v1'
+
+
+@pytest.mark.asyncio
 async def test_save_profile_snapshots_current_llm_when_no_body(
     test_client, settings_store
 ):

--- a/tests/unit/app_server/test_settings_api.py
+++ b/tests/unit/app_server/test_settings_api.py
@@ -225,6 +225,27 @@ async def test_settings_api_endpoints(test_client):
 
 
 @pytest.mark.asyncio
+async def test_settings_api_normalizes_openai_compatible_custom_model(test_client):
+    settings = Settings(
+        agent_settings=OpenHandsAgentSettings(
+            llm=LLM(
+                model='lmstudio-community/gemma-4-e4b-it-mlx',
+                base_url='http://localhost:1234/v1',
+            )
+        )
+    )
+
+    response = test_client.post('/api/v1/settings', json=_dump_update(settings))
+    assert response.status_code == 200
+
+    response = test_client.get('/api/v1/settings')
+    assert response.status_code == 200
+    llm = response.json()['agent_settings']['llm']
+    assert llm['model'] == 'openai/gemma-4-e4b-it-mlx'
+    assert llm['base_url'] == 'http://localhost:1234/v1'
+
+
+@pytest.mark.asyncio
 async def test_store_settings_rejects_legacy_nested_payload_keys(test_client):
     response = test_client.post(
         '/api/v1/settings',

--- a/tests/unit/utils/test_llm_utils.py
+++ b/tests/unit/utils/test_llm_utils.py
@@ -6,6 +6,7 @@ from openhands.app_server.utils.llm import (
     _derive_verified_models,
     get_provider_api_base,
     is_openhands_model,
+    resolve_llm_model,
 )
 
 
@@ -107,6 +108,54 @@ class TestAssignProvider:
         monkeypatch.setattr(llm_utils, 'get_llm_provider', _boom)
 
         assert _assign_provider('whatever') == 'whatever'
+
+
+class TestResolveLlmModel:
+    """Tests for model routing normalization before settings are persisted."""
+
+    def test_custom_openai_compatible_base_url_prefixes_bare_model(self):
+        assert (
+            resolve_llm_model('gemma-4-e4b-it-mlx', 'http://localhost:1234/v1')
+            == 'openai/gemma-4-e4b-it-mlx'
+        )
+
+    def test_custom_openai_compatible_base_url_replaces_unknown_namespace(self):
+        assert (
+            resolve_llm_model(
+                'lmstudio-community/gemma-4-e4b-it-mlx',
+                'http://localhost:1234/v1',
+            )
+            == 'openai/gemma-4-e4b-it-mlx'
+        )
+
+    def test_known_provider_prefix_is_preserved(self):
+        assert (
+            resolve_llm_model(
+                'lm_studio/gemma-4-e4b-it-mlx', 'http://localhost:1234/v1'
+            )
+            == 'lm_studio/gemma-4-e4b-it-mlx'
+        )
+        assert (
+            resolve_llm_model('ollama/llama3', 'http://localhost:11434')
+            == 'ollama/llama3'
+        )
+
+    def test_known_bare_model_with_base_url_is_preserved(self):
+        assert resolve_llm_model('gpt-4', 'https://api.openai.com/v1') == 'gpt-4'
+
+    def test_unknown_bare_model_with_nonlocal_base_url_is_preserved(self):
+        assert resolve_llm_model('test-model', 'https://test.com') == 'test-model'
+
+    def test_unknown_namespace_with_nonlocal_base_url_is_preserved(self):
+        assert (
+            resolve_llm_model('custom-org/test-model', 'https://test.com')
+            == 'custom-org/test-model'
+        )
+
+    def test_empty_base_url_leaves_model_unchanged(self):
+        assert resolve_llm_model('lmstudio-community/gemma', '') == (
+            'lmstudio-community/gemma'
+        )
 
 
 class TestDeriveVerifiedModels:


### PR DESCRIPTION
HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

LM Studio can expose model ids such as lmstudio-community/gemma-4-e4b-it-mlx, where the namespace is not a LiteLLM provider. With a local OpenAI-compatible base URL, that model id can fail provider routing before requests reach LM Studio.

## Summary

- Add LLM model routing normalization for local OpenAI-compatible endpoints.
- Apply normalization in settings save, profile save/activation, running profile switch, and conversation startup paths.
- Preserve known provider prefixes, known bare models, and nonlocal custom base URLs.

## Issue Number

Fixes OpenHands/software-agent-sdk#4247

## How to Test

- [x] uv run --frozen pytest tests/unit/utils/test_llm_utils.py::TestResolveLlmModel tests/unit/app_server/test_settings_api.py::test_settings_api_normalizes_openai_compatible_custom_model tests/unit/app_server/test_profiles_api.py::test_save_profile_normalizes_openai_compatible_custom_model tests/unit/app_server/test_app_conversation_router.py::TestSwitchConversationProfile::test_switch_profile_normalizes_openai_compatible_custom_model tests/unit/app_server/test_live_status_app_conversation_service.py::TestLiveStatusAppConversationService::test_configure_llm_and_mcp_normalizes_openai_compatible_custom_model -q
- [x] uv run --frozen pytest tests/unit/app_server/test_settings_api.py tests/unit/app_server/test_profiles_api.py tests/unit/app_server/test_app_conversation_router.py::TestSwitchConversationProfile -q
- [x] uv run --frozen ruff check openhands/app_server/utils/llm.py openhands/app_server/settings/settings_router.py openhands/app_server/settings/llm_profiles.py openhands/app_server/app_conversation/live_status_app_conversation_service.py tests/unit/utils/test_llm_utils.py tests/unit/app_server/test_settings_api.py tests/unit/app_server/test_profiles_api.py tests/unit/app_server/test_app_conversation_router.py tests/unit/app_server/test_live_status_app_conversation_service.py
- [x] uv run --frozen ruff format --check openhands/app_server/utils/llm.py openhands/app_server/settings/settings_router.py openhands/app_server/settings/llm_profiles.py openhands/app_server/app_conversation/live_status_app_conversation_service.py tests/unit/utils/test_llm_utils.py tests/unit/app_server/test_settings_api.py tests/unit/app_server/test_profiles_api.py tests/unit/app_server/test_app_conversation_router.py tests/unit/app_server/test_live_status_app_conversation_service.py

## Video/Screenshots

N/A - backend routing normalization covered by unit tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

make install-pre-commit-hooks is blocked locally because the shell Python is 3.9.9 while the project requires Python >=3.12,<3.14. File-level pre-commit also cannot complete because the mypy hook installation fails while building litellm due to a missing Rust toolchain manifest. A broader run including tests/unit/utils/test_llm_utils.py surfaced one unrelated environment-sensitive failure because ANTHROPIC_BASE_URL is set to https://api.deepseek.com/anthropic locally.