### PR TITLE
feat(backend): support conversation tags for write and search (#15316)

### DIFF
--- a/enterprise/server/utils/saas_app_conversation_info_injector.py
+++ b/enterprise/server/utils/saas_app_conversation_info_injector.py
@@ -136,6 +136,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        tag: list[str] | None = None,
         sort_order: AppConversationSortOrder = AppConversationSortOrder.CREATED_AT_DESC,
         page_id: str | None = None,
         limit: int = 100,
@@ -159,6 +160,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
             updated_at__gte=updated_at__gte,
             updated_at__lt=updated_at__lt,
             sandbox_id__eq=sandbox_id__eq,
+            tag=tag,
         )
 
         # Add sort order
@@ -217,6 +219,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        tag: list[str] | None = None,
     ) -> int:
         """Count conversations matching the given filters with SAAS metadata."""
         query = (
@@ -240,6 +243,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
             updated_at__gte=updated_at__gte,
             updated_at__lt=updated_at__lt,
             sandbox_id__eq=sandbox_id__eq,
+            tag=tag,
         )
 
         result = await self.db_session.execute(query)
@@ -255,6 +259,7 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        tag: list[str] | None = None,
     ):
         """Apply filters to query that includes SAAS metadata."""
         # Apply the same filters as the base class
@@ -282,6 +287,16 @@ class SaasSQLAppConversationInfoService(SQLAppConversationInfoService):
 
         if sandbox_id__eq is not None:
             conditions.append(StoredConversationMetadata.sandbox_id == sandbox_id__eq)
+
+        if tag is not None:
+            for t in tag:
+                # tag format: key=value
+                if '=' in t:
+                    key, val = t.split('=', 1)
+                    # For a JSON column in SQLAlchemy, we can access the key and compare it as a string
+                    conditions.append(
+                        StoredConversationMetadata.tags[key].as_string() == val
+                    )
 
         if conditions:
             query = query.where(*conditions)

--- a/openhands/app_server/app_conversation/app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/app_conversation_info_service.py
@@ -25,6 +25,7 @@ class AppConversationInfoService(ABC):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        tag: list[str] | None = None,
         sort_order: AppConversationSortOrder = AppConversationSortOrder.CREATED_AT_DESC,
         page_id: str | None = None,
         limit: int = 100,
@@ -41,6 +42,7 @@ class AppConversationInfoService(ABC):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        tag: list[str] | None = None,
     ) -> int:
         """Count sandboxed conversations."""
 

--- a/openhands/app_server/app_conversation/app_conversation_models.py
+++ b/openhands/app_server/app_conversation/app_conversation_models.py
@@ -129,7 +129,6 @@ class AppConversationInfo(BaseModel):
     parent_conversation_id: OpenHandsUUID | None = None
     sub_conversation_ids: list[OpenHandsUUID] = Field(default_factory=list)
 
-
     public: bool | None = None
 
     # Tags for conversation metadata (e.g., automation context, skills used)
@@ -250,7 +249,9 @@ class AppConversationStartRequest(OpenHandsModel):
     agent_type: AgentType = Field(default=AgentType.DEFAULT)
 
     public: bool | None = None
-    tags: dict[str, str] | None = Field(default=None, description='Optional tags to associate with the conversation.')
+    tags: dict[str, str] | None = Field(
+        default=None, description='Optional tags to associate with the conversation.'
+    )
     # Plugin parameters - for loading remote plugins into the conversation
     plugins: list[PluginSpec] | None = Field(
         default=None,
@@ -284,7 +285,9 @@ class AppConversationUpdateRequest(BaseModel):
     selected_repository: str | None = None
     selected_branch: str | None = None
     git_provider: ProviderType | None = None
-    tags: dict[str, str] | None = Field(default=None, description='Optional tags to associate with the conversation.')
+    tags: dict[str, str] | None = Field(
+        default=None, description='Optional tags to associate with the conversation.'
+    )
 
 
 class AppConversationStartTaskStatus(Enum):

--- a/openhands/app_server/app_conversation/app_conversation_models.py
+++ b/openhands/app_server/app_conversation/app_conversation_models.py
@@ -250,7 +250,7 @@ class AppConversationStartRequest(OpenHandsModel):
     agent_type: AgentType = Field(default=AgentType.DEFAULT)
 
     public: bool | None = None
-    tags: dict[str, str] | None = Field(default=None, description="Optional tags to associate with the conversation.")
+    tags: dict[str, str] | None = Field(default=None, description='Optional tags to associate with the conversation.')
     # Plugin parameters - for loading remote plugins into the conversation
     plugins: list[PluginSpec] | None = Field(
         default=None,
@@ -284,7 +284,7 @@ class AppConversationUpdateRequest(BaseModel):
     selected_repository: str | None = None
     selected_branch: str | None = None
     git_provider: ProviderType | None = None
-    tags: dict[str, str] | None = Field(default=None, description="Optional tags to associate with the conversation.")
+    tags: dict[str, str] | None = Field(default=None, description='Optional tags to associate with the conversation.')
 
 
 class AppConversationStartTaskStatus(Enum):

--- a/openhands/app_server/app_conversation/app_conversation_models.py
+++ b/openhands/app_server/app_conversation/app_conversation_models.py
@@ -129,6 +129,7 @@ class AppConversationInfo(BaseModel):
     parent_conversation_id: OpenHandsUUID | None = None
     sub_conversation_ids: list[OpenHandsUUID] = Field(default_factory=list)
 
+
     public: bool | None = None
 
     # Tags for conversation metadata (e.g., automation context, skills used)
@@ -249,7 +250,7 @@ class AppConversationStartRequest(OpenHandsModel):
     agent_type: AgentType = Field(default=AgentType.DEFAULT)
 
     public: bool | None = None
-
+    tags: dict[str, str] | None = Field(default=None, description="Optional tags to associate with the conversation.")
     # Plugin parameters - for loading remote plugins into the conversation
     plugins: list[PluginSpec] | None = Field(
         default=None,
@@ -283,6 +284,7 @@ class AppConversationUpdateRequest(BaseModel):
     selected_repository: str | None = None
     selected_branch: str | None = None
     git_provider: ProviderType | None = None
+    tags: dict[str, str] | None = Field(default=None, description="Optional tags to associate with the conversation.")
 
 
 class AppConversationStartTaskStatus(Enum):

--- a/openhands/app_server/app_conversation/app_conversation_router.py
+++ b/openhands/app_server/app_conversation/app_conversation_router.py
@@ -1043,7 +1043,7 @@ async def delete_app_conversation(
 async def stream_app_conversation_start(
     request: AppConversationStartRequest,
     user_context: UserContext = user_context_dependency,
-) -> list[AppConversationStartTask]:
+) -> StreamingResponse:
     """Start an app conversation start task and stream updates from it.
     Leaves the connection open until either the conversation starts or there was an error
     """

--- a/openhands/app_server/app_conversation/app_conversation_router.py
+++ b/openhands/app_server/app_conversation/app_conversation_router.py
@@ -250,6 +250,10 @@ async def search_app_conversations(
         str | None,
         Query(title='Optional next_page_id from the previously returned page'),
     ] = None,
+    tag: Annotated[
+        list[str] | None,
+        Query(title='Filter by tags (e.g., tag=key=value)'),
+    ] = None,
     limit: Annotated[
         int,
         Query(
@@ -279,6 +283,7 @@ async def search_app_conversations(
         page_id=page_id,
         limit=limit,
         include_sub_conversations=include_sub_conversations,
+        tag=tag,
     )
 
 
@@ -308,6 +313,10 @@ async def count_app_conversations(
         str | None,
         Query(title='Filter by exact sandbox_id'),
     ] = None,
+    tag: Annotated[
+        list[str] | None,
+        Query(title='Filter by tags (e.g., tag=key=value)'),
+    ] = None,
     app_conversation_service: AppConversationService = (
         app_conversation_service_dependency
     ),
@@ -320,6 +329,7 @@ async def count_app_conversations(
         updated_at__gte=updated_at__gte,
         updated_at__lt=updated_at__lt,
         sandbox_id__eq=sandbox_id__eq,
+        tag=tag,
     )
 
 

--- a/openhands/app_server/app_conversation/app_conversation_service.py
+++ b/openhands/app_server/app_conversation/app_conversation_service.py
@@ -42,6 +42,7 @@ class AppConversationService(ABC):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        tag: list[str] | None = None,
         sort_order: AppConversationSortOrder = AppConversationSortOrder.CREATED_AT_DESC,
         page_id: str | None = None,
         limit: int = 100,
@@ -58,6 +59,7 @@ class AppConversationService(ABC):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        tag: list[str] | None = None,
     ) -> int:
         """Count sandboxed conversations."""
 

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -2559,12 +2559,12 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         sandbox = await self.sandbox_service.get_sandbox(
             app_conversation_info.sandbox_id
         )
-        assert sandbox is not None, (
-            f'Sandbox {app_conversation_info.sandbox_id} not found for conversation {conversation_id}'
-        )
-        assert sandbox.exposed_urls is not None, (
-            f'Sandbox {app_conversation_info.sandbox_id} has no exposed URLs for conversation {conversation_id}'
-        )
+        assert (
+            sandbox is not None
+        ), f'Sandbox {app_conversation_info.sandbox_id} not found for conversation {conversation_id}'
+        assert (
+            sandbox.exposed_urls is not None
+        ), f'Sandbox {app_conversation_info.sandbox_id} has no exposed URLs for conversation {conversation_id}'
 
         # Use the existing method to get the agent-server URL
         agent_server_url = self._get_agent_server_url(sandbox)

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -2559,12 +2559,12 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         sandbox = await self.sandbox_service.get_sandbox(
             app_conversation_info.sandbox_id
         )
-        assert (
-            sandbox is not None
-        ), f'Sandbox {app_conversation_info.sandbox_id} not found for conversation {conversation_id}'
-        assert (
-            sandbox.exposed_urls is not None
-        ), f'Sandbox {app_conversation_info.sandbox_id} has no exposed URLs for conversation {conversation_id}'
+        assert sandbox is not None, (
+            f'Sandbox {app_conversation_info.sandbox_id} not found for conversation {conversation_id}'
+        )
+        assert sandbox.exposed_urls is not None, (
+            f'Sandbox {app_conversation_info.sandbox_id} has no exposed URLs for conversation {conversation_id}'
+        )
 
         # Use the existing method to get the agent-server URL
         agent_server_url = self._get_agent_server_url(sandbox)

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -338,6 +338,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        tag: list[str] | None = None,
         sort_order: AppConversationSortOrder = AppConversationSortOrder.CREATED_AT_DESC,
         page_id: str | None = None,
         limit: int = 20,
@@ -351,6 +352,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             updated_at__gte=updated_at__gte,
             updated_at__lt=updated_at__lt,
             sandbox_id__eq=sandbox_id__eq,
+            tag=tag,
             sort_order=sort_order,
             page_id=page_id,
             limit=limit,
@@ -369,7 +371,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        tag: list[str] | None = None,
     ) -> int:
+        """Count sandboxed conversations."""
         return await self.app_conversation_info_service.count_app_conversation_info(
             title__contains=title__contains,
             created_at__gte=created_at__gte,
@@ -377,6 +381,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             updated_at__gte=updated_at__gte,
             updated_at__lt=updated_at__lt,
             sandbox_id__eq=sandbox_id__eq,
+            tag=tag,
         )
 
     async def get_app_conversation(
@@ -574,7 +579,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             # ``agent`` is the source of truth here): the response echoes
             # the same agent back through the AgentBase discriminator.
             request_agent = start_conversation_request.agent
-            tags: dict[str, str] = {}
+            tags: dict[str, str] = request.tags.copy() if request.tags else {}
             # Pin where the workspace was actually created so the delete-time
             # archive captures the right directory without re-deriving the path
             # from settings (e.g. grouping) that may change before delete.

--- a/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
+++ b/openhands/app_server/app_conversation/sql_app_conversation_info_service.py
@@ -182,6 +182,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        tag: list[str] | None = None,
         sort_order: AppConversationSortOrder = AppConversationSortOrder.CREATED_AT_DESC,
         page_id: str | None = None,
         limit: int = 100,
@@ -205,6 +206,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             updated_at__gte=updated_at__gte,
             updated_at__lt=updated_at__lt,
             sandbox_id__eq=sandbox_id__eq,
+            tag=tag,
         )
 
         # Add sort order
@@ -260,6 +262,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        tag: list[str] | None = None,
     ) -> int:
         """Count sandboxed conversations matching the given filters."""
         query = select(func.count(StoredConversationMetadata.conversation_id)).where(
@@ -274,6 +277,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
             updated_at__gte=updated_at__gte,
             updated_at__lt=updated_at__lt,
             sandbox_id__eq=sandbox_id__eq,
+            tag=tag,
         )
 
         result = await self.db_session.execute(query)
@@ -289,6 +293,7 @@ class SQLAppConversationInfoService(AppConversationInfoService):
         updated_at__gte: datetime | None = None,
         updated_at__lt: datetime | None = None,
         sandbox_id__eq: str | None = None,
+        tag: list[str] | None = None,
     ) -> Select:
         # Apply the same filters as search_app_conversations
         conditions: list[ColumnElement[bool]] = []
@@ -315,6 +320,16 @@ class SQLAppConversationInfoService(AppConversationInfoService):
 
         if sandbox_id__eq is not None:
             conditions.append(StoredConversationMetadata.sandbox_id == sandbox_id__eq)
+
+        if tag is not None:
+            for t in tag:
+                # tag format: key=value
+                if '=' in t:
+                    key, val = t.split('=', 1)
+                    # For a JSON column in SQLAlchemy, we can access the key and compare it as a string
+                    conditions.append(
+                        StoredConversationMetadata.tags[key].as_string() == val
+                    )
 
         if conditions:
             query = query.where(*conditions)

--- a/openhands/app_server/shared.py
+++ b/openhands/app_server/shared.py
@@ -12,9 +12,9 @@ from openhands.app_server.utils.import_utils import get_impl
 load_dotenv()
 
 server_config_interface: ServerConfigInterface = load_server_config()
-assert isinstance(server_config_interface, ServerConfig), (
-    'Loaded server config interface is not a ServerConfig, despite this being assumed'
-)
+assert isinstance(
+    server_config_interface, ServerConfig
+), 'Loaded server config interface is not a ServerConfig, despite this being assumed'
 server_config: ServerConfig = server_config_interface
 
 # Note: socketio is no longer used. Redis access should use the standard redis package directly.

--- a/openhands/app_server/shared.py
+++ b/openhands/app_server/shared.py
@@ -12,9 +12,9 @@ from openhands.app_server.utils.import_utils import get_impl
 load_dotenv()
 
 server_config_interface: ServerConfigInterface = load_server_config()
-assert isinstance(
-    server_config_interface, ServerConfig
-), 'Loaded server config interface is not a ServerConfig, despite this being assumed'
+assert isinstance(server_config_interface, ServerConfig), (
+    'Loaded server config interface is not a ServerConfig, despite this being assumed'
+)
 server_config: ServerConfig = server_config_interface
 
 # Note: socketio is no longer used. Redis access should use the standard redis package directly.


### PR DESCRIPTION
HUMAN:
This PR adds the ability to associate arbitrary key-value tags with app conversations when they are started or updated. This makes it possible to query and filter conversations later via the `/search` and `/count` endpoints using the tags.

This adds the ability to associate arbitrary key-value tags with app conversations when they are started or updated, making it possible to query and filter them later via the /search endpoint.

- Adds tags to AppConversationStartRequest and AppConversationUpdateRequest.
- Exposes tag as a query parameter (e.g. tag=key=value) in /search and /count endpoints.
- Plumbs tag filters through the app_server services down to the SQLAlchemy models, parsing and executing JSON equality checks on the database.

- [x] A human has tested these changes.

Fixes OpenHands/enterprise#66