### PR TITLE
ci: disable tag publish triggers for release migration

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,8 +4,6 @@ name: Docker
 on:
   push:
     branches: [main]
-    tags:
-      - "v*"
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,9 +1,6 @@
 name: Publish to npm
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

I've tested that BE connect shows up with cookie based auth.

- [X] A human has tested these changes.

AGENT:

This PR was created by an AI agent (OpenHands) on behalf of the user.

Changed only GitHub Actions trigger configuration. I inspected the rendered diff to confirm:

- `.github/workflows/npm-publish.yml` no longer runs automatically on `v*` tag pushes.
- `.github/workflows/docker.yml` no longer runs on `v*` tag pushes, while keeping `push` on `main`, `pull_request`, and `workflow_dispatch` behavior.

No runtime tests were run because this is a temporary workflow-trigger safety change for release-tag migration and does not affect application code.

---

## Why

Agent Canvas release tags/releases need to be migrated into `OpenHands/OpenHands`. Historical Agent Canvas tags use the `v*` namespace, and the existing npm/Docker publish workflows automatically run on `v*` tag pushes. Temporarily disabling those tag triggers avoids accidental npm or Docker publication while release tags are imported.

## Summary

- Temporarily removes the `v*` push trigger from `Publish to npm`.
- Temporarily removes the `v*` push trigger from `Docker`.
- Keeps manual dispatch publishing and normal Docker branch/PR behavior available.

## Issue Number

N/A

## How to Test

Review the workflow trigger diff:

```bash
git diff main...agent/disable-publish-tags-release-migration -- .github/workflows/npm-publish.yml .github/workflows/docker.yml
```

Expected result:

- `npm-publish.yml` only has `workflow_dispatch` under `on:`.
- `docker.yml` still has `push.branches: [main]`, `pull_request`, and `workflow_dispatch`, but no `push.tags` entry.

## Video/Screenshots

N/A — workflow trigger-only change.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This is intended to be temporary. After the release/tag migration is complete, open a follow-up PR to restore the `v*` tag triggers.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/cd9bf054-dc93-41ac-ad86-dbb67aff0d0f)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.38.0-python` |
| **Automation** | `openhands-automation==1.4.1` |
| **Commit** | `5897266c0bed9f859aee3109420d6348c3f46f83` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-5897266
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-5897266
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-5897266-amd64
ghcr.io/openhands/agent-canvas:agent-disable-publish-tags-release-migration-amd64
ghcr.io/openhands/agent-canvas:pr-16133-amd64
ghcr.io/openhands/agent-canvas:sha-5897266-arm64
ghcr.io/openhands/agent-canvas:agent-disable-publish-tags-release-migration-arm64
ghcr.io/openhands/agent-canvas:pr-16133-arm64
ghcr.io/openhands/agent-canvas:sha-5897266
ghcr.io/openhands/agent-canvas:agent-disable-publish-tags-release-migration
ghcr.io/openhands/agent-canvas:pr-16133
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-5897266`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-5897266-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->