### PR TITLE
fix: keep git diff view in sync after commit/push

### DIFF
--- a/__tests__/hooks/query/use-unified-get-git-changes.test.tsx
+++ b/__tests__/hooks/query/use-unified-get-git-changes.test.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AgentServerGitService from "#/api/git-service/agent-server-git-service.api";
+import { useUnifiedGetGitChanges } from "#/hooks/query/use-unified-get-git-changes";
+import type { GitChange } from "#/api/open-hands.types";
+
+vi.mock("#/hooks/use-conversation-id", () => ({
+  useConversationId: () => ({ conversationId: "conv-1" }),
+  useOptionalConversationId: () => ({ conversationId: "conv-1" }),
+}));
+
+vi.mock("#/hooks/query/use-active-conversation", () => ({
+  useActiveConversation: () => ({
+    data: {
+      id: "conv-1",
+      conversation_url: "https://runtime.example.com/api/conversations/conv-1",
+      session_api_key: "session-key",
+      selected_repository: null,
+      workspace: { working_dir: "/workspace/project" },
+    },
+  }),
+}));
+
+vi.mock("#/hooks/use-runtime-is-ready", () => ({
+  useRuntimeIsReady: () => true,
+}));
+
+const getGitChangesSpy = vi.spyOn(AgentServerGitService, "getGitChanges");
+
+// Wrap in a real QueryClient so refetch/refetchInterval-driven updates flow
+// through the cache exactly as they do in the app.
+function renderHookWithClient() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return renderHook(() => useUnifiedGetGitChanges(), {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  });
+}
+
+const changedFile: GitChange = {
+  status: "M",
+  path: "src/index.ts",
+};
+
+describe("useUnifiedGetGitChanges", () => {
+  beforeEach(() => {
+    getGitChangesSpy.mockReset();
+    getGitChangesSpy.mockResolvedValue([changedFile]);
+  });
+
+  it("exposes the current git changes from the server", async () => {
+    const { result } = renderHookWithClient();
+
+    await waitFor(() => expect(result.current.data).toEqual([changedFile]));
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it("clears stale rows when a refetch returns an empty diff (after commit)", async () => {
+    // Regression for the "diff still shows after commit" bug: the hook must
+    // reflect the freshest server state, not keep a stale accumulation of rows
+    // from an earlier response. Simulate: first fetch sees two changed files,
+    // then a refetch (e.g. triggered by the commit invalidate) returns the now
+    // empty diff.
+    getGitChangesSpy
+      .mockResolvedValueOnce([changedFile, { status: "A", path: "new.ts" }])
+      .mockResolvedValue([]);
+
+    const { result } = renderHookWithClient();
+
+    await waitFor(() => expect(result.current.data).toHaveLength(2));
+
+    // Trigger a background refetch; the new empty diff must replace the rows.
+    await result.current.refetch();
+    await waitFor(() => expect(result.current.data).toHaveLength(0));
+  });
+});

--- a/src/hooks/query/use-unified-get-git-changes.ts
+++ b/src/hooks/query/use-unified-get-git-changes.ts
@@ -5,13 +5,24 @@ import { useConversationId } from "#/hooks/use-conversation-id";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useRuntimeIsReady } from "#/hooks/use-runtime-is-ready";
 import { getGitPath } from "#/utils/get-git-path";
-import type { GitChange } from "#/api/open-hands.types";
 
+/**
+ * The diff view should reflect the *current* git state. Every fetch (initial,
+ * auto-invalidate after a commit/push event, or the periodic poll below)
+ * returns the authoritative, complete ordered list from the server, so we hand
+ * that straight to the UI. Historically this hook accumulated deltas into an
+ * `orderedChanges` buffer whose closure-dependent merge could pin stale rows
+ * after a commit — that's the "diff still shows after commit" bug. The server
+ * already returns the whole picture, so no buffer is needed.
+ *
+ * A short `refetchInterval` also closes the gap where the one-shot invalidate
+ * from the commit event can fire *before* the commit lands on disk: the next
+ * poll picks it up, so the diff clears on its own instead of waiting for a
+ * manual refresh.
+ */
 export const useUnifiedGetGitChanges = () => {
   const { conversationId } = useConversationId();
   const { data: conversation } = useActiveConversation();
-  const [orderedChanges, setOrderedChanges] = React.useState<GitChange[]>([]);
-  const previousDataRef = React.useRef<GitChange[] | null>(null);
   const runtimeIsReady = useRuntimeIsReady();
 
   const conversationUrl = conversation?.conversation_url;
@@ -46,48 +57,21 @@ export const useUnifiedGetGitChanges = () => {
     staleTime: 1000 * 60 * 5, // 5 minutes
     gcTime: 1000 * 60 * 15, // 15 minutes
     refetchOnMount: "always",
+    // Keep the diff in sync after a commit/push lands. The commit event's
+    // invalidate can fire before the backend finishes committing; this poll
+    // guarantees the view converges to the true state shortly after.
+    refetchInterval: 5000,
     enabled: runtimeIsReady && !!conversationId,
     meta: {
       disableToast: true,
     },
   });
 
-  // Latest changes should be on top
-  React.useEffect(() => {
-    if (!result.isFetching && result.isSuccess && result.data) {
-      const currentData = result.data;
-
-      // If this is new data (not the same reference as before)
-      if (currentData !== previousDataRef.current) {
-        previousDataRef.current = currentData;
-
-        // Figure out new items by comparing with what we already have
-        if (Array.isArray(currentData)) {
-          const currentIds = new Set(currentData.map((item) => item.path));
-          const existingIds = new Set(orderedChanges.map((item) => item.path));
-
-          // Filter out items that already exist in orderedChanges
-          const newItems = currentData.filter(
-            (item) => !existingIds.has(item.path),
-          );
-
-          // Filter out items that no longer exist in the API response
-          const existingItems = orderedChanges.filter((item) =>
-            currentIds.has(item.path),
-          );
-
-          // Add new items to the beginning
-          setOrderedChanges([...newItems, ...existingItems]);
-        } else {
-          // If not an array, just use the data directly
-          setOrderedChanges([currentData]);
-        }
-      }
-    }
-  }, [result.isFetching, result.isSuccess, result.data]);
-
+  // Return a stable, flat shape (not the full UseQueryResult union) so
+  // consumers and test mocks can rely on these fields. `data` is always an
+  // array: `undefined` becomes `[]`.
   return {
-    data: orderedChanges,
+    data: result.data ?? [],
     isLoading: result.isLoading,
     isFetching: result.isFetching,
     isSuccess: result.isSuccess,


### PR DESCRIPTION
HUMAN:

The diff view stayed stale after commit/push until a manual refresh. Fixed by returning server-fresh data directly (no stale buffer) and adding a 5s poll so the view re-converges after a commit.

AGENT:

## Why

After the agent commits and pushes, the diff view could keep showing the old changes until the user clicked refresh. Two causes: (1) the hook accumulated deltas into an `orderedChanges` buffer with a fragile closure-dependent merge, and (2) the one-shot `file_changes` invalidate fired by the commit event can land before the backend finishes committing, so a single refetch can still return the pre-commit diff.

## Summary

- Rewrote `useUnifiedGetGitChanges` to return the server's complete, authoritative list directly — no `orderedChanges` accumulation buffer (every response is already the full ordered list, so merging only risked pinning stale rows)
- Added a 5s `refetchInterval` so the diff view converges to the true git state shortly after a commit/push, even when the commit event's invalidate fires early
- Added a regression test asserting the hook drops stale rows when a refetch returns an empty diff

## Issue Number

OpenHands/OpenHands#15692

## How to Test

1. Run `npx vitest run __tests__/hooks/query/use-unified-get-git-changes.test.tsx` — new + existing tests pass
2. Full related suite: `npx vitest run __tests__/routes/changes-tab.test.tsx __tests__/routes/files-tab.test.tsx __tests__/hooks/query/use-workspace-files.test.tsx` — 31 tests pass

## Video/Screenshots

![git diff tests passing](https://tmpfiles.org/wwwAF2ICwDU8/browser_screenshot_527a1a47484b4268a6c76b27796bf4e4.png)

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The 5s interval only polls while the query is mounted (the diff/files view is open) and the runtime is ready, so it adds no background churn when the view is closed.