### PR TITLE
fix: honor home LLM selection at conversation launch

### DIFF
--- a/src/hooks/mutation/conversation-mutation-utils.test.ts
+++ b/src/hooks/mutation/conversation-mutation-utils.test.ts
@@ -1,11 +1,26 @@
 import { describe, expect, it } from "vitest";
 import { QueryClient } from "@tanstack/react-query";
 import {
+  resolveLaunchProfile,
   updateConversationExecutionStatusInCache,
   updateConversationLlmModelInCache,
 } from "./conversation-mutation-utils";
-import { ExecutionStatus } from "#/types/agent-server/core/base/common";
+import type { AgentProfileListResponse } from "#/api/agent-profiles-service/agent-profiles-service.api";
+import type { ProfileListResponse } from "#/api/profiles-service/profiles-service.api";
 import { AppConversation } from "#/api/conversation-service/agent-server-conversation-service.types";
+import { ExecutionStatus } from "#/types/agent-server/core/base/common";
+
+const agentProfiles = (profile: Record<string, unknown>) =>
+  ({
+    profiles: [profile],
+    active_agent_profile_id: profile.id,
+  }) as unknown as AgentProfileListResponse;
+
+const llmProfiles = (activeProfile: string, ...names: string[]) =>
+  ({
+    active_profile: activeProfile,
+    profiles: names.map((name) => ({ name })),
+  }) as unknown as ProfileListResponse;
 
 const createConversation = (): AppConversation => ({
   id: "conversation-1",
@@ -25,6 +40,64 @@ const createConversation = (): AppConversation => ({
   session_api_key: "session-key",
   sandbox_id: null,
   sub_conversation_ids: [],
+});
+
+describe("resolveLaunchProfile", () => {
+  it("honors a home dropdown selection over a named profile's pinned model", () => {
+    const profile = {
+      id: "agent-profile-1",
+      name: "openhands-luna",
+      agent_kind: "openhands",
+      llm_profile_ref: "pinned-model",
+    };
+
+    expect(
+      resolveLaunchProfile({
+        requestedAgentProfileId: profile.id as string,
+        agentProfiles: agentProfiles(profile),
+        llmProfiles: llmProfiles(
+          "selected-model",
+          "pinned-model",
+          "selected-model",
+        ),
+        isCloud: false,
+      }),
+    ).toMatchObject({
+      effectiveAgentProfileId: undefined,
+      launchLlmProfileRef: "selected-model",
+      downgradeReason: "dropdown-llm-profile-selected",
+    });
+  });
+
+  it("keeps the named profile path when its pinned model is selected", () => {
+    const profile = {
+      id: "agent-profile-1",
+      name: "openhands-luna",
+      agent_kind: "openhands",
+      llm_profile_ref: "pinned-model",
+    };
+
+    expect(
+      resolveLaunchProfile({
+        requestedAgentProfileId: profile.id as string,
+        agentProfiles: agentProfiles(profile),
+        llmProfiles: llmProfiles("pinned-model", "pinned-model"),
+        isCloud: false,
+      }),
+    ).toMatchObject({
+      effectiveAgentProfileId: profile.id,
+      launchLlmProfileRef: "pinned-model",
+    });
+  });
+
+  it("uses the active LLM profile when no agent profile is requested", () => {
+    expect(
+      resolveLaunchProfile({
+        llmProfiles: llmProfiles("selected-model", "selected-model"),
+        isCloud: false,
+      }),
+    ).toEqual({ launchLlmProfileRef: "selected-model" });
+  });
 });
 
 describe("updateConversationExecutionStatusInCache", () => {

--- a/src/hooks/mutation/conversation-mutation-utils.ts
+++ b/src/hooks/mutation/conversation-mutation-utils.ts
@@ -4,10 +4,197 @@ import type { StartGoalRequest } from "@openhands/typescript-client";
 import { getActiveBackend } from "#/api/backend-registry/active-store";
 import { pauseCloudSandbox } from "#/api/cloud/conversation-service.api";
 import { getAgentServerClientOptions } from "#/api/agent-server-client-options";
+import {
+  WELL_KNOWN_DEFAULT_AGENT_PROFILE_NAME,
+  type AgentProfileListResponse,
+} from "#/api/agent-profiles-service/agent-profiles-service.api";
+import type { ProfileListResponse } from "#/api/profiles-service/profiles-service.api";
 import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
 import { AppConversation } from "#/api/conversation-service/agent-server-conversation-service.types";
+import type { AgentKind } from "#/types/settings";
 
 type ExecutionStatusValue = AppConversation["execution_status"];
+
+export interface ResolveLaunchProfileOptions {
+  /**
+   * Explicitly requested agent profile id, or the backend's
+   * `active_agent_profile_id` when the home launcher didn't name one (#3727).
+   * Undefined when no agent profile is involved at all (plain agent_settings
+   * launch).
+   */
+  requestedAgentProfileId?: string | null;
+  /** Agent-profile list, as fetched through the shared query cache. */
+  agentProfiles?: AgentProfileListResponse;
+  /**
+   * LLM-profile list; carries the account-wide `active_profile` that the
+   * home-page LLM dropdown activates. Undefined when the list couldn't be
+   * fetched (older backend, or the fetch failed).
+   */
+  llmProfiles?: ProfileListResponse;
+  /**
+   * Cloud backends never carry an `agent_settings` payload to fall back to, so
+   * every profile-path downgrade below is local-only (see #3727 review).
+   */
+  isCloud: boolean;
+}
+
+/**
+ * Why a launch that would have used an AgentProfile id instead fell back to
+ * the agent_settings path. Kept for diagnosable traces; the UI treats all
+ * downgrades as the plain launch path.
+ */
+export type LaunchProfileDowngradeReason =
+  | "default-baseline"
+  | "missing-llm-profile-ref"
+  | "dropdown-llm-profile-selected";
+
+export interface ResolveLaunchProfileResult {
+  /** `agent_profile_id` to send; undefined → launch from agent_settings. */
+  effectiveAgentProfileId?: string;
+  /** Kind of the resolved agent profile, forwarded with the id (#3727). */
+  agentProfileKind?: AgentKind;
+  /**
+   * The LLM profile the conversation will actually run, for the #1082
+   * metadata stamp: the pinned `llm_profile_ref` when a named OpenHands
+   * profile drives the launch, otherwise the account-wide active LLM profile
+   * (the home-dropdown selection). Null when neither is known.
+   */
+  launchLlmProfileRef: string | null;
+  downgradeReason?: LaunchProfileDowngradeReason;
+}
+
+/**
+ * Resolve which AgentProfile (if any) a new conversation launches from, and
+ * which LLM profile it will therefore run.
+ *
+ * The active AgentProfile is the default launch profile for new conversations
+ * (#3727). A named OpenHands profile pins an LLM profile via
+ * `llm_profile_ref`, and launching through it makes the server run that pinned
+ * model. That pin is what the home-page LLM dropdown overrides: the dropdown
+ * activates an account-wide LLM profile (`active_profile` on
+ * `/api/profiles`), so when it differs from the pinned ref the user explicitly
+ * picked a different model and the selection must win (#16539) — launch via
+ * agent_settings instead, which reflects the active LLM profile.
+ *
+ * The seeded OpenHands `default` profile is the enriched baseline, not a
+ * deliberate profile pick — it mirrors global agent_settings, so it always
+ * launches via agent_settings so the canvas-only enrichments the
+ * profile-resolution path drops survive for the common home-launch (the
+ * `<RUNTIME_SERVICES>` system-message suffix and project-skill loading).
+ * Named profiles are deliberate custom configs and still use the profile path
+ * unless the dropdown overrides their model.
+ *
+ * ACP profiles carry no LLM profile at all, so they're never gated here and
+ * always keep the profile path.
+ */
+export function resolveLaunchProfile(
+  options: ResolveLaunchProfileOptions,
+): ResolveLaunchProfileResult {
+  const { requestedAgentProfileId, agentProfiles, llmProfiles, isCloud } =
+    options;
+
+  // No agent profile → the plain agent_settings path, which reflects the
+  // account-wide active LLM profile (the home-dropdown selection).
+  if (!requestedAgentProfileId) {
+    return { launchLlmProfileRef: llmProfiles?.active_profile ?? null };
+  }
+
+  const resolvedAgentProfile = agentProfiles?.profiles?.find(
+    (profile) => profile.id === requestedAgentProfileId,
+  );
+
+  // A requested profile the list doesn't know (stale pointer) still launches
+  // by id; the server resolves or rejects it.
+  if (!resolvedAgentProfile) {
+    return {
+      effectiveAgentProfileId: requestedAgentProfileId,
+      launchLlmProfileRef: llmProfiles?.active_profile ?? null,
+    };
+  }
+
+  const isOpenHands = resolvedAgentProfile.agent_kind === "openhands";
+
+  // The seeded `default` baseline is global agent_settings, not a deliberate
+  // profile pick: launch it via agent_settings so the canvas-only enrichments
+  // survive. Scoped to OpenHands (an ACP `default` must keep the profile
+  // path) and to local (cloud never writes agent_settings, so it always
+  // resolves `default` server-side via agent_profile_id).
+  if (
+    !isCloud &&
+    isOpenHands &&
+    resolvedAgentProfile.name === WELL_KNOWN_DEFAULT_AGENT_PROFILE_NAME
+  ) {
+    return {
+      effectiveAgentProfileId: undefined,
+      agentProfileKind: resolvedAgentProfile.agent_kind,
+      launchLlmProfileRef: llmProfiles?.active_profile ?? null,
+      downgradeReason: "default-baseline",
+    };
+  }
+
+  // Named OpenHands profiles pin an LLM profile by ref. Validate the ref
+  // exists: the agent-server seeds a `default` profile whose ref can point at
+  // an LLM profile that doesn't exist (fresh store, or one configured with
+  // named profiles only); launching from it 404s and would brick home-launch.
+  // When the ref is valid it normally drives the launch — unless the user
+  // explicitly selected a different model in the home LLM dropdown, in which
+  // case the account-wide active LLM profile wins over the pinned ref (#16539).
+  if (isOpenHands && resolvedAgentProfile.llm_profile_ref) {
+    const llmProfileExists =
+      llmProfiles?.profiles.some(
+        (profile) => profile.name === resolvedAgentProfile.llm_profile_ref,
+      ) ?? false;
+
+    if (!llmProfileExists) {
+      // Launching from a profile whose ref doesn't resolve 404s ("LLM
+      // profile '<ref>' not found") and would brick home-launch. The
+      // agent-server seeds a `default` profile whose llm_profile_ref can
+      // point at an LLM profile that doesn't exist (fresh store, or one
+      // configured with named profiles only), and any named profile can
+      // dangle the same way. agent_settings reflects the active LLM, so the
+      // fallback degrades cleanly until the seed mirrors it (SDK #3933).
+      return {
+        effectiveAgentProfileId: undefined,
+        agentProfileKind: resolvedAgentProfile.agent_kind,
+        launchLlmProfileRef: llmProfiles?.active_profile ?? null,
+        downgradeReason: "missing-llm-profile-ref",
+      };
+    }
+
+    if (
+      !isCloud &&
+      llmProfiles?.active_profile &&
+      llmProfiles.active_profile !== resolvedAgentProfile.llm_profile_ref
+    ) {
+      // The home LLM dropdown selected a different profile than the one the
+      // active named AgentProfile pins: honor the dropdown by launching from
+      // agent_settings (which reflects the active LLM profile) instead of the
+      // pinned ref, so the next conversation runs the model the user picked.
+      // Local-only: cloud has no agent_settings fallback payload.
+      return {
+        effectiveAgentProfileId: undefined,
+        agentProfileKind: resolvedAgentProfile.agent_kind,
+        launchLlmProfileRef: llmProfiles.active_profile,
+        downgradeReason: "dropdown-llm-profile-selected",
+      };
+    }
+
+    return {
+      effectiveAgentProfileId: requestedAgentProfileId,
+      agentProfileKind: resolvedAgentProfile.agent_kind,
+      launchLlmProfileRef: resolvedAgentProfile.llm_profile_ref,
+    };
+  }
+
+  // An OpenHands profile without a ref (shouldn't occur — the openhands
+  // variant requires llm_profile_ref) or an ACP profile: keep the profile
+  // path; the LLM comes from the active profile.
+  return {
+    effectiveAgentProfileId: requestedAgentProfileId,
+    agentProfileKind: resolvedAgentProfile.agent_kind,
+    launchLlmProfileRef: llmProfiles?.active_profile ?? null,
+  };
+}
 
 const fetchConversationData = async (
   conversationId: string,

--- a/src/hooks/mutation/use-create-conversation.ts
+++ b/src/hooks/mutation/use-create-conversation.ts
@@ -7,9 +7,10 @@ import { useTracking } from "#/hooks/use-tracking";
 import { useLlmProfiles } from "#/hooks/query/use-llm-profiles";
 import { useAgentProfiles } from "#/hooks/query/use-agent-profiles";
 import { useActiveBackend } from "#/contexts/active-backend-context";
-import ProfilesService from "#/api/profiles-service/profiles-service.api";
+import ProfilesService, {
+  type ProfileListResponse,
+} from "#/api/profiles-service/profiles-service.api";
 import AgentProfilesService, {
-  WELL_KNOWN_DEFAULT_AGENT_PROFILE_NAME,
   type AgentProfileListResponse,
 } from "#/api/agent-profiles-service/agent-profiles-service.api";
 import PluginsManagementService, {
@@ -22,6 +23,7 @@ import {
   AGENT_PROFILES_RETRY_OPTIONS,
 } from "#/hooks/query/query-keys";
 import { pluginReferenceKey } from "#/utils/plugin-display";
+import { resolveLaunchProfile } from "#/hooks/mutation/conversation-mutation-utils";
 import {
   getStoredConversationMetadata,
   setStoredConversationMetadata,
@@ -114,61 +116,21 @@ export const useCreateConversation = () => {
       const requestedAgentProfileId =
         agentProfileId ?? agentProfiles?.active_agent_profile_id ?? undefined;
 
-      // Fall back to the legacy agent_settings launch when the resolved agent
-      // profile can't resolve its LLM. The agent-server seeds a `default`
-      // openhands profile whose `llm_profile_ref` can point at an LLM profile
-      // that doesn't exist (fresh store, or one configured with named profiles
-      // only); launching from it 404s ("LLM profile '<ref>' not found") and
-      // would brick home-launch. agent_settings reflects the active LLM, so the
-      // fallback degrades cleanly until the seed mirrors it (SDK #3933).
-      // ACP profiles carry no llm_profile_ref, so they're never gated here.
+      // Await the LLM-profile list whenever an OpenHands agent profile could
+      // drive the launch, rather than reading the maybe-unresolved
+      // `useLlmProfiles()` result: a send fired before that query loads (or
+      // after it errors) must still validate the pinned llm_profile_ref and
+      // detect an explicit home-dropdown selection (#16539), not launch blind.
+      // ACP profiles carry no LLM profile, so the fetch is skipped for them.
       const resolvedAgentProfile = requestedAgentProfileId
         ? agentProfiles?.profiles?.find(
             (profile) => profile.id === requestedAgentProfileId,
           )
         : undefined;
-      // Cloud has no `agent_settings` payload to fall back to — the downgrade
-      // below only makes sense on local, where it exists and carries the
-      // canvas-only enrichments. Gating it here keeps cloud always launching
-      // from the resolved profile id, so the conversation gets
-      // `launched_agent_profile` stamped and the profile's config applied
-      // (#1571 review).
-      const isCloud = backend.kind === "cloud";
-      let effectiveAgentProfileId = requestedAgentProfileId;
-      if (
-        !isCloud &&
-        resolvedAgentProfile?.name === WELL_KNOWN_DEFAULT_AGENT_PROFILE_NAME &&
-        resolvedAgentProfile?.agent_kind === "openhands"
-      ) {
-        // The seeded OpenHands `default` profile is the enriched baseline, not a
-        // deliberate profile pick — it mirrors global agent_settings. Launch it
-        // via agent_settings so the canvas-only enrichments the profile-resolution
-        // path drops survive for the common home-launch: the <RUNTIME_SERVICES>
-        // system-message suffix and project-skill loading (buildAgentContext).
-        // Named profiles are deliberate custom configs and still use the profile
-        // path (accepting that enrichment boundary).
-        // Trade-off: per-profile fields set on `default` itself don't apply on
-        // home-launch — custom per-profile config belongs in a named profile.
-        //
-        // Scoped to OpenHands: an ACP `default` must keep the profile path.
-        // Activation is pointer-only, so global agent_settings is stale (often
-        // still OpenHands) when an ACP profile is active — launching it via
-        // agent_settings would start the wrong agent. ACP carries no
-        // <RUNTIME_SERVICES> enrichment, so there's nothing to preserve.
-        //
-        // Scoped to local: cloud never writes agent_settings, so it always
-        // resolves `default` server-side via agent_profile_id (validated below).
-        effectiveAgentProfileId = undefined;
-      } else if (
-        resolvedAgentProfile?.agent_kind === "openhands" &&
-        resolvedAgentProfile.llm_profile_ref
-      ) {
-        // Await the LLM-profile list rather than reading the maybe-unresolved
-        // `useLlmProfiles()` result: a send fired before that query loads (or
-        // after it errors) must still validate the ref, not launch blind.
-        let llmProfileExists = false;
+      let fetchedLlmProfiles: ProfileListResponse | undefined;
+      if (resolvedAgentProfile?.agent_kind === "openhands") {
         try {
-          const llm = await queryClient.ensureQueryData({
+          fetchedLlmProfiles = await queryClient.ensureQueryData({
             queryKey: [...LLM_PROFILES_QUERY_KEYS.all, backend.id, orgId],
             queryFn: ProfilesService.listProfiles,
             // Match the agent-profiles fetch above: on a backend where this
@@ -176,21 +138,36 @@ export const useCreateConversation = () => {
             // stalling the send through the default exponential backoff.
             retry: false,
           });
-          llmProfileExists = llm.profiles.some(
-            (profile) => profile.name === resolvedAgentProfile.llm_profile_ref,
-          );
         } catch {
-          // List unavailable → can't validate → fall back to agent_settings.
+          // List unavailable → can't validate the pinned ref or detect a
+          // dropdown pick → the resolver falls back to agent_settings, the
+          // same degradation as today's dangling-ref path.
         }
-        if (!llmProfileExists) {
-          // Downgrade is silent in the UI; leave a diagnosable trace.
-          console.warn(
-            `Agent profile "${resolvedAgentProfile.name}" references missing ` +
-              `LLM profile "${resolvedAgentProfile.llm_profile_ref}"; ` +
-              "launching from agent_settings instead.",
-          );
-          effectiveAgentProfileId = undefined;
-        }
+      }
+
+      const {
+        effectiveAgentProfileId,
+        agentProfileKind,
+        launchLlmProfileRef,
+        downgradeReason,
+      } = resolveLaunchProfile({
+        requestedAgentProfileId,
+        agentProfiles,
+        llmProfiles: fetchedLlmProfiles,
+        // Cloud has no `agent_settings` payload to fall back to, so the
+        // resolver's downgrades are local-only; cloud always launches from
+        // the resolved profile id, keeping `launched_agent_profile` stamped
+        // and the profile's config applied (#1571 review).
+        isCloud: backend.kind === "cloud",
+      });
+
+      if (downgradeReason === "missing-llm-profile-ref") {
+        // Downgrade is silent in the UI; leave a diagnosable trace.
+        console.warn(
+          `Agent profile "${resolvedAgentProfile?.name}" references missing ` +
+            `LLM profile "${resolvedAgentProfile?.llm_profile_ref}"; ` +
+            "launching from agent_settings instead.",
+        );
       }
 
       // Only extend the call with the profile fields when launching from a
@@ -215,16 +192,19 @@ export const useCreateConversation = () => {
           ...(effectiveAgentProfileId
             ? {
                 agentProfileId: effectiveAgentProfileId,
-                agentProfileKind: resolvedAgentProfile?.agent_kind,
+                agentProfileKind,
               }
             : {}),
         });
 
-      // Stamp the active LLM profile onto the (local) conversation so the
-      // chat switcher shows the exact profile even when several profiles
-      // share a model (#1082). Cloud conversations don't use local profiles
-      // (app_conversation_id stays null until the sandbox is READY). Merge so
-      // the repo/workspace metadata the service just persisted is preserved.
+      // Stamp the LLM profile the conversation actually runs so the chat
+      // switcher shows the exact profile even when several profiles share a
+      // model (#1082): the pinned `llm_profile_ref` for a launch driven by a
+      // named OpenHands profile, otherwise the account-wide active LLM profile
+      // — which is also what a home-dropdown override resolves to (#16539).
+      // Cloud conversations don't use local profiles (app_conversation_id
+      // stays null until the sandbox is READY). Merge so the repo/workspace
+      // metadata the service just persisted is preserved.
       const localConversationId = conversation.app_conversation_id;
       // Snapshot the conversation's plugins into client-side metadata so the
       // in-conversation plugins view can show what's loaded (coordinates only
@@ -263,16 +243,15 @@ export const useCreateConversation = () => {
       // A launch from a named OpenHands profile runs that profile's
       // `llm_profile_ref`, which can differ from the standalone active LLM
       // profile — stamp the ref so the switcher pill names the exact profile
-      // the conversation runs (#1082). The agent_settings path (the `default`
-      // baseline or a dangling ref, where effectiveAgentProfileId is cleared)
-      // runs the active LLM, so it keeps `active_profile`. ACP profiles carry
-      // no LLM profile, so they fall through to the active-profile stamp
-      // (unused by the ACP model chip).
+      // the conversation runs (#1082). The agent_settings paths (no profile,
+      // the `default` baseline, a dangling ref, or a home-dropdown override,
+      // where effectiveAgentProfileId is cleared) run the account-wide active
+      // LLM profile, so they keep `active_profile`. ACP profiles carry no LLM
+      // profile, so they fall through to the active-profile stamp (unused by
+      // the ACP model chip). The hook's cached list backs the stamp for paths
+      // that never fetched it here.
       const activeProfile =
-        effectiveAgentProfileId &&
-        resolvedAgentProfile?.agent_kind === "openhands"
-          ? resolvedAgentProfile.llm_profile_ref
-          : (llmProfiles?.active_profile ?? null);
+        launchLlmProfileRef ?? llmProfiles?.active_profile ?? null;
       if (localConversationId && (activeProfile || attachedPlugins.length)) {
         const prev = getStoredConversationMetadata(localConversationId);
         setStoredConversationMetadata(localConversationId, {


### PR DESCRIPTION
HUMAN:

AGENT:

## Why

Fixes #16539. The home-page LLM selector updates the account's active LLM profile, but a named active Agent Profile launches through its pinned `llm_profile_ref`, so the conversation can run a different model than the one the user selected.

## Summary

- Added a pure launch-profile resolver that makes a local home-page LLM selection take precedence over a named OpenHands Agent Profile's pinned model.
- Preserved the named profile path when its pinned model is still selected, and preserved ACP/cloud/default-profile behavior.
- Added launch-resolution regression coverage for the conflicting selection, matching selection, and plain agent-settings path.

## Issue Number

Fixes #16539

## How to Test

```text
npm install --no-audit --no-fund
npm test -- --run src/hooks/mutation/conversation-mutation-utils.test.ts
npm run lint -- --no-fix
npm run build
```

Results from this branch:

- Focused Vitest file: 5 passed
- Full `npm run lint`: passed with 3 pre-existing warnings and 0 errors
- `npm run build`: passed
- `git diff --check`: passed

The focused test exercises a named `openhands` profile pinned to `pinned-model`, with `selected-model` active in the home LLM profile list. It asserts that launch downgrades to the `agent_settings` path and records `selected-model` as the effective launch profile. It also asserts that matching the pinned model keeps the Agent Profile path.

## Video/Screenshots

The issue's original bug video is attached to #16539. I verified the fix at the launch-resolution layer with the deterministic Vitest regression above and a production build. I did not run a live Agent Canvas + agent-server session in this environment, so a fixed-behavior browser video is still required before marking this PR ready for review.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The SDK start payload treats `agent_profile_id` and `agent_settings` as separate launch paths; there is no LLM override field alongside `agent_profile_id`. The local downgrade is therefore the narrow client-side way to honor the selector.
- Cloud launches keep the Agent Profile path because cloud doesn't carry the local `agent_settings` fallback payload.
- The repository's `HUMAN:` section is intentionally left for the human contributor to complete.

## Model Used

AI-assisted implementation using OpenAI Codex. The change was developed with repository inspection, GitHub issue/PR validation, local tests, lint, and build verification. No secrets or credentials were included.