### PR TITLE
fix: proxy Canvas runtime requests through Cloud

### DIFF
--- a/openhands/app_server/app_conversation/app_conversation_models.py
+++ b/openhands/app_server/app_conversation/app_conversation_models.py
@@ -415,6 +415,12 @@ class SwitchAcpModelRequest(BaseModel):
     )
 
 
+class RuntimeRequest(BaseModel):
+    method: Literal['GET', 'POST']
+    path: str = Field(min_length=1)
+    body: Any = None
+
+
 class AppSendMessageResponse(BaseModel):
     """Response from sending a message to a conversation."""
 

--- a/openhands/app_server/app_conversation/app_conversation_router.py
+++ b/openhands/app_server/app_conversation/app_conversation_router.py
@@ -13,7 +13,7 @@ from typing import Annotated, Any, AsyncGenerator, Literal
 from uuid import UUID
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.responses import JSONResponse, StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -38,6 +38,7 @@ from openhands.app_server.app_conversation.app_conversation_models import (
     HookDefinitionResponse,
     HookEventResponse,
     HookMatcherResponse,
+    RuntimeRequest,
     SkillResponse,
     SwitchAcpModelRequest,
     SwitchProfileRequest,
@@ -118,6 +119,19 @@ db_session_dependency = depends_db_session()
 httpx_client_dependency = depends_httpx_client()
 sandbox_service_dependency = depends_sandbox_service()
 sandbox_spec_service_dependency = depends_sandbox_spec_service()
+
+_RUNTIME_RESPONSE_STRIPPED_HEADERS = {
+    'connection',
+    'content-encoding',
+    'content-length',
+    'content-type',
+    'keep-alive',
+    'set-cookie',
+    'te',
+    'trailers',
+    'transfer-encoding',
+    'upgrade',
+}
 
 
 @dataclass
@@ -1281,6 +1295,87 @@ async def _proxy_git_runtime_call(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail='Failed to reach agent server.',
         )
+
+
+def _is_allowed_runtime_request(conversation_id: UUID, request: RuntimeRequest) -> bool:
+    path = request.path.partition('?')[0]
+    conversation_path = f'/api/conversations/{conversation_id}'
+    return (request.method, path) in {
+        ('POST', f'{conversation_path}/events'),
+        ('GET', conversation_path),
+        ('POST', f'{conversation_path}/events/respond_to_confirmation'),
+        ('GET', f'{conversation_path}/events/count'),
+        ('POST', '/api/bash/execute_bash_command'),
+        ('GET', '/api/bash/bash_events/search'),
+        ('GET', '/api/file/download'),
+        ('GET', '/api/git/changes'),
+        ('GET', '/api/git/diff'),
+    }
+
+
+@router.post('/{conversation_id}/runtime')
+async def proxy_conversation_runtime_request(
+    conversation_id: UUID,
+    request: RuntimeRequest,
+    app_conversation_service: AppConversationService = (
+        app_conversation_service_dependency
+    ),
+    sandbox_service: SandboxService = sandbox_service_dependency,
+    sandbox_spec_service: SandboxSpecService = sandbox_spec_service_dependency,
+    httpx_client: httpx.AsyncClient = httpx_client_dependency,
+) -> Response:
+    if not _is_allowed_runtime_request(conversation_id, request):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='Unsupported runtime request.',
+        )
+
+    ctx = await _get_agent_server_context(
+        conversation_id,
+        app_conversation_service,
+        sandbox_service,
+        sandbox_spec_service,
+    )
+    if isinstance(ctx, JSONResponse):
+        raise HTTPException(
+            status_code=ctx.status_code, detail='Conversation is not reachable.'
+        )
+    if ctx is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail='Sandbox is paused; resume it before using the runtime.',
+        )
+
+    try:
+        upstream = await httpx_client.request(
+            request.method,
+            f'{ctx.agent_server_url}{request.path}',
+            headers=(
+                {'X-Session-API-Key': ctx.session_api_key}
+                if ctx.session_api_key
+                else {}
+            ),
+            json=request.body if request.method == 'POST' else None,
+            timeout=30.0,
+        )
+    except httpx.RequestError as e:
+        logger.error('Failed to reach agent server during runtime request: %s', e)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Failed to reach agent server.',
+        ) from e
+
+    headers = {
+        name: value
+        for name, value in upstream.headers.items()
+        if name.lower() not in _RUNTIME_RESPONSE_STRIPPED_HEADERS
+    }
+    return Response(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        headers=headers,
+        media_type=upstream.headers.get('content-type'),
+    )
 
 
 @router.get('/{conversation_id}/git/changes')

--- a/openhands/app_server/app_conversation/app_conversation_router.py
+++ b/openhands/app_server/app_conversation/app_conversation_router.py
@@ -1309,6 +1309,7 @@ def _is_allowed_runtime_request(conversation_id: UUID, request: RuntimeRequest) 
         ('GET', '/api/bash/bash_events/search'),
         ('GET', '/api/file/download'),
         ('GET', '/api/git/changes'),
+        ('GET', '/api/git/commits'),
         ('GET', '/api/git/diff'),
     }
 

--- a/openhands/app_server/app_conversation/app_conversation_router.py
+++ b/openhands/app_server/app_conversation/app_conversation_router.py
@@ -1300,7 +1300,15 @@ async def _proxy_git_runtime_call(
 def _is_allowed_runtime_request(conversation_id: UUID, request: RuntimeRequest) -> bool:
     path = request.path.partition('?')[0]
     conversation_path = f'/api/conversations/{conversation_id}'
-    return (request.method, path) in {
+    path_parts = path.split('/')
+    is_commit_changes_request = (
+        request.method == 'GET'
+        and len(path_parts) == 6
+        and path_parts[:4] == ['', 'api', 'git', 'commits']
+        and bool(path_parts[4])
+        and path_parts[5] == 'changes'
+    )
+    return is_commit_changes_request or (request.method, path) in {
         ('POST', f'{conversation_path}/events'),
         ('GET', conversation_path),
         ('POST', f'{conversation_path}/events/respond_to_confirmation'),

--- a/tests/unit/app_server/test_app_conversation_router.py
+++ b/tests/unit/app_server/test_app_conversation_router.py
@@ -17,6 +17,7 @@ from openhands.app_server.app_conversation.app_conversation_models import (
     AppConversation,
     AppConversationInfo,
     AppConversationPage,
+    RuntimeRequest,
     SwitchProfileRequest,
 )
 from openhands.app_server.app_conversation.app_conversation_router import (
@@ -26,6 +27,7 @@ from openhands.app_server.app_conversation.app_conversation_router import (
     count_app_conversations,
     get_conversation_git_changes,
     get_conversation_git_diff,
+    proxy_conversation_runtime_request,
     search_app_conversations,
     switch_conversation_profile,
 )
@@ -823,6 +825,65 @@ def _make_get_httpx_client(get_return=None, get_side_effect=None) -> AsyncMock:
         response = get_return or MagicMock()
         client.get = AsyncMock(return_value=response)
     return client
+
+
+@pytest.mark.asyncio
+class TestRuntimeProxyEndpoint:
+    async def test_forwards_allowed_request_to_its_conversation_runtime(self):
+        conversation_id = uuid4()
+        ctx = _make_agent_server_context(conversation_id)
+        upstream = httpx.Response(
+            status_code=200,
+            content=b'{"exit_code":0}',
+            headers={'content-type': 'application/json', 'set-cookie': 'ignored'},
+        )
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.request = AsyncMock(return_value=upstream)
+
+        with patch(
+            'openhands.app_server.app_conversation.app_conversation_router.'
+            '_get_agent_server_context',
+            new=AsyncMock(return_value=ctx),
+        ):
+            result = await proxy_conversation_runtime_request(
+                conversation_id=conversation_id,
+                request=RuntimeRequest(
+                    method='POST',
+                    path='/api/bash/execute_bash_command',
+                    body={'command': 'pwd'},
+                ),
+                app_conversation_service=MagicMock(),
+                sandbox_service=MagicMock(),
+                sandbox_spec_service=MagicMock(),
+                httpx_client=client,
+            )
+
+        client.request.assert_awaited_once_with(
+            'POST',
+            'http://agent.test/api/bash/execute_bash_command',
+            headers={'X-Session-API-Key': 'sess-key'},
+            json={'command': 'pwd'},
+            timeout=30.0,
+        )
+        assert result.status_code == status.HTTP_200_OK
+        assert result.body == b'{"exit_code":0}'
+        assert 'set-cookie' not in result.headers
+
+    async def test_rejects_requests_outside_the_runtime_allowlist(self):
+        with pytest.raises(HTTPException) as exc_info:
+            await proxy_conversation_runtime_request(
+                conversation_id=uuid4(),
+                request=RuntimeRequest(
+                    method='GET',
+                    path=f'/api/conversations/{uuid4()}',
+                ),
+                app_conversation_service=MagicMock(),
+                sandbox_service=MagicMock(),
+                sandbox_spec_service=MagicMock(),
+                httpx_client=AsyncMock(spec=httpx.AsyncClient),
+            )
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app_server/test_app_conversation_router.py
+++ b/tests/unit/app_server/test_app_conversation_router.py
@@ -885,6 +885,43 @@ class TestRuntimeProxyEndpoint:
 
         assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
 
+    async def test_forwards_commit_changes_request(self):
+        conversation_id = uuid4()
+        ctx = _make_agent_server_context(conversation_id)
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.request = AsyncMock(
+            return_value=httpx.Response(
+                status_code=200,
+                content=b'[]',
+                headers={'content-type': 'application/json'},
+            )
+        )
+
+        with patch(
+            'openhands.app_server.app_conversation.app_conversation_router.'
+            '_get_agent_server_context',
+            new=AsyncMock(return_value=ctx),
+        ):
+            await proxy_conversation_runtime_request(
+                conversation_id=conversation_id,
+                request=RuntimeRequest(
+                    method='GET',
+                    path='/api/git/commits/abc123/changes?path=%2Fworkspace',
+                ),
+                app_conversation_service=MagicMock(),
+                sandbox_service=MagicMock(),
+                sandbox_spec_service=MagicMock(),
+                httpx_client=client,
+            )
+
+        client.request.assert_awaited_once_with(
+            'GET',
+            'http://agent.test/api/git/commits/abc123/changes?path=%2Fworkspace',
+            headers={'X-Session-API-Key': 'sess-key'},
+            json=None,
+            timeout=30.0,
+        )
+
 
 @pytest.mark.asyncio
 class TestGitProxyEndpoints:


### PR DESCRIPTION
## Why

Agent Canvas is deployed as a static Cloud frontend. Its runtime requests currently target the removed `/api/cloud-proxy` endpoint on the Canvas host, causing 503s.

## Change

Add an authenticated, conversation-scoped Cloud API endpoint for the runtime operations Canvas uses. The API resolves the runtime server-side, attaches its session credential, and accepts only the fixed operation allowlist. It does not accept a caller-controlled upstream host.

## Validation

- `poetry run pytest tests/unit/app_server/test_app_conversation_router.py`
- `poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files openhands/app_server/app_conversation/app_conversation_models.py openhands/app_server/app_conversation/app_conversation_router.py tests/unit/app_server/test_app_conversation_router.py`

## Follow-up

[Agent Canvas PR #1837](https://github.com/OpenHands/agent-canvas/pull/1837) calls this endpoint instead of the obsolete runtime proxy route.