### PR TITLE
docs(dev-guide): align Node.js requirement with engines constraint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ We believe in the power of open source to democratize access to cutting-edge AI 
 
 ### Set Up Your Development Environment
 
-- **Requirements**: Linux/Mac/WSL, Docker, Python 3.12, Node.js 22+, Poetry 1.8+
+- **Requirements**: Linux/Mac/WSL, Docker, Python 3.12, Node.js 22.12+, Poetry 1.8+
 - **Quick setup**: `make build`
 - **Run locally**: `make run`
 - **LLM setup (V1 web app)**: configure your model and API key in the Settings UI after the app starts

--- a/Development.md
+++ b/Development.md
@@ -26,7 +26,7 @@ Select your operating system to see the specific setup instructions:
 You'll need the following installed:
 
 - **Python 3.12** — `brew install python@3.12` (see the [official Homebrew Python docs](https://docs.brew.sh/Homebrew-and-Python) for details). Make sure `python3.12` is available in your PATH (the `make build` step will verify this).
-- **Node.js >= 22** — `brew install node`
+- **Node.js 22.12.x or later** — `brew install node` (matches the `frontend/package.json` `engines.node` requirement)
 - **Poetry >= 1.8** — `brew install poetry`
 - **Docker Desktop** — `brew install --cask docker`
   - After installing, open Docker Desktop → **Settings → Advanced** → Enable **"Allow the default Docker socket to be used"**


### PR DESCRIPTION
HUMAN:
The contributor guides under-stated the Node.js version. `Development.md` said "Node.js >= 22" and `CONTRIBUTING.md` said "Node.js 22+", but the frontend actually requires Node 22.12+ (`frontend/package.json` `engines.node`). I aligned both files with the "22.12.x or later" wording already used in `README.md` and `frontend/README.md`. Docs-only.

- [ ] A human has tested these changes.

AGENT:
Drafted with AI assistance. I confirmed `frontend/package.json` `engines.node` is `>=22.12.0`, verified that `README.md` and `frontend/README.md` already document the correct "22.12.x or later" minimum, and grepped the repo for other Node.js requirement strings. I then updated only the two contributor-guide strings that lagged. No code or runtime behavior change; documentation only.

---

## Why

The contributor-facing guides documented the Node.js requirement inconsistently and less strictly than the code actually enforces:

- `frontend/package.json` declares `"engines": { "node": ">=22.12.0" }`.
- `README.md` and `frontend/README.md` already say "Node.js 22.12.x or later".
- But `Development.md` said **"Node.js >= 22"** and `CONTRIBUTING.md` said **"Node.js 22+"**.

A contributor following the contributor guides could install Node 22.0.0–22.11.x and trip the `engines` check, while the README tells them 22.12.x. Same project, two different minimums.

## Summary

- `Development.md`: "Node.js >= 22" → "Node.js 22.12.x or later" (matches README wording and notes it tracks `engines.node`).
- `CONTRIBUTING.md`: "Node.js 22+" → "Node.js 22.12+".

## Issue Number

Self-sourced docs/code consistency fix; no corresponding issue.

## How to Test

Docs-only change. To verify the requirement it documents:
1. `grep '"node"' frontend/package.json` → `"node": ">=22.12.0"`.
2. `grep -n "Node.js" README.md frontend/README.md` → both already say "22.12.x or later".
3. `cat .nvmrc` → pins major `22`.

I did not run a build because no code changed.

## Video/Screenshots

Not applicable — text-only documentation change.

## Type

- [x] Docs / chore

## Notes

Internal consistency fix only. No behavior change, no dependency change. The Linux `nodesource setup_22.x` snippet in `Development.md` is intentionally left as-is because it installs the latest 22.x line (which satisfies `>=22.12.0`); only the stated minimum version strings were corrected.
