### PR TITLE
chore: bump @openhands/extensions to 0.18.0

### DIFF
--- a/__tests__/components/automations/recommended-automations-rail.test.tsx
+++ b/__tests__/components/automations/recommended-automations-rail.test.tsx
@@ -65,8 +65,10 @@ describe("RecommendedAutomationsRail", () => {
       );
 
     expect(cardIds).toEqual([
-      "github-repo-monitor",
+      "github-issue-to-pr",
       "slack-channel-monitor",
+      "github-agents-md-maintainer",
+      "news-digest",
       "slack-standup-digest",
       "linear-triage-assistant",
       "jira-issue-to-pr",
@@ -115,8 +117,10 @@ describe("RecommendedAutomationsRail", () => {
       <RecommendedAutomationsRail
         installedAutomations={[
           { name: "GitHub Code Review Agent" },
-          { name: "GitHub repository monitor" },
+          { name: "GitHub Issue to PR Agent" },
           { name: "Slack channel monitor" },
+          { name: "AGENTS.md Maintainer" },
+          { name: "Daily news digest" },
           { name: "Slack standup digest" },
           { name: "Linear issue triage assistant" },
           { name: "Jira issue to GitHub PR" },

--- a/__tests__/components/automations/recommended-automations.test.tsx
+++ b/__tests__/components/automations/recommended-automations.test.tsx
@@ -206,8 +206,11 @@ describe("recommended automations", () => {
 
     expect(cardIds).toEqual([
       "github-pr-reviewer",
-      "github-repo-monitor",
+      "github-issue-to-pr",
       "slack-channel-monitor",
+      "github-agents-md-maintainer",
+      "news-digest",
+      "github-repo-monitor",
       "slack-standup-digest",
       "linear-triage-assistant",
       "jira-issue-to-pr",
@@ -229,7 +232,7 @@ describe("recommended automations", () => {
     const provenHeading = screen.getByText(
       I18nKey.RECOMMENDED_AUTOMATIONS$SECTION_TITLE,
     ).parentElement!;
-    expect(within(provenHeading).getByText("3")).toBeInTheDocument();
+    expect(within(provenHeading).getByText("5")).toBeInTheDocument();
 
     const betaHeading = screen.getByTestId(
       "recommended-automations-beta-heading",
@@ -237,7 +240,7 @@ describe("recommended automations", () => {
     expect(betaHeading).toHaveTextContent(
       I18nKey.RECOMMENDED_AUTOMATIONS$BETA_LABEL,
     );
-    expect(within(betaHeading).getByText("6")).toBeInTheDocument();
+    expect(within(betaHeading).getByText("7")).toBeInTheDocument();
 
     const betaSection = screen.getByTestId(
       "recommended-automations-beta-section",
@@ -314,6 +317,24 @@ describe("recommended automations", () => {
         "recommended-automation-icon-incident-retrospective-drafter",
       ),
     ).toHaveAttribute("data-layout", "quadrants");
+  });
+
+  it("shows the declared glyph instead of a logo stack when an entry names one", () => {
+    render(
+      <RecommendedAutomationsSection
+        backendKind="local"
+        installedServers={[]}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    // `news-digest` connects to nothing, so there are no logos to stack; it
+    // names its own glyph, and the badge must render that rather than the
+    // generic placeholder a bare empty stack would give.
+    const badge = screen.getByTestId("recommended-automation-icon-news-digest");
+    expect(badge).not.toHaveAttribute("data-layout");
+    expect(badge.querySelector("svg")).toBeInTheDocument();
+    expect(badge.querySelector("img")).not.toBeInTheDocument();
   });
 
   it("renders missing MCP connect copy as a pill on the same row", () => {

--- a/__tests__/constants/extensions-catalogs.test.ts
+++ b/__tests__/constants/extensions-catalogs.test.ts
@@ -72,9 +72,17 @@ describe("OpenHands extensions catalogs", () => {
     const knownMcpIds = new Set(INTEGRATION_CATALOG.map((entry) => entry.id));
     for (const automation of AUTOMATION_CATALOG) {
       const integrationIds = getIntegrationIds(automation);
-      expect(integrationIds.length).toBeGreaterThan(0);
       expect(integrationIds.every((id) => knownMcpIds.has(id))).toBe(true);
     }
+
+    // Declaring none is legitimate — `news-digest` connects to nothing — so the
+    // resolution above is only worth asserting while some entry still declares
+    // one. Without this the loop above would pass over an empty catalog.
+    expect(
+      AUTOMATION_CATALOG.some(
+        (automation) => getIntegrationIds(automation).length > 0,
+      ),
+    ).toBe(true);
   });
 
   it("admits every setup experience the automation catalog ships", () => {

--- a/__tests__/utils/automation-catalog.test.ts
+++ b/__tests__/utils/automation-catalog.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { AUTOMATION_CATALOG } from "@openhands/extensions/automations";
-import { getAutomationLaunchPrompt } from "#/utils/automation-catalog";
+import { Activity, Bot } from "lucide-react";
+import {
+  getAutomationIcon,
+  getAutomationLaunchPrompt,
+} from "#/utils/automation-catalog";
 
 const automationById = (id: string) =>
   AUTOMATION_CATALOG.find((automation) => automation.id === id)!;
@@ -25,5 +29,32 @@ describe("getAutomationLaunchPrompt", () => {
     expect(getAutomationLaunchPrompt(automationById("jira-issue-to-pr"))).toBe(
       "Set up the Jira issue to GitHub PR automation",
     );
+  });
+});
+
+describe("getAutomationIcon", () => {
+  it("resolves the glyph an entry declares", () => {
+    // Arrange / Act / Assert — the two entries that name one, each a
+    // different slug, so the lookup is not passing by returning a constant.
+    expect(getAutomationIcon(automationById("news-digest"))).toBe(Activity);
+    expect(
+      getAutomationIcon(automationById("github-agents-md-maintainer")),
+    ).toBe(Bot);
+  });
+
+  it("returns null for an entry that declares none", () => {
+    // Its integrations' logos identify it instead.
+    expect(getAutomationIcon(automationById("github-pr-reviewer"))).toBeNull();
+  });
+
+  it("returns null for a slug this host has no artwork for", () => {
+    // The catalog is published elsewhere, so an unknown slug must fall back to
+    // the logos rather than render nothing.
+    expect(
+      getAutomationIcon({
+        ...automationById("news-digest"),
+        icon: "not-a-real-slug",
+      } as unknown as Parameters<typeof getAutomationIcon>[0]),
+    ).toBeNull();
   });
 });

--- a/__tests__/utils/recommended-automation-rail.test.ts
+++ b/__tests__/utils/recommended-automation-rail.test.ts
@@ -49,8 +49,10 @@ describe("recommended automation rail", () => {
     ]);
 
     expect(groups.proven.map((entry) => entry.id)).toEqual([
-      "github-repo-monitor",
+      "github-issue-to-pr",
       "slack-channel-monitor",
+      "github-agents-md-maintainer",
+      "news-digest",
     ]);
   });
 
@@ -60,8 +62,10 @@ describe("recommended automation rail", () => {
 
     expect(groups.proven.map((entry) => entry.id)).toEqual([
       "github-pr-reviewer",
-      "github-repo-monitor",
+      "github-issue-to-pr",
       "slack-channel-monitor",
+      "github-agents-md-maintainer",
+      "news-digest",
     ]);
     expect(conversationIds).toEqual([
       "slack-standup-digest",
@@ -71,6 +75,9 @@ describe("recommended automation rail", () => {
     ]);
     expect(conversationIds).not.toContain("upstream-fork-sync");
     expect(conversationIds).not.toContain("incident-retrospective-drafter");
+    // Beta as of extensions 0.18.0, and set up by a host form rather than a
+    // conversation, so it is in neither group.
+    expect(conversationIds).not.toContain("github-repo-monitor");
     expect(isConversationLaunchAutomation(slackStandup)).toBe(true);
     expect(isConversationLaunchAutomation(upstreamFork)).toBe(false);
     expect(SETUP_REGISTRY.findById(upstreamFork.id)).not.toBeNull();
@@ -79,8 +86,10 @@ describe("recommended automation rail", () => {
   it("returns an empty rail when every recommended automation has been added", () => {
     const groups = getRecommendedRailGroups([
       { name: "GitHub Code Review Agent" },
-      { name: "GitHub repository monitor" },
+      { name: "GitHub Issue to PR Agent" },
       { name: "Slack channel monitor" },
+      { name: "AGENTS.md Maintainer" },
+      { name: "Daily news digest" },
       { name: "Slack standup digest" },
       { name: "Linear issue triage assistant" },
       { name: "Jira issue to GitHub PR" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@heroui/react": "2.8.10",
         "@microlink/react-json-view": "1.31.25",
         "@monaco-editor/react": "4.7.0",
-        "@openhands/extensions": "0.17.0",
+        "@openhands/extensions": "0.18.0",
         "@openhands/typescript-client": "1.38.0",
         "@react-router/node": "7.18.2",
         "@react-router/serve": "7.18.2",
@@ -4164,9 +4164,9 @@
       "license": "MIT"
     },
     "node_modules/@openhands/extensions": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@openhands/extensions/-/extensions-0.17.0.tgz",
-      "integrity": "sha512-y3+OSHsMWN1sZVT1NERVdCnZVBgHg3F5E4tlYea6bb/nLzX750SuvJpfUJNitJqxN7ls+jMYVgBOgee6KoeLqA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@openhands/extensions/-/extensions-0.18.0.tgz",
+      "integrity": "sha512-0cbVueh8wk5OLq+kbEgI5k1sFUaNgahmxXwvOR5+4fpxwc2YnVivdyDzxjZ+SiagUmYi/EgADFVa/5X38e9BzQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.20.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@heroui/react": "2.8.10",
     "@microlink/react-json-view": "1.31.25",
     "@monaco-editor/react": "4.7.0",
-    "@openhands/extensions": "0.17.0",
+    "@openhands/extensions": "0.18.0",
     "@openhands/typescript-client": "1.38.0",
     "@react-router/node": "7.18.2",
     "@react-router/serve": "7.18.2",

--- a/src/components/features/automations/recommended-automations-rail.tsx
+++ b/src/components/features/automations/recommended-automations-rail.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import {
+  createElement,
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 import type { RecommendedAutomation } from "@openhands/extensions/automations";
 import {
@@ -8,7 +14,10 @@ import {
 import { I18nKey } from "#/i18n/declaration";
 import { McpLogoBadge } from "#/components/features/mcp-logo-badge";
 import { getMarketplaceEntryById } from "#/utils/mcp-marketplace-utils";
-import { getIntegrationIds } from "#/utils/automation-catalog";
+import {
+  getAutomationIcon,
+  getIntegrationIds,
+} from "#/utils/automation-catalog";
 import {
   flattenRecommendedRailGroups,
   getRecommendedRailGroups,
@@ -42,23 +51,40 @@ function integrationEntries(
 }
 
 function RailIntegrationIcons({
+  automation,
   entries,
   testId,
 }: {
+  automation: RecommendedAutomation;
   entries: MarketplaceEntry[];
   testId: string;
 }) {
   const visibleEntries = entries.slice(0, 4);
   const isOverlap = visibleEntries.length > 1;
+  // A declared glyph replaces the logos rather than joining them: it is the
+  // whole identity of an entry that names one.
+  const Icon = getAutomationIcon(automation);
 
   return (
     <span
       aria-hidden="true"
       data-testid={testId}
-      data-layout={isOverlap ? "overlap" : undefined}
-      className={cn(RAIL_ICON_ROW_CLASS_NAME, isOverlap && "-space-x-2")}
+      data-layout={isOverlap && !Icon ? "overlap" : undefined}
+      className={cn(
+        RAIL_ICON_ROW_CLASS_NAME,
+        isOverlap && !Icon && "-space-x-2",
+      )}
     >
-      {visibleEntries.length === 0 ? (
+      {Icon ? (
+        <McpLogoBadge
+          entry={null}
+          size="base"
+          fallback={createElement(Icon, {
+            className: "h-5 w-5",
+            strokeWidth: 2.25,
+          })}
+        />
+      ) : visibleEntries.length === 0 ? (
         <McpLogoBadge entry={null} size="base" />
       ) : (
         visibleEntries.map((entry) => (
@@ -157,6 +183,7 @@ export function RecommendedAutomationsRail({
                 )}
               >
                 <RailIntegrationIcons
+                  automation={automation}
                   entries={integrationEntries(automation)}
                   testId={`recommended-automation-rail-icon-${automation.id}`}
                 />

--- a/src/components/features/automations/recommended-automations-section.tsx
+++ b/src/components/features/automations/recommended-automations-section.tsx
@@ -1,3 +1,4 @@
+import { createElement } from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { I18nKey } from "#/i18n/declaration";
@@ -24,6 +25,7 @@ import {
 } from "#/utils/mcp-marketplace-utils";
 import { getFeaturedAutomationIds } from "#/manifests/automation-interface";
 import {
+  getAutomationIcon,
   getAutomationLaunchPrompt,
   getIntegrationIds,
 } from "#/utils/automation-catalog";
@@ -109,15 +111,6 @@ function automationMatchesQuery(
   return haystack.includes(query);
 }
 
-/**
- * Keep any automation with declared integrations visible, including when a
- * catalog entry is missing. This makes catalog drift actionable instead of
- * silently hiding the automation.
- */
-function isAutomationAvailable(automation: RecommendedAutomation) {
-  return getIntegrationIds(automation).length > 0;
-}
-
 function buildRecommendedAutomationPills(
   integrations: AutomationIntegration[],
   installedServers: MCPServerConfig[],
@@ -177,6 +170,44 @@ function buildRecommendedAutomationPills(
   return pills;
 }
 
+/**
+ * A card's badge: the declared glyph when the entry names one, and its
+ * integration logos otherwise. Both render into the same slot at the same
+ * size, so a card is laid out the same either way.
+ */
+function AutomationCardIcon({
+  automation,
+  integrations,
+  size,
+  testId,
+}: {
+  automation: RecommendedAutomation;
+  integrations: AutomationIntegration[];
+  size: "base" | "md";
+  testId: string;
+}) {
+  const Icon = getAutomationIcon(automation);
+  if (Icon) {
+    return (
+      <McpLogoBadge
+        entry={null}
+        size={size}
+        testId={testId}
+        fallback={createElement(Icon, {
+          className: "h-5 w-5",
+          strokeWidth: 2.25,
+        })}
+      />
+    );
+  }
+  return (
+    <McpLogoStackBadge
+      entries={integrations.flatMap(({ entry }) => (entry ? [entry] : []))}
+      testId={testId}
+    />
+  );
+}
+
 interface AutomationCardGridProps {
   automations: RecommendedAutomation[];
   installedServers: MCPServerConfig[];
@@ -217,10 +248,10 @@ function AutomationCardGrid({
             )}
           >
             <div className="flex min-w-0 flex-1 items-start gap-3">
-              <McpLogoStackBadge
-                entries={integrations.flatMap(({ entry }) =>
-                  entry ? [entry] : [],
-                )}
+              <AutomationCardIcon
+                automation={automation}
+                integrations={integrations}
+                size="md"
                 testId={`recommended-automation-icon-${automation.id}`}
               />
               <div className="flex min-w-0 flex-1 flex-col gap-3">
@@ -268,13 +299,17 @@ export function RecommendedAutomationsSection({
 }: RecommendedAutomationsSectionProps) {
   const { t } = useTranslation("openhands");
 
-  const visibleAutomations = RECOMMENDED_AUTOMATIONS.filter((automation) => {
-    const integrationEntries = getIntegrationEntries(automation);
-    return (
-      isAutomationAvailable(automation) &&
-      automationMatchesQuery(automation, integrationEntries, query)
-    );
-  });
+  // Only the query narrows the grid. An automation that declares no
+  // integration needs nothing connected, and one naming an integration this
+  // host cannot resolve is shown with that gap on its pill, so neither is a
+  // reason to hide a card the catalog ships.
+  const visibleAutomations = RECOMMENDED_AUTOMATIONS.filter((automation) =>
+    automationMatchesQuery(
+      automation,
+      getIntegrationEntries(automation),
+      query,
+    ),
+  );
 
   if (visibleAutomations.length === 0) return null;
 

--- a/src/manifests/automation-setup.ts
+++ b/src/manifests/automation-setup.ts
@@ -218,7 +218,31 @@ export function buildCreatePayload(
   const trigger = buildTrigger(entry, values);
   if (trigger) payload.trigger = trigger;
 
+  const template = buildTemplate(entry, values);
+  if (template) payload.template = template;
+
   return payload;
+}
+
+/**
+ * The `template` provenance a prompt entry sends, or undefined for one that
+ * publishes no version.
+ *
+ * It is what lets the service recognise a second setup of the same entry as
+ * the automation it already holds. The bundle path derives the same block from
+ * the config the bundle declares; a prompt entry declares none, so the answer
+ * to "what was this created from" is the form as submitted.
+ */
+function buildTemplate(
+  entry: SetupEntry,
+  values: SetupFormValues,
+): SetupRequestBody | undefined {
+  if (!entry.version) return undefined;
+  return {
+    id: entry.id,
+    version: entry.version,
+    config: { ...values },
+  };
 }
 
 /**

--- a/src/manifests/manifest-validation.ts
+++ b/src/manifests/manifest-validation.ts
@@ -26,8 +26,11 @@ const ENTRY_ID_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 const FIELD_NAME_PATTERN = /^[a-z][A-Za-z0-9]*$/;
 /** Copy must never be able to inject markup into the host. */
 const MARKUP_PATTERN = /<[A-Za-z/!]/;
-/** Every `{{` must open a known namespace and close immediately. */
-const BUNDLE_VERSION_PATTERN = /^[0-9]+\.[0-9]+\.[0-9]+$/;
+/**
+ * A template version, declared as `version` by a prompt entry and as
+ * `setup.bundle.version` by a bundle one.
+ */
+const TEMPLATE_VERSION_PATTERN = /^[0-9]+\.[0-9]+\.[0-9]+$/;
 // The characters a command of plain words and paths is made of. No shell
 // metacharacters, which the service rejects anyway and a bundle has no reason
 // to need; where those words may point is `isPlainCommand`'s to say.
@@ -35,6 +38,7 @@ const BUNDLE_COMMAND_PATTERN = /^[A-Za-z0-9 ._/-]+$/;
 const BUNDLE_PATH_PATTERN = /^[A-Za-z0-9._-]+(\/[A-Za-z0-9._-]+)*$/;
 const BUNDLE_SOURCE_PATTERN =
   /^(skills|automations)\/[A-Za-z0-9._-]+(\/[A-Za-z0-9._-]+)*$/;
+/** Every `{{` must open a known namespace and close immediately. */
 const UNKNOWN_PLACEHOLDER_PATTERN = new RegExp(
   `\\{\\{(?!(?:${SETUP_PLACEHOLDER_NAMESPACES.join("|")})\\.[A-Za-z0-9_.]+\\}\\})`,
 );
@@ -175,8 +179,11 @@ function checkRequires(check: SetupChecker, requires: unknown): void {
   }
 
   const { integrations, features } = requires;
-  if (!isRecord(integrations) || Object.keys(integrations).length === 0) {
-    check.fail("requires.integrations", "must be a non-empty object");
+  // Empty is meaningful rather than malformed: an automation that needs no
+  // credential connects to nothing, and the key stays required so that saying
+  // so is a deliberate statement instead of an omission.
+  if (!isRecord(integrations)) {
+    check.fail("requires.integrations", "must be an object");
   } else {
     Object.entries(integrations).forEach(([id, requirement]) => {
       const path = `requires.integrations.${id}`;
@@ -400,7 +407,7 @@ function checkBundle(check: SetupChecker, bundle: unknown): void {
 
   if (
     typeof bundle.version !== "string" ||
-    !BUNDLE_VERSION_PATTERN.test(bundle.version)
+    !TEMPLATE_VERSION_PATTERN.test(bundle.version)
   ) {
     check.fail("setup.bundle.version", "must be a semantic version");
   }
@@ -587,6 +594,13 @@ export function validateSetupEntry(candidate: unknown): SetupValidationResult {
   }
   check.copy(candidate.name, "name");
   check.copy(candidate.description, "description");
+  if (
+    candidate.version !== undefined &&
+    (typeof candidate.version !== "string" ||
+      !TEMPLATE_VERSION_PATTERN.test(candidate.version))
+  ) {
+    check.fail("version", "must be a semantic version");
+  }
   if (
     candidate.skill !== undefined &&
     (typeof candidate.skill !== "string" ||

--- a/src/manifests/types.ts
+++ b/src/manifests/types.ts
@@ -152,6 +152,13 @@ export interface SetupEntry {
   id: string;
   name: string;
   description: string;
+  /**
+   * Version of the template this entry publishes, sent with the create request
+   * as provenance. A bundle declares its own at `setup.bundle.version`; a
+   * prompt entry declares it here. Absent means the entry sends none, so the
+   * service records no template for what it creates.
+   */
+  version?: string;
   requires: SetupPrerequisites;
   /** The skill that owns the launch command. Defaults to `id`. */
   skill?: string;

--- a/src/utils/automation-catalog.ts
+++ b/src/utils/automation-catalog.ts
@@ -3,6 +3,8 @@ import {
   SKILLS_CATALOG,
   type SkillCatalogEntry,
 } from "@openhands/extensions/skills";
+import type { LucideIcon } from "lucide-react";
+import { MANIFEST_ICON_BY_SLUG } from "#/components/features/manifest/manifest-icons";
 
 /**
  * Reading a published automation catalog entry.
@@ -17,6 +19,27 @@ import {
 const SKILL_BY_NAME = new Map<string, SkillCatalogEntry>(
   SKILLS_CATALOG.map((skill) => [skill.name, skill]),
 );
+
+/**
+ * The glyph a card shows in place of its integration logos, or null when it
+ * has none to show and the logos speak for it.
+ *
+ * An entry naming the service it talks to is recognised by that service's
+ * logo; one whose identity is the work itself declares a slug instead. The
+ * lookup is a guard as much as a mapping — the catalog is published elsewhere,
+ * so a slug this host has no artwork for falls back rather than rendering
+ * nothing.
+ */
+export function getAutomationIcon(
+  automation: RecommendedAutomation,
+): LucideIcon | null {
+  const slug = automation.icon;
+  if (!slug) return null;
+  return (
+    (MANIFEST_ICON_BY_SLUG as Record<string, LucideIcon | undefined>)[slug] ??
+    null
+  );
+}
 
 /** Every integration the entry declares, in declaration order. */
 export function getIntegrationIds(automation: RecommendedAutomation): string[] {

--- a/src/utils/recommended-automation-rail.ts
+++ b/src/utils/recommended-automation-rail.ts
@@ -5,7 +5,6 @@ import {
 import { getFeaturedAutomationIds } from "#/manifests/automation-interface";
 import { SETUP_REGISTRY } from "#/manifests/manifest-sources";
 import type { Automation } from "#/types/automation";
-import { getIntegrationIds } from "#/utils/automation-catalog";
 
 export function getAutomationsByPopularity(
   catalog: RecommendedAutomation[],
@@ -49,10 +48,6 @@ export function isCatalogAutomationAdded(
   return catalogMatchKeys(entry).some((key) => installedKeys.has(key));
 }
 
-function isAvailableCatalogEntry(entry: RecommendedAutomation): boolean {
-  return getIntegrationIds(entry).length > 0;
-}
-
 function isProvenAutomation(entry: RecommendedAutomation): boolean {
   return getFeaturedAutomationIds().includes(entry.id);
 }
@@ -77,10 +72,11 @@ export interface RecommendedRailGroups {
 export function getRecommendedRailGroups(
   installed: readonly Pick<Automation, "name">[],
 ): RecommendedRailGroups {
+  // Every catalog entry is offerable: one that declares no integration needs
+  // nothing connected, and one that names an integration this host cannot
+  // resolve stays visible so the drift is actionable rather than hidden.
   const available = getAutomationsByPopularity(AUTOMATION_CATALOG).filter(
-    (entry) =>
-      isAvailableCatalogEntry(entry) &&
-      !isCatalogAutomationAdded(entry, installed),
+    (entry) => !isCatalogAutomationAdded(entry, installed),
   );
 
   return {


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Bump extensions package version

AGENT:

---

## Why

`@openhands/extensions@0.18.0` ships three new automations (`github-issue-to-pr`,
`github-agents-md-maintainer`, `news-digest`), moves `github-repo-monitor` to Beta, and versions
the direct-setup templates so they send provenance.

Two of those changes cross a contract this host implements, and both fail **quietly** rather than
loudly — which is why this is not a pin-only bump:

1. **`requires.integrations` may now be empty.** The published schema dropped `minProperties: 1`,
   and `news-digest` is the first entry to connect to nothing. The host's admission check still
   demanded a non-empty map, so the entry was rejected and dropped from the setup registry. Two
   further filters keyed on the same "has ≥ 1 integration" assumption hid its card.
2. **Prompt entries must now send `template` provenance.** A bundle entry already sends
   `template: { id, version, config }`; 0.18.0 extends that to prompt entries via a top-level
   `version`, and the package's fixtures pin the new body. The host built no such block.

## Summary

- Bump `@openhands/extensions` 0.17.0 → 0.18.0 (`package.json` + `package-lock.json`).
- Accept an empty `requires.integrations`, and stop hiding a card that declares none.
- Send `template` provenance from prompt entries, mirroring the bundle path.
- Render the `icon` slug an entry declares, falling back to its integration logos.
- Follow the catalog's new contents in five test files.

## Issue Number

Fixes #16753

## How to Test

```bash
npm ci
npm run lint      # typecheck + eslint + prettier
npm test          # make-i18n + vitest
npm run build
```

Results on this branch:

```
Test Files  597 passed (597)
     Tests  4905 passed | 4 skipped | 7 todo (4916)

lint:      0 errors, 3 warnings  (all pre-existing, in src/ files this PR does not touch)
typecheck: clean
build:     ✓ built
```

To see it in the app:

```bash
npm run dev:mock          # http://localhost:3001
# → /automations/templates      the two new proven cards and their glyphs
# → /automations/new/news-digest  the setup form for the credential-free entry
```

## Video/Screenshots

https://github.com/user-attachments/assets/93d365c0-ea8e-4d06-9032-8505ad8afa2f



## What changed in 0.18.0, and how the host follows it

| change in the package | effect here |
|---|---|
| `requires.integrations` lost `minProperties: 1`; `news-digest` declares `{}` | admission accepted a non-empty map only → entry rejected, route 404, card hidden in two places |
| entries gained a top-level `version`; `github-pr-reviewer` and `github-repo-monitor` publish `1.0.0` | prompt entries sent no `template` block; the shipped fixture now pins one |
| entries gained an optional `icon` slug; `news-digest` declares `activity`, `github-agents-md-maintainer` declares `bot` | cards fell back to the generic placeholder badge |
| `featuredAutomationIds` swapped `github-repo-monitor` for the three new entries | proven/Beta split moved from 3/6 to 5/7 |

### `requires.integrations` may be empty

`checkRequires` now rejects only a non-object. The key stays **required**, matching the published
schema — an automation that connects to nothing says so deliberately rather than by omission.

Two filters encoded the same assumption and are gone rather than adjusted, because with an empty
map legitimate they are constant-true:

- `isAvailableCatalogEntry` in `recommended-automation-rail.ts`
- `isAutomationAvailable` in `recommended-automations-section.tsx`

Their comments said they existed to keep an entry visible when its integration id does not resolve
— that behaviour is unchanged; such an entry still shows the gap on its pill.

### Prompt-entry provenance

`buildCreatePayload` gains a `buildTemplate` step that emits `{ id, version, config }` when the
entry publishes a `version`, where `config` is the form as submitted. The bundle path is untouched:
it derives the same block from the config a bundle declares. An entry with no `version` sends no
`template` key at all, so nothing else in the catalog changes shape.

`SetupEntry.version` is added to the host's own types, and admission validates it as a semantic
version — the host validates every field it reads, and `BUNDLE_VERSION_PATTERN` is renamed to
`TEMPLATE_VERSION_PATTERN` now that it guards both declaration sites.

These are pinned by the package's fixtures, not by hand: `automation-setup.test.ts` compares the
derived create body and preflight envelope against `tests/fixtures/automations/*.json`, and those
four cases were the ones failing before the change.

### Declared icons

`getAutomationIcon` resolves the slug through the existing `MANIFEST_ICON_BY_SLUG` map, returning
null for an entry that declares none **and** for a slug this host has no artwork for — the catalog
is published elsewhere, so an unknown slug must fall back rather than render nothing. Both card
surfaces render the glyph in the same slot at the same size as the logo stack it replaces.

The badge is built with `createElement` rather than JSX: `react-hooks/static-components` rejects
rendering a call-derived capitalized binding as a JSX tag.

## How the tests followed it

- **`extensions-catalogs.test.ts`** — the per-entry "declares at least one integration" assertion is
  no longer an invariant. The real one it was bundled with (every declared id resolves to a known
  MCP entry) is kept, plus a guard that some entry still declares one, so the loop cannot pass
  vacuously.
- **`recommended-automation-rail.test.ts`**, **`recommended-automations-rail.test.tsx`**,
  **`recommended-automations.test.tsx`** — the proven/Beta membership, ordering and counts follow
  `featuredAutomationIds`. `github-repo-monitor` is now in **neither** rail group: it is Beta, and
  it is set up by a host form rather than a conversation. That is existing rail behaviour, already
  asserted for `upstream-fork-sync` and `incident-retrospective-drafter`; the case now says so for
  the monitor too.
- **`automation-catalog.test.ts`**, **`recommended-automations.test.tsx`** — new cases for the icon
  derivation, including the unknown-slug fallback, and for a card rendering the glyph rather than a
  logo stack.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

`src/manifests/` is also being edited on `vasco/remove-unreachable-frontend-modules` (repo-picker
`multiple`). That branch is based on a pre-#16717 tree and touches different hunks, so the two are
independent, but `buildCreatePayload` will want a careful merge.

The host still ignores one 0.18.0 addition: `automations/catalog.schema.json` documents `version` as
"present only on entries whose direct setup sends provenance", and nothing yet warns when an entry
publishes a `version` this host would send but the deployment's automation service predates the
`template` field. The service accepts unknown keys today, so this is inert.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.8.0` |
| **Commit** | `496bd784732cd5ab20a3cd3ae8f66bb381204e3f` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-496bd78
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-496bd78
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-496bd78-amd64
ghcr.io/openhands/agent-canvas:vasco-bump-extensions-0.18.0-amd64
ghcr.io/openhands/agent-canvas:pr-16754-amd64
ghcr.io/openhands/agent-canvas:sha-496bd78-arm64
ghcr.io/openhands/agent-canvas:vasco-bump-extensions-0.18.0-arm64
ghcr.io/openhands/agent-canvas:pr-16754-arm64
ghcr.io/openhands/agent-canvas:sha-496bd78
ghcr.io/openhands/agent-canvas:vasco-bump-extensions-0.18.0
ghcr.io/openhands/agent-canvas:pr-16754
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-496bd78`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-496bd78-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->