### PR TITLE
feat: show live agent activity in chat

### DIFF
--- a/__tests__/components/chat/chat-interface.test.tsx
+++ b/__tests__/components/chat/chat-interface.test.tsx
@@ -1,12 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  test,
-  vi,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
 import {
   fireEvent,
   render,
@@ -27,7 +19,11 @@ import { useErrorMessageStore } from "#/stores/error-message-store";
 import { useOptimisticUserMessageStore } from "#/stores/optimistic-user-message-store";
 import { useConfig } from "#/hooks/query/use-config";
 import { useUnifiedUploadFiles } from "#/hooks/mutation/use-unified-upload-files";
-import type { MessageEvent } from "#/types/agent-server/core";
+import {
+  SecurityRisk,
+  type ActionEvent,
+  type MessageEvent,
+} from "#/types/agent-server/core";
 import { useEventStore } from "#/stores/use-event-store";
 import { useAgentState } from "#/hooks/use-agent-state";
 import { useLoadOlderEvents } from "#/hooks/use-load-older-events";
@@ -256,11 +252,7 @@ describe("ChatInterface - Chat Suggestions", () => {
       },
     });
 
-    renderWithQueryClient(
-      <ChatInterface />,
-      queryClient,
-      "/task-abc",
-    );
+    renderWithQueryClient(<ChatInterface />, queryClient, "/task-abc");
 
     expect(screen.queryByTestId("chat-suggestions")).not.toBeInTheDocument();
   });
@@ -282,11 +274,7 @@ describe("ChatInterface - Chat Suggestions", () => {
       },
     });
 
-    renderWithQueryClient(
-      <ChatInterface />,
-      queryClient,
-      "/task-abc",
-    );
+    renderWithQueryClient(<ChatInterface />, queryClient, "/task-abc");
 
     expect(screen.queryByTestId("chat-suggestions")).not.toBeInTheDocument();
   });
@@ -884,6 +872,59 @@ describe("ChatInterface - Auto-scroll on submit (issue #817)", () => {
 });
 
 describe("ChatInterface - Status Indicator", () => {
+  it("shows the unresolved terminal action while the agent is running", () => {
+    const terminalAction: ActionEvent = {
+      id: "action-running-terminal",
+      timestamp: "2026-07-27T18:00:00Z",
+      source: "agent",
+      thought: [],
+      thinking_blocks: [],
+      action: {
+        kind: "TerminalAction",
+        command: "git status",
+        is_input: false,
+        timeout: null,
+        reset: false,
+      },
+      tool_name: "terminal",
+      tool_call_id: "tool-running-terminal",
+      tool_call: {
+        id: "tool-running-terminal",
+        type: "function",
+        function: {
+          name: "terminal",
+          arguments: '{"command":"git status"}',
+        },
+      },
+      llm_response_id: "response-running-terminal",
+      security_risk: SecurityRisk.LOW,
+    };
+    useEventStore.setState({
+      events: [terminalAction],
+      eventIds: new Set([terminalAction.id]),
+      uiEvents: [terminalAction],
+    });
+    vi.mocked(useAgentState).mockReturnValue({
+      curAgentState: AgentState.RUNNING,
+    });
+
+    renderChatInterfaceWithRouter();
+
+    const chip = screen.getByTestId("live-activity-chip");
+    expect(chip).toHaveTextContent("ACTION_MESSAGE$RUN");
+    expect(chip.parentElement).toHaveClass("inset-x-9");
+  });
+
+  it("hides the live activity chip when the agent is no longer running", () => {
+    vi.mocked(useAgentState).mockReturnValue({
+      curAgentState: AgentState.PAUSED,
+    });
+
+    renderChatInterfaceWithRouter();
+
+    expect(screen.queryByTestId("live-activity-chip")).not.toBeInTheDocument();
+  });
+
   it("should render ChatStatusIndicator when agent is not awaiting user input / conversation is NOT ready", () => {
     vi.mocked(useAgentState).mockReturnValue({
       curAgentState: AgentState.LOADING,

--- a/__tests__/components/features/chat/typing-indicator.test.ts
+++ b/__tests__/components/features/chat/typing-indicator.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it } from "vitest";
+import { deriveLiveActivity } from "#/components/features/chat/typing-indicator";
+import {
+  SecurityRisk,
+  type ActionEvent,
+  type ObservationEvent,
+  type UserRejectObservation,
+} from "#/types/agent-server/core";
+import type { Action } from "#/types/agent-server/core/base/action";
+import type { ACPToolCallEvent } from "#/types/agent-server/core/events/acp-tool-call-event";
+import type { OHEvent } from "#/stores/use-event-store";
+
+const makeActionEvent = (
+  id: string,
+  action: Action,
+  summary?: string,
+): ActionEvent => ({
+  id,
+  timestamp: `2026-07-27T18:00:${id.padStart(2, "0")}Z`,
+  source: "agent",
+  thought: [],
+  thinking_blocks: [],
+  action,
+  tool_name: action.kind,
+  tool_call_id: `tool-${id}`,
+  tool_call: {
+    id: `tool-${id}`,
+    type: "function",
+    function: {
+      name: action.kind,
+      arguments: "{}",
+    },
+  },
+  llm_response_id: `response-${id}`,
+  security_risk: SecurityRisk.LOW,
+  summary,
+});
+
+const makeObservationEvent = (
+  id: string,
+  action: ActionEvent,
+): ObservationEvent => ({
+  id,
+  timestamp: `2026-07-27T18:01:${id.padStart(2, "0")}Z`,
+  source: "environment",
+  tool_name: action.tool_name,
+  tool_call_id: action.tool_call_id,
+  action_id: action.id,
+  observation: {
+    kind: "TerminalObservation",
+    content: [],
+    command: "git status",
+    exit_code: 0,
+    is_error: false,
+    timeout: false,
+    metadata: {
+      exit_code: 0,
+      pid: 1,
+      username: "openhands",
+      hostname: "runtime",
+      prefix: "",
+      suffix: "",
+      working_dir: "/workspace/project",
+      py_interpreter_path: null,
+    },
+  },
+});
+
+const makeUserRejectObservation = (
+  id: string,
+  action: ActionEvent,
+): UserRejectObservation => ({
+  id,
+  timestamp: `2026-07-27T18:01:${id.padStart(2, "0")}Z`,
+  source: "environment",
+  tool_name: action.tool_name,
+  tool_call_id: action.tool_call_id,
+  action_id: action.id,
+  rejection_reason: "Rejected by user",
+});
+
+const makeACPEvent = (
+  id: string,
+  status: ACPToolCallEvent["status"],
+): ACPToolCallEvent => ({
+  id: `${id}-${status ?? "legacy"}`,
+  timestamp: "2026-07-27T18:02:00Z",
+  kind: "ACPToolCallEvent",
+  source: "agent",
+  tool_call_id: id,
+  title: "Read README.md",
+  status,
+  tool_kind: "read",
+  raw_input: null,
+  raw_output: null,
+  content: null,
+  is_error: status === "failed",
+});
+
+describe("deriveLiveActivity", () => {
+  it.each([
+    {
+      name: "terminal command",
+      action: {
+        kind: "TerminalAction",
+        command: "git status",
+        is_input: false,
+        timeout: null,
+        reset: false,
+      } satisfies Action,
+      expected: {
+        kind: "translation",
+        key: "ACTION_MESSAGE$RUN",
+        values: { command: "git status" },
+      },
+    },
+    {
+      name: "file read",
+      action: {
+        kind: "FileEditorAction",
+        command: "view",
+        path: "README.md",
+        file_text: null,
+        old_str: null,
+        new_str: null,
+        insert_line: null,
+        view_range: null,
+      } satisfies Action,
+      expected: {
+        kind: "translation",
+        key: "ACTION_MESSAGE$READ",
+        values: { path: "README.md" },
+      },
+    },
+    {
+      name: "code search",
+      action: {
+        kind: "GrepAction",
+        pattern: "VITE_",
+        path: null,
+        include: null,
+      } satisfies Action,
+      expected: {
+        kind: "translation",
+        key: "ACTION_MESSAGE$GREP",
+        values: { pattern: "VITE_" },
+      },
+    },
+  ])("describes an unresolved $name", ({ action, expected }) => {
+    const event = makeActionEvent("1", action);
+
+    expect(deriveLiveActivity([event])).toEqual(expected);
+  });
+
+  it("moves to the next unresolved regular action as observations arrive", () => {
+    const first = makeActionEvent("1", {
+      kind: "TerminalAction",
+      command: "npm test",
+      is_input: false,
+      timeout: null,
+      reset: false,
+    });
+    const second = makeActionEvent("2", {
+      kind: "FileEditorAction",
+      command: "view",
+      path: "README.md",
+      file_text: null,
+      old_str: null,
+      new_str: null,
+      insert_line: null,
+      view_range: null,
+    });
+    const secondObservation = makeObservationEvent("3", second);
+    const firstObservation = makeObservationEvent("4", first);
+
+    expect(deriveLiveActivity([first, second, secondObservation])).toEqual({
+      kind: "translation",
+      key: "ACTION_MESSAGE$RUN",
+      values: { command: "npm test" },
+    });
+    expect(
+      deriveLiveActivity([first, second, secondObservation, firstObservation]),
+    ).toEqual({
+      kind: "translation",
+      key: "ACTION_MESSAGE$THINK",
+      values: {},
+    });
+  });
+
+  it("treats a rejected regular action as resolved", () => {
+    const rejected = makeActionEvent("1", {
+      kind: "TerminalAction",
+      command: "rm -rf build",
+      is_input: false,
+      timeout: null,
+      reset: false,
+    });
+
+    expect(
+      deriveLiveActivity([rejected, makeUserRejectObservation("2", rejected)]),
+    ).toEqual({
+      kind: "translation",
+      key: "ACTION_MESSAGE$THINK",
+      values: {},
+    });
+  });
+
+  it("shows the next unresolved action after a newer action is rejected", () => {
+    const remaining = makeActionEvent("1", {
+      kind: "TerminalAction",
+      command: "git status",
+      is_input: false,
+      timeout: null,
+      reset: false,
+    });
+    const rejected = makeActionEvent("2", {
+      kind: "TerminalAction",
+      command: "npm publish",
+      is_input: false,
+      timeout: null,
+      reset: false,
+    });
+
+    expect(
+      deriveLiveActivity([
+        remaining,
+        rejected,
+        makeUserRejectObservation("3", rejected),
+      ]),
+    ).toEqual({
+      kind: "translation",
+      key: "ACTION_MESSAGE$RUN",
+      values: { command: "git status" },
+    });
+  });
+
+  it.each([
+    "completed",
+    "failed",
+    null,
+  ] satisfies readonly ACPToolCallEvent["status"][])(
+    "drops an ACP label when the same call becomes %s",
+    (terminalStatus) => {
+      const started = makeACPEvent("acp-read", "in_progress");
+
+      expect(deriveLiveActivity([started])).toEqual({
+        kind: "translation",
+        key: "ACTION_MESSAGE$ACP_READ",
+        values: { title: "README.md" },
+      });
+      expect(
+        deriveLiveActivity([started, makeACPEvent("acp-read", terminalStatus)]),
+      ).toEqual({
+        kind: "translation",
+        key: "ACTION_MESSAGE$THINK",
+        values: {},
+      });
+    },
+  );
+
+  it("falls back to Thinking for unsupported and planning-only actions", () => {
+    const unsupported = makeActionEvent("1", {
+      kind: "SwitchLLMAction",
+      profile_name: "fast",
+      reason: "Short task",
+    });
+    const planningOnly = {
+      ...makeActionEvent("2", {
+        kind: "TerminalAction",
+        command: "git status",
+        is_input: false,
+        timeout: null,
+        reset: false,
+      }),
+      isFromPlanningAgent: true,
+    } satisfies OHEvent;
+
+    expect(deriveLiveActivity([unsupported])).toEqual({
+      kind: "translation",
+      key: "ACTION_MESSAGE$THINK",
+      values: {},
+    });
+    expect(deriveLiveActivity([planningOnly])).toEqual({
+      kind: "translation",
+      key: "ACTION_MESSAGE$THINK",
+      values: {},
+    });
+    expect(deriveLiveActivity([])).toEqual({
+      kind: "translation",
+      key: "ACTION_MESSAGE$THINK",
+      values: {},
+    });
+  });
+});

--- a/src/components/conversation-events/chat/event-content-helpers/get-action-event-title.ts
+++ b/src/components/conversation-events/chat/event-content-helpers/get-action-event-title.ts
@@ -1,0 +1,140 @@
+import { CANVAS_UI_CLIENT_ACTION_KIND } from "#/constants/canvas-ui";
+import type { ActionEvent } from "#/types/agent-server/core";
+
+export type EventTitleDescriptor =
+  | {
+      readonly kind: "translation";
+      readonly key: string;
+      readonly values: Readonly<Record<string, unknown>>;
+    }
+  | {
+      readonly kind: "text";
+      readonly text: string;
+    };
+
+export const trimEventTitleText = (text: string, maxLength: number): string => {
+  if (!text) return "";
+  return text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
+};
+
+const isServerFallbackSummary = (summary: string): boolean =>
+  /^[a-z][a-z0-9_]*\s*:\s*[[{]/i.test(summary);
+
+export const getActionSummaryTitle = (event: ActionEvent): string | null => {
+  const summary = event.summary?.trim().replace(/\s+/g, " ") || "";
+  return !summary || isServerFallbackSummary(summary) ? null : summary;
+};
+
+export const getActionEventTitleDescriptor = (
+  event: ActionEvent,
+): EventTitleDescriptor => {
+  const summary = getActionSummaryTitle(event);
+  if (summary) {
+    return { kind: "text", text: summary };
+  }
+
+  const actionType = event.action.kind;
+
+  switch (actionType) {
+    case "ExecuteBashAction":
+    case "TerminalAction":
+      return {
+        kind: "translation",
+        key: "ACTION_MESSAGE$RUN",
+        values: { command: trimEventTitleText(event.action.command, 80) },
+      };
+    case "FileEditorAction":
+    case "StrReplaceEditorAction": {
+      const key =
+        event.action.command === "view"
+          ? "ACTION_MESSAGE$READ"
+          : event.action.command === "create"
+            ? "ACTION_MESSAGE$WRITE"
+            : "ACTION_MESSAGE$EDIT";
+      return {
+        kind: "translation",
+        key,
+        values: { path: event.action.path },
+      };
+    }
+    case "MCPToolAction":
+      return {
+        kind: "translation",
+        key: "ACTION_MESSAGE$CALL_TOOL_MCP",
+        values: { mcp_tool_name: event.tool_name },
+      };
+    case "InvokeSkillAction":
+      return {
+        kind: "translation",
+        key: "ACTION_MESSAGE$INVOKE_SKILL",
+        values: { name: event.action.name },
+      };
+    case "TaskAction":
+      return {
+        kind: "translation",
+        key: "ACTION_MESSAGE$TASK",
+        values: { name: event.action.subagent_type },
+      };
+    case "ThinkAction":
+      return {
+        kind: "translation",
+        key: "ACTION_MESSAGE$THINK",
+        values: {},
+      };
+    case "FinishAction":
+      return {
+        kind: "translation",
+        key: "ACTION_MESSAGE$FINISH",
+        values: {},
+      };
+    case "TaskTrackerAction":
+      return {
+        kind: "translation",
+        key: "ACTION_MESSAGE$TASK_TRACKING",
+        values: {},
+      };
+    case "GrepAction":
+      return {
+        kind: "translation",
+        key: "ACTION_MESSAGE$GREP",
+        values: {
+          pattern: event.action.pattern
+            ? trimEventTitleText(event.action.pattern, 50)
+            : "",
+        },
+      };
+    case "GlobAction":
+      return {
+        kind: "translation",
+        key: "ACTION_MESSAGE$GLOB",
+        values: {
+          pattern: event.action.pattern
+            ? trimEventTitleText(event.action.pattern, 50)
+            : "",
+        },
+      };
+    case "BrowserNavigateAction":
+    case "BrowserClickAction":
+    case "BrowserTypeAction":
+    case "BrowserGetStateAction":
+    case "BrowserGetContentAction":
+    case "BrowserScrollAction":
+    case "BrowserGoBackAction":
+    case "BrowserListTabsAction":
+    case "BrowserSwitchTabAction":
+    case "BrowserCloseTabAction":
+      return {
+        kind: "translation",
+        key: "ACTION_MESSAGE$BROWSE",
+        values: {},
+      };
+    case "CanvasUIAction":
+    case CANVAS_UI_CLIENT_ACTION_KIND:
+      return { kind: "text", text: "CANVASUI" };
+    default:
+      return {
+        kind: "text",
+        text: String(actionType).replace("Action", "").toUpperCase(),
+      };
+  }
+};

--- a/src/components/conversation-events/chat/event-content-helpers/get-event-content.tsx
+++ b/src/components/conversation-events/chat/event-content-helpers/get-event-content.tsx
@@ -1,9 +1,6 @@
 import { Trans } from "react-i18next";
 import React from "react";
-import {
-  CANVAS_UI_CLIENT_ACTION_KIND,
-  CANVAS_UI_CLIENT_TOOL_NAME,
-} from "#/constants/canvas-ui";
+import { CANVAS_UI_CLIENT_TOOL_NAME } from "#/constants/canvas-ui";
 import {
   OpenHandsEvent,
   ObservationEvent,
@@ -30,16 +27,17 @@ import { SkillReadyEvent, isSkillReadyEvent } from "./create-skill-ready-event";
 import { resolveVisualizerBody } from "../../../features/chat/tool-visualizers/dispatcher";
 import i18n from "#/i18n";
 import { I18nKey } from "#/i18n/declaration";
-
-const trimText = (text: string, maxLength: number): string => {
-  if (!text) return "";
-  return text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
-};
+import {
+  getActionEventTitleDescriptor,
+  getActionSummaryTitle,
+  trimEventTitleText,
+  type EventTitleDescriptor,
+} from "./get-action-event-title";
 
 // Helper function to create title from translation key
 const createTitleFromKey = (
   key: string,
-  values: Record<string, unknown>,
+  values: Readonly<Record<string, unknown>>,
 ): React.ReactNode => {
   if (!i18n.exists(key)) {
     return key;
@@ -58,26 +56,12 @@ const createTitleFromKey = (
   );
 };
 
-/**
- * Detects the agent-server's default summary fallback, which has the shape
- * `{tool_name}: {json-args}` (see `_extract_summary` in
- * `openhands/sdk/agent/agent.py`). When the LLM omits a summary the server
- * dumps the raw arguments JSON, which renders as a huge unreadable blob in
- * the chat. Treat that case as "no summary" so the action-kind specific
- * title (e.g. "Editing <path>", "Running <cmd>") is used instead.
- */
-const isServerFallbackSummary = (summary: string): boolean =>
-  /^[a-z][a-z0-9_]*\s*:\s*[[{]/i.test(summary);
-
-const getSummaryTitleForActionEvent = (
-  event: ActionEvent,
-): React.ReactNode | null => {
-  const summary = event.summary?.trim().replace(/\s+/g, " ") || "";
-  if (!summary || isServerFallbackSummary(summary)) {
-    return null;
-  }
-  return summary;
-};
+const renderTitleDescriptor = (
+  descriptor: EventTitleDescriptor,
+): React.ReactNode =>
+  descriptor.kind === "text"
+    ? descriptor.text
+    : createTitleFromKey(descriptor.key, descriptor.values);
 
 const getNonEmptyString = (
   value: unknown,
@@ -92,7 +76,7 @@ const getNonEmptyString = (
     return null;
   }
 
-  return maxLength ? trimText(trimmed, maxLength) : trimmed;
+  return maxLength ? trimEventTitleText(trimmed, maxLength) : trimmed;
 };
 
 const getVisionInspectActionTitle = (
@@ -154,106 +138,7 @@ const getActionEventTitle = (event: OpenHandsEvent): React.ReactNode => {
     return visionInspectTitle;
   }
 
-  const summaryTitle = getSummaryTitleForActionEvent(event);
-  if (summaryTitle) {
-    return summaryTitle;
-  }
-
-  const actionType = event.action.kind;
-  let actionKey = "";
-  let actionValues: Record<string, unknown> = {};
-
-  switch (actionType) {
-    case "ExecuteBashAction":
-    case "TerminalAction":
-      actionKey = "ACTION_MESSAGE$RUN";
-      actionValues = {
-        command: trimText(event.action.command, 80),
-      };
-      break;
-    case "FileEditorAction":
-    case "StrReplaceEditorAction":
-      if (event.action.command === "view") {
-        actionKey = "ACTION_MESSAGE$READ";
-      } else if (event.action.command === "create") {
-        actionKey = "ACTION_MESSAGE$WRITE";
-      } else {
-        actionKey = "ACTION_MESSAGE$EDIT";
-      }
-      actionValues = {
-        path: event.action.path,
-      };
-      break;
-    case "MCPToolAction":
-      actionKey = "ACTION_MESSAGE$CALL_TOOL_MCP";
-      actionValues = {
-        mcp_tool_name: event.tool_name,
-      };
-      break;
-    case "InvokeSkillAction":
-      actionKey = "ACTION_MESSAGE$INVOKE_SKILL";
-      actionValues = {
-        name: event.action.name,
-      };
-      break;
-    case "TaskAction":
-      actionKey = "ACTION_MESSAGE$TASK";
-      actionValues = {
-        name: event.action.subagent_type,
-      };
-      break;
-    case "ThinkAction":
-      actionKey = "ACTION_MESSAGE$THINK";
-      break;
-    case "FinishAction":
-      actionKey = "ACTION_MESSAGE$FINISH";
-      break;
-    case "TaskTrackerAction":
-      actionKey = "ACTION_MESSAGE$TASK_TRACKING";
-      break;
-    case "GrepAction":
-      actionKey = "ACTION_MESSAGE$GREP";
-      actionValues = {
-        pattern:
-          "pattern" in event.action && event.action.pattern
-            ? trimText(String(event.action.pattern), 50)
-            : "",
-      };
-      break;
-    case "GlobAction":
-      actionKey = "ACTION_MESSAGE$GLOB";
-      actionValues = {
-        pattern:
-          "pattern" in event.action && event.action.pattern
-            ? trimText(String(event.action.pattern), 50)
-            : "",
-      };
-      break;
-    case "BrowserNavigateAction":
-    case "BrowserClickAction":
-    case "BrowserTypeAction":
-    case "BrowserGetStateAction":
-    case "BrowserGetContentAction":
-    case "BrowserScrollAction":
-    case "BrowserGoBackAction":
-    case "BrowserListTabsAction":
-    case "BrowserSwitchTabAction":
-    case "BrowserCloseTabAction":
-      actionKey = "ACTION_MESSAGE$BROWSE";
-      break;
-    case "CanvasUIAction":
-    case CANVAS_UI_CLIENT_ACTION_KIND:
-      return "CANVASUI";
-    default:
-      // For unknown actions, use the type name
-      return String(actionType).replace("Action", "").toUpperCase();
-  }
-
-  if (actionKey) {
-    return createTitleFromKey(actionKey, actionValues);
-  }
-
-  return actionType;
+  return renderTitleDescriptor(getActionEventTitleDescriptor(event));
 };
 
 // Observation Event Processing
@@ -280,7 +165,7 @@ const getObservationEventTitle = (
       return visionInspectTitle;
     }
 
-    const summaryTitle = getSummaryTitleForActionEvent(correspondingAction);
+    const summaryTitle = getActionSummaryTitle(correspondingAction);
     if (summaryTitle) {
       return summaryTitle;
     }
@@ -296,7 +181,7 @@ const getObservationEventTitle = (
       observationKey = "OBSERVATION_MESSAGE$RUN";
       observationValues = {
         command: event.observation.command
-          ? trimText(event.observation.command, 80)
+          ? trimEventTitleText(event.observation.command, 80)
           : "",
       };
       break;
@@ -366,7 +251,7 @@ const getObservationEventTitle = (
       observationKey = "OBSERVATION_MESSAGE$GLOB";
       observationValues = {
         pattern: event.observation.pattern
-          ? trimText(event.observation.pattern, 50)
+          ? trimEventTitleText(event.observation.pattern, 50)
           : "",
       };
       break;
@@ -374,7 +259,7 @@ const getObservationEventTitle = (
       observationKey = "OBSERVATION_MESSAGE$GREP";
       observationValues = {
         pattern: event.observation.pattern
-          ? trimText(event.observation.pattern, 50)
+          ? trimEventTitleText(event.observation.pattern, 50)
           : "",
       };
       break;

--- a/src/components/features/chat/chat-interface.tsx
+++ b/src/components/features/chat/chat-interface.tsx
@@ -624,8 +624,8 @@ export function ChatInterface() {
                     </div>
                   ) : (
                     curAgentState === AgentState.RUNNING && (
-                      <div className="absolute left-1/2 transform -translate-x-1/2 bottom-0 pointer-events-auto">
-                        <TypingIndicator />
+                      <div className="pointer-events-none absolute inset-x-9 bottom-0 flex justify-center">
+                        <TypingIndicator events={allConversationEvents} />
                       </div>
                     )
                   )}

--- a/src/components/features/chat/typing-indicator.tsx
+++ b/src/components/features/chat/typing-indicator.tsx
@@ -1,9 +1,161 @@
-export function TypingIndicator() {
+import { Trans } from "react-i18next";
+import type { OHEvent } from "#/stores/use-event-store";
+import type { UserRejectObservation } from "#/types/agent-server/core";
+import {
+  isACPToolCallEvent,
+  isActionEvent,
+  isAgentErrorEvent,
+  isObservationEvent,
+} from "#/types/agent-server/type-guards";
+import {
+  getACPToolCallTitleKey,
+  stripRedundantTitlePrefix,
+} from "#/components/conversation-events/chat/event-content-helpers/get-acp-tool-call-content";
+import {
+  getActionEventTitleDescriptor,
+  getActionSummaryTitle,
+  type EventTitleDescriptor,
+} from "#/components/conversation-events/chat/event-content-helpers/get-action-event-title";
+import { MonoComponent } from "./mono-component";
+import { PathComponent } from "./path-component";
+
+const THINKING_ACTIVITY: EventTitleDescriptor = {
+  kind: "translation",
+  key: "ACTION_MESSAGE$THINK",
+  values: {},
+};
+
+const LIVE_ACTION_KINDS = new Set([
+  "ExecuteBashAction",
+  "TerminalAction",
+  "FileEditorAction",
+  "StrReplaceEditorAction",
+  "MCPToolAction",
+  "InvokeSkillAction",
+  "TaskAction",
+  "ThinkAction",
+  "TaskTrackerAction",
+  "GrepAction",
+  "GlobAction",
+  "BrowserNavigateAction",
+  "BrowserClickAction",
+  "BrowserTypeAction",
+  "BrowserGetStateAction",
+  "BrowserGetContentAction",
+  "BrowserScrollAction",
+  "BrowserGoBackAction",
+  "BrowserListTabsAction",
+  "BrowserSwitchTabAction",
+  "BrowserCloseTabAction",
+]);
+
+const getLiveActionTitle = (event: OHEvent): EventTitleDescriptor | null => {
+  if (!isActionEvent(event)) return null;
+
+  const summary = getActionSummaryTitle(event);
+  if (summary) {
+    return { kind: "text", text: summary };
+  }
+
+  return LIVE_ACTION_KINDS.has(event.action.kind)
+    ? getActionEventTitleDescriptor(event)
+    : null;
+};
+
+const isUserRejectObservation = (
+  event: OHEvent,
+): event is UserRejectObservation =>
+  event.source === "environment" && "rejection_reason" in event;
+
+export const deriveLiveActivity = (
+  events: readonly OHEvent[],
+): EventTitleDescriptor => {
+  const resolvedActionIds = new Set<string>();
+  const resolvedToolCallIds = new Set<string>();
+
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event.isFromPlanningAgent) {
+      continue;
+    }
+
+    if (isObservationEvent(event) || isUserRejectObservation(event)) {
+      resolvedActionIds.add(event.action_id);
+      resolvedToolCallIds.add(event.tool_call_id);
+      continue;
+    }
+
+    if (isAgentErrorEvent(event)) {
+      resolvedToolCallIds.add(event.tool_call_id);
+      continue;
+    }
+
+    if (isACPToolCallEvent(event)) {
+      const isInProgress =
+        event.status === "pending" || event.status === "in_progress";
+      if (!isInProgress) {
+        resolvedToolCallIds.add(event.tool_call_id);
+        continue;
+      }
+      if (resolvedToolCallIds.has(event.tool_call_id)) {
+        continue;
+      }
+
+      const title = stripRedundantTitlePrefix(event);
+      return title
+        ? {
+            kind: "translation",
+            key: getACPToolCallTitleKey(event),
+            values: { title },
+          }
+        : THINKING_ACTIVITY;
+    }
+
+    if (
+      isActionEvent(event) &&
+      !resolvedActionIds.has(event.id) &&
+      !resolvedToolCallIds.has(event.tool_call_id)
+    ) {
+      return getLiveActionTitle(event) ?? THINKING_ACTIVITY;
+    }
+  }
+
+  return THINKING_ACTIVITY;
+};
+
+interface TypingIndicatorProps {
+  readonly events: readonly OHEvent[];
+}
+
+export function TypingIndicator({ events }: TypingIndicatorProps) {
+  const activity = deriveLiveActivity(events);
+
   return (
-    <div className="flex items-center space-x-1.5 rounded-full bg-[var(--oh-surface)] px-3 py-1.5">
-      <span className="h-1.5 w-1.5 rounded-full bg-[var(--oh-muted)] animate-[bounce_0.5s_infinite] translate-y-[1px] [animation-delay:0ms]" />
-      <span className="h-1.5 w-1.5 rounded-full bg-[var(--oh-muted)] animate-[bounce_0.5s_infinite] translate-y-[1px] [animation-delay:75ms]" />
-      <span className="h-1.5 w-1.5 rounded-full bg-[var(--oh-muted)] animate-[bounce_0.5s_infinite] translate-y-[1px] [animation-delay:150ms]" />
+    <div
+      className="flex min-w-0 max-w-full items-center gap-2 rounded-full border border-[var(--oh-border)] bg-[var(--oh-surface)] px-3 py-1.5 text-xs text-[var(--oh-text-secondary)]"
+      data-testid="live-activity-chip"
+      role="status"
+      aria-live="polite"
+    >
+      <span
+        aria-hidden="true"
+        className="size-1.5 shrink-0 animate-pulse rounded-full bg-[var(--oh-status-success)] motion-reduce:animate-none"
+      />
+      <span className="min-w-0 truncate">
+        {activity.kind === "text" ? (
+          activity.text
+        ) : (
+          <Trans
+            ns="openhands"
+            i18nKey={activity.key}
+            values={activity.values}
+            components={{
+              path: <PathComponent />,
+              cmd: <MonoComponent />,
+            }}
+          />
+        )}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

I tested and checked all the changes below.

- [x] A human has tested these changes.

AGENT:

- RED: before production edits, the focused Vitest command failed with 9 new failures because the activity derivation and chip did not exist.
- GREEN: `npm exec -- vitest run __tests__/components/features/chat/typing-indicator.test.ts __tests__/components/chat/chat-interface.test.tsx --maxWorkers=4` — 29 passed, 1 pre-existing todo.
- Adjacent regressions: 7 focused suites covering event content, stores, filtering, streaming, plan previews, and ChatInterface — 81 passed, 1 pre-existing todo.
- Browser QA: headed Chromium at 768 px showed a deliberately long `Running printf …` label; the chip remained inside the 468 px chat pane, started 10 px after the enabled 26 px confirmation-mode lock control, ignored pointer input, used the working-status green token, and disabled pulse animation under reduced-motion settings.
- Build gates: `npm run typecheck`, changed-file ESLint/Prettier, `npm run build`, and `npm run build:lib` passed.
- Full-suite validation: 3,999 tests passed; one unrelated ingress-script port-output assertion failed under the parallel run, then the exact ingress suite passed 16/16 in isolation.

---

## Why

The existing three-dot running indicator confirms that an agent is busy but does not explain what it is doing. Longer, multi-step tasks therefore feel opaque even though the existing event stream already contains actionable status information.

## Summary

- replace the generic running dots with a localized live activity chip derived from unresolved raw conversation events
- reuse existing action and ACP title semantics while falling back to `Thinking` for unsupported or currently invisible work
- keep the chip responsive, non-interactive, accessible, and limited to the existing RUNNING-state location above the composer

## Issue Number

Closes #16051

## How to Test

1. Start the app with `npm run dev:mock` or connect it to an agent server.
2. Open a conversation and run a multi-step task that reads a file, searches the repository, and executes a terminal command.
3. Confirm that the chip above the composer changes between action-specific labels such as `Running git status` and `Reading README.md`.
4. Confirm that completed actions no longer remain in the chip, an unsupported/no-current-action state shows `Thinking`, and pausing the conversation removes the chip.
5. Resize to a narrow split-pane layout and confirm long labels truncate without leaving the chat pane.

Automated checks:

```text
npm exec -- vitest run __tests__/components/features/chat/typing-indicator.test.ts __tests__/components/chat/chat-interface.test.tsx --maxWorkers=4
npm run typecheck
npm run build
npm run build:lib
```

## Video/Screenshots

![Live activity chip showing a long running command above the chat composer](https://gist.githubusercontent.com/roian6/a35c996feaec6bf8352c6bcc196593df/raw/8e6461c9fd1e419f646ddc898e3f90245b6cd04d/openhands-16051-final.png)

<sub>Headed Chromium at a 768 px viewport: the long green `Running printf …` chip clears the enabled confirmation-mode lock control and remains centered above the composer.</sub>

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- No backend API or event-store reconciliation behavior changes.
- The chip reads raw events because rendered UI events intentionally replace an action with its observation.
- The one full-suite failure was outside the touched files and passed immediately when its 16-test suite was rerun in isolation.
