### PR TITLE
fix(api): skip retries for non-retryable HTTP errors in withRetry

### DIFF
--- a/src/api/with-retry.ts
+++ b/src/api/with-retry.ts
@@ -1,4 +1,41 @@
 /**
+ * Determine whether an error is worth retrying. Client errors (4xx) and
+ * certain network errors are non-retryable, since retrying them wastes
+ * time and can produce misleading error messages.
+ */
+function isRetryableError(error: unknown): boolean {
+  // Re-throw AbortError - the caller intentionally cancelled the request.
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return false;
+  }
+
+  // Check for HTTP response status codes via common API client patterns.
+  const status = getErrorStatus(error);
+  if (status !== undefined) {
+    // 408 Request Timeout and 429 Too Many Requests are retryable.
+    // All other 4xx errors are client errors that won't change on retry.
+    // 5xx errors are server errors worth retrying.
+    return status === 408 || status === 429 || status >= 500;
+  }
+
+  // Network errors (no response received) are retryable.
+  return true;
+}
+
+function getErrorStatus(error: unknown): number | undefined {
+  if (error == null || typeof error !== "object") return undefined;
+  const err = error as Record<string, unknown>;
+  // Axios-style: error.response.status
+  if (typeof err.response === "object" && err.response !== null) {
+    const response = err.response as Record<string, unknown>;
+    if (typeof response.status === "number") return response.status;
+  }
+  // Fetch-style: error.status (Response objects thrown directly)
+  if (typeof err.status === "number") return err.status;
+  return undefined;
+}
+
+/**
  * Retry helper for API calls with exponential backoff.
  */
 export async function withRetry<T>(
@@ -10,7 +47,7 @@ export async function withRetry<T>(
     try {
       return await fn();
     } catch (error) {
-      if (attempt >= maxRetries - 1) {
+      if (attempt >= maxRetries - 1 || !isRetryableError(error)) {
         throw error;
       }
 


### PR DESCRIPTION
## Problem

The `withRetry` helper in `with-retry.ts` was retrying ALL errors, including 4xx client errors (e.g. 400 Bad Request, 401 Unauthorized, 403 Forbidden, 404 Not Found). These errors are non-retryable since the same request will always produce the same error. This added unnecessary latency (up to 3.5s with default backoff) before surfacing the error to the user.

## Fix

Added an `isRetryableError` check that inspects the HTTP status code from the error. Only retries on:
- 408 Request Timeout
- 429 Too Many Requests
- 5xx Server Errors
- Network errors (no response received)
- AbortError is explicitly excluded

## Testing

- Unit test: mock a 404 response, verify `withRetry` throws immediately without retrying
- Unit test: mock a 503 response, verify `withRetry` retries up to `maxRetries`
- Integration: verify settings fetch failures for 401 are surfaced immediately
