### PR TITLE
chore: bump @openhands/extensions to 0.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@heroui/react": "2.8.10",
         "@microlink/react-json-view": "1.31.20",
         "@monaco-editor/react": "4.7.0",
-        "@openhands/extensions": "0.15.0",
+        "@openhands/extensions": "0.16.0",
         "@openhands/typescript-client": "1.36.1",
         "@react-router/node": "7.18.2",
         "@react-router/serve": "7.18.2",
@@ -4164,9 +4164,9 @@
       "license": "MIT"
     },
     "node_modules/@openhands/extensions": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@openhands/extensions/-/extensions-0.15.0.tgz",
-      "integrity": "sha512-fDzLys9hFLL2CcJVqgN9qHLtkO/1ZZC0P7bm/AezHBUsEws4N2EhbGa/zd+0NwPQel/aUmz6zhCVWeHLTDh2ug==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@openhands/extensions/-/extensions-0.16.0.tgz",
+      "integrity": "sha512-t9rTxmR782UZ6nbbSBK23EMlzsgJzz4yi34q6mxgPY7ukWehiK7RkWY6rP/u4o7/K0zzvR6/nIJ4OijvttrfVA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.20.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@heroui/react": "2.8.10",
     "@microlink/react-json-view": "1.31.20",
     "@monaco-editor/react": "4.7.0",
-    "@openhands/extensions": "0.15.0",
+    "@openhands/extensions": "0.16.0",
     "@openhands/typescript-client": "1.36.1",
     "@react-router/node": "7.18.2",
     "@react-router/serve": "7.18.2",

--- a/tests/e2e/mock-llm/automations/mock-llm-preset-automation.spec.ts
+++ b/tests/e2e/mock-llm/automations/mock-llm-preset-automation.spec.ts
@@ -180,7 +180,11 @@ test.describe("preset automation → slash command conversation", () => {
     });
 
     await routeSessionApiKey(page);
-    await page.goto("/automations", { waitUntil: "domcontentloaded" });
+    // The catalog launcher lives on the Templates sub-page, which is where
+    // the interface manifest places it.
+    await page.goto("/automations/templates", {
+      waitUntil: "domcontentloaded",
+    });
     await dismissAnalyticsModal(page);
 
     // Click the Slack standup digest automation card


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

I have verified the changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

<!-- Describe problem, motivation, etc. -->

`package.json` pinned `@openhands/extensions` at `0.15.0`; `0.16.0` is now `latest`.

The pin is the whole cause. This repo already shipped the manifest-driven sub-page host in `53f284bc4c` (#16303): `src/manifests/types.ts` declares `routes.templates`, `navigation.subPages`, `pages.templates` and `pages.list.{overview,filters,sort,insights}` as optional, `interface-validation.ts` accepts that group all-or-nothing, and `automation-interface.ts` returns `null` from `getSubPagesSpec()`, `getDashboardSpec()` and `getTemplatesPageSpec()` when the manifest doesn't declare it — the host holds no defaults for this surface on purpose. Under 0.15.0's manifest that meant `/automations` rendered today's plain list and `/automations/templates` threw a 404 from its `clientLoader`.

0.16.0 is the release that declares that surface, so bumping the pin is what turns the feature on. No application code has to change to consume it.

## Summary

<!-- 1-3 bullets describing what changed. -->
* Bump `@openhands/extensions` from `0.15.0` to `0.16.0` (`package.json` + lockfile; pin, resolved URL and integrity only — no transitive dependency movement).
* Point the mock-LLM preset-automation spec at `/automations/templates`, where the catalog launcher now lives in dashboard mode.
* No `src/` changes: the published manifest passes the host's existing admission validator unmodified.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

N/A.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

```bash
npm install
npm test          # 4360 passed
npm run typecheck # clean
npm run build     # succeeds

```

Then check the user-visible activation, which is the real point of this bump:

1. `npm run dev:mock` and open `/automations`.
2. The page should now be titled **"Dashboard"** with sub-page navigation (*Dashboard* | *Templates*), four overview tiles (Automations, Needs attention, Total runs, Average duration), status and trigger filter dropdowns, and a sort dropdown defaulting to *Latest run*. Cards and rows should carry health, last-run and stat captions.
3. Click **Templates** → `/automations/templates`, titled "Templates", holding the recommended-automation catalog cards that previously sat at the bottom of the list page. Launching a card from here should behave exactly as before.
4. Confirm the unchanged surfaces: the sidebar still reads **Automate**, the command menu entry is unchanged, and the detail and edit pages are unchanged — those manifest sections are byte-identical between 0.15.0 and 0.16.0.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

N/A.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.39.1-python` |
| **Automation** | `openhands-automation==1.5.0` |
| **Commit** | `8c3432bcfeddc21c20e101b15fe8a0a1e478e527` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-8c3432b
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-8c3432b
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-8c3432b-amd64
ghcr.io/openhands/agent-canvas:hieptl-oss-9064-amd64
ghcr.io/openhands/agent-canvas:pr-16321-amd64
ghcr.io/openhands/agent-canvas:sha-8c3432b-arm64
ghcr.io/openhands/agent-canvas:hieptl-oss-9064-arm64
ghcr.io/openhands/agent-canvas:pr-16321-arm64
ghcr.io/openhands/agent-canvas:sha-8c3432b
ghcr.io/openhands/agent-canvas:hieptl-oss-9064
ghcr.io/openhands/agent-canvas:pr-16321
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-8c3432b`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-8c3432b-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->