### PR TITLE
fix: pass session API key to static-server via env instead of argv

### DIFF
--- a/__tests__/scripts/static-server.test.ts
+++ b/__tests__/scripts/static-server.test.ts
@@ -122,6 +122,52 @@ describe("static-server.mjs", () => {
       expect(config.sessionApiKey).toBeNull();
     });
 
+    it("falls back to the SESSION_API_KEY env var when no flag is given", () => {
+      const previous = process.env.SESSION_API_KEY;
+      try {
+        process.env.SESSION_API_KEY = "env-key";
+        const config = parseArgs([]);
+        expect(config.sessionApiKey).toBe("env-key");
+      } finally {
+        if (previous === undefined) {
+          delete process.env.SESSION_API_KEY;
+        } else {
+          process.env.SESSION_API_KEY = previous;
+        }
+      }
+    });
+
+    it("prefers --session-api-key over the SESSION_API_KEY env var", () => {
+      const previous = process.env.SESSION_API_KEY;
+      try {
+        process.env.SESSION_API_KEY = "env-key";
+        const config = parseArgs(["--session-api-key", "argv-key"]);
+        expect(config.sessionApiKey).toBe("argv-key");
+      } finally {
+        if (previous === undefined) {
+          delete process.env.SESSION_API_KEY;
+        } else {
+          process.env.SESSION_API_KEY = previous;
+        }
+      }
+    });
+
+    it("ignores the SESSION_API_KEY env var in public mode (--auth-required)", () => {
+      const previous = process.env.SESSION_API_KEY;
+      try {
+        process.env.SESSION_API_KEY = "env-key";
+        const config = parseArgs(["--auth-required"]);
+        expect(config.sessionApiKey).toBeNull();
+        expect(config.authRequired).toBe(true);
+      } finally {
+        if (previous === undefined) {
+          delete process.env.SESSION_API_KEY;
+        } else {
+          process.env.SESSION_API_KEY = previous;
+        }
+      }
+    });
+
     it("defaults runtimeServicesInfo to null", () => {
       const config = parseArgs([]);
       expect(config.runtimeServicesInfo).toBeNull();

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -251,12 +251,13 @@ RUNTIME_SERVICES_INFO="$(node /opt/agent-canvas/runtime-services-info.mjs \
   --automation-url "$AUTOMATION_BASE_URL")"
 
 # EFFECTIVE_SESSION_KEY is set above from LOCAL_BACKEND_API_KEY or the persisted api-key.txt
-node /opt/agent-canvas/static-server.mjs \
+# Pass the session key via SESSION_API_KEY env (not argv) so it is not
+# visible in `ps`/`/proc/<pid>/cmdline` on shared hosts.
+SESSION_API_KEY="$EFFECTIVE_SESSION_KEY" node /opt/agent-canvas/static-server.mjs \
   --port "$PORT" \
   --host :: \
   --dir /opt/agent-canvas/frontend \
   --base-path "$AGENT_CANVAS_BASE_PATH" \
-  --session-api-key "$EFFECTIVE_SESSION_KEY" \
   --runtime-services-info "$RUNTIME_SERVICES_INFO" \
   --route "/api/automation=http://127.0.0.1:${AUTOMATION_PORT}" \
   --route "/api=http://127.0.0.1:${AGENT_SERVER_PORT}" \

--- a/scripts/dev-static.mjs
+++ b/scripts/dev-static.mjs
@@ -400,9 +400,8 @@ function startStaticServer(config) {
         : []),
       // Inject the API key so the pre-built frontend can authenticate
       // to the agent-server without a baked-in VITE_SESSION_API_KEY.
-      ...(config.sessionApiKey
-        ? ["--session-api-key", config.sessionApiKey]
-        : []),
+      // The key travels via SESSION_API_KEY env (not argv) so it is not
+      // visible in `ps`/`/proc/<pid>/cmdline` on shared hosts.
       "--runtime-services-info",
       runtimeServicesInfo,
       "--route",
@@ -429,6 +428,11 @@ function startStaticServer(config) {
     {
       cwd: config.canvasPath,
       color: c.magenta,
+      // Pass the session key through the environment instead of argv so it
+      // never shows up in process listings on shared hosts.
+      ...(config.sessionApiKey
+        ? { env: { SESSION_API_KEY: config.sessionApiKey } }
+        : {}),
     },
   );
 }

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -1464,9 +1464,8 @@ function startStaticFrontend(config, staticDir) {
       // In local mode, inject the API key so the pre-built frontend can
       // authenticate transparently. In public mode, pass --auth-required
       // so the frontend shows the API key entry screen instead.
-      ...(config.launchAgentServer && !config.isPublic && config.sessionApiKey
-        ? ["--session-api-key", config.sessionApiKey]
-        : []),
+      // The key travels via SESSION_API_KEY env (not argv) so it is not
+      // visible in `ps`/`/proc/<pid>/cmdline` on shared hosts.
       ...(config.launchAgentServer && config.isPublic
         ? ["--auth-required"]
         : []),
@@ -1483,6 +1482,11 @@ function startStaticFrontend(config, staticDir) {
     {
       cwd: config.canvasPath,
       color: c.magenta,
+      // Pass the session key through the environment instead of argv so it
+      // never shows up in process listings on shared hosts.
+      ...(config.launchAgentServer && !config.isPublic && config.sessionApiKey
+        ? { env: { SESSION_API_KEY: config.sessionApiKey } }
+        : {}),
     },
   );
 }

--- a/scripts/static-server.mjs
+++ b/scripts/static-server.mjs
@@ -156,6 +156,18 @@ export function parseArgs(argv = process.argv.slice(2)) {
     }
   }
 
+  // Fallback: allow the session API key to be supplied via the
+  // SESSION_API_KEY environment variable instead of the command line, so
+  // launchers never have to expose it in `ps`/`/proc/<pid>/cmdline` on
+  // shared hosts. Only used in local mode (never with --auth-required).
+  if (
+    !config.sessionApiKey &&
+    !config.authRequired &&
+    process.env.SESSION_API_KEY
+  ) {
+    config.sessionApiKey = process.env.SESSION_API_KEY;
+  }
+
   // Guard: --session-api-key and --auth-required are semantically
   // mutually exclusive. The first auto-injects the key (local mode);
   // the second forces the user to paste it (public mode). Combining
@@ -196,6 +208,9 @@ OPTIONS:
   --session-api-key <key>      Inject session API key into index.html so the
                                pre-built frontend authenticates to agent-server
                                without needing VITE_SESSION_API_KEY baked in.
+                               Alternatively set SESSION_API_KEY env var (not
+                               shown in process listings), which is preferred on
+                               shared hosts.
   --auth-required              Inject authRequired flag into index.html so the
                                pre-built frontend shows the API key entry screen
                                (public mode) without VITE_AUTH_REQUIRED baked in.


### PR DESCRIPTION
HUMAN:

Tested this with the dev launcher locally. The touched script suites pass (83/83), the full run is green at 4495 tests, and `ps auxww` no longer shows the session key in the process list. The key still reaches the frontend the same way it did before.

AGENT:

Stashed the fix and ran the new regression test: it fails against the old code and passes with the fix applied, so the test actually reproduces the bug.

---

## Why

The launchers passed the session API key to `static-server.mjs` as a command line flag. That puts the key in `ps auxww` and `/proc/<pid>/cmdline`, both world readable on a shared host. Anyone on the box can grab it without special access.

## Summary

- `static-server.mjs` now falls back to the `SESSION_API_KEY` env var when the flag is absent. The flag still works and wins when both are present, so nothing that relied on it breaks.
- Both launcher scripts (`dev-with-automation.mjs`, `dev-static.mjs`) send the key through the spawn env instead of argv.
- `docker/entrypoint.sh` uses an inline env assignment for the same reason.
- Public mode is untouched: `--auth-required` still forces the manual key entry screen and ignores the env var.

## Issue Number

Fixes #16383

## How to Test

1. `npm ci`
2. `npx vitest run __tests__/scripts/static-server.test.ts __tests__/scripts/dev-with-automation.test.ts __tests__/scripts/dev-static.test.ts`
3. Start `dev-static` with a persisted session key, then `ps auxww | grep static-server` and confirm the key is not in the output.
4. Start with `--auth-required` and confirm public mode still shows the key entry screen.

## Video/Screenshots

<img width="1100" height="608" alt="image" src="https://github.com/user-attachments/assets/034b126e-ceb1-4473-925b-b59112a232f7" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Env vars beat argv but are still visible via `/proc/<pid>/environ` to the same user and through `docker inspect`. Reading the key from stdin or a 0600 temp file would close that gap. I left that as a follow-up rather than scope-creeping this PR.
