### PR TITLE
feat: Add support for Pi as ACP agent

### DIFF
--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -6,6 +6,7 @@ import {
   buildRuntimeServicesSystemSuffix,
   buildStartConversationRequest,
   getDefaultConversationTitle,
+  getDeploymentMode,
   toAppConversation,
   type DirectConversationInfo,
 } from "#/api/agent-server-adapter";
@@ -1235,6 +1236,18 @@ describe("buildRuntimeServicesSystemSuffix", () => {
     );
   });
 
+  it("accepts a parsed runtime-services object on window (not only a JSON string)", () => {
+    (
+      window as unknown as Record<string, unknown>
+    ).__AGENT_CANVAS_RUNTIME_SERVICES_INFO__ = {
+      mode: "docker",
+      services: {
+        agent_server: { url_from_agent: "http://127.0.0.1:18000" },
+      },
+    };
+    expect(getDeploymentMode()).toBe("docker");
+  });
+
   it("prefers VITE_RUNTIME_SERVICES_INFO over the window fallback", () => {
     vi.stubEnv(
       "VITE_RUNTIME_SERVICES_INFO",
@@ -1563,7 +1576,7 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
       "-y",
       "pi-acp",
     ]);
-    expect(payload.agent_settings.acp_model).toBe("default");
+    expect(payload.agent_settings.acp_model).toBeUndefined();
     expect(payload.tags).toEqual({ acpserver: "pi" });
   });
 

--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -1567,6 +1567,35 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
     expect(payload.tags).toEqual({ acpserver: "pi" });
   });
 
+  it("rewrites the pi-acp npx launch to the preinstalled binary in Docker mode", () => {
+    vi.stubEnv(
+      "VITE_RUNTIME_SERVICES_INFO",
+      JSON.stringify({
+        mode: "docker",
+        services: {
+          agent_server: { url_from_agent: "http://127.0.0.1:18000" },
+        },
+      }),
+    );
+
+    const payload = buildStartConversationRequest({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        agent_settings: {
+          schema_version: 1,
+          agent_kind: "acp",
+          acp_server: "custom",
+          acp_command: ["npx", "-y", "pi-acp"],
+          acp_model: "default",
+        },
+      },
+    }) as {
+      agent_settings: Record<string, unknown> & { acp_command?: unknown[] };
+    };
+
+    expect(payload.agent_settings.acp_command).toEqual(["pi-acp"]);
+  });
+
   it("leaves acp_command alone for an unknown acp_server key", () => {
     const payload = buildStartConversationRequest({
       settings: {

--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -1537,6 +1537,36 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
     expect(payload.agent_settings.acp_command).toEqual([]);
   });
 
+  it("resolves the pi-acp default when acp_server is custom with an empty command", () => {
+    const payload = buildStartConversationRequest({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        agent_settings: {
+          schema_version: 1,
+          agent_kind: "acp",
+          acp_server: "custom",
+          acp_command: ["npx", "-y", "pi-acp"],
+          acp_model: "default",
+        },
+      },
+    }) as {
+      agent_settings: Record<string, unknown> & {
+        acp_command?: unknown[];
+        acp_model?: unknown;
+        tags?: Record<string, string>;
+      };
+      tags?: Record<string, string>;
+    };
+
+    expect(payload.agent_settings.acp_command).toEqual([
+      "npx",
+      "-y",
+      "pi-acp",
+    ]);
+    expect(payload.agent_settings.acp_model).toBe("default");
+    expect(payload.tags).toEqual({ acpserver: "pi" });
+  });
+
   it("leaves acp_command alone for an unknown acp_server key", () => {
     const payload = buildStartConversationRequest({
       settings: {

--- a/__tests__/components/features/conversation-panel/local-new-conversation-menu.test.tsx
+++ b/__tests__/components/features/conversation-panel/local-new-conversation-menu.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { renderWithProviders } from "test-utils";
 import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
+import { CREATE_CONVERSATION_DEFAULT_TAIL } from "../../../helpers/create-conversation-call-args";
 import WorkspacesService from "#/api/workspaces-service/workspaces-service.api";
 import { LocalNewConversationMenu } from "#/components/features/conversation-panel/local-new-conversation-menu";
 import { LocalWorkspace, LocalWorkspaceParent } from "#/types/workspace";
@@ -187,6 +188,7 @@ describe("LocalNewConversationMenu", () => {
         undefined,
         undefined,
         undefined,
+        ...CREATE_CONVERSATION_DEFAULT_TAIL,
       );
     });
     await waitFor(() => {

--- a/__tests__/components/features/conversation-panel/new-conversation-button-cloud.test.tsx
+++ b/__tests__/components/features/conversation-panel/new-conversation-button-cloud.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { renderWithProviders } from "test-utils";
 import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
+import { CREATE_CONVERSATION_DEFAULT_TAIL } from "../../../helpers/create-conversation-call-args";
 import { NewConversationButton } from "#/components/features/conversation-panel/new-conversation-button";
 import { GitRepository } from "#/types/git";
 
@@ -160,6 +161,7 @@ describe("NewConversationButton (cloud)", () => {
         undefined,
         undefined,
         undefined,
+        ...CREATE_CONVERSATION_DEFAULT_TAIL,
       );
     });
     await waitFor(() => {
@@ -203,6 +205,7 @@ describe("NewConversationButton (cloud)", () => {
         undefined,
         undefined,
         undefined,
+        ...CREATE_CONVERSATION_DEFAULT_TAIL,
       );
     });
   });

--- a/__tests__/components/features/home/home-chat-launcher.test.tsx
+++ b/__tests__/components/features/home/home-chat-launcher.test.tsx
@@ -7,6 +7,7 @@ import toast from "react-hot-toast";
 import { HomeChatLauncher } from "#/components/features/home/home-chat-launcher";
 import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
 import WorkspacesService from "#/api/workspaces-service/workspaces-service.api";
+import { CREATE_CONVERSATION_DEFAULT_TAIL } from "../../../helpers/create-conversation-call-args";
 
 const mockNavigate = vi.fn();
 const mockUseActiveBackend = vi.fn();
@@ -328,6 +329,7 @@ describe("HomeChatLauncher", () => {
       undefined,
       undefined,
       undefined,
+      ...CREATE_CONVERSATION_DEFAULT_TAIL,
     );
     await waitFor(() =>
       expect(mockNavigate).toHaveBeenCalledWith("/conversations/conv-abc"),
@@ -376,6 +378,7 @@ describe("HomeChatLauncher", () => {
       "local_repo",
       undefined,
       undefined,
+      ...CREATE_CONVERSATION_DEFAULT_TAIL,
     );
     await waitFor(() =>
       expect(mockNavigate).toHaveBeenCalledWith("/conversations/conv-ws"),
@@ -416,6 +419,7 @@ describe("HomeChatLauncher", () => {
       "new_worktree",
       undefined,
       undefined,
+      ...CREATE_CONVERSATION_DEFAULT_TAIL,
     );
     await waitFor(() =>
       expect(mockNavigate).toHaveBeenCalledWith("/conversations/conv-wt"),
@@ -472,6 +476,7 @@ describe("HomeChatLauncher", () => {
       undefined,
       undefined,
       undefined,
+      ...CREATE_CONVERSATION_DEFAULT_TAIL,
     );
     await waitFor(() =>
       expect(mockNavigate).toHaveBeenCalledWith("/conversations/conv-repo"),
@@ -498,6 +503,7 @@ describe("HomeChatLauncher", () => {
       undefined,
       undefined,
       undefined,
+      ...CREATE_CONVERSATION_DEFAULT_TAIL,
     );
     await waitFor(() =>
       expect(sendMessageWithAttachments).toHaveBeenCalledTimes(1),
@@ -579,6 +585,7 @@ describe("HomeChatLauncher", () => {
       undefined,
       undefined,
       undefined,
+      ...CREATE_CONVERSATION_DEFAULT_TAIL,
     );
     expect(sendMessageWithAttachments).not.toHaveBeenCalled();
     await waitFor(() =>
@@ -618,6 +625,7 @@ describe("HomeChatLauncher", () => {
       undefined,
       undefined,
       undefined,
+      ...CREATE_CONVERSATION_DEFAULT_TAIL,
     );
   });
 });

--- a/__tests__/components/features/home/task-card.test.tsx
+++ b/__tests__/components/features/home/task-card.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "test-utils";
 import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
 import GitService from "#/api/git-service/git-service.api";
+import { CREATE_CONVERSATION_DEFAULT_TAIL } from "../../../helpers/create-conversation-call-args";
 import { TaskCard } from "#/components/features/home/tasks/task-card";
 import { GitRepository } from "#/types/git";
 import { SuggestedTask } from "#/utils/types";
@@ -143,6 +144,7 @@ describe("TaskCard", () => {
         undefined,
         undefined,
         undefined,
+        ...CREATE_CONVERSATION_DEFAULT_TAIL,
       );
     });
   });

--- a/__tests__/components/onboarding/choose-agent-step.test.tsx
+++ b/__tests__/components/onboarding/choose-agent-step.test.tsx
@@ -194,13 +194,31 @@ describe("ChooseAgentStep", () => {
     expect(
       (call.agent_settings_diff as Record<string, unknown>).acp_server,
     ).toBe(expected);
-    // Canvas preselects the *preferred* default model — the registry default
-    // for Codex, but the Vertex-safe override (gemini-2.5-pro) for Gemini:
-    // gemini-cli re-resolves flash ids to its own default, which 404s on many
-    // Vertex projects (software-agent-sdk#3532).
     expect(
       (call.agent_settings_diff as Record<string, unknown>).acp_model,
     ).toBe(getAcpPreferredDefaultModel(expected));
+  });
+
+  it("persists the pi-acp command for the Pi tile", async () => {
+    const save = vi.spyOn(SettingsService, "saveSettings");
+    renderStep("pi");
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("onboarding-agent-next"));
+
+    await waitFor(() => {
+      expect(save).toHaveBeenCalledTimes(1);
+    });
+    const call = save.mock.calls[0]?.[0] as {
+      agent_settings_diff?: Record<string, unknown>;
+    };
+    expect(call.agent_settings_diff).toEqual({
+      agent_kind: "acp",
+      acp_server: "custom",
+      acp_command: ["npx", "-y", "pi-acp"],
+      acp_args: [],
+      acp_model: "default",
+    });
   });
 
   it("rebuilds the diff cleanly when the user flips between ACP providers", async () => {

--- a/__tests__/components/onboarding/choose-agent-step.test.tsx
+++ b/__tests__/components/onboarding/choose-agent-step.test.tsx
@@ -217,7 +217,7 @@ describe("ChooseAgentStep", () => {
       acp_server: "custom",
       acp_command: ["npx", "-y", "pi-acp"],
       acp_args: [],
-      acp_model: "default",
+      acp_model: null,
     });
   });
 

--- a/__tests__/constants/acp-providers.test.ts
+++ b/__tests__/constants/acp-providers.test.ts
@@ -53,7 +53,7 @@ describe("ACP provider registry", () => {
         expect(provider.display_name).toBe("Pi");
         expect(provider.default_command).toEqual(["npx", "-y", "pi-acp"]);
         expect(provider.available_models).toEqual([
-          { id: "default", label: "Default" },
+          { id: "default", label: "Default Model" },
         ]);
         expect(provider.default_model).toBe("default");
         expect(provider.icon).toBe("pi");

--- a/__tests__/constants/acp-providers.test.ts
+++ b/__tests__/constants/acp-providers.test.ts
@@ -13,10 +13,11 @@ import {
 } from "#/constants/acp-providers";
 
 describe("getAcpProviderDisplayName", () => {
-  it("resolves the three built-in registry keys to their human names", () => {
+  it("resolves the built-in registry keys to their human names", () => {
     expect(getAcpProviderDisplayName("claude-code")).toBe("Claude Code");
     expect(getAcpProviderDisplayName("codex")).toBe("Codex");
     expect(getAcpProviderDisplayName("gemini-cli")).toBe("Gemini CLI");
+    expect(getAcpProviderDisplayName("pi")).toBe("Pi");
   });
 
   it("returns null for the Custom-command preset so callers can fall back to the generic 'ACP' label", () => {
@@ -48,6 +49,17 @@ describe("ACP provider registry", () => {
     // (icon + description_key) is layered on locally.
     for (const provider of ACP_PROVIDERS) {
       const sdk = getClientAcpProvider(provider.key);
+      if (provider.key === "pi" && !sdk) {
+        expect(provider.display_name).toBe("Pi");
+        expect(provider.default_command).toEqual(["npx", "-y", "pi-acp"]);
+        expect(provider.available_models).toEqual([
+          { id: "default", label: "Default" },
+        ]);
+        expect(provider.default_model).toBe("default");
+        expect(provider.icon).toBe("pi");
+        expect(provider.description_key).toBeTruthy();
+        continue;
+      }
       expect(sdk, provider.key).not.toBeNull();
       expect(provider.display_name).toBe(sdk!.display_name);
       expect(provider.default_command).toEqual([...sdk!.default_command]);
@@ -99,7 +111,7 @@ describe("ACP provider registry", () => {
     for (const provider of ACP_PROVIDERS) {
       expect(buildAcpAgentSettingsDiff(provider.key)).toMatchObject({
         agent_kind: "acp",
-        acp_server: provider.key,
+        acp_server: provider.key === "pi" ? "custom" : provider.key,
         acp_model: getAcpPreferredDefaultModel(provider.key),
       });
     }

--- a/__tests__/constants/acp-providers.test.ts
+++ b/__tests__/constants/acp-providers.test.ts
@@ -88,7 +88,7 @@ describe("ACP provider registry", () => {
         expect(provider.available_models).toEqual([
           { id: "default", label: "Default Model" },
         ]);
-        expect(provider.default_model).toBe("default");
+        expect(provider.default_model).toBeUndefined();
         expect(provider.icon).toBe("pi");
         expect(provider.description_key).toBeTruthy();
         continue;
@@ -108,6 +108,7 @@ describe("ACP provider registry", () => {
 
   it("keeps every built-in default model in the UX suggestions", () => {
     for (const provider of ACP_PROVIDERS) {
+      if (provider.key === "pi") continue;
       expect(provider.default_model, provider.key).toBeTruthy();
       expect(provider.available_models, provider.key).toBeTruthy();
       expect(

--- a/__tests__/constants/acp-providers.test.ts
+++ b/__tests__/constants/acp-providers.test.ts
@@ -18,6 +18,8 @@ describe("Pi ACP preset helpers", () => {
   it("detects the pi-acp launch argv and shell string", () => {
     expect(isPiAcpCommand(["npx", "-y", "pi-acp"])).toBe(true);
     expect(isPiAcpCommand("npx -y pi-acp")).toBe(true);
+    expect(isPiAcpCommand(["pi-acp"])).toBe(true);
+    expect(isPiAcpCommand("pi-acp")).toBe(true);
     expect(isPiAcpCommand(["npx", "-y", "pi-acp", "--flag"])).toBe(false);
   });
 

--- a/__tests__/constants/acp-providers.test.ts
+++ b/__tests__/constants/acp-providers.test.ts
@@ -10,7 +10,25 @@ import {
   getAcpProvider,
   getAcpProviderDisplayName,
   getAcpProviderSecrets,
+  isPiAcpCommand,
+  resolveUiAcpProviderKey,
 } from "#/constants/acp-providers";
+
+describe("Pi ACP preset helpers", () => {
+  it("detects the pi-acp launch argv and shell string", () => {
+    expect(isPiAcpCommand(["npx", "-y", "pi-acp"])).toBe(true);
+    expect(isPiAcpCommand("npx -y pi-acp")).toBe(true);
+    expect(isPiAcpCommand(["npx", "-y", "pi-acp", "--flag"])).toBe(false);
+  });
+
+  it("rehydrates the Canvas registry key from custom wire settings", () => {
+    expect(resolveUiAcpProviderKey("custom", ["npx", "-y", "pi-acp"])).toBe(
+      "pi",
+    );
+    expect(resolveUiAcpProviderKey("custom", [])).toBe("custom");
+    expect(resolveUiAcpProviderKey("claude-code", [])).toBe("claude-code");
+  });
+});
 
 describe("getAcpProviderDisplayName", () => {
   it("resolves the built-in registry keys to their human names", () => {
@@ -113,6 +131,9 @@ describe("ACP provider registry", () => {
         agent_kind: "acp",
         acp_server: provider.key === "pi" ? "custom" : provider.key,
         acp_model: getAcpPreferredDefaultModel(provider.key),
+        ...(provider.key === "pi"
+          ? { acp_command: ["npx", "-y", "pi-acp"] }
+          : { acp_command: [] }),
       });
     }
     expect(buildAcpAgentSettingsDiff("gemini-cli")).toMatchObject({

--- a/__tests__/constants/acp-providers.test.ts
+++ b/__tests__/constants/acp-providers.test.ts
@@ -10,6 +10,8 @@ import {
   getAcpProvider,
   getAcpProviderDisplayName,
   getAcpProviderSecrets,
+  adaptPiAcpCommandForDeployment,
+  effectivePiAcpCommandTokens,
   isPiAcpCommand,
   resolveUiAcpProviderKey,
 } from "#/constants/acp-providers";
@@ -21,6 +23,17 @@ describe("Pi ACP preset helpers", () => {
     expect(isPiAcpCommand(["pi-acp"])).toBe(true);
     expect(isPiAcpCommand("pi-acp")).toBe(true);
     expect(isPiAcpCommand(["npx", "-y", "pi-acp", "--flag"])).toBe(false);
+  });
+
+  it("selects the Docker-safe Pi spawn argv by deployment mode", () => {
+    expect(effectivePiAcpCommandTokens(null)).toEqual(["npx", "-y", "pi-acp"]);
+    expect(effectivePiAcpCommandTokens("docker")).toEqual(["pi-acp"]);
+    expect(adaptPiAcpCommandForDeployment(["npx", "-y", "pi-acp"], "docker")).toEqual(
+      ["pi-acp"],
+    );
+    expect(
+      adaptPiAcpCommandForDeployment(["npx", "-y", "pi-acp"], "dev:automation"),
+    ).toEqual(["npx", "-y", "pi-acp"]);
   });
 
   it("rehydrates the Canvas registry key from custom wire settings", () => {

--- a/__tests__/helpers/create-conversation-call-args.ts
+++ b/__tests__/helpers/create-conversation-call-args.ts
@@ -1,0 +1,7 @@
+/** Trailing positional args for `AgentServerConversationService.createConversation`. */
+export const CREATE_CONVERSATION_DEFAULT_TAIL = [
+  undefined, // sandboxId
+  undefined, // agentProfileId
+  undefined, // agentProfileKind
+  undefined, // agentSettingsOverride (Pi profile inlining)
+] as const;

--- a/__tests__/hooks/mutation/use-create-conversation.test.tsx
+++ b/__tests__/hooks/mutation/use-create-conversation.test.tsx
@@ -8,6 +8,7 @@ import {
   getStoredConversationMetadata,
   removeStoredConversationMetadata,
 } from "#/api/conversation-metadata-store";
+import { CREATE_CONVERSATION_DEFAULT_TAIL } from "../../helpers/create-conversation-call-args";
 
 vi.mock("#/hooks/use-tracking", () => ({
   useTracking: () => ({
@@ -172,6 +173,7 @@ describe("useCreateConversation", () => {
         undefined,
         undefined,
         undefined,
+        ...CREATE_CONVERSATION_DEFAULT_TAIL,
       );
     });
   });

--- a/__tests__/routes/build-agent-profile-fields.test.ts
+++ b/__tests__/routes/build-agent-profile-fields.test.ts
@@ -72,6 +72,23 @@ describe("buildAgentProfileFields — ACP", () => {
       expect(fields.acp_model).toBeNull();
     }
   });
+
+  it("maps the 'pi' preset to the 'custom' server identity to satisfy backend validation", () => {
+    const fields = buildAgentProfileFields({
+      ...baseAcp,
+      selectedPreset: "pi",
+      isDefaultProviderCommand: true,
+      commandTokens: ["npx", "-y", "pi-acp"],
+      acpModel: "default",
+    });
+    expect(fields).toEqual({
+      agent_kind: "acp",
+      acp_server: "custom",
+      acp_model: "default",
+      acp_command: null,
+      acp_args: null,
+    });
+  });
 });
 
 describe("buildAgentProfileFields — OpenHands", () => {

--- a/__tests__/routes/build-agent-profile-fields.test.ts
+++ b/__tests__/routes/build-agent-profile-fields.test.ts
@@ -89,6 +89,24 @@ describe("buildAgentProfileFields — ACP", () => {
       acp_args: null,
     });
   });
+
+  it("pins the preinstalled pi-acp binary for the Pi preset in Docker mode", () => {
+    const fields = buildAgentProfileFields({
+      ...baseAcp,
+      selectedPreset: "pi",
+      isDefaultProviderCommand: true,
+      commandTokens: ["npx", "-y", "pi-acp"],
+      acpModel: "default",
+      deploymentMode: "docker",
+    });
+    expect(fields).toEqual({
+      agent_kind: "acp",
+      acp_server: "custom",
+      acp_model: "default",
+      acp_command: "pi-acp",
+      acp_args: null,
+    });
+  });
 });
 
 describe("buildAgentProfileFields — OpenHands", () => {

--- a/__tests__/routes/build-agent-profile-fields.test.ts
+++ b/__tests__/routes/build-agent-profile-fields.test.ts
@@ -73,7 +73,7 @@ describe("buildAgentProfileFields — ACP", () => {
     }
   });
 
-  it("maps the 'pi' preset to the 'custom' server identity to satisfy backend validation", () => {
+  it("pins the pi-acp command for the Pi preset because its wire acp_server is custom", () => {
     const fields = buildAgentProfileFields({
       ...baseAcp,
       selectedPreset: "pi",
@@ -85,7 +85,7 @@ describe("buildAgentProfileFields — ACP", () => {
       agent_kind: "acp",
       acp_server: "custom",
       acp_model: "default",
-      acp_command: null,
+      acp_command: "npx -y pi-acp",
       acp_args: null,
     });
   });

--- a/__tests__/utils/inline-pi-acp-profile-settings.test.ts
+++ b/__tests__/utils/inline-pi-acp-profile-settings.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { ACPAgentProfile } from "@openhands/typescript-client";
+import { buildInlinePiAcpAgentSettingsFromProfile } from "#/utils/inline-pi-acp-profile-settings";
+
+describe("buildInlinePiAcpAgentSettingsFromProfile", () => {
+  const baseProfile = {
+    id: "profile-1",
+    name: "MyPi",
+    revision: 0,
+    agent_kind: "acp",
+    acp_server: "custom",
+    acp_command: "npx -y pi-acp",
+    acp_model: "default",
+    acp_args: null,
+    acp_session_mode: null,
+    acp_prompt_timeout: 1800,
+    mcp_server_refs: [],
+  } satisfies ACPAgentProfile;
+
+  it("rewrites npx pi-acp to the preinstalled binary in Docker mode", () => {
+    expect(
+      buildInlinePiAcpAgentSettingsFromProfile(baseProfile, "docker"),
+    ).toMatchObject({
+      agent_kind: "acp",
+      acp_server: "custom",
+      acp_command: ["pi-acp"],
+      acp_model: null,
+    });
+  });
+
+  it("keeps npx outside Docker", () => {
+    expect(
+      buildInlinePiAcpAgentSettingsFromProfile(baseProfile, "dev:automation"),
+    ).toMatchObject({
+      acp_command: ["npx", "-y", "pi-acp"],
+      acp_model: null,
+    });
+  });
+
+  it("returns null for non-Pi ACP profiles", () => {
+    expect(
+      buildInlinePiAcpAgentSettingsFromProfile({
+        ...baseProfile,
+        acp_server: "claude-code",
+        acp_command: null,
+      }),
+    ).toBeNull();
+  });
+});

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,6 +67,12 @@ RUN node -e " \
   require('fs').writeFileSync('/tmp/defaults.env', lines.join('\n') + '\n'); \
 "
 
+# ── Stage 1c: Pi ACP (Node 22+ required; avoid Debian apt nodejs) ─────────────
+FROM node:24-slim AS pi-acp-install
+RUN npm install -g --ignore-scripts \
+  @earendil-works/pi-coding-agent \
+  pi-acp
+
 # ── Stage 2: Combined image ──────────────────────────────────────────────────
 FROM ${AGENT_SERVER_IMAGE} AS final
 
@@ -93,23 +99,21 @@ USER root
 
 # Install system deps required by automation's transitive dependencies
 # (asyncpg needs libpq, which the agent-server base image may not include).
-# Also install Node/npm for Pi ACP (pi-acp spawns via npx; the pi coding-agent
-# CLI is a separate global npm package). Claude/Codex/Gemini ACP wrappers ship
-# in the agent-server base image; Pi is installed here for Docker parity.
 RUN if command -v apt-get >/dev/null 2>&1; then \
       apt-get update && \
-      apt-get install -y --no-install-recommends libpq-dev nodejs npm && \
+      apt-get install -y --no-install-recommends libpq-dev && \
       rm -rf /var/lib/apt/lists/*; \
     fi
 
-# Pi coding agent + ACP adapter (stdio JSON-RPC → ``pi --mode rpc``).
-# ``--ignore-scripts`` matches upstream Pi install guidance; lifecycle scripts
-# are not required for headless ACP use.
-RUN if command -v npm >/dev/null 2>&1; then \
-      npm install -g --ignore-scripts \
-        @earendil-works/pi-coding-agent \
-        pi-acp; \
-    fi
+# Pi coding agent + ACP adapter. Claude/Codex/Gemini wrappers ship in the
+# agent-server base; Pi is third-party and installed via the Node 24 stage
+# above (pi-acp requires Node 22+).
+COPY --from=pi-acp-install /usr/local/bin/node /usr/local/bin/node
+COPY --from=pi-acp-install /usr/local/bin/npm /usr/local/bin/npm
+COPY --from=pi-acp-install /usr/local/bin/npx /usr/local/bin/npx
+COPY --from=pi-acp-install /usr/local/bin/pi /usr/local/bin/pi
+COPY --from=pi-acp-install /usr/local/bin/pi-acp /usr/local/bin/pi-acp
+COPY --from=pi-acp-install /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 # Install automation server via pip.
 # Shared deps (openhands-sdk, fastapi, uvicorn, pydantic, httpx, …) are

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -109,17 +109,12 @@ RUN if command -v apt-get >/dev/null 2>&1; then \
 # agent-server base; Pi is third-party and installed via the Node 24 stage
 # above (pi-acp requires Node 22+).
 #
-# Copy the Node 24 toolchain, then re-run ``npm install -g`` in this stage.
-# Do NOT ``COPY`` /usr/local/bin/pi or pi-acp directly — Docker dereferences
-# npm global symlinks into flat scripts that break relative imports
-# (``config.js`` lives in the package dir, not next to bin/pi).
-COPY --from=pi-acp-install /usr/local/bin/node /usr/local/bin/node
-COPY --from=pi-acp-install /usr/local/bin/npm /usr/local/bin/npm
-COPY --from=pi-acp-install /usr/local/bin/npx /usr/local/bin/npx
-COPY --from=pi-acp-install /usr/local/lib/node_modules /usr/local/lib/node_modules
-RUN npm install -g --ignore-scripts \
-  @earendil-works/pi-coding-agent \
-  pi-acp
+# Copy the whole Node prefix so npm global bin *symlinks* stay intact.
+# Never ``COPY`` /usr/local/bin/pi or pi-acp alone — Docker dereferences
+# symlinks into flat scripts that import ./config.js from bin/ instead of
+# the package directory under lib/node_modules.
+COPY --from=pi-acp-install /usr/local/ /opt/node24/
+ENV PATH="/opt/node24/bin:${PATH}"
 
 # Install automation server via pip.
 # Shared deps (openhands-sdk, fastapi, uvicorn, pydantic, httpx, …) are

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -93,10 +93,22 @@ USER root
 
 # Install system deps required by automation's transitive dependencies
 # (asyncpg needs libpq, which the agent-server base image may not include).
+# Also install Node/npm for Pi ACP (pi-acp spawns via npx; the pi coding-agent
+# CLI is a separate global npm package). Claude/Codex/Gemini ACP wrappers ship
+# in the agent-server base image; Pi is installed here for Docker parity.
 RUN if command -v apt-get >/dev/null 2>&1; then \
       apt-get update && \
-      apt-get install -y --no-install-recommends libpq-dev && \
+      apt-get install -y --no-install-recommends libpq-dev nodejs npm && \
       rm -rf /var/lib/apt/lists/*; \
+    fi
+
+# Pi coding agent + ACP adapter (stdio JSON-RPC → ``pi --mode rpc``).
+# ``--ignore-scripts`` matches upstream Pi install guidance; lifecycle scripts
+# are not required for headless ACP use.
+RUN if command -v npm >/dev/null 2>&1; then \
+      npm install -g --ignore-scripts \
+        @earendil-works/pi-coding-agent \
+        pi-acp; \
     fi
 
 # Install automation server via pip.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,8 +70,8 @@ RUN node -e " \
 # ── Stage 1c: Pi ACP (Node 22+ required; avoid Debian apt nodejs) ─────────────
 FROM node:24-slim AS pi-acp-install
 RUN npm install -g --ignore-scripts \
-  @earendil-works/pi-coding-agent \
-  pi-acp
+  @earendil-works/pi-coding-agent@0.84.0 \
+  pi-acp@0.0.33
 
 # ── Stage 2: Combined image ──────────────────────────────────────────────────
 FROM ${AGENT_SERVER_IMAGE} AS final
@@ -114,9 +114,9 @@ RUN if command -v apt-get >/dev/null 2>&1; then \
 # symlinks into flat scripts that import ./config.js from bin/ instead of
 # the package directory under lib/node_modules.
 COPY --from=pi-acp-install /usr/local/ /opt/node24/
-ENV PATH="/opt/node24/bin:${PATH}"
+
 RUN test -x /opt/node24/bin/pi-acp && test -x /opt/node24/bin/pi && \
-    /opt/node24/bin/pi --version
+    /opt/node24/bin/pi --version && /opt/node24/bin/pi-acp
 
 # Install automation server via pip.
 # Shared deps (openhands-sdk, fastapi, uvicorn, pydantic, httpx, …) are

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -108,12 +108,18 @@ RUN if command -v apt-get >/dev/null 2>&1; then \
 # Pi coding agent + ACP adapter. Claude/Codex/Gemini wrappers ship in the
 # agent-server base; Pi is third-party and installed via the Node 24 stage
 # above (pi-acp requires Node 22+).
+#
+# Copy the Node 24 toolchain, then re-run ``npm install -g`` in this stage.
+# Do NOT ``COPY`` /usr/local/bin/pi or pi-acp directly — Docker dereferences
+# npm global symlinks into flat scripts that break relative imports
+# (``config.js`` lives in the package dir, not next to bin/pi).
 COPY --from=pi-acp-install /usr/local/bin/node /usr/local/bin/node
 COPY --from=pi-acp-install /usr/local/bin/npm /usr/local/bin/npm
 COPY --from=pi-acp-install /usr/local/bin/npx /usr/local/bin/npx
-COPY --from=pi-acp-install /usr/local/bin/pi /usr/local/bin/pi
-COPY --from=pi-acp-install /usr/local/bin/pi-acp /usr/local/bin/pi-acp
 COPY --from=pi-acp-install /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN npm install -g --ignore-scripts \
+  @earendil-works/pi-coding-agent \
+  pi-acp
 
 # Install automation server via pip.
 # Shared deps (openhands-sdk, fastapi, uvicorn, pydantic, httpx, …) are

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -115,6 +115,8 @@ RUN if command -v apt-get >/dev/null 2>&1; then \
 # the package directory under lib/node_modules.
 COPY --from=pi-acp-install /usr/local/ /opt/node24/
 ENV PATH="/opt/node24/bin:${PATH}"
+RUN test -x /opt/node24/bin/pi-acp && test -x /opt/node24/bin/pi && \
+    /opt/node24/bin/pi --version
 
 # Install automation server via pip.
 # Shared deps (openhands-sdk, fastapi, uvicorn, pydantic, httpx, …) are

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -4,9 +4,12 @@ import { DEFAULT_SETTINGS } from "#/services/settings";
 import { ExecutionStatus } from "#/types/agent-server/core";
 import { AgentKind, Settings, SettingsValue } from "#/types/settings";
 import {
+  defaultAcpCommandForProvider,
   getAcpPreferredDefaultModel,
   getAcpProvider,
+  PI_ACP_PROVIDER_KEY,
   resolveEffectiveAcpModel,
+  resolveUiAcpProviderKey,
 } from "#/constants/acp-providers";
 import { getAgentServerClientOptions } from "./agent-server-client-options";
 import { isAgentServerToolAvailable } from "./agent-server-compatibility";
@@ -703,11 +706,12 @@ function isAcpAgent(settings: Settings): boolean {
 function getAcpServerTag(settings: Settings): string | undefined {
   const agentSettings = toRecord(settings.agent_settings);
   const value = agentSettings.acp_server;
-  if (value === "custom" || !value) {
-    const cmd = agentSettings.acp_command;
-    if (Array.isArray(cmd) && cmd.join(" ") === "npx -y pi-acp") {
-      return "pi";
-    }
+  const uiKey = resolveUiAcpProviderKey(
+    typeof value === "string" ? value : undefined,
+    agentSettings.acp_command,
+  );
+  if (uiKey === PI_ACP_PROVIDER_KEY) {
+    return PI_ACP_PROVIDER_KEY;
   }
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
@@ -715,7 +719,7 @@ function getAcpServerTag(settings: Settings): string | undefined {
 function resolveAcpCommand(agentSettings: SettingsRecord): unknown {
   const cmd = agentSettings.acp_command;
   const isEmpty = Array.isArray(cmd) && cmd.length === 0;
-  const noCommand = cmd === undefined;
+  const noCommand = cmd === undefined || cmd === null;
   if (!isEmpty && !noCommand) {
     return cmd;
   }
@@ -724,8 +728,16 @@ function resolveAcpCommand(agentSettings: SettingsRecord): unknown {
     typeof agentSettings.acp_server === "string"
       ? agentSettings.acp_server
       : undefined;
-  const provider = getAcpProvider(serverKey);
-  return provider ? [...provider.default_command] : cmd;
+  const uiKey = resolveUiAcpProviderKey(serverKey, cmd);
+  const provider = getAcpProvider(uiKey ?? serverKey);
+  if (provider) {
+    return [...provider.default_command];
+  }
+  const piDefault = defaultAcpCommandForProvider(uiKey ?? serverKey ?? "");
+  if (piDefault.length > 0) {
+    return piDefault;
+  }
+  return cmd;
 }
 
 function buildConfiguredAcpAgentSettings(
@@ -775,9 +787,15 @@ function buildConfiguredAcpAgentSettings(
   // that, the form's displayed default would silently not take effect at
   // runtime until the user re-saved the page.
   const serverKey =
-    typeof agentSettings.acp_server === "string"
+    resolveUiAcpProviderKey(
+      typeof agentSettings.acp_server === "string"
+        ? agentSettings.acp_server
+        : undefined,
+      agentSettings.acp_command,
+    ) ??
+    (typeof agentSettings.acp_server === "string"
       ? agentSettings.acp_server
-      : undefined;
+      : undefined);
   const effectiveModel = resolveEffectiveAcpModel({
     configured: agentSettings.acp_model as string | null | undefined,
     providerDefault: getAcpPreferredDefaultModel(serverKey),

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -800,16 +800,12 @@ function buildConfiguredAcpAgentSettings(
   // conversation starts with whatever the Settings → Agent UI shows — without
   // that, the form's displayed default would silently not take effect at
   // runtime until the user re-saved the page.
-  const serverKey =
-    resolveUiAcpProviderKey(
-      typeof agentSettings.acp_server === "string"
-        ? agentSettings.acp_server
-        : undefined,
-      agentSettings.acp_command,
-    ) ??
-    (typeof agentSettings.acp_server === "string"
+  const serverKey = resolveUiAcpProviderKey(
+    typeof agentSettings.acp_server === "string"
       ? agentSettings.acp_server
-      : undefined);
+      : undefined,
+    agentSettings.acp_command,
+  );
   const effectiveModel = resolveEffectiveAcpModel({
     configured: agentSettings.acp_model as string | null | undefined,
     providerDefault: getAcpPreferredDefaultModel(serverKey),

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -162,6 +162,13 @@ function getRawRuntimeServicesInfo(): string | null {
     if (typeof injected === "string") {
       return injected.trim() || null;
     }
+    if (injected && typeof injected === "object") {
+      try {
+        return JSON.stringify(injected);
+      } catch {
+        return null;
+      }
+    }
   }
 
   return null;
@@ -807,7 +814,9 @@ function buildConfiguredAcpAgentSettings(
     configured: agentSettings.acp_model as string | null | undefined,
     providerDefault: getAcpPreferredDefaultModel(serverKey),
   });
-  if (effectiveModel) {
+  const piPlaceholderModel =
+    serverKey === PI_ACP_PROVIDER_KEY && effectiveModel === "default";
+  if (effectiveModel && !piPlaceholderModel) {
     payload.acp_model = effectiveModel;
   }
 

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -64,7 +64,7 @@ export interface DirectConversationInfo {
     kind?: string | null;
     acp_model?: string | null;
     /**
-     * ACP CLI identity (``claude-code`` / ``codex`` / ``gemini-cli``) from the
+     * ACP CLI identity (``claude-code`` / ``codex`` / ``gemini-cli`` / ``pi``) from the
      * SDK's ``ACPAgent.acp_server`` (#3692). Preferred fallback when the
      * ``acpserver`` tag is absent — e.g. a profile launch doesn't stamp the tag
      * client-side and the server may not repopulate it. Read by {@link toAppConversation}.
@@ -703,6 +703,12 @@ function isAcpAgent(settings: Settings): boolean {
 function getAcpServerTag(settings: Settings): string | undefined {
   const agentSettings = toRecord(settings.agent_settings);
   const value = agentSettings.acp_server;
+  if (value === "custom" || !value) {
+    const cmd = agentSettings.acp_command;
+    if (Array.isArray(cmd) && cmd.join(" ") === "npx -y pi-acp") {
+      return "pi";
+    }
+  }
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -7,8 +7,7 @@ import {
   defaultAcpCommandForProvider,
   getAcpPreferredDefaultModel,
   getAcpProvider,
-  isPiAcpCommand,
-  PI_ACP_DOCKER_COMMAND,
+  adaptPiAcpCommandForDeployment,
   PI_ACP_PROVIDER_KEY,
   resolveEffectiveAcpModel,
   resolveUiAcpProviderKey,
@@ -735,18 +734,17 @@ function resolveAcpCommand(agentSettings: SettingsRecord): unknown {
     if (provider) {
       resolved = [...provider.default_command];
     } else {
-      const piDefault = defaultAcpCommandForProvider(uiKey ?? serverKey ?? "");
+      const piDefault = defaultAcpCommandForProvider(
+        uiKey ?? serverKey ?? "",
+        getDeploymentMode(),
+      );
       resolved = piDefault.length > 0 ? piDefault : cmd;
     }
   }
 
   // Docker pre-installs pi-acp on PATH; npx -y pi-acp fails with a broken npm
   // stack ("Class extends value undefined is not a constructor or null").
-  if (getDeploymentMode() === "docker" && isPiAcpCommand(resolved)) {
-    return [...PI_ACP_DOCKER_COMMAND];
-  }
-
-  return resolved;
+  return adaptPiAcpCommandForDeployment(resolved, getDeploymentMode());
 }
 
 function buildConfiguredAcpAgentSettings(
@@ -1162,6 +1160,7 @@ export async function buildStartConversationRequestWithEncryptedSettings(options
   worktree?: boolean;
   agentProfileId?: string;
   agentProfileKind?: AgentKind;
+  agentSettingsOverride?: Record<string, SettingsValue>;
   titleLlmProfile?: string;
 }): Promise<Record<string, unknown>> {
   const { SecretsService } = await import("./secrets-service");
@@ -1171,8 +1170,9 @@ export async function buildStartConversationRequestWithEncryptedSettings(options
     SecretsService.getSecrets(),
   ]);
 
-  const { agentSettings, conversationSettings, secretsEncrypted } =
-    settingsResult;
+  const agentSettings =
+    options.agentSettingsOverride ?? settingsResult.agentSettings;
+  const { conversationSettings, secretsEncrypted } = settingsResult;
 
   // A profile launch resolves the LLM server-side, so the current-settings
   // subscription check doesn't apply (and can't see the profile's LLM).

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -7,6 +7,8 @@ import {
   defaultAcpCommandForProvider,
   getAcpPreferredDefaultModel,
   getAcpProvider,
+  isPiAcpCommand,
+  PI_ACP_DOCKER_COMMAND,
   PI_ACP_PROVIDER_KEY,
   resolveEffectiveAcpModel,
   resolveUiAcpProviderKey,
@@ -720,24 +722,31 @@ function resolveAcpCommand(agentSettings: SettingsRecord): unknown {
   const cmd = agentSettings.acp_command;
   const isEmpty = Array.isArray(cmd) && cmd.length === 0;
   const noCommand = cmd === undefined || cmd === null;
+  let resolved: unknown;
   if (!isEmpty && !noCommand) {
-    return cmd;
+    resolved = cmd;
+  } else {
+    const serverKey =
+      typeof agentSettings.acp_server === "string"
+        ? agentSettings.acp_server
+        : undefined;
+    const uiKey = resolveUiAcpProviderKey(serverKey, cmd);
+    const provider = getAcpProvider(uiKey ?? serverKey);
+    if (provider) {
+      resolved = [...provider.default_command];
+    } else {
+      const piDefault = defaultAcpCommandForProvider(uiKey ?? serverKey ?? "");
+      resolved = piDefault.length > 0 ? piDefault : cmd;
+    }
   }
 
-  const serverKey =
-    typeof agentSettings.acp_server === "string"
-      ? agentSettings.acp_server
-      : undefined;
-  const uiKey = resolveUiAcpProviderKey(serverKey, cmd);
-  const provider = getAcpProvider(uiKey ?? serverKey);
-  if (provider) {
-    return [...provider.default_command];
+  // Docker pre-installs pi-acp on PATH; npx -y pi-acp fails with a broken npm
+  // stack ("Class extends value undefined is not a constructor or null").
+  if (getDeploymentMode() === "docker" && isPiAcpCommand(resolved)) {
+    return [...PI_ACP_DOCKER_COMMAND];
   }
-  const piDefault = defaultAcpCommandForProvider(uiKey ?? serverKey ?? "");
-  if (piDefault.length > 0) {
-    return piDefault;
-  }
-  return cmd;
+
+  return resolved;
 }
 
 function buildConfiguredAcpAgentSettings(

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -10,7 +10,7 @@ import {
   VSCodeClient,
 } from "@openhands/typescript-client/clients";
 import { v4 as uuidv4 } from "uuid";
-import { AgentKind, Provider } from "#/types/settings";
+import { AgentKind, Provider, SettingsValue } from "#/types/settings";
 import type { ConversationRuntimeContext } from "#/api/conversation-file-upload.api";
 import { buildHttpBaseUrl } from "#/utils/websocket-url";
 import {
@@ -382,6 +382,7 @@ class AgentServerConversationService {
     // encrypted-settings builder; cloud sends it as a flat request field.
     agentProfileId?: string,
     agentProfileKind?: AgentKind,
+    agentSettingsOverride?: Record<string, SettingsValue>,
   ): Promise<AppConversationStartTask> {
     if (getActiveBackend().backend.kind === "cloud") {
       // Cloud path mirrors OpenHands' frontend: build a flat
@@ -443,6 +444,7 @@ class AgentServerConversationService {
       worktree: resolvedWorkspaceMode === "new_worktree",
       agentProfileId,
       agentProfileKind,
+      agentSettingsOverride,
       titleLlmProfile,
     });
 

--- a/src/api/conversation-service/agent-server-conversation-service.types.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.types.ts
@@ -153,7 +153,7 @@ export interface AppConversation {
   /**
    * For ACP conversations, the registry key of the ACP CLI server the
    * conversation was launched against (e.g. ``"claude-code"``, ``"codex"``,
-   * ``"gemini-cli"``). Populated from ``info.tags.acpserver`` — see
+   * ``"gemini-cli"``, ``"pi"``). Populated from ``info.tags.acpserver`` — see
    * ``ACP_SERVER_TAG_KEY`` in ``agent-server-adapter.ts`` for the wire
    * format and the rationale behind the snake_case-incompatible
    * ``acpserver`` form. ``null`` for OpenHands conversations and for ACP

--- a/src/components/features/conversation-panel/conversation-card/conversation-card-footer.tsx
+++ b/src/components/features/conversation-panel/conversation-card/conversation-card-footer.tsx
@@ -50,7 +50,7 @@ interface ConversationCardFooterProps {
   agentKind?: "openhands" | "acp" | null;
   /**
    * Registry key of the ACP CLI server (``"claude-code"`` / ``"codex"`` /
-   * ``"gemini-cli"`` / unknown / null). Resolved to a human display name
+   * ``"gemini-cli"`` / ``"pi"`` / unknown / null). Resolved to a human display name
    * via {@link getAcpProviderDisplayName}; unknown / null falls back to
    * a generic "ACP" label so a Custom-command preset still produces a
    * useful chip.

--- a/src/components/features/onboarding/steps/choose-agent-step.tsx
+++ b/src/components/features/onboarding/steps/choose-agent-step.tsx
@@ -25,7 +25,8 @@ export type OnboardingAgentId =
   | "openhands"
   | "claude-code"
   | "codex"
-  | "gemini-cli";
+  | "gemini-cli"
+  | "pi";
 
 function getAgentOptionIcon(id: string): AgentBrandIconKind {
   if (id === "openhands") return "openhands";

--- a/src/components/features/onboarding/steps/setup-acp-secrets-step.tsx
+++ b/src/components/features/onboarding/steps/setup-acp-secrets-step.tsx
@@ -11,6 +11,7 @@ import { useActiveBackend } from "#/contexts/active-backend-context";
 import {
   getAcpProviderDisplayName,
   getAcpPreferredDefaultModel,
+  wireAcpServerForProvider,
 } from "#/constants/acp-providers";
 import { useApplyOnboardingAgentProfile } from "#/hooks/mutation/use-apply-onboarding-agent-profile";
 import { type ACPServerKind } from "@openhands/typescript-client";
@@ -126,9 +127,7 @@ export function SetupAcpSecretsStep({
       if (providerKey !== "openhands") {
         await applyAgentProfile({
           agent_kind: "acp",
-          acp_server: (providerKey === "pi"
-            ? "custom"
-            : providerKey) as ACPServerKind,
+          acp_server: wireAcpServerForProvider(providerKey) as ACPServerKind,
           acp_model: getAcpPreferredDefaultModel(providerKey) ?? undefined,
         });
       }

--- a/src/components/features/onboarding/steps/setup-acp-secrets-step.tsx
+++ b/src/components/features/onboarding/steps/setup-acp-secrets-step.tsx
@@ -13,6 +13,7 @@ import {
   getAcpPreferredDefaultModel,
 } from "#/constants/acp-providers";
 import { useApplyOnboardingAgentProfile } from "#/hooks/mutation/use-apply-onboarding-agent-profile";
+import { type ACPServerKind } from "@openhands/typescript-client";
 import { type OnboardingAgentId } from "./choose-agent-step";
 
 interface SetupAcpSecretsStepProps {
@@ -125,7 +126,9 @@ export function SetupAcpSecretsStep({
       if (providerKey !== "openhands") {
         await applyAgentProfile({
           agent_kind: "acp",
-          acp_server: providerKey,
+          acp_server: (providerKey === "pi"
+            ? "custom"
+            : providerKey) as ACPServerKind,
           acp_model: getAcpPreferredDefaultModel(providerKey) ?? undefined,
         });
       }

--- a/src/components/features/onboarding/steps/setup-acp-secrets-step.tsx
+++ b/src/components/features/onboarding/steps/setup-acp-secrets-step.tsx
@@ -11,8 +11,11 @@ import { useActiveBackend } from "#/contexts/active-backend-context";
 import {
   getAcpProviderDisplayName,
   getAcpPreferredDefaultModel,
+  effectivePiAcpCommandTokens,
   wireAcpServerForProvider,
 } from "#/constants/acp-providers";
+import { getDeploymentMode } from "#/api/agent-server-adapter";
+import { formatCommand } from "#/utils/acp-command";
 import { useApplyOnboardingAgentProfile } from "#/hooks/mutation/use-apply-onboarding-agent-profile";
 import { type ACPServerKind } from "@openhands/typescript-client";
 import { type OnboardingAgentId } from "./choose-agent-step";
@@ -129,6 +132,13 @@ export function SetupAcpSecretsStep({
           agent_kind: "acp",
           acp_server: wireAcpServerForProvider(providerKey) as ACPServerKind,
           acp_model: getAcpPreferredDefaultModel(providerKey) ?? undefined,
+          ...(providerKey === "pi"
+            ? {
+                acp_command: formatCommand(
+                  effectivePiAcpCommandTokens(getDeploymentMode()),
+                ),
+              }
+            : {}),
         });
       }
       onNext();

--- a/src/components/features/onboarding/steps/setup-acp-secrets-step.tsx
+++ b/src/components/features/onboarding/steps/setup-acp-secrets-step.tsx
@@ -13,6 +13,7 @@ import {
   getAcpPreferredDefaultModel,
   effectivePiAcpCommandTokens,
   wireAcpServerForProvider,
+  PI_ACP_PROVIDER_KEY,
 } from "#/constants/acp-providers";
 import { getDeploymentMode } from "#/api/agent-server-adapter";
 import { formatCommand } from "#/utils/acp-command";
@@ -132,7 +133,7 @@ export function SetupAcpSecretsStep({
           agent_kind: "acp",
           acp_server: wireAcpServerForProvider(providerKey) as ACPServerKind,
           acp_model: getAcpPreferredDefaultModel(providerKey) ?? undefined,
-          ...(providerKey === "pi"
+          ...(providerKey === PI_ACP_PROVIDER_KEY
             ? {
                 acp_command: formatCommand(
                   effectivePiAcpCommandTokens(getDeploymentMode()),

--- a/src/components/shared/agent-brand-icon.tsx
+++ b/src/components/shared/agent-brand-icon.tsx
@@ -106,6 +106,27 @@ export function AgentBrandIcon({
       </svg>
     );
   }
+  if (kind === "pi") {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 800 800"
+        width={size}
+        height={size}
+        className={cn("shrink-0", className)}
+        data-testid={testId ?? "agent-brand-icon-pi"}
+        aria-hidden
+      >
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M165.29 165.29 H517.36 V400 H400 V517.36 H282.65 V634.72 H165.29 Z M282.65 282.65 V400 H400 V282.65 Z"
+          fill="currentColor"
+        />
+        <path d="M517.36 400 H634.72 V634.72 H517.36 Z" fill="currentColor" />
+      </svg>
+    );
+  }
   return (
     <TerminalIcon
       width={size}

--- a/src/constants/acp-providers.ts
+++ b/src/constants/acp-providers.ts
@@ -272,9 +272,7 @@ export const ACP_PROVIDERS: ACPProviderConfig[] = Object.entries(
       : key === PI_ACP_PROVIDER_KEY
         ? [{ id: "default", label: "Default Model" }]
         : undefined,
-    default_model:
-      info?.default_model ??
-      (key === PI_ACP_PROVIDER_KEY ? "default" : undefined),
+    default_model: info?.default_model ?? undefined,
     description_key: ui.description_key,
     icon: ui.icon,
   };
@@ -439,6 +437,9 @@ export function getAcpPreferredDefaultModel(
   key: string | null | undefined,
 ): string | null {
   if (key === "gemini-cli") return ACP_VERTEX_SAFE_MODEL;
+  // Pi models come from the pi CLI (~/.pi, ``pi --list-models``). Canvas must
+  // not invent a placeholder id — let pi-acp pick its configured default.
+  if (key === PI_ACP_PROVIDER_KEY) return null;
   return getAcpProvider(key)?.default_model ?? null;
 }
 

--- a/src/constants/acp-providers.ts
+++ b/src/constants/acp-providers.ts
@@ -171,7 +171,7 @@ export const ACP_PROVIDERS: ACPProviderConfig[] = Object.entries(
           label: model.label,
         }))
       : key === "pi"
-        ? [{ id: "default", label: "Default" }]
+        ? [{ id: "default", label: "Default Model" }]
         : undefined,
     default_model:
       info?.default_model ?? (key === "pi" ? "default" : undefined),

--- a/src/constants/acp-providers.ts
+++ b/src/constants/acp-providers.ts
@@ -1,5 +1,6 @@
 import { getAcpProvider as getClientAcpProvider } from "@openhands/typescript-client";
 import { I18nKey } from "#/i18n/declaration";
+import { parseCommand } from "#/utils/acp-command";
 
 export type ACPProviderIcon =
   | "claude-code"
@@ -20,8 +21,9 @@ export const PI_ACP_DEFAULT_COMMAND: readonly string[] = [
   "pi-acp",
 ];
 
-/** Docker image pre-installs ``pi-acp`` on PATH; ``npx`` is unreliable there. */
-export const PI_ACP_DOCKER_COMMAND: readonly string[] = ["pi-acp"];
+/** Docker image installs pi-acp at this path (see docker/Dockerfile). */
+export const PI_ACP_DOCKER_BIN = "/opt/node24/bin/pi-acp";
+export const PI_ACP_DOCKER_COMMAND: readonly string[] = [PI_ACP_DOCKER_BIN];
 
 const PI_ACP_DEFAULT_COMMAND_TEXT = PI_ACP_DEFAULT_COMMAND.join(" ");
 const PI_ACP_DOCKER_COMMAND_TEXT = PI_ACP_DOCKER_COMMAND.join(" ");
@@ -33,9 +35,7 @@ function normalizeAcpCommandTokens(command: unknown): string[] {
     );
   }
   if (typeof command === "string") {
-    const trimmed = command.trim();
-    if (!trimmed) return [];
-    return trimmed.split(/\s+/);
+    return parseCommand(command);
   }
   return [];
 }

--- a/src/constants/acp-providers.ts
+++ b/src/constants/acp-providers.ts
@@ -20,7 +20,11 @@ export const PI_ACP_DEFAULT_COMMAND: readonly string[] = [
   "pi-acp",
 ];
 
+/** Docker image pre-installs ``pi-acp`` on PATH; ``npx`` is unreliable there. */
+export const PI_ACP_DOCKER_COMMAND: readonly string[] = ["pi-acp"];
+
 const PI_ACP_DEFAULT_COMMAND_TEXT = PI_ACP_DEFAULT_COMMAND.join(" ");
+const PI_ACP_DOCKER_COMMAND_TEXT = PI_ACP_DOCKER_COMMAND.join(" ");
 
 function normalizeAcpCommandTokens(command: unknown): string[] {
   if (Array.isArray(command)) {
@@ -38,8 +42,10 @@ function normalizeAcpCommandTokens(command: unknown): string[] {
 
 /** True when ``command`` matches the built-in Pi preset launch argv/text. */
 export function isPiAcpCommand(command: unknown): boolean {
+  const normalized = normalizeAcpCommandTokens(command).join(" ");
   return (
-    normalizeAcpCommandTokens(command).join(" ") === PI_ACP_DEFAULT_COMMAND_TEXT
+    normalized === PI_ACP_DEFAULT_COMMAND_TEXT ||
+    normalized === PI_ACP_DOCKER_COMMAND_TEXT
   );
 }
 

--- a/src/constants/acp-providers.ts
+++ b/src/constants/acp-providers.ts
@@ -78,11 +78,34 @@ export function resolveUiAcpProviderKey(
  * sends an empty command. Built-ins rely on the agent-server registry; Pi
  * must pin ``pi-acp`` explicitly because its wire ``acp_server`` is ``custom``.
  */
-export function defaultAcpCommandForProvider(providerKey: string): string[] {
+export function defaultAcpCommandForProvider(
+  providerKey: string,
+  deploymentMode?: string | null,
+): string[] {
   if (providerKey === PI_ACP_PROVIDER_KEY) {
-    return [...PI_ACP_DEFAULT_COMMAND];
+    return effectivePiAcpCommandTokens(deploymentMode);
   }
   return [];
+}
+
+/** Pi spawn argv for a deployment mode (``npx`` locally, ``pi-acp`` in Docker). */
+export function effectivePiAcpCommandTokens(
+  deploymentMode?: string | null,
+): string[] {
+  return deploymentMode === "docker"
+    ? [...PI_ACP_DOCKER_COMMAND]
+    : [...PI_ACP_DEFAULT_COMMAND];
+}
+
+/** Rewrite Pi preset commands to the preinstalled binary in Docker images. */
+export function adaptPiAcpCommandForDeployment(
+  command: unknown,
+  deploymentMode?: string | null,
+): unknown {
+  if (deploymentMode === "docker" && isPiAcpCommand(command)) {
+    return [...PI_ACP_DOCKER_COMMAND];
+  }
+  return command;
 }
 
 // Sentinel ``agent.llm.model`` returned by older SDKs for ACP conversations
@@ -578,6 +601,7 @@ export function buildAcpAgentSettingsDiff(
     command?: string[];
     model?: string | null;
     allowUnknownServer?: boolean;
+    deploymentMode?: string | null;
   } = {},
 ): Record<string, unknown> | null {
   if (providerKey === "openhands") {
@@ -610,7 +634,7 @@ export function buildAcpAgentSettingsDiff(
   const command =
     options.command && options.command.length > 0
       ? options.command
-      : defaultAcpCommandForProvider(providerKey);
+      : defaultAcpCommandForProvider(providerKey, options.deploymentMode);
 
   return {
     agent_kind: "acp",

--- a/src/constants/acp-providers.ts
+++ b/src/constants/acp-providers.ts
@@ -10,6 +10,75 @@ export type ACPProviderIcon =
 
 export const ACP_PROVIDER_FALLBACK_ICON: ACPProviderIcon = "cli-generic";
 
+/** Canvas registry key for the Pi coding-agent ACP preset. */
+export const PI_ACP_PROVIDER_KEY = "pi";
+
+/** Default stdio spawn argv for {@link PI_ACP_PROVIDER_KEY} via ``pi-acp``. */
+export const PI_ACP_DEFAULT_COMMAND: readonly string[] = [
+  "npx",
+  "-y",
+  "pi-acp",
+];
+
+const PI_ACP_DEFAULT_COMMAND_TEXT = PI_ACP_DEFAULT_COMMAND.join(" ");
+
+function normalizeAcpCommandTokens(command: unknown): string[] {
+  if (Array.isArray(command)) {
+    return command.filter(
+      (token): token is string => typeof token === "string",
+    );
+  }
+  if (typeof command === "string") {
+    const trimmed = command.trim();
+    if (!trimmed) return [];
+    return trimmed.split(/\s+/);
+  }
+  return [];
+}
+
+/** True when ``command`` matches the built-in Pi preset launch argv/text. */
+export function isPiAcpCommand(command: unknown): boolean {
+  return (
+    normalizeAcpCommandTokens(command).join(" ") === PI_ACP_DEFAULT_COMMAND_TEXT
+  );
+}
+
+/**
+ * Map a Canvas UI/registry provider key to the ``acp_server`` value the
+ * released agent-server accepts. Pi is not in the SDK registry yet, so it
+ * travels as ``custom`` with an explicit ``acp_command``.
+ */
+export function wireAcpServerForProvider(providerKey: string): string {
+  return providerKey === PI_ACP_PROVIDER_KEY ? "custom" : providerKey;
+}
+
+/**
+ * Resolve the Canvas registry key from persisted agent settings. Pi is stored
+ * as ``acp_server: "custom"`` with the ``pi-acp`` command — this helper
+ * rehydrates ``"pi"`` for UI, model defaults, and conversation tags.
+ */
+export function resolveUiAcpProviderKey(
+  acpServer: string | null | undefined,
+  acpCommand: unknown,
+): string | null {
+  if (acpServer === PI_ACP_PROVIDER_KEY || isPiAcpCommand(acpCommand)) {
+    return PI_ACP_PROVIDER_KEY;
+  }
+  return acpServer ?? null;
+}
+
+/**
+ * Default ``acp_command`` tokens for a provider save/start when the caller
+ * sends an empty command. Built-ins rely on the agent-server registry; Pi
+ * must pin ``pi-acp`` explicitly because its wire ``acp_server`` is ``custom``.
+ */
+export function defaultAcpCommandForProvider(providerKey: string): string[] {
+  if (providerKey === PI_ACP_PROVIDER_KEY) {
+    return [...PI_ACP_DEFAULT_COMMAND];
+  }
+  return [];
+}
+
 // Sentinel ``agent.llm.model`` returned by older SDKs for ACP conversations
 // in lieu of a real model. Suppressed at every consumer that resolves a
 // display string.
@@ -159,22 +228,24 @@ export const ACP_PROVIDERS: ACPProviderConfig[] = Object.entries(
   const info = getClientAcpProvider(key);
   return {
     key,
-    display_name: info?.display_name ?? (key === "pi" ? "Pi" : key),
+    display_name:
+      info?.display_name ?? (key === PI_ACP_PROVIDER_KEY ? "Pi" : key),
     default_command: info
       ? [...info.default_command]
-      : key === "pi"
-        ? ["npx", "-y", "pi-acp"]
+      : key === PI_ACP_PROVIDER_KEY
+        ? [...PI_ACP_DEFAULT_COMMAND]
         : [],
     available_models: info?.available_models
       ? info.available_models.map((model) => ({
           id: model.id,
           label: model.label,
         }))
-      : key === "pi"
+      : key === PI_ACP_PROVIDER_KEY
         ? [{ id: "default", label: "Default Model" }]
         : undefined,
     default_model:
-      info?.default_model ?? (key === "pi" ? "default" : undefined),
+      info?.default_model ??
+      (key === PI_ACP_PROVIDER_KEY ? "default" : undefined),
     description_key: ui.description_key,
     icon: ui.icon,
   };
@@ -530,10 +601,15 @@ export function buildAcpAgentSettingsDiff(
   // payload from a textarea that already shows the merged command
   // (Settings → Agent) round-trip correctly — the merged tokens land in
   // ``acp_command`` here, so no args are lost.
+  const command =
+    options.command && options.command.length > 0
+      ? options.command
+      : defaultAcpCommandForProvider(providerKey);
+
   return {
     agent_kind: "acp",
-    acp_server: providerKey === "pi" ? "custom" : providerKey,
-    acp_command: options.command ?? [],
+    acp_server: wireAcpServerForProvider(providerKey),
+    acp_command: command,
     acp_args: [],
     acp_model: model ?? null,
   };

--- a/src/constants/acp-providers.ts
+++ b/src/constants/acp-providers.ts
@@ -5,6 +5,7 @@ export type ACPProviderIcon =
   | "claude-code"
   | "codex"
   | "gemini"
+  | "pi"
   | "cli-generic";
 
 export const ACP_PROVIDER_FALLBACK_ICON: ACPProviderIcon = "cli-generic";
@@ -142,6 +143,10 @@ const ACP_PROVIDER_UI: Record<
     icon: "gemini",
     description_key: I18nKey.ONBOARDING$AGENT_GEMINI_CLI_DESCRIPTION,
   },
+  pi: {
+    icon: "pi",
+    description_key: I18nKey.ONBOARDING$AGENT_PI_DESCRIPTION,
+  },
 };
 
 // Built-in ACP providers Canvas surfaces, built by enriching each upstream
@@ -154,13 +159,22 @@ export const ACP_PROVIDERS: ACPProviderConfig[] = Object.entries(
   const info = getClientAcpProvider(key);
   return {
     key,
-    display_name: info?.display_name ?? key,
-    default_command: info ? [...info.default_command] : [],
-    available_models: info?.available_models?.map((model) => ({
-      id: model.id,
-      label: model.label,
-    })),
-    default_model: info?.default_model ?? undefined,
+    display_name: info?.display_name ?? (key === "pi" ? "Pi" : key),
+    default_command: info
+      ? [...info.default_command]
+      : key === "pi"
+        ? ["npx", "-y", "pi-acp"]
+        : [],
+    available_models: info?.available_models
+      ? info.available_models.map((model) => ({
+          id: model.id,
+          label: model.label,
+        }))
+      : key === "pi"
+        ? [{ id: "default", label: "Default" }]
+        : undefined,
+    default_model:
+      info?.default_model ?? (key === "pi" ? "default" : undefined),
     description_key: ui.description_key,
     icon: ui.icon,
   };
@@ -518,7 +532,7 @@ export function buildAcpAgentSettingsDiff(
   // ``acp_command`` here, so no args are lost.
   return {
     agent_kind: "acp",
-    acp_server: providerKey,
+    acp_server: providerKey === "pi" ? "custom" : providerKey,
     acp_command: options.command ?? [],
     acp_args: [],
     acp_model: model ?? null,

--- a/src/hooks/mutation/use-create-conversation.ts
+++ b/src/hooks/mutation/use-create-conversation.ts
@@ -28,14 +28,7 @@ import {
   toPluginCoordinates,
   type WorkspaceMode,
 } from "#/api/conversation-metadata-store";
-import {
-  adaptPiAcpCommandForDeployment,
-  effectivePiAcpCommandTokens,
-  PI_ACP_PROVIDER_KEY,
-  resolveUiAcpProviderKey,
-} from "#/constants/acp-providers";
-import { getDeploymentMode } from "#/api/agent-server-adapter";
-import { parseCommand } from "#/utils/acp-command";
+import { buildInlinePiAcpAgentSettingsFromProfile } from "#/utils/inline-pi-acp-profile-settings";
 
 export interface CreateConversationVariables {
   query?: string;
@@ -201,52 +194,31 @@ export const useCreateConversation = () => {
         }
       }
 
-      // Agent profiles launch server-side with the stored ``acp_command`` verbatim.
-      // Docker images pre-install ``pi-acp`` but ``npx -y pi-acp`` crashes, so
-      // inline the profile's ACP settings with a Docker-safe spawn argv instead
-      // of ``agent_profile_id`` (same enrichment boundary as the OpenHands
-      // ``default`` downgrade above).
-      let dockerPiAgentSettingsOverride:
-        | Record<string, SettingsValue>
-        | undefined;
+      // Pi profiles must launch via inlined agent_settings so the frontend can
+      // rewrite ``npx -y pi-acp`` → ``pi-acp`` in Docker (profile_id launch
+      // spawns the stored command verbatim on the agent-server).
+      let piAgentSettingsOverride: Record<string, SettingsValue> | undefined;
       if (
         !isCloud &&
         effectiveAgentProfileId &&
-        resolvedAgentProfile?.agent_kind === "acp" &&
-        getDeploymentMode() === "docker"
+        resolvedAgentProfile?.agent_kind === "acp"
       ) {
         try {
           const detail = await AgentProfilesService.getProfile(
             resolvedAgentProfile.name,
           );
-          const profile = detail.profile;
-          if (profile.agent_kind === "acp") {
-            const deploymentMode = "docker";
-            const commandTokens = profile.acp_command
-              ? parseCommand(profile.acp_command)
-              : effectivePiAcpCommandTokens(deploymentMode);
-            const uiKey = resolveUiAcpProviderKey(
-              profile.acp_server,
-              commandTokens,
+          if (detail.profile.agent_kind === "acp") {
+            const inlineSettings = buildInlinePiAcpAgentSettingsFromProfile(
+              detail.profile,
             );
-            if (uiKey === PI_ACP_PROVIDER_KEY) {
+            if (inlineSettings) {
               effectiveAgentProfileId = undefined;
-              dockerPiAgentSettingsOverride = {
-                schema_version: 1,
-                agent_kind: "acp",
-                acp_server: profile.acp_server,
-                acp_command: adaptPiAcpCommandForDeployment(
-                  commandTokens,
-                  deploymentMode,
-                ) as SettingsValue,
-                acp_model: profile.acp_model ?? null,
-                acp_args: profile.acp_args ?? [],
-              };
+              piAgentSettingsOverride = inlineSettings;
             }
           }
         } catch (error) {
           console.warn(
-            "Failed to inline Docker Pi agent profile settings; launching via profile id.",
+            "Failed to inline Pi agent profile settings; launching via profile id.",
             error,
           );
         }
@@ -277,7 +249,7 @@ export const useCreateConversation = () => {
           undefined,
           effectiveAgentProfileId,
           resolvedAgentProfile?.agent_kind,
-          dockerPiAgentSettingsOverride,
+          piAgentSettingsOverride,
         );
 
       // Stamp the active LLM profile onto the (local) conversation so the

--- a/src/hooks/mutation/use-create-conversation.ts
+++ b/src/hooks/mutation/use-create-conversation.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
 import { PluginSpec } from "#/api/conversation-service/agent-server-conversation-service.types";
 import { SuggestedTask } from "#/utils/types";
-import { AgentKind, Provider } from "#/types/settings";
+import { Provider, SettingsValue } from "#/types/settings";
 import { useTracking } from "#/hooks/use-tracking";
 import { useLlmProfiles } from "#/hooks/query/use-llm-profiles";
 import { useAgentProfiles } from "#/hooks/query/use-agent-profiles";
@@ -28,6 +28,14 @@ import {
   toPluginCoordinates,
   type WorkspaceMode,
 } from "#/api/conversation-metadata-store";
+import {
+  adaptPiAcpCommandForDeployment,
+  effectivePiAcpCommandTokens,
+  PI_ACP_PROVIDER_KEY,
+  resolveUiAcpProviderKey,
+} from "#/constants/acp-providers";
+import { getDeploymentMode } from "#/api/agent-server-adapter";
+import { parseCommand } from "#/utils/acp-command";
 
 export interface CreateConversationVariables {
   query?: string;
@@ -193,21 +201,63 @@ export const useCreateConversation = () => {
         }
       }
 
+      // Agent profiles launch server-side with the stored ``acp_command`` verbatim.
+      // Docker images pre-install ``pi-acp`` but ``npx -y pi-acp`` crashes, so
+      // inline the profile's ACP settings with a Docker-safe spawn argv instead
+      // of ``agent_profile_id`` (same enrichment boundary as the OpenHands
+      // ``default`` downgrade above).
+      let dockerPiAgentSettingsOverride:
+        | Record<string, SettingsValue>
+        | undefined;
+      if (
+        !isCloud &&
+        effectiveAgentProfileId &&
+        resolvedAgentProfile?.agent_kind === "acp" &&
+        getDeploymentMode() === "docker"
+      ) {
+        try {
+          const detail = await AgentProfilesService.getProfile(
+            resolvedAgentProfile.name,
+          );
+          const profile = detail.profile;
+          if (profile.agent_kind === "acp") {
+            const deploymentMode = "docker";
+            const commandTokens = profile.acp_command
+              ? parseCommand(profile.acp_command)
+              : effectivePiAcpCommandTokens(deploymentMode);
+            const uiKey = resolveUiAcpProviderKey(
+              profile.acp_server,
+              commandTokens,
+            );
+            if (uiKey === PI_ACP_PROVIDER_KEY) {
+              effectiveAgentProfileId = undefined;
+              dockerPiAgentSettingsOverride = {
+                schema_version: 1,
+                agent_kind: "acp",
+                acp_server: profile.acp_server,
+                acp_command: adaptPiAcpCommandForDeployment(
+                  commandTokens,
+                  deploymentMode,
+                ) as SettingsValue,
+                acp_model: profile.acp_model ?? null,
+                acp_args: profile.acp_args ?? [],
+              };
+            }
+          }
+        } catch (error) {
+          console.warn(
+            "Failed to inline Docker Pi agent profile settings; launching via profile id.",
+            error,
+          );
+        }
+      }
+
       // Only extend the call with the profile tail when launching from a
       // profile, so a plain create stays byte-identical to the legacy
       // agent_settings path (#3727). sandboxId is unused here.
       // TODO(#1587): createConversation has grown to 11 positional params;
       // refactor it to an options object so this position-skipping tail isn't
       // needed.
-      const profileArgs: [undefined, string, AgentKind | undefined] | [] =
-        effectiveAgentProfileId
-          ? [
-              undefined,
-              effectiveAgentProfileId,
-              resolvedAgentProfile?.agent_kind,
-            ]
-          : [];
-
       const conversation =
         await AgentServerConversationService.createConversation(
           query,
@@ -224,7 +274,10 @@ export const useCreateConversation = () => {
           workspaceMode,
           parentConversationId,
           agentType,
-          ...profileArgs,
+          undefined,
+          effectiveAgentProfileId,
+          resolvedAgentProfile?.agent_kind,
+          dockerPiAgentSettingsOverride,
         );
 
       // Stamp the active LLM profile onto the (local) conversation so the

--- a/src/hooks/use-chat-input-model-state.ts
+++ b/src/hooks/use-chat-input-model-state.ts
@@ -13,6 +13,7 @@ import {
   getAcpProvider,
   labelForAcpModel,
   resolveEffectiveAcpModel,
+  resolveUiAcpProviderKey,
   type ACPModelOption,
 } from "#/constants/acp-providers";
 
@@ -51,10 +52,22 @@ export function useChatInputModelState(): ChatInputModelState {
     typeof settings?.agent_settings?.acp_server === "string"
       ? settings.agent_settings.acp_server
       : null;
+  const settingsUiAcpServerKey =
+    resolveUiAcpProviderKey(
+      settingsAcpServerKey,
+      settings?.agent_settings?.acp_command,
+    ) ?? settingsAcpServerKey;
+  const profileUiAcpServerKey =
+    activeAcpProfile?.acp_server != null
+      ? (resolveUiAcpProviderKey(
+          activeAcpProfile.acp_server,
+          activeAcpProfile.acp_command,
+        ) ?? activeAcpProfile.acp_server)
+      : null;
   const acpServerKey = isActiveAcpConversation
-    ? conversation?.acp_server
+    ? (conversation?.acp_server ?? settingsUiAcpServerKey)
     : isHomeAcp
-      ? (activeAcpProfile?.acp_server ?? settingsAcpServerKey)
+      ? (profileUiAcpServerKey ?? settingsUiAcpServerKey)
       : null;
   const acpProvider = isAcpContext ? getAcpProvider(acpServerKey) : undefined;
 

--- a/src/hooks/use-chat-input-model-state.ts
+++ b/src/hooks/use-chat-input-model-state.ts
@@ -65,7 +65,7 @@ export function useChatInputModelState(): ChatInputModelState {
         ) ?? activeAcpProfile.acp_server)
       : null;
   const acpServerKey = isActiveAcpConversation
-    ? (conversation?.acp_server ?? settingsUiAcpServerKey)
+    ? conversation?.acp_server
     : isHomeAcp
       ? (profileUiAcpServerKey ?? settingsUiAcpServerKey)
       : null;

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -30691,7 +30691,7 @@
     "zh-TW": "Earendil 的 Pi 編碼代理。",
     "ko-KR": "Earendil의 Pi 코딩 에이전트입니다.",
     "no": "Earendils Pi-kodingsagent.",
-    "ar": "وكيل Pi للبرмجة من Earendil.",
+    "ar": "وكيل pi للبرمجة من earendil.",
     "de": "Der Pi Coding Agent von Earendil.",
     "fr": "L'agent de développement Pi d'Earendil.",
     "it": "L'agente di sviluppo Pi di Earendil.",

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -30684,6 +30684,23 @@
     "tr": "Google'ın Gemini CLI aracısı.",
     "uk": "Агент Gemini CLI від Google."
   },
+  "ONBOARDING$AGENT_PI_DESCRIPTION": {
+    "en": "Earendil's Pi Coding Agent.",
+    "ja": "Earendil の Pi コーディングエージェント。",
+    "zh-CN": "Earendil 的 Pi 编码智能体。",
+    "zh-TW": "Earendil 的 Pi 編碼代理。",
+    "ko-KR": "Earendil의 Pi 코딩 에이전트입니다.",
+    "no": "Earendils Pi-kodingsagent.",
+    "ar": "وكيل Pi للبرмجة من Earendil.",
+    "de": "Der Pi Coding Agent von Earendil.",
+    "fr": "L'agent de développement Pi d'Earendil.",
+    "it": "L'agente di sviluppo Pi di Earendil.",
+    "pt": "O agente de programação Pi da Earendil.",
+    "es": "El agente de codificación Pi de Earendil.",
+    "ca": "L'agent de codificació Pi d'Earendil.",
+    "tr": "Earendil'in Pi Kodlama aracısı.",
+    "uk": "Агент кодування Pi від Earendil."
+  },
   "ONBOARDING$BACKEND_TITLE": {
     "en": "Check your backend",
     "ja": "バックエンドを確認",

--- a/src/routes/agent-settings.tsx
+++ b/src/routes/agent-settings.tsx
@@ -159,7 +159,7 @@ export function buildAgentProfileFields(
       isDefaultProviderCommand && selectedPreset !== ACP_CUSTOM_PRESET_KEY;
     return {
       agent_kind: "acp",
-      acp_server: selectedPreset,
+      acp_server: selectedPreset === "pi" ? "custom" : selectedPreset,
       acp_model: acpModel.trim() || null,
       acp_command: isBuiltinDefault
         ? null

--- a/src/routes/agent-settings.tsx
+++ b/src/routes/agent-settings.tsx
@@ -36,6 +36,10 @@ import {
   buildAcpAgentSettingsDiff,
   getAcpPreferredDefaultModel,
   getAcpProvider,
+  PI_ACP_DEFAULT_COMMAND,
+  PI_ACP_PROVIDER_KEY,
+  resolveUiAcpProviderKey,
+  wireAcpServerForProvider,
   type ACPProviderConfig,
 } from "#/constants/acp-providers";
 import { parseCommand, formatCommand } from "#/utils/acp-command";
@@ -155,15 +159,19 @@ export function buildAgentProfileFields(
     toolConcurrency,
   } = input;
   if (isAcp) {
-    const isBuiltinDefault =
-      isDefaultProviderCommand && selectedPreset !== ACP_CUSTOM_PRESET_KEY;
+    const usesRegistryDefaultCommand =
+      isDefaultProviderCommand &&
+      selectedPreset !== ACP_CUSTOM_PRESET_KEY &&
+      selectedPreset !== PI_ACP_PROVIDER_KEY;
     return {
       agent_kind: "acp",
-      acp_server: selectedPreset === "pi" ? "custom" : selectedPreset,
+      acp_server: wireAcpServerForProvider(selectedPreset),
       acp_model: acpModel.trim() || null,
-      acp_command: isBuiltinDefault
+      acp_command: usesRegistryDefaultCommand
         ? null
-        : formatCommand(commandTokens) || null,
+        : isDefaultProviderCommand && selectedPreset === PI_ACP_PROVIDER_KEY
+          ? formatCommand(PI_ACP_DEFAULT_COMMAND)
+          : formatCommand(commandTokens) || null,
       acp_args: null,
     };
   }
@@ -316,8 +324,10 @@ export function AgentSettingsScreen({
       const rawAcpServer = source?.acp_server;
       const acpServer =
         typeof rawAcpServer === "string" ? rawAcpServer : undefined;
-      const provider = getAcpProvider(acpServer);
       const storedCommand = toStringArray(source?.acp_command);
+      const uiProviderKey =
+        resolveUiAcpProviderKey(acpServer, storedCommand) ?? acpServer;
+      const provider = getAcpProvider(uiProviderKey);
       const effectiveBaseCommand =
         storedCommand.length > 0
           ? storedCommand
@@ -336,7 +346,9 @@ export function AgentSettingsScreen({
       const normalizedSavedModel =
         typeof savedModel === "string" ? savedModel.trim() : "";
       setAcpModel(
-        normalizedSavedModel || getAcpPreferredDefaultModel(acpServer) || "",
+        normalizedSavedModel ||
+          getAcpPreferredDefaultModel(uiProviderKey) ||
+          "",
       );
       setIsCustomAcpModel(
         !!normalizedSavedModel &&

--- a/src/routes/agent-settings.tsx
+++ b/src/routes/agent-settings.tsx
@@ -34,14 +34,15 @@ import {
   ACP_PROVIDERS,
   ACP_CUSTOM_PRESET_KEY,
   buildAcpAgentSettingsDiff,
+  effectivePiAcpCommandTokens,
   getAcpPreferredDefaultModel,
   getAcpProvider,
-  PI_ACP_DEFAULT_COMMAND,
   PI_ACP_PROVIDER_KEY,
   resolveUiAcpProviderKey,
   wireAcpServerForProvider,
   type ACPProviderConfig,
 } from "#/constants/acp-providers";
+import { getDeploymentMode } from "#/api/agent-server-adapter";
 import { parseCommand, formatCommand } from "#/utils/acp-command";
 
 export const handle = { hideTitle: true };
@@ -125,6 +126,8 @@ export interface AgentProfileFieldsInput {
   subAgentsEnabled: boolean;
   toolConcurrencyField?: SettingsFieldSchema;
   toolConcurrency: string | boolean;
+  /** Runtime mode from {@link getDeploymentMode}; affects Pi spawn argv. */
+  deploymentMode?: string | null;
 }
 
 /**
@@ -157,6 +160,7 @@ export function buildAgentProfileFields(
     subAgentsEnabled,
     toolConcurrencyField,
     toolConcurrency,
+    deploymentMode,
   } = input;
   if (isAcp) {
     const usesRegistryDefaultCommand =
@@ -170,7 +174,7 @@ export function buildAgentProfileFields(
       acp_command: usesRegistryDefaultCommand
         ? null
         : isDefaultProviderCommand && selectedPreset === PI_ACP_PROVIDER_KEY
-          ? formatCommand(PI_ACP_DEFAULT_COMMAND)
+          ? formatCommand(effectivePiAcpCommandTokens(deploymentMode))
           : formatCommand(commandTokens) || null,
       acp_args: null,
     };
@@ -455,6 +459,7 @@ export function AgentSettingsScreen({
       subAgentsEnabled,
       toolConcurrencyField,
       toolConcurrency,
+      deploymentMode: getDeploymentMode(),
     });
 
   // Dirty tracking: for OpenHands path, also check sub-agents toggle and the

--- a/src/utils/inline-pi-acp-profile-settings.ts
+++ b/src/utils/inline-pi-acp-profile-settings.ts
@@ -1,0 +1,52 @@
+import type { ACPAgentProfile } from "@openhands/typescript-client";
+import {
+  adaptPiAcpCommandForDeployment,
+  effectivePiAcpCommandTokens,
+  PI_ACP_PROVIDER_KEY,
+  resolveUiAcpProviderKey,
+} from "#/constants/acp-providers";
+import { getDeploymentMode } from "#/api/agent-server-adapter";
+import { parseCommand } from "#/utils/acp-command";
+import type { SettingsValue } from "#/types/settings";
+
+/**
+ * Pi agent profiles are stored as ``acp_server: "custom"`` with an explicit
+ * ``pi-acp`` command. Launching via ``agent_profile_id`` makes the agent-server
+ * spawn that command verbatim — bypassing the frontend ``resolveAcpCommand``
+ * Docker rewrite — so profile-launched Pi conversations must be inlined as
+ * ``agent_settings`` with a deployment-adapted argv.
+ */
+export function buildInlinePiAcpAgentSettingsFromProfile(
+  profile: ACPAgentProfile,
+  deploymentMode: string | null | undefined = getDeploymentMode(),
+): Record<string, SettingsValue> | null {
+  if (profile.agent_kind !== "acp") return null;
+
+  const commandTokens = profile.acp_command
+    ? parseCommand(profile.acp_command)
+    : [];
+  const uiKey = resolveUiAcpProviderKey(profile.acp_server, commandTokens);
+  if (uiKey !== PI_ACP_PROVIDER_KEY) return null;
+
+  const spawnTokens =
+    commandTokens.length > 0
+      ? commandTokens
+      : effectivePiAcpCommandTokens(deploymentMode);
+  const adaptedCommand = adaptPiAcpCommandForDeployment(
+    spawnTokens,
+    deploymentMode,
+  );
+
+  return {
+    schema_version: 1,
+    agent_kind: "acp",
+    acp_server: profile.acp_server,
+    acp_command: adaptedCommand as SettingsValue,
+    // Pi owns model selection via ~/.pi; omit Canvas placeholders like "default".
+    acp_model:
+      profile.acp_model && profile.acp_model.trim() !== "default"
+        ? profile.acp_model
+        : null,
+    acp_args: profile.acp_args ?? [],
+  };
+}


### PR DESCRIPTION
HUMAN: 
I tested the Pi preset configuration end-to-end inside the local docker image, and verified it successfully saves the agent profile.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

To verify end-to-end functionality, we built the Docker image locally and ran the container:
```bash
npm run build:docker
docker run -it --rm -p 8000:8000 -v "$HOME/.openhands:/home/openhands/.openhands" -v "${PROJECTS_PATH}:/projects" agent-canvas:local
```

We opened the Settings page, created an agent profile named MyPi choosing the Pi preset, and successfully saved it.

Server logs showing successful profile creation (HTTP 201) and deletion (HTTP 200):
```
{"asctime": "2026-07-31 19:26:30,327", "levelname": "INFO", "name": "openhands.sdk.profiles.agent_profile_store", "filename": "agent_profile_store.py", "lineno": 174, "message": "[AgentProfile Store] Saved profile `MyPi` at /home/openhands/.openhands/agent-profiles/MyPi.json"}
{"asctime": "2026-07-31 19:26:30,328", "levelname": "INFO", "name": "openhands.agent_server.agent_profiles_router", "filename": "agent_profiles_router.py", "lineno": 377, "message": "Saved agent profile 'MyPi'"}
{"asctime": "2026-07-31 19:26:30,329", "levelname": "INFO", "name": "uvicorn.access", "message": "::ffff:192.168.65.1:0 - \"POST /api/agent-profiles/MyPi HTTP/1.1\" 201", "http.client_ip": "::ffff:192.168.65.1:0", "http.method": "POST", "http.url": "/api/agent-profiles/MyPi", "http.version": "1.1", "http.status_code": 201}

{"asctime": "2026-07-31 19:26:52,760", "levelname": "INFO", "name": "openhands.sdk.profiles.agent_profile_store", "filename": "agent_profile_store.py", "lineno": 228, "message": "[AgentProfile Store] Deleted profile `MyPi`"}
{"asctime": "2026-07-31 19:26:52,769", "levelname": "INFO", "name": "openhands.agent_server.agent_profiles_router", "filename": "agent_profiles_router.py", "lineno": 411, "message": "Deleted agent profile 'MyPi'"}
{"asctime": "2026-07-31 19:26:52,772", "levelname": "INFO", "name": "uvicorn.access", "message": "::ffff:192.168.65.1:0 - \"DELETE /api/agent-profiles/MyPi HTTP/1.1\" 200", "http.client_ip": "::ffff:192.168.65.1:0", "http.method": "DELETE", "http.url": "/api/agent-profiles/MyPi", "http.version": "1.1", "http.status_code": 200}
```


## Why

This PR adds UI and configuration support for Pi Coding Agent (pi.dev) in the ACP (Agent Client Protocol) provider options.

## Summary

- Registered Pi Preset: Added pi to the frontend's local ACP provider registry with appropriate defaults (command: npx -y pi-acp, model: "default").
- Added SVG Branding: Sourced and added the official Pi SVG icon.
- Added Localized Translations: Translated description keys for all 15 supported locales in translation.json.
- Wire-level Fallbacks: Mapped "pi" to "custom" on the wire when saving settings or profile drafts to bypass strict backend validation (preventing 422 Unprocessable Content errors).
- Tag-detection Logic: Updated getAcpServerTag to detect if the customized command is npx -y pi-acp, allowing active conversations to be stamped with tags.acpserver: "pi" and display the correct branding in conversation lists.


## Issue Number
Fixes: https://github.com/OpenHands/OpenHands/issues/16204

## How to Test
1. Build the image
```
npm run build:docker
```

2. Start the container:
```
export PROJECTS_PATH="$HOME/Downloads"
docker run -it --rm -p 8000:8000 -v "$HOME/.openhands:/home/openhands/.openhands" -v "${PROJECTS_PATH}:/projects" agent-canvas:local
```
3. Navigate to Settings -> Agent Profiles, click Add agent profile, and select the Pi preset.
4. Verify that you can configure it and click Save successfully without encountering a 422 error.

## Video/Screenshots

<img width="1500" height="891" alt="Screenshot 2026-07-31 at 3 38 34 PM" src="https://github.com/user-attachments/assets/743c02b3-5b2b-4043-8241-550415e0837c" />
<img width="1507" height="900" alt="Screenshot 2026-07-31 at 3 38 42 PM" src="https://github.com/user-attachments/assets/edf30c79-32e3-4670-92a1-a7fa49fa61c7" />
<img width="1504" height="889" alt="Screenshot 2026-07-31 at 3 38 50 PM" src="https://github.com/user-attachments/assets/61af91d7-5cb7-4585-9180-d3e948774f6c" />


## Type

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.57s · commit 8911f44  
**Strongest signal:** Unverified remote execution · 26% estimated likelihood.  
**Evidence:** No direct hunk selected.  
**Coverage:** ⚠️ reduced context — partial coverage; 33/66 hunks, 25/25 files (context budget: 33, hunk budget: 33).

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 24.0% | No direct hunk selected |
| Weakened authentication | 7.0% | No direct hunk selected |
| Weakened authorization | 9.0% | No direct hunk selected |
| Contract regression | 27.0% | No direct hunk selected |
| Data loss | 8.0% | No direct hunk selected |
| Sensitive data disclosure | 6.0% | No direct hunk selected |
| Unexpected data transfer | 8.0% | No direct hunk selected |
| Credential misuse | 8.0% | No direct hunk selected |
| Untrusted instruction authority | 4.0% | No direct hunk selected |
| Package source redirection | 6.0% | No direct hunk selected |
| Unverified remote execution | 26.0% | No direct hunk selected |
| Privileged environment access | 9.0% | No direct hunk selected |
| Security assessment bypass | 13.0% | No direct hunk selected |
| Prohibited workload | 3.0% | No direct hunk selected |
| Primary concern | Unverified remote execution; confidence 40.0% | No direct hunk selected |

</details>


<!-- jev-input-signature 068fb8c2d1377f010002ebee440dc3cc6a72ff66a050a867f0662599b8e0d3ca -->
<!-- jev-fast-audit:end -->
