### PR TITLE
fix: use IPv4 loopback for local proxy targets

### DIFF
--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -480,7 +480,7 @@ describe("stack mode routing", () => {
     });
   });
 
-  it("routes only agent-server and automation in backend-only mode", async () => {
+  it("routes only local services through IPv4 in backend-only mode", async () => {
     const config = await buildConfig(
       { backendOnly: true },
       envWithIsolatedKeyPath(),
@@ -494,19 +494,19 @@ describe("stack mode routing", () => {
     const routes = getLocalServiceRoutes(config);
     expect(routes).toContainEqual([
       "/api/automation",
-      `http://localhost:${config.autoBackendPort}`,
+      `http://127.0.0.1:${config.autoBackendPort}`,
     ]);
     expect(routes).toContainEqual([
       "/api",
-      `http://localhost:${config.agentServerPort}`,
+      `http://127.0.0.1:${config.agentServerPort}`,
     ]);
 
     const routeArgs = buildRouteArgs(routes);
     expect(routeArgs).toContain(
-      `/api/automation=http://localhost:${config.autoBackendPort}`,
+      `/api/automation=http://127.0.0.1:${config.autoBackendPort}`,
     );
     expect(routeArgs).toContain(
-      `/server_info=http://localhost:${config.agentServerPort}`,
+      `/server_info=http://127.0.0.1:${config.agentServerPort}`,
     );
     expect(routeArgs).not.toContain("--default");
   });

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -682,16 +682,17 @@ const AGENT_SERVER_ROUTE_PREFIXES = [
 function getLocalServiceRoutes(config) {
   const routes = [];
 
+  // These services bind to IPv4 loopback, but localhost can resolve to ::1.
   if (config.launchAutomation) {
     routes.push([
       AUTOMATION_ROUTE_PREFIX,
-      `http://localhost:${config.autoBackendPort}`,
+      `http://127.0.0.1:${config.autoBackendPort}`,
     ]);
   }
 
   if (config.launchAgentServer) {
     for (const prefix of AGENT_SERVER_ROUTE_PREFIXES) {
-      routes.push([prefix, `http://localhost:${config.agentServerPort}`]);
+      routes.push([prefix, `http://127.0.0.1:${config.agentServerPort}`]);
     }
   }
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
I reproduced the startup issue with the previous Agent Canvas EXE on Windows 11, where the /server_info check would fail to complete. After rebuilding and installing the fixed EXE, I verified that the application starts successfully, loads the onboarding UI, and all related service endpoints respond correctly. The original issue has been resolved.

<!-- Human contributors: add a short note about your testing. -->

AGENT:

Reproduced the failure with the official Agent Canvas 1.7.2 installer on Windows 11: the agent server responded with HTTP 200 directly at `127.0.0.1:18000/server_info`, while the ingress request at `127.0.0.1:8000/server_info` returned HTTP 502 and logged `ECONNREFUSED ::1:18000`. Built and freshly installed a patched 1.9.0 validation installer; the onboarding UI loaded, both proxied agent-server and automation endpoints returned HTTP 200, and no `::1` proxy error or startup timeout occurred.

---

## Why

The local agent-server and automation services bind to the IPv4 loopback address. On the affected Windows installation, the Node runtime bundled with Agent Canvas resolves `localhost` only to `::1`. The ingress proxy therefore connects over IPv6 to services that are listening only on `127.0.0.1`, so the `/server_info` readiness check never reaches the agent server.

## Summary

- Route locally launched agent-server and automation requests to `127.0.0.1` instead of `localhost`.
- Update stack-mode routing coverage to assert IPv4 proxy targets for both services.

## Issue Number

Fixes #16203

## How to Test

1. Run `npx vitest run __tests__/scripts/dev-with-automation.test.ts`.
   - Result: 46 passed, 1 skipped.
2. Run `npm run typecheck`.
   - Result: passed.
3. Run `npx eslint scripts/dev-with-automation.mjs`.
   - Result: passed.
4. Run `npx prettier --check scripts/dev-with-automation.mjs __tests__/scripts/dev-with-automation.test.ts`.
   - Result: passed.
5. On Windows 11, build and install Agent Canvas, then verify:
   - `GET http://127.0.0.1:18000/server_info` returns HTTP 200.
   - `GET http://127.0.0.1:8000/server_info` returns HTTP 200 through ingress.
   - `GET http://localhost:8000/server_info` returns HTTP 200.
   - `GET http://127.0.0.1:8000/api/automation/openapi.json` returns HTTP 200.
   - The desktop onboarding UI loads without the 60-second readiness failure.

For the local Windows installer validation, existing verified Node 22.12.0 and uv 0.12.0 resources from the official 1.7.2 package were reused after the network timed out downloading uv, and executable signing/editing was disabled because the local session could not create the symlinks required by the signing-tool extraction. This installer was used only for validating the routing fix, not as a release artifact.

## Video/Screenshots

<img width="2559" height="1368" alt="196a5287aa867a8d42d46ae3349ef467" src="https://github.com/user-attachments/assets/b0aceb74-3ec7-4f0b-b6d4-b3ffda9f1937" />
<img width="651" height="830" alt="be775013b2e201addb31a3e137d5fea5" src="https://github.com/user-attachments/assets/2a054c69-3566-4a74-b7e8-33870a4f45ab" />


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The test file currently has a pre-existing `no-unsafe-finally` finding at line 724 in code introduced by commit `54d9f30cd3`; the changed launcher source passes ESLint, and this PR does not modify that unrelated test cleanup.
