### PR TITLE
feat(app-server): sync managed Codex credentials (Phase 1)

### DIFF
--- a/enterprise/storage/saas_secrets_store.py
+++ b/enterprise/storage/saas_secrets_store.py
@@ -1,17 +1,30 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
 from dataclasses import dataclass, field
 from uuid import UUID
 
 from sqlalchemy import delete, select
 from storage.database import a_session_maker
+from storage.org_member_store import OrgMemberStore
 from storage.stored_custom_secrets import StoredCustomSecrets
 from storage.user_store import UserStore
 
 from openhands.app_server.secrets.secrets_models import Secrets
-from openhands.app_server.secrets.secrets_store import SecretsStore
+from openhands.app_server.secrets.secrets_store import (
+    CredentialVersionConflict,
+    SecretsStore,
+)
 from openhands.app_server.services.jwt_service import JwtService
 from openhands.app_server.utils.logger import openhands_logger as logger
+
+_CODEX_AUTH_SECRET_NAME = "CODEX_AUTH_JSON"
+
+
+def _credential_version(row: StoredCustomSecrets) -> str:
+    state = f"{row.id}\0{row.secret_value}".encode()
+    return hashlib.sha256(state).hexdigest()
 
 
 @dataclass
@@ -24,6 +37,11 @@ class SaasSecretsStore(SecretsStore):
     # (user_id, org_id), so the effective org must flow through here for
     # the right rows to be read/written.
     effective_org_id: UUID | None = None
+    _loaded_codex_auth: dict[UUID | None, str | None] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
 
     async def load(self) -> Secrets | None:
         if not self.user_id:
@@ -32,64 +50,103 @@ class SaasSecretsStore(SecretsStore):
         org_id = self.effective_org_id or (user.current_org_id if user else None)
 
         async with a_session_maker() as session:
-            # Fetch all secrets for the given user ID
             query = select(StoredCustomSecrets).filter(
                 StoredCustomSecrets.keycloak_user_id == self.user_id
             )
             if org_id is not None:
                 query = query.filter(StoredCustomSecrets.org_id == org_id)
-            result = await session.execute(query)
+            result = await session.execute(query.order_by(StoredCustomSecrets.id))
             settings = result.scalars().all()
 
             if not settings:
+                self._loaded_codex_auth[org_id] = None
                 return Secrets()
 
             kwargs = {}
             for secret in settings:
                 kwargs[secret.secret_name] = {
-                    'secret': secret.secret_value,
-                    'description': secret.description,
+                    "secret": secret.secret_value,
+                    "description": secret.description,
                 }
 
             self._decrypt_kwargs(kwargs)
+            codex_info = kwargs.get(_CODEX_AUTH_SECRET_NAME)
+            codex_value = (
+                codex_info.get("secret") if isinstance(codex_info, dict) else None
+            )
+            self._loaded_codex_auth[org_id] = (
+                codex_value if isinstance(codex_value, str) else None
+            )
 
             return Secrets(custom_secrets=kwargs)  # type: ignore[arg-type]
 
     async def store(self, item: Secrets):
         user = await UserStore.get_user_by_id(self.user_id)
         if user is None:
-            raise ValueError(f'User not found: {self.user_id}')
+            raise ValueError(f"User not found: {self.user_id}")
         org_id = self.effective_org_id or user.current_org_id
 
+        kwargs = item.model_dump(context={"expose_secrets": True})
+        del kwargs["provider_tokens"]
+        secrets_json = kwargs.get("custom_secrets", {})
+        codex_info = secrets_json.get(_CODEX_AUTH_SECRET_NAME)
+        submitted_codex = (
+            codex_info.get("secret") if isinstance(codex_info, dict) else None
+        )
+        if not isinstance(submitted_codex, str):
+            submitted_codex = None
+
+        has_baseline = org_id in self._loaded_codex_auth
+        preserve_codex = not has_baseline and codex_info is None
+        if has_baseline and submitted_codex == self._loaded_codex_auth[org_id]:
+            preserve_codex = True
+
         async with a_session_maker() as session:
-            # Incoming secrets are always the most updated ones
-            # Delete existing records for this user AND organization only
-            # org_id is always set: it's either the effective org from
-            # the request or the user's non-nullable current_org_id.
+            result = await session.execute(
+                select(StoredCustomSecrets)
+                .filter(
+                    StoredCustomSecrets.keycloak_user_id == self.user_id,
+                    StoredCustomSecrets.org_id == org_id,
+                )
+                .order_by(StoredCustomSecrets.id)
+                .with_for_update()
+            )
+            codex_rows = [
+                row
+                for row in result.scalars().all()
+                if row.secret_name == _CODEX_AUTH_SECRET_NAME
+            ]
+            if preserve_codex:
+                secrets_json.pop(_CODEX_AUTH_SECRET_NAME, None)
+                if codex_rows and isinstance(codex_info, dict):
+                    description = codex_info.get("description")
+                    encrypted_description = (
+                        self._jwt_svc.encrypt_value(description)
+                        if description is not None
+                        else None
+                    )
+                    for row in codex_rows:
+                        row.description = encrypted_description
+
             delete_query = delete(StoredCustomSecrets).filter(
                 StoredCustomSecrets.keycloak_user_id == self.user_id,
                 StoredCustomSecrets.org_id == org_id,
             )
+            if preserve_codex:
+                delete_query = delete_query.filter(
+                    StoredCustomSecrets.secret_name != _CODEX_AUTH_SECRET_NAME
+                )
             await session.execute(delete_query)
 
-            # Prepare the new secrets data
-            kwargs = item.model_dump(context={'expose_secrets': True})
-            del kwargs[
-                'provider_tokens'
-            ]  # Assuming provider_tokens is not part of custom_secrets
             self._encrypt_kwargs(kwargs)
 
-            secrets_json = kwargs.get('custom_secrets', {})
-
-            # Extract the secrets into tuples for insertion or updating
             secret_tuples = []
             for secret_name, secret_info in secrets_json.items():
-                secret_value = secret_info.get('secret')
-                description = secret_info.get('description')
+                secret_value = secret_info.get("secret")
+                description = secret_info.get("description")
 
                 secret_tuples.append((secret_name, secret_value, description))
 
-            # Add the new secrets
             for secret_name, secret_value, description in secret_tuples:
                 new_secret = StoredCustomSecrets(
                     keycloak_user_id=self.user_id,
@@ -101,6 +158,88 @@ class SaasSecretsStore(SecretsStore):
                 session.add(new_secret)
 
             await session.commit()
+            if not preserve_codex:
+                self._loaded_codex_auth[org_id] = submitted_codex
+
+    async def load_versioned(
+        self,
+        name: str,
+        organization_id: UUID | None = None,
+    ) -> tuple[str, str]:
+        org_id = await self._require_organization_id(name, organization_id)
+        async with a_session_maker() as session:
+            result = await session.execute(self._versioned_query(name, org_id).limit(1))
+            row = result.scalars().first()
+            if row is None:
+                raise KeyError(name)
+            return self._jwt_svc.decrypt_value(row.secret_value), _credential_version(
+                row
+            )
+
+    async def replace_versioned(
+        self,
+        name: str,
+        expected_version: str,
+        value: str,
+        organization_id: UUID | None = None,
+    ) -> str:
+        org_id = await self._require_organization_id(name, organization_id)
+        async with a_session_maker() as session:
+            result = await session.execute(
+                self._versioned_query(name, org_id).with_for_update()
+            )
+            rows = result.scalars().all()
+            if not rows:
+                result = await session.execute(
+                    self._versioned_query(name, org_id).limit(1)
+                )
+                if result.scalars().first() is not None:
+                    raise CredentialVersionConflict
+                raise KeyError(name)
+
+            current_version = _credential_version(rows[0])
+            if not hmac.compare_digest(
+                current_version.encode(),
+                expected_version.encode(errors="surrogatepass"),
+            ):
+                raise CredentialVersionConflict
+
+            encrypted = self._jwt_svc.encrypt_value(value)
+            for row in rows:
+                row.secret_value = encrypted
+            successor = _credential_version(rows[0])
+            await session.commit()
+            return successor
+
+    async def _require_organization_id(
+        self,
+        name: str,
+        organization_id: UUID | None,
+    ) -> UUID:
+        org_id = organization_id or self.effective_org_id
+        if org_id is None:
+            user = await UserStore.get_user_by_id(self.user_id)
+            org_id = user.current_org_id if user else None
+        if org_id is None:
+            raise KeyError(name)
+        try:
+            user_id = UUID(self.user_id)
+        except (TypeError, ValueError) as exc:
+            raise KeyError(name) from exc
+        if await OrgMemberStore.get_org_member(org_id, user_id) is None:
+            raise KeyError(name)
+        return org_id
+
+    def _versioned_query(self, name: str, organization_id: UUID):
+        return (
+            select(StoredCustomSecrets)
+            .filter(
+                StoredCustomSecrets.keycloak_user_id == self.user_id,
+                StoredCustomSecrets.org_id == organization_id,
+                StoredCustomSecrets.secret_name == name,
+            )
+            .order_by(StoredCustomSecrets.id.desc())
+        )
 
     def _decrypt_kwargs(self, kwargs: dict):
         for key, value in kwargs.items():
@@ -142,7 +281,7 @@ class SaasSecretsStore(SecretsStore):
 
         TODO: This method should be replaced with dependency injection.
         """
-        logger.debug(f'saas_secrets_store.get_instance::{user_id}')
+        logger.debug(f"saas_secrets_store.get_instance::{user_id}")
         from storage.encrypt_utils import get_jwt_service
 
         return SaasSecretsStore(

--- a/enterprise/storage/saas_secrets_store.py
+++ b/enterprise/storage/saas_secrets_store.py
@@ -19,11 +19,11 @@ from openhands.app_server.secrets.secrets_store import (
 from openhands.app_server.services.jwt_service import JwtService
 from openhands.app_server.utils.logger import openhands_logger as logger
 
-_CODEX_AUTH_SECRET_NAME = "CODEX_AUTH_JSON"
+_CODEX_AUTH_SECRET_NAME = 'CODEX_AUTH_JSON'
 
 
 def _credential_version(row: StoredCustomSecrets) -> str:
-    state = f"{row.id}\0{row.secret_value}".encode()
+    state = f'{row.id}\0{row.secret_value}'.encode()
     return hashlib.sha256(state).hexdigest()
 
 
@@ -65,14 +65,14 @@ class SaasSecretsStore(SecretsStore):
             kwargs = {}
             for secret in settings:
                 kwargs[secret.secret_name] = {
-                    "secret": secret.secret_value,
-                    "description": secret.description,
+                    'secret': secret.secret_value,
+                    'description': secret.description,
                 }
 
             self._decrypt_kwargs(kwargs)
             codex_info = kwargs.get(_CODEX_AUTH_SECRET_NAME)
             codex_value = (
-                codex_info.get("secret") if isinstance(codex_info, dict) else None
+                codex_info.get('secret') if isinstance(codex_info, dict) else None
             )
             self._loaded_codex_auth[org_id] = (
                 codex_value if isinstance(codex_value, str) else None
@@ -83,15 +83,15 @@ class SaasSecretsStore(SecretsStore):
     async def store(self, item: Secrets):
         user = await UserStore.get_user_by_id(self.user_id)
         if user is None:
-            raise ValueError(f"User not found: {self.user_id}")
+            raise ValueError(f'User not found: {self.user_id}')
         org_id = self.effective_org_id or user.current_org_id
 
-        kwargs = item.model_dump(context={"expose_secrets": True})
-        del kwargs["provider_tokens"]
-        secrets_json = kwargs.get("custom_secrets", {})
+        kwargs = item.model_dump(context={'expose_secrets': True})
+        del kwargs['provider_tokens']
+        secrets_json = kwargs.get('custom_secrets', {})
         codex_info = secrets_json.get(_CODEX_AUTH_SECRET_NAME)
         submitted_codex = (
-            codex_info.get("secret") if isinstance(codex_info, dict) else None
+            codex_info.get('secret') if isinstance(codex_info, dict) else None
         )
         if not isinstance(submitted_codex, str):
             submitted_codex = None
@@ -119,7 +119,7 @@ class SaasSecretsStore(SecretsStore):
             if preserve_codex:
                 secrets_json.pop(_CODEX_AUTH_SECRET_NAME, None)
                 if codex_rows and isinstance(codex_info, dict):
-                    description = codex_info.get("description")
+                    description = codex_info.get('description')
                     encrypted_description = (
                         self._jwt_svc.encrypt_value(description)
                         if description is not None
@@ -142,8 +142,8 @@ class SaasSecretsStore(SecretsStore):
 
             secret_tuples = []
             for secret_name, secret_info in secrets_json.items():
-                secret_value = secret_info.get("secret")
-                description = secret_info.get("description")
+                secret_value = secret_info.get('secret')
+                description = secret_info.get('description')
 
                 secret_tuples.append((secret_name, secret_value, description))
 
@@ -200,7 +200,7 @@ class SaasSecretsStore(SecretsStore):
             current_version = _credential_version(rows[0])
             if not hmac.compare_digest(
                 current_version.encode(),
-                expected_version.encode(errors="surrogatepass"),
+                expected_version.encode(errors='surrogatepass'),
             ):
                 raise CredentialVersionConflict
 
@@ -281,7 +281,7 @@ class SaasSecretsStore(SecretsStore):
 
         TODO: This method should be replaced with dependency injection.
         """
-        logger.debug(f"saas_secrets_store.get_instance::{user_id}")
+        logger.debug(f'saas_secrets_store.get_instance::{user_id}')
         from storage.encrypt_utils import get_jwt_service
 
         return SaasSecretsStore(

--- a/enterprise/storage/saas_secrets_store.py
+++ b/enterprise/storage/saas_secrets_store.py
@@ -108,7 +108,9 @@ class SaasSecretsStore(SecretsStore):
                     StoredCustomSecrets.keycloak_user_id == self.user_id,
                     StoredCustomSecrets.org_id == org_id,
                 )
-                .order_by(StoredCustomSecrets.id)
+                # Lock in the same order as _versioned_query so a concurrent
+                # replace_versioned over the duplicate Codex rows cannot deadlock.
+                .order_by(StoredCustomSecrets.id.desc())
                 .with_for_update()
             )
             codex_rows = [

--- a/enterprise/tests/unit/test_saas_secrets_store.py
+++ b/enterprise/tests/unit/test_saas_secrets_store.py
@@ -1,3 +1,4 @@
+import hashlib
 from types import MappingProxyType
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -5,17 +6,24 @@ from uuid import UUID
 
 import pytest
 from pydantic import SecretStr
+from sqlalchemy import select
 from storage.saas_secrets_store import SaasSecretsStore
 from storage.stored_custom_secrets import StoredCustomSecrets
 
 from openhands.app_server.integrations.provider import CustomSecret
 from openhands.app_server.secrets.secrets_models import Secrets
+from openhands.app_server.secrets.secrets_store import CredentialVersionConflict
 from openhands.app_server.services.jwt_service import JwtService
 from openhands.app_server.utils.encryption_key import EncryptionKey
 
+_MANAGED_NAME = "CODEX_AUTH_JSON"
+_VERSION_USER_ID = UUID("c3333333-3333-3333-3333-333333333333")
+_VERSION_ORG_ID = UUID("a1111111-1111-1111-1111-111111111111")
+_OTHER_ORG_ID = UUID("b2222222-2222-2222-2222-222222222222")
+
 
 def _make_jwt_service() -> JwtService:
-    key = EncryptionKey(kid='test', key=SecretStr('test_secret'), active=True)
+    key = EncryptionKey(kid="test", key=SecretStr("test_secret"), active=True)
     return JwtService(keys=[key])
 
 
@@ -28,7 +36,7 @@ def jwt_svc():
 def mock_user():
     """Mock user with org_id."""
     user = MagicMock()
-    user.current_org_id = UUID('a1111111-1111-1111-1111-111111111111')
+    user.current_org_id = UUID("a1111111-1111-1111-1111-111111111111")
     return user
 
 
@@ -39,16 +47,314 @@ def secrets_store(async_session_maker, jwt_svc):
 
     store_module.a_session_maker = async_session_maker
 
-    store = SaasSecretsStore('user-id', jwt_svc)
+    store = SaasSecretsStore("user-id", jwt_svc)
     # Also add it as an attribute for tests that need direct access
     store.a_session_maker = async_session_maker
     return store
 
 
+@pytest.fixture
+def version_store(async_session_maker, jwt_svc):
+    import storage.saas_secrets_store as store_module
+
+    store_module.a_session_maker = async_session_maker
+    return SaasSecretsStore(str(_VERSION_USER_ID), jwt_svc)
+
+
+@pytest.fixture
+def version_membership():
+    with patch(
+        "storage.saas_secrets_store.OrgMemberStore.get_org_member",
+        new_callable=AsyncMock,
+        return_value=MagicMock(),
+    ) as get_org_member:
+        yield get_org_member
+
+
+async def _insert_versioned(
+    async_session_maker,
+    jwt_svc: JwtService,
+    value: str,
+    org_id: UUID = _VERSION_ORG_ID,
+    description: str = "Managed login",
+) -> None:
+    async with async_session_maker() as session:
+        session.add(
+            StoredCustomSecrets(
+                keycloak_user_id=str(_VERSION_USER_ID),
+                org_id=org_id,
+                secret_name=_MANAGED_NAME,
+                secret_value=jwt_svc.encrypt_value(value),
+                description=jwt_svc.encrypt_value(description),
+            )
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_versioned_compare_and_swap(
+    async_session_maker,
+    jwt_svc,
+    version_store,
+    version_membership,
+):
+    original = '{"tokens":{"refresh_token":"r0"}}'
+    rotated = '{"tokens":{"refresh_token":"r1"}}'
+    await _insert_versioned(async_session_maker, jwt_svc, original)
+
+    value, version = await version_store.load_versioned(
+        _MANAGED_NAME,
+        _VERSION_ORG_ID,
+    )
+    assert value == original
+    assert version != hashlib.sha256(original.encode()).hexdigest()
+
+    with pytest.raises(CredentialVersionConflict):
+        await version_store.replace_versioned(
+            _MANAGED_NAME,
+            "stale",
+            rotated,
+            _VERSION_ORG_ID,
+        )
+    successor = await version_store.replace_versioned(
+        _MANAGED_NAME,
+        version,
+        rotated,
+        _VERSION_ORG_ID,
+    )
+
+    assert successor != version
+    assert await version_store.load_versioned(
+        _MANAGED_NAME,
+        _VERSION_ORG_ID,
+    ) == (rotated, successor)
+
+
+@pytest.mark.asyncio
+async def test_versioned_newest_duplicate_wins_and_replace_converges_rows(
+    async_session_maker,
+    jwt_svc,
+    version_store,
+    version_membership,
+):
+    await _insert_versioned(
+        async_session_maker,
+        jwt_svc,
+        "stale",
+        description="First",
+    )
+    await _insert_versioned(
+        async_session_maker,
+        jwt_svc,
+        "current",
+        description="Newest",
+    )
+
+    value, version = await version_store.load_versioned(
+        _MANAGED_NAME,
+        _VERSION_ORG_ID,
+    )
+    assert value == "current"
+    successor = await version_store.replace_versioned(
+        _MANAGED_NAME,
+        version,
+        "rotated",
+        _VERSION_ORG_ID,
+    )
+
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(StoredCustomSecrets)
+            .filter(
+                StoredCustomSecrets.keycloak_user_id == str(_VERSION_USER_ID),
+                StoredCustomSecrets.org_id == _VERSION_ORG_ID,
+                StoredCustomSecrets.secret_name == _MANAGED_NAME,
+            )
+            .order_by(StoredCustomSecrets.id)
+        )
+        rows = result.scalars().all()
+
+    assert len(rows) == 2
+    assert {jwt_svc.decrypt_value(row.secret_value) for row in rows} == {"rotated"}
+    assert {jwt_svc.decrypt_value(row.description) for row in rows} == {
+        "First",
+        "Newest",
+    }
+    assert await version_store.load_versioned(
+        _MANAGED_NAME,
+        _VERSION_ORG_ID,
+    ) == ("rotated", successor)
+
+
+@pytest.mark.asyncio
+async def test_versioned_delete_and_identical_recreate_rejects_old_generation(
+    async_session_maker,
+    jwt_svc,
+    version_store,
+    version_membership,
+):
+    await _insert_versioned(async_session_maker, jwt_svc, "same")
+    user = MagicMock(current_org_id=_VERSION_ORG_ID)
+    with patch(
+        "storage.saas_secrets_store.UserStore.get_user_by_id",
+        new_callable=AsyncMock,
+        return_value=user,
+    ):
+        assert await version_store.load() is not None
+        _, original_version = await version_store.load_versioned(
+            _MANAGED_NAME,
+            _VERSION_ORG_ID,
+        )
+        await version_store.store(Secrets())
+        await version_store.store(
+            Secrets(
+                custom_secrets={
+                    _MANAGED_NAME: CustomSecret.from_value(
+                        {"secret": "same", "description": "Managed login"}
+                    )
+                }
+            )
+        )
+
+    _, recreated_version = await version_store.load_versioned(
+        _MANAGED_NAME,
+        _VERSION_ORG_ID,
+    )
+    assert recreated_version != original_version
+    with pytest.raises(CredentialVersionConflict):
+        await version_store.replace_versioned(
+            _MANAGED_NAME,
+            original_version,
+            "rotated",
+            _VERSION_ORG_ID,
+        )
+
+
+@pytest.mark.asyncio
+async def test_versioned_access_uses_pinned_org_after_current_org_drift(
+    async_session_maker,
+    version_store,
+    version_membership,
+):
+    await _insert_versioned(
+        async_session_maker,
+        version_store._jwt_svc,
+        "value",
+    )
+    version_store.effective_org_id = _OTHER_ORG_ID
+
+    value, _ = await version_store.load_versioned(
+        _MANAGED_NAME,
+        _VERSION_ORG_ID,
+    )
+    assert value == "value"
+    version_membership.assert_awaited_once_with(
+        _VERSION_ORG_ID,
+        _VERSION_USER_ID,
+    )
+
+    version_membership.reset_mock()
+    version_membership.return_value = None
+    with pytest.raises(KeyError, match=_MANAGED_NAME):
+        await version_store.load_versioned(_MANAGED_NAME, _VERSION_ORG_ID)
+    version_membership.assert_awaited_once_with(
+        _VERSION_ORG_ID,
+        _VERSION_USER_ID,
+    )
+
+
+@pytest.mark.asyncio
+@patch(
+    "storage.saas_secrets_store.UserStore.get_user_by_id",
+    new_callable=AsyncMock,
+)
+async def test_stale_whole_save_preserves_rotation_and_unrelated_edits(
+    mock_get_user,
+    async_session_maker,
+    jwt_svc,
+    version_store,
+    version_membership,
+):
+    user = MagicMock(current_org_id=_VERSION_ORG_ID)
+    mock_get_user.return_value = user
+    original = '{"tokens":{"refresh_token":"r0"}}'
+    rotated = '{"tokens":{"refresh_token":"r1"}}'
+    await version_store.store(
+        Secrets(
+            custom_secrets={
+                _MANAGED_NAME: CustomSecret.from_value(
+                    {"secret": original, "description": "Old description"}
+                ),
+                "OTHER": CustomSecret.from_value({"secret": "old", "description": ""}),
+            }
+        )
+    )
+    stale_store = SaasSecretsStore(str(_VERSION_USER_ID), jwt_svc)
+    stale = await stale_store.load()
+    assert stale is not None
+    _, version = await version_store.load_versioned(
+        _MANAGED_NAME,
+        _VERSION_ORG_ID,
+    )
+    successor = await version_store.replace_versioned(
+        _MANAGED_NAME,
+        version,
+        rotated,
+        _VERSION_ORG_ID,
+    )
+
+    updated = dict(stale.custom_secrets)
+    updated[_MANAGED_NAME] = CustomSecret.from_value(
+        {"secret": original, "description": "New description"}
+    )
+    updated["OTHER"] = CustomSecret.from_value({"secret": "new", "description": ""})
+    await stale_store.store(stale.model_copy(update={"custom_secrets": updated}))
+
+    assert await version_store.load_versioned(
+        _MANAGED_NAME,
+        _VERSION_ORG_ID,
+    ) == (rotated, successor)
+    loaded = await stale_store.load()
+    assert loaded is not None
+    assert loaded.custom_secrets[_MANAGED_NAME].description == "New description"
+    assert loaded.custom_secrets["OTHER"].secret.get_secret_value() == "new"
+
+
+@pytest.mark.asyncio
+async def test_versioned_replace_reports_concurrent_recreate(
+    jwt_svc,
+    version_membership,
+):
+    first_result = MagicMock()
+    first_result.scalars.return_value.all.return_value = []
+    second_result = MagicMock()
+    second_result.scalars.return_value.first.return_value = MagicMock()
+    session = AsyncMock()
+    session.execute.side_effect = [first_result, second_result]
+    session_maker = MagicMock()
+    session_maker.return_value.__aenter__ = AsyncMock(return_value=session)
+    session_maker.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("storage.saas_secrets_store.a_session_maker", session_maker):
+        with pytest.raises(CredentialVersionConflict):
+            await SaasSecretsStore(
+                str(_VERSION_USER_ID),
+                jwt_svc,
+            ).replace_versioned(
+                _MANAGED_NAME,
+                "stale",
+                "rotated",
+                _VERSION_ORG_ID,
+            )
+
+    assert session.execute.await_count == 2
+    assert session.execute.await_args_list[0].args[0]._for_update_arg is not None
+
+
 class TestSaasSecretsStore:
     @pytest.mark.asyncio
     @patch(
-        'storage.saas_secrets_store.UserStore.get_user_by_id',
+        "storage.saas_secrets_store.UserStore.get_user_by_id",
         new_callable=AsyncMock,
     )
     async def test_store_and_load(self, mock_get_user, secrets_store, mock_user):
@@ -59,11 +365,11 @@ class TestSaasSecretsStore:
         user_secrets = Secrets(
             custom_secrets=MappingProxyType(
                 {
-                    'api_token': CustomSecret.from_value(
-                        {'secret': 'secret_api_token', 'description': ''}
+                    "api_token": CustomSecret.from_value(
+                        {"secret": "secret_api_token", "description": ""}
                     ),
-                    'db_password': CustomSecret.from_value(
-                        {'secret': 'my_password', 'description': ''}
+                    "db_password": CustomSecret.from_value(
+                        {"secret": "my_password", "description": ""}
                     ),
                 }
             )
@@ -78,17 +384,17 @@ class TestSaasSecretsStore:
         # Verify the loaded secrets match the original
         assert loaded_secrets is not None
         assert (
-            loaded_secrets.custom_secrets['api_token'].secret.get_secret_value()
-            == 'secret_api_token'
+            loaded_secrets.custom_secrets["api_token"].secret.get_secret_value()
+            == "secret_api_token"
         )
         assert (
-            loaded_secrets.custom_secrets['db_password'].secret.get_secret_value()
-            == 'my_password'
+            loaded_secrets.custom_secrets["db_password"].secret.get_secret_value()
+            == "my_password"
         )
 
     @pytest.mark.asyncio
     @patch(
-        'storage.saas_secrets_store.UserStore.get_user_by_id',
+        "storage.saas_secrets_store.UserStore.get_user_by_id",
         new_callable=AsyncMock,
     )
     async def test_encryption_decryption(self, mock_get_user, secrets_store, mock_user):
@@ -98,22 +404,22 @@ class TestSaasSecretsStore:
         user_secrets = Secrets(
             custom_secrets=MappingProxyType(
                 {
-                    'api_token': CustomSecret.from_value(
-                        {'secret': 'sensitive_token', 'description': ''}
+                    "api_token": CustomSecret.from_value(
+                        {"secret": "sensitive_token", "description": ""}
                     ),
-                    'secret_key': CustomSecret.from_value(
-                        {'secret': 'sensitive_secret', 'description': ''}
+                    "secret_key": CustomSecret.from_value(
+                        {"secret": "sensitive_secret", "description": ""}
                     ),
-                    'normal_data': CustomSecret.from_value(
-                        {'secret': 'not_sensitive', 'description': ''}
+                    "normal_data": CustomSecret.from_value(
+                        {"secret": "not_sensitive", "description": ""}
                     ),
                 }
             )
         )
 
         assert (
-            user_secrets.custom_secrets['api_token'].secret.get_secret_value()
-            == 'sensitive_token'
+            user_secrets.custom_secrets["api_token"].secret.get_secret_value()
+            == "sensitive_token"
         )
         # Store the secrets
         await secrets_store.store(user_secrets)
@@ -124,41 +430,41 @@ class TestSaasSecretsStore:
         async with secrets_store.a_session_maker() as session:
             result = await session.execute(
                 select(StoredCustomSecrets)
-                .filter(StoredCustomSecrets.keycloak_user_id == 'user-id')
+                .filter(StoredCustomSecrets.keycloak_user_id == "user-id")
                 .filter(StoredCustomSecrets.org_id == mock_user.current_org_id)
             )
             stored = result.scalars().first()
 
             # The sensitive data should be encrypted
-            assert stored.secret_value != 'sensitive_token'
-            assert stored.secret_value != 'sensitive_secret'
-            assert stored.secret_value != 'not_sensitive'
+            assert stored.secret_value != "sensitive_token"
+            assert stored.secret_value != "sensitive_secret"
+            assert stored.secret_value != "not_sensitive"
 
         # Load the secrets and verify decryption works
         loaded_secrets = await secrets_store.load()
         assert (
-            loaded_secrets.custom_secrets['api_token'].secret.get_secret_value()
-            == 'sensitive_token'
+            loaded_secrets.custom_secrets["api_token"].secret.get_secret_value()
+            == "sensitive_token"
         )
         assert (
-            loaded_secrets.custom_secrets['secret_key'].secret.get_secret_value()
-            == 'sensitive_secret'
+            loaded_secrets.custom_secrets["secret_key"].secret.get_secret_value()
+            == "sensitive_secret"
         )
         assert (
-            loaded_secrets.custom_secrets['normal_data'].secret.get_secret_value()
-            == 'not_sensitive'
+            loaded_secrets.custom_secrets["normal_data"].secret.get_secret_value()
+            == "not_sensitive"
         )
 
     @pytest.mark.asyncio
     async def test_encrypt_decrypt_kwargs(self, secrets_store):
         # Test encryption and decryption directly
         test_data: dict[str, Any] = {
-            'api_token': 'test_token',
-            'client_secret': 'test_secret',
-            'normal_data': 'not_sensitive',
-            'nested': {
-                'nested_token': 'nested_secret_value',
-                'nested_normal': 'nested_normal_value',
+            "api_token": "test_token",
+            "client_secret": "test_secret",
+            "normal_data": "not_sensitive",
+            "nested": {
+                "nested_token": "nested_secret_value",
+                "nested_normal": "nested_normal_value",
             },
         }
 
@@ -166,31 +472,31 @@ class TestSaasSecretsStore:
         secrets_store._encrypt_kwargs(test_data)
 
         # Sensitive data is encrypted
-        assert test_data['api_token'] != 'test_token'
-        assert test_data['client_secret'] != 'test_secret'
-        assert test_data['normal_data'] != 'not_sensitive'
-        assert test_data['nested']['nested_token'] != 'nested_secret_value'
-        assert test_data['nested']['nested_normal'] != 'nested_normal_value'
+        assert test_data["api_token"] != "test_token"
+        assert test_data["client_secret"] != "test_secret"
+        assert test_data["normal_data"] != "not_sensitive"
+        assert test_data["nested"]["nested_token"] != "nested_secret_value"
+        assert test_data["nested"]["nested_normal"] != "nested_normal_value"
 
         # Decrypt the data
         secrets_store._decrypt_kwargs(test_data)
 
         # Verify sensitive data is properly decrypted
-        assert test_data['api_token'] == 'test_token'
-        assert test_data['client_secret'] == 'test_secret'
-        assert test_data['normal_data'] == 'not_sensitive'
-        assert test_data['nested']['nested_token'] == 'nested_secret_value'
-        assert test_data['nested']['nested_normal'] == 'nested_normal_value'
+        assert test_data["api_token"] == "test_token"
+        assert test_data["client_secret"] == "test_secret"
+        assert test_data["normal_data"] == "not_sensitive"
+        assert test_data["nested"]["nested_token"] == "nested_secret_value"
+        assert test_data["nested"]["nested_normal"] == "nested_normal_value"
 
     @pytest.mark.asyncio
     async def test_empty_user_id(self, secrets_store):
         # Test that load returns None when user_id is empty
-        secrets_store.user_id = ''
+        secrets_store.user_id = ""
         assert await secrets_store.load() is None
 
     @pytest.mark.asyncio
     @patch(
-        'storage.saas_secrets_store.UserStore.get_user_by_id',
+        "storage.saas_secrets_store.UserStore.get_user_by_id",
         new_callable=AsyncMock,
     )
     async def test_update_existing_secrets(
@@ -202,11 +508,11 @@ class TestSaasSecretsStore:
         initial_secrets = Secrets(
             custom_secrets=MappingProxyType(
                 {
-                    'api_token': CustomSecret.from_value(
-                        {'secret': 'initial_token', 'description': ''}
+                    "api_token": CustomSecret.from_value(
+                        {"secret": "initial_token", "description": ""}
                     ),
-                    'other_value': CustomSecret.from_value(
-                        {'secret': 'initial_value', 'description': ''}
+                    "other_value": CustomSecret.from_value(
+                        {"secret": "initial_value", "description": ""}
                     ),
                 }
             )
@@ -217,11 +523,11 @@ class TestSaasSecretsStore:
         updated_secrets = Secrets(
             custom_secrets=MappingProxyType(
                 {
-                    'api_token': CustomSecret.from_value(
-                        {'secret': 'updated_token', 'description': ''}
+                    "api_token": CustomSecret.from_value(
+                        {"secret": "updated_token", "description": ""}
                     ),
-                    'new_value': CustomSecret.from_value(
-                        {'secret': 'new_value', 'description': ''}
+                    "new_value": CustomSecret.from_value(
+                        {"secret": "new_value", "description": ""}
                     ),
                 }
             )
@@ -231,41 +537,37 @@ class TestSaasSecretsStore:
         # Load the secrets and verify they were updated
         loaded_secrets = await secrets_store.load()
         assert (
-            loaded_secrets.custom_secrets['api_token'].secret.get_secret_value()
-            == 'updated_token'
+            loaded_secrets.custom_secrets["api_token"].secret.get_secret_value()
+            == "updated_token"
         )
-        assert 'new_value' in loaded_secrets.custom_secrets
+        assert "new_value" in loaded_secrets.custom_secrets
         assert (
-            loaded_secrets.custom_secrets['new_value'].secret.get_secret_value()
-            == 'new_value'
+            loaded_secrets.custom_secrets["new_value"].secret.get_secret_value()
+            == "new_value"
         )
 
         # The other_value should not still be present
-        assert 'other_value' not in loaded_secrets.custom_secrets
+        assert "other_value" not in loaded_secrets.custom_secrets
 
     @pytest.mark.asyncio
     async def test_get_instance(self, jwt_svc):
         # Test the get_instance class method
-        with patch('storage.encrypt_utils.get_jwt_service', return_value=jwt_svc):
-            store = await SaasSecretsStore.get_instance('test-user-id')
+        with patch("storage.encrypt_utils.get_jwt_service", return_value=jwt_svc):
+            store = await SaasSecretsStore.get_instance("test-user-id")
         assert isinstance(store, SaasSecretsStore)
-        assert store.user_id == 'test-user-id'
+        assert store.user_id == "test-user-id"
         assert store._jwt_svc is jwt_svc
 
     @pytest.mark.asyncio
     @patch(
-        'storage.saas_secrets_store.UserStore.get_user_by_id',
+        "storage.saas_secrets_store.UserStore.get_user_by_id",
         new_callable=AsyncMock,
     )
     async def test_secrets_isolation_between_organizations(
         self, mock_get_user, secrets_store, mock_user
     ):
-        """Test that secrets from one organization are not deleted when storing
-        secrets in another organization. This reproduces a bug where switching
-        organizations and creating a secret would delete all secrets from the
-        user's personal workspace."""
-        org1_id = UUID('a1111111-1111-1111-1111-111111111111')
-        org2_id = UUID('b2222222-2222-2222-2222-222222222222')
+        org1_id = UUID("a1111111-1111-1111-1111-111111111111")
+        org2_id = UUID("b2222222-2222-2222-2222-222222222222")
 
         # Store secrets in org1 (personal workspace)
         mock_user.current_org_id = org1_id
@@ -273,10 +575,10 @@ class TestSaasSecretsStore:
         org1_secrets = Secrets(
             custom_secrets=MappingProxyType(
                 {
-                    'personal_secret': CustomSecret.from_value(
+                    "personal_secret": CustomSecret.from_value(
                         {
-                            'secret': 'personal_secret_value',
-                            'description': 'My personal secret',
+                            "secret": "personal_secret_value",
+                            "description": "My personal secret",
                         }
                     ),
                 }
@@ -287,10 +589,10 @@ class TestSaasSecretsStore:
         # Verify org1 secrets are stored
         loaded_org1 = await secrets_store.load()
         assert loaded_org1 is not None
-        assert 'personal_secret' in loaded_org1.custom_secrets
+        assert "personal_secret" in loaded_org1.custom_secrets
         assert (
-            loaded_org1.custom_secrets['personal_secret'].secret.get_secret_value()
-            == 'personal_secret_value'
+            loaded_org1.custom_secrets["personal_secret"].secret.get_secret_value()
+            == "personal_secret_value"
         )
 
         # Switch to org2 and store secrets there
@@ -299,8 +601,8 @@ class TestSaasSecretsStore:
         org2_secrets = Secrets(
             custom_secrets=MappingProxyType(
                 {
-                    'org2_secret': CustomSecret.from_value(
-                        {'secret': 'org2_secret_value', 'description': 'Org2 secret'}
+                    "org2_secret": CustomSecret.from_value(
+                        {"secret": "org2_secret_value", "description": "Org2 secret"}
                     ),
                 }
             )
@@ -310,10 +612,10 @@ class TestSaasSecretsStore:
         # Verify org2 secrets are stored
         loaded_org2 = await secrets_store.load()
         assert loaded_org2 is not None
-        assert 'org2_secret' in loaded_org2.custom_secrets
+        assert "org2_secret" in loaded_org2.custom_secrets
         assert (
-            loaded_org2.custom_secrets['org2_secret'].secret.get_secret_value()
-            == 'org2_secret_value'
+            loaded_org2.custom_secrets["org2_secret"].secret.get_secret_value()
+            == "org2_secret_value"
         )
 
         # Switch back to org1 and verify secrets are still there
@@ -321,12 +623,12 @@ class TestSaasSecretsStore:
         mock_get_user.return_value = mock_user
         loaded_org1_again = await secrets_store.load()
         assert loaded_org1_again is not None
-        assert 'personal_secret' in loaded_org1_again.custom_secrets
+        assert "personal_secret" in loaded_org1_again.custom_secrets
         assert (
             loaded_org1_again.custom_secrets[
-                'personal_secret'
+                "personal_secret"
             ].secret.get_secret_value()
-            == 'personal_secret_value'
+            == "personal_secret_value"
         )
         # Verify org2 secrets are NOT visible in org1
-        assert 'org2_secret' not in loaded_org1_again.custom_secrets
+        assert "org2_secret" not in loaded_org1_again.custom_secrets

--- a/enterprise/tests/unit/test_saas_secrets_store.py
+++ b/enterprise/tests/unit/test_saas_secrets_store.py
@@ -16,14 +16,14 @@ from openhands.app_server.secrets.secrets_store import CredentialVersionConflict
 from openhands.app_server.services.jwt_service import JwtService
 from openhands.app_server.utils.encryption_key import EncryptionKey
 
-_MANAGED_NAME = "CODEX_AUTH_JSON"
-_VERSION_USER_ID = UUID("c3333333-3333-3333-3333-333333333333")
-_VERSION_ORG_ID = UUID("a1111111-1111-1111-1111-111111111111")
-_OTHER_ORG_ID = UUID("b2222222-2222-2222-2222-222222222222")
+_MANAGED_NAME = 'CODEX_AUTH_JSON'
+_VERSION_USER_ID = UUID('c3333333-3333-3333-3333-333333333333')
+_VERSION_ORG_ID = UUID('a1111111-1111-1111-1111-111111111111')
+_OTHER_ORG_ID = UUID('b2222222-2222-2222-2222-222222222222')
 
 
 def _make_jwt_service() -> JwtService:
-    key = EncryptionKey(kid="test", key=SecretStr("test_secret"), active=True)
+    key = EncryptionKey(kid='test', key=SecretStr('test_secret'), active=True)
     return JwtService(keys=[key])
 
 
@@ -36,7 +36,7 @@ def jwt_svc():
 def mock_user():
     """Mock user with org_id."""
     user = MagicMock()
-    user.current_org_id = UUID("a1111111-1111-1111-1111-111111111111")
+    user.current_org_id = UUID('a1111111-1111-1111-1111-111111111111')
     return user
 
 
@@ -47,7 +47,7 @@ def secrets_store(async_session_maker, jwt_svc):
 
     store_module.a_session_maker = async_session_maker
 
-    store = SaasSecretsStore("user-id", jwt_svc)
+    store = SaasSecretsStore('user-id', jwt_svc)
     # Also add it as an attribute for tests that need direct access
     store.a_session_maker = async_session_maker
     return store
@@ -64,7 +64,7 @@ def version_store(async_session_maker, jwt_svc):
 @pytest.fixture
 def version_membership():
     with patch(
-        "storage.saas_secrets_store.OrgMemberStore.get_org_member",
+        'storage.saas_secrets_store.OrgMemberStore.get_org_member',
         new_callable=AsyncMock,
         return_value=MagicMock(),
     ) as get_org_member:
@@ -76,7 +76,7 @@ async def _insert_versioned(
     jwt_svc: JwtService,
     value: str,
     org_id: UUID = _VERSION_ORG_ID,
-    description: str = "Managed login",
+    description: str = 'Managed login',
 ) -> None:
     async with async_session_maker() as session:
         session.add(
@@ -112,7 +112,7 @@ async def test_versioned_compare_and_swap(
     with pytest.raises(CredentialVersionConflict):
         await version_store.replace_versioned(
             _MANAGED_NAME,
-            "stale",
+            'stale',
             rotated,
             _VERSION_ORG_ID,
         )
@@ -140,25 +140,25 @@ async def test_versioned_newest_duplicate_wins_and_replace_converges_rows(
     await _insert_versioned(
         async_session_maker,
         jwt_svc,
-        "stale",
-        description="First",
+        'stale',
+        description='First',
     )
     await _insert_versioned(
         async_session_maker,
         jwt_svc,
-        "current",
-        description="Newest",
+        'current',
+        description='Newest',
     )
 
     value, version = await version_store.load_versioned(
         _MANAGED_NAME,
         _VERSION_ORG_ID,
     )
-    assert value == "current"
+    assert value == 'current'
     successor = await version_store.replace_versioned(
         _MANAGED_NAME,
         version,
-        "rotated",
+        'rotated',
         _VERSION_ORG_ID,
     )
 
@@ -175,15 +175,15 @@ async def test_versioned_newest_duplicate_wins_and_replace_converges_rows(
         rows = result.scalars().all()
 
     assert len(rows) == 2
-    assert {jwt_svc.decrypt_value(row.secret_value) for row in rows} == {"rotated"}
+    assert {jwt_svc.decrypt_value(row.secret_value) for row in rows} == {'rotated'}
     assert {jwt_svc.decrypt_value(row.description) for row in rows} == {
-        "First",
-        "Newest",
+        'First',
+        'Newest',
     }
     assert await version_store.load_versioned(
         _MANAGED_NAME,
         _VERSION_ORG_ID,
-    ) == ("rotated", successor)
+    ) == ('rotated', successor)
 
 
 @pytest.mark.asyncio
@@ -193,10 +193,10 @@ async def test_versioned_delete_and_identical_recreate_rejects_old_generation(
     version_store,
     version_membership,
 ):
-    await _insert_versioned(async_session_maker, jwt_svc, "same")
+    await _insert_versioned(async_session_maker, jwt_svc, 'same')
     user = MagicMock(current_org_id=_VERSION_ORG_ID)
     with patch(
-        "storage.saas_secrets_store.UserStore.get_user_by_id",
+        'storage.saas_secrets_store.UserStore.get_user_by_id',
         new_callable=AsyncMock,
         return_value=user,
     ):
@@ -210,7 +210,7 @@ async def test_versioned_delete_and_identical_recreate_rejects_old_generation(
             Secrets(
                 custom_secrets={
                     _MANAGED_NAME: CustomSecret.from_value(
-                        {"secret": "same", "description": "Managed login"}
+                        {'secret': 'same', 'description': 'Managed login'}
                     )
                 }
             )
@@ -225,7 +225,7 @@ async def test_versioned_delete_and_identical_recreate_rejects_old_generation(
         await version_store.replace_versioned(
             _MANAGED_NAME,
             original_version,
-            "rotated",
+            'rotated',
             _VERSION_ORG_ID,
         )
 
@@ -239,7 +239,7 @@ async def test_versioned_access_uses_pinned_org_after_current_org_drift(
     await _insert_versioned(
         async_session_maker,
         version_store._jwt_svc,
-        "value",
+        'value',
     )
     version_store.effective_org_id = _OTHER_ORG_ID
 
@@ -247,7 +247,7 @@ async def test_versioned_access_uses_pinned_org_after_current_org_drift(
         _MANAGED_NAME,
         _VERSION_ORG_ID,
     )
-    assert value == "value"
+    assert value == 'value'
     version_membership.assert_awaited_once_with(
         _VERSION_ORG_ID,
         _VERSION_USER_ID,
@@ -265,7 +265,7 @@ async def test_versioned_access_uses_pinned_org_after_current_org_drift(
 
 @pytest.mark.asyncio
 @patch(
-    "storage.saas_secrets_store.UserStore.get_user_by_id",
+    'storage.saas_secrets_store.UserStore.get_user_by_id',
     new_callable=AsyncMock,
 )
 async def test_stale_whole_save_preserves_rotation_and_unrelated_edits(
@@ -283,9 +283,9 @@ async def test_stale_whole_save_preserves_rotation_and_unrelated_edits(
         Secrets(
             custom_secrets={
                 _MANAGED_NAME: CustomSecret.from_value(
-                    {"secret": original, "description": "Old description"}
+                    {'secret': original, 'description': 'Old description'}
                 ),
-                "OTHER": CustomSecret.from_value({"secret": "old", "description": ""}),
+                'OTHER': CustomSecret.from_value({'secret': 'old', 'description': ''}),
             }
         )
     )
@@ -305,10 +305,10 @@ async def test_stale_whole_save_preserves_rotation_and_unrelated_edits(
 
     updated = dict(stale.custom_secrets)
     updated[_MANAGED_NAME] = CustomSecret.from_value(
-        {"secret": original, "description": "New description"}
+        {'secret': original, 'description': 'New description'}
     )
-    updated["OTHER"] = CustomSecret.from_value({"secret": "new", "description": ""})
-    await stale_store.store(stale.model_copy(update={"custom_secrets": updated}))
+    updated['OTHER'] = CustomSecret.from_value({'secret': 'new', 'description': ''})
+    await stale_store.store(stale.model_copy(update={'custom_secrets': updated}))
 
     assert await version_store.load_versioned(
         _MANAGED_NAME,
@@ -316,8 +316,8 @@ async def test_stale_whole_save_preserves_rotation_and_unrelated_edits(
     ) == (rotated, successor)
     loaded = await stale_store.load()
     assert loaded is not None
-    assert loaded.custom_secrets[_MANAGED_NAME].description == "New description"
-    assert loaded.custom_secrets["OTHER"].secret.get_secret_value() == "new"
+    assert loaded.custom_secrets[_MANAGED_NAME].description == 'New description'
+    assert loaded.custom_secrets['OTHER'].secret.get_secret_value() == 'new'
 
 
 @pytest.mark.asyncio
@@ -335,15 +335,15 @@ async def test_versioned_replace_reports_concurrent_recreate(
     session_maker.return_value.__aenter__ = AsyncMock(return_value=session)
     session_maker.return_value.__aexit__ = AsyncMock(return_value=None)
 
-    with patch("storage.saas_secrets_store.a_session_maker", session_maker):
+    with patch('storage.saas_secrets_store.a_session_maker', session_maker):
         with pytest.raises(CredentialVersionConflict):
             await SaasSecretsStore(
                 str(_VERSION_USER_ID),
                 jwt_svc,
             ).replace_versioned(
                 _MANAGED_NAME,
-                "stale",
-                "rotated",
+                'stale',
+                'rotated',
                 _VERSION_ORG_ID,
             )
 
@@ -354,7 +354,7 @@ async def test_versioned_replace_reports_concurrent_recreate(
 class TestSaasSecretsStore:
     @pytest.mark.asyncio
     @patch(
-        "storage.saas_secrets_store.UserStore.get_user_by_id",
+        'storage.saas_secrets_store.UserStore.get_user_by_id',
         new_callable=AsyncMock,
     )
     async def test_store_and_load(self, mock_get_user, secrets_store, mock_user):
@@ -365,11 +365,11 @@ class TestSaasSecretsStore:
         user_secrets = Secrets(
             custom_secrets=MappingProxyType(
                 {
-                    "api_token": CustomSecret.from_value(
-                        {"secret": "secret_api_token", "description": ""}
+                    'api_token': CustomSecret.from_value(
+                        {'secret': 'secret_api_token', 'description': ''}
                     ),
-                    "db_password": CustomSecret.from_value(
-                        {"secret": "my_password", "description": ""}
+                    'db_password': CustomSecret.from_value(
+                        {'secret': 'my_password', 'description': ''}
                     ),
                 }
             )
@@ -384,17 +384,17 @@ class TestSaasSecretsStore:
         # Verify the loaded secrets match the original
         assert loaded_secrets is not None
         assert (
-            loaded_secrets.custom_secrets["api_token"].secret.get_secret_value()
-            == "secret_api_token"
+            loaded_secrets.custom_secrets['api_token'].secret.get_secret_value()
+            == 'secret_api_token'
         )
         assert (
-            loaded_secrets.custom_secrets["db_password"].secret.get_secret_value()
-            == "my_password"
+            loaded_secrets.custom_secrets['db_password'].secret.get_secret_value()
+            == 'my_password'
         )
 
     @pytest.mark.asyncio
     @patch(
-        "storage.saas_secrets_store.UserStore.get_user_by_id",
+        'storage.saas_secrets_store.UserStore.get_user_by_id',
         new_callable=AsyncMock,
     )
     async def test_encryption_decryption(self, mock_get_user, secrets_store, mock_user):
@@ -404,22 +404,22 @@ class TestSaasSecretsStore:
         user_secrets = Secrets(
             custom_secrets=MappingProxyType(
                 {
-                    "api_token": CustomSecret.from_value(
-                        {"secret": "sensitive_token", "description": ""}
+                    'api_token': CustomSecret.from_value(
+                        {'secret': 'sensitive_token', 'description': ''}
                     ),
-                    "secret_key": CustomSecret.from_value(
-                        {"secret": "sensitive_secret", "description": ""}
+                    'secret_key': CustomSecret.from_value(
+                        {'secret': 'sensitive_secret', 'description': ''}
                     ),
-                    "normal_data": CustomSecret.from_value(
-                        {"secret": "not_sensitive", "description": ""}
+                    'normal_data': CustomSecret.from_value(
+                        {'secret': 'not_sensitive', 'description': ''}
                     ),
                 }
             )
         )
 
         assert (
-            user_secrets.custom_secrets["api_token"].secret.get_secret_value()
-            == "sensitive_token"
+            user_secrets.custom_secrets['api_token'].secret.get_secret_value()
+            == 'sensitive_token'
         )
         # Store the secrets
         await secrets_store.store(user_secrets)
@@ -430,41 +430,41 @@ class TestSaasSecretsStore:
         async with secrets_store.a_session_maker() as session:
             result = await session.execute(
                 select(StoredCustomSecrets)
-                .filter(StoredCustomSecrets.keycloak_user_id == "user-id")
+                .filter(StoredCustomSecrets.keycloak_user_id == 'user-id')
                 .filter(StoredCustomSecrets.org_id == mock_user.current_org_id)
             )
             stored = result.scalars().first()
 
             # The sensitive data should be encrypted
-            assert stored.secret_value != "sensitive_token"
-            assert stored.secret_value != "sensitive_secret"
-            assert stored.secret_value != "not_sensitive"
+            assert stored.secret_value != 'sensitive_token'
+            assert stored.secret_value != 'sensitive_secret'
+            assert stored.secret_value != 'not_sensitive'
 
         # Load the secrets and verify decryption works
         loaded_secrets = await secrets_store.load()
         assert (
-            loaded_secrets.custom_secrets["api_token"].secret.get_secret_value()
-            == "sensitive_token"
+            loaded_secrets.custom_secrets['api_token'].secret.get_secret_value()
+            == 'sensitive_token'
         )
         assert (
-            loaded_secrets.custom_secrets["secret_key"].secret.get_secret_value()
-            == "sensitive_secret"
+            loaded_secrets.custom_secrets['secret_key'].secret.get_secret_value()
+            == 'sensitive_secret'
         )
         assert (
-            loaded_secrets.custom_secrets["normal_data"].secret.get_secret_value()
-            == "not_sensitive"
+            loaded_secrets.custom_secrets['normal_data'].secret.get_secret_value()
+            == 'not_sensitive'
         )
 
     @pytest.mark.asyncio
     async def test_encrypt_decrypt_kwargs(self, secrets_store):
         # Test encryption and decryption directly
         test_data: dict[str, Any] = {
-            "api_token": "test_token",
-            "client_secret": "test_secret",
-            "normal_data": "not_sensitive",
-            "nested": {
-                "nested_token": "nested_secret_value",
-                "nested_normal": "nested_normal_value",
+            'api_token': 'test_token',
+            'client_secret': 'test_secret',
+            'normal_data': 'not_sensitive',
+            'nested': {
+                'nested_token': 'nested_secret_value',
+                'nested_normal': 'nested_normal_value',
             },
         }
 
@@ -472,31 +472,31 @@ class TestSaasSecretsStore:
         secrets_store._encrypt_kwargs(test_data)
 
         # Sensitive data is encrypted
-        assert test_data["api_token"] != "test_token"
-        assert test_data["client_secret"] != "test_secret"
-        assert test_data["normal_data"] != "not_sensitive"
-        assert test_data["nested"]["nested_token"] != "nested_secret_value"
-        assert test_data["nested"]["nested_normal"] != "nested_normal_value"
+        assert test_data['api_token'] != 'test_token'
+        assert test_data['client_secret'] != 'test_secret'
+        assert test_data['normal_data'] != 'not_sensitive'
+        assert test_data['nested']['nested_token'] != 'nested_secret_value'
+        assert test_data['nested']['nested_normal'] != 'nested_normal_value'
 
         # Decrypt the data
         secrets_store._decrypt_kwargs(test_data)
 
         # Verify sensitive data is properly decrypted
-        assert test_data["api_token"] == "test_token"
-        assert test_data["client_secret"] == "test_secret"
-        assert test_data["normal_data"] == "not_sensitive"
-        assert test_data["nested"]["nested_token"] == "nested_secret_value"
-        assert test_data["nested"]["nested_normal"] == "nested_normal_value"
+        assert test_data['api_token'] == 'test_token'
+        assert test_data['client_secret'] == 'test_secret'
+        assert test_data['normal_data'] == 'not_sensitive'
+        assert test_data['nested']['nested_token'] == 'nested_secret_value'
+        assert test_data['nested']['nested_normal'] == 'nested_normal_value'
 
     @pytest.mark.asyncio
     async def test_empty_user_id(self, secrets_store):
         # Test that load returns None when user_id is empty
-        secrets_store.user_id = ""
+        secrets_store.user_id = ''
         assert await secrets_store.load() is None
 
     @pytest.mark.asyncio
     @patch(
-        "storage.saas_secrets_store.UserStore.get_user_by_id",
+        'storage.saas_secrets_store.UserStore.get_user_by_id',
         new_callable=AsyncMock,
     )
     async def test_update_existing_secrets(
@@ -508,11 +508,11 @@ class TestSaasSecretsStore:
         initial_secrets = Secrets(
             custom_secrets=MappingProxyType(
                 {
-                    "api_token": CustomSecret.from_value(
-                        {"secret": "initial_token", "description": ""}
+                    'api_token': CustomSecret.from_value(
+                        {'secret': 'initial_token', 'description': ''}
                     ),
-                    "other_value": CustomSecret.from_value(
-                        {"secret": "initial_value", "description": ""}
+                    'other_value': CustomSecret.from_value(
+                        {'secret': 'initial_value', 'description': ''}
                     ),
                 }
             )
@@ -523,11 +523,11 @@ class TestSaasSecretsStore:
         updated_secrets = Secrets(
             custom_secrets=MappingProxyType(
                 {
-                    "api_token": CustomSecret.from_value(
-                        {"secret": "updated_token", "description": ""}
+                    'api_token': CustomSecret.from_value(
+                        {'secret': 'updated_token', 'description': ''}
                     ),
-                    "new_value": CustomSecret.from_value(
-                        {"secret": "new_value", "description": ""}
+                    'new_value': CustomSecret.from_value(
+                        {'secret': 'new_value', 'description': ''}
                     ),
                 }
             )
@@ -537,37 +537,37 @@ class TestSaasSecretsStore:
         # Load the secrets and verify they were updated
         loaded_secrets = await secrets_store.load()
         assert (
-            loaded_secrets.custom_secrets["api_token"].secret.get_secret_value()
-            == "updated_token"
+            loaded_secrets.custom_secrets['api_token'].secret.get_secret_value()
+            == 'updated_token'
         )
-        assert "new_value" in loaded_secrets.custom_secrets
+        assert 'new_value' in loaded_secrets.custom_secrets
         assert (
-            loaded_secrets.custom_secrets["new_value"].secret.get_secret_value()
-            == "new_value"
+            loaded_secrets.custom_secrets['new_value'].secret.get_secret_value()
+            == 'new_value'
         )
 
         # The other_value should not still be present
-        assert "other_value" not in loaded_secrets.custom_secrets
+        assert 'other_value' not in loaded_secrets.custom_secrets
 
     @pytest.mark.asyncio
     async def test_get_instance(self, jwt_svc):
         # Test the get_instance class method
-        with patch("storage.encrypt_utils.get_jwt_service", return_value=jwt_svc):
-            store = await SaasSecretsStore.get_instance("test-user-id")
+        with patch('storage.encrypt_utils.get_jwt_service', return_value=jwt_svc):
+            store = await SaasSecretsStore.get_instance('test-user-id')
         assert isinstance(store, SaasSecretsStore)
-        assert store.user_id == "test-user-id"
+        assert store.user_id == 'test-user-id'
         assert store._jwt_svc is jwt_svc
 
     @pytest.mark.asyncio
     @patch(
-        "storage.saas_secrets_store.UserStore.get_user_by_id",
+        'storage.saas_secrets_store.UserStore.get_user_by_id',
         new_callable=AsyncMock,
     )
     async def test_secrets_isolation_between_organizations(
         self, mock_get_user, secrets_store, mock_user
     ):
-        org1_id = UUID("a1111111-1111-1111-1111-111111111111")
-        org2_id = UUID("b2222222-2222-2222-2222-222222222222")
+        org1_id = UUID('a1111111-1111-1111-1111-111111111111')
+        org2_id = UUID('b2222222-2222-2222-2222-222222222222')
 
         # Store secrets in org1 (personal workspace)
         mock_user.current_org_id = org1_id
@@ -575,10 +575,10 @@ class TestSaasSecretsStore:
         org1_secrets = Secrets(
             custom_secrets=MappingProxyType(
                 {
-                    "personal_secret": CustomSecret.from_value(
+                    'personal_secret': CustomSecret.from_value(
                         {
-                            "secret": "personal_secret_value",
-                            "description": "My personal secret",
+                            'secret': 'personal_secret_value',
+                            'description': 'My personal secret',
                         }
                     ),
                 }
@@ -589,10 +589,10 @@ class TestSaasSecretsStore:
         # Verify org1 secrets are stored
         loaded_org1 = await secrets_store.load()
         assert loaded_org1 is not None
-        assert "personal_secret" in loaded_org1.custom_secrets
+        assert 'personal_secret' in loaded_org1.custom_secrets
         assert (
-            loaded_org1.custom_secrets["personal_secret"].secret.get_secret_value()
-            == "personal_secret_value"
+            loaded_org1.custom_secrets['personal_secret'].secret.get_secret_value()
+            == 'personal_secret_value'
         )
 
         # Switch to org2 and store secrets there
@@ -601,8 +601,8 @@ class TestSaasSecretsStore:
         org2_secrets = Secrets(
             custom_secrets=MappingProxyType(
                 {
-                    "org2_secret": CustomSecret.from_value(
-                        {"secret": "org2_secret_value", "description": "Org2 secret"}
+                    'org2_secret': CustomSecret.from_value(
+                        {'secret': 'org2_secret_value', 'description': 'Org2 secret'}
                     ),
                 }
             )
@@ -612,10 +612,10 @@ class TestSaasSecretsStore:
         # Verify org2 secrets are stored
         loaded_org2 = await secrets_store.load()
         assert loaded_org2 is not None
-        assert "org2_secret" in loaded_org2.custom_secrets
+        assert 'org2_secret' in loaded_org2.custom_secrets
         assert (
-            loaded_org2.custom_secrets["org2_secret"].secret.get_secret_value()
-            == "org2_secret_value"
+            loaded_org2.custom_secrets['org2_secret'].secret.get_secret_value()
+            == 'org2_secret_value'
         )
 
         # Switch back to org1 and verify secrets are still there
@@ -623,12 +623,12 @@ class TestSaasSecretsStore:
         mock_get_user.return_value = mock_user
         loaded_org1_again = await secrets_store.load()
         assert loaded_org1_again is not None
-        assert "personal_secret" in loaded_org1_again.custom_secrets
+        assert 'personal_secret' in loaded_org1_again.custom_secrets
         assert (
             loaded_org1_again.custom_secrets[
-                "personal_secret"
+                'personal_secret'
             ].secret.get_secret_value()
-            == "personal_secret_value"
+            == 'personal_secret_value'
         )
         # Verify org2 secrets are NOT visible in org1
-        assert "org2_secret" not in loaded_org1_again.custom_secrets
+        assert 'org2_secret' not in loaded_org1_again.custom_secrets

--- a/frontend/__tests__/conversation-websocket-handler.test.tsx
+++ b/frontend/__tests__/conversation-websocket-handler.test.tsx
@@ -94,6 +94,7 @@ function renderWithWebSocketContext(
   conversationId = "test-conversation-default",
   conversationUrl = "http://localhost:3000/api/conversations/test-conversation-default",
   sessionApiKey: string | null = null,
+  onCredentialBindingActivationRequired?: () => void,
 ) {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -113,6 +114,9 @@ function renderWithWebSocketContext(
                 conversationId={conversationId}
                 conversationUrl={conversationUrl}
                 sessionApiKey={sessionApiKey}
+                onCredentialBindingActivationRequired={
+                  onCredentialBindingActivationRequired
+                }
               >
                 {children}
               </ConversationWebSocketProvider>
@@ -671,6 +675,53 @@ describe("Conversation WebSocket Handler", () => {
           "none",
         );
       });
+    });
+
+    it("requests credential activation for the binding guard close", async () => {
+      const recoverCredentialBinding = vi.fn();
+      mswServer.use(
+        wsLink.addEventListener("connection", ({ client, server }) => {
+          server.connect();
+          client.close(1013, "credential_binding_activation_required");
+        }),
+      );
+
+      renderWithWebSocketContext(
+        <ConnectionStatusComponent />,
+        undefined,
+        undefined,
+        undefined,
+        recoverCredentialBinding,
+      );
+
+      await waitFor(() => {
+        expect(recoverCredentialBinding).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it("does not request activation for another 1013 reason", async () => {
+      const recoverCredentialBinding = vi.fn();
+      mswServer.use(
+        wsLink.addEventListener("connection", ({ client, server }) => {
+          server.connect();
+          client.close(1013, "try_again_later");
+        }),
+      );
+
+      renderWithWebSocketContext(
+        <ConnectionStatusComponent />,
+        undefined,
+        undefined,
+        undefined,
+        recoverCredentialBinding,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("connection-state")).toHaveTextContent(
+          "CLOSED",
+        );
+      });
+      expect(recoverCredentialBinding).not.toHaveBeenCalled();
     });
 
     it("should clear error message store when connection is restored", async () => {

--- a/frontend/__tests__/conversation-websocket-handler.test.tsx
+++ b/frontend/__tests__/conversation-websocket-handler.test.tsx
@@ -724,6 +724,87 @@ describe("Conversation WebSocket Handler", () => {
       expect(recoverCredentialBinding).not.toHaveBeenCalled();
     });
 
+    it("does not request activation for a previously selected conversation", async () => {
+      const recoverCredentialBinding = vi.fn();
+      const staleConversationId = "conversation-stale";
+      const freshConversationId = "conversation-fresh";
+      const sockets: WebSocket[] = [];
+      const NativeWebSocket = window.WebSocket;
+      const webSocketSpy = vi
+        .spyOn(window, "WebSocket")
+        .mockImplementation(function trackingWebSocket(
+          url: string | URL,
+          protocols?: string | string[],
+        ) {
+          const socket = new NativeWebSocket(url, protocols);
+          sockets.push(socket);
+          return socket;
+        } as unknown as typeof WebSocket);
+
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      const treeFor = (conversationId: string) => (
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={["/conversation"]}>
+            <Routes>
+              <Route
+                path="/conversation"
+                element={
+                  <ConversationWebSocketProvider
+                    conversationId={conversationId}
+                    conversationUrl={`http://localhost:3000/api/conversations/${conversationId}`}
+                    sessionApiKey={null}
+                    onCredentialBindingActivationRequired={
+                      recoverCredentialBinding
+                    }
+                  >
+                    <ConnectionStatusComponent />
+                  </ConversationWebSocketProvider>
+                }
+              />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      );
+
+      try {
+        const { rerender } = render(treeFor(staleConversationId));
+
+        await waitFor(() => {
+          expect(screen.getByTestId("connection-state")).toHaveTextContent(
+            "OPEN",
+          );
+        });
+
+        const staleSocket = sockets[0];
+        expect(staleSocket.url).toContain(staleConversationId);
+
+        // The provider is reused across conversations, so the stale socket's close
+        // is dispatched through the freshly selected conversation's handler.
+        rerender(treeFor(freshConversationId));
+        await waitFor(() => {
+          expect(sockets.length).toBeGreaterThan(1);
+        });
+
+        act(() => {
+          staleSocket.dispatchEvent(
+            new CloseEvent("close", {
+              code: 1013,
+              reason: "credential_binding_activation_required",
+            }),
+          );
+        });
+
+        expect(recoverCredentialBinding).not.toHaveBeenCalled();
+      } finally {
+        webSocketSpy.mockRestore();
+      }
+    });
+
     it("should clear error message store when connection is restored", async () => {
       let connectionAttempt = 0;
 

--- a/frontend/__tests__/hooks/mutation/use-unified-resume-conversation-sandbox.test.tsx
+++ b/frontend/__tests__/hooks/mutation/use-unified-resume-conversation-sandbox.test.tsx
@@ -106,9 +106,11 @@ describe("useUnifiedResumeConversationSandbox", () => {
       .mockRejectedValueOnce(rateLimitError)
       .mockRejectedValueOnce(rateLimitError)
       .mockResolvedValueOnce([createConversation()]);
-    vi.spyOn(SandboxService, "resumeSandbox").mockResolvedValue({
-      success: true,
-    });
+    const activateCredentialBinding = vi
+      .spyOn(SandboxService, "activateCredentialBinding")
+      .mockResolvedValue({
+        success: true,
+      });
 
     const { result } = renderHook(() => useUnifiedResumeConversationSandbox(), {
       wrapper,
@@ -138,6 +140,10 @@ describe("useUnifiedResumeConversationSandbox", () => {
     });
     await expect(resume).resolves.toEqual({ success: true });
     expect(batchGetAppConversations).toHaveBeenCalledTimes(3);
+    expect(activateCredentialBinding).toHaveBeenCalledWith(
+      "test-sandbox-id",
+      "test-conv-id",
+    );
   });
 
   it("invalidates sandbox and vscode_url queries on settled", async () => {
@@ -146,7 +152,7 @@ describe("useUnifiedResumeConversationSandbox", () => {
       V1ConversationService,
       "batchGetAppConversations",
     ).mockResolvedValue([createConversation()]);
-    vi.spyOn(SandboxService, "resumeSandbox").mockResolvedValue({
+    vi.spyOn(SandboxService, "activateCredentialBinding").mockResolvedValue({
       success: true,
     });
 

--- a/frontend/__tests__/hooks/use-sandbox-recovery.test.tsx
+++ b/frontend/__tests__/hooks/use-sandbox-recovery.test.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { useSandboxRecovery } from "#/hooks/use-sandbox-recovery";
 import { useUnifiedResumeConversationSandbox } from "#/hooks/mutation/use-unified-start-conversation";
 import * as customToastHandlers from "#/utils/custom-toast-handlers";
+import type { V1AppConversation } from "#/api/conversation-service/v1-conversation-service.types";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -81,7 +82,7 @@ describe("useSandboxRecovery", () => {
         () =>
           useSandboxRecovery({
             conversationId: "conv-123",
-            sandboxStatus: "PAUSED"
+            sandboxStatus: "PAUSED",
           }),
         { wrapper: createWrapper() },
       );
@@ -100,7 +101,7 @@ describe("useSandboxRecovery", () => {
     });
 
     it("should NOT call resumeSandbox on initial load when conversation is RUNNING", () => {
-      renderHook(
+      const { result } = renderHook(
         () =>
           useSandboxRecovery({
             conversationId: "conv-123",
@@ -110,6 +111,17 @@ describe("useSandboxRecovery", () => {
       );
 
       expect(mockMutate).not.toHaveBeenCalled();
+
+      act(() => {
+        result.current.recoverCredentialBinding();
+        result.current.recoverCredentialBinding();
+      });
+
+      expect(mockMutate).toHaveBeenCalledTimes(1);
+      expect(mockMutate).toHaveBeenCalledWith(
+        expect.objectContaining({ conversationId: "conv-123" }),
+        expect.any(Object),
+      );
     });
 
     it("should NOT call resumeSandbox when conversationId is undefined", () => {
@@ -117,7 +129,7 @@ describe("useSandboxRecovery", () => {
         () =>
           useSandboxRecovery({
             conversationId: undefined,
-            sandboxStatus: "MISSING"
+            sandboxStatus: "MISSING",
           }),
         { wrapper: createWrapper() },
       );
@@ -143,7 +155,7 @@ describe("useSandboxRecovery", () => {
         () =>
           useSandboxRecovery({
             conversationId: "conv-123",
-            sandboxStatus: "PAUSED"
+            sandboxStatus: "PAUSED",
           }),
         { wrapper: createWrapper() },
       );
@@ -161,7 +173,7 @@ describe("useSandboxRecovery", () => {
         ({ conversationId }) =>
           useSandboxRecovery({
             conversationId,
-            sandboxStatus: "PAUSED"
+            sandboxStatus: "PAUSED",
           }),
         {
           wrapper: createWrapper(),
@@ -257,6 +269,42 @@ describe("useSandboxRecovery", () => {
       expect(mockMutate).not.toHaveBeenCalled();
     });
 
+    it("ignores a stale visibility refetch after navigation", async () => {
+      let resolveRefetch!: (value: { data: V1AppConversation }) => void;
+      const mockRefetch = vi.fn(
+        () =>
+          new Promise<{ data: V1AppConversation }>((resolve) => {
+            resolveRefetch = resolve;
+          }),
+      );
+      const { rerender } = renderHook(
+        ({ conversationId }) =>
+          useSandboxRecovery({
+            conversationId,
+            sandboxStatus: "RUNNING",
+            refetchConversation: mockRefetch,
+          }),
+        {
+          wrapper: createWrapper(),
+          initialProps: { conversationId: "conv-123" },
+        },
+      );
+
+      act(() => {
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+      rerender({ conversationId: "conv-456" });
+      await act(async () => {
+        resolveRefetch({
+          data: {
+            sandbox_status: "PAUSED",
+          } as V1AppConversation,
+        });
+      });
+
+      expect(mockMutate).not.toHaveBeenCalled();
+    });
+
     it("should NOT call resumeSandbox when tab becomes visible but refetchConversation is not provided", async () => {
       renderHook(
         () =>
@@ -323,7 +371,7 @@ describe("useSandboxRecovery", () => {
         () =>
           useSandboxRecovery({
             conversationId: "conv-123",
-            sandboxStatus: "MISSING"
+            sandboxStatus: "MISSING",
           }),
         { wrapper: createWrapper() },
       );
@@ -386,7 +434,9 @@ describe("useSandboxRecovery", () => {
     });
 
     it("should handle refetch errors gracefully without crashing", async () => {
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
 
       const mockRefetch = vi.fn().mockRejectedValue(new Error("Network error"));
 
@@ -456,7 +506,7 @@ describe("useSandboxRecovery", () => {
         () =>
           useSandboxRecovery({
             conversationId: "conv-123",
-            sandboxStatus: "MISSING"
+            sandboxStatus: "MISSING",
           }),
         { wrapper: createWrapper() },
       );
@@ -514,7 +564,9 @@ describe("useSandboxRecovery", () => {
 
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenCalledWith(testError);
-      expect(vi.mocked(customToastHandlers.displayErrorToast)).toHaveBeenCalled();
+      expect(
+        vi.mocked(customToastHandlers.displayErrorToast),
+      ).toHaveBeenCalled();
     });
 
     it("should NOT call resumeSandbox when isPending is true", () => {
@@ -540,7 +592,7 @@ describe("useSandboxRecovery", () => {
         () =>
           useSandboxRecovery({
             conversationId: "conv-123",
-            sandboxStatus: "MISSING"
+            sandboxStatus: "MISSING",
           }),
         { wrapper: createWrapper() },
       );
@@ -550,15 +602,8 @@ describe("useSandboxRecovery", () => {
     });
   });
 
-  describe("WebSocket disconnect (negative test)", () => {
-    it("should NOT have any mechanism to auto-resume on WebSocket disconnect", () => {
-      // This test documents the intended behavior: the hook does NOT
-      // listen for WebSocket disconnects. Recovery only happens on:
-      // 1. Initial page load (STOPPED status)
-      // 2. Tab focus (visibilitychange event)
-      //
-      // There is intentionally NO onDisconnect handler or WebSocket listener.
-
+  describe("WebSocket disconnect", () => {
+    it("does not recover a running sandbox without an activation signal", () => {
       const { result } = renderHook(
         () =>
           useSandboxRecovery({
@@ -568,13 +613,69 @@ describe("useSandboxRecovery", () => {
         { wrapper: createWrapper() },
       );
 
-      // The hook should only expose isResuming - no disconnect-related functionality
       expect(result.current).toEqual({
         isResuming: expect.any(Boolean),
+        credentialBindingActivationFailed: false,
+        recoverCredentialBinding: expect.any(Function),
       });
 
-      // No calls should have been made for RUNNING status
       expect(mockMutate).not.toHaveBeenCalled();
+    });
+
+    it("does not loop after credential activation fails", () => {
+      const { result } = renderHook(
+        () =>
+          useSandboxRecovery({
+            conversationId: "conv-123",
+            sandboxStatus: "RUNNING",
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      act(() => {
+        result.current.recoverCredentialBinding();
+      });
+      const options = mockMutate.mock.calls[0][1];
+      act(() => {
+        options.onError(new Error("Activation failed"));
+        result.current.recoverCredentialBinding();
+        result.current.recoverCredentialBinding();
+      });
+
+      expect(mockMutate).toHaveBeenCalledTimes(1);
+      expect(result.current.credentialBindingActivationFailed).toBe(true);
+    });
+
+    it("ignores a stale activation failure after navigation", () => {
+      const { result, rerender } = renderHook(
+        ({ conversationId }) =>
+          useSandboxRecovery({
+            conversationId,
+            sandboxStatus: "RUNNING",
+          }),
+        {
+          wrapper: createWrapper(),
+          initialProps: { conversationId: "conv-123" },
+        },
+      );
+
+      act(() => {
+        result.current.recoverCredentialBinding();
+      });
+      const staleOptions = mockMutate.mock.calls[0][1];
+
+      rerender({ conversationId: "conv-456" });
+      act(() => {
+        staleOptions.onError(new Error("Activation failed"));
+        result.current.recoverCredentialBinding();
+      });
+
+      expect(result.current.credentialBindingActivationFailed).toBe(false);
+      expect(mockMutate).toHaveBeenCalledTimes(2);
+      expect(mockMutate).toHaveBeenLastCalledWith(
+        expect.objectContaining({ conversationId: "conv-456" }),
+        expect.any(Object),
+      );
     });
   });
 });

--- a/frontend/__tests__/hooks/use-websocket.test.ts
+++ b/frontend/__tests__/hooks/use-websocket.test.ts
@@ -211,6 +211,48 @@ describe("useWebSocket", () => {
     });
   });
 
+  it("ignores close handlers from the previous URL", async () => {
+    const firstUrl = "ws://old-conversation.com/ws";
+    const secondUrl = "ws://new-conversation.com/ws";
+    const firstLink = ws.link(firstUrl);
+    const secondLink = ws.link(secondUrl);
+    const onClose = vi.fn();
+    const secondConnected = vi.fn();
+    let closeFirst: (() => void) | undefined;
+    mswServer.use(
+      firstLink.addEventListener("connection", ({ client, server }) => {
+        server.connect();
+        closeFirst = () =>
+          client.close(1013, "credential_binding_activation_required");
+      }),
+      secondLink.addEventListener("connection", ({ server }) => {
+        server.connect();
+        secondConnected();
+      }),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ url }) => useWebSocket(url, { onClose }),
+      { initialProps: { url: firstUrl } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+      expect(closeFirst).toBeDefined();
+    });
+
+    rerender({ url: secondUrl });
+    closeFirst?.();
+
+    await waitFor(() => {
+      expect(secondConnected).toHaveBeenCalledOnce();
+    });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it.skip("should call onMessage handler when WebSocket receives a message", async () => {
     const onMessageSpy = vi.fn();
     const options = { onMessage: onMessageSpy };

--- a/frontend/__tests__/hooks/use-websocket.test.ts
+++ b/frontend/__tests__/hooks/use-websocket.test.ts
@@ -211,48 +211,6 @@ describe("useWebSocket", () => {
     });
   });
 
-  it("ignores close handlers from the previous URL", async () => {
-    const firstUrl = "ws://old-conversation.com/ws";
-    const secondUrl = "ws://new-conversation.com/ws";
-    const firstLink = ws.link(firstUrl);
-    const secondLink = ws.link(secondUrl);
-    const onClose = vi.fn();
-    const secondConnected = vi.fn();
-    let closeFirst: (() => void) | undefined;
-    mswServer.use(
-      firstLink.addEventListener("connection", ({ client, server }) => {
-        server.connect();
-        closeFirst = () =>
-          client.close(1013, "credential_binding_activation_required");
-      }),
-      secondLink.addEventListener("connection", ({ server }) => {
-        server.connect();
-        secondConnected();
-      }),
-    );
-
-    const { result, rerender } = renderHook(
-      ({ url }) => useWebSocket(url, { onClose }),
-      { initialProps: { url: firstUrl } },
-    );
-
-    await waitFor(() => {
-      expect(result.current.isConnected).toBe(true);
-      expect(closeFirst).toBeDefined();
-    });
-
-    rerender({ url: secondUrl });
-    closeFirst?.();
-
-    await waitFor(() => {
-      expect(secondConnected).toHaveBeenCalledOnce();
-    });
-    await new Promise((resolve) => {
-      setTimeout(resolve, 20);
-    });
-    expect(onClose).not.toHaveBeenCalled();
-  });
-
   it.skip("should call onMessage handler when WebSocket receives a message", async () => {
     const onMessageSpy = vi.fn();
     const options = { onMessage: onMessageSpy };

--- a/frontend/__tests__/utils/websocket-url.test.ts
+++ b/frontend/__tests__/utils/websocket-url.test.ts
@@ -4,6 +4,7 @@ import {
   extractPathPrefix,
   buildHttpBaseUrl,
   buildWebSocketUrl,
+  conversationIdFromWebSocketUrl,
 } from "#/utils/websocket-url";
 
 describe("websocket-url utilities", () => {
@@ -180,6 +181,39 @@ describe("websocket-url utilities", () => {
       expect(result).toBe(
         "wss://app.example.com/org/team/runtime/12345/sockets/events/test-conv",
       );
+    });
+  });
+
+  describe("conversationIdFromWebSocketUrl", () => {
+    it("should read back the id buildWebSocketUrl encoded", () => {
+      const url = buildWebSocketUrl(
+        "conv-123",
+        "http://localhost:3000/api/conversations/conv-123",
+      );
+      expect(conversationIdFromWebSocketUrl(url)).toBe("conv-123");
+    });
+
+    it("should ignore query parameters appended by the socket hook", () => {
+      expect(
+        conversationIdFromWebSocketUrl(
+          "ws://localhost:3000/sockets/events/conv-123?resend_all=true&session_api_key=secret",
+        ),
+      ).toBe("conv-123");
+    });
+
+    it("should handle proxy path prefixes", () => {
+      expect(
+        conversationIdFromWebSocketUrl(
+          "wss://app.example.com/runtime/12345/sockets/events/test-conv",
+        ),
+      ).toBe("test-conv");
+    });
+
+    it("should return null for missing or unparseable urls", () => {
+      expect(conversationIdFromWebSocketUrl(null)).toBeNull();
+      expect(conversationIdFromWebSocketUrl(undefined)).toBeNull();
+      expect(conversationIdFromWebSocketUrl("")).toBeNull();
+      expect(conversationIdFromWebSocketUrl("not a url")).toBeNull();
     });
   });
 });

--- a/frontend/__tests__/utils/websocket-url.test.ts
+++ b/frontend/__tests__/utils/websocket-url.test.ts
@@ -4,7 +4,6 @@ import {
   extractPathPrefix,
   buildHttpBaseUrl,
   buildWebSocketUrl,
-  conversationIdFromWebSocketUrl,
 } from "#/utils/websocket-url";
 
 describe("websocket-url utilities", () => {
@@ -181,39 +180,6 @@ describe("websocket-url utilities", () => {
       expect(result).toBe(
         "wss://app.example.com/org/team/runtime/12345/sockets/events/test-conv",
       );
-    });
-  });
-
-  describe("conversationIdFromWebSocketUrl", () => {
-    it("should read back the id buildWebSocketUrl encoded", () => {
-      const url = buildWebSocketUrl(
-        "conv-123",
-        "http://localhost:3000/api/conversations/conv-123",
-      );
-      expect(conversationIdFromWebSocketUrl(url)).toBe("conv-123");
-    });
-
-    it("should ignore query parameters appended by the socket hook", () => {
-      expect(
-        conversationIdFromWebSocketUrl(
-          "ws://localhost:3000/sockets/events/conv-123?resend_all=true&session_api_key=secret",
-        ),
-      ).toBe("conv-123");
-    });
-
-    it("should handle proxy path prefixes", () => {
-      expect(
-        conversationIdFromWebSocketUrl(
-          "wss://app.example.com/runtime/12345/sockets/events/test-conv",
-        ),
-      ).toBe("test-conv");
-    });
-
-    it("should return null for missing or unparseable urls", () => {
-      expect(conversationIdFromWebSocketUrl(null)).toBeNull();
-      expect(conversationIdFromWebSocketUrl(undefined)).toBeNull();
-      expect(conversationIdFromWebSocketUrl("")).toBeNull();
-      expect(conversationIdFromWebSocketUrl("not a url")).toBeNull();
     });
   });
 });

--- a/frontend/src/api/sandbox-service/sandbox-service.api.ts
+++ b/frontend/src/api/sandbox-service/sandbox-service.api.ts
@@ -29,6 +29,17 @@ export class SandboxService {
     return data;
   }
 
+  static async activateCredentialBinding(
+    sandboxId: string,
+    conversationId: string,
+  ): Promise<{ success: boolean }> {
+    const { data } = await openHands.post<{ success: boolean }>(
+      `/api/v1/sandboxes/${sandboxId}/credential-bindings/${conversationId}/activate`,
+      {},
+    );
+    return data;
+  }
+
   /**
    * Search / list available sandbox specs
    * Calls the /api/v1/sandbox-specs/search endpoint

--- a/frontend/src/contexts/conversation-websocket-context.tsx
+++ b/frontend/src/contexts/conversation-websocket-context.tsx
@@ -41,10 +41,7 @@ import type {
   ServerErrorEvent,
 } from "#/types/v1/core/events/conversation-state-event";
 import { handleActionEventCacheInvalidation } from "#/utils/cache-utils";
-import {
-  buildWebSocketUrl,
-  conversationIdFromWebSocketUrl,
-} from "#/utils/websocket-url";
+import { buildWebSocketUrl } from "#/utils/websocket-url";
 import type {
   V1AppConversation,
   V1SendMessageRequest,
@@ -798,14 +795,6 @@ export function ConversationWebSocketProvider({
           event.code === 1013 &&
           event.reason === "credential_binding_activation_required"
         ) {
-          // useWebSocket dispatches close through a mutable options ref, so a late
-          // close for a previous conversation would otherwise recover this one.
-          const closedConversationId = conversationIdFromWebSocketUrl(
-            (event.target as WebSocket | null)?.url,
-          );
-          if (closedConversationId && closedConversationId !== conversationId) {
-            return;
-          }
           onCredentialBindingActivationRequired?.();
         }
       },

--- a/frontend/src/contexts/conversation-websocket-context.tsx
+++ b/frontend/src/contexts/conversation-websocket-context.tsx
@@ -41,7 +41,10 @@ import type {
   ServerErrorEvent,
 } from "#/types/v1/core/events/conversation-state-event";
 import { handleActionEventCacheInvalidation } from "#/utils/cache-utils";
-import { buildWebSocketUrl } from "#/utils/websocket-url";
+import {
+  buildWebSocketUrl,
+  conversationIdFromWebSocketUrl,
+} from "#/utils/websocket-url";
 import type {
   V1AppConversation,
   V1SendMessageRequest,
@@ -795,6 +798,14 @@ export function ConversationWebSocketProvider({
           event.code === 1013 &&
           event.reason === "credential_binding_activation_required"
         ) {
+          // useWebSocket dispatches close through a mutable options ref, so a late
+          // close for a previous conversation would otherwise recover this one.
+          const closedConversationId = conversationIdFromWebSocketUrl(
+            (event.target as WebSocket | null)?.url,
+          );
+          if (closedConversationId && closedConversationId !== conversationId) {
+            return;
+          }
           onCredentialBindingActivationRequired?.();
         }
       },

--- a/frontend/src/contexts/conversation-websocket-context.tsx
+++ b/frontend/src/contexts/conversation-websocket-context.tsx
@@ -95,6 +95,7 @@ export function ConversationWebSocketProvider({
   sessionApiKey,
   subConversations,
   subConversationIds,
+  onCredentialBindingActivationRequired,
 }: {
   children: React.ReactNode;
   conversationId?: string;
@@ -102,6 +103,7 @@ export function ConversationWebSocketProvider({
   sessionApiKey?: string | null;
   subConversations?: V1AppConversation[];
   subConversationIds?: string[];
+  onCredentialBindingActivationRequired?: () => void;
 }) {
   // Separate connection state tracking for each WebSocket
   const [mainConnectionState, setMainConnectionState] =
@@ -787,10 +789,14 @@ export function ConversationWebSocketProvider({
           }
         }
       },
-      onClose: () => {
+      onClose: (event) => {
         setMainConnectionState("CLOSED");
-        // Recovery is handled by useSandboxRecovery on tab focus/page refresh
-        // No error message needed - silent recovery provides better UX
+        if (
+          event.code === 1013 &&
+          event.reason === "credential_binding_activation_required"
+        ) {
+          onCredentialBindingActivationRequired?.();
+        }
       },
       onError: () => {
         setMainConnectionState("CLOSED");
@@ -814,6 +820,7 @@ export function ConversationWebSocketProvider({
     sessionApiKey,
     conversationId,
     conversationUrl,
+    onCredentialBindingActivationRequired,
   ]);
 
   // Separate WebSocket options for planning agent connection

--- a/frontend/src/contexts/websocket-provider-wrapper.tsx
+++ b/frontend/src/contexts/websocket-provider-wrapper.tsx
@@ -10,50 +10,49 @@ interface WebSocketProviderWrapperProps {
   conversationId: string;
 }
 
-/**
- * A wrapper component that conditionally renders either the old v0 WebSocket provider
- * or the new v1 WebSocket provider based on the version prop.
- *
- * @param conversationId - The conversation ID to pass to the provider
- * @param children - The child components to wrap
- */
 export function WebSocketProviderWrapper({
   children,
   conversationId,
 }: WebSocketProviderWrapperProps) {
-  // Get conversation data for V1 provider
   const {
     data: conversation,
     refetch: refetchConversation,
     isFetched,
   } = useActiveConversation();
-  // Get sub-conversation data for V1 provider
   const { data: subConversations } = useSubConversations(
     conversation?.sub_conversation_ids ?? [],
   );
 
-  // Filter out null sub-conversations
   const filteredSubConversations = subConversations?.filter(
     (subConversation) => subConversation !== null,
   );
 
   const isConversationReady =
     !isTaskConversationId(conversationId) && isFetched && !!conversation;
-  // Recovery for V1 conversations - handles page refresh and tab focus
-  // Does NOT resume on WebSocket disconnect (server pauses after 20 min inactivity)
-  useSandboxRecovery({
+  const {
+    isResuming,
+    credentialBindingActivationFailed,
+    recoverCredentialBinding,
+  } = useSandboxRecovery({
     conversationId,
     sandboxStatus: conversation?.sandbox_status,
     refetchConversation: isConversationReady ? refetchConversation : undefined,
   });
+  const runtimeReady =
+    conversation?.sandbox_status === "RUNNING" &&
+    !isResuming &&
+    !credentialBindingActivationFailed;
 
   return (
     <ConversationWebSocketProvider
       conversationId={conversationId}
-      conversationUrl={conversation?.conversation_url}
-      sessionApiKey={conversation?.session_api_key}
-      subConversationIds={conversation?.sub_conversation_ids}
-      subConversations={filteredSubConversations}
+      conversationUrl={runtimeReady ? conversation.conversation_url : undefined}
+      sessionApiKey={runtimeReady ? conversation.session_api_key : undefined}
+      subConversationIds={
+        runtimeReady ? conversation.sub_conversation_ids : undefined
+      }
+      subConversations={runtimeReady ? filteredSubConversations : undefined}
+      onCredentialBindingActivationRequired={recoverCredentialBinding}
     >
       {children}
     </ConversationWebSocketProvider>

--- a/frontend/src/hooks/mutation/conversation-mutation-utils.ts
+++ b/frontend/src/hooks/mutation/conversation-mutation-utils.ts
@@ -73,7 +73,7 @@ export const askV1Agent = async (
  */
 export const resumeV1ConversationSandbox = async (conversationId: string) => {
   const { sandboxId } = await fetchV1ConversationData(conversationId);
-  return SandboxService.resumeSandbox(sandboxId);
+  return SandboxService.activateCredentialBinding(sandboxId, conversationId);
 };
 
 /**

--- a/frontend/src/hooks/use-sandbox-recovery.ts
+++ b/frontend/src/hooks/use-sandbox-recovery.ts
@@ -11,7 +11,6 @@ import { V1AppConversation } from "#/api/conversation-service/v1-conversation-se
 interface UseSandboxRecoveryOptions {
   conversationId: string | undefined;
   sandboxStatus: V1SandboxStatus | undefined;
-  /** Function to refetch the conversation data - used to get fresh status on tab focus */
   refetchConversation?: () => Promise<{
     data: V1AppConversation | null | undefined;
   }>;
@@ -19,25 +18,6 @@ interface UseSandboxRecoveryOptions {
   onError?: (error: Error) => void;
 }
 
-/**
- * Hook that handles sandbox recovery based on user intent.
- *
- * Recovery triggers:
- * - Page refresh: Resumes the sandbox on initial load if it was paused/stopped
- * - Tab gains focus: Resumes the sandbox if it was paused/stopped
- *
- * What does NOT trigger recovery:
- * - WebSocket disconnect: Does NOT automatically resume the sandbox
- *   (The server pauses sandboxes after 20 minutes of inactivity,
- *    and sandboxes should only be resumed when the user explicitly shows intent)
- *
- * @param options.conversationId - The conversation ID to recover
- * @param options.conversationStatus - The current conversation status
- * @param options.refetchConversation - Function to refetch conversation data on tab focus
- * @param options.onSuccess - Callback when recovery succeeds
- * @param options.onError - Callback when recovery fails
- * @returns isResuming - Whether a recovery is in progress
- */
 export function useSandboxRecovery({
   conversationId,
   sandboxStatus,
@@ -47,28 +27,54 @@ export function useSandboxRecovery({
 }: UseSandboxRecoveryOptions) {
   const { t } = useTranslation();
   const { providers } = useUserProviders();
+  const [
+    credentialBindingActivationFailed,
+    setCredentialBindingActivationFailed,
+  ] = React.useState(false);
+  const activeConversationIdRef = React.useRef(conversationId);
+  activeConversationIdRef.current = conversationId;
+  const recoveryInFlightRef = React.useRef(false);
+  const credentialBindingActivationFailedRef = React.useRef(false);
   const { mutate: resumeSandbox, isPending: isResuming } =
     useUnifiedResumeConversationSandbox();
 
-  // Track which conversation ID we've already processed for initial load recovery
   const processedConversationIdRef = React.useRef<string | null>(null);
 
   const attemptRecovery = React.useCallback(
-    (statusOverride?: V1SandboxStatus) => {
+    (statusOverride?: V1SandboxStatus, force = false) => {
       const status = statusOverride ?? sandboxStatus;
-      /**
-       * Only recover if sandbox is paused
-       */
-      if (!conversationId || status !== "PAUSED" || isResuming) {
+      if (
+        !conversationId ||
+        (!force && status !== "PAUSED") ||
+        (force && credentialBindingActivationFailedRef.current) ||
+        isResuming ||
+        recoveryInFlightRef.current
+      ) {
         return;
       }
+      const recoveryConversationId = conversationId;
+      recoveryInFlightRef.current = true;
       resumeSandbox(
-        { conversationId, providers },
+        { conversationId: recoveryConversationId, providers },
         {
           onSuccess: () => {
+            if (activeConversationIdRef.current !== recoveryConversationId) {
+              return;
+            }
+            recoveryInFlightRef.current = false;
+            credentialBindingActivationFailedRef.current = false;
+            setCredentialBindingActivationFailed(false);
             onSuccess?.();
           },
           onError: (error) => {
+            if (activeConversationIdRef.current !== recoveryConversationId) {
+              return;
+            }
+            recoveryInFlightRef.current = false;
+            if (force) {
+              credentialBindingActivationFailedRef.current = true;
+              setCredentialBindingActivationFailed(true);
+            }
             displayErrorToast(
               t(I18nKey.CONVERSATION$FAILED_TO_START_WITH_ERROR, {
                 error: error.message,
@@ -91,11 +97,15 @@ export function useSandboxRecovery({
     ],
   );
 
-  // Handle page refresh (initial load) and conversation navigation
+  React.useEffect(() => {
+    recoveryInFlightRef.current = false;
+    credentialBindingActivationFailedRef.current = false;
+    setCredentialBindingActivationFailed(false);
+  }, [conversationId]);
+
   React.useEffect(() => {
     if (!conversationId || !sandboxStatus) return;
 
-    // Only attempt recovery once per conversation (handles both initial load and navigation)
     if (processedConversationIdRef.current === conversationId) return;
 
     processedConversationIdRef.current = conversationId;
@@ -107,13 +117,19 @@ export function useSandboxRecovery({
   }, [conversationId, sandboxStatus]);
 
   const handleVisible = React.useCallback(async () => {
-    // Skip if no conversation or refetch function
     if (!conversationId || !refetchConversation) return;
+    const visibleConversationId = conversationId;
 
     try {
-      // Refetch to get fresh status - cached status may be stale if sandbox was paused while tab was inactive
       const { data } = await refetchConversation();
-      attemptRecovery(data?.sandbox_status);
+      if (activeConversationIdRef.current !== visibleConversationId) {
+        return;
+      }
+      const retryCredentialBinding =
+        credentialBindingActivationFailedRef.current;
+      credentialBindingActivationFailedRef.current = false;
+      setCredentialBindingActivationFailed(false);
+      attemptRecovery(data?.sandbox_status, retryCredentialBinding);
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(
@@ -121,13 +137,20 @@ export function useSandboxRecovery({
         error,
       );
     }
-  }, [conversationId, refetchConversation, isResuming, attemptRecovery]);
+  }, [conversationId, refetchConversation, attemptRecovery]);
 
-  // Handle tab focus (visibility change) - refetch conversation status and resume if needed
   useVisibilityChange({
     enabled: !!conversationId,
     onVisible: handleVisible,
   });
 
-  return { isResuming };
+  const recoverCredentialBinding = React.useCallback(() => {
+    attemptRecovery(undefined, true);
+  }, [attemptRecovery]);
+
+  return {
+    isResuming,
+    credentialBindingActivationFailed,
+    recoverCredentialBinding,
+  };
 }

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -30,6 +30,8 @@ export const useWebSocket = <T = string>(
 
   // Store options in a ref to avoid reconnecting when callbacks change
   const optionsRef = React.useRef(options);
+  const urlRef = React.useRef(url);
+  urlRef.current = url;
   React.useEffect(() => {
     optionsRef.current = options;
   }, [options]);
@@ -71,6 +73,9 @@ export const useWebSocket = <T = string>(
     };
 
     ws.onclose = (event) => {
+      if (urlRef.current !== url) {
+        return;
+      }
       // Check if this specific WebSocket instance is allowed to reconnect
       const canReconnect = allowedToReconnectRef.current.has(ws);
       setIsConnected(false);

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -87,7 +87,11 @@ export const useWebSocket = <T = string>(
           optionsRef.current?.onError?.(event);
         }
       }
-      optionsRef.current?.onClose?.(event);
+      // optionsRef is mutable, so a superseded socket would otherwise deliver its
+      // close to whichever conversation is selected by the time it arrives.
+      if (ws === wsRef.current) {
+        optionsRef.current?.onClose?.(event);
+      }
 
       // Attempt reconnection if enabled and allowed
       // IMPORTANT: Only reconnect if this specific instance is allowed to reconnect

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -30,8 +30,6 @@ export const useWebSocket = <T = string>(
 
   // Store options in a ref to avoid reconnecting when callbacks change
   const optionsRef = React.useRef(options);
-  const urlRef = React.useRef(url);
-  urlRef.current = url;
   React.useEffect(() => {
     optionsRef.current = options;
   }, [options]);
@@ -73,9 +71,6 @@ export const useWebSocket = <T = string>(
     };
 
     ws.onclose = (event) => {
-      if (urlRef.current !== url) {
-        return;
-      }
       // Check if this specific WebSocket instance is allowed to reconnect
       const canReconnect = allowedToReconnectRef.current.has(ws);
       setIsConnected(false);

--- a/frontend/src/utils/websocket-url.ts
+++ b/frontend/src/utils/websocket-url.ts
@@ -93,21 +93,3 @@ export function buildWebSocketUrl(
 
   return `${protocol}//${baseHost}${pathPrefix}/sockets/events/${conversationId}`;
 }
-
-/**
- * Reads back the conversation ID that buildWebSocketUrl encoded into a live socket URL.
- */
-export function conversationIdFromWebSocketUrl(
-  url: string | null | undefined,
-): string | null {
-  if (!url) {
-    return null;
-  }
-
-  try {
-    const segments = new URL(url).pathname.split("/");
-    return segments[segments.length - 1] || null;
-  } catch {
-    return null;
-  }
-}

--- a/frontend/src/utils/websocket-url.ts
+++ b/frontend/src/utils/websocket-url.ts
@@ -93,3 +93,21 @@ export function buildWebSocketUrl(
 
   return `${protocol}//${baseHost}${pathPrefix}/sockets/events/${conversationId}`;
 }
+
+/**
+ * Reads back the conversation ID that buildWebSocketUrl encoded into a live socket URL.
+ */
+export function conversationIdFromWebSocketUrl(
+  url: string | null | undefined,
+): string | null {
+  if (!url) {
+    return null;
+  }
+
+  try {
+    const segments = new URL(url).pathname.split("/");
+    return segments[segments.length - 1] || null;
+  } catch {
+    return null;
+  }
+}

--- a/openhands/app_server/app_conversation/app_conversation_models.py
+++ b/openhands/app_server/app_conversation/app_conversation_models.py
@@ -32,6 +32,8 @@ __all__ = ['SandboxGroupingStrategy']
 # Constrained to ^[a-z0-9]+$ by the SDK validator — no underscores allowed.
 # The typed ``AppConversationInfo.acp_server`` field is a projection of this tag.
 ACP_SERVER_TAG_KEY = 'acpserver'
+CODEX_CREDENTIAL_BINDING_TAG_KEY = 'codexcredentialbinding'
+CODEX_CREDENTIAL_START_TASK_TAG_KEY = 'codexcredentialstarttask'
 
 # Conversation-tag key pinning the resolved (grouped) workspace path at creation
 # so the delete-time archive captures the right directory without re-deriving it

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -2976,7 +2976,6 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         )
 
         for sub_id in sub_conversation_ids:
-            sub_conversation = None
             try:
                 sub_conversation = await self.get_app_conversation(sub_id)
                 if sub_conversation:
@@ -2989,10 +2988,6 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                         extra={'conversation_id': str(sub_id)},
                     )
             except Exception as e:
-                if sub_conversation and (
-                    CODEX_CREDENTIAL_BINDING_TAG_KEY in sub_conversation.tags
-                ):
-                    raise
                 # Log error but continue deleting remaining sub-conversations
                 _logger.warning(
                     f'Error deleting sub-conversation {sub_id}: {e}',
@@ -3012,7 +3007,8 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 app_conversation.sandbox_id
             )
             if managed_marker is not None:
-                if sandbox is None:
+                # A missing sandbox already ran the barrier on its own teardown.
+                if sandbox is None or sandbox.status == SandboxStatus.MISSING:
                     return
                 if sandbox.status != SandboxStatus.RUNNING:
                     if sandbox.status not in (

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -86,6 +86,7 @@ from openhands.app_server.pending_messages.pending_message_service import (
     PendingMessageService,
 )
 from openhands.app_server.sandbox.docker_sandbox_service import DockerSandboxService
+from openhands.app_server.sandbox.remote_sandbox_service import RemoteSandboxService
 from openhands.app_server.sandbox.sandbox_models import (
     AGENT_SERVER,
     SandboxInfo,
@@ -428,6 +429,8 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         managed_credential_marker_value: str | None = None
         managed_start_attempted = False
         managed_conversation_created = False
+        app_conversation_info: AppConversationInfo | None = None
+        saved_event_callbacks: list[EventCallback] = []
         sandbox: SandboxInfo | None = None
         try:
             async for updated_task in self._wait_for_sandbox_start(task):
@@ -669,13 +672,13 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
 
             # Save processors
             for processor in processors:
-                await self.event_callback_service.save_event_callback(
-                    EventCallback(
-                        conversation_id=info.id,
-                        event_kind=processor.get_event_kind(),
-                        processor=processor,
-                    )
+                event_callback = EventCallback(
+                    conversation_id=info.id,
+                    event_kind=processor.get_event_kind(),
+                    processor=processor,
                 )
+                await self.event_callback_service.save_event_callback(event_callback)
+                saved_event_callbacks.append(event_callback)
 
             if managed_credential_marker_value is not None:
                 assert self.web_url is not None
@@ -699,7 +702,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                     required=True,
                 )
 
+            managed_start_attempted = False
             managed_conversation_created = False
+
             # Update the start task
             task.status = AppConversationStartTaskStatus.READY
             task.app_conversation_id = info.id
@@ -760,6 +765,18 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                         timeout=30.0,
                     )
                     response.raise_for_status()
+                    if app_conversation_info is not None:
+                        await asyncio.gather(
+                            self.app_conversation_info_service.delete_app_conversation_info(
+                                conversation_id
+                            ),
+                            *(
+                                self.event_callback_service.delete_event_callback(
+                                    callback.id
+                                )
+                                for callback in saved_event_callbacks
+                            ),
+                        )
                 except Exception:
                     _logger.exception(
                         'Failed to scrub managed credential after start failure',
@@ -2391,9 +2408,14 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
     ) -> str | None:
         if not codex_credential_sync_enabled() or api_override:
             return None
-        if self.app_mode != 'saas' and not isinstance(
-            self.sandbox_service, DockerSandboxService
-        ):
+        supported_backend = (
+            self.app_mode == 'saas'
+            and isinstance(self.sandbox_service, RemoteSandboxService)
+        ) or (
+            self.app_mode != 'saas'
+            and isinstance(self.sandbox_service, DockerSandboxService)
+        )
+        if not supported_backend:
             return None
         agent = request.agent
         if not isinstance(agent, ACPAgent):
@@ -2421,6 +2443,13 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             return None
         if not self.web_url or not sandbox.session_api_key:
             return None
+        if (
+            await self.app_conversation_info_service.get_app_conversation_info(
+                conversation_id
+            )
+            is not None
+        ):
+            raise SandboxError(f'Conversation already exists: {conversation_id}')
 
         user_id = await self.user_context.get_user_id()
         get_effective_org_id = getattr(self.user_context, 'get_effective_org_id', None)

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -2963,8 +2963,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
     async def _delete_sub_conversations(self, parent_conversation_id: UUID) -> None:
         """Delete all sub-conversations of a parent conversation.
 
-        This method handles errors gracefully, continuing to delete remaining
-        sub-conversations even if one fails.
+        Every sub-conversation is attempted even if one fails. A managed
+        sub-conversation's failure is re-raised afterwards so its unflushed
+        credential stops the parent delete.
 
         Args:
             parent_conversation_id: The UUID of the parent conversation.
@@ -2975,7 +2976,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             )
         )
 
+        managed_error: Exception | None = None
         for sub_id in sub_conversation_ids:
+            sub_conversation = None
             try:
                 sub_conversation = await self.get_app_conversation(sub_id)
                 if sub_conversation:
@@ -2988,12 +2991,19 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                         extra={'conversation_id': str(sub_id)},
                     )
             except Exception as e:
+                # A managed child's failed final flush must reach the caller, but
+                # only after its siblings have had their chance to be deleted.
+                if managed_error is None and sub_conversation is not None:
+                    if CODEX_CREDENTIAL_BINDING_TAG_KEY in sub_conversation.tags:
+                        managed_error = e
                 # Log error but continue deleting remaining sub-conversations
                 _logger.warning(
                     f'Error deleting sub-conversation {sub_id}: {e}',
                     extra={'conversation_id': str(sub_id)},
                     exc_info=True,
                 )
+        if managed_error is not None:
+            raise managed_error
 
     async def _delete_from_agent_server(
         self, app_conversation: AppConversation
@@ -3007,8 +3017,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 app_conversation.sandbox_id
             )
             if managed_marker is not None:
-                # A missing sandbox already ran the barrier on its own teardown.
-                if sandbox is None or sandbox.status == SandboxStatus.MISSING:
+                if sandbox is None:
                     return
                 if sandbox.status != SandboxStatus.RUNNING:
                     if sandbox.status not in (

--- a/openhands/app_server/app_conversation/live_status_app_conversation_service.py
+++ b/openhands/app_server/app_conversation/live_status_app_conversation_service.py
@@ -29,6 +29,8 @@ from openhands.app_server.app_conversation.app_conversation_models import (
     AGENT_PROFILE_ID_TAG_KEY,
     AGENT_PROFILE_REVISION_TAG_KEY,
     ARCHIVE_WORKSPACE_PATH_TAG_KEY,
+    CODEX_CREDENTIAL_BINDING_TAG_KEY,
+    CODEX_CREDENTIAL_START_TASK_TAG_KEY,
     AgentType,
     AppConversation,
     AppConversationInfo,
@@ -94,6 +96,15 @@ from openhands.app_server.sandbox.sandbox_spec_service import (
     SandboxSpecService,
     is_custom_sandbox_spec,
 )
+from openhands.app_server.secrets.credential_binding import (
+    CODEX_AUTH_SECRET_NAME,
+    activate_codex_credential_binding,
+    codex_credential_sync_enabled,
+    credential_binding_callback_path,
+    managed_credential_marker,
+    marker_organization_id,
+    validate_codex_credential,
+)
 from openhands.app_server.services.injector import InjectorState
 from openhands.app_server.services.jwt_service import JwtService
 from openhands.app_server.settings.llm_profiles import resolve_profile_llm
@@ -123,6 +134,7 @@ from openhands.app_server.utils.redis_lock import (
     try_acquire_redis_lock,
 )
 from openhands.sdk import Agent, AgentContext, LocalWorkspace
+from openhands.sdk.agent import ACPAgent
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.llm import LLM
 from openhands.sdk.llm.llm_profile_store import PROFILE_NAME_REGEX
@@ -404,6 +416,8 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             self._inherit_configuration_from_parent(request, parent_info)
 
         self._apply_suggested_task(request)
+        conversation_id = request.conversation_id or uuid4()
+        request = request.model_copy(update={'conversation_id': conversation_id})
 
         task = AppConversationStartTask(
             created_by_user_id=user_id,
@@ -411,6 +425,10 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         )
         yield task
 
+        managed_credential_marker_value: str | None = None
+        managed_start_attempted = False
+        managed_conversation_created = False
+        sandbox: SandboxInfo | None = None
         try:
             async for updated_task in self._wait_for_sandbox_start(task):
                 yield updated_task
@@ -433,9 +451,6 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 sandbox.sandbox_spec_id
             )
             assert sandbox_spec is not None
-
-            # Set up conversation id
-            conversation_id = request.conversation_id or uuid4()
 
             # Setup working dir based on grouping
             sandbox_grouping_strategy = await self._get_sandbox_grouping_strategy()
@@ -493,6 +508,23 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             task.agent_server_url = agent_server_url
             yield task
 
+            managed_credential_marker_value = (
+                await self._prepare_codex_credential_binding(
+                    start_conversation_request,
+                    sandbox=sandbox,
+                    conversation_id=conversation_id,
+                    start_task_id=task.id,
+                    agent_server_url=agent_server_url,
+                    api_override=bool(
+                        request.secrets and CODEX_AUTH_SECRET_NAME in request.secrets
+                    ),
+                )
+            )
+            if managed_credential_marker_value is not None:
+                start_conversation_request.tags[CODEX_CREDENTIAL_START_TASK_TAG_KEY] = (
+                    str(task.id)
+                )
+
             # Start conversation...
             body_json = start_conversation_request.model_dump(
                 mode='json', context={'expose_secrets': True}
@@ -515,13 +547,13 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 if sandbox.session_api_key
                 else {}
             )
+            managed_start_attempted = managed_credential_marker_value is not None
             response = await self.httpx_client.post(
                 f'{agent_server_url}/api/conversations',
                 json=body_json,
                 headers=headers,
                 timeout=self.sandbox_startup_timeout,
             )
-
             try:
                 response.raise_for_status()
             except httpx.HTTPStatusError as exc:
@@ -539,6 +571,14 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                     ) from exc
                 raise
             info = ConversationInfo.model_validate(response.json())
+            if info.id != conversation_id:
+                raise SandboxError('Agent Server returned an unexpected conversation')
+            if managed_credential_marker_value is not None:
+                if info.tags.get(CODEX_CREDENTIAL_START_TASK_TAG_KEY) != str(task.id):
+                    raise SandboxError(
+                        'Agent Server returned an unexpected managed conversation'
+                    )
+                managed_conversation_created = True
             # Determine kind / llm_model from the request we built (its
             # ``agent`` is the source of truth here): the response echoes
             # the same agent back through the AgentBase discriminator.
@@ -585,6 +625,10 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 agent_kind = 'openhands'
 
             conversation_tags: dict[str, str] = dict(tags)
+            if managed_credential_marker_value is not None:
+                conversation_tags[CODEX_CREDENTIAL_BINDING_TAG_KEY] = (
+                    managed_credential_marker_value
+                )
             if request.selected_repository:
                 conversation_tags['repo_name'] = request.selected_repository
             if request.git_provider:
@@ -633,6 +677,29 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                     )
                 )
 
+            if managed_credential_marker_value is not None:
+                assert self.web_url is not None
+                assert sandbox.session_api_key is not None
+                await activate_codex_credential_binding(
+                    self.httpx_client,
+                    self.jwt_service,
+                    agent_server_url=agent_server_url,
+                    callback_url=(
+                        self.web_url.rstrip('/')
+                        + credential_binding_callback_path(sandbox.id, conversation_id)
+                    ),
+                    session_api_key=sandbox.session_api_key,
+                    user_id=user_id or 'root',
+                    organization_id=marker_organization_id(
+                        managed_credential_marker_value
+                    ),
+                    sandbox_id=sandbox.id,
+                    conversation_id=conversation_id,
+                    start_task_id=None,
+                    required=True,
+                )
+
+            managed_conversation_created = False
             # Update the start task
             task.status = AppConversationStartTaskStatus.READY
             task.app_conversation_id = info.id
@@ -648,6 +715,56 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                 )
 
         except Exception as exc:
+            if (
+                managed_start_attempted
+                and not managed_conversation_created
+                and sandbox is not None
+            ):
+                try:
+                    agent_server_url = self._get_agent_server_url(sandbox)
+                    headers = (
+                        {'X-Session-API-Key': sandbox.session_api_key}
+                        if sandbox.session_api_key
+                        else {}
+                    )
+                    response = await self.httpx_client.get(
+                        f'{agent_server_url}/api/conversations/{conversation_id}',
+                        headers=headers,
+                        timeout=30.0,
+                    )
+                    if response.status_code == 200:
+                        payload = response.json()
+                        tags = payload.get('tags')
+                        managed_conversation_created = (
+                            UUID(str(payload.get('id'))) == conversation_id
+                            and isinstance(tags, dict)
+                            and tags.get(CODEX_CREDENTIAL_START_TASK_TAG_KEY)
+                            == str(task.id)
+                        )
+                except Exception:
+                    _logger.exception(
+                        'Failed to verify managed conversation after start failure',
+                        stack_info=True,
+                    )
+            if managed_conversation_created and sandbox is not None:
+                try:
+                    agent_server_url = self._get_agent_server_url(sandbox)
+                    headers = (
+                        {'X-Session-API-Key': sandbox.session_api_key}
+                        if sandbox.session_api_key
+                        else {}
+                    )
+                    response = await self.httpx_client.delete(
+                        f'{agent_server_url}/api/conversations/{conversation_id}',
+                        headers=headers,
+                        timeout=30.0,
+                    )
+                    response.raise_for_status()
+                except Exception:
+                    _logger.exception(
+                        'Failed to scrub managed credential after start failure',
+                        stack_info=True,
+                    )
             _logger.exception('Error starting conversation', stack_info=True)
             task.status = AppConversationStartTaskStatus.ERROR
             task.detail = redact_text_secrets(
@@ -2262,6 +2379,77 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
             _logger.warning(f'Failed to load skills: {e}', exc_info=True)
             return request
 
+    async def _prepare_codex_credential_binding(
+        self,
+        request: StartConversationRequest,
+        *,
+        sandbox: SandboxInfo,
+        conversation_id: UUID,
+        start_task_id: UUID,
+        agent_server_url: str,
+        api_override: bool,
+    ) -> str | None:
+        if not codex_credential_sync_enabled() or api_override:
+            return None
+        if self.app_mode != 'saas' and not isinstance(
+            self.sandbox_service, DockerSandboxService
+        ):
+            return None
+        agent = request.agent
+        if not isinstance(agent, ACPAgent):
+            return None
+        if agent.acp_server != 'codex':
+            return None
+        agent_context_secrets = getattr(agent.agent_context, 'secrets', None) or {}
+        if CODEX_AUTH_SECRET_NAME in agent_context_secrets:
+            return None
+
+        source = (request.secrets or {}).get(CODEX_AUTH_SECRET_NAME)
+        canonical_source = (await self.user_context.get_secrets()).get(
+            CODEX_AUTH_SECRET_NAME
+        )
+        if not isinstance(source, StaticSecret) or not isinstance(
+            canonical_source, StaticSecret
+        ):
+            return None
+        value = source.get_value()
+        if not value or value != canonical_source.get_value():
+            return None
+        try:
+            validate_codex_credential(value)
+        except ValueError:
+            return None
+        if not self.web_url or not sandbox.session_api_key:
+            return None
+
+        user_id = await self.user_context.get_user_id()
+        get_effective_org_id = getattr(self.user_context, 'get_effective_org_id', None)
+        organization_id = (
+            await get_effective_org_id() if get_effective_org_id is not None else None
+        )
+        if self.app_mode == 'saas' and organization_id is None:
+            return None
+        callback_url = self.web_url.rstrip('/') + credential_binding_callback_path(
+            sandbox.id, conversation_id
+        )
+        activated = await activate_codex_credential_binding(
+            self.httpx_client,
+            self.jwt_service,
+            agent_server_url=agent_server_url,
+            callback_url=callback_url,
+            session_api_key=sandbox.session_api_key,
+            user_id=user_id or 'root',
+            organization_id=organization_id,
+            sandbox_id=sandbox.id,
+            conversation_id=conversation_id,
+            start_task_id=start_task_id,
+            required=False,
+        )
+        if not activated:
+            return None
+        request.secrets.pop(CODEX_AUTH_SECRET_NAME, None)
+        return managed_credential_marker(organization_id)
+
     async def _build_acp_start_conversation_request(
         self,
         sandbox: SandboxInfo,
@@ -2726,7 +2914,9 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
 
             # Now delete the parent conversation
             # Delete from agent server if sandbox is running (skip if sandbox is shared)
-            if not skip_agent_server_delete:
+            if not skip_agent_server_delete or (
+                CODEX_CREDENTIAL_BINDING_TAG_KEY in app_conversation.tags
+            ):
                 await self._delete_from_agent_server(app_conversation)
 
             # Delete from database using the conversation info from app_conversation
@@ -2757,6 +2947,7 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
         )
 
         for sub_id in sub_conversation_ids:
+            sub_conversation = None
             try:
                 sub_conversation = await self.get_app_conversation(sub_id)
                 if sub_conversation:
@@ -2769,6 +2960,10 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
                         extra={'conversation_id': str(sub_id)},
                     )
             except Exception as e:
+                if sub_conversation and (
+                    CODEX_CREDENTIAL_BINDING_TAG_KEY in sub_conversation.tags
+                ):
+                    raise
                 # Log error but continue deleting remaining sub-conversations
                 _logger.warning(
                     f'Error deleting sub-conversation {sub_id}: {e}',
@@ -2781,28 +2976,88 @@ class LiveStatusAppConversationService(AppConversationServiceBase):
     ) -> None:
         """Delete conversation from agent server if sandbox is running."""
         conversation_id = app_conversation.id
-        if not (
-            app_conversation.sandbox_status == SandboxStatus.RUNNING
-            and app_conversation.session_api_key
-        ):
-            return
+        managed_marker = app_conversation.tags.get(CODEX_CREDENTIAL_BINDING_TAG_KEY)
 
         try:
-            # Get sandbox info to find agent server URL
             sandbox = await self.sandbox_service.get_sandbox(
                 app_conversation.sandbox_id
             )
-            if sandbox and sandbox.exposed_urls:
+            if managed_marker is not None:
+                if sandbox is None:
+                    return
+                if sandbox.status != SandboxStatus.RUNNING:
+                    if sandbox.status not in (
+                        SandboxStatus.STARTING,
+                        SandboxStatus.PAUSED,
+                        SandboxStatus.ERROR,
+                    ):
+                        raise SandboxError('Managed credential sandbox is unavailable')
+                    if sandbox.status != SandboxStatus.STARTING:
+                        exists = await self.sandbox_service.resume_sandbox(sandbox.id)
+                        if not exists:
+                            sandbox = await self.sandbox_service.get_sandbox(sandbox.id)
+                            if sandbox is None or sandbox.status not in (
+                                SandboxStatus.RUNNING,
+                                SandboxStatus.STARTING,
+                            ):
+                                raise SandboxError(
+                                    'Managed credential sandbox is unavailable'
+                                )
+                    sandbox = await self.sandbox_service.wait_for_sandbox_running(
+                        sandbox.id, httpx_client=self.httpx_client
+                    )
+                if not sandbox.session_api_key or not self.web_url:
+                    raise SandboxError('Managed credential callback is unavailable')
+                organization_id = marker_organization_id(managed_marker)
                 agent_server_url = self._get_agent_server_url(sandbox)
-
-                # Call agent server delete API
-                response = await self.httpx_client.delete(
+                session_api_key = sandbox.session_api_key
+                lookup = await self.httpx_client.get(
                     f'{agent_server_url}/api/conversations/{conversation_id}',
-                    headers={'X-Session-API-Key': app_conversation.session_api_key},
+                    headers={'X-Session-API-Key': session_api_key},
                     timeout=30.0,
                 )
-                response.raise_for_status()
+                if lookup.status_code == 404:
+                    return
+                lookup.raise_for_status()
+                callback_url = self.web_url.rstrip(
+                    '/'
+                ) + credential_binding_callback_path(sandbox.id, app_conversation.id)
+                await activate_codex_credential_binding(
+                    self.httpx_client,
+                    self.jwt_service,
+                    agent_server_url=agent_server_url,
+                    callback_url=callback_url,
+                    session_api_key=session_api_key,
+                    user_id=app_conversation.created_by_user_id or 'root',
+                    organization_id=organization_id,
+                    sandbox_id=sandbox.id,
+                    conversation_id=app_conversation.id,
+                    start_task_id=None,
+                    required=True,
+                )
+            elif not (
+                app_conversation.sandbox_status == SandboxStatus.RUNNING
+                and app_conversation.session_api_key
+                and sandbox is not None
+            ):
+                return
+
+            assert sandbox is not None
+            delete_session_api_key = (
+                sandbox.session_api_key or app_conversation.session_api_key
+            )
+            if not delete_session_api_key:
+                raise SandboxError('Agent Server authorization is unavailable')
+            agent_server_url = self._get_agent_server_url(sandbox)
+            response = await self.httpx_client.delete(
+                f'{agent_server_url}/api/conversations/{conversation_id}',
+                headers={'X-Session-API-Key': delete_session_api_key},
+                timeout=30.0,
+            )
+            response.raise_for_status()
         except Exception as e:
+            if managed_marker is not None:
+                raise
             _logger.warning(
                 f'Failed to delete conversation from agent server: {e}',
                 extra={'conversation_id': str(conversation_id)},

--- a/openhands/app_server/event_callback/webhook_router.py
+++ b/openhands/app_server/event_callback/webhook_router.py
@@ -30,6 +30,8 @@ from openhands.app_server.app_conversation.app_conversation_info_service import 
 )
 from openhands.app_server.app_conversation.app_conversation_models import (
     ACP_SERVER_TAG_KEY,
+    CODEX_CREDENTIAL_BINDING_TAG_KEY,
+    CODEX_CREDENTIAL_START_TASK_TAG_KEY,
     AppConversationInfo,
     ConversationTrigger,
 )
@@ -39,6 +41,7 @@ from openhands.app_server.config import (
     depends_jwt_service,
     get_app_conversation_info_service,
     get_app_conversation_service,
+    get_app_conversation_start_task_service,
     get_event_callback_service,
     get_global_config,
     get_sandbox_service,
@@ -118,18 +121,42 @@ def merge_conversation_tags(
     existing_tags: dict[str, str] | None,
     incoming_tags: dict[str, str] | None,
 ) -> dict[str, str]:
-    """Merge conversation tags with incoming tags overriding existing ones.
-
-    Args:
-        existing_tags: Tags from the existing conversation (may be None)
-        incoming_tags: Tags from the incoming update (may be None)
-
-    Returns:
-        Merged tags dict (empty dict if both inputs are None/empty)
-    """
+    """Merge untrusted conversation tags."""
     existing = existing_tags or {}
-    incoming = incoming_tags or {}
-    return {**existing, **incoming}
+    incoming = dict(incoming_tags or {})
+    incoming.pop(CODEX_CREDENTIAL_START_TASK_TAG_KEY, None)
+    merged = {**existing, **incoming}
+    merged.pop(CODEX_CREDENTIAL_START_TASK_TAG_KEY, None)
+    marker = existing.get(CODEX_CREDENTIAL_BINDING_TAG_KEY)
+    if marker is None:
+        merged.pop(CODEX_CREDENTIAL_BINDING_TAG_KEY, None)
+    else:
+        merged[CODEX_CREDENTIAL_BINDING_TAG_KEY] = marker
+    return merged
+
+
+async def _matches_app_start_task(
+    conversation_info: ConversationInfo,
+    sandbox_record: SandboxRecord,
+) -> bool:
+    value = (conversation_info.tags or {}).get(CODEX_CREDENTIAL_START_TASK_TAG_KEY)
+    if value is None:
+        return False
+    try:
+        task_id = UUID(value)
+    except ValueError:
+        return False
+    state = InjectorState()
+    setattr(state, USER_CONTEXT_ATTR, ADMIN)
+    async with get_app_conversation_start_task_service(state) as task_service:
+        task = await task_service.get_app_conversation_start_task(task_id)
+    return (
+        task is not None
+        and task.id == task_id
+        and task.sandbox_id == sandbox_record.id
+        and task.created_by_user_id == sandbox_record.created_by_user_id
+        and task.request.conversation_id == conversation_info.id
+    )
 
 
 async def _track_conversation_terminal(
@@ -371,6 +398,14 @@ async def on_conversation_update(
     union so both OpenHands (``Agent``) and ACP (``ACPAgent``) payloads are
     accepted on this single endpoint.
     """
+    persisted = await app_conversation_info_service.get_app_conversation_info(
+        conversation_info.id
+    )
+    if persisted is None and await _matches_app_start_task(
+        conversation_info, sandbox_record
+    ):
+        return Success()
+
     existing = await valid_conversation(
         conversation_info.id,
         sandbox_record,

--- a/openhands/app_server/file_store/files.py
+++ b/openhands/app_server/file_store/files.py
@@ -1,8 +1,12 @@
 from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import TypeVar
 
 from pydantic import ConfigDict
 
 from openhands.sdk.utils.models import DiscriminatedUnionMixin
+
+_T = TypeVar('_T')
 
 
 class FileStore(DiscriminatedUnionMixin, ABC):
@@ -40,3 +44,10 @@ class FileStore(DiscriminatedUnionMixin, ABC):
     @abstractmethod
     def delete(self, path: str) -> None:
         pass
+
+    @property
+    def supports_locked_update(self) -> bool:
+        return False
+
+    def locked_update(self, path: str, update: Callable[[], _T]) -> _T:
+        raise NotImplementedError

--- a/openhands/app_server/file_store/local.py
+++ b/openhands/app_server/file_store/local.py
@@ -1,11 +1,25 @@
+import errno
+import importlib
 import os
 import shutil
+import sys
 import threading
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 from pydantic import model_validator
 
 from openhands.app_server.file_store.files import FileStore
 from openhands.app_server.utils.logger import openhands_logger as logger
+
+fcntl: Any = None
+msvcrt: Any = None
+if sys.platform == 'win32':
+    msvcrt = importlib.import_module('msvcrt')
+else:
+    fcntl = importlib.import_module('fcntl')
+
+_T = TypeVar('_T')
 
 
 class LocalFileStore(FileStore):
@@ -22,6 +36,44 @@ class LocalFileStore(FileStore):
         if path.startswith('/'):
             path = path[1:]
         return os.path.join(self.root, path)
+
+    @property
+    def supports_locked_update(self) -> bool:
+        return True
+
+    def locked_update(self, path: str, update: Callable[[], _T]) -> _T:
+        lock_path = self.get_full_path(f'{path}.lock')
+        os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+        descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+        locked = False
+        try:
+            if fcntl is not None:
+                fcntl.flock(descriptor, fcntl.LOCK_EX)
+                locked = True
+            elif msvcrt is not None:
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                while True:
+                    try:
+                        msvcrt.locking(descriptor, msvcrt.LK_LOCK, 1)
+                        break
+                    except OSError as exc:
+                        if exc.errno not in (
+                            errno.EACCES,
+                            errno.EAGAIN,
+                            errno.EDEADLK,
+                        ):
+                            raise
+                locked = True
+            return update()
+        finally:
+            try:
+                if locked and fcntl is not None:
+                    fcntl.flock(descriptor, fcntl.LOCK_UN)
+                elif locked and msvcrt is not None:
+                    os.lseek(descriptor, 0, os.SEEK_SET)
+                    msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+            finally:
+                os.close(descriptor)
 
     def write(self, path: str, contents: str | bytes) -> None:
         full_path = self.get_full_path(path)

--- a/openhands/app_server/file_store/memory.py
+++ b/openhands/app_server/file_store/memory.py
@@ -1,9 +1,14 @@
 import os
+import threading
+from collections.abc import Callable
+from typing import TypeVar
 
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 
 from openhands.app_server.file_store.files import FileStore
 from openhands.app_server.utils.logger import openhands_logger as logger
+
+_T = TypeVar('_T')
 
 
 class InMemoryFileStore(FileStore):
@@ -12,6 +17,15 @@ class InMemoryFileStore(FileStore):
     # it cannot round-trip a binary archive. Not a valid RUNTIME_FILE_ARCHIVE
     # store — see workspace_archive._archive_store_type.
     files: dict[str, str] = Field(default_factory=dict)
+    _update_lock: threading.RLock = PrivateAttr(default_factory=threading.RLock)
+
+    @property
+    def supports_locked_update(self) -> bool:
+        return True
+
+    def locked_update(self, path: str, update: Callable[[], _T]) -> _T:
+        with self._update_lock:
+            return update()
 
     def write(self, path: str, contents: str | bytes) -> None:
         if isinstance(contents, bytes):

--- a/openhands/app_server/sandbox/docker_sandbox_service.py
+++ b/openhands/app_server/sandbox/docker_sandbox_service.py
@@ -534,6 +534,17 @@ class DockerSandboxService(SandboxService):
         except (NotFound, APIError):
             return False
 
+    async def _drain_credentials(self, container, sandbox_id: str) -> None:
+        """Run the credential pause barrier for a running container."""
+        sandbox = await self._container_to_sandbox_info(container)
+        if sandbox is None:
+            # Losing the image tag hides the sandbox, not its binding, so only a
+            # managed sandbox may block here; a legacy one keeps failing open.
+            if await self._has_managed_credential_conversation(sandbox_id):
+                raise SandboxError(f'Could not resolve managed sandbox: {sandbox_id}')
+            return
+        await self._prepare_for_pause(sandbox, self.httpx_client)
+
     async def pause_sandbox(self, sandbox_id: str) -> bool:
         """Pause a running sandbox."""
         try:
@@ -542,12 +553,7 @@ class DockerSandboxService(SandboxService):
             container = self.docker_client.containers.get(sandbox_id)
 
             if container.status == 'running':
-                sandbox = await self._container_to_sandbox_info(container)
-                if sandbox is None:
-                    raise SandboxError(
-                        f'Could not resolve running sandbox: {sandbox_id}'
-                    )
-                await self._prepare_for_pause(sandbox, self.httpx_client)
+                await self._drain_credentials(container, sandbox_id)
                 container.pause()
 
             return True
@@ -562,11 +568,7 @@ class DockerSandboxService(SandboxService):
             container = self.docker_client.containers.get(sandbox_id)
 
             if container.status == 'running':
-                sandbox = await self._container_to_sandbox_info(container)
-                # An unresolvable container carries no binding to drain, and the
-                # delete must still reclaim the container and its volume.
-                if sandbox is not None:
-                    await self._prepare_for_pause(sandbox, self.httpx_client)
+                await self._drain_credentials(container, sandbox_id)
             if container.status in ['running', 'paused']:
                 container.stop(timeout=10)
 

--- a/openhands/app_server/sandbox/docker_sandbox_service.py
+++ b/openhands/app_server/sandbox/docker_sandbox_service.py
@@ -336,7 +336,7 @@ class DockerSandboxService(SandboxService):
                 return None
             container = self.docker_client.containers.get(sandbox_id)
             return await self._container_to_checked_sandbox_info(container)
-        except (NotFound, APIError):
+        except NotFound:
             return None
 
     async def get_sandbox_by_session_api_key(
@@ -542,6 +542,12 @@ class DockerSandboxService(SandboxService):
             container = self.docker_client.containers.get(sandbox_id)
 
             if container.status == 'running':
+                sandbox = await self._container_to_sandbox_info(container)
+                if sandbox is None:
+                    raise SandboxError(
+                        f'Could not resolve running sandbox: {sandbox_id}'
+                    )
+                await self._prepare_for_pause(sandbox, self.httpx_client)
                 container.pause()
 
             return True
@@ -555,7 +561,13 @@ class DockerSandboxService(SandboxService):
                 return False
             container = self.docker_client.containers.get(sandbox_id)
 
-            # Stop the container if it's running
+            if container.status == 'running':
+                sandbox = await self._container_to_sandbox_info(container)
+                if sandbox is None:
+                    raise SandboxError(
+                        f'Could not resolve running sandbox: {sandbox_id}'
+                    )
+                await self._prepare_for_pause(sandbox, self.httpx_client)
             if container.status in ['running', 'paused']:
                 container.stop(timeout=10)
 

--- a/openhands/app_server/sandbox/docker_sandbox_service.py
+++ b/openhands/app_server/sandbox/docker_sandbox_service.py
@@ -336,7 +336,7 @@ class DockerSandboxService(SandboxService):
                 return None
             container = self.docker_client.containers.get(sandbox_id)
             return await self._container_to_checked_sandbox_info(container)
-        except NotFound:
+        except (NotFound, APIError):
             return None
 
     async def get_sandbox_by_session_api_key(
@@ -563,11 +563,10 @@ class DockerSandboxService(SandboxService):
 
             if container.status == 'running':
                 sandbox = await self._container_to_sandbox_info(container)
-                if sandbox is None:
-                    raise SandboxError(
-                        f'Could not resolve running sandbox: {sandbox_id}'
-                    )
-                await self._prepare_for_pause(sandbox, self.httpx_client)
+                # An unresolvable container carries no binding to drain, and the
+                # delete must still reclaim the container and its volume.
+                if sandbox is not None:
+                    await self._prepare_for_pause(sandbox, self.httpx_client)
             if container.status in ['running', 'paused']:
                 container.stop(timeout=10)
 

--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -552,6 +552,7 @@ class RemoteSandboxService(SandboxService):
                 _logger.info(
                     f'Updated session_api_key_hash for sandbox {sandbox_id} after resume'
                 )
+                await self.db_session.commit()
 
             return True
         except httpx.HTTPError:
@@ -569,11 +570,11 @@ class RemoteSandboxService(SandboxService):
             if not stored_sandbox:
                 return False
 
-            # Security: Invalidate the session API key hash to prevent
-            # leaked keys from being used while the sandbox is paused.
-            stored_sandbox.session_api_key_hash = None
-
             runtime_data = await self._get_runtime(sandbox_id)
+            sandbox = self._to_sandbox_info(stored_sandbox, runtime_data)
+            if sandbox.status == SandboxStatus.RUNNING:
+                await self._prepare_for_pause(sandbox, self.httpx_client)
+            stored_sandbox.session_api_key_hash = None
             response = await self._send_runtime_api_request(
                 'POST',
                 '/pause',
@@ -605,22 +606,16 @@ class RemoteSandboxService(SandboxService):
         (router -> 503) and keeps the row + runtime for a retry — so a live sandbox
         is never reported as 404.
 
-        Security: the session_api_key_hash is invalidated UP FRONT (like
-        ``pause_sandbox`` clears it before pausing) so a delete — commonly a
-        revoke of a leaked key — kills it promptly. This goes further than pause:
-        on a transient stop failure the invalidation is committed before raising,
-        so the caller's rollback cannot resurrect the just-revoked key (pause does
-        not commit, so its clear can still be rolled back). The row is kept for
-        retry.
+        Unguarded runtimes revoke their session key before the stop request.
+        Managed runtimes drain credentials first.
         """
         had_key = False
+        stored_sandbox: StoredRemoteSandbox | None = None
         try:
             stored_sandbox = await self._get_stored_sandbox(sandbox_id)
             if not stored_sandbox:
                 return False
-            # Security: drop the key now, before the (fallible) runtime stop.
             had_key = stored_sandbox.session_api_key_hash is not None
-            stored_sandbox.session_api_key_hash = None
             try:
                 runtime_data = await self._get_runtime(sandbox_id)
             except httpx.HTTPStatusError as e:
@@ -631,9 +626,14 @@ class RemoteSandboxService(SandboxService):
                     f'Runtime for sandbox {sandbox_id} already gone (404); '
                     'deleting record'
                 )
+                stored_sandbox.session_api_key_hash = None
                 await self.db_session.delete(stored_sandbox)
                 return True
 
+            sandbox = self._to_sandbox_info(stored_sandbox, runtime_data)
+            if sandbox.status == SandboxStatus.RUNNING:
+                await self._prepare_for_pause(sandbox, self.httpx_client)
+            stored_sandbox.session_api_key_hash = None
             response = await self._send_runtime_api_request(
                 'POST',
                 '/stop',
@@ -644,13 +644,23 @@ class RemoteSandboxService(SandboxService):
             await self.db_session.delete(stored_sandbox)
             return True
         except httpx.HTTPError as e:
-            # Transient runtime lookup/stop failure: keep the row + runtime and
-            # signal retryable (503) — never a 404. Persist the key invalidation
-            # now: the caller rolls back on this raise, which would otherwise
-            # restore the hash and leave a just-revoked key valid.
             _logger.exception(f'Error deleting sandbox {sandbox_id}', stack_info=True)
-            if had_key:
-                await self.db_session.commit()
+            if had_key and stored_sandbox is not None:
+                if stored_sandbox.session_api_key_hash is not None:
+                    try:
+                        managed = await self._has_managed_credential_conversation(
+                            sandbox_id
+                        )
+                    except Exception:
+                        managed = True
+                        _logger.exception(
+                            'Could not determine whether sandbox credentials are managed',
+                            stack_info=True,
+                        )
+                    if not managed:
+                        stored_sandbox.session_api_key_hash = None
+                if stored_sandbox.session_api_key_hash is None:
+                    await self.db_session.commit()
             raise SandboxDeleteRetryError(
                 f'Could not complete delete for sandbox {sandbox_id}: {e}'
             ) from e

--- a/openhands/app_server/sandbox/remote_sandbox_service.py
+++ b/openhands/app_server/sandbox/remote_sandbox_service.py
@@ -552,7 +552,6 @@ class RemoteSandboxService(SandboxService):
                 _logger.info(
                     f'Updated session_api_key_hash for sandbox {sandbox_id} after resume'
                 )
-                await self.db_session.commit()
 
             return True
         except httpx.HTTPError:
@@ -643,7 +642,7 @@ class RemoteSandboxService(SandboxService):
                 response.raise_for_status()
             await self.db_session.delete(stored_sandbox)
             return True
-        except httpx.HTTPError as e:
+        except Exception as e:
             _logger.exception(f'Error deleting sandbox {sandbox_id}', stack_info=True)
             if had_key and stored_sandbox is not None:
                 if stored_sandbox.session_api_key_hash is not None:

--- a/openhands/app_server/sandbox/sandbox_router.py
+++ b/openhands/app_server/sandbox/sandbox_router.py
@@ -383,11 +383,13 @@ async def load_credential_binding(
         value, version = await store.load_versioned(
             CODEX_AUTH_SECRET_NAME, organization_id
         )
-        validate_codex_credential(value)
     except KeyError as exc:
         raise HTTPException(status.HTTP_404_NOT_FOUND) from exc
     except NotImplementedError as exc:
         raise HTTPException(status.HTTP_501_NOT_IMPLEMENTED) from exc
+    # Only an invalid credential is a 422; the SDK turns that into a re-auth prompt.
+    try:
+        validate_codex_credential(value)
     except ValueError as exc:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY) from exc
     return JSONResponse(

--- a/openhands/app_server/sandbox/sandbox_router.py
+++ b/openhands/app_server/sandbox/sandbox_router.py
@@ -2,15 +2,44 @@
 
 import logging
 from typing import Annotated, cast
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+import httpx
+from fastapi import (
+    APIRouter,
+    Depends,
+    Header,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+    status,
+)
+from fastapi.responses import JSONResponse
 from fastapi.security import APIKeyHeader
 
 from openhands.agent_server.models import Success
-from openhands.app_server.config import depends_sandbox_service, depends_user_context
+from openhands.app_server.app_conversation.app_conversation_info_service import (
+    AppConversationInfoService,
+)
+from openhands.app_server.app_conversation.app_conversation_models import (
+    CODEX_CREDENTIAL_BINDING_TAG_KEY,
+    AppConversationStartTaskStatus,
+)
+from openhands.app_server.config import (
+    depends_app_conversation_info_service,
+    depends_httpx_client,
+    depends_jwt_service,
+    depends_sandbox_service,
+    depends_user_context,
+    get_app_conversation_info_service,
+    get_app_conversation_start_task_service,
+    get_global_config,
+)
 from openhands.app_server.sandbox.sandbox_models import (
     SandboxInfo,
     SandboxPage,
+    SandboxStatus,
     SecretNameItem,
     SecretNamesResponse,
 )
@@ -18,7 +47,22 @@ from openhands.app_server.sandbox.sandbox_service import (
     SandboxService,
 )
 from openhands.app_server.sandbox.session_auth import validate_session_key
+from openhands.app_server.secrets.credential_binding import (
+    CODEX_AUTH_SECRET_NAME,
+    CREDENTIAL_BINDING_CONTEXT_HEADER,
+    CredentialBindingContext,
+    CredentialReplacement,
+    activate_codex_credential_binding,
+    credential_binding_callback_path,
+    decode_binding_context,
+    marker_organization_id,
+    validate_codex_credential,
+)
+from openhands.app_server.secrets.secrets_store import CredentialVersionConflict
+from openhands.app_server.services.injector import InjectorState
+from openhands.app_server.services.jwt_service import JwtService
 from openhands.app_server.user.auth_user_context import AuthUserContext
+from openhands.app_server.user.specifiy_user_context import ADMIN, USER_CONTEXT_ATTR
 from openhands.app_server.user.user_context import UserContext
 from openhands.app_server.user_auth.user_auth import (
     get_for_user as get_user_auth_for_user,
@@ -34,6 +78,9 @@ router = APIRouter(
 )
 sandbox_service_dependency = depends_sandbox_service()
 user_context_dependency = depends_user_context()
+app_conversation_info_service_dependency = depends_app_conversation_info_service()
+httpx_client_dependency = depends_httpx_client()
+jwt_service_dependency = depends_jwt_service()
 
 # Read methods
 
@@ -105,6 +152,93 @@ async def resume_sandbox(
     return Success()
 
 
+@router.post(
+    '/{sandbox_id}/credential-bindings/{conversation_id}/activate',
+    responses={404: {'description': 'Item not found'}},
+)
+async def activate_conversation_credential_binding(
+    sandbox_id: str,
+    conversation_id: UUID,
+    sandbox_service: SandboxService = sandbox_service_dependency,
+    user_context: UserContext = user_context_dependency,
+    app_conversation_info_service: AppConversationInfoService = app_conversation_info_service_dependency,
+    httpx_client: httpx.AsyncClient = httpx_client_dependency,
+    jwt_service: JwtService = jwt_service_dependency,
+) -> Success:
+    info = await app_conversation_info_service.get_app_conversation_info(
+        conversation_id
+    )
+    if info is None or info.sandbox_id != sandbox_id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+
+    user_id = info.created_by_user_id or 'root'
+    if user_id != (await user_context.get_user_id() or 'root'):
+        raise HTTPException(status.HTTP_403_FORBIDDEN)
+    marker = info.tags.get(CODEX_CREDENTIAL_BINDING_TAG_KEY)
+    organization_id = None
+    if marker is not None:
+        try:
+            organization_id = marker_organization_id(marker)
+        except ValueError as exc:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                detail='Managed credential metadata is invalid',
+            ) from exc
+
+    if marker is None:
+        exists = await sandbox_service.resume_sandbox(sandbox_id)
+        if not exists:
+            raise HTTPException(status.HTTP_404_NOT_FOUND)
+        return Success()
+
+    sandbox = await sandbox_service.get_sandbox(sandbox_id)
+    if sandbox is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    if sandbox.status not in (SandboxStatus.RUNNING, SandboxStatus.STARTING):
+        exists = await sandbox_service.resume_sandbox(sandbox_id)
+        if not exists:
+            sandbox = await sandbox_service.get_sandbox(sandbox_id)
+            if sandbox is None or sandbox.status not in (
+                SandboxStatus.RUNNING,
+                SandboxStatus.STARTING,
+            ):
+                raise HTTPException(status.HTTP_404_NOT_FOUND)
+    sandbox = await sandbox_service.wait_for_sandbox_running(
+        sandbox_id, httpx_client=httpx_client
+    )
+
+    base_url = get_global_config().web_url
+    if base_url is None:
+        from openhands.app_server.sandbox.docker_sandbox_service import (
+            DockerSandboxService,
+        )
+
+        if isinstance(sandbox_service, DockerSandboxService):
+            base_url = f'http://host.docker.internal:{sandbox_service.host_port}'
+    if not base_url or not sandbox.session_api_key:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail='Managed credential callback is unavailable',
+        )
+    callback_url = base_url.rstrip('/') + credential_binding_callback_path(
+        sandbox_id, conversation_id
+    )
+    await activate_codex_credential_binding(
+        httpx_client,
+        jwt_service,
+        agent_server_url=sandbox_service._get_agent_server_url(sandbox),
+        callback_url=callback_url,
+        session_api_key=sandbox.session_api_key,
+        user_id=user_id,
+        organization_id=organization_id,
+        sandbox_id=sandbox_id,
+        conversation_id=conversation_id,
+        start_task_id=None,
+        required=True,
+    )
+    return Success()
+
+
 @router.delete('/{id}', responses={404: {'description': 'Item not found'}})
 async def delete_sandbox(
     sandbox_id: str,
@@ -152,6 +286,151 @@ async def _get_user_context(sandbox_info: SandboxInfo) -> AuthUserContext:
         )
     user_auth = await get_user_auth_for_user(sandbox_info.created_by_user_id)
     return AuthUserContext(user_auth=user_auth)
+
+
+async def _credential_binding_context(
+    sandbox_id: str,
+    conversation_id: UUID,
+    sandbox_info: SandboxInfo = Depends(_valid_sandbox_from_session_key),
+    context_token: str | None = Header(None, alias=CREDENTIAL_BINDING_CONTEXT_HEADER),
+    jwt_service: JwtService = jwt_service_dependency,
+) -> CredentialBindingContext:
+    if not context_token:
+        raise HTTPException(
+            status.HTTP_401_UNAUTHORIZED,
+            detail='Credential binding context is required',
+        )
+    try:
+        context = decode_binding_context(jwt_service, context_token)
+    except Exception as exc:
+        raise HTTPException(
+            status.HTTP_401_UNAUTHORIZED,
+            detail='Credential binding context is invalid',
+        ) from exc
+    owner_id = sandbox_info.created_by_user_id or 'root'
+    if (
+        context.user_id != owner_id
+        or context.sandbox_id != sandbox_id
+        or context.conversation_id != str(conversation_id)
+        or context.secret_name != CODEX_AUTH_SECRET_NAME
+        or context.actions != ('load', 'replace')
+    ):
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            detail='Credential binding context does not match the runtime',
+        )
+
+    state = InjectorState()
+    setattr(state, USER_CONTEXT_ATTR, ADMIN)
+    async with (
+        get_app_conversation_info_service(state) as info_service,
+        get_app_conversation_start_task_service(state) as task_service,
+    ):
+        info = await info_service.get_app_conversation_info(conversation_id)
+        if info is not None:
+            marker = info.tags.get(CODEX_CREDENTIAL_BINDING_TAG_KEY)
+            if (
+                info.sandbox_id != sandbox_id
+                or (info.created_by_user_id or 'root') != owner_id
+            ):
+                raise HTTPException(status.HTTP_403_FORBIDDEN)
+            if marker is not None:
+                try:
+                    organization_id = marker_organization_id(marker)
+                except ValueError as exc:
+                    raise HTTPException(status.HTTP_403_FORBIDDEN) from exc
+                if context.organization_id != (
+                    str(organization_id) if organization_id else None
+                ):
+                    raise HTTPException(status.HTTP_403_FORBIDDEN)
+                if context.start_task_id is None:
+                    return context
+
+        if context.start_task_id is None:
+            raise HTTPException(status.HTTP_403_FORBIDDEN)
+        try:
+            task_id = UUID(context.start_task_id)
+        except ValueError as exc:
+            raise HTTPException(status.HTTP_403_FORBIDDEN) from exc
+        task = await task_service.get_app_conversation_start_task(task_id)
+        if (
+            task is None
+            or task.id != task_id
+            or task.status != AppConversationStartTaskStatus.STARTING_CONVERSATION
+            or task.sandbox_id != sandbox_id
+            or (task.created_by_user_id or 'root') != owner_id
+            or task.request.conversation_id != conversation_id
+        ):
+            raise HTTPException(status.HTTP_403_FORBIDDEN)
+    return context
+
+
+async def _credential_store(context: CredentialBindingContext):
+    user_auth = await get_user_auth_for_user(context.user_id)
+    return await user_auth.get_secrets_store()
+
+
+@router.get(
+    '/{sandbox_id}/credential-bindings/{conversation_id}/CODEX_AUTH_JSON',
+    include_in_schema=False,
+)
+async def load_credential_binding(
+    context: CredentialBindingContext = Depends(_credential_binding_context),
+) -> JSONResponse:
+    store = await _credential_store(context)
+    organization_id = UUID(context.organization_id) if context.organization_id else None
+    try:
+        value, version = await store.load_versioned(
+            CODEX_AUTH_SECRET_NAME, organization_id
+        )
+        validate_codex_credential(value)
+    except KeyError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND) from exc
+    except NotImplementedError as exc:
+        raise HTTPException(status.HTTP_501_NOT_IMPLEMENTED) from exc
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY) from exc
+    return JSONResponse(
+        {'value': value, 'version': version},
+        headers={'Cache-Control': 'no-store'},
+    )
+
+
+@router.put(
+    '/{sandbox_id}/credential-bindings/{conversation_id}/CODEX_AUTH_JSON',
+    include_in_schema=False,
+)
+async def replace_credential_binding(
+    request: Request,
+    context: CredentialBindingContext = Depends(_credential_binding_context),
+) -> JSONResponse:
+    try:
+        replacement = CredentialReplacement.model_validate(await request.json())
+        validate_codex_credential(replacement.value)
+    except (TypeError, ValueError):
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail='Invalid Codex credential replacement',
+        ) from None
+    store = await _credential_store(context)
+    organization_id = UUID(context.organization_id) if context.organization_id else None
+    try:
+        version = await store.replace_versioned(
+            CODEX_AUTH_SECRET_NAME,
+            replacement.expected_version,
+            replacement.value,
+            organization_id,
+        )
+    except KeyError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND) from exc
+    except CredentialVersionConflict as exc:
+        raise HTTPException(status.HTTP_409_CONFLICT) from exc
+    except NotImplementedError as exc:
+        raise HTTPException(status.HTTP_501_NOT_IMPLEMENTED) from exc
+    return JSONResponse(
+        {'version': version},
+        headers={'Cache-Control': 'no-store'},
+    )
 
 
 @router.get('/{sandbox_id}/settings/secrets')

--- a/openhands/app_server/sandbox/sandbox_service.py
+++ b/openhands/app_server/sandbox/sandbox_service.py
@@ -5,6 +5,9 @@ from abc import ABC, abstractmethod
 
 import httpx
 
+from openhands.app_server.app_conversation.app_conversation_models import (
+    CODEX_CREDENTIAL_BINDING_TAG_KEY,
+)
 from openhands.app_server.errors import SandboxError
 from openhands.app_server.sandbox.sandbox_models import (
     AGENT_SERVER,
@@ -13,7 +16,11 @@ from openhands.app_server.sandbox.sandbox_models import (
     SandboxRecord,
     SandboxStatus,
 )
-from openhands.app_server.services.injector import Injector
+from openhands.app_server.secrets.credential_binding import (
+    agent_server_supports_credential_binding,
+)
+from openhands.app_server.services.injector import Injector, InjectorState
+from openhands.app_server.user.specifiy_user_context import ADMIN, USER_CONTEXT_ATTR
 from openhands.app_server.utils.docker_utils import (
     replace_localhost_hostname_for_docker,
 )
@@ -279,6 +286,75 @@ class SandboxService(ABC):
                 return replace_localhost_hostname_for_docker(exposed_url.url)
 
         raise SandboxError(f'No agent server URL found for sandbox: {sandbox.id}')
+
+    async def _has_managed_credential_conversation(self, sandbox_id: str) -> bool:
+        from openhands.app_server.config import get_app_conversation_info_service
+
+        state = InjectorState()
+        setattr(state, USER_CONTEXT_ATTR, ADMIN)
+        async with get_app_conversation_info_service(state) as service:
+            page_id = None
+            while True:
+                page = await service.search_app_conversation_info(
+                    sandbox_id__eq=sandbox_id,
+                    page_id=page_id,
+                    limit=100,
+                    include_sub_conversations=True,
+                )
+                if any(
+                    CODEX_CREDENTIAL_BINDING_TAG_KEY in item.tags for item in page.items
+                ):
+                    return True
+                page_id = page.next_page_id
+                if page_id is None:
+                    return False
+
+    async def _prepare_for_pause(
+        self,
+        sandbox: SandboxInfo,
+        httpx_client: httpx.AsyncClient,
+    ) -> None:
+        required = await self._has_managed_credential_conversation(sandbox.id)
+        if not sandbox.session_api_key:
+            if required:
+                raise SandboxError('Managed sandbox authorization is unavailable')
+            return
+        agent_server_url = self._get_agent_server_url(sandbox)
+        try:
+            supported = await agent_server_supports_credential_binding(
+                httpx_client,
+                agent_server_url,
+                sandbox.session_api_key,
+            )
+        except httpx.HTTPStatusError as exc:
+            if not required:
+                return
+            raise SandboxError('Could not verify the credential pause barrier') from exc
+        except Exception as exc:
+            if not required:
+                return
+            raise SandboxError('Could not verify the credential pause barrier') from exc
+        if not supported:
+            if required:
+                raise SandboxError('Agent Server lacks the credential pause barrier')
+            return
+        try:
+            response = await httpx_client.post(
+                f'{agent_server_url}/api/conversations/prepare-for-sandbox-pause',
+                headers={'X-Session-API-Key': sandbox.session_api_key},
+                timeout=30.0,
+            )
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            if not required:
+                return
+            raise SandboxError(
+                'Agent Server did not complete its credential pause barrier'
+            ) from exc
+        if response.status_code != 204:
+            if not required:
+                return
+            raise SandboxError('Agent Server returned an invalid pause response')
 
     @abstractmethod
     async def pause_sandbox(self, sandbox_id: str) -> bool:

--- a/openhands/app_server/sandbox/sandbox_service.py
+++ b/openhands/app_server/sandbox/sandbox_service.py
@@ -319,7 +319,12 @@ class SandboxService(ABC):
             if required:
                 raise SandboxError('Managed sandbox authorization is unavailable')
             return
-        agent_server_url = self._get_agent_server_url(sandbox)
+        try:
+            agent_server_url = self._get_agent_server_url(sandbox)
+        except SandboxError:
+            if not required:
+                return
+            raise
         try:
             supported = await agent_server_supports_credential_binding(
                 httpx_client,

--- a/openhands/app_server/secrets/credential_binding.py
+++ b/openhands/app_server/secrets/credential_binding.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import os
+from typing import Literal
+from uuid import UUID
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+
+from openhands.app_server.constants import MAX_API_SECRET_VALUE_LENGTH
+from openhands.app_server.errors import SandboxError
+from openhands.app_server.services.jwt_service import JwtService
+from openhands.sdk.agent.acp_file_credentials import (
+    CODEX_AUTH_SECRET_NAME,
+    is_valid_codex_auth,
+)
+
+CREDENTIAL_BINDING_CONTEXT_HEADER = 'X-Credential-Binding-Context'
+CREDENTIAL_BINDING_CAPABILITIES = frozenset(
+    {
+        'credential_binding_v1',
+        'credential_binding_readiness_probe_v1',
+        'credential_binding_activation_guard_v1',
+    }
+)
+
+
+class CredentialBindingContext(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    purpose: Literal['codex-credential-binding']
+    iat: int
+    user_id: str
+    organization_id: str | None
+    sandbox_id: str
+    conversation_id: str
+    start_task_id: str | None
+    secret_name: Literal['CODEX_AUTH_JSON']
+    actions: tuple[Literal['load'], Literal['replace']]
+
+
+class CredentialReplacement(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    expected_version: str = Field(min_length=1, max_length=256)
+    value: str = Field(max_length=MAX_API_SECRET_VALUE_LENGTH)
+
+
+def codex_credential_sync_enabled() -> bool:
+    return os.getenv('OH_ENABLE_CODEX_CREDENTIAL_SYNC', '').lower() in {
+        '1',
+        'true',
+        'yes',
+    }
+
+
+def managed_credential_marker(organization_id: UUID | None) -> str:
+    return f'org:{organization_id}' if organization_id else 'personal'
+
+
+def marker_organization_id(marker: str | None) -> UUID | None:
+    if marker == 'personal':
+        return None
+    if marker and marker.startswith('org:'):
+        return UUID(marker[4:])
+    raise ValueError('Invalid managed credential marker')
+
+
+def create_binding_context(
+    jwt_service: JwtService,
+    *,
+    user_id: str,
+    organization_id: UUID | None,
+    sandbox_id: str,
+    conversation_id: UUID,
+    start_task_id: UUID | None,
+) -> str:
+    return jwt_service.create_jwe_token(
+        {
+            'purpose': 'codex-credential-binding',
+            'user_id': user_id,
+            'organization_id': (
+                str(organization_id) if organization_id is not None else None
+            ),
+            'sandbox_id': sandbox_id,
+            'conversation_id': str(conversation_id),
+            'start_task_id': str(start_task_id) if start_task_id else None,
+            'secret_name': CODEX_AUTH_SECRET_NAME,
+            'actions': ['load', 'replace'],
+        }
+    )
+
+
+def decode_binding_context(
+    jwt_service: JwtService, token: str
+) -> CredentialBindingContext:
+    return CredentialBindingContext.model_validate(jwt_service.decrypt_jwe_token(token))
+
+
+def credential_binding_callback_path(sandbox_id: str, conversation_id: UUID) -> str:
+    return (
+        f'/api/v1/sandboxes/{sandbox_id}/credential-bindings/'
+        f'{conversation_id}/{CODEX_AUTH_SECRET_NAME}'
+    )
+
+
+async def agent_server_supports_credential_binding(
+    httpx_client: httpx.AsyncClient,
+    agent_server_url: str,
+    session_api_key: str,
+) -> bool:
+    response = await httpx_client.get(
+        f'{agent_server_url}/server_info',
+        headers={'X-Session-API-Key': session_api_key},
+        timeout=30.0,
+    )
+    response.raise_for_status()
+    body = response.json()
+    capabilities = body.get('capabilities') if isinstance(body, dict) else None
+    if capabilities is None:
+        return False
+    if not isinstance(capabilities, list) or not all(
+        isinstance(capability, str) for capability in capabilities
+    ):
+        raise SandboxError('Agent Server returned invalid capability metadata')
+    return CREDENTIAL_BINDING_CAPABILITIES.issubset(capabilities)
+
+
+async def activate_codex_credential_binding(
+    httpx_client: httpx.AsyncClient,
+    jwt_service: JwtService,
+    *,
+    agent_server_url: str,
+    callback_url: str,
+    session_api_key: str,
+    user_id: str,
+    organization_id: UUID | None,
+    sandbox_id: str,
+    conversation_id: UUID,
+    start_task_id: UUID | None,
+    required: bool,
+) -> bool:
+    try:
+        supported = await agent_server_supports_credential_binding(
+            httpx_client, agent_server_url, session_api_key
+        )
+    except httpx.HTTPStatusError as exc:
+        if not required and exc.response.status_code in (404, 501):
+            return False
+        raise SandboxError(
+            'Could not verify Agent Server credential binding support'
+        ) from exc
+    except Exception as exc:
+        raise SandboxError(
+            'Could not verify Agent Server credential binding support'
+        ) from exc
+    if not supported:
+        if required:
+            raise SandboxError('Agent Server lacks managed credential support')
+        return False
+
+    context = create_binding_context(
+        jwt_service,
+        user_id=user_id,
+        organization_id=organization_id,
+        sandbox_id=sandbox_id,
+        conversation_id=conversation_id,
+        start_task_id=start_task_id,
+    )
+    response = await httpx_client.put(
+        (
+            f'{agent_server_url}/api/conversations/{conversation_id}/'
+            f'credential-bindings/{CODEX_AUTH_SECRET_NAME}'
+        ),
+        json={
+            'url': callback_url,
+            'headers': {
+                'X-Session-API-Key': session_api_key,
+                CREDENTIAL_BINDING_CONTEXT_HEADER: context,
+            },
+        },
+        headers={'X-Session-API-Key': session_api_key},
+        timeout=30.0,
+    )
+    if response.status_code == 501 and not required:
+        return False
+    try:
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise SandboxError(
+            'Agent Server rejected managed credential activation'
+        ) from exc
+    if response.status_code != 204:
+        raise SandboxError('Agent Server returned an invalid activation response')
+    return True
+
+
+def validate_codex_credential(value: str) -> None:
+    if len(value.encode()) > MAX_API_SECRET_VALUE_LENGTH or not is_valid_codex_auth(
+        value
+    ):
+        raise ValueError('Invalid Codex credential')

--- a/openhands/app_server/secrets/file_secrets_store.py
+++ b/openhands/app_server/secrets/file_secrets_store.py
@@ -1,37 +1,292 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+import secrets as secrets_module
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID
 
 from openhands.app_server.file_store.files import FileStore
 from openhands.app_server.secrets.secrets_models import Secrets
-from openhands.app_server.secrets.secrets_store import SecretsStore
+from openhands.app_server.secrets.secrets_store import (
+    CredentialVersionConflict,
+    SecretsStore,
+)
 from openhands.app_server.utils.async_utils import call_sync_from_async
+
+_CODEX_AUTH_SECRET_NAME = 'CODEX_AUTH_JSON'
+_CREDENTIAL_VERSIONS_KEY = '_credential_versions'
+
+
+@dataclass(frozen=True)
+class _LoadedCredential:
+    value: str | None
 
 
 @dataclass
 class FileSecretsStore(SecretsStore):
     file_store: FileStore
     path: str = 'secrets.json'
+    _loaded_codex_auth: _LoadedCredential | None = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
 
-    async def load(self) -> Secrets | None:
+    def _read_data(self) -> dict[str, Any] | None:
         try:
-            json_str = await call_sync_from_async(self.file_store.read, self.path)
-            kwargs = json.loads(json_str)
-            provider_tokens = {
-                k: v
-                for k, v in (kwargs.get('provider_tokens') or {}).items()
-                if v.get('token')
-            }
-            kwargs['provider_tokens'] = provider_tokens
-            secrets = Secrets(**kwargs)
-            return secrets
+            data = json.loads(self.file_store.read(self.path))
         except FileNotFoundError:
             return None
+        if not isinstance(data, dict):
+            raise ValueError('Invalid secrets file')
+        return data
+
+    @staticmethod
+    def _entries(data: dict[str, Any], key: str) -> dict[str, Any]:
+        entries = data.get(key)
+        if entries is None:
+            return {}
+        if not isinstance(entries, dict):
+            raise ValueError('Invalid secrets file')
+        return entries
+
+    @classmethod
+    def _secrets(cls, data: dict[str, Any]) -> Secrets:
+        provider_tokens = {
+            name: value
+            for name, value in cls._entries(data, 'provider_tokens').items()
+            if isinstance(value, dict) and value.get('token')
+        }
+        kwargs = dict(data)
+        kwargs['provider_tokens'] = provider_tokens
+        kwargs['custom_secrets'] = cls._entries(data, 'custom_secrets')
+        return Secrets(**kwargs)
+
+    @staticmethod
+    def _versions(data: dict[str, Any]) -> dict[str, Any]:
+        versions = data.get(_CREDENTIAL_VERSIONS_KEY)
+        if versions is None:
+            return {}
+        if not isinstance(versions, dict):
+            raise ValueError('Invalid credential versions')
+        return dict(versions)
+
+    @classmethod
+    def _raw_secret(
+        cls,
+        data: dict[str, Any],
+        name: str,
+    ) -> tuple[dict[str, Any], str]:
+        current = cls._entries(data, 'custom_secrets').get(name)
+        if not isinstance(current, dict):
+            raise KeyError(name)
+        value = current.get('secret')
+        if not isinstance(value, str):
+            raise KeyError(name)
+        return current, value
+
+    @staticmethod
+    def _merge_entries(
+        original: dict[str, Any],
+        incoming: dict[str, Any],
+    ) -> dict[str, Any]:
+        merged = {}
+        for name, value in incoming.items():
+            current = original.get(name)
+            if isinstance(current, dict) and isinstance(value, dict):
+                merged[name] = {**current, **value}
+            else:
+                merged[name] = value
+        return merged
+
+    @staticmethod
+    def _new_version(previous: str | None = None) -> str:
+        while True:
+            version = secrets_module.token_urlsafe(24)
+            if version != previous:
+                return version
+
+    def _write_data(self, data: dict[str, Any]) -> None:
+        self.file_store.write(self.path, json.dumps(data))
+
+    async def load(self) -> Secrets | None:
+        if not self.file_store.supports_locked_update:
+            data = await call_sync_from_async(self._read_data)
+            return self._secrets(data) if data is not None else None
+
+        def load_locked() -> Secrets | None:
+            data = self._read_data()
+            if data is None:
+                self._loaded_codex_auth = _LoadedCredential(None)
+                return None
+            loaded = self._secrets(data)
+            current = loaded.custom_secrets.get(_CODEX_AUTH_SECRET_NAME)
+            value = current.secret.get_secret_value() if current is not None else None
+            self._loaded_codex_auth = _LoadedCredential(value)
+            return loaded
+
+        return await call_sync_from_async(
+            self.file_store.locked_update,
+            self.path,
+            load_locked,
+        )
 
     async def store(self, secrets: Secrets) -> None:
-        json_str = secrets.model_dump_json(context={'expose_secrets': True})
-        await call_sync_from_async(self.file_store.write, self.path, json_str)
+        if not self.file_store.supports_locked_update:
+            json_str = secrets.model_dump_json(context={'expose_secrets': True})
+            await call_sync_from_async(self.file_store.write, self.path, json_str)
+            return
+
+        serialized = secrets.model_dump(
+            mode='json',
+            context={'expose_secrets': True},
+        )
+
+        def store_locked() -> None:
+            data = self._read_data() or {}
+            original_provider_tokens = self._entries(data, 'provider_tokens')
+            original_custom_secrets = self._entries(data, 'custom_secrets')
+            incoming_provider_tokens = serialized['provider_tokens']
+            incoming_custom_secrets = serialized['custom_secrets']
+            versions = self._versions(data)
+
+            submitted_info = incoming_custom_secrets.get(_CODEX_AUTH_SECRET_NAME)
+            submitted_value = (
+                submitted_info.get('secret')
+                if isinstance(submitted_info, dict)
+                else None
+            )
+            if not isinstance(submitted_value, str):
+                submitted_value = None
+
+            baseline = self._loaded_codex_auth
+            preserve = baseline is None and submitted_info is None
+            if baseline is not None and submitted_value == baseline.value:
+                preserve = True
+
+            updated_custom_secrets = self._merge_entries(
+                original_custom_secrets,
+                incoming_custom_secrets,
+            )
+            if preserve:
+                try:
+                    current_info, current_value = self._raw_secret(
+                        data,
+                        _CODEX_AUTH_SECRET_NAME,
+                    )
+                except KeyError:
+                    updated_custom_secrets.pop(_CODEX_AUTH_SECRET_NAME, None)
+                else:
+                    if isinstance(submitted_info, dict):
+                        current_info = {**current_info, **submitted_info}
+                    updated_custom_secrets[_CODEX_AUTH_SECRET_NAME] = {
+                        **current_info,
+                        'secret': current_value,
+                    }
+            elif submitted_value is None:
+                versions.pop(_CODEX_AUTH_SECRET_NAME, None)
+            else:
+                versions[_CODEX_AUTH_SECRET_NAME] = self._new_version(
+                    versions.get(_CODEX_AUTH_SECRET_NAME)
+                    if isinstance(versions.get(_CODEX_AUTH_SECRET_NAME), str)
+                    else None
+                )
+
+            updated = dict(data)
+            updated['provider_tokens'] = self._merge_entries(
+                original_provider_tokens,
+                incoming_provider_tokens,
+            )
+            updated['custom_secrets'] = updated_custom_secrets
+            if versions or _CREDENTIAL_VERSIONS_KEY in data:
+                updated[_CREDENTIAL_VERSIONS_KEY] = versions
+            else:
+                updated.pop(_CREDENTIAL_VERSIONS_KEY, None)
+            self._write_data(updated)
+
+            if not preserve:
+                self._loaded_codex_auth = _LoadedCredential(submitted_value)
+
+        await call_sync_from_async(
+            self.file_store.locked_update,
+            self.path,
+            store_locked,
+        )
+
+    async def load_versioned(
+        self,
+        name: str,
+        organization_id: UUID | None = None,
+    ) -> tuple[str, str]:
+        del organization_id
+        if not self.file_store.supports_locked_update:
+            raise NotImplementedError
+
+        def load_locked() -> tuple[str, str]:
+            data = self._read_data()
+            if data is None:
+                raise KeyError(name)
+            _, value = self._raw_secret(data, name)
+            versions = self._versions(data)
+            version = versions.get(name)
+            if not isinstance(version, str) or not version:
+                version = self._new_version()
+                versions[name] = version
+                updated = dict(data)
+                updated[_CREDENTIAL_VERSIONS_KEY] = versions
+                self._write_data(updated)
+            return value, version
+
+        return await call_sync_from_async(
+            self.file_store.locked_update,
+            self.path,
+            load_locked,
+        )
+
+    async def replace_versioned(
+        self,
+        name: str,
+        expected_version: str,
+        value: str,
+        organization_id: UUID | None = None,
+    ) -> str:
+        del organization_id
+        if not self.file_store.supports_locked_update:
+            raise NotImplementedError
+
+        def replace_locked() -> str:
+            data = self._read_data()
+            if data is None:
+                raise KeyError(name)
+            current, _ = self._raw_secret(data, name)
+            versions = self._versions(data)
+            version = versions.get(name)
+            if (
+                not isinstance(version, str)
+                or not version
+                or not secrets_module.compare_digest(
+                    version.encode(),
+                    expected_version.encode(errors='surrogatepass'),
+                )
+            ):
+                raise CredentialVersionConflict
+
+            successor = self._new_version(version)
+            custom_secrets = dict(self._entries(data, 'custom_secrets'))
+            custom_secrets[name] = {**current, 'secret': value}
+            versions[name] = successor
+            updated = dict(data)
+            updated['custom_secrets'] = custom_secrets
+            updated[_CREDENTIAL_VERSIONS_KEY] = versions
+            self._write_data(updated)
+            return successor
+
+        return await call_sync_from_async(
+            self.file_store.locked_update,
+            self.path,
+            replace_locked,
+        )
 
     @classmethod
     async def get_instance(cls, user_id: str | None) -> FileSecretsStore:

--- a/openhands/app_server/secrets/secrets_store.py
+++ b/openhands/app_server/secrets/secrets_store.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from uuid import UUID
 
 from openhands.app_server.secrets.secrets_models import Secrets
+
+
+class CredentialVersionConflict(Exception):
+    pass
 
 
 class SecretsStore(ABC):
@@ -26,6 +31,22 @@ class SecretsStore(ABC):
     @abstractmethod
     async def store(self, secrets: Secrets) -> None:
         """Store secrets."""
+
+    async def load_versioned(
+        self,
+        name: str,
+        organization_id: UUID | None = None,
+    ) -> tuple[str, str]:
+        raise NotImplementedError
+
+    async def replace_versioned(
+        self,
+        name: str,
+        expected_version: str,
+        value: str,
+        organization_id: UUID | None = None,
+    ) -> str:
+        raise NotImplementedError
 
     @classmethod
     @abstractmethod

--- a/tests/unit/app_server/test_credential_binding.py
+++ b/tests/unit/app_server/test_credential_binding.py
@@ -1,0 +1,237 @@
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from openhands.app_server.errors import SandboxError
+from openhands.app_server.secrets.credential_binding import (
+    CREDENTIAL_BINDING_CAPABILITIES,
+    CREDENTIAL_BINDING_CONTEXT_HEADER,
+    activate_codex_credential_binding,
+    agent_server_supports_credential_binding,
+    decode_binding_context,
+)
+
+
+def _response(status_code: int, body: dict | None = None) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        json=body,
+        request=httpx.Request('GET', 'http://agent-server'),
+    )
+
+
+@pytest.mark.parametrize(
+    'capabilities, expected',
+    [
+        (sorted(CREDENTIAL_BINDING_CAPABILITIES), True),
+        (sorted(CREDENTIAL_BINDING_CAPABILITIES | {'other'}), True),
+        (['credential_binding_v1'], False),
+        ([], False),
+    ],
+)
+async def test_support_requires_all_capabilities(capabilities, expected):
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get.return_value = _response(200, {'capabilities': capabilities})
+
+    supported = await agent_server_supports_credential_binding(
+        client, 'http://agent-server', 'session-key'
+    )
+
+    assert supported is expected
+
+
+async def test_missing_capability_metadata_is_legacy():
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get.return_value = _response(200, {})
+
+    supported = await agent_server_supports_credential_binding(
+        client, 'http://agent-server', 'session-key'
+    )
+
+    assert supported is False
+
+
+@pytest.mark.parametrize('missing', sorted(CREDENTIAL_BINDING_CAPABILITIES))
+async def test_each_capability_is_required(missing):
+    client = AsyncMock(spec=httpx.AsyncClient)
+    capabilities = sorted(CREDENTIAL_BINDING_CAPABILITIES - {missing})
+    client.get.return_value = _response(200, {'capabilities': capabilities})
+
+    supported = await agent_server_supports_credential_binding(
+        client, 'http://agent-server', 'session-key'
+    )
+
+    assert supported is False
+
+
+async def test_malformed_capability_metadata_is_rejected():
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get.return_value = _response(200, {'capabilities': 'all'})
+
+    with pytest.raises(SandboxError, match='invalid capability'):
+        await agent_server_supports_credential_binding(
+            client, 'http://agent-server', 'session-key'
+        )
+
+
+async def test_optional_activation_falls_back_for_missing_capabilities():
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get.return_value = _response(200, {'capabilities': []})
+
+    activated = await activate_codex_credential_binding(
+        client,
+        MagicMock(),
+        agent_server_url='http://agent-server',
+        callback_url='https://app/callback',
+        session_api_key='session-key',
+        user_id='user-id',
+        organization_id=None,
+        sandbox_id='sandbox-id',
+        conversation_id=uuid4(),
+        start_task_id=uuid4(),
+        required=False,
+    )
+
+    assert activated is False
+    client.put.assert_not_awaited()
+
+
+async def test_optional_activation_falls_back_for_501():
+    conversation_id = uuid4()
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get.return_value = _response(
+        200, {'capabilities': sorted(CREDENTIAL_BINDING_CAPABILITIES)}
+    )
+    client.put.return_value = _response(501)
+    jwt_service = MagicMock()
+    jwt_service.create_jwe_token.return_value = 'context-token'
+
+    activated = await activate_codex_credential_binding(
+        client,
+        jwt_service,
+        agent_server_url='http://agent-server',
+        callback_url='https://app/callback',
+        session_api_key='session-key',
+        user_id='user-id',
+        organization_id=None,
+        sandbox_id='sandbox-id',
+        conversation_id=conversation_id,
+        start_task_id=uuid4(),
+        required=False,
+    )
+
+    assert activated is False
+    assert client.put.await_args.kwargs['json'] == {
+        'url': 'https://app/callback',
+        'headers': {
+            'X-Session-API-Key': 'session-key',
+            CREDENTIAL_BINDING_CONTEXT_HEADER: 'context-token',
+        },
+    }
+
+
+@pytest.mark.parametrize('status_code', [400, 401, 409, 500, 501])
+async def test_required_activation_rejects_agent_server_error(status_code):
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get.return_value = _response(
+        200, {'capabilities': sorted(CREDENTIAL_BINDING_CAPABILITIES)}
+    )
+    client.put.return_value = _response(status_code)
+    jwt_service = MagicMock()
+    jwt_service.create_jwe_token.return_value = 'context-token'
+
+    with pytest.raises(SandboxError, match='rejected managed credential'):
+        await activate_codex_credential_binding(
+            client,
+            jwt_service,
+            agent_server_url='http://agent-server',
+            callback_url='https://app/callback',
+            session_api_key='session-key',
+            user_id='user-id',
+            organization_id=None,
+            sandbox_id='sandbox-id',
+            conversation_id=uuid4(),
+            start_task_id=None,
+            required=True,
+        )
+
+
+@pytest.mark.parametrize('status_code', [400, 401, 409, 500])
+async def test_optional_activation_only_falls_back_for_501(status_code):
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get.return_value = _response(
+        200, {'capabilities': sorted(CREDENTIAL_BINDING_CAPABILITIES)}
+    )
+    client.put.return_value = _response(status_code)
+    jwt_service = MagicMock()
+    jwt_service.create_jwe_token.return_value = 'context-token'
+
+    with pytest.raises(SandboxError, match='rejected managed credential'):
+        await activate_codex_credential_binding(
+            client,
+            jwt_service,
+            agent_server_url='http://agent-server',
+            callback_url='https://app/callback',
+            session_api_key='session-key',
+            user_id='user-id',
+            organization_id=None,
+            sandbox_id='sandbox-id',
+            conversation_id=uuid4(),
+            start_task_id=uuid4(),
+            required=False,
+        )
+
+
+async def test_activation_context_is_bound_to_runtime_identity():
+    conversation_id = uuid4()
+    task_id = uuid4()
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get.return_value = _response(
+        200, {'capabilities': sorted(CREDENTIAL_BINDING_CAPABILITIES)}
+    )
+    client.put.return_value = _response(204)
+    jwt_service = MagicMock()
+    jwt_service.create_jwe_token.return_value = 'context-token'
+
+    activated = await activate_codex_credential_binding(
+        client,
+        jwt_service,
+        agent_server_url='http://agent-server',
+        callback_url='https://app/callback',
+        session_api_key='session-key',
+        user_id='user-id',
+        organization_id=None,
+        sandbox_id='sandbox-id',
+        conversation_id=conversation_id,
+        start_task_id=task_id,
+        required=False,
+    )
+
+    assert activated is True
+    claims = jwt_service.create_jwe_token.call_args.args[0]
+    assert claims['user_id'] == 'user-id'
+    assert claims['sandbox_id'] == 'sandbox-id'
+    assert claims['conversation_id'] == str(conversation_id)
+    assert claims['start_task_id'] == str(task_id)
+    assert claims['actions'] == ['load', 'replace']
+
+
+def test_decode_context_rejects_extra_claims():
+    jwt_service = MagicMock()
+    jwt_service.decrypt_jwe_token.return_value = {
+        'purpose': 'codex-credential-binding',
+        'iat': 1,
+        'user_id': 'user-id',
+        'organization_id': None,
+        'sandbox_id': 'sandbox-id',
+        'conversation_id': str(uuid4()),
+        'start_task_id': None,
+        'secret_name': 'CODEX_AUTH_JSON',
+        'actions': ['load', 'replace'],
+        'other': True,
+    }
+
+    with pytest.raises(ValueError):
+        decode_binding_context(jwt_service, 'token')

--- a/tests/unit/app_server/test_docker_sandbox_service.py
+++ b/tests/unit/app_server/test_docker_sandbox_service.py
@@ -382,11 +382,8 @@ class TestDockerSandboxService:
             'Docker daemon error'
         )
 
-        # Execute
-        result = await service.get_sandbox('oh-test-abc123')
-
-        # Verify
-        assert result is None
+        with pytest.raises(APIError, match='Docker daemon error'):
+            await service.get_sandbox('oh-test-abc123')
 
     @patch('openhands.app_server.sandbox.docker_sandbox_service.base62.encodebytes')
     @patch('os.urandom')
@@ -865,17 +862,88 @@ class TestDockerSandboxService:
 
     async def test_pause_sandbox_success(self, service):
         """Test pausing a running sandbox."""
-        # Setup
         mock_container = MagicMock()
         mock_container.status = 'running'
         service.docker_client.containers.get.return_value = mock_container
+        sandbox = MagicMock()
+        order = []
+        service._container_to_sandbox_info = AsyncMock(return_value=sandbox)
+        service._prepare_for_pause = AsyncMock(
+            side_effect=lambda *args: order.append('barrier')
+        )
+        mock_container.pause.side_effect = lambda: order.append('pause')
 
-        # Execute
         result = await service.pause_sandbox('oh-test-abc123')
 
-        # Verify
         assert result is True
+        assert order == ['barrier', 'pause']
+        service._prepare_for_pause.assert_awaited_once_with(
+            sandbox, service.httpx_client
+        )
         mock_container.pause.assert_called_once()
+
+    async def test_pause_barrier_failure_keeps_container_running(self, service):
+        mock_container = MagicMock()
+        mock_container.status = 'running'
+        service.docker_client.containers.get.return_value = mock_container
+        service._container_to_sandbox_info = AsyncMock(return_value=MagicMock())
+        service._prepare_for_pause = AsyncMock(side_effect=SandboxError('flush failed'))
+
+        with pytest.raises(SandboxError, match='flush failed'):
+            await service.pause_sandbox('oh-test-abc123')
+
+        mock_container.pause.assert_not_called()
+
+    @pytest.mark.parametrize(('managed', 'raises'), [(True, True), (False, False)])
+    async def test_missing_pause_barrier_is_strict_only_for_managed(
+        self, service, managed, raises
+    ):
+        sandbox = MagicMock()
+        sandbox.id = 'oh-test-abc123'
+        sandbox.session_api_key = 'session-key'
+        service._get_agent_server_url = MagicMock(return_value='http://agent-server')
+        service._has_managed_credential_conversation = AsyncMock(return_value=managed)
+
+        with patch(
+            'openhands.app_server.sandbox.sandbox_service.agent_server_supports_credential_binding',
+            AsyncMock(return_value=False),
+        ):
+            if raises:
+                with pytest.raises(SandboxError):
+                    await service._prepare_for_pause(sandbox, service.httpx_client)
+            else:
+                await service._prepare_for_pause(sandbox, service.httpx_client)
+
+        service.httpx_client.post.assert_not_awaited()
+
+    async def test_unmanaged_pause_ignores_capability_probe_error(self, service):
+        sandbox = MagicMock()
+        sandbox.id = 'oh-test-abc123'
+        sandbox.session_api_key = 'session-key'
+        service._get_agent_server_url = MagicMock(return_value='http://agent-server')
+        service._has_managed_credential_conversation = AsyncMock(return_value=False)
+
+        with patch(
+            'openhands.app_server.sandbox.sandbox_service.agent_server_supports_credential_binding',
+            AsyncMock(side_effect=httpx.ConnectError('unavailable')),
+        ):
+            await service._prepare_for_pause(sandbox, service.httpx_client)
+
+        service.httpx_client.post.assert_not_awaited()
+
+    async def test_unmanaged_pause_ignores_barrier_error(self, service):
+        sandbox = MagicMock()
+        sandbox.id = 'oh-test-abc123'
+        sandbox.session_api_key = 'session-key'
+        service._get_agent_server_url = MagicMock(return_value='http://agent-server')
+        service._has_managed_credential_conversation = AsyncMock(return_value=False)
+        service.httpx_client.post.side_effect = httpx.ConnectError('unavailable')
+
+        with patch(
+            'openhands.app_server.sandbox.sandbox_service.agent_server_supports_credential_binding',
+            AsyncMock(return_value=True),
+        ):
+            await service._prepare_for_pause(sandbox, service.httpx_client)
 
     async def test_pause_sandbox_not_running(self, service):
         """Test pausing a non-running sandbox."""
@@ -893,19 +961,19 @@ class TestDockerSandboxService:
 
     async def test_delete_sandbox_success(self, service):
         """Test successful sandbox deletion."""
-        # Setup
         mock_container = MagicMock()
         mock_container.status = 'running'
         service.docker_client.containers.get.return_value = mock_container
+        service._container_to_sandbox_info = AsyncMock(return_value=MagicMock())
+        service._prepare_for_pause = AsyncMock()
 
         mock_volume = MagicMock()
         service.docker_client.volumes.get.return_value = mock_volume
 
-        # Execute
         result = await service.delete_sandbox('oh-test-abc123')
 
-        # Verify
         assert result is True
+        service._prepare_for_pause.assert_awaited_once()
         mock_container.stop.assert_called_once_with(timeout=10)
         mock_container.remove.assert_called_once()
         service.docker_client.volumes.get.assert_called_once_with(

--- a/tests/unit/app_server/test_docker_sandbox_service.py
+++ b/tests/unit/app_server/test_docker_sandbox_service.py
@@ -382,8 +382,8 @@ class TestDockerSandboxService:
             'Docker daemon error'
         )
 
-        with pytest.raises(APIError, match='Docker daemon error'):
-            await service.get_sandbox('oh-test-abc123')
+        # A daemon hiccup degrades to "missing" rather than 500ing every caller.
+        assert await service.get_sandbox('oh-test-abc123') is None
 
     @patch('openhands.app_server.sandbox.docker_sandbox_service.base62.encodebytes')
     @patch('os.urandom')

--- a/tests/unit/app_server/test_file_secrets_store_versioning.py
+++ b/tests/unit/app_server/test_file_secrets_store_versioning.py
@@ -1,0 +1,291 @@
+import asyncio
+import json
+import multiprocessing
+from queue import Empty
+from unittest.mock import MagicMock
+
+import pytest
+
+from openhands.app_server.file_store.files import FileStore
+from openhands.app_server.file_store.local import LocalFileStore
+from openhands.app_server.file_store.memory import InMemoryFileStore
+from openhands.app_server.integrations.provider import CustomSecret
+from openhands.app_server.secrets.file_secrets_store import FileSecretsStore
+from openhands.app_server.secrets.secrets_models import Secrets
+from openhands.app_server.secrets.secrets_store import CredentialVersionConflict
+
+_NAME = 'CODEX_AUTH_JSON'
+_ORIGINAL = '{"tokens":{"refresh_token":"r0"}}'
+_ROTATED = '{"tokens":{"refresh_token":"r1"}}'
+
+
+def _secrets(
+    managed: str | None,
+    other: str | None = None,
+    description: str = 'Managed login',
+) -> Secrets:
+    values = {}
+    if managed is not None:
+        values[_NAME] = CustomSecret.from_value(
+            {'secret': managed, 'description': description}
+        )
+    if other is not None:
+        values['OTHER'] = CustomSecret.from_value({'secret': other, 'description': ''})
+    return Secrets(custom_secrets=values)
+
+
+def _replace_in_process(
+    root: str,
+    expected_version: str,
+    value: str,
+    results,
+) -> None:
+    async def replace() -> str:
+        store = FileSecretsStore(LocalFileStore(root=root))
+        return await store.replace_versioned(_NAME, expected_version, value)
+
+    try:
+        results.put(('ok', asyncio.run(replace())))
+    except Exception as exc:
+        results.put((type(exc).__name__, str(exc)))
+
+
+@pytest.fixture
+def store(tmp_path):
+    return FileSecretsStore(LocalFileStore(root=str(tmp_path)))
+
+
+@pytest.mark.asyncio
+async def test_store_creates_persistent_opaque_generation(store):
+    await store.store(_secrets(_ORIGINAL))
+
+    value, version = await store.load_versioned(_NAME)
+    second = FileSecretsStore(store.file_store)
+
+    assert value == _ORIGINAL
+    assert version != _ORIGINAL
+    assert await second.load_versioned(_NAME) == (_ORIGINAL, version)
+
+
+@pytest.mark.asyncio
+async def test_load_versioned_bootstraps_without_rewriting_raw_fields():
+    raw = {
+        'custom_secrets': {
+            _NAME: {
+                'secret': _ORIGINAL,
+                'description': 'Managed login',
+                'future': {'enabled': True},
+            }
+        },
+        'future_top_level': ['keep'],
+    }
+    file_store = InMemoryFileStore(files={'secrets.json': json.dumps(raw)})
+    store = FileSecretsStore(file_store)
+
+    value, version = await store.load_versioned(_NAME)
+    updated = json.loads(file_store.read('secrets.json'))
+    versions = updated.pop('_credential_versions')
+
+    assert (value, versions[_NAME]) == (_ORIGINAL, version)
+    assert updated == raw
+
+
+@pytest.mark.asyncio
+async def test_replace_is_compare_and_swap_and_preserves_raw_fields():
+    raw = {
+        'custom_secrets': {
+            _NAME: {
+                'secret': _ORIGINAL,
+                'description': 'Managed login',
+                'future': True,
+            }
+        },
+        'future_top_level': {'keep': True},
+    }
+    file_store = InMemoryFileStore(files={'secrets.json': json.dumps(raw)})
+    store = FileSecretsStore(file_store)
+    _, version = await store.load_versioned(_NAME)
+
+    with pytest.raises(CredentialVersionConflict):
+        await store.replace_versioned(_NAME, 'stale', _ROTATED)
+    successor = await store.replace_versioned(_NAME, version, _ROTATED)
+    updated = json.loads(file_store.read('secrets.json'))
+
+    assert successor != version
+    assert updated['future_top_level'] == raw['future_top_level']
+    assert updated['custom_secrets'][_NAME] == {
+        **raw['custom_secrets'][_NAME],
+        'secret': _ROTATED,
+    }
+
+
+@pytest.mark.asyncio
+async def test_delete_and_identical_recreate_rejects_old_generation(store):
+    await store.store(_secrets(_ORIGINAL))
+    _, original_version = await store.load_versioned(_NAME)
+
+    await store.store(_secrets(None))
+    await store.store(_secrets(_ORIGINAL))
+    _, recreated_version = await store.load_versioned(_NAME)
+
+    assert recreated_version != original_version
+    with pytest.raises(CredentialVersionConflict):
+        await store.replace_versioned(_NAME, original_version, _ROTATED)
+
+
+@pytest.mark.asyncio
+async def test_stale_whole_save_preserves_rotation_and_unrelated_edits(store):
+    await store.store(_secrets(_ORIGINAL, 'old'))
+    raw = json.loads(store.file_store.read('secrets.json'))
+    raw['custom_secrets'][_NAME]['future'] = 'keep'
+    raw['future_top_level'] = {'keep': True}
+    store.file_store.write('secrets.json', json.dumps(raw))
+
+    stale_store = FileSecretsStore(store.file_store)
+    stale = await stale_store.load()
+    assert stale is not None
+    _, version = await store.load_versioned(_NAME)
+    successor = await store.replace_versioned(_NAME, version, _ROTATED)
+
+    updated = dict(stale.custom_secrets)
+    updated[_NAME] = CustomSecret.from_value(
+        {'secret': _ORIGINAL, 'description': 'Updated description'}
+    )
+    updated['OTHER'] = CustomSecret.from_value({'secret': 'new', 'description': ''})
+    await stale_store.store(stale.model_copy(update={'custom_secrets': updated}))
+
+    loaded = await store.load()
+    saved_raw = json.loads(store.file_store.read('secrets.json'))
+    assert loaded is not None
+    assert loaded.custom_secrets[_NAME].secret.get_secret_value() == _ROTATED
+    assert loaded.custom_secrets[_NAME].description == 'Updated description'
+    assert loaded.custom_secrets['OTHER'].secret.get_secret_value() == 'new'
+    assert await store.load_versioned(_NAME) == (_ROTATED, successor)
+    assert saved_raw['custom_secrets'][_NAME]['future'] == 'keep'
+    assert saved_raw['future_top_level'] == {'keep': True}
+
+
+@pytest.mark.asyncio
+async def test_stale_whole_save_preserves_concurrent_deletion(store):
+    await store.store(_secrets(_ORIGINAL, 'old'))
+    stale_store = FileSecretsStore(store.file_store)
+    deleting_store = FileSecretsStore(store.file_store)
+    stale = await stale_store.load()
+    deleting = await deleting_store.load()
+    assert stale is not None and deleting is not None
+
+    deleted = dict(deleting.custom_secrets)
+    deleted.pop(_NAME)
+    await deleting_store.store(deleting.model_copy(update={'custom_secrets': deleted}))
+
+    updated = dict(stale.custom_secrets)
+    updated['OTHER'] = CustomSecret.from_value({'secret': 'new', 'description': ''})
+    await stale_store.store(stale.model_copy(update={'custom_secrets': updated}))
+
+    loaded = await store.load()
+    assert loaded is not None
+    assert _NAME not in loaded.custom_secrets
+    assert loaded.custom_secrets['OTHER'].secret.get_secret_value() == 'new'
+
+
+@pytest.mark.asyncio
+async def test_explicit_edit_after_rotation_mints_generation(store):
+    await store.store(_secrets(_ORIGINAL))
+    editing_store = FileSecretsStore(store.file_store)
+    editing = await editing_store.load()
+    assert editing is not None
+    _, version = await store.load_versioned(_NAME)
+    rotated_version = await store.replace_versioned(_NAME, version, _ROTATED)
+
+    changed = _secrets('{"tokens":{"refresh_token":"r2"}}')
+    await editing_store.store(changed)
+    value, changed_version = await store.load_versioned(_NAME)
+
+    assert value == '{"tokens":{"refresh_token":"r2"}}'
+    assert changed_version != rotated_version
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('kind', ['local', 'memory'])
+async def test_concurrent_replacements_have_one_winner(kind, tmp_path):
+    file_store: FileStore
+    if kind == 'local':
+        file_store = LocalFileStore(root=str(tmp_path))
+    else:
+        file_store = InMemoryFileStore()
+    store = FileSecretsStore(file_store)
+    await store.store(_secrets(_ORIGINAL))
+    _, version = await store.load_versioned(_NAME)
+
+    results = await asyncio.gather(
+        *(
+            FileSecretsStore(file_store).replace_versioned(
+                _NAME,
+                version,
+                f'{{"tokens":{{"refresh_token":"r{i}"}}}}',
+            )
+            for i in range(8)
+        ),
+        return_exceptions=True,
+    )
+
+    assert sum(isinstance(result, str) for result in results) == 1
+    assert sum(isinstance(result, CredentialVersionConflict) for result in results) == 7
+
+
+@pytest.mark.asyncio
+async def test_local_compare_and_swap_is_cross_process(store, tmp_path):
+    await store.store(_secrets(_ORIGINAL))
+    _, version = await store.load_versioned(_NAME)
+    context = multiprocessing.get_context('spawn')
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_replace_in_process,
+            args=(str(tmp_path), version, f'value-{index}', results),
+        )
+        for index in range(4)
+    ]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=20)
+        assert process.exitcode == 0
+
+    received = []
+    for _ in processes:
+        try:
+            received.append(results.get(timeout=5))
+        except Empty:
+            pytest.fail('A replacement process returned no result')
+
+    assert sum(kind == 'ok' for kind, _ in received) == 1
+    assert (
+        sum(kind == 'CredentialVersionConflict' for kind, _ in received)
+        == len(processes) - 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_unsupported_file_store_retains_legacy_path():
+    file_store = MagicMock(spec=FileStore)
+    file_store.supports_locked_update = False
+    file_store.read.return_value = _secrets(_ORIGINAL).model_dump_json(
+        context={'expose_secrets': True}
+    )
+    store = FileSecretsStore(file_store)
+
+    assert await store.load() == _secrets(_ORIGINAL)
+    with pytest.raises(NotImplementedError):
+        await store.load_versioned(_NAME)
+    with pytest.raises(NotImplementedError):
+        await store.replace_versioned(_NAME, 'version', _ROTATED)
+
+    file_store.reset_mock()
+    updated = _secrets(_ROTATED, 'new')
+    await store.store(updated)
+    file_store.write.assert_called_once_with(
+        'secrets.json',
+        updated.model_dump_json(context={'expose_secrets': True}),
+    )

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -43,6 +43,7 @@ from openhands.app_server.errors import SandboxError
 from openhands.app_server.integrations.provider import ProviderToken, ProviderType
 from openhands.app_server.integrations.service_types import SuggestedTask, TaskType
 from openhands.app_server.sandbox.docker_sandbox_service import DockerSandboxService
+from openhands.app_server.sandbox.process_sandbox_service import ProcessSandboxService
 from openhands.app_server.sandbox.sandbox_models import (
     AGENT_SERVER,
     ExposedUrl,
@@ -2645,6 +2646,152 @@ class TestLiveStatusAppConversationService:
     @patch(
         'openhands.app_server.app_conversation.live_status_app_conversation_service.ConversationInfo'
     )
+    @pytest.mark.parametrize(
+        ('failure_stage', 'delete_status'),
+        [('reactivation', 204), ('reactivation', 500), ('pending_messages', 204)],
+    )
+    async def test_managed_start_cleanup_boundary(
+        self,
+        mock_conversation_info_class,
+        mock_remote_workspace_class,
+        failure_stage,
+        delete_status,
+    ):
+        conversation_id = uuid4()
+        self.mock_user_context.get_user_id = AsyncMock(return_value='test_user_123')
+        self.mock_user_context.get_user_info = AsyncMock(return_value=self.mock_user)
+
+        mock_sandbox_spec = Mock(spec=SandboxSpecInfo)
+        mock_sandbox_spec.working_dir = '/test/workspace'
+        self.mock_sandbox.sandbox_spec_id = 'custom-image'
+        self.mock_sandbox.id = str(uuid4())
+        self.mock_sandbox.session_api_key = 'test_session_key'
+        self.mock_sandbox.exposed_urls = [
+            ExposedUrl(
+                name=AGENT_SERVER,
+                url='http://agent-server:8000',
+                port=60000,
+            )
+        ]
+        self.mock_sandbox_service.get_sandbox = AsyncMock(
+            return_value=self.mock_sandbox
+        )
+        self.mock_sandbox_spec_service.get_sandbox_spec = AsyncMock(
+            return_value=mock_sandbox_spec
+        )
+        mock_remote_workspace_class.return_value = Mock()
+
+        captured_task = {}
+
+        async def mock_wait_for_sandbox(task):
+            captured_task['value'] = task
+            task.sandbox_id = self.mock_sandbox.id
+            yield task
+
+        async def mock_run_setup_scripts(*args):
+            yield args[0]
+
+        self.service._wait_for_sandbox_start = mock_wait_for_sandbox
+        self.service.run_setup_scripts = mock_run_setup_scripts
+        self.service._seed_sandbox_profiles = AsyncMock()
+        mock_agent = Mock(agent_kind='acp', acp_model='gpt-5')
+        mock_start_request = Mock(spec=StartConversationRequest)
+        mock_start_request.agent = mock_agent
+        mock_start_request.tags = {}
+        mock_start_request.model_dump.return_value = {}
+        self.service._build_start_conversation_request_for_user = AsyncMock(
+            return_value=mock_start_request
+        )
+        self.service._prepare_codex_credential_binding = AsyncMock(
+            return_value='personal'
+        )
+
+        def conversation_info(_payload):
+            info = Mock()
+            info.id = conversation_id
+            info.tags = {
+                CODEX_CREDENTIAL_START_TASK_TAG_KEY: str(captured_task['value'].id)
+            }
+            return info
+
+        mock_conversation_info_class.model_validate.side_effect = conversation_info
+        self.mock_httpx_client.post = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                json={'id': str(conversation_id)},
+                request=httpx.Request(
+                    'POST', 'http://agent-server:8000/api/conversations'
+                ),
+            )
+        )
+        self.mock_httpx_client.get = AsyncMock()
+        self.mock_httpx_client.delete = AsyncMock(
+            return_value=httpx.Response(
+                delete_status,
+                request=httpx.Request(
+                    'DELETE',
+                    f'http://agent-server:8000/api/conversations/{conversation_id}',
+                ),
+            )
+        )
+        self.mock_app_conversation_info_service.save_app_conversation_info = AsyncMock()
+        self.mock_app_conversation_info_service.delete_app_conversation_info = (
+            AsyncMock()
+        )
+        self.mock_event_callback_service.save_event_callback = AsyncMock()
+        self.mock_event_callback_service.delete_event_callback = AsyncMock()
+        self.service._process_pending_messages = AsyncMock(
+            side_effect=(
+                RuntimeError('pending message failure')
+                if failure_stage == 'pending_messages'
+                else None
+            )
+        )
+        activation = AsyncMock(
+            side_effect=(
+                SandboxError('taskless activation failure')
+                if failure_stage == 'reactivation'
+                else None
+            )
+        )
+
+        with patch(
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.activate_codex_credential_binding',
+            activation,
+        ):
+            async for _ in self.service._start_app_conversation(
+                AppConversationStartRequest(conversation_id=conversation_id)
+            ):
+                pass
+
+        if failure_stage == 'pending_messages':
+            self.mock_httpx_client.get.assert_not_awaited()
+            self.mock_httpx_client.delete.assert_not_awaited()
+            self.mock_app_conversation_info_service.delete_app_conversation_info.assert_not_awaited()
+            self.mock_event_callback_service.save_event_callback.assert_awaited_once()
+            self.mock_event_callback_service.delete_event_callback.assert_not_awaited()
+        else:
+            self.mock_httpx_client.delete.assert_awaited_once()
+            saved_callback = (
+                self.mock_event_callback_service.save_event_callback.await_args.args[0]
+            )
+            if delete_status == 204:
+                self.mock_app_conversation_info_service.delete_app_conversation_info.assert_awaited_once_with(
+                    conversation_id
+                )
+                self.mock_event_callback_service.delete_event_callback.assert_awaited_once_with(
+                    saved_callback.id
+                )
+            else:
+                self.mock_app_conversation_info_service.delete_app_conversation_info.assert_not_awaited()
+                self.mock_event_callback_service.delete_event_callback.assert_not_awaited()
+
+    @patch(
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace'
+    )
+    @patch(
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.ConversationInfo'
+    )
     @pytest.mark.asyncio
     async def test_start_app_conversation_preserves_acp_and_repository_tags(
         self, mock_conversation_info_class, mock_remote_workspace_class
@@ -4725,6 +4872,9 @@ class TestCodexCredentialBinding:
         )
         user_context.get_user_id = AsyncMock(return_value='user-id')
         user_context.get_effective_org_id = AsyncMock(return_value=None)
+        service.app_conversation_info_service.get_app_conversation_info = AsyncMock(
+            return_value=None
+        )
         catalog_response = Mock(status_code=200)
         catalog_response.raise_for_status = Mock()
         service.httpx_client.get = AsyncMock(return_value=catalog_response)
@@ -4837,11 +4987,18 @@ class TestCodexCredentialBinding:
         assert marker is None
         activate.assert_not_awaited()
 
+    @pytest.mark.parametrize(
+        ('app_mode', 'sandbox_service_type'),
+        [('test', None), ('saas', ProcessSandboxService)],
+    )
     async def test_unsupported_sandbox_service_is_not_managed(
-        self, service, monkeypatch
+        self, service, monkeypatch, app_mode, sandbox_service_type
     ):
         monkeypatch.setenv('OH_ENABLE_CODEX_CREDENTIAL_SYNC', 'true')
-        service.sandbox_service = Mock()
+        service.app_mode = app_mode
+        service.sandbox_service = (
+            Mock(spec=sandbox_service_type) if sandbox_service_type else Mock()
+        )
         source = StaticSecret(value=SecretStr(self.codex_auth))
         request = self._request(source)
         service.user_context.get_secrets = AsyncMock(
@@ -4862,6 +5019,38 @@ class TestCodexCredentialBinding:
             )
 
         assert marker is None
+        assert request.secrets['CODEX_AUTH_JSON'] is source
+        activate.assert_not_awaited()
+
+    async def test_existing_conversation_is_rejected_before_activation(
+        self, service, monkeypatch
+    ):
+        monkeypatch.setenv('OH_ENABLE_CODEX_CREDENTIAL_SYNC', 'true')
+        source = StaticSecret(value=SecretStr(self.codex_auth))
+        request = self._request(source)
+        service.user_context.get_secrets = AsyncMock(
+            return_value={'CODEX_AUTH_JSON': source}
+        )
+        service.app_conversation_info_service.get_app_conversation_info.return_value = (
+            Mock()
+        )
+
+        with (
+            patch(
+                'openhands.app_server.app_conversation.live_status_app_conversation_service.activate_codex_credential_binding',
+                AsyncMock(),
+            ) as activate,
+            pytest.raises(SandboxError, match='already exists'),
+        ):
+            await service._prepare_codex_credential_binding(
+                request,
+                sandbox=self._sandbox(),
+                conversation_id=uuid4(),
+                start_task_id=uuid4(),
+                agent_server_url='http://agent-server',
+                api_override=False,
+            )
+
         assert request.secrets['CODEX_AUTH_JSON'] is source
         activate.assert_not_awaited()
 

--- a/tests/unit/app_server/test_live_status_app_conversation_service.py
+++ b/tests/unit/app_server/test_live_status_app_conversation_service.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
 
+import httpx
 import pytest
 from pydantic import SecretStr
 
@@ -20,6 +21,8 @@ from openhands.agent_server.models import (
     TextContent,
 )
 from openhands.app_server.app_conversation.app_conversation_models import (
+    CODEX_CREDENTIAL_BINDING_TAG_KEY,
+    CODEX_CREDENTIAL_START_TASK_TAG_KEY,
     AgentType,
     AppConversationInfo,
     AppConversationStartRequest,
@@ -39,6 +42,7 @@ from openhands.app_server.app_conversation.live_status_app_conversation_service 
 from openhands.app_server.errors import SandboxError
 from openhands.app_server.integrations.provider import ProviderToken, ProviderType
 from openhands.app_server.integrations.service_types import SuggestedTask, TaskType
+from openhands.app_server.sandbox.docker_sandbox_service import DockerSandboxService
 from openhands.app_server.sandbox.sandbox_models import (
     AGENT_SERVER,
     ExposedUrl,
@@ -57,7 +61,11 @@ from openhands.app_server.utils.redis_lock import RedisLockUnavailable
 from openhands.sdk import Agent, AgentContext, Event
 from openhands.sdk.llm import LLM
 from openhands.sdk.secret import LookupSecret, StaticSecret
-from openhands.sdk.settings import ConversationSettings, OpenHandsAgentSettings
+from openhands.sdk.settings import (
+    ACPAgentSettings,
+    ConversationSettings,
+    OpenHandsAgentSettings,
+)
 from openhands.sdk.workspace.remote.async_remote_workspace import AsyncRemoteWorkspace
 
 
@@ -2506,7 +2514,7 @@ class TestLiveStatusAppConversationService:
         self.mock_event_callback_service.save_event_callback = AsyncMock()
 
         # Create request
-        request = AppConversationStartRequest()
+        request = AppConversationStartRequest(conversation_id=conversation_id)
 
         # Act
         async for task in self.service._start_app_conversation(request):
@@ -2526,6 +2534,110 @@ class TestLiveStatusAppConversationService:
             f'but got "{saved_info.title}"'
         )
         assert saved_info.id == conversation_id
+
+    @patch(
+        'openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace'
+    )
+    @pytest.mark.parametrize('created_by_task', [False, True])
+    @pytest.mark.parametrize(
+        'response_kind', ['http_error', 'malformed', 'transport_error']
+    )
+    async def test_failed_managed_create_only_deletes_task_owned_conversation(
+        self, mock_remote_workspace_class, created_by_task, response_kind
+    ):
+        conversation_id = uuid4()
+        self.mock_user_context.get_user_id = AsyncMock(return_value='test_user_123')
+        self.mock_user_context.get_user_info = AsyncMock(return_value=self.mock_user)
+
+        mock_sandbox_spec = Mock(spec=SandboxSpecInfo)
+        mock_sandbox_spec.working_dir = '/test/workspace'
+        self.mock_sandbox.sandbox_spec_id = 'custom-image'
+        self.mock_sandbox.id = str(uuid4())
+        self.mock_sandbox.session_api_key = 'test_session_key'
+        self.mock_sandbox.exposed_urls = [
+            ExposedUrl(
+                name=AGENT_SERVER,
+                url='http://agent-server:8000',
+                port=60000,
+            )
+        ]
+        self.mock_sandbox_service.get_sandbox = AsyncMock(
+            return_value=self.mock_sandbox
+        )
+        self.mock_sandbox_spec_service.get_sandbox_spec = AsyncMock(
+            return_value=mock_sandbox_spec
+        )
+        mock_remote_workspace_class.return_value = Mock()
+
+        captured_task = {}
+
+        async def mock_wait_for_sandbox(task):
+            captured_task['value'] = task
+            task.sandbox_id = self.mock_sandbox.id
+            yield task
+
+        async def mock_run_setup_scripts(*args):
+            yield args[0]
+
+        self.service._wait_for_sandbox_start = mock_wait_for_sandbox
+        self.service.run_setup_scripts = mock_run_setup_scripts
+        self.service._seed_sandbox_profiles = AsyncMock()
+        mock_start_request = Mock(spec=StartConversationRequest)
+        mock_start_request.tags = {}
+        mock_start_request.model_dump.return_value = {}
+        self.service._build_start_conversation_request_for_user = AsyncMock(
+            return_value=mock_start_request
+        )
+        self.service._prepare_codex_credential_binding = AsyncMock(
+            return_value='personal'
+        )
+
+        request = httpx.Request('POST', 'http://agent-server:8000/api/conversations')
+        if response_kind == 'transport_error':
+            self.mock_httpx_client.post = AsyncMock(
+                side_effect=httpx.ReadTimeout('lost response', request=request)
+            )
+        else:
+            response = (
+                httpx.Response(409, request=request)
+                if response_kind == 'http_error'
+                else httpx.Response(200, request=request, json={'invalid': True})
+            )
+            self.mock_httpx_client.post = AsyncMock(return_value=response)
+        catalog_response = Mock(status_code=200)
+        catalog_response.json = Mock(
+            side_effect=lambda: {
+                'id': str(conversation_id),
+                'tags': (
+                    {
+                        CODEX_CREDENTIAL_START_TASK_TAG_KEY: str(
+                            captured_task['value'].id
+                        )
+                    }
+                    if created_by_task
+                    else {}
+                ),
+            }
+        )
+        self.mock_httpx_client.get = AsyncMock(return_value=catalog_response)
+        delete_response = httpx.Response(
+            204,
+            request=httpx.Request(
+                'DELETE',
+                f'http://agent-server:8000/api/conversations/{conversation_id}',
+            ),
+        )
+        self.mock_httpx_client.delete = AsyncMock(return_value=delete_response)
+
+        async for _ in self.service._start_app_conversation(
+            AppConversationStartRequest(conversation_id=conversation_id)
+        ):
+            pass
+
+        if created_by_task:
+            self.mock_httpx_client.delete.assert_awaited_once()
+        else:
+            self.mock_httpx_client.delete.assert_not_awaited()
 
     @patch(
         'openhands.app_server.app_conversation.live_status_app_conversation_service.AsyncRemoteWorkspace'
@@ -2600,6 +2712,7 @@ class TestLiveStatusAppConversationService:
         self.mock_event_callback_service.save_event_callback = AsyncMock()
 
         request = AppConversationStartRequest(
+            conversation_id=conversation_id,
             selected_repository='OpenHands/OpenHands',
             selected_branch='main',
             git_provider=ProviderType.GITHUB,
@@ -2696,7 +2809,7 @@ class TestLiveStatusAppConversationService:
         self.mock_app_conversation_info_service.save_app_conversation_info = AsyncMock()
 
         async for _ in self.service._start_app_conversation(
-            AppConversationStartRequest()
+            AppConversationStartRequest(conversation_id=conversation_id)
         ):
             pass
 
@@ -4580,6 +4693,326 @@ class TestBuildAcpStartConversationRequestSecrets:
             'conversation_id': str(request.conversation_id),
             'agent_kind': 'acp',
         }
+
+
+class TestCodexCredentialBinding:
+    codex_auth = json.dumps(
+        {'auth_mode': 'chatgpt', 'tokens': {'refresh_token': 'refresh-token'}}
+    )
+
+    @pytest.fixture
+    def service(self):
+        user_context = Mock(spec=UserContext)
+        service = LiveStatusAppConversationService(
+            init_git_in_empty_workspace=True,
+            user_context=user_context,
+            app_conversation_info_service=Mock(),
+            app_conversation_start_task_service=Mock(),
+            event_callback_service=Mock(),
+            event_service=Mock(),
+            sandbox_service=Mock(spec=DockerSandboxService),
+            sandbox_spec_service=Mock(),
+            jwt_service=Mock(),
+            pending_message_service=Mock(),
+            sandbox_startup_timeout=30,
+            sandbox_startup_poll_frequency=1,
+            max_num_conversations_per_sandbox=20,
+            httpx_client=AsyncMock(),
+            web_url='https://app.example.com',
+            openhands_provider_base_url=None,
+            access_token_hard_timeout=None,
+            app_mode='test',
+        )
+        user_context.get_user_id = AsyncMock(return_value='user-id')
+        user_context.get_effective_org_id = AsyncMock(return_value=None)
+        catalog_response = Mock(status_code=200)
+        catalog_response.raise_for_status = Mock()
+        service.httpx_client.get = AsyncMock(return_value=catalog_response)
+        return service
+
+    def _request(self, source, context_secrets=None):
+        agent = ACPAgentSettings(
+            acp_server='codex',
+            agent_context=(
+                AgentContext(secrets=context_secrets) if context_secrets else None
+            ),
+        ).create_agent()
+        return StartConversationRequest(
+            workspace={'working_dir': '/workspace'},
+            agent=agent,
+            secrets={'CODEX_AUTH_JSON': source},
+        )
+
+    def _sandbox(self):
+        return SandboxInfo(
+            id='sandbox-id',
+            created_by_user_id='user-id',
+            sandbox_spec_id='spec-id',
+            status=SandboxStatus.RUNNING,
+            session_api_key='session-key',
+            exposed_urls=[
+                ExposedUrl(
+                    name=AGENT_SERVER,
+                    url='http://agent-server',
+                    port=8000,
+                )
+            ],
+        )
+
+    async def test_initial_activation_removes_plaintext_from_start_request(
+        self, service, monkeypatch
+    ):
+        monkeypatch.setenv('OH_ENABLE_CODEX_CREDENTIAL_SYNC', 'true')
+        source = StaticSecret(value=SecretStr(self.codex_auth))
+        request = self._request(source)
+        service.user_context.get_secrets = AsyncMock(
+            return_value={'CODEX_AUTH_JSON': source}
+        )
+
+        with patch(
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.activate_codex_credential_binding',
+            AsyncMock(return_value=True),
+        ) as activate:
+            marker = await service._prepare_codex_credential_binding(
+                request,
+                sandbox=self._sandbox(),
+                conversation_id=uuid4(),
+                start_task_id=uuid4(),
+                agent_server_url='http://agent-server',
+                api_override=False,
+            )
+
+        assert marker == 'personal'
+        assert 'CODEX_AUTH_JSON' not in request.secrets
+        assert source.get_value() == self.codex_auth
+        assert activate.await_args.kwargs['required'] is False
+
+    async def test_legacy_activation_keeps_plaintext_and_is_not_managed(
+        self, service, monkeypatch
+    ):
+        monkeypatch.setenv('OH_ENABLE_CODEX_CREDENTIAL_SYNC', 'true')
+        source = StaticSecret(value=SecretStr(self.codex_auth))
+        request = self._request(source)
+        service.user_context.get_secrets = AsyncMock(
+            return_value={'CODEX_AUTH_JSON': source}
+        )
+
+        with patch(
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.activate_codex_credential_binding',
+            AsyncMock(return_value=False),
+        ):
+            marker = await service._prepare_codex_credential_binding(
+                request,
+                sandbox=self._sandbox(),
+                conversation_id=uuid4(),
+                start_task_id=uuid4(),
+                agent_server_url='http://agent-server',
+                api_override=False,
+            )
+
+        assert marker is None
+        assert request.secrets['CODEX_AUTH_JSON'] is source
+
+    async def test_invalid_saved_credential_is_not_managed(self, service, monkeypatch):
+        monkeypatch.setenv('OH_ENABLE_CODEX_CREDENTIAL_SYNC', 'true')
+        source = StaticSecret(value=SecretStr('{}'))
+        request = self._request(source)
+        service.user_context.get_secrets = AsyncMock(
+            return_value={'CODEX_AUTH_JSON': source}
+        )
+
+        with patch(
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.activate_codex_credential_binding',
+            AsyncMock(),
+        ) as activate:
+            marker = await service._prepare_codex_credential_binding(
+                request,
+                sandbox=self._sandbox(),
+                conversation_id=uuid4(),
+                start_task_id=uuid4(),
+                agent_server_url='http://agent-server',
+                api_override=False,
+            )
+
+        assert marker is None
+        activate.assert_not_awaited()
+
+    async def test_unsupported_sandbox_service_is_not_managed(
+        self, service, monkeypatch
+    ):
+        monkeypatch.setenv('OH_ENABLE_CODEX_CREDENTIAL_SYNC', 'true')
+        service.sandbox_service = Mock()
+        source = StaticSecret(value=SecretStr(self.codex_auth))
+        request = self._request(source)
+        service.user_context.get_secrets = AsyncMock(
+            return_value={'CODEX_AUTH_JSON': source}
+        )
+
+        with patch(
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.activate_codex_credential_binding',
+            AsyncMock(),
+        ) as activate:
+            marker = await service._prepare_codex_credential_binding(
+                request,
+                sandbox=self._sandbox(),
+                conversation_id=uuid4(),
+                start_task_id=uuid4(),
+                agent_server_url='http://agent-server',
+                api_override=False,
+            )
+
+        assert marker is None
+        assert request.secrets['CODEX_AUTH_JSON'] is source
+        activate.assert_not_awaited()
+
+    async def test_provider_detection_uses_acp_server(self, service, monkeypatch):
+        monkeypatch.setenv('OH_ENABLE_CODEX_CREDENTIAL_SYNC', 'true')
+        source = StaticSecret(value=SecretStr(self.codex_auth))
+        request = self._request(source)
+        request.agent = request.agent.model_copy(
+            update={
+                'acp_server': 'claude-code',
+                'acp_command': ['codex-acp'],
+            }
+        )
+        service.user_context.get_secrets = AsyncMock(
+            return_value={'CODEX_AUTH_JSON': source}
+        )
+
+        with patch(
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.activate_codex_credential_binding',
+            AsyncMock(),
+        ) as activate:
+            marker = await service._prepare_codex_credential_binding(
+                request,
+                sandbox=self._sandbox(),
+                conversation_id=uuid4(),
+                start_task_id=uuid4(),
+                agent_server_url='http://agent-server',
+                api_override=False,
+            )
+
+        assert marker is None
+        activate.assert_not_awaited()
+
+    @pytest.mark.parametrize('override_kind', ['api', 'agent-context'])
+    async def test_explicit_override_is_not_managed(
+        self, service, monkeypatch, override_kind
+    ):
+        monkeypatch.setenv('OH_ENABLE_CODEX_CREDENTIAL_SYNC', 'true')
+        source = StaticSecret(value=SecretStr(self.codex_auth))
+        request = self._request(
+            source,
+            (
+                {'CODEX_AUTH_JSON': 'one-off'}
+                if override_kind == 'agent-context'
+                else None
+            ),
+        )
+        service.user_context.get_secrets = AsyncMock(
+            return_value={'CODEX_AUTH_JSON': source}
+        )
+
+        with patch(
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.activate_codex_credential_binding',
+            AsyncMock(),
+        ) as activate:
+            marker = await service._prepare_codex_credential_binding(
+                request,
+                sandbox=self._sandbox(),
+                conversation_id=uuid4(),
+                start_task_id=uuid4(),
+                agent_server_url='http://agent-server',
+                api_override=override_kind == 'api',
+            )
+
+        assert marker is None
+        activate.assert_not_awaited()
+
+    async def test_managed_delete_propagates_final_flush_failure(self, service):
+        conversation = Mock()
+        conversation.id = uuid4()
+        conversation.sandbox_id = 'sandbox-id'
+        conversation.created_by_user_id = 'user-id'
+        conversation.tags = {CODEX_CREDENTIAL_BINDING_TAG_KEY: 'personal'}
+        conversation.sandbox_status = SandboxStatus.RUNNING
+        conversation.session_api_key = 'old-session-key'
+        service.sandbox_service.get_sandbox = AsyncMock(return_value=self._sandbox())
+
+        with (
+            patch(
+                'openhands.app_server.app_conversation.live_status_app_conversation_service.activate_codex_credential_binding',
+                AsyncMock(side_effect=SandboxError('flush failed')),
+            ),
+            pytest.raises(SandboxError, match='flush failed'),
+        ):
+            await service._delete_from_agent_server(conversation)
+
+        service.httpx_client.delete.assert_not_awaited()
+
+    async def test_managed_delete_waits_for_starting_sandbox(self, service):
+        conversation = Mock()
+        conversation.id = uuid4()
+        conversation.sandbox_id = 'sandbox-id'
+        conversation.created_by_user_id = 'user-id'
+        conversation.tags = {CODEX_CREDENTIAL_BINDING_TAG_KEY: 'personal'}
+        conversation.sandbox_status = SandboxStatus.STARTING
+        conversation.session_api_key = 'session-key'
+        starting = self._sandbox().model_copy(update={'status': SandboxStatus.STARTING})
+        running = self._sandbox()
+        service.sandbox_service.get_sandbox = AsyncMock(return_value=starting)
+        service.sandbox_service.resume_sandbox = AsyncMock()
+        service.sandbox_service.wait_for_sandbox_running = AsyncMock(
+            return_value=running
+        )
+        response = Mock()
+        response.raise_for_status = Mock()
+        service.httpx_client.delete = AsyncMock(return_value=response)
+
+        with patch(
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.activate_codex_credential_binding',
+            AsyncMock(return_value=True),
+        ):
+            await service._delete_from_agent_server(conversation)
+
+        service.sandbox_service.resume_sandbox.assert_not_awaited()
+        service.sandbox_service.wait_for_sandbox_running.assert_awaited_once()
+        service.httpx_client.delete.assert_awaited_once()
+
+    async def test_managed_delete_is_done_when_conversation_is_absent(self, service):
+        conversation = Mock()
+        conversation.id = uuid4()
+        conversation.sandbox_id = 'sandbox-id'
+        conversation.created_by_user_id = 'user-id'
+        conversation.tags = {CODEX_CREDENTIAL_BINDING_TAG_KEY: 'personal'}
+        conversation.sandbox_status = SandboxStatus.RUNNING
+        conversation.session_api_key = 'session-key'
+        service.sandbox_service.get_sandbox = AsyncMock(return_value=self._sandbox())
+        service.httpx_client.get.return_value.status_code = 404
+
+        with patch(
+            'openhands.app_server.app_conversation.live_status_app_conversation_service.activate_codex_credential_binding',
+            AsyncMock(),
+        ) as activate:
+            await service._delete_from_agent_server(conversation)
+
+        activate.assert_not_awaited()
+        service.httpx_client.delete.assert_not_awaited()
+
+    async def test_managed_delete_is_done_when_sandbox_is_absent(self, service):
+        conversation = Mock()
+        conversation.id = uuid4()
+        conversation.sandbox_id = 'sandbox-id'
+        conversation.created_by_user_id = 'user-id'
+        conversation.tags = {CODEX_CREDENTIAL_BINDING_TAG_KEY: 'personal'}
+        conversation.sandbox_status = SandboxStatus.MISSING
+        conversation.session_api_key = None
+        service.sandbox_service.get_sandbox = AsyncMock(return_value=None)
+
+        await service._delete_from_agent_server(conversation)
+
+        service.httpx_client.get.assert_not_awaited()
+        service.httpx_client.delete.assert_not_awaited()
 
 
 def test_exception_detail_strips_http_status_prefix():

--- a/tests/unit/app_server/test_remote_sandbox_service.py
+++ b/tests/unit/app_server/test_remote_sandbox_service.py
@@ -84,7 +84,7 @@ def remote_sandbox_service(
     mock_sandbox_spec_service, mock_user_context, mock_httpx_client, mock_db_session
 ):
     """Create RemoteSandboxService instance with mocked dependencies."""
-    return RemoteSandboxService(
+    service = RemoteSandboxService(
         sandbox_spec_service=mock_sandbox_spec_service,
         api_url='https://api.example.com',
         api_key='test-api-key',
@@ -97,6 +97,8 @@ def remote_sandbox_service(
         httpx_client=mock_httpx_client,
         db_session=mock_db_session,
     )
+    service._has_managed_credential_conversation = AsyncMock(return_value=False)
+    return service
 
 
 def _make_stream_response(
@@ -2774,7 +2776,7 @@ class TestDeleteSandboxKeyHandling:
     def service_with_real_db(
         self, mock_sandbox_spec_service, mock_user_context, real_session
     ):
-        return RemoteSandboxService(
+        service = RemoteSandboxService(
             sandbox_spec_service=mock_sandbox_spec_service,
             api_url='https://api.example.com',
             api_key='test-api-key',
@@ -2787,6 +2789,8 @@ class TestDeleteSandboxKeyHandling:
             httpx_client=AsyncMock(spec=httpx.AsyncClient),
             db_session=real_session,
         )
+        service._has_managed_credential_conversation = AsyncMock(return_value=False)
+        return service
 
     @pytest.mark.asyncio
     async def test_session_key_invalidated_and_survives_rollback(

--- a/tests/unit/app_server/test_remote_sandbox_service.py
+++ b/tests/unit/app_server/test_remote_sandbox_service.py
@@ -621,7 +621,10 @@ class TestSandboxLifecycle:
     @pytest.mark.asyncio
     async def test_resume_sandbox_success(self, remote_sandbox_service):
         """Test successful sandbox resume."""
-        # Setup
+        from openhands.app_server.sandbox.remote_sandbox_service import (
+            _hash_session_api_key,
+        )
+
         stored_sandbox = create_stored_sandbox()
         runtime_data = create_runtime_data()
 
@@ -636,11 +639,13 @@ class TestSandboxLifecycle:
         mock_response.json.return_value = {'session_api_key': 'new-session-key-123'}
         remote_sandbox_service.httpx_client.request.return_value = mock_response
 
-        # Execute
         result = await remote_sandbox_service.resume_sandbox('test-sandbox-123')
 
-        # Verify
         assert result is True
+        assert stored_sandbox.session_api_key_hash == _hash_session_api_key(
+            'new-session-key-123'
+        )
+        remote_sandbox_service.db_session.commit.assert_awaited_once()
         remote_sandbox_service.pause_old_sandboxes.assert_called_once_with(9)
         remote_sandbox_service.httpx_client.request.assert_called_once_with(
             'POST',
@@ -688,8 +693,7 @@ class TestSandboxLifecycle:
     @pytest.mark.asyncio
     async def test_pause_sandbox_success(self, remote_sandbox_service):
         """Test successful sandbox pause."""
-        # Setup
-        stored_sandbox = create_stored_sandbox()
+        stored_sandbox = create_stored_sandbox(session_api_key_hash='old-hash')
         runtime_data = create_runtime_data()
 
         remote_sandbox_service._get_stored_sandbox = AsyncMock(
@@ -699,19 +703,52 @@ class TestSandboxLifecycle:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
-        remote_sandbox_service.httpx_client.request.return_value = mock_response
+        order = []
 
-        # Execute
+        async def prepare(*args):
+            assert stored_sandbox.session_api_key_hash is not None
+            order.append('barrier')
+
+        def request(*args, **kwargs):
+            assert stored_sandbox.session_api_key_hash is None
+            order.append('pause')
+            return mock_response
+
+        remote_sandbox_service._prepare_for_pause = AsyncMock(side_effect=prepare)
+        remote_sandbox_service.httpx_client.request.side_effect = request
+
         result = await remote_sandbox_service.pause_sandbox('test-sandbox-123')
 
-        # Verify
         assert result is True
+        assert order == ['barrier', 'pause']
         remote_sandbox_service.httpx_client.request.assert_called_once_with(
             'POST',
             'https://api.example.com/pause',
             headers={'X-API-Key': 'test-api-key'},
             json={'runtime_id': 'runtime-456'},
         )
+
+    @pytest.mark.asyncio
+    async def test_pause_barrier_failure_keeps_key_and_runtime(
+        self, remote_sandbox_service
+    ):
+        stored_sandbox = create_stored_sandbox(session_api_key_hash='old-hash')
+        original_hash = stored_sandbox.session_api_key_hash
+        remote_sandbox_service._get_stored_sandbox = AsyncMock(
+            return_value=stored_sandbox
+        )
+        remote_sandbox_service._get_runtime = AsyncMock(
+            return_value=create_runtime_data()
+        )
+        remote_sandbox_service._prepare_for_pause = AsyncMock(
+            side_effect=SandboxError('flush failed')
+        )
+
+        with pytest.raises(SandboxError, match='flush failed'):
+            await remote_sandbox_service.pause_sandbox('test-sandbox-123')
+
+        assert stored_sandbox.session_api_key_hash == original_hash
+        remote_sandbox_service.httpx_client.request.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_delete_sandbox_success(self, remote_sandbox_service):
@@ -890,6 +927,9 @@ class TestSandboxLifecycle:
         )
         remote_sandbox_service.db_session.delete = AsyncMock()
         remote_sandbox_service.db_session.commit = AsyncMock()
+        remote_sandbox_service._has_managed_credential_conversation = AsyncMock(
+            return_value=False
+        )
 
         with pytest.raises(SandboxDeleteRetryError):
             await remote_sandbox_service.delete_sandbox('test-sandbox-123')
@@ -899,6 +939,32 @@ class TestSandboxLifecycle:
         remote_sandbox_service.db_session.delete.assert_not_called()
         assert stored_sandbox.session_api_key_hash is None
         remote_sandbox_service.db_session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_transient_error_keeps_managed_session_key(
+        self, remote_sandbox_service
+    ):
+        stored_sandbox = create_stored_sandbox(session_api_key_hash='live-hash')
+        remote_sandbox_service._get_stored_sandbox = AsyncMock(
+            return_value=stored_sandbox
+        )
+        remote_sandbox_service._get_runtime = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                'Server Error',
+                request=httpx.Request('GET', 'https://api.example.com/sessions/x'),
+                response=httpx.Response(503),
+            )
+        )
+        remote_sandbox_service._has_managed_credential_conversation = AsyncMock(
+            return_value=True
+        )
+        remote_sandbox_service.db_session.commit = AsyncMock()
+
+        with pytest.raises(SandboxDeleteRetryError):
+            await remote_sandbox_service.delete_sandbox('test-sandbox-123')
+
+        assert stored_sandbox.session_api_key_hash == 'live-hash'
+        remote_sandbox_service.db_session.commit.assert_not_awaited()
 
 
 class TestSandboxSearch:
@@ -2740,6 +2806,9 @@ class TestDeleteSandboxKeyHandling:
                 response=httpx.Response(503),
             )
         )
+        service_with_real_db._has_managed_credential_conversation = AsyncMock(
+            return_value=False
+        )
 
         with pytest.raises(SandboxDeleteRetryError):
             await service_with_real_db.delete_sandbox('test-sandbox-123')
@@ -2766,7 +2835,7 @@ class TestDeleteSandboxKeyHandling:
         await real_session.commit()
 
         service_with_real_db._get_runtime = AsyncMock(
-            return_value={'runtime_id': 'rt-123'}
+            return_value=create_runtime_data(runtime_id='rt-123')
         )
         stop_response = MagicMock()
         stop_response.status_code = 200

--- a/tests/unit/app_server/test_remote_sandbox_service.py
+++ b/tests/unit/app_server/test_remote_sandbox_service.py
@@ -97,7 +97,6 @@ def remote_sandbox_service(
         httpx_client=mock_httpx_client,
         db_session=mock_db_session,
     )
-    service._has_managed_credential_conversation = AsyncMock(return_value=False)
     return service
 
 
@@ -647,7 +646,9 @@ class TestSandboxLifecycle:
         assert stored_sandbox.session_api_key_hash == _hash_session_api_key(
             'new-session-key-123'
         )
-        remote_sandbox_service.db_session.commit.assert_awaited_once()
+        # The rotated hash is staged for the caller's transaction; committing the
+        # shared request session here would flush the caller's own pending work.
+        remote_sandbox_service.db_session.commit.assert_not_awaited()
         remote_sandbox_service.pause_old_sandboxes.assert_called_once_with(9)
         remote_sandbox_service.httpx_client.request.assert_called_once_with(
             'POST',
@@ -967,6 +968,61 @@ class TestSandboxLifecycle:
 
         assert stored_sandbox.session_api_key_hash == 'live-hash'
         remote_sandbox_service.db_session.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_delete_keeps_session_key_when_managed_probe_raises(
+        self, remote_sandbox_service
+    ):
+        """An unreadable conversation store must not silently revoke a live key."""
+        stored_sandbox = create_stored_sandbox(session_api_key_hash='live-hash')
+        remote_sandbox_service._get_stored_sandbox = AsyncMock(
+            return_value=stored_sandbox
+        )
+        remote_sandbox_service._get_runtime = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                'Server Error',
+                request=httpx.Request('GET', 'https://api.example.com/sessions/x'),
+                response=httpx.Response(503),
+            )
+        )
+        remote_sandbox_service._has_managed_credential_conversation = AsyncMock(
+            side_effect=RuntimeError('conversation store unavailable')
+        )
+        remote_sandbox_service.db_session.commit = AsyncMock()
+
+        with pytest.raises(SandboxDeleteRetryError):
+            await remote_sandbox_service.delete_sandbox('test-sandbox-123')
+
+        assert stored_sandbox.session_api_key_hash == 'live-hash'
+        remote_sandbox_service.db_session.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_delete_revokes_session_key_when_barrier_raises(
+        self, remote_sandbox_service
+    ):
+        """A SandboxError from the pause barrier must not skip key revocation."""
+        stored_sandbox = create_stored_sandbox(session_api_key_hash='live-hash')
+        remote_sandbox_service._get_stored_sandbox = AsyncMock(
+            return_value=stored_sandbox
+        )
+        remote_sandbox_service._get_runtime = AsyncMock(
+            return_value=create_runtime_data('test-sandbox-123')
+        )
+        remote_sandbox_service._prepare_for_pause = AsyncMock(
+            side_effect=SandboxError('No exposed URLs for sandbox: test-sandbox-123')
+        )
+        remote_sandbox_service._has_managed_credential_conversation = AsyncMock(
+            return_value=False
+        )
+        remote_sandbox_service.db_session.delete = AsyncMock()
+        remote_sandbox_service.db_session.commit = AsyncMock()
+
+        with pytest.raises(SandboxDeleteRetryError):
+            await remote_sandbox_service.delete_sandbox('test-sandbox-123')
+
+        remote_sandbox_service.db_session.delete.assert_not_called()
+        assert stored_sandbox.session_api_key_hash is None
+        remote_sandbox_service.db_session.commit.assert_awaited_once()
 
 
 class TestSandboxSearch:

--- a/tests/unit/app_server/test_remote_sandbox_service.py
+++ b/tests/unit/app_server/test_remote_sandbox_service.py
@@ -764,6 +764,7 @@ class TestSandboxLifecycle:
             return_value=stored_sandbox
         )
         remote_sandbox_service._get_runtime = AsyncMock(return_value=runtime_data)
+        remote_sandbox_service._prepare_for_pause = AsyncMock()
         remote_sandbox_service.db_session.delete = AsyncMock()
         remote_sandbox_service.db_session.commit = AsyncMock()
 
@@ -846,6 +847,7 @@ class TestSandboxLifecycle:
             return_value=stored_sandbox
         )
         remote_sandbox_service._get_runtime = AsyncMock(return_value=runtime_data)
+        remote_sandbox_service._prepare_for_pause = AsyncMock()
         remote_sandbox_service.db_session.delete = AsyncMock()
         remote_sandbox_service.db_session.commit = AsyncMock()
 
@@ -1311,6 +1313,7 @@ class TestErrorHandling:
             return_value=stored_sandbox
         )
         remote_sandbox_service._get_runtime = AsyncMock(return_value=runtime_data)
+        remote_sandbox_service._prepare_for_pause = AsyncMock()
         remote_sandbox_service.httpx_client.request.side_effect = httpx.HTTPError(
             'API Error'
         )

--- a/tests/unit/app_server/test_sandbox_router.py
+++ b/tests/unit/app_server/test_sandbox_router.py
@@ -1,0 +1,625 @@
+import json
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from openhands.app_server.app_conversation.app_conversation_models import (
+    CODEX_CREDENTIAL_BINDING_TAG_KEY,
+    AppConversationInfo,
+    AppConversationStartRequest,
+    AppConversationStartTask,
+    AppConversationStartTaskStatus,
+)
+from openhands.app_server.sandbox.sandbox_models import (
+    AGENT_SERVER,
+    ExposedUrl,
+    SandboxInfo,
+    SandboxStatus,
+)
+from openhands.app_server.sandbox.sandbox_router import (
+    _credential_binding_context,
+    activate_conversation_credential_binding,
+    load_credential_binding,
+    replace_credential_binding,
+)
+from openhands.app_server.secrets.credential_binding import (
+    CredentialBindingContext,
+)
+from openhands.app_server.secrets.secrets_store import CredentialVersionConflict
+
+USER_ID = 'user-id'
+SANDBOX_ID = 'sandbox-id'
+VALID_CODEX_AUTH = json.dumps(
+    {'auth_mode': 'chatgpt', 'tokens': {'refresh_token': 'refresh-token'}}
+)
+
+
+def _sandbox() -> SandboxInfo:
+    return SandboxInfo(
+        id=SANDBOX_ID,
+        created_by_user_id=USER_ID,
+        sandbox_spec_id='spec-id',
+        status=SandboxStatus.RUNNING,
+        session_api_key='fresh-session-key',
+        exposed_urls=[
+            ExposedUrl(
+                name=AGENT_SERVER,
+                url='http://agent-server',
+                port=8000,
+            )
+        ],
+    )
+
+
+def _context(
+    *,
+    user_id: str = USER_ID,
+    sandbox_id: str = SANDBOX_ID,
+    conversation_id=None,
+    organization_id: str | None = None,
+    start_task_id=None,
+) -> CredentialBindingContext:
+    return CredentialBindingContext(
+        purpose='codex-credential-binding',
+        iat=1,
+        user_id=user_id,
+        organization_id=organization_id,
+        sandbox_id=sandbox_id,
+        conversation_id=str(conversation_id or uuid4()),
+        start_task_id=str(start_task_id) if start_task_id else None,
+        secret_name='CODEX_AUTH_JSON',
+        actions=('load', 'replace'),
+    )
+
+
+def _service_context(service):
+    @asynccontextmanager
+    async def context(*args, **kwargs):
+        yield service
+
+    return context
+
+
+@pytest.mark.parametrize('mismatch', ['user', 'sandbox', 'conversation'])
+async def test_callback_rejects_runtime_identity_mismatch(mismatch):
+    conversation_id = uuid4()
+    context = _context(conversation_id=conversation_id)
+    updates = {
+        'user': {'user_id': 'other-user'},
+        'sandbox': {'sandbox_id': 'other-sandbox'},
+        'conversation': {'conversation_id': str(uuid4())},
+    }
+    context = context.model_copy(update=updates[mismatch])
+
+    with (
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.decode_binding_context',
+            return_value=context,
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await _credential_binding_context(
+            sandbox_id=SANDBOX_ID,
+            conversation_id=conversation_id,
+            sandbox_info=_sandbox(),
+            context_token='token',
+            jwt_service=MagicMock(),
+        )
+
+    assert exc_info.value.status_code == 403
+
+
+async def test_callback_rejects_task_mismatch_before_conversation_exists():
+    conversation_id = uuid4()
+    task_id = uuid4()
+    context = _context(
+        conversation_id=conversation_id,
+        start_task_id=task_id,
+    )
+    info_service = AsyncMock()
+    info_service.get_app_conversation_info.return_value = None
+    task_service = AsyncMock()
+    task_service.get_app_conversation_start_task.return_value = (
+        AppConversationStartTask(
+            id=uuid4(),
+            created_by_user_id=USER_ID,
+            status=AppConversationStartTaskStatus.STARTING_CONVERSATION,
+            sandbox_id=SANDBOX_ID,
+            request=AppConversationStartRequest(conversation_id=conversation_id),
+        )
+    )
+
+    with (
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.decode_binding_context',
+            return_value=context,
+        ),
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.get_app_conversation_info_service',
+            _service_context(info_service),
+        ),
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.get_app_conversation_start_task_service',
+            _service_context(task_service),
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await _credential_binding_context(
+            sandbox_id=SANDBOX_ID,
+            conversation_id=conversation_id,
+            sandbox_info=_sandbox(),
+            context_token='token',
+            jwt_service=MagicMock(),
+        )
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.parametrize('webhook_stub_exists', [False, True])
+async def test_callback_accepts_exact_start_task(webhook_stub_exists):
+    conversation_id = uuid4()
+    task_id = uuid4()
+    context = _context(
+        conversation_id=conversation_id,
+        start_task_id=task_id,
+    )
+    info_service = AsyncMock()
+    info_service.get_app_conversation_info.return_value = (
+        AppConversationInfo(
+            id=conversation_id,
+            created_by_user_id=USER_ID,
+            sandbox_id=SANDBOX_ID,
+            tags={CODEX_CREDENTIAL_BINDING_TAG_KEY: 'personal'},
+        )
+        if webhook_stub_exists
+        else None
+    )
+    task_service = AsyncMock()
+    task_service.get_app_conversation_start_task.return_value = (
+        AppConversationStartTask(
+            id=task_id,
+            created_by_user_id=USER_ID,
+            status=AppConversationStartTaskStatus.STARTING_CONVERSATION,
+            sandbox_id=SANDBOX_ID,
+            request=AppConversationStartRequest(conversation_id=conversation_id),
+        )
+    )
+
+    with (
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.decode_binding_context',
+            return_value=context,
+        ),
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.get_app_conversation_info_service',
+            _service_context(info_service),
+        ),
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.get_app_conversation_start_task_service',
+            _service_context(task_service),
+        ),
+    ):
+        result = await _credential_binding_context(
+            sandbox_id=SANDBOX_ID,
+            conversation_id=conversation_id,
+            sandbox_info=_sandbox(),
+            context_token='token',
+            jwt_service=MagicMock(),
+        )
+
+    assert result == context
+
+
+async def test_callback_rejects_organization_mismatch_after_start():
+    conversation_id = uuid4()
+    context = _context(
+        conversation_id=conversation_id,
+        organization_id=str(uuid4()),
+    )
+    info_service = AsyncMock()
+    info_service.get_app_conversation_info.return_value = AppConversationInfo(
+        id=conversation_id,
+        created_by_user_id=USER_ID,
+        sandbox_id=SANDBOX_ID,
+        tags={CODEX_CREDENTIAL_BINDING_TAG_KEY: 'personal'},
+    )
+    task_service = AsyncMock()
+
+    with (
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.decode_binding_context',
+            return_value=context,
+        ),
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.get_app_conversation_info_service',
+            _service_context(info_service),
+        ),
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.get_app_conversation_start_task_service',
+            _service_context(task_service),
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await _credential_binding_context(
+            sandbox_id=SANDBOX_ID,
+            conversation_id=conversation_id,
+            sandbox_info=_sandbox(),
+            context_token='token',
+            jwt_service=MagicMock(),
+        )
+
+    assert exc_info.value.status_code == 403
+    task_service.get_app_conversation_start_task.assert_not_awaited()
+
+
+async def test_callback_accepts_taskless_context_for_marked_conversation():
+    conversation_id = uuid4()
+    context = _context(conversation_id=conversation_id)
+    info_service = AsyncMock()
+    info_service.get_app_conversation_info.return_value = AppConversationInfo(
+        id=conversation_id,
+        created_by_user_id=USER_ID,
+        sandbox_id=SANDBOX_ID,
+        tags={CODEX_CREDENTIAL_BINDING_TAG_KEY: 'personal'},
+    )
+    task_service = AsyncMock()
+
+    with (
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.decode_binding_context',
+            return_value=context,
+        ),
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.get_app_conversation_info_service',
+            _service_context(info_service),
+        ),
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.get_app_conversation_start_task_service',
+            _service_context(task_service),
+        ),
+    ):
+        result = await _credential_binding_context(
+            sandbox_id=SANDBOX_ID,
+            conversation_id=conversation_id,
+            sandbox_info=_sandbox(),
+            context_token='token',
+            jwt_service=MagicMock(),
+        )
+
+    assert result == context
+    task_service.get_app_conversation_start_task.assert_not_awaited()
+
+
+async def test_callback_rejects_completed_task_context_after_marker_commit():
+    conversation_id = uuid4()
+    task_id = uuid4()
+    context = _context(
+        conversation_id=conversation_id,
+        start_task_id=task_id,
+    )
+    info_service = AsyncMock()
+    info_service.get_app_conversation_info.return_value = AppConversationInfo(
+        id=conversation_id,
+        created_by_user_id=USER_ID,
+        sandbox_id=SANDBOX_ID,
+        tags={CODEX_CREDENTIAL_BINDING_TAG_KEY: 'personal'},
+    )
+    task_service = AsyncMock()
+    task_service.get_app_conversation_start_task.return_value = (
+        AppConversationStartTask(
+            id=task_id,
+            created_by_user_id=USER_ID,
+            status=AppConversationStartTaskStatus.READY,
+            sandbox_id=SANDBOX_ID,
+            request=AppConversationStartRequest(conversation_id=conversation_id),
+        )
+    )
+
+    with (
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.decode_binding_context',
+            return_value=context,
+        ),
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.get_app_conversation_info_service',
+            _service_context(info_service),
+        ),
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.get_app_conversation_start_task_service',
+            _service_context(task_service),
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await _credential_binding_context(
+            sandbox_id=SANDBOX_ID,
+            conversation_id=conversation_id,
+            sandbox_info=_sandbox(),
+            context_token='token',
+            jwt_service=MagicMock(),
+        )
+
+    assert exc_info.value.status_code == 403
+    task_service.get_app_conversation_start_task.assert_awaited_once_with(task_id)
+
+
+@pytest.mark.parametrize(
+    'error, status_code',
+    [
+        (KeyError(), 404),
+        (NotImplementedError(), 501),
+        (ValueError(), 422),
+    ],
+)
+async def test_load_callback_maps_store_errors(error, status_code):
+    store = AsyncMock()
+    store.load_versioned.side_effect = error
+    context = _context()
+
+    with (
+        patch(
+            'openhands.app_server.sandbox.sandbox_router._credential_store',
+            AsyncMock(return_value=store),
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await load_credential_binding(context=context)
+
+    assert exc_info.value.status_code == status_code
+
+
+@pytest.mark.parametrize(
+    'error, status_code',
+    [
+        (KeyError(), 404),
+        (CredentialVersionConflict(), 409),
+        (NotImplementedError(), 501),
+    ],
+)
+async def test_replace_callback_maps_store_errors(error, status_code):
+    store = AsyncMock()
+    store.replace_versioned.side_effect = error
+    context = _context()
+    request = AsyncMock()
+    request.json.return_value = {
+        'expected_version': 'v1',
+        'value': VALID_CODEX_AUTH,
+    }
+
+    with (
+        patch(
+            'openhands.app_server.sandbox.sandbox_router._credential_store',
+            AsyncMock(return_value=store),
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await replace_credential_binding(
+            request=request,
+            context=context,
+        )
+
+    assert exc_info.value.status_code == status_code
+
+
+async def test_invalid_replacement_does_not_reflect_secret():
+    canary = 'distinct-refresh-token-canary'
+    request = AsyncMock()
+    request.json.return_value = {
+        'expected_version': 'v1',
+        'value': canary * 3000,
+    }
+
+    with pytest.raises(HTTPException) as exc_info:
+        await replace_credential_binding(
+            request=request,
+            context=_context(),
+        )
+
+    assert exc_info.value.status_code == 422
+    assert canary not in json.dumps(exc_info.value.detail)
+
+
+async def test_marked_resume_reactivates_with_stable_url_and_fresh_key():
+    conversation_id = uuid4()
+    info_service = AsyncMock()
+    info_service.get_app_conversation_info.return_value = AppConversationInfo(
+        id=conversation_id,
+        created_by_user_id=USER_ID,
+        sandbox_id=SANDBOX_ID,
+        tags={CODEX_CREDENTIAL_BINDING_TAG_KEY: 'personal'},
+    )
+    sandbox_service = AsyncMock()
+    order = []
+
+    async def resume(*args):
+        order.append('resume-committed-key')
+        return True
+
+    async def activate_binding(*args, **kwargs):
+        order.append('activate')
+        return True
+
+    sandbox_service.resume_sandbox.side_effect = resume
+    sandbox_service.get_sandbox.return_value = _sandbox().model_copy(
+        update={'status': SandboxStatus.PAUSED}
+    )
+    sandbox_service.wait_for_sandbox_running.return_value = _sandbox()
+    sandbox_service._get_agent_server_url.return_value = 'http://agent-server'
+    user_context = AsyncMock()
+    user_context.get_user_id.return_value = USER_ID
+
+    with (
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.get_global_config',
+            return_value=SimpleNamespace(web_url='https://app.example.com/'),
+        ),
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.activate_codex_credential_binding',
+            AsyncMock(side_effect=activate_binding),
+        ) as activate,
+    ):
+        await activate_conversation_credential_binding(
+            sandbox_id=SANDBOX_ID,
+            conversation_id=conversation_id,
+            sandbox_service=sandbox_service,
+            user_context=user_context,
+            app_conversation_info_service=info_service,
+            httpx_client=AsyncMock(),
+            jwt_service=MagicMock(),
+        )
+
+    assert activate.await_args.kwargs['callback_url'] == (
+        f'https://app.example.com/api/v1/sandboxes/{SANDBOX_ID}/'
+        f'credential-bindings/{conversation_id}/CODEX_AUTH_JSON'
+    )
+    assert activate.await_args.kwargs['session_api_key'] == 'fresh-session-key'
+    assert activate.await_args.kwargs['required'] is True
+    assert order == ['resume-committed-key', 'activate']
+
+
+async def test_unmarked_resume_skips_activation():
+    conversation_id = uuid4()
+    info_service = AsyncMock()
+    info_service.get_app_conversation_info.return_value = AppConversationInfo(
+        id=conversation_id,
+        created_by_user_id=USER_ID,
+        sandbox_id=SANDBOX_ID,
+    )
+    sandbox_service = AsyncMock()
+    sandbox_service.resume_sandbox.return_value = True
+    sandbox_service.get_sandbox.return_value = _sandbox().model_copy(
+        update={'status': SandboxStatus.PAUSED}
+    )
+    sandbox_service.wait_for_sandbox_running.return_value = _sandbox()
+    user_context = AsyncMock()
+    user_context.get_user_id.return_value = USER_ID
+
+    with patch(
+        'openhands.app_server.sandbox.sandbox_router.activate_codex_credential_binding',
+        AsyncMock(),
+    ) as activate:
+        await activate_conversation_credential_binding(
+            sandbox_id=SANDBOX_ID,
+            conversation_id=conversation_id,
+            sandbox_service=sandbox_service,
+            user_context=user_context,
+            app_conversation_info_service=info_service,
+            httpx_client=AsyncMock(),
+            jwt_service=MagicMock(),
+        )
+
+    sandbox_service.resume_sandbox.assert_awaited_once_with(SANDBOX_ID)
+    activate.assert_not_awaited()
+
+
+async def test_running_marked_sandbox_reactivates_without_resume():
+    conversation_id = uuid4()
+    info_service = AsyncMock()
+    info_service.get_app_conversation_info.return_value = AppConversationInfo(
+        id=conversation_id,
+        created_by_user_id=USER_ID,
+        sandbox_id=SANDBOX_ID,
+        tags={CODEX_CREDENTIAL_BINDING_TAG_KEY: 'personal'},
+    )
+    sandbox_service = AsyncMock()
+    sandbox_service.get_sandbox.return_value = _sandbox()
+    sandbox_service.wait_for_sandbox_running.return_value = _sandbox()
+    sandbox_service._get_agent_server_url.return_value = 'http://agent-server'
+    user_context = AsyncMock()
+    user_context.get_user_id.return_value = USER_ID
+
+    with (
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.get_global_config',
+            return_value=SimpleNamespace(web_url='https://app.example.com/'),
+        ),
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.activate_codex_credential_binding',
+            AsyncMock(return_value=True),
+        ) as activate,
+    ):
+        await activate_conversation_credential_binding(
+            sandbox_id=SANDBOX_ID,
+            conversation_id=conversation_id,
+            sandbox_service=sandbox_service,
+            user_context=user_context,
+            app_conversation_info_service=info_service,
+            httpx_client=AsyncMock(),
+            jwt_service=MagicMock(),
+        )
+
+    sandbox_service.resume_sandbox.assert_not_awaited()
+    activate.assert_awaited_once()
+
+
+async def test_unauthorized_activation_does_not_resume_sandbox():
+    conversation_id = uuid4()
+    info_service = AsyncMock()
+    info_service.get_app_conversation_info.return_value = AppConversationInfo(
+        id=conversation_id,
+        created_by_user_id=USER_ID,
+        sandbox_id=SANDBOX_ID,
+        tags={CODEX_CREDENTIAL_BINDING_TAG_KEY: 'personal'},
+    )
+    sandbox_service = AsyncMock()
+    user_context = AsyncMock()
+    user_context.get_user_id.return_value = 'other-user'
+
+    with pytest.raises(HTTPException) as exc_info:
+        await activate_conversation_credential_binding(
+            sandbox_id=SANDBOX_ID,
+            conversation_id=conversation_id,
+            sandbox_service=sandbox_service,
+            user_context=user_context,
+            app_conversation_info_service=info_service,
+            httpx_client=AsyncMock(),
+            jwt_service=MagicMock(),
+        )
+
+    assert exc_info.value.status_code == 403
+    sandbox_service.resume_sandbox.assert_not_awaited()
+
+
+async def test_concurrent_resume_is_accepted_after_refetch():
+    conversation_id = uuid4()
+    info_service = AsyncMock()
+    info_service.get_app_conversation_info.return_value = AppConversationInfo(
+        id=conversation_id,
+        created_by_user_id=USER_ID,
+        sandbox_id=SANDBOX_ID,
+        tags={CODEX_CREDENTIAL_BINDING_TAG_KEY: 'personal'},
+    )
+    paused = _sandbox().model_copy(update={'status': SandboxStatus.PAUSED})
+    starting = _sandbox().model_copy(update={'status': SandboxStatus.STARTING})
+    running = _sandbox()
+    sandbox_service = AsyncMock()
+    sandbox_service.get_sandbox.side_effect = [paused, starting]
+    sandbox_service.resume_sandbox.return_value = False
+    sandbox_service.wait_for_sandbox_running.return_value = running
+    user_context = AsyncMock()
+    user_context.get_user_id.return_value = USER_ID
+
+    with (
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.get_global_config',
+            return_value=SimpleNamespace(web_url='https://app.example.com/'),
+        ),
+        patch(
+            'openhands.app_server.sandbox.sandbox_router.activate_codex_credential_binding',
+            AsyncMock(return_value=True),
+        ),
+    ):
+        await activate_conversation_credential_binding(
+            sandbox_id=SANDBOX_ID,
+            conversation_id=conversation_id,
+            sandbox_service=sandbox_service,
+            user_context=user_context,
+            app_conversation_info_service=info_service,
+            httpx_client=AsyncMock(),
+            jwt_service=MagicMock(),
+        )
+
+    sandbox_service.wait_for_sandbox_running.assert_awaited_once()

--- a/tests/unit/app_server/test_sandbox_router.py
+++ b/tests/unit/app_server/test_sandbox_router.py
@@ -351,7 +351,6 @@ async def test_callback_rejects_completed_task_context_after_marker_commit():
     [
         (KeyError(), 404),
         (NotImplementedError(), 501),
-        (ValueError(), 422),
     ],
 )
 async def test_load_callback_maps_store_errors(error, status_code):
@@ -369,6 +368,39 @@ async def test_load_callback_maps_store_errors(error, status_code):
         await load_credential_binding(context=context)
 
     assert exc_info.value.status_code == status_code
+
+
+async def test_load_callback_maps_invalid_credential_to_422():
+    store = AsyncMock()
+    store.load_versioned.return_value = ('not-a-codex-credential', 'v1')
+    context = _context()
+
+    with (
+        patch(
+            'openhands.app_server.sandbox.sandbox_router._credential_store',
+            AsyncMock(return_value=store),
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await load_credential_binding(context=context)
+
+    assert exc_info.value.status_code == 422
+
+
+async def test_load_callback_does_not_map_unreadable_store_to_422():
+    """A corrupt secrets store must not read as "please authenticate again"."""
+    store = AsyncMock()
+    store.load_versioned.side_effect = ValueError('Invalid secrets file')
+    context = _context()
+
+    with (
+        patch(
+            'openhands.app_server.sandbox.sandbox_router._credential_store',
+            AsyncMock(return_value=store),
+        ),
+        pytest.raises(ValueError, match='Invalid secrets file'),
+    ):
+        await load_credential_binding(context=context)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/app_server/test_webhook_router_acp.py
+++ b/tests/unit/app_server/test_webhook_router_acp.py
@@ -7,6 +7,7 @@ correctly discriminated from one carrying a regular ``Agent`` (via the
 are populated accordingly.
 """
 
+from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -18,12 +19,19 @@ from sqlalchemy.pool import StaticPool
 from openhands.agent_server.models import ConversationInfo, Success
 from openhands.app_server.app_conversation.app_conversation_models import (
     ACP_SERVER_TAG_KEY,
+    CODEX_CREDENTIAL_START_TASK_TAG_KEY,
     AppConversationInfo,
+    AppConversationStartRequest,
+    AppConversationStartTask,
+    AppConversationStartTaskStatus,
 )
 from openhands.app_server.app_conversation.sql_app_conversation_info_service import (
     SQLAppConversationInfoService,
 )
-from openhands.app_server.event_callback.webhook_router import on_conversation_update
+from openhands.app_server.event_callback.webhook_router import (
+    _matches_app_start_task,
+    on_conversation_update,
+)
 from openhands.app_server.user.specifiy_user_context import SpecifyUserContext
 from openhands.app_server.utils.sql_utils import Base
 from openhands.sdk import Agent
@@ -178,6 +186,69 @@ async def test_acp_conversation_sets_agent_kind(async_session, service, sandbox_
     assert saved is not None
     assert saved.llm_model is None
     assert saved.agent_kind == 'acp'
+
+
+@pytest.mark.asyncio
+async def test_app_start_webhook_waits_for_final_metadata(service, sandbox_record):
+    task_id = uuid4()
+    acp_info = _make_acp_conversation_info(acp_command=['codex-acp']).model_copy(
+        update={'tags': {CODEX_CREDENTIAL_START_TASK_TAG_KEY: str(task_id)}}
+    )
+    task_service = AsyncMock()
+    task_service.get_app_conversation_start_task.return_value = (
+        AppConversationStartTask(
+            id=task_id,
+            created_by_user_id=sandbox_record.created_by_user_id,
+            status=AppConversationStartTaskStatus.ERROR,
+            sandbox_id=sandbox_record.id,
+            request=AppConversationStartRequest(conversation_id=acp_info.id),
+        )
+    )
+
+    @asynccontextmanager
+    async def service_context(state):
+        yield task_service
+
+    with (
+        patch(
+            'openhands.app_server.event_callback.webhook_router.get_app_conversation_start_task_service',
+            service_context,
+        ),
+        patch(
+            'openhands.app_server.event_callback.webhook_router.valid_conversation',
+            new=AsyncMock(),
+        ) as valid_conversation,
+    ):
+        result = await on_conversation_update(
+            conversation_info=acp_info,
+            sandbox_record=sandbox_record,
+            app_conversation_info_service=service,
+        )
+
+    assert isinstance(result, Success)
+    assert await service.get_app_conversation_info(acp_info.id) is None
+    valid_conversation.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_start_webhook_rejects_unassociated_task(sandbox_record):
+    acp_info = _make_acp_conversation_info(acp_command=['codex-acp']).model_copy(
+        update={'tags': {CODEX_CREDENTIAL_START_TASK_TAG_KEY: str(uuid4())}}
+    )
+    task_service = AsyncMock()
+    task_service.get_app_conversation_start_task.return_value = None
+
+    @asynccontextmanager
+    async def service_context(state):
+        yield task_service
+
+    with patch(
+        'openhands.app_server.event_callback.webhook_router.get_app_conversation_start_task_service',
+        service_context,
+    ):
+        result = await _matches_app_start_task(acp_info, sandbox_record)
+
+    assert result is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app_server/test_webhook_router_tags.py
+++ b/tests/unit/app_server/test_webhook_router_tags.py
@@ -13,6 +13,8 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.pool import StaticPool
 
 from openhands.app_server.app_conversation.app_conversation_models import (
+    CODEX_CREDENTIAL_BINDING_TAG_KEY,
+    CODEX_CREDENTIAL_START_TASK_TAG_KEY,
     ConversationTrigger,
 )
 from openhands.app_server.app_conversation.sql_app_conversation_info_service import (
@@ -197,6 +199,33 @@ def test_merge_conversation_tags_with_both_none():
     merged_tags = merge_conversation_tags(None, None)
 
     assert merged_tags == {}
+
+
+def test_merge_conversation_tags_rejects_managed_marker_injection():
+    merged_tags = merge_conversation_tags(
+        {},
+        {CODEX_CREDENTIAL_BINDING_TAG_KEY: 'personal'},
+    )
+
+    assert CODEX_CREDENTIAL_BINDING_TAG_KEY not in merged_tags
+
+
+def test_merge_conversation_tags_preserves_managed_marker():
+    merged_tags = merge_conversation_tags(
+        {CODEX_CREDENTIAL_BINDING_TAG_KEY: 'org:trusted'},
+        {CODEX_CREDENTIAL_BINDING_TAG_KEY: 'org:forged'},
+    )
+
+    assert merged_tags[CODEX_CREDENTIAL_BINDING_TAG_KEY] == 'org:trusted'
+
+
+def test_merge_conversation_tags_strips_start_task_tag():
+    merged_tags = merge_conversation_tags(
+        {CODEX_CREDENTIAL_START_TASK_TAG_KEY: 'old'},
+        {CODEX_CREDENTIAL_START_TASK_TAG_KEY: 'new'},
+    )
+
+    assert CODEX_CREDENTIAL_START_TASK_TAG_KEY not in merged_tags
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
HUMAN:

This replaces OpenHands/OpenHands#15287 with a narrower Phase 1: OpenHands stores and activates managed Codex credentials, while the pinned SDK owns private-file handling, refresh, merge, and scrubbing.

- [x] A human has tested these changes.

AGENT:

Closes OpenHands/enterprise#70.

Supersedes OpenHands/OpenHands#15287 with the narrower Phase 1 vertical slice described in the issue. The pinned SDK/Agent Server owns the private Codex credential lifecycle; OpenHands only supplies a versioned canonical store, scoped activation, and lifecycle ordering.

## What changed

- Add opaque, ABA-safe compare-and-swap versions for `CODEX_AUTH_JSON` in SaaS SQL and supported OSS stores.
- Preserve a runtime rotation when an unrelated stale whole-secret document is saved.
- Reuse the sandbox session key plus one scoped JWE callback for credential load/replace.
- Arm only for saved ChatGPT credentials, authoritative Codex ACP settings, SaaS remote or OSS Docker, and all three exact SDK 1.37.1 capabilities.
- Remove the managed plaintext credential from the Agent Server start request after readiness succeeds.
- Bind initial activation and failed-create cleanup to the exact internal start-task tag.
- Persist one non-secret managed marker, add one idempotent conversation-scoped reactivation endpoint, and gate WebSocket reconnect on recovery.
- Run the SDK drain barrier before clean remote/Docker pause or delete, and propagate managed final-flush failures.

## Complexity boundary

This is 19 production files and roughly 1.5k added production lines, versus 83 files and more than 10k added lines in OpenHands/OpenHands#15287. It deliberately has no reservation/lease rows, migrations, schedulers, sibling scans, resume-task claiming, generic credential broker, pending-message changes, or duplicated SDK monitor/merge logic.

OSS process sandboxes remain legacy. Docker retains its existing single-user container session key and receives a fresh scoped JWE on activation; Phase 1 does not claim pre-pause JWE rejection for Docker. SaaS remote rotates the runtime session key before reactivation.

## Validation

- 427 focused app-server lifecycle, callback, store, webhook, and sandbox tests passed.
- 13 SaaS secret-store tests passed.
- 53 frontend recovery/WebSocket tests passed (1 skipped, 13 todo).
- Full frontend TypeScript check, source ESLint, Prettier, Ruff, repository pre-commit mypy, and diff checks passed.
- Independent contract, frontend, and security reviews found no remaining blockers.

End-to-end validation built the unmodified pinned SDK/Agent Server 1.37.1 release (`99342c4`) into `openhands-agent-server-e2e:99342c4-1.37.1-python-source-minimal` and used a copied local ChatGPT credential without printing it:

1. Started managed runtime A and completed a real Codex API request.
2. Forced a credential refresh and verified the canonical R0 -> R1 update.
3. Raced an unrelated stale settings edit and verified both R1 and the unrelated edit survived.
4. Cleanly paused and reactivated A, then completed a second real Codex request.
5. Started isolated runtime B from the canonical value and completed a real Codex request.
6. Verified B's private credential matched the canonical store, the legacy auth path was absent, no credential/session value appeared outside the canonical secret store, and the private file was scrubbed before pause.