### PR TITLE
fix(config-service): surface OpenRouter and other model-only providers in Basic picker

### DIFF
--- a/__tests__/api/config-service.test.ts
+++ b/__tests__/api/config-service.test.ts
@@ -58,4 +58,44 @@ describe("ConfigService", () => {
     const openhands = page.items.find((p) => p.name === "openhands");
     expect(openhands).toEqual({ name: "openhands", verified: true });
   });
+
+  it("surfaces providers discoverable only from model ids (e.g. openrouter)", async () => {
+    // Arrange: mirror the real local agent-server, where OpenRouter is absent
+    // from /api/llm/providers and from /api/llm/models/verified, but its models
+    // are listed under /api/llm/models with an "openrouter/..." id prefix.
+    server.use(
+      http.get("/api/llm/providers", () =>
+        HttpResponse.json({ providers: ["anthropic", "openai"] }),
+      ),
+      http.get("/api/llm/models/verified", () =>
+        HttpResponse.json({
+          models: { anthropic: ["claude-opus-4-5-20251101"] },
+        }),
+      ),
+      http.get("/api/llm/models", () =>
+        HttpResponse.json({
+          models: [
+            "anthropic/claude-opus-4-5-20251101",
+            "openai/gpt-4o",
+            "openrouter/anthropic/claude-3.5-sonnet",
+            "openrouter/openai/gpt-4o",
+          ],
+        }),
+      ),
+    );
+
+    // Act
+    const page = await ConfigService.searchProviders({ limit: 50 });
+
+    // Assert: openrouter is surfaced even though it is in neither the
+    // providers list nor the verified-models map, and it is not flagged
+    // verified.
+    const openrouter = page.items.find((p) => p.name === "openrouter");
+    expect(openrouter).toEqual({ name: "openrouter", verified: false });
+
+    // Existing providers are preserved and stay deduplicated.
+    expect(page.items.some((p) => p.name === "anthropic")).toBe(true);
+    expect(page.items.some((p) => p.name === "openai")).toBe(true);
+    expect(page.items.filter((p) => p.name === "anthropic")).toHaveLength(1);
+  });
 });

--- a/src/api/config-service/config-service.api.ts
+++ b/src/api/config-service/config-service.api.ts
@@ -161,13 +161,27 @@ class ConfigService {
       verifiedByProvider !== undefined
         ? Promise.resolve(verifiedByProvider)
         : llmClient.getVerifiedModels();
-    const [providers, verifiedMap] = await Promise.all([
+    const [providers, verifiedMap, models] = await Promise.all([
       llmClient.getProviders(),
       verifiedFetch,
+      llmClient.getModels(),
     ]);
 
     const verifiedProviders = new Set(Object.keys(verifiedMap ?? {}));
-    const names = new Set<string>([...verifiedProviders, ...(providers ?? [])]);
+    // Some providers (e.g. OpenRouter) are absent from /api/llm/providers and
+    // from the verified-models map, yet their models are reachable via
+    // /api/llm/models with a "<provider>/..." id. Derive those providers from
+    // the model id prefixes so they still surface in the Basic provider picker.
+    const modelProviders = new Set(
+      (models ?? [])
+        .map((model) => model.split("/")[0])
+        .filter((provider): provider is string => Boolean(provider)),
+    );
+    const names = new Set<string>([
+      ...verifiedProviders,
+      ...(providers ?? []),
+      ...modelProviders,
+    ]);
     const providerItems: LLMProvider[] = [...names].map((name) => ({
       name,
       verified: verifiedProviders.has(name),


### PR DESCRIPTION
HUMAN:
Verified via the vitest suite for the config-service (4/4 pass) and confirmed RED→GREEN by stashing the source fix. This is a backend provider-list derivation change with no visible UI, so the screenshot shows the test output.

AGENT:

Automated verification only: 4/4 vitest tests pass with the fix; the new regression test fails without it (verified by stashing). No human test performed, no visual change. No secrets introduced; diff +18/-2 source, +40 test.

---

## Why

On the local backend, OpenRouter is missing from the Basic LLM Providers list in Agent Canvas, even though it is available on OpenHands Cloud. See #15576.

## Summary

- `searchProviders` in `config-service.api.ts` now also fetches `/api/llm/models` and derives providers from model ID prefixes (e.g. `openrouter/...`)
- Derived providers are added to the deduplicated set, marked as not verified
- No new dependencies, no UI change

## Issue Number

Fixes #15576

## How to Test

1. `npx vitest run __tests__/api/config-service.test.ts`
2. Expect 4/4 tests to pass, including the new `surfaces providers discoverable only from model ids (e.g. openrouter)` regression test
3. Stash the fix → the new test fails (`openrouter` undefined); restore → passes (RED→GREEN verified)

## Video/Screenshots

![vitest output: 4/4 tests pass for config-service with OpenRouter regression test](https://tmpfiles.org/dl/wkwyFc3q9byf/browser_screenshot_98104a97172e4ce48e4327a0c733e15a.png)

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No new dependencies. Provider-list derivation on the local backend config service. Diff +18/-2 source, +40 test.