### PR TITLE
fix(secrets): preserve description when omitted during update

### DIFF
--- a/openhands/app_server/secrets/secrets_router.py
+++ b/openhands/app_server/secrets/secrets_router.py
@@ -326,7 +326,9 @@ async def update_custom_secret(
 
     custom_secrets[secret_name] = CustomSecret(
         secret=existing_secret.secret,
-        description=secret_description or '',
+        description=secret_description
+        if secret_description is not None
+        else existing_secret.description,
     )
 
     updated_secrets = Secrets(

--- a/tests/unit/app_server/test_secrets_api.py
+++ b/tests/unit/app_server/test_secrets_api.py
@@ -282,6 +282,54 @@ async def test_update_existing_custom_secret(test_client, file_secrets_store):
 
 
 @pytest.mark.asyncio
+async def test_update_custom_secret_preserves_omitted_description(
+    test_client, file_secrets_store
+):
+    """Test renaming a custom secret without replacing its description."""
+    custom_secrets = {
+        'API_KEY': CustomSecret(
+            secret=SecretStr('old-api-key'), description='Production API key'
+        )
+    }
+    await file_secrets_store.store(Secrets(custom_secrets=custom_secrets))
+
+    response = test_client.put(
+        '/secrets/API_KEY',
+        json={'name': 'RENAMED_API_KEY'},
+    )
+
+    assert response.status_code == 200
+    stored_settings = await file_secrets_store.load()
+    assert 'API_KEY' not in stored_settings.custom_secrets
+    assert (
+        stored_settings.custom_secrets['RENAMED_API_KEY'].description
+        == 'Production API key'
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_custom_secret_clears_explicit_empty_description(
+    test_client, file_secrets_store
+):
+    """Test explicitly clearing a custom secret description."""
+    custom_secrets = {
+        'API_KEY': CustomSecret(
+            secret=SecretStr('old-api-key'), description='Production API key'
+        )
+    }
+    await file_secrets_store.store(Secrets(custom_secrets=custom_secrets))
+
+    response = test_client.put(
+        '/secrets/API_KEY',
+        json={'name': 'API_KEY', 'description': ''},
+    )
+
+    assert response.status_code == 200
+    stored_settings = await file_secrets_store.load()
+    assert stored_settings.custom_secrets['API_KEY'].description == ''
+
+
+@pytest.mark.asyncio
 async def test_add_multiple_custom_secrets(test_client, file_secrets_store):
     """Test adding multiple custom secrets at once."""
     # Create initial settings with one custom secret


### PR DESCRIPTION
HUMAN:

- [x] A human has tested these changes.

AGENT: Codex

---

## Why

A name-only `PUT /api/v1/secrets/{secret_id}` update currently replaces an existing custom-secret description with an empty string.

Because `description` is optional, omitting it should preserve the current description. Clients should still be able to explicitly clear the description by sending an empty string.

## Summary

- Preserve the existing custom-secret description when an update omits `description`.
- Continue allowing clients to clear a description explicitly with `description: ""`.
- Add regression tests covering both behaviors.

## Issue Number

N/A — no matching issue was found.

## How to Test

```bash
poetry run pytest \
  tests/unit/app_server/test_secrets_api.py \
  tests/unit/storage/data_models/test_secret_store.py \
  -q
```

Additional validation performed:

* Focused regression test: passed.
* Secrets API and model/store tests: 33 passed.
* Changed-file pre-commit hooks: passed.
* `git diff --check`: passed.
* Backend unit suite: 2,212 passed, 1 unrelated failure.

The remaining backend failure, `TestProcessSandboxServiceInjector.test_default_values`, also fails on an untouched `main` checkout because macOS resolves the temporary directory under `/var/folders/...` rather than the test’s hard-coded `/tmp` path.

## Video/Screenshots

N/A — backend API behavior only.

## Type

* [x] Bug fix
* [ ] Feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Docs / chore

## Changelog

Custom secret descriptions are now preserved when renaming a secret without providing a replacement description.
