### PR TITLE
ci: restore tag publish triggers

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,8 @@ name: Docker
 on:
   push:
     branches: [main]
+    tags:
+      - "v*"
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,6 +1,9 @@
 name: Publish to npm
 
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Simple CI change that will be test after merge.
- [X] A human has tested these changes.

AGENT:

This PR was created by an AI agent (OpenHands) on behalf of the user.

Validation performed:

```bash
git diff main...agent/restore-publish-tag-triggers -- .github/workflows/npm-publish.yml .github/workflows/docker.yml
```

Observed that this PR restores only the previously removed `v*` tag triggers for npm and Docker publishing. No application tests were run because this is a workflow-trigger restoration only.

---

## Why

The temporary release-migration safety window is complete: the baseline `v1.6.1` tag/release has been seeded, the stale release-please boundary override has been removed, and release-please has successfully created the draft `1.7.0` release PR.

Before merging the release PR, automatic publishing should be restored so the `v1.7.0` tag push can trigger npm and Docker release workflows normally.

## Summary

- Restores the `v*` tag push trigger for `Publish to npm`.
- Restores the `v*` tag push trigger for `Docker`.
- Leaves existing manual dispatch, PR, and main-branch Docker behavior unchanged.

## Issue Number

N/A

## How to Test

Review the workflow trigger diff:

```bash
git diff main...agent/restore-publish-tag-triggers -- .github/workflows/npm-publish.yml .github/workflows/docker.yml
```

Expected result:

- `npm-publish.yml` has `on.push.tags: ['v*']` and `workflow_dispatch`.
- `docker.yml` has `on.push.branches: [main]`, `on.push.tags: ['v*']`, `pull_request`, and `workflow_dispatch`.

After this PR merges, do not push historical `v*` tags manually. The next expected `v*` tag should be created by release-please when the release PR is merged.

## Video/Screenshots

N/A — workflow trigger-only change.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This restores the triggers disabled in PR #16133. Merge this before merging release PR #16140 so npm and Docker publishing happen automatically from the release tag.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/cd9bf054-dc93-41ac-ad86-dbb67aff0d0f)