### PR TITLE
fix(issue-readiness): tolerate trailing colons in headings and preserve duplicate sections

### DIFF
--- a/.github/scripts/check_issue_readiness.py
+++ b/.github/scripts/check_issue_readiness.py
@@ -115,7 +115,13 @@ def extract_sections(body: str) -> dict[str, str]:
     for index, match in enumerate(matches):
         start = match.end()
         end = matches[index + 1].start() if index + 1 < len(matches) else len(body)
-        sections[match.group(1).strip().lower()] = body[start:end]
+        raw_heading = match.group(1).strip()
+        heading_key = raw_heading.rstrip(":").strip().lower()
+        content = body[start:end]
+        if heading_key in sections:
+            sections[heading_key] = f"{sections[heading_key]}\n{content}"
+        else:
+            sections[heading_key] = content
     return sections
 
 

--- a/.github/scripts/tests/test_issue_readiness.py
+++ b/.github/scripts/tests/test_issue_readiness.py
@@ -430,3 +430,73 @@ def test_main_event_path_json_ready(tmp_path, capsys, monkeypatch):
     assert len(data["reasons"]) == 0
 
 
+
+
+def test_extract_sections_trailing_colons_and_whitespace():
+    raw_body = chr(10).join([
+        "### Actual Behavior:",
+        "Text 1",
+        "### Acceptance Criteria : ",
+        "- [ ] item"
+    ])
+    sections = extract_sections(raw_body)
+    assert "actual behavior" in sections
+    assert "acceptance criteria" in sections
+    assert "Text 1" in sections["actual behavior"]
+    assert "- [ ] item" in sections["acceptance criteria"]
+
+
+def test_extract_sections_repeated_headings_accumulates_content():
+    body = chr(10).join([
+        "### Actual Behavior",
+        "Part 1",
+        "### Expected Behavior",
+        "Expected",
+        "### Actual Behavior",
+        "Part 2"
+    ])
+    sections = extract_sections(body)
+    assert "Part 1" in sections["actual behavior"]
+    assert "Part 2" in sections["actual behavior"]
+
+
+def test_bug_with_colons_in_headings_is_ready():
+    body_with_colons = chr(10).join([
+        "### Steps to Reproduce:",
+        "1. Run `npm run dev`",
+        "",
+        "### Actual Behavior:",
+        "I ran npm run dev and saw this:",
+        "",
+        "![screenshot](https://github.com/user-attachments/assets/abc123)",
+        "",
+        "The button was misaligned.",
+        "",
+        "### Expected Behavior:",
+        "The button should be centered.",
+        "",
+        "### Acceptance Criteria:",
+        "- [ ] Button is centered",
+        "- [ ] No layout shift on resize"
+    ])
+    result = evaluate_readiness(body_with_colons, [BUG_LABEL])
+    assert result.ready, result.reasons
+
+
+def test_bug_repeated_actual_behavior_preserves_evidence():
+    body_repeated = chr(10).join([
+        "### Steps to Reproduce",
+        "I used agent-canvas to reproduce this.",
+        "",
+        "### Actual Behavior",
+        "First part of description.",
+        "",
+        "### Acceptance Criteria",
+        "- [ ] Fixed",
+        "",
+        "### Actual Behavior",
+        "Additional notes with screenshot:",
+        "![screenshot](https://example.com/screenshot.png)"
+    ])
+    result = evaluate_readiness(body_repeated, [BUG_LABEL])
+    assert result.ready, result.reasons


### PR DESCRIPTION
HUMAN:

Habe das Skript lokal mit einer Test-Issue inkl. doppelter Abschnitte und
Doppelpunkten im Heading ausgeführt. Die Validierung lief erfolgreich durch.

AGENT:

Ausgeführt gegen den Branch-Commit `bd3efdd` und seinen Vorgänger (Ausgaben aus
einer Agent-/CI-Umgebung, als Bild unter `## Video/Screenshots`):

```
# vor dem Fix (main)
$ python .github/scripts/check_issue_readiness.py --body-file issue.md --labels bug
Issue does not meet ready-for-dev criteria:
  - Fill in the `### Actual Behavior` section ...
  - Add an `### Acceptance Criteria` section ...
$ echo $?
1
$ python -m pytest .github/scripts/tests/test_issue_readiness.py -q
4 failed, 26 passed in 0.07s

# nach dem Fix (dieser Branch)
$ python .github/scripts/check_issue_readiness.py --body-file issue.md --labels bug
Issue meets ready-for-dev criteria.
$ echo $?
0
$ python -m pytest .github/scripts/tests/test_issue_readiness.py -q
30 passed in 0.04s
```

Die vier vor dem Fix fehlschlagenden Tests sind genau die neu hinzugefügten:
`test_extract_sections_trailing_colons_and_whitespace`,
`test_extract_sections_repeated_headings_accumulates_content`,
`test_bug_with_colons_in_headings_is_ready`,
`test_bug_repeated_actual_behavior_preserves_evidence`.

---

## Why

Das Validierungsskript `check_issue_readiness.py` hat gültige Issue-Abschnitte
fälschlicherweise verworfen, wenn Headings abschließende Doppelpunkte enthielten
(z. B. `### Summary:`) oder bestimmte Abschnitte mehrfach vorkamen. Dadurch
wurden korrekt ausgefüllte Issues als unvollständig gemeldet.

## Summary

- Trailing colons und umgebende Whitespaces werden beim Normalisieren der Heading-Keys gestrippt.
- Duplizierte Sektionen bleiben erhalten, statt sich gegenseitig zu überschreiben.
- Regressionstests für beide Fälle ergänzt.

## Issue Number

Fixes #16707

## How to Test

1. Eine Test-Issue-Datei mit Headings wie `### Actual Behavior:` sowie duplizierten Sektionen anlegen (z. B. `/tmp/issue.md`).
2. `python .github/scripts/check_issue_readiness.py --body-file /tmp/issue.md --labels bug` ausführen: auf `main` schlägt die Validierung fehl, auf diesem Branch läuft sie mit Exit-Code 0 durch.
3. Die Regressionstests ausführen: `python -m pytest .github/scripts/tests/test_issue_readiness.py`.

## Video/Screenshots
<img width="1397" height="750" alt="image" src="https://github.com/user-attachments/assets/e0e45c89-0b22-4846-ae9a-f32ac0435d36" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Reine CI-/Tooling-Änderung, kein Laufzeitcode betroffen.
.
