### PR TITLE
fix: persist cloud conversation title updates

### DIFF
--- a/__tests__/api/cloud/conversation-title.test.ts
+++ b/__tests__/api/cloud/conversation-title.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetActiveStoreForTests,
+  setActiveSelection,
+  setRegisteredBackends,
+} from "#/api/backend-registry/active-store";
+import type { Backend } from "#/api/backend-registry/types";
+import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
+import {
+  getFetchCall,
+  getJsonBody,
+  mockJsonResponse,
+} from "./fetch-test-utils";
+
+vi.mock("@openhands/typescript-client/clients", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@openhands/typescript-client/clients")
+    >();
+
+  return {
+    ...actual,
+    ConversationClient: vi.fn().mockImplementation(() => ({
+      updateConversation: vi
+        .fn()
+        .mockRejectedValue(
+          new Error("Cloud title updates must not use ConversationClient"),
+        ),
+    })),
+  };
+});
+
+const cloudBackend: Backend = {
+  id: "prod",
+  name: "Production",
+  host: "https://app.all-hands.dev",
+  apiKey: "bearer-token",
+  kind: "cloud",
+};
+
+const originalFetch = global.fetch;
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(
+    mockJsonResponse({ id: "conv-abc", title: "Renamed conversation" }),
+  );
+  global.fetch = fetchMock as typeof fetch;
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+  fetchMock.mockReset();
+  global.fetch = originalFetch;
+});
+
+describe("AgentServerConversationService.updateConversationTitle", () => {
+  it("PATCHes the app-conversation directly on a cloud backend", async () => {
+    setRegisteredBackends([cloudBackend]);
+    setActiveSelection({ backendId: cloudBackend.id });
+
+    const result = await AgentServerConversationService.updateConversationTitle(
+      "conv-abc",
+      "Renamed conversation",
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = getFetchCall(fetchMock);
+    expect(url).toBe(`${cloudBackend.host}/api/v1/app-conversations/conv-abc`);
+    expect(init).toMatchObject({
+      method: "PATCH",
+      headers: { Authorization: "Bearer bearer-token" },
+    });
+    expect(getJsonBody(init)).toEqual({ title: "Renamed conversation" });
+    expect(result).toMatchObject({
+      id: "conv-abc",
+      title: "Renamed conversation",
+    });
+  });
+});

--- a/src/api/cloud/conversation-service.api.ts
+++ b/src/api/cloud/conversation-service.api.ts
@@ -190,6 +190,24 @@ export async function updateCloudConversationPublicFlag(
 }
 
 /**
+ * Rename a cloud v1 app-conversation. The title belongs to the Cloud
+ * app-conversation resource, so updating a runtime Agent Server would not
+ * persist it in the Cloud conversation list.
+ */
+export async function updateCloudConversationTitle(
+  conversationId: string,
+  title: string,
+): Promise<AppConversation> {
+  const backend = getActiveCloudBackend();
+  return callCloudProxy<AppConversation>({
+    backend,
+    method: "PATCH",
+    path: `/api/v1/app-conversations/${conversationId}`,
+    body: { title },
+  });
+}
+
+/**
  * Pause the cloud sandbox backing a v1 app-conversation. Mirrors
  * OpenHands' `SandboxService.pauseSandbox`:
  * `POST /api/v1/sandboxes/{sandboxId}/pause` on the cloud backend, which stops

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -33,6 +33,7 @@ import {
   readCloudConversationFile,
   searchCloudConversations,
   updateCloudConversationPublicFlag,
+  updateCloudConversationTitle,
 } from "../cloud/conversation-service.api";
 import {
   DirectConversationInfo,
@@ -707,6 +708,10 @@ class AgentServerConversationService {
     conversationId: string,
     title: string,
   ): Promise<AppConversation> {
+    if (getActiveBackend().backend.kind === "cloud") {
+      return updateCloudConversationTitle(conversationId, title);
+    }
+
     await new ConversationClient(
       getAgentServerClientOptions(),
     ).updateConversation(conversationId, {

--- a/tests/e2e/cloud-conversation-rename.spec.ts
+++ b/tests/e2e/cloud-conversation-rename.spec.ts
@@ -1,0 +1,191 @@
+import { expect, test } from "@playwright/test";
+
+const CLOUD_HOST = "https://cloud.example.test";
+const CONVERSATION_ID = "cloud-conversation-1";
+
+test("renames a cloud conversation and keeps the title after refetch", async ({
+  page,
+}) => {
+  test.setTimeout(60_000);
+
+  await page.addInitScript(
+    ({ cloudHost, conversationId }) => {
+      const originalFetch = window.fetch.bind(window);
+      const jsonResponse = (body: unknown) =>
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      const getTitle = () =>
+        window.localStorage.getItem("cloud-e2e-title") ??
+        "Original cloud title";
+      const getConversation = () => ({
+        id: conversationId,
+        created_by_user_id: "user-1",
+        selected_repository: null,
+        selected_branch: null,
+        git_provider: null,
+        title: getTitle(),
+        trigger: null,
+        pr_number: [],
+        llm_model: null,
+        metrics: null,
+        created_at: "2026-01-01T00:00:00.000Z",
+        updated_at: "2026-01-01T00:00:00.000Z",
+        execution_status: "idle",
+        conversation_url: null,
+        session_api_key: null,
+        sandbox_id: null,
+        workspace: { working_dir: "/workspace/project" },
+        public: false,
+        sub_conversation_ids: [],
+      });
+
+      const state = window as unknown as {
+        __cloudRenameRequests: Array<{
+          authorization: string | null;
+          body: unknown;
+        }>;
+      };
+      state.__cloudRenameRequests = [];
+
+      window.fetch = async (input, init) => {
+        const request = new Request(input, init);
+        const url = new URL(request.url);
+
+        if (url.origin !== cloudHost) {
+          return originalFetch(input, init);
+        }
+
+        if (url.pathname === "/api/keys/current") {
+          return jsonResponse({ org_id: null });
+        }
+
+        if (url.pathname === "/api/v1/settings") {
+          return jsonResponse({
+            llm_model: "openhands/claude-haiku-4-5-20251001",
+            llm_api_key_set: true,
+            agent_settings: { agent_kind: "openhands" },
+            user_consents_to_analytics: false,
+          });
+        }
+
+        if (url.pathname === "/api/v1/settings/profiles") {
+          return jsonResponse({ profiles: [], active_profile: null });
+        }
+
+        if (url.pathname === "/api/agent-profiles") {
+          return jsonResponse({
+            profiles: [],
+            active_agent_profile_id: null,
+          });
+        }
+
+        if (url.pathname === "/api/organizations") {
+          return jsonResponse({ items: [], current_org_id: null });
+        }
+
+        if (url.pathname === "/api/v1/skills/search") {
+          return jsonResponse({ items: [], next_page_id: null });
+        }
+
+        if (url.pathname === "/api/automation/sdk-version") {
+          return jsonResponse({ version: null });
+        }
+
+        if (
+          request.method === "GET" &&
+          url.pathname === "/api/v1/app-conversations/search"
+        ) {
+          return jsonResponse({
+            items: [getConversation()],
+            next_page_id: null,
+          });
+        }
+
+        if (
+          request.method === "PATCH" &&
+          url.pathname === `/api/v1/app-conversations/${conversationId}`
+        ) {
+          const body = (await request.clone().json()) as { title: string };
+          window.localStorage.setItem("cloud-e2e-title", body.title);
+          state.__cloudRenameRequests.push({
+            authorization: request.headers.get("authorization"),
+            body,
+          });
+          return jsonResponse(getConversation());
+        }
+
+        return jsonResponse({});
+      };
+
+      window.localStorage.setItem("analytics-consent", "false");
+      window.localStorage.setItem("openhands-telemetry-consent", "denied");
+      window.localStorage.setItem("openhands-telemetry-first-use", "true");
+      window.localStorage.setItem("openhands-onboarded", "1");
+      window.localStorage.setItem(
+        "openhands-backends",
+        JSON.stringify([
+          {
+            id: "cloud-e2e",
+            name: "Cloud E2E",
+            host: cloudHost,
+            apiKey: "cloud-test-token",
+            kind: "cloud",
+          },
+        ]),
+      );
+      window.localStorage.setItem(
+        "openhands-active-backend",
+        JSON.stringify({ backendId: "cloud-e2e", orgId: null }),
+      );
+    },
+    { cloudHost: CLOUD_HOST, conversationId: CONVERSATION_ID },
+  );
+
+  await page.goto("/conversations");
+
+  const originalCard = page
+    .getByTestId("conversation-card")
+    .filter({ hasText: "Original cloud title" });
+  await expect(originalCard).toBeVisible({ timeout: 20_000 });
+  const card = page.getByTestId("conversation-card").first();
+  await card.hover();
+  await card.getByTestId("ellipsis-button").click();
+  await page.getByTestId("edit-button").click();
+
+  const titleInput = card.getByTestId("conversation-card-title");
+  await titleInput.fill("Renamed in Cloud");
+  await titleInput.press("Enter");
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as unknown as {
+              __cloudRenameRequests: Array<{
+                authorization: string | null;
+                body: unknown;
+              }>;
+            }
+          ).__cloudRenameRequests,
+      ),
+    )
+    .toEqual([
+      {
+        authorization: "Bearer cloud-test-token",
+        body: { title: "Renamed in Cloud" },
+      },
+    ]);
+  await expect(card.getByTestId("conversation-card-title")).toHaveText(
+    "Renamed in Cloud",
+  );
+
+  await page.reload();
+  await expect(
+    page
+      .getByTestId("conversation-card")
+      .filter({ hasText: "Renamed in Cloud" }),
+  ).toBeVisible({ timeout: 20_000 });
+});


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

亲自查看了代码改动；
亲自核对了 CI/自动测试结果；
点击 Files changed，浏览这 4 个改动文件。
点击 Checks，确认 Ubuntu、Windows、Mock-LLM E2E 是绿色。
本地单元测试以及E2E测试

AGENT:

Ran the checked-in Playwright regression in Chromium against `npm run dev:mock`. Port 3001 was already occupied locally, so the temporary local Playwright config changed only the web-server port and `baseURL` to 3102.

```text
Running 1 test using 1 worker
  1 passed (19.3s)
```

The browser test opens the real conversations UI with a Cloud backend, renames a conversation through the context menu, verifies the authenticated Cloud PATCH payload, reloads the page, and confirms the renamed title is returned by the subsequent Cloud refetch.

Additional validation:

```text
npm test -- __tests__/api/agent-server-conversation-service.test.ts __tests__/api/cloud/conversation-public-flag.test.ts __tests__/api/cloud/conversation-title.test.ts __tests__/components/features/conversation/conversation-name.test.tsx --reporter=dot
Test Files  4 passed (4)
Tests       62 passed (62)

npm run typecheck:staged
completed successfully

npm run build:app
completed successfully
```

---

## Why

Renaming a conversation while a Cloud backend is active currently updates the runtime Agent Server instead of the Cloud app-conversation resource. The UI optimistically shows the new title, but the next Cloud list refetch restores the old title because the Cloud source of truth was never changed.

## Summary

- Route Cloud conversation title updates to `PATCH /api/v1/app-conversations/{conversation_id}`.
- Preserve the existing `ConversationClient` update path for local Agent Server backends.
- Add API regression coverage and a stateful browser test that proves the title survives a Cloud refetch.

## Issue Number

Closes #15830

## How to Test

1. Run the focused API and component tests:
   ```bash
   npm test -- __tests__/api/agent-server-conversation-service.test.ts __tests__/api/cloud/conversation-public-flag.test.ts __tests__/api/cloud/conversation-title.test.ts __tests__/components/features/conversation/conversation-name.test.tsx
   ```
2. Run the browser regression:
   ```bash
   npx playwright test tests/e2e/cloud-conversation-rename.spec.ts --project=chromium
   ```
3. Alternatively, connect a Cloud backend, rename a conversation from the conversations page, and refresh. The new title should remain visible.

## Video/Screenshots

The browser flow is captured as an automated Playwright regression; the exact reproduction path and passing run log are included in the `AGENT:` section above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

A full local `npm test -- --reporter=dot` run completed with 513 files passing and 3 files failing. The same 5 failures were reproduced after stashing this PR's changes and rerunning those files on the clean `main` commit: four Windows path-separator assertions and one existing `NewConversation` interaction test. They are unrelated to this change.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.56s · commit 302ff17  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 5/5 hunks, 4/4 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 8.0% | No direct hunk selected |
| Weakened authorization | 14.0% | No direct hunk selected |
| Contract regression | 11.0% | No direct hunk selected |
| Data loss | 5.0% | No direct hunk selected |
| Sensitive data disclosure | 5.0% | No direct hunk selected |
| Unexpected data transfer | 4.0% | No direct hunk selected |
| Credential misuse | 10.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 4.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 3.0% | No direct hunk selected |
| Security assessment bypass | 4.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 93.0% | No primary concern to locate |

</details>


<!-- jev-input-signature c8010d244bf96e21e1159f01e3dc0b6556469c67a839994a53674db07eb9e6e6 -->
<!-- jev-fast-audit:end -->
