### PR TITLE
ci: remove stale release-please bootstrap sha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "draft-pull-request": true,
-  "last-release-sha": "10ce762e920f70e121314c45ae2a65ecd569d0ce",
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

This is a test. I believe release please boundary doesn't require the latest commit sha and will be detected automatically from the latest tag on the repo, which is now https://github.com/OpenHands/OpenHands/releases/tag/v1.6.1

- [X] A human has tested these changes.

AGENT:

This PR was created by an AI agent (OpenHands) on behalf of the user.

Validation performed:

```bash
node -e "JSON.parse(require('fs').readFileSync('release-please-config.json','utf8')); console.log('release-please-config.json is valid JSON')"
```

Output:

```text
release-please-config.json is valid JSON
```

No application tests were run because this is a release-please configuration cleanup only.

Release-please boundary documentation checked:

- Docs: https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#configfile
- Concise quote from the `last-release-sha` option docs:

> release-please's normal behavior is to find the last merged release PR and use the associated commit sha as the previous marker from which to gather commits for the new release. With this setting you can manually set the commit sha release-please will use from which to gather commits for the current release.

- The same option's notes say:

> never ignored: remove/change it once a good release PR is merged

This PR removes the stale old-repo override so release-please can return to normal release boundary discovery from the seeded `v1.6.1` release/tag in `OpenHands/OpenHands`.

---

## Why

The Agent Canvas codebase was replayed from `OpenHands/agent-canvas` into `OpenHands/OpenHands`, so the existing `last-release-sha` points to a commit SHA that does not exist in the new repository history.

The missing baseline release has now been seeded in this repo as `v1.6.1`, pointing at the replayed release commit. Keeping the old bootstrap SHA is stale and can cause release-please to scan the wrong boundary or refer to old-repo state.

## Summary

- Removes the stale `last-release-sha` from `release-please-config.json`.
- Leaves the manifest at `1.6.1` and keeps `include-v-in-tag: true` so release-please uses the seeded `v1.6.1` release/tag in this repository as the boundary.

## Issue Number

N/A

## How to Test

Validate the config is still valid JSON:

```bash
node -e "JSON.parse(require('fs').readFileSync('release-please-config.json','utf8')); console.log('release-please-config.json is valid JSON')"
```

After merge, verify `release.yml` can find the seeded `v1.6.1` release in `OpenHands/OpenHands` and update/create the release PR instead of failing with `Invalid previous_tag parameter`.

## Video/Screenshots

N/A — release configuration only.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This is step 3 of the Agent Canvas release migration. The publish tag triggers remain temporarily disabled from PR #16133 and should be restored in a follow-up PR after release migration is complete.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/cd9bf054-dc93-41ac-ad86-dbb67aff0d0f)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.38.0-python` |
| **Automation** | `openhands-automation==1.4.1` |
| **Commit** | `bb53985ea0d147c1f09b8c326a7edfffd41e9bf0` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-bb53985
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-bb53985
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-bb53985-amd64
ghcr.io/openhands/agent-canvas:agent-remove-stale-release-please-sha-amd64
ghcr.io/openhands/agent-canvas:pr-16138-amd64
ghcr.io/openhands/agent-canvas:sha-bb53985-arm64
ghcr.io/openhands/agent-canvas:agent-remove-stale-release-please-sha-arm64
ghcr.io/openhands/agent-canvas:pr-16138-arm64
ghcr.io/openhands/agent-canvas:sha-bb53985
ghcr.io/openhands/agent-canvas:agent-remove-stale-release-please-sha
ghcr.io/openhands/agent-canvas:pr-16138
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-bb53985`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-bb53985-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->
