### PR TITLE
docs: fix self-hosting link in DefenseClaw doc

### DIFF
--- a/docs/DefenseClaw.md
+++ b/docs/DefenseClaw.md
@@ -296,7 +296,7 @@ DefenseClaw's registry system (`defenseclaw registry add`) ingests external skil
 - [DefenseClaw CodeGuard Skill](https://github.com/cisco-ai-defense/defenseclaw/blob/main/skills/codeguard/SKILL.md)
 - [OpenHands Agent Server](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-agent-server)
 - [OpenHands SDK Security Analyzer](https://docs.openhands.dev/sdk/arch/security.md)
-- [Agent Canvas Self-Hosting](../SELF_HOSTING.md)
+- [Agent Canvas Self-Hosting](./SELF_HOSTING.md)
 
 ---
 


### PR DESCRIPTION
HUMAN:

Tested manually: opened `docs/DefenseClaw.md` on this branch and followed the "Agent Canvas Self-Hosting" link, which now resolves to `docs/SELF_HOSTING.md`. Verified against the repository tree that `docs/SELF_HOSTING.md` exists and there is no root-level `SELF_HOSTING.md`.

AGENT:

N/A - human-authored, documentation-only change (a single relative Markdown link in `docs/DefenseClaw.md`); no code paths are affected.

---

## Why

The "Agent Canvas Self-Hosting" link in `docs/DefenseClaw.md` points to `../SELF_HOSTING.md`, which resolves to a non-existent root-level `SELF_HOSTING.md` and 404s.

## Summary

- Fix the self-hosting link in `docs/DefenseClaw.md`: `../SELF_HOSTING.md` -> `./SELF_HOSTING.md` (the guide lives at `docs/SELF_HOSTING.md`, which `docs/README.md` already links the same way).

## Issue Number

N/A

## How to Test

Open `docs/DefenseClaw.md` on this branch and click the "Agent Canvas Self-Hosting" link; it resolves to `docs/SELF_HOSTING.md`. Confirm `docs/SELF_HOSTING.md` exists and there is no root-level `SELF_HOSTING.md`.

## Video/Screenshots

N/A - Markdown link fix, no UI change.
