### PR TITLE
fix: prevent add backend dialog overflow on mobile

### DIFF
--- a/src/components/features/backends/backend-form-modal.tsx
+++ b/src/components/features/backends/backend-form-modal.tsx
@@ -1367,7 +1367,7 @@ function AddBackendChooser({
       <div
         role="tablist"
         aria-label={t(I18nKey.BACKEND$CHOOSER_TITLE)}
-        className="grid grid-cols-2 overflow-hidden rounded-lg border border-[var(--oh-border)]"
+        className="grid grid-cols-1 overflow-hidden rounded-lg border border-[var(--oh-border)] md:grid-cols-2"
       >
         <BackendOptionTab
           value="cloud"


### PR DESCRIPTION
Fixes #16366

Make the add-backend option tabs stack on narrow viewports and restore the two-column layout at the md breakpoint.

local verification not run; relying on upstream CI