### PR TITLE
fix(settings): enforce condenser minimum size

### DIFF
--- a/__tests__/components/features/settings/sdk-settings/schema-field.test.tsx
+++ b/__tests__/components/features/settings/sdk-settings/schema-field.test.tsx
@@ -56,6 +56,26 @@ describe("SchemaField", () => {
     expect(input).toHaveAttribute("step", "0.01");
   });
 
+  it("constrains condenser max size to the SDK-supported minimum", () => {
+    render(
+      <SchemaField
+        field={buildField({
+          key: "condenser.max_size",
+          label: "Max size",
+          value_type: "integer",
+        })}
+        value="20"
+        isDisabled={false}
+        onChange={() => {}}
+      />,
+    );
+
+    const input = screen.getByTestId("sdk-settings-condenser.max_size");
+
+    expect(input).toHaveAttribute("min", "20");
+    expect(input).toHaveAttribute("step", "1");
+  });
+
   it("translates schema-backed labels and descriptions", () => {
     render(
       <SchemaField

--- a/__tests__/utils/sdk-settings-schema.test.ts
+++ b/__tests__/utils/sdk-settings-schema.test.ts
@@ -4,6 +4,7 @@ import {
   buildInitialSettingsFormValues,
   buildSdkSettingsPayload,
   buildSdkSettingsPayloadForView,
+  coerceFieldValue,
   getVisibleSettingsSections,
   hasAdvancedSettingsOverrides,
   inferInitialView,
@@ -11,7 +12,11 @@ import {
   SPECIALLY_RENDERED_KEYS,
 } from "#/utils/sdk-settings-schema";
 import { DEFAULT_SETTINGS } from "#/services/settings";
-import { Settings, SettingsSchema } from "#/types/settings";
+import {
+  Settings,
+  SettingsFieldSchema,
+  SettingsSchema,
+} from "#/types/settings";
 
 const BASE_SETTINGS: Settings = {
   ...DEFAULT_SETTINGS,
@@ -151,6 +156,26 @@ const BASE_SETTINGS: Settings = {
 };
 
 describe("sdk settings schema helpers", () => {
+  it("rejects condenser max sizes below the SDK minimum", () => {
+    const field: SettingsFieldSchema = {
+      key: "condenser.max_size",
+      label: "Max size",
+      section: "condenser",
+      section_label: "Condenser",
+      value_type: "integer",
+      default: 240,
+      choices: [],
+      depends_on: ["condenser.enabled"],
+      prominence: "minor",
+      secret: false,
+      required: true,
+    };
+
+    expect(() => coerceFieldValue(field, "19")).toThrow(
+      "Max size must be at least 20",
+    );
+  });
+
   it("builds initial form values from the current settings", () => {
     expect(buildInitialSettingsFormValues(BASE_SETTINGS)).toEqual({
       "verification.critic_mode": "finish_and_message",

--- a/src/utils/sdk-settings-field-metadata.ts
+++ b/src/utils/sdk-settings-field-metadata.ts
@@ -61,6 +61,13 @@ const FIELD_METADATA: Record<string, SettingsFieldMetadata> = {
       step: 0.1,
     },
   },
+  // Mirrors CondenserSettings.max_size (int with ge=20) in the SDK.
+  "condenser.max_size": {
+    constraints: {
+      min: 20,
+      step: 1,
+    },
+  },
 };
 
 export function getSettingsFieldConstraints(fieldKey: string) {


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

I personally reviewed the SDK boundary, the rendered input behavior, and the final diff. I also ran the two focused Vitest suites (18 tests), TypeScript checks, ESLint, Prettier, and the production frontend build locally.

AGENT:

- Reproduced the bug at the component boundary before the fix: the real `SchemaField` number input for `condenser.max_size` had no `min` attribute, and the new regression failed with `Received: null`.
- On commit `289adf7a0`, the same rendered input exposes `min=20` and `step=1`. The save coercion path rejects `19` with `Max size must be at least 20`, matching the SDK's `CondenserSettings.max_size = Field(..., ge=20)` contract.
- `vitest` passed both focused suites: 2 files, 18 tests.
- TypeScript typecheck, ESLint, Prettier, and the production React Router build passed. The build transformed 7,088 client modules and 278 SSR modules.
- AI assistance was used for implementation and test drafting; the issue, SDK source constraint, diff, and verification output were reviewed before submission.

---

## Why

The condenser max-size input accepted values the agent SDK rejects. This lets users enter a negative or otherwise too-small event limit, then encounter an avoidable settings error only when saving.

The current SDK requires at least 20 events, so the frontend should expose and enforce that same boundary.

## Summary

- Add the SDK's `min=20` and integer step to the condenser max-size field metadata.
- Cover both the rendered number-input constraint and save-time validation.

## Issue Number

Fixes #15813

## How to Test

1. Open Settings > Condenser > All.
2. Inspect the Max size number input and verify its minimum is 20 and its step is 1.
3. Enter 19 and save; verify the frontend reports `Max size must be at least 20` without sending an invalid settings request.
4. Run `vitest run __tests__/components/features/settings/sdk-settings/schema-field.test.tsx __tests__/utils/sdk-settings-schema.test.ts`.

## Video/Screenshots

No visual layout changes. The AGENT section includes the before/after DOM constraint and validation reproduction.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The minimum mirrors `OpenHands/software-agent-sdk` rather than using a looser client-only non-negative check, preventing frontend/backend validation drift for this field.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.37s · commit d9763ea  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 4/4 hunks, 3/3 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 2.0% | No direct hunk selected |
| Weakened authentication | 3.0% | No direct hunk selected |
| Weakened authorization | 3.0% | No direct hunk selected |
| Contract regression | 11.0% | No direct hunk selected |
| Data loss | 3.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 2.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 94.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 8464f14849d8db26dd8b44c616b7b3f025dc6f9a134bfb890ebed990883376e9 -->
<!-- jev-fast-audit:end -->
