### PR TITLE
fix(settings): validate LLM API keys and base URLs before save

### DIFF
--- a/__tests__/routes/llm-settings.test.tsx
+++ b/__tests__/routes/llm-settings.test.tsx
@@ -205,6 +205,31 @@ describe("LlmSettingsScreen", () => {
     expect(screen.queryByTestId("set-indicator")).not.toBeInTheDocument();
   });
 
+  it("shows validation errors and does not save an invalid base URL", async () => {
+    const saveSettingsSpy = vi
+      .spyOn(SettingsService, "saveSettings")
+      .mockResolvedValue(true);
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({ llm_model: "openai/gpt-4o" }),
+    );
+
+    renderLlmSettingsScreen();
+
+    await screen.findByTestId("llm-settings-screen");
+    fireEvent.click(screen.getByTestId("sdk-section-advanced-toggle"));
+    fireEvent.change(screen.getByTestId("base-url-input"), {
+      target: { value: "not-a-url" },
+    });
+
+    expect(screen.getByTestId("base-url-input-error")).toHaveTextContent(
+      "Base URL must be a valid HTTP(S) URL.",
+    );
+
+    fireEvent.click(screen.getByTestId("save-button"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(saveSettingsSpy).not.toHaveBeenCalled();
+  });
+
   it("renders ChatGPT subscription settings without API key fields", async () => {
     vi.spyOn(LLMSubscriptionService, "getOpenAIStatus").mockResolvedValue({
       vendor: "openai",

--- a/__tests__/utils/llm-config-validation.test.ts
+++ b/__tests__/utils/llm-config-validation.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  getFirstLlmConfigValidationError,
+  getLlmConfigValidationErrors,
+} from "#/utils/llm-config-validation";
+
+describe("LLM config validation", () => {
+  it("allows provider-specific API keys with a reasonable length", () => {
+    expect(getLlmConfigValidationErrors({ api_key: "provider-key" })).toEqual(
+      {},
+    );
+  });
+
+  it("rejects an API key that is too short", () => {
+    expect(getLlmConfigValidationErrors({ api_key: "short" })).toMatchObject({
+      apiKey: "API key must be at least 8 characters.",
+    });
+  });
+
+  it("allows an empty optional base URL", () => {
+    expect(getLlmConfigValidationErrors({ base_url: "  " })).toEqual({});
+  });
+
+  it.each(["not-a-url", "ftp://api.example.com", "https://"])(
+    "rejects an invalid base URL: %s",
+    (baseUrl) => {
+      expect(getLlmConfigValidationErrors({ base_url: baseUrl })).toMatchObject(
+        {
+          baseUrl: "Base URL must be a valid HTTP(S) URL.",
+        },
+      );
+    },
+  );
+
+  it("accepts local and hosted HTTP(S) endpoints", () => {
+    expect(
+      getLlmConfigValidationErrors({
+        base_url: "http://localhost:8000/v1",
+        api_key: "provider-key",
+      }),
+    ).toEqual({});
+    expect(
+      getFirstLlmConfigValidationError({
+        base_url: "https://api.example.com/v1",
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/components/features/settings/llm-profiles/llm-settings-local-view.tsx
+++ b/src/components/features/settings/llm-profiles/llm-settings-local-view.tsx
@@ -45,6 +45,7 @@ import {
 import { BackNavButton } from "#/components/shared/buttons/back-nav-button";
 import { Typography } from "#/ui/typography";
 import { useSettingsSectionHeader } from "#/contexts/settings-section-header-context";
+import { getFirstLlmConfigValidationError } from "#/utils/llm-config-validation";
 
 type ViewMode = "list" | "create" | "edit";
 
@@ -308,6 +309,14 @@ export function LlmSettingsLocalView() {
     if (!model) {
       displayErrorToast(t(I18nKey.SETTINGS$MODEL_REQUIRED));
       return;
+    }
+
+    if (authType !== LLM_AUTH_TYPE_SUBSCRIPTION) {
+      const validationError = getFirstLlmConfigValidationError(llmConfig);
+      if (validationError) {
+        displayErrorToast(validationError);
+        return;
+      }
     }
 
     const trimmedName = profileName.trim();

--- a/src/routes/llm-settings.tsx
+++ b/src/routes/llm-settings.tsx
@@ -37,6 +37,7 @@ import {
   FREE_OPENHANDS_MODEL_NOTE,
   isFreeOpenHandsModel,
 } from "#/utils/format-model-name";
+import { getLlmConfigValidationErrors } from "#/utils/llm-config-validation";
 
 const LLM_EXCLUDED_KEYS = new Set([
   "llm.model",
@@ -228,6 +229,7 @@ export function LlmSettingsScreen({
       const apiKeyIsSet = embedded
         ? apiKeyValue.length > 0
         : Boolean(settings?.llm_api_key_set);
+      const llmConfigValidationErrors = getLlmConfigValidationErrors(values);
 
       const renderApiKeyInput = (testId: string, helpTestId: string) => (
         <>
@@ -241,6 +243,7 @@ export function LlmSettingsScreen({
             placeholder={apiKeyIsSet ? "<hidden>" : ""}
             onChange={(value) => onChange("llm.api_key", value)}
             isDisabled={isDisabled}
+            error={llmConfigValidationErrors.apiKey}
             startContent={
               apiKeyIsSet ? <KeyStatusIcon isSet={apiKeyIsSet} /> : undefined
             }
@@ -423,6 +426,7 @@ export function LlmSettingsScreen({
                     placeholder="https://api.openai.com"
                     onChange={(value) => onChange("llm.base_url", value)}
                     isDisabled={isDisabled}
+                    error={llmConfigValidationErrors.baseUrl}
                   />
 
                   {renderApiKeyInput(
@@ -465,6 +469,13 @@ export function LlmSettingsScreen({
       );
       const llm = (agentSettings.llm ?? {}) as Record<string, unknown>;
       const authType = resolveLlmAuthType(context.values[LLM_AUTH_TYPE_KEY]);
+
+      if (authType !== LLM_AUTH_TYPE_SUBSCRIPTION) {
+        const validationError = getLlmConfigValidationErrors(context.values);
+        if (validationError.baseUrl || validationError.apiKey) {
+          throw new Error(validationError.baseUrl ?? validationError.apiKey);
+        }
+      }
 
       if (authType === LLM_AUTH_TYPE_SUBSCRIPTION) {
         llm.auth_type = LLM_AUTH_TYPE_SUBSCRIPTION;

--- a/src/utils/llm-config-validation.ts
+++ b/src/utils/llm-config-validation.ts
@@ -1,0 +1,42 @@
+export interface LlmConfigValidationErrors {
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+const MIN_API_KEY_LENGTH = 8;
+
+export function getLlmConfigValidationErrors(
+  config: Record<string, unknown>,
+): LlmConfigValidationErrors {
+  const errors: LlmConfigValidationErrors = {};
+  const rawApiKey = config.api_key ?? config["llm.api_key"];
+  const rawBaseUrl = config.base_url ?? config["llm.base_url"];
+  const apiKey = typeof rawApiKey === "string" ? rawApiKey.trim() : "";
+  const baseUrl = typeof rawBaseUrl === "string" ? rawBaseUrl.trim() : "";
+
+  // API keys differ between providers, so validate only the minimum useful
+  // shape instead of enforcing a provider-specific prefix.
+  if (apiKey && apiKey.length < MIN_API_KEY_LENGTH) {
+    errors.apiKey = "API key must be at least 8 characters.";
+  }
+
+  if (baseUrl) {
+    try {
+      const parsedUrl = new URL(baseUrl);
+      if (!parsedUrl.hostname || !/^https?:$/.test(parsedUrl.protocol)) {
+        errors.baseUrl = "Base URL must be a valid HTTP(S) URL.";
+      }
+    } catch {
+      errors.baseUrl = "Base URL must be a valid HTTP(S) URL.";
+    }
+  }
+
+  return errors;
+}
+
+export function getFirstLlmConfigValidationError(
+  config: Record<string, unknown>,
+): string | null {
+  const errors = getLlmConfigValidationErrors(config);
+  return errors.baseUrl ?? errors.apiKey ?? null;
+}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->
HUMAN: <!-- Human contributors: add a short note about your testing. -->
AGENT: <!-- AI/LLM agents: do not edit the HUMAN section. -->

---

## Why

LLM settings currently accept malformed API keys and base URLs until the save request fails, which gives users late feedback.

## Summary

- Validate optional LLM API keys before saving.
- Reject malformed non-HTTP(S) base URLs.
- Apply the validation to both global settings and LLM profile saves.
- Add regression tests for invalid and valid configuration values.

## Issue Number

Closes #15778

## How to Test

- `npm.cmd test -- __tests__/utils/llm-config-validation.test.ts __tests__/routes/llm-settings.test.tsx`
- `npm.cmd run typecheck`
- `npm.cmd run lint`

## Video/Screenshots

Not applicable; this is form validation covered by automated regression tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No migrations or configuration changes.