### PR TITLE
chore: bump openhands-automation to 1.8.0

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -3,7 +3,7 @@
   "versions": {
     "agentServer": "1.42.1",
     "agentCanvas": "1.14.0",
-    "automation": "1.7.1"
+    "automation": "1.8.0"
   },
   "compatibility": {
     "minimumAgentServer": "1.28.0"


### PR DESCRIPTION
HUMAN:

Bumping automation service version.

AGENT:

---

## Why

`config/defaults.json` still pinned `versions.automation` to `1.7.1`, which is older than the host code already on `main`. Two features shipped their canvas half against endpoints that `1.7.1` does not serve:

- **Git Sync** (#16521) calls `GET /v1/git-sync/status`, `PUT /v1/git-sync/config`, `POST /v1/git-sync/check` and `POST /v1/git-sync/sync`. The `openhands/automation/git_sync/` package is absent from `1.7.1` entirely — it landed in `OpenHands/automation#327`, which merged *after* the `1.7.1` release. All four calls 404, and `use-git-sync.ts` treats a 404 as "this backend has no git-sync API" on purpose: no retry, `disableToast`. So the page renders `git-sync-unsupported-state` and the button does nothing visible — no error, no toast.
- **Catalog bundle install** (#16680) is the host half of `OpenHands/automation#346`, which opened the raw create path and the `customTarball` capability. Also post-`1.7.1`.

`openhands-automation` `1.8.0` was released on 2026-08-19 and carries both.

## Summary

- `config/defaults.json`: `versions.automation` `1.7.1` → `1.8.0`. Single line; it is the only reference to `1.7.1` in the repo, and it feeds the npm, Docker and dev install paths.

## Issue Number

Fixes #16710

## How to Test

**1. The released package really contains the git-sync backend.** Install the new pin and resolve the app's OpenAPI schema:

```
$ UV_PYTHON=3.13 uvx --from "openhands-automation==1.8.0" python -c "
import openhands.automation as a
from openhands.automation.app import app
print('version:', a.__version__)
spec = app.openapi()
for p in sorted(p for p in spec['paths'] if 'git-sync' in p): print(' ', p)
"
version: 1.8.0
  /api/automation/v1/git-sync/check
  /api/automation/v1/git-sync/config
  /api/automation/v1/git-sync/status
  /api/automation/v1/git-sync/sync
```

Those four paths are exactly what `automation-service.api.ts` builds (`AUTOMATION_BASE_PATH = "/api/automation"` + the literal `/v1/git-sync/*` suffixes). The same command against `1.7.1` returns nothing — the module is not in the wheel.

**2. The SDK sync gate passes** (this is what `sdk-version-sync.yml` runs on a `config/defaults.json` change):

```
$ node scripts/check-sdk-version-sync.mjs
Expected automation SDK version: 1.42.1 (from config/defaults.json (versions.agentServer))
Automation package: openhands-automation==1.8.0 (from config/defaults.json (versions.automation))

  openhands-sdk             ✓ 1.42.1
  openhands-workspace       ✓ 1.42.1

All SDK versions are in sync!
```

**3. Unit tests that read the default still pass:**

```
$ npx vitest run __tests__/scripts/dev-with-automation.test.ts
 Test Files  1 passed (1)
      Tests  57 passed (57)
```

**4. Nothing else references the old pin:** `grep -rn "1\.7\.1"` over the repo (excluding `node_modules` and `package-lock.json`) matches only the line this PR changes.

To exercise the button end-to-end, run the stack against a local-mode automation backend (`AUTOMATION_AGENT_SERVER_URL` set) and open **Automations → Git Sync**. `is_git_sync_supported()` returns `get_config().service.is_local_mode`, so a non-local backend still renders `git-sync-not-local-state` — that is the intended behaviour, not the bug this fixes.

## Video/Screenshots

No UI code changes here — the diff is one version string. The behavioural evidence is the endpoint listing in step 1: it is the 404 that made the page render its unsupported state, and `1.8.0` is what stops it.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- Rollout: `1.8.0` also starts a background git-sync loop, but only when `is_git_sync_supported()` (local mode). It idles until a repo and interval are configured from the UI, so this bump changes nothing for non-local deployments.
- No boot-time flag is needed any more. `PUT /v1/git-sync/config` is what turns sync on, so a repo configured from the page takes effect without a restart.
- Migration `015_add_git_sync_state.py` ships in the wheel and runs on startup.
- Unrelated to the automation pin, but worth noting since it was the other half of this alignment: `@openhands/extensions` is still pinned at `0.16.0` while extensions `main` has unreleased commits (release PR OpenHands/extensions#462). #16680 already added `createBundle` and `uploads` to the optional endpoint allowlist, so that bump is no longer blocked — it just has not happened yet.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.8.0` |
| **Commit** | `de334dc040b55052a3975e3577c456453c501760` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-de334dc
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-de334dc
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-de334dc-amd64
ghcr.io/openhands/agent-canvas:vasco-bump-automation-1.8.0-amd64
ghcr.io/openhands/agent-canvas:pr-16712-amd64
ghcr.io/openhands/agent-canvas:sha-de334dc-arm64
ghcr.io/openhands/agent-canvas:vasco-bump-automation-1.8.0-arm64
ghcr.io/openhands/agent-canvas:pr-16712-arm64
ghcr.io/openhands/agent-canvas:sha-de334dc
ghcr.io/openhands/agent-canvas:vasco-bump-automation-1.8.0
ghcr.io/openhands/agent-canvas:pr-16712
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-de334dc`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-de334dc-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->