### PR TITLE
feat: show workspace path in Files view

### DIFF
--- a/__tests__/components/features/files-tab/workspace-path.test.tsx
+++ b/__tests__/components/features/files-tab/workspace-path.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { WorkspacePath } from "#/components/features/files-tab/workspace-path";
+
+const originalClipboard = navigator.clipboard;
+
+describe("WorkspacePath", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: originalClipboard,
+    });
+  });
+
+  it("shows the effective workspace path", () => {
+    const path = "/Users/alice/workspace/project/abc123";
+
+    render(<WorkspacePath path={path} />);
+
+    expect(screen.getByTestId("files-tab-workspace-path")).toHaveTextContent(
+      "WORKSPACE$TITLE:",
+    );
+    expect(
+      screen.getByTestId("files-tab-workspace-path-value"),
+    ).toHaveTextContent(path);
+  });
+
+  it("keeps the complete path available when the text is truncated", () => {
+    const path =
+      "/Users/alice/a-very-long-workspace-name/project/with/nested/directories";
+
+    render(<WorkspacePath path={path} />);
+
+    const value = screen.getByTestId("files-tab-workspace-path-value");
+    expect(value).toHaveClass("truncate");
+    expect(value).toHaveAttribute("title", path);
+  });
+
+  it("copies the complete path and confirms the action", async () => {
+    const path = "C:\\Users\\alice\\workspace\\project";
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(<WorkspacePath path={path} />);
+
+    const workspacePath = screen.getByTestId("files-tab-workspace-path");
+    await user.click(
+      within(workspacePath).getByRole("button", { name: "BUTTON$COPY" }),
+    );
+
+    expect(writeText).toHaveBeenCalledWith(path);
+    expect(
+      within(workspacePath).getByRole("button", { name: "BUTTON$COPIED" }),
+    ).toBeDisabled();
+  });
+
+  it("does not render without a workspace path", () => {
+    const { rerender } = render(<WorkspacePath path={null} />);
+
+    expect(
+      screen.queryByTestId("files-tab-workspace-path"),
+    ).not.toBeInTheDocument();
+
+    rerender(<WorkspacePath path="   " />);
+    expect(
+      screen.queryByTestId("files-tab-workspace-path"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/routes/files-tab.test.tsx
+++ b/__tests__/routes/files-tab.test.tsx
@@ -15,6 +15,7 @@ const useHasGitCommitsMock = vi.fn();
 const useUnifiedGitCommitsMock = vi.fn();
 const useWorkspaceFilesMock = vi.fn();
 const useWorkspaceFileContentMock = vi.fn();
+const useActiveConversationMock = vi.fn();
 const refetchGitChangesMock = vi.fn();
 
 vi.mock("#/hooks/use-has-attached-source", () => ({
@@ -37,6 +38,10 @@ vi.mock("#/hooks/query/use-workspace-files", () => ({
 vi.mock("#/hooks/query/use-workspace-file-content", () => ({
   useWorkspaceFileContent: (path: string | null) =>
     useWorkspaceFileContentMock(path),
+}));
+
+vi.mock("#/hooks/query/use-active-conversation", () => ({
+  useActiveConversation: () => useActiveConversationMock(),
 }));
 
 vi.mock("#/hooks/query/use-unified-get-git-changes", () => ({
@@ -94,6 +99,7 @@ describe("FilesTab", () => {
     useUnifiedGitCommitsMock.mockReset();
     useWorkspaceFilesMock.mockReset();
     useWorkspaceFileContentMock.mockReset();
+    useActiveConversationMock.mockReset();
     refetchGitChangesMock.mockReset();
     // Default: pretend the probe has already resolved with at least one
     // commit. Individual tests can override this for "empty repo" cases.
@@ -128,6 +134,11 @@ describe("FilesTab", () => {
       },
       isLoading: false,
       isError: false,
+    });
+    useActiveConversationMock.mockReturnValue({
+      data: {
+        workspace: { working_dir: "/workspace/project" },
+      },
     });
   });
 
@@ -211,6 +222,24 @@ describe("FilesTab", () => {
     expect(
       screen.getByTestId("files-tab-content-mode-toggle"),
     ).toBeInTheDocument();
+  });
+
+  it("shows the active conversation workspace path in files view", () => {
+    useHasAttachedSourceMock.mockReturnValue({
+      hasAttachedSource: false,
+      isLoading: false,
+    });
+    useActiveConversationMock.mockReturnValue({
+      data: {
+        workspace: { working_dir: "/workspace/project/worktree-123" },
+      },
+    });
+
+    renderTab();
+
+    expect(
+      screen.getByTestId("files-tab-workspace-path-value"),
+    ).toHaveTextContent("/workspace/project/worktree-123");
   });
 
   it("lets users toggle diff view off even when a source is attached", async () => {

--- a/src/components/features/files-tab/workspace-path.tsx
+++ b/src/components/features/files-tab/workspace-path.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import { CopyToClipboardButton } from "#/components/shared/buttons/copy-to-clipboard-button";
+import { I18nKey } from "#/i18n/declaration";
+
+interface WorkspacePathProps {
+  path?: string | null;
+}
+
+export function WorkspacePath({ path }: WorkspacePathProps) {
+  const { t } = useTranslation("openhands");
+  const [isCopied, setIsCopied] = React.useState(false);
+  const workspacePath = path?.trim();
+
+  React.useEffect(() => {
+    if (!isCopied) return undefined;
+
+    const timeout = window.setTimeout(() => setIsCopied(false), 2000);
+    return () => window.clearTimeout(timeout);
+  }, [isCopied]);
+
+  if (!workspacePath) return null;
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(workspacePath);
+    setIsCopied(true);
+  };
+
+  return (
+    <div
+      className="flex min-w-0 items-center gap-2 border-b border-[var(--oh-border)] px-3 py-1.5 text-xs"
+      data-testid="files-tab-workspace-path"
+    >
+      <span className="shrink-0 text-[var(--oh-muted)]">
+        {t(I18nKey.WORKSPACE$TITLE)}:
+      </span>
+      <span
+        className="min-w-0 flex-1 truncate font-mono"
+        data-testid="files-tab-workspace-path-value"
+        title={workspacePath}
+      >
+        {workspacePath}
+      </span>
+      <CopyToClipboardButton
+        isHidden={false}
+        isDisabled={isCopied}
+        onClick={handleCopy}
+        mode={isCopied ? "copied" : "copy"}
+      />
+    </div>
+  );
+}

--- a/src/routes/files-tab.tsx
+++ b/src/routes/files-tab.tsx
@@ -22,9 +22,11 @@ import { FileQuickRow } from "#/components/features/files-tab/file-quick-row";
 import { FileTreeView } from "#/components/features/files-tab/file-tree-view";
 import { FileContentViewer } from "#/components/features/files-tab/file-content-viewer";
 import { SegmentedToggle } from "#/components/features/files-tab/segmented-toggle";
+import { WorkspacePath } from "#/components/features/files-tab/workspace-path";
 import type { ViewMode } from "#/components/features/files-tab/view-mode";
 import RefreshIcon from "#/icons/u-refresh.svg?react";
 import LinkExternalIcon from "#/icons/link-external.svg?react";
+import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useUnifiedGitCommits } from "#/hooks/query/use-unified-git-commits";
 import GitChanges from "./changes-tab";
 import GitCommits from "./commits-tab";
@@ -34,6 +36,9 @@ function FilesTab() {
 
   // Keep the list / content / diff caches fresh as the agent writes files.
   useAutoRefreshFilesOnEdit();
+
+  const { data: activeConversation } = useActiveConversation();
+  const workspacePath = activeConversation?.workspace?.working_dir;
 
   const { hasAttachedSource, isLoading: isAttachedSourceLoading } =
     useHasAttachedSource();
@@ -237,6 +242,7 @@ function FilesTab() {
       )}
       {activeView === "off" && (
         <div className="flex flex-1 flex-col min-h-0">
+          <WorkspacePath path={workspacePath} />
           {filesQuery.isLoading ? (
             <div className="flex flex-1 items-center justify-center text-sm text-[var(--oh-muted)]">
               {t(I18nKey.FILES$LOADING_FILES)}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

I tested the Files view and confirmed the workspace path displays correctly and the copy button copies the complete path.

<!-- Human contributors: add a short note about your testing. -->

AGENT:

Implemented the Files-view workspace path and verified the production build, focused tests, and the feature in the running mock UI.

Browser verification used Node 22.12.0, `npm run dev:mock`, and headless Edge through the installed Playwright dependency. On `/conversations/pagination-local`, the Files view displayed `/workspace/project`, exposed the same full value in its tooltip, copied `/workspace/project` to the clipboard, and changed the button label to `Copied to clipboard`.

---

## Why

The Files view does not currently show the effective workspace directory, making worktree and workspace location issues difficult to diagnose.

## Summary

- Show the active conversation's effective `working_dir` above the file tree.
- Preserve the complete path in a tooltip and copy it with the existing shared clipboard control.
- Hide the row for missing paths and cover display, truncation, copy feedback, and route integration.

## Issue Number

Closes #16330

## How to Test

1. Run `npm run dev:mock` with Node 22.12.0.
2. Open a conversation whose workspace has a `working_dir`.
3. Open the right panel and select Files.
4. Confirm the complete workspace path appears above the file tree.
5. Hover the truncated value to see the full path, then copy it and confirm the copied state.

Automated verification:
- `npx vitest run __tests__/components/features/files-tab/workspace-path.test.tsx --pool=threads --maxWorkers=1` - 4 passed.
- `npx vitest run __tests__/routes/files-tab.test.tsx --pool=threads --maxWorkers=1` - 23 passed.
- `npm run typecheck` - passed.
- `npx eslint src/components/features/files-tab/workspace-path.tsx src/routes/files-tab.tsx` - passed.
- `npx prettier --check ...` for all four changed files - passed.
- `npm run build` - passed.

## Video/Screenshots

![Workspace path displayed in the Files view with copied confirmation](https://github.com/user-attachments/assets/6c8c2c5b-3fe2-412a-8829-ec2ad511d4c8)

The screenshot shows the effective workspace path and the copied confirmation state from the mock UI verification.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The component renders nothing when `working_dir` is null, undefined, empty, or whitespace-only.
