### PR TITLE
fix(modal): lock background page scrolling

### DIFF
--- a/__tests__/components/shared/modals/modal-backdrop.test.tsx
+++ b/__tests__/components/shared/modals/modal-backdrop.test.tsx
@@ -5,12 +5,31 @@ import userEvent from "@testing-library/user-event";
 import { ModalBackdrop } from "#/components/shared/modals/modal-backdrop";
 
 describe("ModalBackdrop", () => {
+  it("locks body scrolling while open and restores the previous overflow after unmount", () => {
+    document.body.style.overflow = "auto";
+
+    const { unmount } = render(
+      <ModalBackdrop>
+        <div />
+      </ModalBackdrop>,
+    );
+
+    expect(document.body.style.overflow).toBe("hidden");
+
+    unmount();
+
+    expect(document.body.style.overflow).toBe("auto");
+  });
+
   it("portals out of a transformed ancestor so position: fixed resolves against the viewport", () => {
     // Arrange: a transformed ancestor would otherwise become the
     // containing block for `position: fixed` descendants and trap the
     // modal inside it (the OnboardingModal / InstallServerModal bug).
     render(
-      <div data-testid="transformed-ancestor" style={{ transform: "translateX(0)" }}>
+      <div
+        data-testid="transformed-ancestor"
+        style={{ transform: "translateX(0)" }}
+      >
         <ModalBackdrop onClose={vi.fn()}>
           <p>modal content</p>
         </ModalBackdrop>

--- a/src/components/shared/modals/modal-backdrop.tsx
+++ b/src/components/shared/modals/modal-backdrop.tsx
@@ -15,6 +15,9 @@ interface ModalBackdropProps {
   "aria-label"?: string;
 }
 
+let activeModalCount = 0;
+let bodyOverflowBeforeLock = "";
+
 export function ModalBackdrop({
   children,
   onClose,
@@ -23,6 +26,22 @@ export function ModalBackdrop({
   elevated = false,
   "aria-label": ariaLabel,
 }: ModalBackdropProps) {
+  React.useEffect(() => {
+    if (activeModalCount === 0) {
+      bodyOverflowBeforeLock = document.body.style.overflow;
+    }
+    activeModalCount += 1;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      activeModalCount -= 1;
+      if (activeModalCount === 0) {
+        document.body.style.overflow = bodyOverflowBeforeLock;
+        bodyOverflowBeforeLock = "";
+      }
+    };
+  }, []);
+
   React.useEffect(() => {
     if (!closeOnEscape) return undefined;
     const handleEscape = (e: KeyboardEvent) => {


### PR DESCRIPTION
HUMAN:

Automation note: I ran the focused modal test and typecheck; the regression test passed for locking and restoring page scroll.

AGENT:

---

## Why

When an OpenHands popup is open, the page behind it remains scrollable. This affects the shared popup surface used across the application.

## Summary

- Lock document body scrolling while any shared modal is mounted.
- Restore the prior overflow value after the final modal closes.
- Add a regression test for lock and cleanup behavior.

## Issue Number

Closes #16367

## How to Test

Run `npm test -- --run __tests__/components/shared/modals/modal-backdrop.test.tsx` and `npm run typecheck:staged -- --pretty false`.

## Video/Screenshots

No uploadable browser screenshot was available in this automation environment; the focused component test asserts the lock and cleanup behavior.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The reference count keeps stacked modals locked until all modal instances are closed.

## Problem

The fixed modal overlay does not prevent the background page from scrolling.

## Root Cause

`ModalBackdrop` does not lock document body scrolling while mounted.

## Solution

Lock `document.body.style.overflow` while at least one modal is mounted and restore its previous value after the last unmount.

## Changes

- Added reference-counted body scroll locking.
- Preserved the original body overflow value.
- Added a regression test.

## Testing

- Baseline focused test: 5 passed.
- Final focused test: 6 passed.
- Prettier, component ESLint, staged typecheck, and `git diff --check`: passed.
- Test-file ESLint retains unrelated legacy literal-string findings.
- Full suite/E2E: not run.

## Compatibility/Risk

Low. Stacked modals remain locked until all close, and modal content scrolling remains available.

## Notes for Reviewer

The change is limited to the shared `ModalBackdrop`, covering all current popup consumers.

## Linked Issue

Closes #16367