### PR TITLE
fix(e2e): disable browser tools during mock LLM builds

### DIFF
--- a/.github/workflows/mock-llm-docker-e2e.yml
+++ b/.github/workflows/mock-llm-docker-e2e.yml
@@ -321,6 +321,10 @@ jobs:
       # Docker) and require build/index.html to exist locally. The regular
       # mock-llm-e2e workflow builds before running; we do the same here.
       - name: Build frontend (for partial-stack tests)
+        env:
+          # Partial-stack tests use the local static build, so keep its tool
+          # payload consistent with the mock-LLM stack runtime settings.
+          VITE_ENABLE_BROWSER_TOOLS: "false"
         run: npm run build:app
 
       # ── Run tests ──────────────────────────────────────────────────────

--- a/.github/workflows/mock-llm-e2e.yml
+++ b/.github/workflows/mock-llm-e2e.yml
@@ -147,6 +147,10 @@ jobs:
           kill $SERVER_PID
 
       - name: Build frontend (for agent-canvas binary)
+        env:
+          # VITE_ENABLE_BROWSER_TOOLS is evaluated at Vite build time;
+          # setting it only when the static stack starts is too late.
+          VITE_ENABLE_BROWSER_TOOLS: "false"
         run: npm run build:app
 
       - name: Resolve affected test directories


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

AGENT:

This PR was created by an AI agent (OpenHands) on behalf of the user.

I investigated the discrepancy between failing npm Mock-LLM E2E runs and passing PR runs. The passing PR built the static frontend with `VITE_ENABLE_BROWSER_TOOLS=false`; main only set that value at stack runtime, which is too late because the frontend reads this flag at Vite build time.

Why browser tools matter here: the Mock-LLM tests expect a deterministic conversation-start payload and tool set. If the frontend is built without `VITE_ENABLE_BROWSER_TOOLS=false`, it still includes `browser_tool_set` in new-conversation requests. That makes the frontend ask the agent-server to start a conversation with a tool configuration the Mock-LLM stack did not intend to expose for these tests. The observed symptom is that conversation creation does not complete normally, so the page stays on `/` and tests time out waiting for `/conversations/<id>`.

Verification performed:

- Inspected failing and passing GitHub Actions logs for Mock-LLM E2E runs.
- Confirmed the failing npm Mock-LLM E2E workflow built the frontend without `VITE_ENABLE_BROWSER_TOOLS=false`.
- Confirmed the passing PR run included `VITE_ENABLE_BROWSER_TOOLS: false` during `npm run build:app`.
- Verified this branch's workflow diff and checked both changed workflow files contain `VITE_ENABLE_BROWSER_TOOLS: "false"` in the build steps.

I did not rerun the full Mock-LLM E2E suite locally because this change only updates GitHub Actions workflow configuration; the PR's CI run is the appropriate end-to-end validation.

---

## Why

The Mock-LLM npm E2E job builds the static frontend before starting the `agent-canvas` binary. `VITE_ENABLE_BROWSER_TOOLS` is evaluated during the Vite build, so setting it only when the static stack starts leaves browser tools baked into the frontend bundle.

That matters because browser-tool inclusion changes the conversation-start payload: the compiled frontend sends `browser_tool_set`, while the Mock-LLM E2E stack is configured around a smaller deterministic tool set. The failing npm runs showed this as repeated navigation timeouts: tests clicked the home-page submit button, but the app remained on `/` instead of reaching `/conversations/<id>`.

## Summary

- Set `VITE_ENABLE_BROWSER_TOOLS=false` while building the static frontend in `mock-llm-e2e.yml`.
- Apply the same build-time flag to the Docker workflow's local partial-stack frontend build for consistency.

## Issue Number

N/A

## How to Test

Run the Mock-LLM workflows on this PR:

- `Mock-LLM E2E Tests`
- `Mock-LLM Docker E2E Tests`

The npm workflow logs should show `VITE_ENABLE_BROWSER_TOOLS: false` on the `Build frontend (for agent-canvas binary)` step before `npm run build:app`.

## Video/Screenshots

N/A — workflow configuration change only.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The key behavior is build-time, not runtime: `VITE_ENABLE_BROWSER_TOOLS=false` must be present on the frontend build step itself. Passing it only to the later `agent-canvas` process cannot remove `browser_tool_set` from an already-built static bundle.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/615af17b-039c-45c7-988d-a27969064e18)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.38.0-python` |
| **Automation** | `openhands-automation==1.4.1` |
| **Commit** | `1c4186d8e9be21c82025ef86611cd1dcc28221ec` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-1c4186d
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-1c4186d
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-1c4186d-amd64
ghcr.io/openhands/agent-canvas:fix-mock-llm-build-disable-browser-tools-amd64
ghcr.io/openhands/agent-canvas:pr-16188-amd64
ghcr.io/openhands/agent-canvas:sha-1c4186d-arm64
ghcr.io/openhands/agent-canvas:fix-mock-llm-build-disable-browser-tools-arm64
ghcr.io/openhands/agent-canvas:pr-16188-arm64
ghcr.io/openhands/agent-canvas:sha-1c4186d
ghcr.io/openhands/agent-canvas:fix-mock-llm-build-disable-browser-tools
ghcr.io/openhands/agent-canvas:pr-16188
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-1c4186d`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-1c4186d-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->
