### PR TITLE
fix: marketplace repo_path traversal, silent analytics failure, GitHub timeout, query re-render

### DIFF
--- a/enterprise/server/config.py
+++ b/enterprise/server/config.py
@@ -115,7 +115,9 @@ class SaaSServerConfig(ServerConfig):
         }
 
         # Make a request to the GitHub API /app endpoint
-        response = requests.get('https://api.github.com/app', headers=headers)
+        response = requests.get(
+            'https://api.github.com/app', headers=headers, timeout=10
+        )
 
         # Check if the response is successful
         if response.status_code != 200:

--- a/frontend/src/hooks/query/use-repository-branches.ts
+++ b/frontend/src/hooks/query/use-repository-branches.ts
@@ -45,7 +45,5 @@ export const useRepositoryBranchesPaginated = (
     initialPageParam: null,
   });
 
-  return {
-    ...result,
-  };
+  return result;
 };

--- a/openhands/app_server/app_conversation/app_conversation_router.py
+++ b/openhands/app_server/app_conversation/app_conversation_router.py
@@ -392,7 +392,7 @@ async def start_app_conversation(
                         ctx=ctx,
                         conversation_id=str(result.app_conversation_id)
                         if result.app_conversation_id
-                        else result.id,
+                        else str(result.id),
                         trigger=start_request.trigger.value
                         if start_request.trigger
                         else None,

--- a/openhands/app_server/user/skills_router.py
+++ b/openhands/app_server/user/skills_router.py
@@ -306,9 +306,16 @@ async def _clone_marketplace_repo(
                 _cleanup_clone_dir(clone_dir)
                 return None, f'Git checkout failed: {checkout_result.stderr}'
 
-        # Navigate to repo_path if specified
+        # Navigate to repo_path if specified. Resolve and confirm containment
+        # within clone_dir: an absolute path replaces the join outright in
+        # pathlib, and '..' segments can walk outside the clone, so either
+        # would otherwise let a marketplace registration read arbitrary paths
+        # on the host (path traversal) via the manifest parse below.
         if marketplace.repo_path:
-            skills_path = clone_dir / marketplace.repo_path
+            skills_path = (clone_dir / marketplace.repo_path).resolve()
+            if not skills_path.is_relative_to(clone_dir.resolve()):
+                _cleanup_clone_dir(clone_dir)
+                return None, f'Invalid repo path: {marketplace.repo_path}'
             if not skills_path.exists():
                 _cleanup_clone_dir(clone_dir)
                 return None, f'Repo path not found: {marketplace.repo_path}'


### PR DESCRIPTION
HUMAN: This PR was built by an AI agent (Claude Code) via a static/security scan of the repo
(ruff, mypy against the project's CI config, eslint, tsc), followed by targeted fixes for what
turned out to be real, verifiable bugs rather than style noise.

- The path-traversal fix was verified live against a running local server: a real git clone
  of a public repo, a symlink-escape test proving the fix catches what the existing string-level
  validator can't, and a legitimate repo_path still resolving successfully.
- The analytics UUID fix was verified by exercising the real AnalyticsService/Posthog client
  directly to confirm the exact pre-fix failure mode (a silently swallowed json.dumps TypeError)
  and the fix's correction.
- The query-hook fix was verified via typecheck/eslint/build and the existing component test
  (repo-selection-form.test.tsx) that renders through the modified hook.
- The GitHub-timeout fix was NOT exercised live (requires SaaS-mode credentials I don't have) —
  verified statically only.

Full backend and frontend test suites pass with no new failures introduced by this change.

- [ ] A human has tested these changes.

## Summary

Four fixes found via a static/security scan (ruff incl. bandit-equivalent rules, mypy against the project's CI config, eslint, tsc) and verified live against a running server/app, not just statically.

- **Security (path traversal, CWE-22)**: `MarketplaceRegistration.repo_path` was joined onto the cloned repo dir with no containment check. An absolute path silently replaces the `pathlib` join outright, and a symlink planted inside the cloned repo (so the `repo_path` string itself is innocuous — no `..`, not absolute) can point the manifest parser at arbitrary host files. The existing Pydantic validator already blocks literal `..`/absolute strings; this closes the symlink-escape gap those checks can't see, by resolving the path and confirming containment.
- **Reliability**: `requests.get()` to the GitHub API in `enterprise/server/config.py` had no timeout, so a slow/unresponsive GitHub could hang server startup indefinitely.
- **Type contract / silent data loss**: the conversation-created analytics call passed a raw `UUID` instead of `str` on its fallback branch, violating `track_conversation_created`'s `str` contract. Live-traced the actual failure mode: `json.dumps` raises `TypeError` on the raw UUID, which `AnalyticsService.capture()` swallows — so the event silently never sends, with no crash and no visible signal.
- **Performance**: `useRepositoryBranchesPaginated` spread its TanStack Query result into a new object, defeating the tracked-query re-render optimization and causing every consumer to re-render on every query state change.

## Verification

- `ruff check` / `mypy --config-file dev_config/python/mypy.ini` clean (mypy at the same 7 pre-existing, unrelated SDK-typing findings as before these changes)
- `npm run typecheck` / `eslint` / `prettier --check` / `npm run build` all clean
- Backend suite: 2256 passed, 1 pre-existing unrelated failure (macOS temp-dir path assumption)
- Frontend suite (Node 22, matching `.nvmrc`): 2483 passed, 5 pre-existing unrelated failures in `home-screen.test.tsx` (reproduced identically with these changes reverted)
- Path-traversal fix exercised live against a running server: real `git clone` of a public repo, confirmed a legitimate `repo_path` still resolves (200, no errors) while a symlink escape is rejected
- Analytics fix exercised against the real `AnalyticsService`/Posthog client to confirm the exact pre-fix failure mode and the fix's correction

## Test plan

- [x] `ruff check openhands/ tests/`
- [x] `mypy --config-file dev_config/python/mypy.ini openhands/`
- [x] `npm run typecheck && npx eslint src --ext .ts,.tsx,.js && npx prettier --check 'src/**/*.{ts,tsx}'`
- [x] `npm run build`
- [x] `poetry run pytest tests/unit`
- [x] `npm test`
- [x] Live path-traversal test against a running server (legit path + traversal + symlink-escape cases)
- [x] Live analytics-fallback test against the real `AnalyticsService`
