### PR TITLE
fix: accept '1' as truthy for SERVE_FRONTEND and AWS_S3_SECURE env toggles

### DIFF
--- a/openhands/app_server/app.py
+++ b/openhands/app_server/app.py
@@ -25,6 +25,7 @@ from openhands.app_server.middleware import (
 )
 from openhands.app_server.static import SPAStaticFiles
 from openhands.app_server.status.status_router import router as health_router
+from openhands.app_server.utils.environment import env_flag_enabled
 from openhands.app_server.version import get_version
 
 # Initialize the Tavily MCP proxy before creating the app
@@ -72,7 +73,7 @@ app.include_router(v1_router.router)
 app.include_router(health_router)
 
 # Middleware and static file setup (merged from listen.py)
-if os.getenv('SERVE_FRONTEND', 'true').lower() == 'true':
+if env_flag_enabled('SERVE_FRONTEND', default=True):
     if os.path.isdir('./frontend/build'):
         app.mount(
             '/', SPAStaticFiles(directory='./frontend/build', html=True), name='dist'

--- a/openhands/app_server/event/aws_event_service.py
+++ b/openhands/app_server/event/aws_event_service.py
@@ -19,6 +19,7 @@ from openhands.app_server.config import get_app_conversation_info_service
 from openhands.app_server.event.event_service import EventService, EventServiceInjector
 from openhands.app_server.event.event_service_base import EventServiceBase
 from openhands.app_server.services.injector import InjectorState
+from openhands.app_server.utils.environment import env_flag_enabled
 from openhands.sdk import Event
 
 _logger = logging.getLogger(__name__)
@@ -81,7 +82,7 @@ def _get_default_aws_endpoint_url() -> str | None:
     endpoint_url = os.getenv('AWS_S3_ENDPOINT')
     if not endpoint_url:
         return None
-    secure = os.getenv('AWS_S3_SECURE', 'true').lower() == 'true'
+    secure = env_flag_enabled('AWS_S3_SECURE', default=True)
     if secure:
         if not endpoint_url.startswith('https://'):
             endpoint_url = 'https://' + endpoint_url.removeprefix('http://')

--- a/openhands/app_server/file_store/s3.py
+++ b/openhands/app_server/file_store/s3.py
@@ -6,6 +6,7 @@ import botocore
 from pydantic import Field, PrivateAttr
 
 from openhands.app_server.file_store.files import FileStore
+from openhands.app_server.utils.environment import env_flag_enabled
 
 
 class S3ObjectDict(TypedDict):
@@ -43,7 +44,7 @@ class S3FileStore(FileStore):
         if self._client is None:
             access_key = os.getenv('AWS_ACCESS_KEY_ID')
             secret_key = os.getenv('AWS_SECRET_ACCESS_KEY')
-            secure = os.getenv('AWS_S3_SECURE', 'true').lower() == 'true'
+            secure = env_flag_enabled('AWS_S3_SECURE', default=True)
             endpoint = self._ensure_url_scheme(secure, os.getenv('AWS_S3_ENDPOINT'))
             self._client = boto3.client(
                 's3',

--- a/openhands/app_server/utils/environment.py
+++ b/openhands/app_server/utils/environment.py
@@ -10,6 +10,19 @@ _LEMONADE_PROVIDER_NAME = 'lemonade'
 _LEMONADE_MODEL_PREFIX = 'lemonade/'
 
 
+def env_flag_enabled(name: str, default: bool = False) -> bool:
+    """Parse a boolean enable toggle from an environment variable.
+
+    Accepts both 'true' and '1' as truthy values (case-insensitive), per the
+    "Environment Variable Enable Toggles" rule in AGENTS.md: older Helm chart
+    versions default to '1' rather than 'true'.
+    """
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in ('true', '1')
+
+
 class StorageProvider(str, Enum):
     """Storage provider types for event and shared event storage."""
 

--- a/tests/unit/app_server/file_store/test_file_store.py
+++ b/tests/unit/app_server/file_store/test_file_store.py
@@ -337,3 +337,43 @@ class TestGoogleCloudFileStore(TestCase, _StorageTest):
 class TestS3FileStore(TestCase, _StorageTest):
     def setUp(self):
         self.store = S3FileStore(bucket_name='dear-liza')
+
+
+class TestS3FileStoreSecureFlag(TestCase):
+    """AWS_S3_SECURE must accept both 'true' and '1' as truthy (AGENTS.md rule)."""
+
+    def _get_use_ssl(self, secure_value: str | None) -> bool:
+        captured: dict = {}
+
+        def fake_client(service, **kwargs):
+            captured.update(kwargs)
+            return _MockS3Client()
+
+        env = {'AWS_S3_SECURE': secure_value} if secure_value is not None else {}
+        with (
+            patch('boto3.client', fake_client),
+            patch.dict('os.environ', env, clear=False),
+        ):
+            if secure_value is None:
+                import os
+
+                os.environ.pop('AWS_S3_SECURE', None)
+            store = S3FileStore(bucket_name='dear-liza')
+            store.client
+        return captured['use_ssl']
+
+    def test_secure_true_enables_ssl(self):
+        assert self._get_use_ssl('true') is True
+
+    def test_secure_one_enables_ssl(self):
+        # Regression: '1' was previously treated as false, silently disabling TLS
+        assert self._get_use_ssl('1') is True
+
+    def test_secure_false_disables_ssl(self):
+        assert self._get_use_ssl('false') is False
+
+    def test_secure_zero_disables_ssl(self):
+        assert self._get_use_ssl('0') is False
+
+    def test_unset_defaults_to_ssl(self):
+        assert self._get_use_ssl(None) is True

--- a/tests/unit/app_server/test_aws_event_service.py
+++ b/tests/unit/app_server/test_aws_event_service.py
@@ -289,6 +289,26 @@ class TestGetDefaultAwsEndpointUrl:
         result = aws_event_service._get_default_aws_endpoint_url()
         assert result == 'http://minio.example.com:9000'
 
+    def test_secure_one_is_truthy(self, monkeypatch):
+        """Test AWS_S3_SECURE='1' means secure (regression: was treated as false)."""
+        monkeypatch.setenv('AWS_S3_ENDPOINT', 'http://minio.example.com:9000')
+        monkeypatch.setenv('AWS_S3_SECURE', '1')
+
+        importlib.reload(aws_event_service)
+
+        result = aws_event_service._get_default_aws_endpoint_url()
+        assert result == 'https://minio.example.com:9000'
+
+    def test_secure_zero_is_falsy(self, monkeypatch):
+        """Test AWS_S3_SECURE='0' means insecure."""
+        monkeypatch.setenv('AWS_S3_ENDPOINT', 'https://minio.example.com:9000')
+        monkeypatch.setenv('AWS_S3_SECURE', '0')
+
+        importlib.reload(aws_event_service)
+
+        result = aws_event_service._get_default_aws_endpoint_url()
+        assert result == 'http://minio.example.com:9000'
+
     def test_secure_default_is_true(self, monkeypatch):
         """Test that secure defaults to true when not set."""
         monkeypatch.setenv('AWS_S3_ENDPOINT', 'minio.example.com:9000')

--- a/tests/unit/utils/test_environment.py
+++ b/tests/unit/utils/test_environment.py
@@ -1,7 +1,11 @@
 import pytest
 
 from openhands.app_server.utils import environment
-from openhands.app_server.utils.environment import StorageProvider, get_storage_provider
+from openhands.app_server.utils.environment import (
+    StorageProvider,
+    env_flag_enabled,
+    get_storage_provider,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -31,6 +35,31 @@ def test_get_effective_base_url_non_lemonade(monkeypatch):
     base_url = 'https://api.example.com'
     result = environment.get_effective_llm_base_url('openai/gpt-4', base_url)
     assert result == base_url
+
+
+class TestEnvFlagEnabled:
+    """Tests for env_flag_enabled function.
+
+    Per AGENTS.md ("Environment Variable Enable Toggles"), both 'true' and '1'
+    must be accepted as truthy because older Helm chart versions default to '1'.
+    """
+
+    @pytest.mark.parametrize('value', ['true', 'True', 'TRUE', '1', ' true ', ' 1 '])
+    def test_truthy_values(self, monkeypatch, value):
+        monkeypatch.setenv('MY_FLAG', value)
+        assert env_flag_enabled('MY_FLAG') is True
+        assert env_flag_enabled('MY_FLAG', default=True) is True
+
+    @pytest.mark.parametrize('value', ['false', 'False', 'FALSE', '0', '', 'no', 'yes'])
+    def test_falsy_values(self, monkeypatch, value):
+        monkeypatch.setenv('MY_FLAG', value)
+        assert env_flag_enabled('MY_FLAG') is False
+        assert env_flag_enabled('MY_FLAG', default=True) is False
+
+    def test_unset_uses_default(self, monkeypatch):
+        monkeypatch.delenv('MY_FLAG', raising=False)
+        assert env_flag_enabled('MY_FLAG') is False
+        assert env_flag_enabled('MY_FLAG', default=True) is True
 
 
 class TestGetStorageProvider:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

This PR fixes a bug where setting the env vars `SERVE_FRONTEND=1` or `AWS_S3_SECURE=1` was treated as "off" instead of "on", because the code only accepted the string `true`. This broke the frontend for Helm deployments that pass `1`, and worse, silently turned off TLS for S3/MinIO connections. The fix makes these three toggles accept both `true` and `1`, as the repo's own AGENTS.md rule requires, and adds tests so it can't regress.

- [ ] A human has tested these changes.

AGENT:

---

## Why

`SERVE_FRONTEND` (`openhands/app_server/app.py`) and `AWS_S3_SECURE` (`openhands/app_server/file_store/s3.py`, `openhands/app_server/event/aws_event_service.py`) only accepted the literal string `'true'` and silently treated `'1'` as false. This violates the "Environment Variable Enable Toggles" rule in AGENTS.md, which requires accepting both `'true'` and `'1'` because older Helm chart versions default to `'1'`.

Impact:
- `SERVE_FRONTEND=1` silently disabled serving the built frontend (`/` returned 404 while the API stayed up).
- `AWS_S3_SECURE=1` silently downgraded the S3/MinIO client from HTTPS to plain HTTP — a security-relevant misconfiguration with no warning.

## Summary

- Added `env_flag_enabled(name, default)` to `openhands/app_server/utils/environment.py` implementing the documented `('true', '1')` pattern.
- Switched the three affected call sites (`SERVE_FRONTEND`, both `AWS_S3_SECURE` reads) to the helper, preserving their default-true behavior.
- Added regression tests: unit tests for the helper, `'1'`/`'0'` cases in the existing `_get_default_aws_endpoint_url` test class, and a new test class asserting `use_ssl` passed to `boto3.client` for each spelling.

Scope is intentionally limited to the three confirmed call sites from the issue; adjacent feature gates mentioned in the issue comments are left for a follow-up if maintainers want them changed.

## Issue Number

Fixes OpenHands/enterprise#57

## How to Test

```bash
uv run pytest tests/unit/utils/test_environment.py tests/unit/app_server/test_aws_event_service.py tests/unit/app_server/file_store/test_file_store.py
```

Runtime check: start the server with `SERVE_FRONTEND=1` and confirm `/` serves the SPA (previously returned 404).

