### PR TITLE
fix(chat): reserve bottom padding for mobile composer 

### DIFF
--- a/src/components/features/chat/chat-interface.tsx
+++ b/src/components/features/chat/chat-interface.tsx
@@ -504,7 +504,7 @@ export function ChatInterface() {
             maybeLoadOlder(e.currentTarget);
           }}
           onWheel={handleWheelForPagination}
-          className="custom-scrollbar-always flex min-h-0 grow flex-col gap-2 overflow-x-hidden overflow-y-auto px-0 pt-4 pb-8 md:px-4"
+          className="custom-scrollbar-always flex min-h-0 grow flex-col gap-2 overflow-x-hidden overflow-y-auto px-0 pt-4 pb-28 md:pb-8 md:px-4"
         >
           {isChatLoading && isReturningToConversation && (
             <ChatMessagesSkeleton />


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
Tested locally using Chrome DevTools mobile emulation. Verified that chat content no longer overlaps the composer on narrow viewports.

AGENT:

## Why

On mobile and narrow viewports, the chat content could scroll underneath the message composer and toolbar. This caused the latest messages to be partially hidden, making conversations difficult to read and interact with.

## Summary

* Added additional bottom padding to the chat scroll container on mobile viewports.
* Ensured the latest messages remain visible above the composer and toolbar.
* Preserved the existing layout and behavior on desktop screens.

## Issue Number

Fixes #16363

## How to Test

1. Install dependencies:

   ```bash
   npm ci
   ```
2. Build and preview the application:

   ```bash
   npm run build:app
   npm run preview
   ```
3. Open the preview URL in a browser.
4. Enable mobile device emulation (e.g., Chrome DevTools → Toggle Device Toolbar) or use a physical mobile device.
5. Open an existing conversation or create a new one.
6. Verify that:

   * The latest chat messages are fully visible above the composer.
   * The composer and toolbar no longer overlap the chat content.
   * Desktop layout remains unchanged.

## Video/Screenshots

N/A

## Type

* [x] Bug fix
* [ ] Feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Docs / chore

## Notes

This is a minimal UI-only change that reserves additional space for the mobile composer by increasing the bottom padding of the chat scroll container. No application logic or desktop behavior is affected.

I attempted to run the test suite, but the current environment did not have the required development dependencies installed (`vitest` was unavailable), so automated tests could not be executed. The change was validated through manual inspection of the UI.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.40s · commit 3baeda0  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 1/1 hunks, 1/1 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 2.0% | No direct hunk selected |
| Weakened authentication | 2.0% | No direct hunk selected |
| Weakened authorization | 2.0% | No direct hunk selected |
| Contract regression | 4.0% | No direct hunk selected |
| Data loss | 2.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 2.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 2.0% | No direct hunk selected |
| Prohibited workload | 1.0% | No direct hunk selected |
| Primary concern | None selected; confidence 99.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 0995eea387e3733a6fcd5679d7cb75880592b85b99da10aec6083739d9dc9a08 -->
<!-- jev-fast-audit:end -->
