### PR TITLE
feat(frontend): add planner markdown copy button

### DIFF
--- a/frontend/src/components/features/conversation/conversation-tabs/conversation-tab-title.test.tsx
+++ b/frontend/src/components/features/conversation/conversation-tabs/conversation-tab-title.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ConversationTabTitle } from "./conversation-tab-title";
+import { useConversationStore } from "#/stores/conversation-store";
+import { AgentState } from "#/types/agent-state";
+
+const mockState = vi.hoisted(() => ({
+  refetch: vi.fn(),
+  isFetching: false,
+  handleBuildPlanClick: vi.fn(),
+  curAgentState: "STOPPED",
+}));
+
+vi.mock("#/hooks/query/use-unified-get-git-changes", () => ({
+  useUnifiedGetGitChanges: () => ({
+    refetch: mockState.refetch,
+    isFetching: mockState.isFetching,
+  }),
+}));
+
+vi.mock("#/hooks/use-handle-build-plan-click", () => ({
+  useHandleBuildPlanClick: () => ({
+    handleBuildPlanClick: mockState.handleBuildPlanClick,
+  }),
+}));
+
+vi.mock("#/hooks/use-agent-state", () => ({
+  useAgentState: () => ({
+    curAgentState: mockState.curAgentState,
+  }),
+}));
+
+describe("ConversationTabTitle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.isFetching = false;
+    mockState.curAgentState = AgentState.STOPPED;
+
+    useConversationStore.setState({
+      planContent: null,
+      conversationMode: "plan",
+    });
+
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it("shows a copy button for planner tabs when plan content exists and copies raw markdown", async () => {
+    useConversationStore.setState({
+      planContent: "# Plan\n\n- Step 1\n- Step 2",
+    });
+
+    render(<ConversationTabTitle title="Planner" conversationKey="planner" />);
+
+    const copyButton = screen.getByTestId("copy-to-clipboard");
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        "# Plan\n\n- Step 1\n- Step 2",
+      );
+    });
+
+    expect(copyButton).toHaveAttribute("aria-label", "BUTTON$COPIED");
+  });
+
+  it("hides the planner copy button and disables build when there is no plan content", () => {
+    render(<ConversationTabTitle title="Planner" conversationKey="planner" />);
+
+    expect(screen.queryByTestId("copy-to-clipboard")).not.toBeInTheDocument();
+    expect(screen.getByTestId("planner-tab-build-button")).toBeDisabled();
+  });
+
+  it("keeps the build button disabled while the agent is running", () => {
+    mockState.curAgentState = AgentState.RUNNING;
+    useConversationStore.setState({
+      planContent: "# Plan\n\n- Step 1",
+    });
+
+    render(<ConversationTabTitle title="Planner" conversationKey="planner" />);
+
+    expect(screen.getByTestId("planner-tab-build-button")).toBeDisabled();
+  });
+});

--- a/frontend/src/components/features/conversation/conversation-tabs/conversation-tab-title.tsx
+++ b/frontend/src/components/features/conversation/conversation-tabs/conversation-tab-title.tsx
@@ -1,5 +1,7 @@
+import React from "react";
 import { useTranslation } from "react-i18next";
 import RefreshIcon from "#/icons/u-refresh.svg?react";
+import { CopyToClipboardButton } from "#/components/shared/buttons/copy-to-clipboard-button";
 import { useUnifiedGetGitChanges } from "#/hooks/query/use-unified-get-git-changes";
 import { useHandleBuildPlanClick } from "#/hooks/use-handle-build-plan-click";
 import { useAgentState } from "#/hooks/use-agent-state";
@@ -24,6 +26,7 @@ export function ConversationTabTitle({
   const { handleBuildPlanClick } = useHandleBuildPlanClick();
   const { curAgentState } = useAgentState();
   const { planContent } = useConversationStore();
+  const [isCopy, setIsCopy] = React.useState(false);
 
   const handleRefresh = () => {
     refetch();
@@ -34,6 +37,29 @@ export function ConversationTabTitle({
     curAgentState === AgentState.RUNNING ||
     curAgentState === AgentState.LOADING;
   const isBuildDisabled = isAgentRunning || !planContent;
+
+  const handleCopyPlanClick = async () => {
+    if (!planContent) {
+      return;
+    }
+
+    await navigator.clipboard.writeText(planContent);
+    setIsCopy(true);
+  };
+
+  React.useEffect(() => {
+    let timeout: NodeJS.Timeout;
+
+    if (isCopy) {
+      timeout = setTimeout(() => {
+        setIsCopy(false);
+      }, 2000);
+    }
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [isCopy]);
 
   return (
     <div className="flex flex-row items-center justify-between border-b border-[#474A54] py-2 px-3">
@@ -54,22 +80,32 @@ export function ConversationTabTitle({
         </button>
       )}
       {conversationKey === "planner" && (
-        <button
-          type="button"
-          onClick={handleBuildPlanClick}
-          disabled={isBuildDisabled}
-          className={cn(
-            "flex items-center justify-center h-5 min-w-17 px-2 rounded bg-white transition-opacity",
-            isBuildDisabled
-              ? "opacity-50 cursor-not-allowed"
-              : "hover:opacity-90 cursor-pointer",
+        <div className="flex items-center gap-1">
+          {planContent && (
+            <CopyToClipboardButton
+              isHidden={false}
+              isDisabled={isCopy}
+              onClick={handleCopyPlanClick}
+              mode={isCopy ? "copied" : "copy"}
+            />
           )}
-          data-testid="planner-tab-build-button"
-        >
-          <Typography.Text className="text-black text-[11px] font-medium leading-5">
-            {t(I18nKey.COMMON$BUILD)} ⌘↩
-          </Typography.Text>
-        </button>
+          <button
+            type="button"
+            onClick={handleBuildPlanClick}
+            disabled={isBuildDisabled}
+            className={cn(
+              "flex items-center justify-center h-5 min-w-17 px-2 rounded bg-white transition-opacity",
+              isBuildDisabled
+                ? "opacity-50 cursor-not-allowed"
+                : "hover:opacity-90 cursor-pointer",
+            )}
+            data-testid="planner-tab-build-button"
+          >
+            <Typography.Text className="text-black text-[11px] font-medium leading-5">
+              {t(I18nKey.COMMON$BUILD)} ⌘↩
+            </Typography.Text>
+          </button>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
HUMAN:

Adds a copy button next to `Build` in the Planner tab header so reviewers can copy the raw `PLAN.md` markdown instead of the rendered text.

- [x] A human has tested these changes.

AGENT:

---

## Why

The planner panel renders the current plan as markdown, but there was no quick way to copy the raw `PLAN.md` content for reuse in another thread or file.

## Summary

- add a copy-to-clipboard action to the planner tab header next to `Build` when plan content exists
- copy the raw markdown from `planContent` and reuse the existing copied-state button behavior
- add a focused frontend test covering copy behavior and planner build button state

## Issue Number

Closes #15389

## How to Test

1. `cd frontend && npm run test -- src/components/features/conversation/conversation-tabs/conversation-tab-title.test.tsx`
2. `cd frontend && npm run lint`
3. `cd frontend && npm run build`
4. Open a conversation with plan content, switch to the `Planner` tab, and click the new copy button next to `Build`.
5. Paste the clipboard contents into a text editor and verify the raw markdown is preserved.

## Video/Screenshots

Local browser verification completed for the Planner tab copy button flow; screenshots were captured during validation but are not embedded in this PR body.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The branch has been rebased onto `upstream/main` so this PR only contains the planner copy button frontend changes for #15389.
