### PR TITLE
fix: preserve URL fragments in backend-scoped paths

### DIFF
--- a/__tests__/api/backend-registry/url-selection.test.ts
+++ b/__tests__/api/backend-registry/url-selection.test.ts
@@ -65,6 +65,31 @@ describe("withBackendSelectionParams", () => {
       `/conversations/abc?tab=files&${BACKEND_QUERY_PARAM}=local-1`,
     );
   });
+
+  it("preserves a fragment after existing query parameters", () => {
+    const path = withBackendSelectionParams(
+      "/conversations/abc?tab=files#details",
+      {
+        backend: localBackend,
+        orgId: null,
+      },
+    );
+
+    expect(path).toBe(
+      `/conversations/abc?tab=files&${BACKEND_QUERY_PARAM}=local-1#details`,
+    );
+  });
+
+  it("preserves a fragment when the path has no query parameters", () => {
+    const path = withBackendSelectionParams("/conversations/abc#details", {
+      backend: localBackend,
+      orgId: null,
+    });
+
+    expect(path).toBe(
+      `/conversations/abc?${BACKEND_QUERY_PARAM}=local-1#details`,
+    );
+  });
 });
 
 describe("readBackendSelectionFromUrl", () => {

--- a/src/api/backend-registry/url-selection.ts
+++ b/src/api/backend-registry/url-selection.ts
@@ -28,12 +28,19 @@ export function withBackendSelectionParams(
   const { backend, orgId } = active;
   if (!backend.id) return path;
 
-  const [pathname, existingSearch = ""] = path.split("?");
+  const hashIndex = path.indexOf("#");
+  const pathAndSearch = hashIndex === -1 ? path : path.slice(0, hashIndex);
+  const hash = hashIndex === -1 ? "" : path.slice(hashIndex);
+  const queryIndex = pathAndSearch.indexOf("?");
+  const pathname =
+    queryIndex === -1 ? pathAndSearch : pathAndSearch.slice(0, queryIndex);
+  const existingSearch =
+    queryIndex === -1 ? "" : pathAndSearch.slice(queryIndex + 1);
   const params = new URLSearchParams(existingSearch);
   params.set(BACKEND_QUERY_PARAM, backend.id);
   if (orgId) params.set(ORG_QUERY_PARAM, orgId);
 
-  return `${pathname}?${params.toString()}`;
+  return `${pathname}?${params.toString()}${hash}`;
 }
 
 /**


### PR DESCRIPTION
HUMAN:

AGENT:

This draft fixes OpenHands/OpenHands#16535, where backend-scoped links with URL fragments were reconstructed incorrectly. The fragment was parsed as part of the last query parameter and encoded as `%23`, so links such as conversation tabs lost their fragment when a backend parameter was appended.

---

## Why

`withBackendSelectionParams` split paths only at `?`, so an input such as `/conversations/abc?tab=files#details` was serialized as `/conversations/abc?tab=files%23details&backend=local-1`. The helper should preserve URL structure and keep the fragment after the query string.

## Summary

- Separate the fragment before parsing existing query parameters and append it after the generated backend/org query parameters.
- Add regression coverage for query-plus-fragment and fragment-only paths.

## Issue Number

Fixes #16535

## How to Test

From the repository root:

```sh
npm ci
npm test -- __tests__/api/backend-registry/url-selection.test.ts
npm run lint
npm test
npm run build
npm run build:lib
npm pack --dry-run
```

Targeted regression result: 1 file passed, 10 tests passed.

The full test suite completed with 4,601 tests passed and 5 pre-existing Windows path-separator failures in `agent-server-adapter`, `resolve-affected-tests`, and `stryker-diff`; the changed test file passed independently.

## Video/Screenshots

Reproduction notes for the deterministic URL helper:

```text
Before: /conversations/abc?tab=files%23details&backend=local-1
After:  /conversations/abc?tab=files&backend=local-1#details

Fragment-only input:
After:  /conversations/abc?backend=local-1#details
```

The Vitest regression tests assert both fixed outputs without network access, browser state, or API keys.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- No production dependencies or public API signatures changed.
- This PR is kept as a draft until the required human testing note and repository readiness label are supplied.
