### PR TITLE
fix(acp): show configured credentials on remote backends

### DIFF
--- a/__tests__/components/onboarding/setup-acp-secrets-step.test.tsx
+++ b/__tests__/components/onboarding/setup-acp-secrets-step.test.tsx
@@ -277,6 +277,38 @@ describe("SetupAcpSecretsStep", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows saved credentials as configured on a cloud backend", async () => {
+    setRegisteredBackends([
+      {
+        id: "cloud-1",
+        name: "Cloud",
+        host: "https://app.example.dev",
+        apiKey: "key",
+        kind: "cloud",
+      },
+    ]);
+    setActiveSelection({ backendId: "cloud-1", orgId: null });
+    acpAuthStatusMock.mockReturnValue({
+      status: "unknown",
+      isChecking: false,
+      isSupported: false,
+    });
+    vi.spyOn(SecretsService, "getSecrets").mockResolvedValue([
+      { name: "CLAUDE_CODE_OAUTH_TOKEN" },
+    ]);
+
+    renderStep("claude-code");
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("onboarding-acp-auth-configured"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByTestId("onboarding-acp-auth-detected"),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders the Codex subscription blob as a multiline textarea", () => {
     renderStep("codex");
 

--- a/__tests__/components/settings/acp-credentials-section.test.tsx
+++ b/__tests__/components/settings/acp-credentials-section.test.tsx
@@ -1,10 +1,14 @@
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { __resetActiveStoreForTests } from "#/api/backend-registry/active-store";
+import {
+  __resetActiveStoreForTests,
+  setActiveSelection,
+  setRegisteredBackends,
+} from "#/api/backend-registry/active-store";
 import { ActiveBackendProvider } from "#/contexts/active-backend-context";
 import { AcpCredentialsSection } from "#/components/features/settings/acp-credentials-section";
 import { useAcpCredentialForm } from "#/hooks/use-acp-credential-form";
@@ -55,6 +59,7 @@ beforeEach(() => {
   vi.spyOn(SecretsService, "getSecrets").mockResolvedValue([]);
 });
 afterEach(() => {
+  localStorage.clear();
   __resetActiveStoreForTests();
 });
 
@@ -139,6 +144,60 @@ describe("AcpCredentialsSection", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByTestId("settings-acp-auth-checking"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows saved credentials as configured on a cloud backend", async () => {
+    setRegisteredBackends([
+      {
+        id: "cloud-1",
+        name: "Cloud",
+        host: "https://app.example.dev",
+        apiKey: "key",
+        kind: "cloud",
+      },
+    ]);
+    setActiveSelection({ backendId: "cloud-1", orgId: null });
+    acpAuthStatusMock.mockReturnValue({
+      status: "unknown",
+      isChecking: false,
+      isSupported: false,
+    });
+    vi.spyOn(SecretsService, "getSecrets").mockResolvedValue([
+      { name: "CLAUDE_CODE_OAUTH_TOKEN" },
+    ]);
+
+    renderSection("claude-code");
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("settings-acp-auth-configured"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByTestId("settings-acp-auth-detected"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows saved credentials when a local backend cannot classify login", async () => {
+    acpAuthStatusMock.mockReturnValue({
+      status: "unknown",
+      isChecking: false,
+      isSupported: true,
+    });
+    vi.spyOn(SecretsService, "getSecrets").mockResolvedValue([
+      { name: "CLAUDE_CODE_OAUTH_TOKEN" },
+    ]);
+
+    renderSection("claude-code");
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("settings-acp-auth-configured"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByTestId("settings-acp-auth-detected"),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/components/features/onboarding/steps/setup-acp-secrets-step.tsx
+++ b/src/components/features/onboarding/steps/setup-acp-secrets-step.tsx
@@ -86,6 +86,9 @@ export function SetupAcpSecretsStep({
   const providerName = getAcpProviderDisplayName(providerKey) ?? providerKey;
 
   const isAuthenticated = authStatus === "authenticated";
+  const credentialsConfigured = fields.some(
+    (field) => field.secret && secretExists(field.name),
+  );
   // Required when the backend can't fall back to a host login (see component
   // docstring). Cloud never has one; a local backend that probes as logged-out
   // is a fresh container — require credentials there, but stay permissive when
@@ -170,6 +173,7 @@ export function SetupAcpSecretsStep({
       <AcpAuthStatusBanner
         status={authStatus}
         isChecking={isCheckingAuth}
+        credentialsConfigured={credentialsConfigured}
         providerName={providerName}
         testIdPrefix="onboarding-acp-auth"
       />

--- a/src/components/features/settings/acp-auth-status-banner.tsx
+++ b/src/components/features/settings/acp-auth-status-banner.tsx
@@ -1,4 +1,4 @@
-import { Check, Loader2 } from "lucide-react";
+import { Check, KeyRound, Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
 import type { AcpAuthStatus } from "#/hooks/query/use-acp-auth-status";
@@ -6,6 +6,8 @@ import type { AcpAuthStatus } from "#/hooks/query/use-acp-auth-status";
 interface AcpAuthStatusBannerProps {
   status: AcpAuthStatus;
   isChecking: boolean;
+  /** Whether a credential is saved for this provider on the active backend. */
+  credentialsConfigured: boolean;
   providerName: string;
   /**
    * Prefix for the banner test ids, e.g. ``"onboarding-acp-auth"`` →
@@ -17,13 +19,14 @@ interface AcpAuthStatusBannerProps {
 /**
  * Auth-status banner shared by the ACP credential forms (the onboarding step
  * and Settings → Agent): a green "already signed in" banner when the local
- * login probe detects a session, or a spinner while it's checking. Renders
- * nothing otherwise (unauthenticated / unknown / non-local backend), so the
- * caller falls back to the API-key fields.
+ * login probe detects a session, a neutral configured-credentials banner when
+ * the active backend has a saved credential whose validity is not verified,
+ * or a spinner while the probe is checking. Renders nothing otherwise.
  */
 export function AcpAuthStatusBanner({
   status,
   isChecking,
+  credentialsConfigured,
   providerName,
   testIdPrefix,
 }: AcpAuthStatusBannerProps) {
@@ -54,6 +57,22 @@ export function AcpAuthStatusBanner({
         <Loader2 className="size-4 shrink-0 animate-spin" aria-hidden />
         <span>
           {t(I18nKey.ONBOARDING$ACP_AUTH_CHECKING, { provider: providerName })}
+        </span>
+      </div>
+    );
+  }
+
+  if (credentialsConfigured) {
+    return (
+      <div
+        data-testid={`${testIdPrefix}-configured`}
+        className="flex items-start gap-2 rounded-xl border border-sky-500/40 bg-sky-500/10 px-4 py-3 text-sm text-sky-200"
+      >
+        <KeyRound className="mt-0.5 size-4 shrink-0 text-sky-400" aria-hidden />
+        <span>
+          {t(I18nKey.ONBOARDING$ACP_CREDENTIALS_CONFIGURED, {
+            provider: providerName,
+          })}
         </span>
       </div>
     );

--- a/src/components/features/settings/acp-credentials-section.tsx
+++ b/src/components/features/settings/acp-credentials-section.tsx
@@ -10,9 +10,9 @@ import type { AcpCredentialForm } from "#/hooks/use-acp-credential-form";
 
 /**
  * Settings → Agent credentials section for a built-in ACP provider: renders the
- * same fields the onboarding step collects (and the same "already signed in"
- * auth banner), so credentials can be added or rotated after onboarding. The
- * form state and the save are owned by the parent (Settings → Agent) so the
+ * same fields the onboarding step collects (and the same auth-status banner),
+ * so credentials can be added or rotated after onboarding. The form state and
+ * the save are owned by the parent (Settings → Agent) so the
  * page has a single Save button for both agent settings and credentials.
  * Renders nothing for providers without credential fields.
  */
@@ -26,6 +26,9 @@ export function AcpCredentialsSection({
   const { t } = useTranslation("openhands");
   const { fields, values, setValue, secretExists, conflicts } = form;
   const { status: authStatus, isChecking } = useAcpAuthStatus(providerKey);
+  const credentialsConfigured = fields.some(
+    (field) => field.secret && secretExists(field.name),
+  );
   const providerName = getAcpProviderDisplayName(providerKey) ?? providerKey;
 
   if (fields.length === 0) return null;
@@ -44,6 +47,7 @@ export function AcpCredentialsSection({
       <AcpAuthStatusBanner
         status={authStatus}
         isChecking={isChecking}
+        credentialsConfigured={credentialsConfigured}
         providerName={providerName}
         testIdPrefix="settings-acp-auth"
       />

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -254,6 +254,23 @@
     "zh-CN": "您已登录 {{provider}} — 下面的字段可以留空。",
     "zh-TW": "您已登入 {{provider}} — 下方欄位可以留空。"
   },
+  "ONBOARDING$ACP_CREDENTIALS_CONFIGURED": {
+    "en": "Credentials for {{provider}} are saved on this backend. Their validity isn't checked here.",
+    "ja": "{{provider}} の認証情報はこのバックエンドに保存されています。ここでは有効性を確認していません。",
+    "zh-CN": "已在此后端保存 {{provider}} 的凭据。此处不会验证其有效性。",
+    "zh-TW": "已在此後端儲存 {{provider}} 的憑證。此處不會驗證其有效性。",
+    "ko-KR": "이 백엔드에 {{provider}} 자격 증명이 저장되어 있습니다. 여기서는 유효성을 확인하지 않습니다.",
+    "no": "Påloggingsinformasjon for {{provider}} er lagret i denne backend-en. Gyldigheten kontrolleres ikke her.",
+    "ar": "تم حفظ بيانات اعتماد {{provider}} على هذا الخادم الخلفي. لا يتم التحقق من صلاحيتها هنا.",
+    "de": "Anmeldedaten für {{provider}} sind in diesem Backend gespeichert. Ihre Gültigkeit wird hier nicht geprüft.",
+    "fr": "Les identifiants de {{provider}} sont enregistrés sur ce backend. Leur validité n'est pas vérifiée ici.",
+    "it": "Le credenziali per {{provider}} sono salvate in questo backend. La loro validità non viene verificata qui.",
+    "pt": "As credenciais de {{provider}} estão salvas neste backend. A validade delas não é verificada aqui.",
+    "es": "Las credenciales de {{provider}} están guardadas en este backend. Aquí no se verifica su validez.",
+    "ca": "Les credencials de {{provider}} estan desades en aquest backend. Aquí no se'n verifica la validesa.",
+    "tr": "{{provider}} kimlik bilgileri bu arka uçta kayıtlı. Geçerlilikleri burada doğrulanmaz.",
+    "uk": "Облікові дані {{provider}} збережено на цьому бекенді. Їхню дійсність тут не перевіряють."
+  },
   "ONBOARDING$ACP_AUTH_CHECKING": {
     "ar": "جارٍ التحقق من وجود تسجيل دخول حالي إلى {{provider}}…",
     "ca": "S'està comprovant si hi ha una sessió existent de {{provider}}…",


### PR DESCRIPTION
HUMAN:

The contributor reviewed the linked issue, focused tests, and local checks for this patch.

AGENT:

## Why

The ACP login probe only verifies host-local provider CLI state. Cloud and containerized backends can have a saved provider credential while the probe is unavailable and returns `unknown`. The previous shared banner rendered nothing for that state, so users received no truthful acknowledgement that their credential was saved.

## Summary

- show a neutral configured-credentials banner when a provider credential exists on the active backend
- keep the green signed-in banner limited to a verified host-login probe
- apply the same behavior in onboarding and Settings through the shared banner
- add focused coverage for cloud/unknown status and saved credential detection

## Issue Number

Fixes #15643

## How to Test

Focused regression tests:

```bash
npm test -- --run __tests__/components/settings/acp-credentials-section.test.tsx __tests__/components/onboarding/setup-acp-secrets-step.test.tsx
```

Local checks:

```bash
npm run typecheck
npm run lint
```

The focused tests and typecheck passed. Lint passed with three pre-existing warnings. The full local `npm test` run reached 592 passing test files; eight unrelated Windows/UV/path-environment tests failed. A live cloud/Docker backend was not available locally, so the behavior is covered through the shared component and surface tests.

## Video/Screenshots

Reference reproduction/fix evidence for this exact configured-banner behavior is available in the corresponding approved implementation:

- [before fix video](https://github.com/user-attachments/assets/8a3eebed-5209-46b5-97c8-c2a4b0a44892)
- [after fix video](https://github.com/user-attachments/assets/b3f3d470-b45d-4964-b5b8-8ef50b4d79a4)
- ![configured credentials banner](https://github.com/user-attachments/assets/4dc0220f-e80f-4db1-b1dc-c4f1a449f938)

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The issue currently lacks the repository-required `ready-for-dev` and `bug` labels. PR #16145 is an existing approved implementation covering the same issue and behavior; this PR should be considered only if maintainers want a separate implementation.
