### PR TITLE
chore: bump @openhands/typescript-client to 1.38.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@microlink/react-json-view": "1.31.25",
         "@monaco-editor/react": "4.7.0",
         "@openhands/extensions": "0.18.0",
-        "@openhands/typescript-client": "1.38.0",
+        "@openhands/typescript-client": "1.38.1",
         "@react-router/node": "7.18.2",
         "@react-router/serve": "7.18.2",
         "@tailwindcss/vite": "4.3.3",
@@ -4178,9 +4178,9 @@
       }
     },
     "node_modules/@openhands/typescript-client": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@openhands/typescript-client/-/typescript-client-1.38.0.tgz",
-      "integrity": "sha512-+0PW2Y6zbM7Jb3E2nGknx5+REuo0k5mCn/GiNMgWmi9pwWPXtVZfNvF371gxzXpc4Jt+/D45nPdsS3zBQcjhpQ==",
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/@openhands/typescript-client/-/typescript-client-1.38.1.tgz",
+      "integrity": "sha512-KYpcmgL85uKZ0pvEQAxuwfj0M/8Qq+c6Q2bhaPxpwGayXkDeVWoUxIxomly4vdAqhYseK2pUJiHVoCc81gcf7Q==",
       "license": "MIT",
       "dependencies": {
         "@openrouter/sdk": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@microlink/react-json-view": "1.31.25",
     "@monaco-editor/react": "4.7.0",
     "@openhands/extensions": "0.18.0",
-    "@openhands/typescript-client": "1.38.0",
+    "@openhands/typescript-client": "1.38.1",
     "@react-router/node": "7.18.2",
     "@react-router/serve": "7.18.2",
     "@tailwindcss/vite": "4.3.3",


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Bump typescript-client version.

AGENT:

---

## Why

`@openhands/typescript-client` **v1.38.1** was released on 2026-08-21. It regenerates the bundled agent-server schema against **software-agent-sdk v1.43.0** (typescript-client#352), so the typed client now matches the agent-server surface that release added.

Verified against the installed package rather than inferred — `node_modules/@openhands/typescript-client/dist/generated/agent-server-schema.js` carries:

```
// Source: ghcr.io/openhands/agent-server:1.43.0-python
```

and now exports operation types that did not exist in 1.38.0, e.g. `CreateDirectoryApiFileCreateDirectoryPost*` (`POST /file/create_directory`) and `ProviderConnectionApiLlmProviderConnections*` (`/api/llm/provider-connections`).

AGENTS.md requires `@openhands/typescript-client` to be pinned to a released npm version rather than an unreleased commit SHA; 1.38.1 is now published on npm, so this picks it up.

**Contents of v1.38.1 (vs 1.38.0):**

- typescript-client#352 — agent-server (software-agent-sdk) to v1.43.0
- typescript-client#340 — agent-server (software-agent-sdk) to v1.42.0
- typescript-client#344, #345 — dev-only eslint / typescript-eslint bumps

## Summary

- `package.json` + `package-lock.json`: `@openhands/typescript-client` `1.38.0` → `1.38.1`

Updated with `npm install @openhands/typescript-client@1.38.1 --save-exact` so both files move together and the pin stays exact (no caret), per AGENTS.md. No other dependency changed — the lockfile diff is confined to the one package's `version` / `resolved` / `integrity`.

## Issue Number

No tracking issue — this is a routine post-release dependency bump, not a change with acceptance criteria. Please link one here if the `ready-for-dev` requirement is meant to cover dependency chores.

## How to Test

All of the following were run on this branch, from a clean `npm install`:

| Command | Result |
| --- | --- |
| `npm install @openhands/typescript-client@1.38.1 --save-exact` | exit 0 — resolves 1.38.1, `added 1396 packages` |
| `npm run make-i18n && npm run typecheck` | exit 0 — **no TypeScript errors** |
| `npm run build` | exit 0 — `✓ built in 1.84s` |
| `npm test` | exit 0 — **597 test files passed, 4912 passed / 4 skipped / 7 todo**, 155s |

Reproduce with:

```bash
npm ci
npm run make-i18n && npm run typecheck
npm run build
npm test
```

Note on `typecheck`: running it before `make-i18n` fails with ~20 × `TS2307: Cannot find module '#/i18n/declaration'`. That is pre-existing and unrelated to this bump — `src/i18n/declaration.ts` is generated, and AGENTS.md documents that `npm test` runs `make-i18n` first for exactly this reason. After generating it, typecheck is clean.

**Not covered:** I did not boot the full stack against a live agent-server for this bump. The change is a patch-level dependency pin with no source changes, and the risk it carries is type-level — which `typecheck` + `build` + the full suite do exercise. Flagging it explicitly rather than implying broader coverage than was run.

## Video/Screenshots

N/A — no user-visible or UI change; this is a dependency pin bump with no source edits. Evidence is the command output in the table above.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- **Deliberately scoped to `typescript-client` only.** `config/defaults.json` still pins `agentServer` at `1.42.1` while this client's generated types now describe agent-server `1.43.0`. The 1.43.0 additions are new endpoints/types rather than changes to existing ones, so the older server stays compatible, but the two are now a release apart. Bumping `versions.agentServer` to `1.43.0` is a reasonable follow-up and was left out of this PR on purpose.
- `scripts/check-sdk-version-sync.mjs` is unaffected: it validates `openhands-automation` against `versions.agentServer` on PyPI and does not look at `typescript-client`.
- Nothing else in the repo records this version. The only other mention is a historical comment in `src/utils/mcp-config.ts:53` referring to typescript-client 1.36.1, which is a note about past behaviour and not a pin.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.8.0` |
| **Commit** | `9ddf98c6348ba4a733752f65c34a58aba1d0e079` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-9ddf98c
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-9ddf98c
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-9ddf98c-amd64
ghcr.io/openhands/agent-canvas:chore-bump-typescript-client-1.38.1-amd64
ghcr.io/openhands/agent-canvas:pr-16780-amd64
ghcr.io/openhands/agent-canvas:sha-9ddf98c-arm64
ghcr.io/openhands/agent-canvas:chore-bump-typescript-client-1.38.1-arm64
ghcr.io/openhands/agent-canvas:pr-16780-arm64
ghcr.io/openhands/agent-canvas:sha-9ddf98c
ghcr.io/openhands/agent-canvas:chore-bump-typescript-client-1.38.1
ghcr.io/openhands/agent-canvas:pr-16780
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-9ddf98c`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-9ddf98c-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->