### PR TITLE
fix(context-meter): draw the ring track from the foreground, not a border token

### DIFF
--- a/__tests__/components/features/chat/components/context-window-meter.test.tsx
+++ b/__tests__/components/features/chat/components/context-window-meter.test.tsx
@@ -96,6 +96,32 @@ describe("ContextWindowMeter", () => {
     );
   });
 
+  // The trigger must share the actions-row icon-button hover fill. Its own
+  // `--oh-interactive-hover` fill was both wrong for this surface (that token
+  // is for 800 backgrounds; the composer is `--oh-surface`) and identical in
+  // value to `--oh-border`, which the ring track used, so hovering erased the
+  // track. `context-window-ring.test.tsx` asserts the resulting contrast.
+  it("uses the shared chat-input icon button styling for its hover fill", () => {
+    useMetricsStore.setState({
+      cost: null,
+      max_budget_per_task: null,
+      usage: {
+        prompt_tokens: 0,
+        completion_tokens: 0,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        context_window: 1_000_000,
+        per_turn_token: 198_500,
+      },
+    });
+
+    renderWithProviders(<ContextWindowMeter />);
+
+    const trigger = screen.getByTestId("context-window-meter");
+    expect(trigger).toHaveClass("hover:bg-white/10");
+    expect(trigger.className).not.toContain("--oh-interactive-hover");
+  });
+
   it("opens a popover with compact usage details", () => {
     useMetricsStore.setState({
       cost: null,

--- a/__tests__/components/features/chat/components/context-window-ring.test.tsx
+++ b/__tests__/components/features/chat/components/context-window-ring.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  ContextWindowRing,
+  CONTEXT_WINDOW_RING_TRACK_ALPHA,
+} from "#/components/features/chat/components/context-window-ring";
+import { COLOR_THEMES } from "#/themes/color-themes";
+
+/**
+ * WCAG 2.1 SC 1.4.11 asks 3:1 for non-text contrast. The ring's track carries
+ * information (the arc's proportion is only readable against it), so it is held
+ * to that bar rather than treated as chrome.
+ */
+const MIN_RATIO = 3;
+
+/**
+ * Themes are read from `color-themes.ts`, not from a stylesheet. `index.css`
+ * ships the deepsea scale but `DEFAULT_COLOR_THEME` overrides it at runtime, so
+ * a stylesheet-derived assertion validates a palette no default install renders.
+ */
+const SURFACE_STOP = "--cool-grey-925"; // --oh-surface, the composer background
+const FOREGROUND_STOP = "--cool-grey-100"; // --oh-foreground, the neutral arc
+
+/** `chatInputIconButtonClassName` fills the trigger with `hover:bg-white/10`. */
+const HOVER_OVERLAY = "#FFFFFF";
+const HOVER_ALPHA = 0.1;
+
+function channels(hex: string): [number, number, number] {
+  const h = hex.replace("#", "");
+  return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16)) as [
+    number,
+    number,
+    number,
+  ];
+}
+
+function relativeLuminance(hex: string): number {
+  const [r, g, b] = channels(hex).map((channel) => {
+    const c = channel / 255;
+    return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrastRatio(a: string, b: string): number {
+  const [high, low] = [relativeLuminance(a), relativeLuminance(b)].sort(
+    (x, y) => y - x,
+  );
+  return (high + 0.05) / (low + 0.05);
+}
+
+/** Composite a translucent overlay onto an opaque backdrop. */
+function composite(overlay: string, backdrop: string, alpha: number): string {
+  const o = channels(overlay);
+  const b = channels(backdrop);
+  return `#${o
+    .map((channel, i) =>
+      Math.round(alpha * channel + (1 - alpha) * b[i])
+        .toString(16)
+        .padStart(2, "0"),
+    )
+    .join("")}`.toUpperCase();
+}
+
+describe("ContextWindowRing", () => {
+  it("draws the track and the arc in different tones", () => {
+    render(<ContextWindowRing percentage={5} />);
+
+    const track = screen.getByTestId("context-window-ring-track");
+    const arc = screen.getByTestId("context-window-ring-arc");
+
+    expect(track.style.stroke).not.toEqual(arc.getAttribute("stroke"));
+  });
+
+  it("derives the track from the foreground rather than a scale stop", () => {
+    render(<ContextWindowRing percentage={5} />);
+
+    // A stop-pinned track cannot hold across palettes; see the constant's docs.
+    expect(screen.getByTestId("context-window-ring-track").style.stroke).toEqual(
+      expect.stringContaining("var(--oh-foreground)"),
+    );
+  });
+
+  /**
+   * Read the alpha back out of what the component actually renders, so the
+   * contrast cases below describe the shipped track rather than a constant that
+   * could drift away from it.
+   */
+  function renderedTrackAlpha(): number {
+    render(<ContextWindowRing percentage={5} />);
+    const { stroke } = screen.getByTestId("context-window-ring-track").style;
+    const percent = stroke.match(/var\(--oh-foreground\)\s+([\d.]+)%/);
+    if (!percent) {
+      throw new Error(`track is not a foreground mix: ${stroke}`);
+    }
+    return Number(percent[1]) / 100;
+  }
+
+  it("renders the alpha it documents", () => {
+    expect(renderedTrackAlpha()).toBeCloseTo(CONTEXT_WINDOW_RING_TRACK_ALPHA, 5);
+  });
+
+  describe.each(Object.entries(COLOR_THEMES))(
+    "contrast under the %s palette",
+    (_key, theme) => {
+      const surface = theme.scale[SURFACE_STOP];
+      const arc = theme.scale[FOREGROUND_STOP];
+      const hoverFill = composite(HOVER_OVERLAY, surface, HOVER_ALPHA);
+
+      it("keeps the track legible against the composer surface", () => {
+        const track = composite(arc, surface, renderedTrackAlpha());
+
+        expect(contrastRatio(track, surface)).toBeGreaterThanOrEqual(MIN_RATIO);
+      });
+
+      it("keeps the track legible under the trigger's hover fill", () => {
+        const track = composite(arc, hoverFill, renderedTrackAlpha());
+
+        expect(contrastRatio(track, hoverFill)).toBeGreaterThanOrEqual(
+          MIN_RATIO,
+        );
+      });
+
+      it("keeps a neutral arc distinguishable from the track in both states", () => {
+        const alpha = renderedTrackAlpha();
+
+        expect(
+          contrastRatio(arc, composite(arc, surface, alpha)),
+        ).toBeGreaterThanOrEqual(MIN_RATIO);
+        expect(
+          contrastRatio(arc, composite(arc, hoverFill, alpha)),
+        ).toBeGreaterThanOrEqual(MIN_RATIO);
+      });
+    },
+  );
+});

--- a/src/components/features/chat/components/context-window-meter.tsx
+++ b/src/components/features/chat/components/context-window-meter.tsx
@@ -11,12 +11,16 @@ import { StyledTooltip } from "#/components/shared/buttons/styled-tooltip";
 import { I18nKey } from "#/i18n/declaration";
 import { Divider } from "#/ui/divider";
 import { cn } from "#/utils/utils";
+import { chatInputIconButtonClassName } from "#/utils/form-control-classes";
 import {
   formatCompactTokenCount,
   getContextWindowUsagePercentage,
 } from "#/utils/format-token-count";
 import { getContextFillTone } from "#/components/features/conversation/usage-panel/context-meter";
-import { ContextWindowRing } from "./context-window-ring";
+import {
+  ContextWindowRing,
+  CONTEXT_WINDOW_TRACK_COLOR,
+} from "./context-window-ring";
 
 const TONE_BAR_CLASS = {
   neutral: "bg-foreground",
@@ -72,7 +76,7 @@ export function ContextWindowMeter() {
         <button
           ref={triggerRef}
           type="button"
-          className="flex size-8 items-center justify-center rounded-full hover:bg-[var(--oh-interactive-hover)] transition-colors"
+          className={cn(chatInputIconButtonClassName, "size-8")}
           aria-label={`${t(I18nKey.CHAT_INTERFACE$CONTEXT_WINDOW_METER_LABEL)}: ${usagePercentLabel}`}
           aria-expanded={isPopoverOpen}
           aria-haspopup="dialog"
@@ -109,7 +113,8 @@ export function ContextWindowMeter() {
             <button
               type="button"
               data-testid="context-window-meter-bar-button"
-              className="relative h-1.5 w-full rounded-full bg-[var(--oh-border)] cursor-pointer"
+              className="relative h-1.5 w-full rounded-full cursor-pointer"
+              style={{ backgroundColor: CONTEXT_WINDOW_TRACK_COLOR }}
               aria-label={t(I18nKey.COMMON$USAGE)}
               onClick={(event) => {
                 event.preventDefault();

--- a/src/components/features/chat/components/context-window-ring.tsx
+++ b/src/components/features/chat/components/context-window-ring.tsx
@@ -4,6 +4,28 @@ import { getContextFillTone } from "#/components/features/conversation/usage-pan
 const CONTEXT_WINDOW_RING_SIZE = 16;
 const CONTEXT_WINDOW_RING_STROKE = 2;
 
+/**
+ * Opacity of the ring's unfilled track, as a fraction of `--oh-foreground`.
+ *
+ * The track is derived from the foreground rather than pinned to a scale stop.
+ * It carries information (the arc's proportion is only readable against it), so
+ * it is a foreground element, and every stop in the surface family sits close
+ * to the surfaces it delimits. Drawing it with `--oh-border` put it in that
+ * family: it was 1.57:1 against the composer at rest, and the trigger's hover
+ * fill resolves to the same stop, taking it to 1.00:1. No stop in that family
+ * fixes it, and no fixed stop holds across the three palettes in
+ * `color-themes.ts`, whose scales differ.
+ *
+ * Compositing the foreground over whatever the active theme paints keeps the
+ * track between surface and arc by construction rather than by coincidence.
+ * 42% is the value that maximises the worst case across the shipped palettes;
+ * `context-window-ring.test.tsx` asserts it per theme.
+ */
+export const CONTEXT_WINDOW_RING_TRACK_ALPHA = 0.42;
+
+/** Shared by the ring's track and the popover's usage bar, which had the same defect. */
+export const CONTEXT_WINDOW_TRACK_COLOR = `color-mix(in srgb, var(--oh-foreground) ${CONTEXT_WINDOW_RING_TRACK_ALPHA * 100}%, transparent)`;
+
 const TONE_STROKE = {
   neutral: "var(--oh-foreground)",
   warning: "#f59e0b", // amber-500
@@ -38,8 +60,9 @@ export function ContextWindowRing({
         cy={CONTEXT_WINDOW_RING_SIZE / 2}
         r={radius}
         fill="none"
-        stroke="var(--oh-border)"
+        style={{ stroke: CONTEXT_WINDOW_TRACK_COLOR }}
         strokeWidth={CONTEXT_WINDOW_RING_STROKE}
+        data-testid="context-window-ring-track"
       />
       <circle
         cx={CONTEXT_WINDOW_RING_SIZE / 2}
@@ -53,6 +76,7 @@ export function ContextWindowRing({
         strokeDashoffset={dashOffset}
         transform={`rotate(-90 ${CONTEXT_WINDOW_RING_SIZE / 2} ${CONTEXT_WINDOW_RING_SIZE / 2})`}
         className="transition-[stroke-dashoffset,stroke] duration-300"
+        data-testid="context-window-ring-arc"
       />
     </svg>
   );


### PR DESCRIPTION
HUMAN:

confirmed working in my browser

AGENT:

Implementation and verification are complete. #16532 carries `ready-for-dev`.

The branch was force-pushed shortly after this PR was opened so the diff matches this description; the earlier red CI run was against the superseded commit and the current head is green.

Verified end to end in a running app, not only unit tests. Full local stack from source, `npm run dev:static` so the assets are the production build, against a real conversation on the default `openhands-neutral` palette. The same stack was rebuilt from `main` and from this branch with nothing else changed, and both states were captured below. Every colour below was read out of the live app with `getComputedStyle`, not derived from a stylesheet.

---

## Why

The context window ring loses its track on hover, so at low usage the control reads as a blank disc with a dot on it rather than a meter.

The collision is the obvious part: the track is stroked `var(--oh-border)` and the trigger paints `hover:bg-[var(--oh-interactive-hover)]` behind it, and both dereference `--cool-grey-700`. But that is the amplifier, not the cause. Give the button the hover token it should have had, so the two are no longer equal, and the track is still 1.17:1 on the default theme. Move it a stop lighter as well and it is 1.65:1. Every stop in the surface family lands between 1.07 and 1.65:1. It also failed before hover was involved, at 1.57:1 against the composer at rest.

The cause is that the track is an information-bearing element coloured out of the surface family. The arc alone says nothing; its proportion is only readable against the track, which makes the track foreground. Every stop in the border and surface family sits close to the surfaces it delimits, and a hover state layer is a lightened surface, so nothing drawn from that family can be reliably distinguishable from it.

## Summary

- The track is derived from `--oh-foreground` and composited over whatever the active theme paints, so it stays between surface and arc by construction rather than by a value that happens to work. Shared by the ring and the popover's usage bar, which had the same defect.
- The trigger uses `chatInputIconButtonClassName`, which every other icon button in that row already uses. Its old hover token is documented for 800-level surfaces while the composer renders on `--oh-surface`. That is a real defect on its own and not why the track vanished.
- Tests read the scales from `color-themes.ts` and assert contrast per theme, parsing the alpha back out of what the component renders so they describe the shipped value rather than a constant that can drift from it.

## Issue Number

Fixes #16532

## How to Test

`npm install && npm run dev`, start a conversation, hover the circular meter left of the send button at low context usage. The ring should stay visible under the hover fill.

One caveat worth knowing: under `npm run dev` the trigger's hover fill does not paint at all, on this branch or on `main`. Tailwind's preflight zeroes `button` backgrounds unlayered while the hover utility sits in `@layer utilities`, and unlayered wins regardless of specificity. The production build resolves the pair the other way. So hover styling has to be checked with `npm run dev:static` or a real build to see what ships. That is a separate defect and I will report it on its own.

Unit: `npm test -- context-window`. To watch the assertions catch the original bug, point the track at a scale stop instead; eleven cases fail.

Full run on this branch: lint clean with 0 errors, 4617 tests passing across 580 files, `npm run build` succeeds.

## Video/Screenshots

Captured from a running instance on the default `openhands-neutral` palette, production build, real `:hover`. Same conversation and same stack throughout; within each pair the only difference is which commit built the bundle.

Hovered, on `main`. The hover fill and the track are the same colour, so the ring is gone and only the arc survives:

<img width="274" height="189" src="https://github.com/user-attachments/assets/72522b40-2c94-4332-8616-2d0484168ee9" />

Hovered, on this branch:

<img width="274" height="189" src="https://github.com/user-attachments/assets/0b720a20-4701-452b-8c2d-6d6177ca48bc" />

At rest, before hover is involved, the track is already faint at 1.57:1 against the composer surface. `main` first: 

<img width="274" height="189" src="https://github.com/user-attachments/assets/856d1c5e-9e1e-4277-b4da-c71747fcebaa" />

then this branch:
<img width="274" height="189" src="https://github.com/user-attachments/assets/588402ff-a2c5-4763-aa0f-4d0f6230a077" />

## Type

- [x] Bug fix

## Notes

Measured on the running production build, default palette:

| | before | after |
|---|---|---|
| track vs composer surface | 1.57:1 | 3.59:1 |
| track vs trigger hover fill | 1.00:1 | 3.14:1 |
| neutral arc vs track, at rest | | 3.84:1 |
| neutral arc vs track, hovered | | 3.25:1 |

Why derived rather than a different token: `color-themes.ts` ships three scales and `DEFAULT_COLOR_THEME` is `openhands-neutral`, whose values differ from the deepsea scale hardcoded in `index.css`. No single stop satisfies all of them. `--oh-text-dim` clears 3:1 on deepsea and misses on the default at 2.55:1, and the stops bright enough everywhere collapse arc-versus-track instead. Worth flagging separately that `index.css` is overridden at runtime by the theme system, so it is not a sound source of truth for what an install renders.

Left alone deliberately: the `warning` and `danger` arcs are raw Tailwind hexes rather than tokens, so they cannot participate in theming, and no track colour clears 3:1 against both of those and both backdrops at once. That is a visual design decision for the people who own the palette rather than mine to make, and fixing the track does not depend on it. Happy to take it as a follow-up if you want the tone colours tokenised.


