### PR TITLE
docs: clarify quickstart prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,25 @@ Notably, you can run the backend in _multiple different environments_, and switc
 them from the same Agent Canvas frontend. E.g. you can share an Agent Server with your team for agents doing
 code review and dependency updates, then have your personal agents running on your laptop.
 
+### Prerequisites
+
+Before choosing an installation method, make sure you have access to a terminal (Terminal on macOS/Linux or
+PowerShell/Windows Terminal on Windows) and install the tools required by that method:
+
+| Installation method | Required software                                                                                                                                                                |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Without a sandbox   | [Node.js 22.12 or later](https://nodejs.org/en/download) (includes npm) and [uv](https://docs.astral.sh/uv/getting-started/installation/)                                        |
+| Docker sandbox      | [Docker Desktop](https://docs.docker.com/desktop/) on macOS/Windows, or [Docker Engine](https://docs.docker.com/engine/install/) on Linux                                        |
+| From source         | [Git](https://git-scm.com/downloads), [Node.js 22.12 or later](https://nodejs.org/en/download) (includes npm), and [uv](https://docs.astral.sh/uv/getting-started/installation/) |
+
+Make sure you also have enough free disk space for the installation method you choose, its dependencies or
+container images, and the projects your agents will use. Windows users following the Docker option should use
+the [Windows quickstart](./README.windows.md).
+
 ### Option 1: Without a Sandbox
 
 > [!WARNING]
 > This runs the agent-server directly on the machine you're installing on — the agent will have full access to your filesystem!
-
-**Prerequisites**: Node.js 22.12.x or later, `uv`
 
 ```sh
 npm install -g @openhands/agent-canvas
@@ -81,10 +94,8 @@ agent-canvas --backend-only   # agent server + automation backend + ingress only
 
 ### Option 2: With a Docker Sandbox
 
-**Prerequisites**:
-
-- Docker: Docker Desktop on macOS/Windows, or Docker Engine/Docker Desktop on Linux.
-- A host directory for `PROJECTS_PATH` containing the project folders you want the agent to access. Create it before starting the container.
+Choose a host directory for `PROJECTS_PATH` containing the project folders you want the agent to access.
+The commands below create it if needed.
 
 **macOS / Linux:**
 
@@ -107,8 +118,6 @@ The agent will be able to access any project under `PROJECTS_PATH`.
 
 > [!WARNING]
 > This runs the agent-server directly on the machine you're installing on — the agent will have full access to your filesystem!
-
-**Prerequisites**: Node.js 22.12.x or later, `npm`, `uv` (for running the agent server via `uvx`)
 
 ```sh
 git clone https://github.com/OpenHands/agent-canvas.git

--- a/README.windows.md
+++ b/README.windows.md
@@ -6,9 +6,10 @@ For the main install options and overall context, see [README.md](./README.md).
 
 ## Option 2: With a Docker Sandbox (Windows)
 
-**Prerequisites**:
+Before starting:
 
-- Docker Desktop for Windows
+- Install [Docker Desktop for Windows](https://docs.docker.com/desktop/setup/install/windows-install/).
+- Make sure Docker has enough free disk space for the Agent Canvas image and your project data.
 - A host directory for `PROJECTS_PATH` containing the project folders you want the agent to access (create it before starting the container)
 
 ```powershell


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing before checking the box. -->

- [ ] A human has tested these changes.

AGENT:

This documentation-only change was implemented and validated by OpenAI Codex. I rendered the updated README through GitHub's Markdown API, verified every newly added external link returned HTTP 200, and ran the repository's full lint, test, application-build, and library-build checks using Node.js 22.12.0 and npm 10.5.0.

---

## Why

The Quickstart currently scatters prerequisites across individual installation options and does not link to the official installation instructions. This makes it harder for first-time users to identify everything they need before starting.

## Summary

- add a consolidated prerequisites table for the npm, Docker, and source installation paths
- link each required tool to its official installation documentation and clarify terminal, platform, and disk-space expectations
- keep the Windows Docker quickstart in sync with the main README

## Issue Number

Closes #15795

## How to Test

Verification performed from a clean dependency install (`npm ci`):

- `npx prettier --check README.md README.windows.md`
- GitHub Markdown API render check for the Prerequisites heading, table, tool links, and Windows quickstart link
- HTTP checks for all six newly added external links (all returned 200)
- `npm run lint` using Node.js 22.12.0 / npm 10.5.0
- `npm test` using Node.js 22.12.0 / npm 10.5.0: 515 files passed, 1 skipped; 3,992 tests passed, 5 skipped, 9 todo
- `npm run build` using Node.js 22.12.0 / npm 10.5.0
- `npm run build:lib` using Node.js 22.12.0 / npm 10.5.0

To inspect the documentation change, open `README.md` and confirm the Prerequisites table appears immediately before the three installation options, then open `README.windows.md` and confirm its Docker prerequisites link to the Windows installation guide.

## Video/Screenshots

Not applicable: this PR changes Markdown documentation only. Rendering was validated with GitHub's Markdown API.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

The issue proposed fixed disk-space values, but the current multi-architecture Docker image alone has approximately 1.72 GB of compressed layers and installed size varies by platform and project data. The docs therefore state the requirement without publishing an inaccurate fixed minimum.
