### PR TITLE
fix: preserve pinned conversations across pages

### DIFF
--- a/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/src/components/features/conversation-panel/conversation-panel.tsx
@@ -193,9 +193,6 @@ export function ConversationPanel({
       state.pinsByBackendId[activeBackend.id] ?? EMPTY_PINNED_CONVERSATION_IDS,
   );
   const togglePin = usePinnedConversationsStore((state) => state.togglePin);
-  const pruneMissingPinnedConversations = usePinnedConversationsStore(
-    (state) => state.pruneMissingConversations,
-  );
 
   const toggleGroupCollapsed = React.useCallback((groupId: string) => {
     setCollapsedGroupIds((prev) => {
@@ -296,21 +293,6 @@ export function ConversationPanel({
     () => resolvePinnedConversations(pinnedIds, conversations),
     [conversations, pinnedIds],
   );
-
-  React.useEffect(() => {
-    if (!isFetched) {
-      return;
-    }
-    pruneMissingPinnedConversations(
-      activeBackend.id,
-      conversations.map((conversation) => conversation.id),
-    );
-  }, [
-    activeBackend.id,
-    conversations,
-    isFetched,
-    pruneMissingPinnedConversations,
-  ]);
 
   React.useEffect(() => {
     if (pinnedIds.length === 0) {


### PR DESCRIPTION
## Summary

Remove stale pinned-conversation pruning based on the current page so pinned conversations from later pages remain available while preserving pin toggling and preview behavior.

## Issue

Fixes #16399

## Verification

- local verification not run; relying on upstream CI