### PR TITLE
docs(agents): update codereview skill org to OpenHands/OpenHands

### DIFF
--- a/.agents/skills/custom-codereview-guide.md
+++ b/.agents/skills/custom-codereview-guide.md
@@ -1,13 +1,13 @@
 ---
 name: custom-codereview-guide
-description: Repo-specific code review guidelines for All-Hands-AI/OpenHands. Provides frontend and backend review rules in addition to the default code review skill.
+description: Repo-specific code review guidelines for OpenHands/OpenHands. Provides frontend and backend review rules in addition to the default code review skill.
 triggers:
 - /codereview
 ---
 
-# All-Hands-AI/OpenHands Code Review Guidelines
+# OpenHands/OpenHands Code Review Guidelines
 
-You are an expert code reviewer for the **All-Hands-AI/OpenHands** repository. This skill provides repo-specific review guidelines.
+You are an expert code reviewer for the **OpenHands/OpenHands** repository. This skill provides repo-specific review guidelines.
 
 ## Automated PR Triage Before Review
 


### PR DESCRIPTION
HUMAN:

This PR updates the custom code-review skill to use the new `OpenHands/OpenHands` org slug instead of the old `All-Hands-AI/OpenHands` name.

- [ ] A human has tested these changes.

AGENT:

## Problem

After the org rename to `OpenHands/OpenHands`, the custom code-review skill still referred to `All-Hands-AI/OpenHands` in its frontmatter description, heading, and intro sentence. Agents following this skill get the wrong canonical repo name.

## Triage / Root cause

`packages/docs/docs/agents/agents-guide/custom-codereview-guide.md` (`.agents/skills/custom-codereview-guide.md` in the working tree) contains the old org slug in three places.

## Fix

- Replace `All-Hands-AI/OpenHands` → `OpenHands/OpenHands` in the skill markdown (3 occurrences).

## Verification

- `grep -R 'All-Hands-AI/OpenHands' .agents/skills/custom-codereview-guide.md` returns no matches.
- Confirmed no open PR already targets this file for the rename.
- `npm run lint:fix`, `npm run build`, and `npm run test` passed for affected frontend packages.

## Notes / Risks

Docs-only string update. Enterprise README still has a separate `All-Hands-AI/OpenHands-Cloud` link; left alone because PR #15135 already touches that file for typos.
