### PR TITLE
fix(electron): allowlist http(s) before shell.openExternal on window.open

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -361,9 +361,10 @@ function createMainWindow() {
   // shell.openExternal hands the URL to the OS, which dispatches by scheme:
   // file: can launch downloaded executables or apps, and custom protocol
   // handlers (smb:, ms-msdt:, etc.) reach arbitrary local applications. Only
-  // http(s) is ever legitimate here; every other scheme is dropped. Renderer
-  // content includes agent-generated markdown, so treat link targets as
-  // untrusted even though they require a user click.
+  // http(s) and mailto: (composes but never sends) are legitimate here; every
+  // other scheme is dropped. Renderer content includes agent-generated
+  // markdown, so treat link targets as untrusted even though they require a
+  // user click.
   const openExternalSafe = (url) => {
     let parsed;
     try {
@@ -371,7 +372,11 @@ function createMainWindow() {
     } catch {
       return false;
     }
-    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    if (
+      parsed.protocol !== "https:" &&
+      parsed.protocol !== "http:" &&
+      parsed.protocol !== "mailto:"
+    ) {
       return false;
     }
     shell.openExternal(url);

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -358,6 +358,26 @@ function createMainWindow() {
     mainWin?.maximize();
   });
 
+  // shell.openExternal hands the URL to the OS, which dispatches by scheme:
+  // file: can launch downloaded executables or apps, and custom protocol
+  // handlers (smb:, ms-msdt:, etc.) reach arbitrary local applications. Only
+  // http(s) is ever legitimate here; every other scheme is dropped. Renderer
+  // content includes agent-generated markdown, so treat link targets as
+  // untrusted even though they require a user click.
+  const openExternalSafe = (url) => {
+    let parsed;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return false;
+    }
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+      return false;
+    }
+    shell.openExternal(url);
+    return true;
+  };
+
   // Route window.open() calls appropriately.
   mainWin.webContents.setWindowOpenHandler(({ url }) => {
     // The "Login with OpenHands Cloud" device-flow opens about:blank immediately
@@ -376,7 +396,7 @@ function createMainWindow() {
       !url.startsWith("http://localhost") &&
       !url.startsWith("http://127.0.0.1")
     ) {
-      shell.openExternal(url);
+      openExternalSafe(url);
       return { action: "deny" };
     }
     return { action: "allow" };
@@ -394,8 +414,9 @@ function createMainWindow() {
         !url.startsWith("http://127.0.0.1")
       ) {
         _event.preventDefault();
-        shell.openExternal(url);
-        popupWin.close();
+        if (openExternalSafe(url)) {
+          popupWin.close();
+        }
       }
     });
   });


### PR DESCRIPTION
HUMAN:

Manual testing performed on macOS with the packaged desktop app. Built the Electron app locally, opened a conversation, and clicked http, https, and mailto links in agent markdown output: http and https opened in the system browser, and mailto opened the mail composer (compose only, nothing sent). From renderer DevTools, window.open("file:///etc/passwd", "_blank") and window.open("smb://attacker/share", "_blank") were dropped with no OS handoff and no new window. The "Login with OpenHands Cloud" device flow still opens the https verification URL in the browser. Change is confined to electron/main.mjs (main process only); node --check passes.

AGENT:

Change is confined to electron/main.mjs. Both shell.openExternal call sites route through openExternalSafe, which parses the URL and forwards only http:, https:, and mailto: (mailto: added per review feedback; it composes but never sends). node --check passes; the allow/deny flow for about:blank, localhost, and external URLs was verified by reading the handler logic end to end. Renderer behavior is unchanged because external links were always denied an in-app window and routed to the browser.

---

## Why

Both external-navigation paths in the Electron shell pass URLs straight to `shell.openExternal`:

1. `setWindowOpenHandler` opens any non-localhost URL externally
2. the device-flow popup's `will-navigate` handler does the same

`shell.openExternal` dispatches by scheme to the OS, so this isn't limited to web pages: `file:` URLs can open downloaded executables or apps, and custom protocol handlers (`smb:`, `ms-msdt:`, vendor schemes) reach arbitrary local applications with whatever arguments the URL carries.

The input is untrusted: the renderer displays agent-generated markdown with clickable links (the agent reads attacker-controlled repository content, so prompt injection can plant links), and server-provided URLs like the VS Code drawer link are opened through the same path.

## Summary

- Add `openExternalSafe` helper: parses the URL, forwards only `http:`/`https:`/`mailto:` to `shell.openExternal`, drops everything else
- Route both `setWindowOpenHandler` and the popup `will-navigate` handler through it
- Localhost window-allow path and the `about:blank` device-flow popup are unchanged

## Issue Number

## How to Test

1. Run the desktop app, open a conversation, click an external https link in agent output - it opens in the system browser as before
2. From DevTools in the renderer: `window.open("file:///etc/passwd", "_blank")` - nothing happens (previously: handed to the OS)
3. `window.open("smb://attacker/share", "_blank")` - nothing happens
4. "Login with OpenHands Cloud" device flow still opens the verification URL in the browser (https)

## Video/Screenshots

N/A - main-process URL-scheme guard; no visible UI change for legitimate links.
