### PR TITLE
fix: scope OpenAI subscription queries by backend

### DIFF
--- a/__tests__/hooks/query/use-llm-subscription-cache-scope.test.tsx
+++ b/__tests__/hooks/query/use-llm-subscription-cache-scope.test.tsx
@@ -1,0 +1,193 @@
+import React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import LLMSubscriptionService from "#/api/llm-subscription-service";
+import {
+  __resetActiveStoreForTests,
+  setActiveSelection,
+  setRegisteredBackends,
+} from "#/api/backend-registry/active-store";
+import type { Backend } from "#/api/backend-registry/types";
+import { ActiveBackendProvider } from "#/contexts/active-backend-context";
+import { useOpenAISubscriptionModels } from "#/hooks/query/use-llm-subscription-models";
+import { useOpenAISubscriptionStatus } from "#/hooks/query/use-llm-subscription-status";
+import { LLM_SUBSCRIPTION_QUERY_KEYS } from "#/hooks/query/query-keys";
+
+vi.mock("#/api/llm-subscription-service", () => ({
+  default: {
+    getOpenAIModels: vi.fn(),
+    getOpenAIStatus: vi.fn(),
+  },
+}));
+
+const localBackend: Backend = {
+  id: "local-1",
+  name: "Local",
+  host: "http://localhost:8000",
+  apiKey: "local-key",
+  kind: "local",
+};
+
+const cloudBackend: Backend = {
+  id: "cloud-1",
+  name: "Cloud",
+  host: "https://app.all-hands.dev",
+  apiKey: "cloud-key",
+  kind: "cloud",
+};
+
+const localStatus = {
+  vendor: "openai" as const,
+  connected: true,
+  accountEmail: "local@example.com",
+  expiresAt: null,
+};
+
+const cloudStatus = {
+  ...localStatus,
+  accountEmail: "cloud@example.com",
+};
+
+function makeWrapper(queryClient: QueryClient) {
+  return function SubscriptionQueryTestWrapper({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ActiveBackendProvider>{children}</ActiveBackendProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function useSubscriptionQueries() {
+  return {
+    status: useOpenAISubscriptionStatus(),
+    models: useOpenAISubscriptionModels(),
+  };
+}
+
+describe("OpenAI subscription query cache scope", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    __resetActiveStoreForTests();
+    setRegisteredBackends([localBackend, cloudBackend]);
+    setActiveSelection({ backendId: localBackend.id, orgId: null });
+
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.mocked(LLMSubscriptionService.getOpenAIStatus).mockReset();
+    vi.mocked(LLMSubscriptionService.getOpenAIModels).mockReset();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    window.localStorage.clear();
+    __resetActiveStoreForTests();
+  });
+
+  it("refetches status and models when the active backend changes", async () => {
+    // Arrange
+    vi.mocked(LLMSubscriptionService.getOpenAIStatus)
+      .mockResolvedValueOnce(localStatus)
+      .mockResolvedValueOnce(cloudStatus);
+    vi.mocked(LLMSubscriptionService.getOpenAIModels)
+      .mockResolvedValueOnce(["local-model"])
+      .mockResolvedValueOnce(["cloud-model"]);
+
+    const { result } = renderHook(() => useSubscriptionQueries(), {
+      wrapper: makeWrapper(queryClient),
+    });
+    await waitFor(() => {
+      expect(result.current.status.data).toEqual(localStatus);
+      expect(result.current.models.data).toEqual(["local-model"]);
+    });
+
+    // Act
+    act(() => {
+      setActiveSelection({ backendId: cloudBackend.id, orgId: "org-a" });
+    });
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.status.data).toEqual(cloudStatus);
+      expect(result.current.models.data).toEqual(["cloud-model"]);
+    });
+    expect(LLMSubscriptionService.getOpenAIStatus).toHaveBeenCalledTimes(2);
+    expect(LLMSubscriptionService.getOpenAIModels).toHaveBeenCalledTimes(2);
+  });
+
+  it("refetches status and models when the active organization changes", async () => {
+    // Arrange
+    setActiveSelection({ backendId: cloudBackend.id, orgId: "org-a" });
+    vi.mocked(LLMSubscriptionService.getOpenAIStatus)
+      .mockResolvedValueOnce(cloudStatus)
+      .mockResolvedValueOnce({
+        ...cloudStatus,
+        accountEmail: "other-org@example.com",
+      });
+    vi.mocked(LLMSubscriptionService.getOpenAIModels)
+      .mockResolvedValueOnce(["org-a-model"])
+      .mockResolvedValueOnce(["org-b-model"]);
+
+    const { result } = renderHook(() => useSubscriptionQueries(), {
+      wrapper: makeWrapper(queryClient),
+    });
+    await waitFor(() => {
+      expect(result.current.models.data).toEqual(["org-a-model"]);
+    });
+
+    // Act
+    act(() => {
+      setActiveSelection({ backendId: cloudBackend.id, orgId: "org-b" });
+    });
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.status.data?.accountEmail).toBe(
+        "other-org@example.com",
+      );
+      expect(result.current.models.data).toEqual(["org-b-model"]);
+    });
+    expect(LLMSubscriptionService.getOpenAIStatus).toHaveBeenCalledTimes(2);
+    expect(LLMSubscriptionService.getOpenAIModels).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps every scoped status cache entry under the shared status prefix", async () => {
+    // Arrange
+    vi.mocked(LLMSubscriptionService.getOpenAIStatus)
+      .mockResolvedValueOnce(localStatus)
+      .mockResolvedValueOnce(cloudStatus);
+
+    const { result } = renderHook(() => useOpenAISubscriptionStatus(), {
+      wrapper: makeWrapper(queryClient),
+    });
+    await waitFor(() => expect(result.current.data).toEqual(localStatus));
+    act(() => {
+      setActiveSelection({ backendId: cloudBackend.id, orgId: "org-a" });
+    });
+    await waitFor(() => expect(result.current.data).toEqual(cloudStatus));
+
+    // Act
+    await queryClient.invalidateQueries({
+      queryKey: LLM_SUBSCRIPTION_QUERY_KEYS.openaiStatus,
+      refetchType: "none",
+    });
+
+    // Assert
+    const statusQueries = queryClient.getQueryCache().findAll({
+      queryKey: LLM_SUBSCRIPTION_QUERY_KEYS.openaiStatus,
+    });
+    expect(statusQueries).toHaveLength(2);
+    expect(statusQueries.every((query) => query.state.isInvalidated)).toBe(
+      true,
+    );
+  });
+});

--- a/src/hooks/query/use-llm-subscription-models.ts
+++ b/src/hooks/query/use-llm-subscription-models.ts
@@ -1,12 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
 import LLMSubscriptionService from "#/api/llm-subscription-service";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import { LLM_SUBSCRIPTION_QUERY_KEYS } from "#/hooks/query/query-keys";
 
 export function useOpenAISubscriptionModels({
   enabled = true,
 }: { enabled?: boolean } = {}) {
+  const { backend, orgId } = useActiveBackend();
+
   return useQuery({
-    queryKey: LLM_SUBSCRIPTION_QUERY_KEYS.openaiModels,
+    queryKey: [...LLM_SUBSCRIPTION_QUERY_KEYS.openaiModels, backend.id, orgId],
     queryFn: LLMSubscriptionService.getOpenAIModels,
     enabled,
     retry: false,

--- a/src/hooks/query/use-llm-subscription-status.ts
+++ b/src/hooks/query/use-llm-subscription-status.ts
@@ -1,12 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
 import LLMSubscriptionService from "#/api/llm-subscription-service";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import { LLM_SUBSCRIPTION_QUERY_KEYS } from "#/hooks/query/query-keys";
 
 export function useOpenAISubscriptionStatus({
   enabled = true,
 }: { enabled?: boolean } = {}) {
+  const { backend, orgId } = useActiveBackend();
+
   return useQuery({
-    queryKey: LLM_SUBSCRIPTION_QUERY_KEYS.openaiStatus,
+    queryKey: [...LLM_SUBSCRIPTION_QUERY_KEYS.openaiStatus, backend.id, orgId],
     queryFn: LLMSubscriptionService.getOpenAIStatus,
     enabled,
     retry: false,


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

The problem has been identified and testing has been completed.
<!-- Human contributors: add a short note about your testing. -->

AGENT:

Reproduced the cache leak with focused hook tests before changing the implementation: after switching the active backend or organization, both hooks kept returning the first selection's still-fresh email and model list. The same tests pass after scoping the keys.

---

## Why

`useOpenAISubscriptionStatus` and `useOpenAISubscriptionModels` resolve the active agent-server when their query functions run, but their React Query keys were global. Because both queries stay fresh for five minutes, switching backend or cloud organization could reuse another selection's subscription account and models without making a request to the newly selected backend.

## Summary

- Append the active `backend.id` and `orgId` to both OpenAI subscription query keys.
- Keep the existing status/model constants as shared key prefixes, so login/logout status invalidation continues to match all scoped status entries.
- Add focused hook tests using the real active-backend provider for backend switching, organization switching, and prefix-based invalidation.

## Issue Number

Fixes #16698

## How to Test

The focused regression test failed in all three cases before the implementation and passes after it:

```bash
npx vitest run __tests__/hooks/query/use-llm-subscription-cache-scope.test.tsx
```

```text
Test Files  1 passed (1)
Tests       3 passed (3)
```

Additional verification:

- `npm run lint` — passed (three existing warnings in untouched files).
- `npm test` — 4,796 passed, 4 skipped, 7 todo; one documented intermittent `delete-profile-modal` test failed in the full run, then the file passed 12/12 on retry.
- `npm run build` — passed.
- `npm run build:lib` — passed.

## Video/Screenshots

Before/after TDD evidence from the focused cache-scope regression test:

<img width="700" height="700" alt="OpenHands #16721 TDD before and after evidence" src="https://github.com/user-attachments/assets/58994002-2153-4a27-9c25-6fa5bace51be" />

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The five-minute `staleTime` and existing mutation invalidation behavior are unchanged. This adds cache identity only; it does not blanket-invalidate queries during a backend switch.
