### PR TITLE
feat: show per-run LLM cost in the Activity Log and exports

### DIFF
--- a/__tests__/components/automations/detail/activity-log-item.test.tsx
+++ b/__tests__/components/automations/detail/activity-log-item.test.tsx
@@ -233,3 +233,58 @@ describe("ActivityLogItem — timestamp fallback", () => {
     expect(container.textContent).not.toContain("2030");
   });
 });
+
+describe("ActivityLogItem — run cost", () => {
+  beforeEach(() => {
+    __resetActiveStoreForTests();
+    setRegisteredBackends([localBackend]);
+    setActiveSelection({ backendId: localBackend.id });
+  });
+
+  afterEach(() => {
+    __resetActiveStoreForTests();
+  });
+
+  it("shows the accumulated LLM cost reported for the run", () => {
+    // Arrange
+    const run = makeRun({ cost: 0.4213 });
+
+    // Act
+    renderItem(run);
+
+    // Assert
+    expect(screen.getByText("$0.4213")).toBeInTheDocument();
+  });
+
+  it("shows a measured zero cost instead of hiding it", () => {
+    // Arrange: the service stores 0 only when the SDK reported a real
+    // zero-cost run, so it must stay distinguishable from an unknown cost.
+    const run = makeRun({ cost: 0 });
+
+    // Act
+    renderItem(run);
+
+    // Assert
+    expect(screen.getByText("$0.0000")).toBeInTheDocument();
+  });
+
+  // `null` is a run whose cost the service could not determine (cancelled,
+  // watchdog timeout, or predating cost tracking); `undefined` is an
+  // automation service too old to send the field at all. Neither has a cost
+  // to show.
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+  ])("shows no cost when the reported cost is %s", (_label, cost) => {
+    // Arrange
+    const run = makeRun({ cost });
+
+    // Act
+    renderItem(run);
+
+    // Assert
+    expect(
+      screen.queryByText((content) => content.startsWith("$")),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/utils/automation-activity-log-export.test.ts
+++ b/__tests__/utils/automation-activity-log-export.test.ts
@@ -56,6 +56,7 @@ const sampleRow = (
   conversation_id: "c1",
   conversation_url: "http://localhost:8000/conversations/c1",
   error: "boom",
+  cost: null,
   ...overrides,
 });
 
@@ -87,6 +88,29 @@ describe("automation-activity-log-export", () => {
         "http://localhost:8000",
       ),
     ).toEqual(sampleRow());
+  });
+
+  it("carries the run's accumulated cost into the export row", () => {
+    // Arrange
+    const run = sampleRun({ cost: 0.4213 });
+
+    // Act
+    const row = mapAutomationRunToExportRow(run, automation);
+
+    // Assert
+    expect(row.cost).toBe(0.4213);
+  });
+
+  it("serializes the cost as a raw number so spreadsheets can total it", () => {
+    // Arrange
+    const rows: AutomationRunExportRow[] = [sampleRow({ cost: 0.4213 })];
+
+    // Act
+    const csv = serializeActivityLogRowsCsv(rows);
+
+    // Assert
+    expect(csv.split("\n")[0]).toContain("cost");
+    expect(csv.split("\n")[1]).toContain("0.4213");
   });
 
   it("serializes CSV with conversation URL and escaped fields", () => {

--- a/src/components/features/automations/detail/activity-log-item.tsx
+++ b/src/components/features/automations/detail/activity-log-item.tsx
@@ -38,6 +38,19 @@ function getConversationUrl(conversationId: string): string {
   return `/conversations/${conversationId}`;
 }
 
+/**
+ * Format the run's accumulated LLM cost, or return null when it is unknown.
+ *
+ * A genuine `0` is rendered (`$0.0000`) rather than hidden: the automation
+ * service records zero only when the SDK reported a real zero-cost run, and
+ * leaves the value null when the cost could not be determined. Matches the
+ * 4-decimal USD convention used by the conversation metrics modal.
+ */
+function formatRunCost(cost: number | null | undefined): string | null {
+  if (typeof cost !== "number" || !Number.isFinite(cost)) return null;
+  return `$${cost.toFixed(4)}`;
+}
+
 export function ActivityLogItem({ run, automation }: ActivityLogItemProps) {
   const { t, i18n } = useTranslation("openhands");
   const hasConversation = !!run.conversation_id;
@@ -65,6 +78,7 @@ export function ActivityLogItem({ run, automation }: ActivityLogItemProps) {
     effectiveStartedAt,
     i18n.language,
   );
+  const formattedCost = formatRunCost(run.cost);
 
   const handleLogsClick = (
     e:
@@ -103,6 +117,15 @@ export function ActivityLogItem({ run, automation }: ActivityLogItemProps) {
         )}
       </div>
       <div className="flex items-center gap-2">
+        {formattedCost && (
+          <span
+            data-testid="run-cost"
+            title={t(I18nKey.AUTOMATIONS$DETAIL$RUN_COST)}
+            className="text-xs tabular-nums text-muted"
+          >
+            {formattedCost}
+          </span>
+        )}
         {logsButton}
         <RunStatusBadge status={run.status} />
       </div>

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -14092,6 +14092,23 @@
     "uk": "Журнал активності",
     "ca": "Registre d'activitat"
   },
+  "AUTOMATIONS$DETAIL$RUN_COST": {
+    "en": "Cost",
+    "ja": "コスト",
+    "zh-CN": "成本",
+    "zh-TW": "成本",
+    "ko-KR": "비용",
+    "no": "Kostnad",
+    "it": "Costo",
+    "pt": "Custo",
+    "es": "Costo",
+    "ar": "التكلفة",
+    "fr": "Coût",
+    "tr": "Maliyet",
+    "de": "Kosten",
+    "uk": "Вартість",
+    "ca": "Cost"
+  },
   "AUTOMATIONS$DETAIL$BACK_TO_LIST": {
     "en": "Back to Automations",
     "ja": "オートメーション一覧に戻る",

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -85,6 +85,14 @@ export interface AutomationRun {
    */
   bash_command_id: string | null;
   error_detail: string | null;
+  /**
+   * Accumulated LLM cost of the run in USD, reported by the SDK in the
+   * completion callback. `null` means unknown — the run predates cost
+   * tracking, or ended without a callback (cancelled, watchdog timeout).
+   * Absent entirely when the automation service is older than the release
+   * that added the field, hence optional.
+   */
+  cost?: number | null;
   started_at: string;
   completed_at: string | null;
 }
@@ -109,4 +117,10 @@ export interface AutomationRunExportRow {
   conversation_id: string | null;
   conversation_url: string | null;
   error: string | null;
+  /**
+   * Accumulated LLM cost in USD, or null when unknown. Unlike
+   * `AutomationRun["cost"]` this is always present: the row normalizes a
+   * missing field to null so every exported record has the same shape.
+   */
+  cost: number | null;
 }

--- a/src/utils/automation-activity-log-export.ts
+++ b/src/utils/automation-activity-log-export.ts
@@ -21,6 +21,9 @@ const CSV_COLUMNS = [
   "conversation_id",
   "conversation_url",
   "error",
+  // Appended rather than grouped with the other run metrics so existing
+  // consumers that read the CSV by column position keep working.
+  "cost",
 ] as const;
 
 export function getActivityLogExportFilename(
@@ -98,6 +101,9 @@ export function mapAutomationRunToExportRow(
       conversationBaseUrl,
     ),
     error: run.error_detail,
+    // Exports carry the raw number and leave formatting to the consumer; the
+    // Activity Log row is the only place that renders it as USD.
+    cost: run.cost ?? null,
   };
 }
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

I have verified the changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

<!-- Describe problem, motivation, etc. -->

Automation runs now carry a cost. `automation#280` added the `cost` column and exposed it on `AutomationRunResponse`, and `software-agent-sdk#4311` made the SDK report the accumulated LLM spend in its completion callback. The Activity Log still showed only a timestamp and a status badge, so the number the backend had just started recording was invisible — users could not see what an automation costs, spot an expensive one, or total spend across runs.

The conversation-level cost already has a home in the metrics modal (`cost-section.tsx`); the per-run automation cost had none. This adds it, on screen and in the exports.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Render each run's accumulated LLM cost beside its status badge in the Activity Log, reusing the 4-decimal USD format already used by the conversation metrics modal.
- Include `cost` in the Activity Log CSV and JSON exports as a raw number, so a spreadsheet can sum or chart it. It is appended as the final CSV column, leaving existing column positions untouched.
- Add `cost` to the `AutomationRun` type as **optional** — an automation service older than the release that added the field omits it rather than sending `null`, and the GUI can be pointed at a cloud backend that has not rolled it out yet. The export row normalizes the missing case to `null` so every exported record has the same shape.
- Keep "measured zero" and "unknown" distinct: `0` renders as `$0.0000`, `null`/absent renders nothing. The SDK goes out of its way to leave cost unreported when it cannot be determined, so collapsing the two would throw away that signal and make a free run look untracked.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

N/A.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

**Unit tests** — 6 new tests, added to the two existing suites:

```bash
npx vitest run __tests__/components/automations/detail/activity-log-item.test.tsx -t "run cost"
# Tests  4 passed | 8 skipped (12)

npx vitest run __tests__/utils/automation-activity-log-export.test.ts
# Tests  9 passed (9)

```

Red/green verified explicitly for both. Reverting `activity-log-item.tsx` fails the two rendering tests:

```
× shows the accumulated LLM cost reported for the run
× shows a measured zero cost instead of hiding it
Tests  2 failed | 10 passed (12)

```

Reverting `automation-activity-log-export.ts` fails the two export tests, plus the pre-existing whole-row equality test that now expects the field:

```
× maps a list run into an export row with conversation URL and duration
× carries the run's accumulated cost into the export row
× serializes the cost as a raw number so spreadsheets can total it
Tests  3 failed | 6 passed (9)

```

The two remaining new tests (`shows no cost when the reported cost is null` / `... is undefined`) pass pre-change by design — they are regression guards that lock in that an unknown cost renders nothing, including against an automation service too old to send the field.

**End-to-end, against the real stack.** Both dependency PRs are unreleased, so the run's sandbox venv must be pointed at the local SDK checkout — otherwise `setup.sh` installs the released `openhands-sdk` from PyPI, no `cost` is ever sent, and the row correctly renders nothing. Create a uv override file:

```
openhands-sdk @ file:///<abs>/software-agent-sdk/openhands-sdk
openhands-tools @ file:///<abs>/software-agent-sdk/openhands-tools
openhands-workspace @ file:///<abs>/software-agent-sdk/openhands-workspace

```

then:

```bash
UV_OVERRIDE=$HOME/.openhands/sdk-local-override.txt \
OH_AGENT_SERVER_LOCAL_PATH=/<abs>/software-agent-sdk \
OH_AUTOMATION_GIT_REF=hieptl/oss-5210 \
npm run dev

```

Open `http://localhost:8000` → **Automations** → pick one → **Run now**. When the run reaches COMPLETED, its Activity Log row shows the cost; **Export CSV** / **Export JSON** in the Activity Log header include a `cost` field per run.

The data path was verified end-to-end on this stack before the UI change, by dispatching a real run and reading the API the Activity Log consumes:

```
# without UV_OVERRIDE (sandbox venv = released openhands-sdk 1.39.1)
{"id": "ebb07827-…", "status": "COMPLETED", "cost": null}

# with UV_OVERRIDE (sandbox venv = PR checkout, openhands_sdk-1.40.0.dist-info)
{"id": "07a450cc-…", "status": "COMPLETED", "cost": 0.0}

```

The `0.0` is accurate, not a plumbing failure: the model used (`minimax-m2.7` via `litellm_proxy`) has no litellm price mapping, so the agent-server logged `Cost calculation failed: This model isn't mapped yet` and the SDK reported a true zero. Use a model litellm can price to see a non-zero figure.

**Full checks:**

```bash
npm run typecheck                      # clean
npm run lint                           # 0 errors (1 pre-existing warning in
                                       # src/hooks/query/use-local-git-info.ts, untouched here)
npm run check-translation-completeness # All translation keys have complete language coverage!
npm run test                           # Test Files 553 passed | 1 skipped (554)
                                       # Tests 4378 passed | 5 skipped | 9 todo (4392)

```

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="798" alt="display-automation-cost-agent-server-gui" src="https://github.com/user-attachments/assets/66f7c658-7cd5-41f3-a487-7c1c9935894c" />

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.40.1-python` |
| **Automation** | `openhands-automation==1.6.0` |
| **Commit** | `e213ec779460613bf6ce7598d3729f05dfd56635` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-e213ec7
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-e213ec7
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-e213ec7-amd64
ghcr.io/openhands/agent-canvas:hieptl-oss-9091-amd64
ghcr.io/openhands/agent-canvas:pr-16351-amd64
ghcr.io/openhands/agent-canvas:sha-e213ec7-arm64
ghcr.io/openhands/agent-canvas:hieptl-oss-9091-arm64
ghcr.io/openhands/agent-canvas:pr-16351-arm64
ghcr.io/openhands/agent-canvas:sha-e213ec7
ghcr.io/openhands/agent-canvas:hieptl-oss-9091
ghcr.io/openhands/agent-canvas:pr-16351
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-e213ec7`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-e213ec7-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->