### PR TITLE
feat: reorder Customize navigation

### DIFF
--- a/__tests__/components/features/skills/extensions-navigation.test.tsx
+++ b/__tests__/components/features/skills/extensions-navigation.test.tsx
@@ -80,6 +80,19 @@ describe("ExtensionsNavigation", () => {
     expect(skillsItem.tagName).toBe("A");
   });
 
+  it("orders MCP Servers before Skills and Plugins", () => {
+    renderExtensionsNavigation(<ExtensionsNavigation />);
+
+    const nav = screen.getByTestId("extensions-navbar-desktop");
+    const navigationItems = within(nav).getAllByRole("link");
+
+    expect(navigationItems.map((item) => item.textContent)).toEqual([
+      "MCP Servers",
+      "Skills",
+      "Plugins",
+    ]);
+  });
+
   it("renders the Plugins item as a live link without a Coming Soon badge", () => {
     renderExtensionsNavigation(<ExtensionsNavigation />);
 

--- a/__tests__/routes/extensions-hub.test.tsx
+++ b/__tests__/routes/extensions-hub.test.tsx
@@ -1,0 +1,35 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockNavigate = vi.fn();
+const mockUseBreakpoint = vi.fn();
+
+vi.mock("react-router", () => ({
+  Navigate: (props: { to: string; replace?: boolean }) => {
+    mockNavigate(props);
+    return null;
+  },
+}));
+
+vi.mock("#/hooks/use-breakpoint", () => ({
+  useBreakpoint: () => mockUseBreakpoint(),
+}));
+
+vi.mock("#/components/features/skills/extensions-mobile-hub", () => ({
+  ExtensionsMobileHub: () => <div data-testid="extensions-mobile-hub" />,
+}));
+
+import ExtensionsHub from "#/routes/extensions-hub";
+
+describe("ExtensionsHub", () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    mockUseBreakpoint.mockReturnValue(false);
+  });
+
+  it("redirects desktop Customize navigation to MCP Servers", () => {
+    render(<ExtensionsHub />);
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/mcp", replace: true });
+  });
+});

--- a/src/components/features/skills/extensions-navigation.tsx
+++ b/src/components/features/skills/extensions-navigation.tsx
@@ -28,15 +28,15 @@ interface ExtensionNavItem {
 
 export const EXTENSIONS_NAV_ITEMS: ExtensionNavItem[] = [
   {
-    to: "/skills",
-    label: "Skills",
-    icon: <SkillsIcon width={16} height={16} aria-hidden="true" />,
-    end: true,
-  },
-  {
     to: "/mcp",
     label: "MCP Servers",
     icon: <ServerProcessIcon width={16} height={16} />,
+    end: true,
+  },
+  {
+    to: "/skills",
+    label: "Skills",
+    icon: <SkillsIcon width={16} height={16} aria-hidden="true" />,
     end: true,
   },
   {

--- a/src/routes/extensions-hub.tsx
+++ b/src/routes/extensions-hub.tsx
@@ -9,5 +9,5 @@ export default function ExtensionsHub() {
     return <ExtensionsMobileHub />;
   }
 
-  return <Navigate to="/skills" replace />;
+  return <Navigate to="/mcp" replace />;
 }


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
Tested locally by me, a real human.

<!-- Human contributors: add a short note about your testing. -->

AGENT:

- Verified the running local Canvas UI at `http://localhost:8000/mcp`. The visible Customize sub-navigation renders in this order: **MCP Servers**, **Skills**, **Plugins**.
- Captured a Canvas browser screenshot during that verification (local session artifact: `browser_screenshot_cefa6fa2.png`).
- Ran the focused unit test and ESLint checks listed below; both passed.

---

## Why

MCP Servers should be the first option in the Customize sub-navigation, ahead of Skills and Plugins.

## Summary

- Reorder the extension navigation to MCP Servers, Skills, then Plugins.
- Add regression tests for the rendered navigation order and desktop Customize landing route.

## Issue Number

N/A

## How to Test

1. Start Agent Canvas and open `http://localhost:8000/mcp`.
2. Click **Customize** in the sidebar; verify it opens the **MCP Servers** page.
3. Under **Customize**, verify the items appear in this order: **MCP Servers**, **Skills**, **Plugins**.
4. Run `npx vitest run __tests__/routes/extensions-hub.test.tsx __tests__/components/features/skills/extensions-navigation.test.tsx` (10 tests passed).
5. Run `npx eslint src/routes/extensions-hub.tsx __tests__/routes/extensions-hub.test.tsx` (passed).

## Video/Screenshots

Canvas UI verification was performed at `http://localhost:8000/mcp`; the captured screenshot shows MCP Servers selected above Skills and Plugins.

https://github.com/user-attachments/assets/8b7d0962-774d-456e-9adf-8a4e311db2fe



## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No migration, configuration, or rollout changes are required.

_This pull request was created by an AI agent (OpenHands) on behalf of the user._

