### PR TITLE
fix(security): avoid direct state mutation in security analyzer store

### DIFF
--- a/src/stores/security-analyzer-store.ts
+++ b/src/stores/security-analyzer-store.ts
@@ -63,8 +63,20 @@ export const useSecurityAnalyzerStore = create<SecurityAnalyzerStore>(
 
         if (existingLog) {
           if (existingLog.confirmation_state !== log.confirmation_state) {
-            existingLog.confirmation_state = log.confirmation_state;
-            existingLog.confirmed_changed = true;
+            // Create a new log object instead of mutating the existing one in place.
+            // Zustand relies on immutable state updates to trigger re-renders;
+            // mutating the stored object directly can cause stale UI and subtle
+            // bugs when other subscribers hold references to the old object.
+            const updatedLog = {
+              ...existingLog,
+              confirmation_state: log.confirmation_state,
+              confirmed_changed: true,
+            };
+            return {
+              logs: state.logs.map((stateLog) =>
+                stateLog === existingLog ? updatedLog : stateLog,
+              ),
+            };
           }
           return { logs: [...state.logs] }; // Return new array to trigger re-render
         }


### PR DESCRIPTION
## Problem

The `appendSecurityAnalyzerInput` handler in `security-analyzer-store.ts` was directly mutating the existing log object inside the Zustand `set()` callback:

```js
existingLog.confirmation_state = log.confirmation_state;
existingLog.confirmed_changed = true;
```

This violates the immutable update contract that Zustand relies on for change detection. Other subscribers holding references to the same object would see stale data, and React's reconciliation may skip re-renders since the object identity didn't change.

## Fix

Create a new updated log object and use `Array.map()` to replace the existing entry, preserving immutability.

## Testing

- Verify that security confirmation state changes still trigger UI re-renders
- Verify that duplicate events are still detected correctly
- Run existing security analyzer tests
