### PR TITLE
fix: spawn launcher services without implicit shell

### DIFF
--- a/__tests__/scripts/dev-process-utils.test.ts
+++ b/__tests__/scripts/dev-process-utils.test.ts
@@ -1,3 +1,6 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -29,6 +32,28 @@ describe("dev process utils", () => {
       cwd: "/tmp",
       detached: process.platform !== "win32",
     });
+  });
+
+  it("passes shell metacharacters to services as literal arguments", async () => {
+    const constraint = "agent-client-protocol<0.11";
+    const child = spawn(
+      process.execPath,
+      ["-e", "process.stdout.write(process.argv[1])", constraint],
+      getProcessTreeSpawnOptions({
+        shell: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    );
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+
+    const [exitCode] = await once(child, "exit");
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe(constraint);
   });
 });
 

--- a/scripts/dev-process-utils.mjs
+++ b/scripts/dev-process-utils.mjs
@@ -15,7 +15,11 @@ export function isProcessRunning(proc) {
 }
 
 /**
- * Add spawn options needed for process-tree cleanup.
+ * Add spawn options needed for safe service launches and process-tree cleanup.
+ *
+ * Arguments must bypass shell parsing so values such as version constraints
+ * containing `<` are forwarded literally. Callers that need shell behavior
+ * must invoke the shell explicitly as the command.
  *
  * On POSIX, `detached: true` makes the spawned service the leader of a new
  * process group. Later we can signal `-pid` to terminate that whole group,
@@ -30,6 +34,7 @@ export function isProcessRunning(proc) {
 export function getProcessTreeSpawnOptions(options = {}) {
   return {
     ...options,
+    shell: false,
     detached: process.platform !== "win32",
   };
 }


### PR DESCRIPTION
HUMAN:

Tested and verified locally on Windows, without these changes the service wouldn't launch.

- [x] A human has tested these changes.

AGENT:

---

## Why

On Windows, `getProcessTreeSpawnOptions()` spreads caller-supplied options without neutralizing an explicit `shell: true`. When a service is spawned through a shell, cmd.exe interprets metacharacters in the arguments: the default agent-server `uvx` arguments include `agent-client-protocol<0.11`, so `<0.11` is parsed as input redirection. The agent-server exits before binding port 18000, leaving ingress to return Bad Gateway responses.

The static/automation launchers already resolve commands to absolute paths via `resolveWindowsCommand()`, but nothing prevents a future caller from re-enabling implicit shell parsing by passing `shell: true`. This change centralizes the guarantee.

## Summary

- Enforce shell-free service spawning centrally in `getProcessTreeSpawnOptions()` by forcing `shell: false`.
- Add a cross-platform process regression test proving `agent-client-protocol<0.11` reaches the child executable literally, even when a caller passes `shell: true`.

## Issue Number

Fixes OpenHands/OpenHands#15488

## Background

This re-creates the fix from the archived `OpenHands/agent-canvas#1668`, which was closed with a request to re-open it here after the repository moved.

## How to Test

1. Install dependencies:
   ```text
   npm ci
   ```
2. Run the focused launcher test:
   ```text
   npx vitest run __tests__/scripts/dev-process-utils.test.ts
   ```

## Evidence

- Reproduced on Windows against the current implementation: spawning with `getProcessTreeSpawnOptions({ shell: true })` and the argument `agent-client-protocol<0.11` exited with code 1 and empty stdout ("The system cannot find the file specified"), because the shell consumed `<0.11`.
- With `shell: false` forced, the same spawn exits 0 and stdout equals `agent-client-protocol<0.11` verbatim.
- The new regression test encodes exactly this behavior.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The fix is centralized so future launcher callers cannot accidentally re-enable implicit shell parsing by passing `shell: true`. Callers that need shell semantics must invoke the shell explicitly as their command.