### PR TITLE
docs: clarify quickstart URLs and next steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ agent-canvas --frontend-only  # static frontend + ingress only
 agent-canvas --backend-only   # agent server + automation backend + ingress only
 ```
 
+When the startup summary shows `Main UI: http://localhost:8000/`, open [http://localhost:8000](http://localhost:8000).
+
 ### Option 2: With a Docker Sandbox
 
 **Prerequisites**:
@@ -103,6 +105,8 @@ docker run -it --rm \
 
 The agent will be able to access any project under `PROJECTS_PATH`.
 
+When the container logs report `All services started`, OpenHands is ready. Open [http://localhost:8000/canvas](http://localhost:8000/canvas).
+
 ### Option 3: From Source
 
 > [!WARNING]
@@ -117,9 +121,15 @@ npm install
 npm run dev
 ```
 
+When the startup summary shows `Main UI: http://localhost:8000/`, open [http://localhost:8000](http://localhost:8000).
+
 ---
 
-Access the UI at [http://localhost:8000](http://localhost:8000) for the npm/source launchers, or [http://localhost:8000/canvas](http://localhost:8000/canvas) for the Docker image. You can add additional backends directly from the UI.
+### Next steps
+
+1. [Configure an LLM profile](https://docs.openhands.dev/openhands/usage/settings/llm-settings#llm-profiles) for your backend.
+2. Choose a workspace in the UI and start a conversation.
+3. Optionally [add another backend](https://docs.openhands.dev/openhands/usage/agent-canvas/backends), such as a remote Agent Server or OpenHands Cloud.
 
 # Architecture
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
I’ve looked over the README changes, double-checked the npm/source and Docker UI links, and also clicked through the next-step doc – it opens without issues.

<!-- Human contributors: add a short note about your testing. -->

AGENT:

Verified the documented startup signals and paths against the current launcher sources:

- npm/source: the startup summary prints `Main UI: http://localhost:8000/`
- Docker: the entrypoint defaults to the `/canvas` base path and logs `All services started`
- `npx prettier@3.8.3 --check README.md`
- `git diff --check`

---

## Why

The Quickstart listed the UI addresses only once after all installation options, making the correct next action easy to miss—especially because Docker uses a different path from npm/source installations.

## Summary

- place the correct UI URL next to each installation method
- document the corresponding startup signal
- add concise first-use steps with links to LLM profile and backend documentation

## Issue Number

Fixes #15797

## How to Test

1. Read each Quickstart installation option and confirm its startup signal and UI URL are shown immediately afterward.
2. Confirm npm/source point to `http://localhost:8000`.
3. Confirm Docker points to `http://localhost:8000/canvas`.
4. Confirm the Next steps links resolve to the existing OpenHands documentation.

## Video/Screenshots

Not applicable; this is a README-only change.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

No runtime behavior or dependencies changed.

<!-- Revalidated after syncing with the latest main branch (133ce0ef6). -->
