### PR TITLE
feat: scope OpenAI subscription caches by backend

### DIFF
--- a/__tests__/hooks/query/use-llm-subscription-queries.test.tsx
+++ b/__tests__/hooks/query/use-llm-subscription-queries.test.tsx
@@ -1,0 +1,152 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import LLMSubscriptionService, {
+  type LLMSubscriptionStatus,
+} from "#/api/llm-subscription-service";
+import {
+  __resetActiveStoreForTests,
+  setActiveSelection,
+  setRegisteredBackends,
+} from "#/api/backend-registry/active-store";
+import type { Backend } from "#/api/backend-registry/types";
+import { ActiveBackendProvider } from "#/contexts/active-backend-context";
+import { LLM_SUBSCRIPTION_QUERY_KEYS } from "#/hooks/query/query-keys";
+import { useOpenAISubscriptionModels } from "#/hooks/query/use-llm-subscription-models";
+import { useOpenAISubscriptionStatus } from "#/hooks/query/use-llm-subscription-status";
+
+vi.mock("#/api/llm-subscription-service");
+
+const localBackend1: Backend = {
+  id: "local-1",
+  name: "Local 1",
+  host: "http://localhost:8000",
+  apiKey: "session-key-1",
+  kind: "local",
+};
+
+const localBackend2: Backend = {
+  id: "local-2",
+  name: "Local 2",
+  host: "http://localhost:9000",
+  apiKey: "session-key-2",
+  kind: "local",
+};
+
+const cloudBackend: Backend = {
+  id: "cloud-1",
+  name: "Cloud",
+  host: "https://app.all-hands.dev",
+  apiKey: "cloud-key",
+  kind: "cloud",
+};
+
+const connectedStatus = (accountEmail: string): LLMSubscriptionStatus => ({
+  vendor: "openai",
+  connected: true,
+  accountEmail,
+  expiresAt: null,
+});
+
+describe("OpenAI subscription queries", () => {
+  let queryClient: QueryClient;
+  let wrapper: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => React.ReactElement;
+
+  beforeEach(() => {
+    __resetActiveStoreForTests();
+    setRegisteredBackends([localBackend1, localBackend2, cloudBackend]);
+    setActiveSelection({ backendId: localBackend1.id, orgId: null });
+
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+    wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        React.createElement(ActiveBackendProvider, null, children),
+      );
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    vi.resetAllMocks();
+    __resetActiveStoreForTests();
+  });
+
+  it("refetches subscription status into a backend-scoped cache", async () => {
+    vi.mocked(LLMSubscriptionService.getOpenAIStatus)
+      .mockResolvedValueOnce(connectedStatus("local-1@example.com"))
+      .mockResolvedValueOnce(connectedStatus("local-2@example.com"));
+
+    const { result, rerender } = renderHook(
+      () => useOpenAISubscriptionStatus(),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data?.accountEmail).toBe("local-1@example.com");
+    });
+
+    act(() => {
+      setActiveSelection({ backendId: localBackend2.id, orgId: null });
+    });
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.data?.accountEmail).toBe("local-2@example.com");
+    });
+    expect(LLMSubscriptionService.getOpenAIStatus).toHaveBeenCalledTimes(2);
+    expect(
+      queryClient
+        .getQueryCache()
+        .findAll({ queryKey: LLM_SUBSCRIPTION_QUERY_KEYS.openaiStatus })
+        .map((query) => query.queryKey),
+    ).toEqual([
+      [...LLM_SUBSCRIPTION_QUERY_KEYS.openaiStatus, localBackend1.id, null],
+      [...LLM_SUBSCRIPTION_QUERY_KEYS.openaiStatus, localBackend2.id, null],
+    ]);
+  });
+
+  it("refetches subscription models into an organization-scoped cache", async () => {
+    setActiveSelection({ backendId: cloudBackend.id, orgId: "org-1" });
+    vi.mocked(LLMSubscriptionService.getOpenAIModels)
+      .mockResolvedValueOnce(["openai/model-for-org-1"])
+      .mockResolvedValueOnce(["openai/model-for-org-2"]);
+
+    const { result, rerender } = renderHook(
+      () => useOpenAISubscriptionModels(),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(["openai/model-for-org-1"]);
+    });
+
+    act(() => {
+      setActiveSelection({ backendId: cloudBackend.id, orgId: "org-2" });
+    });
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(["openai/model-for-org-2"]);
+    });
+    expect(LLMSubscriptionService.getOpenAIModels).toHaveBeenCalledTimes(2);
+    expect(
+      queryClient
+        .getQueryCache()
+        .findAll({ queryKey: LLM_SUBSCRIPTION_QUERY_KEYS.openaiModels })
+        .map((query) => query.queryKey),
+    ).toEqual([
+      [...LLM_SUBSCRIPTION_QUERY_KEYS.openaiModels, cloudBackend.id, "org-1"],
+      [...LLM_SUBSCRIPTION_QUERY_KEYS.openaiModels, cloudBackend.id, "org-2"],
+    ]);
+  });
+});

--- a/src/hooks/query/use-llm-subscription-models.ts
+++ b/src/hooks/query/use-llm-subscription-models.ts
@@ -1,12 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
 import LLMSubscriptionService from "#/api/llm-subscription-service";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import { LLM_SUBSCRIPTION_QUERY_KEYS } from "#/hooks/query/query-keys";
 
 export function useOpenAISubscriptionModels({
   enabled = true,
 }: { enabled?: boolean } = {}) {
+  const { backend, orgId } = useActiveBackend();
+
   return useQuery({
-    queryKey: LLM_SUBSCRIPTION_QUERY_KEYS.openaiModels,
+    queryKey: [...LLM_SUBSCRIPTION_QUERY_KEYS.openaiModels, backend.id, orgId],
     queryFn: LLMSubscriptionService.getOpenAIModels,
     enabled,
     retry: false,

--- a/src/hooks/query/use-llm-subscription-status.ts
+++ b/src/hooks/query/use-llm-subscription-status.ts
@@ -1,12 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
 import LLMSubscriptionService from "#/api/llm-subscription-service";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import { LLM_SUBSCRIPTION_QUERY_KEYS } from "#/hooks/query/query-keys";
 
 export function useOpenAISubscriptionStatus({
   enabled = true,
 }: { enabled?: boolean } = {}) {
+  const { backend, orgId } = useActiveBackend();
+
   return useQuery({
-    queryKey: LLM_SUBSCRIPTION_QUERY_KEYS.openaiStatus,
+    queryKey: [...LLM_SUBSCRIPTION_QUERY_KEYS.openaiStatus, backend.id, orgId],
     queryFn: LLMSubscriptionService.getOpenAIStatus,
     enabled,
     retry: false,


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

全部变更已审阅，所有测试已通过，无任何遗留问题。

AGENT:

OpenAI Codex was used to investigate, implement, and test this change. The
behavior was reproduced through the full React Query + `ActiveBackendProvider`
hook lifecycle, including a live backend/organization selection change and the
subscription service call boundary.

Before the production change, the focused reproduction produced two failures:

```text
backend switch: expected local-2@example.com, received local-1@example.com
organization switch: expected [openai/model-for-org-2], received [openai/model-for-org-1]
2 tests failed
```

In both cases the subscription service was called only once after the switch,
confirming that the still-fresh value from the prior selection was reused. With
this change, the service is called twice and React Query contains separate
cache entries for each backend/organization selection:

```text
Test Files  1 passed (1)
Tests       2 passed (2)
```

---

## Why

The OpenAI subscription status and model hooks resolve the current agent server
inside their query functions, but their cache keys were global. Switching to a
different backend or organization could therefore display the prior
selection's connected email or model list for the five-minute `staleTime`,
without requesting data for the new selection.

Backend-dependent hooks are expected to include `backend.id` and `orgId` in
their keys. Scoping these two keys provides cache isolation while retaining
useful per-backend entries.

## Summary

- Scope OpenAI subscription status and model query keys by backend ID and
  organization ID.
- Add behavior regressions for a backend switch and a same-backend organization
  switch, including service-call and cache-key assertions.

## Issue Number

Fixes #16698

## How to Test

From the repository root:

```bash
npm exec -- vitest run __tests__/hooks/query/use-llm-subscription-queries.test.tsx
npm run typecheck
npm run lint
```

Observed results:

```text
Focused Vitest: 1 file passed, 2 tests passed
Typecheck: passed
Lint: 0 errors; 3 pre-existing warnings in unrelated files
Prettier: All matched files use Prettier code style
```

## Video/Screenshots

This is a non-visual cache-isolation bug. The deterministic reproduction logs
above capture the observable failure and result: before the fix, a backend or
organization switch returns the old selection's value and performs no second
service call; after the fix, the new value is returned, a second request occurs,
and both scoped cache entries exist.

<img width="1400" height="1063" alt="OpenHands subscription cache TDD evidence" src="https://github.com/user-attachments/assets/5e6a2dcd-b11e-4eee-a73f-7ea9bb48b40b" />

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The existing login/logout mutations invalidate the shared base query-key
prefix, so they continue to invalidate all scoped status entries. No migration,
configuration, or public API change is required.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.51s · commit 9386256  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 3/3 hunks, 3/3 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 2.0% | No direct hunk selected |
| Weakened authentication | 4.0% | No direct hunk selected |
| Weakened authorization | 6.0% | No direct hunk selected |
| Contract regression | 9.0% | No direct hunk selected |
| Data loss | 3.0% | No direct hunk selected |
| Sensitive data disclosure | 3.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 7.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 96.0% | No primary concern to locate |

</details>


<!-- jev-input-signature b2788d4ca8d1e9fd94d5f9ac68f59a1ed54a982665b052f168672cfb201e253b -->
<!-- jev-fast-audit:end -->
