### PR TITLE
feat(automations): show configured repositories

### DIFF
--- a/__tests__/components/automations/detail/configuration-section.test.tsx
+++ b/__tests__/components/automations/detail/configuration-section.test.tsx
@@ -77,6 +77,35 @@ describe("ConfigurationSection", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders every repository from preset metadata with its ref", () => {
+    const automation: Automation = {
+      ...cronAutomation,
+      repository: "legacy/repository",
+      branch: "legacy-branch",
+      preset_metadata: {
+        repos: [
+          { url: "OpenHands/docs", ref: "main", provider: "github" },
+          {
+            url: "https://gitlab.com/OpenHands/website",
+            ref: "release",
+            provider: "gitlab",
+            repo_path: "website",
+          },
+        ],
+      },
+    };
+
+    render(<ConfigurationSection automation={automation} />);
+
+    expect(screen.getByText("OpenHands/docs")).toBeInTheDocument();
+    expect(screen.getByText("main")).toBeInTheDocument();
+    expect(
+      screen.getByText("https://gitlab.com/OpenHands/website"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("release")).toBeInTheDocument();
+    expect(screen.queryByText("legacy/repository")).not.toBeInTheDocument();
+  });
+
   it("does not show schedule field for event triggers", () => {
     render(<ConfigurationSection automation={eventAutomation} />);
 

--- a/src/components/features/automations/detail/configuration-section.tsx
+++ b/src/components/features/automations/detail/configuration-section.tsx
@@ -66,6 +66,11 @@ export function ConfigurationSection({
   const triggerDisplay = isEvent
     ? t(I18nKey.AUTOMATIONS$DETAIL$TRIGGER_EVENT)
     : t(I18nKey.AUTOMATIONS$DETAIL$TRIGGER_SCHEDULE);
+  const repositories = automation.preset_metadata?.repos?.length
+    ? automation.preset_metadata.repos
+    : automation.repository
+      ? [{ url: automation.repository, ref: automation.branch }]
+      : [];
 
   return (
     <SectionCard
@@ -73,15 +78,22 @@ export function ConfigurationSection({
       title={t(I18nKey.AUTOMATIONS$DETAIL$CONFIGURATION)}
     >
       <div className="grid grid-cols-2 gap-x-4 gap-y-5">
-        {automation.repository && (
+        {repositories.length > 0 && (
           <ConfigField
             icon={<GitBranchIcon className="size-3.5" />}
             label={t(I18nKey.AUTOMATIONS$DETAIL$REPOSITORIES)}
           >
-            <span className="flex items-center gap-1">
-              {automation.repository}
-              {automation.branch && <BranchBadge branch={automation.branch} />}
-            </span>
+            <div className="flex flex-col gap-1.5">
+              {repositories.map((repository) => (
+                <span
+                  key={`${repository.url}:${repository.ref ?? ""}`}
+                  className="flex items-center gap-1"
+                >
+                  {repository.url}
+                  {repository.ref && <BranchBadge branch={repository.ref} />}
+                </span>
+              ))}
+            </div>
           </ConfigField>
         )}
 

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -21,12 +21,25 @@ export interface AutomationTrigger {
   filter?: string;
 }
 
+export interface AutomationRepository {
+  url: string;
+  ref?: string | null;
+  provider?: string | null;
+  repo_path?: string | null;
+}
+
+export interface AutomationPresetMetadata {
+  repos?: AutomationRepository[];
+}
+
 export interface Automation {
   id: string;
   name: string;
   trigger: AutomationTrigger;
   enabled: boolean;
+  /** Legacy single-repository fields retained for older automations. */
   repository?: string;
+  preset_metadata?: AutomationPresetMetadata | null;
   /** LLM/model profile name used for automation runs. */
   model?: string | null;
   /**


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
Created automations locally using the preset code review template. The implementation has fallbacks for ui output that match the previous output so no changes for any cases where this may have been working should break.

<!-- Human contributors: add a short note about your testing. -->

AGENT:

Implemented on behalf of @DevinVinson.

- Focused component verification: `npm test -- --run __tests__/components/automations/detail/configuration-section.test.tsx` passed (1 file, 7 tests).
- Static verification: `npm run lint -- src/types/automation.ts src/components/features/automations/detail/configuration-section.tsx __tests__/components/automations/detail/configuration-section.test.tsx` passed typecheck, ESLint, and Prettier. It reported only two existing lint warnings in unrelated files.
- The commit hook also passed staged ESLint/Prettier, staged TypeScript checking, and translation completeness validation.
- Manual end-to-end browser validation was not run because this narrow detail-component behavior is covered by its direct rendered-component test; this remains a draft for human validation before full review.

---

## Why

Automations that clone repositories do not show repository information in their detail configuration when the backend provides it through `preset_metadata.repos`.

## Summary

- Render every configured repository and optional ref from `preset_metadata.repos` in the automation configuration section.
- Fall back to the legacy single `repository` and `branch` fields for older automations.
- Add regression coverage for multiple repositories, refs, and metadata precedence.

## Issue Number

Fixes "A. Repositories / repo list (highest priority)" in #16644

## How to Test

1. Run `npm test -- --run __tests__/components/automations/detail/configuration-section.test.tsx`.
2. Open an automation detail page for an automation whose response includes `preset_metadata.repos`.
3. Confirm every repository URL is shown in Configuration, with its configured ref when present.
4. Confirm an automation without `preset_metadata.repos` still displays its legacy `repository` and `branch` fields.

## Video/Screenshots
<img width="886" height="594" alt="Screenshot 2026-08-18 at 11 37 35 AM" src="https://github.com/user-attachments/assets/a16cc068-ab11-4c38-984d-92638a3bd308" />



## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR intentionally implements only the repository-display acceptance criterion from #16644, avoiding overlap with the broader parity work in other contributions.

_This PR was created by an AI agent (OpenHands) on behalf of DevinVinson._
