### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/docs/DefenseClaw.md
+++ b/docs/DefenseClaw.md
@@ -147,6 +147,8 @@ defenseclaw setup guardrail --mode action --restart
 
 The DefenseClaw proxy handles Anthropic (`api.anthropic.com`), OpenAI (`api.openai.com`), OpenRouter, Azure OpenAI, Gemini, Ollama, and Bedrock. Provider detection is automatic based on the target URL.
 
+> **Note:** The same OpenAI-compatible `base_url` pattern works with multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.
+
 ---
 
 ### C. Scan Skills Before Loading


### PR DESCRIPTION
## Summary

The DefenseClaw docs already show OpenAI-compatible `base_url` routing.

This PR adds a one-line note that the same pattern works with multi-model gateways when you are not self-hosting, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] DefenseClaw docs render
- [ ] Existing provider examples unchanged
- [ ] Note is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>