### PR TITLE
fix: clear stale URL search results when input has no repo path

### DIFF
--- a/__tests__/components/features/home/use-url-search.test.tsx
+++ b/__tests__/components/features/home/use-url-search.test.tsx
@@ -237,5 +237,41 @@ describe("useUrlSearch", () => {
         expect(result.current.urlSearchResults).toEqual([]);
       });
     });
+
+    it("should clear results when input changes to an HTTPS URL without a repo path", async () => {
+      mockSearchGitRepositories.mockResolvedValue({
+        items: [
+          { id: "1", full_name: "owner/repo", git_provider: "github", is_public: true },
+        ],
+        next_page_id: null,
+      });
+
+      const { result, rerender } = renderHook(
+        ({ inputValue, provider }) => useUrlSearch(inputValue, provider),
+        {
+          initialProps: {
+            inputValue: "https://github.com/owner/repo",
+            provider: "github" as const,
+          },
+        },
+      );
+
+      // Wait for initial search to complete
+      await waitFor(() => {
+        expect(result.current.urlSearchResults).toHaveLength(1);
+      });
+
+      // Change to an HTTPS URL that does not contain an owner/repo path
+      rerender({
+        inputValue: "https://example.com/",
+        provider: "github" as const,
+      });
+
+      // Results should be cleared and no new search should start
+      await waitFor(() => {
+        expect(result.current.urlSearchResults).toEqual([]);
+      });
+      expect(mockSearchGitRepositories).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/components/features/home/git-repo-dropdown/use-url-search.tsx
+++ b/src/components/features/home/git-repo-dropdown/use-url-search.tsx
@@ -38,6 +38,8 @@ export function useUrlSearch(
           } finally {
             setIsUrlSearchLoading(false);
           }
+        } else {
+          setUrlSearchResults([]);
         }
       } else {
         setUrlSearchResults([]);


### PR DESCRIPTION
Fixes #16663

When the input is an HTTPS URL that does not contain an owner/repo path (e.g. https://example.com/), the repo-path regular expression does not match and the hook previously left stale results from the previous repository URL on screen.

Add the missing else branch so unmatched HTTPS inputs clear urlSearchResults too, mirroring the non-URL branch.

Adds a regression test: after a successful search for owner/repo, changing the input to https://example.com/ clears the results and does not trigger another search.