### PR TITLE
fix: use ref to prevent stale send closure in useHandleWSEvents

### DIFF
--- a/src/hooks/use-handle-ws-events.ts
+++ b/src/hooks/use-handle-ws-events.ts
@@ -24,6 +24,8 @@ const isTypedErrorEvent = (
 
 export const useHandleWSEvents = () => {
   const { send } = useSendMessage();
+  const sendRef = React.useRef(send);
+  sendRef.current = send;
   const events = useEventStore((state) => state.events);
 
   React.useEffect(() => {
@@ -56,7 +58,7 @@ export const useHandleWSEvents = () => {
       const message: string = `${event.message ?? ""}`;
       if (message.startsWith("Agent reached maximum")) {
         // We set the agent state to paused here - if the user clicks resume, it auto updates the max iterations
-        send(generateAgentStateChangeEvent(AgentState.PAUSED));
+        sendRef.current(generateAgentStateChangeEvent(AgentState.PAUSED));
       }
     }
   }, [events.length]);


### PR DESCRIPTION
## Description

Fixes #16582

The `useEffect` in `useHandleWSEvents` referenced `send` from `useSendMessage()` but did not include it in the dependency array. When `send` is recreated after a WebSocket reconnect, the effect captured a stale closure over the old socket's send function. This caused `AgentState.PAUSED` messages sent after a reconnect to be silently dropped.

## Fix

Stored `send` in a ref (`sendRef`) and read `sendRef.current` inside the effect, so the latest send function is always used without re-running the effect on every render.

## Testing

- [x] Code compiles (no new lint errors)
- [x] Consistent with existing ref patterns in the codebase (e.g. `use-agent-notification.ts` uses `prevStateRef.current`)