### PR TITLE
fix(frontend): clear stale urlSearchResults on incomplete https url

### DIFF
--- a/__tests__/components/features/home/use-url-search.test.tsx
+++ b/__tests__/components/features/home/use-url-search.test.tsx
@@ -237,5 +237,39 @@ describe("useUrlSearch", () => {
         expect(result.current.urlSearchResults).toEqual([]);
       });
     });
+
+    it("should clear prior results when an HTTPS URL does not match repo pattern", async () => {
+      mockSearchGitRepositories.mockResolvedValue({
+        items: [
+          { id: "1", full_name: "owner/repo", git_provider: "github", is_public: true },
+        ],
+        next_page_id: null,
+      });
+
+      const { result, rerender } = renderHook(
+        ({ inputValue, provider }) => useUrlSearch(inputValue, provider),
+        {
+          initialProps: {
+            inputValue: "https://github.com/owner/repo",
+            provider: "github" as const,
+          },
+        },
+      );
+
+      await waitFor(() => {
+        expect(result.current.urlSearchResults).toHaveLength(1);
+      });
+
+      rerender({
+        inputValue: "https://example.com/",
+        provider: "github" as const,
+      });
+
+      await waitFor(() => {
+        expect(result.current.urlSearchResults).toEqual([]);
+      });
+
+      expect(mockSearchGitRepositories).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/components/features/home/git-repo-dropdown/use-url-search.tsx
+++ b/src/components/features/home/git-repo-dropdown/use-url-search.tsx
@@ -38,6 +38,8 @@ export function useUrlSearch(
           } finally {
             setIsUrlSearchLoading(false);
           }
+        } else {
+          setUrlSearchResults([]);
         }
       } else {
         setUrlSearchResults([]);


### PR DESCRIPTION
HUMAN:
Verified that typing an incomplete HTTPS URL clears stale search results in the repository dropdown by running unit tests locally.

## Why

In `useUrlSearch` (`src/components/features/home/git-repo-dropdown/use-url-search.tsx`), when the input begins with `https://` but does not match the repository pattern (e.g. `https://example.com/` or an incomplete URL), the hook previously neither performed a search nor cleared prior repository results. Consequently, stale repository search results from earlier valid inputs remained displayed in the dropdown.

## Summary

- Added `else { setUrlSearchResults([]); }` when an `https://` input does not match a repository path regex.
- Verified that results are cleared when transitioning from a valid repository URL to an incomplete HTTPS URL.

## Issue Number

Fixes #16663

## How to Test

Run the frontend test suite or reproduce via the dropdown input by entering a valid repo URL and then changing to an incomplete HTTPS string.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
