### PR TITLE
fix(frontend): stop streaming re-render storm (#12681)

### DIFF
--- a/src/components/conversation-events/chat/event-message.tsx
+++ b/src/components/conversation-events/chat/event-message.tsx
@@ -134,7 +134,22 @@ const renderUserMessageWithSkillReady = (
   }
 };
 
-export function EventMessage({
+const areEventMessagePropsEqual = (
+  prev: Readonly<EventMessageProps>,
+  next: Readonly<EventMessageProps>,
+): boolean =>
+  prev.event === next.event &&
+  prev.isLastMessage === next.isLastMessage &&
+  prev.isInLast10Actions === next.isInLast10Actions &&
+  prev.planPreviewEventIds === next.planPreviewEventIds &&
+  prev.suppressThought === next.suppressThought &&
+  // Compare length, not the array ref: the ref changes every streaming
+  // token, but length only changes when a genuinely new event arrives —
+  // which is exactly when observation cards (which do `messages.find(...)`
+  // below) must re-render.
+  prev.messages.length === next.messages.length;
+
+export const EventMessage = React.memo(function EventMessage({
   event,
   messages,
   isLastMessage,
@@ -344,4 +359,6 @@ export function EventMessage({
   return (
     <GenericEventMessageWrapper event={event} isLastMessage={isLastMessage} />
   );
-}
+}, areEventMessagePropsEqual);
+
+EventMessage.displayName = "EventMessage";

--- a/src/components/conversation-events/chat/hooks/use-plan-preview-events.ts
+++ b/src/components/conversation-events/chat/hooks/use-plan-preview-events.ts
@@ -85,23 +85,33 @@ export interface PlanPreviewEventInfo {
  * @returns Set of event IDs that should render PlanPreview
  */
 export function usePlanPreviewEvents(allEvents: OpenHandsEvent[]): Set<string> {
-  return useMemo(() => {
-    const planPreviewEventIds = new Set<string>();
-
-    // Group events by phases (user message boundaries)
+  // Derive a stable string key from the collected plan-preview ids, keyed on
+  // the *content* of the result (which ids were selected) rather than the
+  // `allEvents` array reference. During streaming, every token produces a fresh
+  // `allEvents` ref even though only the last event's content changed, so this
+  // memo recomputes — but the returned string is value-equal across tokens as
+  // long as no new Plan.md observation arrived.
+  const planPreviewKey = useMemo(() => {
     const phases = groupEventsByPhase(allEvents);
-
-    // For each phase, find the last PlanningFileEditorObservation
+    const ids: string[] = [];
     phases.forEach((phase) => {
       const lastPlanningObservationId =
         findLastPlanningObservationInPhase(phase);
-      if (lastPlanningObservationId) {
-        planPreviewEventIds.add(lastPlanningObservationId);
-      }
+      if (lastPlanningObservationId) ids.push(lastPlanningObservationId);
     });
-
-    return planPreviewEventIds;
+    return ids.join("\n");
   }, [allEvents]);
+
+  // Strings compare by value in useMemo deps, so when no new Plan.md
+  // observation arrived `planPreviewKey` is value-equal and the Set keeps its
+  // identity across streaming tokens.
+  return useMemo(() => {
+    const planPreviewEventIds = new Set<string>();
+    if (planPreviewKey) {
+      planPreviewKey.split("\n").forEach((id) => planPreviewEventIds.add(id));
+    }
+    return planPreviewEventIds;
+  }, [planPreviewKey]);
 }
 
 /**

--- a/src/components/features/chat/chat-message.tsx
+++ b/src/components/features/chat/chat-message.tsx
@@ -30,7 +30,7 @@ interface ChatMessageProps {
   onStop?: () => void;
 }
 
-export function ChatMessage({
+export const ChatMessage = React.memo(function ChatMessage({
   type,
   message,
   children,
@@ -283,4 +283,6 @@ export function ChatMessage({
   }
 
   return messageBubble;
-}
+});
+
+ChatMessage.displayName = "ChatMessage";

--- a/src/components/features/markdown/markdown-renderer.tsx
+++ b/src/components/features/markdown/markdown-renderer.tsx
@@ -1,3 +1,4 @@
+import React, { useMemo } from "react";
 import Markdown, { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
@@ -14,6 +15,34 @@ import { table, th, td } from "./table";
 import { blockquote } from "./blockquote";
 import { hr } from "./horizontal-rule";
 import { remarkGithubAlerts } from "./remark-github-alerts";
+
+// Static component maps hoisted to module scope so they keep stable identity
+// across renders. The combined `components` object passed to <Markdown/> is
+// derived from these via useMemo; without hoisting, every render built a new
+// object/array, which defeated React.memo on consumers and re-parsed markdown
+// for every streaming token.
+const DEFAULT_COMPONENTS: Partial<Components> = {
+  code,
+  ul,
+  ol,
+  li,
+  hr,
+  table,
+  th,
+  td,
+  blockquote,
+};
+const STANDARD_COMPONENTS: Partial<Components> = { a: anchor, p: paragraph };
+const HEADING_COMPONENTS: Partial<Components> = {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+};
+
+const REMARK_PLUGINS = [remarkGithubAlerts, remarkGfm, remarkBreaks];
 
 // Build a sanitize schema that extends rehype-sanitize's defaults with a
 // few markdown-friendly additions. The defaults strip `<script>`, event
@@ -131,7 +160,7 @@ interface MarkdownRendererProps {
  * - includeHeadings: adds h1-h6 heading components
  * - components prop: allows custom overrides or additional components
  */
-export function MarkdownRenderer({
+export const MarkdownRenderer = React.memo(function MarkdownRenderer({
   children,
   content,
   components: customComponents,
@@ -139,31 +168,21 @@ export function MarkdownRenderer({
   includeHeadings = false,
   allowHtml = true,
 }: MarkdownRendererProps) {
-  // Build the components object with defaults and optional additions
-  const components: Components = {
-    code,
-    ul,
-    ol,
-    li,
-    hr,
-    table,
-    th,
-    td,
-    blockquote,
-    ...(includeStandard && {
-      a: anchor,
-      p: paragraph,
-    }),
-    ...(includeHeadings && {
-      h1,
-      h2,
-      h3,
-      h4,
-      h5,
-      h6,
-    }),
-    ...customComponents, // Custom components override defaults
-  };
+  // Build the components object with defaults and optional additions. Memoized
+  // on the flags/custom overrides so the object keeps identity across renders
+  // when the inputs are unchanged — otherwise React.memo consumers re-rendered
+  // and markdown re-parsed on every streaming token.
+  const components = useMemo<Components>(() => {
+    if (!includeStandard && !includeHeadings && !customComponents) {
+      return DEFAULT_COMPONENTS as Components;
+    }
+    return {
+      ...DEFAULT_COMPONENTS,
+      ...(includeStandard ? STANDARD_COMPONENTS : {}),
+      ...(includeHeadings ? HEADING_COMPONENTS : {}),
+      ...customComponents, // Custom components override defaults
+    } as Components;
+  }, [includeStandard, includeHeadings, customComponents]);
 
   const markdownContent = content ?? children ?? "";
 
@@ -171,19 +190,25 @@ export function MarkdownRenderer({
   // tree. `rehype-sanitize` then strips anything dangerous (scripts,
   // event handlers, `javascript:` URLs, etc.). The order matters: sanitize
   // must run *after* raw so it sees the parsed HTML nodes.
-  const rehypePlugins: PluggableList | undefined = allowHtml
-    ? [rehypeRaw, [rehypeSanitize, MARKDOWN_SANITIZE_SCHEMA]]
-    : undefined;
+  const rehypePlugins = useMemo<PluggableList | undefined>(
+    () =>
+      allowHtml
+        ? [rehypeRaw, [rehypeSanitize, MARKDOWN_SANITIZE_SCHEMA]]
+        : undefined,
+    [allowHtml],
+  );
 
   return (
     <div data-testid="markdown-renderer">
       <Markdown
         components={components}
-        remarkPlugins={[remarkGithubAlerts, remarkGfm, remarkBreaks]}
+        remarkPlugins={REMARK_PLUGINS}
         rehypePlugins={rehypePlugins}
       >
         {markdownContent}
       </Markdown>
     </div>
   );
-}
+});
+
+MarkdownRenderer.displayName = "MarkdownRenderer";


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

HUMAN:

Migrated from https://github.com/OpenHands/agent-canvas/pull/1822

I tested this by building it into a deployed agent-canvas image and running a long streaming session. The UI stays responsive throughout the stream. Previously, the window freezes when the LLM is streaming thinking block contents at a fast pace.

- [x] A human has tested these changes.

AGENT:

---

## Why

During token streaming (logs / terminal output), every store merge produces a **fresh `events` array reference**, so every chat card re-renders and **re-parses its markdown on every single token**. The cost grows with conversation length, surfacing as high client-side GPU (~30%) and UI freeze — the symptoms in OpenHands #12681 https://github.com/OpenHands/OpenHands/issues/12681.

## Summary

- Minimal, dependency-free memoization so **only the live streaming bubble re-renders per token**; all prior cards stay referentially stable.
- `EventMessage`: `React.memo` with a custom comparator that compares the event ref, live-state flags, `planPreviewEventIds` ref, `suppressThought`, and `messages.length` (not the array ref).
- `usePlanPreviewEvents`: split into two `useMemo`s keyed on a stable string of collected ids, so the returned `Set` keeps identity across streaming tokens.
- `MarkdownRenderer`: hoist static default components + remark/rehype plugins to module scope; `useMemo` the combined `components`/`rehypePlugins`; wrap in `React.memo`.
- `ChatMessage`: wrap in `React.memo` (shallow compare).

## Issue Number

#12681

## How to Test

1. `npm install && npm run make-i18n && npm run build` (or `npm run dev`).
2. Open a conversation and run an agent that streams a long log / terminal output (e.g. a step that emits many tokens).
3. With DevTools → Performance (or the OS GPU monitor), observe during streaming:
   - **Before:** GPU spikes ~30% and the UI janks/freezes; cost grows with conversation length.
   - **After:** only the streaming bubble re-renders; prior cards do not re-parse markdown; GPU stays flat and the UI stays responsive.
4. Sanity: scroll back through a long conversation mid-stream and confirm cards render correctly and no message content is lost.

## Video/Screenshots

_(Optional — a short screen recording of a long streaming session showing flat GPU / responsive UI vs. the pre-fix freeze would strengthen this. Not required for a pure perf fix.)_

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Pure frontend rendering changes only — no backend, API, websocket, or build-config changes.
- No new dependencies; uses `React.memo` / `useMemo` only.
- The custom `EventMessage` comparator deliberately compares `messages.length` rather than the array ref (which changes every token) — this is the core of the fix.
- This PR was created by an AI agent (OpenHands) on behalf of the maintainer.
