### PR TITLE
fix: suppress mobile keyboard for select-only dropdowns

### DIFF
--- a/__tests__/components/features/settings/settings-dropdown-input.test.tsx
+++ b/__tests__/components/features/settings/settings-dropdown-input.test.tsx
@@ -94,4 +94,32 @@ describe("SettingsDropdownInput", () => {
     expect(onSelectionChange).toHaveBeenCalledWith(null);
     expect(onInputChange).toHaveBeenCalledWith("");
   });
+
+  it("suppresses the mobile keyboard when typing is not enabled", () => {
+    render(
+      <SettingsDropdownInput
+        items={items}
+        label="Language"
+        name="language"
+        testId="language-input"
+      />,
+    );
+    expect(screen.getByLabelText("Language")).toHaveAttribute(
+      "inputmode",
+      "none",
+    );
+  });
+
+  it("keeps the keyboard available when custom values are allowed", () => {
+    render(
+      <SettingsDropdownInput
+        allowsCustomValue
+        items={items}
+        label="Language"
+        name="language"
+        testId="language-input"
+      />,
+    );
+    expect(screen.getByLabelText("Language")).not.toHaveAttribute("inputmode");
+  });
 });

--- a/src/components/features/settings/settings-dropdown-input.tsx
+++ b/src/components/features/settings/settings-dropdown-input.tsx
@@ -54,6 +54,12 @@ export function SettingsDropdownInput({
 }: SettingsDropdownInputProps) {
   const { t } = useTranslation("openhands");
 
+  // Select-only dropdowns must not raise the mobile on-screen keyboard when
+  // opened; filtering and custom values keep text entry available.
+  const supportsTextInput = Boolean(
+    allowsCustomValue || onInputChange || defaultFilter,
+  );
+
   return (
     <label
       className={cn("flex flex-col gap-2.5 w-full min-w-0", wrapperClassName)}
@@ -86,6 +92,7 @@ export function SettingsDropdownInput({
         }}
         selectorButtonProps={{ disableRipple: true }}
         inputProps={{
+          inputMode: supportsTextInput ? undefined : "none",
           classNames: {
             inputWrapper: cn(
               formControlSettingsFieldClassName,


### PR DESCRIPTION
Fixes #16385

Prevents the mobile keyboard from opening for select-only settings dropdowns while preserving text input for custom-value and filter-enabled dropdowns. Adds focused input-mode regression coverage.

local verification not run; relying on upstream CI