### PR TITLE
fix: treat Integrations Hub as a cross-app route

### DIFF
--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -13,6 +13,9 @@ export default [
   route("canvas/*", "routes/cross-app-redirect.tsx", {
     id: "routes/canvas-cross-app-redirect",
   }),
+  route("integrations-hub/*", "routes/cross-app-redirect.tsx", {
+    id: "routes/integrations-hub-cross-app-redirect",
+  }),
   layout("routes/root-layout.tsx", [
     index("routes/home.tsx"),
     route("accept-tos", "routes/accept-tos.tsx"),

--- a/frontend/src/utils/cross-app-redirect.test.ts
+++ b/frontend/src/utils/cross-app-redirect.test.ts
@@ -14,12 +14,23 @@ describe("isCrossAppPath", () => {
     expect(isCrossAppPath("/canvas/conversations/abc")).toBe(true);
   });
 
+  it("detects Integrations Hub app routes", () => {
+    expect(isCrossAppPath("/integrations-hub")).toBe(true);
+    expect(isCrossAppPath("/integrations-hub/integrations")).toBe(true);
+    expect(
+      isCrossAppPath("/integrations-hub/integrations?login_method=github"),
+    ).toBe(true);
+  });
+
   it("does not match similarly-prefixed main app routes", () => {
     expect(isCrossAppPath("/automation")).toBe(false);
     expect(isCrossAppPath("/automations-old")).toBe(false);
     expect(isCrossAppPath("/canvases")).toBe(false);
+    expect(isCrossAppPath("/integrations")).toBe(false);
+    expect(isCrossAppPath("/integrations-hub-old")).toBe(false);
     expect(isCrossAppPath("/settings?returnTo=/automations")).toBe(false);
     expect(isCrossAppPath("/settings?returnTo=/canvas")).toBe(false);
+    expect(isCrossAppPath("/settings?returnTo=/integrations-hub")).toBe(false);
   });
 
   it("does not treat off-origin targets as cross-app paths", () => {

--- a/frontend/src/utils/cross-app-redirect.ts
+++ b/frontend/src/utils/cross-app-redirect.ts
@@ -1,6 +1,10 @@
 import type { NavigateFunction, NavigateOptions } from "react-router";
 
-const CROSS_APP_PATH_PREFIXES = ["/automations", "/canvas"] as const;
+const CROSS_APP_PATH_PREFIXES = [
+  "/automations",
+  "/canvas",
+  "/integrations-hub",
+] as const;
 
 export function isCrossAppPath(destination: string): boolean {
   if (!destination.startsWith("/") || destination.startsWith("//")) {


### PR DESCRIPTION
## Summary
- Adds `/integrations-hub/*` to the same cross-app redirect route used by Canvas and Automations.
- Keeps `/integrations-hub` in the safe hard-redirect allowlist so post-login return URLs hand control back to the microservice frontend instead of the main React app.
- Adds coverage for Integrations Hub path detection.

## Validation
- `cd frontend && npm run test -- src/utils/cross-app-redirect.test.ts src/routes/login.test.ts`
- `cd frontend && npm run typecheck:staged`

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b31d4fab-0de2-41d2-b834-a4fcc7c07837)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-4c7a184   docker.openhands.dev/openhands/openhands:4c7a184
```