### PR TITLE
chore: bump software-agent-sdk to 1.38.0 and automation to 1.4.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -491,10 +491,10 @@ When adding code that needs a new string, decide up front which rule it falls un
 - `scripts/dev-safe.mjs` uses `uvx` for temporary agent-server installation — no permanent `uv tool install` needed. Environment variables (highest precedence first):
   - `OH_AGENT_SERVER_LOCAL_PATH` — absolute path to a local `software-agent-sdk` checkout. Runs the local checkout via `uvx` with `--with-editable` for `openhands-sdk`/`openhands-tools`/`openhands-workspace` and `--reinstall` for `openhands-agent-server`, so SDK edits are picked up on restart. Highest precedence.
   - `OH_AGENT_SERVER_GIT_REF` — git commit SHA or branch name (takes precedence over version)
-  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.37.0")
+  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.38.0")
   - `OH_SECRET_KEY` — secret key for settings encryption; auto-generated and persisted to `~/.openhands/agent-canvas/secret-key.txt` on first run (same file Docker uses), ensuring dev mode and Docker share the same key when both mount the same `~/.openhands` directory. Override with the env var to pin a specific key.
   - `SESSION_API_KEY` / `OH_SESSION_API_KEYS_0` / `VITE_SESSION_API_KEY` — session API key for agent-server authentication; auto-generated using `crypto.randomBytes(32)` if not set, passed to both agent-server (`OH_SESSION_API_KEYS_0`) and frontend (`VITE_SESSION_API_KEY`)
-  - Default: released PyPI version `1.37.0` for agent-server SDK libraries
+  - Default: released PyPI version `1.38.0` for agent-server SDK libraries
 
 - Security: launchers generate and persist a 64-character session API key at `~/.openhands/agent-canvas/session-api-key.txt` unless overridden. The agent-server and automation backend share that session key. `OH_SECRET_KEY` protects settings encryption and is persisted separately at `~/.openhands/agent-canvas/secret-key.txt`.
 - `scripts/dev-safe.mjs` should fail fast if `uvx` cannot be spawned (for example missing PATH entries).

--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -389,18 +389,18 @@ describe("buildAgentServerCommand", () => {
     // Defaults to the released PyPI version with all SDK packages pinned to same version
     expect(cmd.args).toEqual([
       "--from",
-      "openhands-agent-server==1.37.0",
+      "openhands-agent-server==1.38.0",
       "--with",
-      "openhands-sdk==1.37.0",
+      "openhands-sdk==1.38.0",
       "--with",
-      "openhands-tools==1.37.0",
+      "openhands-tools==1.38.0",
       "--with",
-      "openhands-workspace==1.37.0",
+      "openhands-workspace==1.38.0",
       "--with",
       "agent-client-protocol<0.11",
       "agent-server",
     ]);
-    expect(cmd.source).toBe("PyPI (1.37.0, default)");
+    expect(cmd.source).toBe("PyPI (1.38.0, default)");
   });
 
   it("uses specific PyPI version when OH_AGENT_SERVER_VERSION is set with all packages pinned", () => {

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,9 +1,9 @@
 {
   "_comment": "Single source of truth for version pins, ports, paths, and defaults shared across the npm and Docker install paths. Read by scripts/dev-safe.mjs, scripts/dev-with-automation.mjs, docker/entrypoint.sh (via generated defaults.env), and .github/workflows/docker.yml.",
   "versions": {
-    "agentServer": "1.37.0",
+    "agentServer": "1.38.0",
     "agentCanvas": "1.6.1",
-    "automation": "1.3.1"
+    "automation": "1.4.1"
   },
   "compatibility": {
     "minimumAgentServer": "1.28.0"

--- a/scripts/check-sdk-version-sync.mjs
+++ b/scripts/check-sdk-version-sync.mjs
@@ -19,7 +19,7 @@
  *
  * Usage:
  *   node scripts/check-sdk-version-sync.mjs
- *   EXPECTED_SDK_VERSION=1.37.0 node scripts/check-sdk-version-sync.mjs
+ *   EXPECTED_SDK_VERSION=1.38.0 node scripts/check-sdk-version-sync.mjs
  *   node scripts/check-sdk-version-sync.mjs --check-pypi
  *
  * Environment variables:
@@ -78,7 +78,7 @@ Triggering from other repos:
     -H "Authorization: token \$GITHUB_TOKEN" \\
     -H "Accept: application/vnd.github.v3+json" \\
     https://api.github.com/repos/OpenHands/agent-canvas/dispatches \\
-    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.37.0"}}'
+    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.38.0"}}'
 `);
   process.exit(0);
 }
@@ -260,9 +260,9 @@ async function fetchPyPIDependencies(packageName, version) {
  * Parse PyPI requires_dist array and extract SDK package versions
  *
  * PyPI returns dependencies in PEP 508 format like:
- *   "openhands-sdk>=1.37.0,<2.0.0"
- *   "openhands-tools==1.37.0"
- *   "openhands-workspace (>=1.37.0)"
+ *   "openhands-sdk>=1.38.0,<2.0.0"
+ *   "openhands-tools==1.38.0"
+ *   "openhands-workspace (>=1.38.0)"
  */
 function parseSdkVersionsFromRequiresDist(requiresDist) {
   const versions = {};
@@ -276,7 +276,7 @@ function parseSdkVersionsFromRequiresDist(requiresDist) {
       }
 
       // Extract the version number - look for patterns like:
-      // ">=1.37.0", "==1.37.0", "(>=1.37.0)", "~=1.37.0"
+      // ">=1.38.0", "==1.38.0", "(>=1.38.0)", "~=1.38.0"
       // After the package name and before any comma or closing paren
       const versionPattern = /[><=~!]+\s*([0-9]+(?:\.[0-9]+)*)/;
       const match = dep.match(versionPattern);

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -48,7 +48,7 @@ const LOCAL_AGENT_SERVER_SUBDIRS = [
   "openhands-workspace",
 ];
 const DEFAULT_AGENT_SERVER_VERSION = SHARED_DEFAULTS.versions.agentServer;
-// Temporary transitive-dep pin: openhands-sdk 1.37.0 leaves agent-client-protocol
+// Temporary transitive-dep pin: openhands-sdk 1.38.0 leaves agent-client-protocol
 // unbounded (>=0.10.1), but acp 0.11.0 reordered the ACP prompt() args and breaks
 // the SDK's ACP client. Hold acp <0.11 until a fixed SDK ships. See config/defaults.json.
 const AGENT_CLIENT_PROTOCOL_CONSTRAINT =
@@ -399,7 +399,7 @@ export function validateFrontendDependencies(
  *   edits are picked up without a manual reinstall. The agent-server itself
  *   is rebuilt from local source on each invocation (--reinstall).
  * - OH_AGENT_SERVER_GIT_REF: Git commit SHA or branch name
- * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.37.0")
+ * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.38.0")
  *
  * If none are set, defaults to the released version specified by
  * DEFAULT_AGENT_SERVER_VERSION. Set OH_AGENT_SERVER_GIT_REF to use a


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

I have verified the changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

<!-- Describe problem, motivation, etc. -->

Keep the agent-server SDK and automation pins current. `openhands-automation==1.4.1` requires the `1.38.0` SDK line, so both pins in `config/defaults.json` — the single source of truth read by `scripts/dev-safe.mjs`, `scripts/dev-with-automation.mjs`, `docker/entrypoint.sh` (via the generated `defaults.env`), `.github/workflows/docker.yml`, and `.github/workflows/mock-llm-e2e.yml` — must move together to stay in sync and keep the `SDK Version Sync` CI check green.

Leaving the SDK pin at `1.37.0` while bumping automation would also make the Docker image install an automation build whose `openhands-sdk==1.38.0` requirement conflicts with the `1.37.0-python` agent-server base image.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Bump `versions.agentServer` (SDK) `1.37.0` → `1.38.0` and `versions.automation` `1.3.1` → `1.4.1` in `config/defaults.json`.
- Sync the version literals that track that default and are asserted by the repo's drift-detection tests: `__tests__/scripts/dev-safe.test.ts`, `scripts/dev-safe.mjs`, `scripts/check-sdk-version-sync.mjs`, and `AGENTS.md`.
- Retain the temporary `agent-client-protocol<0.11` transitive pin — `openhands-sdk 1.38.0` still leaves acp unbounded (`>=0.10.1`) and no ACP fix shipped in this range.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves https://github.com/OpenHands/OpenHands/issues/16128

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

```bash
# 1. Confirm the automation release still pins the SDK line we expect (live PyPI check)
node scripts/check-sdk-version-sync.mjs        # expect "All SDK versions are in sync!"

# 2. Unit tests + typecheck
npx vitest run __tests__/scripts/              # expect 202 passed
npm run typecheck                              # expect clean
npm test                                       # expect full suite green

# 3. End-to-end: boot the real dev stack (uvx-installs the pinned SDK set
#    and runs openhands-automation==1.4.1)
npm install
npm run dev
```

**1. SDK version sync (live PyPI):**

```
Expected automation SDK version: 1.38.0 (from config/defaults.json (versions.agentServer))
Automation package: openhands-automation==1.4.1 (from config/defaults.json (versions.automation))

Fetching https://pypi.org/pypi/openhands-automation/1.4.1/json
Checking openhands-automation==1.4.1 SDK dependencies:

  openhands-sdk             ✓ 1.38.0
  openhands-tools           - not a direct dependency
  openhands-workspace       ✓ 1.38.0
  openhands-agent-server    - not a direct dependency

All SDK versions are in sync!
```

**2. Dependency resolution.** Dry-ran the exact install set `scripts/dev-safe.mjs` builds, and the Docker layering (agent-server base + `pip install openhands-automation`), to confirm neither conflicts nor moves the SDK:

```
$ uv pip install --dry-run "openhands-agent-server==1.38.0" "openhands-sdk==1.38.0" \
    "openhands-tools==1.38.0" "openhands-workspace==1.38.0" "agent-client-protocol<0.11"
Would install 186 packages
 + agent-client-protocol==0.10.1
 + openhands-agent-server==1.38.0
 + openhands-sdk==1.38.0
 + openhands-tools==1.38.0
 + openhands-workspace==1.38.0

$ uv pip install --dry-run "openhands-agent-server==1.38.0" "openhands-automation==1.4.1" \
    "agent-client-protocol<0.11"
Would install 162 packages
 + agent-client-protocol==0.10.1
 + openhands-agent-server==1.38.0
 + openhands-automation==1.4.1
 + openhands-sdk==1.38.0
 + openhands-workspace==1.38.0
```

The Docker base image `ghcr.io/openhands/agent-server:1.38.0-python` exists (GHCR manifest HTTP 200).

**3. Unit tests + typecheck.**

```
npm run typecheck   → clean
npx vitest run __tests__/scripts/   → Test Files 14 passed | Tests 202 passed
npm test            → Test Files 515 passed | 1 skipped (516)
                      Tests 3992 passed | 5 skipped | 9 todo (4006)
```

**4. End-to-end — `npm run dev` with the new pins.** Full stack boots:

```
13:51:30 [agent-server] Using PyPI (1.38.0, default)
13:51:49 [agent-server] INFO  Uvicorn running on http://127.0.0.1:18000 (Press CTRL+C to quit)
13:51:49 [automation]   Using PyPI (1.4.1, default)
13:51:52 [vite]         ➜  Local:   http://localhost:3001/
13:52:04 [automation]   {"message": "Application startup complete.", "severity": "INFO"}
13:52:04 [automation]   {"message": "Uvicorn running on http://127.0.0.1:18001 (Press CTRL+C to quit)"}
```

Live endpoint probes — both services agree on `1.38.0` at runtime, which is the invariant `check-sdk-version-sync.mjs` enforces statically:

```
$ curl -H "X-Session-API-Key: $KEY" http://127.0.0.1:18000/server_info
{
  "title": "OpenHands Agent Server",
  "version": "1.38.0",
  "sdk_version": "1.38.0",
  "tools_version": "1.38.0",
  "workspace_version": "1.38.0",
  ...
}

$ curl -H "X-Session-API-Key: $KEY" http://127.0.0.1:18001/api/automation/v1
200 {"automations":[],"total":0}

$ curl -H "X-Session-API-Key: $KEY" http://127.0.0.1:18001/api/automation/sdk-version
200 {"version":"1.38.0"}

$ curl -o /dev/null -w "%{http_code}" http://localhost:3001/
200
```

No errors or tracebacks in the stack log.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

_N/A — no UI changes. This is a version-pin bump; verification is the CLI and live-endpoint output shown in the AGENT section above._

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.38.0-python` |
| **Automation** | `openhands-automation==1.4.1` |
| **Commit** | `f205c3a1c15a6ce1a7430f25fc62c19fe9c8f5ad` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-f205c3a
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-f205c3a
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-f205c3a-amd64
ghcr.io/openhands/agent-canvas:hieptl-oss-8603-amd64
ghcr.io/openhands/agent-canvas:pr-16129-amd64
ghcr.io/openhands/agent-canvas:sha-f205c3a-arm64
ghcr.io/openhands/agent-canvas:hieptl-oss-8603-arm64
ghcr.io/openhands/agent-canvas:pr-16129-arm64
ghcr.io/openhands/agent-canvas:sha-f205c3a
ghcr.io/openhands/agent-canvas:hieptl-oss-8603
ghcr.io/openhands/agent-canvas:pr-16129
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-f205c3a`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-f205c3a-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->