### PR TITLE
chore: bump agent-server 1.40.1 and automation 1.6.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -492,10 +492,10 @@ When adding code that needs a new string, decide up front which rule it falls un
 - `scripts/dev-safe.mjs` uses `uvx` for temporary agent-server installation — no permanent `uv tool install` needed. Environment variables (highest precedence first):
   - `OH_AGENT_SERVER_LOCAL_PATH` — absolute path to a local `software-agent-sdk` checkout. Runs the local checkout via `uvx` with `--with-editable` for `openhands-sdk`/`openhands-tools`/`openhands-workspace` and `--reinstall` for `openhands-agent-server`, so SDK edits are picked up on restart. Highest precedence.
   - `OH_AGENT_SERVER_GIT_REF` — git commit SHA or branch name (takes precedence over version)
-  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.39.1")
+  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.40.1")
   - `OH_SECRET_KEY` — secret key for settings encryption; auto-generated and persisted to `~/.openhands/agent-canvas/secret-key.txt` on first run (same file Docker uses), ensuring dev mode and Docker share the same key when both mount the same `~/.openhands` directory. Override with the env var to pin a specific key.
   - `SESSION_API_KEY` / `OH_SESSION_API_KEYS_0` / `VITE_SESSION_API_KEY` — session API key for agent-server authentication; auto-generated using `crypto.randomBytes(32)` if not set, passed to both agent-server (`OH_SESSION_API_KEYS_0`) and frontend (`VITE_SESSION_API_KEY`)
-  - Default: released PyPI version `1.39.1` for agent-server SDK libraries
+  - Default: released PyPI version `1.40.1` for agent-server SDK libraries
 
 - Security: launchers generate and persist a 64-character session API key at `~/.openhands/agent-canvas/session-api-key.txt` unless overridden. The agent-server and automation backend share that session key. `OH_SECRET_KEY` protects settings encryption and is persisted separately at `~/.openhands/agent-canvas/secret-key.txt`.
 - `scripts/dev-safe.mjs` should fail fast if `uvx` cannot be spawned (for example missing PATH entries).

--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -389,18 +389,18 @@ describe("buildAgentServerCommand", () => {
     // Defaults to the released PyPI version with all SDK packages pinned to same version
     expect(cmd.args).toEqual([
       "--from",
-      "openhands-agent-server==1.39.1",
+      "openhands-agent-server==1.40.1",
       "--with",
-      "openhands-sdk==1.39.1",
+      "openhands-sdk==1.40.1",
       "--with",
-      "openhands-tools==1.39.1",
+      "openhands-tools==1.40.1",
       "--with",
-      "openhands-workspace==1.39.1",
+      "openhands-workspace==1.40.1",
       "--with",
       "agent-client-protocol<0.11",
       "agent-server",
     ]);
-    expect(cmd.source).toBe("PyPI (1.39.1, default)");
+    expect(cmd.source).toBe("PyPI (1.40.1, default)");
   });
 
   it("uses specific PyPI version when OH_AGENT_SERVER_VERSION is set with all packages pinned", () => {

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,9 +1,9 @@
 {
   "_comment": "Single source of truth for version pins, ports, paths, and defaults shared across the npm and Docker install paths. Read by scripts/dev-safe.mjs, scripts/dev-with-automation.mjs, docker/entrypoint.sh (via generated defaults.env), and .github/workflows/docker.yml.",
   "versions": {
-    "agentServer": "1.39.1",
+    "agentServer": "1.40.1",
     "agentCanvas": "1.9.0",
-    "automation": "1.5.0"
+    "automation": "1.6.0"
   },
   "compatibility": {
     "minimumAgentServer": "1.28.0"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -171,9 +171,6 @@ PIDS+=($!)
 # ── 2. Start Automation Server ───────────────────────────────────────────────
 log "Starting automation server on port $AUTOMATION_PORT..."
 
-# Disable the automation's own frontend — agent-canvas provides the UI.
-export AUTOMATION_FRONTEND_DIR=""
-
 # File storage — use local filesystem unless the user has configured cloud
 # storage.  Without FILE_STORE=local the automation backend may fall back
 # to a cloud provider (S3/GCS) which will fail without credentials, causing

--- a/scripts/check-sdk-version-sync.mjs
+++ b/scripts/check-sdk-version-sync.mjs
@@ -19,7 +19,7 @@
  *
  * Usage:
  *   node scripts/check-sdk-version-sync.mjs
- *   EXPECTED_SDK_VERSION=1.39.1 node scripts/check-sdk-version-sync.mjs
+ *   EXPECTED_SDK_VERSION=1.40.1 node scripts/check-sdk-version-sync.mjs
  *   node scripts/check-sdk-version-sync.mjs --check-pypi
  *
  * Environment variables:
@@ -78,7 +78,7 @@ Triggering from other repos:
     -H "Authorization: token \$GITHUB_TOKEN" \\
     -H "Accept: application/vnd.github.v3+json" \\
     https://api.github.com/repos/OpenHands/OpenHands/dispatches \\
-    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.39.1"}}'
+    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.40.1"}}'
 `);
   process.exit(0);
 }
@@ -260,9 +260,9 @@ async function fetchPyPIDependencies(packageName, version) {
  * Parse PyPI requires_dist array and extract SDK package versions
  *
  * PyPI returns dependencies in PEP 508 format like:
- *   "openhands-sdk>=1.39.1,<2.0.0"
- *   "openhands-tools==1.39.1"
- *   "openhands-workspace (>=1.39.1)"
+ *   "openhands-sdk>=1.40.1,<2.0.0"
+ *   "openhands-tools==1.40.1"
+ *   "openhands-workspace (>=1.40.1)"
  */
 function parseSdkVersionsFromRequiresDist(requiresDist) {
   const versions = {};
@@ -276,7 +276,7 @@ function parseSdkVersionsFromRequiresDist(requiresDist) {
       }
 
       // Extract the version number - look for patterns like:
-      // ">=1.39.1", "==1.39.1", "(>=1.39.1)", "~=1.39.1"
+      // ">=1.40.1", "==1.40.1", "(>=1.40.1)", "~=1.40.1"
       // After the package name and before any comma or closing paren
       const versionPattern = /[><=~!]+\s*([0-9]+(?:\.[0-9]+)*)/;
       const match = dep.match(versionPattern);

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -48,7 +48,7 @@ const LOCAL_AGENT_SERVER_SUBDIRS = [
   "openhands-workspace",
 ];
 const DEFAULT_AGENT_SERVER_VERSION = SHARED_DEFAULTS.versions.agentServer;
-// Temporary transitive-dep pin: openhands-sdk 1.39.1 leaves agent-client-protocol
+// Temporary transitive-dep pin: openhands-sdk 1.40.1 leaves agent-client-protocol
 // unbounded (>=0.10.1), but acp 0.11.0 reordered the ACP prompt() args and breaks
 // the SDK's ACP client. Hold acp <0.11 until a fixed SDK ships. See config/defaults.json.
 const AGENT_CLIENT_PROTOCOL_CONSTRAINT =
@@ -401,7 +401,7 @@ export function validateFrontendDependencies(
  *   edits are picked up without a manual reinstall. The agent-server itself
  *   is rebuilt from local source on each invocation (--reinstall).
  * - OH_AGENT_SERVER_GIT_REF: Git commit SHA or branch name
- * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.39.1")
+ * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.40.1")
  *
  * If none are set, defaults to the released version specified by
  * DEFAULT_AGENT_SERVER_VERSION. Set OH_AGENT_SERVER_GIT_REF to use a


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

I have verified the changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

<!-- Describe problem, motivation, etc. -->

Keep the agent-server SDK and automation backend pins current.

`openhands-automation==1.6.0` requires `openhands-sdk==1.40.1` and `openhands-workspace==1.40.1`, so the `versions.agentServer` and `versions.automation` pins in `config/defaults.json` — the single source of truth for the npm and Docker install paths — must move together to keep the `sdk-version-sync` CI check green.

One upstream change needs adaptation. `automation#284` retires the standalone automation SPA, deleting `Settings.frontend_dir` / `Settings.frontend_path` and the `_SPAStaticFiles` mount. The Docker entrypoint's `export AUTOMATION_FRONTEND_DIR=""` — and the comment explaining that agent-canvas provides the UI instead — now points at a feature that no longer exists, so it is dropped. It is a no-op either way (pydantic-settings never reads an undeclared env var, confirmed against the installed 1.6.0 package), so this is a clarity fix, not a behavior change.

Everything else upstream is additive and needs no adaptation:

* **`maxAutomationTimeoutSeconds` in capability discovery** (`automation#296`) — `DeploymentCapabilities` already declares the field as optional and `validateAutomationTimeout` already applies it as a ceiling. The deployment now actually reports it (1800s), so the client stops falling back to no ceiling, for free.
* **`cost` on `AutomationRunResponse**` (`automation#280` + `software-agent-sdk#4311`) — an extra JSON field on a response the client already parses.
* **`PATCH /api/settings` loading the profile's LLM when setting `active_profile**` (`software-agent-sdk#4319`) — a server-side fix to the contract the frontend already uses.

## Summary

<!-- 1-3 bullets describing what changed. -->
* Bump `versions.agentServer` `1.39.1` → `1.40.1` and `versions.automation` `1.5.0` → `1.6.0` in `config/defaults.json`.
* Drop the now-dead `export AUTOMATION_FRONTEND_DIR=""` from `docker/entrypoint.sh` — automation 1.6.0 removed the standalone frontend and the setting that hosted it (`automation#284`).
* Sync the version literals that track the `config/defaults.json` default: `AGENTS.md`, `scripts/dev-safe.mjs`, `scripts/check-sdk-version-sync.mjs`, and `__tests__/scripts/dev-safe.test.ts`.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

N/A.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

```bash
npm install

# 1. Confirm the automation release still pins the SDK line we expect (live PyPI check)
node scripts/check-sdk-version-sync.mjs   # expect "All SDK versions are in sync!"

# 2. Typecheck + lint + unit tests + both builds
npm run lint                              # expect clean
npm run test                              # expect 4372 passed, 5 skipped, 9 todo
npm run build
npm run build:lib

# 3. End-to-end: boot the real stack (uvx-installs openhands-agent-server==1.40.1
#    and runs openhands-automation==1.6.0)
npm run dev

# 4. In another shell, confirm the upgraded backends are serving traffic
KEY=$(tr -d '\n' < ~/.openhands/agent-canvas/api-key.txt)
curl -s http://localhost:8000/server_info | jq '{version, sdk_version, tools_version, workspace_version}'
curl -s -H "X-Session-API-Key: $KEY" http://localhost:8000/api/automation/v1
curl -s -H "X-Session-API-Key: $KEY" http://localhost:8000/api/automation/v1/capabilities | jq '.maxAutomationTimeoutSeconds'

# 5. Confirm the automation DB migrated (migration 013 adds the `cost` column)
sqlite3 ~/.openhands/automation/automations.db \
  'select * from alembic_version; pragma table_info(automation_runs);'

# 6. Then open http://localhost:8000/, start a conversation, and confirm it round-trips.

```

Results on this branch:

* `node scripts/check-sdk-version-sync.mjs` → `openhands-sdk ✓ 1.40.1`, `openhands-workspace ✓ 1.40.1`, **All SDK versions are in sync!**
* `npm run lint` → 0 errors. One `no-problems-reported` eslint-disable warning in `src/hooks/query/use-local-git-info.ts:136` is **pre-existing** — reproduced on a stashed tree at `main`.
* `npm test` → **Test Files 553 passed | 1 skipped (554)**, **Tests 4372 passed | 5 skipped | 9 todo (4386)**.
* `npm run build` and `npm run build:lib` → both succeed.
* `npx vitest run __tests__/scripts/` → 16 files, 224 tests passed (re-run after the `entrypoint.sh` edit).

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="798" alt="Screenshot 2026-08-05 at 16 34 35" src="https://github.com/user-attachments/assets/7b575331-c5bd-40b6-8544-355e0fc0e56a" />


## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.40.1-python` |
| **Automation** | `openhands-automation==1.6.0` |
| **Commit** | `f54a229241421e80afbd9398088142b910f11598` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-f54a229
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-f54a229
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-f54a229-amd64
ghcr.io/openhands/agent-canvas:hieptl-oss-9077-amd64
ghcr.io/openhands/agent-canvas:pr-16334-amd64
ghcr.io/openhands/agent-canvas:sha-f54a229-arm64
ghcr.io/openhands/agent-canvas:hieptl-oss-9077-arm64
ghcr.io/openhands/agent-canvas:pr-16334-arm64
ghcr.io/openhands/agent-canvas:sha-f54a229
ghcr.io/openhands/agent-canvas:hieptl-oss-9077
ghcr.io/openhands/agent-canvas:pr-16334
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-f54a229`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-f54a229-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->