### PR TITLE
fix: install dev launcher signal handlers only when a process owns the lifecycle

### DIFF
--- a/__tests__/scripts/dev-static.test.ts
+++ b/__tests__/scripts/dev-static.test.ts
@@ -1,3 +1,8 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { buildAutomationBackendEnv } from "../../scripts/dev-static.mjs";
@@ -22,6 +27,52 @@ describe("dev-static", () => {
       AUTOMATION_POSTHOG_API_KEY:
         "phc_kBtz5nKmxVRRQ7HtPwr2QX9eMC5j65zE86QKocVNwb4U",
       AUTOMATION_POSTHOG_HOST: "https://us.i.posthog.com",
+    });
+  });
+});
+
+describe("dev-static signal handler ownership", () => {
+  // This suite imports dev-static.mjs for buildAutomationBackendEnv above, which
+  // is precisely the case that must not take over the importer's signals: the
+  // handlers would be wired to dev-static's own process registry, empty in a
+  // vitest worker, and its shutdown() calls process.exit on a 3s timer.
+  it("does not install signal handlers when the module is only imported", async () => {
+    const repoRoot = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "../..",
+    );
+    const moduleUrl = pathToFileURL(
+      path.join(repoRoot, "scripts", "dev-static.mjs"),
+    ).href;
+
+    const child = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        [
+          'import { writeSync } from "node:fs";',
+          'const signals = ["SIGINT", "SIGTERM", "SIGHUP"];',
+          "const counts = () =>",
+          "  Object.fromEntries(signals.map((s) => [s, process.listenerCount(s)]));",
+          "const before = counts();",
+          `await import(${JSON.stringify(moduleUrl)});`,
+          'writeSync(1, "COUNTS " + JSON.stringify({ before, after: counts() }) + "\\n");',
+        ].join("\n"),
+      ],
+      { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+    );
+
+    let output = "";
+    child.stdout.on("data", (chunk: Buffer) => (output += chunk.toString()));
+    child.stderr.on("data", (chunk: Buffer) => (output += chunk.toString()));
+    await once(child, "exit");
+
+    const match = output.match(/COUNTS (\{.*\})/);
+    expect(match, output).not.toBeNull();
+    expect(JSON.parse(match![1])).toEqual({
+      before: { SIGINT: 0, SIGTERM: 0, SIGHUP: 0 },
+      after: { SIGINT: 0, SIGTERM: 0, SIGHUP: 0 },
     });
   });
 });

--- a/__tests__/scripts/dev-static.test.ts
+++ b/__tests__/scripts/dev-static.test.ts
@@ -66,7 +66,9 @@ describe("dev-static signal handler ownership", () => {
     let output = "";
     child.stdout.on("data", (chunk: Buffer) => (output += chunk.toString()));
     child.stderr.on("data", (chunk: Buffer) => (output += chunk.toString()));
-    await once(child, "exit");
+    // "close" rather than "exit": exit can fire before the stdio pipes are
+    // drained, and this test parses the child's stdout for its result.
+    await once(child, "close");
 
     const match = output.match(/COUNTS (\{.*\})/);
     expect(match, output).not.toBeNull();

--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -647,7 +647,9 @@ describe("dev-with-automation signal handler ownership", () => {
     let output = "";
     child.stdout.on("data", (chunk: Buffer) => (output += chunk.toString()));
     child.stderr.on("data", (chunk: Buffer) => (output += chunk.toString()));
-    await once(child, "exit");
+    // "close" rather than "exit": exit can fire before the stdio pipes are
+    // drained, and these tests parse the child's stdout for their result.
+    await once(child, "close");
     return output;
   };
 

--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -630,6 +630,80 @@ describe("setServiceLogListener", () => {
   });
 });
 
+describe("dev-with-automation signal handler ownership", () => {
+  const moduleUrl = pathToFileURL(
+    path.join(repoRoot, "scripts", "dev-with-automation.mjs"),
+  ).href;
+
+  const runChild = async (source: string) => {
+    const child = spawn(
+      process.execPath,
+      ["--input-type=module", "--eval", source],
+      {
+        cwd: repoRoot,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let output = "";
+    child.stdout.on("data", (chunk: Buffer) => (output += chunk.toString()));
+    child.stderr.on("data", (chunk: Buffer) => (output += chunk.toString()));
+    await once(child, "exit");
+    return output;
+  };
+
+  const PRELUDE = [
+    'import { writeSync } from "node:fs";',
+    'const signals = ["SIGINT", "SIGTERM", "SIGHUP"];',
+    "const counts = () =>",
+    "  Object.fromEntries(signals.map((s) => [s, process.listenerCount(s)]));",
+  ].join("\n");
+
+  it("does not install signal handlers when the module is only imported", async () => {
+    const output = await runChild(
+      [
+        PRELUDE,
+        "const before = counts();",
+        `await import(${JSON.stringify(moduleUrl)});`,
+        'writeSync(1, "COUNTS " + JSON.stringify({ before, after: counts() }) + "\\n");',
+      ].join("\n"),
+    );
+    const match = output.match(/COUNTS (\{.*\})/);
+    expect(match, output).not.toBeNull();
+    expect(JSON.parse(match![1])).toEqual({
+      before: { SIGINT: 0, SIGTERM: 0, SIGHUP: 0 },
+      after: { SIGINT: 0, SIGTERM: 0, SIGHUP: 0 },
+    });
+  });
+
+  // Guards the wiring, not just the helper: deleting the installSignalHandlers()
+  // call from main() must turn this red. Counts are reported from an `exit` hook
+  // because main() can exit synchronously on a failed prerequisite check before
+  // control returns here, and installSignalHandlers() runs ahead of that.
+  it("installs signal handlers when main() runs", async () => {
+    const output = await runChild(
+      [
+        PRELUDE,
+        `const mod = await import(${JSON.stringify(moduleUrl)});`,
+        "const before = counts();",
+        "process.on('exit', () => {",
+        '  writeSync(1, "COUNTS " + JSON.stringify({ before, after: counts() }) + "\\n");',
+        "});",
+        "try {",
+        "  const pending = mod.main({});",
+        '  if (pending && typeof pending.catch === "function") pending.catch(() => {});',
+        "} catch {}",
+        "process.exit(0);",
+      ].join("\n"),
+    );
+    const match = output.match(/COUNTS (\{.*\})/);
+    expect(match, output).not.toBeNull();
+    expect(JSON.parse(match![1])).toEqual({
+      before: { SIGINT: 0, SIGTERM: 0, SIGHUP: 0 },
+      after: { SIGINT: 1, SIGTERM: 1, SIGHUP: 1 },
+    });
+  });
+});
+
 describe("dev-with-automation CLI", () => {
   it.skipIf(process.platform === "win32")(
     "cleans up detached services when the launcher receives SIGHUP",
@@ -643,7 +717,11 @@ describe("dev-with-automation CLI", () => {
         'server.listen(0, "127.0.0.1", () => console.log("READY", process.pid, server.address().port));',
       ].join("\n");
       const supervisorSource = [
-        `import { spawnService } from ${JSON.stringify(moduleUrl)};`,
+        `import { spawnService, installSignalHandlers } from ${JSON.stringify(moduleUrl)};`,
+        // main() would start the real stack, so install the same handlers it
+        // installs. That the shipped main() actually calls this is covered by
+        // "installs signal handlers when main() runs" above.
+        "installSignalHandlers();",
         `const fixture = spawnService("fixture", process.execPath, ["--input-type=module", "--eval", ${JSON.stringify(fixtureSource)}]);`,
         'console.log("SPAWNED", fixture.pid);',
         "setInterval(() => {}, 1_000);",

--- a/scripts/dev-static.mjs
+++ b/scripts/dev-static.mjs
@@ -63,6 +63,7 @@ import {
   buildAutomationTelemetryEnv,
   buildAutomationRuntimeServicesInfo,
   buildConfig,
+  installSignalHandlers,
 } from "./dev-with-automation.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -510,9 +511,6 @@ function shutdown() {
   }, 3000);
 }
 
-process.on("SIGINT", shutdown);
-process.on("SIGTERM", shutdown);
-
 function printBanner(config) {
   console.log("");
   console.log(
@@ -651,6 +649,11 @@ const isMainModule =
   process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isMainModule) {
+  // Inside the guard, not at module scope: this file is imported for helpers
+  // (its own test suite pulls in buildAutomationBackendEnv), and an importer
+  // must not inherit handlers wired to a process registry it does not own.
+  installSignalHandlers(shutdown);
+
   main().catch((err) => {
     logError(`Fatal error: ${err.message}`);
     if (err.stack) {

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -957,9 +957,17 @@ function shutdown() {
   }, 3000);
 }
 
-process.on("SIGINT", shutdown);
-process.on("SIGTERM", shutdown);
-process.on("SIGHUP", shutdown);
+// Signal handlers are process-global, so registering them at module scope means
+// merely importing this file for its helpers takes over the importer's signal
+// behaviour. dev-static.mjs, static-build.mjs, bin/agent-canvas.mjs and
+// electron/main.mjs all import from here; the ones that own their own lifecycle
+// end up with two shutdown paths racing on the same signal. Register only when a
+// process actually owns the lifecycle, by calling this from main().
+function installSignalHandlers(handler = shutdown) {
+  process.on("SIGINT", handler);
+  process.on("SIGTERM", handler);
+  process.on("SIGHUP", handler);
+}
 
 function startIngress(config) {
   logService("ingress", `Starting on port ${config.ingressPort}...`, c.yellow);
@@ -1278,6 +1286,12 @@ async function main(options = {}) {
   // `spawnService` call (e.g. by future setup steps) are also captured.
   setServiceLogListener(onServiceLog);
 
+  // Registered here rather than at module scope: from this point on the process
+  // owns the lifecycle, and the services spawned below are detached
+  // process-group leaders that would otherwise outlive it. Ahead of the
+  // prerequisite checks, which can exit before any service starts.
+  installSignalHandlers();
+
   const args = parseArgs();
 
   // Allow options to override CLI args for public mode
@@ -1500,6 +1514,7 @@ export {
   buildViteBackendEnv,
   getFrontendBackend,
   getLocalServiceRoutes,
+  installSignalHandlers,
   main,
   registerShutdownHook,
   spawnService,


### PR DESCRIPTION
HUMAN:

AGENT:

---

## Why

`scripts/dev-with-automation.mjs` registered `SIGINT`/`SIGTERM`/`SIGHUP` at module scope, so importing it for its helpers took over the importer's signal behaviour. `dev-static.mjs`, `static-build.mjs`, `bin/agent-canvas.mjs` and `electron/main.mjs` all import from it.

`dev-static` keeps its own process registry and its own `shutdown()`, so it ended up with two shutdown paths racing on one signal, and the imported one walks an empty registry and can call `process.exit` first.

Measured by listener count on `main`:

| module imported | SIGINT | SIGTERM | SIGHUP |
|---|---|---|---|
| `dev-static.mjs` | 2 | 2 | 1 |

Two of each: its own pair, plus the three it inherits.

## Summary

- Move registration into an exported `installSignalHandlers()` and call it from `main()`, ahead of the prerequisite checks that can exit before any service starts.
- `dev-static` registers its own `shutdown` the same way, inside the `isMainModule` guard it already has rather than at module scope, so importing it for `buildAutomationBackendEnv` installs nothing.
- Three regression tests, each verified to fail against the change it guards.

After: `0 / 0 / 0` on import for all four launchers.

## Issue Number

Closes #16257

## How to Test

```
npx vitest run __tests__/scripts/dev-with-automation.test.ts __tests__/scripts/dev-static.test.ts
```

To confirm each test guards something real:

1. Delete the `installSignalHandlers();` call from `main()` in `dev-with-automation.mjs`. "installs signal handlers when main() runs" fails. A test that calls the helper directly instead of running `main()` cannot catch this.
2. Move `installSignalHandlers(shutdown)` in `dev-static.mjs` out of the `isMainModule` guard back to module scope. "does not install signal handlers when the module is only imported" fails.

Direct check without the tests:

```
node --input-type=module --eval '
const s = ["SIGINT","SIGTERM","SIGHUP"];
await import("./scripts/dev-static.mjs");
console.log(Object.fromEntries(s.map(x => [x, process.listenerCount(x)])));'
```

## Video/Screenshots

Not applicable: Node launcher lifecycle, no UI surface. The evidence is the listener counts above and the mutation results under How to Test.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Full suite 4248 passed / 0 failed. `npm run lint` clean.

The `main()` test reads its counts from a `process.on("exit")` hook using `fs.writeSync`, because a failed prerequisite check can exit synchronously before control returns to the test, and `console.log` to a pipe can be dropped on exit. `installSignalHandlers()` runs ahead of those checks, so the handlers exist on that path too.

Overlaps #16262, which takes the same `installSignalHandlers()` approach. Two differences: there the `dev-static` call stays at module scope (so importing it still registers three handlers), and the SIGHUP test calls the helper directly rather than running `main()`, so removing the call from `main()` leaves the suite green.
