### PR TITLE
ci: re-run PR description check when new commits are pushed

### DIFF
--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -6,7 +6,7 @@ name: PR Description Check
 
 on:
     pull_request_target:
-        types: [opened, edited, reopened, ready_for_review]
+        types: [opened, edited, reopened, ready_for_review, synchronize]
 
 permissions:
     contents: read


### PR DESCRIPTION
HUMAN:

Fix the trigger for pr-description-check. Some more words just because why not.

AGENT:

---

## Why

`pr-description-check.yml` triggers on `opened`, `edited`, `reopened` and `ready_for_review`, but not `synchronize`, so the job never re-runs when commits are pushed.

The check run stays attached to the commit it originally ran on. After a push — especially a force-push or rebase — the new head commit has no `Validate PR description` check at all. It is a required status check in the `main` ruleset (no bypass actors), so the PR is left blocked on a check that will never appear. Editing the description or reopening is the only way to unstick it, which is why the failure looks intermittent.

Measured 2026-08-13 across all 46 open non-draft PRs: **10 (22%) had no `Validate PR description` check on their head commit** — 16556, 16523, 16512, 16484, 16482, 16473, 16468, 16460, 16456, 16444. On #16444 no commit on the branch carries the check and `mergeStateStatus` is `BLOCKED`.

## Summary

- Add `synchronize` to the `pull_request_target` trigger types so the check re-runs on every push.

## Issue Number

Fixes #

## How to Test

Check whether a PR's head commit carries the check:

    gh api repos/OpenHands/OpenHands/commits/<head-sha>/check-runs \
      --jq '[.check_runs[]|select(.name=="Validate PR description")|.conclusion]'

Today this returns `[]` for the ten PRs listed above. Once this is merged, pushing a commit to an open PR should produce a fresh `Validate PR description` run against the new head.

## Video/Screenshots

Conclusion of `Validate PR description` on the head commit of each of the 46 open non-draft PRs:

    MISSING   10
    failure   23
    success    3
    other     10   (mixed success/failure/skipped)

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- `pull_request_target` always runs the base-branch version of the workflow, so this only takes effect once merged — the check on this PR does not exercise the change.
- Still needs a linked `ready-for-dev` issue before it can leave draft.
- Out of scope here: draft and bot PRs are skipped by the job-level `if:`, and a skipped check counts as satisfying the required check. #16543 covers the draft half.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.7.1` |
| **Commit** | `f48f7dbe3ac192355b9f707f525f21723d7f4a0c` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-f48f7db
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-f48f7db
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-f48f7db-amd64
ghcr.io/openhands/agent-canvas:vasco-ci-pr-description-check-synchronize-amd64
ghcr.io/openhands/agent-canvas:pr-16607-amd64
ghcr.io/openhands/agent-canvas:sha-f48f7db-arm64
ghcr.io/openhands/agent-canvas:vasco-ci-pr-description-check-synchronize-arm64
ghcr.io/openhands/agent-canvas:pr-16607-arm64
ghcr.io/openhands/agent-canvas:sha-f48f7db
ghcr.io/openhands/agent-canvas:vasco-ci-pr-description-check-synchronize
ghcr.io/openhands/agent-canvas:pr-16607
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-f48f7db`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-f48f7db-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->