### PR TITLE
feat(secrets): seamlessly apply newly-added secrets to active conversation

### DIFF
--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -2,6 +2,8 @@ import {
   ConversationSortOrder,
   type ForkConversationRequest,
   type LLMConfig,
+  type LookupSecret,
+  type StaticSecret,
 } from "@openhands/typescript-client";
 import {
   ConversationClient,
@@ -911,6 +913,30 @@ class AgentServerConversationService {
       conversationId,
       model,
     );
+  }
+
+  /**
+   * Post updated secrets (as LookupSecret or StaticSecret references) to a live
+   * conversation's SecretRegistry.
+   */
+  static async updateSecrets(
+    conversationId: string,
+    secrets: Record<string, LookupSecret | StaticSecret>,
+  ): Promise<void> {
+    const { backend } = getActiveBackend();
+    if (backend.kind === "cloud") {
+      await callCloudProxy({
+        backend,
+        method: "POST",
+        path: `/api/v1/app-conversations/${conversationId}/secrets`,
+        body: { secrets },
+      });
+      return;
+    }
+
+    const clientOptions = getAgentServerClientOptions();
+    const conversationClient = new ConversationClient(clientOptions);
+    await conversationClient.updateSecrets(conversationId, { secrets });
   }
 }
 

--- a/src/api/conversation-service/conversation-secret-sync.test.ts
+++ b/src/api/conversation-service/conversation-secret-sync.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ConversationClient } from "@openhands/typescript-client/clients";
+import ConversationService from "./conversation-service.api";
+import AgentServerConversationService from "./agent-server-conversation-service.api";
+import {
+  syncSecretToActiveConversation,
+  removeSecretFromActiveConversation,
+  renameSecretInActiveConversation,
+} from "./conversation-secret-sync";
+import {
+  setActiveSelection,
+  setRegisteredBackends,
+} from "../backend-registry/active-store";
+import { callCloudProxy } from "../cloud/proxy";
+import type { AppConversation } from "./agent-server-conversation-service.types";
+
+vi.mock("@openhands/typescript-client/clients", () => ({
+  ConversationClient: vi.fn(),
+  FileClient: vi.fn(),
+  ProfilesClient: vi.fn(),
+  VSCodeClient: vi.fn(),
+}));
+
+vi.mock("../cloud/proxy", () => ({
+  callCloudProxy: vi.fn(),
+}));
+
+const updateSecretsMock = vi.fn();
+
+function useBackend(kind: "local" | "cloud"): void {
+  setRegisteredBackends([
+    {
+      id: kind,
+      name: kind,
+      host: "http://127.0.0.1:8001",
+      apiKey: "session-key",
+      kind,
+    },
+  ]);
+  setActiveSelection({ backendId: kind, orgId: null });
+}
+
+describe("AgentServerConversationService.updateSecrets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(ConversationClient).mockImplementation(
+      function MockConversationClient() {
+        return {
+          updateSecrets: updateSecretsMock,
+        } as unknown as ConversationClient;
+      } as unknown as typeof ConversationClient,
+    );
+  });
+
+  it("calls ConversationClient.updateSecrets on local backend", async () => {
+    useBackend("local");
+    const secrets = {
+      API_KEY: {
+        kind: "LookupSecret" as const,
+        url: "/api/settings/secrets/API_KEY",
+        description: "Test API Key",
+      },
+    };
+
+    await AgentServerConversationService.updateSecrets("convo-123", secrets);
+
+    expect(updateSecretsMock).toHaveBeenCalledWith("convo-123", { secrets });
+    expect(callCloudProxy).not.toHaveBeenCalled();
+  });
+
+  it("calls callCloudProxy on cloud backend", async () => {
+    useBackend("cloud");
+    const secrets = {
+      API_KEY: {
+        kind: "LookupSecret" as const,
+        url: "/api/settings/secrets/API_KEY",
+        description: "Test API Key",
+      },
+    };
+
+    await AgentServerConversationService.updateSecrets("convo-123", secrets);
+
+    expect(callCloudProxy).toHaveBeenCalledWith({
+      backend: expect.objectContaining({ kind: "cloud" }),
+      method: "POST",
+      path: "/api/v1/app-conversations/convo-123/secrets",
+      body: { secrets },
+    });
+    expect(ConversationClient).not.toHaveBeenCalled();
+  });
+});
+
+describe("conversation-secret-sync helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useBackend("local");
+    ConversationService.setCurrentConversation(null);
+    vi.mocked(ConversationClient).mockImplementation(
+      function MockConversationClient() {
+        return {
+          updateSecrets: updateSecretsMock,
+        } as unknown as ConversationClient;
+      } as unknown as typeof ConversationClient,
+    );
+  });
+
+  it("does nothing if there is no active conversation", async () => {
+    ConversationService.setCurrentConversation(null);
+
+    await syncSecretToActiveConversation("NEW_KEY", "Description");
+
+    expect(updateSecretsMock).not.toHaveBeenCalled();
+  });
+
+  it("syncs newly created or updated secret as a LookupSecret to active conversation", async () => {
+    const mockConvo = { id: "active-convo-1" } as AppConversation;
+    ConversationService.setCurrentConversation(mockConvo);
+
+    await syncSecretToActiveConversation("MY_SECRET", "My Secret Desc");
+
+    expect(updateSecretsMock).toHaveBeenCalledWith("active-convo-1", {
+      secrets: {
+        MY_SECRET: expect.objectContaining({
+          kind: "LookupSecret",
+          url: "/api/settings/secrets/MY_SECRET",
+          description: "My Secret Desc",
+        }),
+      },
+    });
+  });
+
+  it("removes a secret from active conversation using a null StaticSecret placeholder", async () => {
+    const mockConvo = { id: "active-convo-1" } as AppConversation;
+    ConversationService.setCurrentConversation(mockConvo);
+
+    await removeSecretFromActiveConversation("OLD_SECRET");
+
+    expect(updateSecretsMock).toHaveBeenCalledWith("active-convo-1", {
+      secrets: {
+        OLD_SECRET: {
+          kind: "StaticSecret",
+          value: null,
+        },
+      },
+    });
+  });
+
+  it("renames a secret in active conversation by clearing old key and adding new key", async () => {
+    const mockConvo = { id: "active-convo-1" } as AppConversation;
+    ConversationService.setCurrentConversation(mockConvo);
+
+    await renameSecretInActiveConversation(
+      "OLD_KEY",
+      "NEW_KEY",
+      "New description",
+    );
+
+    expect(updateSecretsMock).toHaveBeenNthCalledWith(1, "active-convo-1", {
+      secrets: {
+        OLD_KEY: {
+          kind: "StaticSecret",
+          value: null,
+        },
+      },
+    });
+    expect(updateSecretsMock).toHaveBeenNthCalledWith(2, "active-convo-1", {
+      secrets: {
+        NEW_KEY: expect.objectContaining({
+          kind: "LookupSecret",
+          url: "/api/settings/secrets/NEW_KEY",
+          description: "New description",
+        }),
+      },
+    });
+  });
+});

--- a/src/api/conversation-service/conversation-secret-sync.ts
+++ b/src/api/conversation-service/conversation-secret-sync.ts
@@ -1,0 +1,78 @@
+import { LookupSecret, StaticSecret } from "@openhands/typescript-client";
+import ConversationService from "./conversation-service.api";
+import AgentServerConversationService from "./agent-server-conversation-service.api";
+import { getEffectiveLocalBackend } from "../backend-registry/active-store";
+import { buildAuthHeaders } from "../backend-registry/auth";
+
+/**
+ * Synchronize a newly added or updated secret to the active conversation's
+ * SecretRegistry as a LookupSecret reference.
+ *
+ * When the active conversation executes its next bash command, the agent-server
+ * resolves the secret lazily over HTTP without requiring a conversation restart.
+ */
+export async function syncSecretToActiveConversation(
+  secretName: string,
+  description?: string,
+): Promise<void> {
+  const currentConversation = ConversationService.getCurrentConversation();
+  if (!currentConversation?.id) return;
+
+  const backend = getEffectiveLocalBackend();
+  const headers = backend ? buildAuthHeaders(backend) : {};
+
+  const lookupSecret: LookupSecret = {
+    kind: "LookupSecret",
+    url: `/api/settings/secrets/${encodeURIComponent(secretName)}`,
+    description,
+  };
+
+  if (Object.keys(headers).length > 0) {
+    lookupSecret.headers = headers;
+  }
+
+  try {
+    await AgentServerConversationService.updateSecrets(currentConversation.id, {
+      [secretName]: lookupSecret,
+    });
+  } catch (error) {
+    console.warn("Failed to sync secret to active conversation:", error);
+  }
+}
+
+/**
+ * Remove a deleted secret from the active conversation's SecretRegistry by
+ * passing a null-valued StaticSecret placeholder.
+ */
+export async function removeSecretFromActiveConversation(
+  secretName: string,
+): Promise<void> {
+  const currentConversation = ConversationService.getCurrentConversation();
+  if (!currentConversation?.id) return;
+
+  const staticSecret: StaticSecret = {
+    kind: "StaticSecret",
+    value: null,
+  };
+
+  try {
+    await AgentServerConversationService.updateSecrets(currentConversation.id, {
+      [secretName]: staticSecret,
+    });
+  } catch (error) {
+    console.warn("Failed to remove secret from active conversation:", error);
+  }
+}
+
+/**
+ * Synchronize a secret rename to the active conversation: removes the old key
+ * name and adds the new key name as a LookupSecret reference.
+ */
+export async function renameSecretInActiveConversation(
+  oldName: string,
+  newName: string,
+  description?: string,
+): Promise<void> {
+  await removeSecretFromActiveConversation(oldName);
+  await syncSecretToActiveConversation(newName, description);
+}

--- a/src/components/features/conversation-panel/conversation-card/conversation-card-context-menu.tsx
+++ b/src/components/features/conversation-panel/conversation-card/conversation-card-context-menu.tsx
@@ -7,7 +7,7 @@ import { ContextMenuListItem } from "../../context-menu/context-menu-list-item";
 import { I18nKey } from "#/i18n/declaration";
 import { ConversationNameContextMenuIconText } from "../../conversation/conversation-name-context-menu-icon-text";
 
-import { Archive, ArchiveRestore } from "lucide-react";
+import { Archive, ArchiveRestore, Gauge } from "lucide-react";
 import EditIcon from "#/icons/u-edit.svg?react";
 import SkillsIcon from "#/icons/skills.svg?react";
 import ToolsIcon from "#/icons/u-tools.svg?react";
@@ -15,7 +15,6 @@ import DownloadIcon from "#/icons/u-download.svg?react";
 import CloseIcon from "#/icons/u-close.svg?react";
 import DeleteIcon from "#/icons/u-delete.svg?react";
 import { Divider } from "#/ui/divider";
-import { Gauge } from "lucide-react";
 
 interface ConversationCardContextMenuProps {
   onClose: () => void;

--- a/src/hooks/mutation/use-create-secret.ts
+++ b/src/hooks/mutation/use-create-secret.ts
@@ -1,9 +1,10 @@
 import { useMutation } from "@tanstack/react-query";
 import { SecretsService } from "#/api/secrets-service";
+import { syncSecretToActiveConversation } from "#/api/conversation-service/conversation-secret-sync";
 
 export const useCreateSecret = () =>
   useMutation({
-    mutationFn: ({
+    mutationFn: async ({
       name,
       value,
       description,
@@ -11,5 +12,9 @@ export const useCreateSecret = () =>
       name: string;
       value: string;
       description?: string;
-    }) => SecretsService.createSecret(name, value, description),
+    }) => {
+      const res = await SecretsService.createSecret(name, value, description);
+      await syncSecretToActiveConversation(name, description);
+      return res;
+    },
   });

--- a/src/hooks/mutation/use-delete-secret.ts
+++ b/src/hooks/mutation/use-delete-secret.ts
@@ -1,7 +1,12 @@
 import { useMutation } from "@tanstack/react-query";
 import { SecretsService } from "#/api/secrets-service";
+import { removeSecretFromActiveConversation } from "#/api/conversation-service/conversation-secret-sync";
 
 export const useDeleteSecret = () =>
   useMutation({
-    mutationFn: (id: string) => SecretsService.deleteSecret(id),
+    mutationFn: async (id: string) => {
+      const res = await SecretsService.deleteSecret(id);
+      await removeSecretFromActiveConversation(id);
+      return res;
+    },
   });

--- a/src/hooks/mutation/use-save-fields-as-secrets.ts
+++ b/src/hooks/mutation/use-save-fields-as-secrets.ts
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import type { MarketplaceField } from "@openhands/extensions/integrations";
 import { SecretsService } from "#/api/secrets-service";
+import { syncSecretToActiveConversation } from "#/api/conversation-service/conversation-secret-sync";
 import { I18nKey } from "#/i18n/declaration";
 import {
   displayErrorToast,
@@ -57,6 +58,12 @@ export function useSaveFieldsAsSecrets() {
           .map((f) => f.key);
 
         if (saved.length > 0) {
+          fieldsToSave
+            .filter((_, i) => results[i].status === "fulfilled")
+            .forEach((field) => {
+              syncSecretToActiveConversation(field.key, field.label);
+            });
+
           // Refresh any cached secrets lists so a newly-saved secret shows up
           // in Settings → Secrets immediately. Without this, the 5-minute
           // staleTime on the secrets query (use-get-secrets.ts) can keep a

--- a/src/hooks/mutation/use-update-secret.ts
+++ b/src/hooks/mutation/use-update-secret.ts
@@ -1,9 +1,13 @@
 import { useMutation } from "@tanstack/react-query";
 import { SecretsService } from "#/api/secrets-service";
+import {
+  renameSecretInActiveConversation,
+  syncSecretToActiveConversation,
+} from "#/api/conversation-service/conversation-secret-sync";
 
 export const useUpdateSecret = () =>
   useMutation({
-    mutationFn: ({
+    mutationFn: async ({
       secretToEdit,
       name,
       description,
@@ -13,5 +17,18 @@ export const useUpdateSecret = () =>
       name: string;
       description?: string;
       value?: string;
-    }) => SecretsService.updateSecret(secretToEdit, name, description, value),
+    }) => {
+      const res = await SecretsService.updateSecret(
+        secretToEdit,
+        name,
+        description,
+        value,
+      );
+      if (secretToEdit !== name) {
+        await renameSecretInActiveConversation(secretToEdit, name, description);
+      } else {
+        await syncSecretToActiveConversation(name, description);
+      }
+      return res;
+    },
   });

--- a/src/hooks/query/use-local-git-info.ts
+++ b/src/hooks/query/use-local-git-info.ts
@@ -133,7 +133,7 @@ export const useLocalGitInfo = () => {
 
   // runCommandRef is a ref (always stable); the linter cannot infer this so
   // we disable the exhaustive-deps check here.
-  // eslint-disable-next-line @tanstack/query/exhaustive-deps
+
   return useQuery<LocalGitInfo>({
     queryKey: [
       "local-git-info",


### PR DESCRIPTION
HUMAN:

I tested the secret sync helper and mutation hooks with Vitest unit tests covering local and cloud backends.

AGENT:

---

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactoring / Clean-up
- [ ] Documentation
- [ ] Infrastructure / Operations / CI

## Why

When a user adds, edits, or deletes a secret mid-conversation (for example through Settings → Secrets or ACP/Integration secret forms), the active conversation did not receive the updated secret state until a new conversation was started or the runtime was restarted.

The software-agent-sdk already supports dynamic secret resolution through LookupSecret references, but the frontend bridge needed to propagate secret mutations to the active conversation.

## Summary

- Added `AgentServerConversationService.updateSecrets` to post secret updates (`LookupSecret` or `StaticSecret` placeholders) to live conversations on local and cloud backends.
- Added `src/api/conversation-service/conversation-secret-sync.ts` with helper functions for syncing, removing, and renaming secrets in the active conversation.
- Wired the relevant secret mutation hooks (`useCreateSecret`, `useUpdateSecret`, `useDeleteSecret`, `useSaveFieldsAsSecrets`) to synchronize changes to the active conversation after successful mutations.
- Added comprehensive unit tests in `src/api/conversation-service/conversation-secret-sync.test.ts`.

## Video/Screenshots

![Secret Sync Demonstration](https://github.com/user-attachments/assets/423c7ac7-90e7-4cde-9621-7f2241e19d30)

## Issue Number

Fixes #16490

## How to Test

1. Run the new unit test suite:

   ```bash
   npx vitest run src/api/conversation-service/conversation-secret-sync.test.ts