### PR TITLE
fix: mount telemetry lifecycle from provider

### DIFF
--- a/__tests__/components/providers/telemetry-provider.test.tsx
+++ b/__tests__/components/providers/telemetry-provider.test.tsx
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+
+const useTelemetryMock = vi.hoisted(() => vi.fn());
+
+vi.mock("#/hooks/use-telemetry", () => ({
+  useTelemetry: useTelemetryMock,
+}));
+
 import { TelemetryProvider } from "#/components/providers/telemetry-provider";
 import * as telemetry from "#/services/telemetry";
 
@@ -24,6 +31,7 @@ describe("TelemetryProvider", () => {
     initializeClientMock = vi
       .spyOn(telemetry, "initializePostHogClient")
       .mockResolvedValue(null);
+    useTelemetryMock.mockClear();
     window.location.hash = "";
     sessionStorage.clear();
   });
@@ -77,6 +85,17 @@ describe("TelemetryProvider", () => {
     });
   });
 
+  it("mounts telemetry lifecycle when analytics are enabled", () => {
+    render(
+      <TelemetryProvider config={runtimeConfig}>
+        <div data-testid="child" />
+      </TelemetryProvider>,
+    );
+
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+    expect(useTelemetryMock).toHaveBeenCalledOnce();
+  });
+
   it("keeps rendering children when eager initialization fails", async () => {
     initializeClientMock.mockRejectedValueOnce(new Error("unavailable"));
 
@@ -90,7 +109,7 @@ describe("TelemetryProvider", () => {
     await waitFor(() => expect(initializeClientMock).toHaveBeenCalledOnce());
   });
 
-  it("does not initialize when analytics are disabled", () => {
+  it("does not initialize telemetry lifecycle when analytics are disabled", () => {
     render(
       <TelemetryProvider config={false}>
         <div data-testid="child" />
@@ -100,5 +119,6 @@ describe("TelemetryProvider", () => {
     expect(screen.getByTestId("child")).toBeInTheDocument();
     expect(configureTelemetryMock).toHaveBeenCalledWith(false);
     expect(initializeClientMock).not.toHaveBeenCalled();
+    expect(useTelemetryMock).not.toHaveBeenCalled();
   });
 });

--- a/src/components/providers/telemetry-provider.tsx
+++ b/src/components/providers/telemetry-provider.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { BootstrapConfig } from "posthog-js";
+import { useTelemetry } from "#/hooks/use-telemetry";
 import {
   configurePostHogBootstrap,
   configureTelemetry,
@@ -62,6 +63,11 @@ function readBootstrapIds(): BootstrapConfig | undefined {
   }
 }
 
+function TelemetryLifecycle() {
+  useTelemetry();
+  return null;
+}
+
 export function TelemetryProvider({
   children,
   config = {},
@@ -91,5 +97,10 @@ export function TelemetryProvider({
     }
   }, [analyticsEnabled, apiHost, apiKey, uiHost]);
 
-  return children;
+  return (
+    <>
+      {analyticsEnabled ? <TelemetryLifecycle /> : null}
+      {children}
+    </>
+  );
 }


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

I've verified that values come in as expected.

- [x] A human has tested these changes.

AGENT:

This PR was created by an AI agent (OpenHands) on behalf of the user.

Validation performed:

```bash
npx vitest run __tests__/components/providers/telemetry-provider.test.tsx __tests__/hooks/use-telemetry.test.tsx __tests__/services/telemetry.test.ts
```

Result: 3 test files passed, 53 tests passed.

```bash
npx eslint src/components/providers/telemetry-provider.tsx __tests__/components/providers/telemetry-provider.test.tsx
```

Result: passed with no lint output.

```bash
npx prettier --check src/components/providers/telemetry-provider.tsx __tests__/components/providers/telemetry-provider.test.tsx
```

Result: `All matched files use Prettier code style!`

```bash
npm run make-i18n && npm run typecheck:staged
```

Result: passed.

End-to-end note: this is a non-visual telemetry lifecycle wiring fix. I did not send live PostHog events from a browser because doing so would pollute production analytics. The added provider test exercises the app/provider mount path that previously stopped calling `useTelemetry()`.

---

## Why

Cloud `canvas_install` tracking dropped to zero after Agent Canvas 1.6.1 was deployed. The telemetry consent banner had previously been the only mounted caller of `useTelemetry()`. When the banner was removed, `trackInstall()` and `trackSessionStart()` became effectively dead code even though other PostHog events continued to work.

## Summary

- Mount a non-visual telemetry lifecycle component from `TelemetryProvider` when analytics is enabled.
- Keep analytics-disabled embedders from mounting the lifecycle.
- Add provider tests to guard the enabled/disabled lifecycle behavior.

## Issue Number

N/A

## How to Test

Run:

```bash
npm ci
npx vitest run __tests__/components/providers/telemetry-provider.test.tsx __tests__/hooks/use-telemetry.test.tsx __tests__/services/telemetry.test.ts
npx eslint src/components/providers/telemetry-provider.tsx __tests__/components/providers/telemetry-provider.test.tsx
npx prettier --check src/components/providers/telemetry-provider.tsx __tests__/components/providers/telemetry-provider.test.tsx
npm run make-i18n && npm run typecheck:staged
```

For functional verification without polluting analytics, inspect the provider test: mounting `TelemetryProvider` with analytics enabled calls `useTelemetry()`, which owns the existing install/session effects. Mounting it with `config={false}` does not call `useTelemetry()`.

## Video/Screenshots

N/A — this is a non-visual telemetry lifecycle fix. No UI changes.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This intentionally keeps telemetry lifecycle separate from any consent modal UI, so removing or suppressing the modal will not disable install/session telemetry again.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/be25698f-d5e3-4378-affe-6999574b6958)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.37.0-python` |
| **Automation** | `openhands-automation==1.3.1` |
| **Commit** | `a196ea289ffa986d8d8201dc734b968e8c2ef28f` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-a196ea2
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-a196ea2
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-a196ea2-amd64
ghcr.io/openhands/agent-canvas:fix-telemetry-lifecycle-install-tracking-amd64
ghcr.io/openhands/agent-canvas:pr-16092-amd64
ghcr.io/openhands/agent-canvas:sha-a196ea2-arm64
ghcr.io/openhands/agent-canvas:fix-telemetry-lifecycle-install-tracking-arm64
ghcr.io/openhands/agent-canvas:pr-16092-arm64
ghcr.io/openhands/agent-canvas:sha-a196ea2
ghcr.io/openhands/agent-canvas:fix-telemetry-lifecycle-install-tracking
ghcr.io/openhands/agent-canvas:pr-16092
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-a196ea2`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-a196ea2-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->