### PR TITLE
fix(dev): ignore agent-canvas runtime state in Vite file watcher

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -433,7 +433,34 @@ export default defineConfig(({ mode }) => {
         },
       },
       watch: {
-        ignored: ["**/node_modules/**", "**/.git/**"],
+        // Ignore node_modules and .git as usual, plus agent-canvas runtime
+        // state directories that may live INSIDE the project tree.
+        //
+        // The dev launchers default `OH_CANVAS_SAFE_STATE_DIR` to
+        // `~/.openhands/agent-canvas` (outside the project), but users can
+        // override it via `.env`. A common misconfiguration is
+        // `OH_CANVAS_SAFE_STATE_DIR="$HOME/.openhands/agent-canvas"`: Node's
+        // `--env-file` does NOT expand `$HOME`, so `path.resolve(cwd, ...)`
+        // produces `<project-root>/$HOME/.openhands/agent-canvas` — i.e. a
+        // literal `$HOME` directory *inside* the project tree. The launcher
+        // then writes conversation events, logs, and session state there,
+        // and every write triggers a Vite file-watch event → HMR attempt →
+        // full page reload (the data files aren't HMR-boundaryable), causing
+        // an infinite reload loop while a conversation is active or being
+        // resent.
+        //
+        // Even with the correct `~/.openhands/...` default, some users keep
+        // per-install state inside the project (e.g. via a relative
+        // `OH_CANVAS_SAFE_STATE_DIR=./.openhands`) for portability. Ignoring
+        // these directories defensively protects both cases.
+        ignored: [
+          "**/node_modules/**",
+          "**/.git/**",
+          "**/.openhands/**",
+          "**/$HOME/**",
+          "**/dev_conversations/**",
+          "**/logs/**",
+        ],
       },
     },
     ssr: {


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

- [ ] A human has tested these changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

Cherry-picked from OpenHands/agent-canvas#1856 (repo has migrated here).

Verification on this branch:
- `npm ci` -> 1393 packages installed, exit 0
- `npm run lint` -> typecheck (react-router typegen + tsc), eslint src, prettier --check all passed, exit 0
- `git diff` confirms only `vite.config.ts` changed (28 insertions, 1 deletion) -- the `server.watch.ignored` array

End-to-end behavior was verified on the original agent-canvas PR (#1856): on `main`, writing 5 JSON files to the runtime state directory triggered multiple Vite HMR full-reload events (infinite loop). On this branch: 0 full-reload events. The dev server stayed stable while the agent streamed events.

---

## Why

The dev launchers default `OH_CANVAS_SAFE_STATE_DIR` to `~/.openhands/agent-canvas` (outside the project tree), but users can override it via `.env`. A common misconfiguration is `OH_CANVAS_SAFE_STATE_DIR="$HOME/.openhands/agent-canvas"` -- Node's `--env-file` does NOT expand `$HOME`, so `path.resolve(cwd, ...)` produces `<project-root>/$HOME/.openhands/agent-canvas`, a literal `$HOME` directory *inside* the project tree. The launcher then writes conversation events, logs, and session state there, and every write triggers a Vite file-watch event -> HMR full-reload (the data files aren't HMR-boundaryable), causing an infinite reload loop while a conversation is active or being resent.

Even with the correct `~/.openhands/...` default, some users keep per-install state inside the project (e.g. via a relative `OH_CANVAS_SAFE_STATE_DIR=./.openhands`) for portability. Ignoring these directories defensively protects both cases.

## Summary

- Extends `server.watch.ignored` in `vite.config.ts` with four glob patterns: `**/.openhands/**`, `**/$HOME/**` (the literal-`$HOME` misconfiguration case), `**/dev_conversations/**`, and `**/logs/**`.
- No behavioral change to the build or production server -- only the Vite dev-server file watcher is affected.

## Issue Number

Closes OpenHands/OpenHands#15441.

## How to Test

1. `npm ci && npm run dev`
2. Set `OH_CANVAS_SAFE_STATE_DIR="$HOME/.openhands/agent-canvas"` in `.env` (the misconfiguration case -- `$HOME` is literal, not expanded)
3. Start a conversation and observe the agent streaming events
4. **Before fix:** browser enters infinite full-reload loop as events are written to `<project-root>/$HOME/.openhands/agent-canvas/`
5. **After fix:** browser stays stable, no reloads

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Originally submitted as OpenHands/agent-canvas#1856. Per @neubig's comment, re-opening here after the repository migration.
