### PR TITLE
fix: keep automation actions stable for long titles

### DIFF
--- a/__tests__/components/automations/automation-card.test.tsx
+++ b/__tests__/components/automations/automation-card.test.tsx
@@ -63,7 +63,12 @@ describe("AutomationCard", () => {
     ).toHaveTextContent("AUTOMATIONS$RUN_NOW");
     expect(screen.getByTestId("automation-run-now-automation-1")).toHaveClass(
       "h-8",
+      "shrink-0",
+      "whitespace-nowrap",
     );
+    expect(
+      screen.getByText("Async Standup Digest").closest("h3"),
+    ).toHaveAttribute("title", "Async Standup Digest");
     expect(screen.queryByRole("switch")).not.toBeInTheDocument();
 
     await user.click(

--- a/src/components/features/automations/automation-action-button-classes.ts
+++ b/src/components/features/automations/automation-action-button-classes.ts
@@ -8,6 +8,6 @@ export const automationIconActionButtonClassName = cn(
 
 /** Text + icon Run now control on automation grid cards (matches kebab height). */
 export const automationRunNowTextButtonClassName = cn(
-  "inline-flex h-8 shrink-0 cursor-pointer items-center gap-1.5 rounded-md border-0 bg-transparent px-2 text-xs text-muted hover:bg-interactive-hover hover:text-white focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted",
+  "inline-flex h-8 shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-md border-0 bg-transparent px-2 text-xs text-muted hover:bg-interactive-hover hover:text-white focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted",
   dropdownInstantColorClassName,
 );

--- a/src/components/features/automations/automation-card.tsx
+++ b/src/components/features/automations/automation-card.tsx
@@ -86,7 +86,10 @@ export function AutomationCard({
     >
       <header className="flex items-start justify-between gap-3">
         <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-          <h3 className="flex items-center gap-2 truncate text-sm font-semibold text-white">
+          <h3
+            className="flex items-center gap-2 truncate text-sm font-semibold text-white"
+            title={automation.name}
+          >
             {automation.trigger.type === "event" ? (
               <GlobeIcon className="size-4 shrink-0 text-muted" />
             ) : (


### PR DESCRIPTION
HUMAN:

Open the Automation page, verify that the excessively long title is truncated, the full title is visible on hover, and the Run now button remains on a single line and is clickable.

AGENT:

AI-assisted contribution. I inspected the affected automation card layout, implemented the fix, and validated it in both component tests and the running mock UI.

End-to-end reproduction:

1. Started the checked-in mock application on port 3103 with `npm run dev:mock -- --host 127.0.0.1 --port 3103`.
2. Opened `/automations` in Chromium.
3. Used a long automation name: `Review every newly opened pull request for security regressions and notify the engineering team`.
4. Confirmed the title is visually truncated while its full value remains available through the heading's `title` attribute.
5. Confirmed the "Run now" action remains a single line with a stable 84 x 32 px bounding box (`white-space: nowrap`).

The running UI screenshot was captured locally as `output/playwright/automation-long-title-fixed.png`.

---

## Why

Long automation names can squeeze the card actions and cause the "Run now" label to wrap or render incorrectly. The primary action should retain a stable size while the title consumes only the remaining width.

## Summary

- Keep the automation "Run now" text on one line while preserving its existing non-shrinking action container.
- Expose the full truncated automation name through the heading's native tooltip.
- Add regression assertions for the action sizing classes and title attribute.

## Issue Number

Closes #16155

## How to Test

```text
npm test -- __tests__/components/automations
Test Files  22 passed (22)
Tests       95 passed (95)

npx eslint src/components/features/automations/automation-card.tsx \
  src/components/features/automations/automation-action-button-classes.ts \
  __tests__/components/automations/automation-card.test.tsx

npx prettier --check src/components/features/automations/automation-card.tsx \
  src/components/features/automations/automation-action-button-classes.ts \
  __tests__/components/automations/automation-card.test.tsx

git diff --check origin/main...HEAD
```

All commands passed.

For manual verification, run the mock app, open `/automations`, and give an enabled automation a title long enough to exceed the available card width. The title should truncate, its full text should be available on hover, and "Run now" should remain on one line.

## Video/Screenshots

Validated in the running Chromium UI at desktop width. The long title truncated to `Review every newly opened pull request for s...`, while the adjacent action remained a single-line 84 x 32 px button.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The change is limited to the automation card's presentation and regression coverage; it does not alter automation dispatch behavior.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.42s · commit 52a5ffe  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 3/3 hunks, 3/3 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 2.0% | No direct hunk selected |
| Weakened authentication | 2.0% | No direct hunk selected |
| Weakened authorization | 3.0% | No direct hunk selected |
| Contract regression | 6.0% | No direct hunk selected |
| Data loss | 3.0% | No direct hunk selected |
| Sensitive data disclosure | 3.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 4.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 88.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 2da1f1c4847cb8df808fa6ab3db8cfd20bad4058b12e4a9d7e90bc68cc98b116 -->
<!-- jev-fast-audit:end -->
