### PR TITLE
fix: correct logger format args and -0 slice bug

### DIFF
--- a/openhands/app_server/event_callback/set_title_callback_processor.py
+++ b/openhands/app_server/event_callback/set_title_callback_processor.py
@@ -68,6 +68,7 @@ async def _poll_for_title(
             # Transient agent-server failures are acceptable; retry later.
             _logger.warning(
                 'Title poll failed for conversation %s: %s',
+                url,
                 exc,
             )
         else:

--- a/openhands/memory/condenser/impl/recent_events_condenser.py
+++ b/openhands/memory/condenser/impl/recent_events_condenser.py
@@ -18,7 +18,7 @@ class RecentEventsCondenser(Condenser):
         """Keep only the most recent events (up to `max_events`)."""
         head = view[: self.keep_first]
         tail_length = max(0, self.max_events - len(head))
-        tail = view[-tail_length:]
+        tail = view[-tail_length:] if tail_length > 0 else []
         return View(events=head + tail)
 
     @classmethod


### PR DESCRIPTION
This PR addresses: correct logger format args and -0 slice bug