### PR TITLE
fix(test): install the ProgressEvent fallback under jsdom, where it is needed

### DIFF
--- a/__tests__/test-support/progress-event-fallback.test.ts
+++ b/__tests__/test-support/progress-event-fallback.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  FallbackProgressEvent,
+  PROGRESS_EVENT_FALLBACK,
+  installProgressEventFallback,
+} from "#/test-support/progress-event-fallback";
+
+describe("ProgressEvent fallback", () => {
+  it("is the class actually installed on the test global", () => {
+    // The regression this guards: the fallback used to be wrapped in
+    // `if (typeof ProgressEvent === "undefined")`, which is false under jsdom.
+    // It therefore installed only where it was not needed, leaving MSW's
+    // interceptor to resolve a binding that environment teardown removes.
+    expect(
+      (globalThis.ProgressEvent as unknown as Record<symbol, unknown>)[
+        PROGRESS_EVENT_FALLBACK
+      ],
+    ).toBe(true);
+  });
+
+  it("installs over an existing ProgressEvent rather than deferring to it", () => {
+    class SomeoneElsesProgressEvent extends Event {}
+    const target = {
+      ProgressEvent: SomeoneElsesProgressEvent,
+    } as unknown as typeof globalThis;
+
+    installProgressEventFallback(target);
+
+    expect(target.ProgressEvent).toBe(FallbackProgressEvent);
+  });
+
+  it("carries the ProgressEvent fields MSW's interceptor constructs", () => {
+    // The interceptor builds these with `{ lengthComputable, loaded, total }`.
+    const event = new FallbackProgressEvent("progress", {
+      lengthComputable: true,
+      loaded: 17,
+      total: 42,
+    });
+
+    expect(event).toBeInstanceOf(Event);
+    expect(event.type).toBe("progress");
+    expect(event.lengthComputable).toBe(true);
+    expect(event.loaded).toBe(17);
+    expect(event.total).toBe(42);
+  });
+
+  it("defaults the fields the way ProgressEventInit does", () => {
+    const event = new FallbackProgressEvent("loadend");
+
+    expect(event.lengthComputable).toBe(false);
+    expect(event.loaded).toBe(0);
+    expect(event.total).toBe(0);
+  });
+});

--- a/src/test-support/progress-event-fallback.ts
+++ b/src/test-support/progress-event-fallback.ts
@@ -1,0 +1,67 @@
+/**
+ * Test-only `ProgressEvent` fallback.
+ *
+ * MSW's XMLHttpRequest interceptor decides ONCE, at module load, whether the
+ * runtime has `ProgressEvent`:
+ *
+ * ```js
+ * const SUPPORTS_PROGRESS_EVENT = typeof ProgressEvent !== "undefined";
+ * // ...later, per event:
+ * const ProgressEventClass = SUPPORTS_PROGRESS_EVENT ? ProgressEvent : ProgressEventPolyfill;
+ * ```
+ *
+ * The capability check is cached; the class is resolved per call. Under
+ * `environment: "jsdom"` the check runs while jsdom's `ProgressEvent` exists,
+ * so the interceptor commits to the `SUPPORTS_PROGRESS_EVENT === true` branch
+ * for the life of the worker. If a late interceptor callback then fires while
+ * Vitest is tearing the environment down between files, evaluating the bare
+ * `ProgressEvent` identifier throws `ReferenceError: ProgressEvent is not
+ * defined` and Vitest fails the run with an unhandled rejection, even when
+ * every test passed.
+ *
+ * Installing our own class unconditionally means the identifier resolves to
+ * something this module owns rather than to a binding the environment
+ * teardown removes. It is defined directly on `globalThis` rather than via
+ * `vi.stubGlobal()` so `vi.unstubAllGlobals()` cannot take it away before
+ * those late callbacks settle.
+ */
+
+/** Marker so tests can assert this fallback is the installed class. */
+export const PROGRESS_EVENT_FALLBACK = Symbol.for(
+  "agent-canvas.progress-event-fallback",
+);
+
+export class FallbackProgressEvent extends Event {
+  static readonly [PROGRESS_EVENT_FALLBACK] = true;
+
+  readonly lengthComputable: boolean;
+
+  readonly loaded: number;
+
+  readonly total: number;
+
+  constructor(type: string, eventInitDict: ProgressEventInit = {}) {
+    super(type, eventInitDict);
+    this.lengthComputable = eventInitDict.lengthComputable ?? false;
+    this.loaded = eventInitDict.loaded ?? 0;
+    this.total = eventInitDict.total ?? 0;
+  }
+}
+
+/**
+ * Install the fallback on `target`, replacing any existing `ProgressEvent`.
+ *
+ * Unconditional by design. Guarding on `typeof ProgressEvent === "undefined"`
+ * (the previous behaviour) makes this a no-op under jsdom, which defines
+ * `ProgressEvent` — so the fallback was only ever installed in the one
+ * environment that did not need it, and never in the one that does.
+ */
+export function installProgressEventFallback(
+  target: typeof globalThis = globalThis,
+) {
+  Object.defineProperty(target, "ProgressEvent", {
+    configurable: true,
+    writable: true,
+    value: FallbackProgressEvent,
+  });
+}

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
 import { cleanup } from "@testing-library/react";
 import { server } from "#/mocks/node";
+import { installProgressEventFallback } from "#/test-support/progress-event-fallback";
 import "@testing-library/jest-dom/vitest";
 
 // Some modules read env at import time before Vitest's per-test hooks run.
@@ -60,32 +61,14 @@ if (typeof requestAnimationFrame === "undefined") {
   );
 }
 
-if (typeof ProgressEvent === "undefined") {
-  class MockProgressEvent extends Event {
-    readonly lengthComputable: boolean;
-
-    readonly loaded: number;
-
-    readonly total: number;
-
-    constructor(type: string, eventInitDict: ProgressEventInit = {}) {
-      super(type, eventInitDict);
-      this.lengthComputable = eventInitDict.lengthComputable ?? false;
-      this.loaded = eventInitDict.loaded ?? 0;
-      this.total = eventInitDict.total ?? 0;
-    }
-  }
-
-  // MSW's XMLHttpRequest interceptor may dispatch progress events while
-  // Vitest is tearing down globals between files. Keep this process-level
-  // fallback outside `vi.stubGlobal()` so `vi.unstubAllGlobals()` does not
-  // remove it before late interceptor callbacks settle.
-  Object.defineProperty(globalThis, "ProgressEvent", {
-    configurable: true,
-    writable: true,
-    value: MockProgressEvent,
-  });
-}
+// MSW's XMLHttpRequest interceptor caches `typeof ProgressEvent !== "undefined"`
+// at module load, then resolves the bare `ProgressEvent` identifier per event.
+// Under jsdom it commits to the "supported" branch, so a late interceptor
+// callback firing during environment teardown throws a ReferenceError and fails
+// the run even when every test passed. Install unconditionally: the previous
+// `typeof ProgressEvent === "undefined"` guard is false under jsdom, so the
+// fallback was only ever installed where it was not needed.
+installProgressEventFallback();
 
 // Mock ResizeObserver for test environment
 class MockResizeObserver {


### PR DESCRIPTION
HUMAN:

I had some flakiness and this was the likely suspect.

AGENT:

Test-infrastructure only. No product code, no runtime behaviour change; `src/test-support/` is not in `tsconfig.lib.json`'s include list, so nothing here reaches the published package.

Evidence: the new test fails on `main` and passes with this change. Full suite green afterwards (562 files, 4496 tests), `npm run typecheck`, eslint and prettier clean. Nothing outside `vitest.setup.ts` referenced `ProgressEvent`.

---

## Why

`test-and-build` can fail with every test passing:

```
Vitest caught 1 unhandled error during the test run.
ReferenceError: ProgressEvent is not defined
 ❯ createEvent node_modules/msw/node_modules/@mswjs/interceptors/lib/node/XMLHttpRequest-Dw6Wm-UU.mjs:91:55
 ❯ XMLHttpRequestController.trigger ...
 Test Files  561 passed | 1 skipped (562)
      Tests  4503 passed | 5 skipped | 9 todo (4517)
```

MSW's XMLHttpRequest interceptor decides once, at module load, whether the runtime has `ProgressEvent`, then resolves the class per event:

```js
const SUPPORTS_PROGRESS_EVENT = typeof ProgressEvent !== "undefined";
// ...later, per event:
const ProgressEventClass = SUPPORTS_PROGRESS_EVENT ? ProgressEvent : ProgressEventPolyfill;
```

The capability check is cached; the class is not. Under `environment: "jsdom"` the check runs while jsdom's `ProgressEvent` exists, so the interceptor commits to the supported branch for the life of the worker. If a late interceptor callback fires while Vitest is tearing the environment down between files, that bare `ProgressEvent` no longer resolves and the run fails on an unhandled rejection.

`vitest.setup.ts` already carried a fallback for exactly this, and its comment names the case: "MSW's XMLHttpRequest interceptor may dispatch progress events while Vitest is tearing down globals between files." It was wrapped in:

```ts
if (typeof ProgressEvent === "undefined") { ... }
```

jsdom defines `ProgressEvent`, so that condition is false in the only environment this suite runs in. The fallback installed itself only where it was not needed, and never where it was.

## Summary

- Install the fallback unconditionally, extracted to `src/test-support/progress-event-fallback.ts` so it can be tested directly.
- Add tests: that the fallback is the class actually on the test global (this one fails without the change), that it installs over an existing `ProgressEvent`, and that it carries the `ProgressEventInit` fields the interceptor constructs, with the right defaults.

## Issue Number

None.

## How to Test

```
npx vitest run __tests__/test-support/progress-event-fallback.test.ts
```

On `main` the first case fails, since the guard leaves jsdom's `ProgressEvent` in place. With this change all four pass.

## Video/Screenshots

No rendering change; this is test infrastructure. The check requires an image on any frontend-touching diff, so here is the red-before-green instead.

<img width="2200" height="1382" alt="1-fails-on-main" src="https://github.com/user-attachments/assets/500474b2-22b8-4ff1-bf20-cc90b3edbd00" />

<img width="2200" height="1240" alt="2-passes-with-fix" src="https://github.com/user-attachments/assets/a1ead3a4-e1e9-4179-b1f5-7dec4d6a88c8" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Worth being precise about the claim: the dead guard is deterministic and provable, but the teardown race that exploits it is order-dependent and I could not reproduce it on demand. The same tree passed twice locally and failed once in CI. So this removes a cause rather than demonstrably ending the symptom.

Replacing jsdom's `ProgressEvent` during tests looked worth checking rather than assuming: nothing outside the setup file referenced it, and the class covers the whole `ProgressEventInit` surface, so the full suite behaves identically.

If you would rather keep jsdom's implementation while the environment is alive and only fall back afterwards, I am happy to rework it. That needs a binding the environment teardown does not remove, which is a bigger change than this one.
