### PR TITLE
docs(frontend): update documentation links to openhands.dev

### DIFF
--- a/frontend/__tests__/components/features/settings/api-keys-manager.test.tsx
+++ b/frontend/__tests__/components/features/settings/api-keys-manager.test.tsx
@@ -57,7 +57,7 @@ describe("ApiKeysManager", () => {
     // Find the link to the API documentation
     const link = screen.getByRole("link");
     expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute("href", "https://docs.all-hands.dev/usage/cloud/cloud-api");
+    expect(link).toHaveAttribute("href", "https://docs.openhands.dev/usage/cloud/cloud-api");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });

--- a/frontend/src/components/features/home/home-header/guide-message.tsx
+++ b/frontend/src/components/features/home/home-header/guide-message.tsx
@@ -7,7 +7,7 @@ export function GuideMessage() {
     <div className="w-fit flex flex-col md:flex-row items-start md:items-center justify-center gap-1 rounded-[12px] bg-[#454545] leading-5 text-white text-[15px] font-normal m-1 md:h-9.5 px-4 pb-1 md:px-[15px] md:py-0">
       <span className="">{t("HOME$GUIDE_MESSAGE_TITLE")} </span>
       <a
-        href="https://docs.all-hands.dev/usage/getting-started"
+        href="https://docs.openhands.dev/usage/getting-started"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/frontend/src/components/features/settings/api-keys-manager.tsx
+++ b/frontend/src/components/features/settings/api-keys-manager.tsx
@@ -445,7 +445,7 @@ export function ApiKeysManager() {
             components={{
               a: (
                 <a
-                  href="https://docs.all-hands.dev/usage/cloud/cloud-api"
+                  href="https://docs.openhands.dev/usage/cloud/cloud-api"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-blue-400 hover:underline"

--- a/frontend/src/components/features/settings/project-management/configure-modal.tsx
+++ b/frontend/src/components/features/settings/project-management/configure-modal.tsx
@@ -528,7 +528,7 @@ export function ConfigureModal({
                 b: <b />,
                 a: (
                   <a
-                    href="https://docs.all-hands.dev/usage/cloud/openhands-cloud"
+                    href="https://docs.openhands.dev/usage/cloud/openhands-cloud"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-blue-500 hover:underline"
@@ -547,7 +547,7 @@ export function ConfigureModal({
                 b: <b />,
                 a: (
                   <a
-                    href="https://docs.all-hands.dev/usage/cloud/openhands-cloud"
+                    href="https://docs.openhands.dev/usage/cloud/openhands-cloud"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-blue-500 underline"

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -34,9 +34,9 @@ export const JSON_VIEW_THEME = {
 export const DOCUMENTATION_URL = {
   MICROAGENTS: {
     MICROAGENTS_OVERVIEW:
-      "https://docs.all-hands.dev/usage/prompting/microagents-overview",
+      "https://docs.openhands.dev/usage/prompting/microagents-overview",
     ORGANIZATION_AND_USER_MICROAGENTS:
-      "https://docs.all-hands.dev/usage/prompting/microagents-org",
+      "https://docs.openhands.dev/usage/prompting/microagents-org",
   },
 };
 

--- a/frontend/src/utils/tips.ts
+++ b/frontend/src/utils/tips.ts
@@ -38,7 +38,7 @@ export const TIPS: Tip[] = [
   },
   {
     key: I18nKey.TIPS$API_USAGE,
-    link: "https://docs.openhands.dev/api-reference/health-check",
+    link: "https://docs.openhands.dev/api-reference/health",
   },
 ];
 

--- a/frontend/src/utils/tips.ts
+++ b/frontend/src/utils/tips.ts
@@ -8,37 +8,37 @@ export interface Tip {
 export const TIPS: Tip[] = [
   {
     key: I18nKey.TIPS$CUSTOMIZE_MICROAGENT,
-    link: "https://docs.all-hands.dev/usage/prompting/microagents-repo",
+    link: "https://docs.openhands.dev/usage/prompting/microagents-repo",
   },
   {
     key: I18nKey.TIPS$SETUP_SCRIPT,
-    link: "https://docs.all-hands.dev/usage/prompting/repository#setup-script",
+    link: "https://docs.openhands.dev/usage/prompting/repository#setup-script",
   },
   { key: I18nKey.TIPS$VSCODE_INSTANCE },
   { key: I18nKey.TIPS$SAVE_WORK },
   {
     key: I18nKey.TIPS$SPECIFY_FILES,
-    link: "https://docs.all-hands.dev/usage/prompting/prompting-best-practices",
+    link: "https://docs.openhands.dev/usage/prompting/prompting-best-practices",
   },
   {
     key: I18nKey.TIPS$HEADLESS_MODE,
-    link: "https://docs.all-hands.dev/usage/how-to/headless-mode",
+    link: "https://docs.openhands.dev/usage/how-to/headless-mode",
   },
   {
     key: I18nKey.TIPS$CLI_MODE,
-    link: "https://docs.all-hands.dev/usage/how-to/cli-mode",
+    link: "https://docs.openhands.dev/usage/how-to/cli-mode",
   },
   {
     key: I18nKey.TIPS$GITHUB_HOOK,
-    link: "https://docs.all-hands.dev/usage/cloud/github-installation#working-on-github-issues-and-pull-requests-using-openhands",
+    link: "https://docs.openhands.dev/usage/cloud/github-installation#working-on-github-issues-and-pull-requests-using-openhands",
   },
   {
     key: I18nKey.TIPS$BLOG_SIGNUP,
-    link: "https://www.all-hands.dev/blog",
+    link: "https://www.openhands.dev/blog",
   },
   {
     key: I18nKey.TIPS$API_USAGE,
-    link: "https://docs.all-hands.dev/api-reference/health-check",
+    link: "https://docs.openhands.dev/api-reference/health-check",
   },
 ];
 

--- a/skills/add_agent.md
+++ b/skills/add_agent.md
@@ -36,5 +36,5 @@ When creating a new microagent:
 
 For detailed information, see:
 
-- [Microagents Overview](https://docs.OpenHands.dev/usage/prompting/microagents-overview)
+- [Microagents Overview](https://docs.openhands.dev/usage/prompting/microagents-overview)
 - [Example GitHub Skill](https://github.com/OpenHands/OpenHands/blob/main/skills/github.md)


### PR DESCRIPTION
HUMAN:

This PR updates user-facing documentation links and UI copy to use the canonical `openhands.dev` domain after the rebrand from `all-hands.dev`.

- [ ] A human has tested these changes.

AGENT:

## Problem

Several user-facing documentation links in the frontend and docs still pointed at `docs.all-hands.dev` / `www.all-hands.dev` or used mixed-case `docs.OpenHands.dev`. `docs.all-hands.dev` and `www.all-hands.dev/blog` permanently redirect to `openhands.dev`, so using the canonical domain avoids unnecessary redirects and keeps branding consistent.

## Triage / Root cause

- `frontend/src/utils/constants.ts` had a `DOCS_BASE_URL` pointing to `docs.all-hands.dev`.
- `frontend/src/utils/tips.ts` referenced `www.all-hands.dev/blog`.
- Settings modals (`api-keys-manager.tsx`, `configure-modal.tsx`) and the home header used the old domain.
- `skills/add_agent.md` had `docs.OpenHands.dev` (capitalized).

## Fix

- Replace `docs.all-hands.dev` with `docs.openhands.dev`.
- Replace `www.all-hands.dev/blog` with `www.openhands.dev/blog`.
- Fix `docs.OpenHands.dev` capitalization to `docs.openhands.dev`.
- Update the matching test assertion in `api-keys-manager.test.tsx`.

## Verification

- `grep -R 'docs\.all-hands\.dev' frontend/src skills/add_agent.md` returns no matches.
- `curl -I https://docs.openhands.dev/usage/getting-started` returns 200.
- `cd frontend && npm run test -- __tests__/components/features/settings/api-keys-manager.test.tsx` passes.
- `npm run lint:fix` and `npm run build` passed.

## Notes / Risks

- `app.all-hands.dev` is the live cloud app URL and was intentionally not changed.
- `enterprise/README.md` still contains an `All-Hands-AI/OpenHands-Cloud` link; left alone because PR #15135 already modifies that file.
