### PR TITLE
fix: support pagination for branch search

### DIFF
--- a/openhands/app_server/git/git_router.py
+++ b/openhands/app_server/git/git_router.py
@@ -244,21 +244,14 @@ async def search_branches(
         page = decoded_page_id
 
     if query:
-        if page != 1:
-            # TODO(#13883): Support pagination for branch search after refactoring.
-            # The search_branches method does not support paging in the same way as
-            # get_branches - those should be merged into a single paginated method
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail='Pagination not yet supported for branch search queries. Use empty query to list all branches with pagination.',
-            )
-        # Get search results - we'll handle pagination ourselves
+        search_offset = decoded_page_id or 0
         branches: list[Branch] = await client.search_branches(
             selected_provider=provider,
             repository=repository,
             query=query,
-            per_page=limit + 1,
+            per_page=search_offset + limit + 1,
         )
+        branches, next_page_id = paginate_results(branches, page_id, limit)
     else:
         current_page = await client.get_branches(
             repository=repository,
@@ -268,10 +261,10 @@ async def search_branches(
         )
         branches = current_page.branches
 
-    next_page_id = None
-    if len(branches) > limit:
-        branches = branches[:-1]
-        next_page_id = encode_page_id(page + 1)
+        next_page_id = None
+        if len(branches) > limit:
+            branches = branches[:-1]
+            next_page_id = encode_page_id(page + 1)
 
     return BranchPage(items=branches, next_page_id=next_page_id)
 

--- a/tests/unit/app_server/test_git_router.py
+++ b/tests/unit/app_server/test_git_router.py
@@ -774,6 +774,47 @@ class TestSearchBranches:
         assert call_kwargs.get('query') == 'feature'
         assert call_kwargs.get('per_page') == 11  # limit + 1
 
+    @pytest.mark.asyncio
+    @patch('openhands.app_server.git.git_router.ProviderHandler')
+    async def test_returns_second_page_for_branch_search(self, mock_handler_cls):
+        """Test that branch search supports requesting a later page."""
+        # Arrange
+        mock_handler = MagicMock()
+        mock_handler.search_branches = AsyncMock(
+            return_value=[
+                Branch(name='feature-a', commit_sha='abc123', protected=False),
+                Branch(name='feature-b', commit_sha='def456', protected=False),
+                Branch(name='feature-c', commit_sha='ghi789', protected=False),
+                Branch(name='feature-d', commit_sha='jkl012', protected=False),
+                Branch(name='feature-e', commit_sha='mno345', protected=False),
+            ]
+        )
+        mock_handler_cls.return_value = mock_handler
+
+        mock_context = _make_mock_user_context(
+            provider_tokens={
+                ProviderType.GITHUB: ProviderToken(user_id='user-123', token='token')
+            },
+            user_id='user-123',
+        )
+
+        # Act
+        result = await search_branches(
+            provider=ProviderType.GITHUB,
+            repository='user/repo',
+            query='feature',
+            page_id=encode_page_id(2),
+            limit=2,
+            user_context=mock_context,
+        )
+
+        # Assert
+        assert [branch.name for branch in result.items] == ['feature-c', 'feature-d']
+        assert result.next_page_id == encode_page_id(4)
+
+        call_kwargs = mock_handler.search_branches.call_args.kwargs
+        assert call_kwargs.get('per_page') == 5  # offset + limit + 1
+
     def test_returns_403_when_no_provider_tokens(self, test_client):
         """Test that 403 is returned when no provider tokens."""
         with patch(


### PR DESCRIPTION
## Summary
- allow branch search requests to use returned page tokens instead of failing on page 2
- request enough search results for the requested offset and reuse existing pagination utilities
- add unit coverage for requesting the second page of branch search results

Fixes OpenHands/enterprise#22

## Verification
- python -m py_compile openhands/app_server/git/git_router.py tests/unit/app_server/test_git_router.py
- git diff --check

Could not complete targeted pytest locally because uv run pytest tests/unit/app_server/test_git_router.py -k SearchBranches timed out while preparing the project dependency environment on Windows.