### PR TITLE
fix: enable Agent Canvas pageview telemetry

### DIFF
--- a/__tests__/services/telemetry.test.ts
+++ b/__tests__/services/telemetry.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 // Mock posthog-js before importing telemetry service
 let identifiedUserId: string | undefined;
 let latestPostHogConfig:
-  | { before_send: (event: unknown) => unknown }
+  | (Record<string, unknown> & { before_send: (event: unknown) => unknown })
   | undefined;
 const mockPosthog = {
   init: vi.fn(),
@@ -107,6 +107,8 @@ describe("Telemetry Service", () => {
           persistence_name: "agent-canvas",
           consent_persistence_name: "agent-canvas-consent",
           person_profiles: "always",
+          capture_pageview: "history_change",
+          autocapture: true,
         }),
         "agent-canvas",
       );

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -49,6 +49,7 @@ const TELEMETRY_CONSENT_CHANGE_EVENT = "openhands-telemetry-consent-change";
 const TELEMETRY_FIRST_USE_KEY = "openhands-telemetry-first-use";
 const TELEMETRY_SESSION_KEY = "openhands-telemetry-session";
 const POSTHOG_INSTANCE_NAME = "agent-canvas";
+const POSTHOG_PAGEVIEW_CAPTURE_MODE = "history_change";
 
 // Unconfigured source builds use staging. Production release workflows pass
 // VITE_POSTHOG_API_KEY explicitly for both the app and library artifacts.
@@ -301,12 +302,12 @@ export async function initializePostHogClient(
         api_host: config.apiHost,
         ui_host: config.uiHost,
         opt_out_capturing_by_default: !enableCapturing,
-        capture_pageview: false,
-        autocapture: false,
         persistence: "localStorage",
         persistence_name: POSTHOG_INSTANCE_NAME,
         consent_persistence_name: `${POSTHOG_INSTANCE_NAME}-consent`,
         person_profiles: "always",
+        capture_pageview: POSTHOG_PAGEVIEW_CAPTURE_MODE,
+        autocapture: true,
         disable_session_recording: true,
         bootstrap,
         before_send: addCanvasEventProperties,


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

AGENT:

This PR was created by an AI agent (OpenHands) on behalf of the user.

Validation performed:

```bash
npx vitest run __tests__/services/telemetry.test.ts
```

Result: 1 test file passed, 37 tests passed.

```bash
npx eslint src/services/telemetry.ts __tests__/services/telemetry.test.ts
npx prettier --check src/services/telemetry.ts __tests__/services/telemetry.test.ts
npm run make-i18n && npm run typecheck:staged
```

Result: passed. Prettier reported `All matched files use Prettier code style!`; typecheck completed successfully.

End-to-end note: this is a telemetry instrumentation change. I did not send live browser events to PostHog from a production-key build because doing so would pollute analytics. The focused service test verifies the PostHog initialization options that control browser pageview and autocapture behavior.

---

## Why

Agent Canvas dashboards include pageview-based panels, but the Canvas-owned PostHog client explicitly disabled pageview and autocapture collection. That left pageview analytics dependent on accidental/default-client behavior from older builds rather than the isolated `agent-canvas` telemetry client.

## Summary

- Enable PostHog pageview capture for initial loads and SPA history changes on the named Agent Canvas client.
- Enable PostHog autocapture on the same consent-controlled client.
- Add a telemetry service regression assertion for the PostHog initialization options.

## Issue Number

N/A

## How to Test

Run:

```bash
npm ci
npx vitest run __tests__/services/telemetry.test.ts
npx eslint src/services/telemetry.ts __tests__/services/telemetry.test.ts
npx prettier --check src/services/telemetry.ts __tests__/services/telemetry.test.ts
npm run make-i18n && npm run typecheck:staged
```

For functional verification without polluting production analytics, inspect the telemetry service test: initializing the Canvas PostHog client now passes `capture_pageview: "history_change"` and `autocapture: true`.

## Video/Screenshots

N/A — non-visual telemetry instrumentation change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

I also updated the existing PostHog `conversation_created` dashboard insight (`71KIFhkA`) outside this PR so the SaaS series includes both `canvas.openhands.dev` and `app.all-hands.dev`, while OSS excludes both hosts.


@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a5ffee45-3315-4fa0-9b6f-ef5c0b0406c7)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.38.0-python` |
| **Automation** | `openhands-automation==1.4.1` |
| **Commit** | `f479a2ee2d36ceea792dbc821c2572591be1729f` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-f479a2e
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-f479a2e
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-f479a2e-amd64
ghcr.io/openhands/agent-canvas:fix-agent-canvas-pageview-telemetry-amd64
ghcr.io/openhands/agent-canvas:pr-16169-amd64
ghcr.io/openhands/agent-canvas:sha-f479a2e-arm64
ghcr.io/openhands/agent-canvas:fix-agent-canvas-pageview-telemetry-arm64
ghcr.io/openhands/agent-canvas:pr-16169-arm64
ghcr.io/openhands/agent-canvas:sha-f479a2e
ghcr.io/openhands/agent-canvas:fix-agent-canvas-pageview-telemetry
ghcr.io/openhands/agent-canvas:pr-16169
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-f479a2e`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-f479a2e-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->