### PR TITLE
feat: add OpenRouter to local LLM provider list

### DIFF
--- a/src/api/config-service/config-service.api.ts
+++ b/src/api/config-service/config-service.api.ts
@@ -168,6 +168,10 @@ class ConfigService {
 
     const verifiedProviders = new Set(Object.keys(verifiedMap ?? {}));
     const names = new Set<string>([...verifiedProviders, ...(providers ?? [])]);
+    // Local agent-server may not list every provider the frontend supports.
+    // OpenRouter is returned by Cloud but missing from the local provider list,
+    // so add it here as a known provider so it's discoverable in the UI.
+    names.add("openrouter");
     const providerItems: LLMProvider[] = [...names].map((name) => ({
       name,
       verified: verifiedProviders.has(name),


### PR DESCRIPTION
HUMAN:

Quick fix: OpenRouter is missing from the local provider dropdown. This adds it as a known provider so users with OpenRouter keys can select it directly instead of typing it in manually.

AGENT:

## Why

OpenRouter is returned correctly by Cloud but missing from the local backend provider list because the Python agent-server (`software-agent-sdk`) does not include OpenRouter in its `getProviders()` response. The frontend must ensure it's discoverable in the local path.

## Summary

- Add `"openrouter"` to the local provider name set in `config-service.api.ts` searchProviders path, ensuring it appears in the provider dropdown alongside other known providers.

## Issue Number

OpenHands/OpenHands#15576

## How to Test

1. Run `npx vitest run __tests__/api/config-service.test.ts` — all 3 tests pass.
2. Start the app with a local backend, open Settings → LLMs, click the provider dropdown — "OpenRouter" now appears.

## Video/Screenshots

![OpenRouter in provider list](https://github.com/user-attachments/assets/5e567b73-c71f-4808-9cfa-a7f086f137d7)

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The screenshot in the issue shows the exact gap being addressed — OpenRouter appears in the Cloud provider list but is absent from the local one. This change ensures OpenRouter appears in both.