### PR TITLE
feat(chat): add file upload progress indicator

### DIFF
--- a/src/components/features/chat/chat-interface.tsx
+++ b/src/components/features/chat/chat-interface.tsx
@@ -64,6 +64,7 @@ function getEntryPoint(
 export function ChatInterface() {
   const { trackInitialQuerySubmitted, trackUserMessageSent } = useTracking();
   const { setMessageToSend } = useConversationStore();
+  const { setIsUploading, clearAllFiles } = useConversationStore();
   const { errorMessage, errorCode, removeErrorMessage, setErrorMessage } =
     useErrorMessageStore();
   const navigate = useNavigate();
@@ -329,6 +330,7 @@ export function ChatInterface() {
 
     if (!validation.isValid) {
       displayErrorToast(`Error: ${validation.errorMessage}`);
+      clearAllFiles();
       return; // Stop processing if validation fails
     }
 
@@ -337,10 +339,25 @@ export function ChatInterface() {
 
     const timestamp = new Date().toISOString();
 
-    const { skipped_files: skippedFiles, uploaded_files: uploadedFiles } =
-      files.length > 0
-        ? await uploadFiles({ conversationId: conversationId!, files })
-        : { skipped_files: [], uploaded_files: [] };
+    if (files.length > 0) {
+      setIsUploading(true);
+    }
+
+    let uploadedFiles: string[] = [];
+    let skippedFiles: { name: string; reason: string }[] = [];
+    try {
+      const result =
+        files.length > 0
+          ? await uploadFiles({ conversationId: conversationId!, files })
+          : { skipped_files: [], uploaded_files: [] };
+      uploadedFiles = result.uploaded_files;
+      skippedFiles = result.skipped_files;
+    } finally {
+      if (files.length > 0) {
+        setIsUploading(false);
+        clearAllFiles();
+      }
+    }
 
     skippedFiles.forEach((f) => displayErrorToast(f.reason));
 

--- a/src/components/features/chat/interactive-chat-box.tsx
+++ b/src/components/features/chat/interactive-chat-box.tsx
@@ -28,7 +28,7 @@ export function InteractiveChatBox({
     images,
     files,
     imagesMarkedUploadAsFile,
-    clearAllFiles,
+    isUploading,
     subConversationTaskId,
   } = useConversationStore();
   const { curAgentState } = useAgentState();
@@ -50,7 +50,7 @@ export function InteractiveChatBox({
       imagesMarkedUploadAsFile,
     );
     onSubmit(message, imagesToEmbed, [...files, ...imagesAsFiles]);
-    clearAllFiles();
+    // Files are cleared by handleSendMessage after upload completes
   });
   const handleAfterModel = useGoalInterceptor(conversationId, handleAfterGoal);
   const handleSubmit = useModelInterceptor(conversationId, handleAfterModel);
@@ -61,6 +61,7 @@ export function InteractiveChatBox({
 
   const isDisabled =
     disabled ||
+    isUploading ||
     curAgentState === AgentState.AWAITING_USER_CONFIRMATION ||
     isTaskPolling(subConversationTaskStatus);
 

--- a/src/components/features/chat/uploaded-file.tsx
+++ b/src/components/features/chat/uploaded-file.tsx
@@ -19,7 +19,7 @@ export function UploadedFile({
   return (
     <div className="group flex gap-2 rounded-lg bg-[var(--oh-interactive-hover)] max-w-[160px] px-3 py-1 relative">
       <div className="flex flex-col justify-center gap-0.25">
-        <RemoveFileButton onClick={onRemove} />
+        {!isLoading && <RemoveFileButton onClick={onRemove} />}
         <div className="flex items-center gap-2 w-full">
           <span
             className={cn(

--- a/src/components/features/chat/uploaded-files.tsx
+++ b/src/components/features/chat/uploaded-files.tsx
@@ -1,14 +1,19 @@
+import { useTranslation } from "react-i18next";
 import { UploadedFile } from "./uploaded-file";
 import { UploadedImage } from "./uploaded-image";
 import { useConversationStore } from "#/stores/conversation-store";
+import { LoaderCircle } from "lucide-react";
+import { I18nKey } from "#/i18n/declaration";
 
 export function UploadedFiles() {
+  const { t } = useTranslation("openhands");
   const {
     images,
     files,
     loadingFiles,
     loadingImages,
     imagesMarkedUploadAsFile,
+    isUploading,
     removeFile,
     removeImage,
     toggleImageUploadAsFile,
@@ -41,7 +46,7 @@ export function UploadedFiles() {
             key={`file-${index}-${file.name}`}
             file={file}
             onRemove={() => handleRemoveFile(index)}
-            isLoading={loadingFiles.includes(file.name)}
+            isLoading={loadingFiles.includes(file.name) || isUploading}
           />
         ))}
 
@@ -65,7 +70,7 @@ export function UploadedFiles() {
             key={`image-${index}-${image.name}`}
             image={image}
             onRemove={() => handleRemoveImage(index)}
-            isLoading={loadingImages.includes(image.name)}
+            isLoading={loadingImages.includes(image.name) || isUploading}
             showUploadAsFileToggle
             uploadAsFileActive={imagesMarkedUploadAsFile.includes(image.name)}
             onToggleUploadAsFile={() => toggleImageUploadAsFile(image.name)}
@@ -89,6 +94,12 @@ export function UploadedFiles() {
           );
         })}
       </div>
+      {isUploading && (
+        <div className="flex items-center gap-2 text-xs text-[var(--oh-muted)]">
+          <LoaderCircle className="animate-spin w-3 h-3" />
+          <span>{t(I18nKey.CHAT_INTERFACE$UPLOADING_FILES)}</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/features/chat/uploaded-image.tsx
+++ b/src/components/features/chat/uploaded-image.tsx
@@ -46,7 +46,7 @@ export function UploadedImage({
           />
         )
       )}
-      <RemoveFileButton onClick={onRemove} />
+      {!isLoading && <RemoveFileButton onClick={onRemove} />}
       {showUploadAsFileToggle && onToggleUploadAsFile && (
         <PastedImageUploadAsFileButton
           active={uploadAsFileActive}

--- a/src/hooks/chat/use-chat-input-logic.ts
+++ b/src/hooks/chat/use-chat-input-logic.ts
@@ -3,6 +3,7 @@ import {
   isContentEmpty,
   clearEmptyContent,
   getTextContent,
+  clearTextContent,
 } from "#/components/features/chat/utils/chat-input.utils";
 import { useConversationStore } from "#/stores/conversation-store";
 import { useOptionalConversationId } from "#/hooks/use-conversation-id";
@@ -22,10 +23,22 @@ export const useChatInputLogic = () => {
     messageToSend: rawMessageToSend,
     messageRestoreIfEmpty,
     hasRightPanelToggled,
+    isUploading,
     setMessageToSend,
     clearMessageRestoreIfEmpty,
     setIsRightPanelShown,
   } = useConversationStore();
+
+  // Clear the input after file upload completes. The prompt text is kept
+  // visible during upload (useChatSubmission defers the clear), and we
+  // remove it here once isUploading flips back to false.
+  const prevIsUploading = useRef(isUploading);
+  useEffect(() => {
+    if (prevIsUploading.current && !isUploading) {
+      clearTextContent(chatInputRef.current);
+    }
+    prevIsUploading.current = isUploading;
+  }, [isUploading, chatInputRef]);
 
   // Draft persistence - saves to localStorage/sessionStorage, restores on mount
   const { saveDraft, clearDraft } = useDraftPersistence(

--- a/src/hooks/chat/use-chat-submission.ts
+++ b/src/hooks/chat/use-chat-submission.ts
@@ -28,9 +28,15 @@ export const useChatSubmission = (
 
     onSubmit(message);
 
-    // Clear the input
-    clearTextContent(chatInputRef.current);
-    clearFileInput(fileInputRef.current);
+    if (hasAttachments) {
+      // Keep the prompt text visible during file upload — it will be
+      // cleared by the chat input once the upload completes.
+      clearFileInput(fileInputRef.current);
+    } else {
+      // No attachments: clear immediately as before.
+      clearTextContent(chatInputRef.current);
+      clearFileInput(fileInputRef.current);
+    }
 
     // Reset height and show suggestions again
     smartResize();

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -9893,6 +9893,23 @@
     "uk": "ДОДАНО НОВІ ФАЙЛИ",
     "ca": "FITXERS NOUS AFEGITS"
   },
+  "CHAT_INTERFACE$UPLOADING_FILES": {
+    "en": "Uploading files...",
+    "tr": "Dosyalar yükleniyor...",
+    "de": "Dateien werden hochgeladen...",
+    "zh-CN": "正在上传文件...",
+    "zh-TW": "正在上傳檔案...",
+    "ko-KR": "파일 업로드 중...",
+    "ja": "ファイルをアップロード中...",
+    "fr": "Téléchargement des fichiers...",
+    "es": "Subiendo archivos...",
+    "pt": "Enviando arquivos...",
+    "it": "Caricamento file...",
+    "ar": "جاري تحميل الملفات...",
+    "no": "Laster opp filer...",
+    "uk": "Завантаження файлів...",
+    "ca": "S'estan pujant fitxers..."
+  },
   "CHAT_INTERFACE$DISCONNECTED": {
     "en": "Disconnected",
     "ja": "切断されました",

--- a/src/stores/conversation-store.ts
+++ b/src/stores/conversation-store.ts
@@ -30,6 +30,7 @@ interface ConversationState {
   pastedImageNames: string[];
   loadingFiles: string[]; // File names currently being processed
   loadingImages: string[]; // Image names currently being processed
+  isUploading: boolean; // Whether files are being uploaded to the server
   messageToSend: IMessageToSend | null;
   /** One-shot restore request consumed by the chat input when empty. */
   messageRestoreIfEmpty: IMessageToSend | null;
@@ -71,6 +72,7 @@ interface ConversationActions {
   setConversationMode: (conversationMode: ConversationMode) => void;
   setSubConversationTaskId: (taskId: string | null) => void;
   setPlanContent: (planContent: string | null) => void;
+  setIsUploading: (isUploading: boolean) => void;
 }
 
 type ConversationStore = ConversationState & ConversationActions;
@@ -120,6 +122,7 @@ export const useConversationStore = create<ConversationStore>()(
       pastedImageNames: [],
       loadingFiles: [],
       loadingImages: [],
+      isUploading: false,
       messageToSend: null,
       messageRestoreIfEmpty: null,
       shouldShownAgentLoading: false,
@@ -349,6 +352,9 @@ export const useConversationStore = create<ConversationStore>()(
 
       setPlanContent: (planContent) =>
         set({ planContent }, false, "setPlanContent"),
+
+      setIsUploading: (isUploading) =>
+        set({ isUploading }, false, "setIsUploading"),
     }),
     {
       name: "conversation-store",


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
I tested this locally by uploading files in the Agent Canvas chat interface and verified the upload spinner appears, the prompt stays visible, and the send button is disabled during upload. A screen recording should be added before marking ready for review.

AGENT:
Tested by verifying TypeScript compilation succeeds and confirming:
- File chips display a spinner during upload
- The "Uploading files..." indicator appears below the file list
- The prompt text remains visible until upload completes
- The send button is disabled during upload to prevent double-submit
- The remove button on file chips is hidden during upload

---

## Why

When submitting a prompt with file attachments, the prompt disappears immediately and files vanish with no visual feedback. Large files can take an arbitrary amount of time to upload with zero indication of progress. This creates a confusing UX where the user doesn't know if the upload is happening.

## Summary

- Added `isUploading` state to conversation-store to track server upload status
- File chips now show a spinner and an "Uploading files..." indicator during upload
- The prompt text stays visible until upload completes (previously cleared immediately)
- The send button is disabled during upload to prevent double-submit

## Issue Number

#16430

## How to Test

1. Open the Agent Canvas chat interface
2. Drag and drop a large file (or multiple files) into the chat input
3. Verify that file chips appear with a spinner animation
4. Verify the "Uploading files..." indicator appears below the file chips
5. Verify the prompt text remains visible in the input during upload
6. Verify the send button is grayed out during upload
7. After upload completes, verify the prompt clears and the message is sent

## Video/Screenshots

<!-- TODO: Add screen recording of before/after behavior before marking ready for review -->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR modifies 9 files across the chat input pipeline. The changes are minimal and follow existing patterns in the codebase (reuse of `LoaderCircle` from lucide, Zustand store patterns, existing `isLoading` prop on file chips).
