### PR TITLE
feat(telemetry): tag conversations with client source and GUI trigger

### DIFF
--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -4,6 +4,8 @@ import { LAUNCH_CHILD_CONVERSATION_TOOL_NAME } from "#/constants/child-conversat
 
 import {
   ACP_SERVER_TAG_KEY,
+  AGENT_CANVAS_SOURCE,
+  CLIENT_SOURCE_TAG_KEY,
   buildRuntimeServicesSystemSuffix,
   buildStartConversationRequest,
   fetchBackendRuntimeServicesInfo,
@@ -1371,7 +1373,10 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
       load_project_skills: true,
     });
     expect(Array.isArray(acpAgentContext.skills)).toBe(true);
-    expect(payload.tags).toEqual({ [ACP_SERVER_TAG_KEY]: "claude-code" });
+    expect(payload.tags).toEqual({
+      [ACP_SERVER_TAG_KEY]: "claude-code",
+      [CLIENT_SOURCE_TAG_KEY]: AGENT_CANVAS_SOURCE,
+    });
   });
 
   it("forwards mcp_config to the ACP subprocess when servers are configured", () => {
@@ -1441,7 +1446,9 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
     expect(payload.agent_settings.acp_command).toBeUndefined();
     expect(payload.agent_settings.acp_server).toBeUndefined();
     expect(payload.agent_settings.llm.model).toBe("gpt-4");
-    expect(payload.tags).toBeUndefined();
+    expect(payload.tags).toEqual({
+      [CLIENT_SOURCE_TAG_KEY]: AGENT_CANVAS_SOURCE,
+    });
   });
 
   it("omits acp_model when the user clears it (null)", () => {

--- a/__tests__/api/agent-server-conversation-service.test.ts
+++ b/__tests__/api/agent-server-conversation-service.test.ts
@@ -1072,7 +1072,7 @@ describe("AgentServerConversationService", () => {
       global.fetch = originalFetch;
     });
 
-    it("forwards parent_conversation_id, agent_type, and sandbox_id to the cloud createConversation payload", async () => {
+    it("marks Canvas-created cloud conversations with the GUI trigger", async () => {
       // Arrange
       fetchMock.mockResolvedValueOnce(
         mockJsonResponse({
@@ -1110,6 +1110,7 @@ describe("AgentServerConversationService", () => {
         parent_conversation_id: "parent-conv-1",
         agent_type: "plan",
         sandbox_id: "sandbox-9",
+        trigger: "gui",
       });
     });
 

--- a/src/api/agent-server-adapter.test.ts
+++ b/src/api/agent-server-adapter.test.ts
@@ -3,7 +3,11 @@ import { CANVAS_UI_CLIENT_TOOL_NAME } from "#/constants/canvas-ui";
 import { LAUNCH_CHILD_CONVERSATION_TOOL_NAME } from "#/constants/child-conversation";
 import { DEFAULT_SETTINGS } from "#/services/settings";
 import type { Settings } from "#/types/settings";
-import { buildStartConversationRequest } from "./agent-server-adapter";
+import {
+  AGENT_CANVAS_SOURCE,
+  buildStartConversationRequest,
+  CLIENT_SOURCE_TAG_KEY,
+} from "./agent-server-adapter";
 
 const encryptedValue = "gAAAAAencrypted-mcp-header";
 
@@ -215,7 +219,9 @@ describe("buildStartConversationRequest — agentProfileId path", () => {
       settings: makeSettings(agentSettings),
       agentProfileId: "profile-xyz",
     });
-    expect(payload.tags).toEqual({ clientsource: "agentcanvas" });
+    expect(payload.tags).toEqual({
+      [CLIENT_SOURCE_TAG_KEY]: AGENT_CANVAS_SOURCE,
+    });
   });
 
   it("suppresses secrets_encrypted when launching from a profile", () => {

--- a/src/api/agent-server-adapter.test.ts
+++ b/src/api/agent-server-adapter.test.ts
@@ -209,13 +209,13 @@ describe("buildStartConversationRequest — agentProfileId path", () => {
         .tags,
     ).toBeDefined();
 
-    // ...but a profile launch resolves the server server-side, so the tag
-    // (which may not match the launched profile) is omitted.
+    // ...but a profile launch resolves the server server-side, so the ACP
+    // server tag (which may not match the launched profile) is omitted.
     const payload = buildStartConversationRequest({
       settings: makeSettings(agentSettings),
       agentProfileId: "profile-xyz",
     });
-    expect(payload.tags).toBeUndefined();
+    expect(payload.tags).toEqual({ clientsource: "agentcanvas" });
   });
 
   it("suppresses secrets_encrypted when launching from a profile", () => {

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -434,6 +434,16 @@ type ConversationSettingsPayload = SettingsRecord & {
 
 export const ACP_SERVER_TAG_KEY = "acpserver";
 export const CLIENT_SOURCE_TAG_KEY = "clientsource";
+
+/**
+ * Raw `clientsource` tag value stamped on Canvas-created conversations. This
+ * is the string the server / backend telemetry pipeline reads to attribute a
+ * conversation to the "canvas" source. It deliberately differs from
+ * `AGENT_CANVAS_CLIENT_SOURCE` ("agent_canvas") in `#/api/client-source`,
+ * which is the value sent in the `X-OpenHands-Client` header and PostHog
+ * event properties — the two must not be "fixed" to match, or backend
+ * telemetry attribution for the tag will silently change.
+ */
 export const AGENT_CANVAS_SOURCE = "agentcanvas";
 
 export const AUTOMATION_TRIGGER_TAG_KEY = "automationtrigger";

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -1123,8 +1123,8 @@ export function buildStartConversationRequest(
     worktree: options.worktree ?? true,
   };
 
-  // Stamp the client source tag so the agent-server can attribute the
-  // conversation to Canvas in telemetry (conversation_source = "canvas").
+  // Stamp the raw client source tag; the backend maps "agentcanvas" to the
+  // "canvas" conversation source in telemetry.
   // A profile launch resolves the ACP server server-side, so don't stamp the
   // tag from current settings (it may not match the launched profile).
   if (!options.agentProfileId && acpServerTag) {

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -1136,7 +1136,7 @@ export function buildStartConversationRequest(
   // Stamp the raw client source tag; the backend maps "agentcanvas" to the
   // "canvas" conversation source in telemetry.
   // A profile launch resolves the ACP server server-side, so don't stamp the
-  // tag from current settings (it may not match the launched profile).
+  // ACP server tag from current settings (it may not match the launched profile).
   if (!options.agentProfileId && acpServerTag) {
     payload.tags = {
       [ACP_SERVER_TAG_KEY]: acpServerTag,

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -433,6 +433,8 @@ type ConversationSettingsPayload = SettingsRecord & {
 };
 
 export const ACP_SERVER_TAG_KEY = "acpserver";
+export const CLIENT_SOURCE_TAG_KEY = "clientsource";
+export const AGENT_CANVAS_SOURCE = "agentcanvas";
 
 export const AUTOMATION_TRIGGER_TAG_KEY = "automationtrigger";
 export const AUTOMATION_ID_TAG_KEY = "automationid";
@@ -456,6 +458,7 @@ export const AUTOMATION_TAG_KEYS: readonly string[] = [
  * rows. Each is either already surfaced by a first-class UI source or is
  * internal routing data:
  * - ``acpserver`` → ACP provider chip
+ * - ``clientsource`` → telemetry attribution
  * - ``title`` → conversation card heading
  * - git / repo / branch / workspace stamps → repo-branch metadata + directory
  *   footer / hovercard rows (``selected_repository``, ``selected_branch``,
@@ -466,6 +469,7 @@ export const AUTOMATION_TAG_KEYS: readonly string[] = [
  */
 export const RESERVED_CONVERSATION_TAG_KEYS: ReadonlySet<string> = new Set([
   ACP_SERVER_TAG_KEY,
+  CLIENT_SOURCE_TAG_KEY,
   AUTOMATION_ID_TAG_KEY,
   AUTOMATION_RUN_ID_TAG_KEY,
   "title",
@@ -1119,10 +1123,17 @@ export function buildStartConversationRequest(
     worktree: options.worktree ?? true,
   };
 
+  // Stamp the client source tag so the agent-server can attribute the
+  // conversation to Canvas in telemetry (conversation_source = "canvas").
   // A profile launch resolves the ACP server server-side, so don't stamp the
   // tag from current settings (it may not match the launched profile).
   if (!options.agentProfileId && acpServerTag) {
-    payload.tags = { [ACP_SERVER_TAG_KEY]: acpServerTag };
+    payload.tags = {
+      [ACP_SERVER_TAG_KEY]: acpServerTag,
+      [CLIENT_SOURCE_TAG_KEY]: AGENT_CANVAS_SOURCE,
+    };
+  } else {
+    payload.tags = { [CLIENT_SOURCE_TAG_KEY]: AGENT_CANVAS_SOURCE };
   }
 
   // ``secrets_encrypted`` makes the agent-server decrypt request secrets at

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -407,6 +407,11 @@ class AgentServerConversationService {
         agent_type: agentType,
         sandbox_id: sandboxId ?? null,
         agent_profile_id: agentProfileId ?? null,
+        // Cloud conversations are attributed to Canvas telemetry via the
+        // `AGENT_CANVAS_CLIENT_HEADERS` (`X-OpenHands-Client`) that
+        // `createCloudAppConversation` sends, so the local `clientsource`
+        // conversation tag is intentionally NOT stamped here; `trigger: "gui"`
+        // marks the GUI-launch origin instead.
         trigger: "gui",
       };
       return createCloudAppConversation(request);

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -407,6 +407,7 @@ class AgentServerConversationService {
         agent_type: agentType,
         sandbox_id: sandboxId ?? null,
         agent_profile_id: agentProfileId ?? null,
+        trigger: "gui",
       };
       return createCloudAppConversation(request);
     }


### PR DESCRIPTION
HUMAN:
I reviewed the telemetry changes and verified the focused conversation API tests and lint expectations.

AGENT:
This PR was created and updated by an AI agent (OpenHands) on behalf of the user.

## Why

Canvas-created conversations are currently indistinguishable from other GUI traffic in telemetry. Stamping the client source and GUI trigger lets downstream analytics attribute these conversations consistently.

## Summary

- Add `clientsource=agentcanvas` to conversations created by Canvas.
- Keep the source tag out of user-facing conversation tag chips.
- Send `trigger: "gui"` for cloud app-conversation starts.

## Issue Number

Closes #16427.

## How to Test

- Run `npx vitest run __tests__/api/agent-server-adapter.test.ts __tests__/api/agent-server-conversation-service.test.ts`.
- Verify a locally created conversation payload includes `clientsource=agentcanvas` and cloud conversation-start payloads include `trigger: "gui"`.
- Verify the client-source tag is reserved from the generic conversation-tag chip list.

## Video/Screenshots

![Conversation source telemetry test evidence](https://raw.githubusercontent.com/OpenHands/OpenHands/80f62adf2dc521e85110f98feec6e147985d0cfb/.pr/llm-preflight-demo.gif)

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The source tag is intended for backend telemetry attribution and is not displayed as a generic user-facing tag.







<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.40.1-python` |
| **Automation** | `openhands-automation==1.6.0` |
| **Commit** | `c82f776601728b58f459786f795e1d281d118f91` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-c82f776
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-c82f776
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-c82f776-amd64
ghcr.io/openhands/agent-canvas:feat-conversation-source-telemetry-amd64
ghcr.io/openhands/agent-canvas:pr-16418-amd64
ghcr.io/openhands/agent-canvas:sha-c82f776-arm64
ghcr.io/openhands/agent-canvas:feat-conversation-source-telemetry-arm64
ghcr.io/openhands/agent-canvas:pr-16418-arm64
ghcr.io/openhands/agent-canvas:sha-c82f776
ghcr.io/openhands/agent-canvas:feat-conversation-source-telemetry
ghcr.io/openhands/agent-canvas:pr-16418
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-c82f776`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-c82f776-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->