### PR TITLE
chore: bump @openhands/extensions to 0.17.0

### DIFF
--- a/__tests__/components/automations/recommended-automations.test.tsx
+++ b/__tests__/components/automations/recommended-automations.test.tsx
@@ -369,7 +369,41 @@ describe("recommended automations", () => {
     }
   });
 
+  /**
+   * Puts a non-MCP-installable requirement back on `jira-issue-to-pr`.
+   *
+   * It declared the HTTP-only `jira` until @openhands/extensions 0.17.0 swapped it
+   * for the MCP `atlassian-rovo`, and no catalog automation declares a non-MCP
+   * integration any more. The cases below are about what a card does with one, so
+   * the requirement is restored for their duration rather than the assertions
+   * rewritten around a property the catalog stopped having. Mirrors the
+   * mutate-and-restore already used for the unknown-ID case.
+   *
+   * @returns the restore function, which the caller must run in a `finally`.
+   */
+  function requireNonMcpIntegration(): () => void {
+    const automation = AUTOMATION_CATALOG.find(
+      (item) => item.id === "jira-issue-to-pr",
+    )!;
+    const mutable = automation as RecommendedAutomation & {
+      requires: { integrations: Record<string, { message?: string }> };
+    };
+    const original = mutable.requires.integrations;
+    const { "atlassian-rovo": rovo, ...rest } = original;
+    // Keyed first, so the pill order and the install queue start where they did.
+    mutable.requires.integrations = {
+      jira: {
+        message: rovo?.message ?? "Reads the project for issues.",
+      },
+      ...rest,
+    };
+    return () => {
+      mutable.requires.integrations = original;
+    };
+  }
+
   it("keeps a non-MCP-installable integration visible on its card instead of dropping it", () => {
+    const restoreRequirement = requireNonMcpIntegration();
     // SkillCardPillRow folds pills behind "+N more" when it measures zero
     // widths in jsdom; give it room so every pill renders.
     const offsetWidthDescriptor = Object.getOwnPropertyDescriptor(
@@ -428,6 +462,7 @@ describe("recommended automations", () => {
         "RECOMMENDED_AUTOMATIONS$MISSING_CONNECT:1",
       );
     } finally {
+      restoreRequirement();
       if (offsetWidthDescriptor) {
         Object.defineProperty(
           HTMLElement.prototype,
@@ -497,17 +532,23 @@ describe("recommended automations", () => {
   });
 
   it("queues installs only for MCP-installable required integrations", async () => {
-    renderLauncher();
+    const restoreRequirement = requireNonMcpIntegration();
 
-    fireEvent.click(
-      screen.getByTestId("recommended-automation-card-jira-issue-to-pr"),
-    );
+    try {
+      renderLauncher();
 
-    // jira cannot go through the local MCP install flow, so the queue starts
-    // directly at github rather than failing or skipping the automation.
-    const modal = await screen.findByTestId("mcp-install-modal");
-    expect(modal).toHaveAttribute("data-marketplace-id", "github");
-    expect(mockCreateConversationMutate).not.toHaveBeenCalled();
+      fireEvent.click(
+        screen.getByTestId("recommended-automation-card-jira-issue-to-pr"),
+      );
+
+      // jira cannot go through the local MCP install flow, so the queue starts
+      // directly at github rather than failing or skipping the automation.
+      const modal = await screen.findByTestId("mcp-install-modal");
+      expect(modal).toHaveAttribute("data-marketplace-id", "github");
+      expect(mockCreateConversationMutate).not.toHaveBeenCalled();
+    } finally {
+      restoreRequirement();
+    }
   });
 
   it("shows a decorative plus badge on each card without toggle behavior", () => {

--- a/__tests__/components/manifest/manifest-setup-dialog.test.tsx
+++ b/__tests__/components/manifest/manifest-setup-dialog.test.tsx
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   runAction: vi.fn(),
   prerequisites: vi.fn(),
   capabilities: vi.fn(),
+  missingCreateEndpoints: vi.fn<(entry: SetupEntry) => string[]>(() => []),
   tracking: {
     trackAutomationSetupOpened: vi.fn(),
     trackAutomationSetupValidated: vi.fn(),
@@ -50,6 +51,15 @@ vi.mock("#/hooks/query/use-manifest-capabilities", () => ({
 
 vi.mock("#/hooks/query/use-manifest-prerequisites", () => ({
   useSetupPrerequisites: () => mocks.prerequisites(),
+}));
+
+// Which endpoints an entry cannot be created without is read off the published
+// interface manifest, so a real one that declares them leaves the refusal path
+// unreachable. Stubbed so the case states the manifest it is about, rather than
+// depending on the packaged manifest continuing not to publish them.
+vi.mock("#/manifests/automation-setup", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("#/manifests/automation-setup")>()),
+  missingCreateEndpoints: mocks.missingCreateEndpoints,
 }));
 
 vi.mock("#/manifests/manifest-actions", () => ({
@@ -98,6 +108,9 @@ async function fillForm(user: ReturnType<typeof userEvent.setup>) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // clearAllMocks resets calls, not implementations, so the one case that
+  // stubs a manifest without the bundle endpoints would leak into the rest.
+  mocks.missingCreateEndpoints.mockReturnValue([]);
   mocks.prerequisites.mockReturnValue(NOTHING_TO_CONNECT);
   mocks.capabilities.mockReturnValue({
     capabilities: null,
@@ -282,6 +295,7 @@ describe("SetupDialog", () => {
   it("refuses an entry the published interface declares no way to create", async () => {
     // Arrange — a bundle entry against an interface manifest published before
     // bundles: neither endpoint it needs exists, and no answer supplies them.
+    mocks.missingCreateEndpoints.mockReturnValue(["createBundle", "uploads"]);
     renderDialog(BUNDLE_ENTRY);
 
     // Assert — said before the form, rather than as a Continue button that

--- a/__tests__/manifests/automation-setup.test.ts
+++ b/__tests__/manifests/automation-setup.test.ts
@@ -20,14 +20,16 @@ import { createSetup, createSetupEntry } from "./manifest-test-data";
 
 // The one word of a derived name the host writes rather than reads off the
 // entry is translated, and the derivation runs where no translator can be
-// passed in, so it reads the shared instance. Stubbed to pin the key and the
-// count rather than a rendered sentence.
-vi.mock("#/i18n", () => ({
-  default: {
-    t: (key: string, options: Record<string, unknown>) =>
-      `${key}(${options.total})`,
-  },
+// passed in, so it reads the shared instance. Rendered as `en` does, because
+// the fixtures pin the sentence the service was sent; the spy is what pins the
+// key, so both halves stay covered.
+const { translate } = vi.hoisted(() => ({
+  translate: vi.fn(
+    (_key: string, options: Record<string, unknown>) =>
+      `${options.total} repositories`,
+  ),
 }));
+vi.mock("#/i18n", () => ({ default: { t: translate } }));
 
 // The command a skill publishes in its own frontmatter, which the host looks
 // up rather than storing. Pinned so the assertion does not move when the
@@ -42,8 +44,20 @@ vi.mock("@openhands/extensions/skills", () => ({
       triggers: ["/incident-retro:setup"],
       content: "",
     },
+    {
+      name: "github-repo-monitor",
+      description: "Watch a GitHub repository for mentions.",
+      triggers: ["/github-monitor:poll"],
+      content: "",
+    },
   ],
 }));
+
+/** The command each assisted entry's skill publishes, keyed by the entry it belongs to. */
+const SETUP_COMMANDS: Record<string, string> = {
+  "incident-retrospective-drafter": "/incident-retro:setup",
+  "github-repo-monitor": "/github-monitor:poll",
+};
 
 /**
  * The reference fixtures `OpenHands/extensions` publishes with its catalog.
@@ -193,13 +207,16 @@ describe("the contract fixtures", () => {
     );
 
     // Assert
-    // Every published fixture is a prompt entry created through the preset
-    // endpoint, so the deduped set collapses to that single path.
+    // The fixtures cover both creation paths: a prompt entry through the preset
+    // endpoint, and a bundle entry through the plain create it uploads to first.
     expect({
       create: [...createPaths].sort(),
       preflight: [...preflightPaths],
     }).toEqual({
-      create: [automationCreateEndpoint()],
+      create: [
+        automationCreateEndpoint(requireEntry("github-pr-reviewer")),
+        automationCreateEndpoint(),
+      ].sort(),
       preflight: ["/v1/validate"],
     });
   });
@@ -228,7 +245,7 @@ describe("buildCreatePayload", () => {
 
     // Act
     const payload = buildCreatePayload(entry, {
-      repository: "OpenHands/automation",
+      repositories: ["OpenHands/automation"],
     });
 
     // Assert
@@ -258,7 +275,10 @@ describe("buildCreatePayload", () => {
     });
 
     // Assert
-    expect(payload?.name).toBe(`${entry.name} - SETUP$REPOSITORY_COUNT(2)`);
+    expect(payload?.name).toBe(`${entry.name} - 2 repositories`);
+    expect(translate).toHaveBeenCalledWith("SETUP$REPOSITORY_COUNT", {
+      total: 2,
+    });
   });
 
   it("sends no request body for an entry that hands setup to a conversation", () => {
@@ -300,7 +320,7 @@ describe("buildAssistedMessage", () => {
       const seed = buildAssistedMessage(entry, formValues);
 
       // Assert
-      expect(seed).toBe(`/incident-retro:setup\n\n${message}`);
+      expect(seed).toBe(`${SETUP_COMMANDS[automationId]}\n\n${message}`);
     },
   );
 });
@@ -329,23 +349,12 @@ describe("service rejections mapped back to fields", () => {
 });
 
 describe("local validation of fixture form values", () => {
-  it("blocks the unsafe trigger phrase before any request is made", () => {
-    // Arrange — the fixture names the failing field; the code is the host's
-    // own vocabulary, rendered through its translations.
-    const scenario = requireScenario(
-      BUNDLES[1],
-      "quote-in-trigger-phrase-blocked-locally",
-    );
-    const entry = requireEntry("github-repo-monitor");
-
-    // Act
-    const errors = validateFormValues(entry.setup, scenario.formValues ?? {});
-
-    // Assert
-    expect(errors).toEqual({
-      triggerPhrase: { code: "unsafeExpressionLiteral" },
-    });
-  });
+  // The unsafe-trigger-phrase case that used to live here is gone: it belonged
+  // to github-repo-monitor's event trigger, whose JMESPath filter the phrase was
+  // interpolated into. The entry now runs on cron, so no catalog entry declares
+  // the `safeExpressionLiteral` constraint any more and there is no fixture to
+  // pin. The constraint itself is still exercised, on a synthetic setup, by
+  // `manifest-local-validation.test.ts`.
 
   it("passes an entirely blank assisted form, as its fixture records", () => {
     // Arrange
@@ -365,13 +374,15 @@ describe("deriveErrorMap", () => {
     // Act
     const errorMap = deriveErrorMap(requireEntry("github-pr-reviewer"));
 
-    // Assert
+    // Assert — a bundle's answers reach the service through its rendered
+    // config rather than through a prompt, so the paths are the config's.
     expect(errorMap).toEqual({
-      name: ["repository"],
-      prompt: ["triggerLabel", "repository", "reviewTone"],
-      "repos[0].url": ["repository"],
+      name: ["repositories"],
       "trigger.schedule": ["schedule"],
       "trigger.timezone": ["timezone"],
+      "template.config.repos": ["repositories"],
+      "template.config.trigger_label": ["triggerLabel"],
+      "template.config.review_tone": ["reviewTone"],
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@heroui/react": "2.8.10",
         "@microlink/react-json-view": "1.31.25",
         "@monaco-editor/react": "4.7.0",
-        "@openhands/extensions": "0.16.0",
+        "@openhands/extensions": "0.17.0",
         "@openhands/typescript-client": "1.38.0",
         "@react-router/node": "7.18.2",
         "@react-router/serve": "7.18.2",
@@ -4164,9 +4164,9 @@
       "license": "MIT"
     },
     "node_modules/@openhands/extensions": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@openhands/extensions/-/extensions-0.16.0.tgz",
-      "integrity": "sha512-t9rTxmR782UZ6nbbSBK23EMlzsgJzz4yi34q6mxgPY7ukWehiK7RkWY6rP/u4o7/K0zzvR6/nIJ4OijvttrfVA==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@openhands/extensions/-/extensions-0.17.0.tgz",
+      "integrity": "sha512-y3+OSHsMWN1sZVT1NERVdCnZVBgHg3F5E4tlYea6bb/nLzX750SuvJpfUJNitJqxN7ls+jMYVgBOgee6KoeLqA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.20.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@heroui/react": "2.8.10",
     "@microlink/react-json-view": "1.31.25",
     "@monaco-editor/react": "4.7.0",
-    "@openhands/extensions": "0.16.0",
+    "@openhands/extensions": "0.17.0",
     "@openhands/typescript-client": "1.38.0",
     "@react-router/node": "7.18.2",
     "@react-router/serve": "7.18.2",


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Updating the extensions package. Moreover, I add to fix a couple of tests which were package dependent.

AGENT:

---

## Why

`@openhands/extensions@0.17.0` adds `defaultEnabled` to catalog skill entries plus a
`DEFAULT_ENABLED_SKILL_NAMES` export (OpenHands/extensions#485). Phase 1 of the curated skill
set needs that export to seed a new workspace, and it cannot start while this repo is pinned
to 0.16.0.

The bump also picks up two weeks of unrelated catalog changes, which is where all of the test
churn comes from.

## Summary

- Bump `@openhands/extensions` 0.16.0 → 0.17.0 (`package.json` + `package-lock.json`).
- Follow the automations contract that 0.17.0 publishes, in three test files.
- **No source change.** Bundle support, `repositories[]` and the translated repository count
  all landed in `src/manifests/` ahead of the catalog publishing them; this bump activates
  code that was already written.

## Issue Number

Refs #16302

<!-- Not "Fixes": this is the dependency prerequisite for phase 1 of that issue, not the
feature itself. #16302 is not currently labeled `ready-for-dev`. -->

## How to Test

```bash
npm ci
npm run lint      # typecheck + eslint + prettier
npx vitest run
```

Results on this branch:

```
Test Files  582 passed (582)
      Tests  4802 passed | 4 skipped | 7 todo (4813)

lint: 0 errors, 3 warnings  (all pre-existing, in src/ files this PR does not touch)
typecheck: clean
```

Verification that the churn is caused by the bump and nothing else: with the pin reverted to
0.16.0 on this same tree, the three affected files were green (`59 passed`). With the bump and
no test change, they failed 10.

## What changed in 0.17.0

The skills catalog is unchanged in shape — same 56 skills, none added or removed, only the new
`defaultEnabled` flag on 11 of them. Every failure came from the automations and integrations
catalogs:

| change | effect |
|---|---|
| `github-pr-reviewer` converted from a **prompt** entry to a **bundle** entry | form field `repository` → `repositories[]`; create path `/v1/preset/prompt` → `/v1`; payload paths `prompt` → `template.config.*`; an upload to `/v1/uploads` now precedes create |
| `github-repo-monitor` moved from a **GitHub event** trigger to **cron** | scenario `quote-in-trigger-phrase-blocked-locally` removed; assisted scenario `fallback-conversation-when-direct-unavailable` added |
| `jira-issue-to-pr` requires `atlassian-rovo` instead of `jira` | it was the only automation declaring a **non-MCP** integration; now none does |
| `automations/interface.json` publishes `createBundle: "/v1"` and `uploads: "/v1/uploads"` | the "interface predates bundles" refusal path is unreachable from the published manifest |
| new `sonarqube` integration (75 → 76) | no test impact |

## How the tests followed it

### `__tests__/manifests/automation-setup.test.ts`

- **Both creation paths are published now**, so the deduped fixture set is asserted as
  `[automationCreateEndpoint(prReviewerEntry), automationCreateEndpoint()]` rather than the
  single preset path.
- **`deriveErrorMap` walks the bundle's rendered config**, so the expected map moved from
  `prompt` / `repos[0].url` to `template.config.{repos,trigger_label,review_tone}`. Verified
  against the installed package rather than hand-written.
- **The `#/i18n` mock now renders as `en` does** (`"2 repositories"`). Two repositories take a
  translated branch that a single `repository` never did, and the fixtures pin the sentence the
  service was actually sent — so rendering it is what makes the contract comparison meaningful.
  The key is still pinned, by a spy assertion, so both halves stay covered.
- **Each assisted case asserts its own skill's command.** `github-repo-monitor` gained an
  assisted scenario, and the assertion had hardcoded `/incident-retro:setup` from when
  `incident-retrospective-drafter` was the only entry with one.
- **The unsafe-trigger-phrase case is removed.** It belonged to the event trigger whose JMESPath
  filter the phrase was interpolated into; on cron there is nothing to interpolate, and **no
  catalog entry declares `safeExpressionLiteral` any more**. No coverage is lost —
  `manifest-local-validation.test.ts:26,73` exercises the constraint on a synthetic setup. A
  comment in place of the deleted case records why.

### `__tests__/components/automations/recommended-automations.test.tsx`

Two cases are about what a card does with a required integration the MCP install flow cannot
install. Since no automation declares one any more, they restore `jira` on `jira-issue-to-pr`
for their duration through a small `requireNonMcpIntegration()` helper, mirroring the
mutate-and-restore this file already uses for the unknown-ID case. That keeps a real catalog id
and real behaviour under test instead of inventing a synthetic entry.

### `__tests__/components/manifest/manifest-setup-dialog.test.tsx`

The refusal case stubs `missingCreateEndpoints` instead of relying on the published manifest not
declaring `createBundle`/`uploads`. That is arguably how it should have been written to begin
with: the case is about a manifest published before bundles, and now it says so rather than
depending on the packaged manifest staying behind. Reset in `beforeEach`, because
`clearAllMocks` resets calls but not implementations.

## Video/Screenshots

Not a UI change — no rendered behaviour differs. Evidence is the test/lint output above plus the
0.16.0 baseline showing the same files green before the bump.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Three judgment calls worth a reviewer's eye, all called out above rather than made quietly:
deleting the unsafe-trigger-phrase case, rendering English in the i18n mock, and restoring the
`jira` requirement for the two card cases.

`src/manifests/` is being edited on another branch, so this PR deliberately touches only
`__tests__/` and the two dependency files.

The new skills flag stays inert until phase 1 reads it; nothing else in the repo consumes it yet.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.8.0` |
| **Commit** | `8ee405bac0051ea9407a593d78e6df5849334b6a` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-8ee405b
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-8ee405b
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-8ee405b-amd64
ghcr.io/openhands/agent-canvas:vasco-bump-extensions-0.17.0-amd64
ghcr.io/openhands/agent-canvas:pr-16717-amd64
ghcr.io/openhands/agent-canvas:sha-8ee405b-arm64
ghcr.io/openhands/agent-canvas:vasco-bump-extensions-0.17.0-arm64
ghcr.io/openhands/agent-canvas:pr-16717-arm64
ghcr.io/openhands/agent-canvas:sha-8ee405b
ghcr.io/openhands/agent-canvas:vasco-bump-extensions-0.17.0
ghcr.io/openhands/agent-canvas:pr-16717
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-8ee405b`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-8ee405b-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->