### PR TITLE
fix(app-server): restore previous DB pool_size default

### DIFF
--- a/openhands/app_server/services/db_session_injector.py
+++ b/openhands/app_server/services/db_session_injector.py
@@ -34,8 +34,8 @@ class DbSessionInjector(BaseModel, Injector[AsyncSession]):
     user: str | None = None
     password: SecretStr | None = None
     echo: bool = False
-    # Defaults follow SQLAlchemy's own pool_size=5, max_overflow=10)
-    pool_size: int = 5
+    # can be overriden with DB_POOL_SIZE / DB_MAX_OVERFLOW (see fill_empty_fields).
+    pool_size: int = 25
     max_overflow: int = 10
     pool_recycle: int = 1800
     pool_use_lifo: bool = True

--- a/tests/unit/app_server/test_db_session_injector.py
+++ b/tests/unit/app_server/test_db_session_injector.py
@@ -103,7 +103,7 @@ class TestDbSessionInjectorConfiguration:
             service.password.get_secret_value() == 'postgres'
         )  # Default from env var processing
         assert service.echo is False
-        assert service.pool_size == 5
+        assert service.pool_size == 25
         assert service.max_overflow == 10
         assert service.pool_use_lifo is True
         assert service.gcp_db_instance is None
@@ -221,7 +221,7 @@ class TestDbSessionInjectorConnections:
 
             # Verify other parameters
             assert call_args[1]['connect_args'] == {}
-            assert call_args[1]['pool_size'] == 5
+            assert call_args[1]['pool_size'] == 25
             assert call_args[1]['max_overflow'] == 10
             assert call_args[1]['pool_pre_ping']
             assert call_args[1]['pool_use_lifo'] is True
@@ -255,7 +255,7 @@ class TestDbSessionInjectorConnections:
 
             # Verify other parameters
             assert call_args[1]['connect_args'] == {}
-            assert call_args[1]['pool_size'] == 5
+            assert call_args[1]['pool_size'] == 25
             assert call_args[1]['max_overflow'] == 10
             assert call_args[1]['pool_pre_ping']
             assert call_args[1]['pool_use_lifo'] is True


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

#15270 did one good thing and one bad thing:
- GOOD: env vars to configure DB pool values. NOT configuring these can negatively impact any given deployment
- BAD: changed the defaults for those pools which DID negatively impact some users working happily under those defaults

This PR keeps the env var, but restores the previous pool size value of `25`

- [x] A human has tested these changes.

AGENT:

---

## Why

#15270 bundled two changes: it made the DB pool env-tunable (`DB_POOL_SIZE` / `DB_MAX_OVERFLOW`) — a net positive that stays — and it also lowered the default `pool_size` from `25` to `5`. Lowering the established default was a mistake: it cut the effective connection ceiling from `pool_size + max_overflow = 35` down to `15` (5x smaller resident pool), which negatively affected some users under concurrent load, with no warning and no communication that a knob now existed to restore the prior behavior. Making a value configurable is backwards-compatible; changing its long-standing default is not.

## Summary

- Restore `pool_size` default to `25` in `DbSessionInjector` (its previous value); `max_overflow` stays `10`.
- Keep the env-tunability from #15270 untouched — anyone wanting a smaller pool can set `DB_POOL_SIZE`.
- Update the three unit-test assertions that expected the lowered default back to `25`.

## Issue Number

Closes #15332

## How to Test

`poetry run pytest tests/unit/app_server/test_db_session_injector.py` — 32 passed. The `test_pool_size_env_vars_override_defaults` test confirms `DB_POOL_SIZE` / `DB_MAX_OVERFLOW` still override the restored default.

## Type

- [x] Bug fix

## Notes

Changelog: Restored the default database `pool_size` to 25 (it was unintentionally lowered to 5 in #15270). The `DB_POOL_SIZE` / `DB_MAX_OVERFLOW` env overrides added in that release are unchanged.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-a35d740   docker.openhands.dev/openhands/openhands:a35d740
```