### PR TITLE
fix(db): create conversation_cost_events table on OSS (migration 015)

### DIFF
--- a/openhands/app_server/app_lifespan/alembic/versions/015.py
+++ b/openhands/app_server/app_lifespan/alembic/versions/015.py
@@ -1,0 +1,73 @@
+"""Create conversation_cost_events table (OSS port of enterprise 134/136)
+
+The per-event cost-delta write code in
+``sql_app_conversation_info_service.py`` (added in commit acc8412ae,
+"feat: track per-event cost deltas") inserts rows into
+``conversation_cost_events`` on every positive cost delta. That table is
+created by the *enterprise* migration tree (revision 134, cascade-fixed in
+136), not the OSS tree, so on a self-hosted OSS install the table never exists
+and every cost-delta write raises ``no such table: conversation_cost_events``
+(hundreds/hour), breaking cost tracking and poisoning the DB session with
+``PendingRollbackError``.
+
+The OSS ``StoredConversationCostEvent`` model already declares the
+``ondelete='CASCADE'`` foreign key and both indexes, so this migration simply
+materialises the model's schema in the OSS migration set, using the final
+upstream form (the enterprise 134 schema with the 136 CASCADE foreign key
+already applied).
+
+Revision ID: 015
+Revises: 014
+Create Date: 2026-07-17 00:00:00.000000
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '015'
+down_revision: str | None = '014'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create conversation_cost_events table with cascade-delete foreign key."""
+    op.create_table(
+        'conversation_cost_events',
+        sa.Column('id', sa.Integer(), sa.Identity(), primary_key=True),
+        sa.Column(
+            'conversation_id',
+            sa.String(),
+            sa.ForeignKey(
+                'conversation_metadata.conversation_id',
+                ondelete='CASCADE',
+            ),
+            nullable=False,
+        ),
+        sa.Column('cost_delta', sa.Float(), nullable=False, server_default='0.0'),
+        sa.Column('occurred_at', sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        'ix_conversation_cost_events_conversation_id',
+        'conversation_cost_events',
+        ['conversation_id'],
+    )
+    op.create_index(
+        'ix_conversation_cost_events_occurred_at',
+        'conversation_cost_events',
+        ['occurred_at'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        'ix_conversation_cost_events_occurred_at',
+        table_name='conversation_cost_events',
+    )
+    op.drop_index(
+        'ix_conversation_cost_events_conversation_id',
+        table_name='conversation_cost_events',
+    )
+    op.drop_table('conversation_cost_events')

--- a/tests/unit/app_server/test_migration_015_conversation_cost_events.py
+++ b/tests/unit/app_server/test_migration_015_conversation_cost_events.py
@@ -13,7 +13,6 @@ foreign key exist after the migration runs.
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
-import pytest
 import sqlalchemy as sa
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
@@ -72,7 +71,9 @@ def test_upgrade_creates_table_indexes_and_cascade_fk(monkeypatch):
             'occurred_at',
         }
         assert table.c.cost_delta.server_default is not None
-        assert table.c.conversation_id.foreign_keys, 'expected FK to conversation_metadata'
+        assert table.c.conversation_id.foreign_keys, (
+            'expected FK to conversation_metadata'
+        )
 
         fk = list(table.c.conversation_id.foreign_keys)[0]
         assert fk.column.table.name == 'conversation_metadata'
@@ -82,7 +83,7 @@ def test_upgrade_creates_table_indexes_and_cascade_fk(monkeypatch):
             i.name
             for i in connection.execute(
                 sa.text(
-                    "SELECT name FROM sqlite_master "
+                    'SELECT name FROM sqlite_master '
                     "WHERE type='index' AND tbl_name='conversation_cost_events'"
                 )
             )
@@ -106,7 +107,7 @@ def test_downgrade_drops_table(monkeypatch):
 
         result = connection.execute(
             sa.text(
-                "SELECT name FROM sqlite_master "
+                'SELECT name FROM sqlite_master '
                 "WHERE type='table' AND name='conversation_cost_events'"
             )
         ).fetchall()

--- a/tests/unit/app_server/test_migration_015_conversation_cost_events.py
+++ b/tests/unit/app_server/test_migration_015_conversation_cost_events.py
@@ -1,0 +1,115 @@
+"""Regression test for OSS migration 015 (conversation_cost_events table).
+
+The per-event cost-delta write code (commit acc8412ae) inserts into
+``conversation_cost_events`` on every positive cost delta, but the table is
+created by the *enterprise* migration tree (134/136), not the OSS tree. On a
+self-hosted OSS install every cost-delta write therefore raises
+``no such table: conversation_cost_events``. This test exercises the OSS
+alembic migration directly (not ``Base.metadata.create_all``, which masks the
+gap by creating every model table) and asserts the table, indexes and cascade
+foreign key exist after the migration runs.
+"""
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / 'openhands'
+    / 'app_server'
+    / 'app_lifespan'
+    / 'alembic'
+    / 'versions'
+    / '015.py'
+)
+spec = spec_from_file_location('migration_015', MIGRATION_PATH)
+assert spec is not None and spec.loader is not None
+migration_015 = module_from_spec(spec)
+spec.loader.exec_module(migration_015)
+
+
+def _conversation_metadata_table() -> tuple[sa.MetaData, sa.Table]:
+    """Minimal parent table the cost-events foreign key references."""
+    metadata = sa.MetaData()
+    table = sa.Table(
+        'conversation_metadata',
+        metadata,
+        sa.Column('conversation_id', sa.String(), primary_key=True),
+    )
+    return metadata, table
+
+
+def test_migration_revises_head():
+    """015 must chain onto the OSS head 014 so alembic runs it."""
+    assert migration_015.revision == '015'
+    assert migration_015.down_revision == '014'
+
+
+def test_upgrade_creates_table_indexes_and_cascade_fk(monkeypatch):
+    engine = sa.create_engine('sqlite://')
+    metadata, _ = _conversation_metadata_table()
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        context = MigrationContext.configure(connection)
+        monkeypatch.setattr(migration_015, 'op', Operations(context))
+        migration_015.upgrade()
+
+        table = sa.Table(
+            'conversation_cost_events', sa.MetaData(), autoload_with=connection
+        )
+
+        # Columns
+        assert {c.name for c in table.columns} == {
+            'id',
+            'conversation_id',
+            'cost_delta',
+            'occurred_at',
+        }
+        assert table.c.cost_delta.server_default is not None
+        assert table.c.conversation_id.foreign_keys, 'expected FK to conversation_metadata'
+
+        fk = list(table.c.conversation_id.foreign_keys)[0]
+        assert fk.column.table.name == 'conversation_metadata'
+        assert fk.ondelete == 'CASCADE'
+
+        indexes = {
+            i.name
+            for i in connection.execute(
+                sa.text(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='index' AND tbl_name='conversation_cost_events'"
+                )
+            )
+        }
+        assert 'ix_conversation_cost_events_conversation_id' in indexes
+        assert 'ix_conversation_cost_events_occurred_at' in indexes
+
+    engine.dispose()
+
+
+def test_downgrade_drops_table(monkeypatch):
+    engine = sa.create_engine('sqlite://')
+    metadata, _ = _conversation_metadata_table()
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        context = MigrationContext.configure(connection)
+        monkeypatch.setattr(migration_015, 'op', Operations(context))
+        migration_015.upgrade()
+        migration_015.downgrade()
+
+        result = connection.execute(
+            sa.text(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='conversation_cost_events'"
+            )
+        ).fetchall()
+        assert result == [], 'table should be dropped on downgrade'
+
+    engine.dispose()


### PR DESCRIPTION
HUMAN:

Adds a new alembic migration (015) that creates the `conversation_cost_events` table on OSS installs, so the per-event cost-delta writer (already in `main`) stops hitting `no such table: conversation_cost_events` on a fresh SQLite DB. Mirrors the enterprise migration 134 (columns, indexes, CASCADE FK to `conversation_metadata`) without pulling in the rest of the enterprise migration tree. Verified end-to-end on a self-hosted OSS box: migration applies 014 -> 015, the table exists with both indexes + the CASCADE FK, the recurring `no such table` errors stopped, and per-event cost deltas persist.

- [ ] A human has tested these changes locally

---

## Why

Self-hosted OSS installs raise `no such table: conversation_cost_events` on every cost-delta write (hundreds/hour), breaking cost tracking and poisoning the DB session with `PendingRollbackError`.

Root cause: the per-event cost-delta write code in `sql_app_conversation_info_service.py` (added in acc8412ae, "feat: track per-event cost deltas") writes to `conversation_cost_events`, but that table is created by the **enterprise** migration tree only (revision 134, cascade-fixed in 136). The OSS migration set (001-014) never creates it, so a fresh OSS DB ends up stamped at head 014 without the table, while the app keeps writing to it.

This shipped undetected because the existing unit test (`test_webhook_router_stats.py`) builds the schema via `Base.metadata.create_all`, which creates every model table including `conversation_cost_events`, masking the missing alembic migration.

## What

Adds OSS alembic migration `015` that creates `conversation_cost_events` in its final upstream form: the enterprise 134 schema with the 136 `ondelete='CASCADE'` foreign key already applied. The OSS `StoredConversationCostEvent` model already declares the CASCADE FK and both indexes, so this just materialises the model's schema in the OSS migration set.

| | |
|---|---|
| revision | `015` |
| down_revision | `014` |
| columns | `id` (Identity PK), `conversation_id` (FK -> conversation_metadata, CASCADE), `cost_delta` (Float, default 0.0), `occurred_at` (DateTime, tz) |
| indexes | `ix_conversation_cost_events_conversation_id`, `ix_conversation_cost_events_occurred_at` |

## Test plan

- New `tests/unit/app_server/test_migration_015_conversation_cost_events.py` runs `upgrade()` directly against a fresh SQLite DB (not `metadata.create_all`) and asserts the table, both indexes, and the `ondelete='CASCADE'` FK to `conversation_metadata`. It fails without the migration and passes with it.
- Downgrade test asserts the table is dropped.
- Verified end-to-end on a self-hosted OSS host: after applying migration 015 the recurring `no such table: conversation_cost_events` errors stopped, and cost-delta rows are now inserted correctly on every metrics flush.

