### PR TITLE
feat(settings): support title generation profile preference

### DIFF
--- a/enterprise/migrations/versions/139_add_title_llm_profile_to_org_member.py
+++ b/enterprise/migrations/versions/139_add_title_llm_profile_to_org_member.py
@@ -1,0 +1,22 @@
+"""Add title LLM profile preference to organization members."""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '139'
+down_revision: Union[str, None] = '138'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'org_member',
+        sa.Column('title_llm_profile', sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('org_member', 'title_llm_profile')

--- a/enterprise/server/routes/org_profiles.py
+++ b/enterprise/server/routes/org_profiles.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path, status
 from pydantic import BaseModel, Field, ValidationError
 from server.constants import LITE_LLM_API_URL
 from server.routes.org_models import OrgNotFoundError
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from storage.agent_profile_resolution import (
     OrgLLMProfileMutator,
@@ -279,7 +279,7 @@ async def delete_profile(
     makes the referrer check and the delete atomic.
     """
     async with _org_profiles_transaction(org_id, user_id) as (
-        _session,
+        session,
         org,
         profiles,
     ):
@@ -295,6 +295,14 @@ async def delete_profile(
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT, detail=str(exc)
             ) from exc
+        await session.execute(
+            update(OrgMember)
+            .where(
+                OrgMember.org_id == org_id,
+                OrgMember.title_llm_profile == name,
+            )
+            .values(title_llm_profile=None)
+        )
 
     return ProfileMutationResponse(name=name, message=f"Profile '{name}' deleted")
 
@@ -405,7 +413,7 @@ async def rename_profile(
     written back in the same transaction.
     """
     async with _org_profiles_transaction(org_id, user_id) as (
-        _session,
+        session,
         org,
         profiles,
     ):
@@ -441,6 +449,14 @@ async def rename_profile(
         after = agent_profiles.model_dump(mode='json', context={'expose_secrets': True})
         if after != before:
             org.agent_profiles = after
+        await session.execute(
+            update(OrgMember)
+            .where(
+                OrgMember.org_id == org_id,
+                OrgMember.title_llm_profile == name,
+            )
+            .values(title_llm_profile=request.new_name)
+        )
 
     return ProfileMutationResponse(
         name=request.new_name,

--- a/enterprise/storage/org_member.py
+++ b/enterprise/storage/org_member.py
@@ -39,6 +39,7 @@ class OrgMember(Base):
     # precedent). NULL falls back to the org default (org.agent_profiles.active)
     # and, pre-migration, to the legacy active-LLM-profile materialization.
     active_agent_profile_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    title_llm_profile: Mapped[str | None] = mapped_column(String, nullable=True)
     conversation_settings_diff: Mapped[dict[str, Any]] = mapped_column(
         JSON, nullable=False, default=dict
     )

--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -366,6 +366,7 @@ class SaasSettingsStore(SettingsStore):
                 if (normalized := c.name.lstrip('_')) in Settings.model_fields
             },
         }
+        kwargs['title_llm_profile'] = org_member.title_llm_profile
         # Drop member-private keys from the org dump before merging so
         # legacy org-level values (older code paths broadcast mcp_config)
         # can no longer leak one member's private config to another. Each
@@ -731,6 +732,7 @@ class SaasSettingsStore(SettingsStore):
             for private_key in MEMBER_PRIVATE_AGENT_KEYS:
                 member_agent_settings_diff.pop(private_key, None)
             org_member.agent_settings_diff = member_agent_settings_diff
+            org_member.title_llm_profile = item.title_llm_profile
             if item._mcp_config_updated:
                 org_member.mcp_config = self._get_persisted_mcp_config(item)
             elif org_member.mcp_config is None and member_mcp_config is not None:

--- a/enterprise/tests/unit/test_agent_profiles.py
+++ b/enterprise/tests/unit/test_agent_profiles.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import FastAPI, HTTPException, status
 from fastapi.testclient import TestClient
-from sqlalchemy import select
+from sqlalchemy import select, update
 from storage.org import Org
 from storage.org_member import OrgMember
 from storage.role import Role
@@ -537,7 +537,32 @@ async def _set_agent_profiles(async_session_maker, org_id, agent_profiles):
         await session.commit()
 
 
+async def _set_title_llm_profile(async_session_maker, org_id, name):
+    async with async_session_maker() as session:
+        await session.execute(
+            update(OrgMember)
+            .where(
+                OrgMember.org_id == org_id,
+                OrgMember.user_id == USER_ID,
+            )
+            .values(title_llm_profile=name)
+        )
+        await session.commit()
+
+
 class TestLLMProfileFKGuard:
+    @pytest.mark.asyncio
+    async def test_delete_clears_member_title_profile_pointer(
+        self, async_session_maker, patch_org_profile_routes
+    ):
+        org_id = patch_org_profile_routes
+        await _set_title_llm_profile(async_session_maker, org_id, 'Default')
+
+        await delete_profile(org_id=org_id, name='Default', user_id=str(USER_ID))
+
+        member = await _read_member(async_session_maker, org_id, USER_ID)
+        assert member.title_llm_profile is None
+
     @pytest.mark.asyncio
     async def test_delete_blocked_by_referencing_agent_profile(
         self, async_session_maker, patch_org_profile_routes
@@ -565,6 +590,7 @@ class TestLLMProfileFKGuard:
             ap, OpenHandsAgentProfile(name='reviewer', llm_profile_ref='Default')
         )
         await _set_agent_profiles(async_session_maker, org_id, ap)
+        await _set_title_llm_profile(async_session_maker, org_id, 'Default')
 
         await rename_profile(
             org_id=org_id,
@@ -582,6 +608,8 @@ class TestLLMProfileFKGuard:
             reloaded = load_agent_profiles(org)
             assert reloaded.load('reviewer').llm_profile_ref == 'Default-v2'
             assert 'Default-v2' in (org.llm_profiles or {}).get('profiles', {})
+        member = await _read_member(async_session_maker, org_id, USER_ID)
+        assert member.title_llm_profile == 'Default-v2'
 
 
 # ── SaasSettingsStore resolution + provenance ──────────────────────────────

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -62,6 +62,51 @@ def _make_settings(
     return s
 
 
+@pytest.mark.asyncio
+async def test_title_llm_profile_is_scoped_to_org_membership(
+    session_maker, async_session_maker, org_with_multiple_members_fixture
+):
+    from sqlalchemy import select
+    from storage.org_member import OrgMember
+
+    fixture = org_with_multiple_members_fixture
+    admin_user_id = fixture['admin_user_id']
+    member_user_id = fixture['member1_user_id']
+    org_id = fixture['org_id']
+    settings = _make_settings(
+        model='openai/gpt-4o',
+        base_url='https://api.openai.com/v1',
+        api_key='test-key',
+    )
+    settings.title_llm_profile = 'Titles'
+
+    with patch('storage.saas_settings_store.a_session_maker', async_session_maker):
+        await SaasSettingsStore(str(admin_user_id)).store(settings)
+
+    with session_maker() as session:
+        members = {
+            member.user_id: member.title_llm_profile
+            for member in session.execute(
+                select(OrgMember).where(OrgMember.org_id == org_id)
+            )
+            .scalars()
+            .all()
+        }
+
+    assert members[admin_user_id] == 'Titles'
+    assert members[member_user_id] is None
+
+    with (
+        patch('storage.saas_settings_store.a_session_maker', async_session_maker),
+        patch('storage.user_store.a_session_maker', async_session_maker),
+        patch('storage.org_store.a_session_maker', async_session_maker),
+    ):
+        loaded = await SaasSettingsStore(str(admin_user_id)).load()
+
+    assert loaded is not None
+    assert loaded.title_llm_profile == 'Titles'
+
+
 # Mock the database module before importing
 with patch('storage.database.a_session_maker'):
     from server.constants import (

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -153,6 +153,21 @@ _logger = logging.getLogger(__name__)
 _EXPORT_LOCK_KEY_PREFIX = 'app_conversation_export'
 
 
+def _resolve_title_llm_profile(user: UserInfo) -> str | None:
+    preference = getattr(user, 'title_llm_profile', None)
+    if (
+        preference
+        and PROFILE_NAME_REGEX.match(preference)
+        and user.llm_profiles.has(preference)
+    ):
+        return preference
+
+    active = user.llm_profiles.active
+    if active and PROFILE_NAME_REGEX.match(active) and user.llm_profiles.has(active):
+        return active
+    return None
+
+
 class _StreamingZipBuffer(io.RawIOBase):
     """Small non-seekable writer used by zipfile to emit chunks incrementally.
 
@@ -2156,6 +2171,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             observability_metadata, resolved_observability_metadata
         )
         create_kwargs: dict[str, Any] = {'agent': agent, 'user_id': laminar_user_id}
+        title_llm_profile = _resolve_title_llm_profile(user)
+        if title_llm_profile:
+            create_kwargs['title_llm_profile'] = title_llm_profile
         if observability_metadata:
             create_kwargs['observability_metadata'] = observability_metadata
         if observability_tags:
@@ -2428,6 +2446,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             'user_id': laminar_user_id,
             'secrets': secrets,
         }
+        title_llm_profile = _resolve_title_llm_profile(user)
+        if title_llm_profile:
+            create_kwargs['title_llm_profile'] = title_llm_profile
         if observability_metadata:
             create_kwargs['observability_metadata'] = observability_metadata
         if observability_tags:

--- a/openhands/app_server/settings/settings_models.py
+++ b/openhands/app_server/settings/settings_models.py
@@ -685,6 +685,7 @@ class Settings(BaseModel):
     email_verified: bool | None = None
     git_user_name: str | None = None
     git_user_email: str | None = None
+    title_llm_profile: str | None = None
     git_full_clone: bool = False
     v1_enabled: bool = True
     agent_settings: AgentSettingsConfig = Field(default_factory=default_agent_settings)
@@ -968,6 +969,8 @@ class Settings(BaseModel):
         was_active = self.llm_profiles.active == name
         if not self.llm_profiles.delete(name):
             return False
+        if self.title_llm_profile == name:
+            self.title_llm_profile = None
         if was_active and self.llm_profiles.profiles:
             fallback = next(iter(self.llm_profiles.profiles))
             self.switch_to_profile(fallback)

--- a/openhands/app_server/settings/settings_router.py
+++ b/openhands/app_server/settings/settings_router.py
@@ -686,6 +686,8 @@ async def rename_profile(
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT, detail=str(exc)
             ) from exc
+        if settings.title_llm_profile == name:
+            settings.title_llm_profile = request.new_name
         await settings_store.store(settings)
 
     return ProfileMutationResponse(

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -32,6 +32,7 @@ from openhands.app_server.app_conversation.app_conversation_service import (
 )
 from openhands.app_server.app_conversation.live_status_app_conversation_service import (
     LiveStatusAppConversationService,
+    _resolve_title_llm_profile,
     effective_disabled_skills,
 )
 from openhands.app_server.integrations.provider import ProviderToken, ProviderType
@@ -211,6 +212,37 @@ def allow_short_context_windows():
             os.environ[_ALLOW_SHORT_CONTEXT_WINDOWS] = old
         else:
             os.environ.pop(_ALLOW_SHORT_CONTEXT_WINDOWS, None)
+
+
+def test_title_profile_resolution_prefers_available_explicit_profile():
+    profiles = LLMProfiles()
+    profiles.save('Default', LLM(model='openai/gpt-4o'))
+    profiles.save('Titles', LLM(model='anthropic/claude-haiku-3-5'))
+    profiles.active = 'Default'
+    user = _TestUserInfo(title_llm_profile='Titles')
+    user.llm_profiles = profiles
+
+    assert _resolve_title_llm_profile(user) == 'Titles'
+
+
+def test_title_profile_resolution_falls_back_to_available_active_profile():
+    profiles = LLMProfiles()
+    profiles.save('Default', LLM(model='openai/gpt-4o'))
+    profiles.active = 'Default'
+    user = _TestUserInfo(title_llm_profile='Deleted')
+    user.llm_profiles = profiles
+
+    assert _resolve_title_llm_profile(user) == 'Default'
+
+
+def test_title_profile_resolution_omits_unseedable_profiles():
+    profiles = LLMProfiles()
+    profiles.save('../unsafe', LLM(model='openai/gpt-4o'))
+    profiles.active = '../unsafe'
+    user = _TestUserInfo(title_llm_profile='../unsafe')
+    user.llm_profiles = profiles
+
+    assert _resolve_title_llm_profile(user) is None
 
 
 class TestLiveStatusAppConversationService:
@@ -1174,6 +1206,39 @@ class TestLiveStatusAppConversationService:
         assert isinstance(result, StartConversationRequest)
         assert result.conversation_id == conversation_id
         self.service._load_skills_and_update_agent.assert_called_once()
+
+    @patch(
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.get_default_tools',
+        return_value=[],
+    )
+    @pytest.mark.asyncio
+    async def test_build_request_passes_title_llm_profile(self, _mock_tools):
+        profiles = LLMProfiles()
+        profiles.save('Titles', LLM(model='anthropic/claude-haiku-3-5'))
+        self.mock_user.llm_profiles = profiles
+        self.mock_user.title_llm_profile = 'Titles'
+        self.mock_user_context.get_user_info.return_value = self.mock_user
+
+        real_llm = LLM(model='gpt-4', api_key=SecretStr('test-key'))
+        mock_agent = Mock(spec=Agent)
+        mock_agent.llm = real_llm
+        mock_agent.condenser = None
+        self.service._setup_secrets_for_git_providers = AsyncMock(return_value={})
+        self.service._configure_llm_and_mcp = AsyncMock(return_value=(real_llm, {}))
+        self.service._load_skills_and_update_agent = AsyncMock(return_value=mock_agent)
+
+        request = await self.service._build_start_conversation_request_for_user(
+            sandbox=self.mock_sandbox,
+            conversation_id=uuid4(),
+            initial_message=None,
+            system_message_suffix=None,
+            git_provider=None,
+            working_dir='/test/dir',
+            remote_workspace=Mock(spec=AsyncRemoteWorkspace),
+            selected_repository='test_repo',
+        )
+
+        assert request.title_llm_profile == 'Titles'
 
     @patch(
         'openhands.app_server.app_conversation.live_status_app_conversation_service.get_default_tools',
@@ -4270,6 +4335,18 @@ class TestBuildAcpStartConversationRequestSecrets:
         assert request.secrets.get('MY_API_KEY') is api_secret
         # Isolation is enabled regardless of whether secrets are present.
         assert request.agent.acp_isolate_data_dir is True
+
+    @pytest.mark.asyncio
+    async def test_acp_request_passes_title_llm_profile(self, service, tmp_path):
+        user = self._make_acp_user()
+        profiles = LLMProfiles()
+        profiles.save('Titles', LLM(model='anthropic/claude-haiku-3-5'))
+        user.llm_profiles = profiles
+        user.title_llm_profile = 'Titles'
+
+        request = await self._call_build(service, user, tmp_path)
+
+        assert request.title_llm_profile == 'Titles'
 
     @pytest.mark.asyncio
     async def test_lookup_secret_forwarded_as_source(self, service, tmp_path):

--- a/tests/unit/app_server/test_profiles_api.py
+++ b/tests/unit/app_server/test_profiles_api.py
@@ -618,6 +618,7 @@ async def test_save_profile_rejects_unknown_llm_field(test_client, settings_stor
 async def test_delete_profile_removes_it(test_client, settings_store):
     settings = _base_settings()
     settings.llm_profiles.save('p', LLM(model='openai/gpt-4o'))
+    settings.title_llm_profile = 'p'
     await _seed(settings_store, settings)
 
     response = test_client.delete('/api/v1/settings/profiles/p')
@@ -625,6 +626,7 @@ async def test_delete_profile_removes_it(test_client, settings_store):
     assert response.status_code == 200
     stored = await settings_store.load()
     assert not stored.llm_profiles.has('p')
+    assert stored.title_llm_profile is None
 
 
 @pytest.mark.asyncio
@@ -726,6 +728,7 @@ async def test_rename_profile_renames_and_preserves_api_key(
         'old',
         LLM(model='openai/gpt-4o', api_key=SecretStr('sk-keep')),
     )
+    settings.title_llm_profile = 'old'
     await _seed(settings_store, settings)
 
     response = test_client.post(
@@ -742,6 +745,7 @@ async def test_rename_profile_renames_and_preserves_api_key(
     renamed = stored.llm_profiles.get('new')
     assert renamed is not None
     assert renamed.api_key.get_secret_value() == 'sk-keep'
+    assert stored.title_llm_profile == 'new'
 
 
 @pytest.mark.asyncio

--- a/tests/unit/storage/data_models/test_settings.py
+++ b/tests/unit/storage/data_models/test_settings.py
@@ -808,6 +808,7 @@ def test_settings_update_batch():
     settings.update(
         {
             'language': 'fr',
+            'title_llm_profile': 'Titles',
             'agent_settings_diff': {
                 'agent': 'TestAgent',
                 'llm': {'model': 'new-model', 'api_key': 'new-key'},
@@ -818,6 +819,7 @@ def test_settings_update_batch():
         }
     )
     assert settings.language == 'fr'
+    assert settings.title_llm_profile == 'Titles'
     assert settings.agent_settings.agent == 'TestAgent'
     assert settings.agent_settings.llm.model == 'new-model'
     assert settings.agent_settings.llm.api_key.get_secret_value() == 'new-key'
@@ -923,7 +925,7 @@ def test_delete_inactive_profile_does_not_touch_active():
 
 
 def test_delete_only_profile_clears_active():
-    settings = Settings()
+    settings = Settings(title_llm_profile='only')
     settings.llm_profiles.save('only', LLM(model='openai/gpt-4o'))
     settings.switch_to_profile('only')
 
@@ -931,6 +933,7 @@ def test_delete_only_profile_clears_active():
 
     assert settings.llm_profiles.profiles == {}
     assert settings.llm_profiles.active is None
+    assert settings.title_llm_profile is None
 
 
 def test_delete_missing_profile_returns_false():


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

Automated backend verification is complete. Simon is testing the companion Canvas UX locally; live SaaS and enterprise deployment validation is still pending.

- [x] A human has tested these changes.

AGENT:

Implemented and verified by Codex.

---

## Why

Title generation currently falls back to the conversation agent's LLM. That couples a lightweight app-level task to the agent configuration and can silently fall back to message truncation when the agent LLM is unavailable.

## Summary

- Persist a title-generation LLM profile as a global user preference, scoped to the active organization membership in SaaS.
- Resolve the explicit preference, then the active/default profile, for both OpenHands and ACP conversation starts.
- Keep profile rename/delete lifecycle atomic and add the enterprise migration and regression coverage.

## Issue Number

Tracks OpenHands/software-agent-sdk#4199.

## How to Test

The following commands pass:

- `pre-commit run --config ./dev_config/python/.pre-commit-config.yaml`
- `uv run pytest -q tests/unit/storage/data_models/test_settings.py tests/unit/app_server/test_profiles_api.py tests/unit/app_server/test_live_status_app_conversation_service.py`
- `cd enterprise && poetry run pytest -q tests/unit/test_saas_settings_store.py tests/unit/test_agent_profiles.py`

The request-construction tests exercise both regular OpenHands and ACP conversation starts. The storage tests exercise personal and organization profile selection, rename, delete, stale-profile fallback, and per-membership scoping.

A live SaaS deployment was not available for manual end-to-end validation.

## Video/Screenshots

Not applicable to this server-side storage and conversation-start change.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Adds enterprise migration `140_add_title_llm_profile_to_org_member`.
- The existing SDK request field is reused; no SDK change is required.
- Companion Canvas PR: OpenHands/agent-canvas#1910.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-60281e5   docker.openhands.dev/openhands/openhands:60281e5
```