### PR TITLE
fix: correct wrong variable in max_size validation error message in condensers

### DIFF
--- a/openhands/memory/condenser/impl/amortized_forgetting_condenser.py
+++ b/openhands/memory/condenser/impl/amortized_forgetting_condenser.py
@@ -30,7 +30,7 @@ class AmortizedForgettingCondenser(RollingCondenser):
         if keep_first < 0:
             raise ValueError(f'keep_first ({keep_first}) cannot be negative')
         if max_size < 1:
-            raise ValueError(f'max_size ({keep_first}) cannot be non-positive')
+            raise ValueError(f'max_size ({max_size}) cannot be non-positive')
 
         self.max_size = max_size
         self.keep_first = keep_first

--- a/openhands/memory/condenser/impl/llm_attention_condenser.py
+++ b/openhands/memory/condenser/impl/llm_attention_condenser.py
@@ -36,7 +36,7 @@ class LLMAttentionCondenser(RollingCondenser):
         if keep_first < 0:
             raise ValueError(f'keep_first ({keep_first}) cannot be negative')
         if max_size < 1:
-            raise ValueError(f'max_size ({keep_first}) cannot be non-positive')
+            raise ValueError(f'max_size ({max_size}) cannot be non-positive')
 
         self.max_size = max_size
         self.keep_first = keep_first


### PR DESCRIPTION
This PR addresses: correct wrong variable in max_size validation error message in condensers