### PR TITLE
fix(frontend): allowlist schemes in transformVSCodeUrl

### DIFF
--- a/__tests__/utils/vscode-url-helper.test.ts
+++ b/__tests__/utils/vscode-url-helper.test.ts
@@ -53,9 +53,25 @@ describe("transformVSCodeUrl", () => {
     expect(transformVSCodeUrl(input)).toBe(input);
   });
 
-  it("should handle invalid URLs gracefully", () => {
+  it("should return null for invalid URLs", () => {
     const input = "not-a-valid-url";
 
+    expect(transformVSCodeUrl(input)).toBeNull();
+  });
+
+  it("should allow vscode: scheme URLs", () => {
+    const input = "vscode://file/workspace/app.ts";
+
     expect(transformVSCodeUrl(input)).toBe(input);
+  });
+
+  it("should return null for javascript: scheme", () => {
+    expect(
+      transformVSCodeUrl("javascript:alert(document.domain)"),
+    ).toBeNull();
+  });
+
+  it("should return null for data: scheme", () => {
+    expect(transformVSCodeUrl("data:text/html,<script>alert(1)</script>")).toBeNull();
   });
 });

--- a/src/utils/vscode-url-helper.ts
+++ b/src/utils/vscode-url-helper.ts
@@ -4,14 +4,24 @@
  * This function checks if a VS Code URL points to localhost and replaces it with
  * the current window's hostname if they don't match.
  *
+ * Only http:, https:, and vscode: schemes are returned. Invalid or non-allowlisted
+ * inputs (e.g. javascript:) yield null so callers that window.open do not navigate
+ * to attacker-controlled schemes.
+ *
  * @param vsCodeUrl The original VS Code URL from the backend
- * @returns The transformed URL with the correct hostname
+ * @returns The transformed URL with the correct hostname, or null if unsafe/invalid
  */
+const ALLOWED_VSCODE_URL_PROTOCOLS = new Set(["http:", "https:", "vscode:"]);
+
 export function transformVSCodeUrl(vsCodeUrl: string | null): string | null {
   if (!vsCodeUrl) return null;
 
   try {
     const url = new URL(vsCodeUrl);
+
+    if (!ALLOWED_VSCODE_URL_PROTOCOLS.has(url.protocol)) {
+      return null;
+    }
 
     // Check if the URL points to localhost
     if (
@@ -25,7 +35,7 @@ export function transformVSCodeUrl(vsCodeUrl: string | null): string | null {
 
     return vsCodeUrl;
   } catch {
-    // Silently handle the error and return the original URL
-    return vsCodeUrl;
+    // Invalid URLs must not be passed through to window.open
+    return null;
   }
 }


### PR DESCRIPTION
HUMAN:

Ran `npx vitest run __tests__/utils/vscode-url-helper.test.ts` locally: 8/8 passed, including new allow (`http`/`https`/`vscode`) and deny (`javascript`/`data`/invalid) cases. Call sites already null-check before `window.open`.

AGENT:

`npx vitest run __tests__/utils/vscode-url-helper.test.ts` — 8 passed. Change confined to `src/utils/vscode-url-helper.ts` (+ unit tests). No packaged desktop retest of VS Code open in this environment.

---

## Why

`transformVSCodeUrl` fail-opens: on parse failure it returns the original string, and it never checks the scheme. Callers (`drawer-vscode-link.tsx`, `conversation-card.tsx`) then `window.open` that value. A hostile or confused `vscode_url` can therefore deliver `javascript:` / `data:` into navigation.

Same class as MCP OAuth authorization_url hardening (#16445) and device-flow verification URL work, on a different path (VS Code open helper).

## Fix

- Allowlist `http:`, `https:`, and `vscode:`
- Return `null` for other schemes and for invalid URLs
- Existing callers already skip `window.open` when the helper returns null

## Test plan

- [x] `npx vitest run __tests__/utils/vscode-url-helper.test.ts` (8/8)
- [ ] Smoke: open VS Code from a conversation with a normal `http://localhost…` URL (localhost rewrite still works)
- [ ] Confirm `javascript:` / garbage strings no longer open a window


Made with [Cursor](https://cursor.com)