### PR TITLE
fix(ci): stop treating markdown as frontend evidence-bearing code

### DIFF
--- a/.github/scripts/check_pr_description.py
+++ b/.github/scripts/check_pr_description.py
@@ -57,9 +57,7 @@ FRONTEND_FILE_EXTENSIONS: tuple[str, ...] = (
     ".sass",
     ".less",
 )
-# Documentation has no visual state, so a screenshot cannot evidence a change to
-# it. Markdown stays non-frontend even under a frontend path prefix; otherwise a
-# link fix in __tests__/*.md or src/*.md is asked for a screenshot it cannot have.
+# Docs carry no visual state, so a screenshot can't evidence a change to them.
 DOCUMENTATION_FILE_EXTENSIONS: tuple[str, ...] = (".md", ".mdx")
 FRONTEND_CONFIG_GLOBS: tuple[str, ...] = (
     "tailwind.config.*",

--- a/.github/scripts/check_pr_description.py
+++ b/.github/scripts/check_pr_description.py
@@ -57,6 +57,10 @@ FRONTEND_FILE_EXTENSIONS: tuple[str, ...] = (
     ".sass",
     ".less",
 )
+# Documentation has no visual state, so a screenshot cannot evidence a change to
+# it. Markdown stays non-frontend even under a frontend path prefix; otherwise a
+# link fix in __tests__/*.md or src/*.md is asked for a screenshot it cannot have.
+DOCUMENTATION_FILE_EXTENSIONS: tuple[str, ...] = (".md", ".mdx")
 FRONTEND_CONFIG_GLOBS: tuple[str, ...] = (
     "tailwind.config.*",
     "vite.config.*",
@@ -155,9 +159,11 @@ def extract_human_note(body: str) -> str:
 def is_frontend_file(path: str) -> bool:
     """Return True if a changed file should be treated as frontend code."""
     normalized = path.lstrip("./")
+    lower = normalized.lower()
+    if lower.endswith(DOCUMENTATION_FILE_EXTENSIONS):
+        return False
     if any(normalized.startswith(prefix) for prefix in FRONTEND_PATH_PREFIXES):
         return True
-    lower = normalized.lower()
     if any(lower.endswith(ext) for ext in FRONTEND_FILE_EXTENSIONS):
         return True
     name = normalized.split("/")[-1]

--- a/.github/scripts/tests/test_pr_description.py
+++ b/.github/scripts/tests/test_pr_description.py
@@ -8,6 +8,8 @@ from unittest.mock import patch
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from check_pr_description import (
+    is_frontend_file,
+    touches_frontend,
     extract_linked_issue_numbers,
     extract_pr_type,
     validate_linked_issue_ready,
@@ -222,3 +224,27 @@ https://youtube.com/watch?v=abc123
 """
     errors = validate_bug_fix_evidence(body)
     assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# is_frontend_file — documentation carries no visual state
+# ---------------------------------------------------------------------------
+
+def test_markdown_under_frontend_prefix_is_not_frontend():
+    assert not is_frontend_file("__tests__/router.md")
+    assert not is_frontend_file("src/notes.md")
+    assert not is_frontend_file("public/README.mdx")
+
+def test_markdown_outside_frontend_prefix_still_not_frontend():
+    assert not is_frontend_file("docs/README.md")
+
+def test_frontend_code_under_prefix_still_frontend():
+    assert is_frontend_file("src/app.tsx")
+    assert is_frontend_file("__tests__/routes/launch.test.tsx")
+    assert is_frontend_file("src/styles/main.css")
+
+def test_docs_only_change_does_not_require_frontend_evidence():
+    assert not touches_frontend(["__tests__/router.md", "docs/README.md"])
+
+def test_mixed_change_still_requires_frontend_evidence():
+    assert touches_frontend(["__tests__/router.md", "src/app.tsx"])

--- a/.github/scripts/tests/test_pr_description.py
+++ b/.github/scripts/tests/test_pr_description.py
@@ -226,10 +226,6 @@ https://youtube.com/watch?v=abc123
     assert errors == []
 
 
-# ---------------------------------------------------------------------------
-# is_frontend_file — documentation carries no visual state
-# ---------------------------------------------------------------------------
-
 def test_markdown_under_frontend_prefix_is_not_frontend():
     assert not is_frontend_file("__tests__/router.md")
     assert not is_frontend_file("src/notes.md")


### PR DESCRIPTION
HUMAN:

I ran the check on main and received True for `__tests__/router.md` and False for `docs/README.md` — the files are of the same type, but the different folder causes different results. Asking for a screenshot of a Markdown file seems unnecessary. The fix appears correct, and the tests cover the relevant cases I was concerned about.

AGENT:

```console
$ # The defect, against the repo's own checker.
$ python3 -c "
import sys; sys.path.insert(0, '.github/scripts')
from check_pr_description import is_frontend_file, touches_frontend
for p in ['__tests__/router.md','src/notes.md','docs/README.md','src/app.tsx']:
    print(f'{p:22} frontend={is_frontend_file(p)}')
print('docs-only PR needs evidence ->', touches_frontend(['__tests__/router.md']))
"
__tests__/router.md    frontend=True      <- markdown, asked for a screenshot
src/notes.md           frontend=True      <- markdown, asked for a screenshot
docs/README.md         frontend=False     <- identical file type, different answer
src/app.tsx            frontend=True
docs-only PR needs evidence -> True

$ # After this change.
__tests__/router.md    frontend=False
src/notes.md           frontend=False
docs/README.md         frontend=False
src/app.tsx            frontend=True
docs-only PR needs evidence -> False

$ # Frontend sources under those prefixes are unchanged.
$ python3 -c "
import sys; sys.path.insert(0, '.github/scripts')
from check_pr_description import is_frontend_file
for p in ['__tests__/routes/launch.test.tsx','src/styles/main.css','tailwind.config.ts']:
    print(f'{p:34} frontend={is_frontend_file(p)}')
"
__tests__/routes/launch.test.tsx   frontend=True
src/styles/main.css                frontend=True
tailwind.config.ts                 frontend=True

$ # Regression tests fail before the change and pass after.
$ git stash && python3 -m pytest .github/scripts/tests/test_pr_description.py -q -k frontend
2 failed, 3 passed
$ git stash pop && python3 -m pytest .github/scripts/tests/ -q
63 passed in 0.05s

$ # This PR itself touches no frontend file, so it needs no evidence.
$ python3 -c "
import sys,subprocess; sys.path.insert(0,'.github/scripts')
from check_pr_description import touches_frontend
print(touches_frontend(subprocess.run(['git','diff','--name-only','HEAD~1'],capture_output=True,text=True).stdout.split()))
"
False
```

---

## Why

`is_frontend_file()` classifies any path under `src/`, `__tests__/`, or `public/` as frontend code without regard to file type, so markdown under those prefixes is treated as frontend and the PR description check demands a screenshot or video.

Documentation has no visual state, so that evidence cannot exist. The same file type answers differently depending only on its directory: `docs/README.md` is not frontend, `src/notes.md` is.

This is reachable today. `__tests__/router.md:221` links to `routes/home-screen.test.tsx`, which no longer exists — the only broken relative markdown link left in the repository. Fixing that one line currently requires attaching an unrelated screenshot to satisfy the check.

## Summary

- Markdown and MDX classify as non-frontend under any path, including the three frontend prefixes.
- `.tsx`, `.css`, and the config globs under those prefixes are unchanged.
- A PR touching both markdown and frontend code still requires evidence.

## Issue Number

Fixes #16692

## How to Test

1. On `main`, confirm the same file type answers differently by directory:
   ```bash
   python3 -c "
   import sys; sys.path.insert(0, '.github/scripts')
   from check_pr_description import is_frontend_file
   print(is_frontend_file('__tests__/router.md'), is_frontend_file('docs/README.md'))"
   ```
   Expected on `main`: `True False`. Expected on this branch: `False False`.
2. Confirm frontend sources are unaffected:
   ```bash
   python3 -c "
   import sys; sys.path.insert(0, '.github/scripts')
   from check_pr_description import is_frontend_file
   print(is_frontend_file('__tests__/routes/launch.test.tsx'), is_frontend_file('src/styles/main.css'))"
   ```
   Expected on both: `True True`.
3. Run the checker suite: `python3 -m pytest .github/scripts/tests/ -v` — 63 passed.

## Video/Screenshots

N/A — CI script logic with no runtime or UI surface. The change is precisely that documentation cannot be evidenced by a screenshot.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- **Why an extension check rather than removing `__tests__/` from the prefixes.** The prefixes are correct for code: a `.test.tsx` under `__tests__/` genuinely affects the frontend. The wrong assumption is that path implies file type, so the fix narrows on type and leaves the prefix list intact.
- **`.mdx` included alongside `.md`** because it is documentation by the same argument; no `.mdx` currently sits under a frontend prefix, so this is forward-looking rather than load-bearing.
- **The broken link in `__tests__/router.md` is deliberately not fixed here.** The description check runs the script from the base branch, so this PR would still be judged by the old classifier and asked for a screenshot. Once this lands, that one-line fix becomes a clean follow-up.
