### PR TITLE
docs(agents): add a repository map clarifying what belongs where

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## General
 
-- This repository is a near-direct port of the OpenHands frontend. Local backends talk straight to `software-agent-sdk` / `agent_server`; optional Cloud backends use the service layer under `src/api/cloud/` and the local cloud proxy.
+- This repository is the OpenHands frontend.
 - Frontend API adaptation lives mainly in `src/api/`:
-  - `option-service` fabricates an OSS web-client config and reads models/providers through `@openhands/typescript-client` LLM endpoints.
+  - `option-service` fabricates a web-client config and reads models/providers through `@openhands/typescript-client` LLM endpoints.
   - `settings-service` uses `@openhands/typescript-client` settings APIs for persistence; reads schemas from `/api/settings/agent-schema` and `/api/settings/conversation-schema`, fetches settings with optional `X-Expose-Secrets: encrypted` header for conversation start payloads, and saves settings via PATCH with diffs.
   - `agent-server-conversation-service`, `event-service`, `agent-server-git-service`, and `skills-service` route local agent-server access through `@openhands/typescript-client` rather than direct HTTP calls.
 - Supported env vars for deployment:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
   - `VITE_BACKEND_BASE_URL` for the agent server base URL.
   - `VITE_SESSION_API_KEY` for optional session auth.
   - `VITE_WORKING_DIR` for the default workspace path sent when starting conversations.
-  - `VITE_ENABLE_BROWSER_TOOLS=false` to omit `BrowserToolSet` from new conversation payloads.
+  - `VITE_ENABLE_BROWSER_TOOLS=false` to omit the `browser_tool_set` tool from new conversation payloads.
   - `VITE_BASE_PATH` for serving the SPA under a subpath such as `/canvas`; pair it with `scripts/static-server.mjs --base-path` at runtime.
 - Public skills are loaded from the `@openhands/extensions` npm package at build time via `SKILLS_CATALOG` (exported from `@openhands/extensions/skills`). The frontend's `SkillsService` maps catalog entries to `SkillInfo` objects and merges them with user/project skills fetched from the agent-server (with `load_public: false`). The agent-server no longer clones the extensions repo or uses `EXTENSIONS_REF` for public skills.
 - Default working-dir fallback is now the relative path `workspace/project` (exported as `DEFAULT_WORKING_DIR` from `src/api/agent-server-config.ts`); git-path heuristics and the default PLAN preview path should reuse that constant instead of hardcoding `/workspace/project`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,28 @@
 - Primary verification commands: `npm run lint`, `npm test`, `npm run build`, and `npm run build:lib`.
 - GitHub automation now includes `.github/workflows/ci.yml` for `npm ci`, `npm test`, and `npm run build`, plus `.github/dependabot.yml` with weekly npm/github-actions updates gated by a 7-day cooldown.
 
+## Repository Map — what belongs where
+
+This repo (`OpenHands/OpenHands`) is **only the agent-canvas frontend**. It is one
+piece of a multi-repo system. Before adding code here, check the change belongs in
+*this* repo — several kinds of work belong in a sibling repo instead. When in doubt,
+add a pointer, not a duplicate implementation.
+
+| Repo | Owns | Add code here when… |
+|------|------|---------------------|
+| **`OpenHands/OpenHands`** (this repo) | The React/TypeScript **frontend** (agent-canvas): UI, routes, frontend services in `src/api/` that *consume* backend APIs. | You are changing UI, frontend state, or how the frontend *calls* an existing backend endpoint. |
+| **`OpenHands/software-agent-sdk`** | The Python **SDK + agent-server**: agents, tools, conversations, events, and the REST/WebSocket **API surface** (`openhands-sdk`, `openhands-tools`, `openhands-agent-server`, `openhands-workspace`). | You are adding or changing a backend endpoint, agent/tool behaviour, or server-side logic. New API **endpoints** live here, not in the frontend. |
+| **`OpenHands/typescript-client`** (`@openhands/typescript-client`) | The generated/maintained **TypeScript client** that mirrors the agent-server API. The frontend's *only* sanctioned way to reach the agent-server (see "API Access Rules"). | You are adding client-side **access to an agent-server endpoint** (typed client method, request/response types). API-access code belongs here, **not** re-implemented in this repo. |
+| **`OpenHands/extensions`** (`@openhands/extensions`) | Public **skills, automations, and integrations** (loaded here at build time via `SKILLS_CATALOG`). | You are adding or editing a skill, automation, or MCP integration. |
+
+Common mis-placements to avoid:
+
+- **API endpoint access** → belongs in `typescript-client`, then consumed here. Do **not**
+  add raw `axios`/`fetch` endpoint code to the frontend (CI guard:
+  `src/api/no-direct-agent-server-calls.test.ts`; see "API Access Rules").
+- **New server endpoints / agent or tool logic** → belongs in `software-agent-sdk`.
+- **Skills / automations / integrations** → belong in `extensions`.
+
 ## PR Description Human Check
 
 The `HUMAN:` section in PR descriptions is reserved for human contributors only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,7 @@
 
 This repo (`OpenHands/OpenHands`) is **only the agent-canvas frontend**. It is one
 piece of a multi-repo system. Before adding code here, check the change belongs in
-*this* repo — several kinds of work belong in a sibling repo instead. When in doubt,
-add a pointer, not a duplicate implementation.
+*this* repo — several kinds of work belong in a sibling repo instead.
 
 | Repo | Owns | Add code here when… |
 |------|------|---------------------|


### PR DESCRIPTION
HUMAN:
This PR proposes an info section with pointers to the main repos in the ecosystem, to guide the agent to the right place for some types of changes. [Slack report](https://openhands-ai.slack.com/archives/C06P5NCGSFP/p1786448544827419)
Also a few updates of outdated info.
<!-- Human contributors: add a short note about your testing. -->

AGENT:

Docs-only change (single new section in `AGENTS.md`), so there is no runtime
behaviour to exercise end-to-end. Verified by rendering the diff and confirming
the new section reads correctly and links to the existing "API Access Rules"
guard. No code, tests, or build outputs are affected.

---

## Why

Agents (and humans) repeatedly implement changes in the wrong repo. A recurring
example: new API-endpoint *access* code keeps landing in this frontend repo
instead of `typescript-client`. `AGENTS.md` documents many specifics but never
states, up front, what this repo owns versus its siblings — so there is nothing
early in the file to steer a change to the right place.

## Summary

- Adds a concise **"Repository Map — what belongs where"** section near the top of
  `AGENTS.md` (right after `## General`).
- A small table of what each repo in the family owns — `OpenHands/OpenHands`
  (this frontend), `software-agent-sdk` (Python SDK + agent-server + the API
  surface), `typescript-client` (the sanctioned client for reaching the
  agent-server), `extensions` (skills/automations/integrations) — and *when* a
  change belongs here versus a sibling.
- A short "common mis-placements to avoid" list naming the exact recurring
  failure modes (endpoint access → `typescript-client`; new endpoints / agent or
  tool logic → `software-agent-sdk`; skills/automations → `extensions`), tied
  into the existing **API Access Rules** CI guard
  (`src/api/no-direct-agent-server-calls.test.ts`).
- KISS: a pointer, not a duplicate of each repo's own docs.

## Issue Number

N/A — documentation-only guidance change requested in the community
(`#general`) thread on agents implementing in the wrong repository.

## How to Test

No runtime steps. Read the new "Repository Map — what belongs where" section in
`AGENTS.md` and confirm it accurately describes repo ownership and the
mis-placement rules. Nothing to build or run.
