### PR TITLE
docs(frontend): clarify dev vs production static serve and update AGENTS.md env vars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,7 @@ Frontend:
   - Build for production: `npm run build`
 - Environment Variables:
   - Set in `frontend/.env` or as environment variables
-  - Available variables: VITE_BACKEND_HOST, VITE_USE_TLS, VITE_INSECURE_SKIP_VERIFY, VITE_FRONTEND_PORT
+  - Available variables: VITE_BACKEND_BASE_URL, VITE_BACKEND_HOST, VITE_MOCK_API, VITE_MOCK_SAAS, VITE_USE_TLS, VITE_FRONTEND_PORT, VITE_INSECURE_SKIP_VERIFY, VITE_GITHUB_TOKEN
 - Internationalization:
   - Generate i18n declaration file: `npm run make-i18n`
 - Data Fetching & Cache Management:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -67,8 +67,12 @@ Or to run backend and frontend separately.
 # Start the backend from the root directory
 make start-backend
 
-# Serve the frontend
-make start-frontend or
+# Develop the frontend (React Router dev server with HMR)
+make start-frontend
+# or
+cd frontend && npm run dev -- --port 3001
+
+# Serve the static production build (requires `npm run build` first)
 cd frontend && npm start -- --port 3001
 ```
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

Docs-only change; no runtime behavior is affected.

- [ ] A human has tested these changes.

AGENT:

This PR was prepared with AI assistance. It updates two frontend documentation files to fix drift between the docs and the actual build/runtime commands.

---

## Why

`frontend/README.md` presented `make start-frontend` and `cd frontend && npm start` as interchangeable ways to serve the frontend, but they are not: `make start-frontend` runs the React Router dev server with HMR (`npm run dev`), while `npm start` serves the static production build from `build/` via `sirv-cli` and requires `npm run build` first. `AGENTS.md` also listed only four of the eight Vite environment variables present in `frontend/.env.sample`.

## Summary

- Clarified `frontend/README.md` so development (`make start-frontend` / `npm run dev`) and production static serve (`npm start` after `npm run build`) are distinct, with the build prerequisite noted.
- Updated `AGENTS.md` to list all eight available Vite environment variables from `frontend/.env.sample`.

## Issue Number



## How to Test

- Read the updated `frontend/README.md` section "Running the Application with the Actual Backend (Production Mode)" and confirm dev and static-serve commands are separated and the build prerequisite is present.
- Read `AGENTS.md` lines 147-149 and confirm it lists all eight variables from `frontend/.env.sample`.

## Video/Screenshots



## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

