### PR TITLE
fix: do not silently persist ACP model picks to agent_settings when profile discovery fails

### DIFF
--- a/__tests__/hooks/mutation/use-switch-acp-model.test.tsx
+++ b/__tests__/hooks/mutation/use-switch-acp-model.test.tsx
@@ -167,23 +167,23 @@ describe("useSwitchAcpModel", () => {
     });
   });
 
-  it("falls back to the agent-settings default when the profiles surface is unavailable", async () => {
+  it("does not persist to agent_settings when the profiles fetch fails", async () => {
+    // Discovery failure propagates instead of downgrading (#16523): an
+    // active-profile launch ignores agent_settings, so persisting the pick
+    // there would silently drop it.
     vi.mocked(AgentProfilesService.listProfiles).mockRejectedValue(
-      new Error("404"),
+      new Error("profile endpoint unavailable"),
     );
-    vi.mocked(SettingsService.saveSettings).mockResolvedValue(true);
 
     const { result } = renderSwitchHook();
 
     result.current.mutate({ conversationId: null, model: "gemini-2.5-pro" });
 
     await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
+      expect(result.current.isError).toBe(true);
     });
 
-    expect(SettingsService.saveSettings).toHaveBeenCalledWith({
-      agent_settings_diff: { acp_model: "gemini-2.5-pro" },
-    });
+    expect(SettingsService.saveSettings).not.toHaveBeenCalled();
     expect(AgentProfilesService.saveProfile).not.toHaveBeenCalled();
   });
 

--- a/src/hooks/mutation/use-switch-acp-model.ts
+++ b/src/hooks/mutation/use-switch-acp-model.ts
@@ -36,9 +36,11 @@ interface SwitchAcpModelVars {
  * launches resolve the agent server-side purely from the stored profile
  * (``agent_profile_id`` and ``agent_settings`` are mutually exclusive launch
  * sources), so writing ``agent_settings.acp_model`` would not affect them.
- * Only when no ACP profile is active (a legacy backend without the
- * /api/agent-profiles surface) does the write fall back to the
- * ``agent_settings_diff`` the legacy launch path reads.
+ * Only when the profile list resolves with no active ACP profile does the
+ * write fall back to the ``agent_settings_diff`` the legacy launch path
+ * reads. A failed profile discovery propagates instead of downgrading
+ * (#16523): an active-profile launch ignores agent_settings, so persisting
+ * the pick there would silently drop it.
  *
  * Invalidates the same conversation/settings query keys the profile hook does
  * so the chat-input model chip + conversation chip refresh with the new model.
@@ -59,21 +61,21 @@ export const useSwitchAcpModel = () => {
 
       // Home page: resolve the active profile from the shared query cache
       // (same keys/retry policy as useCreateConversation's launch path, so a
-      // pick can't disagree with what a subsequent send would launch).
-      let agentProfiles: AgentProfileListResponse | undefined;
-      try {
-        agentProfiles = await queryClient.ensureQueryData({
+      // pick can't disagree with what a subsequent send would launch). Like
+      // that launch path, do not fall back to the legacy agent_settings
+      // persist when profile discovery fails (#16523): an active-profile
+      // launch ignores agent_settings, so the pick would be silently dropped.
+      // The rejection surfaces via the global mutation error toast.
+      const agentProfiles: AgentProfileListResponse =
+        await queryClient.ensureQueryData({
           queryKey: [...AGENT_PROFILES_QUERY_KEYS.all, backend.id, orgId],
           queryFn: AgentProfilesService.listProfiles,
           ...AGENT_PROFILES_RETRY_OPTIONS,
         });
-      } catch {
-        // Profiles unavailable → legacy agent_settings persist below.
-      }
-      const activeProfile = agentProfiles?.profiles?.find(
+      const activeProfile = agentProfiles.profiles?.find(
         (profile) =>
           profile.id != null &&
-          profile.id === agentProfiles?.active_agent_profile_id,
+          profile.id === agentProfiles.active_agent_profile_id,
       );
 
       if (activeProfile?.agent_kind === "acp") {
@@ -98,10 +100,11 @@ export const useSwitchAcpModel = () => {
         return;
       }
 
-      // Legacy/no-profile backends: persist as the agent-settings default. The
-      // backend deep-merges ``agent_settings_diff`` into the existing
-      // ``agent_settings`` dict, so a scalar ``acp_model`` diff updates only
-      // the model and preserves the selected provider + command.
+      // No active ACP profile: persist as the agent-settings default the
+      // legacy launch path reads. The backend deep-merges
+      // ``agent_settings_diff`` into the existing ``agent_settings`` dict, so
+      // a scalar ``acp_model`` diff updates only the model and preserves the
+      // selected provider + command.
       await SettingsService.saveSettings({
         agent_settings_diff: { acp_model: model },
       });


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

I verified the changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

<!-- Describe problem, motivation, etc. -->

#16523 fixed the launch path (`useCreateConversation`): a failed `GET /api/agent-profiles` now blocks the launch instead of silently downgrading to stale global `agent_settings`, because profile activation is pointer-only and those settings can describe a different agent.

`useSwitchAcpModel` still had the identical swallow-and-downgrade pattern on its home-page persist path. If the profiles fetch failed while the user picked an ACP model from the home-page model chip, the pick was silently written to global `agent_settings.acp_model` — which an active-profile launch ignores — so the user's selection was silently dropped (or landed in a different agent's legacy settings). The hook's own comment claims parity with the launch path ("a pick can't disagree with what a subsequent send would launch"); #16523 broke that parity.

## Summary

<!-- 1-3 bullets describing what changed. -->
- `useSwitchAcpModel` no longer catches the `/api/agent-profiles` fetch error on the home-page persist path: the failure propagates, the mutation rejects, and the global mutation error toast reports it — matching the launch path after #16523.
- The deliberate `agent_settings_diff` fallback for a **successfully resolved** profile list with no active ACP profile is unchanged (those launches also go through `agent_settings`, so that persist target is still correct). Doc comments updated to match.
- Updated the one test that pinned the removed fallback: it now asserts the mutation errors and that neither `SettingsService.saveSettings` nor `AgentProfilesService.saveProfile` is called when the profiles fetch fails.

## Issue Number
<!-- Required. The linked issue must carry the `ready-for-dev` label, which
means it has clear acceptance criteria (and, for bugs, reproduction evidence).
If no such issue exists yet, open one using the Bug or Feature Request template
and wait for it to be labeled `ready-for-dev` before opening this PR. -->
Fixes #16522

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

Automated:

1. `npm install`
2. `npx vitest run __tests__/hooks/mutation/use-switch-acp-model.test.tsx __tests__/hooks/mutation/use-create-conversation.test.tsx` — both suites pass (19 tests).

Manual reproduction (before/after):

1. Run the GUI against a local agent-server (`npm run dev`) with an active ACP AgentProfile (e.g. a Claude Code profile).
2. On the home page, open browser devtools → Network and block requests to `**/api/agent-profiles` (or stop the endpoint) to simulate the outage.
3. Pick a different model from the home-page ACP model chip.
4. **Before this fix:** the pick silently succeeds and writes `agent_settings.acp_model` (visible via `GET /api/settings`), which the active-profile launch ignores — the next conversation still uses the profile's stored model.
5. **After this fix:** the switch fails with the global error toast, nothing is written to `agent_settings`, and the user can retry once profiles recover.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

For bug fixes: reproduction evidence is required. Show the bug reproduced (the
error state) and then the result after your fix. A terminal screenshot or video
is fine for non-UI bugs.
-->

<img width="1440" height="754" alt="image" src="https://github.com/user-attachments/assets/06165ab7-b52b-423f-b232-9579055a84a3" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.7.1` |
| **Commit** | `4b662aa95f460241755ab02cea2c2ee6fec6c10a` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-4b662aa
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-4b662aa
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-4b662aa-amd64
ghcr.io/openhands/agent-canvas:hieptl-oss-9482-amd64
ghcr.io/openhands/agent-canvas:pr-16701-amd64
ghcr.io/openhands/agent-canvas:sha-4b662aa-arm64
ghcr.io/openhands/agent-canvas:hieptl-oss-9482-arm64
ghcr.io/openhands/agent-canvas:pr-16701-arm64
ghcr.io/openhands/agent-canvas:sha-4b662aa
ghcr.io/openhands/agent-canvas:hieptl-oss-9482
ghcr.io/openhands/agent-canvas:pr-16701
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-4b662aa`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-4b662aa-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->