### PR TITLE
fix: require web host for self-hosted deployments

### DIFF
--- a/enterprise/server/constants.py
+++ b/enterprise/server/constants.py
@@ -1,8 +1,18 @@
 import os
 import re
 
+DEFAULT_WEB_HOST = 'app.all-hands.dev'
+_WEB_HOST_ENV = os.getenv('WEB_HOST')
+
+
 # Get the host from environment variable
-HOST = os.getenv('WEB_HOST', 'app.all-hands.dev').strip()
+def _get_web_host() -> str:
+    if _WEB_HOST_ENV is None:
+        return DEFAULT_WEB_HOST
+    return _WEB_HOST_ENV.strip()
+
+
+HOST = _get_web_host()
 
 # Check if this is a feature environment
 # Feature environments have a host format like {some-text}.staging.all-hands.dev
@@ -55,6 +65,17 @@ def _get_deployment_mode() -> str:
 
 
 DEPLOYMENT_MODE = _get_deployment_mode()
+
+
+def _validate_self_hosted_web_host() -> None:
+    if DEPLOYMENT_MODE == 'self_hosted' and (_WEB_HOST_ENV is None or not HOST):
+        raise ValueError(
+            'WEB_HOST must be set to the public hostname this self-hosted '
+            'deployment is reached on.'
+        )
+
+
+_validate_self_hosted_web_host()
 
 # Role name constants
 ROLE_OWNER = 'owner'
@@ -119,7 +140,7 @@ SLACK_CLIENT_SECRET = os.environ.get('SLACK_CLIENT_SECRET', None)
 SLACK_SIGNING_SECRET = os.environ.get('SLACK_SIGNING_SECRET', None)
 SLACK_WEBHOOKS_ENABLED = os.environ.get('SLACK_WEBHOOKS_ENABLED', '0') in ('1', 'true')
 
-WEB_HOST = os.getenv('WEB_HOST', 'app.all-hands.dev').strip()
+WEB_HOST = HOST
 PERMITTED_CORS_ORIGINS = [
     host.strip()
     for host in (os.getenv('PERMITTED_CORS_ORIGINS') or f'https://{WEB_HOST}').split(

--- a/enterprise/tests/unit/server/test_constants.py
+++ b/enterprise/tests/unit/server/test_constants.py
@@ -117,6 +117,29 @@ class TestDeploymentMode:
             # Default WEB_HOST is 'app.all-hands.dev' which should be 'cloud'
             assert constants_module.DEPLOYMENT_MODE == 'cloud'
 
+    @pytest.mark.parametrize(
+        'env',
+        [
+            {'WEB_HOST': ''},
+            {'WEB_HOST': '   '},
+            {'OH_DEPLOYMENT_MODE': 'self_hosted'},
+            {'OH_DEPLOYMENT_MODE': 'self_hosted', 'WEB_HOST': ''},
+            {'OH_DEPLOYMENT_MODE': 'self_hosted', 'WEB_HOST': '   '},
+        ],
+    )
+    def test_empty_self_hosted_web_host_fails_fast(self, env: dict[str, str]):
+        """Self-hosted mode must not silently build URLs like ``https://``."""
+        import importlib
+
+        import server.constants as constants_module
+
+        with patch.dict('os.environ', env, clear=True):
+            with pytest.raises(ValueError, match='WEB_HOST must be set'):
+                importlib.reload(constants_module)
+
+        with patch.dict('os.environ', {'WEB_HOST': 'app.all-hands.dev'}, clear=True):
+            importlib.reload(constants_module)
+
 
 class TestStagingAndFeatureEnvDetection:
     """IS_STAGING_ENV / IS_FEATURE_ENV must recognize both the legacy


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

Self-hosted deployments with an empty `WEB_HOST` currently boot and derive malformed URLs such as `https://`, which makes auth, integration callbacks, CORS defaults, and related links difficult to diagnose.

## Summary

- Add import-time validation that fails fast when self-hosted mode has no configured `WEB_HOST`.
- Keep the existing default cloud behavior when `WEB_HOST` is unset and deployment mode is inferred normally.
- Add regression coverage for empty, whitespace-only, and explicit self-hosted `WEB_HOST` cases.

## Issue Number

Fixes OpenHands/enterprise#67

## How to Test

- `PYTHONPATH=enterprise poetry run --project=enterprise pytest enterprise/tests/unit/server/test_constants.py -q`
- `poetry run ruff check --config enterprise/dev_config/python/ruff.toml --fix enterprise/server/constants.py enterprise/tests/unit/server/test_constants.py`
- `poetry run ruff format --config enterprise/dev_config/python/ruff.toml enterprise/server/constants.py enterprise/tests/unit/server/test_constants.py`
- `MYPYPATH=enterprise poetry run mypy --config-file enterprise/dev_config/python/mypy.ini -m server.constants`
- `poetry run python -m py_compile enterprise/server/constants.py enterprise/tests/unit/server/test_constants.py`

The full enterprise pre-commit command was attempted, but hook environment initialization repeatedly timed out while fetching `pre-commit/mirrors-mypy` from GitHub. The installed commit hook ran during commit and passed its checks, including mypy.

## Video/Screenshots

N/A - startup configuration validation covered by unit tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This only changes self-hosted validation. Inferred cloud mode still uses the existing default `app.all-hands.dev` fallback when `WEB_HOST` is unset.
