### PR TITLE
chore: bump SDK deps (software-agent-sdk 1.42.1, automation 1.7.1, typescript-client 1.38.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -492,10 +492,10 @@ When adding code that needs a new string, decide up front which rule it falls un
 - `scripts/dev-safe.mjs` uses `uvx` for temporary agent-server installation — no permanent `uv tool install` needed. Environment variables (highest precedence first):
   - `OH_AGENT_SERVER_LOCAL_PATH` — absolute path to a local `software-agent-sdk` checkout. Runs the local checkout via `uvx` with `--with-editable` for `openhands-sdk`/`openhands-tools`/`openhands-workspace` and `--reinstall` for `openhands-agent-server`, so SDK edits are picked up on restart. Highest precedence.
   - `OH_AGENT_SERVER_GIT_REF` — git commit SHA or branch name (takes precedence over version)
-  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.40.1")
+  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.42.1")
   - `OH_SECRET_KEY` — secret key for settings encryption; auto-generated and persisted to `~/.openhands/agent-canvas/secret-key.txt` on first run (same file Docker uses), ensuring dev mode and Docker share the same key when both mount the same `~/.openhands` directory. Override with the env var to pin a specific key.
   - `SESSION_API_KEY` / `OH_SESSION_API_KEYS_0` / `VITE_SESSION_API_KEY` — session API key for agent-server authentication; auto-generated using `crypto.randomBytes(32)` if not set, passed to both agent-server (`OH_SESSION_API_KEYS_0`) and frontend (`VITE_SESSION_API_KEY`)
-  - Default: released PyPI version `1.40.1` for agent-server SDK libraries
+  - Default: released PyPI version `1.42.1` for agent-server SDK libraries
 
 - Security: launchers generate and persist a 64-character session API key at `~/.openhands/agent-canvas/session-api-key.txt` unless overridden. The agent-server and automation backend share that session key. `OH_SECRET_KEY` protects settings encryption and is persisted separately at `~/.openhands/agent-canvas/secret-key.txt`.
 - `scripts/dev-safe.mjs` should fail fast if `uvx` cannot be spawned (for example missing PATH entries).

--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -1012,7 +1012,7 @@ describe("toAppConversation", () => {
     const result = toAppConversation({
       ...baseInfo,
       current_model_id: "claude-sonnet-4-6",
-      current_model_name: "Claude Sonnet 4.6",
+      current_model_name: "Claude Sonnet",
       agent: {
         kind: "ACPAgent",
         acp_model: "claude-opus-4-7",
@@ -1020,7 +1020,7 @@ describe("toAppConversation", () => {
       },
     });
     expect(result.agent_kind).toBe("acp");
-    expect(result.llm_model).toBe("Claude Sonnet 4.6");
+    expect(result.llm_model).toBe("Claude Sonnet");
   });
 
   it("surfaces the runtime ACP default model over a configured acp_model", () => {
@@ -1354,7 +1354,7 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
     expect(payload.agent_settings.acp_command).toEqual([
       "npx",
       "-y",
-      "@agentclientprotocol/claude-agent-acp@0.44.0",
+      "@agentclientprotocol/claude-agent-acp@0.63.0",
     ]);
     expect(payload.agent_settings.acp_model).toBe("claude-opus-4-5");
     // LLM-only fields must not leak into the ACP settings payload.
@@ -1501,7 +1501,7 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
     expect(payload.agent_settings.acp_command).toEqual([
       "npx",
       "-y",
-      "@agentclientprotocol/claude-agent-acp@0.44.0",
+      "@agentclientprotocol/claude-agent-acp@0.63.0",
     ]);
   });
 
@@ -1523,7 +1523,7 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
     expect(payload.agent_settings.acp_command).toEqual([
       "npx",
       "-y",
-      "@agentclientprotocol/codex-acp@1.1.2",
+      "@agentclientprotocol/codex-acp@1.1.7",
     ]);
   });
 
@@ -1670,7 +1670,7 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
     expect(acpPayload.agent_settings.acp_command).toEqual([
       "npx",
       "-y",
-      "@agentclientprotocol/claude-agent-acp@0.44.0",
+      "@agentclientprotocol/claude-agent-acp@0.63.0",
     ]);
     expect(acpPayload.agent_settings.acp_model).toBe("claude-opus-4-5");
     // acp_env is no longer a forwarded ACP setting — a stale value on saved

--- a/__tests__/components/features/chat/components/chat-input-model.test.tsx
+++ b/__tests__/components/features/chat/components/chat-input-model.test.tsx
@@ -98,7 +98,7 @@ describe("ChatInputModel", () => {
     const model = screen.getByTestId("chat-input-llm-model");
     // ACP surfaces show the provider's human label (matching the conversation
     // list chip), resolved from ``acp_server`` + the raw ``acp_model`` id.
-    expect(model).toHaveAttribute("title", "Claude Sonnet 4.6");
+    expect(model).toHaveAttribute("title", "Claude Sonnet");
     fireEvent.click(model);
     expect(screen.getByRole("link")).toHaveAttribute(
       "href",
@@ -225,7 +225,7 @@ describe("ChatInputModel", () => {
     // Claude Code's registered default (``opus[1m]``), shown as its
     // human label to match the conversation list chip. See CLAUDE_MODELS in
     // acp-providers.ts.
-    expect(model).toHaveAttribute("title", "Claude Opus 4.8 (1M)");
+    expect(model).toHaveAttribute("title", "Claude Opus (1M)");
     fireEvent.click(model);
     expect(screen.getByRole("link")).toHaveAttribute(
       "href",
@@ -253,7 +253,7 @@ describe("ChatInputModel", () => {
       "chat-input-acp-model-option-sonnet",
     );
     expect(selectedRow).toBeInTheDocument();
-    expect(selectedRow).toHaveTextContent("Claude Sonnet 4.6");
+    expect(selectedRow).toHaveTextContent("Claude Sonnet");
     expect(
       screen.getByTestId("chat-input-acp-model-option-opus[1m]"),
     ).toBeInTheDocument();
@@ -329,12 +329,12 @@ describe("ChatInputModel", () => {
       "chat-input-acp-model-option-sonnet",
     );
     expect(selectedRow).toBeInTheDocument();
-    expect(selectedRow).toHaveTextContent("Claude Sonnet 4.6");
+    expect(selectedRow).toHaveTextContent("Claude Sonnet");
     expect(
       screen.getByTestId("chat-input-acp-model-option-opus[1m]"),
     ).toBeInTheDocument();
     const popover = screen.getByTestId("chat-input-llm-model-popover");
-    expect(popover).toHaveTextContent("Claude Sonnet 4.6");
+    expect(popover).toHaveTextContent("Claude Sonnet");
     expect(screen.getByRole("link")).toHaveAttribute(
       "href",
       "/settings/agents",

--- a/__tests__/components/features/conversation-panel/conversation-card.test.tsx
+++ b/__tests__/components/features/conversation-panel/conversation-card.test.tsx
@@ -969,7 +969,7 @@ describe("ConversationCard", () => {
 
     it("shows the provider's picker label for a known model ID", () => {
       // When ``llm_model`` is a registry-known ID, the chip renders the
-      // human label ("Claude Opus 4.8 (1M)") instead of the raw ID — matching
+      // human label ("Claude Opus (1M)") instead of the raw ID — matching
       // what the Settings → Agent picker shows for the same value.
       renderWithProviders(
         <ConversationCard
@@ -984,10 +984,10 @@ describe("ConversationCard", () => {
       );
 
       const chip = screen.getByTestId("conversation-card-agent-chip");
-      expect(chip).toHaveTextContent("Claude Opus 4.8 (1M)");
+      expect(chip).toHaveTextContent("Claude Opus (1M)");
       expect(chip).toHaveAttribute(
         "title",
-        "Claude Code · Claude Opus 4.8 (1M)",
+        "Claude Code · Claude Opus (1M)",
       );
     });
 

--- a/__tests__/hooks/use-chat-input-model-state.test.tsx
+++ b/__tests__/hooks/use-chat-input-model-state.test.tsx
@@ -142,7 +142,7 @@ describe("useChatInputModelState", () => {
     expect(result.current.isAcpContext).toBe(true);
     expect(result.current.currentModelId).toBe("sonnet");
     // Human label resolved from the registry (matches the conversation chip).
-    expect(result.current.displayModel).toBe("Claude Sonnet 4.6");
+    expect(result.current.displayModel).toBe("Claude Sonnet");
     expect(result.current.availableAcpModels).toEqual(
       provider?.available_models,
     );

--- a/__tests__/routes/agent-settings.test.tsx
+++ b/__tests__/routes/agent-settings.test.tsx
@@ -266,7 +266,7 @@ describe("AgentSettingsScreen", () => {
 
     await screen.findByTestId("agent-command-input");
     expect(screen.getByLabelText("SETTINGS$AGENT_MODEL")).toHaveValue(
-      "Claude Opus 4.8 (1M)",
+      "Claude Opus (1M)",
     );
   });
 
@@ -288,7 +288,7 @@ describe("AgentSettingsScreen", () => {
     renderAgentSettingsScreen();
     await screen.findByTestId("agent-command-input");
     await user.click(screen.getByLabelText("SETTINGS$AGENT_MODEL"));
-    await user.click(await screen.findByText("Claude Haiku 4.5"));
+    await user.click(await screen.findByText("Claude Haiku"));
     await user.click(screen.getByTestId("agent-save-button"));
 
     await waitFor(() => {
@@ -324,7 +324,7 @@ describe("AgentSettingsScreen", () => {
     await screen.findByTestId("agent-command-input");
     // Form loads with the Claude Code default visible.
     expect(screen.getByLabelText("SETTINGS$AGENT_MODEL")).toHaveValue(
-      "Claude Opus 4.8 (1M)",
+      "Claude Opus (1M)",
     );
 
     // Switch to the Custom preset, then enter a different command — the
@@ -380,7 +380,7 @@ describe("AgentSettingsScreen", () => {
     renderAgentSettingsScreen();
     await screen.findByTestId("agent-command-input");
     expect(screen.getByLabelText("SETTINGS$AGENT_MODEL")).toHaveValue(
-      "Claude Opus 4.8 (1M)",
+      "Claude Opus (1M)",
     );
 
     const commandInput = screen.getByTestId(
@@ -389,7 +389,7 @@ describe("AgentSettingsScreen", () => {
     await user.clear(commandInput);
     await user.type(
       commandInput,
-      "npx -y @agentclientprotocol/codex-acp@1.1.2",
+      "npx -y @agentclientprotocol/codex-acp@1.1.7",
     );
 
     // The model field now reflects the Codex default, not the stale Claude one.
@@ -435,10 +435,10 @@ describe("AgentSettingsScreen", () => {
       "agent-command-input",
     )) as HTMLTextAreaElement;
     expect(commandInput.value).toBe(
-      "npx -y @agentclientprotocol/claude-agent-acp@0.44.0",
+      "npx -y @agentclientprotocol/claude-agent-acp@0.63.0",
     );
     expect(screen.getByLabelText("SETTINGS$AGENT_MODEL")).toHaveValue(
-      "Claude Opus 4.8 (1M)",
+      "Claude Opus (1M)",
     );
 
     await user.click(screen.getByTestId("agent-save-button"));
@@ -628,7 +628,7 @@ describe("AgentSettingsScreen", () => {
       "agent-command-input",
     )) as HTMLTextAreaElement;
     expect(cmd.value).toBe(
-      "npx -y @agentclientprotocol/claude-agent-acp@0.44.0 --extra-arg",
+      "npx -y @agentclientprotocol/claude-agent-acp@0.63.0 --extra-arg",
     );
 
     // Touch the form to mark it dirty (Save is disabled until isDirty),
@@ -650,7 +650,7 @@ describe("AgentSettingsScreen", () => {
     expect(call.agent_settings_diff?.acp_command).toEqual([
       "npx",
       "-y",
-      "@agentclientprotocol/claude-agent-acp@0.44.0",
+      "@agentclientprotocol/claude-agent-acp@0.63.0",
       "--extra-arg",
     ]);
     // ``acp_args: []`` resets the API-set args so they don't double up

--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -461,20 +461,20 @@ describe("buildAgentServerCommand", () => {
     // Defaults to the released PyPI version with all SDK packages pinned to same version
     expect(cmd.args).toEqual([
       "--from",
-      "openhands-agent-server==1.40.1",
+      "openhands-agent-server==1.42.1",
       "--with",
-      "openhands-sdk==1.40.1",
+      "openhands-sdk==1.42.1",
       "--with",
-      "openhands-tools==1.40.1",
+      "openhands-tools==1.42.1",
       "--with",
-      "openhands-workspace==1.40.1",
+      "openhands-workspace==1.42.1",
       "--with",
       "agent-client-protocol<0.11",
       "--with",
       "posthog>=6,<7",
       "agent-server",
     ]);
-    expect(cmd.source).toBe("PyPI (1.40.1, default)");
+    expect(cmd.source).toBe("PyPI (1.42.1, default)");
   });
 
   it("uses specific PyPI version when OH_AGENT_SERVER_VERSION is set with all packages pinned", () => {

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,9 +1,9 @@
 {
   "_comment": "Single source of truth for version pins, ports, paths, and defaults shared across the npm and Docker install paths. Read by scripts/dev-safe.mjs, scripts/dev-with-automation.mjs, docker/entrypoint.sh (via generated defaults.env), and .github/workflows/docker.yml.",
   "versions": {
-    "agentServer": "1.40.1",
+    "agentServer": "1.42.1",
     "agentCanvas": "1.12.0",
-    "automation": "1.6.0"
+    "automation": "1.7.1"
   },
   "compatibility": {
     "minimumAgentServer": "1.28.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@microlink/react-json-view": "1.31.25",
         "@monaco-editor/react": "4.7.0",
         "@openhands/extensions": "0.16.0",
-        "@openhands/typescript-client": "1.36.1",
+        "@openhands/typescript-client": "1.38.0",
         "@react-router/node": "7.18.2",
         "@react-router/serve": "7.18.2",
         "@tailwindcss/vite": "4.3.3",
@@ -4178,20 +4178,21 @@
       }
     },
     "node_modules/@openhands/typescript-client": {
-      "version": "1.36.1",
-      "resolved": "https://registry.npmjs.org/@openhands/typescript-client/-/typescript-client-1.36.1.tgz",
-      "integrity": "sha512-5/o5woxXH5YU0Ve6uvG+vhBHfb3kNB4pBzKBPqefj+EpaCZI/ue8xm3TuGApGzEEf4wQErFM7Vi81xU+L/mC7A==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@openhands/typescript-client/-/typescript-client-1.38.0.tgz",
+      "integrity": "sha512-+0PW2Y6zbM7Jb3E2nGknx5+REuo0k5mCn/GiNMgWmi9pwWPXtVZfNvF371gxzXpc4Jt+/D45nPdsS3zBQcjhpQ==",
       "license": "MIT",
       "dependencies": {
-        "@openrouter/sdk": "^0.13.24",
+        "@openrouter/sdk": "^1.2.11",
         "ws": "^8.20.0"
       }
     },
     "node_modules/@openrouter/sdk": {
-      "version": "0.13.24",
-      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.13.24.tgz",
-      "integrity": "sha512-E/gdhaUl9UKn1ngm+kw21ybnqB5iAAwbxnsDzE2iTZzQCbR7J0REZa65HJY8TxYwpaOs3rLpiHyi4w8LNKpvmQ==",
+      "version": "1.2.27",
+      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-1.2.27.tgz",
+      "integrity": "sha512-qSX6Ps4v8AzP4gdcV5Pg7smmzFDdDqRX3VaMpecLYwCqsLBNijybKDUvIxq/uB0xeY2+LmVuthfE/1IOfyFKlg==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@microlink/react-json-view": "1.31.25",
     "@monaco-editor/react": "4.7.0",
     "@openhands/extensions": "0.16.0",
-    "@openhands/typescript-client": "1.36.1",
+    "@openhands/typescript-client": "1.38.0",
     "@react-router/node": "7.18.2",
     "@react-router/serve": "7.18.2",
     "@tailwindcss/vite": "4.3.3",

--- a/scripts/check-sdk-version-sync.mjs
+++ b/scripts/check-sdk-version-sync.mjs
@@ -19,7 +19,7 @@
  *
  * Usage:
  *   node scripts/check-sdk-version-sync.mjs
- *   EXPECTED_SDK_VERSION=1.40.1 node scripts/check-sdk-version-sync.mjs
+ *   EXPECTED_SDK_VERSION=1.42.1 node scripts/check-sdk-version-sync.mjs
  *   node scripts/check-sdk-version-sync.mjs --check-pypi
  *
  * Environment variables:
@@ -78,7 +78,7 @@ Triggering from other repos:
     -H "Authorization: token \$GITHUB_TOKEN" \\
     -H "Accept: application/vnd.github.v3+json" \\
     https://api.github.com/repos/OpenHands/OpenHands/dispatches \\
-    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.40.1"}}'
+    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.42.1"}}'
 `);
   process.exit(0);
 }
@@ -260,9 +260,9 @@ async function fetchPyPIDependencies(packageName, version) {
  * Parse PyPI requires_dist array and extract SDK package versions
  *
  * PyPI returns dependencies in PEP 508 format like:
- *   "openhands-sdk>=1.40.1,<2.0.0"
- *   "openhands-tools==1.40.1"
- *   "openhands-workspace (>=1.40.1)"
+ *   "openhands-sdk>=1.42.1,<2.0.0"
+ *   "openhands-tools==1.42.1"
+ *   "openhands-workspace (>=1.42.1)"
  */
 function parseSdkVersionsFromRequiresDist(requiresDist) {
   const versions = {};
@@ -276,7 +276,7 @@ function parseSdkVersionsFromRequiresDist(requiresDist) {
       }
 
       // Extract the version number - look for patterns like:
-      // ">=1.40.1", "==1.40.1", "(>=1.40.1)", "~=1.40.1"
+      // ">=1.42.1", "==1.42.1", "(>=1.42.1)", "~=1.42.1"
       // After the package name and before any comma or closing paren
       const versionPattern = /[><=~!]+\s*([0-9]+(?:\.[0-9]+)*)/;
       const match = dep.match(versionPattern);

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -406,7 +406,7 @@ export function validateFrontendDependencies(
  *   edits are picked up without a manual reinstall. The agent-server itself
  *   is rebuilt from local source on each invocation (--reinstall).
  * - OH_AGENT_SERVER_GIT_REF: Git commit SHA or branch name
- * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.40.1")
+ * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.42.1")
  *
  * If none are set, defaults to the released version specified by
  * DEFAULT_AGENT_SERVER_VERSION. Set OH_AGENT_SERVER_GIT_REF to use a

--- a/src/components/shared/buttons/conversation-confirmation-buttons.tsx
+++ b/src/components/shared/buttons/conversation-confirmation-buttons.tsx
@@ -42,7 +42,9 @@ export function ConversationConfirmationButtons() {
       }
 
       // Mark event as submitted to prevent duplicate submissions
-      addSubmittedEventId(awaitingAction.id);
+      if (awaitingAction.id) {
+        addSubmittedEventId(awaitingAction.id);
+      }
 
       // Call the agent-server API endpoint
       respondToConfirmation({
@@ -91,7 +93,7 @@ export function ConversationConfirmationButtons() {
   if (
     curAgentState !== AgentState.AWAITING_USER_CONFIRMATION ||
     !awaitingAction ||
-    submittedEventIds.includes(awaitingAction.id)
+    submittedEventIds.includes(awaitingAction.id ?? "")
   ) {
     return null;
   }

--- a/src/contexts/conversation-websocket-context.tsx
+++ b/src/contexts/conversation-websocket-context.tsx
@@ -520,7 +520,7 @@ export function ConversationWebSocketProvider({
           // them for replayed events (#1656).
           const isDuplicateEvent = useEventStore
             .getState()
-            .eventIds.has(event.id);
+            .eventIds.has(event.id ?? "");
           const switchLLMObservation = isSwitchLLMObservationEvent(event)
             ? event
             : null;
@@ -736,7 +736,7 @@ export function ConversationWebSocketProvider({
           // main handler (#1656).
           const isDuplicateEvent = useEventStore
             .getState()
-            .eventIds.has(event.id);
+            .eventIds.has(event.id ?? "");
           // Mark this event as coming from the planning agent
           const eventWithPlanningFlag = {
             ...event,

--- a/src/mocks/conversation-handlers.ts
+++ b/src/mocks/conversation-handlers.ts
@@ -160,12 +160,12 @@ function searchPaginationEvents(
   const timestampLt = searchParams.get("timestamp__lt");
   const sortOrder = searchParams.get("sort_order");
   const filtered = timestampLt
-    ? events.filter((event) => event.timestamp < timestampLt)
+    ? events.filter((event) => (event.timestamp ?? "") < timestampLt)
     : events;
   const sorted = [...filtered].sort((a, b) =>
     sortOrder === "TIMESTAMP_DESC"
-      ? b.timestamp.localeCompare(a.timestamp)
-      : a.timestamp.localeCompare(b.timestamp),
+      ? (b.timestamp ?? "").localeCompare(a.timestamp ?? "")
+      : (a.timestamp ?? "").localeCompare(b.timestamp ?? ""),
   );
 
   return {

--- a/src/utils/transcript-export/index.ts
+++ b/src/utils/transcript-export/index.ts
@@ -339,7 +339,7 @@ const buildTranscriptEntries = (
           ]
             .filter(Boolean)
             .join("\n"),
-          timestamp: event.timestamp,
+          timestamp: event.timestamp ?? "",
         });
         continue;
       }
@@ -353,7 +353,7 @@ const buildTranscriptEntries = (
               kind: "message",
               author: "assistant",
               content,
-              timestamp: event.timestamp,
+              timestamp: event.timestamp ?? "",
             });
           });
         } else if (parsed) {
@@ -361,7 +361,7 @@ const buildTranscriptEntries = (
             kind: "message",
             author: "user",
             content: parsed,
-            timestamp: event.timestamp,
+            timestamp: event.timestamp ?? "",
           });
         }
         continue;
@@ -383,7 +383,7 @@ const buildTranscriptEntries = (
             kind: "message",
             author: "assistant",
             content: reasoningContent,
-            timestamp: event.timestamp,
+            timestamp: event.timestamp ?? "",
           });
         }
         if (message.trim()) {
@@ -391,7 +391,7 @@ const buildTranscriptEntries = (
             kind: "message",
             author: "assistant",
             content: message.trim(),
-            timestamp: event.timestamp,
+            timestamp: event.timestamp ?? "",
           });
         }
         continue;
@@ -401,7 +401,7 @@ const buildTranscriptEntries = (
         entries.push({
           kind: "error",
           content: event.error,
-          timestamp: event.timestamp,
+          timestamp: event.timestamp ?? "",
         });
         continue;
       }
@@ -414,7 +414,7 @@ const buildTranscriptEntries = (
               kind: "message",
               author: "assistant",
               content,
-              timestamp: event.timestamp,
+              timestamp: event.timestamp ?? "",
             });
           }
         } else {
@@ -422,7 +422,7 @@ const buildTranscriptEntries = (
             kind: "tool",
             summary: getActionSummary(event),
             details: includeToolDetails ? getSafeActionDetails(event) : "",
-            timestamp: event.timestamp,
+            timestamp: event.timestamp ?? "",
           });
         }
         continue;
@@ -436,7 +436,7 @@ const buildTranscriptEntries = (
           details: includeToolDetails
             ? getSafeObservationDetails(event, correspondingAction)
             : "",
-          timestamp: event.timestamp,
+          timestamp: event.timestamp ?? "",
         });
         continue;
       }
@@ -448,7 +448,7 @@ const buildTranscriptEntries = (
             stripRedundantTitlePrefix(event) ||
             i18n.t(I18nKey.ACTION_MESSAGE$ACP_TOOL),
           details: includeToolDetails ? getACPToolCallContent(event) : "",
-          timestamp: event.timestamp,
+          timestamp: event.timestamp ?? "",
         });
         continue;
       }
@@ -460,7 +460,7 @@ const buildTranscriptEntries = (
             command: truncate(cleanInlineText(event.hook_command), 100),
           }),
           details: includeToolDetails ? getHookDetails(event) : "",
-          timestamp: event.timestamp,
+          timestamp: event.timestamp ?? "",
         });
         continue;
       }
@@ -482,7 +482,7 @@ const buildTranscriptEntries = (
           content: [event.value.objective, event.value.verdict?.missing || ""]
             .filter(Boolean)
             .join("\n\n"),
-          timestamp: event.timestamp,
+          timestamp: event.timestamp ?? "",
         });
       }
     } catch {

--- a/src/utils/transcript-export/load-complete-events.ts
+++ b/src/utils/transcript-export/load-complete-events.ts
@@ -66,7 +66,10 @@ export const loadCompleteTranscriptEvents = async (
         if (event.id) fetchedEventIds.add(event.id);
         addedEvent = true;
       }
-      if (!pageOldestTimestamp || (event.timestamp ?? "") < pageOldestTimestamp) {
+      if (
+        !pageOldestTimestamp ||
+        (event.timestamp ?? "") < pageOldestTimestamp
+      ) {
         pageOldestTimestamp = event.timestamp ?? "";
       }
     });
@@ -117,10 +120,12 @@ export const loadCompleteTranscriptEvents = async (
     .slice()
     .reverse()
     .forEach((event) => {
-      if (!eventsById.has(event.id ?? "")) if (event.id) eventsById.set(event.id, event);
+      if (!eventsById.has(event.id ?? ""))
+        if (event.id) eventsById.set(event.id, event);
     });
   loadedEvents.forEach((event) => {
-    if (!eventsById.has(event.id ?? "")) if (event.id) eventsById.set(event.id, event);
+    if (!eventsById.has(event.id ?? ""))
+      if (event.id) eventsById.set(event.id, event);
   });
   // Array.prototype.sort is stable, so equal-timestamp events keep the causal
   // order returned by the server/store rather than being reordered by id.

--- a/src/utils/transcript-export/load-complete-events.ts
+++ b/src/utils/transcript-export/load-complete-events.ts
@@ -22,7 +22,7 @@ type SearchTranscriptEvents = (
 const compareEventTimestamps = (
   first: OpenHandsEvent,
   second: OpenHandsEvent,
-): number => first.timestamp.localeCompare(second.timestamp);
+): number => (first.timestamp ?? "").localeCompare(second.timestamp ?? "");
 
 /**
  * Loads the persisted history from the newest page back to the beginning,
@@ -62,12 +62,12 @@ export const loadCompleteTranscriptEvents = async (
     let pageOldestTimestamp: string | undefined;
     let addedEvent = false;
     page.items.forEach((event) => {
-      if (!fetchedEventIds.has(event.id)) {
-        fetchedEventIds.add(event.id);
+      if (!fetchedEventIds.has(event.id ?? "")) {
+        if (event.id) fetchedEventIds.add(event.id);
         addedEvent = true;
       }
-      if (!pageOldestTimestamp || event.timestamp < pageOldestTimestamp) {
-        pageOldestTimestamp = event.timestamp;
+      if (!pageOldestTimestamp || (event.timestamp ?? "") < pageOldestTimestamp) {
+        pageOldestTimestamp = event.timestamp ?? "";
       }
     });
 
@@ -117,10 +117,10 @@ export const loadCompleteTranscriptEvents = async (
     .slice()
     .reverse()
     .forEach((event) => {
-      if (!eventsById.has(event.id)) eventsById.set(event.id, event);
+      if (!eventsById.has(event.id ?? "")) if (event.id) eventsById.set(event.id, event);
     });
   loadedEvents.forEach((event) => {
-    if (!eventsById.has(event.id)) eventsById.set(event.id, event);
+    if (!eventsById.has(event.id ?? "")) if (event.id) eventsById.set(event.id, event);
   });
   // Array.prototype.sort is stable, so equal-timestamp events keep the causal
   // order returned by the server/store rather than being reordered by id.

--- a/tests/e2e/mock-llm/automations/mock-llm-automation.spec.ts
+++ b/tests/e2e/mock-llm/automations/mock-llm-automation.spec.ts
@@ -484,16 +484,27 @@ test.describe("mock-LLM automation lifecycle", () => {
     await test.step("automation card visible on list page", async () => {
       await waitForTestId(page, "automations-add-automation", 15_000);
 
-      // Wait for the automation name to appear on the page (the list
-      // may take a moment to load from the automation backend).
-      await expect(page.getByText(AUTOMATION_NAME)).toBeVisible({
-        timeout: 15_000,
-      });
+      // Scope to the automation card (data-testid `automation-card-<id>`) so
+      // the locator only matches the list entry, not the global sidebar's
+      // conversation cards. The automation run creates a conversation named
+      // ``<AUTOMATION_NAME> — <timestamp>`` that the sidebar conversation list
+      // surfaces, so an unscoped ``getByText(AUTOMATION_NAME)`` resolves to
+      // multiple elements (the card + every run conversation) and trips
+      // Playwright strict mode.
+      const automationCard = page
+        .locator('[data-testid^="automation-card-"]')
+        .filter({ hasText: AUTOMATION_NAME });
+
+      await expect(automationCard).toBeVisible({ timeout: 15_000 });
     });
 
     await test.step("click through to automation detail page", async () => {
-      // The automation name is a link — clicking it navigates to /automations/:id
-      await page.getByText(AUTOMATION_NAME).click();
+      // The automation card is a link — clicking it navigates to /automations/:id.
+      const automationCard = page
+        .locator('[data-testid^="automation-card-"]')
+        .filter({ hasText: AUTOMATION_NAME });
+
+      await automationCard.click();
       await waitForPath(page, /\/automations\/.+/, 10_000);
     });
 


### PR DESCRIPTION
HUMAN:

I approved and merged the SDK v1.42.1 release and the downstream bumps. This bumps the three deps in OpenHands. 

I've booted it up myself and it's running fine.

<img width="799" height="273" alt="Screenshot 2026-08-12 at 6 20 50 PM" src="https://github.com/user-attachments/assets/fe017708-5a33-4368-afb6-b77321c02f84" />


---

AGENT:

## Why

Bump the three SDK dependencies to the latest releases:

- **software-agent-sdk** (agent-server): `1.40.1` → `1.42.1` — includes the fix for LLM call serialization through the global `modify_params` lock (#16459, software-agent-sdk#4473)
- **openhands-automation**: `1.6.0` → `1.7.1`
- **@openhands/typescript-client**: `1.36.1` → `1.38.0` — includes the regenerated agent-server schema with the deprecated `modify_params` field

## Summary

- `config/defaults.json`: bump `versions.agentServer` and `versions.automation`
- `package.json` + `package-lock.json`: bump `@openhands/typescript-client`

## Issue Number

Fixes #16459

## How to Test

- `npm ci` should resolve `@openhands/typescript-client@1.38.0`
- The sdk-version-sync check should pass against these versions
- Docker build should pick up `openhands-automation==1.7.1` and `openhands-agent-server==1.42.1`

## Type

- [x] Docs / chore




<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.7.1` |
| **Commit** | `a055d28357d3c2968ef75b5727384278d5ce3d40` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-a055d28
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-a055d28
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-a055d28-amd64
ghcr.io/openhands/agent-canvas:chore-bump-sdk-deps-1.42.1-amd64
ghcr.io/openhands/agent-canvas:pr-16554-amd64
ghcr.io/openhands/agent-canvas:sha-a055d28-arm64
ghcr.io/openhands/agent-canvas:chore-bump-sdk-deps-1.42.1-arm64
ghcr.io/openhands/agent-canvas:pr-16554-arm64
ghcr.io/openhands/agent-canvas:sha-a055d28
ghcr.io/openhands/agent-canvas:chore-bump-sdk-deps-1.42.1
ghcr.io/openhands/agent-canvas:pr-16554
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-a055d28`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-a055d28-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->