### PR TITLE
feat(llms): add Nebius Token Factory as an OpenAI-compatible provider

### DIFF
--- a/docs/openhands/usage/llms/nebius.mdx
+++ b/docs/openhands/usage/llms/nebius.mdx
@@ -1,0 +1,32 @@
+---
+title: Nebius Token Factory
+description: OpenHands uses LiteLLM to make calls to chat models on Nebius Token Factory, an OpenAI-compatible inference service. You can find their documentation [here](https://docs.tokenfactory.nebius.com/).
+---
+
+[Nebius Token Factory](https://tokenfactory.nebius.com/) serves a wide range of open models
+(Qwen, DeepSeek, Llama, GLM, Kimi, MiniMax and more) through an OpenAI-compatible API.
+
+## Configuration
+
+When running OpenHands, you'll need to set the following in the OpenHands UI through the Settings under the `LLM` tab:
+- `LLM Provider` to `Nebius Token Factory`
+- `LLM Model` to the model you will be using. [Visit here to see the list of
+models that Nebius Token Factory hosts](https://docs.tokenfactory.nebius.com/llms.txt). If the model is
+not in the list, enable `Advanced` options, and enter it in `Custom Model` (e.g. `nebius/<model-name>`
+like `nebius/Qwen/Qwen3-235B-A22B-Instruct-2507`).
+- `API Key` to your Nebius Token Factory API key. To find or create your key, [see here](https://tokenfactory.nebius.com/).
+
+OpenHands routes `nebius/*` models to the Token Factory endpoint
+(`https://api.tokenfactory.nebius.com/v1`) automatically, so you do not need to set a Base URL when
+using the `Nebius` provider.
+
+## Using Nebius Token Factory as an OpenAI-Compatible Endpoint
+
+The Nebius Token Factory endpoint for chat completion is OpenAI-compatible. Therefore, you can access
+Nebius models as you would access any OpenAI-compatible endpoint. In the OpenHands UI through the
+Settings under the `LLM` tab:
+1. Enable `Advanced` options
+2. Set the following:
+   - `Custom Model` to the prefix `openai/` + the model you will be using (e.g. `openai/Qwen/Qwen3-235B-A22B-Instruct-2507`)
+   - `Base URL` to `https://api.tokenfactory.nebius.com/v1`
+   - `API Key` to your Nebius Token Factory API key

--- a/frontend/__tests__/routes/llm-settings.test.tsx
+++ b/frontend/__tests__/routes/llm-settings.test.tsx
@@ -498,6 +498,31 @@ describe("LlmSettingsScreen", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("opens basic view when a Nebius model uses the Token Factory default base URL", async () => {
+    // Nebius Token Factory is a known OpenAI-compatible provider; its default
+    // base URL must be treated like OpenAI's so a nebius/* config stays on the
+    // basic tier instead of being mistaken for a user customization.
+    vi.spyOn(organizationService, "getOrganizationSettings").mockResolvedValue(
+      buildSettingsWithAdvancedToggle({
+        llm_model: "nebius/Qwen/Qwen3-235B-A22B-Instruct-2507",
+        llm_base_url: "https://api.tokenfactory.nebius.com/v1",
+        agent_settings: {
+          llm: {
+            model: "nebius/Qwen/Qwen3-235B-A22B-Instruct-2507",
+            base_url: "https://api.tokenfactory.nebius.com/v1",
+          },
+        },
+      }),
+    );
+
+    await renderLlmSettingsScreen({ appMode: "saas", scope: "org" });
+
+    await screen.findByTestId("llm-settings-form-basic");
+    expect(
+      screen.queryByTestId("llm-settings-form-advanced"),
+    ).not.toBeInTheDocument();
+  });
+
   it("opens basic view even when an OpenHands model has a non-managed base URL", async () => {
     // Accepted edge case: the server owns base_url for openhands/* models,
     // so editing always starts on basic — even if the stored URL was set

--- a/frontend/src/routes/llm-settings.tsx
+++ b/frontend/src/routes/llm-settings.tsx
@@ -76,6 +76,12 @@ const getSchemaFieldDefaultValue = (
 
 const KNOWN_PROVIDER_DEFAULT_BASE_URLS: Partial<Record<string, Set<string>>> = {
   openai: new Set(["https://api.openai.com", "https://api.openai.com/v1"]),
+  // Nebius Token Factory (OpenAI-compatible). Keeps a nebius/* config on the
+  // basic settings tier instead of forcing the Advanced view.
+  nebius: new Set([
+    "https://api.tokenfactory.nebius.com",
+    "https://api.tokenfactory.nebius.com/v1",
+  ]),
 };
 
 const normalizeBaseUrl = (baseUrl: string) => {

--- a/frontend/src/utils/map-provider.ts
+++ b/frontend/src/utils/map-provider.ts
@@ -26,6 +26,7 @@ export const MAP_PROVIDER = {
   openhands: "OpenHands",
   lemonade: "Lemonade",
   clarifai: "Clarifai",
+  nebius: "Nebius Token Factory",
 };
 
 export const mapProvider = (provider: string) =>

--- a/openhands/app_server/utils/llm.py
+++ b/openhands/app_server/utils/llm.py
@@ -61,11 +61,30 @@ CLARIFAI_MODELS = [
 # ---------------------------------------------------------------------------
 VERIFIED_PROVIDERS: list[str] = list(_SDK_VERIFIED_MODELS.keys())
 
+# Nebius Token Factory is an OpenAI-compatible provider we promote to the
+# "Verified" section of the model selector even though its individual models
+# are not part of the SDK's curated verified-model catalogue.  Guard against a
+# future SDK release that adds it, so the list never contains duplicates.
+if 'nebius' not in VERIFIED_PROVIDERS:
+    VERIFIED_PROVIDERS.append('nebius')
+
 _BARE_OPENAI_MODELS: set[str] = set(_SDK_OPENAI)
 _BARE_ANTHROPIC_MODELS: set[str] = set(_SDK_ANTHROPIC)
 _BARE_MISTRAL_MODELS: set[str] = set(_SDK_MISTRAL)
 
 DEFAULT_OPENHANDS_MODEL = 'openhands/minimax-m2.7'
+
+# ---------------------------------------------------------------------------
+# Nebius Token Factory — OpenAI-compatible provider.
+#
+# LiteLLM ships a native ``nebius/`` provider, but its built-in default
+# ``api_base`` still points at the legacy AI Studio endpoint
+# (``https://api.studio.nebius.ai/v1``).  Nebius has since rebranded the
+# inference product to **Token Factory**, served from a new host.  We pin the
+# base URL here so that selecting a ``nebius/*`` model resolves to the current
+# endpoint instead of the legacy one.
+# ---------------------------------------------------------------------------
+NEBIUS_TOKEN_FACTORY_API_BASE = 'https://api.tokenfactory.nebius.com/v1'
 
 
 # ---------------------------------------------------------------------------
@@ -176,6 +195,12 @@ def get_provider_api_base(model: str) -> str | None:
     Returns:
         The API base URL if found, None otherwise.
     """
+    # Nebius Token Factory: override LiteLLM's legacy AI Studio default with the
+    # current Token Factory endpoint. Matches ``nebius/<model>`` as well as the
+    # bare ``nebius`` provider name.
+    if model == 'nebius' or model.startswith('nebius/'):
+        return NEBIUS_TOKEN_FACTORY_API_BASE
+
     # First try get_api_base (handles OpenAI, Gemini with specific URL patterns)
     try:
         api_base = litellm.get_api_base(model, {})

--- a/tests/unit/utils/test_llm_utils.py
+++ b/tests/unit/utils/test_llm_utils.py
@@ -2,6 +2,8 @@
 
 from openhands.app_server.utils import llm as llm_utils
 from openhands.app_server.utils.llm import (
+    NEBIUS_TOKEN_FACTORY_API_BASE,
+    VERIFIED_PROVIDERS,
     _assign_provider,
     _derive_verified_models,
     get_provider_api_base,
@@ -165,3 +167,27 @@ class TestGetProviderApiBase:
         # May return None or an API base depending on litellm behavior
         # The function should not raise an exception
         assert result is None or isinstance(result, str)
+
+    def test_nebius_model_returns_token_factory_api_base(self):
+        """Nebius models resolve to the Token Factory endpoint, not the
+        legacy AI Studio default that LiteLLM ships with."""
+        assert (
+            get_provider_api_base('nebius/Qwen/Qwen3-235B-A22B-Instruct-2507')
+            == NEBIUS_TOKEN_FACTORY_API_BASE
+        )
+        # Bare provider name is also handled.
+        assert get_provider_api_base('nebius') == NEBIUS_TOKEN_FACTORY_API_BASE
+        # Sanity check: it is the Token Factory host, not the legacy one.
+        assert 'tokenfactory.nebius.com' in NEBIUS_TOKEN_FACTORY_API_BASE
+
+
+class TestVerifiedProviders:
+    """Tests for the VERIFIED_PROVIDERS list."""
+
+    def test_nebius_is_verified_provider(self):
+        """Nebius Token Factory is promoted to the Verified section."""
+        assert 'nebius' in VERIFIED_PROVIDERS
+
+    def test_no_duplicate_providers(self):
+        """The list must not contain duplicates (guards the append logic)."""
+        assert len(VERIFIED_PROVIDERS) == len(set(VERIFIED_PROVIDERS))


### PR DESCRIPTION
HUMAN:

- [x] A human has tested these changes.

AGENT:

---

## Why

[Nebius Token Factory](https://tokenfactory.nebius.com/) is an OpenAI-compatible inference service serving many open models (Qwen, DeepSeek, Llama, GLM, Kimi, MiniMax, …).

LiteLLM ships a native `nebius/` provider, but its built-in default `api_base` still points at the **legacy** AI Studio endpoint (`https://api.studio.nebius.ai/v1`). Nebius has since rebranded the inference product to **Token Factory**, served from `https://api.tokenfactory.nebius.com/v1`. As a result, selecting a `nebius/*` model in OpenHands routed requests to the wrong (legacy) host, and the provider surfaced only as an unverified entry.

## Summary

- **Backend** (`openhands/app_server/utils/llm.py`): pin `nebius` to the Token Factory endpoint in `get_provider_api_base()` (overriding litellm's legacy default), so both the save/auto-fill and load/hide-if-default paths resolve correctly; promote `nebius` to the `VERIFIED_PROVIDERS` list.
- **Frontend**: add `nebius` to `KNOWN_PROVIDER_DEFAULT_BASE_URLS` so a nebius config stays on the basic settings tier; add a friendly `Nebius Token Factory` display label in `map-provider`.
- **Docs**: new provider page `docs/openhands/usage/llms/nebius.mdx` (modeled on the existing Groq page).
- **Tests**: backend + frontend unit tests covering base-URL resolution, verified-provider promotion, and the basic-view behavior.

Models are sourced from LiteLLM's built-in `nebius/*` catalogue (30 models); users can also enter any current Token Factory model via `Custom Model`. No changes to the external `openhands-sdk` verified-models catalogue.

## Issue Number

N/A

## How to Test

1. In Settings → LLM tab, select provider **Nebius Token Factory**, pick a model (e.g. `Qwen/Qwen3-235B-A22B-Instruct-2507`), and enter a Token Factory API key. The base URL auto-fills to `https://api.tokenfactory.nebius.com/v1` and the form stays on the basic tier.
2. Alternatively (OpenAI-compatible path): enable Advanced, set Custom Model `openai/Qwen/Qwen3-235B-A22B-Instruct-2507`, Base URL `https://api.tokenfactory.nebius.com/v1`, and your key.
3. Automated:
   - Backend: `uv run pytest tests/unit/utils/test_llm_utils.py` (19 passed).
   - Frontend: `cd frontend && npx vitest run __tests__/routes/llm-settings.test.tsx` (81 passed) and `npx vitest run __tests__/utils/map-provider.test.ts`.

Verified live: `GET /v1/models` returns 26 models and a real chat completion succeeds against the Token Factory endpoint.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The docs **navigation** lives in the separate `All-Hands-AI/docs` repo. The `.mdx` here drops into that repo at the same path, but still needs a one-line entry in that repo's `docs.json` under the **LLM Providers** group: `"openhands/usage/llms/nebius"`.
- The backend pre-commit hook (`poetry`) was not available in the authoring environment; `ruff check`, `ruff format --check`, and `mypy` were run manually on the changed files and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)