### PR TITLE
fix(enterprise): give the keycloak_auth cookie a Max-Age matching its JWS TTL

### DIFF
--- a/enterprise/server/auth/cookie_chunking.py
+++ b/enterprise/server/auth/cookie_chunking.py
@@ -61,12 +61,18 @@ def set_chunked_cookie(
     secure: bool = True,
     httponly: bool = True,
     samesite: str = 'lax',
+    max_age: int | None = None,
 ) -> None:
     """Set ``key`` to ``value``, splitting across sibling cookies if needed.
 
     Always clears trailing chunk indices that this write does not use, so a
     value that shrank from N chunks to fewer does not leave stale chunks
     that ``read_chunked_cookie`` would wrongly append.
+
+    ``max_age`` (seconds) makes the cookie persistent so the session
+    survives a full browser quit; without it the browser discards the
+    cookie on exit. It is applied to every chunk — a chunk outliving its
+    siblings would reassemble into a torn token.
     """
     chunks = [value[i : i + CHUNK_SIZE] for i in range(0, len(value), CHUNK_SIZE)] or [
         ''
@@ -80,6 +86,8 @@ def set_chunked_cookie(
         }
         if domain:
             kwargs['domain'] = domain
+        if max_age is not None:
+            kwargs['max_age'] = max_age
         response.set_cookie(key=_chunk_key(key, i), value=chunk, **kwargs)
 
     # Expire any chunks left over from a previously larger value.

--- a/enterprise/server/routes/auth.py
+++ b/enterprise/server/routes/auth.py
@@ -95,6 +95,12 @@ def create_provider_tokens_object(
     return MappingProxyType(provider_information)
 
 
+# The signed JWS inside the cookie and the cookie itself expire together;
+# a persistent Max-Age lets the session survive a full browser quit instead
+# of dying with the browser process as a session cookie.
+AUTH_COOKIE_TTL = timedelta(weeks=1)
+
+
 def set_response_cookie(
     request: Request,
     response: Response,
@@ -112,7 +118,7 @@ def set_response_cookie(
     from storage.encrypt_utils import get_jwt_service
 
     signed_token = get_jwt_service().create_jws_token(
-        cookie_data, expires_in=timedelta(weeks=1)
+        cookie_data, expires_in=AUTH_COOKIE_TTL
     )
 
     # Set secure cookie with signed token. The value can exceed the
@@ -128,6 +134,7 @@ def set_response_cookie(
         secure=secure,
         httponly=True,
         samesite=get_cookie_samesite(),
+        max_age=int(AUTH_COOKIE_TTL.total_seconds()),
     )
 
 

--- a/enterprise/tests/unit/server/auth/test_cookie_chunking.py
+++ b/enterprise/tests/unit/server/auth/test_cookie_chunking.py
@@ -98,3 +98,23 @@ def test_boundary_sizes_roundtrip(size):
     value = 'z' * size
     got, _ = _roundtrip(value)
     assert got == value
+
+
+def test_max_age_applied_to_every_chunk():
+    # Without Max-Age the cookie is a session cookie and dies on browser
+    # quit; every chunk must carry it or the reader reassembles a torn token.
+    resp = Response()
+    set_chunked_cookie(
+        resp, 'keycloak_auth', 'y' * 4125, domain='example.com', max_age=604800
+    )
+    written = [h for h in resp.headers.getlist('set-cookie') if 'Max-Age=0' not in h]
+    assert len(written) == 2
+    assert all('Max-Age=604800' in h for h in written)
+
+
+def test_max_age_omitted_writes_session_cookie():
+    resp = Response()
+    set_chunked_cookie(resp, 'keycloak_auth', 'x' * 100, domain='example.com')
+    written = [h for h in resp.headers.getlist('set-cookie') if 'Max-Age=0' not in h]
+    assert len(written) == 1
+    assert 'Max-Age' not in written[0]


### PR DESCRIPTION
HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

The `keycloak_auth` cookie is written without `Max-Age`/`Expires`, making it a browser *session* cookie: fully quitting the browser discards it, and the user lands back on the login page even though the signed JWS inside the cookie is still valid for a week and their Keycloak session is still alive. This surfaced while investigating repeated forced re-logins on staging — any browser that doesn't restore session cookies logs the user out on every restart.

## Summary

- `set_chunked_cookie` accepts an optional `max_age` and applies it to every chunk (a chunk outliving its siblings would reassemble into a torn token).
- `set_response_cookie` passes `max_age` derived from the same 1-week TTL already used to sign the JWS (`AUTH_COOKIE_TTL`), so the cookie and the token inside it expire together.
- Added regression tests: `max_age` lands on all chunks; omitting it still writes a session cookie.

## Issue Number

N/A

## How to Test

- `PYTHONPATH=enterprise poetry run pytest --noconftest enterprise/tests/unit/server/auth/test_cookie_chunking.py` — 11 passed.
- Manual: log in, inspect the `keycloak_auth` cookie in devtools — Expires should be ~7 days out instead of "Session". Fully quit the browser, reopen, revisit the app: still logged in (previously bounced to the login page).

## Video/Screenshots

N/A (cookie attribute change; behavior visible in devtools per steps above)

_This PR was drafted by an AI agent on behalf of the user._