### PR TITLE
fix: rewrite vscode reverse proxy port and protocol

### DIFF
--- a/__tests__/utils/vscode-url-helper.test.ts
+++ b/__tests__/utils/vscode-url-helper.test.ts
@@ -9,6 +9,8 @@ describe("transformVSCodeUrl", () => {
     Object.defineProperty(window, "location", {
       value: {
         hostname: "example.com",
+        port: "8081",
+        protocol: "https:",
       },
       writable: true,
     });
@@ -28,7 +30,17 @@ describe("transformVSCodeUrl", () => {
 
   it("should replace localhost with current hostname when they differ", () => {
     const input = "http://localhost:8080/?tkn=abc123&folder=/workspace";
-    const expected = "http://example.com:8080/?tkn=abc123&folder=/workspace";
+    const expected =
+      "https://example.com:8081/?tkn=abc123&folder=/workspace";
+
+    expect(transformVSCodeUrl(input)).toBe(expected);
+  });
+
+  it("should route localhost VS Code URLs through the reverse proxy port", () => {
+    const input =
+      "http://localhost:8001/?tkn=abc123&folder=/workspace/project";
+    const expected =
+      "https://example.com:8081/?tkn=abc123&folder=/workspace/project";
 
     expect(transformVSCodeUrl(input)).toBe(expected);
   });
@@ -44,6 +56,8 @@ describe("transformVSCodeUrl", () => {
     Object.defineProperty(window, "location", {
       value: {
         hostname: "localhost",
+        port: "8081",
+        protocol: "http:",
       },
       writable: true,
     });

--- a/src/utils/vscode-url-helper.ts
+++ b/src/utils/vscode-url-helper.ts
@@ -2,10 +2,10 @@
  * Helper function to transform VS Code URLs
  *
  * This function checks if a VS Code URL points to localhost and replaces it with
- * the current window's hostname if they don't match.
+ * the current window's hostname, port, and protocol if they don't match.
  *
  * @param vsCodeUrl The original VS Code URL from the backend
- * @returns The transformed URL with the correct hostname
+ * @returns The transformed URL with the correct hostname, port, and protocol
  */
 export function transformVSCodeUrl(vsCodeUrl: string | null): string | null {
   if (!vsCodeUrl) return null;
@@ -18,8 +18,10 @@ export function transformVSCodeUrl(vsCodeUrl: string | null): string | null {
       url.hostname === "localhost" &&
       window.location.hostname !== "localhost"
     ) {
-      // Replace localhost with the current hostname
+      // Replace localhost with the host exposed to the browser.
       url.hostname = window.location.hostname;
+      url.port = window.location.port;
+      url.protocol = window.location.protocol;
       return url.toString();
     }
 


### PR DESCRIPTION
HUMAN:

- [ ] A human has tested these changes.

AGENT:

Verified with `npm run test -- __tests__/utils/vscode-url-helper.test.ts` (6/6 passing). Pre-commit hooks ran eslint, prettier, and staged typecheck on commit.

---

## Why

VS Code URLs returned from localhost-backed sandbox services need to route through the browser-visible reverse proxy host, port, and protocol. Rewriting only the hostname leaves the internal VS Code port (for example `:8001`) in the URL, which fails behind nginx or similar proxies.

## Summary

- Rewrite localhost VS Code URLs to use `window.location.hostname`, `window.location.port`, and `window.location.protocol`.
- Add a regression test covering reverse proxy port replacement behind HTTPS termination.

## Issue Number

Fixes #15347

## How to Test

- `npm run test -- __tests__/utils/vscode-url-helper.test.ts`
- Serve the frontend behind a reverse proxy on a non-localhost host and confirm VS Code tab links use the proxy port/protocol instead of the internal sandbox port.

## Video/Screenshots

Not applicable; URL transformation helper covered by unit tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No migrations or configuration changes.