### PR TITLE
fix: infer Docker webhook host port from web URL

### DIFF
--- a/openhands/app_server/config.py
+++ b/openhands/app_server/config.py
@@ -3,6 +3,7 @@
 import os
 from pathlib import Path
 from typing import AsyncContextManager, Literal
+from urllib.parse import urlparse
 
 import httpx
 from fastapi import Depends, Request
@@ -98,6 +99,16 @@ def get_default_web_url() -> str | None:
     if not web_host:
         return None
     return f'https://{web_host}'
+
+
+def _get_explicit_url_port(url: str | None) -> int | None:
+    """Return the explicitly configured port from a URL, if present."""
+    if not url:
+        return None
+    try:
+        return urlparse(url).port
+    except ValueError:
+        return None
 
 
 def get_default_permitted_cors_origins() -> list[str]:
@@ -345,6 +356,8 @@ def config_from_env() -> AppServerConfig:
                 docker_sandbox_kwargs['host_port'] = int(
                     os.environ['SANDBOX_HOST_PORT']
                 )
+            elif (web_url_port := _get_explicit_url_port(config.web_url)) is not None:
+                docker_sandbox_kwargs['host_port'] = web_url_port
             if os.getenv('SANDBOX_CONTAINER_URL_PATTERN'):
                 docker_sandbox_kwargs['container_url_pattern'] = os.environ[
                     'SANDBOX_CONTAINER_URL_PATTERN'

--- a/tests/unit/app_server/test_docker_sandbox_service.py
+++ b/tests/unit/app_server/test_docker_sandbox_service.py
@@ -1331,6 +1331,48 @@ class TestDockerSandboxServiceInjectorFromEnv:
             assert config.sandbox is not None
             assert config.sandbox.host_port == 4000
 
+    def test_config_from_env_infers_sandbox_host_port_from_web_url(self):
+        """Test that OH_WEB_URL port configures the Docker webhook host port."""
+        import os
+        from unittest.mock import patch
+
+        env_vars = {
+            'OH_WEB_URL': 'http://192.168.1.220:4000',
+            'SANDBOX_CONTAINER_URL_PATTERN': 'http://192.168.1.220:{port}',
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            # Clear the global config to force reload
+            import openhands.app_server.config as config_module
+            from openhands.app_server.config import config_from_env
+
+            config_module._global_config = None
+
+            config = config_from_env()
+            assert config.sandbox is not None
+            assert config.sandbox.host_port == 4000
+
+    def test_config_from_env_sandbox_host_port_overrides_web_url_port(self):
+        """Test that SANDBOX_HOST_PORT takes precedence over OH_WEB_URL."""
+        import os
+        from unittest.mock import patch
+
+        env_vars = {
+            'OH_WEB_URL': 'http://192.168.1.220:4000',
+            'SANDBOX_HOST_PORT': '5000',
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            # Clear the global config to force reload
+            import openhands.app_server.config as config_module
+            from openhands.app_server.config import config_from_env
+
+            config_module._global_config = None
+
+            config = config_from_env()
+            assert config.sandbox is not None
+            assert config.sandbox.host_port == 5000
+
     def test_config_from_env_with_sandbox_container_url_pattern(self):
         """Test that SANDBOX_CONTAINER_URL_PATTERN environment variable is respected."""
         import os


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

Docker agent-server containers build their webhook callback URL from the app server host port. In self-hosted setups that expose OpenHands on a non-default port through `OH_WEB_URL`, leaving `SANDBOX_HOST_PORT` unset keeps the callback on the default port and can break container-to-server callbacks.

## Summary

- Infer the Docker sandbox webhook host port from the explicit port in `OH_WEB_URL` when `SANDBOX_HOST_PORT` is not set.
- Keep `SANDBOX_HOST_PORT` as the higher-priority explicit override.
- Add regression coverage for the inferred and override behaviors.

## Issue Number

Fixes OpenHands/software-agent-sdk#4245

## How to Test

- `poetry run pytest tests/unit/app_server/test_docker_sandbox_service.py::TestDockerSandboxServiceInjectorFromEnv -q`
- `poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files openhands/app_server/config.py tests/unit/app_server/test_docker_sandbox_service.py`

## Video/Screenshots

N/A, backend configuration behavior only.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

`SANDBOX_HOST_PORT` still takes precedence when both settings are present.
