### PR TITLE
fix: clean up dev services on SIGHUP

### DIFF
--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -12,7 +12,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, expect, it, afterEach } from "vitest";
 import {
   buildAgentServerAutomationEnv,
@@ -631,6 +631,104 @@ describe("setServiceLogListener", () => {
 });
 
 describe("dev-with-automation CLI", () => {
+  it.skipIf(process.platform === "win32")(
+    "cleans up detached services when the launcher receives SIGHUP",
+    async () => {
+      const moduleUrl = pathToFileURL(
+        path.join(repoRoot, "scripts", "dev-with-automation.mjs"),
+      ).href;
+      const fixtureSource = [
+        'import net from "node:net";',
+        "const server = net.createServer(() => {});",
+        'server.listen(0, "127.0.0.1", () => console.log("READY", process.pid, server.address().port));',
+      ].join("\n");
+      const supervisorSource = [
+        `import { spawnService } from ${JSON.stringify(moduleUrl)};`,
+        `const fixture = spawnService("fixture", process.execPath, ["--input-type=module", "--eval", ${JSON.stringify(fixtureSource)}]);`,
+        'console.log("SPAWNED", fixture.pid);',
+        "setInterval(() => {}, 1_000);",
+      ].join("\n");
+
+      const supervisor = spawn(
+        process.execPath,
+        ["--input-type=module", "--eval", supervisorSource],
+        {
+          cwd: repoRoot,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+      let output = "";
+      let fixturePid: number | undefined;
+      let fixturePort: number | undefined;
+      const capture = (chunk: Buffer) => {
+        output += chunk.toString();
+        const spawnedMatch = output.match(/SPAWNED (\d+)/);
+        const readyMatch = output.match(/READY \d+ (\d+)/);
+        if (spawnedMatch) fixturePid = Number(spawnedMatch[1]);
+        if (readyMatch) fixturePort = Number(readyMatch[1]);
+      };
+      supervisor.stdout.on("data", capture);
+      supervisor.stderr.on("data", capture);
+
+      try {
+        const readyDeadline = Date.now() + 5_000;
+        while (!fixturePort && Date.now() < readyDeadline) {
+          if (supervisor.exitCode !== null) break;
+          await delay(25);
+        }
+        expect(fixturePid, output).toBeDefined();
+        expect(fixturePort, output).toBeDefined();
+
+        supervisor.kill("SIGHUP");
+        const exitResult = await Promise.race([
+          once(supervisor, "exit").then(([code, signal]) => ({
+            code,
+            signal,
+            timedOut: false,
+          })),
+          delay(6_000).then(() => ({
+            code: null,
+            signal: null,
+            timedOut: true,
+          })),
+        ]);
+
+        expect(exitResult.timedOut).toBe(false);
+        expect(exitResult).toMatchObject({ code: 0, signal: null });
+
+        const releaseDeadline = Date.now() + 2_000;
+        let portIsOpen = true;
+        while (portIsOpen && Date.now() < releaseDeadline) {
+          portIsOpen = await new Promise<boolean>((resolve) => {
+            const socket = net.connect(fixturePort!, "127.0.0.1");
+            socket.setTimeout(250);
+            socket.once("connect", () => {
+              socket.destroy();
+              resolve(true);
+            });
+            socket.once("error", () => resolve(false));
+            socket.once("timeout", () => {
+              socket.destroy();
+              resolve(false);
+            });
+          });
+          if (portIsOpen) await delay(50);
+        }
+        expect(portIsOpen).toBe(false);
+      } finally {
+        if (supervisor.exitCode === null) supervisor.kill("SIGKILL");
+        if (fixturePid) {
+          try {
+            process.kill(-fixturePid, "SIGKILL");
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+          }
+        }
+      }
+    },
+    15_000,
+  );
+
   it("shows help with --help flag", async () => {
     const child = spawn(
       process.execPath,

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -958,6 +958,7 @@ function shutdown() {
 
 process.on("SIGINT", shutdown);
 process.on("SIGTERM", shutdown);
+process.on("SIGHUP", shutdown);
 
 function startIngress(config) {
   logService("ingress", `Starting on port ${config.ingressPort}...`, c.yellow);


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

I returned to a local npm run dev stack and the launcher was gone. I think it was inside a multiplexer I had closed.
Repro by sending SIGHUP to the launcher, cleanup not hit.

<!-- Human contributors: add a short note about your testing. -->

AGENT:

Reproduced on Linux with a disposable TCP fixture launched through the real `spawnService` path. Before the fix, sending `SIGHUP` terminated the supervisor with signal `SIGHUP` while the detached fixture remained reachable. After the fix, the supervisor exited with code 0 and the test observed the fixture port become unavailable.

Validation run locally:

- `npm test -- --run __tests__/scripts/dev-with-automation.test.ts` — 47/47 tests passed
- `npm test` — passed
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm run build` — passed

---

## Why

The POSIX dev launcher creates detached process groups for its services, but did not run coordinated cleanup when it received `SIGHUP`. Losing the controlling terminal could therefore leave service processes reparented to PID 1 and their ports occupied.

Fixes #16238.

## Summary

- Route `SIGHUP` through the launcher's existing shutdown handler.
- Add a POSIX black-box regression test that verifies the detached service is terminated and releases its port.

## Issue Number

#16238

## How to Test

Run:

```bash
npm test -- --run __tests__/scripts/dev-with-automation.test.ts
```

The regression test starts a disposable detached TCP service through `spawnService`, sends `SIGHUP` to its supervisor, and verifies both a clean supervisor exit and release of the service's dynamically allocated port.

## Video/Screenshots

Not applicable; this changes process lifecycle behavior and is covered by the black-box regression test above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The regression test is skipped on Windows because `SIGHUP` and negative-PID process-group signaling are POSIX behavior.
