### PR TITLE
feat: auto-create/reuse LLM provider connections in profile editor

### DIFF
--- a/__tests__/components/settings/llm-profiles/llm-settings-local-view.test.tsx
+++ b/__tests__/components/settings/llm-profiles/llm-settings-local-view.test.tsx
@@ -11,7 +11,10 @@ import {
 import * as useLlmProfilesHook from "#/hooks/query/use-llm-profiles";
 import * as useActivateLlmProfileHook from "#/hooks/mutation/use-activate-llm-profile";
 import * as useSaveLlmProfileHook from "#/hooks/mutation/use-save-llm-profile";
+import * as useProviderConnectionsHook from "#/hooks/query/use-provider-connections";
+import * as useCreateProviderConnectionHook from "#/hooks/mutation/use-create-provider-connection";
 import ProfilesService from "#/api/profiles-service/profiles-service.api";
+import type { ProviderConnection } from "#/api/provider-connections-service/provider-connections-service.api";
 
 vi.mock("#/routes/llm-settings", async () => {
   const React = await vi.importActual<typeof import("react")>("react");
@@ -32,21 +35,25 @@ vi.mock("#/routes/llm-settings", async () => {
       }) => void;
     }) => {
       const initialValueOverridesRef = React.useRef(initialValueOverrides);
-      const initialValuesRef = React.useRef({
+      const initialValuesRef = React.useRef<Record<string, string | boolean>>({
         "llm.model": "openai/gpt-4o",
         "llm.api_key": "test-api-key",
         "llm.base_url": "",
+        "llm.provider_connection_id": "",
         ...(initialValueOverrides ?? {}),
       });
       const [view, setView] = React.useState<"basic" | "all">("basic");
       const [model, setModel] = React.useState(
         String(initialValuesRef.current["llm.model"] ?? ""),
       );
-      const [apiKey] = React.useState(
+      const [apiKey, setApiKey] = React.useState(
         String(initialValuesRef.current["llm.api_key"] ?? ""),
       );
       const [baseUrl] = React.useState(
         String(initialValuesRef.current["llm.base_url"] ?? ""),
+      );
+      const [connection, setConnection] = React.useState(
+        String(initialValuesRef.current["llm.provider_connection_id"] ?? ""),
       );
       const [temperature, setTemperature] = React.useState("0.2");
       React.useEffect(() => {
@@ -55,6 +62,7 @@ vi.mock("#/routes/llm-settings", async () => {
           "llm.model": model,
           "llm.api_key": apiKey,
           "llm.base_url": baseUrl,
+          "llm.provider_connection_id": connection,
         };
         onSaveControlChange?.({
           save: vi.fn(),
@@ -75,7 +83,15 @@ vi.mock("#/routes/llm-settings", async () => {
             };
           },
         });
-      }, [apiKey, baseUrl, model, onSaveControlChange, temperature, view]);
+      }, [
+        apiKey,
+        baseUrl,
+        connection,
+        model,
+        onSaveControlChange,
+        temperature,
+        view,
+      ]);
 
       return (
         <div data-testid="mock-llm-settings-screen">
@@ -100,6 +116,20 @@ vi.mock("#/routes/llm-settings", async () => {
               onChange={(event) => setModel(event.currentTarget.value)}
             />
           ) : null}
+          {view === "basic" ? (
+            <input
+              data-testid="mock-basic-api-key-input"
+              value={apiKey}
+              onChange={(event) => setApiKey(event.currentTarget.value)}
+            />
+          ) : null}
+          {view === "basic" ? (
+            <input
+              data-testid="mock-connection-input"
+              value={connection}
+              onChange={(event) => setConnection(event.currentTarget.value)}
+            />
+          ) : null}
           {view === "all" ? (
             <input
               data-testid="sdk-settings-llm.temperature"
@@ -116,6 +146,8 @@ vi.mock("#/routes/llm-settings", async () => {
 vi.mock("#/hooks/query/use-llm-profiles");
 vi.mock("#/hooks/mutation/use-activate-llm-profile");
 vi.mock("#/hooks/mutation/use-save-llm-profile");
+vi.mock("#/hooks/query/use-provider-connections");
+vi.mock("#/hooks/mutation/use-create-provider-connection");
 vi.mock("#/api/profiles-service/profiles-service.api");
 
 const mockProfiles = [
@@ -184,6 +216,17 @@ function createMockMutationReturn<T>(
 describe("LlmSettingsLocalView", () => {
   const mockActivateMutateAsync = vi.fn();
   const mockSaveMutateAsync = vi.fn();
+  const mockCreateConnectionMutateAsync = vi.fn();
+
+  function setProviderConnections(connections: ProviderConnection[]) {
+    vi.mocked(
+      useProviderConnectionsHook.useProviderConnections,
+    ).mockReturnValue({
+      data: connections,
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useProviderConnectionsHook.useProviderConnections>);
+  }
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -203,6 +246,19 @@ describe("LlmSettingsLocalView", () => {
         ReturnType<typeof useSaveLlmProfileHook.useSaveLlmProfile>
       >(mockSaveMutateAsync),
     );
+
+    vi.mocked(
+      useCreateProviderConnectionHook.useCreateProviderConnection,
+    ).mockReturnValue(
+      createMockMutationReturn<
+        ReturnType<
+          typeof useCreateProviderConnectionHook.useCreateProviderConnection
+        >
+      >(mockCreateConnectionMutateAsync),
+    );
+
+    // Default: no existing connections. Individual tests override this.
+    setProviderConnections([]);
   });
 
   it("renders profile list by default", () => {
@@ -846,6 +902,141 @@ describe("LlmSettingsLocalView", () => {
       expect(savedLlm.temperature).toBe(0.7);
       expect(savedLlm.model).toBe("anthropic/claude-opus-4-5-20251101");
       expect(savedLlm.api_key).toBe("gAAAA_encrypted_key");
+    });
+  });
+
+  describe("provider connection auto-create / reuse", () => {
+    const openaiConnection: ProviderConnection = {
+      id: "conn-openai",
+      display_name: "openai",
+      provider: "openai",
+      base_url: null,
+      created_at: 1,
+      updated_at: 1,
+      api_key_set: true,
+    };
+
+    async function openCreateView(user: ReturnType<typeof userEvent.setup>) {
+      renderWithProviders(<LlmSettingsLocalView />);
+      await user.click(screen.getByTestId("add-llm-profile"));
+      await screen.findByTestId("mock-basic-model-input");
+    }
+
+    it("auto-creates a connection named after the provider and links the profile", async () => {
+      const user = userEvent.setup();
+      mockCreateConnectionMutateAsync.mockResolvedValueOnce({
+        ...openaiConnection,
+        id: "conn-new",
+      });
+      mockSaveMutateAsync.mockResolvedValueOnce({ success: true });
+
+      await openCreateView(user);
+
+      // Choose a provider-prefixed model and enter a key (no connections exist).
+      const modelInput = screen.getByTestId("mock-basic-model-input");
+      await user.clear(modelInput);
+      await user.type(modelInput, "openai/gpt-4o");
+      const keyInput = screen.getByTestId("mock-basic-api-key-input");
+      await user.clear(keyInput);
+      await user.type(keyInput, "sk-secret");
+
+      await waitFor(() =>
+        expect(screen.getByTestId("save-profile-btn")).not.toBeDisabled(),
+      );
+      await user.click(screen.getByTestId("save-profile-btn"));
+
+      await waitFor(() =>
+        expect(mockCreateConnectionMutateAsync).toHaveBeenCalledWith({
+          display_name: "openai",
+          provider: "openai",
+          api_key: "sk-secret",
+          base_url: null,
+        }),
+      );
+
+      const savedLlm = mockSaveMutateAsync.mock.calls[0][0].request.llm;
+      expect(savedLlm.provider_connection_id).toBe("conn-new");
+      // The profile keeps no inline credential once linked.
+      expect(savedLlm.api_key).toBeUndefined();
+      expect(savedLlm.base_url).toBeUndefined();
+    });
+
+    it("reuses an existing same-provider connection without creating a new one", async () => {
+      const user = userEvent.setup();
+      setProviderConnections([openaiConnection]);
+      mockSaveMutateAsync.mockResolvedValueOnce({ success: true });
+
+      await openCreateView(user);
+
+      const modelInput = screen.getByTestId("mock-basic-model-input");
+      await user.clear(modelInput);
+      await user.type(modelInput, "openai/gpt-4o");
+
+      await waitFor(() =>
+        expect(screen.getByTestId("save-profile-btn")).not.toBeDisabled(),
+      );
+      await user.click(screen.getByTestId("save-profile-btn"));
+
+      await waitFor(() => expect(mockSaveMutateAsync).toHaveBeenCalled());
+      expect(mockCreateConnectionMutateAsync).not.toHaveBeenCalled();
+      const savedLlm = mockSaveMutateAsync.mock.calls[0][0].request.llm;
+      expect(savedLlm.provider_connection_id).toBe("conn-openai");
+      expect(savedLlm.api_key).toBeUndefined();
+    });
+
+    it("aborts the save when connection creation fails", async () => {
+      const user = userEvent.setup();
+      mockCreateConnectionMutateAsync.mockRejectedValueOnce(
+        new AxiosError("boom"),
+      );
+
+      await openCreateView(user);
+
+      const modelInput = screen.getByTestId("mock-basic-model-input");
+      await user.clear(modelInput);
+      await user.type(modelInput, "openai/gpt-4o");
+      const keyInput = screen.getByTestId("mock-basic-api-key-input");
+      await user.clear(keyInput);
+      await user.type(keyInput, "sk-secret");
+
+      await waitFor(() =>
+        expect(screen.getByTestId("save-profile-btn")).not.toBeDisabled(),
+      );
+      await user.click(screen.getByTestId("save-profile-btn"));
+
+      await waitFor(() =>
+        expect(mockCreateConnectionMutateAsync).toHaveBeenCalled(),
+      );
+      expect(mockSaveMutateAsync).not.toHaveBeenCalled();
+    });
+
+    it("keeps the profile inline when the user selects the inline-key option", async () => {
+      const user = userEvent.setup();
+      mockSaveMutateAsync.mockResolvedValueOnce({ success: true });
+
+      await openCreateView(user);
+
+      const modelInput = screen.getByTestId("mock-basic-model-input");
+      await user.clear(modelInput);
+      await user.type(modelInput, "openai/gpt-4o");
+      const keyInput = screen.getByTestId("mock-basic-api-key-input");
+      await user.clear(keyInput);
+      await user.type(keyInput, "sk-secret");
+      // Explicitly opt out of connections.
+      const connectionInput = screen.getByTestId("mock-connection-input");
+      await user.clear(connectionInput);
+      await user.type(connectionInput, "__none__");
+
+      await waitFor(() =>
+        expect(screen.getByTestId("save-profile-btn")).not.toBeDisabled(),
+      );
+      await user.click(screen.getByTestId("save-profile-btn"));
+
+      await waitFor(() => expect(mockSaveMutateAsync).toHaveBeenCalled());
+      expect(mockCreateConnectionMutateAsync).not.toHaveBeenCalled();
+      const savedLlm = mockSaveMutateAsync.mock.calls[0][0].request.llm;
+      expect(savedLlm.api_key).toBe("sk-secret");
+      expect(savedLlm.provider_connection_id).toBeNull();
     });
   });
 });

--- a/__tests__/routes/llm-settings.test.tsx
+++ b/__tests__/routes/llm-settings.test.tsx
@@ -432,6 +432,92 @@ describe("LlmSettingsScreen - provider connection selector", () => {
       await screen.findByTestId("llm-provider-connection-input"),
     ).toBeInTheDocument();
   });
+
+  it("shows the selector on local even with zero connections", async () => {
+    // With no explicit link and no connections, a provider-prefixed model
+    // still surfaces the selector so the "create for <provider>" default is
+    // offered up front — this is what makes connections the default path. The
+    // key field stays visible in "create" mode so the new connection can be
+    // seeded with a key.
+    vi.spyOn(activeBackendContext, "useActiveBackend").mockReturnValue({
+      backend: mockLocalBackend,
+    } as ReturnType<typeof activeBackendContext.useActiveBackend>);
+    vi.spyOn(ProviderConnectionsService, "list").mockResolvedValue([]);
+
+    renderLlmSettingsScreen({
+      embedded: true,
+      hideSaveButton: true,
+      showProviderConnection: true,
+      initialValueOverrides: {
+        "llm.model": "openai/gpt-4o",
+        "llm.provider_connection_id": "",
+      },
+    });
+
+    await screen.findByTestId("llm-settings-screen");
+    expect(
+      await screen.findByTestId("llm-provider-connection-input"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("llm-api-key-input")).toBeInTheDocument();
+  });
+
+  it("hides the inline key field when linked to an existing connection", async () => {
+    // A same-provider connection already exists, so the default resolves to
+    // "link": the credential lives on the connection and the inline key field
+    // is hidden (the reuse case from the feature spec).
+    vi.spyOn(activeBackendContext, "useActiveBackend").mockReturnValue({
+      backend: mockLocalBackend,
+    } as ReturnType<typeof activeBackendContext.useActiveBackend>);
+    vi.spyOn(ProviderConnectionsService, "list").mockResolvedValue([
+      {
+        id: "conn-openai",
+        display_name: "openai",
+        provider: "openai",
+        base_url: null,
+        created_at: 1,
+        updated_at: 1,
+        api_key_set: true,
+      },
+    ]);
+
+    renderLlmSettingsScreen({
+      embedded: true,
+      hideSaveButton: true,
+      showProviderConnection: true,
+      initialValueOverrides: {
+        "llm.model": "openai/gpt-4o",
+        "llm.provider_connection_id": "",
+      },
+    });
+
+    await screen.findByTestId("llm-settings-screen");
+    await screen.findByTestId("llm-provider-connection-input");
+    await waitFor(() =>
+      expect(screen.queryByTestId("llm-api-key-input")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("shows the inline key field when the user opts out of connections", async () => {
+    vi.spyOn(activeBackendContext, "useActiveBackend").mockReturnValue({
+      backend: mockLocalBackend,
+    } as ReturnType<typeof activeBackendContext.useActiveBackend>);
+    vi.spyOn(ProviderConnectionsService, "list").mockResolvedValue([]);
+
+    renderLlmSettingsScreen({
+      embedded: true,
+      hideSaveButton: true,
+      showProviderConnection: true,
+      initialValueOverrides: {
+        "llm.model": "openai/gpt-4o",
+        // Explicit "none" sentinel = inline credentials.
+        "llm.provider_connection_id": "__none__",
+      },
+    });
+
+    await screen.findByTestId("llm-settings-screen");
+    await screen.findByTestId("llm-provider-connection-input");
+    expect(screen.getByTestId("llm-api-key-input")).toBeInTheDocument();
+  });
 });
 
 describe("LlmSettingsRoute - backend mode rendering", () => {

--- a/src/components/features/settings/llm-profiles/llm-settings-local-view.tsx
+++ b/src/components/features/settings/llm-profiles/llm-settings-local-view.tsx
@@ -16,7 +16,9 @@ import {
 import { useActiveBackend } from "#/contexts/active-backend-context";
 import { useSaveLlmProfile } from "#/hooks/mutation/use-save-llm-profile";
 import { useActivateLlmProfile } from "#/hooks/mutation/use-activate-llm-profile";
+import { useCreateProviderConnection } from "#/hooks/mutation/use-create-provider-connection";
 import { useLlmProfiles } from "#/hooks/query/use-llm-profiles";
+import { useProviderConnections } from "#/hooks/query/use-provider-connections";
 import { useSettings } from "#/hooks/query/use-settings";
 import { useAgentSettingsSchema } from "#/hooks/query/use-agent-settings-schema";
 import { DEFAULT_SETTINGS } from "#/services/settings";
@@ -46,6 +48,12 @@ import {
   normalizeFieldValue,
   SettingsFormValues,
 } from "#/utils/sdk-settings-schema";
+import {
+  NO_PROVIDER_CONNECTION,
+  resolveProviderConnectionSelection,
+  type ProviderConnectionSelection,
+} from "#/utils/resolve-provider-connection";
+import { getApiErrorMessage } from "#/utils/api-error-message";
 import { BackNavButton } from "#/components/shared/buttons/back-nav-button";
 import { Typography } from "#/ui/typography";
 import { useSettingsSectionHeader } from "#/contexts/settings-section-header-context";
@@ -93,7 +101,9 @@ export function LlmSettingsLocalView() {
   const { setHideSectionHeader } = useSettingsSectionHeader();
   const saveProfile = useSaveLlmProfile();
   const activateProfile = useActivateLlmProfile();
+  const createConnection = useCreateProviderConnection();
   const { data: profilesData } = useLlmProfiles();
+  const { data: providerConnections } = useProviderConnections();
   const { data: settings } = useSettings();
   const { data: agentSchema } = useAgentSettingsSchema(
     settings?.agent_settings_schema,
@@ -206,11 +216,16 @@ export function LlmSettingsLocalView() {
         }
 
         // Seed the provider-connection link explicitly (it is excluded from the
-        // schema-driven inputs), so an unchanged profile keeps its connection.
+        // schema-driven inputs). A linked profile keeps its connection id; a
+        // legacy inline profile is seeded to the explicit "none" sentinel rather
+        // than an empty value so editing it does not trigger the create/reuse
+        // default (that default is reserved for brand-new profiles, which start
+        // empty). The user can still opt into a connection from the selector.
         initialValues[LLM_PROVIDER_CONNECTION_KEY] =
-          typeof config.provider_connection_id === "string"
+          typeof config.provider_connection_id === "string" &&
+          config.provider_connection_id
             ? config.provider_connection_id
-            : "";
+            : NO_PROVIDER_CONNECTION;
 
         setEditingProfile({ profile, initialValues, baseConfig: config });
         setProfileName(profile.name);
@@ -286,12 +301,46 @@ export function LlmSettingsLocalView() {
     const llmConfig: Record<string, unknown> = { ...baseConfig, ...dirtyLlm };
     const authType = resolveLlmAuthType(llmConfig.auth_type);
 
-    // A profile linked to a provider connection sources its credential from the
-    // connection, so it never carries an inline api_key / base_url. The form
-    // value is the source of truth: empty (or absent) means "not linked".
-    const connectionId = isLocal
-      ? String(saveControl.values[LLM_PROVIDER_CONNECTION_KEY] ?? "").trim()
-      : "";
+    const model = typeof llmConfig.model === "string" ? llmConfig.model : "";
+
+    // Resolve what the profile should do with credentials from the selected
+    // provider-connection option, the model's provider, and the existing
+    // connections. Provider selection doubles as connection selection: with no
+    // explicit choice this reuses a same-provider connection or offers to
+    // create one. Cloud has no connection endpoints, so it always stays inline.
+    const selection: ProviderConnectionSelection = isLocal
+      ? resolveProviderConnectionSelection({
+          model,
+          storedValue: String(
+            saveControl.values[LLM_PROVIDER_CONNECTION_KEY] ?? "",
+          ),
+          connections: providerConnections ?? [],
+        })
+      : {
+          mode: "none",
+          provider: "",
+          selectedKey: NO_PROVIDER_CONNECTION,
+          isOrphanedLink: false,
+        };
+
+    // A freshly typed key (edit mode merges the existing encrypted key into
+    // llmConfig, so only `dirtyLlm` reflects what the user just entered).
+    const typedKey =
+      typeof dirtyLlm.api_key === "string" ? dirtyLlm.api_key.trim() : "";
+
+    // For "create" mode we need a key to seed the new connection; without one
+    // there is nothing to create, so fall back to inline behavior (identical to
+    // today's blank-key profile) rather than erroring.
+    const connectionMode =
+      selection.mode === "create" && !typedKey ? "none" : selection.mode;
+
+    // Deferred connection creation, performed in the async block below so its
+    // failure is surfaced with the server message and aborts the save.
+    let pendingConnection: {
+      provider: string;
+      apiKey: string;
+      baseUrl: string | null;
+    } | null = null;
 
     if (authType === LLM_AUTH_TYPE_SUBSCRIPTION) {
       llmConfig.auth_type = LLM_AUTH_TYPE_SUBSCRIPTION;
@@ -299,10 +348,24 @@ export function LlmSettingsLocalView() {
       llmConfig.provider_connection_id = null;
       delete llmConfig.api_key;
       delete llmConfig.base_url;
-    } else if (connectionId) {
+    } else if (connectionMode === "link" && selection.connectionId) {
       llmConfig.auth_type = LLM_AUTH_TYPE_API_KEY;
       llmConfig.subscription_vendor = null;
-      llmConfig.provider_connection_id = connectionId;
+      llmConfig.provider_connection_id = selection.connectionId;
+      delete llmConfig.api_key;
+      delete llmConfig.base_url;
+    } else if (connectionMode === "create") {
+      llmConfig.auth_type = LLM_AUTH_TYPE_API_KEY;
+      llmConfig.subscription_vendor = null;
+      const baseUrl =
+        typeof llmConfig.base_url === "string" ? llmConfig.base_url.trim() : "";
+      pendingConnection = {
+        provider: selection.provider,
+        apiKey: typedKey,
+        baseUrl: baseUrl || null,
+      };
+      // The connection becomes the source of truth; the profile keeps no inline
+      // copy. provider_connection_id is set after creation succeeds.
       delete llmConfig.api_key;
       delete llmConfig.base_url;
     } else {
@@ -337,11 +400,15 @@ export function LlmSettingsLocalView() {
       }
     }
 
-    const model = typeof llmConfig.model === "string" ? llmConfig.model : "";
     if (!model) {
       displayErrorToast(t(I18nKey.SETTINGS$MODEL_REQUIRED));
       return;
     }
+
+    // Once creation succeeds (below) the credential lives on the connection, so
+    // the profile is treated as linked for preflight / save purposes.
+    const linksConnection =
+      connectionMode === "link" || connectionMode === "create";
 
     const trimmedName = profileName.trim();
     const originalName = editingProfile?.profile.name;
@@ -360,7 +427,7 @@ export function LlmSettingsLocalView() {
       // misconfigured profile before saving it. Skip it for connection-linked
       // profiles: their credential lives on the provider connection, not
       // inline, so there is nothing on this profile to pre-flight here.
-      if (!connectionId) {
+      if (!linksConnection) {
         const preflight = await ProfilesService.validateProfile(trimmedName, {
           llm: llmConfig as SaveProfileRequest["llm"],
           include_secrets: true,
@@ -373,6 +440,26 @@ export function LlmSettingsLocalView() {
       }
 
       setIsValidating(false);
+
+      // Auto-create the shared provider connection (named after the provider)
+      // before saving, then link the profile to it. Surfaces the server message
+      // (e.g. a validation error) and aborts the save on failure.
+      if (pendingConnection) {
+        try {
+          const created = await createConnection.mutateAsync({
+            display_name: pendingConnection.provider,
+            provider: pendingConnection.provider,
+            api_key: pendingConnection.apiKey,
+            base_url: pendingConnection.baseUrl,
+          });
+          llmConfig.provider_connection_id = created.id;
+        } catch (error) {
+          displayErrorToast(
+            getApiErrorMessage(error, t(I18nKey.ERROR$GENERIC)),
+          );
+          return;
+        }
+      }
 
       // If editing and name changed, rename the profile first
       if (isRename) {
@@ -415,8 +502,10 @@ export function LlmSettingsLocalView() {
     viewMode,
     editingProfile,
     profilesData?.active_profile,
+    providerConnections,
     saveProfile,
     activateProfile,
+    createConnection,
     t,
     handleBackToList,
   ]);

--- a/src/components/features/settings/llm-profiles/provider-connection-modal.tsx
+++ b/src/components/features/settings/llm-profiles/provider-connection-modal.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { BrandButton } from "#/components/features/settings/brand-button";
 import { SettingsInput } from "#/components/features/settings/settings-input";
+import { SettingsDropdownInput } from "#/components/features/settings/settings-dropdown-input";
 import { KeyStatusIcon } from "#/components/features/settings/key-status-icon";
+import { useSearchProviders } from "#/hooks/query/use-search-providers";
 import { LoadingSpinner } from "#/components/shared/loading-spinner";
 import { ApiKeyModalBase } from "#/components/features/settings/api-key-modal-base";
 import type { ProviderConnection } from "#/api/provider-connections-service/provider-connections-service.api";
@@ -43,12 +45,23 @@ export function ProviderConnectionModal({
   const { t } = useTranslation("openhands");
   const createConnection = useCreateProviderConnection();
   const updateConnection = useUpdateProviderConnection();
+  const { data: providers = [] } = useSearchProviders();
   const firstFieldRef = useRef<HTMLInputElement>(null);
 
   const [displayName, setDisplayName] = useState("");
   const [provider, setProvider] = useState(DEFAULT_PROVIDER);
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
+
+  // Provider options come from the same litellm source as the model selector.
+  // `custom` is always offered so a provider missing from the catalog can still
+  // be used; `allowsCustomValue` also lets the user type a free-form value.
+  const providerItems = useMemo(() => {
+    const names = new Set<string>([DEFAULT_PROVIDER]);
+    for (const p of providers) names.add(p.name);
+    if (provider) names.add(provider);
+    return Array.from(names).map((name) => ({ key: name, label: name }));
+  }, [providers, provider]);
 
   const isOpen = isCreate || Boolean(connection);
   const keyAlreadySet = Boolean(connection?.api_key_set);
@@ -163,13 +176,18 @@ export function ProviderConnectionModal({
           onChange={setDisplayName}
           required
         />
-        <SettingsInput
+        <SettingsDropdownInput
           testId="provider-connection-provider-input"
+          name="provider-connection-provider"
           label={t(I18nKey.SETTINGS$PROVIDER_CONNECTION_PROVIDER)}
-          type="text"
-          className="w-full"
-          value={provider}
-          onChange={setProvider}
+          items={providerItems}
+          selectedKey={provider}
+          allowsCustomValue
+          isClearable={false}
+          onSelectionChange={(key) => {
+            if (typeof key === "string") setProvider(key);
+          }}
+          onInputChange={setProvider}
         />
         <SettingsInput
           testId="provider-connection-api-key-input"

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -39251,5 +39251,39 @@
     "uk": "Підключення \"{{name}}\" оновлено",
     "zh-CN": "已更新连接“{{name}}”",
     "zh-TW": "已更新連線「{{name}}」"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_CREATE_NEW": {
+    "ar": "إنشاء اتصال جديد لـ {{provider}}",
+    "ca": "Crea una connexió nova per a {{provider}}",
+    "de": "Neue Verbindung für {{provider}} erstellen",
+    "en": "Create new connection for {{provider}}",
+    "es": "Crear nueva conexión para {{provider}}",
+    "fr": "Créer une connexion pour {{provider}}",
+    "it": "Crea nuova connessione per {{provider}}",
+    "ja": "{{provider}} の新しい接続を作成",
+    "ko-KR": "{{provider}}에 대한 새 연결 만들기",
+    "no": "Opprett ny tilkobling for {{provider}}",
+    "pt": "Criar nova conexão para {{provider}}",
+    "tr": "{{provider}} için yeni bağlantı oluştur",
+    "uk": "Створити нове підключення для {{provider}}",
+    "zh-CN": "为 {{provider}} 创建新连接",
+    "zh-TW": "為 {{provider}} 建立新連線"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_USE_INLINE_KEY": {
+    "ar": "استخدام مفتاح خاص بهذا الملف فقط",
+    "ca": "Usa una clau només per a aquest perfil",
+    "de": "Einen Schlüssel nur für dieses Profil verwenden",
+    "en": "Use a key just for this profile",
+    "es": "Usar una clave solo para este perfil",
+    "fr": "Utiliser une clé propre à ce profil",
+    "it": "Usa una chiave solo per questo profilo",
+    "ja": "このプロファイル専用のキーを使用",
+    "ko-KR": "이 프로필 전용 키 사용",
+    "no": "Bruk en nøkkel bare for denne profilen",
+    "pt": "Usar uma chave só para este perfil",
+    "tr": "Yalnızca bu profil için bir anahtar kullan",
+    "uk": "Використовувати ключ лише для цього профілю",
+    "zh-CN": "仅为此配置使用单独密钥",
+    "zh-TW": "僅為此設定檔使用單獨金鑰"
   }
 }

--- a/src/mocks/settings-handlers.ts
+++ b/src/mocks/settings-handlers.ts
@@ -169,6 +169,21 @@ const MOCK_AGENT_SETTINGS_SCHEMA: NonNullable<
           secret: false,
           required: false,
         },
+        {
+          key: "llm.provider_connection_id",
+          label: "Provider connection",
+          description:
+            "Shared provider connection this profile links to for its credential.",
+          section: "llm",
+          section_label: "LLM",
+          value_type: "string",
+          default: null,
+          choices: [],
+          depends_on: [],
+          prominence: "minor",
+          secret: false,
+          required: false,
+        },
       ],
     },
     {

--- a/src/routes/llm-settings.tsx
+++ b/src/routes/llm-settings.tsx
@@ -38,12 +38,14 @@ import {
   FREE_OPENHANDS_MODEL_NOTE,
   isFreeOpenHandsModel,
 } from "#/utils/format-model-name";
+import {
+  NEW_PROVIDER_CONNECTION,
+  NO_PROVIDER_CONNECTION,
+  resolveProviderConnectionSelection,
+} from "#/utils/resolve-provider-connection";
 
 /** Form-values key for the shared provider connection a profile links to. */
 export const LLM_PROVIDER_CONNECTION_KEY = "llm.provider_connection_id";
-
-/** Dropdown sentinel for "no provider connection" (an inline key is used). */
-const NO_PROVIDER_CONNECTION = "__none__";
 
 const LLM_EXCLUDED_KEYS = new Set([
   "llm.model",
@@ -250,27 +252,31 @@ export function LlmSettingsScreen({
         ? apiKeyValue.length > 0
         : Boolean(settings?.llm_api_key_set);
 
-      // A profile linked to a provider connection reads its api_key / base_url
-      // from that connection, so the inline key + base URL inputs are hidden.
+      // Resolve which connection option is effectively selected from the
+      // stored form value + the model's provider + the existing connections.
+      // An empty stored value means "no explicit choice yet", in which case the
+      // resolver defaults to reusing a same-provider connection, else offering
+      // to create one — so provider selection doubles as connection selection.
       const connectionValue =
         typeof values[LLM_PROVIDER_CONNECTION_KEY] === "string"
           ? values[LLM_PROVIDER_CONNECTION_KEY]
           : "";
-      const isLinkedToConnection = Boolean(connectionValue);
-      // Show the selector whenever connections can be linked here. Include the
-      // linked case so a profile pointing at an orphaned connection (its only
-      // connection deleted, or the list still loading) still exposes a control
-      // to unlink — otherwise the API key / base URL inputs stay hidden with no
-      // way to recover.
+      const selection = resolveProviderConnectionSelection({
+        model: modelValue,
+        storedValue: connectionValue,
+        connections: connectionOptions,
+      });
+      // A profile linked to an *existing* connection reads its api_key /
+      // base_url from that connection, so the inline key + base URL inputs are
+      // hidden. In "create" mode the connection does not exist yet, so the key
+      // (and optional base URL) must be entered here to seed it; in "none" mode
+      // the profile keeps its own inline creds. So only "link" hides them.
+      const hideInlineCredentials = selection.mode === "link";
+      // Show the selector for the local profile editor unless the user is on
+      // subscription auth. It stays visible even with zero connections so the
+      // "create for <provider>" default is offered up front.
       const showConnectionSelector =
-        showProviderConnection &&
-        !isSubscriptionAuth &&
-        (isLinkedToConnection || connectionOptions.length > 0);
-      // Surface an orphaned link (a selected id absent from the fetched list)
-      // as its own option so the dropdown reflects it and can be cleared.
-      const isOrphanedLink =
-        isLinkedToConnection &&
-        !connectionOptions.some((c) => c.id === connectionValue);
+        showProviderConnection && !isSubscriptionAuth;
 
       const renderConnectionSelector = () => (
         <SettingsDropdownInput
@@ -278,28 +284,41 @@ export function LlmSettingsScreen({
           name={LLM_PROVIDER_CONNECTION_KEY}
           label={t(I18nKey.SETTINGS$PROVIDER_CONNECTION_SELECT_LABEL)}
           items={[
-            {
-              key: NO_PROVIDER_CONNECTION,
-              label: t(I18nKey.SETTINGS$MCP_AUTH_MODE_NONE),
-            },
             ...connectionOptions.map((connection) => ({
               key: connection.id,
               label: connection.display_name,
             })),
-            ...(isOrphanedLink
+            // Offer to create a new connection for the model's provider when no
+            // existing connection already covers it.
+            ...(selection.provider &&
+            !connectionOptions.some((c) => c.provider === selection.provider)
+              ? [
+                  {
+                    key: NEW_PROVIDER_CONNECTION,
+                    label: t(I18nKey.SETTINGS$PROVIDER_CONNECTION_CREATE_NEW, {
+                      provider: selection.provider,
+                    }),
+                  },
+                ]
+              : []),
+            {
+              key: NO_PROVIDER_CONNECTION,
+              label: t(I18nKey.SETTINGS$PROVIDER_CONNECTION_USE_INLINE_KEY),
+            },
+            // Surface an orphaned link (a selected id absent from the fetched
+            // list) as its own option so it can be seen and cleared.
+            ...(selection.isOrphanedLink
               ? [{ key: connectionValue, label: connectionValue }]
               : []),
           ]}
-          selectedKey={connectionValue || NO_PROVIDER_CONNECTION}
+          selectedKey={selection.selectedKey}
           isClearable={false}
           isDisabled={isDisabled}
           onSelectionChange={(selectedKey) => {
-            const next =
-              typeof selectedKey === "string" &&
-              selectedKey !== NO_PROVIDER_CONNECTION
-                ? selectedKey
-                : "";
-            onChange(LLM_PROVIDER_CONNECTION_KEY, next);
+            onChange(
+              LLM_PROVIDER_CONNECTION_KEY,
+              typeof selectedKey === "string" ? selectedKey : "",
+            );
           }}
         />
       );
@@ -446,11 +465,11 @@ export function LlmSettingsScreen({
 
                   {showConnectionSelector ? renderConnectionSelector() : null}
 
-                  {showOpenHandsApiKeyHelp && !isLinkedToConnection ? (
+                  {showOpenHandsApiKeyHelp && !hideInlineCredentials ? (
                     <OpenHandsApiKeyHelp testId="openhands-api-key-help" />
                   ) : null}
 
-                  {isLinkedToConnection
+                  {hideInlineCredentials
                     ? null
                     : renderApiKeyInput(
                         // eslint-disable-next-line i18next/no-literal-string -- DOM id, not user-facing
@@ -483,7 +502,7 @@ export function LlmSettingsScreen({
                     isDisabled={isDisabled}
                   />
 
-                  {showOpenHandsApiKeyHelp && !isLinkedToConnection ? (
+                  {showOpenHandsApiKeyHelp && !hideInlineCredentials ? (
                     <>
                       {isFreeOpenHandsModel(modelValue) ? (
                         <OpenHandsFreeModelsNote />
@@ -494,7 +513,7 @@ export function LlmSettingsScreen({
 
                   {showConnectionSelector ? renderConnectionSelector() : null}
 
-                  {isLinkedToConnection ? null : (
+                  {hideInlineCredentials ? null : (
                     <SettingsInput
                       testId="base-url-input"
                       label={t(I18nKey.SETTINGS$BASE_URL)}
@@ -508,7 +527,7 @@ export function LlmSettingsScreen({
                     />
                   )}
 
-                  {isLinkedToConnection
+                  {hideInlineCredentials
                     ? null
                     : renderApiKeyInput(
                         // eslint-disable-next-line i18next/no-literal-string -- DOM id, not user-facing

--- a/src/utils/resolve-provider-connection.test.ts
+++ b/src/utils/resolve-provider-connection.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+  NEW_PROVIDER_CONNECTION,
+  NO_PROVIDER_CONNECTION,
+  findConnectionForProvider,
+  resolveProviderConnectionSelection,
+} from "./resolve-provider-connection";
+import type { ProviderConnection } from "#/api/provider-connections-service/provider-connections-service.api";
+
+const makeConnection = (
+  overrides: Partial<ProviderConnection> = {},
+): ProviderConnection => ({
+  id: "conn-openai",
+  display_name: "OpenAI",
+  provider: "openai",
+  base_url: null,
+  created_at: 1,
+  updated_at: 1,
+  api_key_set: true,
+  ...overrides,
+});
+
+describe("findConnectionForProvider", () => {
+  it("matches on the provider field, not the display name", () => {
+    const renamed = makeConnection({ display_name: "Work key" });
+    expect(findConnectionForProvider([renamed], "openai")).toBe(renamed);
+  });
+
+  it("returns undefined for an empty provider", () => {
+    expect(findConnectionForProvider([makeConnection()], "")).toBeUndefined();
+  });
+
+  it("returns undefined when no connection matches", () => {
+    expect(
+      findConnectionForProvider([makeConnection()], "anthropic"),
+    ).toBeUndefined();
+  });
+});
+
+describe("resolveProviderConnectionSelection", () => {
+  describe("no explicit choice (empty storedValue)", () => {
+    it("reuses an existing connection for the model's provider", () => {
+      const connection = makeConnection();
+      const result = resolveProviderConnectionSelection({
+        model: "openai/gpt-4o",
+        storedValue: "",
+        connections: [connection],
+      });
+      expect(result).toMatchObject({
+        mode: "link",
+        connectionId: "conn-openai",
+        selectedKey: "conn-openai",
+        provider: "openai",
+        isOrphanedLink: false,
+      });
+    });
+
+    it("defaults to create when the provider is known but has no connection", () => {
+      const result = resolveProviderConnectionSelection({
+        model: "anthropic/claude-3",
+        storedValue: "",
+        connections: [makeConnection()],
+      });
+      expect(result).toMatchObject({
+        mode: "create",
+        selectedKey: NEW_PROVIDER_CONNECTION,
+        provider: "anthropic",
+      });
+    });
+
+    it("falls back to inline when the model has no provider prefix", () => {
+      const result = resolveProviderConnectionSelection({
+        model: "gpt-4o",
+        storedValue: "",
+        connections: [],
+      });
+      expect(result).toMatchObject({
+        mode: "none",
+        selectedKey: NO_PROVIDER_CONNECTION,
+        provider: "",
+      });
+    });
+  });
+
+  describe("explicit sentinels", () => {
+    it("honors an explicit None even when a match exists", () => {
+      const result = resolveProviderConnectionSelection({
+        model: "openai/gpt-4o",
+        storedValue: NO_PROVIDER_CONNECTION,
+        connections: [makeConnection()],
+      });
+      expect(result.mode).toBe("none");
+      expect(result.selectedKey).toBe(NO_PROVIDER_CONNECTION);
+    });
+
+    it("keeps create mode for an explicit New with a known provider", () => {
+      const result = resolveProviderConnectionSelection({
+        model: "openai/gpt-4o",
+        storedValue: NEW_PROVIDER_CONNECTION,
+        connections: [],
+      });
+      expect(result).toMatchObject({
+        mode: "create",
+        selectedKey: NEW_PROVIDER_CONNECTION,
+        provider: "openai",
+      });
+    });
+
+    it("degrades an explicit New to inline when the provider is unknown", () => {
+      const result = resolveProviderConnectionSelection({
+        model: "gpt-4o",
+        storedValue: NEW_PROVIDER_CONNECTION,
+        connections: [],
+      });
+      expect(result.mode).toBe("none");
+      expect(result.selectedKey).toBe(NO_PROVIDER_CONNECTION);
+    });
+  });
+
+  describe("explicit connection id", () => {
+    it("links to an existing connection id", () => {
+      const connection = makeConnection({ id: "conn-x", provider: "custom" });
+      const result = resolveProviderConnectionSelection({
+        model: "openai/gpt-4o",
+        storedValue: "conn-x",
+        connections: [connection],
+      });
+      expect(result).toMatchObject({
+        mode: "link",
+        connectionId: "conn-x",
+        isOrphanedLink: false,
+      });
+    });
+
+    it("flags an orphaned link when the id is absent from the list", () => {
+      const result = resolveProviderConnectionSelection({
+        model: "openai/gpt-4o",
+        storedValue: "conn-gone",
+        connections: [],
+      });
+      expect(result).toMatchObject({
+        mode: "link",
+        connectionId: "conn-gone",
+        isOrphanedLink: true,
+      });
+    });
+  });
+});

--- a/src/utils/resolve-provider-connection.ts
+++ b/src/utils/resolve-provider-connection.ts
@@ -1,0 +1,155 @@
+import type { ProviderConnection } from "#/api/provider-connections-service/provider-connections-service.api";
+import { extractModelAndProvider } from "#/utils/extract-model-and-provider";
+
+/**
+ * Dropdown sentinel for "no provider connection" — the profile keeps its own
+ * inline api_key / base_url (today's behavior).
+ */
+export const NO_PROVIDER_CONNECTION = "__none__";
+
+/**
+ * Dropdown sentinel for "create a new provider connection for this model's
+ * provider on save". The actual connection is created lazily in the save flow
+ * (see LlmSettingsLocalView), so nothing is persisted until the profile is
+ * saved.
+ */
+export const NEW_PROVIDER_CONNECTION = "__new__";
+
+/**
+ * What the profile should do with credentials, derived from the current model,
+ * the connection the user explicitly picked (if any), and the connections that
+ * exist. This is a pure function so it can drive both the editor UI (which
+ * option is selected, whether to show the inline key field) and the save flow
+ * (link an existing connection, create one, or keep inline creds) from a single
+ * source of truth.
+ */
+export type ProviderConnectionMode = "none" | "link" | "create";
+
+export interface ProviderConnectionSelection {
+  /** The dropdown key to render as selected. */
+  selectedKey: string;
+  /** What the save flow should do. */
+  mode: ProviderConnectionMode;
+  /** For `mode === "link"`: the connection id to reference. */
+  connectionId?: string;
+  /**
+   * The litellm provider derived from the model (e.g. "openai"). Empty when the
+   * model has no provider prefix. Used to name an auto-created connection and to
+   * find an existing connection for the same provider.
+   */
+  provider: string;
+  /**
+   * True when `selectedKey` points at a connection id that is not in the
+   * supplied list (its connection was deleted, or the list is still loading).
+   * The caller surfaces this as its own dropdown option so the link can be seen
+   * and cleared.
+   */
+  isOrphanedLink: boolean;
+}
+
+const deriveProvider = (model: string): string =>
+  extractModelAndProvider(model).provider || "";
+
+/**
+ * Find an existing connection for a provider. Matching is on the connection's
+ * `provider` field (the stable identity) rather than its display name, so a
+ * user renaming a connection in the manager does not break auto-selection.
+ */
+export function findConnectionForProvider(
+  connections: ProviderConnection[],
+  provider: string,
+): ProviderConnection | undefined {
+  if (!provider) return undefined;
+  return connections.find((connection) => connection.provider === provider);
+}
+
+/**
+ * Resolve which provider-connection option a profile should use.
+ *
+ * `storedValue` is the explicit choice held in form state:
+ * - a real connection id → link to it;
+ * - {@link NO_PROVIDER_CONNECTION} → inline creds (user opted out);
+ * - {@link NEW_PROVIDER_CONNECTION} → create-on-save for the model's provider;
+ * - empty string → no explicit choice yet, so fall back to the default:
+ *   reuse an existing connection for the model's provider, otherwise offer to
+ *   create one, otherwise inline.
+ */
+export function resolveProviderConnectionSelection({
+  model,
+  storedValue,
+  connections,
+}: {
+  model: string;
+  storedValue: string;
+  connections: ProviderConnection[];
+}): ProviderConnectionSelection {
+  const provider = deriveProvider(model);
+
+  if (storedValue === NO_PROVIDER_CONNECTION) {
+    return {
+      selectedKey: NO_PROVIDER_CONNECTION,
+      mode: "none",
+      provider,
+      isOrphanedLink: false,
+    };
+  }
+
+  if (storedValue === NEW_PROVIDER_CONNECTION) {
+    // Creating a new connection only makes sense with a known provider.
+    if (!provider) {
+      return {
+        selectedKey: NO_PROVIDER_CONNECTION,
+        mode: "none",
+        provider,
+        isOrphanedLink: false,
+      };
+    }
+    return {
+      selectedKey: NEW_PROVIDER_CONNECTION,
+      mode: "create",
+      provider,
+      isOrphanedLink: false,
+    };
+  }
+
+  if (storedValue) {
+    // An explicit connection id.
+    const exists = connections.some((c) => c.id === storedValue);
+    return {
+      selectedKey: storedValue,
+      mode: "link",
+      connectionId: storedValue,
+      provider,
+      isOrphanedLink: !exists,
+    };
+  }
+
+  // No explicit choice: prefer reusing an existing connection for the provider.
+  const match = findConnectionForProvider(connections, provider);
+  if (match) {
+    return {
+      selectedKey: match.id,
+      mode: "link",
+      connectionId: match.id,
+      provider,
+      isOrphanedLink: false,
+    };
+  }
+
+  // No match: offer to create one when the provider is known, else inline.
+  if (provider) {
+    return {
+      selectedKey: NEW_PROVIDER_CONNECTION,
+      mode: "create",
+      provider,
+      isOrphanedLink: false,
+    };
+  }
+
+  return {
+    selectedKey: NO_PROVIDER_CONNECTION,
+    mode: "none",
+    provider,
+    isOrphanedLink: false,
+  };
+}


### PR DESCRIPTION
## Summary

Builds on the merged provider-connections work (OpenHands/OpenHands#16616 and software-agent-sdk#4492) to make **provider selection double as connection selection** in the local LLM profile editor, so provider connections are created/reused automatically and become the default credential path.

## Behavior

- **Provider combobox** — the provider-connection modal now offers a provider combobox sourced from the litellm provider catalog (same source as the model selector), with a free-form fallback.
- **Auto-create when missing** — pick a provider-prefixed model, and if no connection exists for that provider the selector defaults to "create for `<provider>`". On save it auto-creates one shared connection named after the provider and links the profile to it (reusable afterwards).
- **Reuse when present** — if a same-provider connection already exists, the profile links to it by default (one connection per provider).
- **API key field show/hide** — hidden when linked to an existing connection (credential lives there); shown in create mode so the new connection can be seeded; shown when the user explicitly picks the inline-key option.
- **Connection combobox still shown** and preset to the matching provider connection; the user can override it.
- **Backwards compatible** — legacy inline profiles seed to the explicit "None" option when edited, so they are not silently migrated. Cloud stays inline (no connection endpoints).

## Design

A single pure resolver, `src/utils/resolve-provider-connection.ts`, drives both the UI (which option is selected, whether to show the key field) and the save flow (link / create / none), so the two cannot drift.

## Testing

- Typecheck clean; ESLint clean; i18n completeness passes (2 new keys across all 15 locales).
- **61 tests passing**: resolver (11), local-view component (32, incl. auto-create/reuse/abort-on-failure/opt-out-inline), route (15, incl. selector always shown, key hidden when linked, key shown when opted out), connections manager.

---
This pull request was created by an AI agent (OpenHands) on behalf of the user.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.8.0` |
| **Commit** | `abe862069df26a4b623076fde5175f5092ca429f` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-abe8620
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-abe8620
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-abe8620-amd64
ghcr.io/openhands/agent-canvas:feature-llm-provider-connection-auto-create-amd64
ghcr.io/openhands/agent-canvas:pr-16756-amd64
ghcr.io/openhands/agent-canvas:sha-abe8620-arm64
ghcr.io/openhands/agent-canvas:feature-llm-provider-connection-auto-create-arm64
ghcr.io/openhands/agent-canvas:pr-16756-arm64
ghcr.io/openhands/agent-canvas:sha-abe8620
ghcr.io/openhands/agent-canvas:feature-llm-provider-connection-auto-create
ghcr.io/openhands/agent-canvas:pr-16756
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-abe8620`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-abe8620-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->