### PR TITLE
docs: add DefenseClaw and testing matrix to the docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,5 @@ This directory contains the project documentation.
 - [Using ACP agents](./ACP_AGENTS.md): onboard and configure external agents (Claude Code, Codex, Gemini CLI).
 - [Development guide](./DEVELOPMENT.md)
 - [Self-hosting guide](./SELF_HOSTING.md)
+- [Integrating DefenseClaw](./DefenseClaw.md): run the DefenseClaw security governance layer alongside the Agent Server.
+- [Testing matrix](./TESTING_MATRIX.md): release smoke-test coverage across installers, operating systems, and agents.


### PR DESCRIPTION
HUMAN:

Opened docs/DEVELOPMENT.md on main, clicked the multi-backend-setup.md link around line 87, and got a 404. File doesn't exist in the repo. Read the PR summary — dropping the dead link and keeping the npm run dev:extra-backend pointer makes sense, and adding the two missing docs to the README index is fine. Looks good to merge from my side.

AGENT:

**Scope narrowed 2026-08-18.** The `docs/DEVELOPMENT.md` half of this PR was fixed upstream first by #16627, so that hunk is dropped and only the index change remains. Full history is in the comments; the HUMAN note above predates the narrowing and refers to the original two-part change.

```console
$ git log --oneline -1
685744da5 docs: add DefenseClaw and testing matrix to the docs index

$ # The DEVELOPMENT.md half landed upstream first, so it is no longer part of this PR.
$ git log --oneline -1 upstream/main -- docs/DEVELOPMENT.md
342175e47 docs: fix broken internal links (#16627)
$ git diff upstream/main --stat
 docs/README.md | 2 ++
 1 file changed, 2 insertions(+)

$ # docs/README.md indexed 4 of the 6 documents in docs/.
$ ls docs/*.md | grep -vc README.md
6
$ git show upstream/main:docs/README.md | grep -c '^- \['
4
$ grep -c '^- \[' docs/README.md
6

$ # After the change: every indexed link resolves, and no document is left out.
$ node -e '<resolve each index link from docs/, then diff the file list against the index>'
indexed_links_broken=0 documents_missing_from_index=0
```

---

## Why

`docs/README.md` is the index for the `docs/` directory, but it listed only 4 of the 6 documents there. `DefenseClaw.md` and `TESTING_MATRIX.md` were absent, so neither was discoverable from the index a reader lands on first.

## Summary

- Add `DefenseClaw.md` and `TESTING_MATRIX.md` to the `docs/README.md` index, matching the existing `- [Title](./file.md): description.` style.

## Issue Number

Fixes #16678

## How to Test

1. On `main`, confirm two documents are missing from the index:
   ```sh
   ls docs/*.md | grep -vc README.md   # -> 6 documents
   grep -c '^- \[' docs/README.md      # -> 4 index entries
   ```
2. Check out this branch and confirm the index is complete and every entry resolves:
   ```sh
   grep -c '^- \[' docs/README.md      # -> 6
   node -e '
   const {readFileSync,existsSync}=require("fs"),path=require("path"),{execSync}=require("child_process");
   const idx="docs/README.md", body=readFileSync(idx,"utf8"); let bad=0;
   for (const m of body.matchAll(/\[[^\]\n]*\]\(([^)\s]+)\)/g)) {
     const t=m[1].split("#")[0]; if(!t||/^https?:/.test(t))continue;
     if(!existsSync(path.resolve(path.dirname(idx),t))){bad++;console.log("BROKEN",m[1]);}
   }
   const files=execSync("ls docs/*.md",{encoding:"utf8"}).trim().split("\n").map(f=>f.split("/").pop()).filter(f=>f!=="README.md");
   console.log("broken="+bad,"missing="+files.filter(f=>!body.includes("(./"+f+")")).length);'
   ```
   Expected: `broken=0 missing=0`.

## Video/Screenshots

N/A — documentation-only change; no runtime or UI behavior is affected.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- **Index ordering.** New entries are appended after the existing four so the diff does not reorder lines anyone else is editing. Both carry short descriptions to match the `Architecture` and `Using ACP agents` entries; `Development guide` and `Self-hosting guide` remain description-free as they are today.
- **Descriptions were checked against the documents.** `DefenseClaw.md` describes running DefenseClaw as a security governance layer alongside the Agent Server; `TESTING_MATRIX.md` is an install x OS x agent release smoke-test matrix.
- **`__tests__/router.md` has a separate broken link** (`routes/home-screen.test.tsx`, which no longer exists). Left out of scope: `__tests__/` counts as frontend under `.github/scripts/check_pr_description.py`, so touching it would force a screenshot requirement onto a docs-only PR. Happy to fix it in a follow-up.
- **Lint does not cover this change.** `npm run lint` is `typecheck && eslint src && prettier --check src/**/*.{ts,tsx}` — it only looks at `src/`, so no lint/format gate applies to `docs/`.

