### PR TITLE
fix: avoid import-time signal handlers

### DIFF
--- a/__tests__/scripts/dev-static.test.ts
+++ b/__tests__/scripts/dev-static.test.ts
@@ -1,8 +1,46 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { buildAutomationBackendEnv } from "../../scripts/dev-static.mjs";
 
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
 describe("dev-static", () => {
+  it("does not install signal handlers when imported", async () => {
+    const moduleUrl = pathToFileURL(
+      path.join(repoRoot, "scripts", "dev-static.mjs"),
+    ).href;
+    const child = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        `const signals = ["SIGINT", "SIGTERM", "SIGHUP"]; const before = Object.fromEntries(signals.map((signal) => [signal, process.listenerCount(signal)])); await import(${JSON.stringify(moduleUrl)}); const after = Object.fromEntries(signals.map((signal) => [signal, process.listenerCount(signal)])); console.log(JSON.stringify({ before, after }));`,
+      ],
+      { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let output = "";
+    child.stdout.on("data", (chunk) => {
+      output += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      output += chunk.toString();
+    });
+
+    const [code] = await once(child, "exit");
+    expect(code).toBe(0);
+    expect(JSON.parse(output.trim())).toEqual({
+      before: { SIGINT: 0, SIGTERM: 0, SIGHUP: 0 },
+      after: { SIGINT: 0, SIGTERM: 0, SIGHUP: 0 },
+    });
+  });
+
   it("uses the same session key for both agent-server and automation backend auth", () => {
     const env = buildAutomationBackendEnv(
       {

--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -38,6 +38,21 @@ const repoRoot = path.resolve(
   "../..",
 );
 
+async function getFreePort() {
+  const server = net.createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Expected a TCP address");
+  }
+  const { port } = address;
+  server.close();
+  await once(server, "close");
+  return port;
+}
+
 describe("buildAutomationCommand", () => {
   it("uses released PyPI version by default", () => {
     const cmd = buildAutomationCommand({});
@@ -631,6 +646,35 @@ describe("setServiceLogListener", () => {
 });
 
 describe("dev-with-automation CLI", () => {
+  it("does not install signal handlers when imported", async () => {
+    const moduleUrl = pathToFileURL(
+      path.join(repoRoot, "scripts", "dev-with-automation.mjs"),
+    ).href;
+    const child = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        `const signals = ["SIGINT", "SIGTERM", "SIGHUP"]; const before = Object.fromEntries(signals.map((signal) => [signal, process.listenerCount(signal)])); await import(${JSON.stringify(moduleUrl)}); const after = Object.fromEntries(signals.map((signal) => [signal, process.listenerCount(signal)])); console.log(JSON.stringify({ before, after }));`,
+      ],
+      { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let output = "";
+    child.stdout.on("data", (chunk) => {
+      output += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      output += chunk.toString();
+    });
+
+    const [code] = await once(child, "exit");
+    expect(code).toBe(0);
+    expect(JSON.parse(output.trim())).toEqual({
+      before: { SIGINT: 0, SIGTERM: 0, SIGHUP: 0 },
+      after: { SIGINT: 0, SIGTERM: 0, SIGHUP: 0 },
+    });
+  });
+
   it.skipIf(process.platform === "win32")(
     "cleans up detached services when the launcher receives SIGHUP",
     async () => {
@@ -642,10 +686,26 @@ describe("dev-with-automation CLI", () => {
         "const server = net.createServer(() => {});",
         'server.listen(0, "127.0.0.1", () => console.log("READY", process.pid, server.address().port));',
       ].join("\n");
+      const staticDir = mkdtempSync(
+        path.join(tmpdir(), "agent-canvas-static-"),
+      );
+      const stateDir = mkdtempSync(path.join(tmpdir(), "agent-canvas-state-"));
+      writeFileSync(path.join(staticDir, "index.html"), "<!doctype html>");
       const supervisorSource = [
-        `import { spawnService } from ${JSON.stringify(moduleUrl)};`,
-        `const fixture = spawnService("fixture", process.execPath, ["--input-type=module", "--eval", ${JSON.stringify(fixtureSource)}]);`,
-        'console.log("SPAWNED", fixture.pid);',
+        `import { main, spawnService } from ${JSON.stringify(moduleUrl)};`,
+        'process.argv = [process.execPath, "dev-with-automation.mjs", "--frontend-only"];',
+        `process.env.PORT = "${await getFreePort()}";`,
+        `process.env.OH_CANVAS_SAFE_VITE_PORT = "${await getFreePort()}";`,
+        `process.env.OH_CANVAS_SAFE_STATE_DIR = ${JSON.stringify(stateDir)};`,
+        "await main({",
+        "  staticMode: true,",
+        `  staticDir: ${JSON.stringify(staticDir)},`,
+        "  skipNpmCheck: true,",
+        "  extraPrereqs: () => {",
+        `    const fixture = spawnService("fixture", process.execPath, ["--input-type=module", "--eval", ${JSON.stringify(fixtureSource)}]);`,
+        '    console.log("SPAWNED", fixture.pid);',
+        "  },",
+        "});",
         "setInterval(() => {}, 1_000);",
       ].join("\n");
 
@@ -724,6 +784,8 @@ describe("dev-with-automation CLI", () => {
             if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
           }
         }
+        rmSync(staticDir, { recursive: true, force: true });
+        rmSync(stateDir, { recursive: true, force: true });
       }
     },
     15_000,

--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -675,6 +675,63 @@ describe("dev-with-automation CLI", () => {
     });
   });
 
+  it("installs signal handlers when main is called", async () => {
+    const moduleUrl = pathToFileURL(
+      path.join(repoRoot, "scripts", "dev-with-automation.mjs"),
+    ).href;
+    const stateDir = mkdtempSync(
+      path.join(tmpdir(), "agent-canvas-main-handlers-"),
+    );
+    const child = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        `const signals = ["SIGINT", "SIGTERM", "SIGHUP"];
+const before = Object.fromEntries(signals.map((signal) => [signal, process.listenerCount(signal)]));
+const { main } = await import(${JSON.stringify(moduleUrl)});
+process.argv = [process.execPath, "dev-with-automation.mjs", "--frontend-only", "--backend-only"];
+let mainError;
+try {
+  await main({});
+} catch (error) {
+  mainError = error;
+}
+if (!mainError?.message.includes("cannot be used together")) {
+  throw mainError ?? new Error("Expected mutually exclusive launch modes to reject");
+}
+const after = Object.fromEntries(signals.map((signal) => [signal, process.listenerCount(signal)]));
+process.stdout.write(` +
+          "`\n${JSON.stringify({ before, after })}\n`" +
+          `);`,
+      ],
+      {
+        cwd: repoRoot,
+        env: { ...process.env, OH_CANVAS_SAFE_STATE_DIR: stateDir },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let output = "";
+    child.stdout.on("data", (chunk) => {
+      output += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      output += chunk.toString();
+    });
+
+    try {
+      const [code] = await once(child, "exit");
+      expect(code, output).toBe(0);
+      const result = JSON.parse(output.trim().split("\n").at(-1) ?? "");
+      expect(result).toEqual({
+        before: { SIGINT: 0, SIGTERM: 0, SIGHUP: 0 },
+        after: { SIGINT: 1, SIGTERM: 1, SIGHUP: 1 },
+      });
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it.skipIf(process.platform === "win32")(
     "cleans up detached services when the launcher receives SIGHUP",
     async () => {

--- a/scripts/dev-static.mjs
+++ b/scripts/dev-static.mjs
@@ -63,6 +63,7 @@ import {
   buildAutomationTelemetryEnv,
   buildAutomationRuntimeServicesInfo,
   buildConfig,
+  installSignalHandlers,
 } from "./dev-with-automation.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -510,9 +511,6 @@ function shutdown() {
   }, 3000);
 }
 
-process.on("SIGINT", shutdown);
-process.on("SIGTERM", shutdown);
-
 function printBanner(config) {
   console.log("");
   console.log(
@@ -651,6 +649,7 @@ const isMainModule =
   process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isMainModule) {
+  installSignalHandlers(shutdown);
   main().catch((err) => {
     logError(`Fatal error: ${err.message}`);
     if (err.stack) {

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -957,9 +957,11 @@ function shutdown() {
   }, 3000);
 }
 
-process.on("SIGINT", shutdown);
-process.on("SIGTERM", shutdown);
-process.on("SIGHUP", shutdown);
+function installSignalHandlers(handler = shutdown) {
+  process.on("SIGINT", handler);
+  process.on("SIGTERM", handler);
+  process.on("SIGHUP", handler);
+}
 
 function startIngress(config) {
   logService("ingress", `Starting on port ${config.ingressPort}...`, c.yellow);
@@ -1277,6 +1279,7 @@ async function main(options = {}) {
   // Install the listener early so log lines emitted before the first
   // `spawnService` call (e.g. by future setup steps) are also captured.
   setServiceLogListener(onServiceLog);
+  installSignalHandlers();
 
   const args = parseArgs();
 
@@ -1500,6 +1503,7 @@ export {
   buildViteBackendEnv,
   getFrontendBackend,
   getLocalServiceRoutes,
+  installSignalHandlers,
   main,
   registerShutdownHook,
   spawnService,


### PR DESCRIPTION
HUMAN:

AGENT:
This pull request was prepared with OpenAI Codex. The HUMAN section is intentionally left for a human contributor, per repository guidance.

## Why
Importing scripts/dev-with-automation.mjs currently installs SIGINT, SIGTERM, and SIGHUP handlers before any launcher owns the process lifecycle. Importers such as dev-static therefore inherit a second shutdown handler and can race their own detached-service cleanup.

## Summary
- Move signal registration behind an explicit installSignalHandlers lifecycle hook.
- Install the default handler from main() and let dev-static register its own shutdown handler, including SIGHUP.
- Add a regression proving module import leaves process-global signal listener counts unchanged while preserving SIGHUP cleanup coverage.

## Issue Number
Closes #16257

## How to Test
- npx vitest run __tests__/scripts/dev-with-automation.test.ts (48 passed)
- npm run lint (passed: typecheck, ESLint, Prettier)
- npm run build (passed: production client and server build; existing Vite chunk/future-flag warnings only)
- npx prettier --check scripts/dev-with-automation.mjs scripts/dev-static.mjs __tests__/scripts/dev-with-automation.test.ts (passed)
- git diff --check (passed)
- Direct reproduction after the fix: importing dev-with-automation leaves SIGINT/SIGTERM/SIGHUP listener counts at 0/0/0.

## Video/Screenshots
Not applicable: this is a Node launcher lifecycle fix. The regression runs the actual launcher child-process path and verifies detached-service shutdown behavior.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes
No API or user-facing configuration changes. dev-static now explicitly owns all three termination signals rather than inheriting handlers from an imported module.