### PR TITLE
fix: enforce cloud analytics consent from TOS

### DIFF
--- a/enterprise/server/routes/auth.py
+++ b/enterprise/server/routes/auth.py
@@ -63,7 +63,11 @@ from storage.default_org_service import DefaultOrgBootstrapService
 from storage.user import User
 from storage.user_store import UserStore
 
-from openhands.analytics import get_analytics_service, resolve_analytics_context
+from openhands.analytics import (
+    get_analytics_service,
+    resolve_analytics_context,
+    user_has_analytics_consent,
+)
 from openhands.app_server.integrations.provider import (
     PROVIDER_TOKEN_TYPE,
     ProviderHandler,
@@ -475,7 +479,7 @@ async def keycloak_callback(
     logger.debug('keycloak_user_authenticated', extra={'user_id': user_id})
 
     # Server-side identity — defer to background to avoid blocking auth response
-    consented = user.user_consents_to_analytics is True
+    consented = user_has_analytics_consent(user)
     org_member_ids = [om.org_id for om in user.org_members] if user.org_members else []
 
     background_tasks.add_task(

--- a/enterprise/server/routes/billing.py
+++ b/enterprise/server/routes/billing.py
@@ -22,7 +22,7 @@ from storage.org import Org
 from storage.subscription_access import SubscriptionAccess
 from storage.user_store import UserStore
 
-from openhands.analytics import get_analytics_service
+from openhands.analytics import get_analytics_service, user_has_analytics_consent
 from openhands.app_server.config import get_global_config
 from openhands.app_server.user_auth import get_user_id
 
@@ -320,7 +320,7 @@ async def success_callback(session_id: str, request: Request):
 
                 ctx = AnalyticsContext(
                     user_id=billing_session.user_id,
-                    consented=user.user_consents_to_analytics is True,
+                    consented=user_has_analytics_consent(user),
                     org_id=str(user.current_org_id) if user.current_org_id else None,
                     user=user,
                 )

--- a/enterprise/server/routes/org_invitations.py
+++ b/enterprise/server/routes/org_invitations.py
@@ -30,7 +30,7 @@ from storage.default_org_service import get_default_org_config
 from storage.org_store import OrgStore
 from storage.role_store import RoleStore
 
-from openhands.analytics import get_analytics_service
+from openhands.analytics import get_analytics_service, user_has_analytics_consent
 from openhands.app_server.user_auth import get_user_id
 from openhands.app_server.utils.logger import openhands_logger as logger
 
@@ -125,7 +125,7 @@ async def create_invitation(
                 user_obj = await UserStore.get_user_by_id(user_id)
                 ctx = AnalyticsContext(
                     user_id=user_id,
-                    consented=user_obj.user_consents_to_analytics is True
+                    consented=user_has_analytics_consent(user_obj)
                     if user_obj
                     else False,
                     org_id=str(org_id),

--- a/enterprise/server/routes/user_app_settings_models.py
+++ b/enterprise/server/routes/user_app_settings_models.py
@@ -41,7 +41,7 @@ class UserAppSettingsResponse(BaseModel):
         """Create response from User entity."""
         return cls(
             language=user.language,
-            user_consents_to_analytics=user.user_consents_to_analytics,
+            user_consents_to_analytics=user.accepted_tos is not None,
             enable_sound_notifications=user.enable_sound_notifications,
             git_user_name=user.git_user_name,
             git_user_email=user.git_user_email,
@@ -53,7 +53,6 @@ class UserAppSettingsUpdate(BaseModel):
     """Request model for updating user app settings (partial update)."""
 
     language: str | None = None
-    user_consents_to_analytics: bool | None = None
     enable_sound_notifications: bool | None = None
     git_user_name: str | None = None
     git_user_email: EmailStr | None = None

--- a/enterprise/storage/saas_settings_store.py
+++ b/enterprise/storage/saas_settings_store.py
@@ -410,12 +410,15 @@ class SaasSettingsStore(SettingsStore):
         # Apply default if sandbox_grouping_strategy is None in the database
         if kwargs.get('sandbox_grouping_strategy') is None:
             kwargs.pop('sandbox_grouping_strategy', None)
-        # Apply default if git_full_clone is None in the database (pre-existing rows)
+        # Apply defaults if nullable database columns are None in pre-existing rows
         if kwargs.get('git_full_clone') is None:
             kwargs.pop('git_full_clone', None)
+        if kwargs.get('enable_sound_notifications') is None:
+            kwargs.pop('enable_sound_notifications', None)
         # Apply default if registered_marketplaces is None in the database
         if kwargs.get('registered_marketplaces') is None:
             kwargs.pop('registered_marketplaces', None)
+        kwargs['user_consents_to_analytics'] = user.accepted_tos is not None
 
         # Load personal registered_marketplaces from user_settings table
         user_settings = await self._get_user_settings_by_keycloak_id_async(self.user_id)
@@ -674,6 +677,7 @@ class SaasSettingsStore(SettingsStore):
             kwargs = item.model_dump(context={'expose_secrets': True})
             kwargs.pop('agent_settings', None)
             kwargs.pop('conversation_settings', None)
+            kwargs.pop('user_consents_to_analytics', None)
 
             # Get or create user_settings for this user
             user_settings_result = await session.execute(

--- a/enterprise/tests/unit/server/routes/test_user_app_settings.py
+++ b/enterprise/tests/unit/server/routes/test_user_app_settings.py
@@ -138,7 +138,7 @@ async def test_update_user_app_settings_success(mock_app):
     # Arrange
     updated_response = UserAppSettingsResponse(
         language='es',
-        user_consents_to_analytics=False,
+        user_consents_to_analytics=True,
         enable_sound_notifications=True,
         git_user_name='newuser',
         git_user_email='new@example.com',
@@ -147,10 +147,11 @@ async def test_update_user_app_settings_success(mock_app):
         'language': 'es',
         'user_consents_to_analytics': False,
     }
+    update_mock = AsyncMock(return_value=updated_response)
 
     with patch(
         'server.routes.user_app_settings.UserAppSettingsService.update_user_app_settings',
-        AsyncMock(return_value=updated_response),
+        update_mock,
     ):
         client = TestClient(mock_app)
 
@@ -161,7 +162,9 @@ async def test_update_user_app_settings_success(mock_app):
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
         assert data['language'] == 'es'
-        assert data['user_consents_to_analytics'] is False
+        assert data['user_consents_to_analytics'] is True
+        update_arg = update_mock.call_args.args[0]
+        assert update_arg.model_dump(exclude_unset=True) == {'language': 'es'}
 
 
 @pytest.mark.asyncio

--- a/enterprise/tests/unit/server/services/test_user_app_settings_service.py
+++ b/enterprise/tests/unit/server/services/test_user_app_settings_service.py
@@ -30,6 +30,7 @@ def mock_user(user_id):
     user.id = uuid.UUID(user_id)
     user.language = 'en'
     user.user_consents_to_analytics = True
+    user.accepted_tos = object()
     user.enable_sound_notifications = False
     user.git_user_name = 'testuser'
     user.git_user_email = 'test@example.com'
@@ -108,11 +109,9 @@ async def test_update_user_app_settings_success(
     # Arrange
     mock_user.language = 'es'
     mock_user.user_consents_to_analytics = False
+    mock_user.accepted_tos = object()
 
-    update_data = UserAppSettingsUpdate(
-        language='es',
-        user_consents_to_analytics=False,
-    )
+    update_data = UserAppSettingsUpdate(language='es')
 
     mock_store.update_user_app_settings = AsyncMock(return_value=mock_user)
     service = UserAppSettingsService(store=mock_store, user_context=mock_user_context)
@@ -123,7 +122,7 @@ async def test_update_user_app_settings_success(
     # Assert
     assert isinstance(result, UserAppSettingsResponse)
     assert result.language == 'es'
-    assert result.user_consents_to_analytics is False
+    assert result.user_consents_to_analytics is True
     mock_store.update_user_app_settings.assert_called_once_with(
         user_id=user_id, update_data=update_data
     )

--- a/enterprise/tests/unit/storage/test_user_app_settings_store.py
+++ b/enterprise/tests/unit/storage/test_user_app_settings_store.py
@@ -121,7 +121,6 @@ async def test_update_user_app_settings_success(async_session_maker):
 
         update_data = UserAppSettingsUpdate(
             language='es',
-            user_consents_to_analytics=True,
             enable_sound_notifications=True,
             git_user_name='newuser',
             git_user_email='new@example.com',
@@ -134,7 +133,7 @@ async def test_update_user_app_settings_success(async_session_maker):
     # Assert
     assert result is not None
     assert result.language == 'es'
-    assert result.user_consents_to_analytics is True
+    assert result.user_consents_to_analytics is False
     assert result.enable_sound_notifications is True
     assert result.git_user_name == 'newuser'
     assert result.git_user_email == 'new@example.com'

--- a/enterprise/tests/unit/test_saas_settings_store.py
+++ b/enterprise/tests/unit/test_saas_settings_store.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
@@ -605,6 +606,113 @@ async def test_load_canonicalizes_legacy_litellm_proxy_llm_profiles(
     custom = loaded.llm_profiles.require('custom')
     assert custom.model == 'litellm_proxy/custom-alias'
     assert custom.base_url == LITE_LLM_API_URL
+
+
+@pytest.mark.asyncio
+async def test_load_derives_analytics_consent_from_tos(
+    session_maker, async_session_maker, org_with_multiple_members_fixture
+):
+    from sqlalchemy import select
+    from storage.user import User
+
+    fixture = org_with_multiple_members_fixture
+    admin_user_id = fixture['admin_user_id']
+
+    with session_maker() as session:
+        user = (
+            session.execute(select(User).where(User.id == admin_user_id))
+            .scalars()
+            .first()
+        )
+        assert user is not None
+        user.user_consents_to_analytics = False
+        user.accepted_tos = datetime(2025, 1, 1)
+        session.commit()
+
+    store = SaasSettingsStore(str(admin_user_id))
+    with (
+        patch('storage.saas_settings_store.a_session_maker', async_session_maker),
+        patch('storage.user_store.a_session_maker', async_session_maker),
+        patch('storage.org_store.a_session_maker', async_session_maker),
+    ):
+        loaded = await store.load()
+
+    assert loaded is not None
+    assert loaded.user_consents_to_analytics is True
+
+
+@pytest.mark.asyncio
+async def test_load_without_tos_is_not_consented_even_when_stored_preference_true(
+    session_maker, async_session_maker, org_with_multiple_members_fixture
+):
+    from sqlalchemy import select
+    from storage.user import User
+
+    fixture = org_with_multiple_members_fixture
+    admin_user_id = fixture['admin_user_id']
+
+    with session_maker() as session:
+        user = (
+            session.execute(select(User).where(User.id == admin_user_id))
+            .scalars()
+            .first()
+        )
+        assert user is not None
+        user.user_consents_to_analytics = True
+        user.accepted_tos = None
+        session.commit()
+
+    store = SaasSettingsStore(str(admin_user_id))
+    with (
+        patch('storage.saas_settings_store.a_session_maker', async_session_maker),
+        patch('storage.user_store.a_session_maker', async_session_maker),
+        patch('storage.org_store.a_session_maker', async_session_maker),
+    ):
+        loaded = await store.load()
+
+    assert loaded is not None
+    assert loaded.user_consents_to_analytics is False
+
+
+@pytest.mark.asyncio
+async def test_store_does_not_persist_analytics_consent_override(
+    session_maker, async_session_maker, org_with_multiple_members_fixture
+):
+    from sqlalchemy import select
+    from storage.user import User
+
+    fixture = org_with_multiple_members_fixture
+    admin_user_id = fixture['admin_user_id']
+
+    with session_maker() as session:
+        user = (
+            session.execute(select(User).where(User.id == admin_user_id))
+            .scalars()
+            .first()
+        )
+        assert user is not None
+        user.user_consents_to_analytics = True
+        session.commit()
+
+    settings = _make_settings(
+        model='anthropic/claude-sonnet-4',
+        base_url='https://api.anthropic.com/v1',
+        api_key='external-api-key',
+    )
+    settings.user_consents_to_analytics = False
+
+    store = SaasSettingsStore(str(admin_user_id))
+    with patch('storage.saas_settings_store.a_session_maker', async_session_maker):
+        await store.store(settings)
+
+    with session_maker() as session:
+        user = (
+            session.execute(select(User).where(User.id == admin_user_id))
+            .scalars()
+            .first()
+        )
+        assert user is not None
+        assert user.user_consents_to_analytics is True
 
 
 @pytest.mark.asyncio

--- a/frontend/__tests__/routes/app-settings.test.tsx
+++ b/frontend/__tests__/routes/app-settings.test.tsx
@@ -4,7 +4,9 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import userEvent from "@testing-library/user-event";
 import AppSettingsScreen, { clientLoader } from "#/routes/app-settings";
 import SettingsService from "#/api/settings-service/settings-service.api";
+import OptionService from "#/api/option-service/option-service.api";
 import { MOCK_DEFAULT_USER_SETTINGS } from "#/mocks/handlers";
+import { createMockWebClientConfig } from "#/mocks/settings-handlers";
 import { AvailableLanguages } from "#/i18n";
 import * as CaptureConsent from "#/utils/handle-capture-consent";
 import * as ToastHandlers from "#/utils/custom-toast-handlers";
@@ -12,6 +14,10 @@ import { useSelectedOrganizationStore } from "#/stores/selected-organization-sto
 
 beforeEach(() => {
   useSelectedOrganizationStore.setState({ organizationId: "test-org-id" });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 const renderAppSettingsScreen = () =>
@@ -74,6 +80,27 @@ describe("Content", () => {
     });
   });
 
+  it("should render the analytics toggle as checked and disabled in SaaS", async () => {
+    vi.spyOn(OptionService, "getConfig").mockResolvedValue(
+      createMockWebClientConfig({ app_mode: "saas" }),
+    );
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue({
+      ...MOCK_DEFAULT_USER_SETTINGS,
+      user_consents_to_analytics: false,
+    });
+
+    renderAppSettingsScreen();
+
+    const analytics = await screen.findByTestId("enable-analytics-switch");
+    const submit = await screen.findByTestId("submit-button");
+
+    expect(analytics).toBeChecked();
+    expect(analytics).toBeDisabled();
+
+    await userEvent.click(analytics);
+    expect(submit).toBeDisabled();
+  });
+
   it("should render the language options", async () => {
     renderAppSettingsScreen();
 
@@ -88,10 +115,6 @@ describe("Content", () => {
 });
 
 describe("Form submission", () => {
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("should submit the form with the correct values", async () => {
     const saveSettingsSpy = vi.spyOn(SettingsService, "saveSettings");
     const getSettingsSpy = vi.spyOn(SettingsService, "getSettings");
@@ -129,6 +152,33 @@ describe("Form submission", () => {
         language: "no",
         user_consents_to_analytics: true,
         enable_sound_notifications: true,
+      }),
+    );
+  });
+
+  it("should not submit analytics consent from SaaS app settings", async () => {
+    const saveSettingsSpy = vi.spyOn(SettingsService, "saveSettings");
+    vi.spyOn(OptionService, "getConfig").mockResolvedValue(
+      createMockWebClientConfig({ app_mode: "saas" }),
+    );
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue({
+      ...MOCK_DEFAULT_USER_SETTINGS,
+      user_consents_to_analytics: false,
+    });
+
+    renderAppSettingsScreen();
+
+    const sound = await screen.findByTestId(
+      "enable-sound-notifications-switch",
+    );
+    await userEvent.click(sound);
+
+    const submit = await screen.findByTestId("submit-button");
+    await userEvent.click(submit);
+
+    expect(saveSettingsSpy).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        user_consents_to_analytics: expect.anything(),
       }),
     );
   });

--- a/frontend/src/hooks/use-migrate-user-consent.ts
+++ b/frontend/src/hooks/use-migrate-user-consent.ts
@@ -2,10 +2,12 @@ import React from "react";
 import { usePostHog } from "posthog-js/react";
 import { handleCaptureConsent } from "#/utils/handle-capture-consent";
 import { useSaveSettings } from "./mutation/use-save-settings";
+import { useConfig } from "./query/use-config";
 
 export const useMigrateUserConsent = () => {
   const posthog = usePostHog();
   const { mutate: saveUserSettings } = useSaveSettings();
+  const { data: config } = useConfig();
 
   /**
    * Migrate user consent to the settings store on the server.
@@ -15,7 +17,14 @@ export const useMigrateUserConsent = () => {
       const userAnalyticsConsent = localStorage.getItem("analytics-consent");
 
       if (userAnalyticsConsent) {
+        if (!config?.app_mode) return;
+
         args?.handleAnalyticsWasPresentInLocalStorage();
+
+        if (config.app_mode === "saas") {
+          localStorage.removeItem("analytics-consent");
+          return;
+        }
 
         saveUserSettings(
           { user_consents_to_analytics: userAnalyticsConsent === "true" },
@@ -29,7 +38,7 @@ export const useMigrateUserConsent = () => {
         localStorage.removeItem("analytics-consent");
       }
     },
-    [posthog, saveUserSettings],
+    [config?.app_mode, posthog, saveUserSettings],
   );
 
   return { migrateUserConsent };

--- a/frontend/src/routes/app-settings.tsx
+++ b/frontend/src/routes/app-settings.tsx
@@ -40,6 +40,7 @@ function AppSettingsScreen() {
   const { data: config } = useConfig();
   const { data: sandboxSpecsPage, isLoading: sandboxSpecsLoading } =
     useSandboxSpecs();
+  const isSaasMode = config?.app_mode === "saas";
 
   const [languageInputHasChanged, setLanguageInputHasChanged] =
     React.useState(false);
@@ -84,8 +85,9 @@ function AppSettingsScreen() {
     )?.value;
     const language = languageValue || DEFAULT_SETTINGS.language;
 
-    const enableAnalytics =
-      formData.get("enable-analytics-switch")?.toString() === "on";
+    const enableAnalytics = isSaasMode
+      ? true
+      : formData.get("enable-analytics-switch")?.toString() === "on";
     const enableSoundNotifications =
       formData.get("enable-sound-notifications-switch")?.toString() === "on";
 
@@ -120,45 +122,44 @@ function AppSettingsScreen() {
     const gitFullClone =
       formData.get("git-full-clone-switch")?.toString() === "on";
 
-    saveSettings(
-      {
-        language,
-        user_consents_to_analytics: enableAnalytics,
-        enable_sound_notifications: enableSoundNotifications,
-        enable_proactive_conversation_starters: enableProactiveConversations,
-        enable_solvability_analysis: enableSolvabilityAnalysis,
-        sandbox_grouping_strategy: sandboxGroupingStrategy,
-        default_sandbox_spec_id: defaultSandboxSpecId,
-        max_budget_per_task: maxBudgetPerTask,
-        git_user_name: gitUserName,
-        git_user_email: gitUserEmail,
-        git_full_clone: gitFullClone,
+    const settingsPayload = {
+      language,
+      enable_sound_notifications: enableSoundNotifications,
+      enable_proactive_conversation_starters: enableProactiveConversations,
+      enable_solvability_analysis: enableSolvabilityAnalysis,
+      sandbox_grouping_strategy: sandboxGroupingStrategy,
+      default_sandbox_spec_id: defaultSandboxSpecId,
+      max_budget_per_task: maxBudgetPerTask,
+      git_user_name: gitUserName,
+      git_user_email: gitUserEmail,
+      git_full_clone: gitFullClone,
+      ...(!isSaasMode && { user_consents_to_analytics: enableAnalytics }),
+    };
+
+    saveSettings(settingsPayload, {
+      onSuccess: () => {
+        handleCaptureConsent(posthog, enableAnalytics);
+        displaySuccessToast(t(I18nKey.SETTINGS$SAVED));
       },
-      {
-        onSuccess: () => {
-          handleCaptureConsent(posthog, enableAnalytics);
-          displaySuccessToast(t(I18nKey.SETTINGS$SAVED));
-        },
-        onError: (error) => {
-          const errorMessage = retrieveAxiosErrorMessage(error);
-          displayErrorToast(errorMessage || t(I18nKey.ERROR$GENERIC));
-        },
-        onSettled: () => {
-          setLanguageInputHasChanged(false);
-          setAnalyticsSwitchHasChanged(false);
-          setSoundNotificationsSwitchHasChanged(false);
-          setProactiveConversationsSwitchHasChanged(false);
-          setSandboxGroupingStrategyHasChanged(false);
-          setSelectedSandboxGroupingStrategy(null);
-          setSandboxSpecIdHasChanged(false);
-          setSelectedSandboxSpecId(undefined);
-          setMaxBudgetPerTaskHasChanged(false);
-          setGitUserNameHasChanged(false);
-          setGitUserEmailHasChanged(false);
-          setGitFullCloneHasChanged(false);
-        },
+      onError: (error) => {
+        const errorMessage = retrieveAxiosErrorMessage(error);
+        displayErrorToast(errorMessage || t(I18nKey.ERROR$GENERIC));
       },
-    );
+      onSettled: () => {
+        setLanguageInputHasChanged(false);
+        setAnalyticsSwitchHasChanged(false);
+        setSoundNotificationsSwitchHasChanged(false);
+        setProactiveConversationsSwitchHasChanged(false);
+        setSandboxGroupingStrategyHasChanged(false);
+        setSelectedSandboxGroupingStrategy(null);
+        setSandboxSpecIdHasChanged(false);
+        setSelectedSandboxSpecId(undefined);
+        setMaxBudgetPerTaskHasChanged(false);
+        setGitUserNameHasChanged(false);
+        setGitUserEmailHasChanged(false);
+        setGitFullCloneHasChanged(false);
+      },
+    });
   };
 
   const checkIfLanguageInputHasChanged = (value: string) => {
@@ -269,9 +270,13 @@ function AppSettingsScreen() {
 
           <SettingsSwitch
             testId="enable-analytics-switch"
-            name="enable-analytics-switch"
-            defaultIsToggled={settings.user_consents_to_analytics ?? true}
-            onToggle={checkIfAnalyticsSwitchHasChanged}
+            name={isSaasMode ? undefined : "enable-analytics-switch"}
+            defaultIsToggled={
+              isSaasMode ? true : (settings.user_consents_to_analytics ?? true)
+            }
+            isToggled={isSaasMode ? true : undefined}
+            isDisabled={isSaasMode}
+            onToggle={isSaasMode ? undefined : checkIfAnalyticsSwitchHasChanged}
           >
             {t(I18nKey.ANALYTICS$SEND_ANONYMOUS_DATA)}
           </SettingsSwitch>

--- a/frontend/src/routes/root-layout.tsx
+++ b/frontend/src/routes/root-layout.tsx
@@ -135,7 +135,7 @@ export default function MainApp() {
         },
       });
     }
-  }, [isOnIntermediatePage]);
+  }, [isOnIntermediatePage, migrateUserConsent]);
 
   React.useEffect(() => {
     if (settings?.is_new_user && config.data?.app_mode === "saas") {

--- a/openhands/analytics/__init__.py
+++ b/openhands/analytics/__init__.py
@@ -18,6 +18,7 @@ Usage::
 from openhands.analytics.analytics_context import (
     AnalyticsContext,
     resolve_analytics_context,
+    user_has_analytics_consent,
 )
 from openhands.analytics.analytics_service import AnalyticsService
 from openhands.server.types import AppMode
@@ -56,6 +57,7 @@ def get_analytics_service() -> AnalyticsService | None:
 
 __all__ = [
     'AnalyticsContext',
+    'user_has_analytics_consent',
     'AnalyticsService',
     'get_analytics_service',
     'init_analytics_service',

--- a/openhands/analytics/analytics_context.py
+++ b/openhands/analytics/analytics_context.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from openhands.analytics.user_base import UserBase
 from openhands.analytics.user_provider import AnalyticsUserProvider
+from openhands.app_server.config_api.config_models import AppMode
 from openhands.app_server.utils.import_utils import get_impl
 from openhands.app_server.utils.logger import openhands_logger as logger
 
@@ -27,6 +28,19 @@ _SAFE_DEFAULT_KWARGS: dict[str, Any] = {
     'org_id': None,
     'user': None,
 }
+
+
+def user_has_analytics_consent(user: Any) -> bool:
+    """Return whether analytics is allowed for the user.
+
+    In SaaS, accepting the Terms of Service is the consent signal for
+    analytics. OSS keeps using the explicit analytics preference.
+    """
+    from openhands.app_server.shared import server_config
+
+    if server_config.app_mode == AppMode.SAAS:
+        return getattr(user, 'accepted_tos', None) is not None
+    return getattr(user, 'user_consents_to_analytics', None) is True
 
 
 @dataclass
@@ -80,8 +94,7 @@ async def resolve_analytics_context(user_id: str) -> AnalyticsContext:
         if user is None:
             return AnalyticsContext(user_id=user_id, **_SAFE_DEFAULT_KWARGS)
 
-        # None = undecided = not consented (same logic as auth.py)
-        consented = user.user_consents_to_analytics is True
+        consented = user_has_analytics_consent(user)
         org_id = str(user.current_org_id) if user.current_org_id else None
 
         return AnalyticsContext(

--- a/openhands/app_server/settings/settings_router.py
+++ b/openhands/app_server/settings/settings_router.py
@@ -13,6 +13,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from openhands.analytics import get_analytics_service
+from openhands.app_server.config_api.config_models import AppMode
 from openhands.app_server.integrations.provider import (
     PROVIDER_TOKEN_TYPE,
     ProviderType,
@@ -36,6 +37,7 @@ from openhands.app_server.settings.settings_models import (
     Settings,
 )
 from openhands.app_server.settings.settings_store import SettingsStore
+from openhands.app_server.shared import server_config
 from openhands.app_server.user_auth import (
     get_provider_tokens,
     get_secrets_store,
@@ -60,6 +62,26 @@ from openhands.sdk.settings import (
 LITE_LLM_API_URL = os.environ.get(
     'LITE_LLM_API_URL', 'https://llm-proxy.app.all-hands.dev'
 )
+
+
+def _sanitize_cloud_analytics_consent_override(
+    payload: dict[str, Any],
+) -> JSONResponse | None:
+    """Reject attempts to override TOS-derived analytics consent in SaaS."""
+    if (
+        server_config.app_mode != AppMode.SAAS
+        or 'user_consents_to_analytics' not in payload
+    ):
+        return None
+
+    if payload['user_consents_to_analytics'] is not True:
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            content={'error': 'Analytics consent is controlled by TOS in cloud mode.'},
+        )
+
+    payload.pop('user_consents_to_analytics', None)
+    return None
 
 
 def _get_instance_default_marketplaces() -> list[dict[str, Any]]:
@@ -260,6 +282,10 @@ async def store_settings(
                 'keys': legacy_nested_keys,
             },
         )
+
+    cloud_analytics_consent_error = _sanitize_cloud_analytics_consent_override(payload)
+    if cloud_analytics_consent_error is not None:
+        return cloud_analytics_consent_error
 
     try:
         existing_settings = await settings_store.load()

--- a/tests/unit/app_server/test_settings_api.py
+++ b/tests/unit/app_server/test_settings_api.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 from pydantic import SecretStr
 
 from openhands.app_server.app import app
+from openhands.app_server.config_api.config_models import AppMode
 from openhands.app_server.file_store.memory import InMemoryFileStore
 from openhands.app_server.integrations.provider import ProviderToken, ProviderType
 from openhands.app_server.integrations.service_types import UserGitInfo
@@ -222,6 +223,36 @@ async def test_settings_api_endpoints(test_client):
     response = test_client.get('/api/v1/settings')
     assert response.status_code == 200
     assert response.json()['agent_settings']['llm']['timeout'] == 123
+
+
+@pytest.mark.asyncio
+async def test_store_settings_rejects_cloud_analytics_consent_override(test_client):
+    with patch(
+        'openhands.app_server.settings.settings_router.server_config.app_mode',
+        AppMode.SAAS,
+    ):
+        response = test_client.post(
+            '/api/v1/settings', json={'user_consents_to_analytics': False}
+        )
+
+    assert response.status_code == 422
+    assert response.json() == {
+        'error': 'Analytics consent is controlled by TOS in cloud mode.'
+    }
+
+
+@pytest.mark.asyncio
+async def test_store_settings_ignores_cloud_analytics_consent_true(test_client):
+    with patch(
+        'openhands.app_server.settings.settings_router.server_config.app_mode',
+        AppMode.SAAS,
+    ):
+        response = test_client.post(
+            '/api/v1/settings',
+            json={'language': 'fr', 'user_consents_to_analytics': True},
+        )
+
+    assert response.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_analytics_context.py
+++ b/tests/unit/test_analytics_context.py
@@ -7,11 +7,13 @@ import pytest
 from openhands.analytics.analytics_context import (
     AnalyticsContext,
     resolve_analytics_context,
+    user_has_analytics_consent,
 )
 from openhands.analytics.user_provider import (
     AnalyticsUserProvider,
     DefaultAnalyticsUserProvider,
 )
+from openhands.app_server.config_api.config_models import AppMode
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -53,6 +55,36 @@ class TestAnalyticsUserProvider:
         provider = DefaultAnalyticsUserProvider()
         result = await provider.get_user_by_id('any-user-id')
         assert result is None
+
+
+class TestUserHasAnalyticsConsent:
+    """Tests for app-mode-specific analytics consent resolution."""
+
+    def test_oss_uses_explicit_analytics_preference(self):
+        user = MagicMock()
+        user.user_consents_to_analytics = True
+        user.accepted_tos = None
+
+        with patch(
+            'openhands.app_server.shared.server_config.app_mode', AppMode.OPENHANDS
+        ):
+            assert user_has_analytics_consent(user) is True
+
+    def test_saas_uses_tos_acceptance_instead_of_stored_preference(self):
+        user = MagicMock()
+        user.user_consents_to_analytics = False
+        user.accepted_tos = object()
+
+        with patch('openhands.app_server.shared.server_config.app_mode', AppMode.SAAS):
+            assert user_has_analytics_consent(user) is True
+
+    def test_saas_without_tos_is_not_consented_even_when_preference_is_true(self):
+        user = MagicMock()
+        user.user_consents_to_analytics = True
+        user.accepted_tos = None
+
+        with patch('openhands.app_server.shared.server_config.app_mode', AppMode.SAAS):
+            assert user_has_analytics_consent(user) is False
 
 
 # ---------------------------------------------------------------------------
@@ -104,10 +136,14 @@ class TestResolveContext:
         """resolve_analytics_context with valid user_id returns AnalyticsContext with consented from user, org_id from user."""
         mock_user = MagicMock()
         mock_user.user_consents_to_analytics = True
+        mock_user.accepted_tos = object()
         mock_user.current_org_id = 'org-abc-123'
 
         provider = MockAnalyticsUserProvider(user=mock_user)
-        with _patch_user_provider(provider):
+        with (
+            _patch_user_provider(provider),
+            patch('openhands.app_server.shared.server_config.app_mode', AppMode.SAAS),
+        ):
             ctx = await resolve_analytics_context('user-42')
 
         assert ctx.user_id == 'user-42'


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:


- [ ] A human has tested these changes.

AGENT:

---

## Why

In cloud mode, accepting the Terms of Service is the consent signal for analytics. The analytics setting should therefore appear enabled after the TOS page and users should not be able to disable it through cloud UI or API paths.

## Summary

- Derive SaaS analytics consent from `accepted_tos` for analytics context, SaaS settings reads, and user app settings responses.
- Prevent cloud settings APIs from persisting or accepting analytics consent overrides, while keeping OSS explicit consent behavior unchanged.
- Render the cloud app-settings analytics switch as checked/disabled and skip legacy localStorage consent migration in SaaS.
- Add backend and frontend coverage for TOS-derived consent and UI/API override prevention.

## Issue Number

N/A

## How to Test

- `poetry run pytest tests/unit/test_analytics_context.py tests/unit/app_server/test_settings_api.py`
- `PYTHONPATH=enterprise poetry run --project=enterprise pytest --confcutdir=enterprise/tests/unit enterprise/tests/unit/test_saas_settings_store.py enterprise/tests/unit/server/routes/test_user_app_settings.py enterprise/tests/unit/server/services/test_user_app_settings_service.py enterprise/tests/unit/storage/test_user_app_settings_store.py`
- `cd frontend && npm run test -- __tests__/routes/app-settings.test.tsx`
- `cd frontend && npm run lint:fix && npm run build`
- `poetry run pre-commit run --config ./dev_config/python/.pre-commit-config.yaml`
- `cd enterprise && poetry run pre-commit run --all-files --show-diff-on-failure --config ./dev_config/python/.pre-commit-config.yaml`

## Video/Screenshots

Not applicable; behavior is covered by automated UI tests for the disabled cloud analytics switch.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR was created by an AI agent (OpenHands) on behalf of the user.

Cloud users retain analytics consent through TOS acceptance. OSS users still use the explicit analytics preference.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4afe27a3-3510-4bd8-a5b7-f60c5312d789)

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-24453ed   docker.openhands.dev/openhands/openhands:24453ed
```