### PR TITLE
feat(conversation-panel): group conversations by workspace by default

### DIFF
--- a/__tests__/stores/conversation-panel-preferences-store.test.ts
+++ b/__tests__/stores/conversation-panel-preferences-store.test.ts
@@ -8,13 +8,13 @@ describe("conversation-panel-preferences store", () => {
     window.localStorage.clear();
   });
 
-  it("defaults to showing older conversations, LLM profiles, chronological list, and expected toggles", () => {
+  it("defaults to showing older conversations, LLM profiles, grouped-by-workspace list, and expected toggles", () => {
     const state = useConversationPanelPreferencesStore.getState();
     expect(state.showOlderConversations).toBe(true);
     expect(state.showRepoBranchMetadata).toBe(false);
     expect(state.showLlmProfiles).toBe(true);
     expect(state.showTagsMetadata).toBe(true);
-    expect(state.organizeMode).toBe("chronological");
+    expect(state.organizeMode).toBe("grouped");
     expect(state.conversationSort).toBe("updated");
     expect(state.threadScope).toBe("all");
     expect(state.automationFilterMode).toBe("all");
@@ -174,7 +174,7 @@ describe("conversation-panel-preferences store", () => {
       showRepoBranchMetadata: true,
       // Filled with defaults for missing fields.
       showLlmProfiles: true,
-      organizeMode: "chronological",
+      organizeMode: "grouped",
       conversationSort: "updated",
       threadScope: "all",
     });

--- a/src/stores/conversation-panel-preferences-store.ts
+++ b/src/stores/conversation-panel-preferences-store.ts
@@ -62,7 +62,7 @@ const initialState: ConversationPanelPreferencesState = {
   showLlmProfiles: true,
   showTagsMetadata: true,
   showHoverMetadata: true,
-  organizeMode: "chronological",
+  organizeMode: "grouped",
   conversationSort: "updated",
   threadScope: "all",
   automationFilterMode: "all",


### PR DESCRIPTION
Resolves #15677

Conversations are now grouped by workspace by default in the sidebar. Previously the default was chronological ordering across all workspaces.

### Changes
- `organizeMode` default changed from `"chronological"` to `"grouped"` in `src/stores/conversation-panel-preferences-store.ts` — users now see conversations grouped under their workspace by default, workspaces sorted alphabetically; ungrouped conversations remain in the "No workspace" fallback group. Within each group, conversations remain sorted by most recently updated.
- Updated the two affected tests to expect the new default.

### Before / after
- **Before:** All conversations sorted chronologically regardless of workspace.
- **After:** Conversations grouped under their workspace by default, workspaces sorted alphabetically; ungrouped conversations remain in the "No workspace" fallback group. Conversations within each group remain sorted by most recently updated.

10/10 tests pass.