### PR TITLE
fix(web): fix API Key dialog overflow on mobile by adding viewport width cap

### DIFF
--- a/src/components/features/backends/backend-form-modal.tsx
+++ b/src/components/features/backends/backend-form-modal.tsx
@@ -1563,7 +1563,7 @@ export function BackendFormModal({
             hideCloseButton ? "onboarding-modal" : "add-backend-modal"
           }
           className={cn(
-            "relative max-h-[92vh] w-[720px] overflow-y-auto rounded-xl border border-[var(--oh-border)] bg-base-secondary p-6",
+            "relative max-h-[92vh] w-[720px] overflow-y-auto overflow-x-auto rounded-xl border border-[var(--oh-border)] bg-base-secondary p-6",
             MODAL_MAX_WIDTH_VIEWPORT,
           )}
         >
@@ -1619,6 +1619,7 @@ export function BackendFormModal({
         className={cn(
           "relative bg-base-secondary p-6 rounded-xl flex flex-col gap-4 border border-[var(--oh-border)]",
           modalWidthClassName("md"),
+          MODAL_MAX_WIDTH_VIEWPORT,
         )}
       >
         <ModalCloseButton onClose={onClose} testId={`${testIdRoot}-close`} />

--- a/src/components/features/backends/manage-backends-modal.tsx
+++ b/src/components/features/backends/manage-backends-modal.tsx
@@ -134,7 +134,7 @@ export function ManageBackendsModal({
             "relative flex flex-col bg-[var(--oh-surface)] border border-[var(--oh-border)] rounded-xl",
             modalWidthClassName("lg"),
             MODAL_MAX_WIDTH_VIEWPORT,
-            "max-h-[70vh]",
+            "max-h-[70vh] overflow-x-auto",
           )}
         >
           {recoveryMode ? null : (


### PR DESCRIPTION
## Summary

Fixes #16366 — the API Key creation dialog overflows on mobile devices, causing the sides of the dialog and its contents to be cut off.

## Changes

1. **BackendFormModal (edit mode)**: Added `MODAL_MAX_WIDTH_VIEWPORT` (`max-w-[90vw]`) to the modal container. The edit mode was missing this viewport width cap, so the 520px-wide modal would overflow on mobile screens (375px viewport).

2. **BackendFormModal (add mode)**: Added `overflow-x-auto` to prevent any horizontal content overflow when the modal is constrained to viewport width.

3. **ManageBackendsModal**: Added `overflow-x-auto` for the same reason — safe horizontal scroll on narrow viewports.

## Testing

- On desktop (1440px): No visual change — modals render at their normal fixed widths (520px/640px/720px)
- On mobile (375px): Modals now cap at 90vw (~337px) with horizontal scroll available if content overflows