### PR TITLE
fix: rewrite vscode reverse proxy port

### DIFF
--- a/frontend/__tests__/utils/vscode-url-helper.test.ts
+++ b/frontend/__tests__/utils/vscode-url-helper.test.ts
@@ -9,6 +9,7 @@ describe("transformVSCodeUrl", () => {
     Object.defineProperty(window, "location", {
       value: {
         hostname: "example.com",
+        port: "8081",
       },
       writable: true,
     });
@@ -28,7 +29,16 @@ describe("transformVSCodeUrl", () => {
 
   it("should replace localhost with current hostname when they differ", () => {
     const input = "http://localhost:8080/?tkn=abc123&folder=/workspace";
-    const expected = "http://example.com:8080/?tkn=abc123&folder=/workspace";
+    const expected = "http://example.com:8081/?tkn=abc123&folder=/workspace";
+
+    expect(transformVSCodeUrl(input)).toBe(expected);
+  });
+
+  it("should route localhost VS Code URLs through the reverse proxy port", () => {
+    const input =
+      "http://localhost:8001/?tkn=abc123&folder=/workspace/project";
+    const expected =
+      "http://example.com:8081/?tkn=abc123&folder=/workspace/project";
 
     expect(transformVSCodeUrl(input)).toBe(expected);
   });
@@ -44,6 +54,7 @@ describe("transformVSCodeUrl", () => {
     Object.defineProperty(window, "location", {
       value: {
         hostname: "localhost",
+        port: "8081",
       },
       writable: true,
     });

--- a/frontend/src/utils/vscode-url-helper.ts
+++ b/frontend/src/utils/vscode-url-helper.ts
@@ -2,10 +2,10 @@
  * Helper function to transform VS Code URLs
  *
  * This function checks if a VS Code URL points to localhost and replaces it with
- * the current window's hostname if they don't match.
+ * the current window's hostname and port if they don't match.
  *
  * @param vsCodeUrl The original VS Code URL from the backend
- * @returns The transformed URL with the correct hostname
+ * @returns The transformed URL with the correct hostname and port
  */
 export function transformVSCodeUrl(vsCodeUrl: string | null): string | null {
   if (!vsCodeUrl) return null;
@@ -18,8 +18,9 @@ export function transformVSCodeUrl(vsCodeUrl: string | null): string | null {
       url.hostname === "localhost" &&
       window.location.hostname !== "localhost"
     ) {
-      // Replace localhost with the current hostname
+      // Replace localhost with the current host exposed to the browser.
       url.hostname = window.location.hostname;
+      url.port = window.location.port;
       return url.toString();
     }
 


### PR DESCRIPTION
HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

VS Code URLs returned from localhost-backed sandbox services need to route through the browser-visible reverse proxy host and port. Rewriting only the hostname leaves the internal VS Code port in the URL, which can fail behind nginx or similar proxies.

## Summary

- Rewrite localhost VS Code URLs to use both `window.location.hostname` and `window.location.port`.
- Add a regression test covering reverse proxy port replacement.

## Issue Number

Fixes #15347

## How to Test

- `cd frontend && npm run test -- __tests__/utils/vscode-url-helper.test.ts`
- `cd frontend && npm run lint:fix && npm run build`

## Video/Screenshots

Not applicable; this is a URL transformation helper fix covered by unit tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No migrations or configuration changes.
