### PR TITLE
fix: recover from stale SQLite DB migration crash on startup

### DIFF
--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -902,4 +902,33 @@ describe("dev-with-automation CLI", () => {
     expect(exitResult.code).toBe(1);
     expect(output).toContain("uvx");
   });
+
+  it("triggers onStdout, onStderr, and onExit callbacks when provided", async () => {
+    const stdoutLogs: string[] = [];
+    const stderrLogs: string[] = [];
+    let exitCode: number | null = null;
+
+    const proc = spawnService(
+      "callbacks-test",
+      process.execPath,
+      [
+        "-e",
+        'process.stdout.write("out\\n"); process.stderr.write("err\\n"); process.exit(42);',
+      ],
+      {
+        onStdout: (line: string) => stdoutLogs.push(line),
+        onStderr: (line: string) => stderrLogs.push(line),
+        onExit: (code: number | null) => {
+          exitCode = code;
+        },
+      },
+    );
+
+    await once(proc, "exit");
+    await delay(50);
+
+    expect(stdoutLogs).toContain("out");
+    expect(stderrLogs).toContain("err");
+    expect(exitCode).toBe(42);
+  });
 });

--- a/scripts/dev-static.mjs
+++ b/scripts/dev-static.mjs
@@ -40,6 +40,7 @@ import { spawn, spawnSync } from "node:child_process";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { setTimeout as delay } from "node:timers/promises";
+import { mkdirSync, existsSync, rmSync } from "node:fs";
 import process from "node:process";
 
 import { buildFrontend } from "./static-build.mjs";
@@ -234,7 +235,13 @@ function spawnService(name, command, args, options = {}) {
       .toString()
       .split("\n")
       .filter(Boolean)
-      .forEach((line) => logService(name, line.trim(), color));
+      .forEach((line) => {
+        const trimmed = line.trim();
+        logService(name, trimmed, color);
+        if (options.onStdout) {
+          options.onStdout(trimmed);
+        }
+      });
   });
 
   proc.stderr.on("data", (data) => {
@@ -242,7 +249,13 @@ function spawnService(name, command, args, options = {}) {
       .toString()
       .split("\n")
       .filter(Boolean)
-      .forEach((line) => logService(name, line.trim(), c.yellow));
+      .forEach((line) => {
+        const trimmed = line.trim();
+        logService(name, trimmed, c.yellow);
+        if (options.onStderr) {
+          options.onStderr(trimmed);
+        }
+      });
   });
 
   proc.on("error", (error) => {
@@ -254,6 +267,9 @@ function spawnService(name, command, args, options = {}) {
       logService(name, `Exited with code ${code}`, c.red);
     }
     processes.delete(name);
+    if (options.onExit) {
+      options.onExit(code);
+    }
   });
 
   processes.set(name, proc);
@@ -342,15 +358,30 @@ function buildAutomationBackendEnv(config, env = process.env) {
   };
 }
 
-function startAutomationBackend(config) {
+function startAutomationBackend(config, isRetry = false) {
   logService(
     "automation",
-    `Starting on port ${config.autoBackendPort}...`,
+    isRetry
+      ? "Restarting automation backend..."
+      : `Starting on port ${config.autoBackendPort}...`,
     c.green,
   );
 
   const automationCmd = buildAutomationCommand(process.env);
   logService("automation", `Using ${automationCmd.source}`, c.dim);
+
+  const dbPath = join(config.stateDir, "automations.db");
+  let hasMigrationError = false;
+
+  const checkError = (line) => {
+    if (
+      line.includes("Can't locate revision identified by") ||
+      line.includes("Failed to apply SQLite migrations") ||
+      line.includes("alembic.util.exc.CommandError")
+    ) {
+      hasMigrationError = true;
+    }
+  };
 
   spawnService(
     "automation",
@@ -366,6 +397,35 @@ function startAutomationBackend(config) {
       cwd: config.stateDir,
       env: buildAutomationBackendEnv(config),
       color: c.green,
+      onStdout: checkError,
+      onStderr: checkError,
+      onExit: (code) => {
+        if (shuttingDown) return;
+        if (hasMigrationError && !isRetry) {
+          logError("Automation backend crashed due to database migration error.");
+          logService(
+            "automation",
+            `Removing stale SQLite database at ${dbPath} and retrying...`,
+            c.yellow,
+          );
+          try {
+            if (existsSync(dbPath)) {
+              rmSync(dbPath, { force: true });
+              logSuccess("Stale SQLite database removed successfully.");
+            }
+            const walPath = `${dbPath}-wal`;
+            const shmPath = `${dbPath}-shm`;
+            const journalPath = `${dbPath}-journal`;
+            if (existsSync(walPath)) rmSync(walPath, { force: true });
+            if (existsSync(shmPath)) rmSync(shmPath, { force: true });
+            if (existsSync(journalPath)) rmSync(journalPath, { force: true });
+
+            startAutomationBackend(config, true);
+          } catch (err) {
+            logError(`Failed to remove database file: ${err.message}`);
+          }
+        }
+      },
     },
   );
 }

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -45,7 +45,7 @@
  */
 
 import { spawn, spawnSync } from "node:child_process";
-import { mkdirSync, existsSync, readFileSync } from "node:fs";
+import { mkdirSync, existsSync, readFileSync, rmSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { homedir } from "node:os";
@@ -599,6 +599,9 @@ function spawnService(name, command, args, options = {}) {
           parsed ? parsed.color : color,
         );
         emitServiceLog(name, trimmed, "stdout");
+        if (options.onStdout) {
+          options.onStdout(trimmed);
+        }
       });
   });
 
@@ -616,6 +619,9 @@ function spawnService(name, command, args, options = {}) {
           parsed ? parsed.color : c.yellow,
         );
         emitServiceLog(name, trimmed, "stderr");
+        if (options.onStderr) {
+          options.onStderr(trimmed);
+        }
       });
   });
 
@@ -630,6 +636,9 @@ function spawnService(name, command, args, options = {}) {
       emitServiceLog(name, `exited with code ${code}`, "error");
     }
     processes.delete(name);
+    if (options.onExit) {
+      options.onExit(code);
+    }
   });
 
   processes.set(name, proc);
@@ -842,15 +851,30 @@ function startAgentServer(config) {
   );
 }
 
-function startAutomationBackend(config) {
+function startAutomationBackend(config, isRetry = false) {
   logService(
     "automation",
-    `Starting on port ${config.autoBackendPort}...`,
+    isRetry
+      ? "Restarting automation backend..."
+      : `Starting on port ${config.autoBackendPort}...`,
     c.green,
   );
 
   const automationCmd = buildAutomationCommand(process.env);
   logService("automation", `Using ${automationCmd.source}`, c.dim);
+
+  const dbPath = join(dirname(config.stateDir), SHARED_DEFAULTS.paths.automationDb);
+  let hasMigrationError = false;
+
+  const checkError = (line) => {
+    if (
+      line.includes("Can't locate revision identified by") ||
+      line.includes("Failed to apply SQLite migrations") ||
+      line.includes("alembic.util.exc.CommandError")
+    ) {
+      hasMigrationError = true;
+    }
+  };
 
   spawnService(
     "automation",
@@ -897,7 +921,7 @@ function startAutomationBackend(config) {
           : {}),
         AUTOMATION_AGENT_SERVER_API_KEY: config.sessionApiKey,
         // ~/.openhands/automation/automations.db — matches docker/entrypoint.sh.
-        AUTOMATION_DB_URL: `sqlite+aiosqlite:///${join(dirname(config.stateDir), SHARED_DEFAULTS.paths.automationDb)}`,
+        AUTOMATION_DB_URL: `sqlite+aiosqlite:///${dbPath}`,
         // The automation backend uses this as its publicly-reachable base
         // URL: it's appended to callback URLs and injected into each
         // sandbox as `AUTOMATION_API_URL` (consumed by setup.sh for
@@ -939,6 +963,35 @@ function startAutomationBackend(config) {
         OPENHANDS_SUPPRESS_BANNER: "1",
       },
       color: c.green,
+      onStdout: checkError,
+      onStderr: checkError,
+      onExit: (code) => {
+        if (shuttingDown) return;
+        if (hasMigrationError && !isRetry) {
+          logError("Automation backend crashed due to database migration error.");
+          logService(
+            "automation",
+            `Removing stale SQLite database at ${dbPath} and retrying...`,
+            c.yellow,
+          );
+          try {
+            if (existsSync(dbPath)) {
+              rmSync(dbPath, { force: true });
+              logSuccess("Stale SQLite database removed successfully.");
+            }
+            const walPath = `${dbPath}-wal`;
+            const shmPath = `${dbPath}-shm`;
+            const journalPath = `${dbPath}-journal`;
+            if (existsSync(walPath)) rmSync(walPath, { force: true });
+            if (existsSync(shmPath)) rmSync(shmPath, { force: true });
+            if (existsSync(journalPath)) rmSync(journalPath, { force: true });
+
+            startAutomationBackend(config, true);
+          } catch (err) {
+            logError(`Failed to remove database file: ${err.message}`);
+          }
+        }
+      },
     },
   );
 }


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
I have manually verified that the database recovers and resets automatically after simulating a stale revision.

AGENT:

- Tested by running `npx vitest run __tests__/scripts/dev-with-automation.test.ts` which executed and passed all 48 test assertions successfully.
- Verified end-to-end by corrupting `alembic_version` to `invalid_rev_id` in SQLite and launching the server via `npm run dev`. The logs successfully output:
  ```
  [automation] Failed to apply SQLite migrations: Can't locate revision identified by 'invalid_rev_id'
  [automation] Exited with code 3
  ✗ Automation backend crashed due to database migration error.
  [automation] Removing stale SQLite database at /Users/k9966/.openhands/automation/automations.db and retrying...
  ✓ Stale SQLite database removed successfully.
  [automation] Restarting automation backend...
  ```
  The database was successfully recreated at revision `014` and uvicorn completed startup.

---

## Why

When updating/upgrading the `openhands-automation` package across versions that restructure their database migration history, the SQLite database at `~/.openhands/automation/automations.db` retains reference to old, deleted schema revisions. As a result, Alembic crashes on startup with `Can't locate revision identified by '...'`, exiting uvicorn with code 3 and rendering the "Automate" tab in the UI permanently unavailable.

## Summary

- Added process callback options (`onStdout`, `onStderr`, `onExit`) to the generic `spawnService` process manager.
- Updated `dev-with-automation.mjs` and `dev-static.mjs` to intercept stderr/stdout streams, search for database revision errors, and clean up the database files before restarting uvicorn.
- Added a unit test verifying that `spawnService` successfully triggers the callbacks.

## Issue Number

Fixes #15623

## How to Test

1. Run `npm install` and start the server: `npm run dev`.
2. Stop the server, then artificially corrupt the database revision:
   ```bash
   sqlite3 ~/.openhands/automation/automations.db "UPDATE alembic_version SET version_num='invalid_rev_id';"
   ```
3. Run `npm run dev` again. The server should log the migration error, output `Removing stale SQLite database...`, restart the automation service automatically, and boot up successfully.

## Video/Screenshots

<!-- Drag and drop your screenshots here! -->

### Bug (Before Fix)

UI Error
<img width="1225" height="828" alt="image" src="https://github.com/user-attachments/assets/31246f63-56dd-4817-b3fd-892e988407d1" />
Terminal Error
<img width="1225" height="828" alt="image" src="https://github.com/user-attachments/assets/f0dfa3fe-c6c6-40d4-b3e2-c9c3b5106cde" />

### Fix (After Auto-Recovery)
Terminal crash & autofix 
<img width="1225" height="828" alt="image" src="https://github.com/user-attachments/assets/e951ddb4-f35c-41bc-b1ae-38d8aef2941d" />
UI after fix
<img width="1225" height="828" alt="image" src="https://github.com/user-attachments/assets/dcb4b7fb-b6e1-4b85-a165-b3a673a5395e" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

None.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.69s · commit 3f2aacb  
**Strongest signal:** Data loss · 81% estimated likelihood.  
**Evidence:** [F002H005 · scripts/dev-static.mjs:397–431](https://github.com/OpenHands/OpenHands/blob/3f2aacb6fe9ae88002bf5f691e16cd29e83148e1/scripts/dev-static.mjs#L397-L431).  
**Coverage:** complete supplied coverage; 13/13 hunks, 3/3 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 4.0% | No direct hunk selected |
| Command injection | 6.0% | No direct hunk selected |
| Weakened authentication | 4.0% | No direct hunk selected |
| Weakened authorization | 10.0% | No direct hunk selected |
| Contract regression | 12.0% | No direct hunk selected |
| Data loss | 81.0% | [F002H005 · scripts/dev-static.mjs:397–431](https://github.com/OpenHands/OpenHands/blob/3f2aacb6fe9ae88002bf5f691e16cd29e83148e1/scripts/dev-static.mjs#L397-L431) |
| Sensitive data disclosure | 6.0% | No direct hunk selected |
| Unexpected data transfer | 4.0% | No direct hunk selected |
| Credential misuse | 7.0% | No direct hunk selected |
| Untrusted instruction authority | 3.0% | No direct hunk selected |
| Package source redirection | 4.0% | No direct hunk selected |
| Unverified remote execution | 4.0% | No direct hunk selected |
| Privileged environment access | 58.0% | [F002H005 · scripts/dev-static.mjs:397–431](https://github.com/OpenHands/OpenHands/blob/3f2aacb6fe9ae88002bf5f691e16cd29e83148e1/scripts/dev-static.mjs#L397-L431) |
| Security assessment bypass | 5.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | Data loss; confidence 97.0% | [F002H005 · scripts/dev-static.mjs:397–431](https://github.com/OpenHands/OpenHands/blob/3f2aacb6fe9ae88002bf5f691e16cd29e83148e1/scripts/dev-static.mjs#L397-L431) |

</details>


<!-- jev-input-signature 17fa00797e88d1e2970abcf048c12c26dfabdb2e083997137fd031d7ceb57504 -->
<!-- jev-fast-audit:end -->
