### PR TITLE
fix: support mouse drag-to-scroll on recommended rails

### DIFF
--- a/__tests__/components/automations/recommended-automations-rail.test.tsx
+++ b/__tests__/components/automations/recommended-automations-rail.test.tsx
@@ -29,6 +29,25 @@ describe("RecommendedAutomationsRail", () => {
     vi.unstubAllGlobals();
   });
 
+  function mockScrollMetrics(
+    element: HTMLElement,
+    metrics: { scrollWidth: number; clientWidth: number; scrollLeft: number },
+  ) {
+    Object.defineProperty(element, "scrollWidth", {
+      configurable: true,
+      value: metrics.scrollWidth,
+    });
+    Object.defineProperty(element, "clientWidth", {
+      configurable: true,
+      value: metrics.clientWidth,
+    });
+    Object.defineProperty(element, "scrollLeft", {
+      configurable: true,
+      writable: true,
+      value: metrics.scrollLeft,
+    });
+  }
+
   it("renders remaining proven workflows before conversation-only extras", () => {
     render(
       <RecommendedAutomationsRail
@@ -134,25 +153,6 @@ describe("RecommendedAutomationsRail", () => {
   });
 
   describe("clipped-content fades", () => {
-    function mockScrollMetrics(
-      element: HTMLElement,
-      metrics: { scrollWidth: number; clientWidth: number; scrollLeft: number },
-    ) {
-      Object.defineProperty(element, "scrollWidth", {
-        configurable: true,
-        value: metrics.scrollWidth,
-      });
-      Object.defineProperty(element, "clientWidth", {
-        configurable: true,
-        value: metrics.clientWidth,
-      });
-      Object.defineProperty(element, "scrollLeft", {
-        configurable: true,
-        writable: true,
-        value: metrics.scrollLeft,
-      });
-    }
-
     it("shows an edge gradient only on the clipped side", () => {
       render(
         <RecommendedAutomationsRail
@@ -188,6 +188,122 @@ describe("RecommendedAutomationsRail", () => {
 
       expect(leftFade).toHaveAttribute("data-visible", "true");
       expect(rightFade).toHaveAttribute("data-visible", "false");
+    });
+  });
+
+  describe("drag-to-scroll", () => {
+    it("scrolls the rail while dragging with the mouse", () => {
+      render(
+        <RecommendedAutomationsRail
+          installedAutomations={[]}
+          onSelect={vi.fn()}
+        />,
+      );
+      const scroller = screen.getByTestId(
+        "recommended-automations-rail-scroll",
+      );
+      mockScrollMetrics(scroller, {
+        scrollWidth: 900,
+        clientWidth: 320,
+        scrollLeft: 100,
+      });
+
+      fireEvent.mouseDown(scroller, { button: 0, clientX: 300 });
+      fireEvent.mouseMove(document, { clientX: 250, buttons: 1 });
+
+      expect(scroller.scrollLeft).toBe(150);
+    });
+
+    it("does not select a card on the click that ends a drag, but allows the next click", () => {
+      const onSelect = vi.fn();
+      render(
+        <RecommendedAutomationsRail
+          installedAutomations={[]}
+          onSelect={onSelect}
+        />,
+      );
+      const card = screen.getByTestId(
+        "recommended-automation-rail-card-slack-standup-digest",
+      );
+
+      fireEvent.mouseDown(card, { button: 0, clientX: 300 });
+      fireEvent.mouseMove(document, { clientX: 250, buttons: 1 });
+      fireEvent.mouseUp(document);
+      fireEvent.click(card);
+
+      expect(onSelect).not.toHaveBeenCalled();
+
+      fireEvent.mouseDown(card, { button: 0, clientX: 250 });
+      fireEvent.mouseUp(document);
+      fireEvent.click(card);
+
+      expect(onSelect).toHaveBeenCalledTimes(1);
+    });
+
+    it("treats movement below the drag threshold as a click", () => {
+      const onSelect = vi.fn();
+      render(
+        <RecommendedAutomationsRail
+          installedAutomations={[]}
+          onSelect={onSelect}
+        />,
+      );
+      const card = screen.getByTestId(
+        "recommended-automation-rail-card-slack-standup-digest",
+      );
+
+      fireEvent.mouseDown(card, { button: 0, clientX: 300 });
+      fireEvent.mouseMove(document, { clientX: 301, buttons: 1 });
+      fireEvent.mouseUp(document);
+      fireEvent.click(card);
+
+      expect(onSelect).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores drags started with a non-primary mouse button", () => {
+      render(
+        <RecommendedAutomationsRail
+          installedAutomations={[]}
+          onSelect={vi.fn()}
+        />,
+      );
+      const scroller = screen.getByTestId(
+        "recommended-automations-rail-scroll",
+      );
+      mockScrollMetrics(scroller, {
+        scrollWidth: 900,
+        clientWidth: 320,
+        scrollLeft: 100,
+      });
+
+      fireEvent.mouseDown(scroller, { button: 2, clientX: 300 });
+      fireEvent.mouseMove(document, { clientX: 250, buttons: 2 });
+
+      expect(scroller.scrollLeft).toBe(100);
+    });
+
+    it("ends the drag once the primary button is no longer held", () => {
+      render(
+        <RecommendedAutomationsRail
+          installedAutomations={[]}
+          onSelect={vi.fn()}
+        />,
+      );
+      const scroller = screen.getByTestId(
+        "recommended-automations-rail-scroll",
+      );
+      mockScrollMetrics(scroller, {
+        scrollWidth: 900,
+        clientWidth: 320,
+        scrollLeft: 100,
+      });
+
+      fireEvent.mouseDown(scroller, { button: 0, clientX: 300 });
+      fireEvent.mouseMove(document, { clientX: 250, buttons: 1 });
+      fireEvent.mouseMove(document, { clientX: 200, buttons: 0 });
+      fireEvent.mouseMove(document, { clientX: 100, buttons: 1 });
+
+      expect(scroller.scrollLeft).toBe(150);
     });
   });
 });

--- a/src/components/features/automations/recommended-automations-rail.tsx
+++ b/src/components/features/automations/recommended-automations-rail.tsx
@@ -14,6 +14,7 @@ import {
   getRecommendedRailGroups,
 } from "#/utils/recommended-automation-rail";
 import { readScrollFadeState } from "#/utils/scroll-fade-state";
+import { useDragScroll } from "#/hooks/use-drag-scroll";
 import type { Automation } from "#/types/automation";
 import { AUTOMATION_STACK_SECTION_BOTTOM_CLASS } from "#/utils/automation-stack-section";
 import { cn } from "#/utils/utils";
@@ -87,6 +88,8 @@ export function RecommendedAutomationsRail({
     getRecommendedRailGroups(installedAutomations),
   );
   const scrollRef = useRef<HTMLDivElement>(null);
+  const { handleMouseDown, handleClickCapture, handleDragStart } =
+    useDragScroll(scrollRef);
   const [fadeState, setFadeState] = useState({ left: false, right: false });
 
   const updateFadeState = useCallback(() => {
@@ -130,12 +133,16 @@ export function RecommendedAutomationsRail({
       </h2>
 
       <div className="relative">
+        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- mouse drag-to-scroll is a pointer convenience; keyboard users scroll the list natively via the focusable cards. */}
         <div
           ref={scrollRef}
           role="list"
           data-testid="recommended-automations-rail-scroll"
           onScroll={updateFadeState}
-          className="flex flex-nowrap gap-3 overflow-x-auto scrollbar-hide"
+          onMouseDown={handleMouseDown}
+          onClickCapture={handleClickCapture}
+          onDragStart={handleDragStart}
+          className="flex flex-nowrap gap-3 overflow-x-auto scrollbar-hide select-none"
         >
           {items.map((automation) => (
             <div key={automation.id} role="listitem">

--- a/src/hooks/use-drag-scroll.ts
+++ b/src/hooks/use-drag-scroll.ts
@@ -1,0 +1,94 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+
+/** Movement required before a mouse gesture is treated as a scroll drag. */
+const DRAG_COMMIT_PX = 2;
+
+/**
+ * Mouse drag-to-scroll for a horizontal `overflow-x-auto` container. Touch
+ * input keeps the browser's native panning; only primary-button mouse drags
+ * are handled. After a committed drag, the click that follows mouseup is
+ * suppressed so child buttons are not activated by the drag release.
+ */
+export function useDragScroll(scrollRef: RefObject<HTMLElement | null>) {
+  const [isDragging, setIsDragging] = useState(false);
+  const startXRef = useRef(0);
+  const startScrollLeftRef = useRef(0);
+  const dragCommittedRef = useRef(false);
+
+  const handleMouseDown = useCallback(
+    (event: React.MouseEvent) => {
+      const element = scrollRef.current;
+      if (event.button !== 0 || !element) {
+        return;
+      }
+      dragCommittedRef.current = false;
+      startXRef.current = event.clientX;
+      startScrollLeftRef.current = element.scrollLeft;
+      setIsDragging(true);
+    },
+    [scrollRef],
+  );
+
+  const handleClickCapture = useCallback((event: React.MouseEvent) => {
+    if (!dragCommittedRef.current) {
+      return;
+    }
+    dragCommittedRef.current = false;
+    event.preventDefault();
+    event.stopPropagation();
+  }, []);
+
+  const handleDragStart = useCallback((event: React.DragEvent) => {
+    // Child <img> elements would otherwise start a native image drag.
+    event.preventDefault();
+  }, []);
+
+  useEffect(() => {
+    if (!isDragging) {
+      return undefined;
+    }
+
+    const handleMouseMove = (event: MouseEvent) => {
+      const element = scrollRef.current;
+      if (!element) {
+        return;
+      }
+
+      // The mouseup can be missed when released outside the window; end the
+      // drag once the primary button is no longer held.
+      if ((event.buttons & 1) === 0) {
+        setIsDragging(false);
+        return;
+      }
+
+      if (!dragCommittedRef.current) {
+        if (Math.abs(event.clientX - startXRef.current) < DRAG_COMMIT_PX) {
+          return;
+        }
+        dragCommittedRef.current = true;
+      }
+
+      event.preventDefault();
+      element.scrollLeft =
+        startScrollLeftRef.current - (event.clientX - startXRef.current);
+    };
+
+    const handleMouseUp = () => setIsDragging(false);
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [isDragging, scrollRef]);
+
+  return { handleMouseDown, handleClickCapture, handleDragStart };
+}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

I verified the changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

<!-- Describe problem, motivation, etc. -->

The "Recommended automations" horizontal card rails (home page and Automate dashboard empty state) could not be scrolled by clicking and dragging with the mouse — only keyboard arrows and wheel/trackpad worked. Both surfaces share `RecommendedAutomationsRail`, whose scroll container was a plain `overflow-x-auto` div with no pointer handling; browsers do not provide mouse-drag panning natively.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Add `src/hooks/use-drag-scroll.ts`: a mouse-only drag-to-scroll hook following the existing drag-gesture conventions (`use-drag-resize.ts`) — 2px commit threshold, post-drag click suppression, native image-drag cancellation, and drag termination when the button is released outside the window.
- Wire it into the rail's scroll container in `recommended-automations-rail.tsx` (plus `select-none` so drags don't select card text); one component change fixes both pages.
- Add 5 drag-to-scroll unit tests to `__tests__/components/automations/recommended-automations-rail.test.tsx`.

## Issue Number
<!-- Required. The linked issue must carry the `ready-for-dev` label, which
means it has clear acceptance criteria (and, for bugs, reproduction evidence).
If no such issue exists yet, open one using the Bug or Feature Request template
and wait for it to be labeled `ready-for-dev` before opening this PR. -->
Fixes #16741

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `npm install`, then `npm run dev` (or `npm run dev:mock`).
2. On the home page ("Let's Start Building!"), press and drag the "Recommended automations" cards left/right — the rail scrolls, and releasing after a drag does NOT open the card under the cursor.
3. Click a card without dragging — its setup dialog still opens.
4. Start drags on a card, on a logo image, and in a gap between cards — all scroll; no ghost image drag, no text selection.
5. Confirm wheel/trackpad scrolling and keyboard navigation still work, and the edge fade gradients update while dragging.
6. Repeat on Automate → Dashboard with no automations configured (the rail there appears only in the empty state).
7. `npx vitest run __tests__/components/automations/recommended-automations-rail.test.tsx` — 11 tests pass (6 pre-existing + 5 new).

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

For bug fixes: reproduction evidence is required. Show the bug reproduced (the
error state) and then the result after your fix. A terminal screenshot or video
is fine for non-UI bugs.
-->

https://github.com/user-attachments/assets/d10d61eb-3bab-4624-a91b-b5cd80303bc4

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.8.0` |
| **Commit** | `44611cf2c2511a655ab5ecd511b92d6e4a868c86` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-44611cf
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-44611cf
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-44611cf-amd64
ghcr.io/openhands/agent-canvas:hieptl-oss-10011-amd64
ghcr.io/openhands/agent-canvas:pr-16742-amd64
ghcr.io/openhands/agent-canvas:sha-44611cf-arm64
ghcr.io/openhands/agent-canvas:hieptl-oss-10011-arm64
ghcr.io/openhands/agent-canvas:pr-16742-arm64
ghcr.io/openhands/agent-canvas:sha-44611cf
ghcr.io/openhands/agent-canvas:hieptl-oss-10011
ghcr.io/openhands/agent-canvas:pr-16742
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-44611cf`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-44611cf-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->