### PR TITLE
fix: use hostname as default backend label instead of hardcoded "Local"

### DIFF
--- a/src/api/backend-registry/default-backend.ts
+++ b/src/api/backend-registry/default-backend.ts
@@ -60,9 +60,25 @@ export function makeDefaultLocalBackend(): Backend | null {
 
   if (!host || !apiKey) return null;
 
+  // Use the hostname as the backend name for clarity. On a VM the base URL
+  // is something like https://canvas.acme.com, so showing "Local" is
+  // misleading. Fall back to the default name for loopback addresses.
+  let name: string;
+  try {
+    const url = new URL(host);
+    const hostname = url.hostname;
+    if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1") {
+      name = DEFAULT_LOCAL_BACKEND_NAME;
+    } else {
+      name = url.port ? `${hostname}:${url.port}` : hostname;
+    }
+  } catch {
+    name = DEFAULT_LOCAL_BACKEND_NAME;
+  }
+
   return {
     id: SEEDED_DEFAULT_BACKEND_ID,
-    name: DEFAULT_LOCAL_BACKEND_NAME,
+    name,
     host,
     apiKey,
     kind: "local",


### PR DESCRIPTION
## Summary

Fixes #16297

When running agent-canvas on a VM, the backend was labelled "Local" even though the URL points to a remote hostname. This is confusing — the user expects to see the actual hostname (e.g. `canvas.acme.com`).

## Changes

- **`src/api/backend-registry/default-backend.ts`**: In `makeDefaultLocalBackend()`, extract the hostname from the configured base URL and use it as the display name. Fall back to "Local" only for loopback addresses (`localhost`, `127.0.0.1`, `::1`).

## Testing

- Localhost: `VITE_BACKEND_BASE_URL=http://localhost:3000` → name = "Local"
- VM: `VITE_BACKEND_BASE_URL=https://canvas.acme.com` → name = "canvas.acme.com"
- VM with port: `VITE_BACKEND_BASE_URL=https://canvas.acme.com:8443` → name = "canvas.acme.com:8443"
- Invalid URL → fallback to "Local"