### PR TITLE
fix: always show all workspace folders in grouped view regardless of pagination

### DIFF
--- a/__tests__/components/features/conversation-panel/conversation-panel-list-helpers.test.ts
+++ b/__tests__/components/features/conversation-panel/conversation-panel-list-helpers.test.ts
@@ -628,4 +628,90 @@ describe("conversation-panel-list-helpers", () => {
       ).map((c) => c.id),
     ).toEqual(["audit", "unnamed"]);
   });
+
+  it("pre-seeds workspace groups from knownWorkspaces even when no conversations are loaded for them", () => {
+    const knownWorkspaces = [
+      { id: "/workspace/alpha", name: "alpha", path: "/workspace/alpha" },
+      { id: "/workspace/beta", name: "beta", path: "/workspace/beta" },
+    ];
+    const groups = groupConversations(
+      [],
+      "local",
+      "updated",
+      { emptyWorkspace: "No workspace", emptyRepository: "No repository" },
+      knownWorkspaces,
+    );
+    expect(groups.map((g) => ({ id: g.id, label: g.label }))).toEqual([
+      { id: "ws:/workspace/alpha", label: "alpha" },
+      { id: "ws:/workspace/beta", label: "beta" },
+    ]);
+    expect(groups.every((g) => g.conversations.length === 0)).toBe(true);
+  });
+
+  it("merges known workspaces with conversations from paginated pages into one unified group list", () => {
+    const knownWorkspaces = [
+      { id: "/workspace/alpha", name: "alpha", path: "/workspace/alpha" },
+    ];
+    const pageTwoConversation: AppConversation = {
+      ...base,
+      id: "deep",
+      title: "deep",
+      selected_workspace: "/workspace/beta",
+      updated_at: "2024-01-05T00:00:00.000Z",
+    };
+    const groups = groupConversations(
+      [pageTwoConversation],
+      "local",
+      "updated",
+      { emptyWorkspace: "No workspace", emptyRepository: "No repository" },
+      knownWorkspaces,
+    );
+    const ids = groups.map((g) => g.id);
+    expect(ids).toContain("ws:/workspace/alpha");
+    expect(ids).toContain("ws:/workspace/beta");
+    const alpha = groups.find((g) => g.id === "ws:/workspace/alpha");
+    expect(alpha?.conversations).toHaveLength(0);
+    const beta = groups.find((g) => g.id === "ws:/workspace/beta");
+    expect(beta?.conversations.map((c) => c.id)).toEqual(["deep"]);
+  });
+
+  it("uses the known workspace name for a group whose path is in knownWorkspaces", () => {
+    const knownWorkspaces = [
+      {
+        id: "/workspace/my-project",
+        name: "My Project",
+        path: "/workspace/my-project",
+      },
+    ];
+    const convo: AppConversation = {
+      ...base,
+      id: "c1",
+      title: "c1",
+      selected_workspace: "/workspace/my-project",
+      updated_at: "2024-01-02T00:00:00.000Z",
+    };
+    const groups = groupConversations(
+      [convo],
+      "local",
+      "updated",
+      { emptyWorkspace: "No workspace", emptyRepository: "No repository" },
+      knownWorkspaces,
+    );
+    const group = groups.find((g) => g.id === "ws:/workspace/my-project");
+    expect(group?.label).toBe("My Project");
+  });
+
+  it("ignores knownWorkspaces for cloud backend grouping", () => {
+    const knownWorkspaces = [
+      { id: "/workspace/alpha", name: "alpha", path: "/workspace/alpha" },
+    ];
+    const groups = groupConversations(
+      [],
+      "cloud",
+      "updated",
+      { emptyWorkspace: "No workspace", emptyRepository: "No repository" },
+      knownWorkspaces,
+    );
+    expect(groups).toHaveLength(0);
+  });
 });

--- a/src/components/features/conversation-panel/conversation-panel-list-helpers.ts
+++ b/src/components/features/conversation-panel/conversation-panel-list-helpers.ts
@@ -1,5 +1,6 @@
 import type { AppConversation } from "#/api/conversation-service/agent-server-conversation-service.types";
 import type { BackendKind } from "#/api/backend-registry/types";
+import type { LocalWorkspace } from "#/types/workspace";
 import type { Provider } from "#/types/settings";
 import {
   AUTOMATION_NAME_TAG_KEY,
@@ -419,6 +420,7 @@ export function groupConversations(
   backendKind: BackendKind,
   sortField: ConversationSortField,
   labels: { emptyWorkspace: string; emptyRepository: string },
+  knownWorkspaces?: readonly LocalWorkspace[],
 ): {
   id: string;
   label: string;
@@ -429,6 +431,15 @@ export function groupConversations(
     string,
     { label: string; conversations: AppConversation[] }
   >();
+
+  if (backendKind === "local" && knownWorkspaces) {
+    for (const ws of knownWorkspaces) {
+      const normalized = ws.path.trim().replace(/\/+$/, "");
+      if (normalized) {
+        byId.set(`ws:${normalized}`, { label: ws.name, conversations: [] });
+      }
+    }
+  }
 
   for (const c of items) {
     const { id, label: rawLabel } = getConversationGroupIdentity(

--- a/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/src/components/features/conversation-panel/conversation-panel.tsx
@@ -6,6 +6,7 @@ import { useNavigation } from "#/context/navigation-context";
 import { useActiveBackend } from "#/contexts/active-backend-context";
 import { useBackendScopedPath } from "#/hooks/use-backend-scoped-path";
 import { usePaginatedConversations } from "#/hooks/query/use-paginated-conversations";
+import { useResolvedWorkspaces } from "#/hooks/query/use-resolved-workspaces";
 import { useStartTasks } from "#/hooks/query/use-start-tasks";
 import { useDeleteConversation } from "#/hooks/mutation/use-delete-conversation";
 import { useUnifiedPauseConversation } from "#/hooks/mutation/use-unified-stop-conversation";
@@ -16,6 +17,7 @@ import { NavigationLink } from "#/components/shared/navigation-link";
 import { ExitConversationModal } from "./exit-conversation-modal";
 import { useClickOutsideElement } from "#/hooks/use-click-outside-element";
 import { Provider } from "#/types/settings";
+import type { LocalWorkspace } from "#/types/workspace";
 import { useUpdateConversation } from "#/hooks/mutation/use-update-conversation";
 import {
   displayErrorToast,
@@ -278,6 +280,7 @@ export function ConversationPanel({
     isFetchingNextPage,
     fetchNextPage,
   } = usePaginatedConversations();
+  const { workspaces: knownWorkspaces } = useResolvedWorkspaces();
 
   // Fetch in-progress start tasks
   const { data: startTasks } = useStartTasks();
@@ -341,6 +344,29 @@ export function ConversationPanel({
     () => collectAutomationNameFacets(conversations),
     [conversations],
   );
+
+  const allWorkspacesForGrouping = React.useMemo<
+    readonly LocalWorkspace[]
+  >(() => {
+    if (activeBackend.kind !== "local") {
+      return knownWorkspaces;
+    }
+    const byPath = new Map<string, LocalWorkspace>(
+      knownWorkspaces.map((ws) => [ws.path, ws]),
+    );
+    for (const c of conversations) {
+      const normalized = c.selected_workspace?.trim().replace(/\/+$/, "");
+      if (normalized && !byPath.has(normalized)) {
+        const label = normalized.split("/").filter(Boolean).pop() ?? normalized;
+        byPath.set(normalized, {
+          id: normalized,
+          name: label,
+          path: normalized,
+        });
+      }
+    }
+    return Array.from(byPath.values());
+  }, [activeBackend.kind, conversations, knownWorkspaces]);
 
   const automationFilteredConversations = React.useMemo(
     () =>
@@ -455,12 +481,14 @@ export function ConversationPanel({
       activeBackend.kind,
       conversationSort,
       groupLabels,
+      allWorkspacesForGrouping,
     );
   }, [
     activeBackend.kind,
     conversationSort,
     groupLabels,
     groupedSourceConversations,
+    allWorkspacesForGrouping,
   ]);
 
   const groupDiscoveryConversationIds = React.useMemo(() => {
@@ -957,13 +985,19 @@ export function ConversationPanel({
   const showInitialSkeleton = isLoading || !isFetched;
   const showPinnedSection =
     !compact && !showInitialSkeleton && pinnedConversations.length > 0;
+  const hasVisibleGroups =
+    organizeMode === "grouped" &&
+    !compact &&
+    orderedConversationGroups != null &&
+    orderedConversationGroups.length > 0;
   const showEmptyState =
     isFetched &&
     !isLoading &&
     !compact &&
     listIsEffectivelyEmpty &&
     !showPinnedSection &&
-    !startTasks?.length;
+    !startTasks?.length &&
+    !hasVisibleGroups;
 
   const showConversationHeader = !compact;
 

--- a/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/src/components/features/conversation-panel/conversation-panel.tsx
@@ -348,14 +348,25 @@ export function ConversationPanel({
   const allWorkspacesForGrouping = React.useMemo<
     readonly LocalWorkspace[]
   >(() => {
-    if (activeBackend.kind !== "local") {
-      return knownWorkspaces;
+    if (
+      compact ||
+      organizeMode !== "grouped" ||
+      activeBackend.kind !== "local"
+    ) {
+      return [];
     }
-    const byPath = new Map<string, LocalWorkspace>(
-      knownWorkspaces.map((ws) => [ws.path, ws]),
-    );
+    const normalize = (p: string) => p.trim().replace(/\/+$/, "");
+    const byPath = new Map<string, LocalWorkspace>();
+    for (const ws of knownWorkspaces) {
+      const key = normalize(ws.path);
+      if (key) {
+        byPath.set(key, ws);
+      }
+    }
     for (const c of conversations) {
-      const normalized = c.selected_workspace?.trim().replace(/\/+$/, "");
+      const normalized = c.selected_workspace
+        ? normalize(c.selected_workspace)
+        : "";
       if (normalized && !byPath.has(normalized)) {
         const label = normalized.split("/").filter(Boolean).pop() ?? normalized;
         byPath.set(normalized, {
@@ -366,7 +377,13 @@ export function ConversationPanel({
       }
     }
     return Array.from(byPath.values());
-  }, [activeBackend.kind, conversations, knownWorkspaces]);
+  }, [
+    activeBackend.kind,
+    compact,
+    conversations,
+    knownWorkspaces,
+    organizeMode,
+  ]);
 
   const automationFilteredConversations = React.useMemo(
     () =>


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
  ran the tests locally, all 4496 passed, workspace folders now appear without needing to
  load more pages


<!-- Human contributors: add a short note about your testing. -->

AGENT:

Ran `npx vitest run __tests__/components/features/conversation-panel/` — 237/237 tests passed including 4 new tests added for this fix. Ran `npx eslint` on all 3 modified files — 0 errors. Pre-commit hooks (typecheck, lint, translation completeness) all passed on commit.

---

## Why

When conversations are grouped by workspace, workspace folders only appeared once their conversations had been loaded via pagination. If workspace A had all its conversations buried behind 100 conversations in workspace B, the user had to click "Load more" many times before workspace A ever showed up as a folder in the sidebar. The expected behavior is that all workspaces are always visible as folder rows regardless of how many conversations have been paginated so far.

## Summary

- `groupConversations` now accepts an optional `knownWorkspaces` list and pre-seeds the group bucket map before iterating conversations, so workspaces with zero loaded conversations still render as folder rows
- `conversation-panel.tsx` builds `allWorkspacesForGrouping` by merging the persisted workspace store with workspace paths found across all already-loaded conversation pages (not just the filtered/visible subset), then passes it to `groupConversations`
- Added `hasVisibleGroups` guard to `showEmptyState` so the empty-state message does not replace the workspace folder list when conversations are filtered out

## Issue Number

Fixes #16435

## How to Test

1. Start the app with a local backend
2. Create a conversation in workspace A
3. Create 100+ conversations in workspace B (or use an existing backend with many conversations)
4. Enable grouped-by-workspace view in the conversation panel
5. Without this fix: workspace A does not appear until you load enough pages to surface its conversations
6. With this fix: both workspace A and workspace B appear immediately as folder rows; workspace A shows 0 conversations initially and populates as pages load

Alternatively run the unit tests:
```
npm run make-i18n
npx vitest run __tests__/components/features/conversation-panel/conversation-panel-list-helpers.test.ts
```

## Video/Screenshots

<img width="1143" height="994" alt="image" src="https://github.com/user-attachments/assets/8b2ef4c1-8594-421c-8c92-0f54f77c5bda" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The fix intentionally collects workspace paths from all already-loaded conversation pages rather than only the currently visible (filtered) subset. This means a workspace that appears on page 3 will be pre-seeded as soon as any page containing its conversations has been fetched, even if those conversations are currently hidden by the automation or scope filters.