### PR TITLE
feat: add linux desktop installer build (CI + deb maintainer fix)

### DIFF
--- a/.github/workflows/desktop-linux.yml
+++ b/.github/workflows/desktop-linux.yml
@@ -1,0 +1,98 @@
+name: Desktop (Linux)
+
+# Builds the Agent Canvas Linux packages (AppImage + deb) via
+# `npm run build:desktop` on an Ubuntu runner. The electron-builder Linux
+# targets already exist in electron-builder.config.mjs; this workflow is the
+# CI half that macOS (desktop-macos.yml) and Windows (desktop-windows.yml)
+# already have.
+#   pull_request:      paths-filtered smoke build — the uploaded artifacts are
+#                      what a tester downloads to verify a PR on Linux.
+#   release published: rebuilds from the release tag and attaches the packages
+#                      to the GitHub Release created by release-please.
+#   workflow_dispatch: manual escape hatch for any ref.
+# The packages are not signed (no signing certs exist for any platform);
+# no distro store review is involved, so AppImage/deb install without a
+# Gatekeeper/SmartScreen-style warning. AppImage runs on any modern distro
+# (FUSE required; FUSE 3 distros need the `--appimage-extract-and-run`
+# fallback or libfuse2 installed). The deb targets Debian/Ubuntu; Fedora and
+# other rpm distros use the AppImage.
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/desktop-linux.yml
+      - electron/**
+      - electron-builder.config.mjs
+      - scripts/download-uv.mjs
+      - scripts/download-node.mjs
+  release:
+    types: [published]
+
+concurrency:
+  group: desktop-linux-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# `gh release upload` needs contents: write on release events. Fork PR runs
+# are downgraded to a read-only token by GitHub automatically.
+permissions:
+  contents: write
+
+jobs:
+  build-packages:
+    name: Build Linux packages
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js with npm cache
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Linux packages
+        env:
+          # Production analytics key only for release builds (same split as
+          # docker.yml); PR/manual runs get the staging key. Both are public
+          # client-side keys stored as repo vars — empty on fork PRs, which
+          # simply disables analytics in the built app.
+          VITE_POSTHOG_API_KEY: ${{ github.event_name == 'release' && vars.POSTHOG_PROD_KEY || vars.POSTHOG_STAGING_KEY }}
+          # Authenticates download-uv.mjs's GitHub API version lookup so it
+          # doesn't hit the unauthenticated per-IP rate limit on shared runners.
+          GITHUB_TOKEN: ${{ github.token }}
+        run: npm run build:desktop
+
+      - name: Verify package output
+        run: |
+          ls -la dist-electron
+          appimage_count=$(find dist-electron -maxdepth 1 -name '*.AppImage' | wc -l | tr -d ' ')
+          deb_count=$(find dist-electron -maxdepth 1 -name '*.deb' | wc -l | tr -d ' ')
+          if [ "$appimage_count" -ne 1 ] || [ "$deb_count" -ne 1 ]; then
+            echo "::error::Expected exactly one AppImage and one deb in dist-electron/, found $appimage_count AppImage(s) and $deb_count deb(s)"
+            exit 1
+          fi
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: agent-canvas-linux-packages
+          path: |
+            dist-electron/*.AppImage
+            dist-electron/*.deb
+          if-no-files-found: error
+          # The packages are large (~175 MB each); keep PR artifacts long
+          # enough for manual QA without hoarding storage.
+          retention-days: 14
+
+      - name: Attach packages to GitHub release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$RELEASE_TAG" dist-electron/*.AppImage dist-electron/*.deb --clobber

--- a/electron-builder.config.mjs
+++ b/electron-builder.config.mjs
@@ -352,6 +352,10 @@ const config = {
     ],
     category: "Development",
     // Icon auto-discovered from directories.buildResources/icon.png.
+    // fpm-backed targets (deb) require a maintainer with an email address;
+    // electron/package.json carries no author, so set it here. Without this
+    // the deb step fails with "Please specify author 'email'".
+    maintainer: "All-Hands AI <contact@all-hands.dev>",
   },
 };
 


### PR DESCRIPTION
HUMAN:

Built and running locally on my Fedora latop

AGENT:

End-to-end evidence (Fedora 43, upstream/main @ 6670b4726a, v1.13.0):

1. `npm ci && npm run build:desktop` fails at the deb step on a clean checkout:
   `Error: Please specify author 'email' in the application package.json` — fpm
   requires a maintainer; `electron/package.json` has no author. The AppImage
   target completes; only deb fails. (Full stack trace available on request.)
2. After adding `maintainer` to the linux options in
   `electron-builder.config.mjs`:
   `npx electron-builder --config electron-builder.config.mjs --publish never --linux`
   builds BOTH targets:
   - `OpenHands Agent Canvas-1.13.0.AppImage` (197 MB)
   - `agent-canvas_1.13.0_amd64.deb` (150 MB)
3. Smoke test: launched the AppImage — Electron window opened, stack healthy
   (`curl localhost:8000/health` → `{"status":"ok"}` in ~5 s), frontend loaded
   existing conversations from `~/.openhands`.
4. Build-host env notes (CI-irrelevant: ubuntu-latest ships both): Fedora 43
   needed `libxcrypt-compat` (fpm's bundled ruby links libcrypt.so.1) and
   `fuse-libs` (AppImage runtime needs libfuse.so.2).

---

## Why

The desktop app ships macOS + Windows installers but nothing for Linux, even
though `electron-builder.config.mjs` already defines Linux targets
(AppImage + deb). Those targets have never been exercised by CI — the deb
target cannot build at all today (missing maintainer). Linux users' only
option is the npm launcher, i.e. installing Node + uv and keeping a terminal
open — the friction the desktop app exists to remove.

## Summary

- Add `.github/workflows/desktop-linux.yml`, mirroring `desktop-macos.yml` /
  `desktop-windows.yml` (paths-filtered PR smoke build + artifacts,
  release-published attach, workflow_dispatch).
- Set `linux.maintainer` in `electron-builder.config.mjs` so the existing deb
  target builds (4-line change).

## Issue Number

Closes #16658. 

## How to Test

On any Linux x64 machine (or ubuntu-latest runner):

```
npm ci
npm run build:desktop
ls dist-electron/*.AppImage dist-electron/*.deb
./dist-electron/"OpenHands Agent Canvas"-*.AppImage   # app launches, stack healthy on :8000
```

This PR's own `Desktop (Linux)` run also uploads the AppImage + deb as
artifacts — download and launch the AppImage to verify.

## Video/Screenshots
<img width="3772" height="1596" alt="image" src="https://github.com/user-attachments/assets/016d4a9e-c167-4244-ab19-38ac4af91fc5" />
<img width="1096" height="295" alt="image" src="https://github.com/user-attachments/assets/16d25443-8661-4288-a9d7-3635bd13384c" />
<img width="518" height="170" alt="image" src="https://github.com/user-attachments/assets/b9a9ab56-adff-406c-bc9e-f4b05d6d0b7f" />
<img width="1920" height="2136" alt="image" src="https://github.com/user-attachments/assets/69b4d740-969d-45a2-81be-a4606e9ffdc2" />


## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- rpm deliberately not included; AppImage covers Fedora/RHEL users. Easy
  follow-up once the lane exists.
- No change to macOS/Windows build behavior.
- Pre-existing polish items noticed while testing (not addressed here): the
  deb gets an empty `--description` (`electron/package.json` has no
  description), and electron-builder warns about `desktopName`/WM_CLASS
  window association on Linux.

