### PR TITLE
fix: rename frontend conversation start telemetry

### DIFF
--- a/__tests__/hooks/mutation/use-new-conversation-command.test.tsx
+++ b/__tests__/hooks/mutation/use-new-conversation-command.test.tsx
@@ -137,9 +137,10 @@ describe("useNewConversationCommand", () => {
       app_conversation_id: null,
     });
 
-    vi.spyOn(AgentServerConversationService, "createConversation").mockResolvedValue(
-      errorTask as never,
-    );
+    vi.spyOn(
+      AgentServerConversationService,
+      "createConversation",
+    ).mockResolvedValue(errorTask as never);
 
     const { result } = renderHook(() => useNewConversationCommand(), {
       wrapper,
@@ -155,9 +156,10 @@ describe("useNewConversationCommand", () => {
       app_conversation_id: null,
     });
 
-    vi.spyOn(AgentServerConversationService, "createConversation").mockResolvedValue(
-      workingTask as never,
-    );
+    vi.spyOn(
+      AgentServerConversationService,
+      "createConversation",
+    ).mockResolvedValue(workingTask as never);
 
     const { result } = renderHook(() => useNewConversationCommand(), {
       wrapper,
@@ -175,9 +177,10 @@ describe("useNewConversationCommand", () => {
   it("invalidates conversation list queries on success", async () => {
     const readyTask = makeStartTask();
 
-    vi.spyOn(AgentServerConversationService, "createConversation").mockResolvedValue(
-      readyTask as never,
-    );
+    vi.spyOn(
+      AgentServerConversationService,
+      "createConversation",
+    ).mockResolvedValue(readyTask as never);
 
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
@@ -230,9 +233,10 @@ describe("useNewConversationCommand", () => {
   it("shows a loading toast and dismisses it on success", async () => {
     const readyTask = makeStartTask();
 
-    vi.spyOn(AgentServerConversationService, "createConversation").mockResolvedValue(
-      readyTask as never,
-    );
+    vi.spyOn(
+      AgentServerConversationService,
+      "createConversation",
+    ).mockResolvedValue(readyTask as never);
 
     const { result } = renderHook(() => useNewConversationCommand(), {
       wrapper,
@@ -249,7 +253,7 @@ describe("useNewConversationCommand", () => {
     });
   });
 
-  it("emits conversation_created on success with the /new no-context payload", async () => {
+  it("emits conversation_start_requested on success with the /new no-context payload", async () => {
     const readyTask = makeStartTask();
     vi.spyOn(
       AgentServerConversationService,
@@ -264,7 +268,7 @@ describe("useNewConversationCommand", () => {
 
     await waitFor(() => {
       expect(captureMock).toHaveBeenCalledWith(
-        "conversation_created",
+        "conversation_start_requested",
         expect.objectContaining({
           conversation_id: "new-conv-999",
           task_id: "task-789",

--- a/__tests__/hooks/use-tracking.test.ts
+++ b/__tests__/hooks/use-tracking.test.ts
@@ -69,7 +69,7 @@ describe("useTracking", () => {
   });
 
   describe("trackConversationCreated", () => {
-    it("captures conversation_created with full metadata for a repository, task-start conversation", () => {
+    it("captures conversation_start_requested with full metadata for a repository, task-start conversation", () => {
       getTracking().trackConversationCreated({
         conversationId: "task-abc123",
         taskId: "abc123",
@@ -81,7 +81,7 @@ describe("useTracking", () => {
         entryPoint: "sidebar_cloud_menu",
       });
 
-      expect(captureMock).toHaveBeenCalledWith("conversation_created", {
+      expect(captureMock).toHaveBeenCalledWith("conversation_start_requested", {
         conversation_id: "task-abc123",
         task_id: "abc123",
         // task-prefixed conversation_id => cloud sandbox still provisioning
@@ -98,7 +98,7 @@ describe("useTracking", () => {
       });
     });
 
-    it("captures conversation_created for a local workspace start with no repository", () => {
+    it("captures conversation_start_requested for a local workspace start with no repository", () => {
       getTracking().trackConversationCreated({
         conversationId: "conv-1",
         taskId: "conv-1",
@@ -110,7 +110,7 @@ describe("useTracking", () => {
         entryPoint: "sidebar_local_menu",
       });
 
-      expect(captureMock).toHaveBeenCalledWith("conversation_created", {
+      expect(captureMock).toHaveBeenCalledWith("conversation_start_requested", {
         conversation_id: "conv-1",
         task_id: "conv-1",
         // real conversation_id => ready immediately (local)
@@ -140,7 +140,7 @@ describe("useTracking", () => {
       });
 
       expect(captureMock).toHaveBeenCalledWith(
-        "conversation_created",
+        "conversation_start_requested",
         expect.objectContaining({
           agent_type: "plan",
           has_parent_conversation: true,
@@ -180,7 +180,7 @@ describe("useTracking", () => {
         }),
       );
       expect(captureMock).toHaveBeenCalledWith(
-        "conversation_created",
+        "conversation_start_requested",
         expect.not.objectContaining({
           agent_server_version: "1.36.2",
           automation_sdk_version: "1.36.3",

--- a/src/hooks/use-tracking.ts
+++ b/src/hooks/use-tracking.ts
@@ -82,7 +82,7 @@ export const useTracking = () => {
     hasParentConversation: boolean;
     entryPoint?: string;
   }) => {
-    track("conversation_created", {
+    track("conversation_start_requested", {
       conversation_id: conversationId,
       task_id: taskId,
       is_start_task: conversationId.startsWith("task-"),


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

I've verified the naming change. 

AGENT:

This PR was created by an AI agent (OpenHands) on behalf of the user.

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

The frontend-only `conversation_created` event undercounts Cloud conversations and conflicts with the new authoritative backend `conversation created` metric in Enterprise. Keeping the frontend event under the same name makes dashboards ambiguous and risks double counting once backend tracking lands.

## Summary

- Rename the Agent Canvas frontend event from `conversation_created` to `conversation_start_requested`.
- Keep the same frontend metadata for funnel analysis of user intent/start requests.
- Update tracking unit tests for the new event name.

## Issue Number

N/A

## How to Test

Ran targeted checks:

```bash
npm ci
npm test -- __tests__/hooks/use-tracking.test.ts __tests__/hooks/mutation/use-new-conversation-command.test.tsx
# Test Files  2 passed (2)
# Tests  30 passed (30)

npx eslint src/hooks/use-tracking.ts \
  __tests__/hooks/use-tracking.test.ts \
  __tests__/hooks/mutation/use-new-conversation-command.test.tsx
# passed
```

I did not run full browser E2E because this PR only renames an internal telemetry event and has no user-visible UI path or behavior change. The companion backend PR contains the authoritative server-side `conversation created` tracking path: https://github.com/OpenHands/enterprise/pull/123

## Video/Screenshots

N/A — telemetry event rename only; no visible UI changes.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Companion Enterprise PR: https://github.com/OpenHands/enterprise/pull/123

After both PRs land, dashboards should use backend `conversation created` for authoritative conversation counts and frontend `conversation_start_requested` for start-intent/funnel analysis.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c4cd416d-532a-4179-9e66-ec5cbc464808)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.39.1-python` |
| **Automation** | `openhands-automation==1.5.0` |
| **Commit** | `97cf40495d7bbea81a5af1df5b50ffa785f0e962` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-97cf404
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-97cf404
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-97cf404-amd64
ghcr.io/openhands/agent-canvas:openhands-frontend-conversation-start-requested-amd64
ghcr.io/openhands/agent-canvas:pr-16269-amd64
ghcr.io/openhands/agent-canvas:sha-97cf404-arm64
ghcr.io/openhands/agent-canvas:openhands-frontend-conversation-start-requested-arm64
ghcr.io/openhands/agent-canvas:pr-16269-arm64
ghcr.io/openhands/agent-canvas:sha-97cf404
ghcr.io/openhands/agent-canvas:openhands-frontend-conversation-start-requested
ghcr.io/openhands/agent-canvas:pr-16269
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-97cf404`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-97cf404-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->