### PR TITLE
fix: seed automation prompt on home page chat input (Fixes #16540)

### DIFF
--- a/src/hooks/chat/use-chat-input-logic.ts
+++ b/src/hooks/chat/use-chat-input-logic.ts
@@ -37,9 +37,14 @@ export const useChatInputLogic = () => {
   // mechanism is not relevant.  More importantly, a stale messageToSend value
   // in the Zustand store causes useAutoResize to overwrite the just-restored
   // sessionStorage draft with an empty string (see useAutoResize value effect).
-  // Returning null here keeps value=undefined in useAutoResize so it never
-  // touches the element content on the home page.
-  const messageToSend = conversationId ? rawMessageToSend : null;
+  // We still let a non-empty messageToSend through (e.g. the seeded prompt from
+  // useLaunchSkillInChat when creating an automation), but only when it has
+  // actual content — an empty stale value would clobber the restored draft.
+  // The useAutoResize's onValueApplied callback clears the value one-shot.
+  const messageToSend =
+    conversationId || (rawMessageToSend?.text.trim().length ?? 0) > 0
+      ? rawMessageToSend
+      : null;
 
   // Restore a cancelled pending send back into the input only when empty.
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes #16540 — clicking **Add automation** on the automations page redirected to the home splash page with no seeded prompt, so the user had no idea what to do next.

## Root cause

`useLaunchSkillInChat` (used by the automation "Create Automation" button) calls `navigate("/conversations")` and then sets `messageToSend` via the conversation store. However, `useChatInputLogic` returned a hard-coded `null` for `messageToSend` whenever there was no `conversationId` (i.e. on the home page):

```ts
const messageToSend = conversationId ? rawMessageToSend : null;
```

That guard exists to prevent a *stale* `messageToSend` from clobbering the just-restored sessionStorage draft with an empty string via `useAutoResize`. But it also swallowed the legitimate seeded prompt from the automation flow.

## Fix

Let a non-empty `messageToSend` flow through on the home page, while still filtering out empty stale values that would wipe the restored draft:

```ts
const messageToSend =
  conversationId || (rawMessageToSend?.text.trim().length ?? 0) > 0
    ? rawMessageToSend
    : null;
```

- Non-empty seeded prompt (automation flow) → passes through → `useAutoResize` writes it into the chat input and `onValueApplied` clears it one-shot.
- Empty/stale value → still `null` → `useAutoResize` never touches the element content on the home page (preserves the existing draft-restore behavior).

## Acceptance criteria

- [x] Clicking add automations button opens an empty/active conversation
- [x] The empty conversation has a seeded prompt in the input
- [x] User can modify the seeded prompt prior to submitting their first message
