### PR TITLE
fix(clipboard): add execCommand fallback for HTTP non-secure context

### DIFF
--- a/__tests__/components/buttons/copyable-content-wrapper.test.tsx
+++ b/__tests__/components/buttons/copyable-content-wrapper.test.tsx
@@ -1,9 +1,22 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { CopyableContentWrapper } from "#/components/shared/buttons/copyable-content-wrapper";
 
+const toastMocks = vi.hoisted(() => ({
+  displayErrorToast: vi.fn(),
+}));
+
+vi.mock("#/utils/custom-toast-handlers", () => ({
+  displayErrorToast: toastMocks.displayErrorToast,
+}));
+
 describe("CopyableContentWrapper", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    toastMocks.displayErrorToast.mockClear();
+  });
+
   it("should hide the copy button by default", () => {
     render(
       <CopyableContentWrapper text="hello">
@@ -55,6 +68,29 @@ describe("CopyableContentWrapper", () => {
     expect(screen.getByTestId("copy-to-clipboard")).toHaveAttribute(
       "aria-label",
       "BUTTON$COPIED",
+    );
+  });
+
+  it("shows an error toast and stays in copy mode when the clipboard rejects", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(navigator.clipboard, "writeText").mockRejectedValue(
+      new Error("denied"),
+    );
+
+    render(
+      <CopyableContentWrapper text="copy me">
+        <p>content</p>
+      </CopyableContentWrapper>,
+    );
+
+    await user.click(screen.getByTestId("copy-to-clipboard"));
+
+    expect(toastMocks.displayErrorToast).toHaveBeenCalledWith(
+      "CHAT_INTERFACE$CHAT_MESSAGE_COPY_FAILED",
+    );
+    expect(screen.getByTestId("copy-to-clipboard")).toHaveAttribute(
+      "aria-label",
+      "BUTTON$COPY",
     );
   });
 });

--- a/__tests__/components/chat-message.test.tsx
+++ b/__tests__/components/chat-message.test.tsx
@@ -1,10 +1,22 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import util from "util";
 import { ChatMessage } from "#/components/features/chat/chat-message";
 
+const toastMocks = vi.hoisted(() => ({
+  displayErrorToast: vi.fn(),
+}));
+
+vi.mock("#/utils/custom-toast-handlers", () => ({
+  displayErrorToast: toastMocks.displayErrorToast,
+}));
+
 describe("ChatMessage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    toastMocks.displayErrorToast.mockClear();
+  });
   it("does not update the parent while measuring user-message truncation", async () => {
     // Regression test for the React warning:
     //   "Cannot update a component (`ChatMessage`) while rendering a different
@@ -135,6 +147,27 @@ describe("ChatMessage", () => {
 
     await waitFor(() =>
       expect(navigator.clipboard.readText()).resolves.toBe("Hello, World!"),
+    );
+  });
+
+  it("shows an error toast and stays in copy mode when the clipboard rejects", async () => {
+    vi.spyOn(navigator.clipboard, "writeText").mockRejectedValue(
+      new Error("denied"),
+    );
+
+    const user = userEvent.setup();
+    render(<ChatMessage type="user" message="Hello, World!" />);
+
+    await user.click(screen.getByTestId("copy-to-clipboard"));
+
+    await waitFor(() =>
+      expect(toastMocks.displayErrorToast).toHaveBeenCalledWith(
+        "CHAT_INTERFACE$CHAT_MESSAGE_COPY_FAILED",
+      ),
+    );
+    expect(screen.getByTestId("copy-to-clipboard")).toHaveAttribute(
+      "aria-label",
+      "BUTTON$COPY",
     );
   });
 

--- a/__tests__/utils/clipboard.test.ts
+++ b/__tests__/utils/clipboard.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import { copyToClipboard } from "#/utils/clipboard";
+
+// jsdom does not define navigator.clipboard or document.execCommand, and the
+// util tests do not pull in @testing-library/user-event (which polyfills the
+// clipboard). Stub both globals explicitly so the helper is exercised in
+// isolation.
+describe("copyToClipboard", () => {
+  let writeText: ReturnType<typeof vi.fn>;
+  let execCommand: ReturnType<typeof vi.fn>;
+  let restoreClipboard: () => void;
+
+  beforeEach(() => {
+    writeText = vi.fn();
+    execCommand = vi.fn();
+    const previous = navigator.clipboard;
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    restoreClipboard = () => {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: previous,
+      });
+    };
+    // jsdom does not define document.execCommand, so define it directly rather
+    // than spying on a missing property.
+    document.execCommand =
+      execCommand as unknown as typeof document.execCommand;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    restoreClipboard();
+    // @ts-expect-error restore jsdom's undefined
+    delete document.execCommand;
+  });
+
+  it("uses navigator.clipboard.writeText when it succeeds", async () => {
+    writeText.mockResolvedValue(undefined);
+
+    const ok = await copyToClipboard("hello");
+
+    expect(ok).toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  it("falls back to execCommand when writeText rejects", async () => {
+    writeText.mockRejectedValue(new Error("denied"));
+    execCommand.mockReturnValue(true);
+
+    const ok = await copyToClipboard("recover");
+
+    expect(ok).toBe(true);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("returns false when both clipboard and execCommand fail", async () => {
+    writeText.mockRejectedValue(new Error("denied"));
+    execCommand.mockReturnValue(false);
+
+    const ok = await copyToClipboard("nope");
+
+    expect(ok).toBe(false);
+  });
+
+  it("falls back to execCommand when navigator.clipboard is undefined", async () => {
+    // Drop the clipboard entirely, as in a non-secure HTTP context.
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      get: () => undefined,
+    });
+    execCommand.mockReturnValue(true);
+
+    const ok = await copyToClipboard("fallback text");
+
+    expect(ok).toBe(true);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+});

--- a/src/components/features/chat/chat-message.tsx
+++ b/src/components/features/chat/chat-message.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "#/utils/utils";
 import { CopyToClipboardButton } from "#/components/shared/buttons/copy-to-clipboard-button";
+import { copyToClipboard } from "#/utils/clipboard";
+import { displayErrorToast } from "#/utils/custom-toast-handlers";
 import type { SourceType } from "#/types/agent-server/core/base/common";
 import { StyledTooltip } from "#/components/shared/buttons/styled-tooltip";
 import { I18nKey } from "#/i18n/declaration";
@@ -54,8 +56,11 @@ export function ChatMessage({
   }, [message]);
 
   const handleCopyToClipboard = async () => {
-    await navigator.clipboard.writeText(message);
-    setIsCopy(true);
+    if (await copyToClipboard(message)) {
+      setIsCopy(true);
+    } else {
+      displayErrorToast(t(I18nKey.CHAT_INTERFACE$CHAT_MESSAGE_COPY_FAILED));
+    }
   };
 
   React.useEffect(() => {

--- a/src/components/features/chat/error-message-banner.tsx
+++ b/src/components/features/chat/error-message-banner.tsx
@@ -4,6 +4,7 @@ import { Check, CircleX, Copy, X } from "lucide-react";
 import { OH_STATUS_ERROR_COLOR } from "#/constants/status-colors";
 import { I18nKey } from "#/i18n/declaration";
 import { displayErrorToast } from "#/utils/custom-toast-handlers";
+import { copyToClipboard } from "#/utils/clipboard";
 import { getAcpErrorHeaderKey } from "#/utils/acp-error-codes";
 import { cn } from "#/utils/utils";
 
@@ -41,10 +42,9 @@ export function ErrorMessageBanner({
   const isCollapsed = shouldShowToggle && !isExpanded;
 
   const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(displayTextForLength);
+    if (await copyToClipboard(displayTextForLength)) {
       setIsCopied(true);
-    } catch {
+    } else {
       displayErrorToast(t(I18nKey.CHAT_INTERFACE$CHAT_MESSAGE_COPY_FAILED));
     }
   };

--- a/src/components/shared/buttons/copyable-content-wrapper.tsx
+++ b/src/components/shared/buttons/copyable-content-wrapper.tsx
@@ -1,4 +1,8 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
+import { I18nKey } from "#/i18n/declaration";
+import { displayErrorToast } from "#/utils/custom-toast-handlers";
+import { copyToClipboard } from "#/utils/clipboard";
 import { CopyToClipboardButton } from "./copy-to-clipboard-button";
 
 export function CopyableContentWrapper({
@@ -8,12 +12,16 @@ export function CopyableContentWrapper({
   text: string;
   children: React.ReactNode;
 }) {
+  const { t } = useTranslation("openhands");
   const [isHovering, setIsHovering] = React.useState(false);
   const [isCopied, setIsCopied] = React.useState(false);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(text);
-    setIsCopied(true);
+    if (await copyToClipboard(text)) {
+      setIsCopied(true);
+    } else {
+      displayErrorToast(t(I18nKey.CHAT_INTERFACE$CHAT_MESSAGE_COPY_FAILED));
+    }
   };
 
   React.useEffect(() => {

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,51 @@
+/**
+ * Copy text to the clipboard, with a fallback for non-secure contexts.
+ *
+ * `navigator.clipboard` is only exposed in secure contexts (HTTPS, localhost,
+ * 127.0.0.1, file:). When the frontend is served over plain HTTP on a
+ * non-loopback host (e.g. a remote IPv6 address), `navigator.clipboard` is
+ * `undefined` and `navigator.clipboard.writeText` throws. This helper falls
+ * back to the deprecated-but-widely-supported `document.execCommand("copy")`
+ * via a transient textarea so copy still works in those contexts.
+ *
+ * Returns true on success, false on failure.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to the execCommand fallback.
+    }
+  }
+  return copyWithExecCommand(text);
+}
+
+function copyWithExecCommand(text: string): boolean {
+  if (typeof document === "undefined" || !document.execCommand) {
+    return false;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  // Move off-screen and hide so the fallback is invisible; `display: none`
+  // prevents selection, so use positioning + opacity instead.
+  textarea.style.position = "fixed";
+  textarea.style.top = "-9999px";
+  textarea.style.left = "-9999px";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  let ok = false;
+  try {
+    ok = document.execCommand("copy");
+  } catch {
+    ok = false;
+  }
+
+  document.body.removeChild(textarea);
+  return ok;
+}


### PR DESCRIPTION
HUMAN:

<!-- Human contributors: add a short note about your testing. -->
I have deployed the branch and tested that copy button in conversations work after the fix.
May relate: #16136 similar non-secure environment root causes in deployments over wireguard.

AGENT:

This PR was created by an AI agent (OpenHands) on behalf of the user.

End-to-end verification was run against the `fix/clipboard-http-copy-openhands`
branch (commit `9e4737a1d`) in this worktree. Commands run and results:

**Unit tests (the affected files):**
```
npx vitest run \
  __tests__/utils/clipboard.test.ts \
  __tests__/components/chat-message.test.tsx \
  __tests__/components/buttons/copyable-content-wrapper.test.tsx
```
Result: `3 Test Files passed (3)` / `22 Tests passed (22)` in ~1.4s. No
skips, no failures.

The helper test file covers all four code paths of `copyToClipboard`:
- uses `navigator.clipboard.writeText` when it succeeds (secure context)
- falls back to `document.execCommand("copy")` when `writeText` rejects
- falls back to `execCommand` when `navigator.clipboard` is `undefined`
  (this is the exact regression this PR fixes — plain-HTTP / non-loopback hosts)
- returns `false` when both paths fail

The wrapper test (`copyable-content-wrapper.test.tsx`) additionally asserts
the failure path renders a localized error toast and stays in copy mode when
the clipboard rejects.

**Typecheck:**
```
npm run make-i18n   # regenerate src/i18n/declaration.ts first
npm run typecheck
```
The remaining `tsc` errors are all in `src/api/cloud/client.ts`,
`src/api/device-flow-client.ts`, and `src/hooks/use-device-flow.ts`
(`@openhands/typescript-client` cloud/device-flow symbols). These are
**pre-existing baseline errors** — the same 9 errors reproduce on
`origin/main` (`git checkout origin/main && npm run typecheck` → 9 errors).
None of the clipboard-touched files (`src/utils/clipboard.ts`,
`chat-message.tsx`, `error-message-banner.tsx`, `copyable-content-wrapper.tsx`)
produce any typecheck error.

**Lint (changed source files only):**
```
npx eslint \
  src/utils/clipboard.ts \
  src/components/features/chat/chat-message.tsx \
  src/components/features/chat/error-message-banner.tsx \
  src/components/shared/buttons/copyable-content-wrapper.tsx
```
Result: clean (no errors, no warnings). The `i18next/no-literal-string` rule
is satisfied — the new user-facing toast copy goes through the existing
`t(I18nKey.CHAT_INTERFACE$CHAT_MESSAGE_COPY_FAILED)` key, which is present in
all 15 supported languages in `src/i18n/translation.json`.

**What I could not test here:** a live browser session over plain HTTP on a
non-loopback host to observe the fallback firing in the real DOM. The
`navigator.clipboard === undefined` branch is covered by the jsdom unit test
(stubbing `navigator.clipboard` to `undefined` and asserting the
`execCommand` fallback is invoked), which exercises the exact regression
condition without a remote HTTP deployment.

---

## Why

When the agent-canvas frontend is served over plain HTTP on a non-loopback
host (e.g. a remote IPv6 address, or any deployment that isn't `localhost` /
`127.0.0.1` / `file:`), the browser withholds the async Clipboard API:
`navigator.clipboard` is `undefined`. Every copy interaction that called
`navigator.clipboard.writeText(...)` directly then threw
`Cannot read properties of undefined (reading 'writeText')`, and the copy
silently failed with no user feedback. This affected three copy surfaces:
code blocks (`CopyableContentWrapper`), chat messages (`ChatMessage`), and
the error message banner (`ErrorMessageBanner`).

## Summary

- Add `src/utils/clipboard.ts` exporting `copyToClipboard(text)` — tries
  `navigator.clipboard.writeText` first, falls back to a transient off-screen
  `<textarea>` + `document.execCommand("copy")` for non-secure contexts.
  Returns `Promise<boolean>` so callers can branch on success.
- Route the three copy surfaces (`CopyableContentWrapper`, `ChatMessage`,
  `ErrorMessageBanner`) through `copyToClipboard`, replacing their direct
  `navigator.clipboard.writeText` calls. On failure each now surfaces a
  localized error toast via `displayErrorToast(t(I18nKey.CHAT_INTERFACE$CHAT_MESSAGE_COPY_FAILED))`
  instead of silently swallowing the error.
- Add unit tests for the helper (all four paths) and extend the
  `CopyableContentWrapper` and `ChatMessage` tests to cover the fallback /
  failure-toast behavior.

## Issue Number

N/A

## How to Test

1. `npm install` then `npm run make-i18n` (regenerates `src/i18n/declaration.ts`).
2. `npm run dev` and open the UI over a **plain-HTTP, non-loopback** origin
   (e.g. serve over a remote IP / IPv6 address rather than `localhost`) so
   `navigator.clipboard` is `undefined`. The simplest local reproduction is
   a non-secure context — `localhost` will NOT trigger it because `localhost`
   is treated as a secure context.
3. Copy a code block (hover → copy button), copy a chat message, and copy the
   error banner text. Each should copy successfully via the `execCommand`
   fallback instead of throwing, and the "copied" state should still appear.
4. To verify the failure toast: temporarily make both paths fail (e.g. stub
   `navigator.clipboard` to `undefined` and `document.execCommand` to return
   `false` in the browser console), then click copy — a localized
   "Failed to copy message to clipboard" toast should appear.
5. Regression check over HTTPS / `localhost`: copy should still use the
   native `navigator.clipboard.writeText` path (no behavior change).
6. `npx vitest run __tests__/utils/clipboard.test.ts __tests__/components/chat-message.test.tsx __tests__/components/buttons/copyable-content-wrapper.test.tsx`
   → 22 passed.

## Video/Screenshots

Not attached. The fix is covered by the unit tests above (helper paths +
wrapper failure-toast). A browser recording over a real non-secure HTTP
origin was not produced in this environment; see "How to Test" for the
manual reproduction steps.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- This is a cherry-pick of legacy commit `3796dc06e` rebased onto the
  `origin/main` lineage; the source change is content-equivalent to the
  legacy version (same `copyToClipboard` helper and the same three call-site
  rewrites).
- The fallback uses the deprecated `document.execCommand("copy")`, which is
  still widely supported and is the standard fallback for non-secure
  contexts; the native async Clipboard API remains the primary path.
- No new dependencies. The error toast reuses the existing
  `CHAT_INTERFACE$CHAT_MESSAGE_COPY_FAILED` i18n key (present in all 15
  supported languages), so no new translation entries were added.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.47s · commit 9e4737a  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 12/12 hunks, 7/7 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 3.0% | No direct hunk selected |
| Weakened authorization | 5.0% | No direct hunk selected |
| Contract regression | 11.0% | No direct hunk selected |
| Data loss | 3.0% | No direct hunk selected |
| Sensitive data disclosure | 3.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 4.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 4.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 91.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 2344a5c546c9e25a2152ba32899b3f2b99bc606dde07cd9b24c222630ebd88dd -->
<!-- jev-fast-audit:end -->
