### PR TITLE
fix(ci): prevent issue readiness workflow from failing on not-ready issues

### DIFF
--- a/.github/scripts/tests/test_issue_readiness.py
+++ b/.github/scripts/tests/test_issue_readiness.py
@@ -13,6 +13,7 @@ from check_issue_readiness import (
     references_run_method,
     has_checklist_item,
     visible_text,
+    main,
     BUG_LABEL,
     ENHANCEMENT_LABEL,
 )
@@ -278,3 +279,49 @@ I ran `npm run dev` and saw the crash above.
     sections = extract_sections(body)
     assert {"relevant logs", "actual behavior", "acceptance criteria"} <= set(sections)
     assert evaluate_readiness(body, [BUG_LABEL]).ready
+
+def test_main_json_not_ready(tmp_path, capsys, monkeypatch):
+    import json
+    body_file = tmp_path / "issue.md"
+    body_file.write_text(BUG_BODY_NO_SCREENSHOT)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "check_issue_readiness.py",
+            "--body-file",
+            str(body_file),
+            "--labels",
+            "bug",
+            "--json",
+        ],
+    )
+    exit_code = main()
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["ready"] is False
+    assert len(data["reasons"]) > 0
+
+
+def test_main_json_ready(tmp_path, capsys, monkeypatch):
+    import json
+    body_file = tmp_path / "issue.md"
+    body_file.write_text(BUG_BODY_READY)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "check_issue_readiness.py",
+            "--body-file",
+            str(body_file),
+            "--labels",
+            "bug",
+            "--json",
+        ],
+    )
+    exit_code = main()
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["ready"] is True
+    assert len(data["reasons"]) == 0
+

--- a/.github/scripts/tests/test_issue_readiness.py
+++ b/.github/scripts/tests/test_issue_readiness.py
@@ -305,6 +305,7 @@ def test_main_json_not_ready(tmp_path, capsys, monkeypatch):
 
 def test_main_json_ready(tmp_path, capsys, monkeypatch):
     import json
+
     body_file = tmp_path / "issue.md"
     body_file.write_text(BUG_BODY_READY)
     monkeypatch.setattr(
@@ -324,4 +325,74 @@ def test_main_json_ready(tmp_path, capsys, monkeypatch):
     data = json.loads(captured.out)
     assert data["ready"] is True
     assert len(data["reasons"]) == 0
+
+
+def test_main_text_ready(tmp_path, capsys, monkeypatch):
+    body_file = tmp_path / "issue.md"
+    body_file.write_text(BUG_BODY_READY)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "check_issue_readiness.py",
+            "--body-file",
+            str(body_file),
+            "--labels",
+            "bug",
+        ],
+    )
+    exit_code = main()
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Issue meets ready-for-dev criteria." in captured.out
+
+
+def test_main_text_not_ready(tmp_path, capsys, monkeypatch):
+    body_file = tmp_path / "issue.md"
+    body_file.write_text(BUG_BODY_NO_SCREENSHOT)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "check_issue_readiness.py",
+            "--body-file",
+            str(body_file),
+            "--labels",
+            "bug",
+        ],
+    )
+    exit_code = main()
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Issue does not meet ready-for-dev criteria:" in captured.out
+
+
+def test_main_event_path_json_ready(tmp_path, capsys, monkeypatch):
+    import json
+
+    event_file = tmp_path / "event.json"
+    event_file.write_text(
+        json.dumps(
+            {
+                "issue": {
+                    "body": BUG_BODY_READY,
+                    "labels": [{"name": "bug"}],
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "check_issue_readiness.py",
+            "--event-path",
+            str(event_file),
+            "--json",
+        ],
+    )
+    exit_code = main()
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["ready"] is True
+    assert len(data["reasons"]) == 0
+
 

--- a/.github/scripts/tests/test_pr_description.py
+++ b/.github/scripts/tests/test_pr_description.py
@@ -19,7 +19,6 @@ from check_pr_description import (
     validate_bug_fix_evidence,
     BUG_LABEL,
     ENHANCEMENT_LABEL,
-    READY_FOR_DEV_LABEL,
 )
 
 

--- a/.github/workflows/issue-readiness-check.yml
+++ b/.github/workflows/issue-readiness-check.yml
@@ -48,7 +48,7 @@ jobs:
                   GITHUB_EVENT_PATH: ${{ github.event_path }}
               run: |
                   set -euo pipefail
-                  python .github/scripts/check_issue_readiness.py --json > /tmp/result.json
+                  python .github/scripts/check_issue_readiness.py --json > /tmp/result.json || true
                   echo "ready=$(jq -r '.ready' /tmp/result.json)" >> "$GITHUB_OUTPUT"
                   # Write reasons to a file so the comment step can read them
                   # without shell-escaping multiline text.


### PR DESCRIPTION
HUMAN:

I tested the workflow script locally under set -euo pipefail and verified that the test suite passes cleanly.

AGENT:

This pull request was updated by an AI agent (OpenHands) on behalf of the user.

---

## Why

The `Evaluate issue readiness` step in `.github/workflows/issue-readiness-check.yml` ran `python .github/scripts/check_issue_readiness.py --json > /tmp/result.json` under `set -euo pipefail`. 

When an issue was not ready-for-dev (the default state for new issues missing details or screenshots), `check_issue_readiness.py` returned exit code 1. Under `set -e`, this caused bash to abort the step immediately. Consequently, `$GITHUB_OUTPUT` was never populated, skipping label removal and the feedback comment intended to inform the issue author what was missing.

## Summary

- Appended `|| true` to the `check_issue_readiness.py` execution line in `.github/workflows/issue-readiness-check.yml` so non-zero exits on not-ready issues do not fail the workflow step.
- Added CLI unit tests in `.github/scripts/tests/test_issue_readiness.py` to verify `main()` execution, exit codes, and `--json` payload structure for both ready and not-ready issues.

## Issue Number

Fixes #16513

Related: #16827

## How to Test

1. Run the script test suite:
   ```bash
   python3 -m pytest .github/scripts/tests/ -v

