### PR TITLE
fix: support opaque OpenAI-compatible model ids

### DIFF
--- a/frontend/__tests__/routes/llm-settings.test.tsx
+++ b/frontend/__tests__/routes/llm-settings.test.tsx
@@ -1893,10 +1893,17 @@ describe("LlmSettingsScreen", () => {
 
     await renderLlmSettingsScreen({ appMode: "oss" });
 
+    const customModelInput = await screen.findByTestId(
+      "llm-custom-model-input",
+    );
+    await userEvent.clear(customModelInput);
+    await userEvent.type(customModelInput, "local/my-coder");
+
     const baseUrlInput = await screen.findByTestId("base-url-input");
     await userEvent.type(baseUrlInput, "/extra");
 
     await waitFor(() => {
+      expect(customModelInput).toHaveValue("local/my-coder");
       expect(baseUrlInput).toHaveValue("https://custom.example/v1/extra");
       expect(screen.getByTestId("save-button")).not.toBeDisabled();
     });
@@ -1908,6 +1915,7 @@ describe("LlmSettingsScreen", () => {
         expect.objectContaining({
           agent_settings_diff: expect.objectContaining({
             llm: expect.objectContaining({
+              model: "local/my-coder",
               base_url: "https://custom.example/v1/extra",
             }),
           }),

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -112,6 +112,7 @@ from openhands.app_server.utils.docker_utils import (
 )
 from openhands.app_server.utils.git import ensure_valid_git_branch_name
 from openhands.app_server.utils.import_utils import get_impl
+from openhands.app_server.utils.llm import normalize_llm_model_for_runtime
 from openhands.app_server.utils.llm_metadata import (
     get_llm_metadata,
     should_set_litellm_extra_body,
@@ -1252,11 +1253,16 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             user.agent_settings.llm.base_url,
             provider_base_url=self.openhands_provider_base_url,
         )
+        runtime_model, model_canonical_name = normalize_llm_model_for_runtime(
+            model, base_url
+        )
 
         return user.agent_settings.llm.model_copy(
             update={
-                'model': model,
+                'model': runtime_model,
                 'base_url': base_url,
+                'model_canonical_name': model_canonical_name
+                or user.agent_settings.llm.model_canonical_name,
                 'api_key': user.agent_settings.llm.api_key,
                 'usage_id': 'agent',
                 # Force streaming on (the SDK LLM defaults stream=False).

--- a/openhands/app_server/utils/llm.py
+++ b/openhands/app_server/utils/llm.py
@@ -66,6 +66,10 @@ _BARE_ANTHROPIC_MODELS: set[str] = set(_SDK_ANTHROPIC)
 _BARE_MISTRAL_MODELS: set[str] = set(_SDK_MISTRAL)
 
 DEFAULT_OPENHANDS_MODEL = 'openhands/minimax-m2.7'
+_LITELLM_PROXY_PREFIX = 'litellm_proxy/'
+_LITELLM_PROVIDERS = {
+    getattr(provider, 'value', str(provider)) for provider in litellm.provider_list
+}
 
 
 # ---------------------------------------------------------------------------
@@ -104,6 +108,37 @@ class ModelsResponse(BaseModel):
 def is_openhands_model(model: str | None) -> bool:
     """Return True when the model uses the public OpenHands provider prefix."""
     return bool(model and model.startswith('openhands/'))
+
+
+def _is_known_litellm_route(model: str) -> bool:
+    if model in litellm.model_list or model in litellm.model_cost:
+        return True
+
+    provider, separator, _ = model.partition('/')
+    return bool(separator and provider in _LITELLM_PROVIDERS)
+
+
+def normalize_llm_model_for_runtime(
+    model: str, base_url: str | None
+) -> tuple[str, str | None]:
+    """Return the runtime model id and optional canonical model name.
+
+    Custom OpenAI-compatible gateways can expose opaque model ids such as
+    ``local/my-coder``. LiteLLM cannot infer a provider from those ids, but
+    prepending ``openai/`` would change the model sent to the gateway. When a
+    custom ``base_url`` is configured and the model is not a route LiteLLM
+    already understands, use the LiteLLM proxy adapter only at runtime while
+    preserving the user's model id as the canonical name.
+    """
+    if (
+        not base_url
+        or model.startswith(_LITELLM_PROXY_PREFIX)
+        or is_openhands_model(model)
+        or _is_known_litellm_route(model)
+    ):
+        return model, None
+
+    return f'{_LITELLM_PROXY_PREFIX}{model}', model
 
 
 # Canonical masked placeholder for LLM API keys. Matches pydantic's

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -1007,6 +1007,30 @@ class TestLiveStatusAppConversationService:
         assert llm.base_url == 'https://user-llm.example.com'
 
     @pytest.mark.asyncio
+    async def test_configure_llm_and_mcp_routes_opaque_custom_endpoint_model(
+        self,
+    ):
+        """Opaque model ids on custom OpenAI-compatible endpoints need proxy routing.
+
+        A gateway may expose model ids such as ``local/my-coder``.  LiteLLM
+        cannot infer a provider from that id, but adding an ``openai/`` prefix
+        would change the model id that reaches the gateway.  Route through the
+        LiteLLM proxy adapter at runtime and keep the user's model as the
+        canonical name for capability lookups and display.
+        """
+        self.mock_user.llm_model = 'local/my-coder'
+        self.mock_user.llm_base_url = 'http://192.0.2.20:4000/v1'
+        self.mock_user_context.get_mcp_api_key.return_value = None
+
+        llm, _ = await self.service._configure_llm_and_mcp(
+            self.mock_user, None, self.conversation_id
+        )
+
+        assert llm.model == 'litellm_proxy/local/my-coder'
+        assert llm.model_canonical_name == 'local/my-coder'
+        assert llm.base_url == 'http://192.0.2.20:4000/v1'
+
+    @pytest.mark.asyncio
     async def test_configure_llm_and_mcp_non_openhands_model_ignores_provider(self):
         """Non-openhands model ignores provider base URL and uses user base URL."""
         # Arrange

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -882,7 +882,8 @@ class TestLiveStatusAppConversationService:
             self.mock_user, None, self.conversation_id
         )
 
-        assert llm.model == 'sdk-model'
+        assert llm.model == 'litellm_proxy/sdk-model'
+        assert llm.model_canonical_name == 'sdk-model'
         assert llm.base_url == 'https://sdk-llm.example.com'
         assert llm.stream is True
 

--- a/tests/unit/utils/test_llm_utils.py
+++ b/tests/unit/utils/test_llm_utils.py
@@ -6,6 +6,7 @@ from openhands.app_server.utils.llm import (
     _derive_verified_models,
     get_provider_api_base,
     is_openhands_model,
+    normalize_llm_model_for_runtime,
 )
 
 
@@ -107,6 +108,60 @@ class TestAssignProvider:
         monkeypatch.setattr(llm_utils, 'get_llm_provider', _boom)
 
         assert _assign_provider('whatever') == 'whatever'
+
+
+class TestNormalizeLlmModelForRuntime:
+    """Tests for runtime-only model routing."""
+
+    def test_custom_base_url_routes_opaque_model_through_proxy(self, monkeypatch):
+        """Opaque model ids use LiteLLM proxy routing without changing display id."""
+        monkeypatch.setattr(llm_utils, '_LITELLM_PROVIDERS', {'openai', 'anthropic'})
+        monkeypatch.setattr(llm_utils.litellm, 'model_list', [])
+        monkeypatch.setattr(llm_utils.litellm, 'model_cost', {})
+
+        runtime_model, canonical_name = normalize_llm_model_for_runtime(
+            'local/my-coder', 'https://gateway.example/v1'
+        )
+
+        assert runtime_model == 'litellm_proxy/local/my-coder'
+        assert canonical_name == 'local/my-coder'
+
+    def test_no_base_url_leaves_opaque_model_unchanged(self, monkeypatch):
+        """Provider inference should be left to the normal path without a custom URL."""
+        monkeypatch.setattr(llm_utils, '_LITELLM_PROVIDERS', {'openai', 'anthropic'})
+        monkeypatch.setattr(llm_utils.litellm, 'model_list', [])
+        monkeypatch.setattr(llm_utils.litellm, 'model_cost', {})
+
+        assert normalize_llm_model_for_runtime('local/my-coder', None) == (
+            'local/my-coder',
+            None,
+        )
+
+    def test_known_litellm_routes_are_not_rewritten(self, monkeypatch):
+        """Known LiteLLM provider routes already carry their adapter hint."""
+        monkeypatch.setattr(llm_utils, '_LITELLM_PROVIDERS', {'openai', 'anthropic'})
+        monkeypatch.setattr(llm_utils.litellm, 'model_list', ['gpt-4o'])
+        monkeypatch.setattr(llm_utils.litellm, 'model_cost', {})
+
+        assert normalize_llm_model_for_runtime(
+            'openai/custom-alias', 'https://gateway.example/v1'
+        ) == ('openai/custom-alias', None)
+        assert normalize_llm_model_for_runtime(
+            'gpt-4o', 'https://gateway.example/v1'
+        ) == ('gpt-4o', None)
+
+    def test_proxy_and_openhands_routes_are_not_rewritten(self, monkeypatch):
+        """Existing internal routes keep their original model ids."""
+        monkeypatch.setattr(llm_utils, '_LITELLM_PROVIDERS', {'openai', 'anthropic'})
+        monkeypatch.setattr(llm_utils.litellm, 'model_list', [])
+        monkeypatch.setattr(llm_utils.litellm, 'model_cost', {})
+
+        assert normalize_llm_model_for_runtime(
+            'litellm_proxy/local/my-coder', 'https://gateway.example/v1'
+        ) == ('litellm_proxy/local/my-coder', None)
+        assert normalize_llm_model_for_runtime(
+            'openhands/gpt-5', 'https://gateway.example/v1'
+        ) == ('openhands/gpt-5', None)
 
 
 class TestDeriveVerifiedModels:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

OpenAI-compatible gateways can expose opaque model ids such as `local/my-coder`. LiteLLM still needs an internal routing hint, but the upstream model id should remain exactly what the user entered so proxies and gateways do not need extra aliases.

## Summary

- Preserve opaque OpenAI-compatible model ids when the advanced LLM settings form is saved.
- Route unknown custom-endpoint model ids through the LiteLLM proxy adapter at conversation runtime while keeping the original model as the canonical name.
- Add focused backend and frontend regression coverage for custom endpoint model ids.

## Issue Number

Fixes #14525

## How to Test

- `poetry run pytest tests/unit/utils/test_llm_utils.py::TestNormalizeLlmModelForRuntime tests/unit/app_server/test_live_status_app_conversation_service.py::TestLiveStatusAppConversationService::test_configure_llm_and_mcp_routes_opaque_custom_endpoint_model -q`
- `poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files openhands/app_server/utils/llm.py openhands/app_server/app_conversation/live_status_app_conversation_service.py tests/unit/app_server/test_live_status_app_conversation_service.py tests/unit/utils/test_llm_utils.py`
- `npm run test -- --run __tests__/routes/llm-settings.test.tsx -t "submits advanced form values through SDK setting keys"`
- `npm run lint:fix`
- `npm run build`

## Video/Screenshots

Not applicable; covered by focused backend and frontend regression tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Known LiteLLM/provider-prefixed models are left unchanged. Only opaque model ids with a configured custom base URL use runtime proxy routing.
