### PR TITLE
fix(scripts): use 127.0.0.1 for remaining localhost service URLs

### DIFF
--- a/__tests__/scripts/dev-static.test.ts
+++ b/__tests__/scripts/dev-static.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { buildAutomationBackendEnv } from "../../scripts/dev-static.mjs";
+import {
+  buildAutomationBackendEnv,
+  buildLocalServiceRouteArgs,
+} from "../../scripts/dev-static.mjs";
 
 describe("dev-static", () => {
   it("uses the same session key for both agent-server and automation backend auth", () => {
@@ -16,12 +19,25 @@ describe("dev-static", () => {
 
     // Both backends receive the same key value
     expect(env).toMatchObject({
-      AUTOMATION_AGENT_SERVER_URL: "http://localhost:18000",
+      AUTOMATION_AGENT_SERVER_URL: "http://127.0.0.1:18000",
       AUTOMATION_AGENT_SERVER_API_KEY: "shared-session-key",
       AUTOMATION_LOCAL_API_KEY: "shared-session-key",
       AUTOMATION_POSTHOG_API_KEY:
         "phc_kBtz5nKmxVRRQ7HtPwr2QX9eMC5j65zE86QKocVNwb4U",
       AUTOMATION_POSTHOG_HOST: "https://us.i.posthog.com",
     });
+  });
+
+  it("points every local proxy route at the IPv4 loopback", () => {
+    // Both backends bind to `0.0.0.0`, which only accepts IPv4, so a
+    // `localhost` target strands the proxy on ::1 on Windows.
+    const args = buildLocalServiceRouteArgs({
+      agentServerPort: 18000,
+      autoBackendPort: 18001,
+    });
+
+    expect(args).toContain("/api/automation=http://127.0.0.1:18001");
+    expect(args).toContain("/server_info=http://127.0.0.1:18000");
+    expect(args.filter((arg: string) => arg.includes("localhost"))).toEqual([]);
   });
 });

--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -21,6 +21,7 @@ import {
   buildConfig,
   buildRouteArgs,
   buildViteBackendEnv,
+  getAgentServerBaseUrl,
   getFrontendBackend,
   getLocalServiceRoutes,
   setServiceLogListener,
@@ -509,6 +510,18 @@ describe("stack mode routing", () => {
       `/server_info=http://127.0.0.1:${config.agentServerPort}`,
     );
     expect(routeArgs).not.toContain("--default");
+  });
+
+  it("addresses the agent-server over IPv4 for readiness and secret seeding", async () => {
+    const config = await buildConfig({}, envWithIsolatedKeyPath());
+
+    // The launcher starts the agent-server with `--host 127.0.0.1`, so the
+    // readiness probe (`/server_info`), the secret-seeding request, and the
+    // automation backend's AUTOMATION_AGENT_SERVER_URL must all skip the
+    // `localhost` lookup that resolves to ::1 first on Windows.
+    expect(getAgentServerBaseUrl(config)).toBe(
+      `http://127.0.0.1:${config.agentServerPort}`,
+    );
   });
 
   it("rejects mutually exclusive partial-stack modes", async () => {

--- a/scripts/dev-static.mjs
+++ b/scripts/dev-static.mjs
@@ -285,6 +285,44 @@ async function waitForService(name, url, timeoutMs = 30000) {
 // dev-with-automation; the only difference is the frontend service.)
 // ═══════════════════════════════════════════════════════════════════════════
 
+// Both backends bind to `0.0.0.0`, which only accepts IPv4, but localhost can
+// resolve to ::1 first (notably on Windows). Every proxy target and readiness
+// probe pointed at them must therefore address IPv4 explicitly.
+function getAgentServerBaseUrl(config) {
+  return `http://127.0.0.1:${config.agentServerPort}`;
+}
+
+function getAutomationBaseUrl(config) {
+  return `http://127.0.0.1:${config.autoBackendPort}`;
+}
+
+const AUTOMATION_ROUTE_PREFIX = "/api/automation";
+const AGENT_SERVER_ROUTE_PREFIXES = [
+  "/api",
+  "/sockets",
+  "/server_info",
+  "/health",
+  "/ready",
+  "/alive",
+  "/docs",
+  "/redoc",
+  "/openapi.json",
+];
+
+// The static server and the ingress proxy front the same two local backends,
+// so they share one route table.
+function buildLocalServiceRouteArgs(config) {
+  const agentServerUrl = getAgentServerBaseUrl(config);
+  return [
+    "--route",
+    `${AUTOMATION_ROUTE_PREFIX}=${getAutomationBaseUrl(config)}`,
+    ...AGENT_SERVER_ROUTE_PREFIXES.flatMap((prefix) => [
+      "--route",
+      `${prefix}=${agentServerUrl}`,
+    ]),
+  ];
+}
+
 function startAgentServer(config) {
   logService(
     "agent-server",
@@ -328,7 +366,7 @@ function startAgentServer(config) {
 function buildAutomationBackendEnv(config, env = process.env) {
   // Both backends share the same session API key value.
   return {
-    AUTOMATION_AGENT_SERVER_URL: `http://localhost:${config.agentServerPort}`,
+    AUTOMATION_AGENT_SERVER_URL: getAgentServerBaseUrl(config),
     AUTOMATION_AGENT_SERVER_API_KEY: config.sessionApiKey,
     AUTOMATION_DB_URL: `sqlite+aiosqlite:///${join(config.stateDir, "automations.db")}`,
     AUTOMATION_BASE_URL: `http://localhost:${config.ingressPort}`,
@@ -405,26 +443,7 @@ function startStaticServer(config) {
         : []),
       "--runtime-services-info",
       runtimeServicesInfo,
-      "--route",
-      `/api/automation=http://localhost:${config.autoBackendPort}`,
-      "--route",
-      `/api=http://localhost:${config.agentServerPort}`,
-      "--route",
-      `/sockets=http://localhost:${config.agentServerPort}`,
-      "--route",
-      `/server_info=http://localhost:${config.agentServerPort}`,
-      "--route",
-      `/health=http://localhost:${config.agentServerPort}`,
-      "--route",
-      `/ready=http://localhost:${config.agentServerPort}`,
-      "--route",
-      `/alive=http://localhost:${config.agentServerPort}`,
-      "--route",
-      `/docs=http://localhost:${config.agentServerPort}`,
-      "--route",
-      `/redoc=http://localhost:${config.agentServerPort}`,
-      "--route",
-      `/openapi.json=http://localhost:${config.agentServerPort}`,
+      ...buildLocalServiceRouteArgs(config),
     ],
     {
       cwd: config.canvasPath,
@@ -453,26 +472,7 @@ function startIngress(config) {
       config.ingressPort.toString(),
       "--runtime-services-info",
       runtimeServicesInfo,
-      "--route",
-      `/api/automation=http://localhost:${config.autoBackendPort}`,
-      "--route",
-      `/api=http://localhost:${config.agentServerPort}`,
-      "--route",
-      `/sockets=http://localhost:${config.agentServerPort}`,
-      "--route",
-      `/server_info=http://localhost:${config.agentServerPort}`,
-      "--route",
-      `/health=http://localhost:${config.agentServerPort}`,
-      "--route",
-      `/ready=http://localhost:${config.agentServerPort}`,
-      "--route",
-      `/alive=http://localhost:${config.agentServerPort}`,
-      "--route",
-      `/docs=http://localhost:${config.agentServerPort}`,
-      "--route",
-      `/redoc=http://localhost:${config.agentServerPort}`,
-      "--route",
-      `/openapi.json=http://localhost:${config.agentServerPort}`,
+      ...buildLocalServiceRouteArgs(config),
       "--default",
       `http://localhost:${config.vitePort}`,
     ],
@@ -621,7 +621,7 @@ async function main() {
   startAgentServer(config);
   await waitForService(
     "agent-server",
-    `http://localhost:${config.agentServerPort}/server_info`,
+    `${getAgentServerBaseUrl(config)}/server_info`,
   );
 
   startAutomationBackend(config);
@@ -641,7 +641,13 @@ async function main() {
 // Exports for testing
 // ═══════════════════════════════════════════════════════════════════════════
 
-export { buildAutomationBackendEnv, buildFrontend, startStaticServer };
+export {
+  buildAutomationBackendEnv,
+  buildFrontend,
+  buildLocalServiceRouteArgs,
+  getAgentServerBaseUrl,
+  startStaticServer,
+};
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Main entry point (only when run directly, not when imported)

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -679,6 +679,13 @@ const AGENT_SERVER_ROUTE_PREFIXES = [
   "/openapi.json",
 ];
 
+// This launcher starts the agent-server with `--host 127.0.0.1`, but localhost
+// can resolve to ::1 first (notably on Windows), so every request this process
+// or the automation backend makes to it must address IPv4 explicitly.
+function getAgentServerBaseUrl(config) {
+  return `http://127.0.0.1:${config.agentServerPort}`;
+}
+
 function getLocalServiceRoutes(config) {
   const routes = [];
 
@@ -692,7 +699,7 @@ function getLocalServiceRoutes(config) {
 
   if (config.launchAgentServer) {
     for (const prefix of AGENT_SERVER_ROUTE_PREFIXES) {
-      routes.push([prefix, `http://127.0.0.1:${config.agentServerPort}`]);
+      routes.push([prefix, getAgentServerBaseUrl(config)]);
     }
   }
 
@@ -858,10 +865,10 @@ function startAutomationBackend(config) {
         //
         // Priority:
         //   1. AUTOMATION_AGENT_SERVER_URL explicitly set in the user's env
-        //   2. `localhost:<agentServerPort>`
+        //   2. `127.0.0.1:<agentServerPort>`
         AUTOMATION_AGENT_SERVER_URL:
           process.env.AUTOMATION_AGENT_SERVER_URL ||
-          `http://localhost:${config.agentServerPort}`,
+          getAgentServerBaseUrl(config),
         // The URL exported into the in-sandbox bash chain as
         // `AGENT_SERVER_URL` (read by main.py / setup.sh to call back into
         // the agent-server).
@@ -1068,7 +1075,7 @@ async function seedAutomationSecret(config, options = {}) {
 
   logService("secrets", `Seeding ${secretName} into agent-server...`, c.dim);
 
-  const url = `http://localhost:${config.agentServerPort}/api/settings/secrets`;
+  const url = `${getAgentServerBaseUrl(config)}/api/settings/secrets`;
   const body = JSON.stringify({
     name: secretName,
     value: config.sessionApiKey,
@@ -1388,7 +1395,7 @@ async function main(options = {}) {
 
     agentServerReady = await waitForService(
       "agent-server",
-      `http://localhost:${config.agentServerPort}/server_info`,
+      `${getAgentServerBaseUrl(config)}/server_info`,
       agentServerReadyTimeoutMs,
     );
   }
@@ -1498,6 +1505,7 @@ export {
   buildConfig,
   buildRouteArgs,
   buildViteBackendEnv,
+  getAgentServerBaseUrl,
   getFrontendBackend,
   getLocalServiceRoutes,
   main,


### PR DESCRIPTION
HUMAN:

Ran the vitest suite for the two launcher test files on this branch: npx vitest run __tests__/scripts/dev-static.test.ts __tests__/scripts/dev-with-automation.test.ts — all 50 tests passed. Also skimmed the PR: remaining localhost service URLs switched to 127.0.0.1 for IPv4-only binds, display/banner strings left alone. Matches the Windows ECONNREFUSED ::1 issue. No Windows box here so I didn't run npm run dev:static end-to-end, but the unit coverage looks solid.

AGENT:

I traced the remaining `localhost` service URLs in the two launcher scripts, classified each one as either an internal service-to-service target or a user-facing display string, and changed only the former. The classification is grounded in how each service actually binds: `dev-with-automation.mjs` starts the agent-server and automation backend with `--host 127.0.0.1`, and `dev-static.mjs` starts them with `--host 0.0.0.0` — both IPv4-only, so a `localhost` client that resolves to `::1` first can never reach them. By contrast the ingress proxy (`scripts/ingress.mjs`, `server.listen(port)` with no host) and the static server (`scripts/static-server.mjs`, default `host: "::"`) bind dual-stack, so URLs pointing at *those* are unaffected and were left as `localhost`.

To make the changed URLs verifiable I routed them through one small helper per script (`getAgentServerBaseUrl`, plus `buildLocalServiceRouteArgs` in `dev-static.mjs`, which also collapses a route table that was duplicated verbatim between the static server and the ingress). This follows the existing exported-helper convention in `dev-with-automation.mjs` (`getLocalServiceRoutes`, `getFrontendBackend`).

Commands run locally (Node v26.5.0, npm 11.17.0, vitest 4.1.10, base `upstream/main` 3c562fa69):

```
$ npx vitest run __tests__/scripts/dev-static.test.ts __tests__/scripts/dev-with-automation.test.ts
  -> with the launcher scripts reverted to main: Test Files 2 failed, Tests 3 failed | 47 passed (50)
  -> with this branch:                           Test Files 2 passed, Tests 50 passed (50)
$ npx eslint scripts/dev-static.mjs scripts/dev-with-automation.mjs
  -> clean (no output)
$ npx prettier --check scripts/dev-static.mjs scripts/dev-with-automation.mjs __tests__/scripts/dev-static.test.ts __tests__/scripts/dev-with-automation.test.ts
  -> All matched files use Prettier code style!
$ npm run lint
  -> passed (1 pre-existing warning in src/hooks/query/use-local-git-info.ts, untouched here)
$ npm test
  -> Tests 15 failed | 4470 passed | 5 skipped | 9 todo (4499)
     The 15 failures are pre-existing and reproduce identically on a clean upstream/main
     checkout; see ## Notes.
```

The terminal capture of the before/after runs is attached under `## Video/Screenshots`.

I do not have a Windows machine, so the end-to-end Windows verification is the one thing I could not perform — see `## Notes`.

---

## Why

On Windows, Node resolves `localhost` to the IPv6 loopback `::1` before `127.0.0.1`, and the IPv6 loopback interface stays up even when IPv6 is disabled on the network adapter. The local agent-server and automation backend listen on IPv4 only, so any component that reaches them through the name `localhost` gets `connect ECONNREFUSED ::1:18000` and the app never finishes starting:

```
[agent-server] Uvicorn running on http://127.0.0.1:18000
[ingress] [ingress:8000] Proxy error -> http://localhost:18000/: connect ECONNREFUSED ::1:18000
[desktop] Agent server at http://localhost:8000/server_info never came up (60s)
```

#16290 fixed this class for the ingress route targets in `scripts/dev-with-automation.mjs`. Several service-to-service URLs were left behind, so the same failure still reaches users who run `npm run dev:static`, and — within the default stack — the readiness probe, the secret-seeding request, and the URL handed to the automation backend all still resolve `localhost`.

## Summary

- `scripts/dev-with-automation.mjs`: route the agent-server readiness probe (`/server_info`), the automation secret-seeding request, and the automation backend's `AUTOMATION_AGENT_SERVER_URL` through `127.0.0.1` via a new `getAgentServerBaseUrl` helper.
- `scripts/dev-static.mjs`: apply the same substitution to `AUTOMATION_AGENT_SERVER_URL`, the readiness probe, and both proxy route tables (static server + ingress), extracting the duplicated table into `buildLocalServiceRouteArgs`.
- Extend `__tests__/scripts/dev-static.test.ts` and `__tests__/scripts/dev-with-automation.test.ts` to lock in the IPv4 targets.

## Issue Number

Fixes #16275

## How to Test

1. Confirm the new assertions fail against the current launcher code:
   ```sh
   git checkout upstream/main -- scripts/dev-static.mjs scripts/dev-with-automation.mjs
   npx vitest run __tests__/scripts/dev-static.test.ts __tests__/scripts/dev-with-automation.test.ts
   ```
   Expected: **fails on main** — `Tests 3 failed | 47 passed (50)`, naming `points every local proxy route at the IPv4 loopback` and `addresses the agent-server over IPv4 for readiness and secret seeding`.
2. Restore this branch's code and re-run:
   ```sh
   git checkout HEAD -- scripts/dev-static.mjs scripts/dev-with-automation.mjs
   npx vitest run __tests__/scripts/dev-static.test.ts __tests__/scripts/dev-with-automation.test.ts
   ```
   Expected: **passes with this change** — `Test Files 2 passed (2)`, `Tests 50 passed (50)`.
3. Lint and format the touched files:
   ```sh
   npx eslint scripts/dev-static.mjs scripts/dev-with-automation.mjs
   npx prettier --check scripts/dev-static.mjs scripts/dev-with-automation.mjs __tests__/scripts/dev-static.test.ts __tests__/scripts/dev-with-automation.test.ts
   npm run lint
   ```
   Expected: eslint clean on both scripts; prettier reports `All matched files use Prettier code style!`; `npm run lint` passes.
4. Confirm no internal target was missed, and that only display strings still say `localhost`:
   ```sh
   grep -n 'http://localhost' scripts/dev-static.mjs scripts/dev-with-automation.mjs
   ```
   Expected: every remaining hit is a banner/help/header-comment line, a CORS origin list (which already contains both `localhost` and `127.0.0.1`), `AUTOMATION_BASE_URL`, or a frontend `--default` target. Each is justified under `## Notes`.
5. On Windows 11 (the environment from the issue), run the stack and verify the failure is gone:
   ```sh
   npm run dev
   npm run dev:static
   ```
   Expected: startup completes; the log no longer contains `ECONNREFUSED ::1`, and `Agent server at ... never came up (60s)` does not appear. Without the fix, `npm run dev:static` reproduces the issue's log verbatim.

## Video/Screenshots

<img width="2176" height="1090" alt="16275-vitest" src="https://github.com/user-attachments/assets/b7f16953-2757-4da3-888f-150fd031dab3" />

Terminal capture of the before/after test runs plus the lint/format checks is attached (`16275-vitest.png`). No UI is affected by this change — the launcher scripts have no rendered surface — so the screenshot shows the verification output rather than the app.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **What I deliberately left as `localhost`,** because changing it would be wrong or pointless:
  - **Banner, `--help`, and header-comment URLs** (`dev-static.mjs` 13/172/173/531/536, `dev-with-automation.mjs` 11/268/269/1189/1196/1204/1223/1225/1229). These are printed for the user to paste into a browser; `localhost` is the friendlier and correct display form, and browsers fall back across address families.
  - **`AUTOMATION_CORS_ORIGINS`** — a browser-origin allowlist, not a connection target, and it already lists both `localhost` and `127.0.0.1` for each port.
  - **`AUTOMATION_BASE_URL`** — documented in-tree as the automation backend's *publicly reachable* base URL; it is appended to callback URLs and injected into sandboxes as `AUTOMATION_API_URL`. It points at the ingress port, which binds dual-stack, so it is not affected by this bug. `dev-with-automation.mjs` already parameterizes it via `config.automationApiHost`.
  - **The frontend `--default` targets** (`getFrontendBackend`, and `dev-static.mjs`'s static-server target). Vite's `host: true` resolves to an undefined listen host and `static-server.mjs` defaults to `host: "::"` — both dual-stack — so `localhost` reaches them on either family. Pinning IPv4 here would add risk without fixing anything, and #16290 scoped around them for the same reason.
  - **`scripts/runtime-services-info.mjs`** — its URLs are descriptions handed to the LLM about how to reach services from inside a sandbox, they already have a dedicated `agentHostAlias` option for exactly this concern, and their shape is documented in `AGENTS.md`. Out of scope here.
  - **`electron/main.mjs`** — it produces the exact error string in the issue, but it probes the *ingress* (`http://localhost:8000/server_info`), which binds dual-stack and was reachable all along. In the issue's log the ingress answered and returned 502; the failing hop was ingress -> agent-server. No change needed, and it would not fit this PR's `scripts` scope.
- **Why helpers instead of a flat find-and-replace.** The three `dev-with-automation.mjs` sites sit in non-exported code (`startAutomationBackend`, `seedAutomationSecret`, `main`), so without a seam the fix could not be asserted in a unit test. `getAgentServerBaseUrl` is the smallest seam that covers all three and matches the file's existing convention. In `dev-static.mjs` the two route tables were already byte-identical duplicates of each other; `buildLocalServiceRouteArgs` makes them one testable definition. I also pointed the existing `getLocalServiceRoutes` at the new helper — same value, no behavior change — so there is a single source of truth.
- **A pre-existing test assertion changed.** `__tests__/scripts/dev-static.test.ts` asserted `AUTOMATION_AGENT_SERVER_URL: "http://localhost:18000"`, i.e. it locked in the buggy value. It is updated to `127.0.0.1`, the same way #16290 updated its routing assertions.
- **`npm test` is not green on this checkout, and was not green before my change.** 15 tests across `__tests__/api/cloud/conversation-runtime-info.test.ts`, `__tests__/components/automations/recommended-automations.test.tsx`, and `__tests__/components/features/home/featured-automations-section.test.tsx` fail identically on a clean `upstream/main`. They appear to be a Node 26 environment issue — Node now ships a global `localStorage` that shadows jsdom's, and the failures are all `window.localStorage` assertions. None of them touch `scripts/`. Flagging rather than fixing, since it is unrelated to this PR; the repo's `engines` field asks for `>=22.12`.
- **`no-unsafe-finally` in `__tests__/scripts/dev-with-automation.test.ts`** is reported by eslint at the line my additions shift from 724 to 737. It is pre-existing (it reproduces on a pristine `upstream/main` checkout) and is the same finding #16290 documented; I did not touch that code.
- **Not verified on Windows.** I have no Windows host, so steps 1-4 above are the extent of my verification; step 5 is written for a reviewer who does. The reasoning is grounded in the bind addresses quoted at the top of this section, and the change is the same substitution a maintainer already merged in #16290 for this exact failure mode.
