### PR TITLE
[draft] Provider Connections section (refresh / rotate / disconnect)

### DIFF
--- a/src/components/shared/modals/settings/provider-connections-section.tsx
+++ b/src/components/shared/modals/settings/provider-connections-section.tsx
@@ -1,0 +1,25 @@
+/**
+ * Provider Connections section (scaffold, draft).
+ *
+ * Shown on the LLM Profiles page:
+ *   Anthropic - 6 models - last refreshed 3 days ago
+ *     -> Refresh / Rotate key / Disconnect
+ *
+ * Rotate re-saves the named secret; Disconnect removes the connection
+ * (optionally its spawned profiles).
+ *
+ * Tracking: OpenHands/OpenHands#15492, Linear OSS-5295.
+ * Scope: OpenHands frontend PR4 of the provider-connections plan.
+ *
+ * TODO (implementation):
+ *  - Section component listing connections + actions.
+ *  - Refresh = re-validate + re-fetch catalog (pull-on-demand, no bg job).
+ *  - Rotate = update the named secret the connection/profiles reference.
+ *  - Disconnect = delete connection; decide profile fate (keep/delete).
+ *  - Decide behavior for running conversations using a rotated/disconnected key.
+ */
+
+export function ProviderConnectionsSection() {
+  // TODO
+  return null;
+}


### PR DESCRIPTION
## What

Draft scaffold for **PR4 of the "Connect a provider once" plan** (OpenHands/OpenHands#15492, Linear OSS-5295).

Adds a **Provider Connections** section to the LLM Profiles page:

> Anthropic · 6 models · last refreshed 3 days ago
> ↳ Refresh · Rotate key · Disconnect

## Actions

- **Refresh** — re-validate + re-fetch the provider's model catalog (pull-on-demand; **no background job**).
- **Rotate key** — update the named secret the connection/profiles reference (one operation updates all spawned profiles).
- **Disconnect** — delete the connection; decide profile fate (keep / delete).

## Difficulty / risk

- **Medium.**
- Behavior of **running conversations** whose key is rotated/disconnected (needs a defined policy — warn vs hard-stop).
- Refresh-without-background-job semantics (stale-while-revalidate?).

## Dependencies / sequencing

- Depends on `typescript-client` PR2 (release gate) + frontend PR3 (wizard creates the connections this section lists).
- Frontend PR5 (tests) covers this section.

## Scaffold

This PR currently only adds a stub component `provider-connections-section.tsx`.

_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7f10a13a-58ce-4816-ac30-01b6b33ab101)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.40.1-python` |
| **Automation** | `openhands-automation==1.6.0` |
| **Commit** | `e32d6f907c205fa8543d224b9e323d3942f2be20` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-e32d6f9
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-e32d6f9
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-e32d6f9-amd64
ghcr.io/openhands/agent-canvas:feat-provider-connections-section-amd64
ghcr.io/openhands/agent-canvas:pr-16498-amd64
ghcr.io/openhands/agent-canvas:sha-e32d6f9-arm64
ghcr.io/openhands/agent-canvas:feat-provider-connections-section-arm64
ghcr.io/openhands/agent-canvas:pr-16498-arm64
ghcr.io/openhands/agent-canvas:sha-e32d6f9
ghcr.io/openhands/agent-canvas:feat-provider-connections-section
ghcr.io/openhands/agent-canvas:pr-16498
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-e32d6f9`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-e32d6f9-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->