### PR TITLE
feat: Expose app and SDK versions in server info

### DIFF
--- a/openhands/app_server/status/system_stats.py
+++ b/openhands/app_server/status/system_stats.py
@@ -7,12 +7,22 @@
 # Tag: Legacy-V0
 """Utilities for getting system resource statistics."""
 
+import importlib.metadata
 import time
 
 import psutil
 
+from openhands.app_server.version import get_version
+
 _start_time = time.time()
 _last_execution_time = time.time()
+
+
+def get_sdk_version() -> str:
+    try:
+        return importlib.metadata.version('openhands-sdk')
+    except importlib.metadata.PackageNotFoundError:
+        return 'unknown'
 
 
 def get_system_info() -> dict[str, object]:
@@ -22,6 +32,8 @@ def get_system_info() -> dict[str, object]:
     return {
         'uptime': uptime,
         'idle_time': idle_time,
+        'app_version': get_version(),
+        'sdk_version': get_sdk_version(),
         'resources': get_system_stats(),
     }
 

--- a/tests/unit/app_server/test_status_router.py
+++ b/tests/unit/app_server/test_status_router.py
@@ -3,11 +3,15 @@
 This module tests the status router endpoints (/alive, /health, /server_info, /ready).
 """
 
+import importlib.metadata
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from openhands.app_server.status import system_stats
 from openhands.app_server.status.status_router import router
+from openhands.app_server.version import get_version
 
 
 @pytest.fixture
@@ -50,12 +54,30 @@ class TestServerInfoEndpoint:
     """Test suite for the /server_info endpoint."""
 
     def test_server_info_returns_system_info(self, test_client):
-        """Test that /server_info returns system information."""
+        """Test that /server_info returns system and version information."""
         response = test_client.get('/server_info')
 
         assert response.status_code == 200
-        # Should return a dict with system info
-        assert isinstance(response.json(), dict)
+        payload = response.json()
+        assert isinstance(payload['uptime'], float)
+        assert isinstance(payload['idle_time'], float)
+        assert payload['app_version'] == get_version()
+        assert payload['sdk_version'] == system_stats.get_sdk_version()
+        assert isinstance(payload['resources'], dict)
+
+    def test_get_sdk_version_returns_unknown_when_package_missing(self, monkeypatch):
+        """Test missing SDK metadata returns a stable fallback."""
+
+        def raise_package_not_found(package_name: str) -> str:
+            raise importlib.metadata.PackageNotFoundError(package_name)
+
+        monkeypatch.setattr(
+            system_stats.importlib.metadata,
+            'version',
+            raise_package_not_found,
+        )
+
+        assert system_stats.get_sdk_version() == 'unknown'
 
 
 class TestReadyEndpoint:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

The `/server_info` endpoint already centralizes operational diagnostics. Including the app and SDK versions there makes it easier to confirm which OpenHands release and SDK package a running server is using.

## Summary

- Added `app_version` to `/server_info` using the existing app version helper.
- Added `sdk_version` to `/server_info` from installed `openhands-sdk` package metadata, with an `unknown` fallback.
- Updated status router tests to cover the new fields and SDK metadata fallback.

## Issue Number

N/A

## How to Test

- `poetry run pytest tests/unit/app_server/test_status_router.py`
- `poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml`

## Video/Screenshots

N/A — backend API response change only.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR was created by an AI agent (OpenHands) on behalf of the user.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/50bfce21-8e9c-4eb3-b089-424004efb71b)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-ec52e77   docker.openhands.dev/openhands/openhands:ec52e77
```