### PR TITLE
feat(settings): migrate page bodies to the section registry + first cloud-only Application section (PR 3/stack)

### DIFF
--- a/__tests__/routes/app-settings.test.tsx
+++ b/__tests__/routes/app-settings.test.tsx
@@ -201,4 +201,78 @@ describe("AppSettingsScreen", () => {
       );
     });
   });
+
+  it("hides the cloud-only advanced section on local backends", async () => {
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(buildSettings());
+
+    renderAppSettingsScreen();
+
+    // The general section renders, proving the page loaded...
+    await screen.findByTestId("app-settings-general-submit");
+    // ...but the cloud-gated advanced section does not.
+    expect(
+      screen.queryByTestId("app-settings-advanced-section"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the advanced section on cloud backends", async () => {
+    activeBackendState.kind = "cloud";
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({
+        max_budget_per_task: 25,
+        enable_solvability_analysis: true,
+        enable_proactive_conversation_starters: false,
+      }),
+    );
+
+    renderAppSettingsScreen();
+
+    expect(
+      await screen.findByTestId("app-settings-advanced-section"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("max-budget-per-task-input")).toHaveValue(25);
+    expect(
+      screen.getByTestId("enable-solvability-analysis-switch"),
+    ).toBeChecked();
+    expect(
+      screen.getByTestId("enable-proactive-conversation-starters-switch"),
+    ).not.toBeChecked();
+  });
+
+  it("saves only the advanced fields it owns (section-owned save)", async () => {
+    activeBackendState.kind = "cloud";
+    const saveSettingsSpy = vi
+      .spyOn(SettingsService, "saveSettings")
+      .mockResolvedValue(true);
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({
+        max_budget_per_task: null,
+        enable_solvability_analysis: false,
+        enable_proactive_conversation_starters: false,
+      }),
+    );
+
+    renderAppSettingsScreen();
+
+    const user = userEvent.setup();
+    await user.click(
+      await screen.findByTestId("enable-solvability-analysis-switch"),
+    );
+    await user.click(screen.getByTestId("app-settings-advanced-submit"));
+
+    await waitFor(() => {
+      expect(saveSettingsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enable_solvability_analysis: true,
+          enable_proactive_conversation_starters: false,
+          max_budget_per_task: null,
+        }),
+      );
+    });
+    // Section-owned save: it must not touch fields other sections own.
+    const payload = saveSettingsSpy.mock.calls[0][0];
+    expect(payload).not.toHaveProperty("git_user_name");
+    expect(payload).not.toHaveProperty("title_llm_profile");
+    expect(payload).not.toHaveProperty("language");
+  });
 });

--- a/__tests__/routes/condenser-settings.test.tsx
+++ b/__tests__/routes/condenser-settings.test.tsx
@@ -1,0 +1,51 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SettingsService from "#/api/settings-service/settings-service.api";
+import { MOCK_DEFAULT_USER_SETTINGS } from "#/mocks/handlers";
+import CondenserSettingsScreen from "#/routes/condenser-settings";
+import { Settings } from "#/types/settings";
+
+function buildSettings(overrides: Partial<Settings> = {}): Settings {
+  return {
+    ...MOCK_DEFAULT_USER_SETTINGS,
+    ...overrides,
+    agent_settings: {
+      ...MOCK_DEFAULT_USER_SETTINGS.agent_settings,
+      ...overrides.agent_settings,
+    },
+    agent_settings_schema:
+      overrides.agent_settings_schema ??
+      MOCK_DEFAULT_USER_SETTINGS.agent_settings_schema,
+  };
+}
+
+function renderCondenserSettingsScreen() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(<CondenserSettingsScreen />, {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("CondenserSettingsScreen", () => {
+  it("renders the condenser section from the agent schema via the registry host", async () => {
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(buildSettings());
+
+    renderCondenserSettingsScreen();
+
+    // The registry host renders the registered CondenserSection, which keeps
+    // the same testId the page had before the conversion.
+    expect(
+      await screen.findByTestId("condenser-settings-screen"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/features/settings/agent-context-settings/agent-context-section.tsx
+++ b/src/components/features/settings/agent-context-settings/agent-context-section.tsx
@@ -1,0 +1,19 @@
+import { SdkSectionPage } from "#/components/features/settings/sdk-settings/sdk-section-page";
+
+/**
+ * Agent-context settings, rendered from the agent schema's `agent_context`
+ * section (today only persistent memory). Section-owned save is handled by
+ * {@link SdkSectionPage}. Unchanged in behaviour from the former inline page
+ * body — it is just registered as a section now so the Agent Context page uses
+ * the same host as every other settings page.
+ */
+export function AgentContextSection() {
+  return (
+    <SdkSectionPage
+      settingsSources={[
+        { settingsSource: "agent_settings", sectionKeys: ["agent_context"] },
+      ]}
+      testId="agent-context-settings-screen"
+    />
+  );
+}

--- a/src/components/features/settings/app-settings/sections/advanced-application-section.tsx
+++ b/src/components/features/settings/app-settings/sections/advanced-application-section.tsx
@@ -1,0 +1,146 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { useSaveSettings } from "#/hooks/mutation/use-save-settings";
+import { useSettings } from "#/hooks/query/use-settings";
+import { BrandButton } from "#/components/features/settings/brand-button";
+import { SettingsInput } from "#/components/features/settings/settings-input";
+import { SettingsSwitch } from "#/components/features/settings/settings-switch";
+import { I18nKey } from "#/i18n/declaration";
+import { parseMaxBudgetPerTask } from "#/utils/settings-utils";
+import {
+  displayErrorToast,
+  displaySuccessToast,
+} from "#/utils/custom-toast-handlers";
+import { retrieveAxiosErrorMessage } from "#/utils/retrieve-axios-error-message";
+
+/**
+ * Advanced Application settings that only exist on cloud/enterprise backends:
+ * a per-task budget cap, solvability analysis, and proactive GitHub task
+ * suggestions. Registered with a `when: ctx => ctx.backendKind === "cloud"`
+ * predicate rather than an inline `if (isCloud)` in the page host.
+ *
+ * Section-owned save — it persists only these three fields, so the host never
+ * needs to know they exist. This is the first backend-specific section to use
+ * the registry's `when` gate (issue #16596): it closes part of the concrete
+ * enterprise-parity gap the registry was built to close.
+ */
+export function AdvancedApplicationSection() {
+  const { t } = useTranslation("openhands");
+  const { mutate: saveSettings, isPending } = useSaveSettings();
+  const { data: settings } = useSettings();
+
+  const [maxBudgetHasChanged, setMaxBudgetHasChanged] = React.useState(false);
+  const [solvabilityHasChanged, setSolvabilityHasChanged] =
+    React.useState(false);
+  const [proactiveHasChanged, setProactiveHasChanged] = React.useState(false);
+
+  if (!settings) return null;
+
+  const storedMaxBudget =
+    settings.max_budget_per_task === null ||
+    settings.max_budget_per_task === undefined
+      ? ""
+      : String(settings.max_budget_per_task);
+
+  const formAction = (formData: FormData) => {
+    const maxBudget = parseMaxBudgetPerTask(
+      formData.get("max-budget-per-task-input")?.toString() ?? "",
+    );
+    const enableSolvability =
+      formData.get("enable-solvability-analysis-switch")?.toString() === "on";
+    const enableProactive =
+      formData
+        .get("enable-proactive-conversation-starters-switch")
+        ?.toString() === "on";
+
+    saveSettings(
+      {
+        max_budget_per_task: maxBudget,
+        enable_solvability_analysis: enableSolvability,
+        enable_proactive_conversation_starters: enableProactive,
+      },
+      {
+        onSuccess: () => displaySuccessToast(t(I18nKey.SETTINGS$SAVED)),
+        onError: (error) => {
+          const errorMessage = retrieveAxiosErrorMessage(error);
+          displayErrorToast(errorMessage || t(I18nKey.ERROR$GENERIC));
+        },
+        onSettled: () => {
+          setMaxBudgetHasChanged(false);
+          setSolvabilityHasChanged(false);
+          setProactiveHasChanged(false);
+        },
+      },
+    );
+  };
+
+  const checkIfMaxBudgetHasChanged = (value: string) => {
+    setMaxBudgetHasChanged(value !== storedMaxBudget);
+  };
+
+  const checkIfSolvabilityHasChanged = (checked: boolean) => {
+    setSolvabilityHasChanged(
+      checked !== !!settings.enable_solvability_analysis,
+    );
+  };
+
+  const checkIfProactiveHasChanged = (checked: boolean) => {
+    setProactiveHasChanged(
+      checked !== !!settings.enable_proactive_conversation_starters,
+    );
+  };
+
+  const formIsClean =
+    !maxBudgetHasChanged && !solvabilityHasChanged && !proactiveHasChanged;
+
+  return (
+    <form
+      data-testid="app-settings-advanced-section"
+      action={formAction}
+      className="flex flex-col gap-6"
+    >
+      <SettingsInput
+        testId="max-budget-per-task-input"
+        name="max-budget-per-task-input"
+        type="number"
+        label={t(I18nKey.SETTINGS$MAX_BUDGET_PER_TASK)}
+        defaultValue={storedMaxBudget}
+        min={1}
+        step={1}
+        showOptionalTag
+        onChange={checkIfMaxBudgetHasChanged}
+        className="w-full max-w-[680px]"
+      />
+
+      <SettingsSwitch
+        testId="enable-solvability-analysis-switch"
+        name="enable-solvability-analysis-switch"
+        defaultIsToggled={!!settings.enable_solvability_analysis}
+        onToggle={checkIfSolvabilityHasChanged}
+      >
+        {t(I18nKey.SETTINGS$SOLVABILITY_ANALYSIS)}
+      </SettingsSwitch>
+
+      <SettingsSwitch
+        testId="enable-proactive-conversation-starters-switch"
+        name="enable-proactive-conversation-starters-switch"
+        defaultIsToggled={!!settings.enable_proactive_conversation_starters}
+        onToggle={checkIfProactiveHasChanged}
+      >
+        {t(I18nKey.SETTINGS$PROACTIVE_CONVERSATION_STARTERS)}
+      </SettingsSwitch>
+
+      <div className="flex justify-start">
+        <BrandButton
+          testId="app-settings-advanced-submit"
+          variant="primary"
+          type="submit"
+          isDisabled={isPending || formIsClean}
+        >
+          {!isPending && t(I18nKey.SETTINGS$SAVE_CHANGES)}
+          {isPending && t(I18nKey.SETTINGS$SAVING)}
+        </BrandButton>
+      </div>
+    </form>
+  );
+}

--- a/src/components/features/settings/condenser-settings/condenser-section.tsx
+++ b/src/components/features/settings/condenser-settings/condenser-section.tsx
@@ -1,0 +1,19 @@
+import { SdkSectionPage } from "#/components/features/settings/sdk-settings/sdk-section-page";
+
+/**
+ * Condenser settings, rendered from the agent schema's `condenser` section.
+ * Section-owned save is handled by {@link SdkSectionPage} (it persists only the
+ * fields it renders). Unchanged in behaviour from the former inline page body —
+ * it is just registered as a section now so the Condenser page uses the same
+ * host as every other settings page.
+ */
+export function CondenserSection() {
+  return (
+    <SdkSectionPage
+      settingsSources={[
+        { settingsSource: "agent_settings", sectionKeys: ["condenser"] },
+      ]}
+      testId="condenser-settings-screen"
+    />
+  );
+}

--- a/src/routes/agent-context-settings.tsx
+++ b/src/routes/agent-context-settings.tsx
@@ -1,13 +1,25 @@
-import { SdkSectionPage } from "#/components/features/settings/sdk-settings/sdk-section-page";
+import { getSettingsSections } from "#/settings/registry";
+import { useSettingsContext } from "#/settings/use-settings-context";
+// Registers the SDK-schema settings sections (Condenser, Agent Context).
+import "#/settings/register-sdk-settings-sections";
 
+const AGENT_CONTEXT_SETTINGS_PAGE = "/settings/agent-context";
+
+/**
+ * Host for the Agent Context settings page. Renders whatever sections are
+ * registered for this page and visible in the current
+ * {@link useSettingsContext} — the same host every settings page now uses.
+ */
 function AgentContextSettingsScreen() {
+  const context = useSettingsContext();
+  const sections = getSettingsSections(AGENT_CONTEXT_SETTINGS_PAGE, context);
+
   return (
-    <SdkSectionPage
-      settingsSources={[
-        { settingsSource: "agent_settings", sectionKeys: ["agent_context"] },
-      ]}
-      testId="agent-context-settings-screen"
-    />
+    <div className="flex flex-col gap-6">
+      {sections.map(({ id, Component }) => (
+        <Component key={id} />
+      ))}
+    </div>
   );
 }
 

--- a/src/routes/condenser-settings.tsx
+++ b/src/routes/condenser-settings.tsx
@@ -1,13 +1,25 @@
-import { SdkSectionPage } from "#/components/features/settings/sdk-settings/sdk-section-page";
+import { getSettingsSections } from "#/settings/registry";
+import { useSettingsContext } from "#/settings/use-settings-context";
+// Registers the SDK-schema settings sections (Condenser, Agent Context).
+import "#/settings/register-sdk-settings-sections";
 
+const CONDENSER_SETTINGS_PAGE = "/settings/condenser";
+
+/**
+ * Host for the Condenser settings page. Renders whatever sections are
+ * registered for this page and visible in the current
+ * {@link useSettingsContext} — the same host every settings page now uses.
+ */
 function CondenserSettingsScreen() {
+  const context = useSettingsContext();
+  const sections = getSettingsSections(CONDENSER_SETTINGS_PAGE, context);
+
   return (
-    <SdkSectionPage
-      settingsSources={[
-        { settingsSource: "agent_settings", sectionKeys: ["condenser"] },
-      ]}
-      testId="condenser-settings-screen"
-    />
+    <div className="flex flex-col gap-6">
+      {sections.map(({ id, Component }) => (
+        <Component key={id} />
+      ))}
+    </div>
   );
 }
 

--- a/src/settings/register-app-settings-sections.ts
+++ b/src/settings/register-app-settings-sections.ts
@@ -2,6 +2,7 @@ import { registerSettingsSection } from "./registry";
 import { GeneralSection } from "#/components/features/settings/app-settings/sections/general-section";
 import { ConversationTitlesSection } from "#/components/features/settings/app-settings/sections/conversation-titles-section";
 import { GitSection } from "#/components/features/settings/app-settings/sections/git-section";
+import { AdvancedApplicationSection } from "#/components/features/settings/app-settings/sections/advanced-application-section";
 
 const APP_SETTINGS_PAGE = "/settings/app";
 
@@ -34,6 +35,17 @@ export function registerAppSettingsSections(): void {
     page: APP_SETTINGS_PAGE,
     order: 30,
     Component: GitSection,
+  });
+
+  // Backend-specific: only cloud/enterprise backends support these fields. It
+  // appears by registration + a `when` predicate instead of an inline
+  // `if (isCloud)` block in the page host (issue #16596).
+  registerSettingsSection({
+    id: "app.advanced",
+    page: APP_SETTINGS_PAGE,
+    order: 40,
+    when: (context) => context.backendKind === "cloud",
+    Component: AdvancedApplicationSection,
   });
 }
 

--- a/src/settings/register-sdk-settings-sections.ts
+++ b/src/settings/register-sdk-settings-sections.ts
@@ -1,0 +1,30 @@
+import { registerSettingsSection } from "./registry";
+import { CondenserSection } from "#/components/features/settings/condenser-settings/condenser-section";
+import { AgentContextSection } from "#/components/features/settings/agent-context-settings/agent-context-section";
+
+/**
+ * Register the SDK-schema-driven settings pages that are a single section each
+ * (Condenser, Agent Context) as registry sections, so their routes use the
+ * same host as the Application page instead of rendering a bespoke body.
+ *
+ * These are first-party sections registered from OSS code; importing this
+ * module for its side effect (see the corresponding routes) performs the
+ * registration, which is idempotent by section id.
+ */
+export function registerSdkSettingsSections(): void {
+  registerSettingsSection({
+    id: "condenser.main",
+    page: "/settings/condenser",
+    order: 10,
+    Component: CondenserSection,
+  });
+
+  registerSettingsSection({
+    id: "agent-context.main",
+    page: "/settings/agent-context",
+    order: 10,
+    Component: AgentContextSection,
+  });
+}
+
+registerSdkSettingsSections();


### PR DESCRIPTION
## What

**PR 3 of the settings-registry stack** (see #16596). Stacked on top of #16599 (base branch is `feat/settings-nav-registry`).

This is the *bulk body-migration + enterprise-parity* step. Two parts:

1. **Convert flat-form pages to registry hosts.** The **Condenser** and **Agent Context** pages become registry hosts (the same host `app-settings` uses). Their `SdkSectionPage` bodies move into registered sections; behaviour and all test IDs are unchanged.
2. **Add the first backend-specific, `when`-gated section.** A new **Advanced Application** section (max budget per task, solvability analysis, proactive conversation starters) is registered on `/settings/app` with `when: ctx => ctx.backendKind === "cloud"` — appearing by registration + predicate instead of an inline `if (isCloud)` block. This is the concrete enterprise-parity gap #16596 set out to close, and the first real use of PR 2's expanded context.

## Why

Per #16596, the registry is meant to (a) generalize beyond the Application page and (b) let backend-specific settings be added by registration rather than by editing shared files. This PR demonstrates both: three pages now share one host, and the enterprise-only Application fields land as a `when`-gated section rather than more `backend.kind` conditionals.

The three advanced fields (`max_budget_per_task`, `enable_solvability_analysis`, `enable_proactive_conversation_starters`) are **real top-level `Settings` keys** that flow through the standard `useSaveSettings` PATCH path — the same path `GeneralSection` already uses for `enable_sound_notifications` — so this is functional, not a stub. The section uses **section-owned save**: it persists only its own three fields.

## Changes

- `src/routes/condenser-settings.tsx`, `src/routes/agent-context-settings.tsx` — now registry hosts that render `getSettingsSections(page, ctx)`.
- `src/components/features/settings/condenser-settings/condenser-section.tsx`, `.../agent-context-settings/agent-context-section.tsx` — the extracted `SdkSectionPage` bodies (unchanged behaviour / test IDs).
- `src/settings/register-sdk-settings-sections.ts` — registers `condenser.main` and `agent-context.main`.
- `src/components/features/settings/app-settings/sections/advanced-application-section.tsx` — new cloud-only, section-owned-save section.
- `src/settings/register-app-settings-sections.ts` — register `app.advanced` (order 40) with the cloud `when` predicate.

## Scope / not in this PR (deferred to the specialized-cases slice)

- **Verification** page — its screen is a *parameterized reused export* (`scope`, `renderTopContent`) consumed outside its route; converting it safely is its own change.
- **Secrets** page — a stateful list/add/edit sub-view machine (PR 4 / exception cases).
- Per-page chrome (`handle.hideTitle`) and the stateful LLM/agent-profiles pages remain PR 4.

## Testing

- New `__tests__/routes/condenser-settings.test.tsx` — the registry host renders the registered condenser section (test ID preserved).
- `__tests__/routes/app-settings.test.tsx` gains three cases for the advanced section: **hidden on local**, **visible + hydrated on cloud**, and **section-owned save** (asserts the payload contains only its own fields and none owned by General/Git/Titles).
- Existing `agent-context-settings` and `verification-settings` suites pass unchanged.
- Full `npm test` suite green (583 files) and `npm run lint` clean (pre-existing unrelated warnings only).

---

_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6138182e-d95f-4fe8-a0cb-cadb08f4f75c)