### PR TITLE
fix(frontend): require https for OpenAI subscription verification URLs

### DIFF
--- a/__tests__/utils/verification-url.test.ts
+++ b/__tests__/utils/verification-url.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { isValidVerificationUrl } from "#/utils/verification-url";
+
+describe("isValidVerificationUrl", () => {
+  it("accepts https URLs", () => {
+    expect(isValidVerificationUrl("https://auth.openai.com/device")).toBe(true);
+  });
+
+  it("rejects non-https schemes", () => {
+    expect(isValidVerificationUrl("http://auth.openai.com/device")).toBe(false);
+    expect(isValidVerificationUrl("javascript:alert(1)")).toBe(false);
+    expect(isValidVerificationUrl("data:text/html,<script>alert(1)</script>")).toBe(
+      false,
+    );
+    expect(isValidVerificationUrl("not-a-url")).toBe(false);
+  });
+});

--- a/src/components/features/settings/llm-settings/openai-subscription-auth-card.tsx
+++ b/src/components/features/settings/llm-settings/openai-subscription-auth-card.tsx
@@ -16,6 +16,7 @@ import {
   displayErrorToast,
   displaySuccessToast,
 } from "#/utils/custom-toast-handlers";
+import { isValidVerificationUrl } from "#/utils/verification-url";
 
 const DEFAULT_DEVICE_POLL_INTERVAL_SECONDS = 5;
 const MIN_DEVICE_POLL_INTERVAL_SECONDS = 1;
@@ -24,8 +25,21 @@ interface OpenAISubscriptionAuthCardProps {
   isDisabled?: boolean;
 }
 
-function openVerificationUrl(challenge: LLMSubscriptionDeviceChallenge) {
+function resolveVerificationUrl(
+  challenge: LLMSubscriptionDeviceChallenge,
+): string | null {
   const url = challenge.verificationUriComplete ?? challenge.verificationUri;
+  if (!url || !isValidVerificationUrl(url)) {
+    return null;
+  }
+  return url;
+}
+
+function openVerificationUrl(challenge: LLMSubscriptionDeviceChallenge) {
+  const url = resolveVerificationUrl(challenge);
+  if (!url) {
+    return;
+  }
   window.open(url, "_blank", "noopener,noreferrer");
 }
 
@@ -149,6 +163,10 @@ export function OpenAISubscriptionAuthCard({
     setIsPendingLogin(false);
   };
 
+  const verificationUrl = challenge
+    ? resolveVerificationUrl(challenge)
+    : null;
+
   return (
     <section
       data-testid="openai-subscription-auth-card"
@@ -215,17 +233,17 @@ export function OpenAISubscriptionAuthCard({
               mode={copied ? "copied" : "copy"}
             />
           </div>
-          <a
-            href={
-              challenge.verificationUriComplete ?? challenge.verificationUri
-            }
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center gap-1 text-sm text-[var(--oh-accent)] underline"
-          >
-            {t(I18nKey.SETTINGS$SUBSCRIPTION_OPEN_LOGIN)}
-            <ExternalLink size={14} aria-hidden />
-          </a>
+          {verificationUrl ? (
+            <a
+              href={verificationUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-sm text-[var(--oh-accent)] underline"
+            >
+              {t(I18nKey.SETTINGS$SUBSCRIPTION_OPEN_LOGIN)}
+              <ExternalLink size={14} aria-hidden />
+            </a>
+          ) : null}
           {isPendingLogin ? (
             <span className="text-warning">
               {t(I18nKey.SETTINGS$SUBSCRIPTION_PENDING_TOAST)}

--- a/src/utils/verification-url.ts
+++ b/src/utils/verification-url.ts
@@ -1,0 +1,12 @@
+/**
+ * Validate that a device-login verification URL is safe to open / link.
+ * Prevents XSS via javascript: / data: / other non-https schemes.
+ */
+export function isValidVerificationUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
HUMAN:

Ran `npx vitest run __tests__/utils/verification-url.test.ts` locally: 2/2 passed (https allow + javascript/data/http/invalid deny). Call sites no-op / omit link when invalid.

AGENT:

`npx vitest run __tests__/utils/verification-url.test.ts` — 2 passed. Change confined to subscription auth card + shared `isValidVerificationUrl` helper. No packaged OpenAI device-login retest in this environment.

---

## Why

`OpenAISubscriptionAuthCard` opens backend-returned `verification_uri` / `verification_uri_complete` with bare `window.open` and also renders a raw `<a href>`. No scheme allowlist.

Sibling `DeviceFlowAuth` already requires `https:` via `isValidVerificationUrl`. A malicious or compromised agent-server can return `javascript:` / `data:` / other schemes into this subscription login path.

Distinct from #16445 (MCP OAuth), #16446 (`transformVSCodeUrl`), and Electron #16376/#16419.

## Fix

Shared `isValidVerificationUrl` (https only). `openVerificationUrl` no-ops when invalid; the challenge link is omitted unless the URL is https.

## Test plan

- [x] `npx vitest run __tests__/utils/verification-url.test.ts` (2/2)
- [ ] Normal https OpenAI device URL still opens / links
- [ ] Non-https schemes do not open a window or render an href


Made with [Cursor](https://cursor.com)