### PR TITLE
docs: fix runtime modes table in architecture doc

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,9 +48,9 @@ Agent Canvas supports several modes:
 
 | Mode | Purpose |
 |---|---|
-| `npm run dev:docker` | Starts the UI with an Agent Server in a Docker sandbox. This is the default safer local workflow. |
-| `npm run dev:dangerously-dockerless` | Starts the UI and Agent Server directly on the host. This is useful for servers and trusted environments, but the agent has host filesystem access. |
-| `npm run dev:automation` | Starts the local stack with an automation backend. |
+| `npm run dev` | Starts the full local stack directly on the host: agent-server and automation backend via `uvx`, the Vite dev server, and an ingress proxy. The agent has host filesystem access; use only in trusted environments. |
+| `npm run dev:minimal` | Starts just the agent-server plus Vite dev server, without the automation backend. |
+| `npm run dev:static` | Same as `dev`, but serves a production build of the frontend instead of the Vite dev server. |
 | `npm run dev:mock` | Runs the frontend against MSW mocks for UI development and tests. |
 | `npm run build` | Builds the standalone application. |
 | `npm run build:lib` | Builds library entrypoints for embedding Agent Canvas components. |


### PR DESCRIPTION
HUMAN:

Docs-only change. Grepped `package.json` and confirmed the three scripts the old doc mentioned don't exist, while `dev` /`dev:minimal` / `dev:static` do. The description already matches how AGENTS.md talks about these modes.

AGENT:

Verified by running each renamed script against the current `package.json`:

```
$ for s in dev:docker dev:dangerously-dockerless dev:automation; do
    grep -q "\"$s\":" package.json || echo "missing $s"
  done
missing dev:docker
missing dev:dangerously-dockerless
missing dev:automation

$ for s in dev dev:minimal dev:static; do
    grep -q "\"$s\":" package.json && echo "found $s"
  done
found dev
found dev:minimal
found dev:static
```

Also cross-checked against `AGENTS.md` (`Runtime Services in Dev Stacks` and `scripts/dev-safe.mjs` / `dev-with-automation.mjs` sections), which describe `npm run dev` as the full uvx stack and `dev:minimal` as agent-server + Vite only.

---

## Why

The `Runtime modes` table in `docs/architecture.md` listed `npm run dev:docker`, `npm run dev:dangerously-dockerless`, and `npm run dev:automation`. None of those scripts exist in `package.json`. A first-time contributor following the doc hits `npm error Missing script:` immediately.

## Summary

- Replace `npm run dev:docker` / `dev:dangerously-dockerless` / `dev:automation` with the scripts that actually ship in `package.json`: `dev`, `dev:minimal`, `dev:static`.

## Issue Number

None.

## How to Test

Verify the previously listed commands do not exist and the new ones do:

```
grep -E '"dev(:minimal|:static)?": ' package.json
# → the three matching script definitions
```

Rendered locally by scanning the diff; no test suite is affected.

## Video/Screenshots

N/A — docs-only change.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Docker-sandbox usage is still documented in `README.md` under "Option 2: With a Docker Sandbox" and does not require a corresponding `npm` script — it runs the published `ghcr.io/openhands/agent-canvas` image directly.
