### PR TITLE
fix: Revive local telemetry consent banner

### DIFF
--- a/__tests__/api/settings-service.test.ts
+++ b/__tests__/api/settings-service.test.ts
@@ -199,6 +199,24 @@ describe("SettingsService", () => {
     ]);
   });
 
+  it("treats omitted app-preferences analytics consent as unset", async () => {
+    server.use(
+      http.get("*/api/settings", () =>
+        HttpResponse.json({
+          agent_settings: {},
+          conversation_settings: {},
+          llm_api_key_is_set: false,
+          misc_settings: { app_preferences: {} },
+        }),
+      ),
+    );
+    SettingsService.invalidateCache();
+
+    const settings = await SettingsService.getSettings();
+
+    expect(settings.user_consents_to_analytics).toBeNull();
+  });
+
   it("surfaces server-side misc_settings.app_preferences in getSettings on a local backend", async () => {
     // The local agent-server returns app_preferences nested under
     // `misc_settings` on GET /api/settings. The mock handler echoes whatever

--- a/__tests__/components/analytics/telemetry-consent-banner.test.tsx
+++ b/__tests__/components/analytics/telemetry-consent-banner.test.tsx
@@ -5,6 +5,7 @@ import { TelemetryConsentBanner } from "#/components/features/analytics/telemetr
 
 const useActiveBackendMock = vi.fn();
 const useSettingsMock = vi.fn();
+const useBackendsHealthMock = vi.fn();
 const saveSettingsMock = vi.fn();
 const getLockedCloudHostMock = vi.fn();
 const setTelemetryConsentMock = vi.fn();
@@ -35,6 +36,10 @@ vi.mock("#/hooks/query/use-settings", () => ({
   useSettings: () => useSettingsMock(),
 }));
 
+vi.mock("#/hooks/query/use-backends-health", () => ({
+  useBackendsHealth: (...args: unknown[]) => useBackendsHealthMock(...args),
+}));
+
 vi.mock("#/hooks/mutation/use-save-settings", () => ({
   useSaveSettings: () => ({
     mutateAsync: saveSettingsMock,
@@ -59,6 +64,10 @@ describe("TelemetryConsentBanner", () => {
         host: "http://localhost:12000",
       },
     });
+    useBackendsHealthMock.mockReturnValue({
+      local: { isConnected: true },
+    });
+
     useSettingsMock.mockReturnValue({
       data: { user_consents_to_analytics: null },
       isSuccess: true,
@@ -78,11 +87,28 @@ describe("TelemetryConsentBanner", () => {
     ).toBeInTheDocument();
   });
 
-
   it("does not render until the local backend settings are connected", async () => {
     useSettingsMock.mockReturnValue({
       data: { user_consents_to_analytics: null },
       isSuccess: false,
+    });
+
+    render(<TelemetryConsentBanner />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("telemetry-consent-form"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("does not render when the active local backend is unhealthy", async () => {
+    useBackendsHealthMock.mockReturnValue({
+      local: { isConnected: false },
+    });
+    useSettingsMock.mockReturnValue({
+      data: { user_consents_to_analytics: null },
+      isSuccess: true,
     });
 
     render(<TelemetryConsentBanner />);

--- a/__tests__/components/analytics/telemetry-consent-banner.test.tsx
+++ b/__tests__/components/analytics/telemetry-consent-banner.test.tsx
@@ -36,7 +36,10 @@ vi.mock("#/hooks/query/use-settings", () => ({
 }));
 
 vi.mock("#/hooks/mutation/use-save-settings", () => ({
-  useSaveSettings: () => ({ mutate: saveSettingsMock }),
+  useSaveSettings: () => ({
+    mutateAsync: saveSettingsMock,
+    isPending: false,
+  }),
 }));
 
 vi.mock("#/services/telemetry", () => ({
@@ -46,6 +49,7 @@ vi.mock("#/services/telemetry", () => ({
 describe("TelemetryConsentBanner", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    saveSettingsMock.mockResolvedValue(undefined);
     getLockedCloudHostMock.mockReturnValue(null);
     useActiveBackendMock.mockReturnValue({
       backend: {
@@ -57,6 +61,7 @@ describe("TelemetryConsentBanner", () => {
     });
     useSettingsMock.mockReturnValue({
       data: { user_consents_to_analytics: null },
+      isSuccess: true,
     });
   });
 
@@ -73,11 +78,28 @@ describe("TelemetryConsentBanner", () => {
     ).toBeInTheDocument();
   });
 
+
+  it("does not render until the local backend settings are connected", async () => {
+    useSettingsMock.mockReturnValue({
+      data: { user_consents_to_analytics: null },
+      isSuccess: false,
+    });
+
+    render(<TelemetryConsentBanner />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("telemetry-consent-form"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it.each([true, false])(
     "does not render when agent-server consent is %s",
     async (serverConsent) => {
       useSettingsMock.mockReturnValue({
         data: { user_consents_to_analytics: serverConsent },
+        isSuccess: true,
       });
 
       render(<TelemetryConsentBanner />);
@@ -129,4 +151,22 @@ describe("TelemetryConsentBanner", () => {
       user_consents_to_analytics: false,
     });
   });
+
+  it("does not persist browser consent when the backend save fails", async () => {
+    const user = userEvent.setup();
+    saveSettingsMock.mockRejectedValue(new Error("unauthorized"));
+    render(<TelemetryConsentBanner />);
+
+    await screen.findByTestId("telemetry-consent-form");
+    await user.click(screen.getByTestId("confirm-telemetry-preferences"));
+
+    await waitFor(() => {
+      expect(saveSettingsMock).toHaveBeenCalledWith({
+        user_consents_to_analytics: true,
+      });
+    });
+    expect(setTelemetryConsentMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId("telemetry-consent-form")).toBeInTheDocument();
+  });
+
 });

--- a/__tests__/components/analytics/telemetry-consent-banner.test.tsx
+++ b/__tests__/components/analytics/telemetry-consent-banner.test.tsx
@@ -12,7 +12,10 @@ const setTelemetryConsentMock = vi.fn();
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     ready: true,
-    t: (key: string) => key,
+    t: (key: string, options?: Record<string, string>) =>
+      key === "TELEMETRY$BACKEND_SCOPE"
+        ? `This preference is saved for ${options?.name} at ${options?.host}.`
+        : key,
   }),
 }));
 
@@ -45,7 +48,12 @@ describe("TelemetryConsentBanner", () => {
     vi.clearAllMocks();
     getLockedCloudHostMock.mockReturnValue(null);
     useActiveBackendMock.mockReturnValue({
-      backend: { id: "local", kind: "local" },
+      backend: {
+        id: "local",
+        kind: "local",
+        name: "Local Dev",
+        host: "http://localhost:12000",
+      },
     });
     useSettingsMock.mockReturnValue({
       data: { user_consents_to_analytics: null },
@@ -57,6 +65,11 @@ describe("TelemetryConsentBanner", () => {
 
     expect(
       await screen.findByTestId("telemetry-consent-form"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This preference is saved for Local Dev at http://localhost:12000.",
+      ),
     ).toBeInTheDocument();
   });
 

--- a/__tests__/components/analytics/telemetry-consent-banner.test.tsx
+++ b/__tests__/components/analytics/telemetry-consent-banner.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TelemetryConsentBanner } from "#/components/features/analytics/telemetry-consent-banner";
+
+const useActiveBackendMock = vi.fn();
+const useSettingsMock = vi.fn();
+const saveSettingsMock = vi.fn();
+const getLockedCloudHostMock = vi.fn();
+const setTelemetryConsentMock = vi.fn();
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    ready: true,
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("#/i18n", () => ({
+  OPENHANDS_I18N_NAMESPACE: "openhands",
+}));
+
+vi.mock("#/api/agent-server-config", () => ({
+  getLockedCloudHost: () => getLockedCloudHostMock(),
+}));
+
+vi.mock("#/contexts/active-backend-context", () => ({
+  useActiveBackend: () => useActiveBackendMock(),
+}));
+
+vi.mock("#/hooks/query/use-settings", () => ({
+  useSettings: () => useSettingsMock(),
+}));
+
+vi.mock("#/hooks/mutation/use-save-settings", () => ({
+  useSaveSettings: () => ({ mutate: saveSettingsMock }),
+}));
+
+vi.mock("#/services/telemetry", () => ({
+  setTelemetryConsent: (...args: unknown[]) => setTelemetryConsentMock(...args),
+}));
+
+describe("TelemetryConsentBanner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getLockedCloudHostMock.mockReturnValue(null);
+    useActiveBackendMock.mockReturnValue({
+      backend: { id: "local", kind: "local" },
+    });
+    useSettingsMock.mockReturnValue({
+      data: { user_consents_to_analytics: null },
+    });
+  });
+
+  it("renders in local mode when agent-server consent is null", async () => {
+    render(<TelemetryConsentBanner />);
+
+    expect(
+      await screen.findByTestId("telemetry-consent-form"),
+    ).toBeInTheDocument();
+  });
+
+  it.each([true, false])(
+    "does not render when agent-server consent is %s",
+    async (serverConsent) => {
+      useSettingsMock.mockReturnValue({
+        data: { user_consents_to_analytics: serverConsent },
+      });
+
+      render(<TelemetryConsentBanner />);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("telemetry-consent-form"),
+        ).not.toBeInTheDocument();
+      });
+    },
+  );
+
+  it("does not render for cloud backends", async () => {
+    useActiveBackendMock.mockReturnValue({
+      backend: { id: "cloud", kind: "cloud" },
+    });
+
+    render(<TelemetryConsentBanner />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("telemetry-consent-form"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("does not render in locked Cloud mode", async () => {
+    getLockedCloudHostMock.mockReturnValue("https://app.all-hands.dev");
+
+    render(<TelemetryConsentBanner />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("telemetry-consent-form"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("persists the user's local-mode consent choice without useTelemetry", async () => {
+    const user = userEvent.setup();
+    render(<TelemetryConsentBanner />);
+
+    const checkbox = await screen.findByRole("checkbox");
+    await user.click(checkbox);
+    await user.click(screen.getByTestId("confirm-telemetry-preferences"));
+
+    expect(setTelemetryConsentMock).toHaveBeenCalledWith("denied");
+    expect(saveSettingsMock).toHaveBeenCalledWith({
+      user_consents_to_analytics: false,
+    });
+  });
+});

--- a/__tests__/hooks/use-sync-telemetry-consent.test.ts
+++ b/__tests__/hooks/use-sync-telemetry-consent.test.ts
@@ -146,6 +146,19 @@ describe("useSyncTelemetryConsent", () => {
     expect(saveSettingsMock).not.toHaveBeenCalled();
   });
 
+  it("does not auto-fill unset consent on another local backend", () => {
+    state.backendKind = "local";
+    state.pendingConsent = "granted";
+    useSettingsMock.mockReturnValue({
+      data: { user_consents_to_analytics: null },
+    });
+
+    renderHook(() => useSyncTelemetryConsent());
+
+    expect(saveSettingsMock).not.toHaveBeenCalled();
+    expect(setTelemetryConsentMock).not.toHaveBeenCalled();
+  });
+
   it("does not start another mutation while bounded retries run", () => {
     state.pendingConsent = "granted";
     useSettingsMock.mockReturnValue({

--- a/__tests__/hooks/use-sync-telemetry-consent.test.ts
+++ b/__tests__/hooks/use-sync-telemetry-consent.test.ts
@@ -60,16 +60,14 @@ describe("useSyncTelemetryConsent", () => {
     pendingConsentListener = null;
   });
 
-  it("calls opt-out when user_consents_to_analytics is null", () => {
+  it("leaves browser consent pending when user_consents_to_analytics is null", () => {
     useSettingsMock.mockReturnValue({
       data: { user_consents_to_analytics: null },
     });
 
     renderHook(() => useSyncTelemetryConsent());
 
-    expect(setTelemetryConsentMock).toHaveBeenCalledWith("denied", {
-      syncToCloud: false,
-    });
+    expect(setTelemetryConsentMock).not.toHaveBeenCalled();
   });
 
   it("calls opt-out when user_consents_to_analytics is false", () => {
@@ -165,12 +163,10 @@ describe("useSyncTelemetryConsent", () => {
 
   it("reacts when a first-run choice is made after the hook has mounted", () => {
     useSettingsMock.mockReturnValue({
-      data: { user_consents_to_analytics: false },
+      data: { user_consents_to_analytics: null },
     });
     renderHook(() => useSyncTelemetryConsent());
-    expect(setTelemetryConsentMock).toHaveBeenCalledWith("denied", {
-      syncToCloud: false,
-    });
+    expect(setTelemetryConsentMock).not.toHaveBeenCalled();
 
     vi.clearAllMocks();
     state.pendingConsent = "granted";

--- a/src/components/features/analytics/telemetry-consent-banner.tsx
+++ b/src/components/features/analytics/telemetry-consent-banner.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { getLockedCloudHost } from "#/api/agent-server-config";
 import { useActiveBackend } from "#/contexts/active-backend-context";
+import type { Backend } from "#/api/backend-registry/types";
 import { useSaveSettings } from "#/hooks/mutation/use-save-settings";
+import { useBackendsHealth } from "#/hooks/query/use-backends-health";
 import { useSettings } from "#/hooks/query/use-settings";
 import { I18nKey } from "#/i18n/declaration";
 import { OPENHANDS_I18N_NAMESPACE } from "#/i18n";
@@ -23,9 +25,11 @@ function LocalTelemetryConsentBanner({
   backend,
   onChoice,
 }: TelemetryConsentBannerProps & {
-  backend: { id: string; name: string; host: string };
+  backend: Backend;
 }) {
   const { t, ready } = useTranslation(OPENHANDS_I18N_NAMESPACE);
+  const health = useBackendsHealth([backend]);
+  const isBackendConnected = health[backend.id]?.isConnected === true;
   const { data: settings, isSuccess: hasLoadedSettings } = useSettings();
   const { mutateAsync: saveSettings, isPending: isSavingSettings } =
     useSaveSettings();
@@ -37,6 +41,7 @@ function LocalTelemetryConsentBanner({
   }, [backend.id]);
 
   const shouldShow =
+    isBackendConnected &&
     hasLoadedSettings &&
     settings?.user_consents_to_analytics === null &&
     !hasSubmittedChoice;
@@ -66,7 +71,7 @@ function LocalTelemetryConsentBanner({
     onChoice?.(granted);
   };
 
-  if (!isReady) return null;
+  if (!shouldShow || !isReady) return null;
 
   return (
     <ModalBackdrop elevated aria-label={t(I18nKey.TELEMETRY$CONSENT_TITLE)}>

--- a/src/components/features/analytics/telemetry-consent-banner.tsx
+++ b/src/components/features/analytics/telemetry-consent-banner.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { getLockedCloudHost } from "#/api/agent-server-config";
+import { useActiveBackend } from "#/contexts/active-backend-context";
+import { useSaveSettings } from "#/hooks/mutation/use-save-settings";
+import { useSettings } from "#/hooks/query/use-settings";
+import { I18nKey } from "#/i18n/declaration";
+import { OPENHANDS_I18N_NAMESPACE } from "#/i18n";
+import { ModalBackdrop } from "#/components/shared/modals/modal-backdrop";
+import { ModalBody } from "#/components/shared/modals/modal-body";
+import {
+  BaseModalTitle,
+  BaseModalDescription,
+} from "#/components/shared/modals/confirmation-modals/base-modal";
+import { BrandButton } from "#/components/features/settings/brand-button";
+import { setTelemetryConsent } from "#/services/telemetry";
+
+interface TelemetryConsentBannerProps {
+  onChoice?: (granted: boolean) => void;
+}
+
+function LocalTelemetryConsentBanner({
+  backendId,
+  onChoice,
+}: TelemetryConsentBannerProps & { backendId: string }) {
+  const { t, ready } = useTranslation(OPENHANDS_I18N_NAMESPACE);
+  const { data: settings } = useSettings();
+  const { mutate: saveSettings } = useSaveSettings();
+  const [isReady, setIsReady] = React.useState(false);
+  const [hasSubmittedChoice, setHasSubmittedChoice] = React.useState(false);
+
+  React.useEffect(() => {
+    setHasSubmittedChoice(false);
+  }, [backendId]);
+
+  const shouldShow =
+    settings?.user_consents_to_analytics === null && !hasSubmittedChoice;
+
+  React.useEffect(() => {
+    if (ready && shouldShow) {
+      const timer = setTimeout(() => setIsReady(true), 50);
+      return () => clearTimeout(timer);
+    }
+    setIsReady(false);
+    return undefined;
+  }, [ready, shouldShow]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const granted = formData.get("analytics") === "on";
+
+    setHasSubmittedChoice(true);
+    void setTelemetryConsent(granted ? "granted" : "denied");
+    saveSettings({ user_consents_to_analytics: granted });
+    onChoice?.(granted);
+  };
+
+  if (!isReady) return null;
+
+  return (
+    <ModalBackdrop elevated aria-label={t(I18nKey.TELEMETRY$CONSENT_TITLE)}>
+      <form
+        data-testid="telemetry-consent-form"
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-2"
+      >
+        <ModalBody className="border border-[var(--oh-border)]">
+          <BaseModalTitle title={t(I18nKey.TELEMETRY$CONSENT_TITLE)} />
+          <BaseModalDescription>
+            {t(I18nKey.TELEMETRY$CONSENT_DESCRIPTION)}
+          </BaseModalDescription>
+
+          <label className="flex gap-2 items-center self-start text-sm cursor-pointer">
+            <input
+              name="analytics"
+              type="checkbox"
+              defaultChecked
+              className="w-4 h-4 cursor-pointer"
+            />
+            {t(I18nKey.TELEMETRY$SEND_ANONYMOUS_DATA)}
+          </label>
+
+          <BrandButton
+            testId="confirm-telemetry-preferences"
+            type="submit"
+            variant="primary"
+            className="w-full"
+          >
+            {t(I18nKey.TELEMETRY$CONFIRM_PREFERENCES)}
+          </BrandButton>
+        </ModalBody>
+      </form>
+    </ModalBackdrop>
+  );
+}
+
+export function TelemetryConsentBanner({
+  onChoice,
+}: TelemetryConsentBannerProps) {
+  const { backend } = useActiveBackend();
+
+  if (getLockedCloudHost() !== null || backend.kind !== "local") return null;
+
+  return (
+    <LocalTelemetryConsentBanner backendId={backend.id} onChoice={onChoice} />
+  );
+}

--- a/src/components/features/analytics/telemetry-consent-banner.tsx
+++ b/src/components/features/analytics/telemetry-consent-banner.tsx
@@ -26,8 +26,9 @@ function LocalTelemetryConsentBanner({
   backend: { id: string; name: string; host: string };
 }) {
   const { t, ready } = useTranslation(OPENHANDS_I18N_NAMESPACE);
-  const { data: settings } = useSettings();
-  const { mutate: saveSettings } = useSaveSettings();
+  const { data: settings, isSuccess: hasLoadedSettings } = useSettings();
+  const { mutateAsync: saveSettings, isPending: isSavingSettings } =
+    useSaveSettings();
   const [isReady, setIsReady] = React.useState(false);
   const [hasSubmittedChoice, setHasSubmittedChoice] = React.useState(false);
 
@@ -36,7 +37,9 @@ function LocalTelemetryConsentBanner({
   }, [backend.id]);
 
   const shouldShow =
-    settings?.user_consents_to_analytics === null && !hasSubmittedChoice;
+    hasLoadedSettings &&
+    settings?.user_consents_to_analytics === null &&
+    !hasSubmittedChoice;
 
   React.useEffect(() => {
     if (ready && shouldShow) {
@@ -47,14 +50,19 @@ function LocalTelemetryConsentBanner({
     return undefined;
   }, [ready, shouldShow]);
 
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
     const granted = formData.get("analytics") === "on";
 
+    try {
+      await saveSettings({ user_consents_to_analytics: granted });
+    } catch {
+      return;
+    }
+
     setHasSubmittedChoice(true);
-    void setTelemetryConsent(granted ? "granted" : "denied");
-    saveSettings({ user_consents_to_analytics: granted });
+    await setTelemetryConsent(granted ? "granted" : "denied");
     onChoice?.(granted);
   };
 
@@ -94,6 +102,7 @@ function LocalTelemetryConsentBanner({
             type="submit"
             variant="primary"
             className="w-full"
+            isDisabled={isSavingSettings}
           >
             {t(I18nKey.TELEMETRY$CONFIRM_PREFERENCES)}
           </BrandButton>

--- a/src/components/features/analytics/telemetry-consent-banner.tsx
+++ b/src/components/features/analytics/telemetry-consent-banner.tsx
@@ -20,9 +20,11 @@ interface TelemetryConsentBannerProps {
 }
 
 function LocalTelemetryConsentBanner({
-  backendId,
+  backend,
   onChoice,
-}: TelemetryConsentBannerProps & { backendId: string }) {
+}: TelemetryConsentBannerProps & {
+  backend: { id: string; name: string; host: string };
+}) {
   const { t, ready } = useTranslation(OPENHANDS_I18N_NAMESPACE);
   const { data: settings } = useSettings();
   const { mutate: saveSettings } = useSaveSettings();
@@ -31,7 +33,7 @@ function LocalTelemetryConsentBanner({
 
   React.useEffect(() => {
     setHasSubmittedChoice(false);
-  }, [backendId]);
+  }, [backend.id]);
 
   const shouldShow =
     settings?.user_consents_to_analytics === null && !hasSubmittedChoice;
@@ -70,6 +72,12 @@ function LocalTelemetryConsentBanner({
           <BaseModalDescription>
             {t(I18nKey.TELEMETRY$CONSENT_DESCRIPTION)}
           </BaseModalDescription>
+          <p className="text-xs text-neutral-400">
+            {t(I18nKey.TELEMETRY$BACKEND_SCOPE, {
+              name: backend.name,
+              host: backend.host,
+            })}
+          </p>
 
           <label className="flex gap-2 items-center self-start text-sm cursor-pointer">
             <input
@@ -102,7 +110,5 @@ export function TelemetryConsentBanner({
 
   if (getLockedCloudHost() !== null || backend.kind !== "local") return null;
 
-  return (
-    <LocalTelemetryConsentBanner backendId={backend.id} onChoice={onChoice} />
-  );
+  return <LocalTelemetryConsentBanner backend={backend} onChoice={onChoice} />;
 }

--- a/src/hooks/use-sync-telemetry-consent.ts
+++ b/src/hooks/use-sync-telemetry-consent.ts
@@ -23,8 +23,8 @@ import { useSettings } from "./query/use-settings";
  * Consent model:
  *   true  → opt in  (user explicitly accepted)
  *   false → opt out (user explicitly denied)
- *   null  → opt out (consent not yet collected — safe default while loading
- *           or on first visit, prevents capturing before the user has decided)
+ *   null  → pending (consent not yet collected; PostHog stays opted out until
+ *           the user decides)
  */
 export const useSyncTelemetryConsent = () => {
   const { backend } = useActiveBackend();
@@ -69,8 +69,8 @@ export const useSyncTelemetryConsent = () => {
       return;
     }
 
-    // null and false are both treated as "not consented".
-    // Only an explicit true opts PostHog in.
+    if (settings.user_consents_to_analytics === null) return;
+
     void setTelemetryConsent(
       settings.user_consents_to_analytics === true ? "granted" : "denied",
       { syncToCloud: false },

--- a/src/hooks/use-sync-telemetry-consent.ts
+++ b/src/hooks/use-sync-telemetry-consent.ts
@@ -15,7 +15,9 @@ import { useSettings } from "./query/use-settings";
  * Reconciles the browser's capture state with the backend preference.
  *
  * A first-run user can make an explicit choice before Cloud login. That newer
- * browser decision remains pending across local backends and is written to the
+ * browser decision remains pending across local backends, but does not
+ * automatically fill unset local backend settings; each local backend can ask
+ * for its own persisted preference. The pending decision is written to the
  * Cloud backend after login; until Cloud confirms it, a stale/default backend
  * value must not overwrite it. With no pending browser choice, backend updates
  * remain authoritative so revocation in another tab or via the API is respected.
@@ -58,6 +60,8 @@ export const useSyncTelemetryConsent = () => {
         }
         return;
       }
+
+      if (backend.kind !== "cloud") return;
 
       const syncKey = `${backend.id}:${pendingBrowserConsent}`;
       if (isSavingSettings || attemptedSyncRef.current === syncKey) return;

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -29885,6 +29885,23 @@
     "tr": "Ürünü geliştirmek için anonim kullanım verileri topluyoruz. Kişisel bilgi toplanmaz. Bu ayarı istediğiniz zaman değiştirebilirsiniz.",
     "uk": "Ми збираємо анонімні дані про використання для покращення продукту. Особиста інформація не збирається. Ви можете змінити цей параметр у будь-який час."
   },
+  "TELEMETRY$BACKEND_SCOPE": {
+    "en": "This preference is saved for the local backend “{{name}}” at {{host}}.",
+    "ja": "この設定は {{host}} のローカルバックエンド「{{name}}」に保存されます。",
+    "zh-CN": "此偏好设置将保存到 {{host}} 的本地后端“{{name}}”。",
+    "zh-TW": "此偏好設定將儲存到 {{host}} 的本機後端「{{name}}」。",
+    "ko-KR": "이 환경 설정은 {{host}}의 로컬 백엔드 “{{name}}”에 저장됩니다.",
+    "no": "Denne innstillingen lagres for den lokale backend-en «{{name}}» på {{host}}.",
+    "ar": "يتم حفظ هذا التفضيل للواجهة الخلفية المحلية \"{{name}}\" على {{host}}.",
+    "de": "Diese Einstellung wird für das lokale Backend „{{name}}“ unter {{host}} gespeichert.",
+    "fr": "Cette préférence est enregistrée pour le backend local « {{name}} » sur {{host}}.",
+    "it": "Questa preferenza viene salvata per il backend locale “{{name}}” su {{host}}.",
+    "pt": "Esta preferência é salva para o backend local “{{name}}” em {{host}}.",
+    "es": "Esta preferencia se guarda para el backend local “{{name}}” en {{host}}.",
+    "ca": "Aquesta preferència es desa per al backend local “{{name}}” a {{host}}.",
+    "tr": "Bu tercih, {{host}} adresindeki “{{name}}” yerel arka ucu için kaydedilir.",
+    "uk": "Цей параметр зберігається для локального бекенда «{{name}}» на {{host}}."
+  },
   "TELEMETRY$ACCEPT": {
     "en": "Accept",
     "ja": "同意する",

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -43,6 +43,7 @@ import { LoadingSpinner } from "#/components/shared/loading-spinner";
 import { useConfig } from "#/hooks/query/use-config";
 import { QUERY_KEYS } from "#/hooks/query/query-keys";
 import { AgentServerUIRoot } from "#/components/providers";
+import { TelemetryConsentBanner } from "#/components/features/analytics/telemetry-consent-banner";
 import { buildAgentCanvasPath } from "#/utils/base-path";
 import { useOnboardingCompletion } from "#/components/features/onboarding/use-onboarding-completion";
 import { NavigationProvider } from "#/context/navigation-context";
@@ -336,7 +337,12 @@ export default function App() {
     isCloudBackendApiKeyOrNetworkHealthError(activeCloudHealth.lastError);
 
   if (showFirstRunOnboarding) {
-    return <FirstRunOnboardingScreen onClose={markCompleted} />;
+    return (
+      <>
+        <FirstRunOnboardingScreen onClose={markCompleted} />
+        <TelemetryConsentBanner />
+      </>
+    );
   }
 
   if (waitingForMainAppAuth || redirectingToMainAppLogin) {
@@ -365,5 +371,10 @@ export default function App() {
     return <MissingAgentServerScreen />;
   }
 
-  return <Outlet />;
+  return (
+    <>
+      <Outlet />
+      <TelemetryConsentBanner />
+    </>
+  );
 }

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -18,7 +18,7 @@ export const DEFAULT_SETTINGS: Settings = {
   enable_default_condenser: true,
   condenser_max_size: 240,
   enable_sound_notifications: false,
-  user_consents_to_analytics: false,
+  user_consents_to_analytics: null,
   enable_proactive_conversation_starters: false,
   enable_solvability_analysis: false,
   search_api_key: "",

--- a/tests/e2e/live/utils/agent-server-conversation.ts
+++ b/tests/e2e/live/utils/agent-server-conversation.ts
@@ -127,6 +127,9 @@ export async function configureLiveAgentServer(
         confirmation_mode: false,
         max_iterations: 6,
       },
+      misc_settings_diff: {
+        app_preferences: { user_consents_to_analytics: false },
+      },
     },
   });
   expect(

--- a/tests/e2e/mock-llm/backends/mock-llm-auth-modes.spec.ts
+++ b/tests/e2e/mock-llm/backends/mock-llm-auth-modes.spec.ts
@@ -68,6 +68,16 @@ test.describe("auth mode: fresh install with runtime-injected key", () => {
       window.localStorage.setItem("openhands-telemetry-consent", "denied");
     });
 
+    const consentResp = await request.patch(`${BACKEND_URL}/api/settings`, {
+      headers: { "X-Session-API-Key": SESSION_API_KEY },
+      data: {
+        misc_settings_diff: {
+          app_preferences: { user_consents_to_analytics: false },
+        },
+      },
+    });
+    expect(consentResp.ok()).toBe(true);
+
     await routeSessionApiKey(page);
     await page.goto("/", { waitUntil: "domcontentloaded" });
 

--- a/tests/e2e/mock-llm/backends/mock-llm-cross-connect.spec.ts
+++ b/tests/e2e/mock-llm/backends/mock-llm-cross-connect.spec.ts
@@ -151,6 +151,26 @@ async function suppressAnalytics(page: Page) {
   });
 }
 
+async function seedBackendAnalyticsConsent(backendUrl: string, apiKey: string) {
+  const response = await fetch(`${backendUrl}/api/settings`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Session-API-Key": apiKey,
+    },
+    body: JSON.stringify({
+      misc_settings_diff: {
+        app_preferences: { user_consents_to_analytics: false },
+      },
+    }),
+  });
+
+  expect(
+    response.ok,
+    `failed to seed analytics consent on ${backendUrl}: ${response.status}`,
+  ).toBe(true);
+}
+
 async function addBackendViaOnboarding(
   page: Page,
   opts: { name: string; host: string; apiKey: string },
@@ -251,6 +271,7 @@ test.describe("cross-connect: frontend-only → backend-only", () => {
       beStatus,
       `Backend-only never ready.\nOutput: ${beOutput.get().slice(-800)}`,
     ).not.toBeNull();
+    await seedBackendAnalyticsConsent(beUrl, beEnv.sessionKey);
 
     // ── 4. Open browser to the frontend-only instance ─────────────────
     await suppressAnalytics(page);
@@ -297,12 +318,12 @@ test.describe("cross-connect: frontend-only → backend-only", () => {
     ).toBe(true);
 
     // The manage-backends modal and auth screen must NOT be showing.
-    await expect(
-      page.getByTestId("manage-backends-modal"),
-    ).not.toBeVisible({ timeout: 2_000 });
-    await expect(
-      page.getByTestId("api-key-entry-screen"),
-    ).not.toBeVisible({ timeout: 2_000 });
+    await expect(page.getByTestId("manage-backends-modal")).not.toBeVisible({
+      timeout: 2_000,
+    });
+    await expect(page.getByTestId("api-key-entry-screen")).not.toBeVisible({
+      timeout: 2_000,
+    });
   });
 });
 
@@ -391,6 +412,10 @@ test.describe("cross-connect: frontend-only → multiple backends", () => {
     ]);
     expect(infoA).toHaveProperty("version");
     expect(infoB).toHaveProperty("version");
+    await Promise.all([
+      seedBackendAnalyticsConsent(beUrlA, beEnvA.sessionKey),
+      seedBackendAnalyticsConsent(beUrlB, beEnvB.sessionKey),
+    ]);
 
     // ── 4. Open browser to the frontend-only instance ─────────────────
     await suppressAnalytics(page);

--- a/tests/e2e/mock-llm/utils/mock-llm-helpers.ts
+++ b/tests/e2e/mock-llm/utils/mock-llm-helpers.ts
@@ -70,7 +70,31 @@ export const SESSION_API_KEY = (() => {
  *  localStorage no longer needs this seeding to reach onboarding.  See
  *  `auth mode: fresh install with runtime-injected key` in
  *  `mock-llm-auth-modes.spec.ts` for the test that covers that path. */
+export async function seedBackendAnalyticsConsent(
+  backendUrl = BACKEND_URL,
+  apiKey = SESSION_API_KEY,
+) {
+  const response = await fetch(`${backendUrl}/api/settings`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Session-API-Key": apiKey,
+    },
+    body: JSON.stringify({
+      misc_settings_diff: {
+        app_preferences: { user_consents_to_analytics: false },
+      },
+    }),
+  });
+
+  expect(
+    response.ok,
+    `failed to seed analytics consent on ${backendUrl}: ${response.status}`,
+  ).toBe(true);
+}
+
 export async function seedLocalStorage(page: Page) {
+  await seedBackendAnalyticsConsent();
   await page.addInitScript(
     ({ apiKey }) => {
       window.localStorage.setItem("analytics-consent", "false");
@@ -141,7 +165,7 @@ export async function dismissAnalyticsModal(page: Page) {
   // pointer events (e.g. the delete-profile confirmation left by a prior
   // test).
   try {
-    const form = page.getByTestId("user-capture-consent-form");
+    const form = page.getByTestId("telemetry-consent-form");
     await form.waitFor({ state: "visible", timeout: 5_000 });
     await form.getByRole("button", { name: "Confirm preferences" }).click();
     // Wait for the modal to fully close so the backdrop no longer
@@ -892,9 +916,7 @@ export async function setChatInput(
   // dismissAnalyticsModal's give-up window to paint the composer on a
   // loaded CI runner, and the querySelector below would throw. Wait for
   // the input the way a locator action would before setting text.
-  await page
-    .getByTestId(testId)
-    .waitFor({ state: "visible", timeout: 30_000 });
+  await page.getByTestId(testId).waitFor({ state: "visible", timeout: 30_000 });
   await page.evaluate(
     ({ tid, inputText }) => {
       const el = document.querySelector(`[data-testid="${tid}"]`);


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

AGENT:

This PR was created by an AI agent (OpenHands) on behalf of the user.

Validation performed:

```bash
npx vitest run __tests__/components/analytics/telemetry-consent-banner.test.tsx __tests__/hooks/use-sync-telemetry-consent.test.ts
```

Result: 2 test files passed, 15 tests passed.

```bash
npm run typecheck
```

Result: passed.

```bash
npm run lint
```

Result: passed, including `npm run make-i18n`, typecheck, ESLint, and Prettier check for `src/**/*.{ts,tsx}`.

```bash
npm run build
```

Result: passed. The first build attempt caught that the banner could not live in the outer document `Layout` because it used React Query before the provider existed during SPA prerender; the banner was moved into `App`, and the final build passed.

---

## Why

Local-mode first-run users currently keep `user_consents_to_analytics` as `null` without seeing an explicit opt-in / opt-out prompt. Because `null` previously synced as denied, users were not automatically opted in and had no first-run local banner path to make a choice.

## Summary

- Add a local-only `TelemetryConsentBanner` that appears only when the active local agent-server reports `user_consents_to_analytics === null`.
- Persist the user's choice through the existing settings mutation and update browser telemetry consent without moving telemetry lifecycle ownership into the banner.
- Keep `null` consent pending in `useSyncTelemetryConsent` so first-run local users can decide instead of being silently synced to denied.
- Add focused tests for local null consent, true/false server consent, Cloud suppression, locked-Cloud suppression, and choice persistence.

## Issue Number

N/A

## How to Test

Run:

```bash
npx vitest run __tests__/components/analytics/telemetry-consent-banner.test.tsx __tests__/hooks/use-sync-telemetry-consent.test.ts
npm run typecheck
npm run lint
npm run build
```

Expected results: all commands pass. In local mode with `user_consents_to_analytics: null`, the consent banner appears. With server consent `true` or `false`, or with a Cloud backend / locked Cloud mode, the banner does not appear.

## Video/Screenshots

Not captured. The UI behavior is covered by the new React Testing Library tests, and the app production build passes.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Cloud consent remains owned by the Cloud settings path (`GET/POST /api/v1/settings`) and is not handled by this local-only banner. Local consent continues to use the agent-server settings path (`misc_settings.app_preferences.user_consents_to_analytics`).

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/afc26f43-5d9f-4ff9-9cde-8f6602f68038)




<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.38.0-python` |
| **Automation** | `openhands-automation==1.4.1` |
| **Commit** | `7fc7c4641cfc961b71f9bdbbcaaf2de93fdc41cb` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-7fc7c46
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-7fc7c46
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-7fc7c46-amd64
ghcr.io/openhands/agent-canvas:revive-local-telemetry-consent-banner-amd64
ghcr.io/openhands/agent-canvas:pr-16183-amd64
ghcr.io/openhands/agent-canvas:sha-7fc7c46-arm64
ghcr.io/openhands/agent-canvas:revive-local-telemetry-consent-banner-arm64
ghcr.io/openhands/agent-canvas:pr-16183-arm64
ghcr.io/openhands/agent-canvas:sha-7fc7c46
ghcr.io/openhands/agent-canvas:revive-local-telemetry-consent-banner
ghcr.io/openhands/agent-canvas:pr-16183
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-7fc7c46`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-7fc7c46-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->