### PR TITLE
fix(settings): de-duplicate LLM Profile attributes in the "All" tab

### DIFF
--- a/__tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx
+++ b/__tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx
@@ -181,6 +181,53 @@ describe("SdkSectionPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders each field once when the schema has duplicate sections for a key", async () => {
+    // The combined AgentSettings schema emits an "llm" section for each agent
+    // variant ("openhands" and "acp") with identical field keys. Only the first
+    // is used; without de-duplication every field would render twice (and React
+    // would warn about duplicate keys).
+    const llmSection = {
+      key: "llm",
+      label: "LLM",
+      fields: [
+        {
+          key: "llm.api_version",
+          label: "API Version",
+          section: "llm",
+          section_label: "LLM",
+          value_type: "string" as const,
+          default: null,
+          choices: [],
+          depends_on: [],
+          prominence: "minor" as const,
+          secret: false,
+          required: false,
+        },
+      ],
+    };
+    const schema: NonNullable<Settings["agent_settings_schema"]> = {
+      model_name: "AgentSettings",
+      sections: [llmSection, { ...llmSection }],
+    };
+
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({
+        agent_settings_schema: schema,
+        agent_settings: {},
+      }),
+    );
+
+    renderSdkSectionPage({
+      settingsSources: [
+        { settingsSource: "agent_settings", sectionKeys: ["llm"] },
+      ],
+      getInitialView: () => "all",
+    });
+
+    const fields = await screen.findAllByTestId("sdk-settings-llm.api_version");
+    expect(fields).toHaveLength(1);
+  });
+
   it("preserves the selected view when parent rerenders with the same settings", async () => {
     const schema: NonNullable<Settings["agent_settings_schema"]> = {
       model_name: "AgentSettings",

--- a/src/components/features/settings/sdk-settings/sdk-section-page.tsx
+++ b/src/components/features/settings/sdk-settings/sdk-section-page.tsx
@@ -299,9 +299,19 @@ export function SdkSectionPage({
           return { ...src, filteredSchema: null };
         }
         const sectionSet = new Set(src.sectionKeys);
+        // The agent schema can carry more than one section per key — e.g. the
+        // combined AgentSettings schema emits an "llm" section for both the
+        // "openhands" and "acp" variants. Only the first (openhands) is used,
+        // so keep the first section per key; otherwise every field renders
+        // twice and React sees duplicate section keys.
+        const seenKeys = new Set<string>();
         const filteredSchema: SettingsSchema = {
           ...schema,
-          sections: schema.sections.filter((s) => sectionSet.has(s.key)),
+          sections: schema.sections.filter((s) => {
+            if (!sectionSet.has(s.key) || seenKeys.has(s.key)) return false;
+            seenKeys.add(s.key);
+            return true;
+          }),
         };
         return { ...src, filteredSchema };
       }),


### PR DESCRIPTION
HUMAN:

Spotted this in the UI: when creating/editing an LLM Profile, the "All" tab listed every attribute twice. Asked for it to be fixed. I have not run the GUI end-to-end myself — see the AGENT section for how it was verified.

AGENT:

I verified the regression is real and that the fix removes it via a new unit test plus static checks. I did **not** run the full GUI end-to-end (the mock-LLM E2E gate is a separate, currently-flaky infra job — see Notes). Reviewer steps to confirm in the UI are in "How to Test".

- Reproduced the bug at the component level: rendering the LLM Profile form ("All" view) with a schema that has two same-key `llm` sections produced two identical inputs per field (`findAllByTestId("sdk-settings-llm.api_version")` → 2), plus a duplicate React section key `agent_settings:llm`.
- Added regression test `renders each field once when the schema has duplicate sections for a key`. Confirmed it **fails on the pre-fix filter** (`AssertionError: expected length 1 but got 2`) and **passes** with the fix.
- Commands run locally:
  - `npm run make-i18n && npx vitest run __tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx` → 15 passed
  - `npx eslint src/components/features/settings/sdk-settings/sdk-section-page.tsx __tests__/.../sdk-section-page.test.tsx` → clean
  - `npx react-router typegen && npx tsc --noEmit` → clean

---

## Why

The LLM Profile create/edit form renders every LLM attribute **twice** in the **All** tab. Basic and Advanced look correct because they only surface `critical`/`major` fields, while all the affected fields are `minor` — so the duplication is only visible under "All".

Root cause: the combined `AgentSettings` schema served at `/api/.../settings/agent-schema` emits **two sections keyed `llm`** — one per agent variant, tagged `variant: "openhands"` and `variant: "acp"` — with identical field keys. `SdkSectionPage` builds each source's filtered schema by matching sections on **key only**:

```ts
sections: schema.sections.filter((s) => sectionSet.has(s.key)),
```

`LlmSettingsScreen` requests `sectionKeys: ["llm"]`, so **both** `llm` sections match and every field is rendered twice. As a side effect the two sections also produce the same React section key (`agent_settings:llm`), which triggers a duplicate-key warning.

## Summary

- Keep only the **first section per key** when building the filtered schema in `SdkSectionPage`, so a key that appears in more than one variant renders once.
- Only the first (`openhands`) `llm` section is ever used; the unused `acp` variant is dropped as before — no schema/type changes and no `variant` plumbing.
- Also removes the duplicate React section-key warning.
- Adds a regression test asserting a field renders exactly once when the schema carries duplicate same-key sections.

## Issue Number

N/A

## How to Test

Unit (automated):

```bash
npm run make-i18n
npx vitest run __tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx
```

The new test `renders each field once when the schema has duplicate sections for a key` fails on `main` (renders 2 inputs) and passes with this change.

Manual (GUI) for the reviewer:

1. Run the app against a backend whose agent schema includes both agent variants (so the combined schema has `llm` for `openhands` and `acp`).
2. Go to Settings → LLM → add or edit a Profile.
3. Switch the form to the **All** tab.
4. Confirm each LLM attribute now appears once (before the fix, every attribute was listed twice). No duplicate-key warning in the console.

## Video/Screenshots

Not captured — change verified via the component test above; no visual styling change beyond removing the duplicated fields.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The `mock-llm-e2e` check is failing on this PR, but it is failing the same way on unrelated PRs right now (e.g. `fix-docker-workspace-discovery`, `fix/15694-preserve-skill-toggle-state`): conversations time out waiting for the `/conversations/...` URL, on whichever test happens to start a conversation. This is a mock-backend startup flake unrelated to this change (which only affects settings-form rendering). A re-run should clear it.
