### PR TITLE
chore: bump @openhands/extensions to 0.13.0

### DIFF
--- a/__tests__/manifests/manifest-validation.test.ts
+++ b/__tests__/manifests/manifest-validation.test.ts
@@ -34,10 +34,6 @@ describe("validateSetupEntry", () => {
       { setup: createSetup({ prompt: "Use {{secrets.githubToken}}." }) },
     ],
     [
-      "an assisted message on an entry that sends a request",
-      { setup: createSetup({ message: "Finish setup with the agent." }) },
-    ],
-    [
       // The host reads one trigger kind to build the request, so a second one
       // would be silently dropped rather than refused.
       "more trigger kinds than the host can send",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@heroui/react": "2.8.10",
         "@microlink/react-json-view": "1.31.20",
         "@monaco-editor/react": "4.7.0",
-        "@openhands/extensions": "0.12.0",
+        "@openhands/extensions": "0.13.0",
         "@openhands/typescript-client": "1.36.1",
         "@react-router/node": "7.17.0",
         "@react-router/serve": "7.17.0",
@@ -4167,9 +4167,9 @@
       "license": "MIT"
     },
     "node_modules/@openhands/extensions": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@openhands/extensions/-/extensions-0.12.0.tgz",
-      "integrity": "sha512-S7s4hWcvrOfxUT4PMv/Sz5zRNh1tZEF5wQoWo/4TQKJFIgzy9trQJ0xz9UOZFgf4nh0juJEM2jwG9HMo8pmYfA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@openhands/extensions/-/extensions-0.13.0.tgz",
+      "integrity": "sha512-+pHEyd2rOdFuLR35yg+M33nQbaDAcIZRWe+yErSkHmTn3wM1hpkgQmG1E0jBgkOTUXMScxDMJAHChrna2GFgHg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.20.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@heroui/react": "2.8.10",
     "@microlink/react-json-view": "1.31.20",
     "@monaco-editor/react": "4.7.0",
-    "@openhands/extensions": "0.12.0",
+    "@openhands/extensions": "0.13.0",
     "@openhands/typescript-client": "1.36.1",
     "@react-router/node": "7.17.0",
     "@react-router/serve": "7.17.0",

--- a/src/manifests/manifest-validation.ts
+++ b/src/manifests/manifest-validation.ts
@@ -41,7 +41,7 @@ const TRIGGER_KINDS = ["cron", "event"] as const;
 const CONSTRAINT_FORMATS = ["safeExpressionLiteral"] as const;
 
 /** Setup context only, so this can never become a channel for runtime instructions. */
-const MAX_ASSISTED_MESSAGE_LENGTH = 2000;
+const MAX_MESSAGE_LENGTH = 2000;
 
 export interface SetupValidationResult {
   valid: boolean;
@@ -310,6 +310,17 @@ function hasRepoPicker(form: unknown): boolean {
   );
 }
 
+function checkMessage(check: SetupChecker, message: unknown): void {
+  if (check.templateCopy(message, "setup.message")) {
+    if ((message as string).length > MAX_MESSAGE_LENGTH) {
+      check.fail(
+        "setup.message",
+        `must be at most ${MAX_MESSAGE_LENGTH} characters`,
+      );
+    }
+  }
+}
+
 function checkMode(check: SetupChecker, setup: Rec, kinds: string[]): void {
   if (!isOneOf(setup.mode, SETUP_MODES)) {
     check.fail("setup.mode", "is not a supported mode");
@@ -318,12 +329,9 @@ function checkMode(check: SetupChecker, setup: Rec, kinds: string[]): void {
 
   if (setup.mode === "direct") {
     check.templateValue(setup.prompt, "setup.prompt");
-    check.absent(
-      setup,
-      "message",
-      "setup",
-      "is only allowed for assisted setup",
-    );
+    // Optional here: it seeds the fallback conversation offered when the
+    // deployment cannot run the direct path.
+    if (setup.message !== undefined) checkMessage(check, setup.message);
 
     // The derivation reads a single trigger kind, and an event trigger takes
     // its source from the repository field's provider.
@@ -349,14 +357,7 @@ function checkMode(check: SetupChecker, setup: Rec, kinds: string[]): void {
     return;
   }
 
-  if (check.templateCopy(setup.message, "setup.message")) {
-    if ((setup.message as string).length > MAX_ASSISTED_MESSAGE_LENGTH) {
-      check.fail(
-        "setup.message",
-        `must be at most ${MAX_ASSISTED_MESSAGE_LENGTH} characters`,
-      );
-    }
-  }
+  checkMessage(check, setup.message);
   check.absent(setup, "prompt", "setup", "is only allowed for direct setup");
   check.absent(setup, "filter", "setup", "is only allowed for direct setup");
 }

--- a/src/manifests/types.ts
+++ b/src/manifests/types.ts
@@ -75,7 +75,11 @@ export interface SetupBlock {
   prompt?: string;
   /** direct only, event trigger only. Which delivered events belong to it. */
   filter?: string;
-  /** assisted only. Setup context for the conversation that finishes setup. */
+  /**
+   * Setup context for the conversation that finishes setup. Required for
+   * assisted mode. Optional for direct mode, where it seeds the fallback
+   * conversation offered when the deployment cannot run the direct path.
+   */
   message?: string;
 }
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

I have verified the changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

<!-- Describe problem, motivation, etc. -->

The extensions repository released 0.13.0 ([https://github.com/OpenHands/extensions/releases/tag/v0.13.0](https://github.com/OpenHands/extensions/releases/tag/v0.13.0)). Beyond additive features (a new `AUTOMATION_INTERFACE` production manifest export and two new export paths), it changes the automation setup contract: `setup.message` — which the 0.12.0 schema explicitly forbade on direct-mode entries — is now optional for direct mode, seeding the fallback conversation a host may offer when the deployment cannot run the direct path. Both published direct-mode entries (`github-pr-reviewer`, `github-repo-monitor`) now carry one.

Our admission validator (`src/manifests/manifest-validation.ts`) is a trust boundary that mirrors the published schema rather than trusting it, and it still enforced the 0.12.0 rule. A bare version bump would therefore silently reject both direct entries at admission and drop them from the recommended automations.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Bump `@openhands/extensions` from 0.12.0 to 0.13.0 (`package.json` + lockfile).
- Align `checkMode` in `src/manifests/manifest-validation.ts` with the 0.13.0 schema: a direct entry's optional `message` is validated with the same rules as the assisted one (shared `checkMessage` helper; `MAX_ASSISTED_MESSAGE_LENGTH` renamed to `MAX_MESSAGE_LENGTH` since the 2000-char cap is now mode-independent). Assisted validation is unchanged.
- Mirror the published declaration in `SetupBlock.message`'s doc comment (`src/manifests/types.ts`) and remove the test case pinning the old direct-mode refusal.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

N/A.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `npm install`
2. `npm test` — the suite includes the catalog-admission test that validates the real published 0.13.0 catalog against the host validator; on `main` without this PR's validator change, bumping the package makes it fail.
3. `npm run typecheck`
4. In the app (`npm run dev`): open the Automations page and confirm the **GitHub PR Reviewer** and **GitHub Repo Monitor** cards still appear under recommended automations (they would vanish if admission had regressed), and that opening either one still shows its setup form.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

N/A.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.39.1-python` |
| **Automation** | `openhands-automation==1.5.0` |
| **Commit** | `12a6dbdcaca957b42885f334a495d013d380092d` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-12a6dbd
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-12a6dbd
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-12a6dbd-amd64
ghcr.io/openhands/agent-canvas:hieptl-oss-8982-amd64
ghcr.io/openhands/agent-canvas:pr-16258-amd64
ghcr.io/openhands/agent-canvas:sha-12a6dbd-arm64
ghcr.io/openhands/agent-canvas:hieptl-oss-8982-arm64
ghcr.io/openhands/agent-canvas:pr-16258-arm64
ghcr.io/openhands/agent-canvas:sha-12a6dbd
ghcr.io/openhands/agent-canvas:hieptl-oss-8982
ghcr.io/openhands/agent-canvas:pr-16258
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-12a6dbd`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-12a6dbd-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->