### PR TITLE
fix: prevent background scrolling while popups are open

### DIFF
--- a/src/components/shared/modals/modal-backdrop.tsx
+++ b/src/components/shared/modals/modal-backdrop.tsx
@@ -33,6 +33,14 @@ export function ModalBackdrop({
     return () => window.removeEventListener("keydown", handleEscape);
   }, [closeOnEscape, onClose]);
 
+  React.useEffect(() => {
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, []);
+
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!closeOnBackdropClick) return;
     if (e.target === e.currentTarget) onClose?.(); // only close if the click was on the backdrop


### PR DESCRIPTION
Fixes #16367.

Lock document body scrolling while a modal is mounted and restore the prior overflow value on cleanup, preventing the page behind popups from scrolling.

local verification not run; relying on upstream CI