### PR TITLE
fix(ci): grant release workflow content write access

### DIFF
--- a/.github/workflows/release-ready.yml
+++ b/.github/workflows/release-ready.yml
@@ -9,7 +9,7 @@ jobs:
     if: "${{ contains(github.event.pull_request.labels.*.name, 'release-line: gui') }}"
     permissions:
       actions: write
-      contents: read
+      contents: write
       issues: write
       pull-requests: write
     secrets: inherit
@@ -22,7 +22,7 @@ jobs:
     if: "${{ contains(github.event.pull_request.labels.*.name, 'release-line: cloud') }}"
     permissions:
       actions: write
-      contents: read
+      contents: write
       issues: write
       pull-requests: write
     secrets: inherit


### PR DESCRIPTION
## Summary

Grants `contents: write` to both jobs that call the shared release-ready workflow.

The reusable workflow currently contains nested jobs that freeze releases to `release/**` branches and therefore requests write access to repository contents. The caller only granted read access, causing the workflow to fail during startup before any job could run.

Tracking: #15396
Observed failure: https://github.com/OpenHands/OpenHands/actions/runs/30258991997

## Validation

- Repository pre-commit suite passed for `.github/workflows/release-ready.yml`
- YAML validation passed
- Repository-wide mypy hook passed
- Diff is limited to the two `contents` permission entries

This is an infrastructure fix for the existing default-branch workflow and is separate from the repository-content cutover PRs.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   --name openhands-app-5373b31   docker.openhands.dev/openhands/openhands:5373b31
```