### PR TITLE
fix(ci): ignore fenced code-block headings in issue/PR readiness checkers

### DIFF
--- a/.github/scripts/check_issue_readiness.py
+++ b/.github/scripts/check_issue_readiness.py
@@ -33,6 +33,8 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from markdown_utils import find_fenced_regions, is_inside_fenced_region
+
 BUG_LABEL = "bug"
 ENHANCEMENT_LABEL = "enhancement"
 
@@ -106,8 +108,16 @@ def extract_sections(body: str) -> dict[str, str]:
     Issue forms render every field this way. Free-form issues (not created via a
     form) may still use `###` headings; if they don't, the map is empty and the
     caller falls back to whole-body checks.
+
+    Headings inside fenced code blocks (`` ``` `` or `~~~`) are ignored, so
+    pasted logs or quoted templates cannot spoof or truncate a real section.
     """
-    matches = list(HEADING_RE.finditer(body))
+    regions = find_fenced_regions(body)
+    matches = [
+        m
+        for m in HEADING_RE.finditer(body)
+        if not is_inside_fenced_region(m.start(), regions)
+    ]
     sections: dict[str, str] = {}
     for index, match in enumerate(matches):
         start = match.end()

--- a/.github/scripts/check_pr_description.py
+++ b/.github/scripts/check_pr_description.py
@@ -32,6 +32,8 @@ import re
 import sys
 from pathlib import Path
 
+from markdown_utils import find_fenced_regions, is_inside_fenced_region
+
 
 # Reject placeholders while allowing a concise human-written sentence.
 MIN_HUMAN_NOTE_CHARS = 20
@@ -130,7 +132,17 @@ def first_visible_line(text: str) -> str:
 
 
 def extract_sections(body: str) -> dict[str, str]:
-    matches = list(HEADING_RE.finditer(body))
+    """Split the body into a {heading: text} map using `## <heading>` boundaries.
+
+    Headings inside fenced code blocks (`` ``` `` or `~~~`) are ignored, so
+    pasted snippets or quoted templates cannot spoof or truncate a real section.
+    """
+    regions = find_fenced_regions(body)
+    matches = [
+        m
+        for m in HEADING_RE.finditer(body)
+        if not is_inside_fenced_region(m.start(), regions)
+    ]
     sections: dict[str, str] = {}
     for index, match in enumerate(matches):
         start = match.end()

--- a/.github/scripts/markdown_utils.py
+++ b/.github/scripts/markdown_utils.py
@@ -1,0 +1,53 @@
+"""Helpers for parsing Markdown in GitHub automation scripts."""
+
+from __future__ import annotations
+
+import re
+
+# A fenced code-block opener: up to 3 leading spaces, then 3+ backticks or tildes,
+# then an optional info string. GitHub/CommonMark only recognises fences with up to
+# 3 leading spaces, so stricter indent avoids false positives from indented text.
+_FENCE_START_RE = re.compile(r"^\s{0,3}(?P<fence>`{3,}|~{3,})(?P<info>.*)$")
+
+
+def find_fenced_regions(text: str) -> list[tuple[int, int]]:
+    """Return the (start, end) character ranges of fenced code blocks in `text`.
+
+    Supports both triple-backtick and triple-tilde fences, and fenced blocks that
+    run to the end of the body without a closing fence.
+    """
+    regions: list[tuple[int, int]] = []
+    inside = False
+    fence_char = ""
+    fence_len = 0
+    start = 0
+    lines = text.splitlines(keepends=True)
+    offset = 0
+
+    for line in lines:
+        if not inside:
+            m = _FENCE_START_RE.match(line)
+            if m:
+                fence_char = m.group("fence")[0]
+                fence_len = len(m.group("fence"))
+                start = offset
+                inside = True
+        else:
+            # The closing fence must use the same character and be at least as long.
+            pattern = r"^\s{0,3}" + re.escape(fence_char) + "{" + str(fence_len) + r",}\s*$"
+            if re.match(pattern, line):
+                end = offset + len(line)
+                regions.append((start, end))
+                inside = False
+        offset += len(line)
+
+    # An unclosed fence extends to the end of the body.
+    if inside:
+        regions.append((start, offset))
+
+    return regions
+
+
+def is_inside_fenced_region(pos: int, regions: list[tuple[int, int]]) -> bool:
+    """Return True if `pos` falls inside one of the fenced regions."""
+    return any(start <= pos < end for start, end in regions)

--- a/.github/scripts/tests/test_issue_readiness.py
+++ b/.github/scripts/tests/test_issue_readiness.py
@@ -227,3 +227,55 @@ def test_extract_sections():
     assert "title two" in sections
     assert "Text 1" in sections["title one"]
     assert "Text 2" in sections["title two"]
+
+
+BUG_BODY_FENCED_HEADING_IN_ACTUAL = """### Actual Behavior
+
+Run method: `npm run dev`
+
+The server returned:
+
+```
+### Error detail
+something went wrong
+```
+
+<img width="800" alt="Image" src="https://github.com/user-attachments/assets/abc123" />
+
+### Acceptance Criteria
+
+- [ ] the bug is fixed
+"""
+
+ENHANCEMENT_BODY_FENCED_ACCEPTANCE = """### Desired Behavior
+
+Make the thing work.
+
+### Notes
+
+The template asks for:
+
+```markdown
+### Acceptance Criteria
+- [ ] checklist items go here
+```
+"""
+
+
+def test_extract_sections_ignores_fenced_headings():
+    sections = extract_sections("### One\n```\n### Two\n```\n### Three\n")
+    assert "one" in sections
+    assert "two" not in sections
+    assert "three" in sections
+    assert "### Two" in sections["one"]
+
+
+def test_bug_ready_with_fenced_heading_in_actual():
+    result = evaluate_readiness(BUG_BODY_FENCED_HEADING_IN_ACTUAL, [BUG_LABEL])
+    assert result.ready, result.reasons
+
+
+def test_enhancement_not_ready_with_only_fenced_acceptance():
+    result = evaluate_readiness(ENHANCEMENT_BODY_FENCED_ACCEPTANCE, [ENHANCEMENT_LABEL])
+    assert not result.ready
+    assert any("Acceptance Criteria" in r for r in result.reasons)

--- a/.github/scripts/tests/test_markdown_utils.py
+++ b/.github/scripts/tests/test_markdown_utils.py
@@ -1,0 +1,53 @@
+"""Tests for markdown_utils.py."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from markdown_utils import find_fenced_regions, is_inside_fenced_region
+
+
+def test_find_fenced_regions_backticks():
+    text = "### Heading\n```\n### Not a heading\n```\n### After"
+    regions = find_fenced_regions(text)
+    assert len(regions) == 1
+    start, end = regions[0]
+    assert text[start:end] == "```\n### Not a heading\n```\n"
+
+
+def test_find_fenced_regions_tildes():
+    text = "### Heading\n~~~python\n### Not a heading\n~~~\n### After"
+    regions = find_fenced_regions(text)
+    assert len(regions) == 1
+    start, end = regions[0]
+    assert text[start:end] == "~~~python\n### Not a heading\n~~~\n"
+
+
+def test_find_fenced_regions_multiple_blocks():
+    text = "```\nfirst\n```\n\n```\nsecond\n```"
+    regions = find_fenced_regions(text)
+    assert len(regions) == 2
+
+
+def test_find_fenced_regions_unclosed():
+    text = "### Heading\n```\n### Not a heading"
+    regions = find_fenced_regions(text)
+    assert len(regions) == 1
+    assert regions[0][1] == len(text)
+
+
+def test_find_fenced_regions_length_mismatch():
+    # A 4-backtick fence needs at least 4 backticks to close; 3 should not close it.
+    text = "#### Heading\n````\n### Not a heading\n```\n### After"
+    regions = find_fenced_regions(text)
+    assert len(regions) == 1
+    assert regions[0][1] == len(text)
+
+
+def test_is_inside_fenced_region():
+    text = "before\n```\ninside\n```\nafter"
+    regions = find_fenced_regions(text)
+    assert is_inside_fenced_region(text.find("inside"), regions)
+    assert not is_inside_fenced_region(text.find("before"), regions)
+    assert not is_inside_fenced_region(text.find("after"), regions)

--- a/.github/scripts/tests/test_pr_description.py
+++ b/.github/scripts/tests/test_pr_description.py
@@ -12,6 +12,8 @@ from check_pr_description import (
     extract_pr_type,
     validate_linked_issue_ready,
     validate_bug_fix_evidence,
+    validate_pr_body,
+    extract_sections,
     BUG_LABEL,
     ENHANCEMENT_LABEL,
     READY_FOR_DEV_LABEL,
@@ -221,4 +223,74 @@ def test_bug_fix_with_video_link_no_errors():
 https://youtube.com/watch?v=abc123
 """
     errors = validate_bug_fix_evidence(body)
+    assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# Fenced code block handling
+# ---------------------------------------------------------------------------
+
+def test_extract_sections_ignores_fenced_headings():
+    sections = extract_sections("## Why\nText\n```\n## Summary\n```\n## How to Test\n")
+    assert "Why" in sections
+    assert "Summary" not in sections
+    assert "How to Test" in sections
+    assert "## Summary" in sections["Why"]
+
+
+def test_extract_linked_issue_numbers_ignores_fenced_heading():
+    # The fenced "## Issue Number" should not be treated as the real section,
+    # so a bare issue number inside the fence is not extracted.
+    body = """## Why
+
+Fix a thing.
+
+```
+## Issue Number
+#999
+```
+
+## Issue Number
+
+Fixes #123
+"""
+    assert extract_linked_issue_numbers(body) == [123]
+
+
+PR_BODY_FENCED_HOW_TO_TEST = """HUMAN:
+
+A human note for the PR.
+
+AGENT:
+
+## Why
+
+Fix a bug.
+
+## Summary
+
+One line.
+
+```
+## How to Test
+Run nothing.
+```
+
+## How to Test
+
+Run `python -m pytest .github/scripts/tests`.
+
+## Issue Number
+
+Fixes #123
+
+## Type
+
+- [ ] Bug fix
+- [ ] Feature
+"""
+
+
+def test_pr_description_valid_with_fenced_template_heading():
+    errors = validate_pr_body(PR_BODY_FENCED_HOW_TO_TEST)
     assert errors == []


### PR DESCRIPTION
HUMAN:

Verified the fix by running the issue repro and the full `.github/scripts/tests` suite; the failing cases now pass and the existing tests still pass.

AGENT:

---

## Why

`extract_sections()` in `.github/scripts/check_issue_readiness.py` and `.github/scripts/check_pr_description.py` splits bodies on `### ` or `## ` headings with no awareness of fenced code blocks, so a heading inside a fence is treated as a real section boundary. This can grant false readiness when a fenced heading is the only one, or truncate a real section when a fence contains a heading.

## Summary

- Add `.github/scripts/markdown_utils.py` with `find_fenced_regions()` and `is_inside_fenced_region()`.
- Update `extract_sections()` in both `check_issue_readiness.py` and `check_pr_description.py` to skip headings whose start position lies inside a fenced code block.
- Add regression tests in `test_issue_readiness.py`, `test_pr_description.py`, and a new `test_markdown_utils.py` covering both the false-section and truncated-section cases.

## Issue Number

Fixes #16553

## How to Test

Run the regression suite:

```bash
python3 -m pytest .github/scripts/tests -v
```

For a manual repro, paste the snippet from #16553 into `repro.py` and run `python3 repro.py`; it now reports the expected readiness and sections.

## Video/Screenshots

Reproduction screenshot from #16553 showing the broken output:

![repro](https://github.com/user-attachments/assets/25b0887b-42bc-4452-b74b-2799247033af)

After the fix, the same repro reports the correct readiness and sections.

## Type

- [x] Bug fix
- [ ] Feature

## Notes

This is a non-visual CI fix; the verification is the issue repro and the expanded regression test suite.
