### PR TITLE
docs: fix two broken links in the developer docs

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -83,9 +83,8 @@ OH_AGENT_SERVER_VERSION=1.18.0 npm run dev
 ### Multiple local backends (shared persistence)
 
 To run a second standalone agent-server alongside `npm run dev` while sharing
-its conversation history and encrypted secrets, see
-[docs/multi-backend-setup.md](./docs/multi-backend-setup.md). The
-`npm run dev:extra-backend` helper launches an extra server on `:18002` that
+its conversation history and encrypted secrets, see the
+`npm run dev:extra-backend` helper, which launches an extra server on `:18002` that
 reuses the bundled instance's state dir.
 
 ### Frontend against an existing backend

--- a/docs/DefenseClaw.md
+++ b/docs/DefenseClaw.md
@@ -296,7 +296,7 @@ DefenseClaw's registry system (`defenseclaw registry add`) ingests external skil
 - [DefenseClaw CodeGuard Skill](https://github.com/cisco-ai-defense/defenseclaw/blob/main/skills/codeguard/SKILL.md)
 - [OpenHands Agent Server](https://github.com/OpenHands/software-agent-sdk/tree/main/openhands-agent-server)
 - [OpenHands SDK Security Analyzer](https://docs.openhands.dev/sdk/arch/security.md)
-- [Agent Canvas Self-Hosting](../SELF_HOSTING.md)
+- [Agent Canvas Self-Hosting](./SELF_HOSTING.md)
 
 ---
 


### PR DESCRIPTION
HUMAN:
 the change does not affect the code  in annyways  while testing my agent  found there is a flaw in the documentation  and  fixed it 

<!-- Human contributors: add a short note about your testing. -->

AGENT:

Docs-only change, so there is no runtime behaviour to exercise end-to-end. Verified statically:
the target file `SELF_HOSTING.md` exists in `docs/`, the `npm run dev:extra-backend` script is
declared in `package.json`, and `docs/multi-backend-setup.md` does not exist anywhere in the tree.

---

## Why

Two links in the docs point at files that do not exist:

- `docs/DEVELOPMENT.md` references `docs/multi-backend-setup.md`, which is not in the repository. The paragraph already describes the `npm run dev:extra-backend` helper that the missing page would cover, so it now points at that helper directly.
- `docs/DefenseClaw.md` links to `../SELF_HOSTING.md`, which resolves outside the `docs/` directory to a file that does not exist. The correct target is `./SELF_HOSTING.md` (the file lives in `docs/`).

## Summary

- `docs/DEVELOPMENT.md`: replace the dead link to `docs/multi-backend-setup.md` with a direct reference to the `npm run dev:extra-backend` helper.
- `docs/DefenseClaw.md`: fix the relative path to `SELF_HOSTING.md` from `../SELF_HOSTING.md` to `./SELF_HOSTING.md`.

## Issue Number
Fixes #16617

<!-- To be filled in by the human contributor: link an issue carrying the ready-for-dev label. -->

## How to Test

No runtime steps. Confirm both links in the rendered docs resolve to existing files: `docs/DEVELOPMENT.md` (Multiple local backends section) and `docs/DefenseClaw.md` (related resources list).

## Video/Screenshots

None - docs-only change.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

None.