### PR TITLE
fix(frontend): patch known-CVE dependencies (axios, react-router, postcss, js-yaml)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4541,6 +4541,21 @@
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
+    "node_modules/@react-spectrum/provider": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/provider/-/provider-3.11.1.tgz",
+      "integrity": "sha512-TsoNdVdmlQ7L+75ILq5Yb3+wp/I1AtIeat0o+Y+ZBxP+TtWpwT1ZtCB5l3cplFVzHzOpZlzO0VaDrDP9ElGYDw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@adobe/react-spectrum": "^3.47.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/@react-spectrum/slider": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/@react-spectrum/slider/-/slider-3.9.0.tgz",
@@ -6571,7 +6586,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -16599,7 +16613,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -17549,7 +17563,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,14 +11,14 @@
         "@heroui/react": "2.8.8",
         "@microlink/react-json-view": "1.27.1",
         "@monaco-editor/react": "4.7.0",
-        "@react-router/node": "7.17.0",
-        "@react-router/serve": "7.17.0",
+        "@react-router/node": "7.18.1",
+        "@react-router/serve": "7.18.1",
         "@tailwindcss/vite": "4.1.18",
         "@tanstack/react-query": "5.90.20",
         "@uidotdev/usehooks": "2.4.1",
         "@xterm/addon-fit": "0.11.0",
         "@xterm/xterm": "6.0.0",
-        "axios": "1.16.0",
+        "axios": "1.18.1",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "downshift": "9.3.2",
@@ -37,7 +37,7 @@
         "react-i18next": "16.6.6",
         "react-icons": "5.5.0",
         "react-markdown": "10.1.0",
-        "react-router": "7.17.0",
+        "react-router": "7.18.1",
         "react-syntax-highlighter": "16.1.0",
         "remark-breaks": "4.0.0",
         "remark-gfm": "4.0.1",
@@ -51,7 +51,7 @@
       "devDependencies": {
         "@mswjs/socket.io-binding": "0.2.0",
         "@playwright/test": "1.60.0",
-        "@react-router/dev": "7.17.0",
+        "@react-router/dev": "7.18.1",
         "@tailwindcss/typography": "0.5.19",
         "@tanstack/eslint-plugin-query": "5.100.10",
         "@testing-library/dom": "10.4.1",
@@ -4376,9 +4376,9 @@
       }
     },
     "node_modules/@react-router/dev": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@react-router/dev/-/dev-7.17.0.tgz",
-      "integrity": "sha512-+ITMmv/1xUB+QF6ehCCOIVBNBDuKIEE+3JKCt+kTBvxDTk1s49qHbtCA4TzJYge41pNRGtFIiy5VAksLSVJheg==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/@react-router/dev/-/dev-7.18.1.tgz",
+      "integrity": "sha512-1Yu5272BI8g5sl1jwmhM3aFeajXQwNbWP4qrdMYfC+ayT2khxV6KPCitLNJl+jT6DMGEKb/hmwcmKd0lFIBjxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4389,7 +4389,7 @@
         "@babel/preset-typescript": "^7.27.1",
         "@babel/traverse": "^7.27.7",
         "@babel/types": "^7.27.7",
-        "@react-router/node": "7.17.0",
+        "@react-router/node": "7.18.1",
         "@remix-run/node-fetch-server": "^0.13.0",
         "arg": "^5.0.1",
         "babel-dead-code-elimination": "^1.0.6",
@@ -4418,9 +4418,9 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@react-router/serve": "^7.17.0",
+        "@react-router/serve": "^7.18.1",
         "@vitejs/plugin-rsc": "~0.5.21",
-        "react-router": "^7.17.0",
+        "react-router": "^7.18.1",
         "react-server-dom-webpack": "^19.2.3",
         "typescript": "^5.1.0 || ^6.0.0",
         "vite": "^5.1.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -4445,19 +4445,19 @@
       }
     },
     "node_modules/@react-router/express": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@react-router/express/-/express-7.17.0.tgz",
-      "integrity": "sha512-/onhRWlfCRTq0bI7t06d2KGRUr+Gy12+CHLZDaHkdtkHJxsUFPGlnfomBMQXQLIPW544I5ykKAY8Z2d/1J6+bQ==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/@react-router/express/-/express-7.18.1.tgz",
+      "integrity": "sha512-F5Ty/NhRMEHfFCZW2hKG9RCzd75isd1BqCF1xx/Oo2CGQKp1hvVTBV+oie4qbgMMSfhdhKfLA2+wLWUIxl60xQ==",
       "license": "MIT",
       "dependencies": {
-        "@react-router/node": "7.17.0"
+        "@react-router/node": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
         "express": "^4.17.1 || ^5",
-        "react-router": "7.17.0",
+        "react-router": "7.18.1",
         "typescript": "^5.1.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
@@ -4467,9 +4467,9 @@
       }
     },
     "node_modules/@react-router/node": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@react-router/node/-/node-7.17.0.tgz",
-      "integrity": "sha512-RYR47qM9gJ8zV8Ntial5Rkgcst2YnwWXt0Ai34FezzkDK6AILpxpVatEzFEhNRwbSh6JO6iweY7XhfM4/K5dBA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/@react-router/node/-/node-7.18.1.tgz",
+      "integrity": "sha512-2GhAwa90z/+GMFM8Q5HsgwzakYogbQcZpqpNonhN4YWDRjWkSz+t5jgwNAFvG8ENR8fKGEVEsOHIaNVDfW9Ouw==",
       "license": "MIT",
       "dependencies": {
         "@mjackson/node-fetch-server": "^0.2.0"
@@ -4478,7 +4478,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react-router": "7.17.0",
+        "react-router": "7.18.1",
         "typescript": "^5.1.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
@@ -4488,14 +4488,14 @@
       }
     },
     "node_modules/@react-router/serve": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@react-router/serve/-/serve-7.17.0.tgz",
-      "integrity": "sha512-cjVz/HiZbkZe4urdImO6V+KFYDIGJk59DJXGnJ5XeDoltRi+buba0K6oTHIh0G0uoYJMm3gKqHKSiCN/a0dhJw==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/@react-router/serve/-/serve-7.18.1.tgz",
+      "integrity": "sha512-D7V4x+mc7CM2+A9l05bVC/wPxlbc3cPHuFaYu/NIfJjr+Rnj3jQe5LcVjbN6hOwSJLge7MeBSA3iMLEZ90+sDw==",
       "license": "MIT",
       "dependencies": {
         "@mjackson/node-fetch-server": "^0.2.0",
-        "@react-router/express": "7.17.0",
-        "@react-router/node": "7.17.0",
+        "@react-router/express": "7.18.1",
+        "@react-router/node": "7.18.1",
         "compression": "^1.8.1",
         "express": "^4.19.2",
         "get-port": "5.1.1",
@@ -4509,7 +4509,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react-router": "7.17.0"
+        "react-router": "7.18.1"
       }
     },
     "node_modules/@react-spectrum/dialog": {
@@ -4535,21 +4535,6 @@
         "@adobe/react-spectrum": "3.47.0",
         "@swc/helpers": "^0.5.0",
         "react-stately": "3.46.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-spectrum/provider": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@react-spectrum/provider/-/provider-3.11.1.tgz",
-      "integrity": "sha512-TsoNdVdmlQ7L+75ILq5Yb3+wp/I1AtIeat0o+Y+ZBxP+TtWpwT1ZtCB5l3cplFVzHzOpZlzO0VaDrDP9ElGYDw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@adobe/react-spectrum": "^3.47.0",
-        "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
@@ -6586,6 +6571,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7651,14 +7637,40 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -11678,10 +11690,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -13617,9 +13639,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -14208,9 +14230,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -14227,7 +14249,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -14762,9 +14784,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -16577,7 +16599,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -17527,7 +17549,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,14 +10,14 @@
     "@heroui/react": "2.8.8",
     "@microlink/react-json-view": "1.27.1",
     "@monaco-editor/react": "4.7.0",
-    "@react-router/node": "7.17.0",
-    "@react-router/serve": "7.17.0",
+    "@react-router/node": "7.18.1",
+    "@react-router/serve": "7.18.1",
     "@tailwindcss/vite": "4.1.18",
     "@tanstack/react-query": "5.90.20",
     "@uidotdev/usehooks": "2.4.1",
     "@xterm/addon-fit": "0.11.0",
     "@xterm/xterm": "6.0.0",
-    "axios": "1.16.0",
+    "axios": "1.18.1",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "downshift": "9.3.2",
@@ -36,7 +36,7 @@
     "react-i18next": "16.6.6",
     "react-icons": "5.5.0",
     "react-markdown": "10.1.0",
-    "react-router": "7.17.0",
+    "react-router": "7.18.1",
     "react-syntax-highlighter": "16.1.0",
     "remark-breaks": "4.0.0",
     "remark-gfm": "4.0.1",
@@ -82,7 +82,7 @@
   "devDependencies": {
     "@mswjs/socket.io-binding": "0.2.0",
     "@playwright/test": "1.60.0",
-    "@react-router/dev": "7.17.0",
+    "@react-router/dev": "7.18.1",
     "@tailwindcss/typography": "0.5.19",
     "@tanstack/eslint-plugin-query": "5.100.10",
     "@testing-library/dom": "10.4.1",
@@ -132,6 +132,8 @@
     "dompurify": "3.4.11",
     "qs": "6.15.2",
     "@opentelemetry/core": "2.8.0",
-    "ws": ">=8.21.0"
+    "ws": ">=8.21.0",
+    "postcss": "8.5.23",
+    "js-yaml": "4.3.0"
   }
 }


### PR DESCRIPTION
HUMAN: This PR was built by an AI agent (Claude Code) as a targeted, incremental fix for the
5 known-CVE npm packages flagged by `npm audit` (axios, brace-expansion, js-yaml, postcss,
react-router), applied without touching ESLint's major version — eslint-config-airbnb has no
ESLint 9 support at all, which rules that path out.

4 of 5 are resolved (axios, postcss, js-yaml, and 4 of react-router's 5 bundled advisories).
2 are deliberately left open and explained in the PR description: react-router's remaining
advisory needs a v8 major bump (breaking, out of scope here), and brace-expansion breaks the
ESLint toolchain whenever forced to a patched version (reproduced twice, confirmed not a fluke).

Every change was verified with typecheck/eslint/prettier/build and the full test suite, plus a
before/after npm audit diff. CI on this PR is fully green, including a real regenerated lockfile
after an npm-ci-compatibility bug surfaced and was fixed mid-review.

- [ ] A human has tested these changes.

## Summary

Targeted fix for the 5 known-CVE npm dependencies flagged by `npm audit` (axios, brace-expansion, js-yaml, postcss, react-router), applied without touching ESLint's major version or `eslint-config-airbnb` (which has no ESLint 9 support at all, ruling out that path).

- **axios** 1.16.0 → 1.18.1 (direct dependency)
- **react-router** family (`react-router`, `@react-router/dev`, `@react-router/node`, `@react-router/serve`) 7.17.0 → 7.18.1, bumped in lockstep since their peer deps require an exact matching version across all four
- **postcss** override → 8.5.23 (transitive, via `vite`)
- **js-yaml** override → 4.3.0 (transitive, via `eslint`'s own `@eslint/eslintrc`)

## Deliberately not fixed here

- **react-router's remaining advisory** (RSC Mode CSRF Bypass) is only fixed in v8.3.0+; 7.18.1 is the latest 7.x release. A v8 migration is a real breaking change and out of scope for this pass.
- **brace-expansion** (reached via `@tanstack/eslint-plugin-query`'s own nested `@typescript-eslint/utils@8.x` → `minimatch@10.x` chain) breaks `eslint-plugin-import`'s bundled (older) minimatch whenever forced to a patched version, via a blanket override or a scoped one — confirmed by reproducing the exact `TypeError: expand is not a function` crash both ways. Also, independently: any full/fresh dependency re-resolution in this repo (e.g. deleting `package-lock.json`) currently surfaces ~20 unrelated ESLint-toolchain vulnerabilities regardless of which package triggers it — this looks like a pre-existing registry-resolution sensitivity in the ESLint 8.x/airbnb devDependency tree, not something introduced by this change. Every change in this PR was applied via targeted, incremental `npm install`/`overrides` edits with immediate `eslint`/`typecheck` verification after each one — never a full lockfile regeneration.

## Verification

- `npm run typecheck` clean
- `eslint` clean (same 4 pre-existing, unrelated `console` warnings as before)
- `prettier --check` clean
- `npm run build` succeeds
- Full vitest suite: 2483 passed, same 5 pre-existing unrelated `home-screen.test.tsx` failures as before this change (verified identical with these changes reverted)
- `npm audit`: high-severity package count down from 5 unique advisories to 2 (react-router's v8-only advisory, and brace-expansion — both explained above)
- CI: fully green after a follow-up commit fixed an `npm ci` lockfile-sync issue that surfaced on the first push (caught via CI, reproduced locally, fixed with a plain regenerated lockfile)

## Test plan

- [x] `npm run typecheck`
- [x] `npx eslint src --ext .ts,.tsx,.js`
- [x] `npx prettier --check 'src/**/*.{ts,tsx}'`
- [x] `npm run build`
- [x] `npm test` (full vitest suite)
- [x] `npm audit` before/after comparison, package-by-package
- [x] `npm ci` (confirmed lockfile sync after the fixup commit)
