### PR TITLE
fix: configure agent-server telemetry in Canvas launchers

### DIFF
--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -20,6 +20,8 @@ import {
   buildSafeDevConfigAsync,
   buildNpmScriptCommand,
   buildAgentServerCommand,
+  buildAgentServerEnv,
+  buildAgentServerTelemetryEnv,
   buildRuntimeServicesInfo,
   formatMissingUvxGuidance,
   formatMissingFrontendDependenciesGuidance,
@@ -381,6 +383,76 @@ describe("formatMissingUvxGuidance", () => {
   });
 });
 
+describe("buildAgentServerTelemetryEnv", () => {
+  it("configures PostHog telemetry by default without seeding consent", () => {
+    expect(buildAgentServerTelemetryEnv({})).toEqual({
+      OH_TELEMETRY_EXPORTER: "posthog",
+      OH_TELEMETRY_POSTHOG_API_KEY:
+        "phc_kBtz5nKmxVRRQ7HtPwr2QX9eMC5j65zE86QKocVNwb4U",
+      OH_TELEMETRY_POSTHOG_HOST: "https://us.i.posthog.com",
+    });
+  });
+
+  it("prefers explicit agent-server telemetry settings", () => {
+    expect(
+      buildAgentServerTelemetryEnv({
+        OH_TELEMETRY_EXPORTER: "http",
+        OH_TELEMETRY_CONSENT: "denied",
+        OH_TELEMETRY_POSTHOG_API_KEY: "phc_agent",
+        OH_TELEMETRY_POSTHOG_HOST: "https://agent.example",
+        VITE_POSTHOG_API_KEY: "phc_frontend",
+        VITE_POSTHOG_HOST: "https://frontend.example",
+      }),
+    ).toEqual({
+      OH_TELEMETRY_EXPORTER: "http",
+      OH_TELEMETRY_CONSENT: "denied",
+      OH_TELEMETRY_POSTHOG_API_KEY: "phc_agent",
+      OH_TELEMETRY_POSTHOG_HOST: "https://agent.example",
+    });
+  });
+
+  it("uses frontend telemetry settings when agent-server settings are absent", () => {
+    expect(
+      buildAgentServerTelemetryEnv({
+        VITE_POSTHOG_API_KEY: "phc_frontend",
+        VITE_POSTHOG_HOST: "https://frontend.example",
+      }),
+    ).toEqual({
+      OH_TELEMETRY_EXPORTER: "posthog",
+      OH_TELEMETRY_POSTHOG_API_KEY: "phc_frontend",
+      OH_TELEMETRY_POSTHOG_HOST: "https://frontend.example",
+    });
+  });
+
+  it("maps frontend do-not-track to the agent-server kill switch", () => {
+    expect(buildAgentServerTelemetryEnv({ VITE_DO_NOT_TRACK: "1" })).toEqual({
+      DO_NOT_TRACK: "1",
+    });
+  });
+
+  it("includes telemetry defaults in the full agent-server environment", () => {
+    const env = buildAgentServerEnv(
+      {
+        tmuxTmpDir: "/tmp/tmux",
+        stateDir: "/tmp/state",
+        conversationsPath: "/tmp/conversations",
+        bashEventsDir: "/tmp/bash-events",
+        vscodePort: 19000,
+        secretKey: "secret",
+        sessionApiKey: "session",
+        backendBaseUrl: "http://127.0.0.1:18000",
+        canvasToolsDir: "/tmp/tools",
+      },
+      {},
+    );
+
+    expect(env).toMatchObject({
+      OH_TELEMETRY_EXPORTER: "posthog",
+      OH_SESSION_API_KEYS_0: "session",
+    });
+  });
+});
+
 describe("buildAgentServerCommand", () => {
   it("uses released PyPI version by default with all packages pinned", () => {
     const cmd = buildAgentServerCommand({});
@@ -398,6 +470,8 @@ describe("buildAgentServerCommand", () => {
       "openhands-workspace==1.40.1",
       "--with",
       "agent-client-protocol<0.11",
+      "--with",
+      "posthog>=6,<7",
       "agent-server",
     ]);
     expect(cmd.source).toBe("PyPI (1.40.1, default)");
@@ -420,6 +494,8 @@ describe("buildAgentServerCommand", () => {
       "openhands-workspace==1.18.0",
       "--with",
       "agent-client-protocol<0.11",
+      "--with",
+      "posthog>=6,<7",
       "agent-server",
     ]);
     expect(cmd.source).toBe("PyPI (1.18.0)");
@@ -441,6 +517,8 @@ describe("buildAgentServerCommand", () => {
       "git+https://github.com/OpenHands/software-agent-sdk@feature-branch#subdirectory=openhands-tools",
       "--with",
       "git+https://github.com/OpenHands/software-agent-sdk@feature-branch#subdirectory=openhands-workspace",
+      "--with",
+      "posthog>=6,<7",
       "agent-server",
     ]);
     expect(cmd.source).toBe("git (feature-branch)");
@@ -460,6 +538,8 @@ describe("buildAgentServerCommand", () => {
       "git+https://github.com/OpenHands/software-agent-sdk@abc1234#subdirectory=openhands-tools",
       "--with",
       "git+https://github.com/OpenHands/software-agent-sdk@abc1234#subdirectory=openhands-workspace",
+      "--with",
+      "posthog>=6,<7",
       "agent-server",
     ]);
     expect(cmd.source).toBe("git (abc1234)");
@@ -494,6 +574,8 @@ describe("buildAgentServerCommand", () => {
       path.join(sdk, "openhands-tools"),
       "--with-editable",
       path.join(sdk, "openhands-workspace"),
+      "--with",
+      "posthog>=6,<7",
       "agent-server",
     ]);
     expect(cmd.source).toBe(`local (${sdk})`);

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -125,6 +125,30 @@ if [ -n "${AUTOMATION_POSTHOG_API_KEY:-}" ]; then
   export AUTOMATION_POSTHOG_HOST="${AUTOMATION_POSTHOG_HOST:-${VITE_POSTHOG_HOST:-${CONFIG_POSTHOG_HOST:-}}}"
 fi
 
+# Configure product analytics for the agent-server. The SDK uses its own
+# OH_TELEMETRY_* variables, so mirror the same Canvas/PostHog defaults used by
+# the frontend and automation backend while preserving explicit operator
+# overrides. Consent stays in persisted settings, where the backend/UI owns it.
+if [ "${VITE_DO_NOT_TRACK:-}" = "1" ]; then
+  export DO_NOT_TRACK="${DO_NOT_TRACK:-1}"
+fi
+
+if [ -z "${OH_TELEMETRY_POSTHOG_API_KEY:-}" ]; then
+  if [ -n "${VITE_POSTHOG_API_KEY:-}" ]; then
+    export OH_TELEMETRY_POSTHOG_API_KEY="$VITE_POSTHOG_API_KEY"
+  elif [ "${DO_NOT_TRACK:-}" != "1" ]; then
+    export OH_TELEMETRY_POSTHOG_API_KEY="${CONFIG_POSTHOG_API_KEY:-}"
+  fi
+fi
+
+if [ -z "${OH_TELEMETRY_EXPORTER:-}" ] && [ -n "${OH_TELEMETRY_POSTHOG_API_KEY:-}" ]; then
+  export OH_TELEMETRY_EXPORTER="posthog"
+fi
+
+if [ "${OH_TELEMETRY_EXPORTER:-}" = "posthog" ] && [ -n "${OH_TELEMETRY_POSTHOG_API_KEY:-}" ]; then
+  export OH_TELEMETRY_POSTHOG_HOST="${OH_TELEMETRY_POSTHOG_HOST:-${VITE_POSTHOG_HOST:-${CONFIG_POSTHOG_HOST:-}}}"
+fi
+
 # AGENT_SERVER_URL — needed by automation sandbox callbacks.
 export AGENT_SERVER_URL="${AGENT_SERVER_URL:-http://127.0.0.1:${AGENT_SERVER_PORT}}"
 

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -53,6 +53,11 @@ const DEFAULT_AGENT_SERVER_VERSION = SHARED_DEFAULTS.versions.agentServer;
 // the SDK's ACP client. Hold acp <0.11 until a fixed SDK ships. See config/defaults.json.
 const AGENT_CLIENT_PROTOCOL_CONSTRAINT =
   SHARED_DEFAULTS.constraints?.agentClientProtocol;
+const DEFAULT_AGENT_SERVER_TELEMETRY_POSTHOG_API_KEY =
+  SHARED_DEFAULTS.telemetry.posthogApiKey;
+const DEFAULT_AGENT_SERVER_TELEMETRY_POSTHOG_HOST =
+  SHARED_DEFAULTS.telemetry.posthogHost;
+const AGENT_SERVER_POSTHOG_CONSTRAINT = "posthog>=6,<7";
 const FRONTEND_REQUIRED_BINS = ["cross-env", "react-router"];
 
 /**
@@ -434,6 +439,8 @@ export function buildAgentServerCommand(env = process.env) {
       path.join(localPath, "openhands-tools"),
       "--with-editable",
       path.join(localPath, "openhands-workspace"),
+      "--with",
+      AGENT_SERVER_POSTHOG_CONSTRAINT,
       "agent-server",
     );
     source = `local (${localPath})`;
@@ -458,6 +465,8 @@ export function buildAgentServerCommand(env = process.env) {
       `${baseGitUrl}#subdirectory=openhands-tools`,
       "--with",
       `${baseGitUrl}#subdirectory=openhands-workspace`,
+      "--with",
+      AGENT_SERVER_POSTHOG_CONSTRAINT,
       "agent-server",
     );
     source = `git (${gitRef})`;
@@ -478,6 +487,7 @@ export function buildAgentServerCommand(env = process.env) {
     if (AGENT_CLIENT_PROTOCOL_CONSTRAINT) {
       uvxArgs.push("--with", AGENT_CLIENT_PROTOCOL_CONSTRAINT);
     }
+    uvxArgs.push("--with", AGENT_SERVER_POSTHOG_CONSTRAINT);
     uvxArgs.push("agent-server");
     source = `PyPI (${version})`;
   } else {
@@ -496,6 +506,7 @@ export function buildAgentServerCommand(env = process.env) {
     if (AGENT_CLIENT_PROTOCOL_CONSTRAINT) {
       uvxArgs.push("--with", AGENT_CLIENT_PROTOCOL_CONSTRAINT);
     }
+    uvxArgs.push("--with", AGENT_SERVER_POSTHOG_CONSTRAINT);
     uvxArgs.push("agent-server");
     source = `PyPI (${DEFAULT_AGENT_SERVER_VERSION}, default)`;
   }
@@ -685,8 +696,52 @@ function buildConfigFromPorts(ports, cwd, env) {
  * @param {ReturnType<typeof buildSafeDevConfig>} config - Config from buildSafeDevConfig
  * @returns {Record<string, string>} Environment variables for agent-server
  */
-export function buildAgentServerEnv(config) {
+export function buildAgentServerTelemetryEnv(env = process.env) {
+  const telemetryDisabled =
+    env.VITE_DO_NOT_TRACK === "1" || env.DO_NOT_TRACK === "1";
+  const result = {};
+
+  for (const key of [
+    "OH_TELEMETRY_EXPORTER",
+    "OH_TELEMETRY_POSTHOG_API_KEY",
+    "OH_TELEMETRY_POSTHOG_HOST",
+    "OH_TELEMETRY_HTTP_ENDPOINT",
+    "OH_TELEMETRY_HTTP_TOKEN",
+    "OH_TELEMETRY_CONSENT",
+    "OH_TELEMETRY_CONSENT_MODE",
+    "OH_TELEMETRY_SALT",
+  ]) {
+    if (env[key]) result[key] = env[key];
+  }
+
+  if (telemetryDisabled) {
+    result.DO_NOT_TRACK = "1";
+  }
+
+  const apiKey =
+    env.OH_TELEMETRY_POSTHOG_API_KEY ||
+    env.VITE_POSTHOG_API_KEY ||
+    (telemetryDisabled ? "" : DEFAULT_AGENT_SERVER_TELEMETRY_POSTHOG_API_KEY);
+  const exporter = env.OH_TELEMETRY_EXPORTER || (apiKey ? "posthog" : "");
+
+  if (exporter) {
+    result.OH_TELEMETRY_EXPORTER = exporter;
+  }
+
+  if (exporter === "posthog" && apiKey) {
+    result.OH_TELEMETRY_POSTHOG_API_KEY = apiKey;
+    result.OH_TELEMETRY_POSTHOG_HOST =
+      env.OH_TELEMETRY_POSTHOG_HOST ||
+      env.VITE_POSTHOG_HOST ||
+      DEFAULT_AGENT_SERVER_TELEMETRY_POSTHOG_HOST;
+  }
+
+  return result;
+}
+
+export function buildAgentServerEnv(config, env = process.env) {
   return {
+    ...buildAgentServerTelemetryEnv(env),
     // Force Python to use UTF-8 for all file I/O and streams.
     //
     // On Windows, Python defaults to the system ANSI codepage (e.g. cp1252).


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

- [x] A human has tested these changes.

I've tested that the events come through for agent server as expected now.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

Implemented and verified the Canvas launcher telemetry wiring for agent-server configuration paths. I confirmed from `OpenHands/software-agent-sdk` that a newly-created conversation emits `agent_server.conversation_started` through `TelemetrySubscriber.emit_started()` when the conversation telemetry subscriber is attached for a new conversation.

Commands run:

```bash
npm test -- __tests__/scripts/dev-safe.test.ts __tests__/scripts/dev-with-automation.test.ts __tests__/scripts/dev-static.test.ts
```

Result: 3 test files passed, 105 tests passed.

```bash
npm run lint
```

Result: passed. Existing warning remains in `src/hooks/query/use-local-git-info.ts` for an unused eslint-disable directive; no errors.

---

## Why

Agent Canvas already configures PostHog for the browser frontend and automation backend, but the Python agent-server uses its own SDK telemetry variables. Without those variables and the PostHog dependency in the `uvx` environment, agent-server product analytics cannot emit even after local analytics consent is granted through settings.

## Summary

- Configure agent-server `OH_TELEMETRY_*` transport env vars from Canvas launch defaults in Node launchers and Docker entrypoint.
- Add the agent-server PostHog dependency to `uvx` launch commands so the SDK PostHog exporter can import successfully.
- Keep consent owned by persisted backend/UI settings rather than seeding local consent via env; preserve explicit operator-provided telemetry envs and `DO_NOT_TRACK` behavior.
- Add regression coverage for agent-server telemetry launcher env behavior and updated `uvx` command construction.

## Issue Number

N/A

## How to Test

Run:

```bash
npm ci
npm test -- __tests__/scripts/dev-safe.test.ts __tests__/scripts/dev-with-automation.test.ts __tests__/scripts/dev-static.test.ts
npm run lint
```

For manual verification, start a local Canvas stack, grant analytics in the UI, create a conversation, and confirm the agent-server logs initialize telemetry with the PostHog exporter. A new conversation should emit the SDK event `agent_server.conversation_started` once consent is granted and the exporter is configured.

## Video/Screenshots

<img width="2430" height="274" alt="image" src="https://github.com/user-attachments/assets/1cd1a2a8-fb61-42b1-a379-f9fedd51e07c" />


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR was created by an AI agent (OpenHands) on behalf of the user.

Consent is intentionally not forced via `OH_TELEMETRY_CONSENT` for local launches. The agent-server reads consent from persisted settings metadata (`misc_settings.telemetry.consent`) and also supports Canvas's legacy `misc_settings.app_preferences.user_consents_to_analytics` fallback.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/37513bfc-6960-4c76-a1d2-fb9108ae8614)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.40.1-python` |
| **Automation** | `openhands-automation==1.6.0` |
| **Commit** | `c9fc72af46d4bbe6118c269403fc085bda586f60` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-c9fc72a
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-c9fc72a
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-c9fc72a-amd64
ghcr.io/openhands/agent-canvas:agent-server-telemetry-launch-env-amd64
ghcr.io/openhands/agent-canvas:pr-16348-amd64
ghcr.io/openhands/agent-canvas:sha-c9fc72a-arm64
ghcr.io/openhands/agent-canvas:agent-server-telemetry-launch-env-arm64
ghcr.io/openhands/agent-canvas:pr-16348-arm64
ghcr.io/openhands/agent-canvas:sha-c9fc72a
ghcr.io/openhands/agent-canvas:agent-server-telemetry-launch-env
ghcr.io/openhands/agent-canvas:pr-16348
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-c9fc72a`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-c9fc72a-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->