### PR TITLE
feat(sidebar): support configurable sidebar links via JSON config

### DIFF
--- a/__tests__/components/features/sidebar/sidebar-configured-links.test.tsx
+++ b/__tests__/components/features/sidebar/sidebar-configured-links.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "test-utils";
+import { SidebarConfiguredLinks } from "#/components/features/sidebar/sidebar-configured-links";
+import * as sidebarLinksConfig from "#/config/sidebar-links";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("SidebarConfiguredLinks", () => {
+  it("renders nothing when there are no configured links", () => {
+    vi.spyOn(sidebarLinksConfig, "getConfiguredSidebarLinks").mockReturnValue(
+      [],
+    );
+
+    const { container } = renderWithProviders(
+      <SidebarConfiguredLinks collapsed={false} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders a same-origin link as in-app navigation, not a new tab", () => {
+    vi.spyOn(sidebarLinksConfig, "getConfiguredSidebarLinks").mockReturnValue([
+      {
+        id: "dashboard",
+        label: "Conversations Dashboard",
+        url: `${window.location.origin}/dashboard?tab=all`,
+        icon: "external-link",
+      },
+    ]);
+
+    renderWithProviders(<SidebarConfiguredLinks collapsed={false} />);
+    const link = screen.getByTestId("sidebar-configured-link-dashboard");
+
+    expect(link).toHaveAttribute("href", "/dashboard?tab=all");
+    expect(link).not.toHaveAttribute("target");
+    expect(link).not.toHaveAttribute("rel");
+    // No trailing "external" affordance for an in-app destination.
+    expect(link.querySelectorAll("svg")).toHaveLength(1);
+  });
+
+  it("renders a cross-origin link as an external link that opens in a new tab", () => {
+    vi.spyOn(sidebarLinksConfig, "getConfiguredSidebarLinks").mockReturnValue([
+      {
+        id: "enterprise",
+        label: "OpenHands Enterprise",
+        url: "https://openhands.dev",
+        icon: "cloud",
+      },
+    ]);
+
+    renderWithProviders(<SidebarConfiguredLinks collapsed={false} />);
+    const link = screen.getByTestId("sidebar-configured-link-enterprise");
+
+    expect(link).toHaveAttribute("href", "https://openhands.dev");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    // Icon slot + trailing external-link affordance.
+    expect(link.querySelectorAll("svg")).toHaveLength(2);
+  });
+});

--- a/__tests__/config/sidebar-links.test.ts
+++ b/__tests__/config/sidebar-links.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getConfiguredSidebarLinks,
+  resetConfiguredSidebarLinksCache,
+} from "#/config/sidebar-links";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  delete (window as unknown as Record<string, unknown>)
+    .__AGENT_CANVAS_SIDEBAR_LINKS__;
+  resetConfiguredSidebarLinksCache();
+});
+
+describe("getConfiguredSidebarLinks", () => {
+  it("returns an empty array when no config is present", () => {
+    expect(getConfiguredSidebarLinks()).toEqual([]);
+  });
+
+  it("parses a valid entry from VITE_SIDEBAR_LINKS", () => {
+    vi.stubEnv(
+      "VITE_SIDEBAR_LINKS",
+      JSON.stringify([
+        { id: "enterprise", label: "Enterprise", url: "https://openhands.dev" },
+      ]),
+    );
+
+    expect(getConfiguredSidebarLinks()).toEqual([
+      {
+        id: "enterprise",
+        label: "Enterprise",
+        url: "https://openhands.dev",
+        icon: "external-link",
+      },
+    ]);
+  });
+
+  it("falls back to window.__AGENT_CANVAS_SIDEBAR_LINKS__ when VITE_SIDEBAR_LINKS is empty", () => {
+    (
+      window as unknown as Record<string, unknown>
+    ).__AGENT_CANVAS_SIDEBAR_LINKS__ = JSON.stringify([
+      {
+        id: "docs",
+        label: "Docs",
+        url: "https://docs.example.com",
+        icon: "book-open",
+      },
+    ]);
+
+    expect(getConfiguredSidebarLinks()).toEqual([
+      {
+        id: "docs",
+        label: "Docs",
+        url: "https://docs.example.com",
+        icon: "book-open",
+      },
+    ]);
+  });
+
+  it("prefers VITE_SIDEBAR_LINKS over the injected window global", () => {
+    vi.stubEnv(
+      "VITE_SIDEBAR_LINKS",
+      JSON.stringify([
+        { id: "from-env", label: "From env", url: "https://a.example.com" },
+      ]),
+    );
+    (
+      window as unknown as Record<string, unknown>
+    ).__AGENT_CANVAS_SIDEBAR_LINKS__ = JSON.stringify([
+      { id: "from-window", label: "From window", url: "https://b.example.com" },
+    ]);
+
+    expect(getConfiguredSidebarLinks().map((l) => l.id)).toEqual(["from-env"]);
+  });
+
+  it("memoizes the result across calls", () => {
+    vi.stubEnv(
+      "VITE_SIDEBAR_LINKS",
+      JSON.stringify([
+        { id: "cached", label: "Cached", url: "https://example.com" },
+      ]),
+    );
+
+    const first = getConfiguredSidebarLinks();
+    vi.stubEnv("VITE_SIDEBAR_LINKS", "");
+    const second = getConfiguredSidebarLinks();
+
+    expect(second).toBe(first);
+  });
+
+  it("drops the whole config when it is not valid JSON", () => {
+    vi.stubEnv("VITE_SIDEBAR_LINKS", "{not json");
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(getConfiguredSidebarLinks()).toEqual([]);
+  });
+
+  it("drops the whole config when it is not a JSON array", () => {
+    vi.stubEnv("VITE_SIDEBAR_LINKS", JSON.stringify({ id: "not-an-array" }));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(getConfiguredSidebarLinks()).toEqual([]);
+  });
+
+  it("drops an entry missing a label", () => {
+    vi.stubEnv(
+      "VITE_SIDEBAR_LINKS",
+      JSON.stringify([{ id: "no-label", url: "https://example.com" }]),
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(getConfiguredSidebarLinks()).toEqual([]);
+  });
+
+  it("drops an entry with a non-http(s) URL", () => {
+    vi.stubEnv(
+      "VITE_SIDEBAR_LINKS",
+      JSON.stringify([
+        { id: "js-url", label: "Bad", url: "javascript:alert(1)" },
+      ]),
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(getConfiguredSidebarLinks()).toEqual([]);
+  });
+
+  it("drops an entry with an invalid id", () => {
+    vi.stubEnv(
+      "VITE_SIDEBAR_LINKS",
+      JSON.stringify([
+        { id: "Not Kebab Case!", label: "Bad", url: "https://example.com" },
+      ]),
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(getConfiguredSidebarLinks()).toEqual([]);
+  });
+
+  it("drops the second entry when two entries share an id, keeping the first", () => {
+    vi.stubEnv(
+      "VITE_SIDEBAR_LINKS",
+      JSON.stringify([
+        { id: "dup", label: "First", url: "https://a.example.com" },
+        { id: "dup", label: "Second", url: "https://b.example.com" },
+      ]),
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(getConfiguredSidebarLinks()).toEqual([
+      {
+        id: "dup",
+        label: "First",
+        url: "https://a.example.com",
+        icon: "external-link",
+      },
+    ]);
+  });
+
+  it("falls back to the external-link icon for an unknown icon slug", () => {
+    vi.stubEnv(
+      "VITE_SIDEBAR_LINKS",
+      JSON.stringify([
+        {
+          id: "unknown-icon",
+          label: "Unknown",
+          url: "https://example.com",
+          icon: "rocket",
+        },
+      ]),
+    );
+
+    expect(getConfiguredSidebarLinks()[0]?.icon).toBe("external-link");
+  });
+
+  it("keeps valid entries alongside a dropped invalid one", () => {
+    vi.stubEnv(
+      "VITE_SIDEBAR_LINKS",
+      JSON.stringify([
+        { id: "ok", label: "OK", url: "https://example.com" },
+        { id: "bad", label: "", url: "https://example.com" },
+      ]),
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(getConfiguredSidebarLinks().map((l) => l.id)).toEqual(["ok"]);
+  });
+});

--- a/__tests__/scripts/static-server.test.ts
+++ b/__tests__/scripts/static-server.test.ts
@@ -145,6 +145,23 @@ describe("static-server.mjs", () => {
       expect(config.lockToCloud).toBeNull();
     });
 
+    it("defaults sidebarLinks to null", () => {
+      const config = parseArgs([]);
+      expect(config.sidebarLinks).toBeNull();
+    });
+
+    it("parses --sidebar-links", () => {
+      const json =
+        '[{"id":"enterprise","label":"Enterprise","url":"https://openhands.dev"}]';
+      const config = parseArgs(["--sidebar-links", json]);
+      expect(config.sidebarLinks).toBe(json);
+    });
+
+    it("treats empty string as null for sidebarLinks", () => {
+      const config = parseArgs(["--sidebar-links", ""]);
+      expect(config.sidebarLinks).toBeNull();
+    });
+
     it("defaults basePath to root", () => {
       const config = parseArgs([]);
       expect(config.basePath).toBe("/");
@@ -372,6 +389,63 @@ describe("static-server.mjs", () => {
 
       expect(response.status).toBe(200);
       expect(body).toContain("__AGENT_CANVAS_LOCK_TO_CLOUD__");
+    });
+  });
+
+  describe("sidebar links injection", () => {
+    async function startServerWithSidebarLinks(
+      dir: string,
+      sidebarLinks: string,
+    ) {
+      const server = await startStaticServer({
+        port: 0,
+        host: "127.0.0.1",
+        dir,
+        routes: {},
+        sidebarLinks,
+      });
+      servers.push(server);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Static server did not bind to a TCP port");
+      }
+      return `http://127.0.0.1:${address.port}`;
+    }
+
+    it("exposes the sidebar links JSON on window.__AGENT_CANVAS_SIDEBAR_LINKS__", async () => {
+      const buildDir = mkdtempSync(path.join(tmpdir(), "agent-canvas-build-"));
+      tempDirs.push(buildDir);
+      writeFileSync(
+        path.join(buildDir, "index.html"),
+        "<html><head></head><body>app</body></html>",
+      );
+
+      const sidebarLinks =
+        '[{"id":"enterprise","label":"Enterprise","url":"https://openhands.dev"}]';
+      const origin = await startServerWithSidebarLinks(buildDir, sidebarLinks);
+      const body = await (await fetch(`${origin}/`)).text();
+
+      expect(body).toContain("window.__AGENT_CANVAS_SIDEBAR_LINKS__");
+      expect(body).toContain("https://openhands.dev");
+    });
+
+    it("injects sidebar links into SPA fallback index.html", async () => {
+      const buildDir = mkdtempSync(path.join(tmpdir(), "agent-canvas-build-"));
+      tempDirs.push(buildDir);
+      writeFileSync(
+        path.join(buildDir, "index.html"),
+        "<html><head></head><body>app</body></html>",
+      );
+
+      const origin = await startServerWithSidebarLinks(
+        buildDir,
+        '[{"id":"enterprise","label":"Enterprise","url":"https://openhands.dev"}]',
+      );
+      const response = await fetch(`${origin}/some/deep/route`);
+      const body = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(body).toContain("__AGENT_CANVAS_SIDEBAR_LINKS__");
     });
   });
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -39,6 +39,10 @@
 #                          Override in production when the external URL differs.
 #   AUTOMATION_WORKSPACE_BASE – Directory for automation run workspaces
 #                          (default: ~/.openhands/workspaces)
+#   AGENT_CANVAS_SIDEBAR_LINKS – JSON array of extra sidebar nav links
+#                          ({id, label, url, icon?}), e.g. an OpenHands
+#                          Enterprise link, injected into the frontend
+#                          without a rebuild (default: unset, no extra links)
 #   Any agent-server or automation env vars are passed through.
 # ═══════════════════════════════════════════════════════════════════════════════
 set -uo pipefail
@@ -282,6 +286,7 @@ node /opt/agent-canvas/static-server.mjs \
   --base-path "$AGENT_CANVAS_BASE_PATH" \
   --session-api-key "$EFFECTIVE_SESSION_KEY" \
   --runtime-services-info "$RUNTIME_SERVICES_INFO" \
+  --sidebar-links "${AGENT_CANVAS_SIDEBAR_LINKS:-}" \
   --route "/api/automation=http://127.0.0.1:${AUTOMATION_PORT}" \
   --route "/api=http://127.0.0.1:${AGENT_SERVER_PORT}" \
   --route "/server_info=http://127.0.0.1:${AGENT_SERVER_PORT}" \
@@ -309,6 +314,7 @@ if [ -n "${PUBLIC_MODE_PORT:-}" ]; then
     --base-path "$AGENT_CANVAS_BASE_PATH" \
     --auth-required \
     --runtime-services-info "$RUNTIME_SERVICES_INFO" \
+    --sidebar-links "${AGENT_CANVAS_SIDEBAR_LINKS:-}" \
     --route "/api/automation=http://127.0.0.1:${AUTOMATION_PORT}" \
     --route "/api=http://127.0.0.1:${AGENT_SERVER_PORT}" \
     --route "/server_info=http://127.0.0.1:${AGENT_SERVER_PORT}" \

--- a/scripts/static-server.mjs
+++ b/scripts/static-server.mjs
@@ -88,6 +88,7 @@ export function parseArgs(argv = process.argv.slice(2)) {
     authRequired: false,
     runtimeServicesInfo: null,
     lockToCloud: null,
+    sidebarLinks: null,
     basePath: "/",
   };
 
@@ -129,6 +130,9 @@ export function parseArgs(argv = process.argv.slice(2)) {
         break;
       case "--lock-to-cloud":
         config.lockToCloud = argv[++i] || null;
+        break;
+      case "--sidebar-links":
+        config.sidebarLinks = argv[++i] || null;
         break;
       case "--base-path":
         config.basePath = normalizeBasePath(argv[++i]);
@@ -208,6 +212,11 @@ OPTIONS:
   --lock-to-cloud <cloud-url>  Lock backend setup to a single OpenHands Cloud
                                URL. Hides manual/local backend setup and the
                                custom Cloud URL field in the pre-built frontend.
+  --sidebar-links <json>       Inject a JSON array of extra sidebar nav links
+                               ({id, label, url, icon?}) into index.html so an
+                               operator can add e.g. an OpenHands Enterprise
+                               link to the pre-built frontend without
+                               VITE_SIDEBAR_LINKS baked in.
   --base-path <path>           Mount the SPA under <path> (default: /).
                                For example, --base-path /canvas serves
                                index.html and assets under /canvas.
@@ -265,6 +274,12 @@ ROUTING:
  *   `agent-server-config.ts` so pre-built frontend bundles can hide manual
  *   backend setup and the custom Cloud URL field at runtime.
  *
+ * - `sidebarLinks`: a JSON string describing extra sidebar nav links, exposed
+ *   as `window.__AGENT_CANVAS_SIDEBAR_LINKS__`. Read by
+ *   `getConfiguredSidebarLinks()` in `#/config/sidebar-links` as a fallback
+ *   when `VITE_SIDEBAR_LINKS` is empty, so an operator can add e.g. an
+ *   OpenHands Enterprise link to a published build without a rebuild.
+ *
  * - `basePath`: the path prefix the SPA is mounted under, exposed as
  *   `window.__AGENT_CANVAS_BASE_PATH__` so runtime static assets like locale
  *   files can resolve through the same subpath as the built bundle.
@@ -274,6 +289,7 @@ function makeConfigInjectionScript(
   authRequired,
   runtimeServicesInfo,
   lockToCloud,
+  sidebarLinks,
   basePath,
 ) {
   const parts = [];
@@ -318,6 +334,15 @@ function makeConfigInjectionScript(
     );
   }
 
+  if (sidebarLinks) {
+    // Stored as the raw JSON string, same reasoning as runtimeServicesInfo:
+    // the browser-side parser (getConfiguredSidebarLinks) JSON.parses it
+    // exactly like the VITE_SIDEBAR_LINKS env var.
+    parts.push(
+      `window.__AGENT_CANVAS_SIDEBAR_LINKS__=${JSON.stringify(sidebarLinks)};`,
+    );
+  }
+
   if (basePath && basePath !== "/") {
     parts.push(
       `window.__AGENT_CANVAS_BASE_PATH__=${JSON.stringify(basePath)};`,
@@ -342,6 +367,7 @@ async function serveInjectedIndexHtml(
     authRequired,
     runtimeServicesInfo,
     lockToCloud,
+    sidebarLinks,
     basePath,
   } = {},
 ) {
@@ -357,6 +383,7 @@ async function serveInjectedIndexHtml(
     authRequired,
     runtimeServicesInfo,
     lockToCloud,
+    sidebarLinks,
     basePath,
   );
   // Inject right before </head> so the key is available before any app code runs.
@@ -406,6 +433,7 @@ function needsRuntimeInjection(injectionOpts) {
     injectionOpts.authRequired ||
     injectionOpts.runtimeServicesInfo ||
     injectionOpts.lockToCloud ||
+    injectionOpts.sidebarLinks ||
     (injectionOpts.basePath && injectionOpts.basePath !== "/"),
   );
 }
@@ -549,6 +577,7 @@ export function startStaticServer(config) {
     authRequired: config.authRequired || false,
     runtimeServicesInfo: config.runtimeServicesInfo || null,
     lockToCloud: config.lockToCloud || null,
+    sidebarLinks: config.sidebarLinks || null,
     basePath: normalizeBasePath(config.basePath),
   };
   const basePath = injectionOpts.basePath;

--- a/src/components/features/sidebar/sidebar-configured-links.tsx
+++ b/src/components/features/sidebar/sidebar-configured-links.tsx
@@ -1,0 +1,92 @@
+import { ExternalLink } from "lucide-react";
+import { getConfiguredSidebarLinks } from "#/config/sidebar-links";
+import { NavigationLink } from "#/components/shared/navigation-link";
+import { cn } from "#/utils/utils";
+import { SIDEBAR_LINK_ICON_BY_SLUG } from "./sidebar-link-icons";
+import {
+  SIDEBAR_ICON_SLOT_CLASS,
+  SIDEBAR_ROW_INTERACTIVE_CLASS,
+  sidebarNavLabelClassName,
+  sidebarNavRowClassName,
+} from "./sidebar-layout";
+
+/** `to` when the URL targets this same deployment, `null` for a true external URL. */
+function resolveInternalPath(url: string): string | null {
+  if (typeof window === "undefined") return null;
+
+  const parsed = new URL(url);
+  if (parsed.origin !== window.location.origin) return null;
+
+  return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+}
+
+/**
+ * Renders operator-configured links (see `#/config/sidebar-links`) after the
+ * built-in nav items. Empty when no `AGENT_CANVAS_SIDEBAR_LINKS` config is
+ * present, which is the common case.
+ *
+ * A configured URL that resolves to this same origin navigates in-app (no
+ * new tab, no full reload) exactly like the built-in nav links above it —
+ * an operator can point a link at an in-app route, not just an external
+ * site. A genuinely external URL still opens in a new tab so it never
+ * navigates the user's conversations away.
+ */
+export function SidebarConfiguredLinks({ collapsed }: { collapsed: boolean }) {
+  const links = getConfiguredSidebarLinks();
+  if (links.length === 0) return null;
+
+  return (
+    <>
+      {links.map((link) => {
+        const Icon = SIDEBAR_LINK_ICON_BY_SLUG[link.icon];
+        const internalPath = resolveInternalPath(link.url);
+        const rowClassName = cn(
+          sidebarNavRowClassName({ collapsed }),
+          SIDEBAR_ROW_INTERACTIVE_CLASS.idle,
+        );
+        const content = (
+          <>
+            <span className={SIDEBAR_ICON_SLOT_CLASS}>
+              <Icon className="size-[18px] shrink-0" aria-hidden />
+            </span>
+            <span className={cn(sidebarNavLabelClassName(collapsed), "flex-1")}>
+              {link.label}
+            </span>
+            {!collapsed && internalPath === null && (
+              <ExternalLink
+                className="size-3.5 shrink-0 text-[var(--oh-muted)]"
+                aria-hidden
+              />
+            )}
+          </>
+        );
+
+        if (internalPath !== null) {
+          return (
+            <NavigationLink
+              key={link.id}
+              data-testid={`sidebar-configured-link-${link.id}`}
+              to={internalPath}
+              className={rowClassName}
+            >
+              {content}
+            </NavigationLink>
+          );
+        }
+
+        return (
+          <a
+            key={link.id}
+            data-testid={`sidebar-configured-link-${link.id}`}
+            href={link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={rowClassName}
+          >
+            {content}
+          </a>
+        );
+      })}
+    </>
+  );
+}

--- a/src/components/features/sidebar/sidebar-link-icons.ts
+++ b/src/components/features/sidebar/sidebar-link-icons.ts
@@ -1,0 +1,15 @@
+import { BookOpen, Cloud, ExternalLink, LifeBuoy } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { SidebarLinkIconSlug } from "#/config/sidebar-links";
+
+/**
+ * The artwork behind each sidebar link icon slug. `satisfies` keeps this map
+ * and the config validator's closed set in lockstep: a slug without artwork,
+ * or artwork without a slug, fails to compile.
+ */
+export const SIDEBAR_LINK_ICON_BY_SLUG = {
+  "external-link": ExternalLink,
+  cloud: Cloud,
+  "book-open": BookOpen,
+  "life-buoy": LifeBuoy,
+} satisfies Record<SidebarLinkIconSlug, LucideIcon>;

--- a/src/components/features/sidebar/sidebar-rail-body.tsx
+++ b/src/components/features/sidebar/sidebar-rail-body.tsx
@@ -14,6 +14,7 @@ import {
   getInterfaceCopy,
 } from "#/manifests/automation-interface";
 import { SidebarCollapsedIconSlot } from "./sidebar-collapsed-icon-slot";
+import { SidebarConfiguredLinks } from "./sidebar-configured-links";
 import { SidebarNavLink } from "./sidebar-nav-link";
 import { I18nKey } from "#/i18n/declaration";
 import { cn } from "#/utils/utils";
@@ -212,6 +213,7 @@ export function SidebarRailBody({
           collapsed={collapsed}
           icon={<AutomationsIcon width={ICON_SIZE} height={ICON_SIZE} />}
         />
+        <SidebarConfiguredLinks collapsed={collapsed} />
       </nav>
 
       <SidebarConversationList collapsed={collapsed} />

--- a/src/config/sidebar-links.ts
+++ b/src/config/sidebar-links.ts
@@ -1,0 +1,150 @@
+/**
+ * Operator-configured external links appended to the sidebar navigation
+ * (e.g. an OpenHands Enterprise link), added without a Canvas code change.
+ *
+ * Two sources are consulted, in order — mirroring getBakedSessionApiKey() /
+ * getLockedCloudHost() in `agent-server-config.ts`:
+ *   1. `VITE_SIDEBAR_LINKS` — baked into the bundle at build time (dev server).
+ *   2. `window.__AGENT_CANVAS_SIDEBAR_LINKS__` — injected into index.html at
+ *      serve time by `scripts/static-server.mjs --sidebar-links <json>`, fed
+ *      from the `AGENT_CANVAS_SIDEBAR_LINKS` env var in
+ *      `docker/entrypoint.sh`. This is what lets an operator add a link to a
+ *      published build without a rebuild.
+ *
+ * Each entry is data, not instructions: a malformed or unsafe entry (missing
+ * fields, non-http(s) URL, unknown icon slug, duplicate id) is dropped rather
+ * than partially rendered.
+ */
+
+export const SIDEBAR_LINK_ICON_SLUGS = [
+  "external-link",
+  "cloud",
+  "book-open",
+  "life-buoy",
+] as const;
+
+export type SidebarLinkIconSlug = (typeof SIDEBAR_LINK_ICON_SLUGS)[number];
+
+export interface SidebarLink {
+  id: string;
+  label: string;
+  url: string;
+  icon: SidebarLinkIconSlug;
+}
+
+const ID_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+function isSafeUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "https:" || parsed.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+function isIconSlug(value: unknown): value is SidebarLinkIconSlug {
+  return (
+    typeof value === "string" &&
+    (SIDEBAR_LINK_ICON_SLUGS as readonly string[]).includes(value)
+  );
+}
+
+function validateEntry(candidate: unknown, index: number): SidebarLink | null {
+  if (typeof candidate !== "object" || candidate === null) {
+    console.warn(`Rejected sidebar link at index ${index}: not an object`);
+    return null;
+  }
+
+  const { id, label, url, icon } = candidate as Record<string, unknown>;
+
+  const safeId = typeof id === "string" && ID_PATTERN.test(id) ? id : null;
+  if (!safeId) {
+    console.warn(
+      `Rejected sidebar link at index ${index}: "id" must be a kebab-case string`,
+    );
+    return null;
+  }
+
+  if (typeof label !== "string" || !label.trim()) {
+    console.warn(`Rejected sidebar link "${safeId}": "label" is required`);
+    return null;
+  }
+
+  if (typeof url !== "string" || !isSafeUrl(url)) {
+    console.warn(
+      `Rejected sidebar link "${safeId}": "url" must be an http(s) URL`,
+    );
+    return null;
+  }
+
+  return {
+    id: safeId,
+    label,
+    url,
+    icon: isIconSlug(icon) ? icon : "external-link",
+  };
+}
+
+function parseSidebarLinks(raw: string | null | undefined): SidebarLink[] {
+  if (!raw) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    console.warn("Rejected sidebar links config: invalid JSON");
+    return [];
+  }
+
+  if (!Array.isArray(parsed)) {
+    console.warn("Rejected sidebar links config: expected a JSON array");
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const links: SidebarLink[] = [];
+
+  parsed.forEach((candidate, index) => {
+    const link = validateEntry(candidate, index);
+    if (!link) return;
+
+    if (seen.has(link.id)) {
+      console.warn(`Rejected sidebar link: id "${link.id}" is already used`);
+      return;
+    }
+
+    seen.add(link.id);
+    links.push(link);
+  });
+
+  return links;
+}
+
+function getRawSidebarLinksConfig(): string | null {
+  const envValue = import.meta.env.VITE_SIDEBAR_LINKS;
+  if (envValue) return envValue;
+
+  if (typeof window !== "undefined") {
+    const injected = (window as unknown as Record<string, unknown>)
+      .__AGENT_CANVAS_SIDEBAR_LINKS__;
+    if (typeof injected === "string") return injected;
+  }
+
+  return null;
+}
+
+let cached: SidebarLink[] | null = null;
+
+/** Operator-configured sidebar links, parsed and validated once per session. */
+export function getConfiguredSidebarLinks(): SidebarLink[] {
+  if (cached === null) {
+    cached = parseSidebarLinks(getRawSidebarLinksConfig());
+  }
+  return cached;
+}
+
+/** Test-only: clears the memoized result so a test can re-seed config. */
+export function resetConfiguredSidebarLinksCache(): void {
+  cached = null;
+}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

AGENT:

Verified end-to-end against a real local `agent-server` (not just unit tests):

- Ran `npm run dev:frontend` with `VITE_SIDEBAR_LINKS` set to an external URL and to a same-origin URL, then drove the app with a headless Playwright session.
- Confirmed via `context.pages().length` staying at 1 across a click that a same-origin configured link navigates in-app (no new tab), while a cross-origin one opens `target="_blank"`.
- `npx eslint`, `npx tsc --noEmit -p tsconfig.json`, and `npx vitest run` all clean on every changed/added file (69 tests: config validation, static-server injection, sidebar rendering behavior).
- `npm run check-translation-completeness` clean (no i18n strings added — the label is operator-supplied data, not app copy).

---

## Why

#16401: operators need a way to add sidebar nav items (e.g. an OpenHands Enterprise link, docs) without a Canvas code change. The existing `CanvasExtensionManifest`/`canvas-extension.json` pipeline (software-agent-sdk) already models routed page contributions, but that pipeline doesn't reach the Canvas frontend yet — no code here calls `/canvas-extensions/*`, and the install-manifest API doesn't even return `contributes` today. Building the full extension pipeline just to ship a static link would be disproportionate for this ask, so this lands a minimal, independent runtime config instead, with room to converge into the extension manifest later once that pipeline exists.

## Summary

- New `src/config/sidebar-links.ts`: parses/validates a JSON array of `{id, label, url, icon?}` from `VITE_SIDEBAR_LINKS` (dev) or the `window.__AGENT_CANVAS_SIDEBAR_LINKS__` global injected by `static-server.mjs` (prod/Docker) — mirrors the existing `getBakedSessionApiKey()`/`getLockedCloudHost()` fallback pattern in `agent-server-config.ts`. Rejects malformed entries (non-http(s) URLs, missing fields, duplicate ids) rather than partially rendering.
- `SidebarConfiguredLinks` renders the validated links after the built-in nav items. A same-origin URL navigates in-app via the existing `NavigationLink` (no new tab, no reload — same behavior as `/conversations`, `/customize`, etc.); a genuinely external URL opens in a new tab with the usual external-link affordance.
- `scripts/static-server.mjs` gets a new `--sidebar-links <json>` flag, injected the same way `--lock-to-cloud`/`--session-api-key` already are; `docker/entrypoint.sh` threads a new `AGENT_CANVAS_SIDEBAR_LINKS` env var through to it.

## Issue Number

Fixes #16401

## How to Test

```
VITE_SIDEBAR_LINKS='[{"id":"enterprise","label":"OpenHands Enterprise","url":"https://openhands.dev"}]' npm run dev:frontend
```

Sign in, and the sidebar should show an "OpenHands Enterprise" row after Automate, opening `https://openhands.dev` in a new tab. Swap the `url` for a same-origin path (e.g. `http://localhost:3001/settings`) to see it navigate in-app instead — no new tab, `SidebarNavLink`-style click.

For the Docker/published-binary path: `docker/entrypoint.sh` now accepts `AGENT_CANVAS_SIDEBAR_LINKS` as a JSON string env var, passed straight to `static-server.mjs --sidebar-links`.

Automated coverage: `npx vitest run __tests__/config/sidebar-links.test.ts __tests__/components/features/sidebar/sidebar-configured-links.test.tsx __tests__/scripts/static-server.test.ts`.

## Video/Screenshots

Not attached to this PR body — I don't have a way to embed local screenshots into a PR description over the CLI (GitHub's inline-image upload is a browser-session-only endpoint, not reachable from `gh`/the REST API). I did capture screenshots during manual verification (sidebar row rendering correctly styled with the external-link affordance; same page after clicking a same-origin link showing the URL bar changed with no new tab) — happy to attach them via the web UI if useful, or a maintainer can reproduce with the steps above in under a minute.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Deliberately does **not** touch `CanvasExtensionManifest`/`canvas-extension.json` (software-agent-sdk) — see Why above.
- While building a demo page to exercise the same-origin-navigation path, found and filed #16480: `toAppConversation` (`agent-server-adapter.ts`) drops the wire's `stats.usage_to_metrics`, so `AppConversation.metrics` is null for most conversations from the search endpoint. Unrelated to this PR's diff, not fixed here.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.40.1-python` |
| **Automation** | `openhands-automation==1.6.0` |
| **Commit** | `1df745bd18d9fa16944321e7ffc80e4ab936b957` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-1df745b
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-1df745b
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-1df745b-amd64
ghcr.io/openhands/agent-canvas:issue-16401-sidebar-links-amd64
ghcr.io/openhands/agent-canvas:pr-16481-amd64
ghcr.io/openhands/agent-canvas:sha-1df745b-arm64
ghcr.io/openhands/agent-canvas:issue-16401-sidebar-links-arm64
ghcr.io/openhands/agent-canvas:pr-16481-arm64
ghcr.io/openhands/agent-canvas:sha-1df745b
ghcr.io/openhands/agent-canvas:issue-16401-sidebar-links
ghcr.io/openhands/agent-canvas:pr-16481
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-1df745b`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-1df745b-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->