### PR TITLE
refactor: replace positional createConversation params with an options object (#1587)

### DIFF
--- a/__tests__/api/agent-server-conversation-service.test.ts
+++ b/__tests__/api/agent-server-conversation-service.test.ts
@@ -411,13 +411,9 @@ describe("AgentServerConversationService", () => {
         },
       });
 
-      await AgentServerConversationService.createConversation(
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        "/Users/jane/projects/foo",
-      );
+      await AgentServerConversationService.createConversation({
+        workingDirOverride: "/Users/jane/projects/foo",
+      });
 
       const [payloadCall] = mockHttpPost.mock.calls;
       const payload = payloadCall[1] as {
@@ -446,14 +442,10 @@ describe("AgentServerConversationService", () => {
         },
       });
 
-      await AgentServerConversationService.createConversation(
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        "/Users/jane/projects/foo",
-        "new_worktree",
-      );
+      await AgentServerConversationService.createConversation({
+        workingDirOverride: "/Users/jane/projects/foo",
+        workspaceMode: "new_worktree",
+      });
 
       const [payloadCall] = mockHttpPost.mock.calls;
       const payload = payloadCall[1] as {
@@ -482,15 +474,11 @@ describe("AgentServerConversationService", () => {
         },
       });
 
-      await AgentServerConversationService.createConversation(
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        "/Users/jane/projects/foo",
-        "new_worktree",
-        "parent-conversation-id",
-      );
+      await AgentServerConversationService.createConversation({
+        workingDirOverride: "/Users/jane/projects/foo",
+        workspaceMode: "new_worktree",
+        parentConversationId: "parent-conversation-id",
+      });
 
       const [payloadCall] = mockHttpPost.mock.calls;
       expect(payloadCall[1]).toMatchObject({
@@ -1087,17 +1075,11 @@ describe("AgentServerConversationService", () => {
       );
 
       // Act
-      await AgentServerConversationService.createConversation(
-        undefined,
-        undefined,
-        undefined,
-        null,
-        undefined,
-        undefined,
-        "parent-conv-1",
-        "plan",
-        "sandbox-9",
-      );
+      await AgentServerConversationService.createConversation({
+        parentConversationId: "parent-conv-1",
+        agentType: "plan",
+        sandboxId: "sandbox-9",
+      });
 
       // Assert
       const [url, init] = getFetchCall(fetchMock);

--- a/__tests__/api/cloud/conversation-create.test.ts
+++ b/__tests__/api/cloud/conversation-create.test.ts
@@ -55,17 +55,16 @@ describe("AgentServerConversationService cloud branch", () => {
       }),
     );
 
-    const result = await AgentServerConversationService.createConversation(
-      "fix the bug",
-      "Optional title",
-      undefined,
-      {
+    const result = await AgentServerConversationService.createConversation({
+      initialUserMsg: "fix the bug",
+      conversationInstructions: "Optional title",
+      metadata: {
         selected_repository: "user/repo",
         selected_branch: "main",
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         git_provider: "github" as any,
       },
-    );
+    });
 
     expect(fetchMock).toHaveBeenCalledOnce();
     const [url, init] = getFetchCall(fetchMock);

--- a/__tests__/components/automations/detail/debug-automation-button.test.tsx
+++ b/__tests__/components/automations/detail/debug-automation-button.test.tsx
@@ -124,16 +124,18 @@ describe("DebugAutomationButton", () => {
     // Act
     fireEvent.click(screen.getByTestId("debug-automation-button"));
 
-    // Assert — the first arg is the initial user message (the debug prompt).
+    // Assert — the options object carries the debug prompt as the initial
+    // user message.
     await waitFor(() =>
       expect(
         AgentServerConversationService.createConversation,
       ).toHaveBeenCalledTimes(1),
     );
-    const query = vi.mocked(AgentServerConversationService.createConversation)
-      .mock.calls[0][0];
-    expect(query).toContain("HTTP Error 410: Gone");
-    expect(query).toContain("Daily Jira digest");
+    const { initialUserMsg } =
+      vi.mocked(AgentServerConversationService.createConversation).mock
+        .calls[0][0] ?? {};
+    expect(initialUserMsg).toContain("HTTP Error 410: Gone");
+    expect(initialUserMsg).toContain("Daily Jira digest");
 
     await waitFor(() =>
       expect(navigate).toHaveBeenCalledWith("/conversations/task-abc123"),

--- a/__tests__/components/features/chat/skill-install-restart-banner.test.tsx
+++ b/__tests__/components/features/chat/skill-install-restart-banner.test.tsx
@@ -175,10 +175,9 @@ describe("SkillInstallRestartBanner", () => {
 
     await waitFor(() => {
       const call = createConversationSpy.mock.lastCall;
-      // Positional contract of createConversation: workingDir is #5 and
-      // workspaceMode #6 — the parsed install root, reused directly.
-      expect(call?.[4]).toBe("/tmp/demo-ws");
-      expect(call?.[5]).toBe("local_repo");
+      // The parsed install root is reused directly as the launch workspace.
+      expect(call?.[0]?.workingDirOverride).toBe("/tmp/demo-ws");
+      expect(call?.[0]?.workspaceMode).toBe("local_repo");
       expect(navigate).toHaveBeenCalledWith("/conversations/new-conv-1");
     });
   });

--- a/__tests__/components/features/conversation-panel/local-new-conversation-menu.test.tsx
+++ b/__tests__/components/features/conversation-panel/local-new-conversation-menu.test.tsx
@@ -100,7 +100,10 @@ const renderMenu = ({
 describe("LocalNewConversationMenu", () => {
   beforeEach(() => {
     mockSearchSubdirectories.mockReset();
-    mockSearchSubdirectories.mockResolvedValue({ items: [], next_page_id: null });
+    mockSearchSubdirectories.mockResolvedValue({
+      items: [],
+      next_page_id: null,
+    });
   });
 
   afterEach(() => {
@@ -178,16 +181,10 @@ describe("LocalNewConversationMenu", () => {
 
     // Assert
     await waitFor(() => {
-      expect(createSpy).toHaveBeenCalledWith(
-        undefined,
-        undefined,
-        undefined,
-        null,
-        "/workspace/project/repo1",
-        undefined,
-        undefined,
-        undefined,
-      );
+      expect(createSpy).toHaveBeenCalledWith({
+        metadata: null,
+        workingDirOverride: "/workspace/project/repo1",
+      });
     });
     await waitFor(() => {
       expect(navigate).toHaveBeenCalledWith("/conversations/conv-123");

--- a/__tests__/components/features/conversation-panel/new-conversation-button-cloud.test.tsx
+++ b/__tests__/components/features/conversation-panel/new-conversation-button-cloud.test.tsx
@@ -147,20 +147,13 @@ describe("NewConversationButton (cloud)", () => {
     await user.click(items[1]); // octo/dog, main_branch = "trunk"
 
     await waitFor(() => {
-      expect(createSpy).toHaveBeenCalledWith(
-        undefined,
-        undefined,
-        undefined,
-        {
+      expect(createSpy).toHaveBeenCalledWith({
+        metadata: {
           selected_repository: "octo/dog",
           selected_branch: "trunk",
           git_provider: "github",
         },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-      );
+      });
     });
     await waitFor(() => {
       expect(navigate).toHaveBeenCalledWith("/conversations/conv-xyz");
@@ -190,20 +183,13 @@ describe("NewConversationButton (cloud)", () => {
     await user.click(screen.getByTestId("launch-repository"));
 
     await waitFor(() => {
-      expect(createSpy).toHaveBeenCalledWith(
-        undefined,
-        undefined,
-        undefined,
-        {
+      expect(createSpy).toHaveBeenCalledWith({
+        metadata: {
           selected_repository: "octo/no-main",
           selected_branch: "main",
           git_provider: "github",
         },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-      );
+      });
     });
   });
 

--- a/__tests__/components/features/home/home-chat-launcher.test.tsx
+++ b/__tests__/components/features/home/home-chat-launcher.test.tsx
@@ -319,16 +319,10 @@ describe("HomeChatLauncher", () => {
     await user.click(screen.getByTestId("stub-chat-submit"));
 
     await waitFor(() => expect(createSpy).toHaveBeenCalledTimes(1));
-    expect(createSpy).toHaveBeenCalledWith(
-      "hello world",
-      undefined,
-      undefined,
-      null,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-    );
+    expect(createSpy).toHaveBeenCalledWith({
+      initialUserMsg: "hello world",
+      metadata: null,
+    });
     await waitFor(() =>
       expect(mockNavigate).toHaveBeenCalledWith("/conversations/conv-abc"),
     );
@@ -367,16 +361,12 @@ describe("HomeChatLauncher", () => {
     await user.click(screen.getByTestId("stub-chat-submit"));
 
     await waitFor(() => expect(createSpy).toHaveBeenCalledTimes(1));
-    expect(createSpy).toHaveBeenCalledWith(
-      "hello world",
-      undefined,
-      undefined,
-      null,
-      "/p/app",
-      "local_repo",
-      undefined,
-      undefined,
-    );
+    expect(createSpy).toHaveBeenCalledWith({
+      initialUserMsg: "hello world",
+      metadata: null,
+      workingDirOverride: "/p/app",
+      workspaceMode: "local_repo",
+    });
     await waitFor(() =>
       expect(mockNavigate).toHaveBeenCalledWith("/conversations/conv-ws"),
     );
@@ -407,16 +397,12 @@ describe("HomeChatLauncher", () => {
     await user.click(screen.getByTestId("stub-chat-submit"));
 
     await waitFor(() => expect(createSpy).toHaveBeenCalledTimes(1));
-    expect(createSpy).toHaveBeenCalledWith(
-      "hello world",
-      undefined,
-      undefined,
-      null,
-      "/p/app",
-      "new_worktree",
-      undefined,
-      undefined,
-    );
+    expect(createSpy).toHaveBeenCalledWith({
+      initialUserMsg: "hello world",
+      metadata: null,
+      workingDirOverride: "/p/app",
+      workspaceMode: "new_worktree",
+    });
     await waitFor(() =>
       expect(mockNavigate).toHaveBeenCalledWith("/conversations/conv-wt"),
     );
@@ -459,20 +445,14 @@ describe("HomeChatLauncher", () => {
     await user.click(screen.getByTestId("stub-chat-submit"));
 
     await waitFor(() => expect(createSpy).toHaveBeenCalledTimes(1));
-    expect(createSpy).toHaveBeenCalledWith(
-      "hello world",
-      undefined,
-      undefined,
-      {
+    expect(createSpy).toHaveBeenCalledWith({
+      initialUserMsg: "hello world",
+      metadata: {
         selected_repository: "org/repo",
         selected_branch: "main",
         git_provider: "github",
       },
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-    );
+    });
     await waitFor(() =>
       expect(mockNavigate).toHaveBeenCalledWith("/conversations/conv-repo"),
     );
@@ -489,16 +469,9 @@ describe("HomeChatLauncher", () => {
     await user.click(screen.getByTestId("stub-chat-submit"));
 
     await waitFor(() => expect(createSpy).toHaveBeenCalledTimes(1));
-    expect(createSpy).toHaveBeenCalledWith(
-      undefined,
-      undefined,
-      undefined,
-      null,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-    );
+    expect(createSpy).toHaveBeenCalledWith({
+      metadata: null,
+    });
     await waitFor(() =>
       expect(sendMessageWithAttachments).toHaveBeenCalledTimes(1),
     );
@@ -570,16 +543,9 @@ describe("HomeChatLauncher", () => {
     await user.click(screen.getByTestId("stub-chat-submit"));
 
     await waitFor(() => expect(createSpy).toHaveBeenCalledTimes(1));
-    expect(createSpy).toHaveBeenCalledWith(
-      undefined,
-      undefined,
-      undefined,
-      null,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-    );
+    expect(createSpy).toHaveBeenCalledWith({
+      metadata: null,
+    });
     expect(sendMessageWithAttachments).not.toHaveBeenCalled();
     await waitFor(() =>
       expect(enqueueHomeTaskPendingMessage).toHaveBeenCalledWith({
@@ -609,15 +575,10 @@ describe("HomeChatLauncher", () => {
     await user.click(screen.getByTestId("stub-chat-submit"));
 
     await waitFor(() => expect(createSpy).toHaveBeenCalledTimes(1));
-    expect(createSpy).toHaveBeenCalledWith(
-      "hello world",
-      undefined,
-      [{ source: "github:o/a", ref: null, repo_path: null }],
-      null,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-    );
+    expect(createSpy).toHaveBeenCalledWith({
+      initialUserMsg: "hello world",
+      plugins: [{ source: "github:o/a", ref: null, repo_path: null }],
+      metadata: null,
+    });
   });
 });

--- a/__tests__/components/features/home/task-card.test.tsx
+++ b/__tests__/components/features/home/task-card.test.tsx
@@ -9,9 +9,9 @@ import { GitRepository } from "#/types/git";
 import { SuggestedTask } from "#/utils/types";
 
 vi.mock("#/hooks/query/use-settings", async () => {
-  const actual = await vi.importActual<typeof import("#/hooks/query/use-settings")>(
-    "#/hooks/query/use-settings",
-  );
+  const actual = await vi.importActual<
+    typeof import("#/hooks/query/use-settings")
+  >("#/hooks/query/use-settings");
   return {
     ...actual,
     getSettingsQueryFn: vi.fn().mockResolvedValue({}),
@@ -31,7 +31,12 @@ const MOCK_RESPOSITORIES: GitRepository[] = [
   { id: "2", full_name: "repo2", git_provider: "github", is_public: true },
   { id: "3", full_name: "repo3", git_provider: "gitlab", is_public: true },
   { id: "4", full_name: "repo4", git_provider: "gitlab", is_public: true },
-  { id: "5", full_name: "repo5", git_provider: "azure_devops", is_public: true },
+  {
+    id: "5",
+    full_name: "repo5",
+    git_provider: "azure_devops",
+    is_public: true,
+  },
 ];
 
 const renderTaskCard = (task = MOCK_TASK_1, navigate = vi.fn()) =>
@@ -130,27 +135,23 @@ describe("TaskCard", () => {
       const launchButton = screen.getByTestId("task-launch-button");
       await userEvent.click(launchButton);
 
-      expect(createConversationSpy).toHaveBeenCalledWith(
-        undefined,
-        undefined,
-        undefined,
-        {
+      expect(createConversationSpy).toHaveBeenCalledWith({
+        metadata: {
           selected_repository: MOCK_TASK_1.repo,
           selected_branch: null,
           git_provider: MOCK_TASK_1.git_provider,
         },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-      );
+      });
     });
   });
 
   it("should navigate to the conversation page after creating a conversation", async () => {
     const navigate = vi.fn();
 
-    vi.spyOn(AgentServerConversationService, "createConversation").mockResolvedValue({
+    vi.spyOn(
+      AgentServerConversationService,
+      "createConversation",
+    ).mockResolvedValue({
       id: "task-id",
       created_by_user_id: null,
       status: "READY",

--- a/__tests__/hooks/mutation/use-create-conversation.test.tsx
+++ b/__tests__/hooks/mutation/use-create-conversation.test.tsx
@@ -159,20 +159,20 @@ describe("useCreateConversation", () => {
     });
 
     await waitFor(() => {
-      expect(createConversationSpy).toHaveBeenCalledWith(
-        "Please address the comments",
-        "Focus on review comments",
-        undefined,
-        {
+      expect(createConversationSpy).toHaveBeenCalledWith({
+        initialUserMsg: "Please address the comments",
+        conversationInstructions: "Focus on review comments",
+        plugins: undefined,
+        metadata: {
           selected_repository: "owner/repo",
           selected_branch: "main",
           git_provider: "github",
         },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-      );
+        workingDirOverride: undefined,
+        workspaceMode: undefined,
+        parentConversationId: undefined,
+        agentType: undefined,
+      });
     });
   });
 
@@ -200,10 +200,10 @@ describe("useCreateConversation", () => {
     await result.current.mutateAsync({ query: "hello" });
 
     await waitFor(() => {
-      // sandboxId (#9) is undefined; the active profile id rides as #10.
+      // sandboxId is never passed; the active profile id rides as agentProfileId.
       const call = createConversationSpy.mock.lastCall;
-      expect(call?.[8]).toBeUndefined();
-      expect(call?.[9]).toBe("profile-abc");
+      expect(call?.[0]?.sandboxId).toBeUndefined();
+      expect(call?.[0]?.agentProfileId).toBe("profile-abc");
     });
   });
 
@@ -242,7 +242,7 @@ describe("useCreateConversation", () => {
     await pending;
 
     const call = createConversationSpy.mock.lastCall;
-    expect(call?.[9]).toBe("profile-late");
+    expect(call?.[0]?.agentProfileId).toBe("profile-late");
   });
 
   it("falls back to the agent_settings launch when the profiles fetch fails", async () => {
@@ -268,7 +268,7 @@ describe("useCreateConversation", () => {
 
     // No profile tail — the create stays on the legacy agent_settings path.
     const call = createConversationSpy.mock.lastCall;
-    expect(call?.[9]).toBeUndefined();
+    expect(call?.[0]?.agentProfileId).toBeUndefined();
   });
 
   it("invalidates the conversation list and start-tasks queries on success", async () => {
@@ -420,7 +420,7 @@ describe("useCreateConversation", () => {
     await result.current.mutateAsync({ query: "hello" });
 
     const call = createConversationSpy.mock.lastCall;
-    expect(call?.[9]).toBeUndefined();
+    expect(call?.[0]?.agentProfileId).toBeUndefined();
   });
 
   it("keeps the profile path for an ACP `default` profile (agent_settings can't carry ACP config)", async () => {
@@ -460,8 +460,8 @@ describe("useCreateConversation", () => {
     await result.current.mutateAsync({ query: "hello" });
 
     const call = createConversationSpy.mock.lastCall;
-    expect(call?.[9]).toBe("profile-acp-default");
-    expect(call?.[10]).toBe("acp");
+    expect(call?.[0]?.agentProfileId).toBe("profile-acp-default");
+    expect(call?.[0]?.agentProfileKind).toBe("acp");
   });
 
   it("launches the seeded `default` profile from its resolved id on cloud (no agent_settings fallback exists there) (#1571)", async () => {
@@ -510,7 +510,7 @@ describe("useCreateConversation", () => {
     await result.current.mutateAsync({ query: "hello" });
 
     const call = createConversationSpy.mock.lastCall;
-    expect(call?.[9]).toBe("profile-default");
+    expect(call?.[0]?.agentProfileId).toBe("profile-default");
   });
 
   it("stamps the launched openhands profile's llm_profile_ref into conversation metadata (#1082)", async () => {
@@ -556,7 +556,7 @@ describe("useCreateConversation", () => {
     await result.current.mutateAsync({ query: "hello" });
 
     const call = createConversationSpy.mock.lastCall;
-    expect(call?.[9]).toBe("profile-custom");
+    expect(call?.[0]?.agentProfileId).toBe("profile-custom");
     await waitFor(() =>
       expect(
         getStoredConversationMetadata("conv-ref-stamp")?.active_profile,

--- a/__tests__/hooks/mutation/use-new-conversation-command.test.tsx
+++ b/__tests__/hooks/mutation/use-new-conversation-command.test.tsx
@@ -213,20 +213,12 @@ describe("useNewConversationCommand", () => {
     });
     await result.current.mutateAsync();
 
-    // Assert — sandbox_id is the 9th positional argument; parent_conversation_id
-    // and agent_type stay undefined because /new is NOT a sub-conversation.
+    // Assert — only sandbox_id travels; parent_conversation_id and agent_type
+    // stay undefined because /new is NOT a sub-conversation.
     await waitFor(() => {
-      expect(createSpy).toHaveBeenCalledWith(
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        "sandbox-abc",
-      );
+      expect(createSpy).toHaveBeenCalledWith({
+        sandboxId: "sandbox-abc",
+      });
     });
   });
 

--- a/__tests__/services/child-conversation-launch.test.ts
+++ b/__tests__/services/child-conversation-launch.test.ts
@@ -201,15 +201,13 @@ describe("handleLaunchChildConversationAction", () => {
         nextToolCallId(),
       );
 
-      expect(mockCreateConversation).toHaveBeenCalledWith(
-        "Add a regression test for the parser",
-        undefined,
-        undefined,
-        PARENT_REPO_METADATA,
-        "/Users/jane/projects/foo",
-        "new_worktree",
-        PARENT_ID,
-      );
+      expect(mockCreateConversation).toHaveBeenCalledWith({
+        initialUserMsg: "Add a regression test for the parser",
+        metadata: PARENT_REPO_METADATA,
+        workingDirOverride: "/Users/jane/projects/foo",
+        workspaceMode: "new_worktree",
+        parentConversationId: PARENT_ID,
+      });
     });
 
     it("reports the child's id, url and status back to the agent", async () => {
@@ -252,15 +250,13 @@ describe("handleLaunchChildConversationAction", () => {
         nextToolCallId(),
       );
 
-      expect(mockCreateConversation).toHaveBeenCalledWith(
-        expect.anything(),
-        undefined,
-        undefined,
-        null,
-        "/Users/jane/projects/foo",
-        "local_repo",
-        PARENT_ID,
-      );
+      expect(mockCreateConversation).toHaveBeenCalledWith({
+        initialUserMsg: expect.anything(),
+        metadata: null,
+        workingDirOverride: "/Users/jane/projects/foo",
+        workspaceMode: "local_repo",
+        parentConversationId: PARENT_ID,
+      });
     });
 
     // `parent_conversation_id` landed in agent-server 1.37.1; older servers
@@ -308,15 +304,13 @@ describe("handleLaunchChildConversationAction", () => {
       );
 
       expect(mockCreateConversation).toHaveBeenCalledTimes(1);
-      expect(mockCreateConversation).toHaveBeenCalledWith(
-        expect.anything(),
-        undefined,
-        undefined,
-        null,
-        "/Users/jane/projects/foo",
-        "local_repo",
-        PARENT_ID,
-      );
+      expect(mockCreateConversation).toHaveBeenCalledWith({
+        initialUserMsg: expect.anything(),
+        metadata: null,
+        workingDirOverride: "/Users/jane/projects/foo",
+        workspaceMode: "local_repo",
+        parentConversationId: PARENT_ID,
+      });
 
       const result = reportedResult();
       expect(result).toMatchObject({ status: "launched", isolation: "shared" });
@@ -340,15 +334,13 @@ describe("handleLaunchChildConversationAction", () => {
       );
 
       expect(mockCreateConversation).toHaveBeenCalledTimes(2);
-      expect(mockCreateConversation).toHaveBeenLastCalledWith(
-        expect.anything(),
-        undefined,
-        undefined,
-        PARENT_REPO_METADATA,
-        "/Users/jane/projects/foo",
-        "local_repo",
-        PARENT_ID,
-      );
+      expect(mockCreateConversation).toHaveBeenLastCalledWith({
+        initialUserMsg: expect.anything(),
+        metadata: PARENT_REPO_METADATA,
+        workingDirOverride: "/Users/jane/projects/foo",
+        workspaceMode: "local_repo",
+        parentConversationId: PARENT_ID,
+      });
 
       const result = reportedResult();
       expect(result).toMatchObject({

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -319,6 +319,32 @@ function requireAppConversation(
   return conversation;
 }
 
+/**
+ * Options for {@link AgentServerConversationService.createConversation}.
+ *
+ * Everything is optional; callers pass only the fields they need, so a plain
+ * create stays byte-identical to the legacy agent_settings path and the
+ * profile tail is a simple conditional spread instead of position-skipping
+ * arguments (#1587).
+ */
+export interface CreateConversationOptions {
+  initialUserMsg?: string;
+  conversationInstructions?: string;
+  plugins?: PluginSpec[];
+  metadata?: ConversationMetadata | null;
+  workingDirOverride?: string;
+  workspaceMode?: WorkspaceMode;
+  parentConversationId?: string;
+  agentType?: "default" | "plan";
+  sandboxId?: string;
+  // Launch from a saved AgentProfile (resolved server-side) instead of the
+  // current encrypted agent_settings (#3727). Supported on both local and the
+  // cloud app-server (OpenHands #15060): local threads it through the
+  // encrypted-settings builder; cloud sends it as a flat request field.
+  agentProfileId?: string;
+  agentProfileKind?: AgentKind;
+}
+
 class AgentServerConversationService {
   static async sendMessage(
     conversationId: string,
@@ -367,22 +393,22 @@ class AgentServerConversationService {
   }
 
   static async createConversation(
-    initialUserMsg?: string,
-    conversationInstructions?: string,
-    plugins?: PluginSpec[],
-    metadata?: ConversationMetadata | null,
-    workingDirOverride?: string,
-    workspaceMode?: WorkspaceMode,
-    parentConversationId?: string,
-    agentType?: "default" | "plan",
-    sandboxId?: string,
-    // Launch from a saved AgentProfile (resolved server-side) instead of the
-    // current encrypted agent_settings (#3727). Supported on both local and the
-    // cloud app-server (OpenHands #15060): local threads it through the
-    // encrypted-settings builder; cloud sends it as a flat request field.
-    agentProfileId?: string,
-    agentProfileKind?: AgentKind,
+    options: CreateConversationOptions = {},
   ): Promise<AppConversationStartTask> {
+    const {
+      initialUserMsg,
+      conversationInstructions,
+      plugins,
+      metadata,
+      workingDirOverride,
+      workspaceMode,
+      parentConversationId,
+      agentType,
+      sandboxId,
+      agentProfileId,
+      agentProfileKind,
+    } = options;
+
     if (getActiveBackend().backend.kind === "cloud") {
       // Cloud path mirrors OpenHands' frontend: build a flat
       // AppConversationStartRequest, POST /api/v1/app-conversations

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -321,11 +321,6 @@ function requireAppConversation(
 
 /**
  * Options for {@link AgentServerConversationService.createConversation}.
- *
- * Everything is optional; callers pass only the fields they need, so a plain
- * create stays byte-identical to the legacy agent_settings path and the
- * profile tail is a simple conditional spread instead of position-skipping
- * arguments (#1587).
  */
 export interface CreateConversationOptions {
   initialUserMsg?: string;

--- a/src/hooks/mutation/use-create-conversation.ts
+++ b/src/hooks/mutation/use-create-conversation.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
 import { PluginSpec } from "#/api/conversation-service/agent-server-conversation-service.types";
 import { SuggestedTask } from "#/utils/types";
-import { AgentKind, Provider } from "#/types/settings";
+import { Provider } from "#/types/settings";
 import { useTracking } from "#/hooks/use-tracking";
 import { useLlmProfiles } from "#/hooks/query/use-llm-profiles";
 import { useAgentProfiles } from "#/hooks/query/use-agent-profiles";
@@ -193,39 +193,32 @@ export const useCreateConversation = () => {
         }
       }
 
-      // Only extend the call with the profile tail when launching from a
+      // Only extend the call with the profile fields when launching from a
       // profile, so a plain create stays byte-identical to the legacy
       // agent_settings path (#3727). sandboxId is unused here.
-      // TODO(#1587): createConversation has grown to 11 positional params;
-      // refactor it to an options object so this position-skipping tail isn't
-      // needed.
-      const profileArgs: [undefined, string, AgentKind | undefined] | [] =
-        effectiveAgentProfileId
-          ? [
-              undefined,
-              effectiveAgentProfileId,
-              resolvedAgentProfile?.agent_kind,
-            ]
-          : [];
-
       const conversation =
-        await AgentServerConversationService.createConversation(
-          query,
+        await AgentServerConversationService.createConversation({
+          initialUserMsg: query,
           conversationInstructions,
           plugins,
-          repository
+          metadata: repository
             ? {
                 selected_repository: repository.name,
                 selected_branch: repository.branch ?? null,
                 git_provider: repository.gitProvider,
               }
             : null,
-          workingDir,
+          workingDirOverride: workingDir,
           workspaceMode,
           parentConversationId,
           agentType,
-          ...profileArgs,
-        );
+          ...(effectiveAgentProfileId
+            ? {
+                agentProfileId: effectiveAgentProfileId,
+                agentProfileKind: resolvedAgentProfile?.agent_kind,
+              }
+            : {}),
+        });
 
       // Stamp the active LLM profile onto the (local) conversation so the
       // chat switcher shows the exact profile even when several profiles

--- a/src/hooks/mutation/use-new-conversation-command.ts
+++ b/src/hooks/mutation/use-new-conversation-command.ts
@@ -29,15 +29,9 @@ export const useNewConversationCommand = () => {
       // cloud behavior); it is NOT a sub-conversation, so parent_conversation_id
       // and agent_type stay undefined.
       const startTask = await AgentServerConversationService.createConversation(
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        conversation.sandbox_id ?? undefined,
+        {
+          sandboxId: conversation.sandbox_id ?? undefined,
+        },
       );
 
       if (startTask.status === "ERROR") {

--- a/src/services/child-conversation-launch.ts
+++ b/src/services/child-conversation-launch.ts
@@ -283,21 +283,19 @@ async function launchLocalChild(
   const parentMetadata = getStoredConversationMetadata(parentConversationId);
 
   const createChild = (isolation: ChildConversationIsolation) =>
-    AgentServerConversationService.createConversation(
-      params.task,
-      undefined,
-      undefined,
-      parentMetadata
+    AgentServerConversationService.createConversation({
+      initialUserMsg: params.task,
+      metadata: parentMetadata
         ? {
             selected_repository: parentMetadata.selected_repository,
             selected_branch: parentMetadata.selected_branch,
             git_provider: parentMetadata.git_provider,
           }
         : null,
-      workspace,
-      isolation === "shared" ? "local_repo" : "new_worktree",
+      workingDirOverride: workspace,
+      workspaceMode: isolation === "shared" ? "local_repo" : "new_worktree",
       parentConversationId,
-    );
+    });
 
   let isolation = params.isolation;
   let isolationNote: string | null = null;


### PR DESCRIPTION
HUMAN:

Tested on Node 24.13 to match CI:  npm run typecheck ,  npm run lint , and the full  npm test  suite all pass — 578 files, 4600 tests, exit code 0. 

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

Validated locally:
- `npm run typecheck` — clean
- `npm run lint` — 0 errors (3 pre-existing warnings in untouched files)
- `npm run test` on the 12 affected suites — 111/111 pass
  (agent-server-conversation-service, cloud/conversation-create,
  use-create-conversation, use-new-conversation-command,
  child-conversation-launch, skill-install-restart-banner,
  debug-automation-button, new-conversation-button-cloud,
  local-new-conversation-menu, home-chat-launcher, new-conversation, task-card)
- Full `npm test` under Node 24.13 (matching CI's 24.15): 578 files, 4600 tests, exit code 0.

---

## Why

`AgentServerConversationService.createConversation` had grown to 11 positional
parameters, forcing callers to skip positions with long runs of `undefined`
(`use-new-conversation-command` passed 8 of them) and one caller to build a
position-skipping `[undefined, agentProfileId, agentProfileKind]` tuple spread
flagged by TODO(#1587).

## Summary

- Introduce an exported `CreateConversationOptions` interface; change
  `createConversation` to accept a single optional options object (default `{}`).
- Update all three production callers (the create hook, the /new command hook,
  and the child-conversation launcher) to named fields; the profile launch now
  uses a conditional `agentProfileId`/`agentProfileKind` spread.
- Rewrite the 11 test files that asserted the positional contract to
  options-object assertions (incl. `call?.[0]?.agentProfileId`-style checks).
- Remove the resolved TODO(#1587) and the now-unused `AgentKind` import.

## Issue Number

Fixes #16501

## How to Test

1. `npm ci`
2. `npm run typecheck` && `npm run lint`
3. `npm test -- __tests__/hooks/mutation/use-create-conversation.test.tsx \
   __tests__/hooks/mutation/use-new-conversation-command.test.tsx \
   __tests__/services/child-conversation-launch.test.ts \
   __tests__/api/agent-server-conversation-service.test.ts`
4. Optional end-to-end: `npm run dev` and create a conversation, launch a child
   conversation from the agent, and use `/new` — behavior is unchanged.

## Video/Screenshots

<img width="1068" height="114" alt="image" src="https://github.com/user-attachments/assets/9c247d4e-26dd-4c8f-8b60-8762d5446f4d" />

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- No behavior change: absent vs `undefined` option fields are equivalent (the
  service already coalesces with `?? null`), and the profile-tail conditional
  spread fires only when `effectiveAgentProfileId` is set.
- Prettier normalized pre-existing formatting drift in two test files
  (task-card, local-new-conversation-menu) — same as the pre-commit hook does.
- #16501 will need the `ready-for-dev` label before this PR can merge (per repo policy); ask a maintainer to add the `enhancement` label so the readiness check can apply it.

