### PR TITLE
fix: refresh commits after terminal commands

### DIFF
--- a/__tests__/routes/commits-tab.test.tsx
+++ b/__tests__/routes/commits-tab.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -10,6 +10,8 @@ import AgentServerGitService from "#/api/git-service/agent-server-git-service.ap
 import { useAgentState } from "#/hooks/use-agent-state";
 import { AgentState } from "#/types/agent-state";
 import type { GitCommit } from "#/api/open-hands.types";
+import { useEventStore } from "#/stores/use-event-store";
+import type { OHEvent } from "#/stores/use-event-store";
 
 const conversation = {
   conversation_url: "http://localhost:18000/api/conversations/c1",
@@ -58,6 +60,7 @@ describe("Commits Tab", () => {
   const getGitChangesSpy = vi.spyOn(AgentServerGitService, "getGitChanges");
 
   beforeEach(() => {
+    act(() => useEventStore.getState().clearEvents());
     getGitCommitsSpy.mockReset();
     getCommitChangesSpy.mockReset();
     getGitChangesSpy.mockReset();
@@ -176,5 +179,34 @@ describe("Commits Tab", () => {
     expect(
       await screen.findByTestId("commit-list-cap-notice"),
     ).toBeInTheDocument();
+  });
+
+  it("refreshes commits and uncommitted changes after a terminal command", async () => {
+    // Arrange
+    getGitCommitsSpy.mockResolvedValue({ commits: [], hasMore: false });
+    render(<GitCommits />, { wrapper });
+    await waitFor(() => expect(getGitCommitsSpy).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(getGitChangesSpy).toHaveBeenCalledTimes(1));
+
+    const terminalObservation = {
+      id: "terminal-observation-1",
+      timestamp: new Date().toISOString(),
+      source: "environment",
+      tool_name: "terminal",
+      tool_call_id: "tool-call-1",
+      action_id: "action-1",
+      observation: {
+        kind: "TerminalObservation",
+        command: "git commit -m 'done'",
+        output: "committed",
+      },
+    } as unknown as OHEvent;
+
+    // Act
+    act(() => useEventStore.getState().addEvent(terminalObservation));
+
+    // Assert
+    await waitFor(() => expect(getGitCommitsSpy).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(getGitChangesSpy).toHaveBeenCalledTimes(2));
   });
 });

--- a/src/routes/commits-tab.tsx
+++ b/src/routes/commits-tab.tsx
@@ -11,6 +11,7 @@ import { useAgentState } from "#/hooks/use-agent-state";
 import { RuntimeWaitingState } from "#/components/features/conversation-panel/runtime-waiting-state";
 import { ConversationTabEmptyState } from "#/components/features/conversation/conversation-tab-empty-state";
 import { useConversationStore } from "#/stores/conversation-store";
+import { useAutoRefreshFilesOnEdit } from "#/hooks/use-auto-refresh-files-on-edit";
 
 /**
  * The Files tab's "Commits" view: the workspace's recent commit history
@@ -19,6 +20,7 @@ import { useConversationStore } from "#/stores/conversation-store";
  * offered when the agent server supports the commits API.
  */
 function GitCommits() {
+  useAutoRefreshFilesOnEdit();
   const { t } = useTranslation("openhands");
   const { conversationId } = useConversationId();
   const { commits, hasMore, isUnsupported, isLoading, isSuccess } =


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

I ran Agent Canvas locally on Windows and successfully reproduced the Commits tab failing to refresh. After applying the fix, commit 69cc6b4 appeared automatically without switching tabs.

AGENT:

Reproduced the issue locally in Agent Canvas by keeping the Commits tab open while the agent modified and committed a file. Before the fix, the commit completed but the Commits tab continued showing stale uncommitted changes.

After the fix, repeated the same workflow. The new commit appeared immediately and the uncommitted changes refreshed without switching tabs.

Verification performed:

- Targeted tests: 20/20 passed
- TypeScript, ESLint, and Prettier checks passed
- Production build passed
- Full suite: 4896 passed; 5 unrelated existing Windows path-separator failures


---

## Why

The automatic file and Git query refresh hook was mounted only by the Files tab. Because inactive tabs are unmounted, the hook was not active while the Commits tab was selected. Terminal observations such as `git commit` therefore did not invalidate the commit and uncommitted-change queries, leaving a stale diff visible.


## Summary

- Mount the existing automatic refresh hook in the Commits tab.
- Refresh commit history and uncommitted changes after terminal observations.
- Add a regression test covering a terminal `git commit` event while the Commits tab is mounted.


## Issue Number
<!-- Required. The linked issue must carry the `ready-for-dev` label, which
means it has clear acceptance criteria (and, for bugs, reproduction evidence).
If no such issue exists yet, open one using the Bug or Feature Request template
and wait for it to be labeled `ready-for-dev` before opening this PR. -->

Fixes #15692

## How to Test

1. Start Agent Canvas and open a local Git workspace.
2. Keep the Commits tab selected.
3. Ask the agent to modify a file and commit the change.
4. Confirm that the new commit appears automatically.
5. Confirm that stale uncommitted changes disappear without switching tabs.


Automated verification:

```bash
npm test -- __tests__/routes/commits-tab.test.tsx __tests__/hooks/use-auto-refresh-files-on-edit.test.tsx
npm run lint
npm run build
```
## Video/Screenshots
<img width="2056" height="1195" alt="image" src="https://github.com/user-attachments/assets/c071c50b-ef9d-4b70-ae5f-d90b0fce1da9" />

The earlier screenshot showing the stale uncommitted diff after a commit.
The latest screenshot showing commit 69cc6b4 appearing automatically.

After 
<img width="2064" height="1067" alt="image" src="https://github.com/user-attachments/assets/6228540d-120e-4217-b772-fc368499ff27" />



## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The full test suite has five existing Windows-specific path-separator failures. The targeted tests, lint checks, type checking, and production build pass.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.41s · commit e5d7b92  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 6/6 hunks, 2/2 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 4.0% | No direct hunk selected |
| Weakened authentication | 3.0% | No direct hunk selected |
| Weakened authorization | 5.0% | No direct hunk selected |
| Contract regression | 7.0% | No direct hunk selected |
| Data loss | 3.0% | No direct hunk selected |
| Sensitive data disclosure | 3.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 4.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 4.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 3.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 99.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 031f4f078e775c256d75061b444e1540becd3c7d395f893d94adb54a3fea3ea8 -->
<!-- jev-fast-audit:end -->
