### PR TITLE
fix: verify desktop runtime downloads

### DIFF
--- a/__tests__/scripts/download-integrity.test.ts
+++ b/__tests__/scripts/download-integrity.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment node
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  checksumForFile,
+  verifyFileSha256,
+} from "../../scripts/download-integrity.mjs";
+
+const SHA256_A = "a".repeat(64);
+const SHA256_B = "b".repeat(64);
+const TRUSTED_ARCHIVE_SHA256 =
+  "1bfefc79b77185639257480b7bd91ec719430531d457075317d5e10dcb655f1d";
+
+let tempDir: string | undefined;
+
+afterEach(async () => {
+  if (tempDir) {
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+describe("download integrity", () => {
+  it("selects the exact archive from uv and Node checksum formats", () => {
+    expect(
+      checksumForFile(
+        `${SHA256_A}  uv-aarch64-apple-darwin.tar.gz\n`,
+        "uv-aarch64-apple-darwin.tar.gz",
+      ),
+    ).toBe(SHA256_A);
+
+    expect(
+      checksumForFile(
+        [
+          `${SHA256_A}  node-v22.12.0-darwin-x64.tar.gz`,
+          `${SHA256_B} *node-v22.12.0-darwin-arm64.tar.gz`,
+        ].join("\n"),
+        "node-v22.12.0-darwin-arm64.tar.gz",
+      ),
+    ).toBe(SHA256_B);
+  });
+
+  it.each([
+    {
+      name: "missing filename",
+      contents: `${SHA256_A}  other.tar.gz\n`,
+      error: /no SHA-256 checksum found/i,
+    },
+    {
+      name: "malformed digest",
+      contents: "not-a-sha256  archive.tar.gz\n",
+      error: /no SHA-256 checksum found/i,
+    },
+    {
+      name: "duplicate entries",
+      contents: `${SHA256_A}  archive.tar.gz\n${SHA256_B}  archive.tar.gz\n`,
+      error: /multiple SHA-256 checksums found/i,
+    },
+  ])("rejects $name", ({ contents, error }) => {
+    expect(() => checksumForFile(contents, "archive.tar.gz")).toThrow(error);
+  });
+
+  it("accepts the expected archive and rejects changed bytes", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "download-integrity-"));
+    const archive = join(tempDir, "archive.tar.gz");
+    await writeFile(archive, "trusted archive");
+
+    await expect(
+      verifyFileSha256(archive, TRUSTED_ARCHIVE_SHA256),
+    ).resolves.toBeUndefined();
+    await expect(verifyFileSha256(archive, SHA256_A)).rejects.toThrow(
+      /SHA-256 mismatch/,
+    );
+  });
+});

--- a/scripts/download-integrity.mjs
+++ b/scripts/download-integrity.mjs
@@ -1,0 +1,45 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { basename } from "node:path";
+
+const SHA256_PATTERN = /^[a-fA-F0-9]{64}$/;
+const CHECKSUM_LINE_PATTERN = /^([a-fA-F0-9]{64})[ \t]+\*?(.+)$/;
+
+export function checksumForFile(contents, filename) {
+  const matches = [];
+
+  for (const line of contents.split(/\r?\n/)) {
+    const match = CHECKSUM_LINE_PATTERN.exec(line);
+    if (match?.[2] === filename) {
+      matches.push(match[1].toLowerCase());
+    }
+  }
+
+  if (matches.length === 0) {
+    throw new Error(`No SHA-256 checksum found for ${filename}`);
+  }
+  if (matches.length > 1) {
+    throw new Error(`Multiple SHA-256 checksums found for ${filename}`);
+  }
+
+  return matches[0];
+}
+
+export async function verifyFileSha256(filePath, expectedSha256) {
+  if (!SHA256_PATTERN.test(expectedSha256)) {
+    throw new Error(`Invalid SHA-256 checksum for ${basename(filePath)}`);
+  }
+
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(filePath)) {
+    hash.update(chunk);
+  }
+
+  const actualSha256 = hash.digest("hex");
+  if (actualSha256 !== expectedSha256.toLowerCase()) {
+    throw new Error(
+      `SHA-256 mismatch for ${basename(filePath)}: expected ` +
+        `${expectedSha256.toLowerCase()}, received ${actualSha256}`,
+    );
+  }
+}

--- a/scripts/download-node.mjs
+++ b/scripts/download-node.mjs
@@ -41,6 +41,7 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
+  readFileSync,
   readdirSync,
   readlinkSync,
   rmSync,
@@ -52,6 +53,8 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
+
+import { checksumForFile, verifyFileSha256 } from "./download-integrity.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(__dirname, "..");
@@ -345,6 +348,8 @@ async function main() {
   const archiveName = `${spec.name}.${spec.ext}`;
   const url = `https://nodejs.org/dist/v${version}/${archiveName}`;
   const tmpFile = join(tmpdir(), `node-download-${Date.now()}.${spec.ext}`);
+  const tmpChecksumFile = `${tmpFile}.sha256`;
+  const checksumsUrl = `https://nodejs.org/dist/v${version}/SHASUMS256.txt`;
 
   console.log(
     `[download-node] Downloading Node v${version} for ${PLATFORM}/${ARCH}`,
@@ -360,6 +365,13 @@ async function main() {
 
     console.log(`[download-node] Downloading to ${tmpFile}`);
     await downloadFile(url, tmpFile);
+    await downloadFile(checksumsUrl, tmpChecksumFile);
+    const expectedSha256 = checksumForFile(
+      readFileSync(tmpChecksumFile, "utf8"),
+      archiveName,
+    );
+    await verifyFileSha256(tmpFile, expectedSha256);
+    console.log("[download-node] SHA-256 checksum verified.");
     console.log(`[download-node] Extracting to ${outDir}`);
     extract(tmpFile, outDir, spec.ext);
 
@@ -372,6 +384,9 @@ async function main() {
   } finally {
     try {
       rmSync(tmpFile, { force: true });
+    } catch {}
+    try {
+      rmSync(tmpChecksumFile, { force: true });
     } catch {}
   }
 }

--- a/scripts/download-uv.mjs
+++ b/scripts/download-uv.mjs
@@ -21,6 +21,7 @@ import {
   createWriteStream,
   existsSync,
   mkdirSync,
+  readFileSync,
   rmSync,
 } from "node:fs";
 import { get } from "node:https";
@@ -28,6 +29,8 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
+
+import { checksumForFile, verifyFileSha256 } from "./download-integrity.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(__dirname, "..");
@@ -160,6 +163,7 @@ async function main() {
   const filename = `${spec.target}.${spec.ext}`;
   const url = `https://github.com/astral-sh/uv/releases/download/${version}/${filename}`;
   const tmpFile = join(tmpdir(), `uv-download-${Date.now()}.${spec.ext}`);
+  const tmpChecksumFile = `${tmpFile}.sha256`;
   const extractDir = join(tmpdir(), `uv-extract-${Date.now()}`);
 
   try {
@@ -168,6 +172,13 @@ async function main() {
 
     console.log(`[download-uv] URL: ${url}`);
     await downloadFile(url, tmpFile);
+    await downloadFile(`${url}.sha256`, tmpChecksumFile);
+    const expectedSha256 = checksumForFile(
+      readFileSync(tmpChecksumFile, "utf8"),
+      filename,
+    );
+    await verifyFileSha256(tmpFile, expectedSha256);
+    console.log("[download-uv] SHA-256 checksum verified.");
     console.log(`[download-uv] Extracting to ${outDir}...`);
     extract(tmpFile, extractDir, spec.ext);
 
@@ -194,6 +205,7 @@ async function main() {
   } finally {
     // Clean up temp files (best-effort)
     try { rmSync(tmpFile, { force: true }); } catch {}
+    try { rmSync(tmpChecksumFile, { force: true }); } catch {}
     try { rmSync(extractDir, { recursive: true, force: true }); } catch {}
   }
 }


### PR DESCRIPTION
HUMAN:

<!-- Human contributors: add a short note about your testing. -->

AGENT:

The implementation and verification below were performed with AI assistance.
The human section above is intentionally left for the human contributor.

---

## Why

The desktop build downloads the uv and Node runtime archives and extracts them
without checking the publisher's SHA-256 metadata first. A corrupted or
unexpected archive can therefore be bundled into the application while the
build reports success. This is the bounded archive-integrity portion of #16161.

## Summary

- Add a shared exact-filename SHA-256 parser and streaming archive verifier.
- Verify uv release sidecars and Node `SHASUMS256.txt` entries before extraction.
- Add regression coverage for both metadata formats and fail-closed cases.

## Issue Number

Part of #16161

## How to Test

With Node 24.15.0:

```sh
npm test -- __tests__/scripts
npm run lint
npm run build
NODE_VERSION=24.15.0 npm run download-node
```

The focused script suite passes 222 tests. The full suite passes 4,147 tests;
the repository build and lint checks also pass. The Node download command
verifies the published archive checksum before extracting the runtime.

## Video/Screenshots

Not applicable: this change affects build-time archive verification and has no
user-interface behavior.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This change is intentionally limited to archive integrity checks. Action
pinning, image pinning, dependency locking, version pinning, and installer
changes from the broader audit remain separate work.
