### PR TITLE
fix: deduplicate duplicate diff entries by path

### DIFF
--- a/__tests__/hooks/query/use-unified-get-git-changes.test.tsx
+++ b/__tests__/hooks/query/use-unified-get-git-changes.test.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import AgentServerGitService from "#/api/git-service/agent-server-git-service.api";
+import type { GitChange } from "#/api/open-hands.types";
+import { useUnifiedGetGitChanges } from "#/hooks/query/use-unified-get-git-changes";
+
+vi.mock("#/api/git-service/agent-server-git-service.api", () => ({
+  default: {
+    getGitChanges: vi.fn(),
+  },
+}));
+
+vi.mock("#/hooks/use-conversation-id", () => ({
+  useConversationId: () => ({ conversationId: "test-conversation-id" }),
+}));
+
+vi.mock("#/hooks/query/use-active-conversation", () => ({
+  useActiveConversation: () => ({
+    data: {
+      conversation_url: null,
+      session_api_key: null,
+      selected_repository: null,
+      workspace: { working_dir: "/workspace" },
+    },
+  }),
+}));
+
+vi.mock("#/hooks/use-runtime-is-ready", () => ({
+  useRuntimeIsReady: () => true,
+}));
+
+const buildChanges = (paths: string[]): GitChange[] =>
+  paths.map((path) => ({ path }) as GitChange);
+
+const renderUseUnifiedGetGitChanges = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  const wrapper = ({ children }: React.PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return renderHook(() => useUnifiedGetGitChanges(), { wrapper });
+};
+
+describe("useUnifiedGetGitChanges", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not return duplicate entries when the API response contains duplicate paths", async () => {
+    vi.mocked(AgentServerGitService.getGitChanges).mockResolvedValue(
+      buildChanges(["file-a.ts", "file-a.ts", "file-b.ts"]),
+    );
+
+    const { result } = renderUseUnifiedGetGitChanges();
+
+    await waitFor(() => {
+      expect(result.current.data.map((change) => change.path)).toEqual([
+        "file-a.ts",
+        "file-b.ts",
+      ]);
+    });
+  });
+
+  it("does not duplicate entries across refetches and keeps the latest changes on top", async () => {
+    const getGitChangesMock = vi.mocked(AgentServerGitService.getGitChanges);
+    getGitChangesMock.mockResolvedValueOnce(
+      buildChanges(["file-a.ts", "file-b.ts"]),
+    );
+
+    const { result } = renderUseUnifiedGetGitChanges();
+
+    await waitFor(() => {
+      expect(result.current.data.map((change) => change.path)).toEqual([
+        "file-a.ts",
+        "file-b.ts",
+      ]);
+    });
+
+    getGitChangesMock.mockResolvedValueOnce(
+      buildChanges(["file-b.ts", "file-c.ts"]),
+    );
+
+    await result.current.refetch();
+
+    await waitFor(() => {
+      expect(result.current.data.map((change) => change.path)).toEqual([
+        "file-c.ts",
+        "file-b.ts",
+      ]);
+    });
+  });
+});

--- a/src/hooks/query/use-unified-get-git-changes.ts
+++ b/src/hooks/query/use-unified-get-git-changes.ts
@@ -63,21 +63,42 @@ export const useUnifiedGetGitChanges = () => {
 
         // Figure out new items by comparing with what we already have
         if (Array.isArray(currentData)) {
-          const currentIds = new Set(currentData.map((item) => item.path));
-          const existingIds = new Set(orderedChanges.map((item) => item.path));
+          // The API can return duplicate entries for the same path (e.g.
+          // staged and unstaged entries for one file); keep only the first
+          // occurrence so the diff list shows one entry per changed file
+          const seenPaths = new Set<string>();
+          const uniqueCurrentData = currentData.filter((item) => {
+            if (seenPaths.has(item.path)) {
+              return false;
+            }
+            seenPaths.add(item.path);
+            return true;
+          });
 
-          // Filter out items that already exist in orderedChanges
-          const newItems = currentData.filter(
-            (item) => !existingIds.has(item.path),
+          const currentIds = new Set(
+            uniqueCurrentData.map((item) => item.path),
           );
 
-          // Filter out items that no longer exist in the API response
-          const existingItems = orderedChanges.filter((item) =>
-            currentIds.has(item.path),
-          );
+          // Merge against the latest stored changes (functional update) so
+          // entries already processed in previous renders are never re-added
+          setOrderedChanges((previousChanges) => {
+            const existingIds = new Set(
+              previousChanges.map((item) => item.path),
+            );
 
-          // Add new items to the beginning
-          setOrderedChanges([...newItems, ...existingItems]);
+            // Filter out items that already exist in orderedChanges
+            const newItems = uniqueCurrentData.filter(
+              (item) => !existingIds.has(item.path),
+            );
+
+            // Filter out items that no longer exist in the API response
+            const existingItems = previousChanges.filter((item) =>
+              currentIds.has(item.path),
+            );
+
+            // Add new items to the beginning
+            return [...newItems, ...existingItems];
+          });
         } else {
           // If not an array, just use the data directly
           setOrderedChanges([currentData]);


### PR DESCRIPTION
## Summary
- deduplicate changed-file results by path before rendering the diff list
- use a functional state update so refetches cannot reintroduce already-seen paths
- add regression coverage for duplicate API paths and refetch ordering

Fixes #16454

## Validation
- npm exec -- vitest run __tests__/hooks/query/use-unified-get-git-changes.test.tsx
- npm run make-i18n && npm run typecheck
- npm exec -- eslint src/hooks/query/use-unified-get-git-changes.ts __tests__/hooks/query/use-unified-get-git-changes.test.tsx
- npm exec -- prettier --check src/hooks/query/use-unified-get-git-changes.ts __tests__/hooks/query/use-unified-get-git-changes.test.tsx