### PR TITLE
fix: managed profile key resolution

### DIFF
--- a/enterprise/server/routes/org_models.py
+++ b/enterprise/server/routes/org_models.py
@@ -287,6 +287,7 @@ class OrgUpdate(BaseModel):
     v1_enabled: bool | None = None
     search_api_key: str | None = None
     llm_api_key: str | None = None
+    reset_member_custom_llm_keys: bool | None = None
     agent_settings_diff: dict[str, Any] | None = None
     conversation_settings_diff: dict[str, Any] | None = None
 
@@ -380,6 +381,7 @@ class OrgUpdate(BaseModel):
                 'conversation_settings_diff',
                 'search_api_key',
                 'llm_api_key',
+                'reset_member_custom_llm_keys',
             }
         )
 
@@ -391,6 +393,7 @@ class OrgUpdate(BaseModel):
             'search_api_key',
             'sandbox_api_key',
             'llm_api_key',
+            'reset_member_custom_llm_keys',
         }
 
     def model_update_dict(self) -> dict[str, Any]:

--- a/enterprise/server/routes/orgs.py
+++ b/enterprise/server/routes/orgs.py
@@ -309,6 +309,7 @@ async def update_org_defaults_settings(
             'conversation_settings_diff',
             'search_api_key',
             'llm_api_key',
+            'reset_member_custom_llm_keys',
         }
         invalid_fields = settings.updated_fields() - allowed_fields
         if invalid_fields:

--- a/enterprise/storage/org_store.py
+++ b/enterprise/storage/org_store.py
@@ -439,14 +439,16 @@ class OrgStore:
                         user_id,
                     )
                 )
-                should_reset_custom_key_flag = (
-                    update_data.llm_api_key is not None
-                    or effective_managed_key is not None
+                should_reset_custom_key_flag = bool(
+                    update_data.reset_member_custom_llm_keys
                 )
                 if effective_managed_key is not None:
                     if member_updates is None:
                         member_updates = OrgMemberSettingsUpdate()
                     member_updates.llm_api_key = SecretStr(effective_managed_key)
+
+                if should_reset_custom_key_flag and member_updates is None:
+                    member_updates = OrgMemberSettingsUpdate()
 
                 if member_updates is not None:
                     if should_reset_custom_key_flag:

--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -191,23 +191,6 @@ class SaasSettingsStore(SettingsStore):
 
         llm_store = OrgLLMProfileLoader(load_llm_profiles(org))
         try:
-            resolved_base_url = resolve_llm_base_url(
-                model=profile.llm.model,
-                base_url=profile.llm.base_url,
-                managed_proxy_url=LITE_LLM_API_URL,
-            )
-            uses_managed_proxy = bool(
-                resolved_base_url
-                and resolved_base_url.rstrip('/') == LITE_LLM_API_URL.rstrip('/')
-            )
-            fallback_api_key = effective_llm_api_key
-            if uses_managed_proxy:
-                fallback_api_key = self._get_effective_llm_api_key(
-                    org,
-                    org_member,
-                    allow_org_key=False,
-                )
-
             resolved = resolve_agent_profile(
                 profile,
                 llm_store=llm_store,
@@ -221,6 +204,23 @@ class SaasSettingsStore(SettingsStore):
             # base URLs behave exactly as the non-profile path. Reuses the existing
             # resolve_profile_llm helper rather than re-deriving key resolution.
             if resolved.agent_kind == 'openhands':
+                resolved_base_url = resolve_llm_base_url(
+                    model=resolved.llm.model,
+                    base_url=resolved.llm.base_url,
+                    managed_proxy_url=LITE_LLM_API_URL,
+                )
+                uses_managed_proxy = bool(
+                    resolved_base_url
+                    and resolved_base_url.rstrip('/') == LITE_LLM_API_URL.rstrip('/')
+                )
+                fallback_api_key = effective_llm_api_key
+                if uses_managed_proxy:
+                    fallback_api_key = self._get_effective_llm_api_key(
+                        org,
+                        org_member,
+                        allow_org_key=False,
+                    )
+
                 resolved = resolved.model_copy(
                     update={
                         'llm': resolve_profile_llm(

--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -37,7 +37,7 @@ from openhands.app_server.utils.jsonpatch_compat import (
     deep_merge,
     deep_merge_with_wholesale_keys,
 )
-from openhands.app_server.utils.llm import is_openhands_model
+from openhands.app_server.utils.llm import is_openhands_model, resolve_llm_base_url
 from openhands.sdk.llm.utils.openhands_provider import (
     canonicalize_openhands_llm_payload,
 )
@@ -104,10 +104,12 @@ class SaasSettingsStore(SettingsStore):
     def _get_effective_llm_api_key(
         org: Org,
         org_member: OrgMember,
+        *,
+        allow_org_key: bool = True,
     ) -> SecretStr | None:
         if org_member.has_custom_llm_api_key:
             return org_member.llm_api_key
-        if org.llm_api_key:
+        if allow_org_key and org.llm_api_key:
             return org.llm_api_key
         # Managed keys are stored on the member row (has_custom=False); fall back to
         # it, but only decrypt when actually set to avoid the empty-value error (#14898).
@@ -189,6 +191,23 @@ class SaasSettingsStore(SettingsStore):
 
         llm_store = OrgLLMProfileLoader(load_llm_profiles(org))
         try:
+            resolved_base_url = resolve_llm_base_url(
+                model=profile.llm.model,
+                base_url=profile.llm.base_url,
+                managed_proxy_url=LITE_LLM_API_URL,
+            )
+            uses_managed_proxy = bool(
+                resolved_base_url
+                and resolved_base_url.rstrip('/') == LITE_LLM_API_URL.rstrip('/')
+            )
+            fallback_api_key = effective_llm_api_key
+            if uses_managed_proxy:
+                fallback_api_key = self._get_effective_llm_api_key(
+                    org,
+                    org_member,
+                    allow_org_key=False,
+                )
+
             resolved = resolve_agent_profile(
                 profile,
                 llm_store=llm_store,
@@ -207,7 +226,7 @@ class SaasSettingsStore(SettingsStore):
                         'llm': resolve_profile_llm(
                             resolved.llm,
                             managed_proxy_url=LITE_LLM_API_URL,
-                            fallback_api_key=effective_llm_api_key,
+                            fallback_api_key=fallback_api_key,
                         )
                     }
                 )
@@ -649,11 +668,6 @@ class SaasSettingsStore(SettingsStore):
                 OrgMemberSettingsUpdate(
                     agent_settings_diff=shared_agent_settings_diff,
                     conversation_settings_diff=effective_conversation_diff,
-                    llm_api_key=(
-                        current_member_llm_api_key_raw  # type: ignore[arg-type]
-                        if not uses_managed_llm_key
-                        else None
-                    ),
                 ),
             )
 

--- a/enterprise/tests/unit/test_org_store.py
+++ b/enterprise/tests/unit/test_org_store.py
@@ -1465,7 +1465,8 @@ async def test_update_org_defaults_async_propagates_managed_key_reset():
         agent_settings=OpenHandsAgentSettings(llm={'model': 'openhands/claude-3'}),
     )
     update_data = OrgUpdate(
-        agent_settings_diff={'llm': {'model': 'openhands/claude-3'}}
+        agent_settings_diff={'llm': {'model': 'openhands/claude-3'}},
+        reset_member_custom_llm_keys=True,
     )
 
     mock_session = AsyncMock()

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -608,10 +608,10 @@ async def test_load_canonicalizes_legacy_litellm_proxy_llm_profiles(
 
 
 @pytest.mark.asyncio
-async def test_store_updates_org_defaults_and_all_members_for_shared_keys(
+async def test_store_updates_org_defaults_without_broadcasting_member_keys(
     session_maker, async_session_maker, org_with_multiple_members_fixture
 ):
-    """External provider keys should still sync as an org-wide shared snapshot."""
+    """External provider keys stay scoped to the acting member."""
     from sqlalchemy import select
     from storage.org import Org
     from storage.org_member import OrgMember
@@ -658,7 +658,14 @@ async def test_store_updates_org_defaults_and_all_members_for_shared_keys(
                 == 'https://api.anthropic.com/v1'
             )
             assert member.conversation_settings_diff['max_iterations'] == 100
-            assert decrypt_value(member._llm_api_key) == 'shared-external-api-key'
+
+        admin_member = members[str(fixture['admin_user_id'])]
+        assert decrypt_value(admin_member._llm_api_key) == 'shared-external-api-key'
+
+        member1 = members[str(fixture['member1_user_id'])]
+        member2 = members[str(fixture['member2_user_id'])]
+        assert decrypt_value(member1._llm_api_key) == 'member1-initial-key'
+        assert decrypt_value(member2._llm_api_key) == 'member2-initial-key'
 
 
 @pytest.mark.asyncio
@@ -1603,6 +1610,26 @@ class TestGetEffectiveLlmApiKey:
 
         # Must return org key when has_custom_llm_api_key is False
         assert result == SecretStr('org-api-key')
+
+    def test_skips_org_key_when_disallowed(self):
+        """When allow_org_key is False, fall back to the member-managed key."""
+        from pydantic import SecretStr
+        from storage.saas_settings_store import SaasSettingsStore
+
+        org = MagicMock()
+        org.llm_api_key = SecretStr('org-api-key')
+
+        member = MagicMock()
+        member.has_custom_llm_api_key = False
+        member._llm_api_key = 'encrypted-managed-key'
+        type(member).llm_api_key = PropertyMock(return_value=SecretStr('managed-key'))
+
+        result = SaasSettingsStore._get_effective_llm_api_key(
+            org, member, allow_org_key=False
+        )
+
+        assert result == SecretStr('managed-key')
+
 
     def test_falls_back_to_managed_member_key_when_org_key_unset(self):
         """has_custom False + no org key: fall back to the managed key on the member row.

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -1630,7 +1630,6 @@ class TestGetEffectiveLlmApiKey:
 
         assert result == SecretStr('managed-key')
 
-
     def test_falls_back_to_managed_member_key_when_org_key_unset(self):
         """has_custom False + no org key: fall back to the managed key on the member row.
 


### PR DESCRIPTION
## Summary\n- ignore org.llm_api_key when a managed profile is selected (fallback to member-managed key)\n- gate has_custom_llm_api_key reset behind reset_member_custom_llm_keys\n- stop bulk propagation of member llm_api_key on user save; keep keys member-scoped\n- ensure agent profile resolution skips org key only for managed profiles\n\n## Testing\n- not run (not requested)\n\n_This PR description was created by an AI agent (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-65f1cf1   docker.openhands.dev/openhands/openhands:65f1cf1
```