### PR TITLE
fix(ci): stop one stalled mock-LLM test from ending the whole run

### DIFF
--- a/.github/workflows/mock-llm-e2e.yml
+++ b/.github/workflows/mock-llm-e2e.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-24.04
     # Full-suite runs can spend several minutes on dependency, browser, uv,
     # and frontend setup before Playwright starts. Keep Playwright's own
-    # 10-minute test deadline below, but give the job enough wall-clock room
+    # 15-minute test deadline below, but give the job enough wall-clock room
     # for setup plus reporting so GitHub does not terminate it mid-suite.
     timeout-minutes: 30
 
@@ -216,13 +216,13 @@ jobs:
           $PW_CMD &
           PW_PID=$!
 
-          # Wait for tests to complete. Playwright's globalTimeout is 600s
-          # (10 min) in CI; we add 60s buffer for webServer startup/teardown.
+          # Wait for tests to complete. Playwright's globalTimeout is 900s
+          # (15 min) in CI; we add 60s buffer for webServer startup/teardown.
           # The custom DoneMarkerReporter writes .tests-done only after ALL
           # tests finish (pass or fail), before webServer teardown begins.
           # .results.json is flushed after every single test, so even if we
           # hit the deadline mid-suite the report script still has data.
-          deadline=$((SECONDS + 660))
+          deadline=$((SECONDS + 960))
           while [ "$SECONDS" -lt "$deadline" ]; do
             if ! kill -0 "$PW_PID" 2>/dev/null; then
               break

--- a/__tests__/e2e/mock-llm-timeout-budget.test.ts
+++ b/__tests__/e2e/mock-llm-timeout-budget.test.ts
@@ -1,0 +1,163 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The mock-LLM specs run serially (`workers: 1`) under a single
+ * `globalTimeout`, so every per-test ceiling is drawn from one shared budget.
+ * A test allowed a large share of that budget turns a single stall into a
+ * whole-suite failure: the run is killed at the cap and the remaining tests
+ * never report, so the result says nothing about the change under test.
+ *
+ * These tests pin the relationship between the two numbers rather than the
+ * numbers themselves, so the suite can be retuned without editing this file —
+ * but not in a way that reintroduces the imbalance. Both configs that run
+ * these specs are checked, since a ceiling is shared by all of them.
+ */
+
+const SPEC_ROOT = join(process.cwd(), "tests/e2e/mock-llm");
+
+const CONFIGS = [
+  "playwright.mock-llm.config.ts",
+  "playwright.mock-llm-docker.config.ts",
+] as const;
+
+/** No single test may claim more than this share of the smallest budget. */
+const MAX_SHARE_OF_GLOBAL_BUDGET = 0.25;
+
+const toMs = (literal: string): number => Number(literal.replace(/_/g, ""));
+
+/**
+ * Read the CI branch of `globalTimeout`. The docker config routes it through a
+ * named constant that falls back to a default, so resolve one hop through the
+ * file's numeric `const` declarations rather than grabbing the next number.
+ */
+function readGlobalTimeoutMs(configFile: string): number {
+  const source = readFileSync(join(process.cwd(), configFile), "utf8");
+  const branch = source.match(
+    /globalTimeout:\s*process\.env\.CI\s*\?\s*([\w$]+)/,
+  );
+  if (!branch) {
+    throw new Error(
+      `Could not read globalTimeout from ${configFile}. If the config changed shape, update this test.`,
+    );
+  }
+
+  const value = branch[1];
+  if (/^\d[\d_]*$/.test(value)) return toMs(value);
+
+  const numericConsts = new Map<string, number>();
+  for (const decl of source.matchAll(
+    /const\s+([\w$]+)\s*=\s*(\d[\d_]*)\s*;/g,
+  )) {
+    numericConsts.set(decl[1], toMs(decl[2]));
+  }
+  if (numericConsts.has(value)) return numericConsts.get(value)!;
+
+  // One hop: find the identifier's declaration and take the first numeric
+  // const it refers to — that is the documented default.
+  const declaration = source.match(
+    new RegExp(`const\\s+${value}\\s*=([\\s\\S]*?);`),
+  );
+  for (const ref of declaration?.[1].matchAll(/[\w$]+/g) ?? []) {
+    const resolved = numericConsts.get(ref[0]);
+    if (resolved !== undefined) return resolved;
+  }
+
+  throw new Error(
+    `globalTimeout in ${configFile} resolves to "${value}", whose value could not be read.`,
+  );
+}
+
+function specFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return specFiles(path);
+    return entry.name.endsWith(".spec.ts") ? [path] : [];
+  });
+}
+
+interface Ceiling {
+  file: string;
+  line: number;
+  ms: number;
+}
+
+function declaredCeilings(): Ceiling[] {
+  return specFiles(SPEC_ROOT).flatMap((file) =>
+    readFileSync(file, "utf8")
+      .split("\n")
+      .flatMap((text, index) => {
+        const match = text.match(/test\.setTimeout\(\s*([\d_]+)\s*\)/);
+        if (!match) return [];
+        return [
+          {
+            file: file.slice(process.cwd().length + 1),
+            line: index + 1,
+            ms: Number(match[1].replace(/_/g, "")),
+          },
+        ];
+      }),
+  );
+}
+
+describe("mock-LLM per-test timeout budget", () => {
+  it("reads a global timeout from every config that runs these specs", () => {
+    for (const config of CONFIGS) {
+      expect(readGlobalTimeoutMs(config), config).toBeGreaterThan(0);
+    }
+    expect(declaredCeilings().length).toBeGreaterThan(0);
+  });
+
+  it("keeps every per-test ceiling within its share of the smallest budget", () => {
+    const budget = Math.min(...CONFIGS.map(readGlobalTimeoutMs));
+    const limit = budget * MAX_SHARE_OF_GLOBAL_BUDGET;
+
+    const offenders = declaredCeilings()
+      .filter((ceiling) => ceiling.ms > limit)
+      .map(
+        (ceiling) =>
+          `${ceiling.file}:${ceiling.line} declares ${ceiling.ms / 1000}s, ` +
+          `over the ${limit / 1000}s ceiling ` +
+          `(${MAX_SHARE_OF_GLOBAL_BUDGET * 100}% of the ${budget / 1000}s budget)`,
+      );
+
+    expect(offenders, offenders.join("\n")).toEqual([]);
+  });
+
+  it("keeps each readiness poll inside the ceiling of the test that runs it", () => {
+    // A poll that outlasts its own test is unreachable: Playwright ends the
+    // test first, replacing a readable "never ready" assertion with an opaque
+    // timeout. `test.setTimeout` opens a test body, so attribute each poll to
+    // the most recent ceiling above it.
+    const offenders: string[] = [];
+
+    for (const file of specFiles(SPEC_ROOT)) {
+      let ceiling: { ms: number; line: number } | null = null;
+
+      readFileSync(file, "utf8")
+        .split("\n")
+        .forEach((text, index) => {
+          const declared = text.match(/test\.setTimeout\(\s*([\d_]+)\s*\)/);
+          if (declared) {
+            ceiling = { ms: toMs(declared[1]), line: index + 1 };
+            return;
+          }
+
+          const poll = text.match(/pollUrl\([^,]*,\s*([\d_]+)\s*\)/);
+          if (!poll || !ceiling) return;
+
+          const ms = toMs(poll[1]);
+          if (ms >= ceiling.ms) {
+            offenders.push(
+              `${file.slice(process.cwd().length + 1)}:${index + 1} polls for ` +
+                `${ms / 1000}s inside a test capped at ${ceiling.ms / 1000}s ` +
+                `(line ${ceiling.line})`,
+            );
+          }
+        });
+    }
+
+    expect(offenders, offenders.join("\n")).toEqual([]);
+  });
+});

--- a/playwright.mock-llm.config.ts
+++ b/playwright.mock-llm.config.ts
@@ -83,7 +83,10 @@ export default defineConfig({
   retries: 0,
   workers: 1,
   timeout: 60_000,
-  globalTimeout: process.env.CI ? 600_000 : 0, // 10 min hard cap in CI
+  // 15 min hard cap in CI. Healthy full runs land at 8.6-9.7m, so the
+  // previous 10-minute cap left as little as 18s of margin and any slow
+  // test ended the run before most of the suite had reported.
+  globalTimeout: process.env.CI ? 900_000 : 0,
   reporter: [
     ["line"],
     ["json", { outputFile: "test-results-mock-llm/results.json" }],

--- a/tests/e2e/mock-llm/backends/mock-llm-cross-connect.spec.ts
+++ b/tests/e2e/mock-llm/backends/mock-llm-cross-connect.spec.ts
@@ -340,8 +340,12 @@ test.describe("cross-connect: frontend-only → backend-only", () => {
   test("frontend-only connects to a separate backend-only instance", async ({
     page,
   }) => {
-    // Backend-only needs uvx → agent-server: 3+ minutes
-    test.setTimeout(300_000);
+    // Spawns one backend-only instance via uvx. Measured at 15-25s across
+    // recent CI runs — the uv cache is warm by this point because the
+    // Playwright webServer spawns the full stack first. The ceiling is
+    // headroom for a slow runner, not an expected duration; the readiness
+    // poll below trips first, and with a readable message.
+    test.setTimeout(90_000);
 
     // These tests spawn bin/agent-canvas.mjs locally, which needs a
     // pre-built frontend. Skip when running in Docker-only CI (no local build).
@@ -378,7 +382,7 @@ test.describe("cross-connect: frontend-only → backend-only", () => {
 
     const [feStatus, beStatus] = await Promise.all([
       pollUrl(`${feUrl}/`, 60_000),
-      pollUrl(`${beUrl}/server_info`, 180_000),
+      pollUrl(`${beUrl}/server_info`, 60_000),
     ]);
 
     expect(
@@ -463,8 +467,9 @@ test.describe("cross-connect: frontend-only → multiple backends", () => {
   test("connects to two separate backends and switches between them", async ({
     page,
   }) => {
-    // Two backend-only instances via uvx — very slow
-    test.setTimeout(360_000);
+    // Two backend-only instances plus a frontend, all via uvx. Measured at
+    // 28-32s across recent CI runs. See the note above on the ceiling.
+    test.setTimeout(120_000);
 
     test.skip(
       !existsSync(join(PROJECT_ROOT, "build/index.html")),
@@ -506,8 +511,8 @@ test.describe("cross-connect: frontend-only → multiple backends", () => {
 
     const [feStatus, beStatusA, beStatusB] = await Promise.all([
       pollUrl(`${feUrl}/`, 60_000),
-      pollUrl(`${beUrlA}/server_info`, 180_000),
-      pollUrl(`${beUrlB}/server_info`, 180_000),
+      pollUrl(`${beUrlA}/server_info`, 60_000),
+      pollUrl(`${beUrlB}/server_info`, 60_000),
     ]);
 
     expect(
@@ -666,8 +671,9 @@ test.describe("cross-connect: sidebar links pin their backend", () => {
     page,
     context,
   }) => {
-    // Two backend-only instances via uvx — very slow
-    test.setTimeout(360_000);
+    // Two backend-only instances plus a frontend, all via uvx. Measured at
+    // 19-25s across recent CI runs. See the note above on the ceiling.
+    test.setTimeout(120_000);
 
     test.skip(
       !existsSync(join(PROJECT_ROOT, "build/index.html")),
@@ -708,8 +714,8 @@ test.describe("cross-connect: sidebar links pin their backend", () => {
 
     const [feStatus, beStatusA, beStatusB] = await Promise.all([
       pollUrl(`${feUrl}/`, 60_000),
-      pollUrl(`${beUrlA}/server_info`, 180_000),
-      pollUrl(`${beUrlB}/server_info`, 180_000),
+      pollUrl(`${beUrlA}/server_info`, 60_000),
+      pollUrl(`${beUrlB}/server_info`, 60_000),
     ]);
 
     expect(

--- a/tests/e2e/mock-llm/backends/mock-llm-partial-stack.spec.ts
+++ b/tests/e2e/mock-llm/backends/mock-llm-partial-stack.spec.ts
@@ -199,8 +199,10 @@ test.describe("partial stack: --frontend-only", () => {
       (child = spawnAgentCanvas(["--frontend-only"], isolated.env)),
     );
 
-    // Wait for the ingress to start serving
-    const rootStatus = await pollUrl(`${FRONTEND_ONLY_URL}/`, 60_000);
+    // Wait for the ingress to start serving. Frontend-only needs no uvx, so
+    // this resolves in seconds; keep it under the test ceiling so a genuine
+    // failure surfaces the assertion below rather than an opaque timeout.
+    const rootStatus = await pollUrl(`${FRONTEND_ONLY_URL}/`, 30_000);
     expect(
       rootStatus,
       `Frontend-only ingress never became ready.\nOutput: ${output.get().slice(-500)}`,


### PR DESCRIPTION
HUMAN:

Ran the guard against both trees on Node 24.15: it fails on current `main` naming all five offending ceilings and the unreachable poll, and passes with the change. Full unit suite green, 4608 tests.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

Validated locally on Node 24.15:

- `npx vitest run` — **4608 passed**, 580 files.
- `npx vitest run __tests__/e2e/` — 19 passed.
- `npx tsc --noEmit` — clean. `npm run lint` — 0 errors (3 pre-existing warnings in untouched files). `npx prettier --check` over all 5 changed files — clean.
- Restoring `tests/e2e/mock-llm` and `playwright.mock-llm.config.ts` to `main` and re-running the new guard — it fails, naming every offender:

```
mock-llm-automation.spec.ts:317      declares 180s, over the 150s ceiling (25% of the 600s budget)
mock-llm-cross-connect.spec.ts:344   declares 300s, over the 150s ceiling
mock-llm-cross-connect.spec.ts:467   declares 360s, over the 150s ceiling
mock-llm-cross-connect.spec.ts:670   declares 360s, over the 150s ceiling
mock-llm-partial-stack.spec.ts:266   declares 180s, over the 150s ceiling
mock-llm-partial-stack.spec.ts:203   polls for 60s inside a test capped at 60s
```

The durations behind the new ceilings came from CI rather than a local sample. I read the per-test slots out of the `[N/62]` progress lines across recent green runs of this workflow: `:340` 15-25s, `:463` 19-25s, `:665` 28-32s, against declared ceilings of 300s, 360s and 360s.

## Why

The mock-LLM suite runs serially (`workers: 1`, `fullyParallel: false`) under a single `globalTimeout`, so every per-test ceiling is drawn from one budget shared by all 62 tests. Three tests in `mock-llm-cross-connect.spec.ts` claimed 300s, 360s and 360s of a 600s budget. When one of them stalls it spends most of the budget before Playwright gives up, the run is killed at the cap, and the remaining tests never execute — the job reports red carrying no information about the change under test.

Run [31592886678](https://github.com/OpenHands/OpenHands/actions/runs/31592886678) is the shape of it: one test consumed 6.9 minutes, then `Timed out waiting 600s for the test suite to run`, `1 failed / 38 did not run / 23 passed`.

There is also no slack to absorb a slow run. Healthy full runs land between 8.6m and 9.7m against the 10-minute cap, so the worst of them finishes with about 18 seconds to spare.

## Summary

- Bring the three `mock-llm-cross-connect.spec.ts` ceilings to 90s and 120s, in line with the 60-120s the rest of the suite uses.
- Lower the backend readiness polls in those tests from 180s to 60s. A poll that outlasts its own test is unreachable — Playwright ends the test first and replaces the readable `Backend-only never ready` assertion with an opaque timeout — so the polls have to come down with the ceilings for the diagnostics to survive. `mock-llm-partial-stack.spec.ts` already had this mismatch (a 60s ingress poll inside a 60s test); that one drops to 30s.
- Raise `globalTimeout` to 900s and the workflow watchdog to 960s, preserving the documented `globalTimeout + 60s` relationship. See the note below — this part is separable.
- Add `__tests__/e2e/mock-llm-timeout-budget.test.ts`. It reads the budget from both configs that run these specs, and asserts that no test claims more than a quarter of the smaller one and that no readiness poll outlasts the test that runs it. It pins the relationships rather than the values, so the suite can be retuned without editing the test.

## Issue Number

Fixes #16552

## How to Test

1. `npm ci`
2. `npx vitest run __tests__/e2e/mock-llm-timeout-budget.test.ts` — 3 passed.
3. To see what it catches, restore the previous numbers and re-run:
   ```
   git checkout origin/main -- tests/e2e/mock-llm playwright.mock-llm.config.ts
   npx vitest run __tests__/e2e/mock-llm-timeout-budget.test.ts
   ```
   Two assertions fail, naming five oversized ceilings and one unreachable poll.
4. `npx tsc --noEmit && npm run lint`
5. Full suite: `npx vitest run` — 4608 passed.

The mock-LLM e2e suite itself is exercised by this workflow on CI; the change is to its budgets, so the meaningful end-to-end signal is a green `mock-llm-e2e` run on this PR.

## Video/Screenshots

<img width="3600" height="1332" alt="openhands-16552-timeout-budget-before-after" src="https://github.com/user-attachments/assets/482297af-0099-4cce-a235-f3bdf6719afe" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**The `globalTimeout` raise is separable.** It is the last commit and reverting it leaves the ceiling and poll changes intact. I included it because lowering ceilings alone does not satisfy the issue's third criterion: with an 18-second margin, any slow run still ends at the cap. But it is your CI budget, and there is a reasonable argument for taking the headroom out of #15479 instead — that issue already measures roughly 200s of avoidable waiting in this same suite, including three consent-helper call sites in `mock-llm-cross-connect.spec.ts`. Happy to drop the raise if you would rather go that route.

Worth knowing if the raise stays: at a 600s budget a quarter is 150s, and `mock-llm-automation.spec.ts:317` and `mock-llm-partial-stack.spec.ts:266` both declare 180s. Dropping the raise means either lowering those two as well or loosening the guard's fraction. I left them alone because I have not measured them.

Raising the cap does not slow healthy runs — it bounds a run rather than extending it — and `timeout-minutes: 30` already covers setup and reporting on top.

**Overlap with #16088.** That PR rewrites `mock-llm-e2e.yml` and removes selective execution. My change to that file is a one-line watchdog value plus comments, so a rebase either way is trivial. Since it makes every surviving run a full 62-test run against this same budget, the two changes point the same direction.

**Out of scope:** the root cause of the stall in run 31592886678. It did not reproduce locally in four runs and #16091 is already open against that test's subject area. This PR is only about the amplification — one stall costing the other 38 tests.
