### PR TITLE
fix: guard Automate tab against catalog entry with missing `requires`

### DIFF
--- a/__tests__/utils/automation-catalog.test.ts
+++ b/__tests__/utils/automation-catalog.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
+import type { RecommendedAutomation } from "@openhands/extensions/automations";
 import { AUTOMATION_CATALOG } from "@openhands/extensions/automations";
-import { getAutomationLaunchPrompt } from "#/utils/automation-catalog";
+import {
+  getAutomationLaunchPrompt,
+  getIntegrationIds,
+  getRequiredIntegrationIds,
+} from "#/utils/automation-catalog";
 
 const automationById = (id: string) =>
   AUTOMATION_CATALOG.find((automation) => automation.id === id)!;
@@ -25,5 +30,31 @@ describe("getAutomationLaunchPrompt", () => {
     expect(getAutomationLaunchPrompt(automationById("jira-issue-to-pr"))).toBe(
       "Set up the Jira issue to GitHub PR automation",
     );
+  });
+});
+
+describe("integration id readers tolerate malformed entries", () => {
+  // A catalog entry that violates the type by omitting `requires` (e.g. an
+  // older/mismatched @openhands/extensions build) must not crash the Automate
+  // tab; it should simply contribute no integrations.
+  const withoutRequires = {
+    id: "broken-entry",
+    name: "Broken entry",
+  } as unknown as RecommendedAutomation;
+
+  const withoutIntegrations = {
+    id: "empty-requires",
+    name: "Empty requires",
+    requires: {},
+  } as unknown as RecommendedAutomation;
+
+  it("getIntegrationIds returns [] when requires/integrations are missing", () => {
+    expect(getIntegrationIds(withoutRequires)).toEqual([]);
+    expect(getIntegrationIds(withoutIntegrations)).toEqual([]);
+  });
+
+  it("getRequiredIntegrationIds returns [] when requires/integrations are missing", () => {
+    expect(getRequiredIntegrationIds(withoutRequires)).toEqual([]);
+    expect(getRequiredIntegrationIds(withoutIntegrations)).toEqual([]);
   });
 });

--- a/src/utils/automation-catalog.ts
+++ b/src/utils/automation-catalog.ts
@@ -20,7 +20,7 @@ const SKILL_BY_NAME = new Map<string, SkillCatalogEntry>(
 
 /** Every integration the entry declares, in declaration order. */
 export function getIntegrationIds(automation: RecommendedAutomation): string[] {
-  return Object.keys(automation.requires.integrations);
+  return Object.keys(automation.requires?.integrations ?? {});
 }
 
 /**
@@ -31,7 +31,7 @@ export function getIntegrationIds(automation: RecommendedAutomation): string[] {
 export function getRequiredIntegrationIds(
   automation: RecommendedAutomation,
 ): string[] {
-  return Object.entries(automation.requires.integrations)
+  return Object.entries(automation.requires?.integrations ?? {})
     .filter(([, requirement]) => requirement.required !== false)
     .map(([id]) => id);
 }


### PR DESCRIPTION
HUMAN:

Reviewed the guard locally: added two unit tests for malformed catalog entries and confirmed all 4 tests pass. The pre-existing tsc errors in the repo (unrelated i18n keys) are not touched by this change.

AGENT:

## Why

A malformed automation-catalog entry — one missing `requires` or `requires.integrations` — throws in `getIntegrationIds` / `getRequiredIntegrationIds`, which **white-screens the entire recommended-automations ("Automate") tab** instead of degrading gracefully. The catalog is populated from `@openhands/extensions`; a version skew or hand-authored entry can produce an item without `requires`, and one bad entry should not brick the tab for every automation.

Fixes #16277

## Summary

- Guard `getIntegrationIds` and `getRequiredIntegrationIds` with optional chaining + empty-object fallback (`automation.requires?.integrations ?? {}`), so a malformed entry contributes no integrations instead of throwing.
- Add two unit tests covering a fully-missing `requires` and a `requires: {}` with no `integrations`; both readers return `[]`.

```ts
// before: throws if requires is undefined
Object.keys(automation.requires.integrations)
// after: safe
Object.keys(automation.requires?.integrations ?? {})
```

## How to Test

1. `npx vitest run __tests__/utils/automation-catalog.test.ts` → 4 tests pass (2 existing + 2 new guard tests).
2. Manual: add a catalog entry without `requires` (or `requires: {}`), open the Automate tab. Before: white screen. After: the tab renders and the malformed entry contributes no integrations.

---
🐾 Filed on behalf of the #proj-agent-canvas thread. Companion SDK issue: OpenHands/software-agent-sdk#4343.

Co-authored-by: smolpaws <engel@enyst.org>
