### PR TITLE
fix: correct base64 padding logic in paging_utils

### DIFF
--- a/openhands/app_server/utils/paging_utils.py
+++ b/openhands/app_server/utils/paging_utils.py
@@ -47,7 +47,8 @@ def decode_page_id(page_id: str | None) -> int | None:
         return None
     try:
         # Add padding back if needed
-        padded = page_id + '=' * (4 - len(page_id) % 4)
+        padding_len = (4 - len(page_id) % 4) % 4
+        padded = page_id + '=' * padding_len
         decoded = base64.urlsafe_b64decode(padded.encode()).decode()
         return int(decoded)
     except (ValueError, Exception):


### PR DESCRIPTION
## Summary
Fixes a bug in `openhands/app_server/utils/paging_utils.py` where the base64 padding calculation would incorrectly append `====` if the `page_id` string length was already a multiple of 4. 

The previous logic:
`padded = page_id + '=' * (4 - len(page_id) % 4)`
resulted in 4 padding characters when `len(page_id) % 4 == 0`, leading to an invalid base64 padding structure that silently failed during `urlsafe_b64decode`.

## Fix
Updated the modulo calculation to correctly append `0` characters when the length is already a multiple of 4:
`padding_len = (4 - len(page_id) % 4) % 4`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
