### PR TITLE
fix: upgraded instances with no superadmin

### DIFF
--- a/enterprise/migrations/versions/138_backfill_initial_superadmin.py
+++ b/enterprise/migrations/versions/138_backfill_initial_superadmin.py
@@ -1,0 +1,49 @@
+"""Ensure upgraded instances have an initial superadmin.
+
+Revision ID: 138
+Revises: 137
+Create Date: 2026-07-21 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '138'
+down_revision: Union[str, None] = '137'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    metadata = sa.MetaData()
+    role = sa.Table('role', metadata, autoload_with=connection)
+    user = sa.Table('user', metadata, autoload_with=connection)
+
+    admin_role_id = sa.select(role.c.id).where(role.c.name == 'admin').scalar_subquery()
+    has_superadmin = sa.exists(
+        sa.select(user.c.id).where(user.c.role_id == admin_role_id)
+    )
+    oldest_user_id = (
+        sa.select(user.c.id)
+        .order_by(
+            sa.func.coalesce(user.c.first_login_at, user.c.accepted_tos)
+            .asc()
+            .nulls_last(),
+            user.c.id.asc(),
+        )
+        .limit(1)
+        .scalar_subquery()
+    )
+
+    connection.execute(
+        sa.update(user)
+        .where(user.c.id == oldest_user_id, ~has_superadmin)
+        .values(role_id=admin_role_id)
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/enterprise/tests/unit/test_migration_138_backfill_initial_superadmin.py
+++ b/enterprise/tests/unit/test_migration_138_backfill_initial_superadmin.py
@@ -1,0 +1,117 @@
+from datetime import datetime
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / 'migrations'
+    / 'versions'
+    / '138_backfill_initial_superadmin.py'
+)
+spec = spec_from_file_location('migration_138', MIGRATION_PATH)
+assert spec is not None and spec.loader is not None
+migration_138 = module_from_spec(spec)
+spec.loader.exec_module(migration_138)
+
+
+def _run_upgrade(connection: sa.Connection) -> None:
+    context = MigrationContext.configure(connection)
+    with Operations.context(context):
+        migration_138.upgrade()
+
+
+def _database() -> tuple[sa.Engine, sa.Table, sa.Table]:
+    engine = sa.create_engine('sqlite://')
+    metadata = sa.MetaData()
+    role = sa.Table(
+        'role',
+        metadata,
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('name', sa.String(), nullable=False, unique=True),
+    )
+    user = sa.Table(
+        'user',
+        metadata,
+        sa.Column('id', sa.String(), primary_key=True),
+        sa.Column('role_id', sa.Integer(), sa.ForeignKey('role.id')),
+        sa.Column('accepted_tos', sa.DateTime()),
+        sa.Column('first_login_at', sa.DateTime()),
+    )
+    metadata.create_all(engine)
+    return engine, role, user
+
+
+def test_upgrade_promotes_oldest_user_when_no_superadmin_exists():
+    engine, role, user = _database()
+
+    with engine.begin() as connection:
+        connection.execute(
+            role.insert(),
+            [{'id': 1, 'name': 'admin'}, {'id': 2, 'name': 'user'}],
+        )
+        connection.execute(
+            user.insert(),
+            [
+                {
+                    'id': 'newer',
+                    'role_id': 2,
+                    'accepted_tos': datetime(2025, 2, 1),
+                },
+                {
+                    'id': 'oldest',
+                    'role_id': None,
+                    'accepted_tos': datetime(2025, 1, 1),
+                },
+            ],
+        )
+
+        _run_upgrade(connection)
+        roles = dict(
+            connection.execute(sa.select(user.c.id, user.c.role_id)).tuples().all()
+        )
+
+    assert roles == {'newer': 2, 'oldest': 1}
+
+
+def test_upgrade_is_idempotent_when_superadmin_exists():
+    engine, role, user = _database()
+
+    with engine.begin() as connection:
+        connection.execute(
+            role.insert(),
+            [{'id': 1, 'name': 'admin'}, {'id': 2, 'name': 'user'}],
+        )
+        connection.execute(
+            user.insert(),
+            [
+                {'id': 'admin', 'role_id': 1},
+                {
+                    'id': 'older-non-admin',
+                    'role_id': 2,
+                    'accepted_tos': datetime(2024, 1, 1),
+                },
+            ],
+        )
+
+        _run_upgrade(connection)
+        _run_upgrade(connection)
+        roles = dict(
+            connection.execute(sa.select(user.c.id, user.c.role_id)).tuples().all()
+        )
+
+    assert roles == {'admin': 1, 'older-non-admin': 2}
+
+
+def test_upgrade_noops_when_there_are_no_users():
+    engine, role, user = _database()
+
+    with engine.begin() as connection:
+        connection.execute(role.insert(), [{'id': 1, 'name': 'admin'}])
+        _run_upgrade(connection)
+        users = connection.execute(sa.select(user)).all()
+
+    assert users == []


### PR DESCRIPTION
HUMAN:

I've tested this - if there is no admin user, the oldest is given that power -  on prem customers shoul

- [x] A human has tested these changes.

AGENT:

Implemented and tested by OpenHands on behalf of the user.

---

## Why

Enterprise instances upgraded from before the role migration can contain users without any superadmin. The first-user bootstrap cannot repair those instances because their user table is already populated, leaving superadmin-only functions inaccessible without a manual database update.

## Summary

- Add an idempotent data migration that grants the `admin` role when no superadmin exists.
- Select the oldest user by the earliest available login or terms-acceptance timestamp, with user ID as a deterministic fallback.
- Cover upgrades with no superadmin, an existing superadmin, and no users.

## Issue Number

OHE-2791
Closes #15327

## How to Test

```bash
PYTHONPATH=enterprise poetry run pytest enterprise/tests/unit/test_migration_138_backfill_initial_superadmin.py -q
poetry run pre-commit run --config enterprise/dev_config/python/.pre-commit-config.yaml --files enterprise/migrations/versions/138_backfill_initial_superadmin.py enterprise/tests/unit/test_migration_138_backfill_initial_superadmin.py --show-diff-on-failure
```

Expected: 3 tests pass and all pre-commit checks pass.

## Video/Screenshots

<img width="872" height="290" alt="image" src="https://github.com/user-attachments/assets/a64f3f0a-38a1-42a1-8c10-18a64aa3e796" />


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The `user` table has no creation timestamp. The migration uses `COALESCE(first_login_at, accepted_tos)` as the best available age signal and user ID for stable ordering when both timestamps are absent. Downgrade intentionally does not revoke the promoted role because it cannot distinguish migration-created grants from later operator decisions.

_This pull request was created by an AI agent (OpenHands) on behalf of the user._

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-0c60473   docker.openhands.dev/openhands/openhands:0c60473
```