### PR TITLE
fix(chat): scope Cmd+Enter build shortcut to plan mode

### DIFF
--- a/__tests__/components/chat/chat-interface.test.tsx
+++ b/__tests__/components/chat/chat-interface.test.tsx
@@ -1033,3 +1033,112 @@ describe("ChatInterface - Tracking", () => {
     expect(trackInitialQuerySubmittedMock).not.toHaveBeenCalled();
   });
 });
+
+describe("ChatInterface - Build plan keyboard shortcut", () => {
+  let queryClient: QueryClient;
+
+  const BUILD_PROMPT =
+    "Execute the plan based on the .agents_tmp/PLAN.md file.";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSend.mockResolvedValue({ queued: false });
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    useOptimisticUserMessageStore.setState({ pendingMessages: [] });
+    useErrorMessageStore.setState({ errorMessage: null });
+    (useConfig as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {},
+    });
+    (
+      useUnifiedUploadFiles as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue({
+      mutateAsync: vi
+        .fn()
+        .mockResolvedValue({ skipped_files: [], uploaded_files: [] }),
+      isLoading: false,
+    });
+    useEventStore.setState({ events: [], eventIds: new Set(), uiEvents: [] });
+  });
+
+  function renderInterface() {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/test-conversation-id"]}>
+          <Routes>
+            <Route path=":conversationId" element={<ChatInterface />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  }
+
+  const pressBuildShortcut = () => {
+    fireEvent.keyDown(document, { key: "Enter", metaKey: true });
+    fireEvent.keyDown(document, { key: "Enter", ctrlKey: true });
+  };
+
+  const sentBuildPrompt = () =>
+    mockSend.mock.calls.some(([message]) =>
+      JSON.stringify(message).includes(BUILD_PROMPT),
+    );
+
+  it("does not send the build prompt in code mode", () => {
+    act(() => {
+      useConversationStore.setState({
+        conversationMode: "code",
+        planContent: null,
+      });
+    });
+
+    renderInterface();
+    pressBuildShortcut();
+
+    expect(sentBuildPrompt()).toBe(false);
+  });
+
+  it("does not send the build prompt in code mode when a plan exists", () => {
+    act(() => {
+      useConversationStore.setState({
+        conversationMode: "code",
+        planContent: "# Plan\n\n- step one",
+      });
+    });
+
+    renderInterface();
+    pressBuildShortcut();
+
+    expect(sentBuildPrompt()).toBe(false);
+  });
+
+  it("does not send the build prompt in plan mode when no plan exists", () => {
+    act(() => {
+      useConversationStore.setState({
+        conversationMode: "plan",
+        planContent: null,
+      });
+    });
+
+    renderInterface();
+    pressBuildShortcut();
+
+    expect(sentBuildPrompt()).toBe(false);
+  });
+
+  it("sends the build prompt in plan mode when a plan exists", async () => {
+    act(() => {
+      useConversationStore.setState({
+        conversationMode: "plan",
+        planContent: "# Plan\n\n- step one",
+      });
+    });
+
+    renderInterface();
+    fireEvent.keyDown(document, { key: "Enter", metaKey: true });
+
+    await waitFor(() => {
+      expect(sentBuildPrompt()).toBe(true);
+    });
+  });
+});

--- a/src/components/features/chat/chat-interface.tsx
+++ b/src/components/features/chat/chat-interface.tsx
@@ -63,7 +63,8 @@ function getEntryPoint(
 
 export function ChatInterface() {
   const { trackInitialQuerySubmitted, trackUserMessageSent } = useTracking();
-  const { setMessageToSend } = useConversationStore();
+  const { setMessageToSend, conversationMode, planContent } =
+    useConversationStore();
   const {
     errorMessage,
     errorCode,
@@ -133,9 +134,11 @@ export function ChatInterface() {
 
   // Global keyboard shortcut for Build button (Cmd+Enter / Ctrl+Enter)
   // This is placed here instead of PlanPreview to avoid duplicate listeners
-  // when multiple PlanPreview components exist in the chat
+  // when multiple PlanPreview components exist in the chat.
+  // Gated on the same conditions as the Build button (ConversationTabs'
+  // `isBuildDisabled`) so it cannot fire outside the plan flow.
   React.useEffect(() => {
-    if (isAgentRunning) {
+    if (isAgentRunning || conversationMode !== "plan" || !planContent) {
       return undefined;
     }
 
@@ -154,7 +157,13 @@ export function ChatInterface() {
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [isAgentRunning, handleBuildPlanClick, scrollDomToBottom]);
+  }, [
+    isAgentRunning,
+    conversationMode,
+    planContent,
+    handleBuildPlanClick,
+    scrollDomToBottom,
+  ]);
 
   const { selectedRepository, replayJson } = useInitialQueryStore();
   const { conversationId } = useOptionalConversationId();


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Small fix for https://github.com/OpenHands/OpenHands/issues/15293. 

AGENT:

Verification commands and logs are under `## How to Test`. A screenshot/video
still needs a human — GitHub only accepts attachments uploaded through the web
editor.

---

## Why

`ChatInterface` registers a `document`-wide `keydown` listener for
`Cmd/Ctrl+Enter` gated on one condition: whether the agent is running. It never
checks the conversation mode or whether a plan exists, so in an idle
**code-mode** conversation the shortcut still fires `useHandleBuildPlanClick`,
which switches to code mode and sends the hard-coded prompt:

> Execute the plan based on the .agents_tmp/PLAN.md file.

To the user that reads as a random message injection — no plan is being built
and nothing in the UI offered a Build action. Nothing upstream intercepts the
event either: the chat input's key handler (`use-chat-input-events.ts`) returns
early for non-`Enter` keys and never stops propagation.

The explicit Build controls already gate themselves correctly — `ConversationTabs`
computes `isBuildDisabled = isAgentRunning || !planContent`, and `PlanPreview`
renders nothing without `planContent`. Only the global shortcut was missing that
check.

## Summary

- Gate the global `Cmd/Ctrl+Enter` Build shortcut on the same eligibility the
  Build button uses: agent idle, `conversationMode === "plan"`, and `planContent`
  present.
- Add regression coverage for the three excluded states plus the valid plan path.

`useHandleBuildPlanClick` and the explicit Build buttons are untouched.

## Issue Number

Fixes #15293

## How to Test

Manual:

1. `npm run dev`, open an idle conversation in **code** mode.
2. Press `Cmd+Enter` (macOS) / `Ctrl+Enter` (Windows/Linux).
   Before: `Execute the plan based on the .agents_tmp/PLAN.md file.` is sent.
   After: nothing happens.
3. Switch to **Plan** mode (`Shift+Tab`), let a plan be written, press
   `Cmd+Enter` — Build still runs as before.

Automated:

```
$ npx vitest run
 Test Files  578 passed (578)
      Tests  4728 passed | 4 skipped | 7 todo (4739)

$ npm run lint
✖ 3 problems (0 errors, 3 warnings)   # all pre-existing, unrelated files

$ npm run build
✓ built in 4.59s
```

The new tests are a real regression guard — reverting only
`src/components/features/chat/chat-interface.tsx` to `main` fails three of them:

```
$ git checkout origin/main -- src/components/features/chat/chat-interface.tsx
$ npx vitest run __tests__/components/chat/chat-interface.test.tsx -t "Build plan keyboard shortcut"

 × does not send the build prompt in code mode
 × does not send the build prompt in code mode when a plan exists
 × does not send the build prompt in plan mode when no plan exists
 AssertionError: expected true to be false

 Tests  3 failed | 1 passed | 22 skipped (26)
```

## Video/Screenshots

_Pending — needs a human to attach the terminal capture of the before/after test
run._

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Deliberately out of scope: `use-chat-input-events.ts:87` submits on
  `!e.shiftKey && !disabled` without excluding `metaKey`/`ctrlKey`, so with text
  in the composer `Cmd+Enter` also sends the typed message. Separate one-line
  fix, not part of #15293.
- Two earlier attempts (#15294, #15317) were closed unmerged on the same minute,
  which looks like a bulk close rather than a review rejection. Both targeted the
  old `frontend/`-prefixed paths.


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.7.1` |
| **Commit** | `2684138b061fbe5de0eae8e52a048780afbf79b9` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-2684138
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-2684138
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-2684138-amd64
ghcr.io/openhands/agent-canvas:vasco-scope-plan-build-shortcut-amd64
ghcr.io/openhands/agent-canvas:pr-16703-amd64
ghcr.io/openhands/agent-canvas:sha-2684138-arm64
ghcr.io/openhands/agent-canvas:vasco-scope-plan-build-shortcut-arm64
ghcr.io/openhands/agent-canvas:pr-16703-arm64
ghcr.io/openhands/agent-canvas:sha-2684138
ghcr.io/openhands/agent-canvas:vasco-scope-plan-build-shortcut
ghcr.io/openhands/agent-canvas:pr-16703
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-2684138`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-2684138-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->