### PR TITLE
fix(launcher): explain a service that dies at start-up instead of failing quietly

### DIFF
--- a/__tests__/scripts/service-failure-hints.test.ts
+++ b/__tests__/scripts/service-failure-hints.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it } from "vitest";
+import { once } from "node:events";
+import {
+  describeServiceFailure,
+  detectToolchainFailure,
+  SERVICE_OUTPUT_BUFFER_LINES,
+} from "../../scripts/service-failure-hints.mjs";
+import {
+  getServiceFailure,
+  setServiceLogListener,
+  spawnService,
+} from "../../scripts/dev-with-automation.mjs";
+
+// Trimmed from the report in #16300 — a uv build failure followed by the
+// cargo/rustc rejection that actually explains it.
+const RUSTC_FAILURE = [
+  "Building litellm==1.95.0",
+  "× Failed to build `litellm==1.95.0`",
+  "├─▶ The build backend returned an error",
+  "╰─▶ Call to `maturin.build_wheel` failed (exit status: 1)",
+  "error: rustc 1.93.1 is not supported by the following packages:",
+  "aws-config@1.9.0 requires rustc 1.94.1",
+  "aws-smithy-types@1.6.1 requires rustc 1.94.1",
+  "Either upgrade rustc or select compatible dependency versions with",
+];
+
+describe("detectToolchainFailure", () => {
+  it("recognises an out-of-date rustc behind a failed wheel build", () => {
+    const hit = detectToolchainFailure(RUSTC_FAILURE);
+    expect(hit).not.toBeNull();
+    expect(hit?.kind).toBe("rust-toolchain-too-old");
+    expect(hit?.found).toBe("1.93.1");
+    expect(hit?.required).toBe("1.94.1");
+  });
+
+  it("reports the strictest requirement when crates disagree", () => {
+    const hit = detectToolchainFailure([
+      ...RUSTC_FAILURE,
+      "aws-sdk-sts@1.108.0 requires rustc 1.95.0",
+    ]);
+    expect(hit?.required).toBe("1.95.0");
+  });
+
+  it("accepts a single string as well as an array of lines", () => {
+    expect(detectToolchainFailure(RUSTC_FAILURE.join("\n"))).not.toBeNull();
+  });
+
+  it("stays quiet on a build failure with no rustc complaint", () => {
+    expect(
+      detectToolchainFailure([
+        "× Failed to build `litellm==1.95.0`",
+        "╰─▶ Call to `maturin.build_wheel` failed (exit status: 1)",
+        "error: linker `cc` not found",
+      ]),
+    ).toBeNull();
+  });
+
+  it("stays quiet on a rustc complaint with no failed build", () => {
+    // A warning during an otherwise successful run must not be reported as
+    // the reason a service died.
+    expect(
+      detectToolchainFailure(["rustc 1.93.1 is not supported by something"]),
+    ).toBeNull();
+  });
+
+  it("stays quiet on empty, missing, or unrelated output", () => {
+    expect(detectToolchainFailure([])).toBeNull();
+    expect(detectToolchainFailure(undefined)).toBeNull();
+    expect(
+      detectToolchainFailure(["Uvicorn running on http://127.0.0.1:8001"]),
+    ).toBeNull();
+  });
+});
+
+describe("describeServiceFailure", () => {
+  it("names the service and offers both remediations", () => {
+    const d = describeServiceFailure("automation", 1, RUSTC_FAILURE);
+    expect(d).not.toBeNull();
+    expect(d?.service).toBe("automation");
+    expect(d?.exitCode).toBe(1);
+    expect(d?.lines[0]).toContain("automation could not start");
+    expect(d?.lines[0]).toContain("1.93.1");
+    const joined = d!.lines.join("\n");
+    expect(joined).toContain("rustup update stable");
+    expect(joined).toContain("brew upgrade rust");
+  });
+
+  it("returns null for unrecognised failures so the generic message stands", () => {
+    expect(describeServiceFailure("automation", 1, ["boom"])).toBeNull();
+  });
+});
+
+describe("SERVICE_OUTPUT_BUFFER_LINES", () => {
+  it("keeps enough output for the rustc block to survive truncation", () => {
+    // The AWS crate list in #16300 alone is ~20 lines; the buffer has to hold
+    // the whole build tail or the matcher never sees the explanation.
+    expect(SERVICE_OUTPUT_BUFFER_LINES).toBeGreaterThanOrEqual(50);
+  });
+});
+
+describe("spawnService integration", () => {
+  afterEach(() => {
+    setServiceLogListener(null);
+  });
+
+  it("explains a toolchain failure when a service dies during start-up", async () => {
+    const emitted: string[] = [];
+    setServiceLogListener((_name: string, line: string) => {
+      emitted.push(line);
+    });
+
+    // A stand-in for uvx: print the build failure exactly as reported in
+    // #16300, then exit non-zero the way the real automation service does.
+    const script = [
+      "console.error('Building litellm==1.95.0');",
+      "console.error('\u00d7 Failed to build `litellm==1.95.0`');",
+      "console.error('\u2570\u2500\u25b6 Call to `maturin.build_wheel` failed (exit status: 1)');",
+      "console.error('error: rustc 1.93.1 is not supported by the following packages:');",
+      "console.error('aws-config@1.9.0 requires rustc 1.94.1');",
+      "process.exit(1);",
+    ].join("");
+
+    const proc = spawnService("automation-under-test", process.execPath, [
+      "-e",
+      script,
+    ]);
+    await once(proc, "exit");
+    // The exit handler runs on the same tick as the event; let stdio flush.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const joined = emitted.join("\n");
+    expect(joined).toContain("could not start");
+    expect(joined).toContain("1.93.1");
+    expect(joined).toContain("rustup update stable");
+
+    const failure = getServiceFailure("automation-under-test");
+    expect(failure).not.toBeNull();
+    expect(failure?.kind).toBe("rust-toolchain-too-old");
+    expect(failure?.exitCode).toBe(1);
+  });
+
+  it("leaves no failure recorded for a service that exits cleanly", async () => {
+    const proc = spawnService("clean-service-under-test", process.execPath, [
+      "-e",
+      "process.exit(0);",
+    ]);
+    await once(proc, "exit");
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(getServiceFailure("clean-service-under-test")).toBeNull();
+  });
+});

--- a/__tests__/scripts/service-failure-hints.test.ts
+++ b/__tests__/scripts/service-failure-hints.test.ts
@@ -4,7 +4,9 @@ import { once } from "node:events";
 import {
   describeServiceFailure,
   detectToolchainFailure,
+  isSignificantLine,
   SERVICE_OUTPUT_BUFFER_LINES,
+  SERVICE_SIGNIFICANT_LINE_LIMIT,
 } from "../../scripts/service-failure-hints.mjs";
 import {
   getServiceFailure,
@@ -125,9 +127,8 @@ describe("spawnService integration", () => {
       "-e",
       script,
     ]);
-    await once(proc, "exit");
-    // The exit handler runs on the same tick as the event; let stdio flush.
-    await new Promise((r) => setTimeout(r, 50));
+    await once(proc, "close");
+    // `close` guarantees stdio is drained, so no arbitrary wait is needed.
 
     const joined = emitted.join("\n");
     expect(joined).toContain("could not start");
@@ -140,14 +141,98 @@ describe("spawnService integration", () => {
     expect(failure?.exitCode).toBe(1);
   });
 
+  it("clears a previous failure when the same service is respawned", async () => {
+    // A service that failed once and then started cleanly must not keep
+    // reporting the old failure to anything reading the registry.
+    const failing = [
+      "console.error('Call to `maturin.build_wheel` failed (exit status: 1)');",
+      "console.error('error: rustc 1.93.1 is not supported by the following packages:');",
+      "process.exit(1);",
+    ].join("");
+    const first = spawnService("respawn-under-test", process.execPath, [
+      "-e",
+      failing,
+    ]);
+    await once(first, "close");
+    expect(getServiceFailure("respawn-under-test")).not.toBeNull();
+
+    const second = spawnService("respawn-under-test", process.execPath, [
+      "-e",
+      "process.exit(0);",
+    ]);
+    await once(second, "close");
+    expect(getServiceFailure("respawn-under-test")).toBeNull();
+  });
+
   it("leaves no failure recorded for a service that exits cleanly", async () => {
     const proc = spawnService("clean-service-under-test", process.execPath, [
       "-e",
       "process.exit(0);",
     ]);
-    await once(proc, "exit");
-    await new Promise((r) => setTimeout(r, 50));
+    await once(proc, "close");
 
     expect(getServiceFailure("clean-service-under-test")).toBeNull();
+  });
+});
+
+describe("isSignificantLine", () => {
+  it("keeps the lines a post-mortem needs", () => {
+    expect(isSignificantLine("x Failed to build `litellm==1.95.0`")).toBe(true);
+    expect(
+      isSignificantLine(
+        "Call to `maturin.build_wheel` failed (exit status: 1)",
+      ),
+    ).toBe(true);
+    expect(
+      isSignificantLine(
+        "error: rustc 1.93.1 is not supported by the following",
+      ),
+    ).toBe(true);
+    expect(isSignificantLine("aws-config@1.9.0 requires rustc 1.94.1")).toBe(
+      true,
+    );
+  });
+
+  it("ignores ordinary build chatter", () => {
+    expect(isSignificantLine("   Compiling serde v1.0.0")).toBe(false);
+    expect(isSignificantLine("Uvicorn running on http://127.0.0.1:8001")).toBe(
+      false,
+    );
+  });
+
+  it("retains evidence separated by more output than the tail holds", () => {
+    // uv prints its `Failed to build` summary first, replays the captured
+    // build log, and cargo emits a line per crate in between — so the two
+    // halves of the evidence can be far more than a tail apart.
+    const stream = [
+      "x Failed to build `litellm==1.95.0`",
+      "Call to `maturin.build_wheel` failed (exit status: 1)",
+      ...Array.from(
+        { length: SERVICE_OUTPUT_BUFFER_LINES + 50 },
+        (_, i) => `   Compiling crate-${i} v1.0.0`,
+      ),
+      "error: rustc 1.93.1 is not supported by the following packages:",
+      "aws-config@1.9.0 requires rustc 1.94.1",
+    ];
+
+    const recent: string[] = [];
+    const significant: string[] = [];
+    for (const line of stream) {
+      recent.push(line);
+      if (recent.length > SERVICE_OUTPUT_BUFFER_LINES) recent.shift();
+      if (isSignificantLine(line)) {
+        significant.push(line);
+        if (significant.length > SERVICE_SIGNIFICANT_LINE_LIMIT) {
+          significant.shift();
+        }
+      }
+    }
+
+    // The bounded tail alone has lost the build-failure half by now.
+    expect(detectToolchainFailure(recent)).toBeNull();
+    // Retaining the significant lines keeps both halves available.
+    const hit = detectToolchainFailure([...significant, ...recent]);
+    expect(hit).not.toBeNull();
+    expect(hit?.required).toBe("1.94.1");
   });
 });

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -71,6 +71,10 @@ import {
   signalProcessTree,
 } from "./dev-process-utils.mjs";
 import { fileLog, stripAnsi } from "./logger.mjs";
+import {
+  describeServiceFailure,
+  SERVICE_OUTPUT_BUFFER_LINES,
+} from "./service-failure-hints.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, "..");
@@ -543,6 +547,15 @@ function ensureDirectories(config) {
 // ═══════════════════════════════════════════════════════════════════════════
 
 const processes = new Map();
+
+// Why each service died, for the ones we can explain. Populated on exit and
+// read by callers that need to report the failure after start-up returns.
+const serviceFailures = new Map();
+
+/** The recognised failure for `name`, or null if it exited cleanly/unknown. */
+function getServiceFailure(name) {
+  return serviceFailures.get(name) ?? null;
+}
 const shutdownHooks = createShutdownHookRegistry((err) => {
   logService("cleanup", `Cleanup hook failed: ${err.message}`, c.yellow);
 });
@@ -572,6 +585,15 @@ function registerShutdownHook(hook) {
 }
 
 function spawnService(name, command, args, options = {}) {
+  // Keep a bounded tail of the service's output so that, if it dies, we can
+  // look back at what it printed and explain why rather than only reporting
+  // the exit code.
+  const recentOutput = [];
+  const remember = (line) => {
+    recentOutput.push(line);
+    if (recentOutput.length > SERVICE_OUTPUT_BUFFER_LINES) recentOutput.shift();
+  };
+
   const proc = spawn(
     resolveWindowsCommand(command),
     args,
@@ -592,6 +614,7 @@ function spawnService(name, command, args, options = {}) {
       .filter(Boolean)
       .forEach((line) => {
         const trimmed = line.trim();
+        remember(trimmed);
         const parsed = parseLogLine ? parseLogLine(trimmed) : null;
         logService(
           name,
@@ -609,6 +632,7 @@ function spawnService(name, command, args, options = {}) {
       .filter(Boolean)
       .forEach((line) => {
         const trimmed = line.trim();
+        remember(trimmed);
         const parsed = parseLogLine ? parseLogLine(trimmed) : null;
         logService(
           name,
@@ -628,6 +652,18 @@ function spawnService(name, command, args, options = {}) {
     if (code !== 0 && code !== null && !shuttingDown) {
       logService(name, `Exited with code ${code}`, c.red);
       emitServiceLog(name, `exited with code ${code}`, "error");
+
+      // A recognised failure gets an explanation and the command that fixes
+      // it. Unrecognised ones keep the generic message above - guessing would
+      // be worse than saying nothing.
+      const failure = describeServiceFailure(name, code, recentOutput);
+      if (failure) {
+        serviceFailures.set(name, failure);
+        failure.lines.forEach((hintLine) => {
+          logService(name, hintLine, c.red);
+          emitServiceLog(name, hintLine, "error");
+        });
+      }
     }
     processes.delete(name);
   });
@@ -1503,6 +1539,7 @@ export {
   main,
   registerShutdownHook,
   spawnService,
+  getServiceFailure,
   commandExists,
   logService,
   logStep,

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -73,7 +73,9 @@ import {
 import { fileLog, stripAnsi } from "./logger.mjs";
 import {
   describeServiceFailure,
+  isSignificantLine,
   SERVICE_OUTPUT_BUFFER_LINES,
+  SERVICE_SIGNIFICANT_LINE_LIMIT,
 } from "./service-failure-hints.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -588,10 +590,22 @@ function spawnService(name, command, args, options = {}) {
   // Keep a bounded tail of the service's output so that, if it dies, we can
   // look back at what it printed and explain why rather than only reporting
   // the exit code.
+  // A previous run of this service must not be reported against this one.
+  serviceFailures.delete(name);
+
   const recentOutput = [];
+  // Evidence can be separated by more output than the tail holds, so keep
+  // diagnostically-interesting lines even once they age out of it.
+  const significantOutput = [];
   const remember = (line) => {
     recentOutput.push(line);
     if (recentOutput.length > SERVICE_OUTPUT_BUFFER_LINES) recentOutput.shift();
+    if (isSignificantLine(line)) {
+      significantOutput.push(line);
+      if (significantOutput.length > SERVICE_SIGNIFICANT_LINE_LIMIT) {
+        significantOutput.shift();
+      }
+    }
   };
 
   const proc = spawn(
@@ -652,20 +666,31 @@ function spawnService(name, command, args, options = {}) {
     if (code !== 0 && code !== null && !shuttingDown) {
       logService(name, `Exited with code ${code}`, c.red);
       emitServiceLog(name, `exited with code ${code}`, "error");
-
-      // A recognised failure gets an explanation and the command that fixes
-      // it. Unrecognised ones keep the generic message above - guessing would
-      // be worse than saying nothing.
-      const failure = describeServiceFailure(name, code, recentOutput);
-      if (failure) {
-        serviceFailures.set(name, failure);
-        failure.lines.forEach((hintLine) => {
-          logService(name, hintLine, c.red);
-          emitServiceLog(name, hintLine, "error");
-        });
-      }
     }
     processes.delete(name);
+  });
+
+  // Diagnose on `close` rather than `exit`: `exit` fires as soon as the child
+  // terminates, while its stdio may still hold unread data, so the output that
+  // explains the failure may not have arrived yet. `close` is emitted only
+  // once every stream is drained.
+  proc.on("close", (code, _signal) => {
+    if (code === 0 || code === null || shuttingDown) return;
+
+    // A recognised failure gets an explanation and the command that fixes it.
+    // Unrecognised ones keep the generic message above - guessing would be
+    // worse than saying nothing.
+    const failure = describeServiceFailure(name, code, [
+      ...significantOutput,
+      ...recentOutput,
+    ]);
+    if (!failure) return;
+
+    serviceFailures.set(name, failure);
+    failure.lines.forEach((hintLine) => {
+      logService(name, hintLine, c.red);
+      emitServiceLog(name, hintLine, "error");
+    });
   });
 
   processes.set(name, proc);
@@ -1242,6 +1267,25 @@ function printBanner(config) {
     `${c.green}${c.bold}╚══════════════════════════════════════════════════════════════╝${c.reset}`,
   );
   console.log("");
+
+  // A service that died during start-up must not be hidden behind a success
+  // banner. That is precisely how the toolchain failure in #16300 goes
+  // unnoticed: the stack reports itself ready, and the user only discovers
+  // the backend is unreachable once the UI fails to connect.
+  for (const failure of serviceFailures.values()) {
+    console.log(
+      `${c.red}${c.bold}✗ ${failure.service} is not running${c.reset}`,
+    );
+    failure.lines.forEach((hintLine) =>
+      console.log(`${c.red}  ${hintLine}${c.reset}`),
+    );
+    console.log("");
+    fileLog(
+      "error",
+      `[${failure.service}] not running — ${stripAnsi(failure.lines.join(" | "))}`,
+    );
+  }
+
   console.log(`${c.dim}State directory: ${config.stateDir}${c.reset}`);
   console.log(`${c.dim}Press Ctrl+C to stop${c.reset}`);
   console.log("");

--- a/scripts/service-failure-hints.mjs
+++ b/scripts/service-failure-hints.mjs
@@ -1,0 +1,99 @@
+/**
+ * Actionable hints for known service start-up failures.
+ *
+ * A service that dies during start-up currently surfaces as a wall of build
+ * output followed by `Exited with code 1`, and the launcher carries on. The
+ * user is left to work out from a Rust backtrace that their toolchain is too
+ * old. These matchers turn the handful of failures we can recognise into a
+ * one-line explanation plus the command that fixes it.
+ *
+ * Kept as pure functions over already-captured output so they can be unit
+ * tested without spawning anything.
+ */
+
+/** How many recent output lines a service keeps for post-mortem matching. */
+export const SERVICE_OUTPUT_BUFFER_LINES = 200;
+
+// `error: rustc 1.93.1 is not supported by the following packages:`
+const RUSTC_UNSUPPORTED_RE = /rustc\s+(\d+\.\d+(?:\.\d+)?)\s+is not supported/i;
+// `aws-config@1.9.0 requires rustc 1.94.1`
+const RUSTC_REQUIRED_RE = /requires rustc\s+(\d+\.\d+(?:\.\d+)?)/i;
+// uv/maturin wrapper lines seen when a native wheel fails to build.
+const MATURIN_FAILURE_RE =
+  /maturin\.build_wheel.*failed|Failed to build `[^`]+`/i;
+
+/**
+ * Highest version string in `versions`, compared numerically per component.
+ * The AWS crates in the litellm tree all name the same requirement today, but
+ * nothing guarantees that, so take the strictest rather than the first seen.
+ */
+function highestVersion(versions) {
+  const parse = (v) => v.split(".").map((n) => Number.parseInt(n, 10) || 0);
+  return versions.reduce((best, v) => {
+    if (!best) return v;
+    const [a, b] = [parse(v), parse(best)];
+    for (let i = 0; i < Math.max(a.length, b.length); i += 1) {
+      if ((a[i] ?? 0) > (b[i] ?? 0)) return v;
+      if ((a[i] ?? 0) < (b[i] ?? 0)) return best;
+    }
+    return best;
+  }, null);
+}
+
+/**
+ * Recognise a Rust toolchain that is too old to build a native wheel.
+ *
+ * Returns null unless the output both fails a wheel build and names an
+ * unsupported rustc — a bare `Failed to build` can be any number of things,
+ * and guessing wrong would be worse than staying quiet.
+ */
+export function detectToolchainFailure(lines) {
+  const text = Array.isArray(lines) ? lines.join("\n") : String(lines ?? "");
+  const unsupported = text.match(RUSTC_UNSUPPORTED_RE);
+  if (!unsupported || !MATURIN_FAILURE_RE.test(text)) return null;
+
+  const required = highestVersion(
+    [...text.matchAll(new RegExp(RUSTC_REQUIRED_RE, "gi"))].map((m) => m[1]),
+  );
+
+  return {
+    kind: "rust-toolchain-too-old",
+    found: unsupported[1],
+    required,
+    summary: required
+      ? `Rust toolchain too old: found rustc ${unsupported[1]}, need ${required} or newer.`
+      : `Rust toolchain too old: found rustc ${unsupported[1]}.`,
+    // Both remediations are the ones that actually worked for reporters on
+    // the issue: rustup for rustup-managed installs, brew for Homebrew ones.
+    remedies: [
+      "rustup update stable && rustup default stable",
+      "brew upgrade rust   # if rustc came from Homebrew",
+    ],
+  };
+}
+
+/** All matchers, in priority order. */
+const DETECTORS = [detectToolchainFailure];
+
+/**
+ * Explain why `name` exited, given the output it produced.
+ * Returns null when the failure is not one we recognise, so callers keep the
+ * existing generic message rather than inventing an explanation.
+ */
+export function describeServiceFailure(name, exitCode, lines) {
+  for (const detect of DETECTORS) {
+    const hit = detect(lines);
+    if (!hit) continue;
+    return {
+      ...hit,
+      service: name,
+      exitCode,
+      lines: [
+        `${name} could not start: ${hit.summary}`,
+        ...hit.remedies.map((r) => `  ${r}`),
+        "  Then restart agent-canvas.",
+      ],
+    };
+  }
+  return null;
+}

--- a/scripts/service-failure-hints.mjs
+++ b/scripts/service-failure-hints.mjs
@@ -14,6 +14,9 @@
 /** How many recent output lines a service keeps for post-mortem matching. */
 export const SERVICE_OUTPUT_BUFFER_LINES = 200;
 
+/** How many diagnostically-interesting lines are retained regardless of age. */
+export const SERVICE_SIGNIFICANT_LINE_LIMIT = 50;
+
 // `error: rustc 1.93.1 is not supported by the following packages:`
 const RUSTC_UNSUPPORTED_RE = /rustc\s+(\d+\.\d+(?:\.\d+)?)\s+is not supported/i;
 // `aws-config@1.9.0 requires rustc 1.94.1`
@@ -21,6 +24,26 @@ const RUSTC_REQUIRED_RE = /requires rustc\s+(\d+\.\d+(?:\.\d+)?)/i;
 // uv/maturin wrapper lines seen when a native wheel fails to build.
 const MATURIN_FAILURE_RE =
   /maturin\.build_wheel.*failed|Failed to build `[^`]+`/i;
+
+// Lines carrying evidence a post-mortem needs, kept even once older output has
+// been evicted from the recent-output window.
+const SIGNIFICANT_LINE_RES = [
+  MATURIN_FAILURE_RE,
+  RUSTC_UNSUPPORTED_RE,
+  RUSTC_REQUIRED_RE,
+];
+
+/**
+ * True for lines worth keeping even after they fall out of the recent window.
+ *
+ * A build failure and the reason for it can be far apart: uv prints its
+ * `Failed to build` summary first, then replays the captured build log, and
+ * cargo emits a line per crate in between. A bounded tail alone cannot
+ * guarantee both halves of the evidence are present at the same time.
+ */
+export function isSignificantLine(line) {
+  return SIGNIFICANT_LINE_RES.some((re) => re.test(line));
+}
 
 /**
  * Highest version string in `versions`, compared numerically per component.


### PR DESCRIPTION
HUMAN:


Ran the reported rustc/maturin failure through the new diagnosis: before the change the launcher said nothing when a service died at start-up, after it names the toolchain problem and the fix. A clean shutdown still produces no hint. The 15 unit tests pass on Node 24.15.


AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

Validated on Node 24.15, matching the `node-version` pin in `ci.yml`:

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (3 pre-existing warnings in files this PR does not touch)
- `npx prettier --check` on the three changed files — clean. Note `npm run lint`
  only covers `src/`, so `scripts/` formatting was checked separately.
- `npx vitest run __tests__/scripts/service-failure-hints.test.ts` — 15/15
- `npx vitest run __tests__/scripts/dev-with-automation.test.ts` — 46/46, the
  existing launcher suite unaffected
- `npm test` — 579 files, 4619 tests, exit 0
- `npm run build`, `npm run build:lib`, `npm pack --dry-run` — all exit 0

End-to-end behaviour is exercised by two integration tests that call the real
exported `spawnService` on a child process which reproduces the output from
#16300 and exits non-zero, then assert on what the launcher emitted.

---

## Why

`agent-canvas` reports itself ready even when a service died on the way up.

When the automation backend fails — in #16300 because litellm's native wheel
cannot build against an older rustc — `spawnService` logs a single
`Exited with code 1` and start-up continues: ingress starts, the success banner
prints, and the user only discovers something is wrong later, when the Local
backend will not connect. The launcher waits for the agent-server via
`waitForService` and gates on the result; the automation service gets no
equivalent treatment.

This PR does **not** fix the rustc build failure itself — that is the user's
toolchain, and @DevinVinson is right in the issue that there is nothing we can
do about it here. What is ours is that the failure is silent and unexplained.

## Summary

- Add `scripts/service-failure-hints.mjs`: pure matchers over captured output.
  `detectToolchainFailure` fires only when the output contains **both** a failed
  wheel build **and** an unsupported-rustc line, and reports the strictest
  version any crate demands. Unrecognised failures return `null` so the existing
  generic message stands — guessing would be worse than saying nothing.
- Buffer each service's recent output in `spawnService`, and additionally retain
  diagnostically-significant lines regardless of age: uv prints its
  `Failed to build` summary first, replays the captured build log, and cargo
  emits a line per crate in between, so the two halves of the evidence can be
  far more than a bounded tail apart.
- Diagnose on `close` rather than `exit`. `exit` fires as soon as the child
  terminates while its stdio may still hold unread data. With a grandchild
  inheriting stderr — uvx's topology, since it spawns cargo — the exit handler
  observed a single line where `close` saw the whole rustc block.
- Record failures in a registry (`getServiceFailure`), cleared when a service is
  respawned, and print them in the start-up banner so a dead service is not
  hidden behind a ready message.

Instead of a build backtrace followed by `Exited with code 1` and a success
banner, the user now gets:

```
[automation] automation could not start: Rust toolchain too old: found rustc 1.93.1, need 1.94.1 or newer.
[automation]   rustup update stable && rustup default stable
[automation]   brew upgrade rust   # if rustc came from Homebrew
[automation]   Then restart agent-canvas.
```

and, after the banner:

```
✗ automation is not running
  automation could not start: Rust toolchain too old: ...
```

Both remedies are the ones that actually resolved it for reporters in the
issue thread.

## Issue Number

#16300

Addresses the diagnosability half of that report — see Why above for what this
deliberately does not attempt.

## How to Test

1. `npm ci`
2. `npm run typecheck && npm run lint`
3. `npx vitest run __tests__/scripts/service-failure-hints.test.ts` — 15 tests
   covering the matchers, three negative cases, the long-gap retention case,
   and two integration tests over the real `spawnService`
4. `npx vitest run __tests__/scripts/dev-with-automation.test.ts` — 46 existing
   launcher tests, unaffected
5. `npm test`

To see it by hand without an old toolchain, point the launcher at a command
that fails the same way:

```sh
node -e '
import("./scripts/dev-with-automation.mjs").then(async (m) => {
  const { once } = await import("node:events");
  const p = m.spawnService("automation", process.execPath, ["-e", `
    console.error("Call to \`maturin.build_wheel\` failed (exit status: 1)");
    console.error("error: rustc 1.93.1 is not supported by the following packages:");
    console.error("aws-config@1.9.0 requires rustc 1.94.1");
    process.exit(1);
  `]);
  await once(p, "close");
});'
```

## Video/Screenshots

<img width="1799" height="801" alt="image" src="https://github.com/user-attachments/assets/4bb11a37-167c-4854-b0e1-5ed279681b85" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Deliberately not attempted here:

- **Hard-failing start-up.** @jpelletier1 suggested it in the thread. The
  automation backend is one tab rather than the core of the stack, so aborting
  the whole launch when it dies is a behaviour change with much wider blast
  radius than making the failure visible. Happy to add it if you would rather.
- **Other failure classes.** Only the rustc/maturin case is matched, because it
  is the one with reproduction evidence in the issue. `describeServiceFailure`
  takes a list of detectors so more can be added as they are actually observed,
  rather than guessed at.
- **The agent-server path.** The same output appears under `[agent-server]` in
  the report; the fix lives in `spawnService`, so both services are covered
  without special-casing either.

