### PR TITLE
fix: preserve conversation metrics from usage stats

### DIFF
--- a/__tests__/api/agent-server-conversation-service.test.ts
+++ b/__tests__/api/agent-server-conversation-service.test.ts
@@ -636,6 +636,67 @@ describe("AgentServerConversationService", () => {
       expect(result.items[0]?.sandbox_status).toBe("PAUSED");
     });
 
+    it("falls back to aggregated usage metrics from searchConversations stats", async () => {
+      const searchSpy = vi.fn().mockResolvedValue({
+        items: [
+          {
+            id: "conv-with-stats",
+            created_at: "2024-01-01",
+            updated_at: "2024-01-01",
+            metrics: null,
+            stats: {
+              usage_to_metrics: {
+                agent: {
+                  accumulated_cost: 1.25,
+                  max_budget_per_task: 10,
+                  accumulated_token_usage: {
+                    prompt_tokens: 100,
+                    completion_tokens: 20,
+                    cache_read_tokens: 30,
+                    cache_write_tokens: 5,
+                    context_window: 128_000,
+                    per_turn_token: 120,
+                  },
+                },
+                condenser: {
+                  accumulated_cost: 0.5,
+                  max_budget_per_task: null,
+                  accumulated_token_usage: {
+                    prompt_tokens: 40,
+                    completion_tokens: 10,
+                    cache_read_tokens: 15,
+                    cache_write_tokens: 2,
+                    context_window: 200_000,
+                    per_turn_token: 50,
+                  },
+                },
+              },
+            },
+          },
+        ],
+        next_page_id: null,
+      });
+      mockConversationClient.mockReturnValue({
+        searchConversations: searchSpy,
+      });
+
+      const result =
+        await AgentServerConversationService.searchConversations(10);
+
+      expect(result.items[0]?.metrics).toEqual({
+        accumulated_cost: 1.75,
+        max_budget_per_task: 10,
+        accumulated_token_usage: {
+          prompt_tokens: 140,
+          completion_tokens: 30,
+          cache_read_tokens: 45,
+          cache_write_tokens: 7,
+          context_window: 200_000,
+          per_turn_token: 120,
+        },
+      });
+    });
+
     it("preserves the launched Agent Profile through the wire normalizer", async () => {
       mockHttpGet.mockResolvedValue({
         data: [

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -22,6 +22,7 @@ import {
   PluginSpec,
   AppConversation,
   AppConversationPage,
+  RuntimeConversationStats,
   SandboxStatus,
 } from "./conversation-service/agent-server-conversation-service.types";
 import SettingsService from "./settings-service/settings-service.api";
@@ -42,6 +43,7 @@ import {
   LAUNCH_CHILD_CONVERSATION_CLIENT_TOOL,
   LAUNCH_CHILD_CONVERSATION_TOOL_NAME,
 } from "./launch-child-conversation-client-tool";
+import { getCombinedMetrics } from "#/utils/conversation-metrics";
 
 export interface DirectConversationInfo {
   id: string;
@@ -63,6 +65,7 @@ export interface DirectConversationInfo {
       per_turn_token?: number;
     } | null;
   } | null;
+  stats?: RuntimeConversationStats | null;
   agent?: {
     /**
      * Pydantic discriminator from the SDK union: ``"ACPAgent"`` for ACP CLI
@@ -310,6 +313,9 @@ export function toAppConversation(
   info: DirectConversationInfo,
 ): AppConversation {
   const metadata = getStoredConversationMetadata(info.id);
+  const metrics =
+    info.metrics ??
+    (info.stats ? getCombinedMetrics({ stats: info.stats }) : null);
   // ACPAgent conversations carry a sentinel ``llm`` on older SDKs. Prefer the
   // runtime model fields when available, then the configured ``acp_model`` that
   // Canvas saves for built-in providers. ``agent_kind`` still gates model
@@ -354,24 +360,24 @@ export function toAppConversation(
           sdkLlm: info.agent?.llm?.model,
         })
       : (info.agent?.llm?.model ?? DEFAULT_SETTINGS.llm_model),
-    metrics: info.metrics
+    metrics: metrics
       ? {
-          accumulated_cost: info.metrics.accumulated_cost ?? null,
-          max_budget_per_task: info.metrics.max_budget_per_task ?? null,
-          accumulated_token_usage: info.metrics.accumulated_token_usage
+          accumulated_cost: metrics.accumulated_cost ?? null,
+          max_budget_per_task: metrics.max_budget_per_task ?? null,
+          accumulated_token_usage: metrics.accumulated_token_usage
             ? {
                 prompt_tokens:
-                  info.metrics.accumulated_token_usage.prompt_tokens ?? 0,
+                  metrics.accumulated_token_usage.prompt_tokens ?? 0,
                 completion_tokens:
-                  info.metrics.accumulated_token_usage.completion_tokens ?? 0,
+                  metrics.accumulated_token_usage.completion_tokens ?? 0,
                 cache_read_tokens:
-                  info.metrics.accumulated_token_usage.cache_read_tokens ?? 0,
+                  metrics.accumulated_token_usage.cache_read_tokens ?? 0,
                 cache_write_tokens:
-                  info.metrics.accumulated_token_usage.cache_write_tokens ?? 0,
+                  metrics.accumulated_token_usage.cache_write_tokens ?? 0,
                 context_window:
-                  info.metrics.accumulated_token_usage.context_window ?? 0,
+                  metrics.accumulated_token_usage.context_window ?? 0,
                 per_turn_token:
-                  info.metrics.accumulated_token_usage.per_turn_token ?? 0,
+                  metrics.accumulated_token_usage.per_turn_token ?? 0,
               }
             : null,
         }

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -135,6 +135,38 @@ function normalizeMetrics(value: unknown): MetricsSnapshot | null {
   };
 }
 
+function normalizeConversationStats(
+  value: unknown,
+): DirectConversationInfo["stats"] {
+  if (!isRecord(value) || !isRecord(value.usage_to_metrics)) return null;
+
+  const usageToMetrics: NonNullable<
+    DirectConversationInfo["stats"]
+  >["usage_to_metrics"] = {};
+
+  for (const [usageId, rawMetrics] of Object.entries(value.usage_to_metrics)) {
+    if (!isRecord(rawMetrics)) continue;
+
+    usageToMetrics[usageId] = {
+      model_name: stringOrNull(rawMetrics.model_name) ?? "",
+      accumulated_cost: numberOrZero(rawMetrics.accumulated_cost),
+      max_budget_per_task: numberOrNull(rawMetrics.max_budget_per_task),
+      accumulated_token_usage: normalizeTokenUsage(
+        rawMetrics.accumulated_token_usage,
+      ),
+      costs: Array.isArray(rawMetrics.costs) ? rawMetrics.costs : [],
+      response_latencies: Array.isArray(rawMetrics.response_latencies)
+        ? rawMetrics.response_latencies
+        : [],
+      token_usages: Array.isArray(rawMetrics.token_usages)
+        ? rawMetrics.token_usages
+        : [],
+    };
+  }
+
+  return { usage_to_metrics: usageToMetrics };
+}
+
 function normalizeAgent(value: unknown): DirectConversationInfo["agent"] {
   if (!isRecord(value)) return null;
   const llm = isRecord(value.llm)
@@ -244,6 +276,7 @@ function requireDirectConversationInfo(item: unknown): DirectConversationInfo {
     execution_status: stringOrNull(item.execution_status),
     sandbox_status: stringOrNull(item.sandbox_status),
     metrics: normalizeMetrics(item.metrics),
+    stats: normalizeConversationStats(item.stats),
     agent: normalizeAgent(item.agent),
     workspace: normalizeWorkspace(item.workspace),
     tags: normalizeTags(item.tags),
@@ -658,19 +691,14 @@ class AgentServerConversationService {
     conversationUrl: string | null | undefined,
     sessionApiKey?: string | null,
   ): Promise<RuntimeConversationInfo> {
-    type RawRuntime = DirectConversationInfo & {
-      stats?: RuntimeConversationInfo["stats"];
-    };
-
     // Fetch directly from the per-conversation runtime agent-server at conversationUrl.
     const response = await new ConversationClient(
       getAgentServerClientOptions({
         conversationUrl,
         sessionApiKey,
       }),
-    ).getConversation<RawRuntime>(conversationId);
+    ).getConversation<DirectConversationInfo>(conversationId);
     const data = requireDirectConversationInfo(response);
-    const stats = isRecord(response) ? response.stats : null;
 
     return {
       id: data.id,
@@ -681,7 +709,7 @@ class AgentServerConversationService {
       created_at: data.created_at,
       updated_at: data.updated_at,
       status: toRuntimeStatus(data.execution_status),
-      stats: isRecord(stats) ? stats : { usage_to_metrics: {} },
+      stats: data.stats ?? { usage_to_metrics: {} },
     };
   }
 

--- a/src/utils/conversation-metrics.ts
+++ b/src/utils/conversation-metrics.ts
@@ -9,7 +9,7 @@ import type {
  * Combines metrics from all LLM usage IDs in the conversation stats
  */
 export function getCombinedMetrics(
-  conversationInfo: RuntimeConversationInfo,
+  conversationInfo: Pick<RuntimeConversationInfo, "stats">,
 ): MetricsSnapshot {
   const { stats } = conversationInfo;
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
OpenHands is a really solid open‑source project that aligns well with the AI agent direction I’m interested in working on. I picked this issue because it addresses an actual real‑world bug: conversation metrics aren’t being properly passed from the agent server to the frontend. Working on this gave me deeper familiarity with the codebase, and let me practice writing backward‑compatible code as well as regression tests. On a personal note, I also wanted to build hands‑on open‑source experience. I’m looking forward to feedback from maintainers, and hope to keep growing my engineering skills through contributions like this.
<!-- This section is reserved for human contributors. Agents must leave it unchanged. -->

AGENT:
- Reproduced the bug with a focused search/list regression test: a response containing `metrics: null` and two `stats.usage_to_metrics` entries produced `AppConversation.metrics === null` before this change.
- After the change, the same wire response produces aggregated cost, budget, and token usage while explicit legacy `metrics` still takes precedence.
- Validation completed locally:
  - `npm run typecheck`
  - `npm run lint` (passes with 3 pre-existing warnings in unrelated files)
  - `npm test -- --run`: 579 files passed; 4739 passed, 4 skipped, 7 todo
  - `npm run build`
  - `npm run build:lib`

## Why

The conversation search/list endpoint exposes accumulated usage under `stats.usage_to_metrics`, but the direct conversation normalizer discarded `stats`. As a result, `toAppConversation` received no usable metrics and conversation cards always showed null metrics.

## Summary

- Normalize `stats.usage_to_metrics` from direct conversation responses.
- Reuse the existing runtime metrics aggregation logic as a fallback when legacy `metrics` is absent.
- Preserve explicit `metrics` precedence for backward compatibility.
- Add regression coverage for multiple usage IDs and token aggregation.

## Issue Number

Fixes #16480

## How to Test

```bash
npm ci --registry=https://registry.npmjs.org
npm run make-i18n
npx vitest run __tests__/api/agent-server-conversation-service.test.ts __tests__/api/agent-server-adapter.test.ts __tests__/hooks/query/use-conversation-metrics.test.tsx
npm run typecheck
npm run lint
npm test -- --run
npm run build
npm run build:lib
```

The focused regression traverses the search client response normalization and `toAppConversation` mapping.

## Video/Screenshots

**Before — base commit `551e9a9`: the regression test fails because conversation metrics are `null`.**

![Before: focused regression test fails with Received null](https://raw.githubusercontent.com/vcvyg/OpenHands/pr-assets-16706/pr-assets/16706/before.png)

**After — PR commit `80d9f0a`: the same regression test passes.**

![After: focused regression test passes](https://raw.githubusercontent.com/vcvyg/OpenHands/pr-assets-16706/pr-assets/16706/after.png)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove the fix is effective.
- [x] New and existing tests pass locally.
- [x] No dependency or lockfile changes are included.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.61s · commit 80d9f0a  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 11/11 hunks, 4/4 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 4.0% | No direct hunk selected |
| Weakened authorization | 7.0% | No direct hunk selected |
| Contract regression | 18.0% | No direct hunk selected |
| Data loss | 3.0% | No direct hunk selected |
| Sensitive data disclosure | 4.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 5.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 8.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 84.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 73a52aa180d9fe0b44448403f225519b0964929f391837ce4dbf48d3637294d9 -->
<!-- jev-fast-audit:end -->
