### PR TITLE
fix(bash): correlate bash echoes by command, not queue position

### DIFF
--- a/__tests__/hooks/use-bash-command-runner.test.ts
+++ b/__tests__/hooks/use-bash-command-runner.test.ts
@@ -76,7 +76,13 @@ describe("useBashCommandRunner", () => {
       JSON.stringify({ command: "pwd", cwd: "/workspace", timeout: 30 }),
     ]);
 
-    socket.receive({ kind: "BashCommand", id: "command-1" });
+    socket.receive({
+      kind: "BashCommand",
+      id: "command-1",
+      command: "pwd",
+      cwd: "/workspace",
+      timeout: 30,
+    });
     socket.receive({
       kind: "BashOutput",
       command_id: "command-1",
@@ -115,7 +121,13 @@ describe("useBashCommandRunner", () => {
       }),
     ]);
 
-    socket.receive({ kind: "BashCommand", id: "command-1" });
+    socket.receive({
+      kind: "BashCommand",
+      id: "command-1",
+      command: "git status",
+      cwd: "/workspace",
+      timeout: 10,
+    });
     socket.receive({
       kind: "BashOutput",
       command_id: "command-1",
@@ -128,6 +140,153 @@ describe("useBashCommandRunner", () => {
       stdout: "",
       stderr: "",
     });
+
+    unmount();
+  });
+
+  // Regression test for #15543 ("Bad parsing for branch retrieval"), where a
+  // filename showed up in the git branch badge.
+  //
+  // `/sockets/bash-events` is not a private channel: the agent-server
+  // subscribes every socket to one shared `BashEventService` PubSub, and
+  // `start_bash_command` publishes the `BashCommand` event to all subscribers
+  // regardless of who started it (REST `POST /api/bash/start_bash_command`
+  // included). This hook used to pair each echo with the oldest outstanding
+  // request by queue position, so a command we never sent could capture our
+  // pending promise and resolve it with its own stdout.
+  //
+  // Downstream, `useLocalGitInfo`'s `probeGitInfo` reads line 1 as the git
+  // remote URL and everything after the first newline as the branch — which is
+  // how foreign output whose second line was a filename rendered that filename
+  // as the branch.
+  it("ignores a foreign command's echo and still resolves with its own output", async () => {
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    const { result, unmount } = renderHook(() =>
+      useBashCommandRunner(
+        "http://runtime.example.com/api/conversations/conv-1",
+        null,
+        true,
+      ),
+    );
+    const socket = MockWebSocket.instance!;
+    socket.open();
+
+    // The git-info probe this hook actually exists to run.
+    const probe = result.current(
+      "git rev-parse --abbrev-ref HEAD",
+      "/workspace",
+      10,
+    );
+    expect(socket.sent).toEqual([
+      JSON.stringify({
+        command: "git rev-parse --abbrev-ref HEAD",
+        cwd: "/workspace",
+        timeout: 10,
+      }),
+    ]);
+
+    // Something else on this conversation starts a command — another client,
+    // an automation run, a second tab. The server broadcasts it to us too.
+    // Note the id and the command text are both plainly not ours.
+    socket.receive({
+      kind: "BashCommand",
+      id: "foreign-1",
+      command: "ls",
+      cwd: "/tmp",
+      timeout: 10,
+    });
+    socket.receive({
+      kind: "BashOutput",
+      command_id: "foreign-1",
+      stdout: "x\nNOT-A-BRANCH.txt",
+      stderr: "",
+      exit_code: 0,
+      order: 0,
+    });
+
+    // The probe must not adopt that output. Racing against a sentinel is how
+    // we assert "still pending" without hanging the test.
+    const pendingSentinel = Symbol("pending");
+    await expect(
+      Promise.race([probe, Promise.resolve().then(() => pendingSentinel)]),
+    ).resolves.toBe(pendingSentinel);
+
+    // Our own echo and output still land correctly afterwards.
+    socket.receive({
+      kind: "BashCommand",
+      id: "ours-1",
+      command: "git rev-parse --abbrev-ref HEAD",
+      cwd: "/workspace",
+      timeout: 10,
+    });
+    socket.receive({
+      kind: "BashOutput",
+      command_id: "ours-1",
+      stdout: "main\n",
+      stderr: "",
+      exit_code: 0,
+      order: 0,
+    });
+    await expect(probe).resolves.toEqual({
+      exit_code: 0,
+      stdout: "main\n",
+      stderr: "",
+    });
+
+    unmount();
+  });
+
+  // Two conversations probing different workspaces run a byte-identical script,
+  // so `command` alone cannot tell their echoes apart — `cwd` breaks the tie.
+  it("routes echoes of an identical command to the request with the matching cwd", async () => {
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    const { result, unmount } = renderHook(() =>
+      useBashCommandRunner(
+        "http://runtime.example.com/api/conversations/conv-1",
+        null,
+        true,
+      ),
+    );
+    const socket = MockWebSocket.instance!;
+    socket.open();
+
+    const probeA = result.current("git branch --show-current", "/repo-a", 10);
+    const probeB = result.current("git branch --show-current", "/repo-b", 10);
+
+    // B's echo arrives first, out of request order.
+    socket.receive({
+      kind: "BashCommand",
+      id: "cmd-b",
+      command: "git branch --show-current",
+      cwd: "/repo-b",
+      timeout: 10,
+    });
+    socket.receive({
+      kind: "BashOutput",
+      command_id: "cmd-b",
+      stdout: "branch-b\n",
+      stderr: "",
+      exit_code: 0,
+      order: 0,
+    });
+    socket.receive({
+      kind: "BashCommand",
+      id: "cmd-a",
+      command: "git branch --show-current",
+      cwd: "/repo-a",
+      timeout: 10,
+    });
+    socket.receive({
+      kind: "BashOutput",
+      command_id: "cmd-a",
+      stdout: "branch-a\n",
+      stderr: "",
+      exit_code: 0,
+      order: 0,
+    });
+
+    await expect(probeA).resolves.toMatchObject({ stdout: "branch-a\n" });
+    await expect(probeB).resolves.toMatchObject({ stdout: "branch-b\n" });
 
     unmount();
   });

--- a/src/hooks/use-bash-command-runner.ts
+++ b/src/hooks/use-bash-command-runner.ts
@@ -18,6 +18,10 @@ interface WaitingCommand {
 }
 
 interface PendingCommand {
+  // Kept so a `BashCommand` echo can be matched back to the request that
+  // produced it — see `takeMatchingPending`.
+  command: string;
+  cwd: string;
   resolve: (result: CommandResult) => void;
   reject: (error: Error) => void;
 }
@@ -46,14 +50,64 @@ function isBashError(event: BashEvent): event is BashError {
 }
 
 /**
+ * Remove and return the queued request that a `BashCommand` echo belongs to,
+ * or `null` when the echo is not ours.
+ *
+ * The agent-server subscribes every `/sockets/bash-events` connection to one
+ * shared `BashEventService`, and `start_bash_command` publishes to all
+ * subscribers regardless of origin — including commands started through
+ * `POST /api/bash/start_bash_command` by an automation run, another tab, or
+ * the SDK. So an echo arriving here is *not* necessarily a reply to us, and
+ * pairing echoes with the oldest outstanding request by position alone let a
+ * foreign command capture our promise and resolve it with its own output
+ * (a filename would surface as the git branch — #15543).
+ *
+ * `command` is the match key: it is the only field the protocol marks as
+ * required (`BashCommand extends ExecuteBashRequest`) and the server echoes it
+ * verbatim, since it is the literal string it has to execute. `cwd` is a
+ * tiebreaker rather than part of the key — it is optional in the protocol, so
+ * requiring it to match would strand the promise forever against any server
+ * that omitted it. The tiebreaker matters when two conversations probe
+ * different workspaces with the same script: without it, one could adopt the
+ * other's result.
+ *
+ * Two of *our own* in-flight requests sharing a command and cwd are
+ * interchangeable, so taking the oldest is correct. A foreign command that
+ * happens to be byte-identical to ours (a second tab running the same git
+ * probe) can still be adopted, which is harmless: identical command, identical
+ * cwd, equivalent output.
+ */
+function takeMatchingPending(
+  queue: PendingCommand[],
+  echo: BashCommand,
+): PendingCommand | null {
+  const matchesCommand = (pending: PendingCommand) =>
+    pending.command === echo.command;
+
+  let index = queue.findIndex(
+    (pending) => matchesCommand(pending) && pending.cwd === echo.cwd,
+  );
+  if (index === -1) {
+    index = queue.findIndex(matchesCommand);
+  }
+  if (index === -1) {
+    return null;
+  }
+
+  const [pending] = queue.splice(index, 1);
+  return pending;
+}
+
+/**
  * Maintains a persistent WebSocket connection to the agent-server's
  * `/sockets/bash-events` endpoint and exposes a `runCommand` function that
  * executes a bash command and returns a Promise that resolves when the
  * final `BashOutput` (non-null `exit_code`) arrives.
  *
- * Commands are correlated using a FIFO queue: each `BashCommand` echo
- * received from the server is paired with the oldest outstanding request in
- * the queue, and subsequent `BashOutput` events are matched by `command_id`.
+ * The socket is a shared broadcast, not a private channel, so each
+ * `BashCommand` echo is matched back to the request that produced it by
+ * command text (see `takeMatchingPending`) rather than by queue position;
+ * subsequent `BashOutput` events are then matched by `command_id`.
  *
  * Commands are buffered until the socket's open handler sends authentication.
  */
@@ -88,7 +142,7 @@ export function useBashCommandRunner(
         resolve,
         reject,
       } of waitingQueueRef.current) {
-        pendingQueueRef.current.push({ resolve, reject });
+        pendingQueueRef.current.push({ command, cwd, resolve, reject });
         ws.send(JSON.stringify({ command, cwd, timeout }));
       }
       waitingQueueRef.current = [];
@@ -103,8 +157,9 @@ export function useBashCommandRunner(
       }
 
       if (isBashCommand(data)) {
-        // Associate the next pending request with the server-assigned command_id
-        const pending = pendingQueueRef.current.shift();
+        // Associate the matching pending request with the server-assigned
+        // command_id. Echoes for commands we did not send are ignored.
+        const pending = takeMatchingPending(pendingQueueRef.current, data);
         if (pending) {
           activeCommandsRef.current.set(data.id, {
             ...pending,
@@ -185,7 +240,7 @@ export function useBashCommandRunner(
             reject,
           });
         } else {
-          pendingQueueRef.current.push({ resolve, reject });
+          pendingQueueRef.current.push({ command, cwd, resolve, reject });
           ws.send(JSON.stringify({ command, cwd, timeout }));
         }
       }),


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

AGENT:

Verified end-to-end against a real `openhands-agent-server` (1.39.1), not just unit tests. Details in **How to Test** and **Video/Screenshots** below: the same reproduction script, against the same server, under the same contention, mis-correlates **80/150** probes before this change and **0/150** after.

---

## Why

`/sockets/bash-events` is a shared broadcast, not a private channel. On the server side (`openhands-agent-server`), `bash_service.py` holds a single `PubSub` and `start_bash_command` publishes every `BashCommand` to **all** subscribers regardless of who started it:

```python
command = BashCommand(**request.model_dump())
self._save_event_to_file(command)
await self._pub_sub(command)          # -> every subscriber
```

`sockets.py`'s `bash_events_socket` just calls `subscribe_to_events(...)` on that shared service. Commands also enter it via `POST /api/bash/start_bash_command`, which is used by automation runs, the SDK's `remote_workspace_mixin`, and `typescript-client`'s `bash-client.ts`.

`useBashCommandRunner` assumed every echo was its own reply and paired it with the oldest outstanding request by queue position:

```ts
if (isBashCommand(data)) {
  const pending = pendingQueueRef.current.shift();   // no identity check
```

So any command started elsewhere while a request was in flight would capture that pending promise and resolve it with **its own stdout**. Our real output then arrived under a `command_id` no longer in `activeCommands` and was silently dropped.

The git-info probe is the visible victim. `probeGitInfo` (`use-local-git-info.ts`) reads line 1 as the remote URL and everything after the first newline as the branch, so foreign output whose second line is a filename renders that filename in the branch badge — the symptom reported in #15543, including "it changed to `main` after a few seconds" (the next 10s `refetchInterval` probe correlated correctly).

This is broader than the branch badge: any consumer of this hook could be handed another command's output.

## Summary

- Correlate `BashCommand` echoes by `command` text (with `cwd` as a tiebreaker) instead of queue position, and ignore echoes for commands we never sent.
- `PendingCommand` now carries `command`/`cwd` so the match is possible; populated at both enqueue sites.
- Added regression tests for the foreign-echo case and for identical commands across different `cwd`s; made the two pre-existing `BashCommand` mocks protocol-faithful (they omitted `command`, which no real server does).

## Issue Number

Fixes #15543

## How to Test

Unit:

```sh
npm install
npx vitest run __tests__/hooks/use-bash-command-runner.test.ts
```

Full suite / typecheck / lint:

```sh
npm run test        # 534 files passed | 1 skipped, 4189 tests passed
npm run typecheck   # clean (runs make-i18n first via npm run test; typecheck alone needs it generated)
npx eslint src/hooks/use-bash-command-runner.ts __tests__/hooks/use-bash-command-runner.test.ts
```

End-to-end against a real agent-server, which is what actually demonstrates the bug:

1. Run an agent-server (any isolated install works; `npm run dev` needs `uv`):
   ```sh
   agent-server --host 127.0.0.1 --port 18099
   ```
2. Make a dirty git repo with a remote at `/tmp/ghrepo` (branch `main`, `origin` set).
3. Open a WebSocket to `ws://127.0.0.1:18099/sockets/bash-events`, send the real `GIT_INFO_COMMAND` from `use-local-git-info.ts` with `cwd=/tmp/ghrepo`, and correlate replies using this hook's logic.
4. Concurrently POST a competing command the frontend never sends, whose second output line is a filename:
   ```sh
   curl -s -X POST http://127.0.0.1:18099/api/bash/start_bash_command \
     -H 'Content-Type: application/json' \
     -d '{"command":"printf \"x\\nNOT-A-BRANCH.txt\"","cwd":"/tmp","timeout":10}'
   ```
5. Parse each probe result with `probeGitInfo`'s logic and count how often the branch is not `main`.

## Video/Screenshots

No UI capture: reproducing the badge in the browser additionally requires `uv` (or Docker) plus a configured LLM profile to create a conversation, which I did not have. Instead the reproduction drives the **real server** through the exact frontend logic (`GIT_INFO_COMMAND`, `probeGitInfo`'s parse, and the hook's correlation), so the transport and server behaviour are real and only the rendering step is inferred from `git-control-bar.tsx` (`selectedBranch = conversationBranch || localGitInfo?.branch`).

Before the fix, a probe resolving with foreign output:

```
attempts:      150
mis-correlated: 80
clean:          70

--- attempt 17
    probe stdout : "x\nNOT-A-BRANCH.txt"
    parsed remote: x
    parsed BRANCH: NOT-A-BRANCH.txt   <-- rendered in the badge
    first echo   : "printf \"x\\nNOT-A-BRANCH.txt\""
```

`first echo` is the key line: the first `BashCommand` frame the socket received was the foreign `printf`, not our git script — confirming the broadcast.

After the fix, identical server, script and contention:

```
attempts:      150
mis-correlated: 0
clean:          150
```

| correlation | attempts | mis-correlated |
| --- | --- | --- |
| old (queue position) | 150 | 80 |
| new (match by command) | 150 | 0 |

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Why `command` is the key and `cwd` only a tiebreaker.** `BashCommand extends BashEventBase, ExecuteBashRequest`, where `command: string` is required but `cwd?`/`timeout?` are optional. `command` is also echoed verbatim, since it is the literal string the server executes. Requiring `cwd` to match would strand the promise forever against any server that omitted it — worse than the bug, because a never-settling probe blocks React Query's `refetchInterval` and git info would stop updating entirely. Used as a tiebreaker it still resolves the case where two conversations probe different workspaces with a byte-identical script.

**Known residual.** A foreign command byte-identical to ours in the same `cwd` (e.g. a second tab running the same git probe) can still be adopted. That is harmless — same command, same cwd, equivalent output — and is noted in the code.

**No server change.** A client-supplied correlation id on `ExecuteBashRequest` would be a cleaner protocol-level fix and would remove the residual above, but that needs an agent-server change; this is frontend-only and works against existing servers.
