### PR TITLE
fix: unsandbox the PDF preview iframe so the built-in viewer renders

### DIFF
--- a/src/components/features/files-tab/file-content-viewer.tsx
+++ b/src/components/features/files-tab/file-content-viewer.tsx
@@ -138,19 +138,19 @@ export function FileContentViewer({ path, viewMode }: FileContentViewerProps) {
   }
 
   if (kind === "pdf") {
-    // PDFs can carry embedded JavaScript (AcroForm, OpenAction…). Even
-    // though `staticUrl` lives on the agent server origin, the PDF
-    // viewer's scripting capability isn't worth the risk for a file
-    // preview, so we sandbox the iframe. `allow-same-origin` lets the
-    // browser's built-in PDF viewer load the underlying bytes without
-    // tripping cross-origin restrictions; we omit `allow-scripts`
-    // because no PDF preview we care about needs to run JS in the
-    // parent's origin.
+    // Deliberately NOT sandboxed: Chromium refuses to instantiate its
+    // built-in PDF viewer inside any sandboxed frame (the `sandbox`
+    // attribute disables plugins unconditionally — no token re-enables
+    // them), rendering "This page has been blocked by Chrome" instead of
+    // the document. Unsandboxed is safe here: the fileserver declares
+    // `Content-Type: application/pdf`, which browsers never sniff into
+    // HTML, so the frame can only host the PDF viewer — and PDF-embedded
+    // JS (AcroForm, OpenAction…) runs in the viewer's own sandboxed
+    // engine with no access to this page's DOM.
     return (
       <iframe
         title={path}
         src={bustedStaticUrl}
-        sandbox="allow-same-origin"
         data-testid="file-content-viewer-iframe"
         className="h-full w-full bg-white"
       />


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

I verified the changes

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

<!-- Describe problem, motivation, etc. -->

Every PDF opened in the Agent Canvas Files/Preview panel rendered blank with Chromium's "This page has been blocked by Chrome" page. The PDF and the server were fine (the same URL renders in a top-level tab; the agent server serves `Content-Type: application/pdf` correctly). The frontend previewed PDFs inside `<iframe sandbox="allow-same-origin">`, and Chromium never grants its built-in PDF viewer to sandboxed frames — the `sandbox` attribute disables plugins unconditionally and no token re-enables them. Firefox's PDF.js viewer likewise fails without `allow-scripts`.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Remove the `sandbox` attribute from the **PDF branch only** of `FileContentViewer` so the browser's built-in PDF viewer can render workspace PDFs inline (`src/components/features/files-tab/file-content-viewer.tsx`).
- Rewrite the branch's inline comment to document why the frame is deliberately unsandboxed and why that is safe for PDFs (the fileserver declares `application/pdf`, which is never sniffed into HTML, so the frame can only host the PDF viewer; PDF-embedded JS runs in the viewer's own sandboxed engine with no DOM access).
- The HTML/SVG preview branch keeps its intentional `sandbox="allow-same-origin"` (previewed HTML `<script>` stays inert), guarded by the existing test.

## Issue Number
<!-- Required. The linked issue must carry the `ready-for-dev` label, which
means it has clear acceptance criteria (and, for bugs, reproduction evidence).
If no such issue exists yet, open one using the Bug or Feature Request template
and wait for it to be labeled `ready-for-dev` before opening this PR. -->
Fixes #16474

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Run the local Agent Canvas stack (`npm install`, then `npm run dev`).
2. In a conversation, have the agent create or add any `.pdf` file to the workspace (e.g. export a deck to PDF).
3. Open the **Files** tab and select the `.pdf` file.
4. **Before this fix:** the preview pane shows Chromium's "This page has been blocked by Chrome" block page. **After:** the PDF renders inline as a scrollable document in the preview pane.
5. Regression check: select an `.html` file and confirm it still previews, and (via devtools) that its iframe still has `sandbox="allow-same-origin"`.

Automated checks run: the three related vitest files (35/35 passing, including the HTML-sandbox guard), `npm run typecheck`, eslint, and prettier — all clean.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

For bug fixes: reproduction evidence is required. Show the bug reproduced (the
error state) and then the result after your fix. A terminal screenshot or video
is fine for non-UI bugs.
-->

<img width="1440" height="754" alt="image" src="https://github.com/user-attachments/assets/07a980a8-0bc1-4dde-8da0-157d9e99bcba" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.7.1` |
| **Commit** | `233a13e513a27737a5f7472ea780e9d4ceb45737` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-233a13e
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-233a13e
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-233a13e-amd64
ghcr.io/openhands/agent-canvas:hieptl-oss-9455-amd64
ghcr.io/openhands/agent-canvas:pr-16702-amd64
ghcr.io/openhands/agent-canvas:sha-233a13e-arm64
ghcr.io/openhands/agent-canvas:hieptl-oss-9455-arm64
ghcr.io/openhands/agent-canvas:pr-16702-arm64
ghcr.io/openhands/agent-canvas:sha-233a13e
ghcr.io/openhands/agent-canvas:hieptl-oss-9455
ghcr.io/openhands/agent-canvas:pr-16702
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-233a13e`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-233a13e-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->