### PR TITLE
fix(conversations): preserve pinned conversations across pagination

### DIFF
--- a/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
+++ b/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
@@ -2304,6 +2304,45 @@ describe("ConversationPanel", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps a pinned conversation from a later page pinned after loading it", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(AgentServerConversationService, "searchConversations")
+      .mockResolvedValueOnce({
+        items: [
+          createMockConversation({
+            id: "newest",
+            title: "Newest visible conversation",
+          }),
+        ],
+        next_page_id: "page-2",
+      })
+      .mockResolvedValueOnce({
+        items: [
+          createMockConversation({
+            id: "older-pinned",
+            title: "Older pinned conversation",
+          }),
+        ],
+        next_page_id: null,
+      });
+    usePinnedConversationsStore
+      .getState()
+      .pinConversation("default-local", "older-pinned");
+
+    renderConversationPanel();
+    await user.click(await screen.findByTestId("load-more-conversations"));
+
+    const pinnedSection = await screen.findByTestId(
+      "conversation-panel-pinned-section",
+    );
+    expect(
+      within(pinnedSection).getByText("Older pinned conversation"),
+    ).toBeInTheDocument();
+    expect(
+      usePinnedConversationsStore.getState().pinsByBackendId["default-local"],
+    ).toContain("older-pinned");
+  });
+
   it("renders pinned conversations only in the pinned section in chronological mode", async () => {
     usePinnedConversationsStore
       .getState()

--- a/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/src/components/features/conversation-panel/conversation-panel.tsx
@@ -364,7 +364,7 @@ export function ConversationPanel({
   );
 
   React.useEffect(() => {
-    if (!isFetched) {
+    if (!isFetched || hasNextPage) {
       return;
     }
     // Prune pins against the unfiltered loaded pages so archived-but-still-
@@ -374,7 +374,13 @@ export function ConversationPanel({
     const loadedIds =
       data?.pages.flatMap((page) => page.items.map((item) => item.id)) ?? [];
     pruneMissingPinnedConversations(activeBackend.id, loadedIds);
-  }, [activeBackend.id, data, isFetched, pruneMissingPinnedConversations]);
+  }, [
+    activeBackend.id,
+    data,
+    hasNextPage,
+    isFetched,
+    pruneMissingPinnedConversations,
+  ]);
 
   React.useEffect(() => {
     if (pinnedIds.length === 0) {


### PR DESCRIPTION
HUMAN:

I personally reproduced the paginated conversation case and verified that the page-2 conversation remains pinned after reload and loading more conversations.

AGENT:

Implemented with Codex assistance. The change was developed test-first and verified with automated tests plus a local mock browser reproduction.

- Confirmed the new regression test fails before the guard change because the later-page pinned ID is pruned.
- Confirmed the pinned conversation remains in the Pinned section after loading page 2 with the fix applied.
- Ran the focused component suite, lint/typecheck, and production build successfully.

---

## Why

The conversation panel prunes persisted pinned IDs after only the first page of conversations is fetched. A valid pinned conversation on page 2 or later is therefore removed from local storage during reload.

## Summary

- Delay missing-pin pruning until all conversation pages have been loaded.
- Preserve the upstream behavior of pruning against unfiltered loaded pages.
- Add a two-page regression test that verifies a later-page conversation stays pinned.

## Issue Number

Fixes #16399

## How to Test

Automated verification:

- `npm test -- __tests__/components/features/conversation-panel/conversation-panel.test.tsx` — 55 tests passed.
- `npm run lint` — passed with one pre-existing unrelated warning in `src/hooks/query/use-local-git-info.ts`.
- `npm run build` — passed.
- `git diff --check` — passed.

Browser reproduction:

1. Seed more than 20 conversations and pin a conversation that appears only on page 2.
2. Reload while only page 1 is available.
3. Load page 2.
4. Confirm the conversation appears in the Pinned section and the persisted pin remains intact.

## Video/Screenshots

Before: after reload and loading page 2, the conversation appears in the ordinary list because its pin was pruned.

<img width="642" height="604" alt="Before: later-page conversation appears in the ordinary list after its pin was pruned" src="https://github.com/user-attachments/assets/7486fc17-debb-4b97-8352-49e1d6471e46" />

After: after reload and loading page 2, the conversation remains in the Pinned section.

<img width="642" height="604" alt="After: later-page conversation remains in the Pinned section" src="https://github.com/user-attachments/assets/43f8e8fd-53b3-41e4-a294-4f8a1bf1203b" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The implementation is intentionally limited to the pagination-aware pruning guard and its regression test. No migrations or configuration changes are required.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.42s · commit c7a793a  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 3/3 hunks, 2/2 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 2.0% | No direct hunk selected |
| Weakened authentication | 3.0% | No direct hunk selected |
| Weakened authorization | 4.0% | No direct hunk selected |
| Contract regression | 7.0% | No direct hunk selected |
| Data loss | 7.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 94.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 698f8fc02adb11b567b9d6ff295bcb21c7456e46102703ef614239fe4c0a328c -->
<!-- jev-fast-audit:end -->
