### PR TITLE
fix(jira): allow conversations without repositories

### DIFF
--- a/enterprise/integrations/jira/jira_manager.py
+++ b/enterprise/integrations/jira/jira_manager.py
@@ -21,7 +21,7 @@ from integrations.jira.jira_payload import (
 )
 from integrations.jira.jira_types import (
     JiraViewInterface,
-    RepositoryNotFoundError,
+    RepositorySelectionError,
     StartingConvoException,
 )
 from integrations.jira.jira_view import JiraFactory
@@ -141,9 +141,9 @@ class JiraManager(Manager[JiraViewInterface]):
                 user_auth=saas_user_auth,
                 decrypted_api_key=decrypted_api_key,
             )
-        except RepositoryNotFoundError as e:
+        except RepositorySelectionError as e:
             logger.warning(
-                '[Jira] Repository not found',
+                '[Jira] Repository selection failed',
                 extra={'issue_key': payload.issue_key, 'error': str(e)},
             )
             await self._send_error_from_payload(payload, workspace, str(e))

--- a/enterprise/integrations/jira/jira_types.py
+++ b/enterprise/integrations/jira/jira_types.py
@@ -59,7 +59,7 @@ class StartingConvoException(Exception):
     pass
 
 
-class RepositoryNotFoundError(Exception):
+class RepositorySelectionError(Exception):
     """Raised when a mentioned repository cannot be selected.
 
     This is a separate error domain from StartingConvoException - it represents

--- a/enterprise/integrations/jira/jira_types.py
+++ b/enterprise/integrations/jira/jira_types.py
@@ -60,10 +60,10 @@ class StartingConvoException(Exception):
 
 
 class RepositoryNotFoundError(Exception):
-    """Raised when a repository cannot be determined from the issue.
+    """Raised when a mentioned repository cannot be selected.
 
     This is a separate error domain from StartingConvoException - it represents
-    a precondition failure (no repo configured/found) rather than a conversation
+    a repository verification or disambiguation failure rather than a conversation
     creation failure. The manager catches this and converts it to a user-friendly
     message.
     """

--- a/enterprise/integrations/jira/jira_view.py
+++ b/enterprise/integrations/jira/jira_view.py
@@ -64,7 +64,7 @@ class JiraNewConversationView(JiraViewInterface):
     saas_user_auth: UserAuth
     jira_user: JiraUser
     jira_workspace: JiraWorkspace
-    selected_repo: str = ''
+    selected_repo: str | None = None
     conversation_id: str = ''
 
     # Lazy-loaded issue details (cached after first fetch)
@@ -183,9 +183,6 @@ class JiraNewConversationView(JiraViewInterface):
         Raises:
             StartingConvoException: If conversation creation fails
         """
-        if not self.selected_repo:
-            raise StartingConvoException('No repository selected for this conversation')
-
         jira_conversation = JiraConversation(
             conversation_id=self.conversation_id,
             issue_id=self.payload.issue_id,
@@ -241,7 +238,7 @@ class JiraNewConversationView(JiraViewInterface):
             initial_message=initial_message,
             selected_repository=self.selected_repo,
             selected_branch=None,
-            git_provider=ProviderType.GITHUB,
+            git_provider=ProviderType.GITHUB if self.selected_repo else None,
             title=f'Jira Issue {self.payload.issue_key}: {self._issue_title or "Unknown"}',
             trigger=ConversationTrigger.JIRA,
             processors=[jira_callback_processor],
@@ -291,29 +288,34 @@ class JiraNewConversationView(JiraViewInterface):
 
     async def _get_resolved_org_id(self) -> UUID | None:
         """Resolve the org ID for V1 conversations."""
+        selected_repo = self.selected_repo
+        if not selected_repo:
+            return None
+
         provider_tokens = await self.saas_user_auth.get_provider_tokens()
         if not provider_tokens:
             return None
 
         try:
             provider_handler = ProviderHandler(provider_tokens)
-            repository = await provider_handler.verify_repo_provider(self.selected_repo)
+            repository = await provider_handler.verify_repo_provider(selected_repo)
             resolved_org_id = await resolve_org_for_repo(
                 provider=repository.git_provider.value,
-                full_repo_name=self.selected_repo,
+                full_repo_name=selected_repo,
                 keycloak_user_id=self.jira_user.keycloak_user_id,
             )
             return resolved_org_id
         except Exception as e:
-            logger.warning(
-                f'[Jira] Failed to resolve org for {self.selected_repo}: {e}'
-            )
+            logger.warning(f'[Jira] Failed to resolve org for {selected_repo}: {e}')
             return None
 
     def get_response_msg(self) -> str:
         """Get the response message to send back to Jira."""
         conversation_link = CONVERSATION_URL.format(self.conversation_id)
-        return f"I'm on it! {self.payload.display_name} can [track my progress here|{conversation_link}]."
+        message = f"I'm on it! {self.payload.display_name} can [track my progress here|{conversation_link}]."
+        if self.selected_repo is None:
+            message += '\n\nNote: This conversation started without a repository.'
+        return message
 
 
 class JiraFactory:
@@ -324,8 +326,8 @@ class JiraFactory:
     - Inferring and selecting the repository
     - Validating all required data is available
 
-    Repository selection happens here so that view creation either
-    succeeds with a valid repo or fails with a clear error.
+    Repository selection happens here so view creation succeeds either with a
+    verified repository or with no repository when none was mentioned.
     """
 
     @staticmethod
@@ -351,24 +353,20 @@ class JiraFactory:
         issue_description: str,
         user_msg: str,
     ) -> list[str]:
-        """Extract potential repository names from issue content.
-
-        Raises:
-            RepositoryNotFoundError: If no potential repos found in text.
-        """
+        """Extract potential repository names from issue content."""
         search_text = f'{issue_title}\n{issue_description}\n{user_msg}'
         potential_repos = infer_repo_from_message(search_text)
 
-        if not potential_repos:
-            raise RepositoryNotFoundError(
-                'Could not determine which repository to use. '
-                'Please mention the repository (e.g., owner/repo) in the issue description or comment.'
+        if potential_repos:
+            logger.info(
+                '[Jira] Found potential repositories in issue content',
+                extra={'issue_key': issue_key, 'potential_repos': potential_repos},
             )
-
-        logger.info(
-            '[Jira] Found potential repositories in issue content',
-            extra={'issue_key': issue_key, 'potential_repos': potential_repos},
-        )
+        else:
+            logger.info(
+                '[Jira] No repositories mentioned in issue content',
+                extra={'issue_key': issue_key},
+            )
         return potential_repos
 
     @staticmethod
@@ -435,21 +433,23 @@ class JiraFactory:
         user_auth: UserAuth,
         issue_title: str,
         issue_description: str,
-    ) -> str:
+    ) -> str | None:
         """Infer and verify the repository from issue content.
 
         Raises:
-            RepositoryNotFoundError: If no valid repository can be determined.
+            RepositoryNotFoundError: If a mentioned repository cannot be selected.
         """
+        potential_repos = JiraFactory._extract_potential_repos(
+            payload.issue_key, issue_title, issue_description, payload.user_msg
+        )
+        if not potential_repos:
+            return None
+
         provider_handler = await JiraFactory._create_provider_handler(user_auth)
         if not provider_handler:
             raise RepositoryNotFoundError(
                 'No Git provider connected. Please connect a Git provider in OpenHands settings.'
             )
-
-        potential_repos = JiraFactory._extract_potential_repos(
-            payload.issue_key, issue_title, issue_description, payload.user_msg
-        )
 
         verified_repos = await JiraFactory._verify_repos(
             payload.issue_key, potential_repos, provider_handler
@@ -467,12 +467,12 @@ class JiraFactory:
         user_auth: UserAuth,
         decrypted_api_key: str,
     ) -> JiraViewInterface:
-        """Create a Jira view with repository already selected.
+        """Create a Jira view with an optional selected repository.
 
         This factory method:
         1. Creates the view with payload and auth context
         2. Fetches issue details (needed for repo inference)
-        3. Infers and selects the repository
+        3. Infers and selects a repository when one is mentioned
 
         If any step fails, an appropriate exception is raised with
         a user-friendly message.
@@ -485,11 +485,11 @@ class JiraFactory:
             decrypted_api_key: Decrypted service account API key
 
         Returns:
-            A JiraViewInterface with selected_repo populated
+            A JiraViewInterface with selected_repo set when one was verified
 
         Raises:
             StartingConvoException: If view creation fails
-            RepositoryNotFoundError: If repository cannot be determined
+            RepositoryNotFoundError: If a mentioned repository cannot be selected
         """
         logger.info(
             '[Jira] Creating view',

--- a/enterprise/integrations/jira/jira_view.py
+++ b/enterprise/integrations/jira/jira_view.py
@@ -13,7 +13,7 @@ import httpx
 from integrations.jira.jira_payload import JiraWebhookPayload
 from integrations.jira.jira_types import (
     JiraViewInterface,
-    RepositoryNotFoundError,
+    RepositorySelectionError,
     StartingConvoException,
 )
 from integrations.jira.jira_v1_callback_processor import (
@@ -407,16 +407,16 @@ class JiraFactory:
         """Select exactly one repo from verified repos.
 
         Raises:
-            RepositoryNotFoundError: If zero or multiple repos verified.
+            RepositorySelectionError: If zero or multiple repos verified.
         """
         if len(verified_repos) == 0:
-            raise RepositoryNotFoundError(
+            raise RepositorySelectionError(
                 f'Could not access any of the mentioned repositories: {", ".join(potential_repos)}. '
                 'Please ensure you have access to the repository and it exists.'
             )
 
         if len(verified_repos) > 1:
-            raise RepositoryNotFoundError(
+            raise RepositorySelectionError(
                 f'Multiple repositories found: {", ".join(verified_repos)}. '
                 'Please specify exactly one repository in the issue description or comment.'
             )
@@ -437,7 +437,7 @@ class JiraFactory:
         """Infer and verify the repository from issue content.
 
         Raises:
-            RepositoryNotFoundError: If a mentioned repository cannot be selected.
+            RepositorySelectionError: If a mentioned repository cannot be selected.
         """
         potential_repos = JiraFactory._extract_potential_repos(
             payload.issue_key, issue_title, issue_description, payload.user_msg
@@ -447,7 +447,7 @@ class JiraFactory:
 
         provider_handler = await JiraFactory._create_provider_handler(user_auth)
         if not provider_handler:
-            raise RepositoryNotFoundError(
+            raise RepositorySelectionError(
                 'No Git provider connected. Please connect a Git provider in OpenHands settings.'
             )
 
@@ -489,7 +489,7 @@ class JiraFactory:
 
         Raises:
             StartingConvoException: If view creation fails
-            RepositoryNotFoundError: If a mentioned repository cannot be selected
+            RepositorySelectionError: If a mentioned repository cannot be selected
         """
         logger.info(
             '[Jira] Creating view',

--- a/enterprise/integrations/jira_dc/jira_dc_manager.py
+++ b/enterprise/integrations/jira_dc/jira_dc_manager.py
@@ -534,6 +534,14 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
             target_str = f'{jira_dc_view.job_context.issue_description}\n{jira_dc_view.job_context.user_msg}'
             mentioned_repos = infer_repo_from_message(target_str)
 
+            if not mentioned_repos:
+                jira_dc_view.selected_repo = None
+                logger.info(
+                    '[Jira DC] repo resolution issue=%s inferred=[] verified=[]',
+                    jira_dc_view.job_context.issue_key,
+                )
+                return True
+
             # Verify each mentioned repo directly rather than enumerating the
             # user's full repo list (which is capped and misses repos on large
             # Bitbucket DC instances).
@@ -562,7 +570,7 @@ class JiraDcManager(Manager[JiraDcViewInterface]):
                 )
                 return True
 
-            # Zero or multiple matches -- ask the user to disambiguate.
+            # Unverified or multiple mentioned repositories still require user action.
             await self._send_repo_selection_comment(
                 jira_dc_view, mentioned_repos, verified_repos
             )

--- a/enterprise/integrations/jira_dc/jira_dc_view.py
+++ b/enterprise/integrations/jira_dc/jira_dc_view.py
@@ -83,9 +83,6 @@ class JiraDcNewConversationView(JiraDcViewInterface):
         Raises:
             StartingConvoException: If conversation creation fails
         """
-        if not self.selected_repo:
-            raise StartingConvoException('No repository selected for this conversation')
-
         # Generate conversation ID
         self.conversation_id = uuid4().hex
 
@@ -187,23 +184,25 @@ class JiraDcNewConversationView(JiraDcViewInterface):
 
     async def _get_resolved_org_id(self) -> UUID | None:
         """Resolve the org ID for V1 conversations."""
+        selected_repo = self.selected_repo
+        if not selected_repo:
+            return None
+
         provider_tokens = await self.saas_user_auth.get_provider_tokens()
-        if not provider_tokens or not self.selected_repo:
+        if not provider_tokens:
             return None
 
         try:
             provider_handler = ProviderHandler(provider_tokens)
-            repository = await provider_handler.verify_repo_provider(self.selected_repo)
+            repository = await provider_handler.verify_repo_provider(selected_repo)
             resolved_org_id = await resolve_org_for_repo(
                 provider=repository.git_provider.value,
-                full_repo_name=self.selected_repo,
+                full_repo_name=selected_repo,
                 keycloak_user_id=self.jira_dc_user.keycloak_user_id,
             )
             return resolved_org_id
         except Exception as e:
-            logger.warning(
-                f'[Jira DC] Failed to resolve org for {self.selected_repo}: {e}'
-            )
+            logger.warning(f'[Jira DC] Failed to resolve org for {selected_repo}: {e}')
             return None
 
     def get_response_msg(self) -> str:
@@ -215,7 +214,10 @@ class JiraDcNewConversationView(JiraDcViewInterface):
             if self.selected_repo
             else "I'm on it!"
         )
-        return f'{prefix} {self.job_context.display_name} can [track my progress here|{conversation_link}].'
+        message = f'{prefix} {self.job_context.display_name} can [track my progress here|{conversation_link}].'
+        if self.selected_repo is None:
+            message += '\n\nNote: This conversation started without a repository.'
+        return message
 
 
 @dataclass

--- a/enterprise/server/routes/integration/jira.py
+++ b/enterprise/server/routes/integration/jira.py
@@ -301,7 +301,21 @@ async def jira_events(
 
         signature = parts[1]
         body = await request.body()
-        payload = await request.json()
+        try:
+            payload = await request.json()
+        except json.JSONDecodeError:
+            logger.error(
+                '[Jira] Webhook body is not valid JSON',
+                extra={
+                    'content_type': request.headers.get('content-type'),
+                    'body_length': len(body),
+                    'body_preview': body[:2000].decode('utf-8', errors='replace'),
+                },
+            )
+            raise HTTPException(
+                status_code=400,
+                detail='Webhook body is not valid JSON',
+            )
 
         await verify_jira_signature(body, signature, payload)
 

--- a/enterprise/tests/unit/integrations/jira/test_jira_view.py
+++ b/enterprise/tests/unit/integrations/jira/test_jira_view.py
@@ -12,7 +12,10 @@ from integrations.jira.jira_payload import (
     JiraPayloadSkipped,
     JiraPayloadSuccess,
 )
-from integrations.jira.jira_types import RepositoryNotFoundError, StartingConvoException
+from integrations.jira.jira_types import (
+    RepositorySelectionError,
+    StartingConvoException,
+)
 from integrations.jira.jira_view import (
     JiraFactory,
     JiraNewConversationView,
@@ -263,7 +266,7 @@ class TestJiraFactory:
             )
 
             with pytest.raises(
-                RepositoryNotFoundError,
+                RepositorySelectionError,
                 match='Could not access any of the mentioned repositories',
             ):
                 await JiraFactory.create_view(
@@ -310,7 +313,7 @@ class TestJiraFactory:
             )
 
             with pytest.raises(
-                RepositoryNotFoundError, match='Multiple repositories found'
+                RepositorySelectionError, match='Multiple repositories found'
             ):
                 await JiraFactory.create_view(
                     payload=sample_webhook_payload,
@@ -348,7 +351,7 @@ class TestJiraFactory:
             )
 
             with pytest.raises(
-                RepositoryNotFoundError, match='No Git provider connected'
+                RepositorySelectionError, match='No Git provider connected'
             ):
                 await JiraFactory.create_view(
                     payload=sample_webhook_payload,

--- a/enterprise/tests/unit/integrations/jira/test_jira_view.py
+++ b/enterprise/tests/unit/integrations/jira/test_jira_view.py
@@ -18,6 +18,10 @@ from integrations.jira.jira_view import (
     JiraNewConversationView,
 )
 
+from openhands.app_server.app_conversation.app_conversation_models import (
+    AppConversationStartTaskStatus,
+)
+
 
 class TestJiraNewConversationView:
     """Tests for JiraNewConversationView"""
@@ -86,14 +90,39 @@ class TestJiraNewConversationView:
         assert 'Test Issue' in user_msg
 
     @pytest.mark.asyncio
+    @patch('integrations.jira.jira_view.get_app_conversation_service')
+    @patch('integrations.jira.jira_view.integration_store')
     async def test_create_or_update_conversation_no_repo(
-        self, new_conversation_view, mock_jinja_env
+        self,
+        mock_store,
+        mock_get_service,
+        new_conversation_view,
+        mock_jinja_env,
     ):
-        """Test conversation creation without selected repo"""
+        """Test conversation creation without a selected repository."""
         new_conversation_view.selected_repo = None
+        new_conversation_view._issue_title = 'Test Issue'
+        new_conversation_view._issue_description = 'Test description'
+        mock_store.create_conversation = AsyncMock()
+        captured_requests = []
 
-        with pytest.raises(StartingConvoException, match='No repository selected'):
-            await new_conversation_view.create_or_update_conversation(mock_jinja_env)
+        async def mock_start_generator(request):
+            captured_requests.append(request)
+            yield MagicMock(status=AppConversationStartTaskStatus.READY)
+
+        mock_service = MagicMock()
+        mock_service.start_app_conversation = mock_start_generator
+        mock_get_service.return_value.__aenter__.return_value = mock_service
+
+        result = await new_conversation_view.create_or_update_conversation(
+            mock_jinja_env
+        )
+
+        assert result
+        assert len(captured_requests) == 1
+        assert captured_requests[0].selected_repository is None
+        assert captured_requests[0].git_provider is None
+        mock_store.create_conversation.assert_awaited_once()
 
     def test_get_response_msg(self, new_conversation_view):
         """Test get_response_msg method"""
@@ -103,6 +132,14 @@ class TestJiraNewConversationView:
         assert 'Test User' in response
         assert 'track my progress here' in response
         assert 'conv-123' in response
+        assert 'started without a repository' not in response
+
+    def test_get_response_msg_without_repo(self, new_conversation_view):
+        new_conversation_view.selected_repo = None
+
+        response = new_conversation_view.get_response_msg()
+
+        assert 'Note: This conversation started without a repository.' in response
 
 
 class TestJiraFactory:
@@ -167,11 +204,7 @@ class TestJiraFactory:
         sample_jira_user,
         sample_jira_workspace,
     ):
-        """Test factory raises error when no repo mentioned in text."""
-        mock_handler = MagicMock()
-        mock_create_handler.return_value = mock_handler
-
-        # No repos found in text
+        """Test factory creates a view without a selected repository."""
         mock_infer_repos.return_value = []
 
         mock_response = MagicMock()
@@ -185,16 +218,16 @@ class TestJiraFactory:
                 return_value=mock_response
             )
 
-            with pytest.raises(
-                RepositoryNotFoundError, match='Could not determine which repository'
-            ):
-                await JiraFactory.create_view(
-                    payload=sample_webhook_payload,
-                    workspace=sample_jira_workspace,
-                    user=sample_jira_user,
-                    user_auth=sample_user_auth,
-                    decrypted_api_key='test_api_key',
-                )
+            view = await JiraFactory.create_view(
+                payload=sample_webhook_payload,
+                workspace=sample_jira_workspace,
+                user=sample_jira_user,
+                user_auth=sample_user_auth,
+                decrypted_api_key='test_api_key',
+            )
+
+        assert view.selected_repo is None
+        mock_create_handler.assert_not_awaited()
 
     @pytest.mark.asyncio
     @patch('integrations.jira.jira_view.JiraFactory._create_provider_handler')
@@ -289,15 +322,18 @@ class TestJiraFactory:
 
     @pytest.mark.asyncio
     @patch('integrations.jira.jira_view.JiraFactory._create_provider_handler')
+    @patch('integrations.jira.jira_view.infer_repo_from_message')
     async def test_create_view_no_provider(
         self,
+        mock_infer_repos,
         mock_create_handler,
         sample_webhook_payload,
         sample_user_auth,
         sample_jira_user,
         sample_jira_workspace,
     ):
-        """Test factory raises error when no provider is connected."""
+        """Test factory raises error for a mentioned repo without a provider."""
+        mock_infer_repos.return_value = ['test/repo1']
         mock_create_handler.return_value = None
 
         mock_response = MagicMock()
@@ -480,6 +516,17 @@ class TestJiraV1Conversation:
             await new_conversation_view._initialize_conversation()
 
             assert new_conversation_view.resolved_org_id == test_org_id
+
+    @pytest.mark.asyncio
+    async def test_get_resolved_org_id_without_repo_skips_provider_lookup(
+        self, new_conversation_view
+    ):
+        new_conversation_view.selected_repo = None
+
+        resolved_org_id = await new_conversation_view._get_resolved_org_id()
+
+        assert resolved_org_id is None
+        new_conversation_view.saas_user_auth.get_provider_tokens.assert_not_awaited()
 
     def test_create_jira_v1_callback_processor(
         self, new_conversation_view, sample_jira_workspace

--- a/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_manager.py
+++ b/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_manager.py
@@ -1104,10 +1104,37 @@ class TestIsJobRequested:
         assert mock_view.selected_repo == 'company/repo'
 
     @pytest.mark.asyncio
-    async def test_is_job_requested_new_conversation_no_repo_match(
+    async def test_is_job_requested_new_conversation_without_repo(
         self, jira_dc_manager, sample_job_context, sample_user_auth
     ):
-        """Zero verified repos -> repository-selection comment, job blocked."""
+        """No mentioned repository allows the job to start with an empty workspace."""
+        mock_view = MagicMock(spec=JiraDcNewConversationView)
+        mock_view.saas_user_auth = sample_user_auth
+        mock_view.job_context = sample_job_context
+        mock_view.selected_repo = None
+
+        jira_dc_manager._create_provider_handler = AsyncMock()
+        jira_dc_manager._verify_mentioned_repos = AsyncMock()
+        jira_dc_manager._send_repo_selection_comment = AsyncMock()
+
+        with patch(
+            'integrations.jira_dc.jira_dc_manager.infer_repo_from_message',
+            return_value=[],
+        ):
+            message = Message(source=SourceType.JIRA_DC, message={})
+            result = await jira_dc_manager.is_job_requested(message, mock_view)
+
+        assert result is True
+        assert mock_view.selected_repo is None
+        jira_dc_manager._create_provider_handler.assert_not_awaited()
+        jira_dc_manager._verify_mentioned_repos.assert_not_awaited()
+        jira_dc_manager._send_repo_selection_comment.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_is_job_requested_blocks_unverified_mentioned_repo(
+        self, jira_dc_manager, sample_job_context, sample_user_auth
+    ):
+        """An explicitly mentioned inaccessible repository still blocks the job."""
         mock_view = MagicMock(spec=JiraDcNewConversationView)
         mock_view.saas_user_auth = sample_user_auth
         mock_view.job_context = sample_job_context
@@ -1118,14 +1145,55 @@ class TestIsJobRequested:
 
         with patch(
             'integrations.jira_dc.jira_dc_manager.infer_repo_from_message',
-            return_value=[],
+            return_value=['company/missing'],
         ):
             message = Message(source=SourceType.JIRA_DC, message={})
             result = await jira_dc_manager.is_job_requested(message, mock_view)
 
         assert result is False
-        jira_dc_manager._send_repo_selection_comment.assert_called_once_with(
-            mock_view, [], []
+        jira_dc_manager._send_repo_selection_comment.assert_awaited_once_with(
+            mock_view, ['company/missing'], []
+        )
+
+    @pytest.mark.asyncio
+    async def test_is_job_requested_blocks_multiple_verified_repos(
+        self, jira_dc_manager, sample_job_context, sample_user_auth
+    ):
+        """Multiple verified repositories still require disambiguation."""
+        mock_view = MagicMock(spec=JiraDcNewConversationView)
+        mock_view.saas_user_auth = sample_user_auth
+        mock_view.job_context = sample_job_context
+        repos = [
+            Repository(
+                id='1',
+                full_name='company/repo1',
+                stargazers_count=10,
+                git_provider=ProviderType.GITHUB,
+                is_public=True,
+            ),
+            Repository(
+                id='2',
+                full_name='company/repo2',
+                stargazers_count=5,
+                git_provider=ProviderType.GITHUB,
+                is_public=True,
+            ),
+        ]
+
+        jira_dc_manager._create_provider_handler = AsyncMock(return_value=MagicMock())
+        jira_dc_manager._verify_mentioned_repos = AsyncMock(return_value=repos)
+        jira_dc_manager._send_repo_selection_comment = AsyncMock()
+
+        with patch(
+            'integrations.jira_dc.jira_dc_manager.infer_repo_from_message',
+            return_value=['company/repo1', 'company/repo2'],
+        ):
+            message = Message(source=SourceType.JIRA_DC, message={})
+            result = await jira_dc_manager.is_job_requested(message, mock_view)
+
+        assert result is False
+        jira_dc_manager._send_repo_selection_comment.assert_awaited_once_with(
+            mock_view, ['company/repo1', 'company/repo2'], repos
         )
 
     @pytest.mark.asyncio
@@ -1174,8 +1242,12 @@ class TestIsJobRequested:
             side_effect=Exception('boom')
         )
 
-        message = Message(source=SourceType.JIRA_DC, message={})
-        result = await jira_dc_manager.is_job_requested(message, mock_view)
+        with patch(
+            'integrations.jira_dc.jira_dc_manager.infer_repo_from_message',
+            return_value=['company/repo'],
+        ):
+            message = Message(source=SourceType.JIRA_DC, message={})
+            result = await jira_dc_manager.is_job_requested(message, mock_view)
 
         assert result is False
 

--- a/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_manager.py
+++ b/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_manager.py
@@ -1097,8 +1097,12 @@ class TestIsJobRequested:
         jira_dc_manager._create_provider_handler = AsyncMock(return_value=MagicMock())
         jira_dc_manager._verify_mentioned_repos = AsyncMock(return_value=[repo])
 
-        message = Message(source=SourceType.JIRA_DC, message={})
-        result = await jira_dc_manager.is_job_requested(message, mock_view)
+        with patch(
+            'integrations.jira_dc.jira_dc_manager.infer_repo_from_message',
+            return_value=['company/repo'],
+        ):
+            message = Message(source=SourceType.JIRA_DC, message={})
+            result = await jira_dc_manager.is_job_requested(message, mock_view)
 
         assert result is True
         assert mock_view.selected_repo == 'company/repo'

--- a/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_view.py
+++ b/enterprise/tests/unit/integrations/jira_dc/test_jira_dc_view.py
@@ -109,7 +109,7 @@ def _make_start_conversation_patches():
         )
 
         with (
-            patch('integrations.jira_dc.jira_dc_view.integration_store'),
+            patch('integrations.jira_dc.jira_dc_view.integration_store') as mock_store,
             patch(
                 'integrations.jira_dc.jira_dc_view.resolve_org_for_repo',
                 new=AsyncMock(return_value=None),
@@ -119,6 +119,7 @@ def _make_start_conversation_patches():
                 'integrations.jira_dc.jira_dc_view.get_app_conversation_service',
             ) as mock_svc_ctx,
         ):
+            mock_store.create_conversation = AsyncMock()
             mock_svc_ctx.return_value.__aenter__ = AsyncMock(
                 return_value=mock_app_conversation_service
             )
@@ -175,3 +176,35 @@ async def test_create_v1_conversation_does_not_fetch_jira_dc_token(
 
     assert len(captured_requests) == 1
     assert captured_requests[0].secrets is None
+
+
+@pytest.mark.asyncio
+async def test_create_conversation_without_repository(
+    new_conversation_view, mock_jinja_env
+):
+    new_conversation_view.selected_repo = None
+    captured_requests = []
+
+    async def _fake_start(request):
+        captured_requests.append(request)
+        return
+        yield
+
+    async with _make_start_conversation_patches()(new_conversation_view) as mock_svc:
+        mock_svc.start_app_conversation = _fake_start
+        conversation_id = await new_conversation_view.create_or_update_conversation(
+            mock_jinja_env
+        )
+
+    assert conversation_id
+    assert len(captured_requests) == 1
+    assert captured_requests[0].selected_repository is None
+    assert captured_requests[0].git_provider is None
+
+
+def test_get_response_msg_without_repository(new_conversation_view):
+    new_conversation_view.selected_repo = None
+
+    response = new_conversation_view.get_response_msg()
+
+    assert 'Note: This conversation started without a repository.' in response

--- a/enterprise/tests/unit/server/routes/test_jira_integration_routes.py
+++ b/enterprise/tests/unit/server/routes/test_jira_integration_routes.py
@@ -453,6 +453,38 @@ async def test_jira_events_general_exception(mock_redis, mock_verify, mock_reque
         assert 'Internal server error processing webhook' in body['error']
 
 
+@pytest.mark.asyncio
+@patch('server.routes.integration.jira.logger')
+@patch('server.routes.integration.jira.verify_jira_signature', new_callable=AsyncMock)
+@patch('server.routes.integration.jira.redis_client', new_callable=MagicMock)
+async def test_jira_events_invalid_json_body(
+    mock_redis, mock_verify, mock_logger, mock_request
+):
+    """A non-JSON body should be logged with its preview and return 400."""
+    with patch('server.routes.integration.jira.JIRA_WEBHOOKS_ENABLED', True):
+        bad_body = b'<html>some proxy error page</html>'
+        mock_request.body = AsyncMock(return_value=bad_body)
+        mock_request.json = AsyncMock(
+            side_effect=json.JSONDecodeError('Expecting value', '', 0)
+        )
+        mock_request.headers = {'content-type': 'text/html'}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await jira_events(
+                mock_request, MagicMock(), x_hub_signature='sha256=sig123'
+            )
+
+        assert exc_info.value.status_code == 400
+        assert 'not valid JSON' in exc_info.value.detail
+        mock_logger.error.assert_called_once()
+        log_kwargs = mock_logger.error.call_args.kwargs
+        assert log_kwargs['extra']['body_preview'] == bad_body.decode('utf-8')
+        assert log_kwargs['extra']['body_length'] == len(bad_body)
+        assert log_kwargs['extra']['content_type'] == 'text/html'
+        # Signature verification must NOT have been reached
+        mock_verify.assert_not_called()
+
+
 # Test verify_jira_signature
 class TestVerifyJiraSignature:
     """Test Jira webhook signature verification."""


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

I've tested this in my own private jira account.

- [X] A human has tested these changes.

AGENT:

_This pull request was created by an AI agent (OpenHands) on behalf of the user._

---

## Why

Jira Cloud and Jira Data Center currently require exactly one repository before starting a resolver conversation. This blocks repository-free tasks such as PRD decomposition, translation, and log analysis.

## Summary

- represent a missing Jira repository as `None` and start the conversation with an empty workspace
- skip Git provider and organization resolution when no repository is mentioned, while preserving inaccessible and multiple-repository errors
- add the repository-free acknowledgement note and focused Jira/Jira DC unit coverage

## Issue Number

[OHE-1068](https://linear.app/all-hands-ai/issue/OHE-1068/jira-missing-repo-information-should-be-optional)

Related to OpenHands/enterprise#44; this PR intentionally covers only the zero-repository case.

## How to Test

Automated validation completed:

```bash
poetry run pre-commit run --all-files --show-diff-on-failure --config ./enterprise/dev_config/python/.pre-commit-config.yaml
```

This passed, including Ruff and mypy. Python compilation and `git diff --check` also passed.

To run the focused tests after installing enterprise test dependencies:

```bash
cd enterprise
poetry install --with dev,test
PYTHONPATH=".:$PYTHONPATH" poetry run pytest \
  tests/unit/integrations/jira/test_jira_view.py \
  tests/unit/integrations/jira_dc/test_jira_dc_view.py \
  tests/unit/integrations/jira_dc/test_jira_dc_manager.py
```

The focused pytest suite was not run in the agent environment because its enterprise virtualenv did not contain `keycloak`, so collection stopped with `ModuleNotFoundError` before executing tests.

## Video/Screenshots

<img width="1366" height="883" alt="image" src="https://github.com/user-attachments/assets/21066323-d66b-44d3-81c6-7da03f89a477" />
<img width="765" height="586" alt="image" src="https://github.com/user-attachments/assets/da5cf2b3-f8a3-492b-82c6-e6937ee28ae9" />


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No migrations or configuration changes are required. Explicit inaccessible repositories and multiple verified repositories retain their existing error behavior.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-e2d58ce   docker.openhands.dev/openhands/openhands:e2d58ce
```