### PR TITLE
docs: explain connecting to OpenHands Cloud and the two Cloud API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,24 @@ npm run dev
 
 Access the UI at [http://localhost:8000](http://localhost:8000) for the npm/source launchers, or [http://localhost:8000/canvas](http://localhost:8000/canvas) for the Docker image. You can add additional backends directly from the UI.
 
+## Connect to OpenHands Cloud
+
+To run agents on [OpenHands Cloud](https://app.all-hands.dev) instead of your own machine, open
+**Manage Backends** in the sidebar, choose **Add Backend → OpenHands Cloud**, and select **Connect to
+OpenHands**. That signs you in through your browser and stores the key for you, so there is nothing
+to copy by hand.
+
+OpenHands Cloud uses two different API keys, and they are not interchangeable:
+
+| Key                            | Where it goes                                                                   | What it authenticates                                                                                                                                                             |
+| ------------------------------ | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **OpenHands API key**          | The backend's **API Key** field — filled in for you by **Connect to OpenHands** | Agent Canvas's own requests to the Cloud backend, sent as `Authorization: Bearer`                                                                                                 |
+| **OpenHands Provider LLM key** | **Settings → LLM**, in the **API Key** field                                    | Your model requests, when you select a model whose name starts with `openhands/`. Copy it from the [API Keys](https://app.all-hands.dev/settings/api-keys) tab of OpenHands Cloud |
+
+A local or remote agent-server backend takes a third, unrelated key in the same **API Key** field:
+its own `LOCAL_BACKEND_API_KEY`, sent as `X-Session-API-Key`. See
+[SELF_HOSTING.md](docs/SELF_HOSTING.md) for that one.
+
 # Architecture
 
 Agent Canvas is powered by the [OpenHands Agent Server](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-agent-server/openhands/agent_server), a REST API for running multiple agents on a single machine. Each Agent Server runs on a single host/port; the Agent Canvas can connect to multiple Agent Servers and easily flip between them.


### PR DESCRIPTION
HUMAN:

<!--
  REQUIRED — the human contributor writes this in their own words, and nothing else may.
  The repo's AGENTS.md reserves this section for humans, and .github/workflows/pr-description-check.yml
  fails the PR until it holds at least 20 characters of real text (placeholders are rejected).
  Say what you tested. For example: which section you read in the rendered README, and which of the
  cited source files you opened to confirm the two keys really are different.
-->

AGENT:

Documentation-only change; no runtime code was touched. Every factual claim in the new section was
traced to a file at the base commit `947d9a0358a4034288ed93ad8866e46a3b3c75c5` before it was written:

- `src/components/features/backends/backend-form-modal.tsx:147` — `DEFAULT_OPENHANDS_CLOUD_HOST` is
  `https://app.all-hands.dev`.
- `backend-form-modal.tsx:993-1001` — the Cloud login's success handler stores the returned value as
  the backend's `apiKey` with `kind: "cloud"`, which is why there is nothing to paste by hand.
- `src/api/backend-registry/auth.ts:14,17` — a `cloud` backend's key is sent as
  `Authorization: Bearer`; a local/remote backend's key is sent as `X-Session-API-Key`.
- `src/routes/llm-settings.tsx:100,196` and `src/i18n/translation.json`
  (`SETTINGS$OPENHANDS_API_KEY_HELP_TEXT`) — the LLM key is a separate key, named "OpenHands Provider
  LLM Key" in the UI, linked to the API Keys tab, and surfaced when the model starts with `openhands/`.
- `docs/SELF_HOSTING.md:17,48-57` and `docs/DEVELOPMENT.md:101` — `LOCAL_BACKEND_API_KEY` is the
  agent server's own key and is already documented there, so the new section links out instead of
  repeating it.

The `test-and-build (ubuntu)` job from `.github/workflows/ci.yml` was replayed verbatim in a clean
worktree, on **Node v24.15.0 / npm 11.12.1** — the exact `node-version: "24.15"` CI pins:

| CI step | Command | Exit |
| --- | --- | --- |
| Install dependencies | `npm ci` | 0 |
| Lint | `npm run lint` (typecheck + eslint + prettier) | 0 |
| Test | `npm test` | 0 — 553 files passed, 4372 tests passed, 5 skipped, 9 todo |
| Build app | `npm run build` | 0 |
| Build library | `npm run build:lib` | 0 |
| Verify package contents | `npm pack --dry-run` | 0 |

Also: `npx prettier --check README.md README.windows.md` → 0 (and `prettier README.md` is
byte-identical to the committed file), `codespell README.md` → 0, `git diff --check` → 0.
`git diff --stat` is `README.md | 18 ++++++++++++++++++`, one file; `git status` after `npm ci`
shows no modified tracked files.

The one eslint **warning** (`src/hooks/query/use-local-git-info.ts:136`, unused eslint-disable) is
pre-existing — this diff touches nothing under `src/` — and does not fail `lint`.

Both new external links were fetched and returned HTTP 200 (`https://app.all-hands.dev`,
`https://app.all-hands.dev/settings/api-keys`); the one relative link, `docs/SELF_HOSTING.md`,
exists. The new section was also rendered and checked structurally: it produces an `<h2>` and a
3-column table with balanced markup and no leaked pipes.

Re-verified against `main` at `56638693908b8ac83a2fa3bde6eb6c33aae37f4b` (release 1.10.0): the patch
still applies as +18/−0 with no rebase, and every source line cited above still resolves to the same
code. The only upstream change to `README.md` since the base commit is release-please bumping the
docker tag `1.9.0` → `1.10.0`, about 25 lines above where this section is inserted;
`docs/SELF_HOSTING.md` is unchanged. The CI job above was re-run on that exact tree.

---

## Why

`README.md` names OpenHands Cloud twice — in the intro and in the Architecture list — but never says
how to connect to it. There is no occurrence of "api key" anywhere in `README.md` or
`README.windows.md`.

That leaves the question in #15947 unanswered: OpenHands Cloud involves two different API keys, and a
reader has no way to tell which one belongs where. The confusion is easy to hit, because both are
entered into a field labelled **API Key** — one on a backend, one in LLM settings — and a third,
unrelated key (`LOCAL_BACKEND_API_KEY`) uses the same label again for local backends.

## Summary

- Add a `## Connect to OpenHands Cloud` section after the quickstart, describing the
  **Manage Backends → Add Backend → OpenHands Cloud → Connect to OpenHands** login.
- Add a short table separating the **OpenHands API key** (authenticates Agent Canvas to the Cloud
  backend, sent as `Authorization: Bearer`, filled in by the login) from the **OpenHands Provider LLM
  key** (authenticates model requests for `openhands/` models, copied from the API Keys tab into
  **Settings → LLM**).
- Note the unrelated `LOCAL_BACKEND_API_KEY` that shares the same field label on local and remote
  backends, and link to the existing `docs/SELF_HOSTING.md` rather than restating it.

## Issue Number

Closes #15947

## How to Test

This is a README-only change, so the review is a read plus a formatting check:

1. Read the new **Connect to OpenHands Cloud** section in the rendered `README.md`, between the
   "Access the UI at …" line and `# Architecture`.
2. Confirm the two keys are described correctly by opening `src/api/backend-registry/auth.ts` — the
   `cloud` branch returns `Authorization: Bearer`, the fallback returns `X-Session-API-Key` — and
   `src/routes/llm-settings.tsx:100,196`, where the "OpenHands Provider LLM Key" help link is shown
   for `openhands/` models.
3. Run `npx prettier --check README.md README.windows.md` — exits 0.
4. Optionally run `npm run lint && npm test && npm run build`; all pass, unchanged from the base
   commit, since no source file was touched.

## Video/Screenshots

Not applicable — no UI change. The change is 18 added lines in `README.md`.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

`README.windows.md` is intentionally unchanged. It states that it holds "**Windows-specific** command
syntax for running Agent Canvas with the **Docker sandbox**" and defers to `README.md` for the main
install options; connecting to Cloud happens in the browser UI and has no Windows-specific command
syntax to mirror.

Deliberately left out, because they could not be verified from this repository: the layout of the
OpenHands Cloud dashboard beyond the URL the app itself links to, and any sign-up walkthrough. The
translation keys `BACKEND$KEY_HELPER_CLOUD`, `BACKEND$KEY_HELPER_LOCAL`, `BACKEND$KEY_DOCS_HINT`,
`BACKEND$KEY_DOCS_LINK` and `BACKEND$LOGIN_OR_MANUAL` were not used as sources either — they still
exist in `src/i18n/translation.json` but nothing in `src/` references them, so the header behaviour
was taken from `auth.ts` instead. Those stale keys may be worth a separate cleanup.
