### PR TITLE
feat: set Canvas default model to Kimi K3 and tag it free

### DIFF
--- a/__tests__/api/settings-service.test.ts
+++ b/__tests__/api/settings-service.test.ts
@@ -53,7 +53,7 @@ describe("SettingsService", () => {
 
     // Should have normalized settings with derived fields
     expect(settings.agent).toBe("CodeActAgent");
-    expect(settings.llm_model).toBe("openhands/glm-5.2");
+    expect(settings.llm_model).toBe("openhands/kimi-k3");
     expect(settings.confirmation_mode).toBe(false);
     expect(settings.security_analyzer).toBe("llm");
   });

--- a/__tests__/components/settings/llm-profiles/llm-settings-local-view.test.tsx
+++ b/__tests__/components/settings/llm-profiles/llm-settings-local-view.test.tsx
@@ -331,10 +331,10 @@ describe("LlmSettingsLocalView", () => {
 
       // The profile name is auto-derived from the prefilled free default model.
       const nameInput = screen.getByTestId("profile-name-input");
-      expect(nameInput).toHaveValue("glm-5.2");
+      expect(nameInput).toHaveValue("kimi-k3");
 
       expect(screen.getByTestId("mock-basic-model-input")).toHaveValue(
-        "openhands/glm-5.2",
+        "openhands/kimi-k3",
       );
     });
 
@@ -348,7 +348,7 @@ describe("LlmSettingsLocalView", () => {
 
       // The profile name starts from the free-model derived default.
       const nameInput = screen.getByTestId("profile-name-input");
-      expect(nameInput).toHaveValue("glm-5.2");
+      expect(nameInput).toHaveValue("kimi-k3");
 
       // Go back to list
       await user.click(screen.getByTestId("back-to-profiles"));
@@ -360,7 +360,7 @@ describe("LlmSettingsLocalView", () => {
       // The profile name should return to the free-model derived default
       // again (fresh form).
       const freshNameInput = screen.getByTestId("profile-name-input");
-      expect(freshNameInput).toHaveValue("glm-5.2");
+      expect(freshNameInput).toHaveValue("kimi-k3");
     });
 
     it("does not carry over values from edit mode to create mode", async () => {
@@ -375,7 +375,7 @@ describe("LlmSettingsLocalView", () => {
 
       // Should be in create view with the free-model derived profile name.
       const nameInput = screen.getByTestId("profile-name-input");
-      expect(nameInput).toHaveValue("glm-5.2");
+      expect(nameInput).toHaveValue("kimi-k3");
 
       // The key "new-profile" should be used, ensuring a fresh form mount
       // that doesn't inherit any existing profile data

--- a/__tests__/utils/format-model-name.test.ts
+++ b/__tests__/utils/format-model-name.test.ts
@@ -17,6 +17,7 @@ describe("formatNativeModelName", () => {
 
   it("labels only configured OpenHands free-model routes as free", () => {
     expect(Object.keys(FREE_OPENHANDS_MODELS)).toEqual([
+      "openhands/kimi-k3",
       "openhands/glm-5.2",
       "openhands/deepseek-v4-flash",
       "openhands/minimax-m2.7",

--- a/specs/llm-defaults.md
+++ b/specs/llm-defaults.md
@@ -3,7 +3,7 @@
 ---
 
 ### LLD-001: Frontend always sends its chosen default model
-- [x] When the agent-server returns an absent or empty `llm.model` (e.g. because the user has never saved settings), the frontend adapter shall substitute `DEFAULT_SETTINGS.llm_model` (`"openhands/glm-5.2"`) before sending the conversation-start request.
+- [x] When the agent-server returns an absent or empty `llm.model` (e.g. because the user has never saved settings), the frontend adapter shall substitute `DEFAULT_SETTINGS.llm_model` (`"openhands/kimi-k3"`) before sending the conversation-start request.
 - [x] The frontend shall never rely on the agent-server SDK's own default model (`gpt-5.5`); it shall always send an explicit model value.
 - [x] Whitespace-only model strings shall be treated as absent and fall back to the default.
 - [x] The same guard applies when LLM settings arrive via `encryptedAgentSettings` (the conversation-start encrypted payload path).

--- a/src/components/features/onboarding/steps/setup-llm-step.tsx
+++ b/src/components/features/onboarding/steps/setup-llm-step.tsx
@@ -17,7 +17,7 @@ interface SetupLlmStepProps {
 
 /**
  * Pre-fills the LLM form with the OpenHands provider's free default model
- * (`openhands/glm-5.2`), matching `DEFAULT_SETTINGS.llm_model`. The OpenHands
+ * (`openhands/kimi-k3`), matching `DEFAULT_SETTINGS.llm_model`. The OpenHands
  * provider is the agent the user just selected, so the onboarding override
  * keeps the LLM provider aligned with that choice rather than silently
  * switching to OpenAI. Canvas stores provider-qualified LiteLLM model ids,
@@ -25,7 +25,7 @@ interface SetupLlmStepProps {
  * explicit override marks the model dirty so the Next button persists the
  * suggested default immediately.
  */
-export const ONBOARDING_DEFAULT_LLM_MODEL = "openhands/glm-5.2";
+export const ONBOARDING_DEFAULT_LLM_MODEL = "openhands/kimi-k3";
 
 /**
  * Step 2: embed the LLM settings form. The screen runs in `embedded`

--- a/src/mocks/settings-handlers.ts
+++ b/src/mocks/settings-handlers.ts
@@ -595,6 +595,7 @@ const MOCK_MODELS = [
   "openhands/claude-sonnet-4-5-20250929",
   "openhands/claude-haiku-4-5-20251001",
   "openhands/claude-opus-4-5-20251101",
+  "openhands/kimi-k3",
   "openhands/glm-5.2",
   "sambanova/Meta-Llama-3.1-8B-Instruct",
 ];
@@ -608,6 +609,7 @@ const MOCK_VERIFIED_MODELS = new Set([
   "openai/gpt-5.5",
   "openhands/claude-opus-4-5-20251101",
   "openhands/claude-sonnet-4-5-20250929",
+  "openhands/kimi-k3",
   "openhands/glm-5.2",
 ]);
 
@@ -733,7 +735,7 @@ export const SETTINGS_HANDLERS = [
         "claude-sonnet-4-5-20250929",
       ],
       verified_providers: MOCK_VERIFIED_PROVIDERS,
-      default_model: "openhands/glm-5.2",
+      default_model: "openhands/kimi-k3",
     }),
   ),
 

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -3,7 +3,7 @@ import { Settings } from "#/types/settings";
 export const LATEST_SETTINGS_VERSION = 5;
 
 export const DEFAULT_SETTINGS: Settings = {
-  llm_model: "openhands/glm-5.2",
+  llm_model: "openhands/kimi-k3",
   llm_base_url: "",
   agent: "CodeActAgent",
   language: "en",
@@ -37,7 +37,7 @@ export const DEFAULT_SETTINGS: Settings = {
     agent_kind: "openhands",
     agent: "CodeActAgent",
     llm: {
-      model: "openhands/glm-5.2",
+      model: "openhands/kimi-k3",
     },
     condenser: {
       enabled: true,

--- a/src/utils/format-model-name.ts
+++ b/src/utils/format-model-name.ts
@@ -1,6 +1,7 @@
 export const FREE_MODEL_BADGE_LABEL = "Free";
 
 export const FREE_OPENHANDS_MODELS = {
+  "openhands/kimi-k3": "OpenHands Kimi K3 (free)",
   "openhands/glm-5.2": "OpenHands GLM-5.2 (free)",
   "openhands/deepseek-v4-flash": "OpenHands DeepSeek V4 Flash (free)",
   "openhands/minimax-m2.7": "OpenHands MiniMax M2.7 (free)",

--- a/tests/e2e/mock-llm/onboarding/mock-llm-onboarding-regressions.spec.ts
+++ b/tests/e2e/mock-llm/onboarding/mock-llm-onboarding-regressions.spec.ts
@@ -99,8 +99,8 @@ test.describe("onboarding recent regressions", () => {
     // The model input displays the model ID without the provider prefix.
     await expect(
       modelInput,
-      "first-run onboarding should default to GLM-5.2",
-    ).toHaveValue("glm-5.2", {
+      "first-run onboarding should default to Kimi K3",
+    ).toHaveValue("kimi-k3", {
       timeout: 10_000,
     });
     await expect(

--- a/tests/e2e/support/onboarding-helpers.ts
+++ b/tests/e2e/support/onboarding-helpers.ts
@@ -21,7 +21,7 @@ export async function routeOnboardingLlmCatalog(page: Page) {
         models: {
           anthropic: ["claude-opus-4-8"],
           openai: ["gpt-5.5"],
-          openhands: ["claude-opus-4-5-20251101", "glm-5.2"],
+          openhands: ["claude-opus-4-5-20251101", "kimi-k3", "glm-5.2"],
         },
       }),
     });
@@ -36,6 +36,7 @@ export async function routeOnboardingLlmCatalog(page: Page) {
           "anthropic/claude-opus-4-8",
           "openai/gpt-5.5",
           "openhands/claude-opus-4-5-20251101",
+          "openhands/kimi-k3",
           "openhands/glm-5.2",
         ],
       }),


### PR DESCRIPTION
## Summary

Makes `openhands/kimi-k3` the **default** OpenHands model in Canvas and tags it as a **free** OpenHands model, mirroring how `glm-5.2` was rolled out (#16146 + #16281).

## Changes
- `src/services/settings.ts`: `DEFAULT_SETTINGS.llm_model` and `agent_settings.llm.model` → `openhands/kimi-k3`.
- `src/components/features/onboarding/steps/setup-llm-step.tsx`: `ONBOARDING_DEFAULT_LLM_MODEL` → `openhands/kimi-k3` (+ docstring).
- `src/utils/format-model-name.ts`: add `"openhands/kimi-k3": "OpenHands Kimi K3 (free)"` to `FREE_OPENHANDS_MODELS` (listed first).
- Mocks/specs/tests updated: `src/mocks/settings-handlers.ts`, `specs/llm-defaults.md`, `__tests__/api/settings-service.test.ts`, `__tests__/utils/format-model-name.test.ts`, `__tests__/components/settings/llm-profiles/llm-settings-local-view.test.tsx`, and e2e onboarding helpers/spec.

## Notes
- The SDK's `VERIFIED_OPENHANDS_MODELS` already includes `kimi-k3`, so no SDK change is required.
- This depends on `kimi-k3` being served as free by the LiteLLM proxy (companion PR: OpenHands/saas-deploy#645) and the SaaS-side default/migration (companion enterprise PR).

## Verification
- `vitest run` on all affected unit test files passes (format-model-name, settings-service, llm-settings-local-view, model-selector, onboarding-host, etc.).
- Pre-commit hooks (eslint, prettier, staged typecheck) passed.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.7.1` |
| **Commit** | `4e534efd3213976cb7cd9aee60f3d41a69998b2b` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-4e534ef
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-4e534ef
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-4e534ef-amd64
ghcr.io/openhands/agent-canvas:feat-kimi-k3-default-free-amd64
ghcr.io/openhands/agent-canvas:pr-16657-amd64
ghcr.io/openhands/agent-canvas:sha-4e534ef-arm64
ghcr.io/openhands/agent-canvas:feat-kimi-k3-default-free-arm64
ghcr.io/openhands/agent-canvas:pr-16657-arm64
ghcr.io/openhands/agent-canvas:sha-4e534ef
ghcr.io/openhands/agent-canvas:feat-kimi-k3-default-free
ghcr.io/openhands/agent-canvas:pr-16657
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-4e534ef`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-4e534ef-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->