### PR TITLE
fix(electron): require exact loopback hostname for in-app navigation

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -358,6 +358,25 @@ function createMainWindow() {
     mainWin?.maximize();
   });
 
+  // Exact loopback hostnames only. String prefix checks like
+  // startsWith("http://localhost") also match http://localhost.evil.com and
+  // http://localhost@evil.com (userinfo), which would open attacker content
+  // inside the Electron shell instead of the system browser.
+  const LOCAL_APP_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+  const isLocalAppUrl = (url) => {
+    let parsed;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return false;
+    }
+    // The local stack is served over plain HTTP on loopback; do not treat
+    // https://localhost.evil.com style hosts as in-app either.
+    return (
+      parsed.protocol === "http:" && LOCAL_APP_HOSTNAMES.has(parsed.hostname)
+    );
+  };
+
   // Route window.open() calls appropriately.
   mainWin.webContents.setWindowOpenHandler(({ url }) => {
     // The "Login with OpenHands Cloud" device-flow opens about:blank immediately
@@ -371,11 +390,8 @@ function createMainWindow() {
         overrideBrowserWindowOptions: { width: 800, height: 700 },
       };
     }
-    // All other external URLs open directly in the system browser.
-    if (
-      !url.startsWith("http://localhost") &&
-      !url.startsWith("http://127.0.0.1")
-    ) {
+    // Non-loopback URLs open in the system browser (never as an in-app window).
+    if (!isLocalAppUrl(url)) {
       shell.openExternal(url);
       return { action: "deny" };
     }
@@ -388,11 +404,7 @@ function createMainWindow() {
   // now-unneeded Electron popup.
   mainWin.webContents.on("did-create-window", (popupWin) => {
     popupWin.webContents.on("will-navigate", (_event, url) => {
-      if (
-        url !== "about:blank" &&
-        !url.startsWith("http://localhost") &&
-        !url.startsWith("http://127.0.0.1")
-      ) {
+      if (url !== "about:blank" && !isLocalAppUrl(url)) {
         _event.preventDefault();
         shell.openExternal(url);
         popupWin.close();


### PR DESCRIPTION
HUMAN:

Verified with `node --check electron/main.mjs` and a local classification smoke over the new hostname helper: legitimate `http://localhost:8000/`, `http://127.0.0.1:8000/`, and `http://[::1]:8000/` still allow in-app; `localhost.evil.com`, `localhost@evil.com`, `127.0.0.1@evil.com`, `localhost:8000@evil.com`, `127.0.0.1.attacker.test`, `https://localhost`, and `file:` are denied in-app. Change is confined to `electron/main.mjs`. Full packaged desktop retest of device-flow and DevTools `window.open` still pending on a local build.

AGENT:

Change is confined to `electron/main.mjs`. Both `setWindowOpenHandler` and the device-flow popup `will-navigate` handler now call `isLocalHttpUrl`, which parses with the URL constructor and allows in-app navigation only for `http:` URLs whose hostname is exactly `localhost`, `127.0.0.1`, or `::1` (including bracketed `[::1]`). Prefix `startsWith` matches on `http://localhost` / `http://127.0.0.1` are removed so attacker hosts like `localhost.evil.com` and userinfo forms like `localhost@evil.com` no longer open as in-app windows. `node --check` passes; classification smoke covers allow and deny cases above.

---

## Why

`setWindowOpenHandler` and the device-flow popup `will-navigate` handler treated a URL as local (load inside the Electron shell) when it `startsWith("http://localhost")` or `startsWith("http://127.0.0.1")`.

Those prefix checks also match attacker-controlled hosts such as:

- `http://localhost.evil.com/`
- `http://localhost@evil.com/` (userinfo form; `URL.hostname` is `evil.com`)
- `http://127.0.0.1.attacker.test/`

So content that should leave the app via the system browser could instead open as an in-app BrowserWindow.

Independent of the scheme allowlist on `shell.openExternal` in #16376. That PR still matters for `file:` / custom schemes; this PR closes the in-app allow-path host confusion that survives that change.

## Summary

- Replace localhost prefix checks with exact-hostname classification via the URL constructor
- Allow in-app only for `http:` + hostname `localhost` / `127.0.0.1` / `::1`
- Deny confused hosts (`localhost.evil.com`, userinfo forms, etc.) so they go through the external path

## Issue Number

## How to Test

1. `node --check electron/main.mjs`
2. Local classification smoke: legitimate `http://localhost:8000/` / `http://127.0.0.1:8000/` / `http://[::1]:8000/` allow; `localhost.evil.com`, `localhost@evil.com`, `127.0.0.1@evil.com`, `localhost:8000@evil.com`, `127.0.0.1.attacker.test`, `https://localhost`, `file:` deny in-app
3. Manual desktop: Login with OpenHands Cloud device flow still opens the https verification URL in the system browser
4. Manual: `window.open("http://localhost.evil.com", "_blank")` from renderer DevTools no longer gets an in-app window

## Video/Screenshots

N/A - main-process hostname guard; no visible UI change for legitimate localhost links.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Pairs with #16376 (scheme allowlist on `shell.openExternal`). This PR is only the in-app localhost allow-path fix.
