### PR TITLE
fix: render conversation error events in chat UI

### DIFF
--- a/src/components/conversation-events/chat/event-content-helpers/should-render-event.ts
+++ b/src/components/conversation-events/chat/event-content-helpers/should-render-event.ts
@@ -116,6 +116,11 @@ export const shouldRenderEvent = (event: OpenHandsEvent) => {
     return true;
   }
 
+  // Render conversation error events (LLM provider errors, etc.)
+  if (isConversationErrorEvent(event)) {
+    return true;
+  }
+
   // Render hook execution events
   if (isHookExecutionEvent(event)) {
     return true;


### PR DESCRIPTION
## Summary

Added support for rendering `ConversationErrorEvent` in the chat UI. Previously, LLM provider errors (such as Nebius 404 model not found) were silently hidden from users. Now these errors will be displayed as observable events in the chat.

## Changes

- Modified `shouldRenderEvent` to return `true` for `isConversationErrorEvent(event)`, ensuring conversation errors are visible in the chat interface.

## How to Test

1. Start a conversation with a provider that may return errors (e.g., Nebius, OpenAI with invalid model)
2. Send a request that results in an error
3. Verify the error message is now visible in the chat instead of being hidden

Fixes #16686