### PR TITLE
fix: fail fast on unwritable Docker bind mounts and document the permission fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ docker run -it --rm \
   -p 8000:8000 \
   -v "$HOME/.openhands:/home/openhands/.openhands" \
   -v "${PROJECTS_PATH}:/projects" \
-  ghcr.io/openhands/agent-canvas:1.12.0 # x-release-please-version
+  ghcr.io/openhands/agent-canvas:1.14.0 # x-release-please-version
 ```
 
 > [!NOTE]
@@ -124,7 +124,7 @@ docker run -it --rm \
 >   -p 8000:8000 \
 >   -v "$HOME/.openhands:/home/openhands/.openhands" \
 >   -v "${PROJECTS_PATH}:/projects" \
->   ghcr.io/openhands/agent-canvas:1.12.0 # x-release-please-version
+>   ghcr.io/openhands/agent-canvas:1.14.0 # x-release-please-version
 > ```
 >
 > The `-e HOME=/home/openhands` is required: the entrypoint derives all

--- a/README.md
+++ b/README.md
@@ -91,9 +91,6 @@ agent-canvas --backend-only   # agent server + automation backend + ingress only
 ```sh
 export PROJECTS_PATH="$HOME/projects"  # directory containing your project folders
 mkdir -p "$PROJECTS_PATH" "$HOME/.openhands"
-# The container runs as uid 10001 (openhands) — bind-mounted host dirs must be
-# writable by that uid, or the agent-server and automation crash at startup.
-chmod -R a+rwX "$HOME/.openhands" "$PROJECTS_PATH"
 
 docker run -it --rm \
   -p 8000:8000 \
@@ -101,6 +98,18 @@ docker run -it --rm \
   -v "${PROJECTS_PATH}:/projects" \
   ghcr.io/openhands/agent-canvas:1.12.0 # x-release-please-version
 ```
+
+> [!NOTE]
+> **Linux (Docker Engine) only:** the container runs as uid 10001 (openhands) —
+> bind-mounted host dirs must be writable by that uid, or the agent-server and
+> automation crash at startup. Run this **before** `docker run`:
+>
+> ```sh
+> chmod -R a+rwX "$HOME/.openhands" "$PROJECTS_PATH"
+> ```
+>
+> Docker Desktop (macOS/Windows) handles bind-mount permissions transparently, so
+> no `chmod` is needed there.
 
 > [!TIP]
 > The image's `openhands` user is **uid 10001**. Instead of `chmod`-ing the host

--- a/README.md
+++ b/README.md
@@ -100,22 +100,11 @@ docker run -it --rm \
 ```
 
 > [!NOTE]
-> **Linux (Docker Engine) only:** the container runs as uid 10001 (openhands) —
+> **Linux (Docker Engine):** the container runs as uid 10001 (`openhands`) —
 > bind-mounted host dirs must be writable by that uid, or the agent-server and
-> automation crash at startup. Run this **before** `docker run`:
->
-> ```sh
-> chmod -R a+rwX "$HOME/.openhands" "$PROJECTS_PATH"
-> ```
->
-> Docker Desktop (macOS/Windows) handles bind-mount permissions transparently, so
-> no `chmod` is needed there.
-
-> [!TIP]
-> The image's `openhands` user is **uid 10001**. Instead of `chmod`-ing the host
-> dirs, you can run the container as your own user so the bind mounts are
-> writable automatically (all persistent state lives under the mounted
-> `.openhands` dir, so this is safe in practice):
+> automation crash at startup. The easiest fix is to run the container as your
+> own user, so the bind mounts are writable automatically (all persistent state
+> lives under the mounted `.openhands` dir, so this is safe in practice):
 >
 > ```sh
 > docker run -it --rm \
@@ -132,6 +121,18 @@ docker run -it --rm \
 > no `/etc/passwd` entry inside the container, so `$HOME` would not resolve to
 > `/home/openhands` — without pinning it, state would silently detach from the
 > bind mount.
+>
+> Alternatively, grant write access on the host — scoped to directories only,
+> because a recursive `chmod -R` would also strip the `600` permission of the
+> persisted secret files (`secret-key.txt`, `api-key.txt`) and make them
+> world-readable:
+>
+> ```sh
+> find "$HOME/.openhands" "$PROJECTS_PATH" -type d -exec chmod a+rwX {} +
+> ```
+>
+> Docker Desktop (macOS/Windows) handles bind-mount permissions transparently,
+> so none of this is needed there.
 
 **Windows (PowerShell / Windows Terminal):** See [README.windows.md](./README.windows.md) for the equivalent commands.
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ docker run -it --rm \
   -p 8000:8000 \
   -v "$HOME/.openhands:/home/openhands/.openhands" \
   -v "${PROJECTS_PATH}:/projects" \
-  ghcr.io/openhands/agent-canvas:1.14.0 # x-release-please-version
+  ghcr.io/openhands/agent-canvas:1.15.0 # x-release-please-version
 ```
 
 > [!NOTE]
@@ -113,7 +113,7 @@ docker run -it --rm \
 >   -p 8000:8000 \
 >   -v "$HOME/.openhands:/home/openhands/.openhands" \
 >   -v "${PROJECTS_PATH}:/projects" \
->   ghcr.io/openhands/agent-canvas:1.14.0 # x-release-please-version
+>   ghcr.io/openhands/agent-canvas:1.15.0 # x-release-please-version
 > ```
 >
 > The `-e HOME=/home/openhands` is required: the entrypoint derives all

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ agent-canvas --backend-only   # agent server + automation backend + ingress only
 ```sh
 export PROJECTS_PATH="$HOME/projects"  # directory containing your project folders
 mkdir -p "$PROJECTS_PATH" "$HOME/.openhands"
+# The container runs as uid 10001 (openhands) — bind-mounted host dirs must be
+# writable by that uid, or the agent-server and automation crash at startup.
+chmod -R a+rwX "$HOME/.openhands" "$PROJECTS_PATH"
 
 docker run -it --rm \
   -p 8000:8000 \
@@ -98,6 +101,21 @@ docker run -it --rm \
   -v "${PROJECTS_PATH}:/projects" \
   ghcr.io/openhands/agent-canvas:1.12.0 # x-release-please-version
 ```
+
+> [!TIP]
+> The image's `openhands` user is **uid 10001**. Instead of `chmod`-ing the host
+> dirs, you can run the container as your own user so the bind mounts are
+> writable automatically (all persistent state lives under the mounted
+> `.openhands` dir, so this is safe in practice):
+>
+> ```sh
+> docker run -it --rm \
+>   --user "$(id -u):$(id -g)" \
+>   -p 8000:8000 \
+>   -v "$HOME/.openhands:/home/openhands/.openhands" \
+>   -v "${PROJECTS_PATH}:/projects" \
+>   ghcr.io/openhands/agent-canvas:1.12.0 # x-release-please-version
+> ```
 
 **Windows (PowerShell / Windows Terminal):** See [README.windows.md](./README.windows.md) for the equivalent commands.
 

--- a/README.md
+++ b/README.md
@@ -120,11 +120,18 @@ docker run -it --rm \
 > ```sh
 > docker run -it --rm \
 >   --user "$(id -u):$(id -g)" \
+>   -e HOME=/home/openhands \
 >   -p 8000:8000 \
 >   -v "$HOME/.openhands:/home/openhands/.openhands" \
 >   -v "${PROJECTS_PATH}:/projects" \
 >   ghcr.io/openhands/agent-canvas:1.12.0 # x-release-please-version
 > ```
+>
+> The `-e HOME=/home/openhands` is required: the entrypoint derives all
+> persistence paths from `$HOME`, and an arbitrary uid (e.g. your host uid) has
+> no `/etc/passwd` entry inside the container, so `$HOME` would not resolve to
+> `/home/openhands` — without pinning it, state would silently detach from the
+> bind mount.
 
 **Windows (PowerShell / Windows Terminal):** See [README.windows.md](./README.windows.md) for the equivalent commands.
 

--- a/README.windows.md
+++ b/README.windows.md
@@ -12,7 +12,7 @@ For the main install options and overall context, see [README.md](./README.md).
 - A host directory for `PROJECTS_PATH` containing the project folders you want the agent to access (create it before starting the container)
 
 ```powershell
-docker pull ghcr.io/openhands/agent-canvas:1.14.0 # x-release-please-version
+docker pull ghcr.io/openhands/agent-canvas:1.15.0 # x-release-please-version
 
 $env:PROJECTS_PATH = Join-Path $HOME "projects"  # directory containing your project folders
 New-Item -ItemType Directory -Force -Path $env:PROJECTS_PATH, (Join-Path $env:USERPROFILE ".openhands") | Out-Null
@@ -21,7 +21,7 @@ docker run -it --rm `
   -p 8000:8000 `
   -v "$($env:USERPROFILE)\.openhands:/home/openhands/.openhands" `
   -v "$($env:PROJECTS_PATH):/projects" `
-  ghcr.io/openhands/agent-canvas:1.14.0 # x-release-please-version
+  ghcr.io/openhands/agent-canvas:1.15.0 # x-release-please-version
 ```
 
 Open [http://localhost:8000/canvas](http://localhost:8000/canvas) in your browser.

--- a/README.windows.md
+++ b/README.windows.md
@@ -27,3 +27,10 @@ docker run -it --rm `
 Open [http://localhost:8000/canvas](http://localhost:8000/canvas) in your browser.
 
 The agent will be able to access any project under `PROJECTS_PATH`.
+
+> [!NOTE]
+> Docker Desktop for Windows/macOS handles bind-mount permissions transparently.
+> On Linux (Docker Engine), the container's `openhands` user is **uid 10001** —
+> if the agent-server and automation fail to start, make the mounted host dirs
+> writable by that uid (see the note in
+> [README.md](./README.md#option-2-with-a-docker-sandbox)).

--- a/README.windows.md
+++ b/README.windows.md
@@ -12,7 +12,7 @@ For the main install options and overall context, see [README.md](./README.md).
 - A host directory for `PROJECTS_PATH` containing the project folders you want the agent to access (create it before starting the container)
 
 ```powershell
-docker pull ghcr.io/openhands/agent-canvas:1.12.0 # x-release-please-version
+docker pull ghcr.io/openhands/agent-canvas:1.14.0 # x-release-please-version
 
 $env:PROJECTS_PATH = Join-Path $HOME "projects"  # directory containing your project folders
 New-Item -ItemType Directory -Force -Path $env:PROJECTS_PATH, (Join-Path $env:USERPROFILE ".openhands") | Out-Null
@@ -21,7 +21,7 @@ docker run -it --rm `
   -p 8000:8000 `
   -v "$($env:USERPROFILE)\.openhands:/home/openhands/.openhands" `
   -v "$($env:PROJECTS_PATH):/projects" `
-  ghcr.io/openhands/agent-canvas:1.12.0 # x-release-please-version
+  ghcr.io/openhands/agent-canvas:1.14.0 # x-release-please-version
 ```
 
 Open [http://localhost:8000/canvas](http://localhost:8000/canvas) in your browser.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -150,6 +150,7 @@ RUN mkdir -p /home/openhands/.openhands/agent-canvas/conversations \
              /home/openhands/.openhands/agent-canvas/bash_events \
              /home/openhands/.openhands/automation \
              /projects && \
+    chmod 755 /home/openhands && \
     chown -R openhands:openhands /home/openhands/.openhands /projects
 
 USER openhands

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -67,13 +67,9 @@ export OH_CONVERSATIONS_PATH="${OH_CONVERSATIONS_PATH:-${OPENHANDS_DIR}/${CONFIG
 export OH_BASH_EVENTS_DIR="${OH_BASH_EVENTS_DIR:-${OPENHANDS_DIR}/${CONFIG_BASH_EVENTS:-agent-canvas/bash_events}}"
 
 # ── Preflight: persistence dir must be writable ────────────────────────────
-# The image runs as uid 10001 (openhands). A bind-mounted host directory
-# (e.g. `-v ~/.openhands:/home/openhands/.openhands`) that isn't writable by
-# that uid makes BOTH the agent-server (conversations dir) and automation
-# (SQLite DB) crash at startup while the static frontend keeps serving — a
-# half-dead stack that looks fine in the browser but 502s on every API call.
-# Fail fast with an actionable message instead of letting users chase a
-# phantom backend error.
+# The image runs as uid 10001 (openhands); a host bind mount that isn't
+# writable by that uid leaves the backend half-dead (frontend serves,
+# APIs 502). Fail fast with an actionable message.
 if ! (mkdir -p "$OPENHANDS_DIR" && touch "$OPENHANDS_DIR/.write-test" 2>/dev/null); then
   log_error "Persistence directory is not writable: $OPENHANDS_DIR"
   log_error "The container runs as uid $(id -u); the bind-mounted host dir"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -66,6 +66,24 @@ export OH_PERSISTENCE_DIR="${OH_PERSISTENCE_DIR:-${OPENHANDS_DIR}}"
 export OH_CONVERSATIONS_PATH="${OH_CONVERSATIONS_PATH:-${OPENHANDS_DIR}/${CONFIG_CONVERSATIONS:-agent-canvas/conversations}}"
 export OH_BASH_EVENTS_DIR="${OH_BASH_EVENTS_DIR:-${OPENHANDS_DIR}/${CONFIG_BASH_EVENTS:-agent-canvas/bash_events}}"
 
+# ── Preflight: persistence dir must be writable ────────────────────────────
+# The image runs as uid 10001 (openhands). A bind-mounted host directory
+# (e.g. `-v ~/.openhands:/home/openhands/.openhands`) that isn't writable by
+# that uid makes BOTH the agent-server (conversations dir) and automation
+# (SQLite DB) crash at startup while the static frontend keeps serving — a
+# half-dead stack that looks fine in the browser but 502s on every API call.
+# Fail fast with an actionable message instead of letting users chase a
+# phantom backend error.
+if ! (mkdir -p "$OPENHANDS_DIR" && touch "$OPENHANDS_DIR/.write-test" 2>/dev/null); then
+  log_error "Persistence directory is not writable: $OPENHANDS_DIR"
+  log_error "The container runs as uid $(id -u); the bind-mounted host dir"
+  log_error "must be writable by that uid. Fix with either:"
+  log_error "  1) chmod -R a+rwX ~/.openhands   # run ON THE HOST, not in the container"
+  log_error "  2) docker run ... --user \"\$(id -u):\$(id -g)\""
+  exit 1
+fi
+rm -f "$OPENHANDS_DIR/.write-test"
+
 # OH_SECRET_KEY is required for settings/secrets encryption. Without it the
 # agent-server refuses to return encrypted secrets → conversation creation
 # fails with a 503.  Auto-generate and persist (just like the session API key)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -78,8 +78,8 @@ for dir in "$OPENHANDS_DIR" "$OH_PERSISTENCE_DIR" "$OH_CONVERSATIONS_PATH" "$OH_
     log_error "Persistence directory is not writable: $dir"
     log_error "The container runs as uid $(id -u); the bind-mounted host dir"
     log_error "must be writable by that uid. Fix with either:"
-    log_error "  1) chmod -R a+rwX ~/.openhands   # run ON THE HOST, not in the container"
-    log_error "  2) docker run ... --user \"\$(id -u):\$(id -g)\""
+    log_error "  1) rerun with --user \"\$(id -u):\$(id -g)\" (add -e HOME=/home/openhands)"
+    log_error "  2) find ~/.openhands -type d -exec chmod a+rwX {} +  # host shell; dirs only"
     exit 1
   fi
   rm -f "$dir/.write-test"
@@ -95,8 +95,8 @@ if [ -d /projects ]; then
     log_error "Workspace directory is not writable: /projects"
     log_error "The container runs as uid $(id -u); the bind-mounted host dir"
     log_error "must be writable by that uid. Fix with either:"
-    log_error "  1) chmod -R a+rwX ~/projects   # run ON THE HOST, not in the container"
-    log_error "  2) docker run ... --user \"\$(id -u):\$(id -g)\""
+    log_error "  1) rerun with --user \"\$(id -u):\$(id -g)\""
+    log_error "  2) find ~/projects -type d -exec chmod a+rwX {} +  # host shell; dirs only"
     exit 1
   fi
   rm -f /projects/.write-test

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -85,6 +85,23 @@ for dir in "$OPENHANDS_DIR" "$OH_PERSISTENCE_DIR" "$OH_CONVERSATIONS_PATH" "$OH_
   rm -f "$dir/.write-test"
 done
 
+# ── Preflight: /projects workspace mount must be writable ──────────────────
+# Optional — only probed when the user actually mounted a workspace dir
+# (e.g. -v "$PROJECTS_PATH:/projects"). A uid-mismatched or read-only mount
+# here breaks the agent's file access the same way, so fail fast too. We
+# deliberately don't mkdir: an absent /projects just means no workspace mount.
+if [ -d /projects ]; then
+  if ! touch /projects/.write-test 2>/dev/null; then
+    log_error "Workspace directory is not writable: /projects"
+    log_error "The container runs as uid $(id -u); the bind-mounted host dir"
+    log_error "must be writable by that uid. Fix with either:"
+    log_error "  1) chmod -R a+rwX ~/projects   # run ON THE HOST, not in the container"
+    log_error "  2) docker run ... --user \"\$(id -u):\$(id -g)\""
+    exit 1
+  fi
+  rm -f /projects/.write-test
+fi
+
 # OH_SECRET_KEY is required for settings/secrets encryption. Without it the
 # agent-server refuses to return encrypted secrets → conversation creation
 # fails with a 503.  Auto-generate and persist (just like the session API key)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -66,19 +66,24 @@ export OH_PERSISTENCE_DIR="${OH_PERSISTENCE_DIR:-${OPENHANDS_DIR}}"
 export OH_CONVERSATIONS_PATH="${OH_CONVERSATIONS_PATH:-${OPENHANDS_DIR}/${CONFIG_CONVERSATIONS:-agent-canvas/conversations}}"
 export OH_BASH_EVENTS_DIR="${OH_BASH_EVENTS_DIR:-${OPENHANDS_DIR}/${CONFIG_BASH_EVENTS:-agent-canvas/bash_events}}"
 
-# ── Preflight: persistence dir must be writable ────────────────────────────
+# ── Preflight: persistence dirs must be writable ───────────────────────────
 # The image runs as uid 10001 (openhands); a host bind mount that isn't
 # writable by that uid leaves the backend half-dead (frontend serves,
 # APIs 502). Fail fast with an actionable message.
-if ! (mkdir -p "$OPENHANDS_DIR" && touch "$OPENHANDS_DIR/.write-test" 2>/dev/null); then
-  log_error "Persistence directory is not writable: $OPENHANDS_DIR"
-  log_error "The container runs as uid $(id -u); the bind-mounted host dir"
-  log_error "must be writable by that uid. Fix with either:"
-  log_error "  1) chmod -R a+rwX ~/.openhands   # run ON THE HOST, not in the container"
-  log_error "  2) docker run ... --user \"\$(id -u):\$(id -g)\""
-  exit 1
-fi
-rm -f "$OPENHANDS_DIR/.write-test"
+# Probe the effective paths (not just $OPENHANDS_DIR): OH_PERSISTENCE_DIR /
+# OH_CONVERSATIONS_PATH / OH_BASH_EVENTS_DIR can be overridden by the user,
+# and $OPENHANDS_DIR itself still hosts the persisted secret-key/api-key files.
+for dir in "$OPENHANDS_DIR" "$OH_PERSISTENCE_DIR" "$OH_CONVERSATIONS_PATH" "$OH_BASH_EVENTS_DIR"; do
+  if ! (mkdir -p "$dir" && touch "$dir/.write-test" 2>/dev/null); then
+    log_error "Persistence directory is not writable: $dir"
+    log_error "The container runs as uid $(id -u); the bind-mounted host dir"
+    log_error "must be writable by that uid. Fix with either:"
+    log_error "  1) chmod -R a+rwX ~/.openhands   # run ON THE HOST, not in the container"
+    log_error "  2) docker run ... --user \"\$(id -u):\$(id -g)\""
+    exit 1
+  fi
+  rm -f "$dir/.write-test"
+done
 
 # OH_SECRET_KEY is required for settings/secrets encryption. Without it the
 # agent-server refuses to return encrypted secrets → conversation creation


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Tested the Docker quickstart with the chmod fix, now stack boots cleanly and fail fast error appears on a broken mount.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

Verified end-to-end by building the Docker image locally from this branch and
running an A/B test against identical mounts:

- **Build:** `node scripts/docker-build.mjs --tag agent-canvas:preflight` (agent-server 1.40.1 base, automation 1.6.0) — exit 0.
- **A — new entrypoint + broken mount** (host dir uid 1000, mode 700): container **exits code 1 in 2s** with `[agent-canvas] ERROR: Persistence directory is not writable: /home/openhands/.openhands` plus both fixes (`chmod` / `--user`).
- **B — new entrypoint + permissive mount** (mode 777): full stack boots — `/server_info` 200 in ~14s, `/canvas` 200.
- **C — old image (`1.12.0`) + same broken mount**: container stays up, frontend 200, `/server_info` 502 — the half-dead trap this PR removes.
- `bash -n docker/entrypoint.sh` clean; functional preflight test passed all three cases (writable / read-only / nonexistent dir).

---

## Why

The Docker quickstart in `README.md` is broken for typical Linux users. The container runs as uid **10001** (`openhands`), but the bind-mounted `~/.openhands` is owned by the host user (uid 1000, mode `700`). The agent-server (conversations dir) and automation (SQLite DB) both crash at startup with `Permission denied`, while the static frontend keeps serving — a half-dead stack that looks fine in the browser but 502s on every API call, with no hint of why.

## Summary

- `docker/entrypoint.sh`: add a writability preflight for the persistence dir that **fails fast** with an actionable error (both fixes: `chmod` the host dirs, or `--user "$(id -u):$(id -g)"`) instead of silently running a broken stack.
- `README.md`: Docker quickstart now makes the mounted dirs writable (with a uid-10001 note) and documents the `--user` alternative in a tip block.
- `README.windows.md`: note that the uid issue is Linux-only — Docker Desktop handles bind-mount permissions transparently.

## Issue Number

Fixes #16511

## How to Test

1. `docker build` from this branch: `node scripts/docker-build.mjs --tag agent-canvas:preflight` (or rely on the published image once this lands).
2. **Reproduce the bug**: run the README quickstart with the host dir at default perms — with the fix, the container now exits within ~2s with a clear error message instead of running a half-dead stack.
3. **Verify the fix**: apply either documented fix, then re-run:
   - `chmod -R a+rwX "$HOME/.openhands" "$PROJECTS_PATH"`, or
   - add `--user "$(id -u):$(id -g)"` to `docker run`.
4. Confirm the stack boots: `curl http://localhost:8000/server_info` returns 200 and the UI loads at `http://localhost:8000/canvas`.

## Video/Screenshots

### Before

<img width="1500" height="482" alt="image" src="https://github.com/user-attachments/assets/43bbedb2-c9fb-4c94-96ad-2a116d8975c9" />

### After

<img width="1255" height="450" alt="image" src="https://github.com/user-attachments/assets/0c0fb857-cf56-49e2-a4cd-341fde7e14f8" />

<!-- For bug fixes: reproduction evidence is required. Add a terminal screenshot
showing (1) the old half-dead behavior or the new fail-fast error on the broken
mount, and (2) the fixed stack booting. -->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The entrypoint change is baked in at image build time — the published image must be rebuilt/released for end users to get the fail-fast behavior. The README fix helps immediately regardless.
