### PR TITLE
fix(ci): let a bug with no rendered surface prove itself with a command

### DIFF
--- a/.github/scripts/check_issue_readiness.py
+++ b/.github/scripts/check_issue_readiness.py
@@ -6,7 +6,11 @@ The criteria are type-specific:
   least one supported run method (`agent-canvas`, `npm run`, or
   `app.all-hands.dev/canvas`), the Actual Behavior section must embed a
   screenshot or video, and there must be a non-empty Acceptance Criteria
-  section with at least one checklist item.
+  section with at least one checklist item. A bug with no rendered surface —
+  in a build script, a workflow, or any other path with no Agent Canvas
+  session to record — satisfies the first two instead by fencing its
+  reproduction command in Steps to Reproduce and showing that command's
+  output, in Actual Behavior or in the form's Relevant Logs field.
 
 - Enhancements (labeled `enhancement`): the body must contain non-empty
   Desired Behavior and Acceptance Criteria sections, the latter with at least
@@ -57,6 +61,16 @@ RUN_METHOD_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"npm\s+run", re.IGNORECASE),
     re.compile(r"app\.all-hands\.dev/canvas", re.IGNORECASE),
 )
+
+# Fenced code block, split by fence character because CommonMark treats their info
+# strings differently: a backtick fence's may not contain a backtick, a tilde's may.
+# An opener is indented by at most three *spaces* — a tab makes it indented code, not
+# a fence. A closer repeats the opening character at least as many times and is
+# followed by nothing but spaces or tabs; a marker with trailing text is still content.
+# Keeping all of that exact is what makes these agree with what the reporter sees
+# rendered, which is the only reason to require a fence at all.
+BACKTICK_FENCE_RE = re.compile(r"(?m)^ {0,3}(`{3,})[^`\n]*\n[\s\S]*?^ {0,3}\1`*[ \t]*$")
+TILDE_FENCE_RE = re.compile(r"(?m)^ {0,3}(~{3,})[^\n]*\n[\s\S]*?^ {0,3}\1~*[ \t]*$")
 
 # Markdown image: ![alt](url)
 MARKDOWN_IMAGE_RE = re.compile(r"!\[[^\]]*\]\([^)]+\)")
@@ -151,28 +165,54 @@ def has_checklist_item(text: str) -> bool:
     return bool(CHECKLIST_ITEM_RE.search(text))
 
 
+def has_fenced_block(text: str) -> bool:
+    """Whether `text` contains a code block GitHub would actually render as fenced."""
+    return bool(BACKTICK_FENCE_RE.search(text) or TILDE_FENCE_RE.search(text))
+
+
+def shown_by_reproduction_command(reproduction: str, actual: str, logs: str) -> bool:
+    """Whether the report shows the bug as a command and the output it produced.
+
+    The evidence a bug with no rendered surface can actually supply. The command
+    must be fenced in Steps to Reproduce, which is the half worth being strict
+    about: it is what lets someone else run it. The output may be fenced in Actual
+    Behavior or pasted into Relevant Logs, which the bug form renders as `shell`
+    and fences on the reporter's behalf. Requiring the command keeps a lone
+    snippet from qualifying on its own.
+    """
+    if not has_fenced_block(reproduction):
+        return False
+    return has_fenced_block(actual) or bool(logs)
+
+
 def check_bug(sections: dict[str, str]) -> ReadinessResult:
     result = ReadinessResult(ready=True)
 
     reproduction = visible_text(find_section(sections, "steps to reproduce", "reproduction"))
+    actual = visible_text(find_section(sections, "actual behavior", "actual"))
+    logs = visible_text(find_section(sections, "relevant logs", "logs"))
+    by_command = shown_by_reproduction_command(reproduction, actual, logs)
+
     if not reproduction:
         result.add(
             "Fill in the `### Steps to Reproduce` section showing how you reproduced "
-            "the bug in a live Agent Canvas session."
+            "the bug in a live Agent Canvas session, or the command that reproduces it."
         )
-    elif not references_run_method(reproduction):
+    elif not by_command and not references_run_method(reproduction):
         result.add(
             "The Steps to Reproduce section must reference a supported run method: "
-            "`agent-canvas`, `npm run`, or `app.all-hands.dev/canvas`."
+            "`agent-canvas`, `npm run`, or `app.all-hands.dev/canvas`. If the bug has no "
+            "Agent Canvas surface, give the reproduction command in a fenced block instead, "
+            "with its output in Actual Behavior or Relevant Logs."
         )
 
-    actual = visible_text(find_section(sections, "actual behavior", "actual"))
     if not actual:
         result.add("Fill in the `### Actual Behavior` section describing the observed bug.")
-    elif not has_screenshot_or_video(actual):
+    elif not by_command and not has_screenshot_or_video(actual):
         result.add(
             "The Actual Behavior section must include a screenshot or video of "
-            "the bug (drag a file into the field or paste a link)."
+            "the bug (drag a file into the field or paste a link), or the output of "
+            "the fenced reproduction command."
         )
 
     acceptance = visible_text(find_section(sections, "acceptance criteria", "acceptance"))

--- a/.github/scripts/tests/test_issue_readiness.py
+++ b/.github/scripts/tests/test_issue_readiness.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from check_issue_readiness import (
     evaluate_readiness,
+    shown_by_reproduction_command,
     extract_sections,
     has_screenshot_or_video,
     references_run_method,
@@ -430,3 +431,84 @@ def test_main_event_path_json_ready(tmp_path, capsys, monkeypatch):
     assert len(data["reasons"]) == 0
 
 
+# ---------------------------------------------------------------------------
+# Bugs with no rendered surface
+# ---------------------------------------------------------------------------
+
+NON_UI_BUG = """### Steps to Reproduce
+Against a body whose Acceptance Criteria section is present:
+
+```bash
+python3 .github/scripts/check_issue_readiness.py --body-file /tmp/body.md
+```
+
+### Actual Behavior
+The checker asks for the section the body already has:
+
+```
+ready: False
+ - Fill in the `### Acceptance Criteria` section with testable checklist items.
+```
+
+### Acceptance Criteria
+- [ ] The section that is present is not reported as missing
+"""
+
+
+def test_fenced_command_and_output_stand_in_for_canvas_evidence():
+    """A CI-script bug has no Agent Canvas session to record and no screen to shoot."""
+    result = evaluate_readiness(NON_UI_BUG, [BUG_LABEL])
+    assert result.ready, result.reasons
+
+
+def test_output_may_live_in_relevant_logs():
+    """The bug form renders Relevant Logs as `shell`, so it arrives already fenced."""
+    body = NON_UI_BUG[: NON_UI_BUG.index("### Actual Behavior")] + (
+        "### Actual Behavior\nThe section that is present is reported as missing.\n\n"
+        "### Relevant Logs\nready: False\n\n"
+        "### Acceptance Criteria\n- [ ] The section that is present is not reported as missing\n"
+    )
+    assert "### Relevant Logs" in body
+    assert evaluate_readiness(body, [BUG_LABEL]).ready
+
+
+def test_a_command_with_no_output_is_not_enough():
+    """Otherwise a bare snippet qualifies and the report shows nothing."""
+    body = """### Steps to Reproduce
+Against a body whose Acceptance Criteria section is present:
+
+```bash
+python3 .github/scripts/check_issue_readiness.py --body-file /tmp/body.md
+```
+
+### Actual Behavior
+It reports a section that is present as missing.
+
+### Acceptance Criteria
+- [ ] Fixed
+"""
+    assert not evaluate_readiness(body, [BUG_LABEL]).ready
+
+
+def test_output_without_a_fenced_command_still_needs_a_run_method():
+    """The command is the half that makes the report reproducible by someone else."""
+    body = """### Steps to Reproduce
+Run the checker against a body whose Acceptance Criteria section is present.
+
+### Actual Behavior
+The checker rejects it:
+
+```
+ready: False
+```
+
+### Acceptance Criteria
+- [ ] Fixed
+"""
+    assert not evaluate_readiness(body, [BUG_LABEL]).ready
+
+
+def test_shown_by_reproduction_command_requires_the_command():
+    assert not shown_by_reproduction_command("", "```\nout\n```", "")
+    assert not shown_by_reproduction_command("```\ncmd\n```", "", "")
+    assert shown_by_reproduction_command("```\ncmd\n```", "", "out")


### PR DESCRIPTION
HUMAN:

I hit this twice in one week. I filed a bug about a Vercel install script and another about a workflow that fails on every not-ready issue. Neither could ever get ready-for-dev because the criteria require a screenshot of a live Agent Canvas session, and neither bug has a screen to photograph. The PRs fixing them just sit there with a red check I have no way to clear.
What I can always give you is the command and what it printed. That is checkable by anyone in about five seconds, which is the whole point of the rule. So that now counts, and I left the screenshot path exactly as it was for bugs that actually have a UI.
One thing I want to be upfront about: I filed the issue this fixes, and one of my own bug reports was still being rejected by my first version of this rule. I widened it because the form already fences the Relevant Logs field for you, not because it was mine.

AGENT:

Rewritten on top of `main` after #16828 moved the run-method check to Steps to Reproduce. That
restructure made this smaller: the section this change wants the command in is now the section the
run method is already read from. The PR is down from 5 files to 2, and no longer depends on #16814.

```console
$ cd .github/scripts && python3 -m pytest tests/ -q
93 passed

$ # with the two `not by_command and` guards removed, keeping the new tests
2 failed, 91 passed
```

---

## Summary

`check_bug()` accepts a second form of evidence, so a bug with no rendered surface can prove itself
with its reproduction command and that command's output instead of a run method and a screenshot.
The existing path is untouched.

## Issue Number

Fixes #16744

## Why

`check_bug()` asks Steps to Reproduce for `agent-canvas`, `npm run`, or `app.all-hands.dev/canvas`,
and Actual Behavior for a screenshot or video. A bug in a CI script, a workflow, or a build path has
no Agent Canvas session to record and no screen to shoot. Neither criterion can be met without
writing something untrue, the issue never reaches `ready-for-dev`, and `check_pr_description.py`
then fails every PR opened against it.

## What changed

`check_bug()` accepts a second evidence form: the reproduction command, **fenced**, in Steps to
Reproduce, together with **that command's output** — fenced in Actual Behavior, or pasted into the
form's Relevant Logs field, which the bug form renders as `shell` and fences for the reporter.

Both halves are required. A command alone is a snippet that shows nothing; output alone is not
reproducible by anyone else. The existing path is untouched — a report with a run method and a
screenshot is judged exactly as before, and all 88 pre-existing tests pass unchanged.

## Measured on real issues

Two reports are stuck on this today. Both are bugs in `.github/scripts`, both were used to check the
change end to end:

| issue | before | after |
|---|---|---|
| #16707 — readiness drops sections whose heading has a trailing colon | not ready: no run method | **ready** |
| #16813 — a section whose first line opens a fenced block loses that block | not ready: no run method | **ready** |

Both already carry a terminal screenshot of the reproduction, added after the criteria rejected
them; neither can claim a run method, because there is no product surface involved.

## Tests

Five added. Two are red without the change and green with it:

- `test_fenced_command_and_output_stand_in_for_canvas_evidence`
- `test_output_may_live_in_relevant_logs`

Three are guards that stay green either way, which is the point of them — they pin that the new path
does not over-accept:

- `test_a_command_with_no_output_is_not_enough`
- `test_output_without_a_fenced_command_still_needs_a_run_method`
- `test_shown_by_reproduction_command_requires_the_command`

## How to Test

```bash
cd .github/scripts && python3 -m pytest tests/ -q     # 93 passed
```

Remove the two `not by_command and` guards from `check_bug()` and re-run: 2 failed, 91 passed.

To see it against a real report:

```bash
gh api repos/OpenHands/OpenHands/issues/16707 --jq .body > /tmp/b.md
cd .github/scripts && python3 -c "import check_issue_readiness as c; print(c.evaluate_readiness(open('/tmp/b.md').read(), [c.BUG_LABEL]))"
```

## Notes

- Fence detection keeps its own two regexes rather than calling
  `markdown_sections.without_fenced_code_blocks()`. One parser would be better than two, and I tried
  the swap, but that module accepts a backtick inside a backtick fence's info string and accepts any
  opener indent including a tab. Harmless for masking headings, wrong for "would the reporter see a
  rendered block". Happy to tighten it in a follow-up and drop these.
- The test fixtures deliberately put a sentence before each fence. A section whose *first* line
  opens a fence currently loses that block to #16813; writing the fixtures the other way would have
  made this PR depend on #16814 for no reason.
