### PR TITLE
fix: update release repository metadata

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -449,7 +449,7 @@ jobs:
             --arg automation_version "$AUTOMATION_VERSION" \
             --arg git_sha "$GIT_SHA" \
             --arg git_ref "$GIT_REF" \
-            --arg ghcr_url "https://github.com/OpenHands/agent-canvas/pkgs/container/agent-canvas" \
+            --arg ghcr_url "https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas" \
             '{image: $image, short_sha: $short_sha, all_tags: $all_tags, architectures: $archs, agent_server_image: $agent_server_image, automation_version: $automation_version, git_sha: $git_sha, git_ref: $git_ref, ghcr_package_url: $ghcr_url}')
 
           echo "Consolidated build summary:"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </div>
 <div align="center">
   <a href="https://github.com/OpenHands/incubator-program"><img src="https://img.shields.io/badge/status-beta-blue?style=for-the-badge" alt="Project status beta"></a>
-  <a href="https://github.com/OpenHands/agent-canvas/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/OpenHands/agent-canvas/ci.yml?branch=main&style=for-the-badge" alt="CI status"></a>
+  <a href="https://github.com/OpenHands/OpenHands/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/OpenHands/OpenHands/ci.yml?branch=main&style=for-the-badge" alt="CI status"></a>
   <a href="https://www.npmjs.com/package/@openhands/agent-canvas"><img src="https://img.shields.io/npm/v/%40openhands%2Fagent-canvas?style=for-the-badge&logo=npm" alt="npm version"></a>
   <a href="https://docs.openhands.dev/openhands/usage/agent-canvas/backends"><img src="https://img.shields.io/badge/Documentation-000?logo=googledocs&logoColor=FFE165&style=for-the-badge" alt="Documentation"></a>
   <a href="https://go.openhands.dev/slack"><img src="https://img.shields.io/badge/Slack-Join%20the%20community-611f69?logo=slack&logoColor=white&style=for-the-badge" alt="Join us on Slack"></a>
@@ -111,8 +111,8 @@ The agent will be able to access any project under `PROJECTS_PATH`.
 **Prerequisites**: Node.js 22.12.x or later, `npm`, `uv` (for running the agent server via `uvx`)
 
 ```sh
-git clone https://github.com/OpenHands/agent-canvas.git
-cd agent-canvas
+git clone https://github.com/OpenHands/OpenHands.git
+cd OpenHands
 npm install
 npm run dev
 ```

--- a/__tests__/github-workflows/npm-publish.test.ts
+++ b/__tests__/github-workflows/npm-publish.test.ts
@@ -36,6 +36,15 @@ describe("npm publish workflow", () => {
     );
   });
 
+  it("does not let electron-builder auto-publish during desktop builds", () => {
+    const packageJson = JSON.parse(read("package.json"));
+
+    expect(packageJson.scripts["build:desktop"]).toContain("--publish never");
+    expect(packageJson.scripts["build:desktop:universal"]).toContain(
+      "--publish never",
+    );
+  });
+
   it("builds both package surfaces with the production PostHog key", () => {
     const workflow = read(".github/workflows/npm-publish.yml");
     const buildAppStep = workflow.match(

--- a/__tests__/github-workflows/npm-publish.test.ts
+++ b/__tests__/github-workflows/npm-publish.test.ts
@@ -14,13 +14,35 @@ function read(rel: string): string {
 }
 
 describe("npm publish workflow", () => {
+  it("uses the canonical GitHub repository in release metadata", () => {
+    const packageJson = JSON.parse(read("package.json"));
+    const dockerfile = read("docker/Dockerfile");
+    const dockerWorkflow = read(".github/workflows/docker.yml");
+
+    expect(packageJson.repository.url).toBe(
+      "https://github.com/OpenHands/OpenHands",
+    );
+    expect(packageJson.homepage).toBe(
+      "https://github.com/OpenHands/OpenHands#readme",
+    );
+    expect(packageJson.bugs.url).toBe(
+      "https://github.com/OpenHands/OpenHands/issues",
+    );
+    expect(dockerfile).toContain(
+      'LABEL org.opencontainers.image.source="https://github.com/OpenHands/OpenHands"',
+    );
+    expect(dockerWorkflow).toContain(
+      "https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas",
+    );
+  });
+
   it("builds both package surfaces with the production PostHog key", () => {
     const workflow = read(".github/workflows/npm-publish.yml");
     const buildAppStep = workflow.match(
       /- name: Build app[\s\S]*?(?=\n\s*- name: Build library)/,
     )?.[0];
     const buildLibraryStep = workflow.match(
-      /- name: Build library[\s\S]*?(?=\n\s*- name: Verify package contents)/,
+      /- name: Build library[\s\S]*?(?=\n\s*- name: Bake package telemetry defaults)/,
     )?.[0];
 
     expect(buildAppStep).toBeTruthy();

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,7 +80,7 @@ ARG VITE_POSTHOG_API_KEY=""
 ARG AGENT_CANVAS_VERSION=dev
 LABEL org.opencontainers.image.title="agent-canvas"
 LABEL org.opencontainers.image.description="All-in-one agent-canvas: Agent Server + Automation + Frontend"
-LABEL org.opencontainers.image.source="https://github.com/OpenHands/agent-canvas"
+LABEL org.opencontainers.image.source="https://github.com/OpenHands/OpenHands"
 LABEL org.opencontainers.image.version="${AGENT_CANVAS_VERSION}"
 LABEL org.opencontainers.image.revision="${OPENHANDS_BUILD_GIT_SHA}"
 

--- a/helm/agent-canvas/Chart.yaml
+++ b/helm/agent-canvas/Chart.yaml
@@ -15,9 +15,9 @@ version: 0.1.0
 # hand; the trailing annotation is what marks this line for replacement.
 appVersion: "1.7.0" # x-release-please-version
 kubeVersion: ">=1.24.0-0"
-home: https://github.com/OpenHands/agent-canvas
+home: https://github.com/OpenHands/OpenHands
 sources:
-  - https://github.com/OpenHands/agent-canvas
+  - https://github.com/OpenHands/OpenHands
 keywords:
   - openhands
   - agent

--- a/helm/agent-canvas/README.md
+++ b/helm/agent-canvas/README.md
@@ -1,6 +1,6 @@
 # agent-canvas Helm chart
 
-Helm chart for running the [OpenHands agent-canvas](https://github.com/OpenHands/agent-canvas)
+Helm chart for running the [OpenHands agent-canvas](https://github.com/OpenHands/OpenHands)
 all-in-one image (frontend + agent-server + automation) on Kubernetes as a
 `StatefulSet` with persistent storage, an `Ingress`, and optional in-cluster
 RBAC.

--- a/package.json
+++ b/package.json
@@ -102,8 +102,8 @@
     "build:docker": "node scripts/docker-build.mjs",
     "example:acp-docker:env": "node scripts/gen-acp-docker-env.mjs",
     "desktop": "npm run build:app && electron electron/main.mjs",
-    "build:desktop": "npm run build:app && node scripts/download-uv.mjs && node scripts/download-node.mjs && electron-builder --config electron-builder.config.mjs",
-    "build:desktop:universal": "npm run build:app && node scripts/download-uv.mjs && node scripts/download-node.mjs && cross-env ELECTRON_ARCH=universal electron-builder --config electron-builder.config.mjs",
+    "build:desktop": "npm run build:app && node scripts/download-uv.mjs && node scripts/download-node.mjs && electron-builder --config electron-builder.config.mjs --publish never",
+    "build:desktop:universal": "npm run build:app && node scripts/download-uv.mjs && node scripts/download-node.mjs && cross-env ELECTRON_ARCH=universal electron-builder --config electron-builder.config.mjs --publish never",
     "download-uv": "node scripts/download-uv.mjs",
     "download-node": "node scripts/download-node.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OpenHands/agent-canvas"
+    "url": "https://github.com/OpenHands/OpenHands"
   },
-  "homepage": "https://github.com/OpenHands/agent-canvas#readme",
+  "homepage": "https://github.com/OpenHands/OpenHands#readme",
   "bugs": {
-    "url": "https://github.com/OpenHands/agent-canvas/issues"
+    "url": "https://github.com/OpenHands/OpenHands/issues"
   },
   "bin": {
     "agent-canvas": "bin/agent-canvas.mjs"

--- a/scripts/check-sdk-version-sync.mjs
+++ b/scripts/check-sdk-version-sync.mjs
@@ -77,7 +77,7 @@ Triggering from other repos:
   curl -X POST \\
     -H "Authorization: token \$GITHUB_TOKEN" \\
     -H "Accept: application/vnd.github.v3+json" \\
-    https://api.github.com/repos/OpenHands/agent-canvas/dispatches \\
+    https://api.github.com/repos/OpenHands/OpenHands/dispatches \\
     -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.38.0"}}'
 `);
   process.exit(0);

--- a/src/api/agent-canvas-updates.ts
+++ b/src/api/agent-canvas-updates.ts
@@ -10,7 +10,7 @@ const NPM_LATEST_VERSION_URL =
   "https://registry.npmjs.org/@openhands/agent-canvas/latest";
 
 export const AGENT_CANVAS_RELEASE_NOTES_URL =
-  "https://github.com/OpenHands/agent-canvas/releases";
+  "https://github.com/OpenHands/OpenHands/releases";
 
 /** Literal shell commands — intentionally not localized. */
 export const AGENT_CANVAS_UPDATE_COMMANDS = {


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

AGENT:

Release-context evidence:
- The v1.7.0 npm publish failed with npm provenance validation because `package.json` identified `https://github.com/OpenHands/agent-canvas`, while GitHub Actions provenance identified `https://github.com/OpenHands/OpenHands`.
- The v1.7.0 desktop release jobs failed while trying to publish to `https://api.github.com/repos/OpenHands/agent-canvas/releases` during the packaging step.

Validation performed:
- Ran a dependency-free Node metadata check against `package.json`, `docker/Dockerfile`, and `.github/workflows/docker.yml`; it passed.
- Verified the desktop build scripts include `--publish never`, so `electron-builder` cannot auto-publish during packaging; the workflows still attach artifacts with the explicit `gh release upload` steps.
- Re-scanned release/source metadata paths for stale `OpenHands/agent-canvas` publish URLs; only historical issue-reference comments remain.
- Attempted `npm test -- __tests__/github-workflows/npm-publish.test.ts src/api/agent-canvas-updates.test.ts`; it could not run in this checkout because dependencies are not installed (`vitest: not found`).

This PR was created by an AI agent (OpenHands) on behalf of the user.

---

## Why

The `v1.7.0` release published Docker successfully, but npm rejected the package provenance because the package repository metadata still pointed at the previous `OpenHands/agent-canvas` repository instead of the current `OpenHands/OpenHands` repository. The same stale repository metadata also caused desktop release jobs to target the old GitHub releases endpoint.

## Summary

- Update npm package, Docker image, Helm, README, release notes, and workflow metadata to use `OpenHands/OpenHands`.
- Update the SDK version-check repository-dispatch example to the current repository.
- Add regression coverage for canonical release metadata and desktop packaging not auto-publishing through `electron-builder`.

## Issue Number

N/A

## How to Test

1. Inspect the package metadata:
   ```sh
   node -e 'const pkg=require("./package.json"); console.log(pkg.repository.url, pkg.homepage, pkg.bugs.url)'
   ```
   Expected: all URLs point at `https://github.com/OpenHands/OpenHands`.
2. Confirm desktop packaging is non-publishing:
   ```sh
   node -e 'const pkg=require("./package.json"); console.log(pkg.scripts["build:desktop"], pkg.scripts["build:desktop:universal"])'
   ```
   Expected: both scripts include `--publish never`.
3. Run the targeted regression test in an environment with dependencies installed:
   ```sh
   npm test -- __tests__/github-workflows/npm-publish.test.ts src/api/agent-canvas-updates.test.ts
   ```
4. On the next tag release, confirm `npm-publish.yml` provenance validation succeeds and desktop workflows attach release assets through their explicit upload steps.

## Video/Screenshots

N/A — release metadata/workflow fix; no UI changes.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

After this lands, a patch release should be cut so npm can publish `@openhands/agent-canvas@1.7.1` from the corrected repository metadata.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.38.0-python` |
| **Automation** | `openhands-automation==1.4.1` |
| **Commit** | `849702d7f84b8120af5341bcd815eb0fe32256db` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-849702d
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-849702d
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-849702d-amd64
ghcr.io/openhands/agent-canvas:fix-release-repo-metadata-amd64
ghcr.io/openhands/agent-canvas:pr-16186-amd64
ghcr.io/openhands/agent-canvas:sha-849702d-arm64
ghcr.io/openhands/agent-canvas:fix-release-repo-metadata-arm64
ghcr.io/openhands/agent-canvas:pr-16186-arm64
ghcr.io/openhands/agent-canvas:sha-849702d
ghcr.io/openhands/agent-canvas:fix-release-repo-metadata
ghcr.io/openhands/agent-canvas:pr-16186
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-849702d`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-849702d-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->