### PR TITLE
docs: encourage .pr/ HTML design doc + htmlpreview link for non-trivial PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,6 +42,19 @@ Provide a video or screenshots of testing your PR. e.g. you added a new feature 
 
 -->
 
+## Design Doc
+
+<!--
+Optional, encouraged for non-trivial PRs. Add a self-contained HTML design doc under the
+temporary `.pr/` directory (e.g. `.pr/design.html`) covering the code/API design and a
+before/after of your change, then link it here via htmlpreview so reviewers see it at a glance:
+
+  https://htmlpreview.github.io/?https://github.com/<your-fork>/<repo>/blob/<your-branch>/.pr/design.html
+
+The `.pr/` directory is temporary — it is removed automatically when the PR is approved.
+See docs/DEVELOPMENT.md ("Design doc for non-trivial PRs") for details.
+-->
+
 ## Type
 
 - [ ] Bug fix

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -149,6 +149,33 @@ threshold.
 Stryker does not cover the small Python surface in this repository; mutating it
 would need a Python test harness and Python-specific mutation tool.
 
+## Design doc for non-trivial PRs
+
+For a non-trivial PR — a new or changed public API, a new subsystem, a behavior change in
+core logic, or a migration — a reviewer often has to reconstruct the design from the diff
+alone. That is slow. You are encouraged (not required) to add a short design doc so reviewers
+grasp the proposal at a glance.
+
+The convention:
+
+1. Write a **self-contained HTML** page (inline CSS/SVG, opens by double-click) that covers
+   the code/API design and a **before/after** of your change, grounded to the actual code.
+2. Commit it under the temporary **`.pr/`** directory, e.g. `.pr/design.html`. This directory
+   is for PR-only artifacts and is **removed automatically when the PR is approved**
+   (`.github/workflows/pr-artifacts.yml`), so it never lands in `main`.
+3. Link it near the top of the PR description via htmlpreview, pointing at the fork and branch
+   the PR is opened from so it renders before the PR is merged:
+
+   ```
+   https://htmlpreview.github.io/?https://github.com/<your-fork>/<repo>/blob/<your-branch>/.pr/design.html
+   ```
+
+Skip this for trivial PRs (a typo, a one-line guard, a dependency bump) — there, a design doc
+is just noise. htmlpreview only works for public repos and self-contained pages.
+
+The `pr-design-doc` skill in the [OpenHands extensions](https://github.com/OpenHands/extensions)
+repo can generate the page for you.
+
 ## CSS isolation and host-app customization
 
 The standalone app and the exported provider/root wrapper now scope all bundled CSS under a dedicated shell element with the `data-agent-server-ui` attribute. That means Tailwind utilities, HeroUI component styles, xterm styles, and local CSS only apply inside the OpenHands UI subtree instead of leaking into a host app.


### PR DESCRIPTION
HUMAN:

Docs-only change. Reviewed the rendered PR template and DEVELOPMENT.md section locally; the htmlpreview link shape is verified against the .pr/ convention already wired in this repo.

AGENT:

## Why

Reviewers of a non-trivial PR often reconstruct the design from the diff alone — slow and error-prone. This adds a soft, optional guideline: commit a self-contained HTML design doc under the temporary `.pr/` directory and link it via htmlpreview so reviewers see the code/API design and before/after at a glance. The `.pr/` directory is already auto-removed on approval (`.github/workflows/pr-artifacts.yml`), so the doc never lands in `main`, and htmlpreview renders files on an unmerged PR branch.

Implements the guideline from #16304.

## Summary

- **PR template**: add an optional `## Design Doc` section with the htmlpreview link shape.
- **docs/DEVELOPMENT.md**: add a "Design doc for non-trivial PRs" section — the convention, when to skip it (trivial PRs), and a pointer to the `pr-design-doc` skill.

## Issue Number

Relates to #16304

## How to Test

Docs only — nothing to run. Read `.github/pull_request_template.md` (new `## Design Doc` block) and `docs/DEVELOPMENT.md` ("Design doc for non-trivial PRs"). The htmlpreview link shape is:

```
https://htmlpreview.github.io/?https://github.com/<your-fork>/<repo>/blob/<your-branch>/.pr/design.html
```

Companion skill PR: OpenHands/extensions#451. A matching guideline PR for the SDK: OpenHands/software-agent-sdk#4371.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Soft-encouraged, not enforced. htmlpreview works only for public repos and self-contained pages.

Co-authored-by: smolpaws <engel@enyst.org>
