### PR TITLE
fix(e2e): shut the mock-LLM stack down gracefully so it stops leaking processes

### DIFF
--- a/playwright.mock-llm.config.ts
+++ b/playwright.mock-llm.config.ts
@@ -154,6 +154,16 @@ export default defineConfig({
       url: `http://localhost:${INGRESS_PORT}/api/automation/v1`,
       timeout: 180_000, // allow extra time for build + agent-server + automation startup
       reuseExistingServer: !process.env.CI,
+      // Without this, Playwright tears the webServer down with
+      // process.kill(-pid, "SIGKILL"), which the stack cannot catch. Its
+      // services are spawned detached (see scripts/dev-process-utils.mjs), so
+      // they sit in their own process groups and survive that group kill,
+      // orphaning to PID 1 while still holding 18000/18001/18300/3001. Asking
+      // for SIGTERM lets the existing shutdown handler in
+      // scripts/dev-with-automation.mjs run, which stops each service, waits
+      // 3s, then force-kills stragglers. The timeout below leaves headroom
+      // over that 3s pass.
+      gracefulShutdown: { signal: "SIGTERM", timeout: 15_000 },
     },
     // 3. Public-mode static server — same build/, same backend, but with
     //    --auth-required (no session key injected). The agent-server's


### PR DESCRIPTION
HUMAN:

100% real human used in testing. Worked even when some commands were entered using fingers.

- [x] A human has tested these changes.

AGENT:

Ran the full mock-LLM suite on this checkout, with and without the change, plus a process-tree probe around teardown. Commands and numbers below.

**Before the change**, 13 seconds after Playwright exits, six processes are still alive, four of them reparented to PID 1:

```
  PID    PPID   PGID  COMMAND
1952843       1 1952843  uv tool uvx --from openhands-agent-server==1.38.0 ...
1952977 1952843 1952843  python .../agent-server --host 127.0.0.1 --port 18000
1953088       1 1953088  uv tool uvx --from openhands-automation==1.4.1 uvicorn ...
1953089       1 1953089  node scripts/static-server.mjs --dir build --port 3001
1953175 1953088 1953088  python .../uvicorn openhands.automation.app:app --port 18001
1953207       1 1953207  node scripts/ingress.mjs --port 18300 ...

LISTEN 127.0.0.1:18000   LISTEN 127.0.0.1:18001
LISTEN *:18300           LISTEN *:3001
```

**After the change**, the same probe reports zero processes and zero bound ports, checked at both +3s and +13s.

**Full suite, same checkout:** 60 passed / 1 skipped either way, and no ports left bound afterwards. The skipped test is the ACP banner spec skipping itself on a host that has a real provider login.

## Why

Playwright force-kills a webServer with `process.kill(-pid, "SIGKILL")` unless the entry declares `gracefulShutdown`. In `webServerPlugin.js`, `attemptToGracefullyClose` throws `"skip graceful shutdown"` when the field is absent, and `processLauncher.js` catches that and goes straight to the force path.

SIGKILL cannot be caught, so the stack never runs its shutdown handler. And because `scripts/dev-process-utils.mjs` spawns each service with `detached: true`, every service leads its own process group and is not in the group Playwright kills. So the parent dies, the services do not, and they orphan to PID 1 holding 18000, 18001, 18300, and 3001.

The next local run then goes one of two ways. Either the ingress is no longer answering and `assertPortsFree` aborts with "Another agent-canvas instance may already be running", or the ingress is still answering and, since `reuseExistingServer` is on outside CI, Playwright silently adopts the survivors. Adoption is the expensive one: the state-dir wipe lives inside the webServer `command`, so a reused stack never gets wiped, and the run executes against the previous run's profiles and session key. That surfaces as an unrelated helper failing to find the seeded `default` agent profile.

CI is not affected, since `reuseExistingServer` is false there and each job gets a fresh runner.

## Summary

- Declare `gracefulShutdown: { signal: "SIGTERM", timeout: 15_000 }` on the webServer entry that runs the agent-canvas stack, so the shutdown handler in `scripts/dev-with-automation.mjs` gets the signal it was already written for.
- The 15s timeout leaves headroom over that handler's own 3000 ms pass before it force-kills stragglers.
- Only this entry needs it. The mock-LLM server and the public-mode static server are single `exec`'d processes with no detached children, and were confirmed not to leak.

## Issue Number

Fixes #16151

## How to Test

```bash
npm ci
uv venv .mock-llm-venv
uv pip install -p .mock-llm-venv "openhands-sdk==1.38.0" "agent-client-protocol<0.11"

MOCK_LLM_PYTHON=.mock-llm-venv/bin/python3 \
  npx playwright test --config=playwright.mock-llm.config.ts \
  tests/e2e/mock-llm/settings/mock-llm-acp-agent.spec.ts

# then, after playwright has exited:
ss -ltnp | grep -E ':(18000|18001|18300|3001)\b'
ps -eo pid,ppid,pgid,args | grep -E 'uvx|static-server|ingress\.mjs'
```

On `main` those two commands list the leftover stack. On this branch they come back empty. The test run itself passes either way, so the difference is teardown only.

## Video/Screenshots

Terminal captures are inline above; the change has no UI surface.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- `playwright.mock-llm-docker.config.ts` has the same shape, and a comment noting that Playwright's SIGTERM has to reach `docker run`, so it may want the same field. Left out here because verifying it needs an image built from the branch, and I would rather not ship a change I have not measured.
- The handler being force-fed SIGTERM is not new behavior. `scripts/dev-with-automation.mjs` already registers it, and the config comments already describe the `exec` chain that exists to deliver it. This change is what asks Playwright to send it.
