### PR TITLE
fix(automation): auto-recover from stale SQLite DB on dev startup

### DIFF
--- a/__tests__/scripts/automation-db-recovery.test.ts
+++ b/__tests__/scripts/automation-db-recovery.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment node
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  automationDbSidecarPaths,
+  createAutomationDbRecovery,
+  isAutomationMigrationError,
+} from "../../scripts/automation-db-recovery.mjs";
+
+const MIGRATION_LINE =
+  "Failed to apply SQLite migrations: Can't locate revision identified by '007'";
+
+describe("isAutomationMigrationError", () => {
+  it("matches the stale-migration failure lines", () => {
+    expect(isAutomationMigrationError(MIGRATION_LINE)).toBe(true);
+    expect(
+      isAutomationMigrationError("Can't locate revision identified by 'abc'"),
+    ).toBe(true);
+  });
+
+  it("ignores unrelated automation output", () => {
+    expect(isAutomationMigrationError("Application startup complete")).toBe(
+      false,
+    );
+    expect(isAutomationMigrationError("")).toBe(false);
+  });
+});
+
+describe("automationDbSidecarPaths", () => {
+  it("expands the DB path to its SQLite sidecar files", () => {
+    expect(automationDbSidecarPaths("/state/automations.db")).toEqual([
+      "/state/automations.db",
+      "/state/automations.db-wal",
+      "/state/automations.db-shm",
+      "/state/automations.db-journal",
+    ]);
+  });
+});
+
+describe("createAutomationDbRecovery", () => {
+  const tempDirs = [];
+
+  afterEach(() => {
+    while (tempDirs.length) {
+      rmSync(tempDirs.pop(), { recursive: true, force: true });
+    }
+  });
+
+  function makeTempDb() {
+    const dir = mkdtempSync(path.join(tmpdir(), "automation-recovery-"));
+    tempDirs.push(dir);
+    const dbPath = path.join(dir, "automations.db");
+    writeFileSync(dbPath, "stale");
+    writeFileSync(`${dbPath}-wal`, "stale-wal");
+    return dbPath;
+  }
+
+  it("resets the stale DB and restarts once when a migration error precedes a non-zero exit", () => {
+    // Arrange
+    const dbPath = makeTempDb();
+    const messages = [];
+    let restarts = 0;
+    const recovery = createAutomationDbRecovery({
+      dbPath,
+      log: (message) => messages.push(message),
+      restart: () => {
+        restarts += 1;
+      },
+    });
+
+    // Act
+    recovery.handleLine(MIGRATION_LINE);
+    const recovered = recovery.handleExit(3);
+
+    // Assert
+    expect(recovered).toBe(true);
+    expect(restarts).toBe(1);
+    expect(existsSync(dbPath)).toBe(false);
+    expect(existsSync(`${dbPath}-wal`)).toBe(false);
+    expect(messages.join("\n")).toContain("stale automation database");
+  });
+
+  it("recovers at most once so a persistently broken DB cannot loop", () => {
+    // Arrange
+    const dbPath = makeTempDb();
+    let restarts = 0;
+    const recovery = createAutomationDbRecovery({
+      dbPath,
+      log: () => {},
+      restart: () => {
+        restarts += 1;
+      },
+    });
+
+    // Act: a second migration failure after the first recovery must be ignored.
+    recovery.handleLine(MIGRATION_LINE);
+    expect(recovery.handleExit(3)).toBe(true);
+    recovery.handleLine(MIGRATION_LINE);
+    const secondRecovered = recovery.handleExit(3);
+
+    // Assert
+    expect(secondRecovered).toBe(false);
+    expect(restarts).toBe(1);
+  });
+
+  it("does not touch the DB when the crash is unrelated to a migration", () => {
+    // Arrange
+    const dbPath = makeTempDb();
+    let restarts = 0;
+    const recovery = createAutomationDbRecovery({
+      dbPath,
+      log: () => {},
+      restart: () => {
+        restarts += 1;
+      },
+    });
+
+    // Act
+    recovery.handleLine("ValueError: something else went wrong");
+    const recovered = recovery.handleExit(3);
+
+    // Assert
+    expect(recovered).toBe(false);
+    expect(restarts).toBe(0);
+    expect(existsSync(dbPath)).toBe(true);
+  });
+
+  it("does not recover on a clean exit even after a migration warning", () => {
+    const dbPath = makeTempDb();
+    let restarts = 0;
+    const recovery = createAutomationDbRecovery({
+      dbPath,
+      log: () => {},
+      restart: () => {
+        restarts += 1;
+      },
+    });
+
+    recovery.handleLine(MIGRATION_LINE);
+
+    expect(recovery.handleExit(0)).toBe(false);
+    expect(recovery.handleExit(null)).toBe(false);
+    expect(restarts).toBe(0);
+    expect(existsSync(dbPath)).toBe(true);
+  });
+
+  it("skips reset and does not restart when no DB file exists to delete", () => {
+    // Arrange: injected fs reports the DB as absent.
+    const removed = [];
+    let restarts = 0;
+    const recovery = createAutomationDbRecovery({
+      dbPath: "/nonexistent/automations.db",
+      log: () => {},
+      restart: () => {
+        restarts += 1;
+      },
+      fs: {
+        existsSync: () => false,
+        rmSync: (p) => removed.push(p),
+      },
+    });
+
+    // Act
+    recovery.handleLine(MIGRATION_LINE);
+    const recovered = recovery.handleExit(3);
+
+    // Assert
+    expect(recovered).toBe(false);
+    expect(restarts).toBe(0);
+    expect(removed).toEqual([]);
+  });
+});

--- a/scripts/automation-db-recovery.mjs
+++ b/scripts/automation-db-recovery.mjs
@@ -1,0 +1,121 @@
+/**
+ * Stale automation SQLite DB recovery.
+ *
+ * When `openhands-automation` is upgraded to a version that restructured its
+ * Alembic migration history, the on-disk `automations.db` can point at a
+ * revision that no longer exists in the new migration chain. Alembic's
+ * `upgrade head` then fails on startup with e.g.:
+ *
+ *   Failed to apply SQLite migrations: Can't locate revision identified by '007'
+ *
+ * The automation backend exits non-zero and the Automate tab becomes
+ * unavailable. This module gives the dev launchers a narrowly-scoped recovery:
+ * detect that specific failure in the service output, delete the stale DB
+ * (plus its SQLite sidecar files) and restart the backend exactly once.
+ *
+ * Kept dependency-free and side-effect-injectable so the detection/retry
+ * behaviour can be unit tested without spawning real processes.
+ */
+
+import { existsSync, rmSync } from "node:fs";
+
+// Patterns that identify a stale-migration startup failure. Kept intentionally
+// specific so unrelated automation crashes are never silently masked.
+export const AUTOMATION_MIGRATION_ERROR_PATTERNS = [
+  /Failed to apply SQLite migrations/i,
+  /Can't locate revision identified by/i,
+];
+
+/**
+ * @param {string} line A single line of automation service output.
+ * @returns {boolean} True if the line matches a stale-migration failure.
+ */
+export function isAutomationMigrationError(line) {
+  if (!line) return false;
+  return AUTOMATION_MIGRATION_ERROR_PATTERNS.some((pattern) =>
+    pattern.test(line),
+  );
+}
+
+/**
+ * SQLite keeps auxiliary files next to the main DB (write-ahead log, shared
+ * memory, rollback journal). A clean reset removes all of them.
+ *
+ * @param {string} dbPath Absolute path to the `automations.db` file.
+ * @returns {string[]} The DB path plus its sidecar files.
+ */
+export function automationDbSidecarPaths(dbPath) {
+  return [dbPath, `${dbPath}-wal`, `${dbPath}-shm`, `${dbPath}-journal`];
+}
+
+/**
+ * Create a recovery helper for a single automation backend launch.
+ *
+ * The returned `handleLine`/`handleExit` callbacks are meant to be wired into
+ * the launcher's `spawnService` for the automation service. Recovery fires at
+ * most once per helper instance: the caller is responsible for arming a fresh
+ * helper only on the first launch attempt so a persistently-broken DB cannot
+ * cause an infinite restart loop.
+ *
+ * @param {object} options
+ * @param {string} options.dbPath Absolute path to the automation SQLite DB.
+ * @param {(message: string) => void} options.log Logger for recovery messages.
+ * @param {() => void} options.restart Re-launches the automation backend.
+ * @param {{ existsSync: Function, rmSync: Function }} [options.fs] Injected fs.
+ * @returns {{ handleLine: (line: string) => void, handleExit: (code: number|null) => boolean }}
+ */
+export function createAutomationDbRecovery({ dbPath, log, restart, fs }) {
+  const fileSystem = fs ?? { existsSync, rmSync };
+  let sawMigrationError = false;
+  let recovered = false;
+
+  return {
+    handleLine(line) {
+      if (!sawMigrationError && isAutomationMigrationError(line)) {
+        sawMigrationError = true;
+      }
+    },
+
+    /**
+     * @returns {boolean} True when a recovery restart was triggered, so the
+     *   caller can suppress the generic "exited with code N" error log.
+     */
+    handleExit(code) {
+      // A clean exit or an already-consumed recovery attempt is not our case.
+      if (code === 0 || code === null) return false;
+      if (recovered || !sawMigrationError) return false;
+
+      recovered = true;
+      log(
+        `Detected a stale automation database (SQLite migration failure). ` +
+          `Resetting ${dbPath} and restarting the automation service once...`,
+      );
+
+      let removedAny = false;
+      for (const path of automationDbSidecarPaths(dbPath)) {
+        try {
+          if (fileSystem.existsSync(path)) {
+            fileSystem.rmSync(path);
+            removedAny = true;
+          }
+        } catch (error) {
+          log(
+            `Failed to delete stale automation DB file ${path}: ${error.message}`,
+          );
+          return false;
+        }
+      }
+
+      if (!removedAny) {
+        log(
+          `No automation database file found at ${dbPath}; skipping automatic ` +
+            `reset. The migration error is likely unrelated to a stale local DB.`,
+        );
+        return false;
+      }
+
+      restart();
+      return true;
+    },
+  };
+}

--- a/scripts/dev-static.mjs
+++ b/scripts/dev-static.mjs
@@ -63,6 +63,7 @@ import {
   buildAutomationTelemetryEnv,
   buildConfig,
 } from "./dev-with-automation.mjs";
+import { createAutomationDbRecovery } from "./automation-db-recovery.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, "..");
@@ -233,7 +234,11 @@ function spawnService(name, command, args, options = {}) {
       .toString()
       .split("\n")
       .filter(Boolean)
-      .forEach((line) => logService(name, line.trim(), color));
+      .forEach((line) => {
+        const trimmed = line.trim();
+        if (options.onLine) options.onLine(trimmed, "stdout");
+        logService(name, trimmed, color);
+      });
   });
 
   proc.stderr.on("data", (data) => {
@@ -241,7 +246,11 @@ function spawnService(name, command, args, options = {}) {
       .toString()
       .split("\n")
       .filter(Boolean)
-      .forEach((line) => logService(name, line.trim(), c.yellow));
+      .forEach((line) => {
+        const trimmed = line.trim();
+        if (options.onLine) options.onLine(trimmed, "stderr");
+        logService(name, trimmed, c.yellow);
+      });
   });
 
   proc.on("error", (error) => {
@@ -249,7 +258,8 @@ function spawnService(name, command, args, options = {}) {
   });
 
   proc.on("exit", (code) => {
-    if (code !== 0 && code !== null && !shuttingDown) {
+    const recovered = options.onExit ? options.onExit(code) : false;
+    if (!recovered && code !== 0 && code !== null && !shuttingDown) {
       logService(name, `Exited with code ${code}`, c.red);
     }
     processes.delete(name);
@@ -341,7 +351,7 @@ function buildAutomationBackendEnv(config, env = process.env) {
   };
 }
 
-function startAutomationBackend(config) {
+function startAutomationBackend(config, attempt = 0) {
   logService(
     "automation",
     `Starting on port ${config.autoBackendPort}...`,
@@ -350,6 +360,21 @@ function startAutomationBackend(config) {
 
   const automationCmd = buildAutomationCommand(process.env);
   logService("automation", `Using ${automationCmd.source}`, c.dim);
+
+  // Absolute path of the SQLite DB the backend will migrate — must match the
+  // AUTOMATION_DB_URL in buildAutomationBackendEnv so recovery deletes the
+  // right file.
+  const automationDbPath = join(config.stateDir, "automations.db");
+  // Arm stale-DB recovery only on the first attempt so a persistently broken
+  // migration can never trigger an infinite restart loop.
+  const recovery =
+    attempt === 0
+      ? createAutomationDbRecovery({
+          dbPath: automationDbPath,
+          log: (message) => logService("automation", message, c.yellow),
+          restart: () => startAutomationBackend(config, attempt + 1),
+        })
+      : null;
 
   spawnService(
     "automation",
@@ -365,6 +390,8 @@ function startAutomationBackend(config) {
       cwd: config.stateDir,
       env: buildAutomationBackendEnv(config),
       color: c.green,
+      onLine: recovery ? recovery.handleLine : undefined,
+      onExit: recovery ? recovery.handleExit : undefined,
     },
   );
 }

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -71,6 +71,7 @@ import {
   signalProcessTree,
 } from "./dev-process-utils.mjs";
 import { fileLog, stripAnsi } from "./logger.mjs";
+import { createAutomationDbRecovery } from "./automation-db-recovery.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, "..");
@@ -592,6 +593,7 @@ function spawnService(name, command, args, options = {}) {
       .filter(Boolean)
       .forEach((line) => {
         const trimmed = line.trim();
+        if (options.onLine) options.onLine(trimmed, "stdout");
         const parsed = parseLogLine ? parseLogLine(trimmed) : null;
         logService(
           name,
@@ -609,6 +611,7 @@ function spawnService(name, command, args, options = {}) {
       .filter(Boolean)
       .forEach((line) => {
         const trimmed = line.trim();
+        if (options.onLine) options.onLine(trimmed, "stderr");
         const parsed = parseLogLine ? parseLogLine(trimmed) : null;
         logService(
           name,
@@ -625,7 +628,8 @@ function spawnService(name, command, args, options = {}) {
   });
 
   proc.on("exit", (code, _signal) => {
-    if (code !== 0 && code !== null && !shuttingDown) {
+    const recovered = options.onExit ? options.onExit(code) : false;
+    if (!recovered && code !== 0 && code !== null && !shuttingDown) {
       logService(name, `Exited with code ${code}`, c.red);
       emitServiceLog(name, `exited with code ${code}`, "error");
     }
@@ -824,7 +828,7 @@ function startAgentServer(config) {
   );
 }
 
-function startAutomationBackend(config) {
+function startAutomationBackend(config, attempt = 0) {
   logService(
     "automation",
     `Starting on port ${config.autoBackendPort}...`,
@@ -833,6 +837,23 @@ function startAutomationBackend(config) {
 
   const automationCmd = buildAutomationCommand(process.env);
   logService("automation", `Using ${automationCmd.source}`, c.dim);
+
+  // Absolute path of the SQLite DB the backend will migrate — must match the
+  // AUTOMATION_DB_URL passed below so recovery deletes the right file.
+  const automationDbPath = join(
+    dirname(config.stateDir),
+    SHARED_DEFAULTS.paths.automationDb,
+  );
+  // Arm stale-DB recovery only on the first attempt so a persistently broken
+  // migration can never trigger an infinite restart loop.
+  const recovery =
+    attempt === 0
+      ? createAutomationDbRecovery({
+          dbPath: automationDbPath,
+          log: (message) => logService("automation", message, c.yellow),
+          restart: () => startAutomationBackend(config, attempt + 1),
+        })
+      : null;
 
   spawnService(
     "automation",
@@ -921,6 +942,8 @@ function startAutomationBackend(config) {
         OPENHANDS_SUPPRESS_BANNER: "1",
       },
       color: c.green,
+      onLine: recovery ? recovery.handleLine : undefined,
+      onExit: recovery ? recovery.handleExit : undefined,
     },
   );
 }


### PR DESCRIPTION
## Summary

Fixes #15623 — the automation backend crashes on startup (exit code 3) and the
**Automate tab becomes unavailable** when `openhands-automation` is upgraded to a
version whose Alembic migration history was restructured. The on-disk
`~/.openhands/automation/automations.db` still points at a revision (e.g. `007`)
that no longer exists in the new migration chain, so `alembic upgrade head` fails:

```
[automation] Failed to apply SQLite migrations: Can't locate revision identified by '007'
[automation] Application startup failed. Exiting.
[automation] Exited with code 3
```

Previously the dev launcher had no recovery, so the tab stayed broken with no guidance.

## What changed

A narrowly-scoped, **launcher-only** auto-recovery:

- **New shared module `scripts/automation-db-recovery.mjs`** with pure, unit-testable logic:
  - `isAutomationMigrationError(line)` — matches only the specific stale-migration
    failure lines, so unrelated automation crashes are never silently masked.
  - `automationDbSidecarPaths(dbPath)` — expands the DB path to its SQLite sidecar
    files (`-wal`, `-shm`, `-journal`) for a clean reset.
  - `createAutomationDbRecovery({ dbPath, log, restart, fs })` — on a
    migration-related **non-zero** exit, deletes the stale DB and restarts the
    backend. `fs` is injectable for testing.
- **Wired into both launchers** (`dev-with-automation.mjs` and `dev-static.mjs`,
  per the maintainer's note that both start the same backend):
  - `spawnService` gains optional `onLine` / `onExit` hooks (backward compatible;
    all existing callers are unaffected).
  - `startAutomationBackend(config, attempt)` arms recovery **only on the first
    attempt**, so a persistently-broken DB can never cause an infinite restart loop.
    Each launcher resolves its own DB path (matching its `AUTOMATION_DB_URL`).
  - A recovered exit suppresses the generic red "Exited with code N" log and
    prints a clear message explaining what was reset and why.

## Behaviour

- Migration error seen → non-zero exit → stale `automations.db` (+ sidecars)
  deleted → backend restarted **once** → Automate tab works again.
- Unrelated crash (no migration error) → DB untouched, no restart, normal error log.
- Clean exit → nothing happens, even if a migration warning appeared earlier.
- No DB file present → no reset, no restart (the failure isn't a stale local DB).

## Testing

- New `__tests__/scripts/automation-db-recovery.test.ts` (8 cases, AAA style):
  detection patterns, sidecar expansion, reset+restart, retry-once guarantee,
  unrelated-crash no-op, clean-exit no-op, and missing-DB no-op.
- `npx vitest run __tests__/scripts/automation-db-recovery.test.ts` → 8/8 pass.
- Existing launcher suites still green: `dev-with-automation.test.ts` +
  `dev-static.test.ts` → 47/47 pass.
- `eslint` clean on all changed files.

## Notes for reviewers

- Recovery is intentionally dev-launcher-scoped and fires at most once; it does not
  change the automation backend itself or any production/Docker path.
- The two launchers use different on-disk DB locations today
  (`dirname(stateDir)/automation/automations.db` vs `stateDir/automations.db`);
  each recovery resolves the path from its own launcher, so both reset the correct file.
