### PR TITLE
fix: decrypt stored LLM profile keys

### DIFF
--- a/enterprise/server/routes/org_profiles.py
+++ b/enterprise/server/routes/org_profiles.py
@@ -15,7 +15,7 @@ from typing import Any, AsyncIterator
 from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, status
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field
 from server.constants import LITE_LLM_API_URL
 from server.routes.org_models import OrgNotFoundError
 from sqlalchemy import select
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from storage.agent_profile_resolution import (
     OrgLLMProfileMutator,
     load_agent_profiles,
+    load_llm_profiles,
 )
 from storage.database import a_session_maker
 from storage.org import Org
@@ -40,7 +41,6 @@ from openhands.app_server.settings.settings_models import (
     _load_persisted_agent_settings,
 )
 from openhands.app_server.utils.llm import MASKED_API_KEY, is_openhands_model
-from openhands.app_server.utils.logger import openhands_logger as logger
 from openhands.sdk.llm import LLM
 from openhands.sdk.profiles import (
     ProfileReferenced,
@@ -128,16 +128,7 @@ class RenameProfileRequest(BaseModel):
 
 def _load_profiles(org: Org) -> LLMProfiles:
     """Load LLMProfiles from org row, defaulting to empty if not set."""
-    if org.llm_profiles is None:
-        return LLMProfiles()
-    try:
-        return LLMProfiles.model_validate(org.llm_profiles)
-    except ValidationError as exc:
-        # Schema drift / partially-invalid stored profiles: degrade to empty
-        # rather than 500-ing. Other exceptions (DB decrypt failures, etc.)
-        # bubble up so they're surfaced instead of silently masked.
-        logger.warning('Failed to load org profiles for %s: %s', org.id, exc)
-        return LLMProfiles()
+    return load_llm_profiles(org)
 
 
 async def _get_org(org_id: UUID, user_id: str) -> Org:

--- a/enterprise/storage/agent_profile_resolution.py
+++ b/enterprise/storage/agent_profile_resolution.py
@@ -12,9 +12,11 @@ Used by the ``/api/agent-profiles`` router, the LLM-profile FK guard in
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any
 
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
+from storage.encrypt_utils import decrypt_value
 
 from openhands.app_server.settings.agent_profiles import AgentProfiles
 from openhands.app_server.settings.llm_profiles import LLMProfiles
@@ -49,10 +51,52 @@ def load_llm_profiles(org: Org) -> LLMProfiles:
     if org.llm_profiles is None:
         return LLMProfiles()
     try:
-        return LLMProfiles.model_validate(org.llm_profiles)
+        return LLMProfiles.model_validate(
+            _decrypt_nested_llm_profile_api_keys(org.llm_profiles)
+        )
     except ValidationError as exc:
         logger.warning('Failed to load org LLM profiles for %s: %s', org.id, exc)
         return LLMProfiles()
+
+
+def _decrypt_nested_llm_profile_api_keys(raw: Any) -> Any:
+    """Decrypt legacy per-profile ``api_key`` leaves inside ``llm_profiles``.
+
+    Newer org rows are encrypted at the JSON-column boundary, but older saves
+    may still contain Fernet/JWE-encrypted strings under
+    ``profiles.<name>.api_key``. The resolver needs cleartext at load time,
+    while plain keys and masked/empty values must pass through unchanged.
+    """
+    if not isinstance(raw, dict):
+        return raw
+
+    normalized = deepcopy(raw)
+    profiles = normalized.get('profiles')
+    if not isinstance(profiles, dict):
+        return normalized
+
+    for profile in profiles.values():
+        if not isinstance(profile, dict) or profile.get('api_key') is None:
+            continue
+        api_key = profile['api_key']
+        if not _looks_like_encrypted_value(api_key):
+            continue
+        try:
+            profile['api_key'] = decrypt_value(api_key)
+        except Exception:
+            # Malformed legacy encrypted leaves should not brick profile load.
+            # Keep them intact and let model validation handle the rest without
+            # logging secret material.
+            profile['api_key'] = api_key
+
+    return normalized
+
+
+def _looks_like_encrypted_value(value: Any) -> bool:
+    raw = value.get_secret_value() if isinstance(value, SecretStr) else value
+    if not isinstance(raw, str) or not raw:
+        return False
+    return raw.startswith('gAAAA') or raw.count('.') == 4
 
 
 class OrgLLMProfileLoader:

--- a/enterprise/tests/unit/test_agent_profiles.py
+++ b/enterprise/tests/unit/test_agent_profiles.py
@@ -54,6 +54,7 @@ with patch('storage.database.a_session_maker'):
     )
     from storage.agent_profile_resolution import (
         load_agent_profiles,
+        load_llm_profiles,
         member_mcp_config,
     )
 
@@ -150,6 +151,58 @@ def test_load_agent_profiles_defaults_empty_and_degrades():
     # Garbage envelope degrades to empty rather than raising.
     org.agent_profiles = {'profiles': 'not-a-dict'}
     assert load_agent_profiles(org).list_summaries() == []
+
+
+def test_load_llm_profiles_decrypts_nested_legacy_api_keys():
+    org = MagicMock(spec=Org)
+    org.id = ORG_ID
+    org.llm_profiles = {
+        'profiles': {
+            'Default': {
+                'model': 'gpt-4o',
+                'api_key': 'gAAAA-encrypted-profile-key',
+            }
+        },
+        'active': 'Default',
+    }
+
+    with patch(
+        'storage.agent_profile_resolution.decrypt_value',
+        return_value='sk-decrypted-profile-key',
+        create=True,
+    ):
+        loaded = load_llm_profiles(org)
+
+    assert (
+        loaded.require('Default').api_key.get_secret_value()
+        == 'sk-decrypted-profile-key'
+    )
+
+
+def test_load_llm_profiles_keeps_plain_api_keys_when_decrypt_fails():
+    org = MagicMock(spec=Org)
+    org.id = ORG_ID
+    org.llm_profiles = {
+        'profiles': {
+            'Default': {
+                'model': 'gpt-4o',
+                'api_key': 'sk-plain-profile-key',
+            }
+        },
+        'active': 'Default',
+    }
+
+    with patch(
+        'storage.agent_profile_resolution.decrypt_value',
+        side_effect=ValueError('not encrypted'),
+        create=True,
+    ) as decrypt_value:
+        loaded = load_llm_profiles(org)
+
+    assert (
+        loaded.require('Default').api_key.get_secret_value() == 'sk-plain-profile-key'
+    )
+    decrypt_value.assert_not_called()
 
 
 def test_member_mcp_config_degrades_on_non_validation_error():
@@ -663,6 +716,33 @@ class TestResolveActiveAgentProfile:
         assert dump['agent_kind'] == 'openhands'
         # The resolved LLM came from the referenced org LLM profile.
         assert dump['llm']['model'] == 'gpt-4o'
+
+    def test_resolves_profile_with_legacy_encrypted_llm_api_key(self):
+        store = self._store()
+        org, pid = self._org_with(
+            OpenHandsAgentProfile(name='reviewer', llm_profile_ref='Default')
+        )
+        org.llm_profiles = {
+            'profiles': {
+                'Default': {
+                    'model': 'gpt-4o',
+                    'api_key': 'gAAAA-encrypted-profile-key',
+                }
+            },
+            'active': 'Default',
+        }
+        member = MagicMock(spec=OrgMember)
+        member.active_agent_profile_id = pid
+
+        with patch(
+            'storage.agent_profile_resolution.decrypt_value',
+            return_value='sk-decrypted-profile-key',
+        ):
+            result = store._resolve_active_agent_profile(org, member, {}, None)
+
+        assert result is not None
+        dump, _resolved_id, _revision = result
+        assert dump['llm']['api_key'] == 'sk-decrypted-profile-key'
 
     def test_resolve_canonicalizes_legacy_litellm_proxy_llm(self):
         """A profile referencing an org LLM profile with a legacy

--- a/enterprise/tests/unit/test_org_profiles.py
+++ b/enterprise/tests/unit/test_org_profiles.py
@@ -84,6 +84,29 @@ class TestLoadProfiles:
         assert 'my-profile' in names
         assert 'backup' in names
 
+    def test_load_profiles_decrypts_nested_legacy_api_keys(self, sample_org):
+        """Test loading profiles decrypts older per-profile encrypted keys."""
+        sample_org.llm_profiles = {
+            'profiles': {
+                'Default': {
+                    'model': 'gpt-4o',
+                    'api_key': 'gAAAA-encrypted-profile-key',
+                }
+            },
+            'active': 'Default',
+        }
+
+        with patch(
+            'storage.agent_profile_resolution.decrypt_value',
+            return_value='sk-decrypted-profile-key',
+        ):
+            profiles = _load_profiles(sample_org)
+
+        assert (
+            profiles.require('Default').api_key.get_secret_value()
+            == 'sk-decrypted-profile-key'
+        )
+
     def test_load_profiles_invalid_data(self, sample_org):
         """Test loading profiles when org has invalid data."""
         sample_org.llm_profiles = {'invalid': 'data'}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

LLM profiles saved through older encryption paths can contain encrypted per-profile API keys under `org.llm_profiles`. When an agent profile references one, that encrypted leaf can be passed through to LiteLLM during sub-agent calls.

## Summary

- Decrypt legacy Fernet/JWE-looking `llm_profiles.profiles[*].api_key` values at the shared org LLM profile load boundary.
- Reuse the shared org LLM profile loader in the org profile routes so UI readback and agent profile resolution use the same compatibility path.
- Add regression coverage for direct loading, active agent profile resolution, and the org profile route helper.

## Issue Number

Fixes OpenHands/software-agent-sdk#4270

## How to Test

- `PYTHONPATH=enterprise poetry run --project=enterprise pytest enterprise/tests/unit/test_agent_profiles.py enterprise/tests/unit/test_org_profiles.py -q`
- `poetry run ruff check --config enterprise/dev_config/python/ruff.toml --fix enterprise/storage/agent_profile_resolution.py enterprise/server/routes/org_profiles.py enterprise/tests/unit/test_agent_profiles.py enterprise/tests/unit/test_org_profiles.py`
- `poetry run ruff format --config enterprise/dev_config/python/ruff.toml enterprise/storage/agent_profile_resolution.py enterprise/server/routes/org_profiles.py enterprise/tests/unit/test_agent_profiles.py enterprise/tests/unit/test_org_profiles.py`
- `MYPYPATH=enterprise poetry run mypy --config-file enterprise/dev_config/python/mypy.ini -p storage`
- `MYPYPATH=enterprise poetry run mypy --config-file enterprise/dev_config/python/mypy.ini -m server.routes.org_profiles`
- `poetry run python -m py_compile enterprise/storage/agent_profile_resolution.py enterprise/server/routes/org_profiles.py enterprise/tests/unit/test_agent_profiles.py enterprise/tests/unit/test_org_profiles.py`

The full enterprise pre-commit command was attempted, but hook environment initialization repeatedly timed out while fetching `pre-commit/mirrors-mypy` from GitHub. The installed commit hook ran during commit and passed its checks, including mypy.

## Video/Screenshots

N/A - backend storage compatibility fix covered by unit tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This only decrypts values that look like legacy Fernet (`gAAAA...`) or compact JWE tokens. Plain API keys and masked values remain unchanged.
