### PR TITLE
fix(ci): edit the mock-LLM E2E PR comment in place

### DIFF
--- a/__tests__/e2e/mock-llm-reporting.test.ts
+++ b/__tests__/e2e/mock-llm-reporting.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment node
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { renderReport } from "../../tests/e2e/mock-llm/scripts/render-mock-llm-report.mjs";
 import {
   buildCommentBody,
   findMatchingJobComments,
+  upsertJobComment,
 } from "../../tests/e2e/mock-llm/scripts/upsert-pr-comment.mjs";
 
 const MOCK_MARKER = "<!-- agent-canvas-mock-llm-e2e-report -->";
@@ -85,5 +86,60 @@ describe("mock-LLM E2E reporting", () => {
     expect(matching.map((comment: { id: number }) => comment.id)).toEqual([
       1, 2,
     ]);
+  });
+
+  it("edits the existing report in place instead of reposting it", async () => {
+    const requests: { method: string; path: string }[] = [];
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (url, init) => {
+        const method = init?.method ?? "GET";
+        const path =
+          new URL(String(url)).pathname + new URL(String(url)).search;
+        requests.push({ method, path });
+
+        if (method === "GET") {
+          return new Response(
+            JSON.stringify(
+              path.includes("page=1")
+                ? [
+                    { id: 11, body: "unrelated", user: { type: "User" } },
+                    {
+                      id: 22,
+                      body: `${MOCK_MARKER}\n## ✅ Mock-LLM E2E Tests`,
+                      user: { login: "github-actions[bot]", type: "Bot" },
+                    },
+                  ]
+                : [],
+            ),
+            { status: 200 },
+          );
+        }
+        return new Response(JSON.stringify({ id: 22 }), { status: 200 });
+      });
+
+    const result = await upsertJobComment({
+      repo: "OpenHands/OpenHands",
+      issueNumber: "16521",
+      token: "t",
+      body: "## ✅ Mock-LLM E2E Tests\n\n**62/62 passed**",
+      marker: MOCK_MARKER,
+      legacyTitle: "Mock-LLM E2E Tests",
+    });
+
+    expect(result).toMatchObject({ updated: true, deleted: 0 });
+    expect(requests.filter((r) => r.method === "PATCH")).toEqual([
+      {
+        method: "PATCH",
+        path: "/repos/OpenHands/OpenHands/issues/comments/22",
+      },
+    ]);
+    expect(requests.some((r) => r.method === "POST")).toBe(false);
+    expect(requests.some((r) => r.method === "DELETE")).toBe(false);
+    fetchMock.mockRestore();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 });

--- a/tests/e2e/mock-llm/scripts/upsert-pr-comment.mjs
+++ b/tests/e2e/mock-llm/scripts/upsert-pr-comment.mjs
@@ -188,7 +188,7 @@ export function findMatchingJobComments(comments, options) {
   return comments.filter((comment) => isMatchingJobComment(comment, options));
 }
 
-export async function replaceJobComment({
+export async function upsertJobComment({
   repo,
   issueNumber,
   token,
@@ -197,24 +197,41 @@ export async function replaceJobComment({
   legacyTitle = "",
 }) {
   const comments = await listIssueComments(repo, issueNumber, token);
-  const existing = findMatchingJobComments(comments, { marker, legacyTitle });
+  const [existing, ...duplicates] = findMatchingJobComments(comments, {
+    marker,
+    legacyTitle,
+  });
+  const commentBody = buildCommentBody(body, marker);
 
-  for (const comment of existing) {
+  // Edit the oldest report in place so the comment keeps its position in the
+  // thread and does not notify subscribers on every run. Anything beyond it is
+  // a leftover duplicate from an earlier run.
+  for (const duplicate of duplicates) {
     await githubRequest(
       "DELETE",
-      `/repos/${repo}/issues/comments/${comment.id}`,
+      `/repos/${repo}/issues/comments/${duplicate.id}`,
       token,
     );
+  }
+
+  if (existing) {
+    const updated = await githubRequest(
+      "PATCH",
+      `/repos/${repo}/issues/comments/${existing.id}`,
+      token,
+      { body: commentBody },
+    );
+    return { updated: true, deleted: duplicates.length, comment: updated };
   }
 
   const created = await githubRequest(
     "POST",
     `/repos/${repo}/issues/${issueNumber}/comments`,
     token,
-    { body: buildCommentBody(body, marker) },
+    { body: commentBody },
   );
 
-  return { deleted: existing.length, created };
+  return { updated: false, deleted: duplicates.length, comment: created };
 }
 
 async function main() {
@@ -245,7 +262,7 @@ async function main() {
   );
   const body = readFileSync(bodyFile, "utf8");
 
-  const result = await replaceJobComment({
+  const result = await upsertJobComment({
     repo,
     issueNumber: validatedIssueNumber,
     token,
@@ -254,11 +271,14 @@ async function main() {
     legacyTitle: args.legacy_title ?? "",
   });
 
-  console.log(
-    `Deleted ${result.deleted} existing PR comment${
-      result.deleted === 1 ? "" : "s"
-    }; created PR comment ${result.created.id}.`,
-  );
+  const action = result.updated ? "Updated" : "Created";
+  const cleanup =
+    result.deleted === 0
+      ? ""
+      : ` Deleted ${result.deleted} duplicate PR comment${
+          result.deleted === 1 ? "" : "s"
+        }.`;
+  console.log(`${action} PR comment ${result.comment.id}.${cleanup}`);
 }
 
 if (


### PR DESCRIPTION
HUMAN:

Updating E2E tests to update the last msg posted in the PR and not posting a brand-new one every time the tests ran.

AGENT:

---

## Why

Every mock-LLM E2E run posts a **brand-new** PR comment instead of editing the
existing one. `replaceJobComment` in
`tests/e2e/mock-llm/scripts/upsert-pr-comment.mjs` deleted every matching
comment and then `POST`ed a fresh one, so despite the file name nothing was
actually being upserted.

Only one report is visible at any instant — each run deletes its predecessor —
but every run is a *comment creation*, which means a new notification and the
report jumping to the bottom of the conversation as new activity. #16521 has had
12 Mock-LLM E2E runs and 12 Mock-LLM Docker E2E runs, so that branch generated 24
comment creations for 2 comments' worth of information.

The live E2E copy of this script (`tests/e2e/live/scripts/upsert-pr-comment.mjs`)
already `PATCH`es in place. The mock-LLM copy had drifted from it.

## Summary

- `replaceJobComment` → `upsertJobComment`: it now `PATCH`es the **oldest**
  matching comment, so the report keeps its position in the thread and GitHub
  sends no notification (comment edits do not notify).
- Duplicates beyond the first are still deleted, which cleans up the leftovers
  the old behaviour scattered across existing PRs. A comment is created only when
  no report exists yet.
- Covers all three call sites automatically: `mock-llm-e2e.yml`,
  `mock-llm-docker-e2e.yml`, and the fork-PR path in `mock-llm-e2e-comment.yml`.

## Issue Number

**No `ready-for-dev` issue exists for this yet.** Flagging rather than linking
something that does not meet the bar — happy to open one and wait for triage
before this leaves draft.

## How to Test

The script's entire job is HTTP calls against the GitHub API, and it honours
`GITHUB_API_URL`. So it can be driven end-to-end against a stateful stand-in for
the comments API, which is what I did — no unit-test mocks, the real CLI over
real HTTP.

**1. Confirm the bug on `main`:**

```bash
git show origin/main:tests/e2e/mock-llm/scripts/upsert-pr-comment.mjs > /tmp/old-upsert.mjs
```

Driving the old `replaceJobComment` against a thread that already contains its
report issues:

```
OLD implementation issued: GET, DELETE, POST
```

Every run destroys and recreates — that is the churn.

**2. Confirm the fix.** Start a stateful fake API on `:8765` seeded with one
human comment, then run the real CLI four times, injecting two stale leftovers
before the last run:

```bash
export GITHUB_API_URL=http://localhost:8765 GITHUB_TOKEN=fake-token
node tests/e2e/mock-llm/scripts/upsert-pr-comment.mjs \
  --repo OpenHands/OpenHands --issue-number 16521 \
  --body-file mock-llm-report.md \
  --marker "<!-- agent-canvas-mock-llm-e2e-report -->" \
  --legacy-title "Mock-LLM E2E Tests"
```

Script output across the four runs:

```
--- CI run #1 ---
Created PR comment 101.
--- CI run #2 ---
Updated PR comment 101.
--- CI run #3 ---
Updated PR comment 101.
--- CI run #4 (with 2 leftovers in thread) ---
Updated PR comment 101. Deleted 2 duplicate PR comments.
```

Every HTTP call the server received:

```
GET    /repos/OpenHands/OpenHands/issues/16521/comments
POST   /repos/OpenHands/OpenHands/issues/16521/comments      <- run 1, first ever report
GET    /repos/OpenHands/OpenHands/issues/16521/comments
PATCH  /repos/OpenHands/OpenHands/issues/comments/101        <- run 2, edited in place
GET    /repos/OpenHands/OpenHands/issues/16521/comments
PATCH  /repos/OpenHands/OpenHands/issues/comments/101        <- run 3, edited in place
POST   /repos/OpenHands/OpenHands/issues/16521/comments      <- injected leftover (curl, not the script)
POST   /repos/OpenHands/OpenHands/issues/16521/comments      <- injected legacy unmarked comment (curl)
GET    /repos/OpenHands/OpenHands/issues/16521/comments
DELETE /repos/OpenHands/OpenHands/issues/comments/102        <- run 4, duplicate cleaned up
DELETE /repos/OpenHands/OpenHands/issues/comments/103        <- run 4, legacy comment cleaned up
PATCH  /repos/OpenHands/OpenHands/issues/comments/101        <- run 4, still the same comment
```

Final thread state — one report, still sitting where it was created, below the
human comment rather than bumped past it:

```
id=1   LGTM, nice work
id=101 <!-- agent-canvas-mock-llm-e2e-report --> | ## ✅ Mock-LLM E2E Tests
```

`101` is created once and edited three times. On `main` that same sequence would
have produced four different comment IDs.

**3. Unit tests.** `npm test` — **4605 passing**, 0 failures. The new case in
`__tests__/e2e/mock-llm-reporting.test.ts` asserts a `PATCH` with no `POST` and
no `DELETE`; it fails against the old implementation. `npx eslint` clean,
prettier applied.

## Video/Screenshots

<img width="889" height="282" alt="Screenshot 2026-08-13 at 16 09 25" src="https://github.com/user-attachments/assets/7198f63e-bbe4-4a79-afa3-03bf1b5665b2" />


## Type

- [x] Bug fix

## Notes

**Two comments remain, not one.** The regular and Docker E2E reports use separate
markers and come from two independent workflows, so a PR still shows two report
comments — each now stable instead of churning. Merging them into a single
comment would need cross-workflow coordination; happy to follow up if that is
wanted.

**The live E2E script is untouched.** It already does the right thing. The two
scripts are near-duplicates that have drifted; de-duplicating them is a
reasonable follow-up but felt out of scope for a bug fix.

**Existing PRs self-heal.** The first run after this merges adopts whatever
report comment is already there and deletes any stragglers, so no manual cleanup
is needed.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.7.1` |
| **Commit** | `f6929b5e39e7bdfff798ea8e4311107cee38d372` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-f6929b5
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-f6929b5
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-f6929b5-amd64
ghcr.io/openhands/agent-canvas:vasco-fix-e2e-comment-churn-amd64
ghcr.io/openhands/agent-canvas:pr-16591-amd64
ghcr.io/openhands/agent-canvas:sha-f6929b5-arm64
ghcr.io/openhands/agent-canvas:vasco-fix-e2e-comment-churn-arm64
ghcr.io/openhands/agent-canvas:pr-16591-arm64
ghcr.io/openhands/agent-canvas:sha-f6929b5
ghcr.io/openhands/agent-canvas:vasco-fix-e2e-comment-churn
ghcr.io/openhands/agent-canvas:pr-16591
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-f6929b5`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-f6929b5-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->