### PR TITLE
fix: preserve custom OpenAI-compatible model aliases

### DIFF
--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -112,6 +112,7 @@ from openhands.app_server.utils.docker_utils import (
 )
 from openhands.app_server.utils.git import ensure_valid_git_branch_name
 from openhands.app_server.utils.import_utils import get_impl
+from openhands.app_server.utils.llm import normalize_llm_model_for_runtime
 from openhands.app_server.utils.llm_metadata import (
     get_llm_metadata,
     should_set_litellm_extra_body,
@@ -1252,11 +1253,16 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             user.agent_settings.llm.base_url,
             provider_base_url=self.openhands_provider_base_url,
         )
+        runtime_model, model_canonical_name = normalize_llm_model_for_runtime(
+            model, base_url
+        )
 
         return user.agent_settings.llm.model_copy(
             update={
-                'model': model,
+                'model': runtime_model,
                 'base_url': base_url,
+                'model_canonical_name': model_canonical_name
+                or user.agent_settings.llm.model_canonical_name,
                 'api_key': user.agent_settings.llm.api_key,
                 'usage_id': 'agent',
                 # Force streaming on (the SDK LLM defaults stream=False).

--- a/openhands/app_server/utils/llm.py
+++ b/openhands/app_server/utils/llm.py
@@ -1,4 +1,5 @@
 import warnings
+from urllib.parse import urlparse
 
 from pydantic import BaseModel
 
@@ -66,6 +67,9 @@ _BARE_ANTHROPIC_MODELS: set[str] = set(_SDK_ANTHROPIC)
 _BARE_MISTRAL_MODELS: set[str] = set(_SDK_MISTRAL)
 
 DEFAULT_OPENHANDS_MODEL = 'openhands/minimax-m2.7'
+_OPENAI_PREFIX = 'openai/'
+_LITELLM_PROXY_PREFIX = 'litellm_proxy/'
+_OPENAI_API_HOSTS = {'api.openai.com'}
 
 
 # ---------------------------------------------------------------------------
@@ -104,6 +108,49 @@ class ModelsResponse(BaseModel):
 def is_openhands_model(model: str | None) -> bool:
     """Return True when the model uses the public OpenHands provider prefix."""
     return bool(model and model.startswith('openhands/'))
+
+
+def _is_official_openai_base_url(base_url: str | None) -> bool:
+    if not base_url:
+        return False
+    try:
+        return (urlparse(base_url).hostname or '').lower() in _OPENAI_API_HOSTS
+    except ValueError:
+        return False
+
+
+def _is_known_openai_model(model: str) -> bool:
+    bare_model = model.removeprefix(_OPENAI_PREFIX)
+    return (
+        bare_model in litellm.open_ai_chat_completion_models
+        or bare_model in litellm.open_ai_text_completion_models
+        or bare_model in litellm.open_ai_embedding_models
+        or bare_model in litellm.openai_image_generation_models
+        or bare_model in litellm.openai_video_generation_models
+        or bare_model in litellm.model_cost
+        or bare_model in litellm.model_list
+    )
+
+
+def normalize_llm_model_for_runtime(
+    model: str, base_url: str | None
+) -> tuple[str, str | None]:
+    """Return the runtime model id and optional canonical model name.
+
+    Unknown ``openai/*`` aliases on custom OpenAI-compatible endpoints need the
+    full provider/model id in the request body. LiteLLM strips the ``openai/``
+    prefix when it routes through the direct OpenAI provider, so route only
+    those unknown custom aliases through ``litellm_proxy``. Known OpenAI models
+    keep the existing direct-provider behavior for compatibility.
+    """
+    if (
+        model.startswith(_OPENAI_PREFIX)
+        and base_url
+        and not _is_official_openai_base_url(base_url)
+        and not _is_known_openai_model(model)
+    ):
+        return f'{_LITELLM_PROXY_PREFIX}{model}', model
+    return model, None
 
 
 # Canonical masked placeholder for LLM API keys. Matches pydantic's

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -1007,6 +1007,44 @@ class TestLiveStatusAppConversationService:
         assert llm.base_url == 'https://user-llm.example.com'
 
     @pytest.mark.asyncio
+    async def test_configure_llm_and_mcp_preserves_unknown_openai_prefix_for_custom_base_url(
+        self,
+    ):
+        """Custom OpenAI-compatible aliases may need the full provider/model id.
+
+        LiteLLM strips ``openai/`` from the request body when it routes through
+        the direct OpenAI provider.  For unknown model aliases on a custom
+        OpenAI-compatible endpoint, route through ``litellm_proxy`` so the
+        gateway receives the exact model id the user configured.
+        """
+        self.mock_user.llm_base_url = 'http://192.0.2.10:8088/v1'
+        self.mock_user_context.get_mcp_api_key.return_value = None
+
+        llm, _ = await self.service._configure_llm_and_mcp(
+            self.mock_user, 'openai/hybrid-auto-router', self.conversation_id
+        )
+
+        assert llm.model == 'litellm_proxy/openai/hybrid-auto-router'
+        assert llm.model_canonical_name == 'openai/hybrid-auto-router'
+        assert llm.base_url == 'http://192.0.2.10:8088/v1'
+
+    @pytest.mark.asyncio
+    async def test_configure_llm_and_mcp_keeps_known_openai_model_with_custom_base_url(
+        self,
+    ):
+        """Known OpenAI model names keep the existing direct-provider routing."""
+        self.mock_user.llm_base_url = 'https://custom-openai.example.com/v1'
+        self.mock_user_context.get_mcp_api_key.return_value = None
+
+        llm, _ = await self.service._configure_llm_and_mcp(
+            self.mock_user, 'openai/gpt-4o', self.conversation_id
+        )
+
+        assert llm.model == 'openai/gpt-4o'
+        assert llm.model_canonical_name is None
+        assert llm.base_url == 'https://custom-openai.example.com/v1'
+
+    @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_non_openhands_model_ignores_provider(self):
         """Non-openhands model ignores provider base URL and uses user base URL."""
         # Arrange


### PR DESCRIPTION
HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

OpenAI-compatible gateways can require the full configured model id in the request body. For unknown custom aliases such as `openai/hybrid-auto-router`, LiteLLM direct OpenAI routing strips the `openai/` prefix before sending the request, while some gateways route on the full provider/model string.

Fixes OpenHands/software-agent-sdk#4272

## Summary

- Route unknown `openai/*` aliases with custom non-OpenAI base URLs through `litellm_proxy/` at conversation runtime.
- Preserve `model_canonical_name` for capability lookups while leaving saved user settings unchanged.
- Keep known OpenAI models such as `openai/gpt-4o` on the existing direct-provider path for compatibility.

## How to Test

- `poetry run pytest tests/unit/app_server/test_live_status_app_conversation_service.py::TestLiveStatusAppConversationService::test_configure_llm_and_mcp_preserves_unknown_openai_prefix_for_custom_base_url tests/unit/app_server/test_live_status_app_conversation_service.py::TestLiveStatusAppConversationService::test_configure_llm_and_mcp_keeps_known_openai_model_with_custom_base_url -q`
- `poetry run pytest tests/unit/app_server/test_live_status_app_conversation_service.py -q`
- `poetry run pytest tests/unit/utils/test_environment.py tests/unit/app_server/test_resolve_provider_llm_base_url.py -q`
- `poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files openhands/app_server/utils/llm.py openhands/app_server/app_conversation/live_status_app_conversation_service.py tests/unit/app_server/test_live_status_app_conversation_service.py`

## Video/Screenshots

N/A, backend LLM routing fix covered by unit tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
