### PR TITLE
ci: bump agent-canvas chart image tag on release

### DIFF
--- a/.github/workflows/bump-chart.yml
+++ b/.github/workflows/bump-chart.yml
@@ -1,0 +1,60 @@
+name: Bump chart image tag
+
+# Opens a PR in OpenHands/OpenHands-Cloud pointing the agent-canvas subchart's
+# image.tag at the release that was just tagged. release-please pushes the semver
+# tag (with the App token, so this trigger fires); docker.yml concurrently tags
+# the ghcr.io/openhands/agent-canvas image with the same bare semver.
+#
+# Mirrors the OpenHands/automation caller of the same name. Two adjustments for
+# this repo:
+#   - Trigger on `v*` tags (OpenHands tags are `v1.12.0`, not bare semver).
+#   - The chart's image.tag is a bare semver (e.g. "1.12.0", no `v`), so strip
+#     the leading `v` before passing `tag`. A reusable-workflow caller job can't
+#     run steps, so the tag is computed in a small upstream job.
+#
+# See OpenHands/OpenHands-Cloud docs/automated-image-tag-bumps.md for caller
+# setup and the auth model. secrets: inherit forwards RELEASE_APP_ID /
+# RELEASE_APP_PRIVATE_KEY that the reusable workflow needs.
+
+on:
+  push:
+    tags:
+      # Stable semver only — the chart default should track a published release.
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to bump the chart to (e.g. v1.12.0 or 1.12.0)'
+        required: true
+        type: string
+
+concurrency:
+  group: bump-chart-${{ inputs.tag || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.t.outputs.tag }}
+    steps:
+      - id: t
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          # Resolve the bare semver (no leading `v`).
+          RAW="${INPUT_TAG:-$GITHUB_REF_NAME}"
+          TAG="${RAW#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+  bump-chart:
+    needs: prepare-tag
+    # secrets: inherit forwards the org secrets RELEASE_APP_ID /
+    # RELEASE_APP_PRIVATE_KEY that the reusable workflow needs.
+    secrets: inherit
+    uses: OpenHands/OpenHands-Cloud/.github/workflows/bump-image-tag.yml@main
+    with:
+      component: agent-canvas
+      chart_file: charts/openhands/charts/agent-canvas/values.yaml
+      tag: ${{ needs.prepare-tag.outputs.tag }}


### PR DESCRIPTION
## Summary

Automates the `agent-canvas` chart image-tag bump that's currently done by hand. Today every agent-canvas release needs a manual PR into `OpenHands/OpenHands-Cloud` bumping `charts/openhands/charts/agent-canvas/values.yaml` → `.image.tag` (e.g. OpenHands/OpenHands-Cloud#1036). This adds the tag-push-triggered caller that should have existed alongside the other component repos.

`OpenHands/OpenHands-Cloud` already ships a reusable workflow for this — [`.github/workflows/bump-image-tag.yml`](https://github.com/OpenHands/OpenHands-Cloud/blob/main/.github/workflows/bump-image-tag.yml) — and component repos like [`OpenHands/automation`](https://github.com/OpenHands/automation/blob/main/.github/workflows/bump-chart.yml) call it from a tiny tag-push workflow. `OpenHands/OpenHands` (which builds `ghcr.io/openhands/agent-canvas` and cuts `v1.12.0`) was the one component that never wired it up: `release.yml` only runs release-please and `docker.yml` only builds/pushes the image.

This PR adds `.github/workflows/bump-chart.yml`, mirroring the `automation` caller with two adjustments for this repo:

1. **Trigger on `v*` tags** (OpenHands tags are `v1.12.0`, not bare semver), stable-only via `v[0-9]+.[0-9]+.[0-9]+` — matches the chart's "known-good release" default convention.
2. **Strip the leading `v`** before passing `tag`, since the chart's `image.tag` is a bare semver (`"1.12.0"`). Computed in a small `prepare-tag` job because a reusable-workflow caller job can't run steps.

Also adds a `workflow_dispatch` input so the bump can be re-triggered for a specific tag if needed.

```yaml
jobs:
  prepare-tag:
    outputs:
      tag: ${{ steps.t.outputs.tag }}
    steps:
      - id: t
        run: echo "tag=${${INPUT_TAG:-$GITHUB_REF_NAME}#v}" ...  # bare semver
  bump-chart:
    needs: prepare-tag
    secrets: inherit
    uses: OpenHands/OpenHands-Cloud/.github/workflows/bump-image-tag.yml@main
    with:
      component: agent-canvas
      chart_file: charts/openhands/charts/agent-canvas/values.yaml
      tag: ${{ needs.prepare-tag.outputs.tag }}
```

## Notes for reviewers

- `secrets: inherit` forwards `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` (already in scope for this repo's release-please workflow) to the reusable workflow, which mints a scoped App token to write to `OpenHands/OpenHands-Cloud`.
- **Prereq to confirm:** the shared release App must be installed on `OpenHands/OpenHands-Cloud` with Contents + Pull requests read/write. Other component repos already rely on this, so an org-wide install should cover it.
- The reusable workflow opens a `feat(agent-canvas): bump image tag to <tag>` PR that release-please folds into the chart's release PR; it does **not** bump the chart `version` (owned by release-please).
- Uses the default `pr_branch` (`bump-image-tag/agent-canvas`), which rolls one open PR per component and advances it to the latest tag. Switch to a tag-specific branch if one-PR-per-release is preferred.
- `docker.yml` also publishes pre-release tags (`1.x.0-alpha.y`); the `v[0-9]+.[0-9]+.[0-9]+` filter matches stable only, so alpha tags won't land in the chart default.

## Validation

- New file only; no source changes. YAML parses; jobs/inputs/triggers reviewed against the `automation` caller and the reusable workflow's contract.
- Not exercised against a real tag push here (that fires on the next release).

_This PR was created by an AI agent (OpenHands) on behalf of juanmichelini._


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.40.1-python` |
| **Automation** | `openhands-automation==1.6.0` |
| **Commit** | `99772f6599b63460337e043354b8f3a68d944d0a` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-99772f6
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-99772f6
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-99772f6-amd64
ghcr.io/openhands/agent-canvas:add-agent-canvas-chart-bump-workflow-amd64
ghcr.io/openhands/agent-canvas:pr-16411-amd64
ghcr.io/openhands/agent-canvas:sha-99772f6-arm64
ghcr.io/openhands/agent-canvas:add-agent-canvas-chart-bump-workflow-arm64
ghcr.io/openhands/agent-canvas:pr-16411-arm64
ghcr.io/openhands/agent-canvas:sha-99772f6
ghcr.io/openhands/agent-canvas:add-agent-canvas-chart-bump-workflow
ghcr.io/openhands/agent-canvas:pr-16411
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-99772f6`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-99772f6-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->