### PR TITLE
fix(settings): surface providers discoverable only from model IDs

### DIFF
--- a/__tests__/api/config-service.test.ts
+++ b/__tests__/api/config-service.test.ts
@@ -8,7 +8,9 @@ describe("ConfigService", () => {
     const page = await ConfigService.searchProviders({ limit: 10 });
 
     expect(page.next_page_id).toBeNull();
-    expect(page.items.some((provider) => provider.name === "anthropic")).toBe(true);
+    expect(page.items.some((provider) => provider.name === "anthropic")).toBe(
+      true,
+    );
     expect(
       page.items.find((provider) => provider.name === "anthropic")?.verified,
     ).toBe(true);
@@ -21,10 +23,12 @@ describe("ConfigService", () => {
     });
 
     expect(page.next_page_id).toBeNull();
-    expect(page.items.some((model) => model.name === "claude-opus-4-5-20251101")).toBe(
+    expect(
+      page.items.some((model) => model.name === "claude-opus-4-5-20251101"),
+    ).toBe(true);
+    expect(page.items.every((model) => model.provider === "anthropic")).toBe(
       true,
     );
-    expect(page.items.every((model) => model.provider === "anthropic")).toBe(true);
   });
 
   it("includes verified providers absent from /api/llm/providers and keeps them within the limit", async () => {
@@ -57,5 +61,41 @@ describe("ConfigService", () => {
     // Assert
     const openhands = page.items.find((p) => p.name === "openhands");
     expect(openhands).toEqual({ name: "openhands", verified: true });
+  });
+
+  it("includes providers only discoverable from model IDs (e.g. openrouter)", async () => {
+    // Arrange: mirror the real local agent-server, where "openrouter" is
+    // absent from both /api/llm/providers and /api/llm/models/verified but
+    // its models appear in /api/llm/models as "openrouter/<model>" IDs.
+    server.use(
+      http.get("/api/llm/providers", () =>
+        HttpResponse.json({ providers: ["anthropic"] }),
+      ),
+      http.get("/api/llm/models", () =>
+        HttpResponse.json({
+          models: [
+            "anthropic/claude-opus-4-5-20251101",
+            "openrouter/anthropic/claude-opus-4-5",
+            "openrouter/openai/gpt-5.5",
+            "standalone-model",
+          ],
+        }),
+      ),
+      http.get("/api/llm/models/verified", () =>
+        HttpResponse.json({
+          models: { anthropic: ["claude-opus-4-5-20251101"] },
+        }),
+      ),
+    );
+
+    // Act
+    const page = await ConfigService.searchProviders({ limit: 10 });
+
+    // Assert: openrouter is surfaced (unverified), providers stay
+    // deduplicated, and bare model IDs don't become providers.
+    const openrouter = page.items.find((p) => p.name === "openrouter");
+    expect(openrouter).toEqual({ name: "openrouter", verified: false });
+    expect(page.items.filter((p) => p.name === "anthropic")).toHaveLength(1);
+    expect(page.items.some((p) => p.name === "standalone-model")).toBe(false);
   });
 });

--- a/src/api/config-service/config-service.api.ts
+++ b/src/api/config-service/config-service.api.ts
@@ -61,10 +61,14 @@ class ConfigService {
    *   local reconstruction path. Ignored for cloud backends, which call
    *   `/api/v1/config/models/search` directly (verified status is embedded in
    *   each returned item).
+   * @param modelIds - Pre-fetched raw model-ID list from /api/llm/models, also
+   *   only used by the local reconstruction path. Lets callers share one fetch
+   *   across searchModels and searchProviders.
    */
   static async searchModels(
     params: SearchModelsParams = {},
     verifiedByProvider?: Record<string, string[]>,
+    modelIds?: string[],
   ): Promise<LLMModelPage> {
     const active = getActiveBackend();
 
@@ -90,8 +94,12 @@ class ConfigService {
       verifiedByProvider !== undefined
         ? Promise.resolve(verifiedByProvider)
         : llmClient.getVerifiedModels();
+    const modelsFetch =
+      modelIds !== undefined
+        ? Promise.resolve(modelIds)
+        : llmClient.getModels();
     const [models, verifiedMap] = await Promise.all([
-      llmClient.getModels(),
+      modelsFetch,
       verifiedFetch,
     ]);
 
@@ -133,10 +141,14 @@ class ConfigService {
    *   local reconstruction path. Ignored for cloud backends, which call
    *   `/api/v1/config/providers/search` directly (verified status is embedded in
    *   each returned item).
+   * @param modelIds - Pre-fetched raw model-ID list from /api/llm/models, also
+   *   only used by the local reconstruction path. Lets callers share one fetch
+   *   across searchModels and searchProviders.
    */
   static async searchProviders(
     params: SearchProvidersParams = {},
     verifiedByProvider?: Record<string, string[]>,
+    modelIds?: string[],
   ): Promise<ProviderPage> {
     const active = getActiveBackend();
 
@@ -161,9 +173,13 @@ class ConfigService {
       verifiedByProvider !== undefined
         ? Promise.resolve(verifiedByProvider)
         : llmClient.getVerifiedModels();
+    const modelsFetch =
+      modelIds !== undefined
+        ? Promise.resolve(modelIds)
+        : llmClient.getModels();
     const [providers, models, verifiedMap] = await Promise.all([
       llmClient.getProviders(),
-      llmClient.getModels(),
+      modelsFetch,
       verifiedFetch,
     ]);
 

--- a/src/api/config-service/config-service.api.ts
+++ b/src/api/config-service/config-service.api.ts
@@ -161,13 +161,26 @@ class ConfigService {
       verifiedByProvider !== undefined
         ? Promise.resolve(verifiedByProvider)
         : llmClient.getVerifiedModels();
-    const [providers, verifiedMap] = await Promise.all([
+    const [providers, models, verifiedMap] = await Promise.all([
       llmClient.getProviders(),
+      llmClient.getModels(),
       verifiedFetch,
     ]);
 
+    // /api/llm/providers can omit providers (e.g. "openrouter") whose models
+    // are still present in /api/llm/models as "<provider>/<model>" IDs, so
+    // derive those provider names from the model list as well.
+    const modelDerivedProviders = (models ?? [])
+      .filter((model) => model.includes("/"))
+      .map((model) => model.slice(0, model.indexOf("/")))
+      .filter((prefix) => prefix.length > 0);
+
     const verifiedProviders = new Set(Object.keys(verifiedMap ?? {}));
-    const names = new Set<string>([...verifiedProviders, ...(providers ?? [])]);
+    const names = new Set<string>([
+      ...verifiedProviders,
+      ...(providers ?? []),
+      ...modelDerivedProviders,
+    ]);
     const providerItems: LLMProvider[] = [...names].map((name) => ({
       name,
       verified: verifiedProviders.has(name),

--- a/src/hooks/query/use-llm-models.ts
+++ b/src/hooks/query/use-llm-models.ts
@@ -1,0 +1,18 @@
+import { LLMMetadataClient } from "@openhands/typescript-client/clients";
+import { getAgentServerClientOptions } from "#/api/agent-server-client-options";
+import { getActiveBackend } from "#/api/backend-registry/active-store";
+
+export const LLM_MODELS_QUERY_KEY = ["config", "llm-models"] as const;
+
+export async function fetchLlmModels(): Promise<string[]> {
+  const active = getActiveBackend();
+  if (active.backend.kind === "cloud") {
+    // Cloud backends use /api/v1/config/providers/search and /api/v1/config/models/search
+    // directly. The raw model-ID list is only used by the local ConfigService
+    // reconstruction logic, so callers can safely treat this empty list as a
+    // no-op for cloud.
+    return [];
+  }
+  const client = new LLMMetadataClient(getAgentServerClientOptions());
+  return (await client.getModels()) ?? [];
+}

--- a/src/hooks/query/use-provider-models.ts
+++ b/src/hooks/query/use-provider-models.ts
@@ -7,12 +7,14 @@ import {
   VERIFIED_MODELS_STALE_TIME,
   fetchVerifiedModelsByProvider,
 } from "./use-verified-models";
+import { LLM_MODELS_QUERY_KEY, fetchLlmModels } from "./use-llm-models";
 
 const MAX_PAGINATION_DEPTH = 10;
 
 async function fetchPage(
   provider: string,
   verifiedByProvider: Record<string, string[]>,
+  modelIds: string[],
   pageId?: string,
   depth = 0,
 ): Promise<LLMModel[]> {
@@ -27,12 +29,14 @@ async function fetchPage(
       page_id: pageId,
     },
     verifiedByProvider,
+    modelIds,
   );
 
   if (page.next_page_id) {
     const rest = await fetchPage(
       provider,
       verifiedByProvider,
+      modelIds,
       page.next_page_id,
       depth + 1,
     );
@@ -45,12 +49,19 @@ export const useProviderModels = (provider: string | null) =>
   useQuery({
     queryKey: ["config", "models", provider],
     queryFn: async ({ client }) => {
-      const verifiedByProvider = await client.fetchQuery({
-        queryKey: VERIFIED_MODELS_QUERY_KEY,
-        queryFn: fetchVerifiedModelsByProvider,
-        staleTime: VERIFIED_MODELS_STALE_TIME,
-      });
-      return fetchPage(provider!, verifiedByProvider);
+      const [verifiedByProvider, modelIds] = await Promise.all([
+        client.fetchQuery({
+          queryKey: VERIFIED_MODELS_QUERY_KEY,
+          queryFn: fetchVerifiedModelsByProvider,
+          staleTime: VERIFIED_MODELS_STALE_TIME,
+        }),
+        client.fetchQuery({
+          queryKey: LLM_MODELS_QUERY_KEY,
+          queryFn: fetchLlmModels,
+          staleTime: VERIFIED_MODELS_STALE_TIME,
+        }),
+      ]);
+      return fetchPage(provider!, verifiedByProvider, modelIds);
     },
     enabled: !!provider,
     staleTime: VERIFIED_MODELS_STALE_TIME,

--- a/src/hooks/query/use-search-providers.ts
+++ b/src/hooks/query/use-search-providers.ts
@@ -7,20 +7,29 @@ import {
   VERIFIED_MODELS_STALE_TIME,
   fetchVerifiedModelsByProvider,
 } from "./use-verified-models";
+import { LLM_MODELS_QUERY_KEY, fetchLlmModels } from "./use-llm-models";
 
 export const useSearchProviders = () =>
   useQuery({
     queryKey: ["config", "providers"],
     queryFn: async ({ client }): Promise<LLMProvider[]> => {
-      const verifiedByProvider = await client.fetchQuery({
-        queryKey: VERIFIED_MODELS_QUERY_KEY,
-        queryFn: fetchVerifiedModelsByProvider,
-        staleTime: VERIFIED_MODELS_STALE_TIME,
-      });
+      const [verifiedByProvider, modelIds] = await Promise.all([
+        client.fetchQuery({
+          queryKey: VERIFIED_MODELS_QUERY_KEY,
+          queryFn: fetchVerifiedModelsByProvider,
+          staleTime: VERIFIED_MODELS_STALE_TIME,
+        }),
+        client.fetchQuery({
+          queryKey: LLM_MODELS_QUERY_KEY,
+          queryFn: fetchLlmModels,
+          staleTime: VERIFIED_MODELS_STALE_TIME,
+        }),
+      ]);
       // Providers are a small set; fetch all in one call with a high limit.
       const page = await ConfigService.searchProviders(
         { limit: 100 },
         verifiedByProvider,
+        modelIds,
       );
       return page.items;
     },


### PR DESCRIPTION
HUMAN:

I hit #15576 myself on a local setup (OpenRouter models usable but the provider missing from the Basic LLM Providers picker), directed this fix, and reviewed the change and regression tests.

AGENT:

Verified by tests against MSW mocks mirroring the real local agent-server responses (no live agent-server e2e run — noted honestly below):

- `npx vitest run __tests__/api/config-service.test.ts` — 5/5 passing, including the new regression test where `openrouter` is absent from `/api/llm/providers` and `/api/llm/models/verified` but present via `openrouter/<model>` IDs.
- `npx vitest run __tests__/components/modals/settings/model-selector-openhands.test.tsx` — passing, confirming the ModelSelector still issues exactly one request each to `/api/llm/providers`, `/api/llm/models`, and `/api/llm/models/verified` (a first iteration of this fix duplicated the models fetch; CI caught it and it now goes through a shared react-query fetch).
- `npx vitest run __tests__/hooks/query` — 24 files / 135 tests passing.
- `npx tsc --noEmit`, `eslint`, and `prettier --check` clean on all touched files.

---

## Why

On local backends, the Basic LLM Providers list was built from `/api/llm/providers` and the verified-models map only. Providers such as `openrouter`, whose models appear in `/api/llm/models` as `<provider>/<model>` IDs but which are absent from both other sources, never showed up in the picker — even though `searchModels` could already list their models.

## Summary

- `ConfigService.searchProviders` now also derives provider names from `<provider>/<model>`-prefixed IDs in `/api/llm/models`, merged into the existing name set (dedup and verified-first ordering unchanged; bare IDs without `/` ignored).
- The raw model-ID list is fetched once and shared between `useSearchProviders` and `useProviderModels` via react-query (`use-llm-models.ts`), mirroring the existing verified-models pre-fetch pattern, so `/api/llm/models` is not requested twice.
- Regression test added mirroring the real local agent-server response shape.

## Issue Number

Fixes #15576

## How to Test

1. `npm install`
2. `npx vitest run __tests__/api/config-service.test.ts __tests__/components/modals/settings/model-selector-openhands.test.tsx` — the first file includes the regression test "includes providers only discoverable from model IDs (e.g. openrouter)".
3. Manual: run the frontend against a local agent server whose `/api/llm/models` includes `openrouter/...` IDs while `/api/llm/providers` omits `openrouter`; open Settings → LLM → provider picker and confirm OpenRouter appears.

## Video/Screenshots

Not included — the change is in the provider-list reconstruction logic; behavior is covered by the request-shape regression tests above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No config or migration impact. Cloud backends are untouched (they use `/api/v1/config/*/search` directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
