### PR TITLE
fix(enterprise): bootstrap superadmin when upgraded tenants have none

### DIFF
--- a/enterprise/migrations/versions/138_backfill_first_superadmin.py
+++ b/enterprise/migrations/versions/138_backfill_first_superadmin.py
@@ -1,0 +1,62 @@
+"""Backfill a superadmin when upgraded instances have users but none.
+
+Revision ID: 138
+Revises: 137
+Create Date: 2026-07-20
+
+Upgrades that introduced ``user.role_id`` left existing tenants with users
+but zero superadmins (#15327). Promote the earliest user (by first_login_at,
+then email, then id) when the admin role exists and nobody holds it.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "138"
+down_revision = "137"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    admin_role_id = conn.execute(
+        sa.text("SELECT id FROM role WHERE name = 'admin' LIMIT 1")
+    ).scalar()
+    if admin_role_id is None:
+        return
+
+    superadmin_count = conn.execute(
+        sa.text('SELECT COUNT(*) FROM "user" WHERE role_id = :rid'),
+        {"rid": admin_role_id},
+    ).scalar()
+    if superadmin_count and superadmin_count > 0:
+        return
+
+    user_count = conn.execute(sa.text('SELECT COUNT(*) FROM "user"')).scalar()
+    if not user_count:
+        return
+
+    # Prefer the first-ever login; fall back to email/id for deterministic pick.
+    target = conn.execute(
+        sa.text(
+            'SELECT id FROM "user" '
+            "ORDER BY first_login_at ASC NULLS LAST, email ASC NULLS LAST, id ASC "
+            "LIMIT 1"
+        )
+    ).scalar()
+    if target is None:
+        return
+
+    conn.execute(
+        sa.text('UPDATE "user" SET role_id = :rid WHERE id = :uid'),
+        {"rid": admin_role_id, "uid": target},
+    )
+
+
+def downgrade() -> None:
+    # Non-destructive: do not strip superadmin grants on downgrade.
+    pass

--- a/enterprise/storage/user_store.py
+++ b/enterprise/storage/user_store.py
@@ -100,23 +100,32 @@ class UserStore:
             if existing_user:
                 return existing_user
 
-            # First-user → superadmin: if the caller did not specify a
-            # super ``role_id`` and there are no existing users in the
-            # database, designate this user as a ``superadmin`` (the
-            # ``admin`` role attached via ``user.role_id``). Super-role
-            # permissions are explicit in ``server.auth.authorization``
-            # and do not inherit org-scoped admin permissions.
+            # First-user / zero-superadmin → superadmin.
+            # Fresh installs: empty user table → first user becomes superadmin.
+            # Upgraded installs (#15327): users may already exist from before
+            # the role feature, with nobody holding the admin super role.
+            # In that case promote this user so the instance is not stuck
+            # with zero superadmins and no bootstrap path.
             if role_id is None:
-                existing_user_count = await session.scalar(
-                    select(func.count()).select_from(User)
-                )
-                if existing_user_count == 0:
-                    superadmin_role = await RoleStore.get_role_by_name('admin', session)
-                    if superadmin_role is not None:
+                superadmin_role = await RoleStore.get_role_by_name('admin', session)
+                if superadmin_role is not None:
+                    existing_user_count = await session.scalar(
+                        select(func.count()).select_from(User)
+                    )
+                    superadmin_count = await session.scalar(
+                        select(func.count())
+                        .select_from(User)
+                        .where(User.role_id == superadmin_role.id)
+                    )
+                    if existing_user_count == 0 or (superadmin_count or 0) == 0:
                         role_id = superadmin_role.id
                         logger.info(
-                            'user_store:create_user:first_user_designated_superadmin',
-                            extra={'user_id': user_id},
+                            'user_store:create_user:designated_superadmin',
+                            extra={
+                                'user_id': user_id,
+                                'existing_user_count': existing_user_count,
+                                'superadmin_count': superadmin_count or 0,
+                            },
                         )
 
             org = await session.get(Org, user_uuid)

--- a/enterprise/tests/unit/test_user_store.py
+++ b/enterprise/tests/unit/test_user_store.py
@@ -227,6 +227,30 @@ async def test_create_user_subsequent_users_are_not_superadmins(async_session_ma
 
 
 @pytest.mark.asyncio
+async def test_create_user_promotes_when_existing_users_have_zero_superadmins(
+    async_session_maker,
+):
+    """Upgraded tenants with users but no superadmin still need a bootstrap (#15327)."""
+    admin_role_id = await _seed_admin_role(async_session_maker)
+    org_id = await _seed_org(async_session_maker)
+    # Pre-existing user from before the role feature (role_id is NULL).
+    await _seed_user(async_session_maker, org_id, None, 'legacy@example.com')
+
+    new_user_id = str(uuid.uuid4())
+    with (
+        patch('storage.user_store.a_session_maker', async_session_maker),
+        patch('storage.role_store.a_session_maker', async_session_maker),
+        _mock_create_default_settings_returning_default(),
+    ):
+        user = await UserStore.create_user(
+            new_user_id, {'email': 'bootstrap@example.com'}
+        )
+
+    assert user is not None
+    assert user.role_id == admin_role_id
+
+
+@pytest.mark.asyncio
 async def test_create_user_explicit_role_id_is_respected_for_first_user(
     async_session_maker,
 ):


### PR DESCRIPTION
## Summary

Upgraded Enterprise instances can end up with users but **zero superadmins**, because `create_user()` only auto-grants the admin super role when the user table is empty (#15327).

### Changes

1. **`UserStore.create_user`** — if no superadmin exists yet, promote the user being created (covers both fresh installs and upgraded tenants with pre-role users).
2. **Alembic `138`** — one-shot data migration: when the `admin` role exists and nobody holds it, promote the earliest existing user (`first_login_at`, then `email`, then `id`).
3. **Unit test** for the zero-superadmin bootstrap path.

## Testing

```text
# targeted (enterprise unit suite; local env may need full deps)
pytest enterprise/tests/unit/test_user_store.py \
  -k "first_user_is_designated or subsequent_users or zero_superadmins" -q
```

`py_compile` clean on changed Python files.

Fixes #15327
