### PR TITLE
chore: remove the human-tested checkbox from the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,14 +2,12 @@
 
 HUMAN:
 
-<!-- Human contributors: add a short note about your testing before checking the box. -->
-
-- [ ] A human has tested these changes.
+<!-- Human contributors: add a short note about your testing. -->
 
 AGENT:
 
 <!-- AI/LLM agents:
-Do not edit the HUMAN section or human-tested checkbox.
+Do not edit the HUMAN section.
 In this AGENT section and the template fields below, provide evidence that the
 code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
 exactly what command you ran and include logs, screenshots, or reproduction notes.

--- a/.github/scripts/check_pr_description.py
+++ b/.github/scripts/check_pr_description.py
@@ -16,7 +16,6 @@ import sys
 from pathlib import Path
 
 
-HUMAN_TESTED_TEXT = "A human has tested these changes."
 # Reject placeholders while allowing a concise human-written sentence.
 MIN_HUMAN_NOTE_CHARS = 20
 # These are the only PR-template sections that must remain and contain content.
@@ -26,18 +25,6 @@ HTML_COMMENT_RE = re.compile(r"<!--[\s\S]*?-->")
 HEADING_RE = re.compile(r"(?m)^##\s+(.+?)\s*$")
 HUMAN_HEADING_RE = re.compile(r"(?im)^\s*HUMAN:\s*$")
 AGENT_HEADING_RE = re.compile(r"(?im)^\s*AGENT:\s*$")
-
-
-def checkbox_re(label: str) -> re.Pattern[str]:
-    return re.compile(rf"(?im)^\s*[-*]\s+\[(?P<mark>[ xX])]\s+{re.escape(label)}\s*$")
-
-
-def checkbox_is_checked(pattern: re.Pattern[str], text: str) -> bool:
-    match = pattern.search(text)
-    return match is not None and match.group("mark").lower() == "x"
-
-
-HUMAN_TESTED_RE = checkbox_re(HUMAN_TESTED_TEXT)
 
 
 def visible_text(text: str) -> str:
@@ -69,16 +56,16 @@ def extract_sections(body: str) -> dict[str, str]:
 
 
 def extract_human_note(body: str) -> str:
-    """Return human-written text in the required location before the checkbox."""
+    """Return human-written text in the required location before `AGENT:`."""
     human_match = HUMAN_HEADING_RE.search(body)
     if human_match is None:
         return ""
 
-    checkbox_match = HUMAN_TESTED_RE.search(body, human_match.end())
-    if checkbox_match is None:
+    agent_match = AGENT_HEADING_RE.search(body, human_match.end())
+    if agent_match is None:
         return ""
 
-    return visible_text(body[human_match.end() : checkbox_match.start()])
+    return visible_text(body[human_match.end() : agent_match.start()])
 
 
 def validate_pr_body(body: str) -> list[str]:
@@ -89,20 +76,7 @@ def validate_pr_body(body: str) -> list[str]:
 
     human_note = extract_human_note(body)
     if len(human_note) < MIN_HUMAN_NOTE_CHARS:
-        errors.append(
-            "Add a short human-written note between `HUMAN:` and "
-            "the human-tested checkbox."
-        )
-
-    human_tested = HUMAN_TESTED_RE.search(body)
-    if human_tested is None:
-        errors.append(
-            f"Keep the `- [ ] {HUMAN_TESTED_TEXT}` checkbox in the PR description."
-        )
-    elif not checkbox_is_checked(HUMAN_TESTED_RE, body):
-        errors.append(
-            "A human must check `A human has tested these changes.` before review."
-        )
+        errors.append("Add a short human-written note between `HUMAN:` and `AGENT:`.")
 
     if AGENT_HEADING_RE.search(body) is None:
         errors.append("Keep the `AGENT:` marker from the PR template.")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,12 +21,11 @@
 
 ## PR Description Human Check
 
-The `HUMAN:` section and the `A human has tested these changes.` checkbox in
-PR descriptions are reserved for human contributors only. AI agents
-MUST NOT add to, edit, move, remove, or check these fields. If the PR description
-CI fails because these fields are missing, empty, or unchecked, stop and ask the
-human user to update them in their own words. If the fields were already updated
-by a human, report the exact validator error rather than editing them yourself.
+The `HUMAN:` section in PR descriptions is reserved for human contributors only.
+AI agents MUST NOT add to, edit, move, or remove it. If the PR description
+CI fails because the section is missing or empty, stop and ask the
+human user to update it in their own words. If the section was already updated
+by a human, report the exact validator error rather than editing it yourself.
 
 ## Tracking / Analytics Architecture
 


### PR DESCRIPTION
HUMAN:

I checked that the PR is doing the correct fix.

AGENT:

Verified by importing `.github/scripts/check_pr_description.py` and running
`validate_pr_body()` against real description bodies built from the updated template:

| body | result |
| --- | --- |
| unfilled template | 4 errors — missing human note, empty `Why` / `Summary` / `How to Test` |
| filled template, no checkbox anywhere | `[]` — passes |
| filled template, 2-char human note | `["Add a short human-written note between \`HUMAN:\` and \`AGENT:\`."]` |
| filled template that still contains the old checkbox | `[]` — back-compat, already-open PRs keep passing |
| filled template with `AGENT:` removed | note error + ``Keep the `AGENT:` marker from the PR template.`` |

Also confirmed no dangling references to the removed `HUMAN_TESTED_TEXT`,
`HUMAN_TESTED_RE`, `checkbox_re`, or `checkbox_is_checked` symbols remain in the file.

`uvx ruff format --diff` reports the file as already formatted. `uvx ruff check`
reports 2 findings (`I001` import sorting, `E501` on line 98) — both are present
unchanged on `main`, so they are pre-existing and deliberately left alone.

---

## Why

The `- [ ] A human has tested these changes.` checkbox duplicated the human-written
testing note directly above it. The note already states what was tested and is
validated for real content, so the checkbox was a second gate carrying no
information the note did not already provide.

## Summary

- Removed the human-tested checkbox from `.github/pull_request_template.md`.
- Dropped the checkbox presence/checked validation from `check_pr_description.py`, and
  re-anchored the human-note extraction to the `AGENT:` marker — the checkbox previously
  delimited the end of the note region, so that anchor had to move with it.
- Updated the `PR Description Human Check` section of `AGENTS.md` to match.

The `HUMAN:` section and its required note are unchanged, as is every other check
(`AGENT:` marker, `Why`, `Summary`, `How to Test`).

## Issue Number

N/A

## How to Test

The description check runs on this PR once it leaves draft, which exercises the new
validator against a real body. To check locally:

```bash
# passes: template with a filled-in human note and no checkbox
python .github/scripts/check_pr_description.py --body-file /tmp/pr-body.md
```

Point `--body-file` at a copy of the new template with the `HUMAN:` note, `## Why`,
`## Summary`, and `## How to Test` filled in — it should print
`PR description validation passed.` with no checkbox present anywhere in the body.
Blanking the human note should produce exactly one error.

## Video/Screenshots

N/A — CI/template change with no UI surface.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Backwards compatible with PRs already open: a description that still contains the old
checkbox continues to validate, whether checked or not. No workflow file changes are
needed — `pr-description-check.yml` runs the script from the base branch, so the new
rules take effect for every PR as soon as this merges.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.37.0-python` |
| **Automation** | `openhands-automation==1.3.1` |
| **Commit** | `7d5558864fbb48ec3191ddacd5557b8e01dcb52a` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-7d55588
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-7d55588
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-7d55588-amd64
ghcr.io/openhands/agent-canvas:remove-human-tested-checkbox-amd64
ghcr.io/openhands/agent-canvas:pr-16122-amd64
ghcr.io/openhands/agent-canvas:sha-7d55588-arm64
ghcr.io/openhands/agent-canvas:remove-human-tested-checkbox-arm64
ghcr.io/openhands/agent-canvas:pr-16122-arm64
ghcr.io/openhands/agent-canvas:sha-7d55588
ghcr.io/openhands/agent-canvas:remove-human-tested-checkbox
ghcr.io/openhands/agent-canvas:pr-16122
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-7d55588`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-7d55588-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->