### PR TITLE
fix: surface uploaded file paths to agents

### DIFF
--- a/__tests__/api/conversation-file-upload.test.ts
+++ b/__tests__/api/conversation-file-upload.test.ts
@@ -77,7 +77,9 @@ describe("uploadFilesToConversation", () => {
       expect.objectContaining({ name: "a.txt" }),
       "/Users/test/workspace/project/a.txt",
     );
-    expect(result.uploaded_files).toEqual(["a.txt"]);
+    expect(result.uploaded_files).toEqual([
+      "/Users/test/workspace/project/a.txt",
+    ]);
     expect(batchGetCloudConversations).not.toHaveBeenCalled();
     expect(getHomeMock).toHaveBeenCalled();
   });
@@ -109,7 +111,9 @@ describe("uploadFilesToConversation", () => {
       expect.objectContaining({ name: "notes.md" }),
       "/Users/test/projects/foo/notes.md",
     );
-    expect(result.uploaded_files).toEqual(["notes.md"]);
+    expect(result.uploaded_files).toEqual([
+      "/Users/test/projects/foo/notes.md",
+    ]);
     expect(getHomeMock).not.toHaveBeenCalled();
   });
 
@@ -142,6 +146,6 @@ describe("uploadFilesToConversation", () => {
       expect.objectContaining({ name: "notes.md" }),
       "/workspace/project/notes.md",
     );
-    expect(result.uploaded_files).toEqual(["notes.md"]);
+    expect(result.uploaded_files).toEqual(["/workspace/project/notes.md"]);
   });
 });

--- a/__tests__/api/conversation-service.test.ts
+++ b/__tests__/api/conversation-service.test.ts
@@ -35,7 +35,7 @@ describe("ConversationService", () => {
     // @spec WUP-001 — The default fallback working dir is relative
     // (`workspace/project`); the upload path is resolved against the
     // agent-server's home directory via /api/file/home.
-    it("uploads files through RemoteWorkspace and reports successes", async () => {
+    it("uploads files through RemoteWorkspace and reports their absolute paths", async () => {
       fileUploadMock.mockResolvedValue(undefined);
 
       const result = await ConversationService.uploadFiles("conv-1", [
@@ -58,12 +58,15 @@ describe("ConversationService", () => {
         "/Users/agent/workspace/project/b.txt",
       );
       expect(result).toEqual({
-        uploaded_files: ["a.txt", "b.txt"],
+        uploaded_files: [
+          "/Users/agent/workspace/project/a.txt",
+          "/Users/agent/workspace/project/b.txt",
+        ],
         skipped_files: [],
       });
     });
 
-    it("uploads using only the basename of user-provided file names", async () => {
+    it("sanitizes user-provided file names and reports the resolved path", async () => {
       fileUploadMock.mockResolvedValue(undefined);
 
       const result = await ConversationService.uploadFiles("conv-1", [
@@ -75,7 +78,7 @@ describe("ConversationService", () => {
         "/Users/agent/workspace/project/evil.txt",
       );
       expect(result).toEqual({
-        uploaded_files: ["evil.txt"],
+        uploaded_files: ["/Users/agent/workspace/project/evil.txt"],
         skipped_files: [],
       });
     });
@@ -113,7 +116,7 @@ describe("ConversationService", () => {
         expect.objectContaining({ apiKey: "session-key" }),
       );
       expect(result).toEqual({
-        uploaded_files: ["ok.txt"],
+        uploaded_files: ["/Users/agent/workspace/project/ok.txt"],
         skipped_files: [{ name: "bad.txt", reason: "too large" }],
       });
     });
@@ -136,7 +139,9 @@ describe("ConversationService", () => {
 
       expect(fileUploadMock).toHaveBeenCalledTimes(7);
       expect(maxActiveUploads).toBe(5);
-      expect(result.uploaded_files).toEqual(files.map((file) => file.name));
+      expect(result.uploaded_files).toEqual(
+        files.map((file) => `/Users/agent/workspace/project/${file.name}`),
+      );
       expect(result.skipped_files).toEqual([]);
     });
   });

--- a/__tests__/hooks/mutation/use-unified-upload-files.test.tsx
+++ b/__tests__/hooks/mutation/use-unified-upload-files.test.tsx
@@ -1,0 +1,129 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useUnifiedUploadFiles } from "#/hooks/mutation/use-unified-upload-files";
+import type { FileUploadSuccessResponse } from "#/api/open-hands.types";
+import { ActiveBackendProvider } from "#/contexts/active-backend-context";
+import { WORKSPACE_QUERY_KEYS } from "#/hooks/query/query-keys";
+
+const uploadFilesToConversationMock = vi.fn();
+
+vi.mock("#/api/conversation-file-upload.api", () => ({
+  uploadFilesToConversation: (...args: unknown[]) =>
+    uploadFilesToConversationMock(...args),
+}));
+
+function makeFile(name: string) {
+  return new File(["content"], name, { type: "text/plain" });
+}
+
+function createWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <ActiveBackendProvider>{children}</ActiveBackendProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe("useUnifiedUploadFiles", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    vi.clearAllMocks();
+  });
+
+  it("invalidates file_changes and workspace-files for the conversation when a file is uploaded to an absolute path", async () => {
+    const conversationId = "conv-1";
+    const absolutePath = "/workspace/project/notes.md";
+
+    uploadFilesToConversationMock.mockResolvedValue({
+      uploaded_files: [absolutePath],
+      skipped_files: [],
+    } as FileUploadSuccessResponse);
+
+    const fileChangesKey = WORKSPACE_QUERY_KEYS.fileChanges(
+      conversationId,
+      "https://conversation.example",
+      "session-key",
+      "/workspace/project",
+    );
+    const workspaceFilesKey = WORKSPACE_QUERY_KEYS.files(
+      conversationId,
+      "http://localhost:3000",
+      "session-key",
+      "/workspace/project",
+    );
+    queryClient.setQueryData(fileChangesKey, []);
+    queryClient.setQueryData(workspaceFilesKey, ["existing.txt"]);
+    const wrapper = createWrapper(queryClient);
+
+    const { result } = renderHook(() => useUnifiedUploadFiles(), {
+      wrapper,
+    });
+
+    const response = await result.current.mutateAsync({
+      conversationId,
+      files: [makeFile("notes.md")],
+    });
+
+    expect(response.uploaded_files).toEqual([absolutePath]);
+    await waitFor(() => {
+      expect(queryClient.getQueryState(fileChangesKey)?.isInvalidated).toBe(
+        true,
+      );
+      expect(queryClient.getQueryState(workspaceFilesKey)?.isInvalidated).toBe(
+        true,
+      );
+    });
+  });
+
+  it("does not invalidate either prefix when every file is skipped", async () => {
+    const conversationId = "conv-2";
+
+    uploadFilesToConversationMock.mockResolvedValue({
+      uploaded_files: [],
+      skipped_files: [{ name: "notes.md", reason: "Upload failed" }],
+    } as FileUploadSuccessResponse);
+
+    const fileChangesKey = WORKSPACE_QUERY_KEYS.fileChanges(
+      conversationId,
+      "https://conversation.example",
+      "session-key",
+      "/workspace/project",
+    );
+    const workspaceFilesKey = WORKSPACE_QUERY_KEYS.files(
+      conversationId,
+      "http://localhost:3000",
+      "session-key",
+      "/workspace/project",
+    );
+    queryClient.setQueryData(fileChangesKey, []);
+    queryClient.setQueryData(workspaceFilesKey, ["existing.txt"]);
+    const wrapper = createWrapper(queryClient);
+
+    const { result } = renderHook(() => useUnifiedUploadFiles(), {
+      wrapper,
+    });
+
+    await result.current.mutateAsync({
+      conversationId,
+      files: [makeFile("notes.md")],
+    });
+
+    expect(queryClient.getQueryState(fileChangesKey)?.isInvalidated).toBe(
+      false,
+    );
+    expect(queryClient.getQueryState(workspaceFilesKey)?.isInvalidated).toBe(
+      false,
+    );
+  });
+});

--- a/src/api/conversation-file-upload.api.ts
+++ b/src/api/conversation-file-upload.api.ts
@@ -6,7 +6,6 @@ import type { AppConversation } from "#/api/conversation-service/agent-server-co
 import type { FileUploadSuccessResponse } from "#/api/open-hands.types";
 import {
   buildWorkspaceUploadPath,
-  getSafeUploadFileName,
   resolveConversationUploadWorkingDir,
 } from "#/api/workspace-upload-path";
 
@@ -131,7 +130,6 @@ async function uploadFilesToRuntime(options: {
 
   const uploadFile = async (file: File) => {
     try {
-      const safeName = getSafeUploadFileName(file.name);
       // @spec WUP-001 — Build an absolute upload path that's anchored against
       // the agent-server's home dir (when `workingDir` is relative) instead
       // of the filesystem root. Without this, default conversations whose
@@ -143,7 +141,7 @@ async function uploadFilesToRuntime(options: {
         sessionApiKey,
       });
       await workspace.fileUpload(file, uploadPath);
-      return { uploadedFile: safeName, skippedFile: null };
+      return { uploadedFile: uploadPath, skippedFile: null };
     } catch (error) {
       return {
         uploadedFile: null,

--- a/src/hooks/mutation/use-unified-upload-files.ts
+++ b/src/hooks/mutation/use-unified-upload-files.ts
@@ -1,6 +1,7 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { uploadFilesToConversation } from "#/api/conversation-file-upload.api";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
+import { WORKSPACE_QUERY_KEYS } from "#/hooks/query/query-keys";
 import { FileUploadSuccessResponse } from "#/api/open-hands.types";
 
 interface UnifiedUploadFilesVariables {
@@ -13,6 +14,7 @@ interface UnifiedUploadFilesVariables {
  */
 export const useUnifiedUploadFiles = () => {
   const { data: conversation } = useActiveConversation();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationKey: ["unified-upload-files"],
@@ -21,6 +23,18 @@ export const useUnifiedUploadFiles = () => {
     ): Promise<FileUploadSuccessResponse> => {
       const { conversationId, files } = variables;
       return uploadFilesToConversation(conversationId, files, conversation);
+    },
+    onSuccess: (data, variables) => {
+      if (data.uploaded_files.length > 0) {
+        const { conversationId } = variables;
+        queryClient.invalidateQueries({
+          queryKey:
+            WORKSPACE_QUERY_KEYS.fileChangesForConversation(conversationId),
+        });
+        queryClient.invalidateQueries({
+          queryKey: WORKSPACE_QUERY_KEYS.filesForConversation(conversationId),
+        });
+      }
     },
     meta: {
       disableToast: true,

--- a/src/hooks/query/query-keys.ts
+++ b/src/hooks/query/query-keys.ts
@@ -60,6 +60,41 @@ export const APP_UPDATE_QUERY_KEYS = {
   latestVersion: ["agent-canvas-latest-version"] as const,
 } as const;
 
+export const WORKSPACE_QUERY_KEYS = {
+  allFileChanges: ["file_changes"] as const,
+  fileChanges: (
+    conversationId: string | null | undefined,
+    conversationUrl: string | null | undefined,
+    sessionApiKey: string | null | undefined,
+    gitPath: string,
+  ) =>
+    [
+      "file_changes",
+      conversationId,
+      conversationUrl,
+      sessionApiKey,
+      gitPath,
+    ] as const,
+  fileChangesForConversation: (conversationId: string | null | undefined) =>
+    ["file_changes", conversationId] as const,
+  allFiles: ["workspace-files"] as const,
+  files: (
+    conversationId: string | null | undefined,
+    conversationUrl: string | null | undefined,
+    sessionApiKey: string | null | undefined,
+    workingDir: string | null | undefined,
+  ) =>
+    [
+      "workspace-files",
+      conversationId,
+      conversationUrl,
+      sessionApiKey,
+      workingDir,
+    ] as const,
+  filesForConversation: (conversationId: string | null | undefined) =>
+    ["workspace-files", conversationId] as const,
+} as const;
+
 /** Cache configuration shared across all config-related queries */
 export const CONFIG_CACHE_OPTIONS = {
   staleTime: 1000 * 60 * 5, // 5 minutes

--- a/src/hooks/query/use-unified-get-git-changes.ts
+++ b/src/hooks/query/use-unified-get-git-changes.ts
@@ -4,6 +4,7 @@ import AgentServerGitService from "#/api/git-service/agent-server-git-service.ap
 import { useConversationId } from "#/hooks/use-conversation-id";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useRuntimeIsReady } from "#/hooks/use-runtime-is-ready";
+import { WORKSPACE_QUERY_KEYS } from "#/hooks/query/query-keys";
 import { getGitPath } from "#/utils/get-git-path";
 import type { GitChange } from "#/api/open-hands.types";
 
@@ -25,13 +26,12 @@ export const useUnifiedGetGitChanges = () => {
   );
 
   const result = useQuery({
-    queryKey: [
-      "file_changes",
+    queryKey: WORKSPACE_QUERY_KEYS.fileChanges(
       conversationId,
       conversationUrl,
       sessionApiKey,
       gitPath,
-    ],
+    ),
     queryFn: async () => {
       if (!conversationId) throw new Error("No conversation ID");
 

--- a/src/hooks/query/use-workspace-files.ts
+++ b/src/hooks/query/use-workspace-files.ts
@@ -6,6 +6,7 @@ import { useActiveBackend } from "#/contexts/active-backend-context";
 import { useActiveConversation } from "#/hooks/query/use-active-conversation";
 import { useRuntimeIsReady } from "#/hooks/use-runtime-is-ready";
 import { useUnifiedGetGitChanges } from "#/hooks/query/use-unified-get-git-changes";
+import { WORKSPACE_QUERY_KEYS } from "#/hooks/query/query-keys";
 
 // Cap the number of files we render so a giant repo doesn't freeze the UI.
 const MAX_FILES = 2000;
@@ -66,13 +67,12 @@ function useLocalWorkspaceFiles(enabled: boolean): WorkspaceFilesResult {
   const workingDir = conversation?.workspace?.working_dir?.trim();
 
   const query = useQuery<string[]>({
-    queryKey: [
-      "workspace-files",
+    queryKey: WORKSPACE_QUERY_KEYS.files(
       conversationId,
       conversationUrl,
       sessionApiKey,
       workingDir,
-    ],
+    ),
     queryFn: async () => {
       const result = await AgentServerRuntimeService.executeCommand(
         conversationUrl,

--- a/src/hooks/use-auto-refresh-files-on-edit.ts
+++ b/src/hooks/use-auto-refresh-files-on-edit.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 
 import { useEventStore, type OHEvent } from "#/stores/use-event-store";
 import { useWorkspaceMutationCounter } from "#/stores/use-workspace-mutation-counter";
+import { WORKSPACE_QUERY_KEYS } from "#/hooks/query/query-keys";
 
 // `kind` values we treat as a file-mutation observation.
 const FILE_EDIT_OBSERVATION_KINDS = new Set([
@@ -132,12 +133,16 @@ export function useAutoRefreshFilesOnEdit(): void {
     // observation); per-commit queries (`commit_changes` /
     // `commit_file_diff`) are sha-addressed and immutable, so they are
     // deliberately NOT invalidated.
-    queryClient.invalidateQueries({ queryKey: ["file_changes"] });
+    queryClient.invalidateQueries({
+      queryKey: WORKSPACE_QUERY_KEYS.allFileChanges,
+    });
     queryClient.invalidateQueries({ queryKey: ["file_diff"] });
     queryClient.invalidateQueries({ queryKey: ["git_commits"] });
 
     if (hasNewFileEdits) {
-      queryClient.invalidateQueries({ queryKey: ["workspace-files"] });
+      queryClient.invalidateQueries({
+        queryKey: WORKSPACE_QUERY_KEYS.allFiles,
+      });
       queryClient.invalidateQueries({ queryKey: ["workspace-file-content"] });
       // Force iframes / <img> tags pointing at the static workspace
       // fileserver to re-fetch. Without this they happily keep showing the

--- a/src/routes/files-tab.tsx
+++ b/src/routes/files-tab.tsx
@@ -11,6 +11,7 @@ import { useHasAttachedSource } from "#/hooks/use-has-attached-source";
 import { useHasGitCommits } from "#/hooks/query/use-has-git-commits";
 import { useAutoRefreshFilesOnEdit } from "#/hooks/use-auto-refresh-files-on-edit";
 import { useUnifiedGetGitChanges } from "#/hooks/query/use-unified-get-git-changes";
+import { WORKSPACE_QUERY_KEYS } from "#/hooks/query/query-keys";
 import { useOptionalConversationId } from "#/hooks/use-conversation-id";
 import { useConversationLocalStorageState } from "#/utils/conversation-local-storage";
 import {
@@ -137,7 +138,7 @@ function FilesTab() {
     useUnifiedGetGitChanges();
   const refreshFiles = () => {
     refetchGitChanges();
-    queryClient.invalidateQueries({ queryKey: ["workspace-files"] });
+    queryClient.invalidateQueries({ queryKey: WORKSPACE_QUERY_KEYS.allFiles });
     queryClient.invalidateQueries({ queryKey: ["workspace-file-content"] });
     queryClient.invalidateQueries({ queryKey: ["git_commits"] });
   };

--- a/src/utils/cache-utils.ts
+++ b/src/utils/cache-utils.ts
@@ -1,6 +1,7 @@
 import { QueryClient } from "@tanstack/react-query";
 import type { ActionEvent } from "#/types/agent-server/core/events/action-event";
 import { useModelStore } from "#/stores/model-store";
+import { WORKSPACE_QUERY_KEYS } from "#/hooks/query/query-keys";
 import { stripWorkspacePrefix } from "./path-utils";
 
 /**
@@ -30,7 +31,8 @@ export const handleActionEventCacheInvalidation = (
   ) {
     queryClient.invalidateQueries(
       {
-        queryKey: ["file_changes", conversationId],
+        queryKey:
+          WORKSPACE_QUERY_KEYS.fileChangesForConversation(conversationId),
       },
       { cancelRefetch: false },
     );

--- a/tests/e2e/mock-llm/files/mock-llm-file-upload.spec.ts
+++ b/tests/e2e/mock-llm/files/mock-llm-file-upload.spec.ts
@@ -54,7 +54,9 @@ test("an uploaded file reaches the agent by absolute path and appears without a 
     await expect(panelToggle).toHaveAttribute("aria-pressed", "true");
     await page.getByTestId("conversation-tab-files").click();
     await expect(page.getByTestId("files-tab-diff-toggle")).toBeVisible();
-    await page.getByTestId("files-tab-diff-toggle-option-off").click();
+    await expect(
+      page.getByTestId("files-tab-diff-toggle-option-off"),
+    ).toHaveAttribute("aria-checked", "true");
     await page.getByTestId("file-quick-row-tree-toggle").click();
     await expect(page.getByTestId("files-tab-tree")).toBeVisible();
 

--- a/tests/e2e/mock-llm/files/mock-llm-file-upload.spec.ts
+++ b/tests/e2e/mock-llm/files/mock-llm-file-upload.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "@playwright/test";
+import {
+  activateTrajectory,
+  deleteConversation,
+  dismissAnalyticsModal,
+  ensureMockLLMProfile,
+  getConversationIdFromURL,
+  getMockLLMRequests,
+  registerTrajectory,
+  resetMockLLM,
+  routeSessionApiKey,
+  seedLocalStorage,
+  setChatInput,
+  waitForNonUserMessageText,
+  waitForPath,
+  waitForTestId,
+} from "../utils/mock-llm-helpers";
+
+const INITIAL_REPLY = "MOCK_LLM_FILE_UPLOAD_READY";
+const UPLOAD_REPLY = "MOCK_LLM_FILE_UPLOAD_DONE";
+const FILE_NAME = "bug.txt";
+
+test("an uploaded file reaches the agent by absolute path and appears without a manual refresh", async ({
+  page,
+  request,
+}) => {
+  test.setTimeout(120_000);
+  let conversationId: string | null = null;
+
+  try {
+    await seedLocalStorage(page);
+    await ensureMockLLMProfile(page);
+    await resetMockLLM(request);
+    await registerTrajectory(request, "file-upload-path", [
+      { text: "" },
+      { text: INITIAL_REPLY },
+      { text: UPLOAD_REPLY },
+    ]);
+    await activateTrajectory(request, "file-upload-path");
+
+    await routeSessionApiKey(page);
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await dismissAnalyticsModal(page);
+    await waitForTestId(page, "home-chat-launcher");
+
+    await setChatInput(page, "Start a conversation for the upload test.");
+    await page.getByTestId("submit-button").click();
+    await waitForPath(page, /\/conversations\/.+/, 30_000);
+    conversationId = getConversationIdFromURL(page);
+    await waitForNonUserMessageText(page, INITIAL_REPLY, 30_000);
+
+    const panelToggle = page.getByTestId("right-panel-toggle");
+    await panelToggle.click();
+    await expect(panelToggle).toHaveAttribute("aria-pressed", "true");
+    await page.getByTestId("conversation-tab-files").click();
+    await expect(page.getByTestId("files-tab-diff-toggle")).toBeVisible();
+    await page.getByTestId("files-tab-diff-toggle-option-off").click();
+    await page.getByTestId("file-quick-row-tree-toggle").click();
+    await expect(page.getByTestId("files-tab-tree")).toBeVisible();
+
+    await page.getByTestId("upload-image-input").setInputFiles({
+      name: FILE_NAME,
+      mimeType: "text/plain",
+      buffer: Buffer.from("uploaded file contents"),
+    });
+    await setChatInput(page, "Read the uploaded file.");
+    await expect(page.getByTestId("submit-button")).toBeEnabled();
+    await page.getByTestId("submit-button").click();
+
+    await waitForNonUserMessageText(page, UPLOAD_REPLY, 30_000);
+
+    await expect
+      .poll(
+        async () => {
+          const requests = await getMockLLMRequests(request);
+          return requests.some((body) => {
+            const serialized = JSON.stringify(body);
+            return new RegExp(`(?:/[^"\\s]+)+/${FILE_NAME}`).test(serialized);
+          });
+        },
+        { timeout: 15_000 },
+      )
+      .toBe(true);
+
+    await expect(page.getByTestId(`file-tree-file-${FILE_NAME}`)).toBeVisible({
+      timeout: 15_000,
+    });
+  } finally {
+    if (conversationId) {
+      await deleteConversation(request, conversationId).catch(() => undefined);
+    }
+    await resetMockLLM(request).catch(() => undefined);
+  }
+});

--- a/tests/e2e/mock-llm/files/mock-llm-file-upload.spec.ts
+++ b/tests/e2e/mock-llm/files/mock-llm-file-upload.spec.ts
@@ -57,7 +57,9 @@ test("an uploaded file reaches the agent by absolute path and appears without a 
     await expect(
       page.getByTestId("files-tab-diff-toggle-option-off"),
     ).toHaveAttribute("aria-checked", "true");
-    await page.getByTestId("file-quick-row-tree-toggle").click();
+    const fileTreeToggle = page.getByTestId("file-quick-row-tree-toggle");
+    await expect(fileTreeToggle).toBeVisible();
+    await fileTreeToggle.click({ force: true });
     await expect(page.getByTestId("files-tab-tree")).toBeVisible();
 
     await page.getByTestId("upload-image-input").setInputFiles({


### PR DESCRIPTION
HUMAN:
I reviewed the changes in this PR, confirmed that all required checks have passed, and checked the CI logs; no unusual warnings or errors were found.

AGENT:

A GLM-backed Claude Code pass produced the initial focused implementation. Codex then reproduced the bug, replaced duplicated query-key literals with shared factories, added regression coverage, ran an independent review pass, and verified the production and library builds. The mock-LLM browser test is included for the repository's Linux workflow; local execution was blocked by the upstream POSIX-only Playwright webServer command plus repeated PyPI dependency timeouts on Windows.

---

## Why

Canvas uploads a file to an absolute workspace path but reports only its basename to the message composer. Cloud agents therefore receive `Files uploaded: notes.md` without a usable location, and an already-open Files tab can remain stale after the browser upload.

## Summary

- Return the resolved absolute workspace path for each successful upload, while preserving filename sanitization and per-file failure reporting.
- Invalidate the conversation-scoped cloud and local workspace queries after a successful upload, using shared typed query-key factories across every producer and invalidator.
- Add API, mutation/cache, and mock-LLM browser regressions covering the prompt path and immediate Files-tab refresh.

## Issue Number

Closes #16339

## How to Test

1. Run the focused regression suite:
   `npm test -- __tests__/api/conversation-service.test.ts __tests__/api/conversation-file-upload.test.ts __tests__/hooks/mutation/use-unified-upload-files.test.tsx __tests__/hooks/use-auto-refresh-files-on-edit.test.tsx __tests__/routes/files-tab.test.tsx __tests__/hooks/query/use-workspace-files.test.tsx src/hooks/query/query-keys.test.ts __tests__/utils/cache-utils.test.ts`
2. Run `npm run lint`.
3. Run `npm run build:app` and `npm run build:lib`.
4. Run the mock-LLM browser regression on Linux:
   `npm run test:e2e:mock-llm -- tests/e2e/mock-llm/files/mock-llm-file-upload.spec.ts`

Local results: 54 focused tests passed; lint passed with one pre-existing warning in `use-local-git-info.ts`; both production and library builds passed. A full Windows Vitest run reached 4474 passing tests and exposed 20 unrelated platform/baseline failures (POSIX-only path assertions and the Node 25 localStorage shim). The four upload-contract failures from this change were updated and pass in the focused suite.

## Video/Screenshots
[video.webm](https://github.com/user-attachments/assets/dbde7aa0-bafb-4d73-919f-160b355628ef)



## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The PR is intentionally kept as a draft until the required human testing note and browser evidence are added. No API schema changed; `uploaded_files` now carries the same sanitized absolute destination already used by `RemoteWorkspace.fileUpload`.