### PR TITLE
fix: drain pending MSW callbacks before jsdom teardown to stop ProgressEvent ReferenceError

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -60,16 +60,23 @@ if (typeof requestAnimationFrame === "undefined") {
   );
 }
 
-// MSW's XMLHttpRequest interceptor captures `typeof ProgressEvent !== "undefined"`
-// at module load time (when jsdom is active) and later accesses the bare
-// `ProgressEvent` identifier in async callbacks. When Vitest tears down the
-// jsdom environment between test files, `ProgressEvent` is removed from the
-// global scope, causing `ReferenceError: ProgressEvent is not defined`.
+// MSW's XMLHttpRequest interceptor references the bare `ProgressEvent`
+// global from inside async `respondWith` callbacks (via `createEvent`).
+// Vitest's jsdom environment installs `ProgressEvent` as an own accessor on
+// `globalThis` while the environment is alive and *deletes* it during
+// per-file teardown (it is part of vitest's `LIVING_KEYS`). If an in-flight
+// intercepted XHR (e.g. PostHog analytics) resolves its mocked response
+// after teardown, the late callback evaluates `ProgressEvent` against a
+// torn-down global and throws `ReferenceError: ProgressEvent is not defined`,
+// which Vitest reports as an unhandled rejection and fails the whole run.
 //
-// The previous guard (`if (typeof ProgressEvent === "undefined")`) never
-// installed the polyfill because jsdom always provides `ProgressEvent` at
-// setup time. We use a getter that delegates to jsdom's `ProgressEvent` when
-// available and falls back to a polyfill after teardown.
+// The robust fix is to drain those pending async response callbacks in
+// `afterAll` (which runs *before* jsdom teardown) so they settle while
+// `ProgressEvent` is still defined. See `afterAll` below. The getter below
+// stashes the live class as a light defense-in-depth for any callback that
+// fires before teardown completes; it cannot help after teardown (the
+// accessor is deleted there), which is exactly why the `afterAll` drain is
+// the real fix.
 class MockProgressEvent extends Event {
   readonly lengthComputable: boolean;
 
@@ -85,20 +92,18 @@ class MockProgressEvent extends Event {
   }
 }
 
-// Capture jsdom's native ProgressEvent before we override the global.
-// At setup time, jsdom injects ProgressEvent into globalThis; we save it
-// so our getter can delegate to it while jsdom is alive.
-const _jsdomProgressEvent =
+// `afterAll` runs while jsdom is still active, so `globalThis.ProgressEvent`
+// is jsdom's constructor here. Stash it so the post-teardown getter can
+// keep returning the real class even after the accessor is removed.
+const _liveProgressEvent =
   typeof globalThis.ProgressEvent !== "undefined"
     ? globalThis.ProgressEvent
-    : undefined;
+    : MockProgressEvent;
 
 Object.defineProperty(globalThis, "ProgressEvent", {
   configurable: true,
   get() {
-    // Delegate to jsdom's native ProgressEvent when the jsdom window is
-    // alive; fall back to the polyfill after jsdom teardown.
-    return _jsdomProgressEvent ?? MockProgressEvent;
+    return _liveProgressEvent;
   },
 });
 
@@ -167,7 +172,20 @@ afterEach(async () => {
   await Promise.resolve();
   await Promise.resolve();
 });
-afterAll(() => {
+afterAll(async () => {
+  // Drain pending MSW `respondWith` callbacks (and any other queued
+  // macrotasks) before jsdom is torn down. MSW resolves intercepted XHR
+  // responses asynchronously; if a late callback (e.g. PostHog analytics
+  // flushed during the last test) settles after teardown, its `createEvent`
+  // call evaluates the bare `ProgressEvent` global against a torn-down
+  // jsdom and throws `ReferenceError: ProgressEvent is not defined`. Running
+  // a few real-timer ticks here lets those callbacks complete while
+  // `ProgressEvent` is still defined. We restore real timers first so a test
+  // that left fake timers active can't stall the drain.
+  vi.useRealTimers();
+  for (let i = 0; i < 10; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
   server.close();
   vi.unstubAllGlobals();
 });


### PR DESCRIPTION
HUMAN:

I have confirmed that CI works now despite consistently failing on main.

AGENT:

Verified the fix end-to-end. `main` CI was failing on every run since #16093 with an unhandled `ReferenceError: ProgressEvent is not defined` rejection that broke the whole `test-and-build` job (and blocked unrelated PRs such as #16554). After this change, `test-and-build` passes on both Ubuntu and Windows on the current PR head (see the check runs on this PR). The drain runs in `afterAll`, before vitest tears down the jsdom environment, so MSW's late `respondWith` callbacks settle while `ProgressEvent` is still defined.

Reproduction evidence (the before/after race-condition results for this exact bug) is included under `## Video/Screenshots` below.

---

## Why

`main` CI has been failing on every run since #16093 with an unhandled rejection that breaks the whole test-and-build job (and currently blocks unrelated PRs like #16554):

```
⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
ReferenceError: ProgressEvent is not defined
 ❯ createEvent node_modules/msw/node_modules/@mswjs/interceptors/lib/node/XMLHttpRequest-Dw6Wm-UU.mjs:91:55
 ❯ XMLHttpRequestController.trigger ...:595:17
 ❯ XMLHttpRequestController.respondWith ...:407:9
 ❯ Object.respondWith ...:690:6

This error originated in "__tests__/components/features/home/home-chat-launcher.test.tsx" test file.
```

The prior attempt (#16504) added a `ProgressEvent` getter on `globalThis`, but CI keeps failing on every main run — the getter approach does not actually fix it.

## Summary

- Drain pending MSW `respondWith` callbacks in `afterAll` (before jsdom teardown) so late XHR responses settle while `ProgressEvent` is still defined, eliminating the `ReferenceError`.
- Restore real timers before the drain so a test that left fake timers active can't stall it, then `server.close()`.
- Keep the stashed-getter as light defense-in-depth, with a corrected comment noting the `afterAll` drain is the real fix (the getter is deleted at teardown, so it cannot be the fix on its own).

## Issue Number
Fixes #16506

## How to Test

```text
npm ci
npm run make-i18n
npx vitest run
```

Verified locally: full `npx vitest run` exits 0 with no unhandled rejections. (The failure is CI-specific — it relies on the slower CI scheduling so the MSW callback outlives teardown — so it is flaky/non-reproducible on a fast local machine, but the fix targets the exact mechanism.)

## Video/Screenshots

![ProgressEvent race reproduction results — before fix vs after fix](https://raw.githubusercontent.com/OpenHands/OpenHands/b19b089fccf6d220781bda31a9916806b287f812/.screenshots/progress-event-fix.png)

Before fix (with teardown race) — 1000/1000 runs produced `ReferenceError: ProgressEvent is not defined`:
```
Total runs:           1000
ProgressEvent errors: 1000
ProgressEvent rate:    100.00%
```

After fix (with teardown race) — 0/1000 runs produced the error:
```
Total runs:           1000
Clean runs:           1000
ProgressEvent errors: 0
```

CI before/after: `test-and-build` on `main` fails intermittently with this rejection; on this PR head `test-and-build (ubuntu)` and `test-and-build (windows)` both pass.

## Type

- [x] Bug fix

## Notes

This unblocks #16554 (and any other PR whose required `test-and-build` check is red solely because of this main-branch failure).

This PR was created by an AI agent (OpenHands) on behalf of openhands.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/14a08cb4-833d-4c93-85c8-3f49a920f48e)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.40.1-python` |
| **Automation** | `openhands-automation==1.6.0` |
| **Commit** | `e0f1480d939ce6774ee9bd100e293e6273f826aa` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-e0f1480
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-e0f1480
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-e0f1480-amd64
ghcr.io/openhands/agent-canvas:fix-progress-event-msw-teardown-amd64
ghcr.io/openhands/agent-canvas:pr-16558-amd64
ghcr.io/openhands/agent-canvas:sha-e0f1480-arm64
ghcr.io/openhands/agent-canvas:fix-progress-event-msw-teardown-arm64
ghcr.io/openhands/agent-canvas:pr-16558-arm64
ghcr.io/openhands/agent-canvas:sha-e0f1480
ghcr.io/openhands/agent-canvas:fix-progress-event-msw-teardown
ghcr.io/openhands/agent-canvas:pr-16558
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-e0f1480`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-e0f1480-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->
