### PR TITLE
docs(frontend): update README tech stack to React Router v7

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,7 +6,7 @@ This is the frontend of the OpenHands project. It is a React application that pr
 
 ## Tech Stack
 
-- Remix SPA Mode (React + Vite + React Router)
+- React Router v7 SPA Mode (React + Vite)
 - TypeScript
 - Redux
 - TanStack Query
@@ -133,7 +133,7 @@ components
 
 - Real-time updates with WebSockets
 - Internationalization
-- Router data loading with Remix
+- Router data loading with React Router v7
 - User authentication with GitHub OAuth (if saas mode is enabled)
 
 ## Testing


### PR DESCRIPTION
HUMAN:

Update the frontend README tech-stack wording to reflect that the app has migrated from Remix to React Router v7.

- [ ] A human has tested these changes.

AGENT:

This change was prepared with assistance from an AI coding assistant. No code changes — documentation only.

## Problem

`frontend/README.md` still describes the SPA stack as "Remix SPA Mode" in the Tech Stack list and "Router data loading with Remix" in the features list. The frontend no longer depends on Remix: `frontend/package.json` uses `react-router`, `@react-router/dev`, `@react-router/node`, and `@react-router/serve` at `7.17.0`, with no `@remix-run/*` packages. The wording is therefore out of date.

## Triage / Root cause

Two stale "Remix" references in `frontend/README.md` (Tech Stack line and the Real-time/features list) were left over from the Remix → React Router v7 migration.

## Fix

- Tech Stack: `Remix SPA Mode (React + Vite + React Router)` → `React Router v7 SPA Mode (React + Vite)`.
- Features: `Router data loading with Remix` → `Router data loading with React Router v7`.

## Verification

- Verified against `upstream/main`: the README still reads "Remix SPA Mode" and "Router data loading with Remix", so the drift is still live.
- `grep -i remix frontend/package.json` returns no Remix dependencies; `react-router`/`@react-router/*` resolve to `7.17.0`.
- Docs-only change; no test or build impact.

## Notes / Risks

Docs-only. Self-sourced (no linked issue). A separate open PR (#15380) updates the same README for the Redux→Zustand migration on different lines; the two changes are independent and do not overlap.
