### PR TITLE
docs(frontend): update README to reflect Redux->Zustand migration

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,7 +8,7 @@ This is the frontend of the OpenHands project. It is a React application that pr
 
 - Remix SPA Mode (React + Vite + React Router)
 - TypeScript
-- Redux
+- Zustand
 - TanStack Query
 - Tailwind CSS
 - i18next
@@ -110,7 +110,7 @@ frontend
 │   ├── mocks # MSW mocks for development
 │   ├── routes # React Router file-based routes
 │   ├── services
-│   ├── state # Redux state management
+│   ├── stores # Zustand state management
 │   ├── types
 │   ├── utils # Utility/helper functions
 │   └── root.tsx # Entry point
@@ -163,7 +163,7 @@ npm run test:coverage
 
 1. **Component Testing**
    - Test components in isolation
-   - Use our custom [`renderWithProviders()`](https://github.com/OpenHands/OpenHands/blob/ce26f1c6d3feec3eedf36f823dee732b5a61e517/frontend/test-utils.tsx#L56-L85) that wraps the components we want to test in our providers. It is especially useful for components that use Redux
+   - Use our custom [`renderWithProviders()`](https://github.com/OpenHands/OpenHands/blob/main/frontend/test-utils.tsx#L65-L83) that wraps the components we want to test in our QueryClient and i18next providers. It is especially useful for components that use TanStack Query or i18next
    - Use `render()` from React Testing Library to render components
    - Prefer querying elements by role, label, or test ID over CSS selectors
    - Test both rendering and interaction scenarios
@@ -176,7 +176,7 @@ npm run test:coverage
 3. **Mocking**
    - We test components that make network requests by mocking those requests with Mock Service Worker (MSW)
    - Use `vi.fn()` to create mock functions for callbacks and event handlers
-   - Mock external dependencies and API calls (more info)[https://mswjs.io/docs/getting-started]
+   - Mock external dependencies and API calls ([more info](https://mswjs.io/docs/getting-started))
    - Verify mock function calls using `.toHaveBeenCalledWith()`, `.toHaveBeenCalledTimes()`
 
 4. **Accessibility Testing**


### PR DESCRIPTION
HUMAN:

Doc-only update to `frontend/README.md` so the testing/stack docs match the current Zustand-based frontend. Not human-tested.

- [ ] A human has tested these changes.

AGENT:

AI-sourced docs-drift fix. Verified against `upstream/main` (commit `2295590`) before opening. All changes are in `frontend/README.md` only.

---

## Why

The frontend migrated from Redux to Zustand + TanStack Query, but `frontend/README.md` still documents Redux. `frontend/package.json` has no Redux dependencies (only `zustand@5.0.13` and `@tanstack/react-query@5.90.20`), there are 17 Zustand stores under `frontend/src/stores/`, and there are zero `redux` / `react-redux` references anywhere in `frontend/src/`. The README is therefore misleading in three places, and one link in the same testing section is malformed.

## Summary

- Tech Stack: `Redux` → `Zustand` (TanStack Query was already listed separately).
- Project structure tree: `state # Redux state management` → `stores # Zustand state management` — the `state/` directory no longer exists; the current directory is `src/stores/`.
- Testing guide: updated the `renderWithProviders()` description (it now wraps components in `QueryClient` + `i18next` providers, not Redux) and repointed its permalink from the old Redux implementation (`ce26f1c6#L56-L85`) to the current one (`main#L65-L83`), matching the `blob/main/` style used by the other example-test links in this file.
- Testing guide: fixed a malformed markdown link in the Mocking subsection — `(more info)[https://mswjs.io/docs/getting-started]` (inverted `[text](url)` syntax; did not render as a link) → `([more info](https://mswjs.io/docs/getting-started))`.

## Issue Number

Self-sourced — no tracking issue. Discovered while reading the frontend testing docs.

## How to Test

Docs-only change to `frontend/README.md`; no build or runtime impact. The code state can be confirmed directly:

```sh
grep -E '"(redux|react-redux|@reduxjs|zustand|@tanstack/react-query)"' frontend/package.json
ls frontend/src/stores                  # 17 zustand stores; no src/state/ dir
sed -n '63,84p' frontend/test-utils.tsx  # renderWithProviders now spans lines 65-83
```

## Video/Screenshots

N/A — docs-only change.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- Searched for duplicate work: the only `Redux Zustand` PR is #5095 (the closed migration proposal itself). My other open PR #15357 touches different frontend files + `skills/add_agent.md`, not `frontend/README.md`.
- The malformed MSW link is bundled in because it sits in the same Testing → Mocking subsection; happy to split if a maintainer prefers.
- Per the template guidance for AI/LLM agents, the "A human has tested these changes" box is intentionally left unchecked.
