### PR TITLE
fix: auto-recover from stale SQLite migration on automation backend

### DIFF
--- a/__tests__/scripts/dev-migration-watch.test.ts
+++ b/__tests__/scripts/dev-migration-watch.test.ts
@@ -1,0 +1,154 @@
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { watchAutomationMigration } from "../../scripts/dev-process-utils.mjs";
+
+type LogKind = "warn" | "ok" | "error";
+
+interface FakeProc extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+}
+
+/** Minimal fake of a spawned child: EventEmitters for stdout/stderr/self. */
+function makeFakeProc(): FakeProc {
+  const proc = new EventEmitter() as FakeProc;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  return proc;
+}
+
+const MIGRATION_LOG_LINE =
+  'alembic.runtime.migration: Can\'t locate revision identified by "abc123"';
+
+describe("watchAutomationMigration", () => {
+  it("recovers (deletes the DB) when the migration error and exit code 3 line up", () => {
+    const proc = makeFakeProc();
+    let recovered = false;
+    watchAutomationMigration(proc, {
+      dbPath: "/tmp/fake-automations.db",
+      onRecover: () => {
+        recovered = true;
+      },
+      log: () => {},
+    });
+
+    proc.stdout.emit("data", Buffer.from(MIGRATION_LOG_LINE));
+    proc.emit("exit", 3);
+
+    expect(recovered).toBe(true);
+  });
+
+  it("does not delete the DB when the exit code is not 3", () => {
+    const proc = makeFakeProc();
+    let recovered = false;
+    watchAutomationMigration(proc, {
+      dbPath: "/tmp/fake-automations.db",
+      onRecover: () => {
+        recovered = true;
+      },
+      log: () => {},
+    });
+
+    proc.stdout.emit("data", Buffer.from(MIGRATION_LOG_LINE));
+    proc.emit("exit", 1);
+
+    expect(recovered).toBe(false);
+  });
+
+  it("does not delete the DB when the log pattern never appeared", () => {
+    const proc = makeFakeProc();
+    let recovered = false;
+    watchAutomationMigration(proc, {
+      dbPath: "/tmp/fake-automations.db",
+      onRecover: () => {
+        recovered = true;
+      },
+      log: () => {},
+    });
+
+    // A coincidental exit 3 from some other cause must never delete the DB.
+    proc.emit("exit", 3);
+
+    expect(recovered).toBe(false);
+  });
+
+  it("latches after one recovery attempt so a broken backend cannot loop", () => {
+    const proc = makeFakeProc();
+    let recoverCount = 0;
+    const logs: string[] = [];
+    watchAutomationMigration(proc, {
+      dbPath: "/tmp/fake-automations.db",
+      onRecover: () => {
+        recoverCount += 1;
+      },
+      log: (message: string) => logs.push(message),
+    });
+
+    // First failure: recovery runs.
+    proc.stdout.emit("data", Buffer.from(MIGRATION_LOG_LINE));
+    proc.emit("exit", 3);
+
+    // Second failure (restart failed too): no second recovery, we give up.
+    proc.stdout.emit("data", Buffer.from(MIGRATION_LOG_LINE));
+    proc.emit("exit", 3);
+
+    expect(recoverCount).toBe(1);
+    expect(logs.some((m) => m.includes("giving up"))).toBe(true);
+  });
+
+  it("reports a recovery failure instead of throwing", () => {
+    const proc = makeFakeProc();
+    const logs: string[] = [];
+    watchAutomationMigration(proc, {
+      dbPath: "/tmp/fake-automations.db",
+      onRecover: () => {
+        throw new Error("EACCES: read-only file system");
+      },
+      log: (message: string) => logs.push(message),
+    });
+
+    proc.stdout.emit("data", Buffer.from(MIGRATION_LOG_LINE));
+
+    expect(() => proc.emit("exit", 3)).not.toThrow();
+    expect(
+      logs.some((m) => m.includes("Failed to remove stale automations.db")),
+    ).toBe(true);
+  });
+});
+
+// Real-filesystem integration: prove onRecover wiring deletes an actual file.
+describe("watchAutomationMigration integration", () => {
+  let dir: string;
+
+  afterEach(() => {
+    if (dir && existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("deletes a real stale DB file exactly once across repeated failures", () => {
+    dir = mkdtempSync(join(tmpdir(), "oh-migration-test-"));
+    const dbPath = join(dir, "automations.db");
+    writeFileSync(dbPath, "stale sqlite data");
+
+    const proc = makeFakeProc();
+    watchAutomationMigration(proc, {
+      dbPath,
+      onRecover: () => rmSync(dbPath),
+      log: () => {},
+    });
+
+    proc.stdout.emit("data", Buffer.from(MIGRATION_LOG_LINE));
+    proc.emit("exit", 3);
+    expect(existsSync(dbPath)).toBe(false);
+
+    // Second failure must not attempt anything further.
+    proc.emit("exit", 3);
+    expect(existsSync(dbPath)).toBe(false);
+  });
+});

--- a/__tests__/scripts/dev-migration-watch.test.ts
+++ b/__tests__/scripts/dev-migration-watch.test.ts
@@ -3,11 +3,12 @@ import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { watchAutomationMigration } from "../../scripts/dev-process-utils.mjs";
-
-type LogKind = "warn" | "ok" | "error";
+import {
+  resetAutomationMigrationLatch,
+  watchAutomationMigration,
+} from "../../scripts/dev-process-utils.mjs";
 
 interface FakeProc extends EventEmitter {
   stdout: EventEmitter;
@@ -22,10 +23,19 @@ function makeFakeProc(): FakeProc {
   return proc;
 }
 
+function fireMigrationExit(proc: FakeProc) {
+  proc.stdout.emit("data", Buffer.from(MIGRATION_LOG_LINE));
+  proc.emit("exit", 3);
+}
+
 const MIGRATION_LOG_LINE =
   'alembic.runtime.migration: Can\'t locate revision identified by "abc123"';
 
 describe("watchAutomationMigration", () => {
+  beforeEach(() => {
+    resetAutomationMigrationLatch();
+  });
+
   it("recovers (deletes the DB) when the migration error and exit code 3 line up", () => {
     const proc = makeFakeProc();
     let recovered = false;
@@ -37,8 +47,7 @@ describe("watchAutomationMigration", () => {
       log: () => {},
     });
 
-    proc.stdout.emit("data", Buffer.from(MIGRATION_LOG_LINE));
-    proc.emit("exit", 3);
+    fireMigrationExit(proc);
 
     expect(recovered).toBe(true);
   });
@@ -90,12 +99,42 @@ describe("watchAutomationMigration", () => {
     });
 
     // First failure: recovery runs.
-    proc.stdout.emit("data", Buffer.from(MIGRATION_LOG_LINE));
-    proc.emit("exit", 3);
+    fireMigrationExit(proc);
 
-    // Second failure (restart failed too): no second recovery, we give up.
-    proc.stdout.emit("data", Buffer.from(MIGRATION_LOG_LINE));
-    proc.emit("exit", 3);
+    // Second failure on the same process: no second recovery, we give up.
+    fireMigrationExit(proc);
+
+    expect(recoverCount).toBe(1);
+    expect(logs.some((m) => m.includes("giving up"))).toBe(true);
+  });
+
+  it("does not recover again on a new watcher after a restart", () => {
+    // This is the real failure mode: recovery respawns the backend, which
+    // installs a *new* watcher. A per-instance latch would miss this and
+    // loop forever.
+    const first = makeFakeProc();
+    let recoverCount = 0;
+    const logs: string[] = [];
+
+    watchAutomationMigration(first, {
+      dbPath: "/tmp/fake-automations.db",
+      onRecover: () => {
+        recoverCount += 1;
+      },
+      log: (message: string) => logs.push(message),
+    });
+    fireMigrationExit(first);
+    expect(recoverCount).toBe(1);
+
+    const second = makeFakeProc();
+    watchAutomationMigration(second, {
+      dbPath: "/tmp/fake-automations.db",
+      onRecover: () => {
+        recoverCount += 1;
+      },
+      log: (message: string) => logs.push(message),
+    });
+    fireMigrationExit(second);
 
     expect(recoverCount).toBe(1);
     expect(logs.some((m) => m.includes("giving up"))).toBe(true);
@@ -112,9 +151,7 @@ describe("watchAutomationMigration", () => {
       log: (message: string) => logs.push(message),
     });
 
-    proc.stdout.emit("data", Buffer.from(MIGRATION_LOG_LINE));
-
-    expect(() => proc.emit("exit", 3)).not.toThrow();
+    expect(() => fireMigrationExit(proc)).not.toThrow();
     expect(
       logs.some((m) => m.includes("Failed to remove stale automations.db")),
     ).toBe(true);
@@ -124,6 +161,10 @@ describe("watchAutomationMigration", () => {
 // Real-filesystem integration: prove onRecover wiring deletes an actual file.
 describe("watchAutomationMigration integration", () => {
   let dir: string;
+
+  beforeEach(() => {
+    resetAutomationMigrationLatch();
+  });
 
   afterEach(() => {
     if (dir && existsSync(dir)) {
@@ -143,8 +184,7 @@ describe("watchAutomationMigration integration", () => {
       log: () => {},
     });
 
-    proc.stdout.emit("data", Buffer.from(MIGRATION_LOG_LINE));
-    proc.emit("exit", 3);
+    fireMigrationExit(proc);
     expect(existsSync(dbPath)).toBe(false);
 
     // Second failure must not attempt anything further.

--- a/scripts/dev-process-utils.mjs
+++ b/scripts/dev-process-utils.mjs
@@ -150,8 +150,23 @@ export function createShutdownHookRegistry(onError) {
 }
 
 /**
+ * Process-wide latch for stale-DB recovery.
+ *
+ * The latch MUST outlive a single watcher instance. Recovery deletes the
+ * DB then respawns the backend, and that spawn installs a *new* watcher.
+ * If the latch lived on the old instance, the new watcher would recover
+ * again, and `npm run dev` would restart forever.
+ */
+let recoveryAttempted = false;
+
+/** Test-only: reset the process-wide latch between cases. */
+export function resetAutomationMigrationLatch() {
+  recoveryAttempted = false;
+}
+
+/**
  * Watch a spawned automation backend for a stale SQLite migration failure
- * and recover once by deleting the stale DB and restarting.
+ * and recover once by deleting the stale DB.
  *
  * The failure happens when openhands-automation is updated to a version
  * with a restructured Alembic revision chain: the old DB references a
@@ -161,24 +176,24 @@ export function createShutdownHookRegistry(onError) {
  * Both dev launchers (dev-static and dev-with-automation) need exactly
  * this behaviour; keeping it here means they cannot drift apart.
  *
- * Recovery is single-shot by design. If the restart also fails with a
- * migration error — broken upstream package, read-only filesystem,
+ * Recovery is single-shot for the whole process. If the restarted backend
+ * fails the same way — broken upstream package, read-only filesystem,
  * changed error wording — we log loudly and give up rather than loop.
  * An unbounded respawn cycle would wedge `npm run dev` and mask the real
  * breakage from the developer.
  *
+ * Callers put the restart *inside* `onRecover`, after the delete. Do not
+ * also restart on a bare exit-code-3 handler: that would respawn even
+ * when the log pattern never appeared, and it would bypass this latch.
+ *
  * Params are injectable so tests can drive the whole lifecycle with fake
- * streams and timers.
+ * streams.
  */
 export function watchAutomationMigration(
   proc,
   { dbPath, onRecover, log, pattern = "Can't locate revision identified by" },
 ) {
   let detected = false;
-  // Single-shot latch, scoped to THIS watcher instance. One recovery
-  // attempt per launcher run: if the restarted backend fails the same way
-  // again we log loudly and give up rather than respawn forever.
-  let attempted = false;
 
   const checkForMigrationError = (data) => {
     if (!detected && data.toString().includes(pattern)) {
@@ -201,12 +216,11 @@ export function watchAutomationMigration(
       return;
     }
 
-    // Single-shot latch: one recovery attempt per launcher run, ever.
-    if (attempted) {
+    if (recoveryAttempted) {
       log?.("Migration error again after recovery — giving up.", "error");
       return;
     }
-    attempted = true;
+    recoveryAttempted = true;
 
     log?.(`Migration error detected — removing stale DB at ${dbPath}...`, "warn");
     try {

--- a/scripts/dev-process-utils.mjs
+++ b/scripts/dev-process-utils.mjs
@@ -148,3 +148,72 @@ export function createShutdownHookRegistry(onError) {
     },
   };
 }
+
+/**
+ * Watch a spawned automation backend for a stale SQLite migration failure
+ * and recover once by deleting the stale DB and restarting.
+ *
+ * The failure happens when openhands-automation is updated to a version
+ * with a restructured Alembic revision chain: the old DB references a
+ * revision the new chain doesn't know about, and the backend exits with
+ * Alembic's "Can't locate revision identified by" error.
+ *
+ * Both dev launchers (dev-static and dev-with-automation) need exactly
+ * this behaviour; keeping it here means they cannot drift apart.
+ *
+ * Recovery is single-shot by design. If the restart also fails with a
+ * migration error — broken upstream package, read-only filesystem,
+ * changed error wording — we log loudly and give up rather than loop.
+ * An unbounded respawn cycle would wedge `npm run dev` and mask the real
+ * breakage from the developer.
+ *
+ * Params are injectable so tests can drive the whole lifecycle with fake
+ * streams and timers.
+ */
+export function watchAutomationMigration(
+  proc,
+  { dbPath, onRecover, log, pattern = "Can't locate revision identified by" },
+) {
+  let detected = false;
+  // Single-shot latch, scoped to THIS watcher instance. One recovery
+  // attempt per launcher run: if the restarted backend fails the same way
+  // again we log loudly and give up rather than respawn forever.
+  let attempted = false;
+
+  const checkForMigrationError = (data) => {
+    if (!detected && data.toString().includes(pattern)) {
+      detected = true;
+    }
+  };
+
+  proc.stdout?.on("data", checkForMigrationError);
+  proc.stderr?.on("data", checkForMigrationError);
+
+  proc.on("exit", (code) => {
+    if (!detected) {
+      return;
+    }
+
+    // Exit code 3 is how the automation backend currently surfaces an
+    // unrecoverable startup error. We still require the log pattern so a
+    // coincidental exit 3 from another cause never deletes the DB.
+    if (code !== 3) {
+      return;
+    }
+
+    // Single-shot latch: one recovery attempt per launcher run, ever.
+    if (attempted) {
+      log?.("Migration error again after recovery — giving up.", "error");
+      return;
+    }
+    attempted = true;
+
+    log?.(`Migration error detected — removing stale DB at ${dbPath}...`, "warn");
+    try {
+      onRecover();
+      log?.("Deleted stale automations.db, restarting...", "ok");
+    } catch (err) {
+      log?.(`Failed to remove stale automations.db: ${err.message}`, "error");
+    }
+  });
+}

--- a/scripts/dev-static.mjs
+++ b/scripts/dev-static.mjs
@@ -37,6 +37,7 @@
  */
 
 import { spawn, spawnSync } from "node:child_process";
+import { unlinkSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { setTimeout as delay } from "node:timers/promises";
@@ -383,7 +384,9 @@ function startAutomationBackend(config) {
   const automationCmd = buildAutomationCommand(process.env);
   logService("automation", `Using ${automationCmd.source}`, c.dim);
 
-  spawnService(
+  const autoDbPath = join(config.stateDir, "automations.db");
+
+  const proc = spawnService(
     "automation",
     automationCmd.command,
     [
@@ -399,6 +402,43 @@ function startAutomationBackend(config) {
       color: c.green,
     },
   );
+
+  // Detect stale SQLite migration failures (identical recovery as
+  // dev-with-automation.mjs).
+  let detectedMigrationError = false;
+  const MIGRATION_ERROR_PATTERN = "Can't locate revision identified by";
+
+  const checkForMigrationError = (data) => {
+    if (!detectedMigrationError && data.toString().includes(MIGRATION_ERROR_PATTERN)) {
+      detectedMigrationError = true;
+    }
+  };
+
+  proc.stdout.on("data", checkForMigrationError);
+  proc.stderr.on("data", checkForMigrationError);
+
+  proc.on("exit", (code) => {
+    if (code === 3 && detectedMigrationError) {
+      logService(
+        "automation",
+        `Migration error — removing stale DB at ${autoDbPath} and restarting...`,
+        c.yellow,
+      );
+      try {
+        unlinkSync(autoDbPath);
+        logService(
+          "automation",
+          `Deleted stale automations.db, restarting...`,
+          c.green,
+        );
+        startAutomationBackend(config);
+      } catch (err) {
+        logError(
+          `Failed to remove stale automations.db: ${err.message}`,
+        );
+      }
+    }
+  });
 }
 
 function startStaticServer(config) {

--- a/scripts/dev-static.mjs
+++ b/scripts/dev-static.mjs
@@ -57,6 +57,7 @@ import {
   isProcessRunning,
   resolveWindowsCommand,
   signalProcessTree,
+  watchAutomationMigration,
 } from "./dev-process-utils.mjs";
 import {
   buildAgentServerAutomationEnv,
@@ -403,40 +404,23 @@ function startAutomationBackend(config) {
     },
   );
 
-  // Detect stale SQLite migration failures (identical recovery as
-  // dev-with-automation.mjs).
-  let detectedMigrationError = false;
-  const MIGRATION_ERROR_PATTERN = "Can't locate revision identified by";
+  // Detect stale SQLite migration failures and recover once via the
+  // shared watcher in dev-process-utils.mjs (same behaviour as
+  // dev-with-automation.mjs — single shared implementation).
+  watchAutomationMigration(proc, {
+    dbPath: autoDbPath,
+    onRecover: () => unlinkSync(autoDbPath),
+    log: (message, kind) => {
+      const colors = { warn: c.yellow, ok: c.green, error: c.red };
+      logService("automation", message, colors[kind] ?? c.dim);
+    },
+  });
 
-  const checkForMigrationError = (data) => {
-    if (!detectedMigrationError && data.toString().includes(MIGRATION_ERROR_PATTERN)) {
-      detectedMigrationError = true;
-    }
-  };
-
-  proc.stdout.on("data", checkForMigrationError);
-  proc.stderr.on("data", checkForMigrationError);
-
+  // Restart the backend after the watcher deletes the stale DB. The
+  // watcher's latch guarantees this happens at most once per run.
   proc.on("exit", (code) => {
-    if (code === 3 && detectedMigrationError) {
-      logService(
-        "automation",
-        `Migration error — removing stale DB at ${autoDbPath} and restarting...`,
-        c.yellow,
-      );
-      try {
-        unlinkSync(autoDbPath);
-        logService(
-          "automation",
-          `Deleted stale automations.db, restarting...`,
-          c.green,
-        );
-        startAutomationBackend(config);
-      } catch (err) {
-        logError(
-          `Failed to remove stale automations.db: ${err.message}`,
-        );
-      }
+    if (code === 3) {
+      startAutomationBackend(config);
     }
   });
 }

--- a/scripts/dev-static.mjs
+++ b/scripts/dev-static.mjs
@@ -409,19 +409,14 @@ function startAutomationBackend(config) {
   // dev-with-automation.mjs — single shared implementation).
   watchAutomationMigration(proc, {
     dbPath: autoDbPath,
-    onRecover: () => unlinkSync(autoDbPath),
+    onRecover: () => {
+      unlinkSync(autoDbPath);
+      startAutomationBackend(config);
+    },
     log: (message, kind) => {
       const colors = { warn: c.yellow, ok: c.green, error: c.red };
       logService("automation", message, colors[kind] ?? c.dim);
     },
-  });
-
-  // Restart the backend after the watcher deletes the stale DB. The
-  // watcher's latch guarantees this happens at most once per run.
-  proc.on("exit", (code) => {
-    if (code === 3) {
-      startAutomationBackend(config);
-    }
   });
 }
 

--- a/scripts/dev-static.mjs
+++ b/scripts/dev-static.mjs
@@ -37,6 +37,7 @@
  */
 
 import { spawn, spawnSync } from "node:child_process";
+import { unlinkSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { setTimeout as delay } from "node:timers/promises";
@@ -352,7 +353,9 @@ function startAutomationBackend(config) {
   const automationCmd = buildAutomationCommand(process.env);
   logService("automation", `Using ${automationCmd.source}`, c.dim);
 
-  spawnService(
+  const autoDbPath = join(config.stateDir, "automations.db");
+
+  const proc = spawnService(
     "automation",
     automationCmd.command,
     [
@@ -368,6 +371,43 @@ function startAutomationBackend(config) {
       color: c.green,
     },
   );
+
+  // Detect stale SQLite migration failures (identical recovery as
+  // dev-with-automation.mjs).
+  let detectedMigrationError = false;
+  const MIGRATION_ERROR_PATTERN = "Can't locate revision identified by";
+
+  const checkForMigrationError = (data) => {
+    if (!detectedMigrationError && data.toString().includes(MIGRATION_ERROR_PATTERN)) {
+      detectedMigrationError = true;
+    }
+  };
+
+  proc.stdout.on("data", checkForMigrationError);
+  proc.stderr.on("data", checkForMigrationError);
+
+  proc.on("exit", (code) => {
+    if (code === 3 && detectedMigrationError) {
+      logService(
+        "automation",
+        `Migration error — removing stale DB at ${autoDbPath} and restarting...`,
+        c.yellow,
+      );
+      try {
+        unlinkSync(autoDbPath);
+        logService(
+          "automation",
+          `Deleted stale automations.db, restarting...`,
+          c.green,
+        );
+        startAutomationBackend(config);
+      } catch (err) {
+        logError(
+          `Failed to remove stale automations.db: ${err.message}`,
+        );
+      }
+    }
+  });
 }
 
 function startStaticServer(config) {

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -45,7 +45,7 @@
  */
 
 import { spawn, spawnSync } from "node:child_process";
-import { mkdirSync, existsSync, readFileSync } from "node:fs";
+import { mkdirSync, existsSync, readFileSync, unlinkSync } from "node:fs";
 import { join, resolve, dirname, isAbsolute } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { homedir } from "node:os";
@@ -970,7 +970,12 @@ function startAutomationBackend(config) {
   const automationCmd = buildAutomationCommand(process.env);
   logService("automation", `Using ${automationCmd.source}`, c.dim);
 
-  spawnService(
+  const autoDbPath = join(
+    dirname(config.stateDir),
+    SHARED_DEFAULTS.paths.automationDb,
+  );
+
+  const proc = spawnService(
     "automation",
     automationCmd.command,
     [
@@ -1015,7 +1020,7 @@ function startAutomationBackend(config) {
           : {}),
         AUTOMATION_AGENT_SERVER_API_KEY: config.sessionApiKey,
         // ~/.openhands/automation/automations.db — matches docker/entrypoint.sh.
-        AUTOMATION_DB_URL: `sqlite+aiosqlite:///${join(dirname(config.stateDir), SHARED_DEFAULTS.paths.automationDb)}`,
+        AUTOMATION_DB_URL: `sqlite+aiosqlite:///${autoDbPath}`,
         // The automation backend uses this as its publicly-reachable base
         // URL: it's appended to callback URLs and injected into each
         // sandbox as `AUTOMATION_API_URL` (consumed by setup.sh for
@@ -1059,6 +1064,45 @@ function startAutomationBackend(config) {
       color: c.green,
     },
   );
+
+  // Detect stale SQLite migration failures (happens when openhands-automation
+  // is updated to a version with a restructured Alembic revision chain, and
+  // the old DB references a revision the new chain doesn't know about).
+  // Recovery: delete the stale DB and restart once.
+  let detectedMigrationError = false;
+  const MIGRATION_ERROR_PATTERN = "Can't locate revision identified by";
+
+  const checkForMigrationError = (data) => {
+    if (!detectedMigrationError && data.toString().includes(MIGRATION_ERROR_PATTERN)) {
+      detectedMigrationError = true;
+    }
+  };
+
+  proc.stdout.on("data", checkForMigrationError);
+  proc.stderr.on("data", checkForMigrationError);
+
+  proc.on("exit", (code) => {
+    if (code === 3 && detectedMigrationError) {
+      logService(
+        "automation",
+        `Migration error — removing stale DB at ${autoDbPath} and restarting...`,
+        c.yellow,
+      );
+      try {
+        unlinkSync(autoDbPath);
+        logService(
+          "automation",
+          `Deleted stale automations.db, restarting...`,
+          c.green,
+        );
+        startAutomationBackend(config);
+      } catch (err) {
+        logError(
+          `Failed to remove stale automations.db: ${err.message}`,
+        );
+      }
+    }
+  });
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -69,6 +69,7 @@ import {
   isProcessRunning,
   resolveWindowsCommand,
   signalProcessTree,
+  watchAutomationMigration,
 } from "./dev-process-utils.mjs";
 import { fileLog, stripAnsi } from "./logger.mjs";
 
@@ -1065,42 +1066,25 @@ function startAutomationBackend(config) {
     },
   );
 
-  // Detect stale SQLite migration failures (happens when openhands-automation
-  // is updated to a version with a restructured Alembic revision chain, and
-  // the old DB references a revision the new chain doesn't know about).
-  // Recovery: delete the stale DB and restart once.
-  let detectedMigrationError = false;
-  const MIGRATION_ERROR_PATTERN = "Can't locate revision identified by";
+  // Detect stale SQLite migration failures and recover once via the
+  // shared watcher in dev-process-utils.mjs (single shared implementation
+  // with dev-static.mjs). The latch inside the watcher guarantees at most
+  // one recovery attempt per run, so a persistently broken backend can
+  // never wedge this launcher in a restart loop.
+  watchAutomationMigration(proc, {
+    dbPath: autoDbPath,
+    onRecover: () => unlinkSync(autoDbPath),
+    log: (message, kind) => {
+      const colors = { warn: c.yellow, ok: c.green, error: c.red };
+      logService("automation", message, colors[kind] ?? c.dim);
+      fileLog(kind === "error" ? "error" : "info", message);
+    },
+  });
 
-  const checkForMigrationError = (data) => {
-    if (!detectedMigrationError && data.toString().includes(MIGRATION_ERROR_PATTERN)) {
-      detectedMigrationError = true;
-    }
-  };
-
-  proc.stdout.on("data", checkForMigrationError);
-  proc.stderr.on("data", checkForMigrationError);
-
+  // Restart the backend after the watcher deletes the stale DB.
   proc.on("exit", (code) => {
-    if (code === 3 && detectedMigrationError) {
-      logService(
-        "automation",
-        `Migration error — removing stale DB at ${autoDbPath} and restarting...`,
-        c.yellow,
-      );
-      try {
-        unlinkSync(autoDbPath);
-        logService(
-          "automation",
-          `Deleted stale automations.db, restarting...`,
-          c.green,
-        );
-        startAutomationBackend(config);
-      } catch (err) {
-        logError(
-          `Failed to remove stale automations.db: ${err.message}`,
-        );
-      }
+    if (code === 3) {
+      startAutomationBackend(config);
     }
   });
 }

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -1073,19 +1073,15 @@ function startAutomationBackend(config) {
   // never wedge this launcher in a restart loop.
   watchAutomationMigration(proc, {
     dbPath: autoDbPath,
-    onRecover: () => unlinkSync(autoDbPath),
+    onRecover: () => {
+      unlinkSync(autoDbPath);
+      startAutomationBackend(config);
+    },
     log: (message, kind) => {
       const colors = { warn: c.yellow, ok: c.green, error: c.red };
       logService("automation", message, colors[kind] ?? c.dim);
       fileLog(kind === "error" ? "error" : "info", message);
     },
-  });
-
-  // Restart the backend after the watcher deletes the stale DB.
-  proc.on("exit", (code) => {
-    if (code === 3) {
-      startAutomationBackend(config);
-    }
   });
 }
 

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -45,7 +45,7 @@
  */
 
 import { spawn, spawnSync } from "node:child_process";
-import { mkdirSync, existsSync, readFileSync } from "node:fs";
+import { mkdirSync, existsSync, readFileSync, unlinkSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { homedir } from "node:os";
@@ -835,7 +835,12 @@ function startAutomationBackend(config) {
   const automationCmd = buildAutomationCommand(process.env);
   logService("automation", `Using ${automationCmd.source}`, c.dim);
 
-  spawnService(
+  const autoDbPath = join(
+    dirname(config.stateDir),
+    SHARED_DEFAULTS.paths.automationDb,
+  );
+
+  const proc = spawnService(
     "automation",
     automationCmd.command,
     [
@@ -880,7 +885,7 @@ function startAutomationBackend(config) {
           : {}),
         AUTOMATION_AGENT_SERVER_API_KEY: config.sessionApiKey,
         // ~/.openhands/automation/automations.db — matches docker/entrypoint.sh.
-        AUTOMATION_DB_URL: `sqlite+aiosqlite:///${join(dirname(config.stateDir), SHARED_DEFAULTS.paths.automationDb)}`,
+        AUTOMATION_DB_URL: `sqlite+aiosqlite:///${autoDbPath}`,
         // The automation backend uses this as its publicly-reachable base
         // URL: it's appended to callback URLs and injected into each
         // sandbox as `AUTOMATION_API_URL` (consumed by setup.sh for
@@ -924,6 +929,45 @@ function startAutomationBackend(config) {
       color: c.green,
     },
   );
+
+  // Detect stale SQLite migration failures (happens when openhands-automation
+  // is updated to a version with a restructured Alembic revision chain, and
+  // the old DB references a revision the new chain doesn't know about).
+  // Recovery: delete the stale DB and restart once.
+  let detectedMigrationError = false;
+  const MIGRATION_ERROR_PATTERN = "Can't locate revision identified by";
+
+  const checkForMigrationError = (data) => {
+    if (!detectedMigrationError && data.toString().includes(MIGRATION_ERROR_PATTERN)) {
+      detectedMigrationError = true;
+    }
+  };
+
+  proc.stdout.on("data", checkForMigrationError);
+  proc.stderr.on("data", checkForMigrationError);
+
+  proc.on("exit", (code) => {
+    if (code === 3 && detectedMigrationError) {
+      logService(
+        "automation",
+        `Migration error — removing stale DB at ${autoDbPath} and restarting...`,
+        c.yellow,
+      );
+      try {
+        unlinkSync(autoDbPath);
+        logService(
+          "automation",
+          `Deleted stale automations.db, restarting...`,
+          c.green,
+        );
+        startAutomationBackend(config);
+      } catch (err) {
+        logError(
+          `Failed to remove stale automations.db: ${err.message}`,
+        );
+      }
+    }
+  });
 }
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
HUMAN:

I picked up #15623 looking for a first contribution here. Full honesty on the testing: I could not run the live launcher end-to-end against a real broken DB, so the evidence in this PR is the test suite instead - seven cases driving the recovery watcher, including one that deletes a real file on disk. The screenshot further down is that run on my machine.

AGENT:

## Why

When `openhands-automation` is updated and its Alembic revision chain is restructured, the old `automations.db` references a revision that no longer exists. The service exits with code 3 and the Automate tab stays broken with no recovery path.

## Summary

- Shared `watchAutomationMigration()` helper in `scripts/dev-process-utils.mjs`, used by both `dev-with-automation.mjs` and `dev-static.mjs`
- Process-wide latch: one recovery attempt per launcher run, then a loud give-up instead of a restart loop
- Restart only happens inside `onRecover` after a successful DB delete
- Seven regression tests covering pattern+code, latch across a new watcher, and a real-filesystem delete

## Issue Number

Fixes #15623

## How to Test

1. Simulate a stale DB: create a `~/.openhands/automation/automations.db` with an Alembic revision that doesn't exist in the current chain
2. Run `node scripts/dev-with-automation.mjs`
3. The automation backend crashes once with the migration error
4. The script detects it, deletes the stale DB, and restarts successfully
5. A second crash of the same kind does not restart again
6. `npx vitest run __tests__/scripts/dev-migration-watch.test.ts` — 7/7 passing

## Video/Screenshots

![vitest: 7/7 passing on the migration recovery latch](https://tmpfiles.org/dl/wnwlGw60bU5D/oh16393_vitest.png)

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Recovery is single-shot for the whole process. If the restart also fails (different root cause), the second crash is not retried.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.55s · commit 931f719  
**Strongest signal:** Data loss · 65% estimated likelihood.  
**Evidence:** [F003H004 · scripts/dev-static.mjs:403–423](https://github.com/OpenHands/OpenHands/blob/931f719beb4db7906abaa7e767d72c689db73c44/scripts/dev-static.mjs#L403-L423).  
**Coverage:** complete supplied coverage; 11/11 hunks, 4/4 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 6.0% | No direct hunk selected |
| Weakened authentication | 5.0% | No direct hunk selected |
| Weakened authorization | 10.0% | No direct hunk selected |
| Contract regression | 12.0% | No direct hunk selected |
| Data loss | 65.0% | [F003H004 · scripts/dev-static.mjs:403–423](https://github.com/OpenHands/OpenHands/blob/931f719beb4db7906abaa7e767d72c689db73c44/scripts/dev-static.mjs#L403-L423) |
| Sensitive data disclosure | 5.0% | No direct hunk selected |
| Unexpected data transfer | 4.0% | No direct hunk selected |
| Credential misuse | 6.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 4.0% | No direct hunk selected |
| Unverified remote execution | 3.0% | No direct hunk selected |
| Privileged environment access | 45.0% | [F003H004 · scripts/dev-static.mjs:403–423](https://github.com/OpenHands/OpenHands/blob/931f719beb4db7906abaa7e767d72c689db73c44/scripts/dev-static.mjs#L403-L423) |
| Security assessment bypass | 4.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | Data loss; confidence 93.0% | [F003H004 · scripts/dev-static.mjs:403–423](https://github.com/OpenHands/OpenHands/blob/931f719beb4db7906abaa7e767d72c689db73c44/scripts/dev-static.mjs#L403-L423) |

</details>


<!-- jev-input-signature f99fb9a1d2855abad61a26a5818748037b3594dbb0d105d78031aff84728e603 -->
<!-- jev-fast-audit:end -->
