### PR TITLE
fix(ui): clarify repository selector placeholder

### DIFF
--- a/__tests__/components/features/home/repo-selection-form.test.tsx
+++ b/__tests__/components/features/home/repo-selection-form.test.tsx
@@ -197,7 +197,12 @@ describe("RepositorySelectionForm", () => {
     });
 
     renderForm();
-    expect(await screen.findByTestId("git-repo-dropdown")).toBeInTheDocument();
+    const repositoryInput = await screen.findByTestId("git-repo-dropdown");
+    expect(repositoryInput).toBeInTheDocument();
+    expect(repositoryInput).toHaveAttribute(
+      "placeholder",
+      "COMMON$SELECT_REPOSITORY_PLACEHOLDER",
+    );
   });
 
   it("shows error message when repository fetch fails", async () => {

--- a/src/components/features/home/repo-selection-form.tsx
+++ b/src/components/features/home/repo-selection-form.tsx
@@ -147,8 +147,7 @@ export function RepositorySelectionForm({
         provider={selectedProvider || providers[0]}
         value={selectedRepository?.id || null}
         repositoryName={selectedRepository?.full_name || null}
-        // eslint-disable-next-line i18next/no-literal-string -- example value, not translatable
-        placeholder="user/repo"
+        placeholder={t(I18nKey.COMMON$SELECT_REPOSITORY_PLACEHOLDER)}
         disabled={!selectedProvider || isLoadingSettings}
         onChange={handleRepoSelection}
         className="max-w-auto"

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -34254,6 +34254,23 @@
     "uk": "Пошук репозиторіїв...",
     "ca": "Cerca repositoris..."
   },
+  "COMMON$SELECT_REPOSITORY_PLACEHOLDER": {
+    "en": "Select repository...",
+    "ja": "Select repository...",
+    "zh-CN": "Select repository...",
+    "zh-TW": "Select repository...",
+    "ko-KR": "Select repository...",
+    "no": "Select repository...",
+    "it": "Select repository...",
+    "pt": "Select repository...",
+    "es": "Select repository...",
+    "ar": "Select repository...",
+    "fr": "Select repository...",
+    "tr": "Select repository...",
+    "de": "Select repository...",
+    "uk": "Select repository...",
+    "ca": "Select repository..."
+  },
   "COMMON$SELECT_BRANCH_PLACEHOLDER": {
     "en": "Select branch...",
     "ja": "ブランチを選択...",


### PR DESCRIPTION
HUMAN:

Automation note: I ran the focused repository-selector test and typecheck; the rendered placeholder assertion passed.

AGENT:

---

## Why

The repository selector currently uses `user/repo` as its placeholder, which looks like an example value rather than an instruction. This makes the control less clear than the adjacent branch selector, which says `Select branch...`.

## Summary

- Replace the ambiguous repository selector placeholder with localized `Select repository...` copy.
- Add a regression assertion for the rendered placeholder.

## Issue Number

Fixes #16369

## How to Test

Run `npm test -- --run __tests__/components/features/home/repo-selection-form.test.tsx` and `npm run typecheck:staged -- --pretty false`.

## Video/Screenshots

No uploadable browser screenshot was available in this automation environment; the focused component test asserts the rendered placeholder value.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The change is limited to UI copy and the existing translation system.

## Problem

The repository selector placeholder is ambiguous.

## Root Cause

`RepositorySelectionForm` passes the literal `user/repo` string to `GitRepoDropdown`.

## Solution

Use a localized `COMMON$SELECT_REPOSITORY_PLACEHOLDER` translation key.

## Changes

- Added the repository-selection placeholder translation key.
- Replaced the ambiguous `user/repo` placeholder.
- Added a regression assertion.

## Testing

- Baseline focused test: 6 passed.
- Final focused test: 6 passed.
- Prettier, staged typecheck, and `git diff --check`: passed.
- Full test suite and build: not run.

## Compatibility/Risk

No runtime or API behavior changes; only the empty-state placeholder is clarified.

## Notes for Reviewer

The new test uses the existing translation mock and verifies the requested translation key.

## Linked Issue

Fixes #16369