### PR TITLE
fix: preserve workspace sessions across backend changes

### DIFF
--- a/__tests__/api/agent-server-conversation-service.test.ts
+++ b/__tests__/api/agent-server-conversation-service.test.ts
@@ -247,6 +247,40 @@ describe("AgentServerConversationService", () => {
         expect.anything(),
       );
     });
+
+    it("uses the conversation URL and session key for workspace resolution and download", async () => {
+      const encodedFile = new TextEncoder().encode("document").buffer;
+      mockHttpGet.mockImplementation((url: string) => {
+        if (url === "/api/conversations") {
+          return Promise.resolve({
+            data: [
+              {
+                id: "conv-123",
+                created_at: "2024-01-01",
+                updated_at: "2024-01-01",
+                workspace: { working_dir: "/workspace/project/conv-123" },
+              },
+            ],
+          });
+        }
+        return Promise.resolve({ data: encodedFile });
+      });
+
+      await AgentServerConversationService.readConversationFile(
+        "conv-123",
+        "/workspace/project/conv-123/document-viewer-test.md",
+        "http://conversation.example:8000",
+        "conversation-session-key",
+      );
+
+      const expectedClientOptions = {
+        host: "http://conversation.example:8000",
+        apiKey: "conversation-session-key",
+        workingDir: "/workspace/project/agent-canvas",
+      };
+      expect(ConversationClient).toHaveBeenCalledWith(expectedClientOptions);
+      expect(FileClient).toHaveBeenCalledWith(expectedClientOptions);
+    });
   });
 
   describe("createConversation", () => {

--- a/__tests__/hooks/query/use-workspace-file-content.test.tsx
+++ b/__tests__/hooks/query/use-workspace-file-content.test.tsx
@@ -49,6 +49,7 @@ vi.mock("#/api/cloud/conversation-service.api", () => ({
 }));
 
 const fetchMock = vi.fn();
+const refreshWorkspaceSessionMock = vi.fn();
 
 function makeWrapper() {
   const client = new QueryClient({
@@ -74,6 +75,9 @@ describe("useWorkspaceFileContent", () => {
     vi.stubGlobal("fetch", fetchMock);
     fetchMock.mockReset();
     useWorkspaceSessionMock.mockReset();
+    refreshWorkspaceSessionMock.mockReset().mockResolvedValue({
+      baseUrl: BASE_URL,
+    });
     useActiveConversationMock.mockReset();
     useRuntimeIsReadyMock.mockReset();
     getActiveBackendMock.mockReset();
@@ -92,6 +96,7 @@ describe("useWorkspaceFileContent", () => {
       isLoading: false,
       isError: false,
       error: null,
+      refresh: refreshWorkspaceSessionMock,
     });
     getActiveBackendMock.mockReturnValue({
       backend: { id: "local-1", kind: "local", host: "http://localhost:8000" },
@@ -269,6 +274,32 @@ describe("useWorkspaceFileContent", () => {
         message: "Failed to read missing.txt: 404",
       }),
     );
+  });
+
+  it("re-mints the workspace session and retries once after a 401", async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        arrayBuffer: () =>
+          Promise.resolve(arrayBufferFromString("# Recovered document")),
+      });
+
+    const { result } = renderHook(
+      () => useWorkspaceFileContent("conversation-log.md"),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(refreshWorkspaceSessionMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.current.data?.text).toBe("# Recovered document");
   });
 
   describe("cloud backend", () => {

--- a/__tests__/hooks/query/use-workspace-session.test.tsx
+++ b/__tests__/hooks/query/use-workspace-session.test.tsx
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
-import { callCloudProxy } from "#/api/cloud/proxy";
 import {
   joinWorkspaceUrl,
   useWorkspaceSession,
@@ -94,7 +93,11 @@ describe("useWorkspaceSession", () => {
   describe("local backend", () => {
     it("calls startWorkspaceSession and exposes the returned baseUrl", async () => {
       getActiveBackendMock.mockReturnValue({
-        backend: { id: "local-1", kind: "local", host: "http://localhost:8000" },
+        backend: {
+          id: "local-1",
+          kind: "local",
+          host: "http://localhost:8000",
+        },
       });
       useActiveConversationMock.mockReturnValue({
         data: {
@@ -125,8 +128,7 @@ describe("useWorkspaceSession", () => {
 
       expect(getAgentServerClientOptionsMock).toHaveBeenCalledTimes(1);
       expect(getAgentServerClientOptionsMock).toHaveBeenCalledWith({
-        conversationUrl:
-          "https://agent.example.com/api/conversations/conv-1",
+        conversationUrl: "https://agent.example.com/api/conversations/conv-1",
         sessionApiKey: "key-abc",
       });
       expect(RemoteWorkspace).toHaveBeenCalledTimes(1);
@@ -138,6 +140,49 @@ describe("useWorkspaceSession", () => {
       expect(startWorkspaceSessionMock).toHaveBeenCalledTimes(1);
       expect(startWorkspaceSessionMock).toHaveBeenCalledWith("conv-1");
       expect(callCloudProxyMock).not.toHaveBeenCalled();
+    });
+
+    it("re-mints the workspace session after switching local backends", async () => {
+      getActiveBackendMock.mockReturnValue({
+        backend: { id: "local-1", kind: "local", host: "http://one.example" },
+      });
+      useActiveConversationMock.mockReturnValue({
+        data: {
+          id: "conv-1",
+          conversation_url: "http://one.example",
+          session_api_key: "key-abc",
+        },
+      });
+      startWorkspaceSessionMock.mockResolvedValue(
+        "http://one.example/api/conversations/conv-1/workspace/",
+      );
+      getAgentServerClientOptionsMock.mockReturnValue({});
+
+      const { rerender } = renderHook(() => useWorkspaceSession(), {
+        wrapper: makeWrapper(),
+      });
+      await waitFor(() =>
+        expect(startWorkspaceSessionMock).toHaveBeenCalledTimes(1),
+      );
+
+      getActiveBackendMock.mockReturnValue({
+        backend: { id: "local-2", kind: "local", host: "http://two.example" },
+      });
+      useActiveConversationMock.mockReturnValue({
+        data: {
+          id: "conv-1",
+          conversation_url: "http://two.example",
+          session_api_key: "key-def",
+        },
+      });
+      startWorkspaceSessionMock.mockResolvedValue(
+        "http://two.example/api/conversations/conv-1/workspace/",
+      );
+      rerender();
+
+      await waitFor(() =>
+        expect(startWorkspaceSessionMock).toHaveBeenCalledTimes(2),
+      );
     });
   });
 
@@ -177,8 +222,7 @@ describe("useWorkspaceSession", () => {
     useActiveConversationMock.mockReturnValue({
       data: {
         id: "conv-1",
-        conversation_url:
-          "https://agent.example.com/api/conversations/conv-1",
+        conversation_url: "https://agent.example.com/api/conversations/conv-1",
         session_api_key: "key-abc",
       },
     });

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -508,8 +508,11 @@ class AgentServerConversationService {
     // `useUnifiedVSCodeUrl` + `useCloudSandbox`); the runtime's own
     // `/api/vscode/url` only knows its internal `localhost:8001`, which
     // the user's browser can't reach.
-    const workspaceDir =
-      await this.resolveConversationWorkingDir(conversationId);
+    const workspaceDir = await this.resolveConversationWorkingDir(
+      conversationId,
+      conversationUrl,
+      sessionApiKey,
+    );
     // Local mode: the typescript-client targets the local agent-server
     // directly via the conversationUrl override.
     const vscodeUrl = await new VSCodeClient(
@@ -528,15 +531,21 @@ class AgentServerConversationService {
 
   static async resolveConversationWorkingDir(
     conversationId: string,
+    conversationUrl?: string | null,
+    sessionApiKey?: string | null,
   ): Promise<string> {
-    const [conversation] = await this.batchGetAppConversations([
-      conversationId,
-    ]);
+    const [conversation] = await this.batchGetAppConversations(
+      [conversationId],
+      conversationUrl,
+      sessionApiKey,
+    );
     return conversation?.workspace?.working_dir ?? getAgentServerWorkingDir();
   }
 
   static async batchGetAppConversations(
     ids: string[],
+    conversationUrl?: string | null,
+    sessionApiKey?: string | null,
   ): Promise<(AppConversation | null)[]> {
     if (ids.length === 0) return [];
 
@@ -545,7 +554,7 @@ class AgentServerConversationService {
     }
 
     const data = await new ConversationClient(
-      getAgentServerClientOptions(),
+      getAgentServerClientOptions({ conversationUrl, sessionApiKey }),
     ).getConversations<DirectConversationInfo>(ids);
 
     return requireDirectConversationItems(data).map((item) =>
@@ -589,6 +598,8 @@ class AgentServerConversationService {
   static async readConversationFile(
     conversationId: string,
     filePath?: string,
+    conversationUrl?: string | null,
+    sessionApiKey?: string | null,
   ): Promise<string> {
     if (getActiveBackend().backend.kind === "cloud") {
       // Cloud exposes a per-conversation file endpoint; the sandbox
@@ -601,22 +612,32 @@ class AgentServerConversationService {
       return readCloudConversationFile(conversationId, path);
     }
 
-    const workingDir = await this.resolveConversationWorkingDir(conversationId);
+    const workingDir = await this.resolveConversationWorkingDir(
+      conversationId,
+      conversationUrl,
+      sessionApiKey,
+    );
     const path = requirePathInsideDirectory(
       filePath ?? `${workingDir}/.agents_tmp/PLAN.md`,
       workingDir,
     );
-    return new FileClient(getAgentServerClientOptions()).downloadTextFile(path);
+    return new FileClient(
+      getAgentServerClientOptions({ conversationUrl, sessionApiKey }),
+    ).downloadTextFile(path);
   }
 
-  static async downloadConversation(conversationId: string): Promise<Blob> {
+  static async downloadConversation(
+    conversationId: string,
+    conversationUrl?: string | null,
+    sessionApiKey?: string | null,
+  ): Promise<Blob> {
     if (getActiveBackend().backend.kind === "cloud") {
       return downloadCloudConversation(conversationId);
     }
 
-    return new FileClient(getAgentServerClientOptions()).downloadTrajectory(
-      conversationId,
-    );
+    return new FileClient(
+      getAgentServerClientOptions({ conversationUrl, sessionApiKey }),
+    ).downloadTrajectory(conversationId);
   }
 
   static async getHooks(conversationId: string): Promise<GetHooksResponse> {

--- a/src/contexts/conversation-websocket-context.tsx
+++ b/src/contexts/conversation-websocket-context.tsx
@@ -427,6 +427,10 @@ export function ConversationWebSocketProvider({
         {
           conversationId: currentPlanningConversationId,
           filePath: path,
+          conversationUrl:
+            subConversations?.[0]?.conversation_url ?? conversationUrl,
+          sessionApiKey:
+            subConversations?.[0]?.session_api_key ?? sessionApiKey,
         },
         {
           onSuccess: (fileContent) => {
@@ -441,7 +445,14 @@ export function ConversationWebSocketProvider({
       // Clear the ref after calling the API
       latestPlanningFileEventRef.current = null;
     }
-  }, [isLoadingHistoryPlanning, readConversationFile, setPlanContent]);
+  }, [
+    isLoadingHistoryPlanning,
+    readConversationFile,
+    setPlanContent,
+    subConversations,
+    conversationUrl,
+    sessionApiKey,
+  ]);
 
   useEffect(() => {
     hasConnectedRefMain.current = false;
@@ -810,6 +821,12 @@ export function ConversationWebSocketProvider({
                     {
                       conversationId: planningConversationId,
                       filePath: path,
+                      conversationUrl:
+                        planningAgentConversation.conversation_url ??
+                        conversationUrl,
+                      sessionApiKey:
+                        planningAgentConversation.session_api_key ??
+                        sessionApiKey,
                     },
                     {
                       onSuccess: (fileContent) => {
@@ -840,6 +857,8 @@ export function ConversationWebSocketProvider({
       consumeMatchingPendingMessage,
       queryClient,
       subConversations,
+      conversationUrl,
+      sessionApiKey,
       conversationId,
       setExecutionStatus,
       appendInput,

--- a/src/hooks/mutation/use-read-conversation-file.ts
+++ b/src/hooks/mutation/use-read-conversation-file.ts
@@ -4,6 +4,8 @@ import AgentServerConversationService from "#/api/conversation-service/agent-ser
 interface UseReadConversationFileVariables {
   conversationId: string;
   filePath?: string;
+  conversationUrl?: string | null;
+  sessionApiKey?: string | null;
 }
 
 export const useReadConversationFile = () =>
@@ -12,9 +14,13 @@ export const useReadConversationFile = () =>
     mutationFn: async ({
       conversationId,
       filePath,
+      conversationUrl,
+      sessionApiKey,
     }: UseReadConversationFileVariables): Promise<string> =>
       AgentServerConversationService.readConversationFile(
         conversationId,
         filePath,
+        conversationUrl,
+        sessionApiKey,
       ),
   });

--- a/src/hooks/query/use-workspace-file-content.ts
+++ b/src/hooks/query/use-workspace-file-content.ts
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { readCloudConversationFile } from "#/api/cloud/conversation-service.api";
@@ -142,7 +143,10 @@ function arrayBufferToBase64(buffer: ArrayBuffer): string {
 export function useWorkspaceFileContent(relativePath: string | null) {
   const { data: conversation } = useActiveConversation();
   const runtimeIsReady = useRuntimeIsReady();
-  const { data: workspaceSession } = useWorkspaceSession();
+  const { data: workspaceSession, refresh: refreshWorkspaceSession } =
+    useWorkspaceSession();
+  const refreshWorkspaceSessionRef = useRef(refreshWorkspaceSession);
+  refreshWorkspaceSessionRef.current = refreshWorkspaceSession;
   // Bump on every agent-side file mutation so the query refetches the
   // currently-selected file's body even when the *path* hasn't changed.
   // The iframe / <img> cache-busting for the rich preview is handled at
@@ -172,6 +176,8 @@ export function useWorkspaceFileContent(relativePath: string | null) {
     ? `${workspaceRoot}/${relativePath}`
     : null;
 
+  // The ref supplies a stable callback for one-time 401 recovery; it is not
+  // cache identity and therefore must not be a query-key member.
   return useQuery<WorkspaceFileContent>({
     queryKey: [
       "workspace-file-content",
@@ -263,9 +269,18 @@ export function useWorkspaceFileContent(relativePath: string | null) {
       // (it travels because we opt in to credentialed requests). This
       // matches the auth path the iframe / <img> uses, and avoids a CORS
       // preflight for a custom header.
-      const response = await fetch(staticUrl, {
+      let response = await fetch(staticUrl, {
         credentials: "include",
       });
+      // A browser may have discarded the partitioned workspace cookie (for
+      // example after a context change), while React Query still holds the
+      // successful mint result. Re-mint once and retry the same request.
+      if (response.status === 401) {
+        await refreshWorkspaceSessionRef.current();
+        response = await fetch(staticUrl, {
+          credentials: "include",
+        });
+      }
       if (!response.ok) {
         throw new Error(`Failed to read ${relativePath}: ${response.status}`);
       }

--- a/src/hooks/query/use-workspace-session.ts
+++ b/src/hooks/query/use-workspace-session.ts
@@ -48,6 +48,7 @@ export function useWorkspaceSession(): {
   isLoading: boolean;
   isError: boolean;
   error: Error | null;
+  refresh: () => Promise<WorkspaceSession | null>;
 } {
   const { data: conversation } = useActiveConversation();
   const runtimeIsReady = useRuntimeIsReady();
@@ -55,13 +56,16 @@ export function useWorkspaceSession(): {
   const conversationId = conversation?.id;
   const conversationUrl = conversation?.conversation_url;
   const sessionApiKey = conversation?.session_api_key;
-  const isLocal = getActiveBackend().backend.kind === "local";
+  const activeBackend = getActiveBackend().backend;
+  const isLocal = activeBackend.kind === "local";
 
   const enabled = runtimeIsReady && !!conversationId && isLocal;
 
   const query = useQuery<WorkspaceSession>({
     queryKey: [
       "workspace-session",
+      activeBackend.id,
+      activeBackend.host,
       conversationId,
       conversationUrl,
       sessionApiKey,
@@ -91,6 +95,11 @@ export function useWorkspaceSession(): {
     isLoading: query.isLoading,
     isError: query.isError,
     error: (query.error as Error | null) ?? null,
+    refresh: async () => {
+      const result = await query.refetch();
+      if (result.error) throw result.error;
+      return result.data ?? null;
+    },
   };
 }
 


### PR DESCRIPTION
HUMAN:
Please review this focused workspace session recovery fix.

AGENT:
## Summary
- Key workspace-session queries and retries by backend identity.
- Refreshes the current backend session once after the first authenticated file-read failure, then retries once without looping.
- Adds focused coverage for backend isolation and workspace file-content recovery.

## Why
Workspace file reads can retain a stale session when the selected backend changes. After an authenticated file-read failure, the UI should refresh that backend-specific session once and retry once rather than reusing another backend session or retrying indefinitely.

## How to Test
- Run i18n generation, typecheck, and ESLint/Prettier for changed files.
- Run the 54 focused tests covering conversation service, workspace-session, and workspace-file-content behavior.
- In Canvas, select a workspace, open the File panel, and switch between backends; confirm file access obtains the current backend session.
- Simulate a first 401 and confirm exactly one refresh/retry; confirm a second 401 or refresh failure surfaces an error without looping.

## Video/Screenshots
Production Canvas File panel with the File tab selected. The capture is cropped to the panel controls and contains no workspace paths, file contents, conversation content, or credentials.

![Canvas File panel with File selected](https://raw.githubusercontent.com/QutritSystems/OpenHands/pr-assets/screenshots/workspace-file-panel-selected.png)

## Warp context
- Conversation: https://app.warp.dev/conversation/82cf2096-d62c-4227-9889-7e1a7d7f99b8
- Upgrade plan: https://app.warp.dev/drive/notebook/O9hfZZT5OYgPZGULG3HoHz

Co-Authored-By: Oz <oz-agent@warp.dev>