### PR TITLE
fix: stop the "Creating conversation" toast getting stuck on screen

### DIFF
--- a/__tests__/components/features/home/home-chat-launcher.test.tsx
+++ b/__tests__/components/features/home/home-chat-launcher.test.tsx
@@ -2,11 +2,13 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import toast from "react-hot-toast";
+import toast, { useToasterStore } from "react-hot-toast";
 
 import { HomeChatLauncher } from "#/components/features/home/home-chat-launcher";
 import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
 import WorkspacesService from "#/api/workspaces-service/workspaces-service.api";
+import AgentProfilesService from "#/api/agent-profiles-service/agent-profiles-service.api";
+import PluginsManagementService from "#/api/plugins-management-service";
 
 const mockNavigate = vi.fn();
 const mockUseActiveBackend = vi.fn();
@@ -240,6 +242,51 @@ const renderLauncher = () =>
     ),
   });
 
+/**
+ * Reports how many toasts are currently on screen. Reads react-hot-toast's own
+ * store rather than the rendered `<Toaster />`: a dismissed toast keeps its DOM
+ * node for the exit animation, so "still in the document" is not the same
+ * question as "still shown".
+ */
+function VisibleToastCount() {
+  const { toasts } = useToasterStore();
+  return (
+    <span data-testid="visible-toast-count">
+      {toasts.filter((item) => item.visible).length}
+    </span>
+  );
+}
+
+/**
+ * Renders the launcher next to the toast probe. `unmountLauncher` drops only
+ * the launcher, leaving the probe mounted so the toast state can still be read
+ * after the component that created the toast is gone.
+ */
+const renderWithToastProbe = () => {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const view = render(
+    <QueryClientProvider client={client}>
+      <VisibleToastCount />
+      <HomeChatLauncher />
+    </QueryClientProvider>,
+  );
+
+  return {
+    ...view,
+    unmountLauncher: () =>
+      view.rerender(
+        <QueryClientProvider client={client}>
+          <VisibleToastCount />
+        </QueryClientProvider>,
+      ),
+  };
+};
+
 function makeConversationResponse(
   overrides: Record<string, unknown> = {},
 ): never {
@@ -302,6 +349,19 @@ describe("HomeChatLauncher", () => {
       workspaces: [],
       workspaceParents: [],
     });
+    // The create mutation awaits these two round trips itself — the agent
+    // profiles before it creates anything, the installed plugins after. Left
+    // unmocked they escape to the network and the mutation never reaches
+    // `createConversation` within the assertion window, so stub them to the
+    // "nothing configured" shape that exercises the plain agent_settings path.
+    vi.spyOn(AgentProfilesService, "listProfiles").mockResolvedValue({
+      profiles: [],
+      active_agent_profile_id: null,
+    });
+    vi.spyOn(
+      PluginsManagementService,
+      "listInstalledPlugins",
+    ).mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -520,6 +580,45 @@ describe("HomeChatLauncher", () => {
 
     await waitFor(() => expect(mockDisplayErrorToast).toHaveBeenCalled());
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("takes the creating-conversation toast down when creation fails", async () => {
+    vi.spyOn(
+      AgentServerConversationService,
+      "createConversation",
+    ).mockRejectedValue(new Error("Network down"));
+
+    renderWithToastProbe();
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("stub-chat-submit"));
+
+    await waitFor(() => expect(mockDisplayErrorToast).toHaveBeenCalled());
+    expect(screen.getByTestId("visible-toast-count")).toHaveTextContent("0");
+  });
+
+  it("takes the creating-conversation toast down when the launcher unmounts before creation settles", async () => {
+    // A create that never settles. The mutation keeps running past the point
+    // where the conversation exists (agent profiles, installed plugins), so
+    // leaving the home page inside that window is ordinary. The toast has an
+    // infinite duration, and until #15701 the only thing that could dismiss it
+    // was this promise chain — so a chain that never got there left it on
+    // screen for the rest of the session.
+    vi.spyOn(
+      AgentServerConversationService,
+      "createConversation",
+    ).mockReturnValue(new Promise(() => {}) as never);
+
+    const { unmountLauncher } = renderWithToastProbe();
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("stub-chat-submit"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("visible-toast-count")).toHaveTextContent("1"),
+    );
+
+    unmountLauncher();
+
+    expect(screen.getByTestId("visible-toast-count")).toHaveTextContent("0");
   });
 
   it("enqueues an optimistic pending message when cloud returns a start task", async () => {

--- a/src/components/features/home/home-chat-launcher.tsx
+++ b/src/components/features/home/home-chat-launcher.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { CustomChatInput } from "#/components/features/chat/custom-chat-input";
@@ -35,6 +35,18 @@ import { OpenLauncherButton } from "./open-launcher-button";
 import { OpenWorkspaceDialog } from "./open-workspace-dialog";
 import { OpenRepositoryDialog } from "./open-repository-dialog";
 import { HomeGitControlBarPreview } from "./home-git-control-bar-preview";
+
+/**
+ * Fixed id for the "Creating conversation…" toast.
+ *
+ * react-hot-toast gives loading toasts an infinite duration, so this one only
+ * ever leaves the screen when something dismisses it by id. Under a generated
+ * id a toast that outlives its dismiss becomes unreachable — no other code can
+ * name it — and stays up until the page is reloaded (#15701). A fixed id keeps
+ * it addressable, and means a repeat submit reuses the same toast instead of
+ * stacking another one that also has to be cleaned up.
+ */
+const CREATING_CONVERSATION_TOAST_ID = "creating-conversation";
 
 export function HomeChatLauncher() {
   const { t } = useTranslation("openhands");
@@ -74,6 +86,15 @@ export function HomeChatLauncher() {
   const hasSelection = isLocal
     ? !!pendingWorkspace
     : !!pendingRepository && !!pendingBranch;
+
+  // The submit below drives a promise chain that isn't tied to this component,
+  // and the create mutation stays pending past the point where the conversation
+  // itself exists (it also resolves agent profiles and snapshots installed
+  // plugins). Leaving the home page inside that window — clicking a sidebar
+  // conversation, switching backend — tears the launcher down while the chain
+  // is still awaiting, so clear the toast on the way out rather than trusting
+  // the chain to get there.
+  useEffect(() => () => toast.dismiss(CREATING_CONVERSATION_TOAST_ID), []);
 
   const handleSubmit = (message: string) => {
     const trimmed = message.trim();
@@ -125,16 +146,20 @@ export function HomeChatLauncher() {
     }
 
     // Loading toast gives the user a clear signal that the request is in
-    // flight; dismissed precisely once the mutation resolves.
-    const toastId = toast.loading(
-      t(I18nKey.HOME$CREATING_CONVERSATION),
-      TOAST_OPTIONS,
-    );
+    // flight; dismissed as soon as the conversation exists, and again in the
+    // `finally` below so no exit path can leave it behind.
+    toast.loading(t(I18nKey.HOME$CREATING_CONVERSATION), {
+      ...TOAST_OPTIONS,
+      id: CREATING_CONVERSATION_TOAST_ID,
+    });
 
     void (async () => {
       try {
         const data = await createConversation(variables);
-        toast.dismiss(toastId);
+        // The conversation exists from here on, so drop the toast before the
+        // attachment / pending-message work instead of leaving a "Creating
+        // conversation…" label up for a step that isn't creating anything.
+        toast.dismiss(CREATING_CONVERSATION_TOAST_ID);
         try {
           sessionStorage.removeItem(HOME_PROMPT_DRAFT_KEY);
         } catch {
@@ -204,8 +229,12 @@ export function HomeChatLauncher() {
 
         navigate(`/conversations/${targetConversationId}`);
       } catch (error) {
-        toast.dismiss(toastId);
         displayErrorToast(error instanceof Error ? error.message : null);
+      } finally {
+        // Safety net for every path above, including the early returns. The
+        // toast has no duration of its own, so a single missed dismiss leaves
+        // it on screen for the rest of the session.
+        toast.dismiss(CREATING_CONVERSATION_TOAST_ID);
       }
     })();
   };

--- a/src/hooks/mutation/use-create-conversation.ts
+++ b/src/hooks/mutation/use-create-conversation.ts
@@ -249,6 +249,14 @@ export const useCreateConversation = () => {
           installed = await queryClient.ensureQueryData({
             queryKey: PLUGINS_QUERY_KEYS.installed,
             queryFn: () => PluginsManagementService.listInstalledPlugins(),
+            // This runs *after* the conversation has been created, and the
+            // mutation doesn't resolve until it settles — so its failure mode
+            // is charged to the caller's "Creating conversation…" spinner
+            // (#15701). On a cold cache the default three retries with backoff
+            // hold that open for minutes on a backend that can't answer.
+            // Match the profile lookups above and fail fast; the snapshot is
+            // best-effort metadata for the plugins view either way.
+            retry: false,
           });
         } catch {
           // Best-effort: never let plugin lookup block conversation creation.

--- a/tests/e2e/mock-llm/regressions/mock-llm-ui-regressions.spec.ts
+++ b/tests/e2e/mock-llm/regressions/mock-llm-ui-regressions.spec.ts
@@ -15,7 +15,16 @@ import type { ActionEvent, MessageEvent } from "#/types/agent-server/core";
 import { SecurityRisk } from "#/types/agent-server/core";
 import type { FinishAction } from "#/types/agent-server/core/base/action";
 import type { CriticResult } from "#/types/agent-server/core/base/critic";
-import { seedLocalStorage, routeSessionApiKey } from "../utils/mock-llm-helpers";
+import { tmpdir } from "node:os";
+import {
+  seedLocalStorage,
+  routeSessionApiKey,
+  setChatInput,
+  waitForPath,
+  ensureMockLLMProfile,
+  BACKEND_URL,
+  SESSION_API_KEY,
+} from "../utils/mock-llm-helpers";
 
 test.describe.configure({ mode: "serial" });
 
@@ -353,6 +362,40 @@ async function triggerOlderEventLoad(page: Page) {
   });
 }
 
+// ─── conversation seeding ────────────────────────────────────────────
+
+/**
+ * Create a conversation straight through the API. `POST /api/conversations`
+ * provisions the conversation without contacting the model, so this needs no
+ * credentials and produces a sidebar row to navigate to.
+ */
+async function seedConversation(): Promise<string> {
+  const response = await fetch(`${BACKEND_URL}/api/conversations`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Session-API-Key": SESSION_API_KEY,
+    },
+    body: JSON.stringify({
+      workspace: { kind: "LocalWorkspace", working_dir: tmpdir() },
+      agent_settings: {
+        llm: {
+          model: "openai/mock-test-model",
+          api_key: "mock-api-key-for-testing",
+          base_url: "http://127.0.0.1:9/v1",
+        },
+      },
+    }),
+  });
+
+  expect(response.ok, `failed to seed conversation: ${response.status}`).toBe(
+    true,
+  );
+
+  const { id } = (await response.json()) as { id: string };
+  return id;
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 // Tests
 // ═══════════════════════════════════════════════════════════════════════
@@ -643,5 +686,68 @@ test.describe("UI regressions", () => {
     const dropdown = page.getByTestId("workspace-dropdown");
     await expect(dropdown).toBeEnabled({ timeout: 15_000 });
     await expect(dropdown).toHaveValue("");
+  });
+
+  // ── #15701: "Creating conversation…" toast stuck on screen ────────
+
+  test("creating-conversation toast does not outlive the home page", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+
+    // Without a configured LLM the launcher disables sending outright, so the
+    // submit below would never fire.
+    await ensureMockLLMProfile(page);
+
+    await routeSessionApiKey(page);
+
+    // A conversation to navigate to. It has to exist up front: the sidebar
+    // list is refreshed by the create mutation's `onSuccess`, which never runs
+    // while that mutation is stalled below.
+    const seededId = await seedConversation();
+
+    // Stall the installed-plugins lookup. The create mutation awaits it
+    // *after* the conversation has been created, so this puts the app in
+    // exactly the reported state — the conversation exists, but the mutation
+    // hasn't resolved and the loading toast is still up. A flaky or
+    // slow-to-answer backend produces the same window on its own.
+    await page.route("**/api/plugins/installed**", async (route, request) => {
+      if (request.method() !== "GET") {
+        await route.fallback();
+        return;
+      }
+      await new Promise((resolve) => {
+        setTimeout(resolve, 60_000);
+      });
+      await route.abort();
+    });
+
+    await page.goto("/conversations", { waitUntil: "domcontentloaded" });
+
+    const sidebarLink = page
+      .getByTestId("conversation-panel")
+      .locator(`a[href*="${seededId}"]`)
+      .first();
+    await expect(sidebarLink).toBeVisible({ timeout: 30_000 });
+
+    await setChatInput(page, "stuck toast regression");
+    await page.getByTestId("submit-button").click();
+
+    const creatingToast = page.getByText("Creating conversation…", {
+      exact: true,
+    });
+    await expect(creatingToast).toBeVisible({ timeout: 30_000 });
+
+    // Client-side navigation off the home page, which unmounts the launcher
+    // while the create mutation is still pending. It has to be a link click
+    // rather than page.goto: a full page load drops the toast on its own and
+    // would pass with or without the fix.
+    await sidebarLink.click();
+    await waitForPath(page, new RegExp(`/conversations/${seededId}`));
+
+    // Assert on removal from the DOM rather than visibility — a dismissed
+    // toast keeps its node for the exit animation, and an animated-out node
+    // still reports a box to Playwright.
+    await expect(creatingToast).toHaveCount(0, { timeout: 15_000 });
   });
 });


### PR DESCRIPTION
HUMAN:

Went after this one because the "intermittent" in the report bugged me — the dismiss looked covered on every path, so I dug into what actually keeps the mutation pending. Reproduced it end to end and the screenshot from the failing run is basically identical to the one in the issue.

AGENT:

---

## Why

`toast.loading` has an infinite duration in react-hot-toast — `loading` is the one type with no default timeout:

```js
se = { blank: 4e3, error: 4e3, success: 2e3, loading: 1/0, custom: 4e3 }
```

`TOAST_OPTIONS` doesn't set one either, so the "Creating conversation…" toast only ever leaves the screen when something dismisses it by id. In `home-chat-launcher.tsx` that was a single `toast.dismiss(toastId)` inside a promise chain, under a generated id.

Two things fall out of that:

**The toast outlives the page it belongs to.** The create mutation keeps running well past the point where the conversation exists — after `AgentServerConversationService.createConversation` returns, `useCreateConversation` still awaits `ensureQueryData(PLUGINS_QUERY_KEYS.installed)` to snapshot the installed plugins into client metadata. On a cold cache that's a real round trip with React Query's default three retries and backoff (the app sets no `defaultOptions`, so v5 defaults apply). Leave the home page inside that window — click a sidebar conversation, switch backend — and the launcher unmounts while the chain is still awaiting. Nothing takes the toast down.

**Once it's stranded, nothing can reach it.** The id was generated, so no other code can name that toast. A later successful create dismisses only its own. It stays until reload.

That also explains the "intermittent" in the report: `ensureQueryData` returns cached data immediately when the query is already populated, so the window only opens on a cold plugins cache — typically the first conversation created after a page load.

## Summary

- Give the toast a fixed id (`creating-conversation`), matching what `use-new-conversation-command.ts` already does with `clear-conversation`. A leaked toast stays addressable, and a repeat submit reuses it instead of stacking another.
- Dismiss in a `finally` so every exit path is covered, including the early returns in the attachment branches.
- Dismiss on unmount, so a create that outlives the launcher can't strand it.
- Drop the retries on the post-creation installed-plugins lookup. It runs after the conversation already exists but still holds the mutation open, and the two profile lookups in the same function already use `retry: false`.

## Issue Number

Fixes #15701

## How to Test

### End-to-end

Added `creating-conversation toast does not outlive the home page` to `tests/e2e/mock-llm/regressions/mock-llm-ui-regressions.spec.ts`. It stalls `GET /api/plugins/installed`, submits from the home launcher, waits for the toast, then clicks a seeded conversation in the sidebar. The navigation is a link click rather than `page.goto` on purpose — a full page load drops the toast by itself and would pass with or without the fix.

Conversations are seeded through `POST /api/conversations`, which never contacts the LLM at creation time, so no model credentials are needed.

```
MOCK_LLM_PYTHON=.mock-llm-venv/bin/python3 npx playwright test \
  --config=playwright.mock-llm.config.ts \
  tests/e2e/mock-llm/regressions/mock-llm-ui-regressions.spec.ts
```

```
6 passed (44.4s)
```

The full mock-LLM suite is green in CI too — `62 passed (9.8m)`.

**It fails on the parent commit.** I reverted just the two `src/` files to `HEAD~1`, rebuilt, and re-ran:

```
Locator:  getByText('Creating conversation…', { exact: true })
Expected: 0
Received: 1
Timeout:  15000ms

  1 failed
```

The screenshot from that failing run shows the conversation sitting in the sidebar, the app on a different conversation, and the toast still up in the corner — the same state as the issue screenshot.

Note the E2E config only builds when `build/index.html` is missing, so `npm run build:app` is needed between toggling the fix; a stale `build/` silently tests the wrong code.

### Unit

Two cases added to `__tests__/components/features/home/home-chat-launcher.test.tsx`. The unmount one fails on the parent commit:

```
× takes the creating-conversation toast down when the launcher unmounts before creation settles
```

```
npx vitest run __tests__/components/features/home/home-chat-launcher.test.tsx
```

```
Test Files  1 passed (1)
     Tests  13 passed (13)
```

Full suite, `npx vitest run`:

```
Test Files  6 failed | 538 passed | 1 skipped (545)
     Tests  16 failed | 4256 passed | 5 skipped | 9 todo (4286)
```

Those failures are pre-existing on `main`. I captured the failing-file list on a clean checkout and after the change and diffed them — the only difference is that `home-chat-launcher.test.tsx` no longer appears:

```
3d2
<  ❯ __tests__/components/features/home/home-chat-launcher.test.tsx (11 tests | 9 failed)
```

That file was failing 9 of 11 on `main` before this PR. The create mutation awaits two round trips of its own — agent profiles before it creates anything, installed plugins after — and neither was stubbed, so they escaped to the network and the mutation never reached `createConversation` inside the assertion window. Stubbing them in `beforeEach` was needed to make the new cases trustworthy, and it takes the file green as a side effect. Happy to split that into its own PR if you'd rather keep this focused.

Also green: `npm run typecheck`, `npx eslint src`, `prettier --check`, `npm run build:app`.

### Manually

```
npm run dev
```

Throttle or block `GET /api/plugins/installed` in devtools, submit a prompt from the home page, then click a conversation in the sidebar while the toast is up. Before the change the toast stays for the rest of the session; after it goes away with the launcher.

## Video/Screenshots

The mock-LLM run records video (`video: "on"` in `playwright.mock-llm.config.ts`), so `test-results-mock-llm/` holds the before/after captures alongside the failing-run screenshot described above.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/e177ef54-4583-45a6-98d0-79e393314c73" />


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The dismiss right after `createConversation` resolves is kept on top of the `finally`, so the toast still goes away before the attachment upload / pending-message step rather than sitting there labelled "Creating conversation…" during work that isn't creating anything.
- `retry: false` bounds the failure case but not a hang — React Query's default `networkMode: "online"` pauses a query indefinitely while the browser reports offline, and that lookup would still hold the mutation open. The unmount cleanup covers the visible symptom either way. Moving the plugin snapshot out of the awaited path entirely would close it properly, but that changes when the metadata lands, so it felt like a separate call to make.
