### PR TITLE
Add execution_status__eq filter to app-conversations search/count endpoints

### DIFF
--- a/enterprise/server/utils/saas_app_conversation_info_injector.py
+++ b/enterprise/server/utils/saas_app_conversation_info_injector.py
@@ -25,6 +25,7 @@ from openhands.app_server.app_conversation.sql_app_conversation_info_service imp
 from openhands.app_server.errors import AuthError
 from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.user.specifiy_user_context import ADMIN
+from openhands.sdk.conversation import ConversationExecutionStatus
 
 
 class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
@@ -136,6 +137,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        execution_status__eq: ConversationExecutionStatus | None = None,
         sort_order: AppConversationSortOrder = AppConversationSortOrder.CREATED_AT_DESC,
         page_id: str | None = None,
         limit: int = 100,
@@ -159,6 +161,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
             updated_at__gte=updated_at__gte,
             updated_at__lt=updated_at__lt,
             sandbox_id__eq=sandbox_id__eq,
+            execution_status__eq=execution_status__eq,
         )
 
         # Add sort order
@@ -217,6 +220,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        execution_status__eq: ConversationExecutionStatus | None = None,
     ) -> int:
         """Count conversations matching the given filters with SAAS metadata."""
         query = (
@@ -240,6 +244,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
             updated_at__gte=updated_at__gte,
             updated_at__lt=updated_at__lt,
             sandbox_id__eq=sandbox_id__eq,
+            execution_status__eq=execution_status__eq,
         )
 
         result = await self.db_session.execute(query)
@@ -255,6 +260,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        execution_status__eq: ConversationExecutionStatus | None = None,
     ):
         """Apply filters to query that includes SAAS metadata."""
         # Apply the same filters as the base class
@@ -282,6 +288,12 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
 
         if sandbox_id__eq is not None:
             conditions.append(StoredConversationMetadata.sandbox_id == sandbox_id__eq)
+
+        if execution_status__eq is not None:
+            conditions.append(
+                StoredConversationMetadata.execution_status
+                == execution_status__eq.value
+            )
 
         if conditions:
             query = query.where(*conditions)

--- a/openhands/app_server/app_conversation/app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/app_conversation_info_service.py
@@ -9,6 +9,7 @@ from openhands.app_server.app_conversation.app_conversation_models import (
     AppConversationSortOrder,
 )
 from openhands.app_server.services.injector import Injector
+from openhands.sdk.conversation import ConversationExecutionStatus
 from openhands.sdk.event import ConversationStateUpdateEvent
 from openhands.sdk.utils.models import DiscriminatedUnionMixin
 
@@ -25,6 +26,7 @@ class AppConversationInfoService(ABC):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        execution_status__eq: ConversationExecutionStatus | None = None,
         sort_order: AppConversationSortOrder = AppConversationSortOrder.CREATED_AT_DESC,
         page_id: str | None = None,
         limit: int = 100,
@@ -41,6 +43,7 @@ class AppConversationInfoService(ABC):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        execution_status__eq: ConversationExecutionStatus | None = None,
     ) -> int:
         """Count sandboxed conversations."""
 

--- a/openhands/app_server/app_conversation/app_conversation_router.py
+++ b/openhands/app_server/app_conversation/app_conversation_router.py
@@ -89,6 +89,7 @@ from openhands.app_server.utils.dependencies import get_dependencies
 from openhands.app_server.utils.docker_utils import (
     replace_localhost_hostname_for_docker,
 )
+from openhands.sdk.conversation import ConversationExecutionStatus
 from openhands.sdk.skills import KeywordTrigger, TaskTrigger
 from openhands.sdk.workspace.remote.async_remote_workspace import AsyncRemoteWorkspace
 
@@ -246,6 +247,10 @@ async def search_app_conversations(
         str | None,
         Query(title='Filter by exact sandbox_id'),
     ] = None,
+    execution_status__eq: Annotated[
+        ConversationExecutionStatus | None,
+        Query(title='Filter by exact execution status (e.g. running, finished, error)'),
+    ] = None,
     page_id: Annotated[
         str | None,
         Query(title='Optional next_page_id from the previously returned page'),
@@ -276,6 +281,7 @@ async def search_app_conversations(
         updated_at__gte=updated_at__gte,
         updated_at__lt=updated_at__lt,
         sandbox_id__eq=sandbox_id__eq,
+        execution_status__eq=execution_status__eq,
         page_id=page_id,
         limit=limit,
         include_sub_conversations=include_sub_conversations,
@@ -308,6 +314,10 @@ async def count_app_conversations(
         str | None,
         Query(title='Filter by exact sandbox_id'),
     ] = None,
+    execution_status__eq: Annotated[
+        ConversationExecutionStatus | None,
+        Query(title='Filter by exact execution status (e.g. running, finished, error)'),
+    ] = None,
     app_conversation_service: AppConversationService = (
         app_conversation_service_dependency
     ),
@@ -320,6 +330,7 @@ async def count_app_conversations(
         updated_at__gte=updated_at__gte,
         updated_at__lt=updated_at__lt,
         sandbox_id__eq=sandbox_id__eq,
+        execution_status__eq=execution_status__eq,
     )
 
 

--- a/openhands/app_server/app_conversation/app_conversation_service.py
+++ b/openhands/app_server/app_conversation/app_conversation_service.py
@@ -14,6 +14,7 @@ from openhands.app_server.app_conversation.app_conversation_models import (
 )
 from openhands.app_server.sandbox.sandbox_models import SandboxInfo
 from openhands.app_server.services.injector import Injector
+from openhands.sdk.conversation import ConversationExecutionStatus
 from openhands.sdk.utils.models import DiscriminatedUnionMixin
 from openhands.sdk.workspace.remote.async_remote_workspace import AsyncRemoteWorkspace
 
@@ -42,6 +43,7 @@ class AppConversationService(ABC):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        execution_status__eq: ConversationExecutionStatus | None = None,
         sort_order: AppConversationSortOrder = AppConversationSortOrder.CREATED_AT_DESC,
         page_id: str | None = None,
         limit: int = 100,
@@ -58,6 +60,7 @@ class AppConversationService(ABC):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        execution_status__eq: ConversationExecutionStatus | None = None,
     ) -> int:
         """Count sandboxed conversations."""
 

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -123,6 +123,7 @@ from openhands.app_server.utils.redis_lock import (
     try_acquire_redis_lock,
 )
 from openhands.sdk import Agent, AgentContext, LocalWorkspace
+from openhands.sdk.conversation import ConversationExecutionStatus
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.llm import LLM
 from openhands.sdk.llm.llm_profile_store import PROFILE_NAME_REGEX
@@ -338,6 +339,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        execution_status__eq: ConversationExecutionStatus | None = None,
         sort_order: AppConversationSortOrder = AppConversationSortOrder.CREATED_AT_DESC,
         page_id: str | None = None,
         limit: int = 20,
@@ -351,6 +353,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             updated_at__gte=updated_at__gte,
             updated_at__lt=updated_at__lt,
             sandbox_id__eq=sandbox_id__eq,
+            execution_status__eq=execution_status__eq,
             sort_order=sort_order,
             page_id=page_id,
             limit=limit,
@@ -369,6 +372,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        execution_status__eq: ConversationExecutionStatus | None = None,
     ) -> int:
         return await self.app_conversation_info_service.count_app_conversation_info(
             title__contains=title__contains,
@@ -377,6 +381,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             updated_at__gte=updated_at__gte,
             updated_at__lt=updated_at__lt,
             sandbox_id__eq=sandbox_id__eq,
+            execution_status__eq=execution_status__eq,
         )
 
     async def get_app_conversation(

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -59,6 +59,7 @@ from openhands.app_server.utils.sql_utils import (
     create_json_type_decorator,
 )
 from openhands.sdk import ConversationStats
+from openhands.sdk.conversation import ConversationExecutionStatus
 from openhands.sdk.event import ConversationStateUpdateEvent
 from openhands.sdk.llm import MetricsSnapshot, TokenUsage
 
@@ -182,6 +183,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        execution_status__eq: ConversationExecutionStatus | None = None,
         sort_order: AppConversationSortOrder = AppConversationSortOrder.CREATED_AT_DESC,
         page_id: str | None = None,
         limit: int = 100,
@@ -205,6 +207,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             updated_at__gte=updated_at__gte,
             updated_at__lt=updated_at__lt,
             sandbox_id__eq=sandbox_id__eq,
+            execution_status__eq=execution_status__eq,
         )
 
         # Add sort order
@@ -260,6 +263,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        execution_status__eq: ConversationExecutionStatus | None = None,
     ) -> int:
         """Count sandboxed conversations matching the given filters."""
         query = select(func.count(StoredConversationMetadata.conversation_id)).where(
@@ -274,6 +278,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             updated_at__gte=updated_at__gte,
             updated_at__lt=updated_at__lt,
             sandbox_id__eq=sandbox_id__eq,
+            execution_status__eq=execution_status__eq,
         )
 
         result = await self.db_session.execute(query)
@@ -289,6 +294,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        execution_status__eq: ConversationExecutionStatus | None = None,
     ) -> Select:
         # Apply the same filters as search_app_conversations
         conditions: list[ColumnElement[bool]] = []
@@ -315,6 +321,12 @@ class SQLAppConversationInfoService(AppConversationInfoService):
 
         if sandbox_id__eq is not None:
             conditions.append(StoredConversationMetadata.sandbox_id == sandbox_id__eq)
+
+        if execution_status__eq is not None:
+            conditions.append(
+                StoredConversationMetadata.execution_status
+                == execution_status__eq.value
+            )
 
         if conditions:
             query = query.where(*conditions)

--- a/tests/unit/app_server/test_app_conversation_router.py
+++ b/tests/unit/app_server/test_app_conversation_router.py
@@ -32,6 +32,7 @@ from openhands.app_server.app_conversation.app_conversation_router import (
 from openhands.app_server.sandbox.sandbox_models import SandboxStatus
 from openhands.app_server.settings.llm_profiles import LLMProfiles
 from openhands.app_server.settings.settings_models import Settings
+from openhands.sdk.conversation import ConversationExecutionStatus
 from openhands.sdk.llm import LLM
 from openhands.sdk.settings import OpenHandsAgentSettings
 
@@ -315,6 +316,40 @@ class TestSearchAppConversations:
         assert call_kwargs.get('limit') == 50
         assert call_kwargs.get('include_sub_conversations') is True
 
+    async def test_search_with_execution_status_filter(self):
+        """Test that execution_status__eq filter is passed to the service."""
+        # Arrange
+        mock_service = _make_mock_service()
+
+        # Act
+        await search_app_conversations(
+            execution_status__eq=ConversationExecutionStatus.RUNNING,
+            app_conversation_service=mock_service,
+        )
+
+        # Assert
+        mock_service.search_app_conversations.assert_called_once()
+        call_kwargs = mock_service.search_app_conversations.call_args[1]
+        assert (
+            call_kwargs.get('execution_status__eq')
+            == ConversationExecutionStatus.RUNNING
+        )
+
+    async def test_search_without_execution_status_filter(self):
+        """Test that execution_status__eq defaults to None when not provided."""
+        # Arrange
+        mock_service = _make_mock_service()
+
+        # Act
+        await search_app_conversations(
+            app_conversation_service=mock_service,
+        )
+
+        # Assert
+        mock_service.search_app_conversations.assert_called_once()
+        call_kwargs = mock_service.search_app_conversations.call_args[1]
+        assert call_kwargs.get('execution_status__eq') is None
+
 
 @pytest.mark.asyncio
 class TestCountAppConversations:
@@ -388,6 +423,26 @@ class TestCountAppConversations:
         assert call_kwargs.get('sandbox_id__eq') == sandbox_id
         assert call_kwargs.get('title__contains') == 'test'
         assert result == 3
+
+    async def test_count_with_execution_status_filter(self):
+        """Test that execution_status__eq filter is passed to the service."""
+        # Arrange
+        mock_service = _make_mock_service(count_return=7)
+
+        # Act
+        result = await count_app_conversations(
+            execution_status__eq=ConversationExecutionStatus.RUNNING,
+            app_conversation_service=mock_service,
+        )
+
+        # Assert
+        mock_service.count_app_conversations.assert_called_once()
+        call_kwargs = mock_service.count_app_conversations.call_args[1]
+        assert (
+            call_kwargs.get('execution_status__eq')
+            == ConversationExecutionStatus.RUNNING
+        )
+        assert result == 7
 
 
 # ─── switch_conversation_profile ────────────────────────────────────────────

--- a/tests/unit/app_server/test_sql_app_conversation_info_service.py
+++ b/tests/unit/app_server/test_sql_app_conversation_info_service.py
@@ -24,6 +24,7 @@ from openhands.app_server.app_conversation.sql_app_conversation_info_service imp
 from openhands.app_server.integrations.service_types import ProviderType
 from openhands.app_server.user.specifiy_user_context import SpecifyUserContext
 from openhands.app_server.utils.sql_utils import Base
+from openhands.sdk.conversation import ConversationExecutionStatus
 from openhands.sdk.llm import MetricsSnapshot, TokenUsage
 
 # Note: org_id column exists but foreign key constraint is not enforced in tests
@@ -528,6 +529,70 @@ class TestSQLAppConversationInfoService:
         # Count with no matches
         count = await service.count_app_conversation_info(title__contains='nonexistent')
         assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_search_conversation_info_execution_status_filter(
+        self,
+        service: SQLAppConversationInfoService,
+        multiple_conversation_infos: list[AppConversationInfo],
+    ):
+        """Test search filtered by execution_status__eq."""
+        for info in multiple_conversation_infos:
+            await service.save_app_conversation_info(info)
+
+        # Mark the first two conversations as RUNNING and the rest as FINISHED
+        for info in multiple_conversation_infos[:2]:
+            await service.update_execution_status(
+                info.id, ConversationExecutionStatus.RUNNING.value
+            )
+        for info in multiple_conversation_infos[2:]:
+            await service.update_execution_status(
+                info.id, ConversationExecutionStatus.FINISHED.value
+            )
+
+        running = await service.search_app_conversation_info(
+            execution_status__eq=ConversationExecutionStatus.RUNNING
+        )
+        assert len(running.items) == 2
+
+        finished = await service.search_app_conversation_info(
+            execution_status__eq=ConversationExecutionStatus.FINISHED
+        )
+        assert len(finished.items) == 3
+
+        # A status that no conversation has should return nothing
+        errored = await service.search_app_conversation_info(
+            execution_status__eq=ConversationExecutionStatus.ERROR
+        )
+        assert len(errored.items) == 0
+
+    @pytest.mark.asyncio
+    async def test_count_conversation_info_execution_status_filter(
+        self,
+        service: SQLAppConversationInfoService,
+        multiple_conversation_infos: list[AppConversationInfo],
+    ):
+        """Test count filtered by execution_status__eq."""
+        for info in multiple_conversation_infos:
+            await service.save_app_conversation_info(info)
+
+        for info in multiple_conversation_infos[:2]:
+            await service.update_execution_status(
+                info.id, ConversationExecutionStatus.RUNNING.value
+            )
+
+        assert (
+            await service.count_app_conversation_info(
+                execution_status__eq=ConversationExecutionStatus.RUNNING
+            )
+            == 2
+        )
+        assert (
+            await service.count_app_conversation_info(
+                execution_status__eq=ConversationExecutionStatus.ERROR
+            )
+            == 0
+        )
 
     @pytest.mark.asyncio
     async def test_update_conversation_info(


### PR DESCRIPTION
## Summary

Closes OpenHands/enterprise#65.

Adds an `execution_status__eq` query parameter to the V1 conversation endpoints so clients can filter by execution status server-side instead of fetching all conversations and filtering client-side:

- `GET /api/v1/app-conversations/search?execution_status__eq=running`
- `GET /api/v1/app-conversations/count?execution_status__eq=running`

The value is validated against the SDK `ConversationExecutionStatus` enum (e.g. `running`, `finished`, `error`, `stuck`, `idle`, `paused`, `waiting_for_confirmation`, `deleting`).

## Why not `sandbox_status__eq`?

The issue also proposed `sandbox_status__eq`. Unlike `execution_status`, `sandbox_status` is **not** persisted — it is computed live from the sandbox service when building each `AppConversation`. Filtering on it at the SQL/pagination layer isn't possible without a much larger change (it would break offset-based pagination and require fetching live status before paginating). `execution_status`, on the other hand, is already stored in the `StoredConversationMetadata.execution_status` column and updated via the webhook callback, so it can be filtered efficiently in the query. This PR therefore implements the stored, index-friendly `execution_status__eq` filter that satisfies the primary use case in the issue title (filtering by execution status, e.g. only `RUNNING` conversations).

## Changes

- Router: added `execution_status__eq` query param to `search_app_conversations` and `count_app_conversations`.
- Threaded the parameter through:
  - `AppConversationService` (abstract) + `LiveStatusAppConversationService`
  - `AppConversationInfoService` (abstract) + `SQLAppConversationInfoService`
  - `SaasSQLAppConversationInfoService` (enterprise override)
- Applied the SQL condition in `_apply_filters` / `_apply_filters_with_saas_metadata` against the stored `execution_status` column.

## Tests

- SQL info service: search + count filtered by `execution_status__eq` (RUNNING / FINISHED / ERROR).
- Router: `execution_status__eq` is passed through on both `search` and `count` (and defaults to `None`).

All targeted unit tests pass locally (`test_sql_app_conversation_info_service.py`, `test_app_conversation_router.py`, `test_live_status_app_conversation_service.py`), along with `ruff check`/`ruff format`.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4ded0a1b-a5d5-4c2c-af1d-27e3eaaadcf7)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-6f7ccfa   docker.openhands.dev/openhands/openhands:6f7ccfa
```