### PR TITLE
chore: PLTF-3502 add SonarQube analysis

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,53 @@
+name: SonarQube
+
+# Community Build has one branch per project, so a PR scan becomes the report card until
+# the next push to main. That is wanted during the POC: it shows the repo's grade without
+# merging first. pull_request_target must never be used -- unlike pull_request, it exposes
+# secrets to fork-triggered runs.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.head_ref && github.ref) || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    # Fork PRs get no secrets, so the scan could only fail on a missing token.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    name: Coverage and SonarQube analysis
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # SonarQube reads git history to attribute issues to authors.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          # package.json requires >=22.12.0; there is no .nvmrc to read.
+          node-version: '22'
+          cache: npm
+
+      # Not only for coverage: SonarJS resolves types from node_modules and degrades to a
+      # shallower analysis silently without them.
+      - name: Install dependencies
+        run: npm ci
+
+      # No workflow generates coverage today, so it is produced here -- which also keeps
+      # it consistent with the commit being analysed.
+      - name: Tests with coverage
+        continue-on-error: true
+        run: npm run test:coverage
+
+      - uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,15 @@
+sonar.projectKey=OpenHands
+sonar.projectName=OpenHands
+
+# __tests__ and tests/ are both top level, so sources and tests are already disjoint --
+# SonarQube aborts if a file is reachable from both.
+sonar.sources=src,electron
+sonar.tests=__tests__,tests
+
+sonar.exclusions=**/node_modules/**,**/dist/**,**/*.d.ts,public/**,docs/**,helm/**
+
+# Written by `npm run test:coverage` in the scan workflow. vite.config.ts already emits
+# lcov; its coverage include is src/**, so electron/ reports no coverage by design.
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=OpenHands
-sonar.projectName=OpenHands
+sonar.projectKey=openhands
+sonar.projectName=openhands
 
 # __tests__ and tests/ are both top level, so sources and tests are already disjoint --
 # SonarQube aborts if a file is reachable from both.


### PR DESCRIPTION
## Why

We're evaluating SonarQube as a code health scorecard across five repos, and this is the analysis config for this one. It is self-contained rather than hooked into an existing job because **no workflow currently generates coverage** — the `test:coverage` script exists but nothing runs it in CI. Producing it in the scan job also means the report always matches the commit being analysed. `npm ci` earns its place regardless of coverage: SonarJS resolves types from `node_modules` and degrades to a shallower analysis silently without them, so omitting it yields a green run and a misleadingly good grade.

`__tests__` and `tests/` are both top level, so sources and tests are disjoint sets — SonarQube aborts when a file is reachable from both. The POC is time-boxed and the instance is disposable, so this is expected to be reverted rather than kept.

## Validation

- **`vite.config.ts` already emits lcov** to `coverage/`, which is the format and path SonarQube reads, so no reporter change was needed.
- **Coverage scope is narrower than analysis scope, deliberately** — the vitest `coverage.include` is `src/**`, so `electron/` is analysed but reports no coverage. That is the existing config, not something introduced here.
- **Node 22 comes from `package.json`** (`engines.node >= 22.12.0`); there is no `.nvmrc` in this repo to read from.
- **Sources and tests are disjoint** — both test trees sit at the repo root, not inside `src` or `electron`.
- **Both actions pinned to full commit SHAs**, with the version in a trailing comment.

This PR was drafted by an AI agent on behalf of the user.







<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.49.2-python` |
| **Automation** | `openhands-automation==1.13.2` |
| **Commit** | `81e63130607a01aa9230127aa3f0b5798f015cbd` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-81e6313
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-81e6313
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-81e6313-amd64
ghcr.io/openhands/agent-canvas:av-sonarqube-scan-amd64
ghcr.io/openhands/agent-canvas:pr-16728-amd64
ghcr.io/openhands/agent-canvas:sha-81e6313-arm64
ghcr.io/openhands/agent-canvas:av-sonarqube-scan-arm64
ghcr.io/openhands/agent-canvas:pr-16728-arm64
ghcr.io/openhands/agent-canvas:sha-81e6313
ghcr.io/openhands/agent-canvas:av-sonarqube-scan
ghcr.io/openhands/agent-canvas:pr-16728
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-81e6313`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-81e6313-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->