### PR TITLE
fix: honor the home LLM dropdown selection over an agent profile's pinned LLM

### DIFF
--- a/__tests__/hooks/mutation/use-create-conversation.test.tsx
+++ b/__tests__/hooks/mutation/use-create-conversation.test.tsx
@@ -98,6 +98,7 @@ describe("useCreateConversation", () => {
     useLlmProfilesMock.mockReturnValue({ data: { active_profile: null } });
     removeStoredConversationMetadata("conv-with-plugins");
     removeStoredConversationMetadata("conv-ref-stamp");
+    removeStoredConversationMetadata("conv-dropdown-override");
   });
 
   it("passes suggested tasks to the V1 create conversation API", async () => {
@@ -514,9 +515,11 @@ describe("useCreateConversation", () => {
   });
 
   it("stamps the launched openhands profile's llm_profile_ref into conversation metadata (#1082)", async () => {
-    // A named (non-default) profile launches via the profile path and runs its
-    // own llm_profile_ref — which differs from the standalone active LLM
-    // profile — so the switcher pill must name the ref, not the active profile.
+    // A named (non-default) profile launches via the profile path when no
+    // dropdown selection exists (active_profile null — a differing selection
+    // would win the launch instead, #16539) and runs its own llm_profile_ref,
+    // so the switcher pill must name the ref, not the hook's stale cached
+    // active profile.
     useLlmProfilesMock.mockReturnValue({
       data: { active_profile: "standalone-active" },
     });
@@ -535,7 +538,7 @@ describe("useCreateConversation", () => {
     });
     listLlmProfilesMock.mockResolvedValue({
       profiles: [{ name: "claude" }],
-      active_profile: "standalone-active",
+      active_profile: null,
     });
     const createConversationSpy = vi
       .spyOn(AgentServerConversationService, "createConversation")
@@ -562,5 +565,186 @@ describe("useCreateConversation", () => {
         getStoredConversationMetadata("conv-ref-stamp")?.active_profile,
       ).toBe("claude"),
     );
+  });
+
+  it("honors the home LLM dropdown selection over a named profile's pinned ref (#16539)", async () => {
+    // The home pill shows the account-wide active LLM profile, so when it
+    // differs from the active named profile's pinned llm_profile_ref the
+    // launch must run the selection: downgrade to the agent_settings path
+    // (which the dropdown activation syncs) and stamp the selected profile.
+    listAgentProfilesMock.mockResolvedValue({
+      profiles: [
+        {
+          id: "profile-luna",
+          name: "openhands-luna",
+          agent_kind: "openhands",
+          revision: 1,
+          llm_profile_ref: "pinned-model",
+          mcp_server_refs: null,
+        },
+      ],
+      active_agent_profile_id: "profile-luna",
+    });
+    listLlmProfilesMock.mockResolvedValue({
+      profiles: [{ name: "pinned-model" }, { name: "selected-model" }],
+      active_profile: "selected-model",
+    });
+    const createConversationSpy = vi
+      .spyOn(AgentServerConversationService, "createConversation")
+      .mockResolvedValue({
+        id: "task-id",
+        app_conversation_id: "conv-dropdown-override",
+        agent_server_url: "http://agent-server.local",
+      } as never);
+
+    const { result } = renderHook(() => useCreateConversation(), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={new QueryClient()}>
+          {children}
+        </QueryClientProvider>
+      ),
+    });
+
+    await result.current.mutateAsync({ query: "hello" });
+
+    const call = createConversationSpy.mock.lastCall;
+    expect(call?.[0]?.agentProfileId).toBeUndefined();
+    await waitFor(() =>
+      expect(
+        getStoredConversationMetadata("conv-dropdown-override")?.active_profile,
+      ).toBe("selected-model"),
+    );
+  });
+
+  it("keeps the named profile path when the dropdown selection matches its pinned ref (#16539)", async () => {
+    listAgentProfilesMock.mockResolvedValue({
+      profiles: [
+        {
+          id: "profile-luna",
+          name: "openhands-luna",
+          agent_kind: "openhands",
+          revision: 1,
+          llm_profile_ref: "pinned-model",
+          mcp_server_refs: null,
+        },
+      ],
+      active_agent_profile_id: "profile-luna",
+    });
+    listLlmProfilesMock.mockResolvedValue({
+      profiles: [{ name: "pinned-model" }],
+      active_profile: "pinned-model",
+    });
+    const createConversationSpy = vi
+      .spyOn(AgentServerConversationService, "createConversation")
+      .mockResolvedValue({
+        id: "task-id",
+        app_conversation_id: "conv-1",
+        agent_server_url: "http://agent-server.local",
+      } as never);
+
+    const { result } = renderHook(() => useCreateConversation(), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={new QueryClient()}>
+          {children}
+        </QueryClientProvider>
+      ),
+    });
+
+    await result.current.mutateAsync({ query: "hello" });
+
+    const call = createConversationSpy.mock.lastCall;
+    expect(call?.[0]?.agentProfileId).toBe("profile-luna");
+  });
+
+  it("keeps an explicitly-picked agent profile over the dropdown selection (#16539)", async () => {
+    // An explicit `agentProfileId` (the in-conversation profile picker) is a
+    // deliberate profile pick — its pinned ref stays authoritative even when
+    // the account-wide active LLM profile differs.
+    listAgentProfilesMock.mockResolvedValue({
+      profiles: [
+        {
+          id: "profile-luna",
+          name: "openhands-luna",
+          agent_kind: "openhands",
+          revision: 1,
+          llm_profile_ref: "pinned-model",
+          mcp_server_refs: null,
+        },
+      ],
+      active_agent_profile_id: null,
+    });
+    listLlmProfilesMock.mockResolvedValue({
+      profiles: [{ name: "pinned-model" }, { name: "selected-model" }],
+      active_profile: "selected-model",
+    });
+    const createConversationSpy = vi
+      .spyOn(AgentServerConversationService, "createConversation")
+      .mockResolvedValue({
+        id: "task-id",
+        app_conversation_id: "conv-1",
+        agent_server_url: "http://agent-server.local",
+      } as never);
+
+    const { result } = renderHook(() => useCreateConversation(), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={new QueryClient()}>
+          {children}
+        </QueryClientProvider>
+      ),
+    });
+
+    await result.current.mutateAsync({
+      query: "hello",
+      agentProfileId: "profile-luna",
+    });
+
+    const call = createConversationSpy.mock.lastCall;
+    expect(call?.[0]?.agentProfileId).toBe("profile-luna");
+  });
+
+  it("keeps the named profile path on cloud regardless of the active LLM profile (#16539)", async () => {
+    // The dropdown override is local-only, like the other downgrades: cloud
+    // has no agent_settings payload to fall back to.
+    mockUseActiveBackend.mockReturnValue({
+      backend: { id: "cloud-1", kind: "cloud" },
+      orgId: null,
+    });
+    listAgentProfilesMock.mockResolvedValue({
+      profiles: [
+        {
+          id: "profile-luna",
+          name: "openhands-luna",
+          agent_kind: "openhands",
+          revision: 1,
+          llm_profile_ref: "pinned-model",
+          mcp_server_refs: null,
+        },
+      ],
+      active_agent_profile_id: "profile-luna",
+    });
+    listLlmProfilesMock.mockResolvedValue({
+      profiles: [{ name: "pinned-model" }, { name: "selected-model" }],
+      active_profile: "selected-model",
+    });
+    const createConversationSpy = vi
+      .spyOn(AgentServerConversationService, "createConversation")
+      .mockResolvedValue({
+        id: "task-id",
+        app_conversation_id: "conv-1",
+        agent_server_url: "http://agent-server.local",
+      } as never);
+
+    const { result } = renderHook(() => useCreateConversation(), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={new QueryClient()}>
+          {children}
+        </QueryClientProvider>
+      ),
+    });
+
+    await result.current.mutateAsync({ query: "hello" });
+
+    const call = createConversationSpy.mock.lastCall;
+    expect(call?.[0]?.agentProfileId).toBe("profile-luna");
   });
 });

--- a/src/hooks/mutation/use-create-conversation.ts
+++ b/src/hooks/mutation/use-create-conversation.ts
@@ -135,6 +135,10 @@ export const useCreateConversation = () => {
       // (#1571 review).
       const isCloud = backend.kind === "cloud";
       let effectiveAgentProfileId = requestedAgentProfileId;
+      // The account-wide active LLM profile from the launch-path fetch below
+      // (null when that fetch didn't run or failed). Fresher than the
+      // `useLlmProfiles()` render snapshot, which a fast send can outrun.
+      let fetchedActiveLlmProfile: string | null = null;
       if (
         !isCloud &&
         resolvedAgentProfile?.name === WELL_KNOWN_DEFAULT_AGENT_PROFILE_NAME &&
@@ -179,6 +183,7 @@ export const useCreateConversation = () => {
           llmProfileExists = llm.profiles.some(
             (profile) => profile.name === resolvedAgentProfile.llm_profile_ref,
           );
+          fetchedActiveLlmProfile = llm.active_profile ?? null;
         } catch {
           // List unavailable → can't validate → fall back to agent_settings.
         }
@@ -189,6 +194,27 @@ export const useCreateConversation = () => {
               `LLM profile "${resolvedAgentProfile.llm_profile_ref}"; ` +
               "launching from agent_settings instead.",
           );
+          effectiveAgentProfileId = undefined;
+        } else if (
+          !isCloud &&
+          !agentProfileId &&
+          fetchedActiveLlmProfile &&
+          fetchedActiveLlmProfile !== resolvedAgentProfile.llm_profile_ref
+        ) {
+          // The home LLM pill shows — and its dropdown activates — the
+          // account-wide active LLM profile, never the pinned ref
+          // (useChatInputLlmProfileState), so when the two differ the launch
+          // must run the selection or the UI advertises a model the
+          // conversation won't use (#16539). Launch via agent_settings, which
+          // the dropdown's profile activation syncs to the selection. Scoped
+          // to the implicit active-profile launch: an explicit `agentProfileId`
+          // (the in-conversation profile picker) is a deliberate profile pick,
+          // so its pinned ref stays authoritative. Local-only like the
+          // downgrades above — cloud has no agent_settings payload to fall
+          // back to. Trade-off: the named profile's non-LLM config doesn't
+          // apply to this launch; the start request has no per-launch LLM
+          // override that could preserve it (AgentLaunchAdditions carries only
+          // a system-message suffix).
           effectiveAgentProfileId = undefined;
         }
       }
@@ -263,16 +289,17 @@ export const useCreateConversation = () => {
       // A launch from a named OpenHands profile runs that profile's
       // `llm_profile_ref`, which can differ from the standalone active LLM
       // profile — stamp the ref so the switcher pill names the exact profile
-      // the conversation runs (#1082). The agent_settings path (the `default`
-      // baseline or a dangling ref, where effectiveAgentProfileId is cleared)
-      // runs the active LLM, so it keeps `active_profile`. ACP profiles carry
-      // no LLM profile, so they fall through to the active-profile stamp
-      // (unused by the ACP model chip).
+      // the conversation runs (#1082). The agent_settings paths (the `default`
+      // baseline, a dangling ref, or a dropdown override (#16539) — where
+      // effectiveAgentProfileId is cleared) run the active LLM, so they stamp
+      // the active profile, preferring the launch-path fetch over the hook's
+      // render snapshot. ACP profiles carry no LLM profile, so they fall
+      // through to the active-profile stamp (unused by the ACP model chip).
       const activeProfile =
         effectiveAgentProfileId &&
         resolvedAgentProfile?.agent_kind === "openhands"
           ? resolvedAgentProfile.llm_profile_ref
-          : (llmProfiles?.active_profile ?? null);
+          : (fetchedActiveLlmProfile ?? llmProfiles?.active_profile ?? null);
       if (localConversationId && (activeProfile || attachedPlugins.length)) {
         const prev = getStoredConversationMetadata(localConversationId);
         setStoredConversationMetadata(localConversationId, {


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

I verified the changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

<!-- Describe problem, motivation, etc. -->

On the home screen, the LLM pill shows — and its dropdown activates — the **account-wide active LLM profile** (`useChatInputLlmProfileState`). But when a named Agent Profile is active, `useCreateConversation` sends `agent_profile_id`, and the agent-server resolves that profile's pinned `llm_profile_ref` server-side. Result: the user picks a model in the dropdown, the pill displays it, and the conversation silently launches with a different model — the profile's pinned one (#16539).

There is no per-launch LLM override in the start request (`AgentLaunchAdditions` carries only a system-message suffix), so the only place the selection can win is the client's choice of launch path.

## Summary

<!-- 1-3 bullets describing what changed. -->
- When the fetched account-wide active LLM profile differs from the active agent profile's pinned `llm_profile_ref`, downgrade the launch to the `agent_settings` path (which LLM-profile activation keeps in sync with the dropdown selection), so the conversation runs the model the UI advertises.
- Scope the override narrowly: implicit active-profile launches only (an explicit `agentProfileId` from the in-conversation profile picker stays authoritative), local backend only (cloud has no `agent_settings` payload), matching the existing downgrade gates for the seeded `default` profile and dangling refs.
- Stamp conversation metadata with the launch-path active-profile fetch instead of the hook's render snapshot, so the switcher pill names the actual selection even when a fast send outruns the snapshot.

## Issue Number
<!-- Required. The linked issue must carry the `ready-for-dev` label, which
means it has clear acceptance criteria (and, for bugs, reproduction evidence).
If no such issue exists yet, open one using the Bug or Feature Request template
and wait for it to be labeled `ready-for-dev` before opening this PR. -->
Fixes #16539

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Start the dev stack: `npm install`, then `npm run dev`; open `http://localhost:3001`.
2. In **Settings → LLM**, create two LLM profiles with different models (e.g. `pinned-model` and `selected-model`).
3. In **Settings → Agent**, create a named Agent Profile pinned to `pinned-model` and **activate it**.
4. On the home screen, open the LLM pill dropdown and select `selected-model`.
5. Send a message to launch a conversation.
6. Verify the conversation runs the dropdown selection:

```
curl -s -H "X-Session-API-Key: $(cat ~/.openhands/agent-canvas/api-key.txt)" \
  [http://127.0.0.1:18000/api/conversations/](http://127.0.0.1:18000/api/conversations/)<conversation-id> \
  | jq '{model: .agent.llm.model, launched_agent_profile}'

```

Expected: `model` is `selected-model`'s model and `launched_agent_profile` is `null`. Before this fix, `model` was the pinned model and `launched_agent_profile` named the agent profile. 7. Regression checks: pick the profile explicitly via the in-conversation Agent Profile picker → the pinned ref must still win; set the dropdown to the pinned profile itself → the named-profile path is kept (`launched_agent_profile` populated).

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

For bug fixes: reproduction evidence is required. Show the bug reproduced (the
error state) and then the result after your fix. A terminal screenshot or video
is fine for non-UI bugs.
-->

https://github.com/user-attachments/assets/f6714f13-162a-4b5d-8891-ffe126e099c2

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.7.1` |
| **Commit** | `71aa8c88db82f872742fd1b808fcc5f27556c2bf` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-71aa8c8
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-71aa8c8
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-71aa8c8-amd64
ghcr.io/openhands/agent-canvas:hieptl-oss-9493-amd64
ghcr.io/openhands/agent-canvas:pr-16671-amd64
ghcr.io/openhands/agent-canvas:sha-71aa8c8-arm64
ghcr.io/openhands/agent-canvas:hieptl-oss-9493-arm64
ghcr.io/openhands/agent-canvas:pr-16671-arm64
ghcr.io/openhands/agent-canvas:sha-71aa8c8
ghcr.io/openhands/agent-canvas:hieptl-oss-9493
ghcr.io/openhands/agent-canvas:pr-16671
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-71aa8c8`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-71aa8c8-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->