### PR TITLE
fix(settings): reject malformed LLM base URLs instead of saving them

### DIFF
--- a/__tests__/routes/llm-settings.test.tsx
+++ b/__tests__/routes/llm-settings.test.tsx
@@ -182,6 +182,52 @@ describe("LlmSettingsScreen", () => {
     expect(llmPayload).not.toHaveProperty("base_url");
   });
 
+  it("shows an inline error and blocks the save for a malformed base URL", async () => {
+    // Reported in #15774: "." was accepted with a success toast and only
+    // surfaced later as an opaque provider error.
+    const saveSettingsSpy = vi
+      .spyOn(SettingsService, "saveSettings")
+      .mockResolvedValue(true);
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({
+        llm_model: "openai/gpt-4o",
+        agent_settings: {
+          ...MOCK_DEFAULT_USER_SETTINGS.agent_settings,
+          llm: { model: "openai/gpt-4o", api_key: null, base_url: "" },
+        },
+      }),
+    );
+
+    renderLlmSettingsScreen();
+
+    await screen.findByTestId("llm-settings-screen");
+    fireEvent.click(screen.getByTestId("sdk-section-advanced-toggle"));
+    fireEvent.change(screen.getByTestId("base-url-input"), {
+      target: { value: "." },
+    });
+
+    expect(
+      await screen.findByTestId("base-url-input-error"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("save-button"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("base-url-input-error")).toBeInTheDocument(),
+    );
+    expect(saveSettingsSpy).not.toHaveBeenCalled();
+
+    // Clearing the field must retract the error, not leave it stranded: the
+    // field is optional, so blank has to remain a saveable state.
+    fireEvent.change(screen.getByTestId("base-url-input"), {
+      target: { value: "" },
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("base-url-input-error")).toBeNull(),
+    );
+  });
+
   it("does not show a 'key set' indicator for a brand-new embedded profile even when a global key exists (bug #640)", async () => {
     // A global key exists, but a fresh profile form must look unset so the user
     // knows they have to enter one — otherwise the profile saves with no key.

--- a/__tests__/utils/sdk-settings-schema.test.ts
+++ b/__tests__/utils/sdk-settings-schema.test.ts
@@ -375,4 +375,66 @@ describe("sdk settings schema helpers", () => {
       expect(getVisibleSettingsSections(malformed, {}, "basic")).toEqual([]);
     });
   });
+
+  describe("URL field validation", () => {
+    const buildPayloadWithBaseUrl = (baseUrl: string) =>
+      buildSdkSettingsPayload(
+        BASE_SETTINGS.agent_settings_schema!,
+        {
+          ...buildInitialSettingsFormValues(BASE_SETTINGS),
+          "llm.base_url": baseUrl,
+        },
+        { "llm.base_url": true },
+      );
+
+    it.each([".", "-", "localhost:8000", "api.openai.com", "ftp://files.test"])(
+      "refuses to build a payload for the malformed base URL %j",
+      (baseUrl) => {
+        // SDK-defined: the field is what the user typed into Settings -> LLM,
+        // and a value this broken must never reach the provider.
+        expect(() => buildPayloadWithBaseUrl(baseUrl)).toThrow(
+          "Base URL must use http:// or https://",
+        );
+      },
+    );
+
+    it.each([
+      "https://api.openai.com",
+      "https://api.openai.com/v1",
+      "http://127.0.0.1:8000",
+    ])("passes the valid base URL %j through unchanged", (baseUrl) => {
+      expect(buildPayloadWithBaseUrl(baseUrl)).toEqual({
+        llm: { base_url: baseUrl },
+      });
+    });
+
+    it("treats a blank base URL as clearing the field, not as invalid", () => {
+      // SDK-defined: `llm.base_url` is optional, so blank means "use the
+      // provider default" and must stay saveable.
+      expect(buildPayloadWithBaseUrl("")).toEqual({ llm: { base_url: null } });
+    });
+
+    it("validates the trimmed value but stores the raw one", () => {
+      // Pins current coercion behaviour: surrounding whitespace is tolerated
+      // for the format check, while trimming itself stays the adapter's job.
+      expect(buildPayloadWithBaseUrl("  https://api.openai.com  ")).toEqual({
+        llm: { base_url: "  https://api.openai.com  " },
+      });
+    });
+
+    it("leaves string fields that are not URLs unvalidated", () => {
+      // Proves the gate is scoped by field key: a model name is a plain
+      // string and "." is a legitimate (if odd) value for it.
+      const payload = buildSdkSettingsPayload(
+        BASE_SETTINGS.agent_settings_schema!,
+        {
+          ...buildInitialSettingsFormValues(BASE_SETTINGS),
+          "llm.model": ".",
+        },
+        { "llm.model": true },
+      );
+
+      expect(payload).toEqual({ llm: { model: "." } });
+    });
+  });
 });

--- a/src/components/features/settings/sdk-settings/schema-field.tsx
+++ b/src/components/features/settings/sdk-settings/schema-field.tsx
@@ -10,6 +10,7 @@ import {
   resolveSchemaChoiceLabel,
   resolveSchemaFieldLabel,
 } from "#/utils/sdk-settings-field-metadata";
+import { isUrlField } from "#/utils/sdk-settings-schema";
 import { cn } from "#/utils/utils";
 import {
   formControlMultilineFieldClassName,
@@ -37,10 +38,6 @@ function isBooleanField(field: SettingsFieldSchema): boolean {
 
 function isJsonField(field: SettingsFieldSchema): boolean {
   return field.value_type === "array" || field.value_type === "object";
-}
-
-function isUrlField(field: SettingsFieldSchema): boolean {
-  return field.key.endsWith("url") || field.key.endsWith("_url");
 }
 
 function getInputType(

--- a/src/routes/llm-settings.tsx
+++ b/src/routes/llm-settings.tsx
@@ -19,6 +19,7 @@ import { Settings, SettingsSchema, SettingsScope } from "#/types/settings";
 import { extractModelAndProvider } from "#/utils/extract-model-and-provider";
 import {
   inferInitialView,
+  isValidSettingsUrl,
   type SettingsFormValues,
   type SettingsView,
 } from "#/utils/sdk-settings-schema";
@@ -193,6 +194,13 @@ export function LlmSettingsScreen({
         typeof values["llm.base_url"] === "string"
           ? values["llm.base_url"]
           : "";
+      // Blank is valid — the field is optional — so only flag a value the save
+      // would reject, and flag it here so the user sees why before clicking.
+      const trimmedBaseUrlValue = baseUrlValue.trim();
+      const baseUrlError =
+        trimmedBaseUrlValue && !isValidSettingsUrl(trimmedBaseUrlValue)
+          ? t(I18nKey.SETTINGS$MCP_ERROR_URL_INVALID_PROTOCOL)
+          : undefined;
       const showOpenHandsApiKeyHelp = modelValue.startsWith("openhands/");
       const authType = resolveLlmAuthType(values[LLM_AUTH_TYPE_KEY]);
       const isSubscriptionAuth = authType === LLM_AUTH_TYPE_SUBSCRIPTION;
@@ -401,6 +409,7 @@ export function LlmSettingsScreen({
                     placeholder="https://api.openai.com"
                     onChange={(value) => onChange("llm.base_url", value)}
                     isDisabled={isDisabled}
+                    error={baseUrlError}
                   />
 
                   {renderApiKeyInput(

--- a/src/utils/sdk-settings-schema.ts
+++ b/src/utils/sdk-settings-schema.ts
@@ -336,6 +336,26 @@ function parseBooleanFieldValue(rawValue: string | boolean): boolean | null {
   throw new Error(`Expected a boolean value, received: ${rawValue}`);
 }
 
+/** Fields whose value is a URL, by naming convention. Decides both the
+ *  `type="url"` input rendering and the save-time format check, so the two can
+ *  never disagree. */
+export function isUrlField(field: SettingsFieldSchema): boolean {
+  return field.key.endsWith("url") || field.key.endsWith("_url");
+}
+
+/** A URL we are willing to send to a provider: parseable, and http(s) rather
+ *  than `file:`, `javascript:` or a bare host that parses as its own scheme
+ *  (`localhost:8000` yields `protocol === "localhost:"`). Matches the check
+ *  MCP server URLs already get in `mcp-server-form.tsx`. */
+export function isValidSettingsUrl(value: string): boolean {
+  try {
+    const { protocol } = new URL(value);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 export function coerceFieldValue(
   field: SettingsFieldSchema,
   rawValue: string | boolean,
@@ -403,6 +423,14 @@ export function coerceFieldValue(
   const stringValue = String(rawValue);
   if (stringValue === "" && !field.secret) {
     return null;
+  }
+
+  // Reject a malformed URL here rather than saving it: the field is optional so
+  // blank stays valid, but a value like "." is accepted all the way to a green
+  // "saved" toast and only resurfaces later as an opaque provider error.
+  const trimmedValue = stringValue.trim();
+  if (trimmedValue && isUrlField(field) && !isValidSettingsUrl(trimmedValue)) {
+    throw new Error(`${field.label} must use http:// or https://`);
   }
 
   return stringValue;


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Tested locally with npm run dev. In Settings → LLM → Add LLM Profile → Advanced I entered "." as the Base URL: the field turned red with "URL must use http:// or https://" and Save was refused with a matching toast. A valid https URL saves fine.

AGENT:

Disclosure: this change was written with AI assistance (Claude Code). Evidence of
what was actually executed is below, stated precisely -- including what was *not*
exercised.

Commands run in the repo at `main` + this branch:

- `npm run lint` -> clean (`react-router typegen && tsc`, `eslint src`, `prettier --check src/**`)
- `npm test` -> **4046 passed** | 5 skipped | 9 todo across 520 files.
  Baseline on `main` before the change was 4034 passed, i.e. exactly the +12 added here.
- `npm run build` -> `✓ built in 1.03s`
- Red-before/green-after was verified explicitly, not assumed: with `git stash push -- src/`
  (tests kept, fix removed) the new assertions fail --
  5 failures in `__tests__/utils/sdk-settings-schema.test.ts`
  (`expected [Function] to throw an error`) and 1 in `__tests__/routes/llm-settings.test.tsx`
  (`Unable to find an element by: [data-testid="base-url-input-error"]`).
  Restoring `src/` turns all 34 green.

Verified in the running app (`npm run dev`, ingress on `:8000`), not only in unit tests.
Path exercised: **Settings -> LLM -> Add LLM Profile -> Advanced -> Base URL**, entering `.`:

- the field border turns red and the inline message "URL must use http:// or https://"
  renders under it, and
- clicking **Save** is refused with the toast "Base URL must use http:// or https://" --
  which is the `coerceFieldValue` throw surfacing through
  `LlmSettingsLocalView`'s catch. The toast replaced the prior "Model is required",
  confirming the new gate is what blocked the save.

Worth noting for review: on a Local backend that profile editor is the real user path, and
it builds its payload via `saveControl.getDirtyPayload()` rather than the route's own save.
That is precisely why the check belongs in `coerceFieldValue` -- a fix placed in
`llm-settings.tsx` alone would leave this page still saving `.`.

Not exercised: a real provider round-trip (no live API key was used) -- unnecessary here,
since the bug is form validation and never reaches the network.

---

## Why

Settings -> LLM accepted any string as the Base URL. Entering `.` saved
"successfully" with a green toast; the bad value then resurfaced much later as an
opaque provider/connection error during a conversation, which is expensive to
diagnose. This is the exact flow in the issue's Expected Behavior.

The gap is that nothing validated the value on the way out. `coerceFieldValue`
(`src/utils/sdk-settings-schema.ts`) is the single funnel every settings save
passes through, and its numeric branch already throws on min/max violations --
that is the established save-time validation convention here. Its string branch
returned the value verbatim.

Scope note: this validates **Base URL format only**. API-key content validation is
deliberately left to #15778 -- @DevinVinson split the two on this issue, `-` is not
detectably invalid client-side, and guessing per-provider key shapes would reject
real keys.

## Summary

- Add `isValidSettingsUrl` -- parseable and `http(s)` -- mirroring the check MCP
  server URLs already get in `mcp-server-form.tsx` so the two agree.
- Gate URL-typed fields inside `coerceFieldValue`, which covers **both** save paths:
  the built-in Save, and the Settings -> LLM profile editor, which builds its payload
  through `saveControl.getDirtyPayload()` rather than the route's save. A fix in the
  route component alone would have left the profile editor still broken.
- Surface the message inline under the field using `SettingsInput`'s existing `error`
  prop (red border + `role="alert"`), reusing the already-translated
  `SETTINGS$MCP_ERROR_URL_INVALID_PROTOCOL` -- so no new i18n key and no
  `translation.json` churn. Happy to rename it to a generic key if you'd prefer.
- Export `isUrlField` from the schema util and delete the duplicate in
  `schema-field.tsx`, so the predicate deciding `type="url"` rendering is the same
  one deciding validation.

A blank Base URL stays valid (the field is optional). Validation runs on the trimmed
value while the stored value is returned unchanged, so trimming remains the adapter's job.

## Issue Number

Fixes #15774

## How to Test

Automated:

```bash
npm ci
npx vitest run __tests__/utils/sdk-settings-schema.test.ts __tests__/routes/llm-settings.test.tsx
npm run lint && npm test && npm run build
```

To see the tests genuinely cover the fix, remove it and watch them fail:

```bash
git stash push -- src/    # keep the tests, drop the fix
npx vitest run __tests__/utils/sdk-settings-schema.test.ts __tests__/routes/llm-settings.test.tsx
git stash pop
```

Manually, in the app:

1. `npm run dev`, then open the ingress URL (`http://localhost:8000`).
2. Go to **Settings -> LLM -> Add LLM Profile** and select the **Advanced** tab.
   (On a Local backend the LLM page is the profile manager, so the fields live one
   level in, behind **Add LLM Profile**.)
3. Type `.` into **Base URL**. The field turns red with an inline
   "URL must use http:// or https://" underneath.
4. Click **Save** -- refused, with a toast naming the field. Before this change the
   profile saved and a success toast appeared.
5. Replace it with `https://api.openai.com` -- the error clears and Save works.
6. Clear the field entirely -- blank is still valid and still saves.

## Video/Screenshots

Settings -> LLM -> Add LLM Profile -> Advanced, with `Base URL` set to `.`: the field
gets a red border and the inline message `URL must use http:// or https://`, and Save is
refused with a matching toast instead of reporting success.

<img width="1024" height="665" alt="Base URL rejected with an inline error and a toast" src="https://github.com/user-attachments/assets/2f399bc5-80b5-49d0-a748-4cde9f310efc" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**One deliberate behaviour tightening, worth a reviewer's opinion:** requiring an
explicit scheme now rejects bare hosts such as `localhost:8000` or `api.openai.com`,
which previously saved. `new URL("localhost:8000")` parses with
`protocol === "localhost:"`, so the allow-list rejects it. The permissive
normalize-first alternative (`isValidHostUrl` in `backend-form-modal.tsx`, which
prepends `https://`) would accept `"."` and therefore fail this issue's own
acceptance criterion -- so I chose strictness. Easy to soften to
"prepend `https://` when no scheme is present" if you'd rather not tighten it.

Not done, on purpose, to keep the diff reviewable:

- Visually disabling **Save** until the form is valid (suggested in the good-first-issue
  checklist). That needs new props threaded through `SdkSectionPage` /
  `SdkSectionHeaderProps` / `SdkSectionSaveControl`, because the profile editor owns
  its own `save-profile-btn` -- roughly triples the diff. The thrown error + inline
  message already block the save and say why. Happy to follow up.
- A preflight "can we actually reach this provider" connection check.
- The issue also notes "the save appears successful even when it does not persist";
  that half is backend/persistence behaviour outside this frontend repo.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.57s · commit 58a5d73  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 9/9 hunks, 5/5 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 2.0% | No direct hunk selected |
| Weakened authentication | 3.0% | No direct hunk selected |
| Weakened authorization | 4.0% | No direct hunk selected |
| Contract regression | 29.0% | [F005H002 · src/utils/sdk-settings-schema.ts:425–438](https://github.com/OpenHands/OpenHands/blob/58a5d733d34cc9ced381ea7c90db0c042810e977/src/utils/sdk-settings-schema.ts#L425-L438) |
| Data loss | 4.0% | No direct hunk selected |
| Sensitive data disclosure | 3.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 56.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 6692e2c96160aea02da1795812f5aab0499de93d6d5bc1e8c77f2855548078e5 -->
<!-- jev-fast-audit:end -->
