### PR TITLE
fix(terminal): key persistent command index per conversation id

### DIFF
--- a/__tests__/hooks/use-terminal.test.tsx
+++ b/__tests__/hooks/use-terminal.test.tsx
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it, vi, afterEach } from "vitest";
+import { act } from "@testing-library/react";
 import { useTerminal } from "#/hooks/use-terminal";
 import { Command, useCommandStore } from "#/stores/command-store";
 import { renderWithProviders } from "../../test-utils";
@@ -97,6 +98,114 @@ describe("useTerminal", () => {
 
     expect(mockTerminal.writeln).toHaveBeenNthCalledWith(1, "echo hello");
     expect(mockTerminal.writeln).toHaveBeenNthCalledWith(2, "hello");
+  });
+
+  it("should render new commands in two concurrent instances independently", () => {
+    // Arrange - two mounted instances keyed to different conversations
+    renderWithProviders(<TestTerminalComponent />, {
+      navigation: { conversationId: "conv-a" },
+    });
+    renderWithProviders(<TestTerminalComponent />, {
+      navigation: { conversationId: "conv-b" },
+    });
+
+    // Act
+    act(() => {
+      useCommandStore.getState().appendOutput("hello");
+    });
+
+    // Assert - each instance renders the new command (2 total). With a shared
+    // singleton index, whichever instance ran first advanced the index and the
+    // second rendered nothing.
+    const helloCalls = mockTerminal.writeln.mock.calls.filter(
+      ([line]) => line === "hello",
+    );
+    expect(helloCalls).toHaveLength(2);
+  });
+
+  it("should preserve terminal history across unmount and remount", () => {
+    // Arrange
+    const commands: Command[] = [
+      { content: "echo hello", type: "input" },
+      { content: "hello", type: "output" },
+    ];
+    useCommandStore.setState({ commands });
+
+    const { unmount } = renderWithProviders(<TestTerminalComponent />);
+
+    expect(mockTerminal.writeln).toHaveBeenNthCalledWith(1, "echo hello");
+    expect(mockTerminal.writeln).toHaveBeenNthCalledWith(2, "hello");
+
+    // Act - unmount and remount with the same conversation id
+    unmount();
+    mockTerminal.writeln.mockClear();
+    renderWithProviders(<TestTerminalComponent />);
+
+    // Assert - full history is replayed on remount
+    expect(mockTerminal.writeln).toHaveBeenNthCalledWith(1, "echo hello");
+    expect(mockTerminal.writeln).toHaveBeenNthCalledWith(2, "hello");
+
+    // Assert - index continuity: a new command renders exactly once
+    act(() => {
+      useCommandStore.getState().appendOutput("world");
+    });
+    const worldCalls = mockTerminal.writeln.mock.calls.filter(
+      ([line]) => line === "world",
+    );
+    expect(worldCalls).toHaveLength(1);
+  });
+
+  it("should not corrupt a sibling instance when one instance unmounts", () => {
+    // Arrange - one replayed command in each of two instances
+    useCommandStore.setState({
+      commands: [{ content: "c1", type: "output" }],
+    });
+    renderWithProviders(<TestTerminalComponent />, {
+      navigation: { conversationId: "conv-a" },
+    });
+    const instanceB = renderWithProviders(<TestTerminalComponent />, {
+      navigation: { conversationId: "conv-b" },
+    });
+    expect(
+      mockTerminal.writeln.mock.calls.filter(([line]) => line === "c1"),
+    ).toHaveLength(2);
+
+    // Act - unmount B, then append a new command
+    instanceB.unmount();
+    act(() => {
+      useCommandStore.getState().appendOutput("c2");
+    });
+
+    // Assert - only A renders the new command, and A does not re-render "c1"
+    // (with the old shared index, B's cleanup reset it to 0 and A duplicated
+    // the replayed history)
+    expect(
+      mockTerminal.writeln.mock.calls.filter(([line]) => line === "c2"),
+    ).toHaveLength(1);
+    expect(
+      mockTerminal.writeln.mock.calls.filter(([line]) => line === "c1"),
+    ).toHaveLength(2);
+  });
+
+  it("should reset the index when commands are cleared so re-streamed history renders", () => {
+    // Arrange - a replayed command advances the index to 1
+    useCommandStore.setState({
+      commands: [{ content: "c1", type: "output" }],
+    });
+    renderWithProviders(<TestTerminalComponent />);
+
+    // Act - clear the store (conversation switch), then stream a new command
+    act(() => {
+      useCommandStore.getState().clearTerminal();
+    });
+    act(() => {
+      useCommandStore.getState().appendOutput("c2");
+    });
+
+    // Assert - the shrink guard reset the index, so the new command renders
+    expect(
+      mockTerminal.writeln.mock.calls.filter(([line]) => line === "c2"),
+    ).toHaveLength(1);
   });
 
   it("should not call fit() when terminal.element is null", () => {

--- a/src/hooks/use-terminal.ts
+++ b/src/hooks/use-terminal.ts
@@ -1,6 +1,7 @@
 import { FitAddon } from "@xterm/addon-fit";
 import { Terminal } from "@xterm/xterm";
 import React from "react";
+import { useOptionalConversationId } from "#/hooks/use-conversation-id";
 import { Command, useCommandStore } from "#/stores/command-store";
 import { parseTerminalOutput } from "#/utils/parse-terminal-output";
 
@@ -85,16 +86,32 @@ function resolveTerminalForeground(host: HTMLElement): string {
   return getComputedStyle(host).color;
 }
 
-// Create a persistent reference that survives component unmounts
-// This ensures terminal history is preserved when navigating away and back
-const persistentLastCommandIndex = { current: 0 };
+// Create persistent references that survive component unmounts, keyed per
+// conversation id, so terminal history-position tracking is per conversation
+// and sibling terminal instances for different conversations don't corrupt
+// each other's state.
+const persistentLastCommandIndexes = new Map<string, { current: number }>();
+
+const FALLBACK_COMMAND_INDEX_KEY = "__no-conversation__";
+
+function getPersistentLastCommandIndex(key: string) {
+  let entry = persistentLastCommandIndexes.get(key);
+  if (!entry) {
+    entry = { current: 0 };
+    persistentLastCommandIndexes.set(key, entry);
+  }
+  return entry;
+}
 
 export const useTerminal = () => {
   const commands = useCommandStore((state) => state.commands);
   const terminal = React.useRef<Terminal | null>(null);
   const fitAddon = React.useRef<FitAddon | null>(null);
   const ref = React.useRef<HTMLDivElement>(null);
-  const lastCommandIndex = persistentLastCommandIndex; // Use the persistent reference
+  const { conversationId } = useOptionalConversationId();
+  const lastCommandIndex = getPersistentLastCommandIndex(
+    conversationId ?? FALLBACK_COMMAND_INDEX_KEY,
+  );
   const isDisposed = React.useRef(false);
 
   const createTerminal = (host: HTMLDivElement) =>
@@ -159,19 +176,27 @@ export const useTerminal = () => {
           // and need to show all previous commands
           renderCommand(commands[i], terminal.current, false);
         }
-        lastCommandIndex.current = commands.length;
       }
+      // Always sync the entry to the replayed history length (0 when empty).
+      // This self-heals stale entries left over from a prior mount whose
+      // commands were cleared while unmounted.
+      lastCommandIndex.current = commands.length;
       // Don't show prompt in read-only terminal
     }
 
     return () => {
       isDisposed.current = true;
       terminal.current?.dispose();
-      lastCommandIndex.current = 0;
     };
   }, []);
 
   React.useEffect(() => {
+    // The command store only appends or clears, so a shrink means the store
+    // was cleared (e.g. on conversation switch); reset so re-streamed history
+    // renders from scratch.
+    if (lastCommandIndex.current > commands.length) {
+      lastCommandIndex.current = 0;
+    }
     if (
       terminal.current &&
       commands.length > 0 &&


### PR DESCRIPTION
HUMAN:

AGENT:

This change was produced by an agent pipeline with human review at two gates: the proposed approach was posted on the issue and approved before any code was written, and the final diff, tests, and evidence were reviewed before this PR was opened. Evidence below includes a failing run of the new tests against unfixed main and the green run after the fix, plus lint and typecheck results.

---

## Why

Opening a second terminal while another one is mounted renders an empty terminal: no history, no output. `persistentLastCommandIndex` in `src/hooks/use-terminal.ts` (line 90) is a single module-level counter shared by every mounted `useTerminal` instance. The first instance advances the shared counter, so the second instance starts at an already advanced index and writes nothing. The module scope itself is intentional (it preserves history across unmount and remount), so the fix keeps that behavior instead of simply moving the counter into the hook.

## Summary

- Replace the module-level singleton with a module-level `Map<string, { current: number }>` keyed by conversation id from `useOptionalConversationId()`, with a named fallback key when no conversation id is available. The id is read synchronously from navigation context, so the key is stable from first render.
- Remove the cleanup reset that zeroed the counter on unmount and corrupted sibling instances. The mount effect now always syncs the entry to the replayed history length, which also self-heals stale entries left from a prior mount whose commands were cleared while unmounted.
- Reset an entry only when the command store shrinks. The store only appends or clears, so a shrink means `clearTerminal` ran (for example on conversation switch) and re-streamed history should render from scratch.
- Add four regression tests: concurrent instances render independently, remount persistence is preserved, unmounting one instance does not corrupt a sibling, and clearing commands resets the index.

## Issue Number

Fixes #16581

## How to Test

```bash
npm install
npx vitest run __tests__/hooks/use-terminal.test.tsx
```

To reproduce the bug, check out `src/hooks/use-terminal.ts` from main while keeping the test file from this branch: 3 of the 7 tests fail (concurrent render, sibling isolation, reset on clear). With the fix, all 7 pass.

Manual check: mount two terminals for different conversations at the same time and both render their command history. With a single terminal, navigate away and back and history is still replayed.

## Video/Screenshots

Terminal logs for this non-UI bug.

New tests against unfixed main:

```
FAIL should render new commands in two concurrent instances independently
AssertionError: expected [ [ 'hello' ] ] to have a length of 2 but got 1
FAIL should not corrupt a sibling instance when one instance unmounts
AssertionError: expected [ [ 'c1' ], [ 'c1' ], [ 'c1' ] ] to have a length of 2 but got 3
FAIL should reset the index when commands are cleared so re-streamed history renders
AssertionError: expected [] to have a length of 1 but got +0
Tests  3 failed | 4 passed (7)
```

Same tests after the fix:

```
Test Files  1 passed (1)
Tests  7 passed (7)
```

`npm run lint` (typecheck, eslint, prettier) passes with no errors.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Scope boundary: two terminals mounted for the same conversation id still share one entry and one command store. That matches current product behavior and is intentionally out of scope here.
- The linked issue does not yet carry the `ready-for-dev` label. It was filed on 2026-08-13 with the root cause and file references in the body, and the approach in this PR was posted there as a comment before implementation. Happy to adjust if maintainers want acceptance criteria tightened first.
