### PR TITLE
chore: Suppress verbose Laminar info logs

### DIFF
--- a/openhands/app_server/utils/logger.py
+++ b/openhands/app_server/utils/logger.py
@@ -439,6 +439,7 @@ LOQUACIOUS_LOGGERS = [
     'aiosqlite',
     'alembic.runtime.plugins',
     'sqlalchemy.orm.mapper.Mapper',
+    'lmnr',
 ]
 
 for logger_name in LOQUACIOUS_LOGGERS:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

Clean up detritus from the production logs.

- [x] A human has tested these changes.

AGENT:

This pull request was created by an AI agent (OpenHands) on behalf of the user.

---

## Why

Laminar installs colorful stream handlers and emits expected endpoint-normalization messages at INFO level. These messages are noisy in OpenHands production logs and can be misclassified during structured log ingestion.

## Summary

- Add the parent `lmnr` logger to `LOQUACIOUS_LOGGERS` so Laminar INFO messages are suppressed while warnings and errors remain visible.

## Issue Number

N/A

## How to Test

1. Import `openhands.app_server.utils.logger`.
2. Confirm `logging.getLogger("lmnr.opentelemetry_lib.tracing.exporter").getEffectiveLevel()` is `logging.WARNING`.
3. Run `poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml --files openhands/app_server/utils/logger.py`.

## Video/Screenshots

<img width="1500" height="272" alt="image" src="https://github.com/user-attachments/assets/a344def8-1178-4efd-812d-3d555d6f83c5" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This retains Laminar warning and error output and avoids modifying or monkey-patching Laminar's logger initialization.

---


To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-87682de   docker.openhands.dev/openhands/openhands:87682de
```