### PR TITLE
fix: show conversations in collapsed sidebar

### DIFF
--- a/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
+++ b/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
@@ -581,7 +581,7 @@ describe("ConversationPanel", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("hides closed conversations in compact mode", async () => {
+  it("shows closed conversations in compact mode", async () => {
     vi.spyOn(
       AgentServerConversationService,
       "searchConversations",
@@ -617,9 +617,7 @@ describe("ConversationPanel", () => {
     expect(
       await screen.findByLabelText("Running Conversation"),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByLabelText("Closed Conversation"),
-    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Closed Conversation")).toBeInTheDocument();
   });
 
   it("should not render fetch errors in the conversation panel", async () => {

--- a/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
+++ b/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
@@ -295,7 +295,7 @@ describe("ConversationPanel", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("hides closed conversations in compact mode", async () => {
+  it("shows closed conversations in compact mode", async () => {
     vi.spyOn(
       AgentServerConversationService,
       "searchConversations",
@@ -331,9 +331,7 @@ describe("ConversationPanel", () => {
     expect(
       await screen.findByLabelText("Running Conversation"),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByLabelText("Closed Conversation"),
-    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Closed Conversation")).toBeInTheDocument();
   });
 
   it("should not render fetch errors in the conversation panel", async () => {

--- a/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/src/components/features/conversation-panel/conversation-panel.tsx
@@ -537,16 +537,7 @@ export function ConversationPanel({
     [conversationGroups],
   );
 
-  const compactVisibleConversations = React.useMemo(
-    () =>
-      sortConversationsByField(
-        recentScoped.filter((conversation) =>
-          isExecutionActive(conversation.execution_status),
-        ),
-        conversationSort,
-      ),
-    [conversationSort, recentScoped],
-  );
+  const compactVisibleConversations = sortedVisibleConversations;
 
   const visibleFlatCount = sortedVisibleConversations.length;
 

--- a/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/src/components/features/conversation-panel/conversation-panel.tsx
@@ -360,16 +360,7 @@ export function ConversationPanel({
     [conversationGroups],
   );
 
-  const compactVisibleConversations = React.useMemo(
-    () =>
-      sortConversationsByField(
-        recentScoped.filter((conversation) =>
-          isExecutionActive(conversation.execution_status),
-        ),
-        conversationSort,
-      ),
-    [conversationSort, recentScoped],
-  );
+  const compactVisibleConversations = sortedVisibleConversations;
 
   const visibleFlatCount = sortedVisibleConversations.length;
 
@@ -465,8 +456,8 @@ export function ConversationPanel({
   // pagination, which previously caused the panel to feel like it had stray
   // scrollable space at the bottom.
   const olderHidden = olderScoped.length > 0 && !showOlderConversations;
-  // Compact mode also hides "Load more" — paginating into archived
-  // conversations contradicts the "active only" intent of the icon rail.
+  // Compact mode also hides "Load more" — the icon rail should stay small
+  // and use the same currently visible conversation set as the expanded list.
   // Do not show when the visible list is empty (e.g. filters hide every
   // loaded conversation) — that state already shows "No conversations found".
   const showLoadMore =

--- a/src/components/features/sidebar/sidebar-conversation-list.tsx
+++ b/src/components/features/sidebar/sidebar-conversation-list.tsx
@@ -23,10 +23,6 @@ interface SidebarConversationListProps {
 export function SidebarConversationList({
   collapsed,
 }: SidebarConversationListProps) {
-  if (collapsed) {
-    return null;
-  }
-
   return (
     <div className="flex flex-col flex-1 min-h-0">
       {/* Avoid overflow-hidden here: ConversationPanel's header uses `-ml-2.5` +
@@ -34,7 +30,7 @@ export function SidebarConversationList({
           the aside; clipping would inset the border. Scroll stays on the inner
           list. */}
       <div className="flex min-h-0 w-full flex-1 flex-col">
-        <ConversationPanel />
+        <ConversationPanel compact={collapsed} />
       </div>
     </div>
   );

--- a/tests/e2e/mock-llm/conversations/mock-llm-conversation.spec.ts
+++ b/tests/e2e/mock-llm/conversations/mock-llm-conversation.spec.ts
@@ -419,12 +419,24 @@ test.describe("mock-LLM agent-server conversation", () => {
     const sidebarCards = page.locator('[data-testid="conversation-card"]');
     await expect(sidebarCards.first()).toBeVisible({ timeout: 15_000 });
 
-    // Find the sidebar link to our conversation and click it
+    // Confirm the conversation is present in the expanded sidebar before
+    // switching to the compact icon rail.
     const conversationLink = page.locator(
       `a[href*="/conversations/${step3ConversationId}"]`,
     );
     await expect(conversationLink.first()).toBeVisible({ timeout: 10_000 });
-    await conversationLink.first().click();
+
+    const collapseToggle = page.getByTestId("sidebar-collapse-toggle").first();
+    await expect(collapseToggle).toBeVisible({ timeout: 5_000 });
+    if ((await collapseToggle.getAttribute("aria-pressed")) !== "true") {
+      await collapseToggle.click();
+    }
+
+    const compactConversationRow = page.locator(
+      `[data-testid="compact-conversation-row"][data-conversation-id="${step3ConversationId}"]`,
+    );
+    await expect(compactConversationRow).toBeVisible({ timeout: 10_000 });
+    await compactConversationRow.click();
 
     // Wait for navigation back to the conversation page
     await waitForPath(page, /\/conversations\/.+/, 15_000);


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

- [ ] A human has tested these changes.

AGENT:

This reopens OpenHands/agent-canvas#1398 in the consolidated repository, as requested by the maintainer when the original repository moved. I reproduced the issue from #15662: `SidebarRailBody` passes the collapsed state to `SidebarConversationList`, but `SidebarConversationList` returned `null` when collapsed, removing the existing compact conversation picker.

The focused mock-LLM browser flow passed end to end. It creates a real agent-server conversation, navigates away, collapses the sidebar, selects the compact conversation row, and verifies the original messages remain visible without error banners.

---

## Why

When the desktop sidebar is collapsed, users should still be able to select an existing conversation without expanding the sidebar first. The current collapsed render path removes the conversation list entirely.

## Summary

- Render `ConversationPanel` in compact mode inside the collapsed sidebar instead of returning `null`.
- Use the same currently visible conversation set for compact rows, including closed conversations that are visible in the expanded list.
- Add a mock-LLM E2E regression step that collapses the sidebar and resumes an existing conversation through the compact row.

## Issue Number

Fixes #15662

## How to Test

Agent-run checks:

- `npm test -- __tests__/components/features/conversation-panel/conversation-panel.test.tsx` - 47/47 passed
- `npm run typecheck` - passed
- `npm run lint` - passed
- `npm run build:app` - passed
- `MOCK_LLM_PYTHON=.mock-llm-venv/bin/python3 npm run test:e2e:mock-llm -- tests/e2e/mock-llm/conversations/mock-llm-conversation.spec.ts` - 4/4 passed in 2.5 minutes

Reviewer reproduction:

1. Create or open an existing conversation.
2. Confirm it appears in the expanded sidebar.
3. Collapse the sidebar.
4. Confirm the compact conversation row remains visible.
5. Select the compact row and confirm the existing conversation resumes.

## Video/Screenshots

No screenshot attached. The deterministic mock-LLM browser test covers the full interaction and passed all four steps, including the collapsed-sidebar resume path.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Supersedes OpenHands/agent-canvas#1398 following the repository move.
- No schema, configuration, or dependency changes.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.41s · commit f5b0820  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 5/5 hunks, 4/4 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 4.0% | No direct hunk selected |
| Weakened authorization | 9.0% | No direct hunk selected |
| Contract regression | 14.0% | No direct hunk selected |
| Data loss | 3.0% | No direct hunk selected |
| Sensitive data disclosure | 3.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 4.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 4.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 88.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 95a3dd69204094c723f00f39ade5ab1bc32839e6976c20261ee94a01e0bef52d -->
<!-- jev-fast-audit:end -->
