### PR TITLE
fix(enterprise): window usage cost/token aggregations on spend time

### DIFF
--- a/enterprise/server/routes/org_models.py
+++ b/enterprise/server/routes/org_models.py
@@ -913,7 +913,7 @@ class DailyUsageData(BaseModel):
 
     date: str  # ISO date string (YYYY-MM-DD)
     tokens: int = 0
-    conversations: int = 0
+    conversations: int = 0  # Conversations started
 
 
 class TeamUsageData(BaseModel):
@@ -975,7 +975,8 @@ class OrgUsageStats(BaseModel):
 
     # Top-level metrics
     active_users: int = 0  # Users with activity in last 7 days
-    agent_runs: int = 0  # Total conversations in last 7 days
+    agent_runs: int = 0  # Conversations started in last 7 days
+    usage_conversation_count: int = 0  # Conversations with usage in last 7 days
     total_tokens: int = 0  # Total tokens in last 7 days
     estimated_spend: float = 0.0  # Estimated cost in last 7 days
 

--- a/enterprise/server/services/org_conversation_service.py
+++ b/enterprise/server/services/org_conversation_service.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import AsyncGenerator
+from typing import Any, AsyncGenerator
 from uuid import UUID
 
 from fastapi import Request
@@ -63,27 +63,27 @@ AGENT_LABELS = {
 }
 
 
-def _format_acp_agent_label(llm_model: str | None) -> str:
-    if not llm_model:
-        return AGENT_LABELS['acp']
-    llm_model_lower = llm_model.lower()
-    if 'claude' in llm_model_lower:
-        return 'Claude'
-    if 'codex' in llm_model_lower:
-        return 'Codex'
-    if 'gpt' in llm_model_lower or 'openai' in llm_model_lower:
-        return 'OpenAI'
-    if 'gemini' in llm_model_lower:
-        return 'Gemini'
-    return llm_model
-
-
-def _format_agent_label(agent_kind: str | None, llm_model: str | None) -> str:
-    if agent_kind == 'acp':
-        return _format_acp_agent_label(llm_model)
-    if not agent_kind:
-        return AGENT_LABELS['openhands']
-    return AGENT_LABELS.get(agent_kind, agent_kind)
+def _agent_label_expression(llm_model: Any) -> Any:
+    model_lower = func.lower(llm_model)
+    acp_label = case(
+        (llm_model.is_(None), AGENT_LABELS['acp']),
+        (model_lower.contains('claude'), 'Claude'),
+        (model_lower.contains('codex'), 'Codex'),
+        (or_(model_lower.contains('gpt'), model_lower.contains('openai')), 'OpenAI'),
+        (model_lower.contains('gemini'), 'Gemini'),
+        else_=llm_model,
+    )
+    return case(
+        (StoredConversationMetadata.agent_kind == 'acp', acp_label),
+        (
+            or_(
+                StoredConversationMetadata.agent_kind.is_(None),
+                StoredConversationMetadata.agent_kind == 'openhands',
+            ),
+            AGENT_LABELS['openhands'],
+        ),
+        else_=StoredConversationMetadata.agent_kind,
+    )
 
 
 MAX_SANDBOX_STATUS_FILTER_ROWS = 5000
@@ -697,9 +697,8 @@ class OrgConversationService:
 
     async def _get_usage_totals(
         self, base_filter: list, cutoff: datetime
-    ) -> tuple[float, int, int]:
-        """Windowed (cost, prompt, completion) totals from the ledger, plus a
-        legacy created_at fallback for conversations with no ledger rows."""
+    ) -> tuple[float, int, int, int]:
+        """Windowed cost, tokens, and conversation count."""
         ledger_query = (
             select(
                 func.coalesce(func.sum(StoredConversationCostEvent.cost_delta), 0),
@@ -715,6 +714,7 @@ class OrgConversationService:
                     ),
                     0,
                 ),
+                func.count(func.distinct(StoredConversationCostEvent.conversation_id)),
             )
             .select_from(StoredConversationCostEvent)
             .join(
@@ -731,7 +731,9 @@ class OrgConversationService:
             .where(StoredConversationCostEvent.occurred_at >= cutoff)
         )
         result = await self.db_session.execute(ledger_query)
-        ledger_cost, ledger_prompt, ledger_completion = result.one()
+        ledger_cost, ledger_prompt, ledger_completion, ledger_conversations = (
+            result.one()
+        )
 
         legacy_query = (
             select(
@@ -740,6 +742,7 @@ class OrgConversationService:
                 func.coalesce(
                     func.sum(StoredConversationMetadata.completion_tokens), 0
                 ),
+                func.count(StoredConversationMetadata.conversation_id),
             )
             .select_from(StoredConversationMetadata)
             .join(
@@ -759,23 +762,24 @@ class OrgConversationService:
             )
         )
         result = await self.db_session.execute(legacy_query)
-        legacy_cost, legacy_prompt, legacy_completion = result.one()
+        legacy_cost, legacy_prompt, legacy_completion, legacy_conversations = (
+            result.one()
+        )
 
         return (
             float(ledger_cost or 0) + float(legacy_cost or 0),
             int(ledger_prompt or 0) + int(legacy_prompt or 0),
             int(ledger_completion or 0) + int(legacy_completion or 0),
+            int(ledger_conversations or 0) + int(legacy_conversations or 0),
         )
 
     async def _get_daily_token_usage(
         self, base_filter: list, cutoff: datetime
     ) -> dict[str, int]:
         """Tokens per ISO day on spend time; legacy fallback by created_at."""
-        from sqlalchemy import Date, cast
-
         tokens: dict[str, int] = {}
 
-        ledger_day = cast(StoredConversationCostEvent.occurred_at, Date)
+        ledger_day = func.date(StoredConversationCostEvent.occurred_at)
         ledger_query = (
             select(
                 ledger_day.label('day'),
@@ -809,7 +813,7 @@ class OrgConversationService:
             key = str(row[0])[:10]
             tokens[key] = tokens.get(key, 0) + int(row[1] or 0)
 
-        legacy_day = cast(StoredConversationMetadata.created_at, Date)
+        legacy_day = func.date(StoredConversationMetadata.created_at)
         legacy_query = (
             select(
                 legacy_day.label('day'),
@@ -846,11 +850,10 @@ class OrgConversationService:
 
         return tokens
 
-    async def _get_team_token_usage(
+    async def _get_team_usage(
         self, base_filter: list, cutoff: datetime
-    ) -> dict[str, tuple[int, str | None, str | None]]:
-        """Per-user (tokens, email, git_user_name) on spend time; legacy
-        fallback for conversations with no ledger rows."""
+    ) -> dict[str, tuple[int, int, str | None, str | None]]:
+        """Per-user conversation and token usage on spend time."""
         merged: dict[str, list] = {}
 
         ledger_query = (
@@ -858,6 +861,7 @@ class OrgConversationService:
                 StoredConversationMetadataSaas.user_id,
                 User.email,
                 User.git_user_name,
+                func.count(func.distinct(StoredConversationCostEvent.conversation_id)),
                 func.coalesce(
                     func.sum(
                         func.coalesce(StoredConversationCostEvent.prompt_tokens, 0)
@@ -893,6 +897,7 @@ class OrgConversationService:
                 StoredConversationMetadataSaas.user_id,
                 User.email,
                 User.git_user_name,
+                func.count(StoredConversationMetadata.conversation_id),
                 func.coalesce(
                     func.sum(
                         StoredConversationMetadata.prompt_tokens
@@ -927,26 +932,27 @@ class OrgConversationService:
         for query in (ledger_query, legacy_query):
             result = await self.db_session.execute(query)
             for row in result.all():
-                entry = merged.setdefault(str(row[0]), [0, row[1], row[2]])
+                entry = merged.setdefault(str(row[0]), [0, 0, row[1], row[2]])
                 entry[0] += int(row[3] or 0)
+                entry[1] += int(row[4] or 0)
 
-        return {key: (val[0], val[1], val[2]) for key, val in merged.items()}
+        return {key: (val[0], val[1], val[2], val[3]) for key, val in merged.items()}
 
-    async def _get_agent_cost_usage(
+    async def _get_agent_usage(
         self, base_filter: list, cutoff: datetime
-    ) -> dict[str, float]:
-        """Cost per agent label on spend time; legacy fallback for
-        conversations with no ledger rows."""
-        costs: dict[str, float] = {}
+    ) -> dict[str, tuple[int, float]]:
+        """Conversation count and cost per agent label on spend time."""
+        usage: dict[str, tuple[int, float]] = {}
 
         model_label = func.coalesce(
             StoredConversationCostEvent.llm_model,
             StoredConversationMetadata.llm_model,
         )
+        ledger_agent_label = _agent_label_expression(model_label)
         ledger_query = (
             select(
-                StoredConversationMetadata.agent_kind,
-                model_label.label('llm_model'),
+                ledger_agent_label.label('agent_name'),
+                func.count(func.distinct(StoredConversationCostEvent.conversation_id)),
                 func.coalesce(func.sum(StoredConversationCostEvent.cost_delta), 0),
             )
             .select_from(StoredConversationCostEvent)
@@ -962,12 +968,15 @@ class OrgConversationService:
             )
             .where(*base_filter)
             .where(StoredConversationCostEvent.occurred_at >= cutoff)
-            .group_by(StoredConversationMetadata.agent_kind, model_label)
+            .group_by(ledger_agent_label)
+        )
+        legacy_agent_label = _agent_label_expression(
+            StoredConversationMetadata.llm_model
         )
         legacy_query = (
             select(
-                StoredConversationMetadata.agent_kind,
-                StoredConversationMetadata.llm_model,
+                legacy_agent_label.label('agent_name'),
+                func.count(StoredConversationMetadata.conversation_id),
                 func.coalesce(func.sum(StoredConversationMetadata.accumulated_cost), 0),
             )
             .select_from(StoredConversationMetadata)
@@ -986,18 +995,18 @@ class OrgConversationService:
                 )
                 .exists()
             )
-            .group_by(
-                StoredConversationMetadata.agent_kind,
-                StoredConversationMetadata.llm_model,
-            )
+            .group_by(legacy_agent_label)
         )
         for query in (ledger_query, legacy_query):
             result = await self.db_session.execute(query)
             for row in result.all():
-                label = _format_agent_label(row[0], row[1])
-                costs[label] = costs.get(label, 0.0) + float(row[2] or 0.0)
+                conversation_count, total_cost = usage.get(row[0], (0, 0.0))
+                usage[row[0]] = (
+                    conversation_count + int(row[1] or 0),
+                    total_cost + float(row[2] or 0.0),
+                )
 
-        return costs
+        return usage
 
     async def get_usage_stats(
         self,
@@ -1022,22 +1031,7 @@ class OrgConversationService:
             StoredConversationMetadataSaas.org_id == org_id,
         ]
 
-        # 1. Active users (users with activity in the time window)
-        active_users_query = (
-            select(func.count(func.distinct(StoredConversationMetadataSaas.user_id)))
-            .select_from(StoredConversationMetadata)
-            .join(
-                StoredConversationMetadataSaas,
-                StoredConversationMetadata.conversation_id
-                == StoredConversationMetadataSaas.conversation_id,
-            )
-            .where(*base_filter)
-            .where(StoredConversationMetadata.created_at >= cutoff)
-        )
-        result = await self.db_session.execute(active_users_query)
-        active_users = result.scalar() or 0
-
-        # 2. Total agent runs (conversations) in time window
+        # 1. Total agent runs (conversations started) in time window
         agent_runs_query = (
             select(func.count(StoredConversationMetadata.conversation_id))
             .select_from(StoredConversationMetadata)
@@ -1052,21 +1046,20 @@ class OrgConversationService:
         result = await self.db_session.execute(agent_runs_query)
         agent_runs = result.scalar() or 0
 
-        # 3. Total tokens and cost — spend-time (ledger) so the headline
-        # agrees with the model table; legacy fallback for no-ledger rows.
+        # 2. Spend-time totals, with a no-ledger fallback.
         (
             total_cost,
             total_prompt_tokens,
             total_completion_tokens,
+            usage_conversation_count,
         ) = await self._get_usage_totals(base_filter, cutoff)
 
-        # 4. Daily usage breakdown: conversation counts stay on created_at
+        # 3. Daily usage breakdown: conversation counts stay on created_at
         # ("runs started that day"); tokens follow spend time via the ledger.
-        from sqlalchemy import Date, cast
-
+        created_day = func.date(StoredConversationMetadata.created_at)
         daily_query = (
             select(
-                cast(StoredConversationMetadata.created_at, Date).label('day'),
+                created_day.label('day'),
                 func.count(StoredConversationMetadata.conversation_id),
             )
             .select_from(StoredConversationMetadata)
@@ -1077,7 +1070,7 @@ class OrgConversationService:
             )
             .where(*base_filter)
             .where(StoredConversationMetadata.created_at >= cutoff)
-            .group_by(cast(StoredConversationMetadata.created_at, Date))
+            .group_by(created_day)
         )
         result = await self.db_session.execute(daily_query)
         count_map = {str(row[0])[:10]: int(row[1] or 0) for row in result.all()}
@@ -1098,52 +1091,20 @@ class OrgConversationService:
                 )
             )
 
-        # 5. Team usage: conversation counts stay on created_at; tokens
-        # follow spend time via the ledger.
-        team_query = (
-            select(
-                StoredConversationMetadataSaas.user_id,
-                User.email,
-                User.git_user_name,
-                func.count(StoredConversationMetadata.conversation_id).label(
-                    'conv_count'
-                ),
-            )
-            .select_from(StoredConversationMetadata)
-            .join(
-                StoredConversationMetadataSaas,
-                StoredConversationMetadata.conversation_id
-                == StoredConversationMetadataSaas.conversation_id,
-            )
-            .outerjoin(User, StoredConversationMetadataSaas.user_id == User.id)
-            .where(*base_filter)
-            .where(StoredConversationMetadata.created_at >= cutoff)
-            .group_by(
-                StoredConversationMetadataSaas.user_id,
-                User.email,
-                User.git_user_name,
-            )
-        )
-        result = await self.db_session.execute(team_query)
-        count_rows = {str(row.user_id): row for row in result.all()}
-        team_tokens = await self._get_team_token_usage(base_filter, cutoff)
-
-        total_team_convs = sum(int(row.conv_count or 0) for row in count_rows.values())
+        # 4. Team usage follows spend time for both counts and tokens.
+        team_stats = await self._get_team_usage(base_filter, cutoff)
+        active_users = len(team_stats)
+        total_team_convs = sum(entry[0] for entry in team_stats.values())
         team_usage = []
-        for user_id in count_rows.keys() | team_tokens.keys():
-            row = count_rows.get(user_id)
-            token_entry = team_tokens.get(user_id, (0, None, None))
-            conv_count = int(row.conv_count or 0) if row is not None else 0
+        for user_id, (conv_count, tokens, email, git_user_name) in team_stats.items():
             pct = (conv_count / total_team_convs * 100) if total_team_convs > 0 else 0
             team_usage.append(
                 TeamUsageData(
                     user_id=user_id,
-                    user_email=row.email if row is not None else token_entry[1],
-                    user_name=(
-                        row.git_user_name if row is not None else token_entry[2]
-                    ),
+                    user_email=email,
+                    user_name=git_user_name,
                     conversation_count=conv_count,
-                    total_tokens=token_entry[0],
+                    total_tokens=tokens,
                     percentage=round(pct, 1),
                 )
             )
@@ -1151,49 +1112,22 @@ class OrgConversationService:
 
         model_usage = await self._get_model_usage(base_filter, cutoff)
 
-        # Agent usage: conversation counts stay on created_at; cost follows
-        # spend time via the ledger.
-        agent_query = (
-            select(
-                StoredConversationMetadata.agent_kind,
-                StoredConversationMetadata.llm_model,
-                func.count(StoredConversationMetadata.conversation_id).label(
-                    'conv_count'
-                ),
-            )
-            .select_from(StoredConversationMetadata)
-            .join(
-                StoredConversationMetadataSaas,
-                StoredConversationMetadata.conversation_id
-                == StoredConversationMetadataSaas.conversation_id,
-            )
-            .where(*base_filter)
-            .where(StoredConversationMetadata.created_at >= cutoff)
-            .group_by(
-                StoredConversationMetadata.agent_kind,
-                StoredConversationMetadata.llm_model,
-            )
-        )
-        result = await self.db_session.execute(agent_query)
-        agent_counts: dict[str, int] = {}
-        for row in result.all():
-            label = _format_agent_label(row.agent_kind, row.llm_model)
-            agent_counts[label] = agent_counts.get(label, 0) + int(row.conv_count or 0)
-        agent_costs = await self._get_agent_cost_usage(base_filter, cutoff)
-
+        # Agent counts and costs use the same spend-time cohort.
+        agent_stats = await self._get_agent_usage(base_filter, cutoff)
         agent_usage = [
             AgentUsageData(
                 agent_name=label,
-                conversation_count=agent_counts.get(label, 0),
-                total_cost=agent_costs.get(label, 0.0),
+                conversation_count=conversation_count,
+                total_cost=total_cost,
             )
-            for label in agent_counts.keys() | agent_costs.keys()
+            for label, (conversation_count, total_cost) in agent_stats.items()
         ]
         agent_usage.sort(key=lambda item: item.total_cost, reverse=True)
 
         return OrgUsageStats(
             active_users=int(active_users),
             agent_runs=int(agent_runs),
+            usage_conversation_count=usage_conversation_count,
             total_tokens=int(total_prompt_tokens or 0)
             + int(total_completion_tokens or 0),
             estimated_spend=float(total_cost or 0),

--- a/enterprise/server/services/org_conversation_service.py
+++ b/enterprise/server/services/org_conversation_service.py
@@ -695,6 +695,310 @@ class OrgConversationService:
             )
         return model_usage
 
+    async def _get_usage_totals(
+        self, base_filter: list, cutoff: datetime
+    ) -> tuple[float, int, int]:
+        """Windowed (cost, prompt, completion) totals from the ledger, plus a
+        legacy created_at fallback for conversations with no ledger rows."""
+        ledger_query = (
+            select(
+                func.coalesce(func.sum(StoredConversationCostEvent.cost_delta), 0),
+                func.coalesce(
+                    func.sum(
+                        func.coalesce(StoredConversationCostEvent.prompt_tokens, 0)
+                    ),
+                    0,
+                ),
+                func.coalesce(
+                    func.sum(
+                        func.coalesce(StoredConversationCostEvent.completion_tokens, 0)
+                    ),
+                    0,
+                ),
+            )
+            .select_from(StoredConversationCostEvent)
+            .join(
+                StoredConversationMetadata,
+                StoredConversationMetadata.conversation_id
+                == StoredConversationCostEvent.conversation_id,
+            )
+            .join(
+                StoredConversationMetadataSaas,
+                StoredConversationMetadata.conversation_id
+                == StoredConversationMetadataSaas.conversation_id,
+            )
+            .where(*base_filter)
+            .where(StoredConversationCostEvent.occurred_at >= cutoff)
+        )
+        result = await self.db_session.execute(ledger_query)
+        ledger_cost, ledger_prompt, ledger_completion = result.one()
+
+        legacy_query = (
+            select(
+                func.coalesce(func.sum(StoredConversationMetadata.accumulated_cost), 0),
+                func.coalesce(func.sum(StoredConversationMetadata.prompt_tokens), 0),
+                func.coalesce(
+                    func.sum(StoredConversationMetadata.completion_tokens), 0
+                ),
+            )
+            .select_from(StoredConversationMetadata)
+            .join(
+                StoredConversationMetadataSaas,
+                StoredConversationMetadata.conversation_id
+                == StoredConversationMetadataSaas.conversation_id,
+            )
+            .where(*base_filter)
+            .where(StoredConversationMetadata.created_at >= cutoff)
+            .where(
+                ~select(StoredConversationCostEvent.id)
+                .where(
+                    StoredConversationCostEvent.conversation_id
+                    == StoredConversationMetadata.conversation_id
+                )
+                .exists()
+            )
+        )
+        result = await self.db_session.execute(legacy_query)
+        legacy_cost, legacy_prompt, legacy_completion = result.one()
+
+        return (
+            float(ledger_cost or 0) + float(legacy_cost or 0),
+            int(ledger_prompt or 0) + int(legacy_prompt or 0),
+            int(ledger_completion or 0) + int(legacy_completion or 0),
+        )
+
+    async def _get_daily_token_usage(
+        self, base_filter: list, cutoff: datetime
+    ) -> dict[str, int]:
+        """Tokens per ISO day on spend time; legacy fallback by created_at."""
+        from sqlalchemy import Date, cast
+
+        tokens: dict[str, int] = {}
+
+        ledger_day = cast(StoredConversationCostEvent.occurred_at, Date)
+        ledger_query = (
+            select(
+                ledger_day.label('day'),
+                func.coalesce(
+                    func.sum(
+                        func.coalesce(StoredConversationCostEvent.prompt_tokens, 0)
+                        + func.coalesce(
+                            StoredConversationCostEvent.completion_tokens, 0
+                        )
+                    ),
+                    0,
+                ),
+            )
+            .select_from(StoredConversationCostEvent)
+            .join(
+                StoredConversationMetadata,
+                StoredConversationMetadata.conversation_id
+                == StoredConversationCostEvent.conversation_id,
+            )
+            .join(
+                StoredConversationMetadataSaas,
+                StoredConversationMetadata.conversation_id
+                == StoredConversationMetadataSaas.conversation_id,
+            )
+            .where(*base_filter)
+            .where(StoredConversationCostEvent.occurred_at >= cutoff)
+            .group_by(ledger_day)
+        )
+        result = await self.db_session.execute(ledger_query)
+        for row in result.all():
+            key = str(row[0])[:10]
+            tokens[key] = tokens.get(key, 0) + int(row[1] or 0)
+
+        legacy_day = cast(StoredConversationMetadata.created_at, Date)
+        legacy_query = (
+            select(
+                legacy_day.label('day'),
+                func.coalesce(
+                    func.sum(
+                        StoredConversationMetadata.prompt_tokens
+                        + StoredConversationMetadata.completion_tokens
+                    ),
+                    0,
+                ),
+            )
+            .select_from(StoredConversationMetadata)
+            .join(
+                StoredConversationMetadataSaas,
+                StoredConversationMetadata.conversation_id
+                == StoredConversationMetadataSaas.conversation_id,
+            )
+            .where(*base_filter)
+            .where(StoredConversationMetadata.created_at >= cutoff)
+            .where(
+                ~select(StoredConversationCostEvent.id)
+                .where(
+                    StoredConversationCostEvent.conversation_id
+                    == StoredConversationMetadata.conversation_id
+                )
+                .exists()
+            )
+            .group_by(legacy_day)
+        )
+        result = await self.db_session.execute(legacy_query)
+        for row in result.all():
+            key = str(row[0])[:10]
+            tokens[key] = tokens.get(key, 0) + int(row[1] or 0)
+
+        return tokens
+
+    async def _get_team_token_usage(
+        self, base_filter: list, cutoff: datetime
+    ) -> dict[str, tuple[int, str | None, str | None]]:
+        """Per-user (tokens, email, git_user_name) on spend time; legacy
+        fallback for conversations with no ledger rows."""
+        merged: dict[str, list] = {}
+
+        ledger_query = (
+            select(
+                StoredConversationMetadataSaas.user_id,
+                User.email,
+                User.git_user_name,
+                func.coalesce(
+                    func.sum(
+                        func.coalesce(StoredConversationCostEvent.prompt_tokens, 0)
+                        + func.coalesce(
+                            StoredConversationCostEvent.completion_tokens, 0
+                        )
+                    ),
+                    0,
+                ),
+            )
+            .select_from(StoredConversationCostEvent)
+            .join(
+                StoredConversationMetadata,
+                StoredConversationMetadata.conversation_id
+                == StoredConversationCostEvent.conversation_id,
+            )
+            .join(
+                StoredConversationMetadataSaas,
+                StoredConversationMetadata.conversation_id
+                == StoredConversationMetadataSaas.conversation_id,
+            )
+            .outerjoin(User, StoredConversationMetadataSaas.user_id == User.id)
+            .where(*base_filter)
+            .where(StoredConversationCostEvent.occurred_at >= cutoff)
+            .group_by(
+                StoredConversationMetadataSaas.user_id,
+                User.email,
+                User.git_user_name,
+            )
+        )
+        legacy_query = (
+            select(
+                StoredConversationMetadataSaas.user_id,
+                User.email,
+                User.git_user_name,
+                func.coalesce(
+                    func.sum(
+                        StoredConversationMetadata.prompt_tokens
+                        + StoredConversationMetadata.completion_tokens
+                    ),
+                    0,
+                ),
+            )
+            .select_from(StoredConversationMetadata)
+            .join(
+                StoredConversationMetadataSaas,
+                StoredConversationMetadata.conversation_id
+                == StoredConversationMetadataSaas.conversation_id,
+            )
+            .outerjoin(User, StoredConversationMetadataSaas.user_id == User.id)
+            .where(*base_filter)
+            .where(StoredConversationMetadata.created_at >= cutoff)
+            .where(
+                ~select(StoredConversationCostEvent.id)
+                .where(
+                    StoredConversationCostEvent.conversation_id
+                    == StoredConversationMetadata.conversation_id
+                )
+                .exists()
+            )
+            .group_by(
+                StoredConversationMetadataSaas.user_id,
+                User.email,
+                User.git_user_name,
+            )
+        )
+        for query in (ledger_query, legacy_query):
+            result = await self.db_session.execute(query)
+            for row in result.all():
+                entry = merged.setdefault(str(row[0]), [0, row[1], row[2]])
+                entry[0] += int(row[3] or 0)
+
+        return {key: (val[0], val[1], val[2]) for key, val in merged.items()}
+
+    async def _get_agent_cost_usage(
+        self, base_filter: list, cutoff: datetime
+    ) -> dict[str, float]:
+        """Cost per agent label on spend time; legacy fallback for
+        conversations with no ledger rows."""
+        costs: dict[str, float] = {}
+
+        model_label = func.coalesce(
+            StoredConversationCostEvent.llm_model,
+            StoredConversationMetadata.llm_model,
+        )
+        ledger_query = (
+            select(
+                StoredConversationMetadata.agent_kind,
+                model_label.label('llm_model'),
+                func.coalesce(func.sum(StoredConversationCostEvent.cost_delta), 0),
+            )
+            .select_from(StoredConversationCostEvent)
+            .join(
+                StoredConversationMetadata,
+                StoredConversationMetadata.conversation_id
+                == StoredConversationCostEvent.conversation_id,
+            )
+            .join(
+                StoredConversationMetadataSaas,
+                StoredConversationMetadata.conversation_id
+                == StoredConversationMetadataSaas.conversation_id,
+            )
+            .where(*base_filter)
+            .where(StoredConversationCostEvent.occurred_at >= cutoff)
+            .group_by(StoredConversationMetadata.agent_kind, model_label)
+        )
+        legacy_query = (
+            select(
+                StoredConversationMetadata.agent_kind,
+                StoredConversationMetadata.llm_model,
+                func.coalesce(func.sum(StoredConversationMetadata.accumulated_cost), 0),
+            )
+            .select_from(StoredConversationMetadata)
+            .join(
+                StoredConversationMetadataSaas,
+                StoredConversationMetadata.conversation_id
+                == StoredConversationMetadataSaas.conversation_id,
+            )
+            .where(*base_filter)
+            .where(StoredConversationMetadata.created_at >= cutoff)
+            .where(
+                ~select(StoredConversationCostEvent.id)
+                .where(
+                    StoredConversationCostEvent.conversation_id
+                    == StoredConversationMetadata.conversation_id
+                )
+                .exists()
+            )
+            .group_by(
+                StoredConversationMetadata.agent_kind,
+                StoredConversationMetadata.llm_model,
+            )
+        )
+        for query in (ledger_query, legacy_query):
+            result = await self.db_session.execute(query)
+            for row in result.all():
+                label = _format_agent_label(row[0], row[1])
+                costs[label] = costs.get(label, 0.0) + float(row[2] or 0.0)
+
+        return costs
+
     async def get_usage_stats(
         self,
         org_id: UUID,
@@ -748,41 +1052,22 @@ class OrgConversationService:
         result = await self.db_session.execute(agent_runs_query)
         agent_runs = result.scalar() or 0
 
-        # 3. Total tokens and cost in time window
-        totals_query = (
-            select(
-                func.coalesce(func.sum(StoredConversationMetadata.accumulated_cost), 0),
-                func.coalesce(func.sum(StoredConversationMetadata.prompt_tokens), 0),
-                func.coalesce(
-                    func.sum(StoredConversationMetadata.completion_tokens), 0
-                ),
-            )
-            .select_from(StoredConversationMetadata)
-            .join(
-                StoredConversationMetadataSaas,
-                StoredConversationMetadata.conversation_id
-                == StoredConversationMetadataSaas.conversation_id,
-            )
-            .where(*base_filter)
-            .where(StoredConversationMetadata.created_at >= cutoff)
-        )
-        result = await self.db_session.execute(totals_query)
-        total_cost, total_prompt_tokens, total_completion_tokens = result.one()
+        # 3. Total tokens and cost — spend-time (ledger) so the headline
+        # agrees with the model table; legacy fallback for no-ledger rows.
+        (
+            total_cost,
+            total_prompt_tokens,
+            total_completion_tokens,
+        ) = await self._get_usage_totals(base_filter, cutoff)
 
-        # 4. Daily usage breakdown (single query instead of N queries)
+        # 4. Daily usage breakdown: conversation counts stay on created_at
+        # ("runs started that day"); tokens follow spend time via the ledger.
         from sqlalchemy import Date, cast
 
         daily_query = (
             select(
                 cast(StoredConversationMetadata.created_at, Date).label('day'),
                 func.count(StoredConversationMetadata.conversation_id),
-                func.coalesce(
-                    func.sum(
-                        StoredConversationMetadata.prompt_tokens
-                        + StoredConversationMetadata.completion_tokens
-                    ),
-                    0,
-                ),
             )
             .select_from(StoredConversationMetadata)
             .join(
@@ -793,13 +1078,10 @@ class OrgConversationService:
             .where(*base_filter)
             .where(StoredConversationMetadata.created_at >= cutoff)
             .group_by(cast(StoredConversationMetadata.created_at, Date))
-            .order_by(cast(StoredConversationMetadata.created_at, Date).asc())
         )
         result = await self.db_session.execute(daily_query)
-        daily_rows = result.all()
-
-        # Build a map of date -> (conv_count, token_count)
-        daily_map = {row[0]: (row[1], row[2]) for row in daily_rows}
+        count_map = {str(row[0])[:10]: int(row[1] or 0) for row in result.all()}
+        daily_tokens = await self._get_daily_token_usage(base_filter, cutoff)
 
         # Generate entries for all days in range (including days with no data)
         daily_usage = []
@@ -807,17 +1089,17 @@ class OrgConversationService:
             day_start = (now - timedelta(days=i)).replace(
                 hour=0, minute=0, second=0, microsecond=0
             )
-            day_date = day_start.date() if hasattr(day_start, 'date') else day_start
-            conv_count, token_count = daily_map.get(day_date, (0, 0))
+            day_key = day_start.strftime('%Y-%m-%d')
             daily_usage.append(
                 DailyUsageData(
-                    date=day_start.strftime('%Y-%m-%d'),
-                    tokens=int(token_count or 0),
-                    conversations=int(conv_count or 0),
+                    date=day_key,
+                    tokens=daily_tokens.get(day_key, 0),
+                    conversations=count_map.get(day_key, 0),
                 )
             )
 
-        # 5. Team usage (by user)
+        # 5. Team usage: conversation counts stay on created_at; tokens
+        # follow spend time via the ledger.
         team_query = (
             select(
                 StoredConversationMetadataSaas.user_id,
@@ -826,13 +1108,6 @@ class OrgConversationService:
                 func.count(StoredConversationMetadata.conversation_id).label(
                     'conv_count'
                 ),
-                func.coalesce(
-                    func.sum(
-                        StoredConversationMetadata.prompt_tokens
-                        + StoredConversationMetadata.completion_tokens
-                    ),
-                    0,
-                ).label('token_count'),
             )
             .select_from(StoredConversationMetadata)
             .join(
@@ -848,31 +1123,36 @@ class OrgConversationService:
                 User.email,
                 User.git_user_name,
             )
-            .order_by(func.count(StoredConversationMetadata.conversation_id).desc())
         )
         result = await self.db_session.execute(team_query)
-        team_rows = result.all()
+        count_rows = {str(row.user_id): row for row in result.all()}
+        team_tokens = await self._get_team_token_usage(base_filter, cutoff)
 
-        # Calculate percentages
-        total_team_convs = sum(row.conv_count or 0 for row in team_rows)
+        total_team_convs = sum(int(row.conv_count or 0) for row in count_rows.values())
         team_usage = []
-        for row in team_rows:
-            pct = (
-                (row.conv_count / total_team_convs * 100) if total_team_convs > 0 else 0
-            )
+        for user_id in count_rows.keys() | team_tokens.keys():
+            row = count_rows.get(user_id)
+            token_entry = team_tokens.get(user_id)
+            conv_count = int(row.conv_count or 0) if row is not None else 0
+            pct = (conv_count / total_team_convs * 100) if total_team_convs > 0 else 0
             team_usage.append(
                 TeamUsageData(
-                    user_id=str(row.user_id),
-                    user_email=row.email,
-                    user_name=row.git_user_name,
-                    conversation_count=int(row.conv_count or 0),
-                    total_tokens=int(row.token_count or 0),
+                    user_id=user_id,
+                    user_email=row.email if row is not None else token_entry[1],
+                    user_name=(
+                        row.git_user_name if row is not None else token_entry[2]
+                    ),
+                    conversation_count=conv_count,
+                    total_tokens=token_entry[0] if token_entry else 0,
                     percentage=round(pct, 1),
                 )
             )
+        team_usage.sort(key=lambda item: item.conversation_count, reverse=True)
 
         model_usage = await self._get_model_usage(base_filter, cutoff)
 
+        # Agent usage: conversation counts stay on created_at; cost follows
+        # spend time via the ledger.
         agent_query = (
             select(
                 StoredConversationMetadata.agent_kind,
@@ -880,9 +1160,6 @@ class OrgConversationService:
                 func.count(StoredConversationMetadata.conversation_id).label(
                     'conv_count'
                 ),
-                func.coalesce(
-                    func.sum(StoredConversationMetadata.accumulated_cost), 0
-                ).label('total_cost'),
             )
             .select_from(StoredConversationMetadata)
             .join(
@@ -896,30 +1173,21 @@ class OrgConversationService:
                 StoredConversationMetadata.agent_kind,
                 StoredConversationMetadata.llm_model,
             )
-            .order_by(
-                func.coalesce(
-                    func.sum(StoredConversationMetadata.accumulated_cost), 0
-                ).desc()
-            )
         )
         result = await self.db_session.execute(agent_query)
-        agent_rows = result.all()
         agent_counts: dict[str, int] = {}
-        agent_costs: dict[str, float] = {}
-        for row in agent_rows:
+        for row in result.all():
             label = _format_agent_label(row.agent_kind, row.llm_model)
             agent_counts[label] = agent_counts.get(label, 0) + int(row.conv_count or 0)
-            agent_costs[label] = agent_costs.get(label, 0.0) + float(
-                row.total_cost or 0.0
-            )
+        agent_costs = await self._get_agent_cost_usage(base_filter, cutoff)
 
         agent_usage = [
             AgentUsageData(
                 agent_name=label,
-                conversation_count=agent_counts[label],
-                total_cost=agent_costs[label],
+                conversation_count=agent_counts.get(label, 0),
+                total_cost=agent_costs.get(label, 0.0),
             )
-            for label in agent_counts
+            for label in agent_counts.keys() | agent_costs.keys()
         ]
         agent_usage.sort(key=lambda item: item.total_cost, reverse=True)
 

--- a/enterprise/server/services/org_conversation_service.py
+++ b/enterprise/server/services/org_conversation_service.py
@@ -1132,7 +1132,7 @@ class OrgConversationService:
         team_usage = []
         for user_id in count_rows.keys() | team_tokens.keys():
             row = count_rows.get(user_id)
-            token_entry = team_tokens.get(user_id)
+            token_entry = team_tokens.get(user_id, (0, None, None))
             conv_count = int(row.conv_count or 0) if row is not None else 0
             pct = (conv_count / total_team_convs * 100) if total_team_convs > 0 else 0
             team_usage.append(
@@ -1143,7 +1143,7 @@ class OrgConversationService:
                         row.git_user_name if row is not None else token_entry[2]
                     ),
                     conversation_count=conv_count,
-                    total_tokens=token_entry[0] if token_entry else 0,
+                    total_tokens=token_entry[0],
                     percentage=round(pct, 1),
                 )
             )

--- a/enterprise/tests/unit/test_org_conversation_usage_models.py
+++ b/enterprise/tests/unit/test_org_conversation_usage_models.py
@@ -15,7 +15,17 @@ ORG_ID = uuid4()
 USER_ID = uuid4()
 
 
-def _conversation(session, conversation_id, llm_model, cost, prompt, completion):
+def _conversation(
+    session,
+    conversation_id,
+    llm_model,
+    cost,
+    prompt,
+    completion,
+    *,
+    created_at=None,
+    agent_kind=None,
+):
     session.add(
         StoredConversationMetadata(
             conversation_id=conversation_id,
@@ -24,7 +34,8 @@ def _conversation(session, conversation_id, llm_model, cost, prompt, completion)
             accumulated_cost=cost,
             prompt_tokens=prompt,
             completion_tokens=completion,
-            created_at=datetime.now(UTC) - timedelta(days=1),
+            created_at=created_at or datetime.now(UTC) - timedelta(days=1),
+            agent_kind=agent_kind,
         )
     )
     session.add(
@@ -87,6 +98,7 @@ async def test_model_usage_ledger_legacy_and_no_event_rows(async_session_maker):
         ]
         cutoff = datetime.now(UTC) - timedelta(days=30)
         model_usage = await service._get_model_usage(base_filter, cutoff)
+        agent_usage = await service._get_agent_usage(base_filter, cutoff)
 
     by_model = {m.model_name: m for m in model_usage}
     assert by_model['litellm_proxy/gpt-5.5'].total_cost == pytest.approx(0.08)
@@ -102,74 +114,212 @@ async def test_model_usage_ledger_legacy_and_no_event_rows(async_session_maker):
     # Ordered by spend, descending.
     costs = [m.total_cost for m in model_usage]
     assert costs == sorted(costs, reverse=True)
+    assert agent_usage['OpenHands'][0] == 3
+    assert agent_usage['OpenHands'][1] == pytest.approx(1.10)
 
 
-async def _seed_three_conversation_scenario(async_session_maker):
+@pytest.mark.asyncio
+async def test_agent_usage_groups_acp_models_and_deduplicates_conversations(
+    async_session_maker,
+):
     occurred = datetime.now(UTC) - timedelta(hours=2)
     async with async_session_maker() as session:
-        _conversation(session, 'conv-a', 'litellm_proxy/current-label', 0.25, 300, 30)
+        _conversation(
+            session,
+            'acp-openai',
+            'gpt-current',
+            0.30,
+            30,
+            3,
+            agent_kind='acp',
+        )
+        session.add_all(
+            [
+                StoredConversationCostEvent(
+                    conversation_id='acp-openai',
+                    cost_delta=0.10,
+                    occurred_at=occurred,
+                    llm_model='openai/gpt-5',
+                ),
+                StoredConversationCostEvent(
+                    conversation_id='acp-openai',
+                    cost_delta=0.20,
+                    occurred_at=occurred,
+                    llm_model='gpt-4.1',
+                ),
+            ]
+        )
+        _conversation(
+            session,
+            'acp-claude',
+            'claude-current',
+            0.40,
+            40,
+            4,
+            agent_kind='acp',
+        )
         session.add(
             StoredConversationCostEvent(
-                conversation_id='conv-a',
-                cost_delta=0.08,
+                conversation_id='acp-claude',
+                cost_delta=0.40,
                 occurred_at=occurred,
+                llm_model='claude-sonnet',
+            )
+        )
+        _conversation(
+            session,
+            'acp-codex-legacy',
+            'codex-mini',
+            0.50,
+            50,
+            5,
+            agent_kind='acp',
+        )
+        await session.commit()
+
+    async with async_session_maker() as session:
+        service = OrgConversationService(db_session=session)
+        agent_usage = await service._get_agent_usage(
+            [
+                StoredConversationMetadata.conversation_version == 'V1',
+                StoredConversationMetadataSaas.org_id == ORG_ID,
+            ],
+            datetime.now(UTC) - timedelta(days=30),
+        )
+
+    assert set(agent_usage) == {'OpenAI', 'Claude', 'Codex'}
+    assert agent_usage['OpenAI'][0] == 1
+    assert agent_usage['OpenAI'][1] == pytest.approx(0.30)
+    assert agent_usage['Claude'][0] == 1
+    assert agent_usage['Claude'][1] == pytest.approx(0.40)
+    assert agent_usage['Codex'][0] == 1
+    assert agent_usage['Codex'][1] == pytest.approx(0.50)
+
+
+async def _seed_spend_time_boundary_scenario(async_session_maker):
+    now = datetime.now(UTC)
+    recent = now - timedelta(hours=2)
+    old = now - timedelta(days=45)
+    async with async_session_maker() as session:
+        _conversation(
+            session,
+            'old-active-a',
+            'litellm_proxy/current-label',
+            0.40,
+            100,
+            10,
+            created_at=old,
+        )
+        session.add(
+            StoredConversationCostEvent(
+                conversation_id='old-active-a',
+                cost_delta=0.40,
+                occurred_at=recent,
                 usage_id='agent',
                 llm_model='litellm_proxy/gpt-5.5',
                 prompt_tokens=100,
                 completion_tokens=10,
             )
         )
+        _conversation(
+            session,
+            'old-active-b',
+            'litellm_proxy/current-label',
+            0.10,
+            20,
+            2,
+            created_at=old,
+        )
         session.add(
             StoredConversationCostEvent(
-                conversation_id='conv-a',
-                cost_delta=0.17,
-                occurred_at=occurred,
-                usage_id='profile:opus:x1',
-                llm_model='litellm_proxy/claude-opus-4-8',
-                prompt_tokens=200,
-                completion_tokens=20,
+                conversation_id='old-active-b',
+                cost_delta=0.10,
+                occurred_at=recent,
+                usage_id='agent',
+                llm_model='litellm_proxy/gpt-5.5',
+                prompt_tokens=20,
+                completion_tokens=2,
             )
         )
-        _conversation(session, 'conv-b', 'legacy-model', 0.30, 999, 99)
+        _conversation(
+            session,
+            'recent-stale',
+            'stale-model',
+            0.60,
+            600,
+            60,
+            created_at=now - timedelta(days=1),
+        )
         session.add(
             StoredConversationCostEvent(
-                conversation_id='conv-b',
-                cost_delta=0.30,
-                occurred_at=occurred,
+                conversation_id='recent-stale',
+                cost_delta=0.60,
+                occurred_at=old,
+                usage_id='agent',
+                llm_model='stale-model',
+                prompt_tokens=600,
+                completion_tokens=60,
             )
         )
-        _conversation(session, 'conv-c', 'old-model', 0.55, 50, 5)
+        _conversation(
+            session,
+            'recent-no-ledger',
+            'legacy-model',
+            0.25,
+            20,
+            2,
+            created_at=now - timedelta(days=1),
+        )
+        _conversation(
+            session,
+            'old-no-ledger',
+            'old-model',
+            0.90,
+            900,
+            90,
+            created_at=old,
+        )
         await session.commit()
+    return now
 
 
 @pytest.mark.asyncio
-async def test_spend_time_totals_team_and_agent_usage(async_session_maker):
-    """Headline/team/agent aggregations follow the ledger like the model tab."""
-    await _seed_three_conversation_scenario(async_session_maker)
-
-    base_filter = [
-        StoredConversationMetadata.conversation_version == 'V1',
-        StoredConversationMetadataSaas.org_id == ORG_ID,
-    ]
-    cutoff = datetime.now(UTC) - timedelta(days=30)
+async def test_usage_stats_follow_spend_time_across_window_boundaries(
+    async_session_maker,
+):
+    """Spend metrics include recent usage, independent of conversation age."""
+    seeded_at = await _seed_spend_time_boundary_scenario(async_session_maker)
 
     async with async_session_maker() as session:
         service = OrgConversationService(db_session=session)
-        total_cost, prompt, completion = await service._get_usage_totals(
-            base_filter, cutoff
-        )
-        team_tokens = await service._get_team_token_usage(base_filter, cutoff)
-        agent_costs = await service._get_agent_cost_usage(base_filter, cutoff)
+        stats = await service.get_usage_stats(ORG_ID, days=30)
 
-    # Ledger (0.08 + 0.17 + 0.30 legacy NULL rows) + no-ledger fallback (0.55).
-    assert total_cost == pytest.approx(1.10)
-    # Pre-attribution NULL rows carry no token data (conv-b contributes 0);
-    # no-ledger conversations fall back to their column totals.
-    assert prompt == 350
-    assert completion == 35
+    assert stats.agent_runs == 2
+    assert stats.usage_conversation_count == 3
+    assert stats.active_users == 1
+    assert stats.estimated_spend == pytest.approx(0.75)
+    assert stats.total_tokens == 154
 
-    assert set(team_tokens) == {str(USER_ID)}
-    assert team_tokens[str(USER_ID)][0] == 385
+    assert len(stats.team_usage) == 1
+    assert stats.team_usage[0].conversation_count == 3
+    assert stats.team_usage[0].total_tokens == 154
 
-    assert set(agent_costs) == {'OpenHands'}
-    assert agent_costs['OpenHands'] == pytest.approx(1.10)
+    assert len(stats.agent_usage) == 1
+    assert stats.agent_usage[0].agent_name == 'OpenHands'
+    assert stats.agent_usage[0].conversation_count == 3
+    assert stats.agent_usage[0].total_cost == pytest.approx(0.75)
+
+    assert sum(row.conversations for row in stats.daily_usage) == 2
+    assert sum(row.tokens for row in stats.daily_usage) == 154
+    daily_tokens = {row.date: row.tokens for row in stats.daily_usage}
+    expected_daily: dict[str, int] = {}
+    recent_day = (seeded_at - timedelta(hours=2)).strftime('%Y-%m-%d')
+    legacy_day = (seeded_at - timedelta(days=1)).strftime('%Y-%m-%d')
+    expected_daily[recent_day] = expected_daily.get(recent_day, 0) + 132
+    expected_daily[legacy_day] = expected_daily.get(legacy_day, 0) + 22
+    for day, tokens in expected_daily.items():
+        assert daily_tokens[day] == tokens
+
+    assert sum(row.total_cost for row in stats.model_usage) == pytest.approx(0.75)
+    assert sum(row.total_tokens for row in stats.model_usage) == 154
+    assert sum(row.conversation_count for row in stats.model_usage) == 3

--- a/enterprise/tests/unit/test_org_conversation_usage_models.py
+++ b/enterprise/tests/unit/test_org_conversation_usage_models.py
@@ -102,3 +102,74 @@ async def test_model_usage_ledger_legacy_and_no_event_rows(async_session_maker):
     # Ordered by spend, descending.
     costs = [m.total_cost for m in model_usage]
     assert costs == sorted(costs, reverse=True)
+
+
+async def _seed_three_conversation_scenario(async_session_maker):
+    occurred = datetime.now(UTC) - timedelta(hours=2)
+    async with async_session_maker() as session:
+        _conversation(session, 'conv-a', 'litellm_proxy/current-label', 0.25, 300, 30)
+        session.add(
+            StoredConversationCostEvent(
+                conversation_id='conv-a',
+                cost_delta=0.08,
+                occurred_at=occurred,
+                usage_id='agent',
+                llm_model='litellm_proxy/gpt-5.5',
+                prompt_tokens=100,
+                completion_tokens=10,
+            )
+        )
+        session.add(
+            StoredConversationCostEvent(
+                conversation_id='conv-a',
+                cost_delta=0.17,
+                occurred_at=occurred,
+                usage_id='profile:opus:x1',
+                llm_model='litellm_proxy/claude-opus-4-8',
+                prompt_tokens=200,
+                completion_tokens=20,
+            )
+        )
+        _conversation(session, 'conv-b', 'legacy-model', 0.30, 999, 99)
+        session.add(
+            StoredConversationCostEvent(
+                conversation_id='conv-b',
+                cost_delta=0.30,
+                occurred_at=occurred,
+            )
+        )
+        _conversation(session, 'conv-c', 'old-model', 0.55, 50, 5)
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_spend_time_totals_team_and_agent_usage(async_session_maker):
+    """Headline/team/agent aggregations follow the ledger like the model tab."""
+    await _seed_three_conversation_scenario(async_session_maker)
+
+    base_filter = [
+        StoredConversationMetadata.conversation_version == 'V1',
+        StoredConversationMetadataSaas.org_id == ORG_ID,
+    ]
+    cutoff = datetime.now(UTC) - timedelta(days=30)
+
+    async with async_session_maker() as session:
+        service = OrgConversationService(db_session=session)
+        total_cost, prompt, completion = await service._get_usage_totals(
+            base_filter, cutoff
+        )
+        team_tokens = await service._get_team_token_usage(base_filter, cutoff)
+        agent_costs = await service._get_agent_cost_usage(base_filter, cutoff)
+
+    # Ledger (0.08 + 0.17 + 0.30 legacy NULL rows) + no-ledger fallback (0.55).
+    assert total_cost == pytest.approx(1.10)
+    # Pre-attribution NULL rows carry no token data (conv-b contributes 0);
+    # no-ledger conversations fall back to their column totals.
+    assert prompt == 350
+    assert completion == 35
+
+    assert set(team_tokens) == {str(USER_ID)}
+    assert team_tokens[str(USER_ID)][0] == 385
+
+    assert set(agent_costs) == {'OpenHands'}
+    assert agent_costs['OpenHands'] == pytest.approx(1.10)

--- a/frontend/__tests__/hooks/query/use-org-usage-stats.test.tsx
+++ b/frontend/__tests__/hooks/query/use-org-usage-stats.test.tsx
@@ -32,6 +32,7 @@ const createWrapper = () => {
 const mockUsageStats = {
   active_users: 0,
   agent_runs: 0,
+  usage_conversation_count: 0,
   total_tokens: 0,
   estimated_spend: 0,
   daily_usage: [],

--- a/frontend/src/api/organization-service/organization-service.api.ts
+++ b/frontend/src/api/organization-service/organization-service.api.ts
@@ -583,6 +583,7 @@ interface AgentUsageData {
 interface OrgUsageStats {
   active_users: number;
   agent_runs: number;
+  usage_conversation_count: number;
   total_tokens: number;
   estimated_spend: number;
   daily_usage: DailyUsageData[];

--- a/frontend/src/components/features/admin-dashboard/usage-dashboard-tabs.tsx
+++ b/frontend/src/components/features/admin-dashboard/usage-dashboard-tabs.tsx
@@ -28,7 +28,7 @@ export type AgentSpendRow = {
 };
 
 export function OverviewTab({
-  totalConversations,
+  usageConversations,
   activeConversations,
   avgCostPerConversation,
   totalSpend,
@@ -37,7 +37,7 @@ export function OverviewTab({
   agentSpendRows,
   agentSpendTotal,
 }: {
-  totalConversations: number;
+  usageConversations: number;
   activeConversations: number;
   avgCostPerConversation: number;
   totalSpend: string;
@@ -50,8 +50,8 @@ export function OverviewTab({
     <div className="space-y-6">
       <div className="grid grid-cols-4 gap-4">
         <KPICard
-          label="Total Conversations"
-          value={totalConversations.toLocaleString()}
+          label="Conversations With Usage"
+          value={usageConversations.toLocaleString()}
         />
         <KPICard
           label="Active Conversations"
@@ -72,7 +72,7 @@ export function OverviewTab({
           <div className="flex items-start justify-between mb-6">
             <div>
               <h2 className="text-lg font-medium text-white">
-                Conversations per day
+                Conversations started per day
               </h2>
               <p className="text-sm text-zinc-500">
                 {timeWindowLabel} · all users

--- a/frontend/src/components/features/admin-dashboard/usage-dashboard.tsx
+++ b/frontend/src/components/features/admin-dashboard/usage-dashboard.tsx
@@ -103,11 +103,11 @@ export function UsageDashboard() {
     (org) => org.id === organizationId,
   );
 
-  const totalConversations = usageStats?.agent_runs ?? 0;
+  const usageConversations = usageStats?.usage_conversation_count ?? 0;
   const activeConversations = stats?.active_conversations ?? 0;
   const avgCostPerConversation =
-    totalConversations > 0
-      ? (usageStats?.estimated_spend ?? 0) / totalConversations
+    usageConversations > 0
+      ? (usageStats?.estimated_spend ?? 0) / usageConversations
       : 0;
   const totalSpend = formatCost(usageStats?.estimated_spend ?? 0);
 
@@ -267,7 +267,7 @@ export function UsageDashboard() {
         {/* Overview Tab */}
         {activeTab === "overview" && (
           <OverviewTab
-            totalConversations={totalConversations}
+            usageConversations={usageConversations}
             activeConversations={activeConversations}
             avgCostPerConversation={avgCostPerConversation}
             totalSpend={totalSpend}


### PR DESCRIPTION
- [x] A human has tested these changes.

HUMAN: Stacked on #15355 (base branch `alona/cost-model-attribution`). Live-validated on OHE as part of the final stack. This resolves the visible cross-tab inconsistency #15355 would otherwise introduce.

## Problem

After #15355, the Usage screen's Models tab windows on **spend time** (`occurred_at`, agreeing with LiteLLM), while the headline totals, agent tab, team tokens, and daily token bars still window on conversation `created_at`. Summing model rows could therefore disagree with the headline number on the same screen.

Using spend-time cost with a creation-time conversation denominator also produced a visibly invalid average-cost card: a long-running conversation could spend money in the selected window while the UI divided that spend by zero conversations started.

## Changes

- Headline estimated spend and total tokens, agent usage, team usage, and daily token bars aggregate from the cost-event ledger windowed on `occurred_at`, with the same no-ledger legacy fallback used by the model table.
- Add `usage_conversation_count` for distinct conversations in the spend cohort. The overview's average cost divides by this value and labels it **Conversations With Usage**.
- Active users, team conversation counts, and agent conversation counts use the same spend cohort as their cost/token values.
- `agent_runs` and daily conversation bars intentionally remain creation-time metrics and are presented as **Conversations Started**; they measure when runs begin rather than when usage occurs.
- Group agent labels in SQL before distinct conversation counting, so a single ACP conversation that uses multiple models under the same displayed agent label is counted once.
- Use `func.date()` for daily grouping, matching PostgreSQL behavior while allowing the complete endpoint aggregation to run in the SQLite unit harness.

## Transition caveat

Pre-migration ledger rows carry NULL token fields, so token figures for conversations that already had ledger rows before migration 139 can under-report during the transition. This self-corrects as post-139 data accumulates. Cost figures remain exact because the earlier rows contain cost.

## Tests

- Full `get_usage_stats()` boundary test proves that model, headline, team, and agent totals agree for spend that occurs inside the window on conversations created outside it.
- Ledger-attributed, pre-migration NULL-token, and no-ledger fallback scenarios.
- ACP agent-label grouping and distinct-conversation deduplication across multiple models.
- Frontend API and dashboard coverage for `usage_conversation_count`, average-cost calculation, and the started-vs-usage labels.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-2f1f4b5   docker.openhands.dev/openhands/openhands:2f1f4b5
```
