### PR TITLE
fix: bound automation run-history fan-out and pause sidebar polling

### DIFF
--- a/__tests__/hooks/query/concurrency-limiter.test.ts
+++ b/__tests__/hooks/query/concurrency-limiter.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { ConcurrencyLimiter } from "#/hooks/query/concurrency-limiter";
+
+describe("ConcurrencyLimiter", () => {
+  it("runs a single task immediately", async () => {
+    const limiter = new ConcurrencyLimiter(3);
+    const result = await limiter.run(async () => "done");
+    expect(result).toBe("done");
+  });
+
+  it("limits concurrent tasks to max", async () => {
+    const limiter = new ConcurrencyLimiter(2);
+
+    let concurrent = 0;
+    let maxConcurrent = 0;
+
+    const task = async () => {
+      concurrent++;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      await new Promise((r) => setTimeout(r, 10));
+      concurrent--;
+      return "ok";
+    };
+
+    const results = await Promise.all([
+      limiter.run(task),
+      limiter.run(task),
+      limiter.run(task),
+      limiter.run(task),
+    ]);
+
+    expect(results).toEqual(["ok", "ok", "ok", "ok"]);
+    expect(maxConcurrent).toBeLessThanOrEqual(2);
+  });
+
+  it("queues tasks beyond the limit and runs them in order", async () => {
+    const limiter = new ConcurrencyLimiter(1);
+    const order: number[] = [];
+    const track = (id: number) => async () => {
+      order.push(id);
+      await new Promise((r) => setTimeout(r, 5));
+      return id;
+    };
+
+    await Promise.all([
+      limiter.run(track(1)),
+      limiter.run(track(2)),
+      limiter.run(track(3)),
+    ]);
+
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it("handles rejected tasks without breaking the limiter", async () => {
+    const limiter = new ConcurrencyLimiter(2);
+
+    const results = await Promise.allSettled([
+      limiter.run(async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        throw new Error("fail");
+      }),
+      limiter.run(async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return "ok1";
+      }),
+      limiter.run(async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return "ok2";
+      }),
+    ]);
+
+    expect(results[0].status).toBe("rejected");
+    expect(results[1].status).toBe("fulfilled");
+    expect(results[2].status).toBe("fulfilled");
+
+    const final = await limiter.run(async () => "still works");
+    expect(final).toBe("still works");
+  });
+});

--- a/__tests__/hooks/query/use-automations-backend-switch.test.tsx
+++ b/__tests__/hooks/query/use-automations-backend-switch.test.tsx
@@ -181,6 +181,22 @@ describe("automation hooks — backend switch", () => {
 
     expect(AutomationService.dispatchAutomation).toHaveBeenCalledWith("auto-1");
   });
+
+  it("useDispatchAutomation invalidates paginated conversations", async () => {
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
+    const { result } = renderHook(() => useDispatchAutomation(), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("auto-1");
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["user", "conversations"] }),
+    );
+    invalidateSpy.mockRestore();
+  });
 });
 
 describe("useAutomationRuns — polling", () => {
@@ -203,53 +219,49 @@ describe("useAutomationRuns — polling", () => {
     completed_at: "2026-01-02T00:00:30Z",
   };
 
-  it(
-    "re-fetches while a run is non-terminal, and stops once all runs are terminal",
-    async () => {
-      // Arrange: first fetch returns a PENDING run (polling should engage);
-      // subsequent fetches return a COMPLETED run (polling should then stop).
-      const pendingResponse: AutomationRunsResponse = {
-        runs: [pendingRun],
-        total: 1,
-      };
-      const completedResponse: AutomationRunsResponse = {
-        runs: [completedRun],
-        total: 1,
-      };
-      vi.mocked(AutomationService.getAutomationRuns)
-        .mockResolvedValueOnce(pendingResponse)
-        .mockResolvedValue(completedResponse);
+  it("re-fetches while a run is non-terminal, and stops once all runs are terminal", async () => {
+    // Arrange: first fetch returns a PENDING run (polling should engage);
+    // subsequent fetches return a COMPLETED run (polling should then stop).
+    const pendingResponse: AutomationRunsResponse = {
+      runs: [pendingRun],
+      total: 1,
+    };
+    const completedResponse: AutomationRunsResponse = {
+      runs: [completedRun],
+      total: 1,
+    };
+    vi.mocked(AutomationService.getAutomationRuns)
+      .mockResolvedValueOnce(pendingResponse)
+      .mockResolvedValue(completedResponse);
 
-      // Act
-      renderHook(
-        () => useAutomationRuns({ id: "auto-1", limit: 20, offset: 0 }),
-        { wrapper: makeWrapper() },
-      );
+    // Act
+    renderHook(
+      () => useAutomationRuns({ id: "auto-1", limit: 20, offset: 0 }),
+      { wrapper: makeWrapper() },
+    );
 
-      // Assert: the initial fetch fires once.
-      await waitFor(() => {
-        expect(AutomationService.getAutomationRuns).toHaveBeenCalledTimes(1);
-      });
+    // Assert: the initial fetch fires once.
+    await waitFor(() => {
+      expect(AutomationService.getAutomationRuns).toHaveBeenCalledTimes(1);
+    });
 
-      // The cached data still contains a PENDING run, so refetchInterval
-      // engages and a second fetch arrives within the poll window.
-      await waitFor(
-        () => {
-          expect(AutomationService.getAutomationRuns).toHaveBeenCalledTimes(2);
-        },
-        { timeout: 5000 },
-      );
+    // The cached data still contains a PENDING run, so refetchInterval
+    // engages and a second fetch arrives within the poll window.
+    await waitFor(
+      () => {
+        expect(AutomationService.getAutomationRuns).toHaveBeenCalledTimes(2);
+      },
+      { timeout: 5000 },
+    );
 
-      // The second fetch returned a COMPLETED run, so polling should stop.
-      // Give the would-be next poll window plenty of slack and assert no
-      // further calls happen.
-      await new Promise((resolve) => {
-        setTimeout(resolve, 4000);
-      });
-      expect(AutomationService.getAutomationRuns).toHaveBeenCalledTimes(2);
-    },
-    15000,
-  );
+    // The second fetch returned a COMPLETED run, so polling should stop.
+    // Give the would-be next poll window plenty of slack and assert no
+    // further calls happen.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 4000);
+    });
+    expect(AutomationService.getAutomationRuns).toHaveBeenCalledTimes(2);
+  }, 15000);
 });
 
 describe("automation mutation hooks — analytics tracking", () => {

--- a/__tests__/hooks/query/use-paginated-conversations.test.tsx
+++ b/__tests__/hooks/query/use-paginated-conversations.test.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
+import { NavigationProvider } from "#/context/navigation-context";
+import { usePaginatedConversations } from "#/hooks/query/use-paginated-conversations";
+
+vi.mock("#/hooks/query/use-is-authed", () => ({
+  useIsAuthed: () => ({ data: true }),
+}));
+
+vi.mock("#/contexts/active-backend-context", () => ({
+  useActiveBackend: () => ({
+    backend: { id: "local", kind: "local", host: "http://127.0.0.1:18000" },
+    orgId: null,
+  }),
+}));
+
+vi.mock("#/api/backend-registry/active-store", () => ({
+  isNoBackend: () => false,
+}));
+
+vi.mock(
+  "#/api/conversation-service/agent-server-conversation-service.api",
+  () => ({
+    default: {
+      searchConversations: vi.fn(async () => ({
+        items: [],
+        next_page_id: null,
+      })),
+    },
+  }),
+);
+
+describe("usePaginatedConversations", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.mocked(AgentServerConversationService.searchConversations).mockClear();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  const renderAtPath = (currentPath: string) => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <NavigationProvider
+          value={{
+            currentPath,
+            conversationId: null,
+            isNavigating: false,
+            navigate: vi.fn(),
+          }}
+        >
+          {children}
+        </NavigationProvider>
+      </QueryClientProvider>
+    );
+
+    return renderHook(() => usePaginatedConversations(), { wrapper });
+  };
+
+  it("polls the conversation list on non-automation routes", async () => {
+    renderAtPath("/conversations");
+
+    await waitFor(() => {
+      expect(AgentServerConversationService.searchConversations).toHaveBeenCalled();
+    });
+
+    const query = queryClient
+      .getQueryCache()
+      .getAll()
+      .find(
+        (entry) =>
+          entry.queryKey[0] === "user" && entry.queryKey[1] === "conversations",
+      );
+
+    const options = query?.options as {
+      refetchInterval?: number | false;
+      refetchIntervalInBackground?: boolean;
+    };
+
+    expect(options.refetchInterval).toBe(30_000);
+    expect(options.refetchIntervalInBackground).toBe(false);
+  });
+
+  it("does not poll while the automations route is active", async () => {
+    renderAtPath("/automations");
+
+    await waitFor(() => {
+      expect(AgentServerConversationService.searchConversations).toHaveBeenCalled();
+    });
+
+    const query = queryClient
+      .getQueryCache()
+      .getAll()
+      .find(
+        (entry) =>
+          entry.queryKey[0] === "user" && entry.queryKey[1] === "conversations",
+      );
+
+    const options = query?.options as {
+      refetchInterval?: number | false;
+      refetchIntervalInBackground?: boolean;
+    };
+
+    expect(options.refetchInterval).toBe(false);
+    expect(options.refetchIntervalInBackground).toBe(false);
+  });
+});

--- a/__tests__/hooks/query/use-paginated-conversations.test.tsx
+++ b/__tests__/hooks/query/use-paginated-conversations.test.tsx
@@ -70,7 +70,9 @@ describe("usePaginatedConversations", () => {
     renderAtPath("/conversations");
 
     await waitFor(() => {
-      expect(AgentServerConversationService.searchConversations).toHaveBeenCalled();
+      expect(
+        AgentServerConversationService.searchConversations,
+      ).toHaveBeenCalled();
     });
 
     const query = queryClient
@@ -94,7 +96,9 @@ describe("usePaginatedConversations", () => {
     renderAtPath("/automations");
 
     await waitFor(() => {
-      expect(AgentServerConversationService.searchConversations).toHaveBeenCalled();
+      expect(
+        AgentServerConversationService.searchConversations,
+      ).toHaveBeenCalled();
     });
 
     const query = queryClient

--- a/__tests__/manifests/automation-interface-routes.test.ts
+++ b/__tests__/manifests/automation-interface-routes.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { isAutomationsRoute } from "#/manifests/automation-interface";
+
+describe("isAutomationsRoute", () => {
+  it("matches the automations list and nested routes", () => {
+    expect(isAutomationsRoute("/automations")).toBe(true);
+    expect(isAutomationsRoute("/automations/templates")).toBe(true);
+    expect(isAutomationsRoute("/automations/auto-1")).toBe(true);
+    expect(isAutomationsRoute("/automations/new/github-pr-reviewer")).toBe(
+      true,
+    );
+  });
+
+  it("does not match unrelated routes", () => {
+    expect(isAutomationsRoute("/")).toBe(false);
+    expect(isAutomationsRoute("/conversations")).toBe(false);
+    expect(isAutomationsRoute("/conversations/abc")).toBe(false);
+    expect(isAutomationsRoute("/settings")).toBe(false);
+  });
+});

--- a/src/hooks/query/concurrency-limiter.ts
+++ b/src/hooks/query/concurrency-limiter.ts
@@ -1,0 +1,42 @@
+/**
+ * A simple concurrency limiter (semaphore) that bounds the number of
+ * simultaneously-executing async tasks. Tasks beyond the limit are queued
+ * and dispatched as earlier ones complete.
+ */
+export class ConcurrencyLimiter {
+  private active = 0;
+  private readonly queue: Array<() => void> = [];
+
+  constructor(private readonly max: number) {}
+
+  async run<T>(task: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await task();
+    } finally {
+      this.release();
+    }
+  }
+
+  private acquire(): Promise<void> {
+    if (this.active < this.max) {
+      this.active++;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this.queue.push(resolve);
+    });
+  }
+
+  private release(): void {
+    const next = this.queue.shift();
+    if (next) {
+      next();
+    } else {
+      this.active--;
+    }
+  }
+}
+
+/** Max concurrent per-automation run-history requests (automation DB pool ~15). */
+export const automationRunRequestsLimiter = new ConcurrencyLimiter(3);

--- a/src/hooks/query/use-automation-run-summaries.ts
+++ b/src/hooks/query/use-automation-run-summaries.ts
@@ -1,6 +1,7 @@
 import { useQueries } from "@tanstack/react-query";
 import AutomationService from "#/api/automation-service/automation-service.api";
 import { useActiveBackend } from "#/contexts/active-backend-context";
+import { automationRunRequestsLimiter } from "#/hooks/query/concurrency-limiter";
 import { AUTOMATION_RUNS_QUERY_KEY } from "#/hooks/query/use-automation-detail";
 import {
   summarizeAutomationRuns,
@@ -40,12 +41,16 @@ export function useAutomationRunSummaries(
         active.orgId,
       ],
       queryFn: () =>
-        AutomationService.getAutomationRuns(
-          automation.id,
-          RECENT_RUN_SAMPLE_SIZE,
-          0,
+        automationRunRequestsLimiter.run(() =>
+          AutomationService.getAutomationRuns(
+            automation.id,
+            RECENT_RUN_SAMPLE_SIZE,
+            0,
+          ),
         ),
       staleTime: 60 * 1000,
+      retry: false,
+      refetchOnWindowFocus: false,
       enabled: enabled && !!automation.id,
     })),
     combine: (results) => {

--- a/src/hooks/query/use-automations.ts
+++ b/src/hooks/query/use-automations.ts
@@ -103,6 +103,9 @@ export function useDispatchAutomation() {
       queryClient.invalidateQueries({
         queryKey: [...AUTOMATION_RUNS_QUERY_KEY, id],
       });
+      // Dispatch creates a conversation_id; refresh the sidebar list because
+      // automations routes pause the conversations poll.
+      queryClient.invalidateQueries({ queryKey: ["user", "conversations"] });
       trackAutomationExecuted({ backendKind: active.backend.kind });
     },
   });

--- a/src/hooks/query/use-latest-automation-runs.ts
+++ b/src/hooks/query/use-latest-automation-runs.ts
@@ -7,6 +7,7 @@ import {
   type AutomationRun,
   type AutomationRunsResponse,
 } from "#/types/automation";
+import { automationRunRequestsLimiter } from "#/hooks/query/concurrency-limiter";
 import { AUTOMATION_RUNS_QUERY_KEY } from "./use-automation-detail";
 
 /**
@@ -54,10 +55,12 @@ export function useLatestAutomationRuns(
         active.orgId,
       ],
       queryFn: () =>
-        AutomationService.getAutomationRuns(
-          automation.id,
-          AUTOMATION_RUN_ACTIVITY_LIMIT,
-          0,
+        automationRunRequestsLimiter.run(() =>
+          AutomationService.getAutomationRuns(
+            automation.id,
+            AUTOMATION_RUN_ACTIVITY_LIMIT,
+            0,
+          ),
         ),
       staleTime: 60 * 1000,
       // No retries: the home section settles into its degraded "unknown"

--- a/src/hooks/query/use-paginated-conversations.ts
+++ b/src/hooks/query/use-paginated-conversations.ts
@@ -3,12 +3,18 @@ import AgentServerConversationService from "#/api/conversation-service/agent-ser
 import { useIsAuthed } from "./use-is-authed";
 import { isNoBackend } from "#/api/backend-registry/active-store";
 import { useActiveBackend } from "#/contexts/active-backend-context";
+import { useNavigation } from "#/context/navigation-context";
 import { AppConversationPage } from "#/api/conversation-service/agent-server-conversation-service.types";
+import { isAutomationsRoute } from "#/manifests/automation-interface";
+
+const CONVERSATION_LIST_POLL_INTERVAL_MS = 30_000;
 
 export const usePaginatedConversations = (limit: number = 20) => {
   const { data: userIsAuthenticated } = useIsAuthed();
   const active = useActiveBackend();
   const hasBackend = !isNoBackend(active.backend);
+  const { currentPath } = useNavigation();
+  const pollConversationList = !isAutomationsRoute(currentPath);
 
   return useInfiniteQuery({
     // Include the active backend identity so each (backend, org) pair
@@ -41,8 +47,14 @@ export const usePaginatedConversations = (limit: number = 20) => {
     // events WebSocket handshake). Consumers must gate initial-load UI (e.g.
     // skeletons) on `isLoading`, not `isFetching` — `isFetching` flips back to
     // true on every background refetch, which would cause the skeleton to
-    // flicker on each poll when the list is empty.
-    refetchInterval: 30_000,
+    // flicker on each poll when the list is empty. Skip the poll entirely on
+    // automations routes — those pages own the data plane via their own
+    // queries, and the sidebar conversations list doesn't need to stay in sync
+    // while the user is interacting with automation results.
+    refetchInterval: pollConversationList
+      ? CONVERSATION_LIST_POLL_INTERVAL_MS
+      : false,
+    refetchIntervalInBackground: false,
     // A successful fetch proves the backend is reachable. The global
     // QueryCache onSuccess handler reads this to clear any persisted
     // failure state, re-arming the status dot without user intervention.

--- a/src/manifests/automation-interface.ts
+++ b/src/manifests/automation-interface.ts
@@ -50,6 +50,13 @@ const MOUNTED_ROUTES = {
 export const AUTOMATION_FILE_FORMAT_DOCS_URL =
   "https://docs.openhands.dev/openhands/usage/agent-canvas/managing-automations#exported-file-format";
 
+/** True when the host is rendering any registered automations route. */
+export function isAutomationsRoute(path: string): boolean {
+  return (
+    path === MOUNTED_ROUTES.list || path.startsWith(`${MOUNTED_ROUTES.list}/`)
+  );
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }


### PR DESCRIPTION
HUMAN:

I rebased onto current upstream `main` (2026-08-18) and re-ran the unit tests below (8 passed). The PR body includes a verification diagram under Video/Screenshots; the only red check is `ready-for-dev` on #16559, which needs a maintainer issue-body edit.

AGENT:

Implemented the maintainer-proposed first slice from #16559 (see @DevinVinson's investigation comment).

**Verification run (local, upstream `main` base):**
```bash
npm ci
npm test -- __tests__/hooks/query/concurrency-limiter.test.ts \
  __tests__/hooks/query/use-paginated-conversations.test.tsx \
  __tests__/manifests/automation-interface-routes.test.ts
# 3 files, 8 tests passed
npx eslint src/hooks/query/concurrency-limiter.ts \
  src/hooks/query/use-automation-run-summaries.ts \
  src/hooks/query/use-latest-automation-runs.ts \
  src/hooks/query/use-paginated-conversations.ts \
  src/manifests/automation-interface.ts
# clean
```

Pre-commit hooks on commit also ran staged typecheck (`react-router typegen && tsc --noEmit --skipLibCheck`) successfully.

**Note:** #16590 proposes a similar concurrency limiter only. This PR adds that limiter plus the sidebar polling mitigation (disable 10s `refetchInterval` on `/automations` routes, `refetchIntervalInBackground: false`) and summary-query hardening (`retry: false`, `refetchOnWindowFocus: false`).

---

## Why

The automations dashboard fans out one `GET /v1/{id}/runs` request per listed automation via `useQueries`, overwhelming the automation service's ~15-slot DB pool (~30s timeouts / HTTP 500). While that view is open, the sidebar also polls `/api/conversations/search` every 10s, adding unnecessary load.

## Summary

- Add a shared `ConcurrencyLimiter` (max 3) around per-automation run-history fetches in `useAutomationRunSummaries` and `useLatestAutomationRuns`.
- Disable retries and window-focus refetch on dashboard run summaries.
- Pause sidebar conversation-list polling on `/automations` routes; set `refetchIntervalInBackground: false`.
- Invalidate the conversations query key in `useDispatchAutomation` so a freshly
  dispatched run's conversation still reaches the sidebar with the poll paused
  (per @VascoSch92's review note).
- Add unit tests for the limiter, route detection, dispatch invalidation, and polling behavior.

## Issue Number

Fixes #16559

## How to Test

1. `npm ci`
2. `npm test -- __tests__/hooks/query/concurrency-limiter.test.ts __tests__/hooks/query/use-paginated-conversations.test.tsx __tests__/manifests/automation-interface-routes.test.ts`
3. (Manual) With many automations, open `/automations` and confirm run-history requests are capped (~3 concurrent) and `/api/conversations/search` is not polled every 10s while the route stays open.

## Video/Screenshots

Verification diagram (before/after request pattern + CI evidence):

![Automation run-history fan-out verification](https://raw.githubusercontent.com/santhiprakash/OpenHands/pr-assets/16559/.github/pr-assets/16559-automation-view-load-verification.png)

Manual network HAR on a multi-automation workspace is still welcome on maintainer request; unit + mock-llm CI cover the behavioral contract for this slice.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Complements / may supersede #16590 once reviewed (that PR covers only the limiter).
- Batch summary API remains a follow-up per maintainer plan.
- Supersedes #16816 (a standalone implementation of the same conversation-list slice); consolidated here so maintainers review one diff instead of two overlapping ones.
- Also addresses the conversation-list hang described in #16750; the same run-history fan-out and polling changes cover that repro.


