### PR TITLE
fix(enterprise): fix broken import in run_budget_maintenance.py

### DIFF
--- a/enterprise/run_budget_maintenance.py
+++ b/enterprise/run_budget_maintenance.py
@@ -1,0 +1,74 @@
+import asyncio
+
+import run_maintenance_tasks  # noqa: I001
+
+# NOTE: `run_maintenance_tasks` above is imported unqualified rather than as
+# `enterprise.run_maintenance_tasks`. The production Docker image COPYs the
+# contents of `enterprise/` directly into `/app` (flattening it), so in the
+# deployed container there is no importable top-level `enterprise` package --
+# only its flattened sibling modules, like the local/monorepo-dev environment
+# resolves `enterprise` as a package thanks to a dev-only .pth entry.
+from server.logger import logger
+from server.maintenance_task_processor.org_budget_maintenance_processor import (
+    OrgBudgetMaintenanceProcessor,
+)
+from storage.database import session_maker
+from storage.maintenance_task import MaintenanceTask, MaintenanceTaskStatus
+from storage.org_budget_settings import OrgBudgetSettings
+
+BATCH_SIZE = 25
+
+
+def _chunked(values: list[str], size: int) -> list[list[str]]:
+    return [values[i : i + size] for i in range(0, len(values), size)]
+
+
+def enqueue_budget_tasks(batch_size: int = BATCH_SIZE) -> int:
+    with session_maker() as session:
+        processor_type = (
+            f"{OrgBudgetMaintenanceProcessor.__module__}."
+            f"{OrgBudgetMaintenanceProcessor.__name__}"
+        )
+        existing = (
+            session.query(MaintenanceTask)
+            .filter(
+                MaintenanceTask.status.in_(
+                    [MaintenanceTaskStatus.PENDING, MaintenanceTaskStatus.WORKING]
+                )
+            )
+            .filter(MaintenanceTask.processor_type == processor_type)
+            .count()
+        )
+        if existing:
+            logger.info(
+                "Budget maintenance tasks already queued",
+                extra={"count": existing},
+            )
+            return 0
+
+        org_ids = [str(row.org_id) for row in session.query(OrgBudgetSettings.org_id)]
+        if not org_ids:
+            return 0
+
+        for batch in _chunked(org_ids, batch_size):
+            processor = OrgBudgetMaintenanceProcessor(org_ids=batch)
+            task = MaintenanceTask(status=MaintenanceTaskStatus.PENDING)
+            task.set_processor(processor)
+            session.add(task)
+
+        session.commit()
+        return len(org_ids)
+
+
+def main() -> None:
+    total = enqueue_budget_tasks()
+    if total:
+        logger.info("Enqueued org budget maintenance tasks", extra={"orgs": total})
+    else:
+        logger.info("No org budget settings found; skipping maintenance enqueue")
+
+    asyncio.run(run_maintenance_tasks.main())
+
+
+if __name__ == "__main__":
+    main()

--- a/enterprise/tests/unit/test_run_budget_maintenance.py
+++ b/enterprise/tests/unit/test_run_budget_maintenance.py
@@ -1,0 +1,54 @@
+"""
+Regression test for run_budget_maintenance.py's import style.
+
+The production Docker image (enterprise/Dockerfile) does
+`COPY --chown=... enterprise .` into WORKDIR /app, which flattens the
+contents of the `enterprise/` directory directly into /app instead of
+preserving an `enterprise/` subdirectory. This means there is no
+importable top-level `enterprise` package in the deployed container --
+sibling modules like `run_maintenance_tasks` must be imported unqualified,
+exactly like the existing `maintenance-tasks-cronjob.yaml` invokes
+`python -m run_maintenance_tasks` (not `python -m enterprise.run_maintenance_tasks`).
+
+If `run_budget_maintenance.py` ever imports something as `enterprise.foo`
+or `from enterprise import foo`, the budget-maintenance cronjob will crash
+with `ModuleNotFoundError: No module named 'enterprise'` in production,
+even though it works fine in local/monorepo dev environments where a
+`.pth` file on sys.path makes the repo root's `enterprise` directory
+importable as a package.
+"""
+
+import ast
+from pathlib import Path
+
+RUN_BUDGET_MAINTENANCE_PATH = (
+    Path(__file__).resolve().parents[2] / "run_budget_maintenance.py"
+)
+
+
+def _top_level_import_names(source: str) -> set[str]:
+    tree = ast.parse(source)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0 and node.module:
+                names.add(node.module.split(".")[0])
+    return names
+
+
+def test_run_budget_maintenance_does_not_import_enterprise_package():
+    """`enterprise` is not an importable package inside the production
+    container (its contents are flattened directly into /app), so
+    run_budget_maintenance.py must never do `import enterprise` or
+    `from enterprise import ...`."""
+    source = RUN_BUDGET_MAINTENANCE_PATH.read_text()
+    imported_names = _top_level_import_names(source)
+    assert "enterprise" not in imported_names, (
+        "run_budget_maintenance.py must not import the 'enterprise' "
+        "top-level package -- it is not importable in the deployed "
+        "container. Use an unqualified import (e.g. "
+        "`import run_maintenance_tasks`) instead."
+    )


### PR DESCRIPTION
See commit message for details.

Summary: `run_budget_maintenance.py` did `from enterprise import run_maintenance_tasks`, which only resolves in local/monorepo dev environments (a .pth file makes the repo-root enterprise/ directory importable as a package). The production Docker image does `COPY enterprise .` into WORKDIR /app, **flattening** the contents -- so there is no importable top-level `enterprise` package in the deployed container. The existing maintenance-tasks-cronjob.yaml already calls `python -m run_maintenance_tasks` (unqualified) for the same reason.

Without this fix, even after wiring run_budget_maintenance into a cron job (OpenHands/OpenHands-Cloud#780), the budget-maintenance cronjob would crash every run with ModuleNotFoundError, so budget maintenance never executes and org/user budget caps are never enforced.

**Changes:**
- `enterp- `enterp- `enterp- `enterp- `enterp- `enterp- `entee import run_maintenance_tasks` to unqualified `import run_maintenance_tasks`- `enterp- `enterp- `enterp- `enterpprise/tests/unit/test_run_budget_maintenance.py`: new regression test asserting the module never imports the `enterprise` package

**Companion fix** in OpenHands-Cloud: the `budget-maintenance-cronjob.yaml` cron invocation was already corrected to `python -m run_budget_maintenance` (merged in #780's squash-merge, commit 001be4fe).
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.37.0-python` |
| **Automation** | `openhands-automation==1.3.1` |
| **Commit** | `039e15ffa484fea4e144bd69520428846d17581c` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-039e15f
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-039e15f
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-039e15f-amd64
ghcr.io/openhands/agent-canvas:fix-run-budget-maintenance-import-amd64
ghcr.io/openhands/agent-canvas:pr-16094-amd64
ghcr.io/openhands/agent-canvas:sha-039e15f-arm64
ghcr.io/openhands/agent-canvas:fix-run-budget-maintenance-import-arm64
ghcr.io/openhands/agent-canvas:pr-16094-arm64
ghcr.io/openhands/agent-canvas:sha-039e15f
ghcr.io/openhands/agent-canvas:fix-run-budget-maintenance-import
ghcr.io/openhands/agent-canvas:pr-16094
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-039e15f`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-039e15f-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->