### PR TITLE
feat(cli): add --frontend-port option to launcher scripts

### DIFF
--- a/__tests__/scripts/dev-static.test.ts
+++ b/__tests__/scripts/dev-static.test.ts
@@ -8,6 +8,7 @@ describe("dev-static", () => {
       {
         agentServerPort: 18000,
         ingressPort: 8000,
+        vitePort: 3001,
         sessionApiKey: "shared-session-key",
         stateDir: "/tmp/agent-canvas-state",
       },
@@ -23,5 +24,25 @@ describe("dev-static", () => {
         "phc_kBtz5nKmxVRRQ7HtPwr2QX9eMC5j65zE86QKocVNwb4U",
       AUTOMATION_POSTHOG_HOST: "https://us.i.posthog.com",
     });
+  });
+
+  it("advertises the configured frontend port in CORS origins", () => {
+    const env = buildAutomationBackendEnv(
+      {
+        agentServerPort: 18000,
+        ingressPort: 8000,
+        vitePort: 3101,
+        sessionApiKey: "shared-session-key",
+        stateDir: "/tmp/agent-canvas-state",
+      },
+      {},
+    );
+
+    // The CORS allowlist follows the configured frontend port instead of
+    // hardcoding 3001, so a --frontend-port override keeps the browser
+    // origin authorized.
+    expect(env.AUTOMATION_CORS_ORIGINS).toBe(
+      "http://localhost:8000,http://127.0.0.1:8000,http://localhost:3101,http://127.0.0.1:3101",
+    );
   });
 });

--- a/__tests__/scripts/dev-static.test.ts
+++ b/__tests__/scripts/dev-static.test.ts
@@ -11,6 +11,7 @@ describe("dev-static", () => {
       {
         agentServerPort: 18000,
         ingressPort: 8000,
+        vitePort: 3001,
         sessionApiKey: "shared-session-key",
         stateDir: "/tmp/agent-canvas-state",
       },
@@ -39,5 +40,25 @@ describe("dev-static", () => {
     expect(args).toContain("/api/automation=http://127.0.0.1:18001");
     expect(args).toContain("/server_info=http://127.0.0.1:18000");
     expect(args.filter((arg: string) => arg.includes("localhost"))).toEqual([]);
+  });
+
+  it("advertises the configured frontend port in CORS origins", () => {
+    const env = buildAutomationBackendEnv(
+      {
+        agentServerPort: 18000,
+        ingressPort: 8000,
+        vitePort: 3101,
+        sessionApiKey: "shared-session-key",
+        stateDir: "/tmp/agent-canvas-state",
+      },
+      {},
+    );
+
+    // The CORS allowlist follows the configured frontend port instead of
+    // hardcoding 3001, so a --frontend-port override keeps the browser
+    // origin authorized.
+    expect(env.AUTOMATION_CORS_ORIGINS).toBe(
+      "http://localhost:8000,http://127.0.0.1:8000,http://localhost:3101,http://127.0.0.1:3101",
+    );
   });
 });

--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -248,6 +248,25 @@ describe("buildConfig", () => {
     expect(config.ingressPort).toBe(preferredPort);
   });
 
+  it("respects --frontend-port arg for the frontend port", async () => {
+    const preferredFrontendPort = 19503;
+    const config = await buildConfig(
+      { frontendPort: preferredFrontendPort },
+      envWithIsolatedKeyPath(),
+    );
+
+    expect(config.vitePort).toBe(preferredFrontendPort);
+  });
+
+  it("args.frontendPort takes precedence over OH_CANVAS_SAFE_VITE_PORT", async () => {
+    const config = await buildConfig(
+      { frontendPort: 19504 },
+      envWithIsolatedKeyPath({ OH_CANVAS_SAFE_VITE_PORT: "19599" }),
+    );
+
+    expect(config.vitePort).toBe(19504);
+  });
+
   it("throws when ingress port is busy", async () => {
     const busyPort = 8100;
 

--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -344,6 +344,25 @@ describe("buildConfig", () => {
     expect(config.ingressPort).toBe(preferredPort);
   });
 
+  it("respects --frontend-port arg for the frontend port", async () => {
+    const preferredFrontendPort = 19503;
+    const config = await buildConfig(
+      { frontendPort: preferredFrontendPort },
+      envWithIsolatedKeyPath(),
+    );
+
+    expect(config.vitePort).toBe(preferredFrontendPort);
+  });
+
+  it("args.frontendPort takes precedence over OH_CANVAS_SAFE_VITE_PORT", async () => {
+    const config = await buildConfig(
+      { frontendPort: 19504 },
+      envWithIsolatedKeyPath({ OH_CANVAS_SAFE_VITE_PORT: "19599" }),
+    );
+
+    expect(config.vitePort).toBe(19504);
+  });
+
   it("throws when ingress port is busy", async () => {
     const busyPort = 8100;
 

--- a/bin/agent-canvas.mjs
+++ b/bin/agent-canvas.mjs
@@ -75,6 +75,7 @@ AUTH MODES:
 
 OPTIONS:
   -p, --port <port>     Ingress port (default: 8000)
+  --frontend-port <port>  Frontend static-server port (default: 3001)
   --public              Enable public mode (see above)
   --frontend-only       Start only the static frontend behind ingress
   --backend-only        Start only agent-server + automation behind ingress
@@ -106,6 +107,9 @@ EXAMPLES:
 
   # Use a specific port
   npx @openhands/agent-canvas --port 3000
+
+  # Use a specific frontend port (useful when 3001 is already taken)
+  npx @openhands/agent-canvas --frontend-port 3100
 
   # Start only the static frontend behind ingress
   npx @openhands/agent-canvas --frontend-only

--- a/scripts/dev-static.mjs
+++ b/scripts/dev-static.mjs
@@ -107,6 +107,7 @@ function logError(message) {
 export function parseArgs(argv = process.argv.slice(2)) {
   const config = {
     port: null,
+    frontendPort: null,
     automationGitRef: null,
     automationRepo: null,
     skipBuild: false,
@@ -118,6 +119,9 @@ export function parseArgs(argv = process.argv.slice(2)) {
       case "-p":
       case "--port":
         config.port = parseInt(argv[++i], 10);
+        break;
+      case "--frontend-port":
+        config.frontendPort = parseInt(argv[++i], 10);
         break;
       case "--automation-ref":
         config.automationGitRef = argv[++i];
@@ -155,6 +159,7 @@ USAGE:
 
 OPTIONS:
   -p, --port <port>           Ingress port (default: 8000)
+  --frontend-port <port>      Frontend static-server port (default: 3001)
   --automation-ref <ref>      Git ref for automation backend (default: main)
   --automation-repo <url>     Git repo URL for automation
   --skip-build                Reuse existing build/ directory (faster restart)
@@ -334,7 +339,7 @@ function buildAutomationBackendEnv(config, env = process.env) {
     AUTOMATION_WORKSPACE_BASE: join(config.stateDir, "workspaces"),
     AUTOMATION_LOCAL_API_KEY: config.sessionApiKey,
     ...buildAutomationTelemetryEnv(env),
-    AUTOMATION_CORS_ORIGINS: `http://localhost:${config.ingressPort},http://127.0.0.1:${config.ingressPort},http://localhost:3001,http://127.0.0.1:3001`,
+    AUTOMATION_CORS_ORIGINS: `http://localhost:${config.ingressPort},http://127.0.0.1:${config.ingressPort},http://localhost:${config.vitePort},http://127.0.0.1:${config.vitePort}`,
     FILE_STORE: "local",
     LOCAL_STORAGE_PATH: join(config.stateDir, "storage"),
     OPENHANDS_SUPPRESS_BANNER: "1",

--- a/scripts/dev-static.mjs
+++ b/scripts/dev-static.mjs
@@ -113,6 +113,7 @@ function logError(message) {
 export function parseArgs(argv = process.argv.slice(2)) {
   const config = {
     port: null,
+    frontendPort: null,
     automationGitRef: null,
     automationRepo: null,
     skipBuild: false,
@@ -124,6 +125,9 @@ export function parseArgs(argv = process.argv.slice(2)) {
       case "-p":
       case "--port":
         config.port = parseInt(argv[++i], 10);
+        break;
+      case "--frontend-port":
+        config.frontendPort = parseInt(argv[++i], 10);
         break;
       case "--automation-ref":
         config.automationGitRef = argv[++i];
@@ -161,6 +165,7 @@ USAGE:
 
 OPTIONS:
   -p, --port <port>           Ingress port (default: 8000)
+  --frontend-port <port>      Frontend static-server port (default: 3001)
   --automation-ref <ref>      Git ref for automation backend (default: main)
   --automation-repo <url>     Git repo URL for automation
   --skip-build                Reuse existing build/ directory (faster restart)
@@ -366,7 +371,7 @@ function buildAutomationBackendEnv(config, env = process.env) {
     AUTOMATION_WORKSPACE_BASE: join(config.stateDir, "workspaces"),
     AUTOMATION_LOCAL_API_KEY: config.sessionApiKey,
     ...buildAutomationTelemetryEnv(env),
-    AUTOMATION_CORS_ORIGINS: `http://localhost:${config.ingressPort},http://127.0.0.1:${config.ingressPort},http://localhost:3001,http://127.0.0.1:3001`,
+    AUTOMATION_CORS_ORIGINS: `http://localhost:${config.ingressPort},http://127.0.0.1:${config.ingressPort},http://localhost:${config.vitePort},http://127.0.0.1:${config.vitePort}`,
     FILE_STORE: "local",
     LOCAL_STORAGE_PATH: join(config.stateDir, "storage"),
     OPENHANDS_SUPPRESS_BANNER: "1",

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -166,6 +166,7 @@ function parseArgs() {
   const args = process.argv.slice(2);
   const config = {
     port: null,
+    frontendPort: null,
     automationGitRef: null,
     automationRepo: null,
     verbose: false,
@@ -183,6 +184,9 @@ function parseArgs() {
       case "-p":
       case "--port":
         config.port = parseInt(args[++i], 10);
+        break;
+      case "--frontend-port":
+        config.frontendPort = parseInt(args[++i], 10);
         break;
       case "--automation-ref":
         config.automationGitRef = args[++i];
@@ -237,6 +241,7 @@ USAGE:
 
 OPTIONS:
   -p, --port <port>           Ingress port (default: 8000)
+  --frontend-port <port>      Frontend (Vite/static) port (default: 3001)
   --automation-ref <ref>      Git ref for automation (branch/tag/SHA)
   --automation-repo <url>     Git repo URL (default: ${DEFAULT_AUTOMATION_REPO})
   --static                    Serve an existing production build instead of Vite
@@ -372,7 +377,8 @@ async function buildConfig(args, env = process.env) {
     parseInt(env.OH_CANVAS_SAFE_BACKEND_PORT, 10) || DEFAULT_BACKEND_PORT;
   const preferredAutomationPort =
     parseInt(env.OH_CANVAS_SAFE_AUTOMATION_PORT, 10) || DEFAULT_AUTOMATION_PORT;
-  const preferredVitePort = parseInt(env.OH_CANVAS_SAFE_VITE_PORT, 10) || 3001;
+  const preferredVitePort =
+    args.frontendPort || parseInt(env.OH_CANVAS_SAFE_VITE_PORT, 10) || 3001;
 
   // Fail fast if any preferred port for a service in this mode is already in use.
   const requiredPorts = [{ name: "ingress", port: preferredIngressPort }];
@@ -915,7 +921,7 @@ function startAutomationBackend(config) {
         // CORS: allow localhost origins for dev, unless explicitly overridden.
         AUTOMATION_CORS_ORIGINS:
           process.env.AUTOMATION_CORS_ORIGINS ||
-          `http://localhost:${config.ingressPort},http://127.0.0.1:${config.ingressPort},http://localhost:3001,http://127.0.0.1:3001`,
+          `http://localhost:${config.ingressPort},http://127.0.0.1:${config.ingressPort},http://localhost:${config.vitePort},http://127.0.0.1:${config.vitePort}`,
         FILE_STORE: "local",
         LOCAL_STORAGE_PATH: join(config.stateDir, "storage"),
         OPENHANDS_SUPPRESS_BANNER: "1",

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -166,6 +166,7 @@ function parseArgs() {
   const args = process.argv.slice(2);
   const config = {
     port: null,
+    frontendPort: null,
     automationGitRef: null,
     automationRepo: null,
     verbose: false,
@@ -183,6 +184,9 @@ function parseArgs() {
       case "-p":
       case "--port":
         config.port = parseInt(args[++i], 10);
+        break;
+      case "--frontend-port":
+        config.frontendPort = parseInt(args[++i], 10);
         break;
       case "--automation-ref":
         config.automationGitRef = args[++i];
@@ -237,6 +241,7 @@ USAGE:
 
 OPTIONS:
   -p, --port <port>           Ingress port (default: 8000)
+  --frontend-port <port>      Frontend (Vite/static) port (default: 3001)
   --automation-ref <ref>      Git ref for automation (branch/tag/SHA)
   --automation-repo <url>     Git repo URL (default: ${DEFAULT_AUTOMATION_REPO})
   --static                    Serve an existing production build instead of Vite
@@ -428,7 +433,8 @@ async function buildConfig(args, env = process.env) {
     parseInt(env.OH_CANVAS_SAFE_BACKEND_PORT, 10) || DEFAULT_BACKEND_PORT;
   const preferredAutomationPort =
     parseInt(env.OH_CANVAS_SAFE_AUTOMATION_PORT, 10) || DEFAULT_AUTOMATION_PORT;
-  const preferredVitePort = parseInt(env.OH_CANVAS_SAFE_VITE_PORT, 10) || 3001;
+  const preferredVitePort =
+    args.frontendPort || parseInt(env.OH_CANVAS_SAFE_VITE_PORT, 10) || 3001;
 
   // Fail fast if any preferred port for a service in this mode is already in use.
   const requiredPorts = [{ name: "ingress", port: preferredIngressPort }];
@@ -1051,7 +1057,7 @@ function startAutomationBackend(config) {
         // CORS: allow localhost origins for dev, unless explicitly overridden.
         AUTOMATION_CORS_ORIGINS:
           process.env.AUTOMATION_CORS_ORIGINS ||
-          `http://localhost:${config.ingressPort},http://127.0.0.1:${config.ingressPort},http://localhost:3001,http://127.0.0.1:3001`,
+          `http://localhost:${config.ingressPort},http://127.0.0.1:${config.ingressPort},http://localhost:${config.vitePort},http://127.0.0.1:${config.vitePort}`,
         FILE_STORE: "local",
         LOCAL_STORAGE_PATH: join(config.stateDir, "storage"),
         OPENHANDS_SUPPRESS_BANNER: "1",


### PR DESCRIPTION
HUMAN:
I ran the launcher test suites locally on the rebased branch (65 passed / 1 skipped across the two touched test files, covering the new flag, its precedence over OH_CANVAS_SAFE_VITE_PORT/3001, and the CORS allowlist advertisement), confirmed Prettier/ESLint are clean on the changed files, and started the launcher with `--frontend-port 3456` on Windows — the screenshot below shows the frontend served on the custom port.

AGENT:

## Why

The launcher stack hardcoded the frontend port at 3001 with no way to override it from the CLI, so a busy 3001 (or the need to serve the frontend elsewhere) blocked startup.

## Summary

This PR adds `--frontend-port <port>` to the `agent-canvas`, `npm run dev`, and `npm run dev:static` launchers, with `OH_CANVAS_SAFE_VITE_PORT`/3001 as fallbacks, and advertises the configured port in the automation CORS allowlist.

Fixes #16226

## How to Test

- `__tests__/scripts/dev-with-automation.test.ts` and `__tests__/scripts/dev-static.test.ts`: 65 passed / 1 skipped, including new tests for the flag, its precedence, and CORS
- `prettier` and `eslint` clean on the changed files
- `npm run dev -- --frontend-port 3456` starts the stack with the frontend on port 3456 (see screenshot below; vite logs `Local: http://localhost:3456/`)
- Mock-LLM E2E: 60/60 passed in CI on this PR

## Video/Screenshots

![Frontend served on custom port 3456](https://raw.githubusercontent.com/HUAN2022A/OpenHands/pr-evidence-16228/oh-frontend-port-3456.png)

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.61s · commit beffb89  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 14/14 hunks, 5/5 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 6.0% | No direct hunk selected |
| Weakened authentication | 3.0% | No direct hunk selected |
| Weakened authorization | 4.0% | No direct hunk selected |
| Contract regression | 12.0% | No direct hunk selected |
| Data loss | 3.0% | No direct hunk selected |
| Sensitive data disclosure | 4.0% | No direct hunk selected |
| Unexpected data transfer | 4.0% | No direct hunk selected |
| Credential misuse | 6.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 4.0% | No direct hunk selected |
| Privileged environment access | 4.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 92.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 0ab4db806e5a86bff918e3de23a79bb6377654b88846383d23c753e2d8850328 -->
<!-- jev-fast-audit:end -->
