### PR TITLE
feat: add Join Slack link to Agent Canvas sidebar

### DIFF
--- a/__tests__/components/features/sidebar/sidebar.test.tsx
+++ b/__tests__/components/features/sidebar/sidebar.test.tsx
@@ -486,4 +486,32 @@ describe("Sidebar", () => {
       "Automate",
     );
   });
+
+  it("renders the Join Slack action as a new-tab link in the expanded sidebar", () => {
+    renderSidebar("/conversations");
+
+    const sidebar = getDesktopSidebar(false);
+    const joinSlackLink = within(sidebar).getByTestId(
+      "sidebar-join-slack-link",
+    );
+    expect(joinSlackLink).toHaveTextContent("Join Slack");
+    expect(joinSlackLink).toHaveAttribute(
+      "href",
+      "https://go.openhands.dev/slack",
+    );
+    expect(joinSlackLink).toHaveAttribute("target", "_blank");
+    expect(joinSlackLink).toHaveAttribute("rel", expect.stringContaining("noopener"));
+    expect(joinSlackLink).toHaveAttribute("rel", expect.stringContaining("noreferrer"));
+  });
+
+  it("renders the Join Slack iconized action with an accessible label when sidebar is collapsed", () => {
+    useSidebarStore.setState({ collapsed: true });
+    renderSidebar("/conversations");
+
+    const joinSlackLink = screen.getByTestId("sidebar-join-slack-link");
+    expect(joinSlackLink).toHaveAttribute("aria-label", "Join Slack");
+    expect(joinSlackLink).toHaveAttribute("href", "https://go.openhands.dev/slack");
+    expect(joinSlackLink).toHaveAttribute("target", "_blank");
+    expect(joinSlackLink.querySelector("svg")).not.toBeNull();
+  });
 });

--- a/__tests__/i18n/sidebar-join-slack-label.test.ts
+++ b/__tests__/i18n/sidebar-join-slack-label.test.ts
@@ -1,0 +1,31 @@
+import fs from "fs";
+import path from "path";
+import { describe, expect, it } from "vitest";
+
+// The sidebar Join Slack entry renders `t(I18nKey.SIDEBAR$JOIN_SLACK)`, and
+// `I18nKey` is generated from translation.json by make-i18n-translations.cjs.
+// A key missing here therefore compiles to `undefined` and renders an icon
+// with no label. Component tests cannot catch that, because the test i18next
+// mock returns keys rather than resolved translations, so lock it down at the
+// source file the generator actually reads.
+describe("SIDEBAR$JOIN_SLACK label", () => {
+  const translationPath = path.join(
+    __dirname,
+    "../../src/i18n/translation.json",
+  );
+  const translation = JSON.parse(
+    fs.readFileSync(translationPath, "utf-8"),
+  ) as Record<string, Record<string, string>>;
+
+  it('is registered in the generator source as "Join Slack"', () => {
+    expect(translation.SIDEBAR$JOIN_SLACK).toBeDefined();
+    expect(translation.SIDEBAR$JOIN_SLACK.en).toBe("Join Slack");
+  });
+
+  it("covers every locale the other sidebar entries cover", () => {
+    const locales = Object.keys(translation.SIDEBAR$NAVIGATION_LABEL);
+    for (const locale of locales) {
+      expect(translation.SIDEBAR$JOIN_SLACK[locale]?.trim()).toBeTruthy();
+    }
+  });
+});

--- a/src/components/features/sidebar/sidebar-nav-link.tsx
+++ b/src/components/features/sidebar/sidebar-nav-link.tsx
@@ -39,6 +39,12 @@ interface SidebarNavLinkProps {
    * (e.g. the Extensions link being active on /mcp and /plugins too).
    */
   forceActive?: boolean;
+  /** When true, open the link in a new tab instead of navigating in-app. */
+  external?: boolean;
+  /** Optional target override (defaults to _blank when external). */
+  target?: string;
+  /** Optional rel override (defaults to noopener noreferrer when external). */
+  rel?: string;
 }
 
 export function SidebarNavLink({
@@ -52,6 +58,9 @@ export function SidebarNavLink({
   collapsed = false,
   hoverContent,
   forceActive = false,
+  external = false,
+  target,
+  rel,
 }: SidebarNavLinkProps) {
   const { currentPath } = useNavigation();
   const active = forceActive || isPathActive(currentPath, to, end);
@@ -60,6 +69,9 @@ export function SidebarNavLink({
     <NavigationLink
       to={to}
       end={end}
+      target={external ? (target ?? "_blank") : target}
+      rel={external ? (rel ?? "noopener noreferrer") : rel}
+      external={external}
       data-testid={testId}
       tabIndex={disabled ? -1 : 0}
       aria-label={collapsed ? label : undefined}

--- a/src/components/features/sidebar/sidebar-nav-link.tsx
+++ b/src/components/features/sidebar/sidebar-nav-link.tsx
@@ -69,9 +69,11 @@ export function SidebarNavLink({
     <NavigationLink
       to={to}
       end={end}
+      // NavigationLink skips client-side navigation when target is "_blank",
+      // so target/rel are all an external link needs; `external` stays local
+      // to this component as the switch that derives them.
       target={external ? (target ?? "_blank") : target}
       rel={external ? (rel ?? "noopener noreferrer") : rel}
-      external={external}
       data-testid={testId}
       tabIndex={disabled ? -1 : 0}
       aria-label={collapsed ? label : undefined}

--- a/src/components/features/sidebar/sidebar-rail-body.tsx
+++ b/src/components/features/sidebar/sidebar-rail-body.tsx
@@ -4,6 +4,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Plus,
+  Send,
   Server,
   Settings,
 } from "lucide-react";
@@ -223,6 +224,14 @@ export function SidebarRailBody({
             "mt-auto pb-2 cursor-pointer",
           )}
         >
+          <SidebarNavLink
+            to="https://go.openhands.dev/slack"
+            label={t(I18nKey.SIDEBAR$JOIN_SLACK)}
+            testId="sidebar-join-slack-link"
+            external
+            collapsed={collapsed}
+            icon={<Send width={ICON_SIZE} height={ICON_SIZE} />}
+          />
           <StyledTooltip
             content={t(I18nKey.SIDEBAR$SETTINGS)}
             placement="right"
@@ -315,6 +324,13 @@ export function SidebarRailBody({
             "-ml-2.5 w-[calc(100%+0.625rem)] border-t border-[var(--oh-border)] pt-2 px-2.5",
           )}
         >
+          <SidebarNavLink
+            to="https://go.openhands.dev/slack"
+            label={t(I18nKey.SIDEBAR$JOIN_SLACK)}
+            testId="sidebar-join-slack-link"
+            external
+            icon={<Send width={ICON_SIZE} height={ICON_SIZE} />}
+          />
           <AgentCanvasVersionTile hideWhenUpToDate />
           <BackendSelector sidebarCollapsed={collapsed} openUpward />
         </div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,3 +1,0 @@
-{
-  "SIDEBAR$JOIN_SLACK": "Join Slack"
-}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,3 @@
+{
+  "SIDEBAR$JOIN_SLACK": "Join Slack"
+}

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -17492,6 +17492,23 @@
     "uk": "Документація",
     "ca": "Documentació"
   },
+  "SIDEBAR$JOIN_SLACK": {
+    "en": "Join Slack",
+    "ja": "Slack に参加",
+    "zh-CN": "加入 Slack",
+    "zh-TW": "加入 Slack",
+    "ko-KR": "Slack 참여하기",
+    "no": "Bli med i Slack",
+    "it": "Unisciti a Slack",
+    "pt": "Entrar no Slack",
+    "es": "Unirse a Slack",
+    "ar": "انضم إلى Slack",
+    "fr": "Rejoindre Slack",
+    "tr": "Slack'e katıl",
+    "de": "Slack beitreten",
+    "uk": "Приєднатися до Slack",
+    "ca": "Uneix-te a Slack"
+  },
   "SUGGESTIONS$ADD_DOCS": {
     "en": "Add best practices docs for contributors",
     "ja": "コントリビューター向けのベストプラクティスドキュメントを追加",


### PR DESCRIPTION
## Why

Add a direct community-support path from the Agent Canvas sidebar for users who want to join OpenHands Slack.

## Summary

- Adds accessible Join Slack links to the expanded and collapsed sidebar.
- Opens the owned Slack invite in a new tab with safe link attributes.
- Adds focused sidebar coverage for both layouts.

## Issue Number

Closes #15948

## How to Test

- `git apply --check --recount` passed on the reviewed artifact.
- `git diff --check` passed.
- Local verification not run; relying on upstream CI because this fresh worktree has no installed dependencies.

## Video/Screenshots

Not captured.

## Type

- [x] Feature

## Notes

Draft kept pending upstream CI and maintainer review.
