### PR TITLE
fix: handle UTF-8 in plugin launch payloads (issue #16735)

### DIFF
--- a/src/utils/plugin-launch-url.ts
+++ b/src/utils/plugin-launch-url.ts
@@ -1,17 +1,26 @@
 import type { PluginSpec } from "#/api/conversation-service/agent-server-conversation-service.types";
 
-/**
- * Build the in-app path to the `/launch` screen for the given plugins, so the
- * Plugins UI can start a conversation with a plugin by reusing the existing
- * launch flow. Inverse of `parsePluginsFromUrl` in `src/routes/launch.tsx` —
- * keep the base64-encoded JSON `plugins` format in sync with that decoder.
- *
- * The base64 payload can contain `+`, `/`, and `=`; encoding it through
- * `URLSearchParams` percent-escapes those so `/launch` reads back the exact
- * string (a raw `+` would otherwise be decoded as a space and break `atob`).
- */
 export function buildPluginLaunchPath(plugins: PluginSpec[]): string {
-  const encoded = btoa(JSON.stringify(plugins));
+  const jsonString = JSON.stringify(plugins);
+  const utf8Bytes = new TextEncoder().encode(jsonString);
+  const binary = String.fromCharCode.apply(String, utf8Bytes);
+  const encoded = btoa(binary);
   const params = new URLSearchParams({ plugins: encoded });
-  return `/launch?${params.toString()}`;
+  return "/launch?${params.toString()}";
+}
+
+function parsePluginsFromUrl(searchParams: URLSearchParams): ParseResult {
+  const pluginsParam = searchParams.get("plugins");
+  if (pluginsParam) {
+    try {
+      const decoded = atob(pluginsParam);
+      const utf8Bytes = new Uint8Array(decoded.split("").map((ch) => ch.charCodeAt(0)));
+      const jsonString = new TextDecoder("utf-8").decode(utf8Bytes);
+      const parsed = JSON.parse(jsonString);
+      return { plugins: parsed as PluginSpec[] || [], error: "invalid_format" };
+    } catch {
+      return { plugins: [], error: "invalid_format" };
+    }
+  }
+  return { plugins: [], error: "no_plugins" };
 }


### PR DESCRIPTION
## Summary

Fixed Unicode corruption in plugin launch payloads. The `btoa()` function operates on Latin-1 bytes, causing non-Latin-1 characters (Chinese, emoji, etc.) to be silently corrupted when used in plugin parameter base64 payloads.

## Changes

- Modified `buildPluginLaunchPath` to use `TextEncoder` + `btoa` for proper UTF-8 encoding before base64
- Modified `parsePluginsFromUrl` to decode base64 as UTF-8 bytes using `TextDecoder` instead of Latin-1 default

## How to Test

1. Create a plugin with Unicode parameters (e.g., Chinese characters or emoji)
2. Generate a launch URL using `buildPluginLaunchPath`
3. Open the URL and verify the plugin parameters display the correct Unicode text
4. Test with existing ASCII payloads to ensure backward compatibility

## Problem

Using `btoa(JSON.stringify(plugins))` directly corrupts non-Latin-1 characters because `btoa` operates on Latin-1 byte values. Characters like Chinese `整理发布说明 🚀` display as garbled text (`æ^U´ç^P^Få^O^Qå¸^Cè¯´æ^X^N ð^_^Z^@`).

## Acceptance Criteria

- [ ] Unicode plugin parameters round-trip correctly through launch URLs
- [ ] ASCII-only payloads remain fully compatible
- [ ] Existing tests pass
- [ ] Manual UI verification with before/after evidence

Fixes #16735