### PR TITLE
[draft] Connect-a-Provider wizard (vendor + key + test + pick models)

### DIFF
--- a/src/components/shared/modals/settings/connect-provider-wizard.tsx
+++ b/src/components/shared/modals/settings/connect-provider-wizard.tsx
@@ -1,0 +1,25 @@
+/**
+ * Connect-a-Provider wizard (scaffold, draft).
+ *
+ * Flow: Vendor + key -> auto test-connection -> pick models -> confirm.
+ * Writes a connection + bulk-creates N LLM profiles that reference the
+ * connection's secret BY NAME (no inline key duplication).
+ *
+ * Reuses existing: useSearchProviders, useProviderModels, useVerifiedModels,
+ * ModelSelector (verified/unverified split), llm-subscription-service precedent.
+ *
+ * Tracking: OpenHands/OpenHands#15492, Linear OSS-5295.
+ * Scope: OpenHands frontend PR3 of the provider-connections plan.
+ *
+ * TODO (implementation):
+ *  - Wizard steps component under src/components/shared/modals/settings/.
+ *  - Bulk actions: Select all verified / Select all / Clear.
+ *  - "More from {vendor}" collapsible for experimental models.
+ *  - Confirmation summary ("Adding N LLM profiles from {vendor}. One key.").
+ *  - Consumes @openhands/typescript-client connectionService (after release gate).
+ */
+
+export function ConnectProviderWizard() {
+  // TODO
+  return null;
+}


### PR DESCRIPTION
## What

Draft scaffold for **PR3 of the "Connect a provider once" plan** (OpenHands/OpenHands#15492, Linear OSS-5295).

Adds the **"Connect a Provider" wizard** to Settings → LLM Profiles.

## Flow

1. **Vendor + key** — dropdown of single-vendor providers (from `/api/llm/providers`); masked paste field; helper: "We'll save this once and reuse it for every model from this provider."
2. **Test connection** — triggered on key-field blur / "Test connection"; spinner → green check + catalog populates; failure → inline error with cause (e.g. "401 — invalid key") + Try again / Use a different key.
3. **Pick models** — list from `/api/llm/models?provider={vendor}`; each row: name + "Recommended for OpenHands" tag if in `/verified`; default = all verified pre-checked; bulk actions: Select all verified / Select all / Clear; "More from {vendor}" collapsible for experimental models.
4. **Confirm** — summary "Adding N LLM profiles from {vendor}. They'll share one key." → Save → toast → return to profile list.

## Reuses existing

- `useSearchProviders`, `useProviderModels`, `useVerifiedModels`
- `ModelSelector` (verified/unverified split)
- `llm-subscription-service.ts` connect-flow precedent
- duplicate-profile feature mechanics for bulk creation

## Key behavior

- Writes a **connection** + **bulk-creates N profiles** that reference the connection's secret **by name** (no inline key duplication).
- Consumes `@openhands/typescript-client` `connectionService` (after the npm release gate, PR2).

## Difficulty / risk

- **Medium–High.** Bulk profile creation atomicity/perf; de-dup vs existing profiles; Rajiv's "test connectivity from config" must work in cloud too.

## Dependencies / sequencing

- Depends on `typescript-client` PR2 (release gate).
- Frontend PR5 (tests) depends on this + PR4.

## Scaffold

This PR currently only adds a stub component `connect-provider-wizard.tsx`. Real implementation follows once the client is released.

_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7f10a13a-58ce-4816-ac30-01b6b33ab101)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.40.1-python` |
| **Automation** | `openhands-automation==1.6.0` |
| **Commit** | `8f02b5e1d5a2e4be40d68876b2cf65897fefb3e2` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-8f02b5e
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-8f02b5e
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-8f02b5e-amd64
ghcr.io/openhands/agent-canvas:feat-connect-provider-wizard-amd64
ghcr.io/openhands/agent-canvas:pr-16497-amd64
ghcr.io/openhands/agent-canvas:sha-8f02b5e-arm64
ghcr.io/openhands/agent-canvas:feat-connect-provider-wizard-arm64
ghcr.io/openhands/agent-canvas:pr-16497-arm64
ghcr.io/openhands/agent-canvas:sha-8f02b5e
ghcr.io/openhands/agent-canvas:feat-connect-provider-wizard
ghcr.io/openhands/agent-canvas:pr-16497
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-8f02b5e`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-8f02b5e-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->