### PR TITLE
fix(backend-registry): pick a healthy local backend as the fallback

### DIFF
--- a/__tests__/api/backend-registry/active-store.test.ts
+++ b/__tests__/api/backend-registry/active-store.test.ts
@@ -9,11 +9,17 @@ import {
   subscribeActiveBackend,
 } from "#/api/backend-registry/active-store";
 import { SEEDED_DEFAULT_BACKEND_ID } from "#/api/backend-registry/default-backend";
+import { MAX_CONSECUTIVE_FAILURES } from "#/api/backend-registry/health-storage";
+import {
+  __resetHealthStoreForTests,
+  recordBackendFailure,
+} from "#/api/backend-registry/health-store";
 import type { Backend } from "#/api/backend-registry/types";
 
 beforeEach(() => {
   window.localStorage.clear();
   window.sessionStorage.clear();
+  __resetHealthStoreForTests();
   __resetActiveStoreForTests();
 });
 
@@ -21,6 +27,7 @@ afterEach(() => {
   window.localStorage.clear();
   window.sessionStorage.clear();
   vi.unstubAllEnvs();
+  __resetHealthStoreForTests();
   __resetActiveStoreForTests();
 });
 
@@ -39,6 +46,20 @@ const localBackend: Backend = {
   apiKey: "k",
   kind: "local",
 };
+
+const secondLocalBackend: Backend = {
+  id: "local-2",
+  name: "Local 2",
+  host: "http://localhost:9001",
+  apiKey: "k2",
+  kind: "local",
+};
+
+function markBackendUnhealthy(id: string): void {
+  for (let i = 0; i < MAX_CONSECUTIVE_FAILURES; i += 1) {
+    recordBackendFailure(id, new Error("connection failed"));
+  }
+}
 
 describe("active-store", () => {
   it("uses the no-backend sentinel when no backend details are available", () => {
@@ -81,6 +102,41 @@ describe("active-store", () => {
     expect(getActiveBackend().orgId).toBeNull();
   });
 
+  it("falls back to a healthy local backend when a cloud backend is registered first", () => {
+    setRegisteredBackends([cloudBackend, localBackend]);
+    setActiveSelection(null);
+
+    expect(getActiveBackend().backend).toEqual(localBackend);
+  });
+
+  it("skips an unhealthy local backend in favor of a healthy one further down", () => {
+    markBackendUnhealthy(localBackend.id);
+    setRegisteredBackends([localBackend, secondLocalBackend]);
+    setActiveSelection(null);
+
+    expect(getActiveBackend().backend).toEqual(secondLocalBackend);
+  });
+
+  it("still selects a local backend when every local backend is unhealthy", () => {
+    markBackendUnhealthy(localBackend.id);
+    markBackendUnhealthy(secondLocalBackend.id);
+    setRegisteredBackends([cloudBackend, localBackend, secondLocalBackend]);
+    setActiveSelection(null);
+
+    const { backend } = getActiveBackend();
+    expect(backend.kind).toBe("local");
+    expect(backend.id).not.toBe(NO_BACKEND_ID);
+    // Deterministic: first local backend in insertion order.
+    expect(backend).toEqual(localBackend);
+  });
+
+  it("selects a single healthy local backend at the first registry position", () => {
+    setRegisteredBackends([localBackend]);
+    setActiveSelection(null);
+
+    expect(getActiveBackend().backend).toEqual(localBackend);
+  });
+
   it("falls back to the first registered backend when the registry has no local entry", () => {
     setRegisteredBackends([cloudBackend]);
     setActiveSelection(null);
@@ -100,6 +156,15 @@ describe("active-store", () => {
     setActiveSelection({ backendId: cloudBackend.id });
 
     expect(getEffectiveLocalBackend()).toBeNull();
+  });
+
+  it("keeps an explicit cloud selection even when a healthy local backend exists", () => {
+    setRegisteredBackends([localBackend, cloudBackend]);
+    setActiveSelection({ backendId: cloudBackend.id, orgId: "org-2" });
+
+    const { backend, orgId } = getActiveBackend();
+    expect(backend).toEqual(cloudBackend);
+    expect(orgId).toBe("org-2");
   });
 
   it("notifies subscribers when selection changes", () => {

--- a/src/api/backend-registry/active-store.ts
+++ b/src/api/backend-registry/active-store.ts
@@ -1,3 +1,4 @@
+import { getBackendHealthEntry } from "./health-store";
 import {
   readStoredActiveBackend,
   readStoredBackends,
@@ -33,8 +34,27 @@ export function isNoBackend(backend: Backend): boolean {
   return backend.id === NO_BACKEND_ID;
 }
 
+/**
+ * Choose an active backend when there is no valid explicit selection (fresh
+ * start, or the selected backend was removed). Most of the GUI speaks the
+ * local agent-server protocol, so a cloud or dead-local backend at index 0
+ * would leave `getEffectiveLocalBackend()` null and make every local-protocol
+ * call throw "No backend is configured" even when a healthy local backend is
+ * registered further down the list. Consult the synchronous, persisted health
+ * store and prefer a healthy local backend; fall back to any local backend so
+ * the effective-local resolver still resolves, then to the prior deterministic
+ * `backends[0]` behavior for the registry-has-no-local case.
+ */
 function pickFallbackBackend(backends: Backend[]): Backend {
-  return backends[0] ?? NO_BACKEND;
+  const healthyLocalBackend = backends.find(
+    (backend) =>
+      backend.kind === "local" &&
+      getBackendHealthEntry(backend.id)?.disabled !== true,
+  );
+  if (healthyLocalBackend) return healthyLocalBackend;
+
+  const localBackend = backends.find((backend) => backend.kind === "local");
+  return localBackend ?? backends[0] ?? NO_BACKEND;
 }
 
 function computeSnapshot(


### PR DESCRIPTION
HUMAN:
I work with agents, and I check their output before it goes out. Before porting this I had the failure reproduced against current `main` so it wasn't a faith-based port: with a cloud backend at index 0 and a healthy local further down, `getEffectiveLocalBackend()` comes back null and local calls throw. Ran the build and the backend-registry suite locally. The before/after console output is in the agent section below.

AGENT:
Ported from OpenHands/agent-canvas#1457, which @neubig closed asking for it to be reopened here.

Confirmed the bug is live on this base, not just ported on faith. I built a registry matching the failure shape (cloud backend at index 0, a local backend failed past `MAX_CONSECUTIVE_FAILURES`, then a healthy local) and ran it against `main` and against this branch:

On `main` (unpatched):
```
chosen active backend : prod (kind=cloud)
getEffectiveLocalBackend(): null
```

On this branch:
```
chosen active backend : local-ok (kind=local)
getEffectiveLocalBackend(): local-ok
```

The null is the failure: every local-protocol call throws "No backend is configured" while a healthy local backend sits in the registry.

Also ran: `npm run build` (production build succeeds), `npx tsc --noEmit -p tsconfig.json` (0 errors in `src/` and `__tests__/`), and `npx vitest run __tests__/api/backend-registry/` (4 files, 45 tests passed). Pre-commit hooks ran eslint, prettier, staged typecheck, and check-translation-completeness.

Not done: no click-through of the real GUI against a live agent-server. The evidence above is the store logic exercised directly.

---

## Why

With no valid explicit selection, `pickFallbackBackend` returns `backends[0]`. When that is a cloud or dead local backend, `getEffectiveLocalBackend()` is null and local-protocol calls throw even though a healthy local backend is registered further down the list.

## Summary

- Prefer a healthy local backend, consulting the persisted health store
- Fall back to any local backend so the effective-local resolver still resolves
- Then fall back to the prior `backends[0]` behavior for the registry-has-no-local case

## Issue Number

Ported from OpenHands/agent-canvas#1457

## How to Test

```
npm install
npx vitest run __tests__/api/backend-registry/
```

Manual: register a cloud backend first and a healthy local backend second, clear the active selection, then confirm local-protocol calls resolve instead of throwing "No backend is configured".

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
