### PR TITLE
fix: bail out of loadOlder when conversationId changes during await

### DIFF
--- a/__tests__/hooks/use-load-older-events.test.tsx
+++ b/__tests__/hooks/use-load-older-events.test.tsx
@@ -383,6 +383,96 @@ describe("useLoadOlderEvents", () => {
     });
   });
 
+  it("drops in-flight results and does not poison state when navigating to another conversation", async () => {
+    // Seed the store with a single recent event for conversation A so the
+    // hook has an anchor before the request starts.
+    const recent = makeEvent("evt-recent", "2024-06-01T00:00:00Z");
+    act(() => {
+      useEventStore.getState().addEvent(recent);
+    });
+
+    // Hold the page request for conversation A in flight.
+    let resolvePage!: (page: EventSearchPage<OpenHandsEvent>) => void;
+    const pendingPage = new Promise<EventSearchPage<OpenHandsEvent>>(
+      (resolve) => {
+        resolvePage = resolve;
+      },
+    );
+
+    const olderA = [
+      makeEvent("evt-older-a-1", "2024-05-01T00:00:00Z"),
+      makeEvent("evt-older-a-2", "2024-05-15T00:00:00Z"),
+    ];
+    const spy = vi
+      .spyOn(EventService, "searchEvents")
+      .mockReturnValueOnce(pendingPage);
+
+    const { result, rerender } = renderHook(
+      ({ conversationId }: { conversationId: string | null }) =>
+        useLoadOlderEvents(conversationId),
+      {
+        wrapper,
+        initialProps: { conversationId: "conv-a" },
+      },
+    );
+
+    // Start the load, then navigate to conversation B while it's in flight.
+    await act(async () => {
+      const loadPromise = result.current.loadOlder();
+      rerender({ conversationId: "conv-b" });
+      // Resolve A's stale request after the navigation.
+      resolvePage(makePage(olderA, null));
+      await loadPromise;
+    });
+
+    // A's events must NOT be injected into the store.
+    const storeIds = useEventStore
+      .getState()
+      .events.map((e) => (e as any).id);
+    expect(storeIds).toEqual(["evt-recent"]);
+    expect(storeIds).not.toContain("evt-older-a-1");
+
+    // The stale request must not permanently disable "load older".
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it("resets loading state when the stale request finally settles", async () => {
+    act(() => {
+      useEventStore
+        .getState()
+        .addEvent(makeEvent("evt-recent", "2024-06-01T00:00:00Z"));
+    });
+
+    let resolvePage!: (page: EventSearchPage<OpenHandsEvent>) => void;
+    const pendingPage = new Promise<EventSearchPage<OpenHandsEvent>>(
+      (resolve) => {
+        resolvePage = resolve;
+      },
+    );
+
+    vi.spyOn(EventService, "searchEvents").mockReturnValueOnce(pendingPage);
+
+    const { result, rerender } = renderHook(
+      ({ conversationId }: { conversationId: string | null }) =>
+        useLoadOlderEvents(conversationId),
+      {
+        wrapper,
+        initialProps: { conversationId: "conv-a" },
+      },
+    );
+
+    await act(async () => {
+      const loadPromise = result.current.loadOlder();
+      rerender({ conversationId: "conv-b" });
+      resolvePage(makePage([makeEvent("evt-older-a", "2024-05-01T00:00:00Z")], null));
+      await loadPromise;
+    });
+
+    // After navigation, the new conversation's loading state is restored.
+    expect(result.current.isLoading).toBe(false);
+  });
+
   it("does not paginate on start-task placeholder conversation ids", async () => {
     act(() => {
       useEventStore

--- a/src/hooks/use-load-older-events.ts
+++ b/src/hooks/use-load-older-events.ts
@@ -54,6 +54,11 @@ export const useLoadOlderEvents = (
   const [hasMore, setHasMore] = React.useState(true);
   const isLoadingRef = React.useRef(false);
   const hasMoreRef = React.useRef(true);
+  // Mirrors the latest conversationId so in-flight async callbacks (which
+  // capture conversationId in their useCallback closure) can detect that the
+  // user navigated to another conversation while an `await` was pending.
+  const conversationIdRef = React.useRef(conversationId);
+  conversationIdRef.current = conversationId;
 
   React.useEffect(() => {
     isLoadingRef.current = false;
@@ -133,6 +138,13 @@ export const useLoadOlderEvents = (
         },
       );
 
+      // Stale — the user navigated to another conversation while this
+      // search was in flight. Drop the result; the reset effect in the
+      // new conversation already restored its loading/hasMore state.
+      if (conversationId !== conversationIdRef.current) {
+        return;
+      }
+
       if (!Array.isArray(page.items)) {
         throw new Error(
           "Invalid older-events response: expected page.items to be an array.",
@@ -160,8 +172,11 @@ export const useLoadOlderEvents = (
         setHasMore(false);
       }
     } finally {
-      isLoadingRef.current = false;
-      setIsLoading(false);
+      // Only reset isLoading if we're still the active conversation
+      if (conversationId === conversationIdRef.current) {
+        isLoadingRef.current = false;
+        setIsLoading(false);
+      }
     }
   }, [
     conversationId,


### PR DESCRIPTION
## Description

Fixes #16579

When `loadOlder` is an async callback that captures `conversationId` in its closure, navigating to another conversation while an `await EventService.searchEvents(...)` call is in flight can cause:

1. **Wrong conversation events injected** — the old conversation's events are written into the new conversation's event store.
2. **"Load older" permanently disabled** — if the old conversation's page was exhausted, `setHasMore(false)` poisons the new conversation's `hasMore` for the rest of the session.

## Fix

Mirror the latest `conversationId` via a `conversationIdRef` whose `.current` is updated on every render. After each `await`, compare `conversationId` (closure-captured stale value) against `conversationIdRef.current` (latest value). If they differ, the user navigated away — drop the result.

```typescript
const conversationIdRef = React.useRef(conversationId);
conversationIdRef.current = conversationId;

const loadOlder = React.useCallback(async () => {
  // ...
  const page = await EventService.searchEvents(...);
  if (conversationId !== conversationIdRef.current) return;  // stale
  // ... process page ...
}, [conversationId, conversation, ...]);
```

## Testing

- Added **two new test cases** covering the stale-conversationId scenario:
  - `drops in-flight results and does not poison state when navigating to another conversation`
  - `resets loading state when the stale request finally settles`
- All existing tests continue to pass.

## Impact

Low-risk, targeted fix. The pattern (ref-mirror + stale guard) is consistent with React's recommended patterns for async callbacks.