### PR TITLE
fix(frontend): sum all usage buckets in the WebSocket metrics fallback

### DIFF
--- a/frontend/__tests__/utils/conversation-metrics.test.ts
+++ b/frontend/__tests__/utils/conversation-metrics.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { combineUsageMetrics } from "#/utils/conversation-metrics";
+
+const usage = (
+  prompt: number,
+  completion: number,
+  overrides: Partial<{
+    cache_read_tokens: number;
+    cache_write_tokens: number;
+    context_window: number;
+    per_turn_token: number;
+  }> = {},
+) => ({
+  prompt_tokens: prompt,
+  completion_tokens: completion,
+  cache_read_tokens: 0,
+  cache_write_tokens: 0,
+  context_window: 0,
+  per_turn_token: 0,
+  ...overrides,
+});
+
+describe("combineUsageMetrics", () => {
+  // A mid-conversation LLM switch accrues under "profile:*" and ACP under
+  // "acp-managed"; reading only the "agent" bucket under-reports.
+  it("sums cost and tokens across every usage bucket", () => {
+    const combined = combineUsageMetrics({
+      agent: {
+        accumulated_cost: 0.0824,
+        max_budget_per_task: null,
+        accumulated_token_usage: usage(100, 10, { context_window: 200000 }),
+      },
+      condenser: {
+        accumulated_cost: 0,
+        max_budget_per_task: null,
+        accumulated_token_usage: null,
+      },
+      "profile:opus-repro:abc123": {
+        accumulated_cost: 0.1741,
+        max_budget_per_task: null,
+        accumulated_token_usage: usage(200, 20, { per_turn_token: 42 }),
+      },
+    });
+
+    expect(combined.accumulated_cost).toBeCloseTo(0.2565, 10);
+    expect(combined.accumulated_token_usage?.prompt_tokens).toBe(300);
+    expect(combined.accumulated_token_usage?.completion_tokens).toBe(30);
+    expect(combined.accumulated_token_usage?.context_window).toBe(200000);
+  });
+
+  it("keeps the first non-null max budget", () => {
+    const combined = combineUsageMetrics({
+      agent: {
+        accumulated_cost: 0,
+        max_budget_per_task: 10,
+        accumulated_token_usage: null,
+      },
+      "acp-managed": {
+        accumulated_cost: 0.5,
+        max_budget_per_task: null,
+        accumulated_token_usage: usage(50, 5),
+      },
+    });
+
+    expect(combined.max_budget_per_task).toBe(10);
+    expect(combined.accumulated_cost).toBeCloseTo(0.5, 10);
+    expect(combined.accumulated_token_usage?.prompt_tokens).toBe(50);
+  });
+});

--- a/frontend/src/contexts/conversation-websocket-context.tsx
+++ b/frontend/src/contexts/conversation-websocket-context.tsx
@@ -52,6 +52,7 @@ import { useConversationStore } from "#/stores/conversation-store";
 import { isBudgetOrCreditError, trackError } from "#/utils/error-handler";
 import { useReadConversationFile } from "#/hooks/mutation/use-read-conversation-file";
 import useMetricsStore from "#/stores/metrics-store";
+import { combineUsageMetrics } from "#/utils/conversation-metrics";
 import { I18nKey } from "#/i18n/declaration";
 import { useConversationHistory } from "#/hooks/query/use-conversation-history";
 import { setConversationState } from "#/utils/conversation-local-storage";
@@ -161,25 +162,25 @@ export function ConversationWebSocketProvider({
   // Helper function to update metrics from stats event
   const updateMetricsFromStats = useCallback(
     (event: ConversationStateUpdateEventStats) => {
-      if (event.value.usage_to_metrics?.agent) {
-        const agentMetrics = event.value.usage_to_metrics.agent;
+      const usageToMetrics = event.value.usage_to_metrics;
+      if (usageToMetrics && Object.keys(usageToMetrics).length > 0) {
+        // Sum every usage bucket: switched-in LLMs ("profile:*"), ACP
+        // ("acp-managed") and the condenser accrue outside "agent".
+        const combined = combineUsageMetrics(usageToMetrics);
         const metrics = {
-          cost: agentMetrics.accumulated_cost,
-          max_budget_per_task: agentMetrics.max_budget_per_task ?? null,
-          usage: agentMetrics.accumulated_token_usage
+          cost: combined.accumulated_cost ?? 0,
+          max_budget_per_task: combined.max_budget_per_task,
+          usage: combined.accumulated_token_usage
             ? {
-                prompt_tokens:
-                  agentMetrics.accumulated_token_usage.prompt_tokens,
+                prompt_tokens: combined.accumulated_token_usage.prompt_tokens,
                 completion_tokens:
-                  agentMetrics.accumulated_token_usage.completion_tokens,
+                  combined.accumulated_token_usage.completion_tokens,
                 cache_read_tokens:
-                  agentMetrics.accumulated_token_usage.cache_read_tokens,
+                  combined.accumulated_token_usage.cache_read_tokens,
                 cache_write_tokens:
-                  agentMetrics.accumulated_token_usage.cache_write_tokens,
-                context_window:
-                  agentMetrics.accumulated_token_usage.context_window,
-                per_turn_token:
-                  agentMetrics.accumulated_token_usage.per_turn_token,
+                  combined.accumulated_token_usage.cache_write_tokens,
+                context_window: combined.accumulated_token_usage.context_window,
+                per_turn_token: combined.accumulated_token_usage.per_turn_token,
               }
             : null,
         };

--- a/frontend/src/types/v1/core/events/conversation-state-event.ts
+++ b/frontend/src/types/v1/core/events/conversation-state-event.ts
@@ -41,8 +41,9 @@ export interface LLMMetrics {
  * Usage metrics mapping for different components
  */
 export interface UsageToMetrics {
-  agent: LLMMetrics;
-  condenser: LLMMetrics;
+  // Keyed by usage id: "agent", "condenser", plus dynamic buckets such as
+  // "profile:<name>:<hash>" (switched-in LLMs) and "acp-managed".
+  [usageId: string]: LLMMetrics;
 }
 
 /**

--- a/frontend/src/utils/conversation-metrics.ts
+++ b/frontend/src/utils/conversation-metrics.ts
@@ -4,29 +4,34 @@ import type {
   V1TokenUsage,
 } from "#/api/conversation-service/v1-conversation-service.types";
 
+interface CombinableTokenUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  context_window: number;
+  per_turn_token: number;
+}
+
+interface CombinableMetrics {
+  accumulated_cost: number;
+  max_budget_per_task: number | null;
+  accumulated_token_usage?: CombinableTokenUsage | null;
+}
+
 /**
- * TypeScript equivalent of the get_combined_metrics method from the Python SDK
- * Combines metrics from all LLM usage IDs in the conversation stats
+ * Combines metrics across every usage bucket (agent, condenser, profile:*,
+ * acp-managed, ...). Reading a single bucket under-reports whenever spend
+ * accrues outside "agent".
  */
-export function getCombinedMetrics(
-  conversationInfo: V1RuntimeConversationInfo,
+export function combineUsageMetrics(
+  usageToMetrics: Record<string, CombinableMetrics>,
 ): V1MetricsSnapshot {
-  const { stats } = conversationInfo;
-
-  if (!stats?.usage_to_metrics) {
-    return {
-      accumulated_cost: 0,
-      max_budget_per_task: null,
-      accumulated_token_usage: null,
-    };
-  }
-
   let totalCost = 0;
   let maxBudgetPerTask: number | null = null;
   let combinedTokenUsage: V1TokenUsage | null = null;
 
-  // Iterate through all metrics and combine them
-  for (const metrics of Object.values(stats.usage_to_metrics)) {
+  for (const metrics of Object.values(usageToMetrics)) {
     // Add up costs
     totalCost += metrics.accumulated_cost;
 
@@ -68,4 +73,24 @@ export function getCombinedMetrics(
     max_budget_per_task: maxBudgetPerTask,
     accumulated_token_usage: combinedTokenUsage,
   };
+}
+
+/**
+ * TypeScript equivalent of the get_combined_metrics method from the Python SDK
+ * Combines metrics from all LLM usage IDs in the conversation stats
+ */
+export function getCombinedMetrics(
+  conversationInfo: V1RuntimeConversationInfo,
+): V1MetricsSnapshot {
+  const { stats } = conversationInfo;
+
+  if (!stats?.usage_to_metrics) {
+    return {
+      accumulated_cost: 0,
+      max_budget_per_task: null,
+      accumulated_token_usage: null,
+    };
+  }
+
+  return combineUsageMetrics(stats.usage_to_metrics);
 }


### PR DESCRIPTION
- [ ] A human has tested these changes.

HUMAN: Display-only companion to #15354/#15355. Closes #15358.

## Problem

The conversation metrics modal is correct when it fetches live runtime stats (sums every `usage_to_metrics` bucket), but the WebSocket stats-event fallback read only `usage_to_metrics.agent` — under-displaying cost/tokens for switched-in LLMs (`profile:*`), ACP (`acp-managed`), and the condenser.

## Changes

- Extract the bucket-combining loop from `getCombinedMetrics` into `combineUsageMetrics` and use it in the WebSocket fallback.
- Widen `UsageToMetrics` to its real shape (dynamic usage-id keys), which the old two-key type was hiding.

## Tests

- Unit tests for `combineUsageMetrics` (multi-bucket sum incl. `profile:*`/`acp-managed`, max-budget selection). Full frontend lint pipeline passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-3afb7fa   docker.openhands.dev/openhands/openhands:3afb7fa
```