### PR TITLE
feat(settings): expose session-wide max_iterations via a General settings page

### DIFF
--- a/__tests__/routes/general-settings.test.tsx
+++ b/__tests__/routes/general-settings.test.tsx
@@ -1,0 +1,146 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SettingsService from "#/api/settings-service/settings-service.api";
+import { MOCK_DEFAULT_USER_SETTINGS } from "#/mocks/handlers";
+import GeneralSettingsScreen from "#/routes/general-settings";
+import { Settings } from "#/types/settings";
+
+function buildSettings(overrides: Partial<Settings> = {}): Settings {
+  return {
+    ...MOCK_DEFAULT_USER_SETTINGS,
+    ...overrides,
+    conversation_settings: {
+      ...MOCK_DEFAULT_USER_SETTINGS.conversation_settings,
+      ...overrides.conversation_settings,
+    },
+    conversation_settings_schema:
+      overrides.conversation_settings_schema ??
+      MOCK_DEFAULT_USER_SETTINGS.conversation_settings_schema,
+  };
+}
+
+function renderGeneralSettingsScreen() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return render(<GeneralSettingsScreen />, {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("GeneralSettingsScreen", () => {
+  it("renders the max_iterations field from the schema with the default value", async () => {
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(buildSettings());
+
+    renderGeneralSettingsScreen();
+
+    await screen.findByTestId("general-settings-screen");
+
+    // max_iterations is the only field in the general section. The page has
+    // no critical-prominence fields, so it floors its view at "advanced" and
+    // renders the field directly (same behaviour as the memory page).
+    const input = await screen.findByTestId("sdk-settings-max_iterations");
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute("type", "number");
+    // Default from the persisted conversation settings (mock default 500).
+    expect(input).toHaveValue(500);
+  });
+
+  it("reflects a custom persisted max_iterations value", async () => {
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({
+        conversation_settings: {
+          ...MOCK_DEFAULT_USER_SETTINGS.conversation_settings,
+          max_iterations: 2000,
+        },
+      }),
+    );
+
+    renderGeneralSettingsScreen();
+
+    await screen.findByTestId("general-settings-screen");
+
+    const input = await screen.findByTestId("sdk-settings-max_iterations");
+    expect(input).toHaveValue(2000);
+  });
+
+  it("saves an edited value through the conversation settings diff", async () => {
+    let persistedSettings = buildSettings();
+
+    vi.spyOn(SettingsService, "getSettings").mockImplementation(async () =>
+      structuredClone(persistedSettings),
+    );
+    const saveSettingsSpy = vi
+      .spyOn(SettingsService, "saveSettings")
+      .mockImplementation(async (payload) => {
+        const diff = payload.conversation_settings_diff as Record<
+          string,
+          unknown
+        >;
+        if (typeof diff.max_iterations === "number") {
+          persistedSettings = buildSettings({
+            conversation_settings: {
+              ...MOCK_DEFAULT_USER_SETTINGS.conversation_settings,
+              max_iterations: diff.max_iterations,
+            },
+          });
+        }
+        return true;
+      });
+
+    renderGeneralSettingsScreen();
+
+    await screen.findByTestId("general-settings-screen");
+
+    const input = await screen.findByTestId("sdk-settings-max_iterations");
+    await userEvent.clear(input);
+    await userEvent.type(input, "2000");
+    await userEvent.click(screen.getByTestId("save-button"));
+
+    // The value propagates through the conversation-settings diff untouched —
+    // values above the old hard cap (500) must be accepted.
+    await waitFor(() => {
+      expect(saveSettingsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conversation_settings_diff: { max_iterations: 2000 },
+        }),
+      );
+    });
+
+    // Settings refetch after save reflects the persisted value.
+    await waitFor(() => {
+      expect(screen.getByTestId("sdk-settings-max_iterations")).toHaveValue(
+        2000,
+      );
+    });
+  });
+
+  it("keeps a large value (above the old 500 default) without artificial capping", async () => {
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({
+        conversation_settings: {
+          ...MOCK_DEFAULT_USER_SETTINGS.conversation_settings,
+          max_iterations: 5000,
+        },
+      }),
+    );
+
+    renderGeneralSettingsScreen();
+
+    await screen.findByTestId("general-settings-screen");
+
+    const input = await screen.findByTestId("sdk-settings-max_iterations");
+    expect(input).toHaveValue(5000);
+  });
+});

--- a/src/constants/settings-nav.tsx
+++ b/src/constants/settings-nav.tsx
@@ -1,4 +1,4 @@
-import { AppWindow, Brain, Shield } from "lucide-react";
+import { AppWindow, Brain, Gauge, Shield } from "lucide-react";
 import KeyIcon from "#/icons/key.svg?react";
 import MemoryIcon from "#/icons/memory_icon.svg?react";
 import CircuitIcon from "#/icons/u-circuit.svg?react";
@@ -52,6 +52,16 @@ export const OSS_NAV_ITEMS: SettingsNavItem[] = [
     to: "/settings/verification",
     text: "SETTINGS$NAV_VERIFICATION",
     subtitle: "SETTINGS$PAGE_VERIFICATION_SUBLINE",
+  },
+  {
+    // "General" renders the general conversation-settings section, which the
+    // SDK schema exposes — today only `max_iterations`, the session-wide
+    // execution budget. Kept separate from Agent profiles because it lives on
+    // the ConversationSettings record, not the AgentSettings record.
+    icon: <Gauge className="size-4" strokeWidth={2} aria-hidden />,
+    to: "/settings/general",
+    text: "SETTINGS$NAV_GENERAL",
+    subtitle: "SETTINGS$PAGE_GENERAL_SUBLINE",
   },
   {
     icon: <AppWindow className="size-4" strokeWidth={2} aria-hidden />,

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -38163,5 +38163,39 @@
     "tr": "Alt sohbet istendi",
     "uk": "Запитано дочірню розмову",
     "ca": "S'ha sol·licitat una conversa filla"
+  },
+  "SETTINGS$NAV_GENERAL": {
+    "en": "General",
+    "ja": "一般",
+    "zh-CN": "常规",
+    "zh-TW": "一般",
+    "ko-KR": "일반",
+    "no": "Generelt",
+    "it": "Generale",
+    "pt": "Geral",
+    "es": "General",
+    "fr": "Général",
+    "de": "Allgemein",
+    "tr": "Genel",
+    "uk": "Загальні",
+    "ar": "عام",
+    "ca": "General"
+  },
+  "SETTINGS$PAGE_GENERAL_SUBLINE": {
+    "en": "Maximum agent steps and other run limits.",
+    "ja": "エージェントの最大ステップ数などの実行制限。",
+    "zh-CN": "代理的最大步数和其他运行限制。",
+    "zh-TW": "代理的最大步數和其他運行限制。",
+    "ko-KR": "에이전트의 최대 단계 수 및 기타 실행 제한.",
+    "no": "Maksimale agentsteg og andre kjøringsbegrensninger.",
+    "it": "Numero massimo di passi dell'agente e altri limiti di esecuzione.",
+    "pt": "Número máximo de passos do agente e outros limites de execução.",
+    "es": "Número máximo de pasos del agente y otros límites de ejecución.",
+    "fr": "Nombre maximal d'étapes de l'agent et autres limites d'exécution.",
+    "de": "Maximale Agentenschritte und andere Ausführungslimits.",
+    "tr": "Maksimum ajan adımı ve diğer çalıştırma limitleri.",
+    "uk": "Максимальна кількість кроків агента та інші обмеження виконання.",
+    "ar": "الحد الأقصى لخطوات الوكيل وحدود التشغيل الأخرى.",
+    "ca": "Nombre màxim de passos de l'agent i altres límits d'execució."
   }
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -27,6 +27,7 @@ export default [
       route("condenser", "routes/condenser-settings.tsx"),
       route("agent-context", "routes/agent-context-settings.tsx"),
       route("verification", "routes/verification-settings.tsx"),
+      route("general", "routes/general-settings.tsx"),
       route("app", "routes/app-settings.tsx"),
       route("secrets", "routes/secrets-settings.tsx"),
     ]),

--- a/src/routes/general-settings.tsx
+++ b/src/routes/general-settings.tsx
@@ -1,0 +1,39 @@
+import { SdkSectionPage } from "#/components/features/settings/sdk-settings/sdk-section-page";
+import { SettingsScope } from "#/types/settings";
+
+/**
+ * Renders the "general" conversation-settings section. Today it carries
+ * exactly one schema field: `max_iterations` — the session-wide execution
+ * budget (maximum number of agent steps) applied when conversations start.
+ * It is rendered through the schema-driven `SdkSectionPage`, so the input is
+ * always derived from the live agent-server schema (`ge=1`, no artificial
+ * upper cap) rather than a hand-maintained field definition.
+ *
+ * This is a session default: the per-command `/goal --max <n>` flag (see
+ * `use-goal-interceptor`) still overrides it for individual goal runs.
+ */
+export function GeneralSettingsScreen({
+  scope = "personal",
+  renderTopContent,
+  testId = "general-settings-screen",
+}: {
+  scope?: SettingsScope;
+  renderTopContent?: () => React.ReactNode;
+  testId?: string;
+}) {
+  return (
+    <SdkSectionPage
+      scope={scope}
+      settingsSources={[
+        {
+          settingsSource: "conversation_settings",
+          sectionKeys: ["general"],
+        },
+      ]}
+      header={renderTopContent ? () => renderTopContent() : undefined}
+      testId={testId}
+    />
+  );
+}
+
+export default GeneralSettingsScreen;


### PR DESCRIPTION
# feat(settings): expose session-wide `max_iterations` via a General settings page

## Problem

OpenHands stops an agent conversation after `max_iterations` agent steps. The
agent-server SDK ships a sensible default (`500`) and already accepts any value
`>= 1` with no artificial upper cap, but the **web frontend never exposes the
setting** — there is no settings page that renders the conversation-settings
`"general"` section, so users cannot choose an execution budget appropriate for
their tasks.

Long autonomous runs (e.g. multi-file refactors, long migrations, iterative
research) routinely hit the 500-step default with no way to raise it from the
UI. Users are forced to either accept the default or work around it via
per-command `/goal --max <n>` flags, which only apply to individual goal runs.

## Solution

Add a schema-driven **General** settings page that renders the
conversation-settings `"general"` section through the existing
`SdkSectionPage` component. Today that section carries exactly one field:
`max_iterations`.

- **Where the setting lives**: `ConversationSettings.max_iterations` — the
  session-wide execution budget applied when conversations start.
- **How the user changes it**: Settings → General → "Max iterations" (number
  input). A new nav item (`SETTINGS$NAV_GENERAL`) links the page, following the
  exact pattern of the existing Verification settings page.
- **How the value reaches the agent runtime**: saving posts a
  `conversation_settings_diff` via the existing settings PATCH flow
  (`use-save-settings` → `SettingsService.saveSettings`). On conversation
  creation, `agent-server-adapter` already forwards
  `conversationSettings.max_iterations` into `StartConversationRequest`, which
  the agent-server SDK applies as the step budget.
- **Validation**: rendered from the live agent-server schema, so the field is
  a number with `ge=1` — the same constraint the SDK enforces
  (`openhands-sdk` `StartConversationRequest.max_iterations: Field(default=500,
  ge=1)`). There is **no** artificial upper cap: values above 500 are accepted
  and stored.
- **Why the semantics are safe**: this is a *session default*, not
  "unlimited". Every conversation still has a concrete, finite step budget; the
  user simply chooses it. The existing per-goal `/goal --max <n>` flag keeps
  precedence for individual goal runs (`use-goal-interceptor`), and the SDK's
  stuck-detection (`stuck_detection: true`) remains active regardless of the
  budget.

This is intentionally minimal and frontend-only: the backend layer (agent
server + SDK) already fully supports configurable `max_iterations` — verified
against `openhands-sdk` 1.42.1.

## Testing

- `__tests__/routes/general-settings.test.tsx` — 4 new tests:
  - renders the `max_iterations` field with the default value (500),
  - reflects a custom persisted value (2000),
  - saves an edited value through `conversation_settings_diff` (and asserts a
    value **above the old 500 default** is accepted untouched),
  - keeps a large value (5000) without artificial capping.
- `npm run typecheck` — clean.
- `npm run lint` / `prettier` — clean on changed files.
- `npm run check-translation-completeness` — clean (new keys added for all 15
  supported languages).
- Targeted suite (`__tests__/routes/`, `__tests__/components/features/settings/`,
  `__tests__/i18n/`) — 344 passed.
- Full `vitest run` — 4567 passed; the only failures are 19 pre-existing,
  environment-related failures in unrelated files
  (`recommended-automations.test.tsx`, `featured-automations-section.test.tsx`,
  `conversation-runtime-info.test.ts`) that fail identically on `main`
  (`TypeError: Cannot read properties of undefined (reading 'clear')`) and are
  not touched by this change.

## Compatibility

- **Default behaviour unchanged**: when the setting is unset (or left at the
  SDK default), conversations behave exactly as before — `max_iterations`
  defaults to `500` at the SDK layer.
- **Existing sessions**: the setting is read at conversation start; changing it
  does not retroactively affect an already-running conversation.
- **Backwards compatibility**: no API or schema changes; the new page only
  renders a section the SDK already exposes. Existing settings files without
  `max_iterations` fall back to the SDK default via `use-settings`.
- **Cloud path**: `max_iterations` is already part of the cloud settings merge
  (`settings-service.api`), so the value persists through the same save flow.

## Performance / safety

Raising `max_iterations` increases the maximum number of LLM round-trips a
single conversation may run, so cost and runtime grow proportionally. This is
the user's explicit choice. We deliberately do **not** offer an
"unlimited" option: the field stays a bounded integer (`>= 1`) with a clear
default, and the SDK's stuck-detection remains on, so pathological loops still
terminate. The per-goal `/goal --max` flag can cap individual goal runs below
the session default when tighter control is wanted.
