### PR TITLE
feat: offer only proven workflows in the recommended automations section

### DIFF
--- a/__tests__/components/automations/recommended-automations.test.tsx
+++ b/__tests__/components/automations/recommended-automations.test.tsx
@@ -47,6 +47,27 @@ const {
   mockUseSettings: vi.fn(),
 }));
 
+const { featuredIdsOverride } = vi.hoisted(() => ({
+  featuredIdsOverride: { current: null as readonly string[] | null },
+}));
+
+// The section offers only the featured automations, so a test that exercises
+// card behaviour on a specific catalog entry has to feature that entry.
+vi.mock("#/manifests/automation-interface", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("#/manifests/automation-interface")>();
+  return {
+    ...actual,
+    getFeaturedAutomationIds: () =>
+      featuredIdsOverride.current ?? actual.getFeaturedAutomationIds(),
+  };
+});
+
+/** Feature the whole catalog, for tests about a card rather than the set. */
+const featureAllAutomations = () => {
+  featuredIdsOverride.current = AUTOMATION_CATALOG.map((entry) => entry.id);
+};
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, vars?: Record<string, unknown>) => {
@@ -184,10 +205,11 @@ describe("recommended automations", () => {
 
   afterEach(() => {
     localStorage.clear();
+    featuredIdsOverride.current = null;
     __resetActiveStoreForTests();
   });
 
-  it("renders the proven automations before the beta ones, each in popularity order", () => {
+  it("renders only the proven automations, in popularity order", () => {
     render(
       <RecommendedAutomationsSection
         backendKind="local"
@@ -210,17 +232,10 @@ describe("recommended automations", () => {
       "slack-channel-monitor",
       "github-agents-md-maintainer",
       "news-digest",
-      "github-repo-monitor",
-      "slack-standup-digest",
-      "linear-triage-assistant",
-      "jira-issue-to-pr",
-      "research-brief-writer",
-      "upstream-fork-sync",
-      "incident-retrospective-drafter",
     ]);
   });
 
-  it("groups the non-proven automations under a labeled Beta section", () => {
+  it("offers no Beta group and no non-proven automation", () => {
     render(
       <RecommendedAutomationsSection
         backendKind="local"
@@ -234,26 +249,11 @@ describe("recommended automations", () => {
     ).parentElement!;
     expect(within(provenHeading).getByText("5")).toBeInTheDocument();
 
-    const betaHeading = screen.getByTestId(
-      "recommended-automations-beta-heading",
-    );
-    expect(betaHeading).toHaveTextContent(
-      I18nKey.RECOMMENDED_AUTOMATIONS$BETA_LABEL,
-    );
-    expect(within(betaHeading).getByText("7")).toBeInTheDocument();
-
-    const betaSection = screen.getByTestId(
-      "recommended-automations-beta-section",
-    );
     expect(
-      within(betaSection).getByTestId(
-        "recommended-automation-card-slack-standup-digest",
-      ),
-    ).toBeInTheDocument();
+      screen.queryByTestId("recommended-automations-beta-section"),
+    ).not.toBeInTheDocument();
     expect(
-      within(betaSection).queryByTestId(
-        "recommended-automation-card-github-pr-reviewer",
-      ),
+      screen.queryByTestId("recommended-automation-card-slack-standup-digest"),
     ).not.toBeInTheDocument();
   });
 
@@ -280,6 +280,8 @@ describe("recommended automations", () => {
   });
 
   it("filters recommendations by required MCP keywords", () => {
+    featureAllAutomations();
+
     render(
       <RecommendedAutomationsSection
         backendKind="local"
@@ -298,6 +300,8 @@ describe("recommended automations", () => {
   });
 
   it("shows a left-aligned MCP icon stack on each card", () => {
+    featureAllAutomations();
+
     render(
       <RecommendedAutomationsSection
         backendKind="local"
@@ -338,6 +342,8 @@ describe("recommended automations", () => {
   });
 
   it("renders missing MCP connect copy as a pill on the same row", () => {
+    featureAllAutomations();
+
     const offsetWidthDescriptor = Object.getOwnPropertyDescriptor(
       HTMLElement.prototype,
       "offsetWidth",
@@ -431,6 +437,8 @@ describe("recommended automations", () => {
   }
 
   it("keeps a non-MCP-installable integration visible on its card instead of dropping it", () => {
+    featureAllAutomations();
+
     const restoreRequirement = requireNonMcpIntegration();
     // SkillCardPillRow folds pills behind "+N more" when it measures zero
     // widths in jsdom; give it room so every pill renders.
@@ -506,6 +514,8 @@ describe("recommended automations", () => {
   });
 
   it("finds an automation by searching for its non-MCP-installable integration", () => {
+    featureAllAutomations();
+
     render(
       <RecommendedAutomationsSection
         backendKind="local"
@@ -521,6 +531,8 @@ describe("recommended automations", () => {
   });
 
   it("does not silently hide an unknown required integration ID", () => {
+    featureAllAutomations();
+
     const automation = AUTOMATION_CATALOG.find(
       (item) => item.id === "jira-issue-to-pr",
     )!;
@@ -560,6 +572,8 @@ describe("recommended automations", () => {
   });
 
   it("queues installs only for MCP-installable required integrations", async () => {
+    featureAllAutomations();
+
     const restoreRequirement = requireNonMcpIntegration();
 
     try {
@@ -794,6 +808,8 @@ describe("recommended automations", () => {
   });
 
   it("launches an automation that ships no setup form with its slash command", () => {
+    featureAllAutomations();
+
     // Arrange
     mockUseSettings.mockReturnValue({
       data: settingsWithMcpConfig({
@@ -818,6 +834,8 @@ describe("recommended automations", () => {
   });
 
   it("launches without waiting for an integration the automation can start without", () => {
+    featureAllAutomations();
+
     // Arrange — Slack and Linear are connected; Notion, which the entry marks
     // as connectable later, is not.
     mockUseSettings.mockReturnValue({
@@ -993,6 +1011,8 @@ describe("recommended automations", () => {
   });
 
   it("does not show the deployment choice modal for non-responder automations", () => {
+    featureAllAutomations();
+
     renderLauncher();
 
     fireEvent.click(

--- a/src/components/features/automations/recommended-automations-section.tsx
+++ b/src/components/features/automations/recommended-automations-section.tsx
@@ -53,10 +53,10 @@ export { getAutomationsByPopularity };
 
 const RECOMMENDED_AUTOMATIONS = getAutomationsByPopularity(AUTOMATION_CATALOG);
 
-// Proven automations are featured above the Beta group. The set is owned by
-// the interface manifest (falling back to the host default), not derived from
-// popularityRank: slack-standup-digest@94 outranks slack-channel-monitor@92
-// yet is Beta.
+// The only automations this section offers. The set is owned by the interface
+// manifest (falling back to the host default), not derived from popularityRank:
+// slack-standup-digest@94 outranks slack-channel-monitor@92 yet is not proven,
+// so it is not offered here.
 function isProvenAutomation(automation: RecommendedAutomation): boolean {
   return getFeaturedAutomationIds().includes(automation.id);
 }
@@ -311,12 +311,9 @@ export function RecommendedAutomationsSection({
     ),
   );
 
-  if (visibleAutomations.length === 0) return null;
-
   const provenAutomations = visibleAutomations.filter(isProvenAutomation);
-  const betaAutomations = visibleAutomations.filter(
-    (automation) => !isProvenAutomation(automation),
-  );
+
+  if (provenAutomations.length === 0) return null;
 
   return (
     <section
@@ -334,50 +331,22 @@ export function RecommendedAutomationsSection({
             "min-h-0 flex-1 overflow-y-auto custom-scrollbar-always",
         )}
       >
-        {provenAutomations.length > 0 && (
-          <>
-            <div className="flex items-center">
-              <h2 className="text-base font-semibold text-foreground">
-                {t(I18nKey.RECOMMENDED_AUTOMATIONS$SECTION_TITLE)}
-              </h2>
-              <StatusBadge count={provenAutomations.length} />
-            </div>
-            <p className="mt-1 text-sm text-muted">
-              {t(I18nKey.RECOMMENDED_AUTOMATIONS$SECTION_DESCRIPTION)}
-            </p>
+        <div className="flex items-center">
+          <h2 className="text-base font-semibold text-foreground">
+            {t(I18nKey.RECOMMENDED_AUTOMATIONS$SECTION_TITLE)}
+          </h2>
+          <StatusBadge count={provenAutomations.length} />
+        </div>
+        <p className="mt-1 text-sm text-muted">
+          {t(I18nKey.RECOMMENDED_AUTOMATIONS$SECTION_DESCRIPTION)}
+        </p>
 
-            <AutomationCardGrid
-              automations={provenAutomations}
-              installedServers={installedServers}
-              onSelect={onSelect}
-              translate={t}
-            />
-          </>
-        )}
-
-        {betaAutomations.length > 0 && (
-          <section
-            data-testid="recommended-automations-beta-section"
-            className={cn(provenAutomations.length > 0 && "mt-8")}
-          >
-            <div
-              data-testid="recommended-automations-beta-heading"
-              className="flex items-center"
-            >
-              <h2 className="text-base font-semibold text-foreground">
-                {t(I18nKey.RECOMMENDED_AUTOMATIONS$BETA_LABEL)}
-              </h2>
-              <StatusBadge count={betaAutomations.length} />
-            </div>
-
-            <AutomationCardGrid
-              automations={betaAutomations}
-              installedServers={installedServers}
-              onSelect={onSelect}
-              translate={t}
-            />
-          </section>
-        )}
+        <AutomationCardGrid
+          automations={provenAutomations}
+          installedServers={installedServers}
+          onSelect={onSelect}
+          translate={t}
+        />
       </div>
     </section>
   );

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -33166,23 +33166,6 @@
     "tr": "Her şablon bir ajan istemini, uygulama taslağını ve onu kullanışlı kılan MCP'leri içerir. Önceden doldurulmuş bir konuşma açmak ve ayrıntıları ajanla tamamlamak için birini seçin.",
     "uk": "Кожен шаблон містить запит для агента, ескіз реалізації та MCP, потрібні, щоб зробити його корисним. Виберіть один, щоб відкрити попередньо заповнену розмову й завершити деталі з агентом."
   },
-  "RECOMMENDED_AUTOMATIONS$BETA_LABEL": {
-    "en": "Beta",
-    "ja": "ベータ",
-    "zh-CN": "测试版",
-    "zh-TW": "測試版",
-    "ko-KR": "베타",
-    "no": "Beta",
-    "ar": "تجريبي",
-    "de": "Beta",
-    "fr": "Bêta",
-    "it": "Beta",
-    "pt": "Beta",
-    "es": "Beta",
-    "ca": "Beta",
-    "tr": "Beta",
-    "uk": "Бета"
-  },
   "RECOMMENDED_AUTOMATIONS$POPULARITY_SORTED": {
     "en": "Popularity sorted",
     "ja": "人気順",

--- a/tests/e2e/mock-llm/automations/mock-llm-preset-automation.spec.ts
+++ b/tests/e2e/mock-llm/automations/mock-llm-preset-automation.spec.ts
@@ -1,8 +1,9 @@
 /**
  * Mock-LLM E2E test: preset automation card → slash command → skill activation.
  *
- * The `slack-standup-digest` skill ships in the public OpenHands extensions
- * repo with `triggers: ["/standup-digest:setup"]`. The frontend bundles
+ * The `slack-channel-monitor` skill ships in the public OpenHands extensions
+ * repo with `triggers: ["/slack-monitor:poll"]`. It is a featured automation,
+ * which is what the catalog section offers. The frontend bundles
  * public skills from the `@openhands/extensions` npm package and passes
  * them directly in `agent_context.skills` at conversation-start, so the
  * SDK's trigger matching activates them without the agent-server needing
@@ -36,8 +37,8 @@ import {
   setChatInput,
 } from "../utils/mock-llm-helpers";
 
-const SLASH_COMMAND = "/standup-digest:setup";
-const AUTOMATION_CARD_ID = "slack-standup-digest";
+const SLASH_COMMAND = "/slack-monitor:poll";
+const AUTOMATION_CARD_ID = "slack-channel-monitor";
 const REPLY_TOKEN = "PRESET_AUTOMATION_REPLY_OK";
 
 // ── Shared helpers ────────────────────────────────────────────────────
@@ -51,7 +52,7 @@ async function setupTrajectory(
   // Response 1: the actual agent reply.
   await registerTrajectory(request, "preset-automation", [
     { text: "" },
-    { text: `I'll help you set up the standup digest. ${REPLY_TOKEN}` },
+    { text: `I'll help you set up the Slack channel monitor. ${REPLY_TOKEN}` },
   ]);
   await activateTrajectory(request, "preset-automation");
 }
@@ -185,7 +186,7 @@ test.describe("preset automation → slash command conversation", () => {
     });
     await dismissAnalyticsModal(page);
 
-    // Click the Slack standup digest automation card
+    // Click the Slack channel monitor automation card
     await test.step("click automation card", async () => {
       await waitForTestId(page, "recommended-automations-section", 15_000);
       const card = page.getByTestId(


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

AGENT:

Ran the change in a real Agent Canvas dev stack (not just unit tests) — commands, output, and the resulting page state are under **How to Test** below.

---

## Why

The recommended automations catalog section rendered two groups: **Start from a proven workflow** (the ids the interface manifest features) and a **Beta** group holding every other catalog entry. The section should offer only the featured set, so the Beta group has to go.

## Summary

- Drop the `betaAutomations` split and its rendered `<section>` from `recommended-automations-section.tsx`; the empty-check now runs on the proven set, so the section returns `null` instead of rendering an empty shell when a query matches only non-proven entries.
- Remove `RECOMMENDED_AUTOMATIONS$BETA_LABEL` from `translation.json`, whose only consumer was the removed heading (`declaration.ts` is generated and untracked, so it regenerates on the next `make-i18n`).
- Retarget the two grouping unit tests to the proven-only list, give the ten card-behaviour tests a `getFeaturedAutomationIds` override so they keep testing the card rather than the featured set, and move the e2e preset-automation spec off the now-unrendered `slack-standup-digest` onto the featured `slack-channel-monitor`.

## Issue Number

No `ready-for-dev` issue exists for this — it came in as a direct request, so there is nothing to link. Happy to open one under the Feature Request template if the process requires it before review.

## How to Test

```bash
git checkout vasco/recommended-automations-proven-only
npm install
npm run dev            # or, to run beside an existing instance:
                       # PORT=8010 OH_CANVAS_SAFE_BACKEND_PORT=18010 \
                       # OH_CANVAS_SAFE_AUTOMATION_PORT=18011 \
                       # OH_CANVAS_SAFE_VITE_PORT=3011 \
                       # OH_CANVAS_SAFE_STATE_DIR=/tmp/canvas-pr-state npm run dev
```

Open `/automations/templates` (or `/automations`). Expected: a single **Start from a proven workflow** group with a count badge of 5, and no **Beta** heading anywhere on the page.

Verified on a running stack at `http://localhost:8010/automations/templates` with `@openhands/extensions@0.18.0`. The rendered page reported:

```json
{
  "cardCount": 5,
  "ids": [
    "github-pr-reviewer",
    "github-issue-to-pr",
    "slack-channel-monitor",
    "github-agents-md-maintainer",
    "news-digest"
  ],
  "betaSectionPresent": false,
  "headings": ["Start from a proven workflow"]
}
```

That matches `featuredAutomationIds` in the package's `automations/interface.json` exactly, and is down from the 12 cards the section rendered before.

Automated checks:

- `npx vitest run` — 597 files, 4912 passed, 4 skipped, 7 todo, **0 failed**
- `npm run lint` (typecheck + eslint + prettier) — clean; 3 pre-existing warnings in unrelated files
- `npm run check-translation-completeness` — passes
- Playwright e2e **not run locally** (needs the Dockerized mock-LLM stack), so the `mock-llm-preset-automation.spec.ts` retarget is verified only by typecheck and by the catalog facts it depends on: `slack-channel-monitor` is featured, ships no `setup` block (so it launches a conversation rather than a host form), requires the `slack` integration (so the responder-deployment modal still appears), and its skill declares `triggers: ["/slack-monitor:poll"]`.

## Video/Screenshots

Screenshot pending — will attach the rendered Templates page to `.github/pr-assets/` following the existing `pr-<number>-<n>-<name>.png` convention.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Scope.** Only the section changes. The compact rail (home, onboarding, automations empty state) is a separate component with its own proven/conversation grouping and is untouched.

**Follow-up needed in `OpenHands/extensions`.** The Templates page blurb still reads *"Browse proven automations and beta ideas, then launch one into a conversation to tailor it to your work."* That string is `pages.templates.description` in the package's `automations/interface.json`, so it is published by `@openhands/extensions` and cannot be fixed from this repo. It needs a companion PR there once this lands.

**Worth a second opinion.** The section also backs `/automations/templates`, so this hides 7 of the 12 shipped templates on the Templates page, not just on the automations list. If templates are meant to stay browsable in full, that page may want a different treatment.
