### PR TITLE
fix(app-server): support Bitbucket Data Center personal repos as marketplace sources

### DIFF
--- a/openhands/app_server/app_conversation/skill_loader.py
+++ b/openhands/app_server/app_conversation/skill_loader.py
@@ -499,7 +499,7 @@ async def _match_url_source_to_provider(
             matched = (urlparse(token_host).hostname or '').lower() == host
         else:
             default_domain = ProviderHandler.PROVIDER_DOMAINS.get(provider_type)
-            matched = bool(default_domain) and default_domain.lower() == host
+            matched = default_domain is not None and default_domain.lower() == host
         if matched:
             repo_path = _repo_path_from_url_path(path, provider_type)
             if not repo_path or '/' not in repo_path:

--- a/openhands/app_server/app_conversation/skill_loader.py
+++ b/openhands/app_server/app_conversation/skill_loader.py
@@ -12,7 +12,9 @@ All source-specific skill loading is handled by the agent-server.
 
 import asyncio
 import logging
+from collections.abc import Mapping
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 from pydantic import BaseModel
@@ -422,6 +424,34 @@ def parse_marketplace_source(source: str) -> tuple[str, str]:
     return ('github', path)
 
 
+async def _source_host_matches_provider(source: str, user_context: UserContext) -> bool:
+    """True when a URL source's host belongs to a configured provider token."""
+    host = (urlparse(source).hostname or '').lower()
+    if not host:
+        return False
+    try:
+        provider_tokens = await user_context.get_provider_tokens()
+    except Exception:
+        return False
+    if not isinstance(provider_tokens, Mapping):
+        return False
+    for provider, token in provider_tokens.items():
+        token_host = getattr(token, 'host', None)
+        if token_host:
+            if '://' not in token_host:
+                token_host = f'https://{token_host}'
+            if (urlparse(token_host).hostname or '').lower() == host:
+                return True
+        try:
+            provider_type = ProviderType(provider)
+        except ValueError:
+            continue
+        default_domain = ProviderHandler.PROVIDER_DOMAINS.get(provider_type)
+        if default_domain and default_domain.lower() == host:
+            return True
+    return False
+
+
 async def authenticate_marketplace_sources(
     registered_marketplaces: list[MarketplaceRegistration] | None,
     user_context: UserContext,
@@ -457,9 +487,15 @@ async def authenticate_marketplace_sources(
         if not reg.auto_load:
             return reg
         _, repo_name = parse_marketplace_source(reg.source)
-        # Skip sources that are not owner/repo-shaped: single-segment local
-        # paths and URLs on hosts that did not map to a provider repo path.
-        if not repo_name or '/' not in repo_name or '://' in repo_name:
+        # Skip single-segment local paths. Full URLs that did not map to a
+        # provider repo path (repo_name keeps '://') are resolved only when
+        # the URL host belongs to a configured provider (e.g. Bitbucket DC),
+        # so unrelated-host URLs are never rewritten to a provider repo.
+        if not repo_name or '/' not in repo_name:
+            return reg
+        if '://' in repo_name and not await _source_host_matches_provider(
+            reg.source, user_context
+        ):
             return reg
         try:
             async with sem:

--- a/openhands/app_server/app_conversation/skill_loader.py
+++ b/openhands/app_server/app_conversation/skill_loader.py
@@ -12,6 +12,7 @@ All source-specific skill loading is handled by the agent-server.
 
 import asyncio
 import logging
+import re
 from collections.abc import Mapping
 from typing import Any
 from urllib.parse import urlparse
@@ -424,32 +425,87 @@ def parse_marketplace_source(source: str) -> tuple[str, str]:
     return ('github', path)
 
 
-async def _source_host_matches_provider(source: str, user_context: UserContext) -> bool:
-    """True when a URL source's host belongs to a configured provider token."""
-    host = (urlparse(source).hostname or '').lower()
+# Marketplace source prefixes that name a provider explicitly; handled by
+# parse_marketplace_source, never treated as scp-style host:path.
+_PROVIDER_SOURCE_PREFIXES = ('github:', 'gitlab:', 'bitbucket:', 'azure-devops:')
+
+
+def _split_git_url_source(source: str) -> tuple[str, str] | None:
+    """Return ``(host, path)`` for a URL/scp git source, else ``None``.
+
+    Handles ``scheme://[user@]host[:port]/path`` and scp ``[user@]host:path``.
+    The host comes from a real URL parse (userinfo is ignored), so a source
+    like ``https://github.com@evil/o/r`` reports host ``evil`` — it can never
+    masquerade as a provider via substring matching.
+    """
+    s = source.strip()
+    if s.startswith(_PROVIDER_SOURCE_PREFIXES):
+        return None
+    if '://' in s:
+        parsed = urlparse(s)
+        host = (parsed.hostname or '').lower()
+        return (host, parsed.path) if host else None
+    # scp-style: [user@]host:path. Require a dotted host so provider-prefix and
+    # bare name:tag forms don't match.
+    m = re.match(r'^(?:[^@/]+@)?([^/:]+):(.+)$', s)
+    if m and '.' in m.group(1):
+        return (m.group(1).lower(), m.group(2))
+    return None
+
+
+def _repo_path_from_url_path(path: str, provider: ProviderType) -> str:
+    """Extract an ``owner/repo`` path from a git URL path for ``provider``."""
+    p = path.strip('/')
+    if p.endswith('.git'):
+        p = p[:-4]
+    # Bitbucket DC HTTP clone URLs are /scm/<project>/<repo>; the SSH form omits
+    # /scm/. Both reduce to <project>/<repo> (personal repos use ~user).
+    if provider == ProviderType.BITBUCKET_DATA_CENTER and p.startswith('scm/'):
+        p = p[len('scm/') :]
+    return p
+
+
+async def _match_url_source_to_provider(
+    source: str, user_context: UserContext
+) -> tuple[ProviderType, str] | None:
+    """Resolve a URL/scp source to ``(provider, owner/repo)`` by host match.
+
+    Matches strictly on the URL host against configured provider tokens (a
+    token's own ``host``, or the provider default domain only when the token
+    has no host). Returns ``None`` for non-URL sources and for hosts that match
+    no provider, so an unrelated-host URL is never rewritten to a provider repo.
+    """
+    split = _split_git_url_source(source)
+    if split is None:
+        return None
+    host, path = split
     if not host:
-        return False
+        return None
     try:
         provider_tokens = await user_context.get_provider_tokens()
     except Exception:
-        return False
+        return None
     if not isinstance(provider_tokens, Mapping):
-        return False
+        return None
     for provider, token in provider_tokens.items():
-        token_host = getattr(token, 'host', None)
-        if token_host:
-            if '://' not in token_host:
-                token_host = f'https://{token_host}'
-            if (urlparse(token_host).hostname or '').lower() == host:
-                return True
         try:
             provider_type = ProviderType(provider)
         except ValueError:
             continue
-        default_domain = ProviderHandler.PROVIDER_DOMAINS.get(provider_type)
-        if default_domain and default_domain.lower() == host:
-            return True
-    return False
+        token_host = getattr(token, 'host', None)
+        if token_host:
+            if '://' not in token_host:
+                token_host = f'https://{token_host}'
+            matched = (urlparse(token_host).hostname or '').lower() == host
+        else:
+            default_domain = ProviderHandler.PROVIDER_DOMAINS.get(provider_type)
+            matched = bool(default_domain) and default_domain.lower() == host
+        if matched:
+            repo_path = _repo_path_from_url_path(path, provider_type)
+            if not repo_path or '/' not in repo_path:
+                return None
+            return provider_type, repo_path
+    return None
 
 
 async def authenticate_marketplace_sources(
@@ -486,16 +542,33 @@ async def authenticate_marketplace_sources(
         # Only auto_load registrations are cloned during /api/skills.
         if not reg.auto_load:
             return reg
-        _, repo_name = parse_marketplace_source(reg.source)
-        # Skip single-segment local paths. Full URLs that did not map to a
-        # provider repo path (repo_name keeps '://') are resolved only when
-        # the URL host belongs to a configured provider (e.g. Bitbucket DC),
-        # so unrelated-host URLs are never rewritten to a provider repo.
-        if not repo_name or '/' not in repo_name:
+        # URL/scp sources resolve strictly against the provider whose host
+        # matches, pinned so a host-blind resolver can't claim a same-named
+        # repo elsewhere. Unrelated-host URLs match nothing and pass through.
+        matched = await _match_url_source_to_provider(reg.source, user_context)
+        if matched is not None:
+            provider_type, repo_path = matched
+            try:
+                async with sem:
+                    handler = await user_context.get_provider_handler()
+                    url = await handler.get_authenticated_git_url(
+                        repo_path,
+                        is_optional=True,
+                        specified_provider=provider_type,
+                    )
+            except Exception as e:
+                _logger.debug(
+                    f'Could not resolve authenticated URL for marketplace '
+                    f'{reg.name} ({repo_path}); keeping original source: {e}'
+                )
+                return reg
+            return reg.model_copy(update={'source': url})
+        # URL-shaped but no provider host matched: never rewrite to a provider.
+        if _split_git_url_source(reg.source) is not None:
             return reg
-        if '://' in repo_name and not await _source_host_matches_provider(
-            reg.source, user_context
-        ):
+        # Non-URL owner/repo forms (github:owner/repo, bare owner/repo).
+        _, repo_name = parse_marketplace_source(reg.source)
+        if not repo_name or '/' not in repo_name or '://' in repo_name:
             return reg
         try:
             async with sem:

--- a/openhands/app_server/integrations/provider.py
+++ b/openhands/app_server/integrations/provider.py
@@ -508,23 +508,45 @@ class ProviderHandler:
         )
 
     async def get_authenticated_git_url(
-        self, repo_name: str, is_optional: bool = False
+        self,
+        repo_name: str,
+        is_optional: bool = False,
+        specified_provider: ProviderType | None = None,
     ) -> str:
         """Get an authenticated git URL for a repository.
 
         Args:
             repo_name: Repository name (owner/repo)
             is_optional: If True, logs at debug level instead of error level when repo not found
+            specified_provider: If set, resolve only against this provider instead
+                of trying every token in turn (avoids a host-blind resolver
+                claiming a same-named repo on the wrong provider).
 
         Returns:
             Authenticated git URL if credentials are available, otherwise regular HTTPS URL
         """
-        try:
-            repository = await self.verify_repo_provider(
-                repo_name, is_optional=is_optional
-            )
-        except AuthenticationError:
-            raise Exception('Git provider authentication issue when getting remote URL')
+        if specified_provider is not None:
+            # Resolve against ONLY this provider — verify_repo_provider falls
+            # through to every token on failure, which would let a host-blind
+            # resolver claim a same-named repo on the wrong provider.
+            try:
+                service = self.get_service(specified_provider)
+                repository = await service.get_repository_details_from_repo_name(
+                    repo_name
+                )
+            except Exception:
+                raise Exception(
+                    'Git provider authentication issue when getting remote URL'
+                )
+        else:
+            try:
+                repository = await self.verify_repo_provider(
+                    repo_name, is_optional=is_optional
+                )
+            except AuthenticationError:
+                raise Exception(
+                    'Git provider authentication issue when getting remote URL'
+                )
 
         provider = repository.git_provider
         repo_name = repository.full_name

--- a/openhands/app_server/settings/settings_models.py
+++ b/openhands/app_server/settings/settings_models.py
@@ -53,9 +53,12 @@ logger = logging.getLogger(__name__)
 # Valid source patterns for MarketplaceRegistration
 # - github:owner/repo format
 _GITHUB_SOURCE_PATTERN = re.compile(r'^github:[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$')
-# - Git URLs (https, git, ssh protocols)
+# - Git URLs (https, git, ssh protocols). '~' in paths covers Bitbucket Data
+#   Center personal repos (/scm/~user/repo); userinfo may only be a bare
+#   username — 'user:password@' forms stay rejected.
 _GIT_URL_PATTERN = re.compile(
-    r'^(https?://|git@|ssh://|git://)[a-zA-Z0-9_.-]+[:/][a-zA-Z0-9_./-]+$'
+    r'^(https?://(?:[a-zA-Z0-9_.-]+@)?|git@|ssh://(?:[a-zA-Z0-9_.-]+@)?|git://)'
+    r'[a-zA-Z0-9_.-]+[:/][a-zA-Z0-9_.~/-]+$'
 )
 # - Relative local paths (no absolute paths, no parent traversal)
 _LOCAL_PATH_PATTERN = re.compile(r'^[a-zA-Z0-9_][a-zA-Z0-9_./-]*$')

--- a/openhands/app_server/user/skills_router.py
+++ b/openhands/app_server/user/skills_router.py
@@ -14,7 +14,6 @@ from pydantic import BaseModel
 import openhands
 from openhands.app_server.app_conversation.skill_loader import (
     _match_url_source_to_provider,
-    _split_git_url_source,
 )
 from openhands.app_server.app_conversation.skill_loader import (
     parse_marketplace_source as _parse_marketplace_source,
@@ -248,12 +247,17 @@ async def _clone_marketplace_repo(
 
     if authenticated_url:
         clone_url = authenticated_url
-    elif _split_git_url_source(marketplace.source) is not None:
-        # Full-URL source on a host that matches no configured provider — refuse
-        # rather than git-cloning an arbitrary attacker-controlled host (SSRF).
+    elif '://' in repo_path:
+        # repo_path still carries a scheme, so the source is a full URL on a host
+        # _parse_marketplace_source did not recognize AND no configured provider
+        # matched it. Refuse rather than git-cloning an arbitrary (possibly
+        # attacker-controlled) host (SSRF). Recognized public domains
+        # (github.com/gitlab.com/bitbucket.org) reduce to owner/repo above and
+        # fall through to the public clone below regardless of login provider.
         return None, f'Unsupported marketplace host: {marketplace.source}'
     else:
-        # Public bare owner/repo (or recognized provider prefix): public clone.
+        # Public bare owner/repo, recognized provider prefix, or a recognized
+        # public-domain URL: clone from the public domain, no auth needed.
         provider_domain_map = {
             'github': 'github.com',
             'gitlab': 'gitlab.com',

--- a/openhands/app_server/user/skills_router.py
+++ b/openhands/app_server/user/skills_router.py
@@ -214,15 +214,19 @@ async def _clone_marketplace_repo(
     if not repo_path or '/' not in repo_path:
         return None, f'Invalid repository path: {repo_path}'
 
-    # Build fallback URLs for public repositories
+    # Build fallback URLs for public repositories. A repo_path that kept its
+    # scheme is already a full URL (custom host) — use the source as-is.
     provider_domain_map = {
         'github': 'github.com',
         'gitlab': 'gitlab.com',
         'bitbucket': 'bitbucket.org',
     }
-    fallback_url = (
-        f'https://{provider_domain_map.get(provider, "github.com")}/{repo_path}.git'
-    )
+    if '://' in repo_path:
+        fallback_url = marketplace.source
+    else:
+        fallback_url = (
+            f'https://{provider_domain_map.get(provider, "github.com")}/{repo_path}.git'
+        )
 
     # Get authenticated URL from provider handler
     authenticated_url = None

--- a/openhands/app_server/user/skills_router.py
+++ b/openhands/app_server/user/skills_router.py
@@ -13,6 +13,10 @@ from pydantic import BaseModel
 
 import openhands
 from openhands.app_server.app_conversation.skill_loader import (
+    _match_url_source_to_provider,
+    _split_git_url_source,
+)
+from openhands.app_server.app_conversation.skill_loader import (
     parse_marketplace_source as _parse_marketplace_source,
 )
 from openhands.app_server.config import depends_user_context
@@ -214,43 +218,50 @@ async def _clone_marketplace_repo(
     if not repo_path or '/' not in repo_path:
         return None, f'Invalid repository path: {repo_path}'
 
-    # Build fallback URLs for public repositories. A repo_path that kept its
-    # scheme is already a full URL (custom host) — use the source as-is.
-    provider_domain_map = {
-        'github': 'github.com',
-        'gitlab': 'gitlab.com',
-        'bitbucket': 'bitbucket.org',
-    }
-    if '://' in repo_path:
-        fallback_url = marketplace.source
-    else:
-        fallback_url = (
-            f'https://{provider_domain_map.get(provider, "github.com")}/{repo_path}.git'
-        )
-
-    # Get authenticated URL from provider handler
+    # Authenticate URL/scp sources against the provider whose host matches
+    # (pinned), so private self-hosted repos (e.g. Bitbucket DC) clone with
+    # credentials. Non-URL owner/repo sources fall through to the public path.
     authenticated_url = None
     try:
-        provider_tokens = await user_context.get_provider_tokens()
-        if not provider_tokens:
-            logger.info(
-                f'No provider tokens available for {provider}, will try unauthenticated clone'
+        matched = await _match_url_source_to_provider(marketplace.source, user_context)
+        if matched is not None:
+            matched_provider, matched_repo = matched
+            handler = await user_context.get_provider_handler()
+            authenticated_url = await handler.get_authenticated_git_url(
+                matched_repo, specified_provider=matched_provider
             )
-        else:
-            # Cast to expected type - user_context may return dict[str, str] in some contexts
-            typed_provider_tokens = cast(PROVIDER_TOKEN_TYPE, provider_tokens)
-            client = ProviderHandler(
-                provider_tokens=MappingProxyType(typed_provider_tokens),
-                external_auth_id=await user_context.get_user_id(),
-            )
-            authenticated_url = await client.get_authenticated_git_url(repo_path)
+        elif '://' not in repo_path:
+            # Bare owner/repo (or recognized public domain): resolve normally.
+            provider_tokens = await user_context.get_provider_tokens()
+            if provider_tokens:
+                typed_provider_tokens = cast(PROVIDER_TOKEN_TYPE, provider_tokens)
+                client = ProviderHandler(
+                    provider_tokens=MappingProxyType(typed_provider_tokens),
+                    external_auth_id=await user_context.get_user_id(),
+                )
+                authenticated_url = await client.get_authenticated_git_url(repo_path)
     except Exception as e:
         logger.warning(
-            f'Failed to get authenticated URL for {repo_path}: {e}, will try unauthenticated clone'
+            f'Failed to get authenticated URL for {repo_path}: {e}, '
+            'will try unauthenticated clone'
         )
 
-    # Use authenticated URL if available, otherwise fallback to public URL
-    clone_url = authenticated_url or fallback_url
+    if authenticated_url:
+        clone_url = authenticated_url
+    elif _split_git_url_source(marketplace.source) is not None:
+        # Full-URL source on a host that matches no configured provider — refuse
+        # rather than git-cloning an arbitrary attacker-controlled host (SSRF).
+        return None, f'Unsupported marketplace host: {marketplace.source}'
+    else:
+        # Public bare owner/repo (or recognized provider prefix): public clone.
+        provider_domain_map = {
+            'github': 'github.com',
+            'gitlab': 'gitlab.com',
+            'bitbucket': 'bitbucket.org',
+        }
+        clone_url = (
+            f'https://{provider_domain_map.get(provider, "github.com")}/{repo_path}.git'
+        )
 
     # Create unique temporary directory for this clone using tempfile.mkdtemp
     try:

--- a/tests/unit/app_server/test_skill_loader.py
+++ b/tests/unit/app_server/test_skill_loader.py
@@ -26,7 +26,7 @@ from openhands.app_server.app_conversation.skill_loader import (
     build_sandbox_config,
     load_skills_from_agent_server,
 )
-from openhands.app_server.integrations.provider import ProviderType
+from openhands.app_server.integrations.provider import ProviderToken, ProviderType
 from openhands.app_server.integrations.service_types import AuthenticationError
 from openhands.app_server.sandbox.sandbox_models import (
     ExposedUrl,
@@ -1126,13 +1126,70 @@ class TestAuthenticateMarketplaceSources:
         'source',
         [
             'localskills',  # single segment: relative local path
-            'https://codeberg.org/owner/repo.git',  # unrecognized host keeps '://'
+            'https://codeberg.org/owner/repo.git',  # URL host matches no provider
         ],
     )
     async def test_skips_sources_without_provider_repo_shape(self, source):
         """Sources that do not map to an owner/repo path pass through untouched."""
         # Arrange
         mock_user_context = AsyncMock(spec=UserContext)
+        mock_user_context.get_provider_tokens.return_value = None
+        registrations = [_make_registration(source=source)]
+
+        # Act
+        result = await authenticate_marketplace_sources(
+            registrations, mock_user_context
+        )
+
+        # Assert
+        assert result is not None
+        assert result[0].source == source
+        mock_user_context.get_authenticated_git_url.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        'source',
+        [
+            'https://bitbucket.dc.example.com/scm/~jane.doe/skills.git',
+            'ssh://git@bitbucket.dc.example.com:7999/~jane.doe/skills.git',
+        ],
+    )
+    async def test_rewrites_custom_host_url_matching_provider_host(self, source):
+        """Custom-host URLs resolve when the host matches a provider token host."""
+        # Arrange
+        mock_user_context = AsyncMock(spec=UserContext)
+        mock_user_context.get_provider_tokens.return_value = {
+            ProviderType.BITBUCKET_DATA_CENTER: ProviderToken(
+                host='bitbucket.dc.example.com'
+            )
+        }
+        dc_url = 'https://user:pat@bitbucket.dc.example.com/scm/~jane.doe/skills.git'
+        mock_user_context.get_authenticated_git_url.return_value = dc_url
+        registrations = [_make_registration(source=source)]
+
+        # Act
+        result = await authenticate_marketplace_sources(
+            registrations, mock_user_context
+        )
+
+        # Assert
+        assert result is not None
+        assert result[0].source == dc_url
+        mock_user_context.get_authenticated_git_url.assert_awaited_once_with(
+            source.removesuffix('.git'), is_optional=True
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_custom_host_url_on_other_provider_host(self):
+        """A URL on a host that matches no provider token is never rewritten."""
+        # Arrange
+        mock_user_context = AsyncMock(spec=UserContext)
+        mock_user_context.get_provider_tokens.return_value = {
+            ProviderType.BITBUCKET_DATA_CENTER: ProviderToken(
+                host='https://bitbucket.other.example.com'
+            )
+        }
+        source = 'https://git.unrelated.example.com/scm/proj/skills.git'
         registrations = [_make_registration(source=source)]
 
         # Act

--- a/tests/unit/app_server/test_skill_loader.py
+++ b/tests/unit/app_server/test_skill_loader.py
@@ -1040,13 +1040,13 @@ class TestAuthenticateMarketplaceSources:
         [
             'github:OpenHands/extensions-private',
             'OpenHands/extensions-private',
-            'https://github.com/OpenHands/extensions-private.git',
         ],
     )
-    async def test_rewrites_auto_load_source_to_authenticated_url(self, source):
-        """Any stored git source form is resolved and rewritten to a token URL."""
+    async def test_rewrites_owner_repo_source_to_authenticated_url(self, source):
+        """Non-URL owner/repo sources resolve via user_context and are rewritten."""
         # Arrange
         mock_user_context = AsyncMock(spec=UserContext)
+        mock_user_context.get_provider_tokens.return_value = None
         mock_user_context.get_authenticated_git_url.return_value = AUTHENTICATED_URL
         registrations = [_make_registration(source=source)]
 
@@ -1060,6 +1060,37 @@ class TestAuthenticateMarketplaceSources:
         assert result[0].source == AUTHENTICATED_URL
         mock_user_context.get_authenticated_git_url.assert_awaited_once_with(
             'OpenHands/extensions-private', is_optional=True
+        )
+
+    @pytest.mark.asyncio
+    async def test_rewrites_recognized_domain_url_pinned_to_provider(self):
+        """A github.com URL resolves pinned to the matching github token."""
+        # Arrange
+        mock_user_context = AsyncMock(spec=UserContext)
+        mock_user_context.get_provider_tokens.return_value = {
+            ProviderType.GITHUB: ProviderToken()  # host=None -> default domain
+        }
+        handler = AsyncMock()
+        handler.get_authenticated_git_url.return_value = AUTHENTICATED_URL
+        mock_user_context.get_provider_handler.return_value = handler
+        registrations = [
+            _make_registration(
+                source='https://github.com/OpenHands/extensions-private.git'
+            )
+        ]
+
+        # Act
+        result = await authenticate_marketplace_sources(
+            registrations, mock_user_context
+        )
+
+        # Assert
+        assert result is not None
+        assert result[0].source == AUTHENTICATED_URL
+        handler.get_authenticated_git_url.assert_awaited_once_with(
+            'OpenHands/extensions-private',
+            is_optional=True,
+            specified_provider=ProviderType.GITHUB,
         )
 
     @pytest.mark.asyncio
@@ -1151,11 +1182,12 @@ class TestAuthenticateMarketplaceSources:
         'source',
         [
             'https://bitbucket.dc.example.com/scm/~jane.doe/skills.git',
+            'https://jane.doe@bitbucket.dc.example.com/scm/~jane.doe/skills.git',
             'ssh://git@bitbucket.dc.example.com:7999/~jane.doe/skills.git',
         ],
     )
-    async def test_rewrites_custom_host_url_matching_provider_host(self, source):
-        """Custom-host URLs resolve when the host matches a provider token host."""
+    async def test_rewrites_bbdc_personal_url_pinned_to_provider(self, source):
+        """BBDC personal-repo URLs resolve to project/repo pinned to the DC token."""
         # Arrange
         mock_user_context = AsyncMock(spec=UserContext)
         mock_user_context.get_provider_tokens.return_value = {
@@ -1164,7 +1196,9 @@ class TestAuthenticateMarketplaceSources:
             )
         }
         dc_url = 'https://user:pat@bitbucket.dc.example.com/scm/~jane.doe/skills.git'
-        mock_user_context.get_authenticated_git_url.return_value = dc_url
+        handler = AsyncMock()
+        handler.get_authenticated_git_url.return_value = dc_url
+        mock_user_context.get_provider_handler.return_value = handler
         registrations = [_make_registration(source=source)]
 
         # Act
@@ -1172,11 +1206,13 @@ class TestAuthenticateMarketplaceSources:
             registrations, mock_user_context
         )
 
-        # Assert
+        # Assert — /scm/ stripped, .git stripped, resolved pinned to the DC token
         assert result is not None
         assert result[0].source == dc_url
-        mock_user_context.get_authenticated_git_url.assert_awaited_once_with(
-            source.removesuffix('.git'), is_optional=True
+        handler.get_authenticated_git_url.assert_awaited_once_with(
+            '~jane.doe/skills',
+            is_optional=True,
+            specified_provider=ProviderType.BITBUCKET_DATA_CENTER,
         )
 
     @pytest.mark.asyncio
@@ -1200,6 +1236,36 @@ class TestAuthenticateMarketplaceSources:
         # Assert
         assert result is not None
         assert result[0].source == source
+        mock_user_context.get_provider_handler.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        'source',
+        [
+            'https://github.com@evil.example.com/OpenHands/extensions-private.git',
+            'https://evil.example.com/gitlab.com/OpenHands/extensions-private.git',
+        ],
+    )
+    async def test_provider_substring_in_url_does_not_bypass_host_match(self, source):
+        """A provider name in userinfo/path can't route resolution to that provider."""
+        # Arrange — real host is evil.example.com, matching no configured token.
+        mock_user_context = AsyncMock(spec=UserContext)
+        mock_user_context.get_provider_tokens.return_value = {
+            ProviderType.BITBUCKET_DATA_CENTER: ProviderToken(
+                host='bitbucket.dc.example.com'
+            )
+        }
+        registrations = [_make_registration(source=source)]
+
+        # Act
+        result = await authenticate_marketplace_sources(
+            registrations, mock_user_context
+        )
+
+        # Assert — never rewritten, provider handler never consulted.
+        assert result is not None
+        assert result[0].source == source
+        mock_user_context.get_provider_handler.assert_not_awaited()
         mock_user_context.get_authenticated_git_url.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/tests/unit/server/routes/test_skills_api.py
+++ b/tests/unit/server/routes/test_skills_api.py
@@ -432,3 +432,70 @@ class TestMarketplaceSkillsCloneFailures:
 
         assert result[0] is None
         assert 'Repo path not found' in result[1]
+
+    @pytest.mark.asyncio
+    async def test_clone_bbdc_personal_url_uses_pinned_authenticated_url(self):
+        """A BBDC personal-repo URL clones via the host-matched, pinned token URL."""
+        handler = AsyncMock()
+        dc_url = 'https://user:pat@bitbucket.dc.example.com/scm/~jane/marketplace.git'
+        handler.get_authenticated_git_url.return_value = dc_url
+
+        mock_user_context = MagicMock()
+        mock_user_context.get_provider_tokens = AsyncMock(
+            return_value={
+                ProviderType.BITBUCKET_DATA_CENTER: ProviderToken(
+                    host='bitbucket.dc.example.com'
+                )
+            }
+        )
+        mock_user_context.get_user_id = AsyncMock(return_value='test-user')
+        mock_user_context.get_provider_handler = AsyncMock(return_value=handler)
+
+        marketplace = MarketplaceRegistration(
+            name='personal',
+            source='https://bitbucket.dc.example.com/scm/~jane/marketplace.git',
+        )
+
+        mock_clone = MagicMock(returncode=0)
+        with patch(
+            'openhands.app_server.user.skills_router.subprocess.run',
+            return_value=mock_clone,
+        ) as mock_run:
+            with patch('tempfile.mkdtemp', return_value=Path('/tmp/test_clone')):
+                await _clone_marketplace_repo(marketplace, mock_user_context)
+
+        handler.get_authenticated_git_url.assert_awaited_once_with(
+            '~jane/marketplace',
+            specified_provider=ProviderType.BITBUCKET_DATA_CENTER,
+        )
+        clone_argv = mock_run.call_args[0][0]
+        assert clone_argv[:3] == ['git', 'clone', '--']
+        assert clone_argv[3] == dc_url
+
+    @pytest.mark.asyncio
+    async def test_clone_refuses_unmatched_custom_host_url(self):
+        """A full-URL source on a host matching no provider is refused (no SSRF)."""
+        mock_user_context = MagicMock()
+        mock_user_context.get_provider_tokens = AsyncMock(
+            return_value={
+                ProviderType.BITBUCKET_DATA_CENTER: ProviderToken(
+                    host='bitbucket.dc.example.com'
+                )
+            }
+        )
+        mock_user_context.get_user_id = AsyncMock(return_value='test-user')
+        mock_user_context.get_provider_handler = AsyncMock()
+
+        marketplace = MarketplaceRegistration(
+            name='evil',
+            source='https://attacker.example.com/scm/proj/repo.git',
+        )
+
+        with patch(
+            'openhands.app_server.user.skills_router.subprocess.run'
+        ) as mock_run:
+            result = await _clone_marketplace_repo(marketplace, mock_user_context)
+
+        assert result[0] is None
+        assert 'Unsupported marketplace host' in result[1]
+        mock_run.assert_not_called()

--- a/tests/unit/server/routes/test_skills_api.py
+++ b/tests/unit/server/routes/test_skills_api.py
@@ -499,3 +499,35 @@ class TestMarketplaceSkillsCloneFailures:
         assert result[0] is None
         assert 'Unsupported marketplace host' in result[1]
         mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_clone_public_github_url_works_with_non_github_provider(self):
+        """A public github.com URL is a public clone even for a Bitbucket-only user."""
+        mock_user_context = MagicMock()
+        mock_user_context.get_provider_tokens = AsyncMock(
+            return_value={
+                ProviderType.BITBUCKET_DATA_CENTER: ProviderToken(
+                    host='bitbucket.dc.example.com'
+                )
+            }
+        )
+        mock_user_context.get_user_id = AsyncMock(return_value='test-user')
+        mock_user_context.get_provider_handler = AsyncMock()
+
+        marketplace = MarketplaceRegistration(
+            name='public-gh',
+            source='https://github.com/OpenHands/skills.git',
+        )
+
+        mock_clone = MagicMock(returncode=0)
+        with patch(
+            'openhands.app_server.user.skills_router.subprocess.run',
+            return_value=mock_clone,
+        ) as mock_run:
+            with patch('tempfile.mkdtemp', return_value=Path('/tmp/test_clone')):
+                await _clone_marketplace_repo(marketplace, mock_user_context)
+
+        # Not refused; cloned from the public github.com domain (no credentials).
+        clone_argv = mock_run.call_args[0][0]
+        assert clone_argv[3] == 'https://github.com/OpenHands/skills.git'
+        mock_user_context.get_provider_handler.assert_not_awaited()

--- a/tests/unit/storage/data_models/test_settings.py
+++ b/tests/unit/storage/data_models/test_settings.py
@@ -1229,6 +1229,46 @@ class TestMarketplaceRegistration:
         reg = MarketplaceRegistration(name='test', source='git@github.com:owner/repo')
         assert reg.source == 'git@github.com:owner/repo'
 
+    def test_source_validation_bitbucket_dc_personal_https_url(self):
+        """Bitbucket DC personal repos live under /scm/~user/ and are valid."""
+        source = 'https://bitbucket.dc.example.com/scm/~jane.doe_example.com/skills.git'
+        reg = MarketplaceRegistration(name='personal', source=source)
+        assert reg.source == source
+
+    def test_source_validation_https_url_with_username(self):
+        """Copy-pasted DC clone URLs carry a bare username before the host."""
+        source = (
+            'https://jane.doe@bitbucket.dc.example.com/scm/~jane.doe_example.com/'
+            'skills.git'
+        )
+        reg = MarketplaceRegistration(name='personal', source=source)
+        assert reg.source == source
+
+    def test_source_validation_ssh_url_with_user_port_and_tilde(self):
+        """DC SSH clone URLs use ssh://git@host:port/~user/repo.git."""
+        source = 'ssh://git@bitbucket.dc.example.com:7999/~jane.doe/skills.git'
+        reg = MarketplaceRegistration(name='personal', source=source)
+        assert reg.source == source
+
+    def test_source_validation_scp_url_with_tilde(self):
+        """SCP-style SSH URLs may target personal (~user) repos."""
+        source = 'git@bitbucket.dc.example.com:~jane.doe/skills.git'
+        reg = MarketplaceRegistration(name='personal', source=source)
+        assert reg.source == source
+
+    def test_source_validation_rejects_embedded_password(self):
+        """URLs with user:password credentials stay rejected."""
+        with pytest.raises(ValidationError, match='source must be'):
+            MarketplaceRegistration(
+                name='test',
+                source='https://user:secret@host.example.com/scm/proj/repo.git',
+            )
+
+    def test_source_validation_rejects_tilde_local_path(self):
+        """'~' stays rejected for local paths (no home-dir expansion)."""
+        with pytest.raises(ValidationError, match='source must be'):
+            MarketplaceRegistration(name='test', source='~/skills')
+
     def test_source_validation_relative_path(self):
         """Test valid relative local path source."""
         reg = MarketplaceRegistration(name='test', source='local/path/to/skills')


### PR DESCRIPTION
- [x] A human has tested these changes.

HUMAN: Root-caused from a customer report (Bitbucket Data Center personal skill-marketplace repos rejected with a 422). Draft while we validate end-to-end against a real Bitbucket DC instance on a Replicated test install.

## Problem

Registering a skills marketplace hosted in a **Bitbucket Data Center personal repo** (`https://<host>/scm/~user/repo.git`) fails with a 422: `_GIT_URL_PATTERN` has no `~` in its path character class, so the URL fails all three accepted source patterns and pydantic rejects the request body. Bitbucket DC uses `~` to denote personal projects, so personal repos can't be registered at all.

Two further gaps kept custom-host marketplaces from working end-to-end even once registration succeeds:

1. At conversation start, `authenticate_marketplace_sources` skipped credential injection for full-URL sources on a custom host, so **private** custom-host marketplace repos were cloned unauthenticated by the agent-server and failed to load.
2. The preview endpoint built a mangled fallback URL (`https://github.com/https://<host>/...`) for custom-host sources.

## Changes

**Validation** (`settings_models.py`): allow `~` in git-URL paths and an optional **bare-username** userinfo after `https://` / `ssh://` (Bitbucket DC's copy-paste clone URLs carry `user@`). `user:password@` forms stay rejected; `~` is *not* added to the local-path pattern (that would enable home-dir expansion).

**Resolution** (`skill_loader.py`, `provider.py`): URL/scp marketplace sources now resolve **host-aware and provider-pinned**:
- The provider is chosen by the URL's real parsed host (`urlparse`), never by a substring of the raw string — so `https://github.com@evil/o/r` resolves against host `evil` (which matches no provider) instead of GitHub.
- A URL is only rewritten when its host matches a configured provider token (a token's own `host`, or the provider default domain only when the token has no host). Unrelated-host URLs pass through unchanged.
- Resolution is pinned to the matched provider (`ProviderHandler.get_authenticated_git_url` gains `specified_provider`, which bypasses `verify_repo_provider`'s try-every-provider fall-through), so a host-blind resolver can't claim a same-named repo on a different provider/host.
- Bitbucket DC clone paths (`/scm/<project>/<repo>`, or `/<project>/<repo>` for SSH) are normalized to `<project>/<repo>` before resolution.

**Preview** (`skills_router.py`): the preview clone uses the same host-matched, pinned resolution, and **refuses** to `git clone` a full-URL source whose host matches no configured provider — closing an SSRF/port-probe surface.

## Tests

- Validation: BBDC personal HTTPS / `user@` HTTPS / `ssh://git@host:7999` / scp `~user` accepted; embedded-password URLs and `~/` local paths still rejected; existing rejection tests unchanged.
- Resolution: BBDC personal URL → `~user/repo` pinned to the DC token; github.com URL pinned to the github token via default domain; **provider-substring-in-userinfo/path URLs are never rewritten and never consult the provider handler**; unrelated custom hosts pass through.
- Preview: BBDC personal URL clones the pinned authenticated URL; unmatched custom host is refused (no clone).
- `test_skill_loader.py`, `test_settings.py`, `test_skills_api.py` pass locally (163 tests); broader `app_server`/`storage` sweep clean apart from 4 pre-existing env-dependent failures unrelated to this change.

## Follow-ups (separate)

- Auto-load at conversation start for private self-hosted marketplaces now works via host-matched credential injection; the same pinning could be extended to org-config repo resolution.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-e697c4e   docker.openhands.dev/openhands/openhands:e697c4e
```

## End-to-end validation (2026-07-21)

Validated on a Replicated test install (R02) against a real Bitbucket Data Center instance:
- Registered a **private personal** BBDC marketplace (`https://<host>/scm/~alona/marketplace-alona-test.git`) — the exact `~user` shape that previously returned 422 — via the Skills settings UI. Registration + preview succeed (no 422); the credentialed clone resolves the personal repo and lists its skills.
- Verified the agent-server (1.36.0) marketplace loader clones the private `~alona` repo with the credentials produced by `authenticate_marketplace_sources` and loads its skills end-to-end.
- Confirmed the public-domain regression fix: a public `https://github.com/owner/repo.git` marketplace clones publicly even when the only connected provider is Bitbucket.

Note: exercising conversation-start auto-load requires an agent-server >= 1.30.0 (the SDK version that added `registered_marketplaces` support); that is independent of this PR, which is the OHE app-server side (validation + credentialed resolution + preview).
